### PR TITLE
fix copy from for tables without primary key

### DIFF
--- a/inout/src/main/java/io/crate/import_/Importer.java
+++ b/inout/src/main/java/io/crate/import_/Importer.java
@@ -281,7 +281,7 @@ public class Importer {
             parser = XContentFactory.xContent(line.getBytes()).createParser(line.getBytes());
             Token token;
             XContentBuilder sourceBuilder = XContentFactory.contentBuilder(XContentType.JSON);
-            boolean checkPK = (pks != null);
+            boolean checkPK = (pks != null && !pks.isEmpty());
             boolean checkRouting = (routing != null);
             List<String> primaryKeyValues = new ArrayList<>();
             String routingValue = null;


### PR DESCRIPTION
_id was always set to an empty string because "pks" is an empty list if create
table was used to create the table but no primary keys have been defined.
