### PR TITLE
re-use collectExpression in the ImplementationSymbolVisitor

### DIFF
--- a/sql/src/main/java/io/crate/planner/symbol/InputColumn.java
+++ b/sql/src/main/java/io/crate/planner/symbol/InputColumn.java
@@ -86,5 +86,20 @@ public class InputColumn extends Symbol implements Comparable<InputColumn> {
                 .toString();
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
 
+        InputColumn that = (InputColumn) o;
+
+        if (index != that.index) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return index;
+    }
 }


### PR DESCRIPTION
in case of count(col1), avg(col1) the inputs for count and avg need to point
to the same collect expression otherwise the input for the second one would be
null
