### PR TITLE
inout: fix threading issue in Importer

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate Data
 unreleased
 ==========
 
+ - bugfix: the rowcount returned from `copy <table> from <path>` was sometimes
+   wrong.
+
  - log the current version of Crate Data
 
 2014/03/17 0.32.1

--- a/inout/src/main/java/io/crate/action/import_/NodeImportResponse.java
+++ b/inout/src/main/java/io/crate/action/import_/NodeImportResponse.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilderString;
 
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class NodeImportResponse extends NodeOperationResponse implements ToXContent {
 
@@ -75,8 +76,8 @@ public class NodeImportResponse extends NodeOperationResponse implements ToXCont
         for (int i = 0; i < fileCount; i++) {
             Importer.ImportCounts counts = new Importer.ImportCounts();
             counts.fileName = in.readString();
-            counts.successes = in.readInt();
-            counts.failures = in.readInt();
+            counts.successes = new AtomicLong(in.readVLong());
+            counts.failures = new AtomicLong(in.readVLong());
             counts.invalid = in.readInt();
             result.importCounts.add(counts);
         }
@@ -89,8 +90,8 @@ public class NodeImportResponse extends NodeOperationResponse implements ToXCont
         out.writeInt(result.importCounts.size());
         for (Importer.ImportCounts counts : result.importCounts) {
             out.writeString(counts.fileName);
-            out.writeInt(counts.successes);
-            out.writeInt(counts.failures);
+            out.writeVLong(counts.successes.get());
+            out.writeVLong(counts.failures.get());
             out.writeInt(counts.invalid);
         }
     }

--- a/inout/src/main/java/io/crate/import_/Importer.java
+++ b/inout/src/main/java/io/crate/import_/Importer.java
@@ -67,6 +67,7 @@ import org.elasticsearch.indices.IndexMissingException;
 import java.io.*;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -525,8 +526,8 @@ public class Importer {
 
     public static class ImportCounts {
         public String fileName;
-        public int successes = 0;
-        public int failures = 0;
+        public AtomicLong successes = new AtomicLong(0);
+        public AtomicLong failures = new AtomicLong(0);
         public int invalid = 0;
     }
 

--- a/inout/src/test/java/io/crate/module/import_/test/RestImportActionTest.java
+++ b/inout/src/test/java/io/crate/module/import_/test/RestImportActionTest.java
@@ -486,12 +486,11 @@ public class RestImportActionTest extends AbstractRestActionTest {
         List<String> importedFiles = new ArrayList<>();
         for (NodeImportResponse nodeImportResponse : response.getResponses()) {
             for (Importer.ImportCounts importCounts : nodeImportResponse.result().importCounts) {
-                successfullyImported += importCounts.successes;
+                successfullyImported += importCounts.successes.get();
                 importedFiles.add(importCounts.fileName);
             }
         }
         assertEquals(1, successfullyImported);
-
         assertEquals(1, importedFiles.size());
         assertTrue(importedFiles.get(0).matches(
                 "(.*)/importdata/import_10/import_node-import-test-with-path-vars.json"));

--- a/sql/src/main/java/io/crate/executor/transport/task/inout/ImportTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/inout/ImportTask.java
@@ -55,7 +55,7 @@ public class ImportTask implements Task<Object[][]> {
             long rowCount = 0;
             for (NodeImportResponse nodeImportResponse : nodeImportResponses.getResponses()) {
                 for (Importer.ImportCounts importCounts : nodeImportResponse.result().importCounts) {
-                    rowCount += importCounts.successes;
+                    rowCount += importCounts.successes.get();
                 }
             }
             this.future.set(new Object[][]{new Object[]{rowCount}});


### PR DESCRIPTION
afterBulk of the listener is called from different threads, so the
failure/success counters need to be thread-safe.
