### PR TITLE
Increased default ``SELECT`` limit to 10000.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Increased default ``SELECT`` limit to 10000.
+   Also use this default limit on ``GROUP BY`` queries if no limit is defined explicit.
+
  - Fix: NPE was thrown when using a star select on an index with no defined mappings
 
 2013/11/18 0.19.4

--- a/docs/sql/dml.txt
+++ b/docs/sql/dml.txt
@@ -202,7 +202,7 @@ Limits
 ------
 
 As unlimited SELECT queries could break your cluster if the matching rows exceed your node's RAM,
-SELECT statements are limited by default to **1000** rows.
+SELECT statements are limited by default to **10000** rows.
 You can expand this limit by using an explicit LIMIT-clause.
 But you are encouraged to make use of a windowing using LIMIT and OFFSET to iterate through all the results
 of a potentially large resultset instead of expanding the default limit.

--- a/sql/src/main/java/org/cratedb/action/TransportDistributedSQLAction.java
+++ b/sql/src/main/java/org/cratedb/action/TransportDistributedSQLAction.java
@@ -4,14 +4,11 @@ import com.google.common.collect.MinMaxPriorityQueue;
 import org.cratedb.action.groupby.GroupByRow;
 import org.cratedb.action.groupby.GroupByRowComparator;
 import org.cratedb.action.groupby.aggregate.AggState;
-import org.cratedb.action.sql.NodeExecutionContext;
 import org.cratedb.action.sql.ParsedStatement;
 import org.cratedb.action.sql.SQLRequest;
 import org.cratedb.action.sql.SQLResponse;
 import org.cratedb.service.SQLParseService;
 import org.cratedb.sql.CrateException;
-import org.cratedb.sql.SQLParseException;
-import org.cratedb.sql.parser.StandardException;
 import org.elasticsearch.ElasticSearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.NoShardAvailableActionException;
@@ -31,7 +28,10 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.*;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -196,6 +196,8 @@ public class TransportDistributedSQLAction extends TransportAction<DistributedSQ
 
             if (parsedStatement.limit != null) {
                 rowBuilder.maximumSize(parsedStatement.limit);
+            } else {
+                rowBuilder.maximumSize(SQLParseService.DEFAULT_SELECT_LIMIT);
             }
             this.groupByResult = rowBuilder.create();
             clusterState = clusterService.state();

