### PR TITLE
move createAggState method from AggFunction to AggExpr

### DIFF
--- a/sql/src/main/java/org/cratedb/action/SQLMapperResultRequest.java
+++ b/sql/src/main/java/org/cratedb/action/SQLMapperResultRequest.java
@@ -36,7 +36,6 @@ public class SQLMapperResultRequest extends TransportRequest {
             throw new IOException(e);
         }
         groupByResult = SQLGroupByResult.readSQLGroupByResult(
-            status.aggFunctionMap,
             status.parsedStatement.aggregateExpressions,
             in
         );

--- a/sql/src/main/java/org/cratedb/action/SQLReduceJobResponse.java
+++ b/sql/src/main/java/org/cratedb/action/SQLReduceJobResponse.java
@@ -13,13 +13,10 @@ import java.util.*;
 public class SQLReduceJobResponse extends ActionResponse {
 
     private ParsedStatement parsedStatement;
-    private Map<String,AggFunction> aggFunctionMap;
     public Collection<GroupByRow> result;
 
 
-    public SQLReduceJobResponse(Map<String, AggFunction> aggFunctionMap,
-                                ParsedStatement parsedStatement) {
-        this.aggFunctionMap = aggFunctionMap;
+    public SQLReduceJobResponse(ParsedStatement parsedStatement) {
         this.parsedStatement = parsedStatement;
     }
 
@@ -33,8 +30,7 @@ public class SQLReduceJobResponse extends ActionResponse {
         int resultLength = in.readVInt();
         result = new ArrayList<>(resultLength);
         for (int i = 0; i < resultLength; i++) {
-            result.add(GroupByRow.readGroupByRow(
-                aggFunctionMap, parsedStatement.aggregateExpressions, in));
+            result.add(GroupByRow.readGroupByRow(parsedStatement.aggregateExpressions, in));
         }
     }
 

--- a/sql/src/main/java/org/cratedb/action/SQLReduceJobStatus.java
+++ b/sql/src/main/java/org/cratedb/action/SQLReduceJobStatus.java
@@ -4,14 +4,12 @@ import org.cratedb.action.groupby.GroupByHelper;
 import org.cratedb.action.groupby.GroupByKey;
 import org.cratedb.action.groupby.GroupByRow;
 import org.cratedb.action.groupby.GroupByRowComparator;
-import org.cratedb.action.groupby.aggregate.AggFunction;
 import org.cratedb.action.sql.ParsedStatement;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 
@@ -20,17 +18,14 @@ public class SQLReduceJobStatus {
     public final GroupByRowComparator comparator;
     public final Object lock = new Object();
     public final ParsedStatement parsedStatement;
-    public final Map<String, AggFunction> aggFunctionMap;
     public final ConcurrentMap<GroupByKey, GroupByRow> reducedResult;
 
     CountDownLatch shardsToProcess;
 
     public SQLReduceJobStatus(ParsedStatement parsedStatement,
-                              int shardsToProcess,
-                              Map<String, AggFunction> aggFunctionMap)
+                              int shardsToProcess)
     {
         this.parsedStatement = parsedStatement;
-        this.aggFunctionMap = aggFunctionMap;
         this.reducedResult = ConcurrentCollections.newConcurrentMap();
         this.shardsToProcess = new CountDownLatch(shardsToProcess);
         this.comparator = new GroupByRowComparator(
@@ -50,7 +45,7 @@ public class SQLReduceJobStatus {
 
     public void merge(SQLGroupByResult groupByResult) {
         GroupByRow existingRow;
-        for (GroupByRow row : groupByResult.result) {
+        for (GroupByRow row : groupByResult.result()) {
             existingRow = reducedResult.putIfAbsent(row.key, row);
             if (existingRow == null) {
                 continue;

--- a/sql/src/main/java/org/cratedb/action/TransportDistributedSQLAction.java
+++ b/sql/src/main/java/org/cratedb/action/TransportDistributedSQLAction.java
@@ -548,7 +548,7 @@ public class TransportDistributedSQLAction extends TransportAction<DistributedSQ
 
             @Override
             public SQLReduceJobResponse newInstance() {
-                return new SQLReduceJobResponse(aggFunctionMap, parsedStatement);
+                return new SQLReduceJobResponse(parsedStatement);
             }
 
             @Override

--- a/sql/src/main/java/org/cratedb/action/TransportSQLReduceHandler.java
+++ b/sql/src/main/java/org/cratedb/action/TransportSQLReduceHandler.java
@@ -1,6 +1,5 @@
 package org.cratedb.action;
 
-import org.cratedb.action.groupby.aggregate.AggFunction;
 import org.cratedb.action.sql.ParsedStatement;
 import org.cratedb.core.concurrent.FutureConcurrentMap;
 import org.cratedb.service.SQLParseService;
@@ -17,7 +16,6 @@ import org.elasticsearch.transport.TransportResponse;
 import org.elasticsearch.transport.TransportService;
 
 import java.util.Date;
-import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -27,7 +25,6 @@ public class TransportSQLReduceHandler {
     private final TransportService transportService;
     private final FutureConcurrentMap<UUID, SQLReduceJobStatus> activeReduceJobs = FutureConcurrentMap.newMap();
     private final ClusterService clusterService;
-    private final Map<String, AggFunction> aggFunctionMap;
     private final SQLParseService sqlParseService;
 
     public static class Actions {
@@ -38,12 +35,10 @@ public class TransportSQLReduceHandler {
     @Inject
     public TransportSQLReduceHandler(TransportService transportService,
                                      ClusterService clusterService,
-                                     SQLParseService sqlParseService,
-                                     Map<String, AggFunction> aggFunctionMap) {
+                                     SQLParseService sqlParseService) {
         this.sqlParseService = sqlParseService;
         this.clusterService = clusterService;
         this.transportService = transportService;
-        this.aggFunctionMap = aggFunctionMap;
     }
 
     public void registerHandler() {
@@ -57,7 +52,8 @@ public class TransportSQLReduceHandler {
             sqlParseService.parse(request.request.stmt(), request.request.args());
 
         SQLReduceJobStatus reduceJobStatus = new SQLReduceJobStatus(
-            parsedStatement, request.expectedShardResults, aggFunctionMap);
+            parsedStatement, request.expectedShardResults
+        );
 
         activeReduceJobs.put(request.contextId, reduceJobStatus);
 

--- a/sql/src/main/java/org/cratedb/action/groupby/GroupByRow.java
+++ b/sql/src/main/java/org/cratedb/action/groupby/GroupByRow.java
@@ -31,15 +31,9 @@ public class GroupByRow implements Streamable {
     public List<AggState> aggStates;
 
 
-    private Map<String, AggFunction> aggregateFunctions;
     public List<AggExpr> aggExprs;
 
-
-    public GroupByRow() {
-    }
-
-    public GroupByRow(Map<String, AggFunction> aggregateFunctions, List<AggExpr> aggExprs) {
-        this.aggregateFunctions = aggregateFunctions;
+    GroupByRow(List<AggExpr> aggExprs) {
         this.aggExprs = aggExprs;
     }
 
@@ -48,15 +42,10 @@ public class GroupByRow implements Streamable {
         this.key = key;
     }
 
-    public static GroupByRow createEmptyRow(GroupByKey key,
-                                            List<AggExpr> aggExprs,
-                                            AggFunction[] aggregateFunctions) {
+    public static GroupByRow createEmptyRow(GroupByKey key, List<AggExpr> aggExprs) {
         List<AggState> aggStates = new ArrayList<>(aggExprs.size());
-
-        AggExpr aggExpr;
-        for (int i = 0; i < aggregateFunctions.length; i++) {
-            aggExpr = aggExprs.get(i);
-            aggStates.add(aggregateFunctions[i].createAggState(aggExpr));
+        for (AggExpr aggExpr : aggExprs) {
+            aggStates.add(aggExpr.createAggState());
         }
 
         GroupByRow row = new GroupByRow(key, aggStates);
@@ -83,9 +72,8 @@ public class GroupByRow implements Streamable {
         }
     }
 
-    public static GroupByRow readGroupByRow(Map<String, AggFunction> aggregateFunctions,
-                                            List<AggExpr> aggExprs, StreamInput in) throws IOException {
-        GroupByRow row = new GroupByRow(aggregateFunctions, aggExprs);
+    public static GroupByRow readGroupByRow(List<AggExpr> aggExprs, StreamInput in) throws IOException {
+        GroupByRow row = new GroupByRow(aggExprs);
         row.readFrom(in);
         return row;
     }
@@ -97,7 +85,7 @@ public class GroupByRow implements Streamable {
         AggExpr aggExpr;
         for (int i = 0; i < aggExprs.size(); i++) {
             aggExpr = aggExprs.get(i);
-            aggStates.add(i, aggregateFunctions.get(aggExpr.functionName).createAggState(aggExpr));
+            aggStates.add(i, aggExpr.createAggState());
             aggStates.get(i).readFrom(in);
         }
     }
@@ -109,5 +97,4 @@ public class GroupByRow implements Streamable {
             aggState.writeTo(out);
         }
     }
-
 }

--- a/sql/src/main/java/org/cratedb/action/groupby/SQLGroupingCollector.java
+++ b/sql/src/main/java/org/cratedb/action/groupby/SQLGroupingCollector.java
@@ -88,7 +88,7 @@ public class SQLGroupingCollector extends Collector {
         GroupByRow row = resultMap.get(key);
 
         if (row == null) {
-            row = GroupByRow.createEmptyRow(key, parsedStatement.aggregateExpressions, aggFunctions);
+            row = GroupByRow.createEmptyRow(key, parsedStatement.aggregateExpressions);
             resultMap.put(key, row);
         }
 

--- a/sql/src/main/java/org/cratedb/action/groupby/aggregate/AggExpr.java
+++ b/sql/src/main/java/org/cratedb/action/groupby/aggregate/AggExpr.java
@@ -1,6 +1,11 @@
 package org.cratedb.action.groupby.aggregate;
 
+import org.cratedb.DataType;
 import org.cratedb.action.groupby.ParameterInfo;
+import org.cratedb.action.groupby.aggregate.count.CountAggState;
+import org.cratedb.action.groupby.aggregate.max.MaxAggState;
+import org.cratedb.action.groupby.aggregate.min.MinAggState;
+import org.cratedb.action.groupby.aggregate.sum.SumAggState;
 import org.cratedb.action.parser.ColumnDescription;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -9,17 +14,135 @@ import java.io.IOException;
 
 public class AggExpr extends ColumnDescription {
 
+    private AggStateCreator aggStateCreator;
     public String functionName;
     public ParameterInfo parameterInfo;
 
-    public AggExpr(String functionName, ParameterInfo parameterInfo) {
+    public AggExpr(String functionName, final ParameterInfo parameterInfo) {
         super(Types.AGGREGATE_COLUMN);
         this.functionName = functionName;
         this.parameterInfo = parameterInfo;
+
+        createAggStateCreator(functionName, parameterInfo);
     }
 
-    public AggExpr() {
-        super(Types.AGGREGATE_COLUMN);
+    /**
+     * this method is used to generate the aggStateCreator, this creator is then used in {@link #createAggState()}
+     * to instantiate a concrete {@link AggState}
+     *
+     * this built aggStateCreator depends on the functionName and parameterInfo
+     */
+    private void createAggStateCreator(String functionName, ParameterInfo parameterInfo) {
+        switch (functionName) {
+            case "COUNT":
+                createCountAggState();
+                break;
+            case "COUNT(*)":
+                createCountAggState();
+                break;
+            case "SUM":
+                createSumAggState();
+                break;
+            case "MAX":
+                createMaxAggState(parameterInfo);
+                break;
+            case "MIN":
+                createMinAggState(parameterInfo);
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown function " + functionName);
+
+        }
+    }
+
+    private void createMinAggState(ParameterInfo parameterInfo) {
+        if (parameterInfo.dataType == DataType.STRING) {
+            aggStateCreator = new AggStateCreator() {
+                @Override
+                AggState create() {
+                    return new MinAggState<String>();
+                }
+            };
+        } else if (DataType.DECIMAL_TYPES.contains(parameterInfo.dataType)) {
+            aggStateCreator = new AggStateCreator() {
+                @Override
+                AggState create() {
+                    return new MinAggState<Double>();
+                }
+            };
+        } else if (DataType.INTEGER_TYPES.contains(parameterInfo.dataType)
+            || DataType.TIMESTAMP == parameterInfo.dataType)
+        {
+            aggStateCreator = new AggStateCreator() {
+                @Override
+                AggState create() {
+                    return new MinAggState<Long>();
+                }
+            };
+        } else {
+            throw new IllegalArgumentException("Illegal ParameterInfo for MIN");
+        }
+    }
+
+    private void createMaxAggState(ParameterInfo parameterInfo) {
+        if (parameterInfo.dataType == DataType.STRING) {
+            aggStateCreator = new AggStateCreator() {
+                @Override
+                AggState create() {
+                    return new MaxAggState<String>();
+                }
+            };
+        } else if (DataType.DECIMAL_TYPES.contains(parameterInfo.dataType)) {
+            aggStateCreator = new AggStateCreator() {
+                @Override
+                AggState create() {
+                    return new MaxAggState<Double>();
+                }
+            };
+        } else if (DataType.INTEGER_TYPES.contains(parameterInfo.dataType)
+            || DataType.TIMESTAMP == parameterInfo.dataType)
+        {
+            aggStateCreator = new AggStateCreator() {
+                @Override
+                AggState create() {
+                    return new MaxAggState<Long>();
+                }
+            };
+        } else {
+            throw new IllegalArgumentException("Illegal ParameterInfo for MAX");
+        }
+    }
+
+    private void createSumAggState() {
+        aggStateCreator = new AggStateCreator() {
+            @Override
+            AggState create() {
+                return new SumAggState();
+            }
+        };
+    }
+
+    private void createCountAggState() {
+        aggStateCreator = new AggStateCreator() {
+            @Override
+            AggState create() {
+                return new CountAggState();
+            }
+        };
+    }
+
+    /**
+     * internally used to create the {@link #createAggState()} method.
+     */
+    abstract class AggStateCreator {
+        abstract AggState create();
+    }
+
+    /**
+     * can be used to create a concrete AggState that will fit to the functionName
+     */
+    public AggState createAggState() {
+        return aggStateCreator.create();
     }
 
     @Override
@@ -55,12 +178,6 @@ public class AggExpr extends ColumnDescription {
         super.writeTo(out);
         out.writeString(functionName);
         parameterInfo.writeTo(out);
-    }
-
-    public static AggExpr readFromStream(StreamInput in) throws IOException {
-        AggExpr expr = new AggExpr();
-        expr.readFrom(in);
-        return expr;
     }
 
     @Override

--- a/sql/src/main/java/org/cratedb/action/groupby/aggregate/AggFunction.java
+++ b/sql/src/main/java/org/cratedb/action/groupby/aggregate/AggFunction.java
@@ -7,7 +7,5 @@ import java.util.Set;
 public abstract class AggFunction<T extends AggState> {
 
     public abstract void iterate(T state, Object columnValue);
-    public abstract T createAggState(AggExpr aggExpr);
     public abstract Set<DataType> supportedColumnTypes();
-
 }

--- a/sql/src/main/java/org/cratedb/action/groupby/aggregate/count/CountAggFunction.java
+++ b/sql/src/main/java/org/cratedb/action/groupby/aggregate/count/CountAggFunction.java
@@ -1,12 +1,11 @@
 package org.cratedb.action.groupby.aggregate.count;
 
 import org.cratedb.DataType;
-import org.cratedb.action.groupby.aggregate.AggExpr;
 import org.cratedb.action.groupby.aggregate.AggFunction;
 
 import java.util.Set;
 
-public class CountAggFunction<T> extends AggFunction<CountAggState<T>> {
+public class CountAggFunction<T> extends AggFunction<CountAggState> {
 
     public static String NAME = "COUNT";
     public static String COUNT_ROWS_NAME = "COUNT(*)";
@@ -15,12 +14,6 @@ public class CountAggFunction<T> extends AggFunction<CountAggState<T>> {
     public void iterate(CountAggState state, Object columnValue) {
         // TODO: do not count null values when in Column Mode
         state.value++;
-    }
-
-    @Override
-    public CountAggState createAggState(AggExpr aggExpr) {
-        // TODO: count on columns
-        return new CountAggState();
     }
 
     @Override

--- a/sql/src/main/java/org/cratedb/action/groupby/aggregate/count/CountAggState.java
+++ b/sql/src/main/java/org/cratedb/action/groupby/aggregate/count/CountAggState.java
@@ -6,7 +6,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 
-public class CountAggState<T> extends AggState<CountAggState<T>> {
+public class CountAggState extends AggState<CountAggState> {
 
     public long value;
 
@@ -20,13 +20,15 @@ public class CountAggState<T> extends AggState<CountAggState<T>> {
         out.writeVLong(value);
     }
 
-    public void reduce(CountAggState<T> other) {
-        value += other.value;
-    }
 
     @Override
     public Object value() {
         return value;
+    }
+
+    @Override
+    public void reduce(CountAggState other) {
+        value += other.value;
     }
 
     @Override
@@ -35,8 +37,7 @@ public class CountAggState<T> extends AggState<CountAggState<T>> {
     }
 
     @Override
-    public int compareTo(CountAggState<T> o) {
+    public int compareTo(CountAggState o) {
         return Long.compare(value, o.value);
-
     }
 }

--- a/sql/src/main/java/org/cratedb/action/groupby/aggregate/max/MaxAggFunction.java
+++ b/sql/src/main/java/org/cratedb/action/groupby/aggregate/max/MaxAggFunction.java
@@ -24,20 +24,6 @@ public class MaxAggFunction<T extends Comparable<T>> extends AggFunction<MaxAggS
         }
     }
 
-    @Override
-    public MaxAggState createAggState(AggExpr aggExpr) {
-        assert aggExpr.parameterInfo != null;
-        if (DataType.DECIMAL_TYPES.contains(aggExpr.parameterInfo.dataType)) {
-            return new MaxAggState<Double>();
-        } else if (DataType.INTEGER_TYPES.contains(aggExpr.parameterInfo.dataType) ||
-                aggExpr.parameterInfo.dataType == DataType.TIMESTAMP) {
-            return new MaxAggState<Long>();
-        } else if (aggExpr.parameterInfo.dataType == DataType.STRING) {
-            return new MaxAggState<String>();
-        }
-        // shouldn't happen
-        throw new IllegalArgumentException("Illegal AggExpr for MAX");
-    }
 
     @Override
     public Set<DataType> supportedColumnTypes() {

--- a/sql/src/main/java/org/cratedb/action/groupby/aggregate/min/MinAggFunction.java
+++ b/sql/src/main/java/org/cratedb/action/groupby/aggregate/min/MinAggFunction.java
@@ -25,23 +25,10 @@ public class MinAggFunction<T extends Comparable<T>> extends AggFunction<MinAggS
     }
 
     @Override
-    public MinAggState createAggState(AggExpr aggExpr) {
-        assert aggExpr.parameterInfo != null;
-        if (DataType.DECIMAL_TYPES.contains(aggExpr.parameterInfo.dataType)) {
-            return new MinAggState<Double>();
-        } else if (DataType.INTEGER_TYPES.contains(aggExpr.parameterInfo.dataType) ||
-                aggExpr.parameterInfo.dataType == DataType.TIMESTAMP) {
-            return new MinAggState<Long>();
-        } else if (aggExpr.parameterInfo.dataType == DataType.STRING) {
-            return new MinAggState<String>();
-        }
-        // shouldn't happen
-        throw new IllegalArgumentException("Illegal AggExpr for MIN");
-    }
-
-    @Override
     public Set<DataType> supportedColumnTypes() {
         return supportedColumnTypes;
     }
+
+
 
 }

--- a/sql/src/main/java/org/cratedb/action/groupby/aggregate/sum/SumAggFunction.java
+++ b/sql/src/main/java/org/cratedb/action/groupby/aggregate/sum/SumAggFunction.java
@@ -23,11 +23,6 @@ public class SumAggFunction extends AggFunction<SumAggState> {
     }
 
     @Override
-    public SumAggState createAggState(AggExpr aggExpr) {
-        return new SumAggState();
-    }
-
-    @Override
     public Set<DataType> supportedColumnTypes() {
         return supportedColumnTypes;
     }

--- a/sql/src/test/java/org/cratedb/action/SQLGroupByResultTest.java
+++ b/sql/src/test/java/org/cratedb/action/SQLGroupByResultTest.java
@@ -10,6 +10,8 @@ import org.cratedb.action.groupby.aggregate.count.CountAggFunction;
 import org.cratedb.action.groupby.aggregate.count.CountAggState;
 import org.cratedb.action.parser.ColumnDescription;
 import org.cratedb.action.sql.ParsedStatement;
+import org.cratedb.service.SQLParseService;
+import org.cratedb.stubs.HitchhikerMocks;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -24,14 +26,9 @@ public class SQLGroupByResultTest {
     @Test
     public void testMerge() throws Exception {
 
-        ParsedStatement stmt = new ParsedStatement("select count(*) from dummy group by keycol");
-        stmt.resultColumnList = new ArrayList<ColumnDescription>() {{
-            add(new AggExpr(
-                CountAggFunction.COUNT_ROWS_NAME,
-                new ParameterInfo() {{ isAllColumn = true; }}
-            ));
-        }};
-        SQLReduceJobStatus jobStatus = new SQLReduceJobStatus(stmt, 1, new HashMap<String, AggFunction>());
+        SQLParseService parseService = new SQLParseService(HitchhikerMocks.nodeExecutionContext());
+        ParsedStatement stmt = parseService.parse("select count(*) from characters group by gender");
+        SQLReduceJobStatus jobStatus = new SQLReduceJobStatus(stmt, 1);
 
         GroupByKey k1 = new GroupByKey(new Object[] { "k1" });
         GroupByKey k2 = new GroupByKey(new Object[] { "k2" });

--- a/sql/src/test/java/org/cratedb/action/SQLReduceJobStatusTest.java
+++ b/sql/src/test/java/org/cratedb/action/SQLReduceJobStatusTest.java
@@ -34,9 +34,7 @@ public class SQLReduceJobStatusTest {
             "select count(*) from characters group by race order by count(*) desc limit 2");
 
         // result ist from 1 shard, limit is 2; order by first column
-        SQLReduceJobStatus status = new SQLReduceJobStatus(stmt, 1,
-            new HashMap<String, AggFunction>()
-        );
+        SQLReduceJobStatus status = new SQLReduceJobStatus(stmt, 1);
         List<GroupByRow> rows = new ArrayList<>();
         rows.add(new GroupByRow(new GroupByKey(new Object[]{ 1}),
                 new ArrayList<AggState>(1) {{


### PR DESCRIPTION
this avoids dependence on the AggFunction map

Conflicts:
    sql/src/main/java/org/cratedb/action/groupby/aggregate/min/MinAggFunction.java
