### PR TITLE
optimize GroupByRow field-value access when building the SQLResponse

### DIFF
--- a/sql/src/main/java/org/cratedb/action/TransportDistributedSQLAction.java
+++ b/sql/src/main/java/org/cratedb/action/TransportDistributedSQLAction.java
@@ -289,6 +289,7 @@ public class TransportDistributedSQLAction extends TransportAction<DistributedSQ
 
             reduceResponseCounter = new AtomicLong(reducers.length);
             shardResponseCounter = new AtomicLong(expectedShardResponses);
+
             // TODO: put this into a service class
             tableExecutionContext = nodeExecutionContext.tableContext(
                     parsedStatement.schemaName(), parsedStatement.tableName());
@@ -328,7 +329,7 @@ public class TransportDistributedSQLAction extends TransportAction<DistributedSQ
                 Object[][] rows = GroupByHelper.sortedRowsToObjectArray(
                     new LimitingCollectionIterator<>(groupByResult, parsedStatement.totalLimit()),
                     parsedStatement,
-                    tableExecutionContext
+                    GroupByHelper.buildFieldExtractor(parsedStatement, tableExecutionContext.mapper())
                 );
 
                 if (logger.isTraceEnabled()) {

--- a/sql/src/main/java/org/cratedb/action/groupby/GroupByFieldExtractor.java
+++ b/sql/src/main/java/org/cratedb/action/groupby/GroupByFieldExtractor.java
@@ -1,0 +1,20 @@
+package org.cratedb.action.groupby;
+
+/**
+ * provides fast direct access to the value inside a GroupByRow.
+ *
+ * use {@link GroupByHelper#buildFieldExtractor(org.cratedb.action.sql.ParsedStatement, org.cratedb.sql.types.SQLFieldMapper)}
+ * to get an array of GroupByFieldExtractor
+ *
+ * then use the array[resultColumnListIdx].getValue(row) to get values.
+ */
+public abstract class GroupByFieldExtractor {
+
+    protected final int idx;
+
+    public GroupByFieldExtractor(int idx) {
+        this.idx = idx;
+    }
+
+    public abstract Object getValue(GroupByRow row);
+}

--- a/sql/src/main/java/org/cratedb/action/groupby/GroupByHelper.java
+++ b/sql/src/main/java/org/cratedb/action/groupby/GroupByHelper.java
@@ -1,16 +1,15 @@
 package org.cratedb.action.groupby;
 
 import org.cratedb.action.groupby.aggregate.AggExpr;
-import org.cratedb.action.groupby.aggregate.min.MinAggFunction;
+import org.cratedb.action.parser.ColumnDescription;
+import org.cratedb.action.parser.ColumnReferenceDescription;
 import org.cratedb.action.sql.ITableExecutionContext;
 import org.cratedb.action.sql.ParsedStatement;
 import org.cratedb.core.collections.LimitingCollectionIterator;
 import org.cratedb.sql.types.SQLFieldMapper;
+import org.elasticsearch.common.collect.Tuple;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
+import java.util.*;
 
 public class GroupByHelper {
 
@@ -32,9 +31,71 @@ public class GroupByHelper {
         return new LimitingCollectionIterator<>(rows, totalLimit);
     }
 
+    /**
+     * this method can be used to built a GroupByFieldExtractor array which provides fast value
+     * lookup on GroupByRows.
+     *
+     * The Array is in the same order as the parsedStatements resultColumnList
+     *
+     * E.g.
+     *
+     *  GroupByFieldExtractor[1].getValue(groupByRow) will return the value for the second column in
+     *  the resultColumnList.
+     *
+     * see also {@link GroupByFieldExtractor}
+     */
+    public static GroupByFieldExtractor[] buildFieldExtractor(ParsedStatement parsedStatement,
+                                                              final SQLFieldMapper fieldMapper) {
+        GroupByFieldExtractor[] extractors = new GroupByFieldExtractor[parsedStatement.resultColumnList.size()];
+
+        int colIdx = 0;
+        int aggStateIdx = 0;
+        int keyValIdx;
+
+        for (final ColumnDescription columnDescription : parsedStatement.resultColumnList) {
+            if (columnDescription instanceof AggExpr) {
+                // fieldMapper is null in case of group by on information schema
+                if (((AggExpr) columnDescription).parameterInfo.isAllColumn || fieldMapper == null) {
+                    extractors[colIdx] = new GroupByFieldExtractor(aggStateIdx) {
+                        @Override
+                        public Object getValue(GroupByRow row) {
+                            return row.aggStates.get(idx).value();
+                        }
+                    };
+                } else {
+                    // need to use fieldMapper to convert long to int/short, etc..
+                    // groupingCollector/fieldcache doesn't return the correct types.
+                    extractors[colIdx] = new GroupByFieldExtractor(aggStateIdx) {
+                        @Override
+                        public Object getValue(GroupByRow row) {
+                            return fieldMapper.convertToXContentValue(
+                                ((AggExpr) columnDescription).parameterInfo.columnName,
+                                row.aggStates.get(idx).value()
+                            );
+                        }
+                    };
+                }
+                aggStateIdx++;
+            } else {
+                 // currently only AggExpr and ColumnReferenceDescription exists, so this must be true.
+                assert columnDescription instanceof ColumnReferenceDescription;
+                keyValIdx = parsedStatement.groupByColumnNames.indexOf(((ColumnReferenceDescription) columnDescription).name);
+                extractors[colIdx] = new GroupByFieldExtractor(keyValIdx) {
+                    @Override
+                    public Object getValue(GroupByRow row) {
+                        return row.key.get(idx);
+                    }
+                };
+            }
+            colIdx++;
+        }
+
+        return extractors;
+    }
+
     public static Object[][] sortedRowsToObjectArray(Collection<GroupByRow> rows,
                                                      ParsedStatement parsedStatement,
-                                                     ITableExecutionContext tableExecutionContext) {
+                                                     GroupByFieldExtractor[] fieldExtractors) {
         int rowCount = Math.max(0, rows.size() - parsedStatement.offset());
         Object[][] result = new Object[rowCount][parsedStatement.outputFields().size()];
         int currentRow = -1;
@@ -45,32 +106,11 @@ public class GroupByHelper {
                 remainingOffset--;
                 continue;
             }
-
             currentRow++;
-            if (tableExecutionContext != null) {
-                SQLFieldMapper sqlFieldMapper = tableExecutionContext.mapper();
-                for (int i = 0; i < result[currentRow].length; i++) {
-                    Object value = null;
-                    int idx = parsedStatement.idxMap[i];
-                    AggExpr aggExpr = row.getAggExpr(idx);
-                    if (aggExpr == null || aggExpr.parameterInfo.isAllColumn) {
-                        value = row.get(idx);
-                    } else if (aggExpr.functionName.equalsIgnoreCase(MinAggFunction.NAME)) {
-                        value = sqlFieldMapper.convertToXContentValue(
-                                row.getAggExpr(idx).parameterInfo.columnName,
-                                row.get(idx)
-                        );
-                    }
-                    result[currentRow][i] = value;
-                }
-            } else {
-                // simple loop, no mapper available
-                for (int i = 0; i < result[currentRow].length; i++) {
-                    int idx = parsedStatement.idxMap[i];
-                    result[currentRow][i] = row.get(idx);
-                }
-            }
 
+            for (int i = 0; i < result[currentRow].length; i++) {
+                result[currentRow][i] = fieldExtractors[i].getValue(row);
+            }
         }
 
         return result;

--- a/sql/src/main/java/org/cratedb/information_schema/AbstractInformationSchemaTable.java
+++ b/sql/src/main/java/org/cratedb/information_schema/AbstractInformationSchemaTable.java
@@ -144,7 +144,7 @@ public abstract class AbstractInformationSchemaTable implements InformationSchem
             GroupByHelper.sortedRowsToObjectArray(
                 GroupByHelper.sortAndTrimRows(rows, comparator, stmt.totalLimit()),
                 stmt,
-                null // TODO: add context here
+                GroupByHelper.buildFieldExtractor(stmt, null)
             ),
             rows.size() - stmt.offset(),
             requestStartedTime


### PR DESCRIPTION
do so by creating anonymous lookup classes outside the loop
   with direct array access.