--- a/sql/src/main/java/org/cratedb/service/SQLParseService.java
+++ b/sql/src/main/java/org/cratedb/service/SQLParseService.java
@@ -17,7 +17,7 @@ import java.util.List;
 
 public class SQLParseService {
 
-    public static final Integer DEFAULT_SELECT_LIMIT = 1000;
+    public static final Integer DEFAULT_SELECT_LIMIT = 10000;
     public final NodeExecutionContext context;
 
     @Inject

--- a/sql/src/test/java/org/cratedb/module/sql/test/QueryVisitorTest.java
+++ b/sql/src/test/java/org/cratedb/module/sql/test/QueryVisitorTest.java
@@ -188,7 +188,7 @@ public class QueryVisitorTest {
     @Test
     public void testSelectAllAndFieldFromTable() throws StandardException, IOException {
         execStatement("select *, name from locations");
-        assertEquals("{\"fields\":[\"a\",\"b\",\"name\"],\"query\":{\"match_all\":{}},\"size\":1000}",
+        assertEquals("{\"fields\":[\"a\",\"b\",\"name\"],\"query\":{\"match_all\":{}},\"size\":10000}",
                 getSource());
     }
 
@@ -705,7 +705,7 @@ public class QueryVisitorTest {
     @Test
     public void testWhereClauseInList() throws StandardException {
         execStatement("select * from locations where position in (?,?,?)", new Object[]{3, 5, 6});
-        assertEquals("{\"fields\":[\"a\",\"b\"],\"query\":{\"terms\":{\"position\":[3,5,6]}},\"size\":1000}", getSource());
+        assertEquals("{\"fields\":[\"a\",\"b\"],\"query\":{\"terms\":{\"position\":[3,5,6]}},\"size\":10000}", getSource());
     }
 
     @Test
@@ -775,7 +775,7 @@ public class QueryVisitorTest {
     public void testSelectWithWhereLikePrefixQuery() throws Exception {
         execStatement("select kind from locations where kind like 'P%'");
         assertEquals(
-            "{\"fields\":[\"kind\"],\"query\":{\"wildcard\":{\"kind\":\"P*\"}},\"size\":1000}",
+            "{\"fields\":[\"kind\"],\"query\":{\"wildcard\":{\"kind\":\"P*\"}},\"size\":10000}",
             getSource()
         );
     }
@@ -784,7 +784,7 @@ public class QueryVisitorTest {
     public void testSelectWithWhereLikePrefixQueryEscaped() throws Exception {
         execStatement("select kind from locations where kind like 'P\\%'");
         assertEquals(
-            "{\"fields\":[\"kind\"],\"query\":{\"wildcard\":{\"kind\":\"P%\"}},\"size\":1000}",
+            "{\"fields\":[\"kind\"],\"query\":{\"wildcard\":{\"kind\":\"P%\"}},\"size\":10000}",
             getSource()
         );
     }
@@ -793,7 +793,7 @@ public class QueryVisitorTest {
     public void testSelectWithWhereLikeWithEscapedStar() throws Exception {
         execStatement("select kind from locations where kind like 'P*'");
         assertEquals(
-            "{\"fields\":[\"kind\"],\"query\":{\"wildcard\":{\"kind\":\"P\\\\*\"}},\"size\":1000}",
+            "{\"fields\":[\"kind\"],\"query\":{\"wildcard\":{\"kind\":\"P\\\\*\"}},\"size\":10000}",
             getSource()
         );
     }
@@ -802,7 +802,7 @@ public class QueryVisitorTest {
     public void testSelectWithWhereLikeWithoutWildcards() throws Exception {
         execStatement("select kind from locations where kind like 'P'");
         assertEquals(
-            "{\"fields\":[\"kind\"],\"query\":{\"wildcard\":{\"kind\":\"P\"}},\"size\":1000}",
+            "{\"fields\":[\"kind\"],\"query\":{\"wildcard\":{\"kind\":\"P\"}},\"size\":10000}",
             getSource()
         );
     }
@@ -811,7 +811,7 @@ public class QueryVisitorTest {
     public void testSelectWithWhereLikePrefixQueryUnderscore() throws Exception {
         execStatement("select kind from locations where kind like 'P_'");
         assertEquals(
-            "{\"fields\":[\"kind\"],\"query\":{\"wildcard\":{\"kind\":\"P?\"}},\"size\":1000}",
+            "{\"fields\":[\"kind\"],\"query\":{\"wildcard\":{\"kind\":\"P?\"}},\"size\":10000}",
             getSource()
         );
     }
@@ -820,7 +820,7 @@ public class QueryVisitorTest {
     public void testSelectWithWhereLikePrefixQueryUnderscoreEscaped() throws Exception {
         execStatement("select kind from locations where kind like 'P\\_'");
         assertEquals(
-            "{\"fields\":[\"kind\"],\"query\":{\"wildcard\":{\"kind\":\"P_\"}},\"size\":1000}",
+            "{\"fields\":[\"kind\"],\"query\":{\"wildcard\":{\"kind\":\"P_\"}},\"size\":10000}",
             getSource()
         );
     }
@@ -829,7 +829,7 @@ public class QueryVisitorTest {
     public void testSelectWithWhereLikePrefixQueryQuestionmark() throws Exception {
         execStatement("select kind from locations where kind like 'P?'");
         assertEquals(
-            "{\"fields\":[\"kind\"],\"query\":{\"wildcard\":{\"kind\":\"P\\\\?\"}},\"size\":1000}",
+            "{\"fields\":[\"kind\"],\"query\":{\"wildcard\":{\"kind\":\"P\\\\?\"}},\"size\":10000}",
             getSource()
         );
     }
@@ -838,7 +838,7 @@ public class QueryVisitorTest {
     public void testSelectWithWhereLikeReversed() throws Exception {
         execStatement("select kind from locations where 'P_' like kind");
         assertEquals(
-            "{\"fields\":[\"kind\"],\"query\":{\"wildcard\":{\"kind\":\"P?\"}},\"size\":1000}",
+            "{\"fields\":[\"kind\"],\"query\":{\"wildcard\":{\"kind\":\"P?\"}},\"size\":10000}",
             getSource()
         );
     }
@@ -871,7 +871,7 @@ public class QueryVisitorTest {
     public void testSelectWithWhereMatch() throws Exception {
         execStatement("select kind from locations where match(kind, 'Star')");
         assertEquals(
-                "{\"fields\":[\"kind\"],\"query\":{\"match\":{\"kind\":\"Star\"}},\"size\":1000}",
+                "{\"fields\":[\"kind\"],\"query\":{\"match\":{\"kind\":\"Star\"}},\"size\":10000}",
                 getSource()
         );
     }
@@ -880,7 +880,7 @@ public class QueryVisitorTest {
     public void testSelectWithWhereNotMatch() throws Exception {
         execStatement("select kind from locations where not match(kind, 'Star')");
         assertEquals(
-                "{\"fields\":[\"kind\"],\"query\":{\"bool\":{\"must_not\":{\"match\":{\"kind\":\"Star\"}}}},\"size\":1000}",
+                "{\"fields\":[\"kind\"],\"query\":{\"bool\":{\"must_not\":{\"match\":{\"kind\":\"Star\"}}}},\"size\":10000}",
                 getSource()
         );
     }
@@ -889,7 +889,7 @@ public class QueryVisitorTest {
     public void testSelectWithWhereMatchAnd() throws Exception {
         execStatement("select kind from locations where match(kind, 'Star') and name = 'Algol'");
         assertEquals(
-                "{\"fields\":[\"kind\"],\"query\":{\"bool\":{\"minimum_should_match\":1,\"must\":[{\"match\":{\"kind\":\"Star\"}},{\"term\":{\"name\":\"Algol\"}}]}},\"size\":1000}",
+                "{\"fields\":[\"kind\"],\"query\":{\"bool\":{\"minimum_should_match\":1,\"must\":[{\"match\":{\"kind\":\"Star\"}},{\"term\":{\"name\":\"Algol\"}}]}},\"size\":10000}",
                 getSource()
         );
     }
@@ -900,7 +900,7 @@ public class QueryVisitorTest {
                 "order by \"_score\" desc",
                 new Object[]{"Star", "Star"});
         assertEquals(
-                "{\"fields\":[\"kind\"],\"query\":{\"match\":{\"kind\":\"Star\"}},\"sort\":[{\"_score\":{\"order\":\"desc\",\"ignore_unmapped\":true}}],\"size\":1000}",
+                "{\"fields\":[\"kind\"],\"query\":{\"match\":{\"kind\":\"Star\"}},\"sort\":[{\"_score\":{\"order\":\"desc\",\"ignore_unmapped\":true}}],\"size\":10000}",
                 getSource()
         );
     }
@@ -911,7 +911,7 @@ public class QueryVisitorTest {
                 "order by \"_score\" desc",
                 new Object[]{"Star", "Star"});
         assertEquals(
-                "{\"fields\":[\"kind\"],\"query\":{\"match\":{\"kind\":\"Star\"}},\"sort\":[{\"_score\":{\"order\":\"desc\",\"ignore_unmapped\":true}}],\"size\":1000}",
+                "{\"fields\":[\"kind\"],\"query\":{\"match\":{\"kind\":\"Star\"}},\"sort\":[{\"_score\":{\"order\":\"desc\",\"ignore_unmapped\":true}}],\"size\":10000}",
                 getSource()
         );
     }
@@ -922,7 +922,7 @@ public class QueryVisitorTest {
                 "and \"_score\" > 0.05",
                 new Object[]{"Star", "Star"});
         assertEquals(
-                "{\"fields\":[\"kind\"],\"query\":{\"bool\":{\"minimum_should_match\":1,\"must\":[{\"match\":{\"kind\":\"Star\"}},{\"match_all\":{}}]}},\"min_score\":0.05,\"size\":1000}",
+                "{\"fields\":[\"kind\"],\"query\":{\"bool\":{\"minimum_should_match\":1,\"must\":[{\"match\":{\"kind\":\"Star\"}},{\"match_all\":{}}]}},\"min_score\":0.05,\"size\":10000}",
                 getSource()
         );
     }


### PR DESCRIPTION
Also use this default limit on `GROUP BY` queries if no limit is defined explicit.
