### PR TITLE
remove obsolete `index.mapper.map_source` setting.

### DIFF
--- a/sql/src/main/java/io/crate/plugin/SQLPlugin.java
+++ b/sql/src/main/java/io/crate/plugin/SQLPlugin.java
@@ -69,9 +69,6 @@ public class SQLPlugin extends AbstractPlugin {
         // Set default analyzer
         settingsBuilder.put("index.analysis.analyzer.default.type", "keyword");
 
-        // do not map source on GetRequests
-        // evaluated in elasticsearch ShardGetService.innerGet
-        settingsBuilder.put("index.mapper.map_source", false);
         return settingsBuilder.build();
     }
 


### PR DESCRIPTION
the setting was evaluated in a patch we added to elasticsearch. But that patch
isn't needed anymore and has been removed.
