### PR TITLE
sql-parser: change parameterExpression to 1 based indexing

### DIFF
--- a/sql-parser/src/main/java/io/crate/sql/parser/StatementBuilder.g
+++ b/sql-parser/src/main/java/io/crate/sql/parser/StatementBuilder.g
@@ -40,7 +40,7 @@ options {
 }
 
 @members {
-    private int parameterPos = 0;
+    private int parameterPos = 1;
 
     @Override
     protected Object recoverFromMismatchedToken(IntStream input, int tokenType, BitSet follow)

--- a/sql-parser/src/main/java/io/crate/sql/tree/ParameterExpression.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/ParameterExpression.java
@@ -30,7 +30,6 @@ public class ParameterExpression extends Expression{
         this.position = position;
     }
 
-
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
         return visitor.visitParameterExpression(this, context);
@@ -55,5 +54,9 @@ public class ParameterExpression extends Expression{
 
     public int position() {
         return position;
+    }
+
+    public int index() {
+        return position - 1;
     }
 }

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestSqlParser.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestSqlParser.java
@@ -71,7 +71,7 @@ public class TestSqlParser
 
     @Test
     public void testParameter() throws Exception {
-        assertExpression("?", new ParameterExpression(0));
+        assertExpression("?", new ParameterExpression(1));
         for (int i=0;i<1000;i++) {
             assertExpression(String.format("$%d", i), new ParameterExpression(i));
         }

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -183,7 +183,7 @@ public class TestStatementBuilder
 
     @Test
     public void testParameterNode() throws Exception {
-        printStatement("select foo, $0 from foo where a = $1 or a = $2");
+        printStatement("select foo, $1 from foo where a = $2 or a = $3");
 
         final AtomicInteger counter = new AtomicInteger(0);
 
@@ -191,7 +191,7 @@ public class TestStatementBuilder
         inExpression.accept(new DefaultTraversalVisitor<Object, Object>() {
             @Override
             public Object visitParameterExpression(ParameterExpression node, Object context) {
-                assertEquals(counter.getAndIncrement(), node.position());
+                assertEquals(counter.incrementAndGet(), node.position());
                 return super.visitParameterExpression(node, context);
             }
         }, null);
@@ -199,11 +199,11 @@ public class TestStatementBuilder
         assertEquals(3, counter.get());
         counter.set(0);
 
-        Expression andExpression = SqlParser.createExpression("a = ? and b = ? and c = $2");
+        Expression andExpression = SqlParser.createExpression("a = ? and b = ? and c = $3");
         andExpression.accept(new DefaultTraversalVisitor<Object, Object>() {
             @Override
             public Object visitParameterExpression(ParameterExpression node, Object context) {
-                assertEquals(counter.getAndIncrement(), node.position());
+                assertEquals(counter.incrementAndGet(), node.position());
                 return super.visitParameterExpression(node, context);
             }
         }, null);

--- a/sql/src/main/java/io/crate/analyze/StatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/StatementAnalyzer.java
@@ -165,7 +165,7 @@ abstract class StatementAnalyzer<T extends Analysis> extends DefaultTraversalVis
 
     @Override
     public Symbol visitParameterExpression(ParameterExpression node, T context) {
-        Object parameter = context.parameterAt(node.position());
+        Object parameter = context.parameterAt(node.index());
         try {
             return Literal.forValue(parameter);
         } catch (IllegalArgumentException e) {


### PR DESCRIPTION
this way the first "?" and $1 will both create a ParameterExpression with
position 1

and then the index access is consistent
