### PR TITLE
access the tableContext lazy

### DIFF
--- a/sql/src/main/java/org/cratedb/action/parser/InsertVisitor.java
+++ b/sql/src/main/java/org/cratedb/action/parser/InsertVisitor.java
@@ -74,7 +74,6 @@ public class InsertVisitor extends XContentVisitor {
         ResultColumnList targetColumnList = node.getTargetColumnList();
 
         stmt.addIndex(tableName);
-        stmt.tableContext(stmt.context().tableContext(tableName));
 
         // Get column names from index if not defined by query
         // NOTE: returned column name list is alphabetic ordered!

--- a/sql/src/main/java/org/cratedb/action/parser/QueryVisitor.java
+++ b/sql/src/main/java/org/cratedb/action/parser/QueryVisitor.java
@@ -39,7 +39,6 @@ public class QueryVisitor extends XContentVisitor {
 
     private void setTable(String tableName){
         stmt.addIndex(tableName);
-        stmt.tableContext(stmt.context().tableContext(tableName));
     }
 
     public Visitable visit(UpdateNode node) throws StandardException {

--- a/sql/src/main/java/org/cratedb/action/parser/XContentGenerator.java
+++ b/sql/src/main/java/org/cratedb/action/parser/XContentGenerator.java
@@ -234,11 +234,6 @@ public class XContentGenerator {
                     "From type " + table.getClass().getName() + " not supported");
         }
         String name = table.getTableName().getTableName();
-        NodeExecutionContext.TableExecutionContext tableContext = stmt.context().tableContext(name);
-        if (tableContext == null) {
-            throw new SQLParseException("No table definition found for " + name);
-        }
-        stmt.tableContext(tableContext);
         stmt.addIndex(name);
     }
 
@@ -258,7 +253,7 @@ public class XContentGenerator {
                     throw new SQLParseException(
                         "select * with group by not allowed. It is required to specify the columns explicitly");
                 }
-                for (String name : stmt.tableContext().allCols()) {
+                for (String name : stmt.tableContextSafe().allCols()) {
                     stmt.addOutputField(name, name);
                     fields.add(name);
                 }

--- a/sql/src/main/java/org/cratedb/action/sql/ParsedStatement.java
+++ b/sql/src/main/java/org/cratedb/action/sql/ParsedStatement.java
@@ -1,7 +1,9 @@
 package org.cratedb.action.sql;
 
 import org.cratedb.action.parser.*;
+import org.cratedb.sql.CrateException;
 import org.cratedb.sql.ExceptionHelper;
+import org.cratedb.sql.SQLParseException;
 import org.cratedb.sql.facet.InternalSQLFacet;
 import org.cratedb.sql.parser.StandardException;
 import org.cratedb.sql.parser.parser.NodeTypes;
@@ -115,15 +117,46 @@ public class ParsedStatement {
         return indices.add(index);
     }
 
+    public String tableName() {
+        return indices().get(0);
+    }
+
     public NodeExecutionContext context(){
         return context;
     }
 
-    public void tableContext(NodeExecutionContext.TableExecutionContext tableContext) {
-        this.tableContext = tableContext;
+    /**
+     * Access the tableContext for {@link #tableName()} lazily.
+     * The tableName has to be set with {@link #addIndex(String)} before this method can be used.
+     *
+     * Note that for tables that use dynamic mapping without any explicit columns this will always
+     * throw an exception.
+     *
+     * @return TableExecutionContext for the table {@link #tableName()}
+     * @throws SQLParseException in case the TableExecutionContext couldn't be loaded.
+     */
+    public NodeExecutionContext.TableExecutionContext tableContextSafe() throws SQLParseException {
+        if (tableContext == null) {
+            assert tableName() != null;
+            tableContext = context().tableContext(tableName());
+            if (tableContext == null) {
+                throw new SQLParseException("No table definition found for " + tableName());
+            }
+        }
+        return tableContext;
     }
 
+    /**
+     * Same as {@link #tableContextSafe()} but doesn't throw an Exception if the tableContext
+     * cannot be loaded.
+     *
+     * @return TableExecutionContext for the table {@link #tableName()}
+     */
     public NodeExecutionContext.TableExecutionContext tableContext() {
+        if (tableContext == null) {
+            assert tableName() != null;
+            tableContext = context().tableContext(tableName());
+        }
         return tableContext;
     }
 


### PR DESCRIPTION
the table mapping was loaded even though it wasn't always required. Now it's
loaded on the first access.

this should also fix test failures on jenkins that occured due to a race
condition when the mapping couldn't be loaded as the dynamic mapping was just
updated.
