### PR TITLE
set action.disable_delete_all_indices: true in default config

### DIFF
--- a/config/crate.yml
+++ b/config/crate.yml
@@ -33,8 +33,6 @@
 cluster.name: crate
 
 
-################################### Delete ####################################
-
 # disable allowing to delete all indices
 #
 


### PR DESCRIPTION
Since this setting will just apear in the default config it will not affect any production environments and is actually just a hint how to do.
i recommend a plugin "elasticsearch-crate-defaults-plugin" to setup crate's default behavior.
