### PR TITLE
forbid clustered-by without primary key for now

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,6 @@ Changes for Crate Data
 unreleased
 ==========
 
- - support clustered-by key without primary key constraint
 
 2014/03/17 0.32.2
 =================

--- a/sql/src/main/java/io/crate/analyze/CreateTableStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateTableStatementAnalyzer.java
@@ -262,6 +262,10 @@ public class CreateTableStatementAnalyzer extends AbstractStatementAnalyzer<Void
             if (context.primaryKeys().size() > 0 && !context.primaryKeys().contains(routingColumn)) {
                 throw new IllegalArgumentException("Clustered by column must be part of primary keys");
             }
+            // Temporarily forbid clustered-by without primary key
+            if (context.primaryKeys().size() == 0) {
+                throw new IllegalArgumentException("Clustered-by without primary key definition is currently not supported");
+            }
 
             context.routing(routingColumn);
         }

--- a/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -118,7 +118,7 @@ public class CreateAlterTableStatementAnalyzerTest extends BaseAnalyzerTest {
         assertThat(primaryKeys.get(0), is("id"));
     }
 
-    @Test
+    @Test (expected = IllegalArgumentException.class)
     @SuppressWarnings("unchecked")
     public void testCreateTableWithClusteredBy() throws Exception {
         CreateTableAnalysis analysis = (CreateTableAnalysis)analyze(


### PR DESCRIPTION
(until new _id generation behaviour is clearly implemented)
