### PR TITLE
L/is routines

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for Crate Data
 unreleased
 ==========
 
+ - added table information_schema.routines
+
  - error messages will no longer show the 'return type' of a function and
    aggregation
 

--- a/docs/sql/information_schema.txt
+++ b/docs/sql/information_schema.txt
@@ -17,7 +17,7 @@ The information schema contains a table called `tables`.
 This table can be queried to get a list of all available tables and their
 settings like the number of shards or number of replicas::
 
-    cr> select * from information_schema.tables 
+    cr> select * from information_schema.tables
     ... where table_name not like 'my_table%' order by schema_name asc, table_name asc
     +--------------------+-------------------+------------------+--------------------+--------------+
     | schema_name        | table_name        | number_of_shards | number_of_replicas | clustered_by |
@@ -27,13 +27,14 @@ settings like the number of shards or number of replicas::
     | doc                | locations         | 2                | 0                  | id           |
     | doc                | quotes            | 2                | 0                  | id           |
     | information_schema | columns           | 1                | 0                  | NULL         |
+    | information_schema | routines          | 1                | 0                  | NULL         |
     | information_schema | table_constraints | 1                | 0                  | NULL         |
     | information_schema | tables            | 1                | 0                  | NULL         |
     | sys                | cluster           | 1                | 0                  | NULL         |
     | sys                | nodes             | 1                | 0                  | NULL         |
     | sys                | shards            | 1                | 0                  | NULL         |
     +--------------------+-------------------+------------------+--------------------+--------------+
-    SELECT 10 rows in set (... sec)
+    SELECT 11 rows in set (... sec)
 
 
 Columns
@@ -153,35 +154,33 @@ behaviour at Crate, so almost all columns are listed as an index as well::
 Routines
 ========
 
-.. note:: currently not implemented
+The routines table contains all custom analyzers, tokenizers, token-filters
+and char-filters and all custom analyzers created by ``CREATE ANALYZER``
+statements (see :ref:`sql-ddl-custom-analyzer`)::
 
-The routines table contains all custom analyzers, tokenizers, token-filters and char-filters
-and all custom analyzers created by ``CREATE ANALYZER`` statements
-(see :ref:`sql-ddl-custom-analyzer`).
+    cr> select routine_name, routine_type from information_schema.routines
+    ... group by routine_name, routine_type order by routine_name asc limit 5
+    +----------------------+--------------+
+    | routine_name         | routine_type |
+    +----------------------+--------------+
+    | arabic               | ANALYZER     |
+    | arabic_normalization | TOKEN_FILTER |
+    | arabic_stem          | TOKEN_FILTER |
+    | armenian             | ANALYZER     |
+    | asciifolding         | TOKEN_FILTER |
+    +----------------------+--------------+
+    SELECT 5 rows in set (... sec)
 
-The column ``routine_definition`` contains the string ``BUILTIN`` for all builtin *Routines*.
-For custom analyzers it contains the SQL statements used for their creation.
-::
-
-    cr> select * from information_schema.routines where routine_definition != 'BUILTIN' order by routine_name asc  #doctest: +SKIP
-    +-----------------+--------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-    | routine_name    | routine_type | routine_definition                                                                                                                                                                                       |
-    +-----------------+--------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-    | e2              | ANALYZER     | CREATE ANALYZER e2 EXTENDS myanalyzer WITH (TOKENIZER mypattern WITH ("pattern"='.*',"type"='pattern'))                                                                                                  |
-    | german_snowball | ANALYZER     | CREATE ANALYZER german_snowball EXTENDS snowball WITH ("language"='german')                                                                                                                              |
-    | myanalyzer      | ANALYZER     | CREATE ANALYZER myanalyzer WITH (TOKENIZER whitespace, TOKEN_FILTERS WITH (lowercase, kstem), CHAR_FILTERS WITH (html_strip, mymapping WITH ("mappings"=['ph=>f','qu=>q','foo=>bar'],"type"='mapping'))) |
-    +-----------------+--------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-    SELECT 3 rows in set (... sec)
-
-You can use this table to see e.g. what builtin tokenizers exist::
+For example you can use this table to list existing tokenizers like this::
 
     cr> select routine_name from information_schema.routines
-    ... where routine_type='TOKENIZER' and  routine_definition='BUILTIN'
-    ... order by routine_name asc  #doctest: +SKIP
+    ... where routine_type='TOKENIZER'
+    ... order by routine_name asc limit 10
     +----------------+
     | routine_name   |
     +----------------+
     | classic        |
+    | e2_mypattern   |
     | edgeNGram      |
     | edge_ngram     |
     | keyword        |
@@ -190,29 +189,19 @@ You can use this table to see e.g. what builtin tokenizers exist::
     | nGram          |
     | ngram          |
     | path_hierarchy |
-    | pattern        |
-    | standard       |
-    | uax_url_email  |
-    | whitespace     |
     +----------------+
-    SELECT 13 rows in set (... sec)
+    SELECT 10 rows in set (... sec)
+
+Or get an overview of how many routines and routine types are available::
 
     cr> select count(*), routine_type from information_schema.routines
-    ... group by routine_type order by routine_type  #doctest: +SKIP
+    ... group by routine_type order by routine_type
     +----------+--------------+
-    | COUNT(*) | routine_type |
+    | count(*) | routine_type |
     +----------+--------------+
     | 45       | ANALYZER     |
-    | 4        | CHAR_FILTER  |
-    | 13       | TOKENIZER    |
-    | 44       | TOKEN_FILTER |
+    | 5        | CHAR_FILTER  |
+    | 14       | TOKENIZER    |
+    | 46       | TOKEN_FILTER |
     +----------+--------------+
     SELECT 4 rows in set (... sec)
-
-    cr> select count(distinct routine_type) as distinct_routines from information_schema.routines  #doctest: +SKIP
-    +-------------------+
-    | distinct_routines |
-    +-------------------+
-    | 4                 |
-    +-------------------+
-    SELECT 1 row in set (... sec)

--- a/sql/src/main/java/io/crate/metadata/Functions.java
+++ b/sql/src/main/java/io/crate/metadata/Functions.java
@@ -23,6 +23,7 @@ package io.crate.metadata;
 
 import org.elasticsearch.common.inject.Inject;
 
+import java.util.Collection;
 import java.util.Map;
 
 public class Functions {
@@ -48,5 +49,9 @@ public class Functions {
             return dynamicResolver.getForTypes(ident.argumentTypes());
         }
         return null;
+    }
+
+    public Collection<FunctionImplementation> functions() {
+        return functionImplementations.values();
     }
 }

--- a/sql/src/main/java/io/crate/metadata/RoutineInfo.java
+++ b/sql/src/main/java/io/crate/metadata/RoutineInfo.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+package io.crate.metadata;
+
+public class RoutineInfo {
+    private String name;
+    private String type;
+
+    public RoutineInfo(String name, String type) {
+        this.name = name;
+        this.type = type;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public String type() {
+        return type;
+    }
+
+}

--- a/sql/src/main/java/io/crate/metadata/RoutineInfos.java
+++ b/sql/src/main/java/io/crate/metadata/RoutineInfos.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+package io.crate.metadata;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Iterators;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Settings;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map;
+
+import static io.crate.metadata.FulltextAnalyzerResolver.CustomType;
+
+public class RoutineInfos implements Iterable<RoutineInfo> {
+
+    private final ESLogger logger = Loggers.getLogger(getClass());
+    private FulltextAnalyzerResolver ftResolver;
+    private Functions functions;
+
+    private static final String NO_DESC = "";
+
+    private enum RoutineType {
+        ANALYZER(CustomType.ANALYZER.getName().toUpperCase()),
+        CHAR_FILTER(CustomType.CHAR_FILTER.getName().toUpperCase()),
+        TOKEN_FILTER("TOKEN_FILTER"),
+        TOKENIZER(CustomType.TOKENIZER.getName().toUpperCase()),
+        FUNCTION("FUNCTION")
+        ;
+        private String name;
+        private RoutineType(String name) {
+            this.name = name;
+        }
+        public String getName() {
+            return name;
+        }
+    }
+
+    public RoutineInfos(Functions functions, FulltextAnalyzerResolver ftResolver) {
+        this.functions = functions;
+        this.ftResolver = ftResolver;
+    }
+
+    private Iterator<RoutineInfo> builtInAnalyzers() {
+        return Iterators.transform(
+                ftResolver.getBuiltInAnalyzers().iterator(),
+                new Function<String, RoutineInfo>() {
+            @Nullable
+            @Override
+            public RoutineInfo apply(@Nullable String input) {
+                return new RoutineInfo(input,
+                        RoutineType.ANALYZER.getName());
+            }
+        });
+    }
+
+    private Iterator<RoutineInfo> builtInCharFilters() {
+        return Iterators.transform(
+                ftResolver.getBuiltInCharFilters().iterator(),
+                new Function<String, RoutineInfo>() {
+            @Nullable
+            @Override
+            public RoutineInfo apply(@Nullable String input) {
+                return new RoutineInfo(input,
+                        RoutineType.CHAR_FILTER.getName());
+            }
+        });
+    }
+
+    private Iterator<RoutineInfo> builtInTokenFilters() {
+        return Iterators.transform(
+                ftResolver.getBuiltInTokenFilters().iterator(),
+                new Function<String, RoutineInfo>() {
+            @Nullable
+            @Override
+            public RoutineInfo apply(@Nullable String input) {
+                return new RoutineInfo(input,
+                        RoutineType.TOKEN_FILTER.getName());
+            }
+        });
+    }
+
+    private Iterator<RoutineInfo> builtInTokenizers() {
+        return Iterators.transform(
+                ftResolver.getBuiltInTokenizers().iterator(),
+                new Function<String, RoutineInfo>() {
+            @Nullable
+            @Override
+            public RoutineInfo apply(@Nullable String input) {
+                return new RoutineInfo(input,
+                        RoutineType.TOKENIZER.getName());
+            }
+        });
+    }
+
+    private Iterator<RoutineInfo> customIterators() {
+        try {
+            Iterator<RoutineInfo> cAnalyzersIterator;
+            Iterator<RoutineInfo> cCharFiltersIterator;
+            Iterator<RoutineInfo> cTokenFiltersIterator;
+            Iterator<RoutineInfo> cTokenizersIterator;
+            cAnalyzersIterator = Iterators.transform(
+                    ftResolver.getCustomAnalyzers().entrySet().iterator(),
+                    new Function<Map.Entry<String, Settings>, RoutineInfo>() {
+                        @Nullable
+                        @Override
+                        public RoutineInfo apply(@Nullable Map.Entry<String, Settings> input) {
+                            return new RoutineInfo(input.getKey(),
+                                    RoutineType.ANALYZER.getName()
+                            );
+                        }
+                    });
+            cCharFiltersIterator = Iterators.transform(
+                    ftResolver.getCustomCharFilters().entrySet().iterator(),
+                    new Function<Map.Entry<String, Settings>, RoutineInfo>() {
+                        @Nullable
+                        @Override
+                        public RoutineInfo apply(@Nullable Map.Entry<String, Settings> input) {
+                            return new RoutineInfo(input.getKey(),
+                                    RoutineType.CHAR_FILTER.getName()
+                            );
+                        }
+                    });
+            cTokenFiltersIterator = Iterators.transform(
+                    ftResolver.getCustomTokenFilters().entrySet().iterator(),
+                    new Function<Map.Entry<String, Settings>, RoutineInfo>() {
+                        @Nullable
+                        @Override
+                        public RoutineInfo apply(@Nullable Map.Entry<String, Settings> input) {
+                            return new RoutineInfo(input.getKey(),
+                                    RoutineType.TOKEN_FILTER.getName()
+                            );
+                        }
+                    });
+            cTokenizersIterator = Iterators.transform(
+                    ftResolver.getCustomTokenizers().entrySet().iterator(),
+                    new Function<Map.Entry<String, Settings>, RoutineInfo>() {
+                        @Nullable
+                        @Override
+                        public RoutineInfo apply(@Nullable Map.Entry<String, Settings> input) {
+                            return new RoutineInfo(input.getKey(),
+                                    RoutineType.TOKENIZER.getName()
+                            );
+                        }
+                    });
+            return Iterators.concat(cAnalyzersIterator, cCharFiltersIterator,
+                    cTokenFiltersIterator, cTokenizersIterator);
+        } catch (IOException e) {
+            logger.error("Could not retrieve custom routines", e);
+            return null;
+        }
+    }
+
+    @Override
+    public Iterator<RoutineInfo> iterator() {
+        return Iterators.concat(
+                builtInAnalyzers(),
+                builtInCharFilters(),
+                builtInTokenFilters(),
+                builtInTokenizers(),
+                customIterators()
+        );
+    }
+}

--- a/sql/src/main/java/io/crate/metadata/information/InformationSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/information/InformationSchemaInfo.java
@@ -61,11 +61,17 @@ public class InformationSchemaInfo implements SchemaInfo {
             .add("constraint_type", DataType.STRING, null)
             .build();
 
+    public static final InformationTableInfo TABLE_INFO_ROUTINES = new InformationTableInfo.Builder("routines")
+            .add("routine_name", DataType.STRING, null)
+            .add("routine_type", DataType.STRING, null)
+            .build();
+
     public static final ImmutableMap<String, TableInfo> TABLE_INFOS =
             ImmutableMap.<String, TableInfo>builder()
                     .put(TABLE_INFO_TABLES.ident().name(), TABLE_INFO_TABLES)
                     .put(TABLE_INFO_COLUMNS.ident().name(), TABLE_INFO_COLUMNS)
                     .put(TABLE_INFO_TABLE_CONSTRAINTS.ident().name(), TABLE_INFO_TABLE_CONSTRAINTS)
+                    .put(TABLE_INFO_ROUTINES.ident().name(), TABLE_INFO_ROUTINES)
                     .build();
 
     @Override

--- a/sql/src/main/java/io/crate/operation/reference/information/InformationDocLevelReferenceResolver.java
+++ b/sql/src/main/java/io/crate/operation/reference/information/InformationDocLevelReferenceResolver.java
@@ -47,6 +47,9 @@ public class InformationDocLevelReferenceResolver implements DocLevelReferenceRe
         for (InformationCollectorExpression<?, ?> implementation : InformationTableConstraintsExpression.IMPLEMENTATIONS) {
             implementations.put(implementation.info().ident(), implementation);
         }
+        for (InformationCollectorExpression<?, ?> implementation : InformationRoutinesExpression.IMPLEMENTATIONS) {
+            implementations.put(implementation.info().ident(), implementation);
+        }
     }
 
     /**

--- a/sql/src/main/java/io/crate/operation/reference/information/InformationRoutinesExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/information/InformationRoutinesExpression.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+package io.crate.operation.reference.information;
+
+import com.google.common.collect.ImmutableList;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.RoutineInfo;
+import io.crate.metadata.information.InformationCollectorExpression;
+import io.crate.metadata.information.InformationSchemaInfo;
+import org.apache.lucene.util.BytesRef;
+
+public abstract class InformationRoutinesExpression<T>
+    extends InformationCollectorExpression<RoutineInfo, T> {
+
+    public static final ImmutableList<InformationRoutinesExpression<?>> IMPLEMENTATIONS
+            = ImmutableList.<InformationRoutinesExpression<?>>builder()
+            .add(new InformationRoutinesExpression<BytesRef>("routine_name") {
+                @Override
+                public BytesRef value() {
+                    return new BytesRef(row.name());
+                }
+            })
+            .add(new InformationRoutinesExpression<BytesRef>("routine_type") {
+                @Override
+                public BytesRef value() {
+                    return new BytesRef(row.type());
+                }
+            })
+            .build();
+
+    protected InformationRoutinesExpression(String name) {
+        super(InformationSchemaInfo.TABLE_INFO_ROUTINES.getColumnInfo(new ColumnIdent(name)));
+    }
+}

--- a/sql/src/main/java/io/crate/planner/symbol/SymbolFormatter.java
+++ b/sql/src/main/java/io/crate/planner/symbol/SymbolFormatter.java
@@ -72,7 +72,7 @@ public class SymbolFormatter extends SymbolVisitor<Void, String> {
                 symbol.info().ident().name(), argJoiner.join(symbol.info().ident().argumentTypes()));
     }
 
-    @Override
+     @Override
     public String visitReference(Reference symbol, Void context) {
         StringBuilder builder = new StringBuilder();
         String schema = symbol.info().ident().tableIdent().schema();


### PR DESCRIPTION
```
cr> select * from information_schema.routines;
+--------------------------+--------------+
| routine_name             | routine_type |
+--------------------------+--------------+
| italian                  | ANALYZER     |
| standard_html_strip      | ANALYZER     |
| chinese                  | ANALYZER     |
| persian                  | ANALYZER     |
| brazilian                | ANALYZER     |
| french                   | ANALYZER     |
| danish                   | ANALYZER     |
| galician                 | ANALYZER     |
| turkish                  | ANALYZER     |
| hungarian                | ANALYZER     |
| portuguese               | ANALYZER     |
| german                   | ANALYZER     |
| indonesian               | ANALYZER     |
| whitespace               | ANALYZER     |
| snowball                 | ANALYZER     |
| hindi                    | ANALYZER     |
| pattern                  | ANALYZER     |
| swedish                  | ANALYZER     |
| greek                    | ANALYZER     |
| thai                     | ANALYZER     |
| classic                  | ANALYZER     |
| latvian                  | ANALYZER     |
| romanian                 | ANALYZER     |
| english                  | ANALYZER     |
| armenian                 | ANALYZER     |
| dutch                    | ANALYZER     |
| default                  | ANALYZER     |
| basque                   | ANALYZER     |
| standard                 | ANALYZER     |
| norwegian                | ANALYZER     |
| spanish                  | ANALYZER     |
| catalan                  | ANALYZER     |
| czech                    | ANALYZER     |
| finnish                  | ANALYZER     |
| simple                   | ANALYZER     |
| arabic                   | ANALYZER     |
| stop                     | ANALYZER     |
| russian                  | ANALYZER     |
| cjk                      | ANALYZER     |
| bulgarian                | ANALYZER     |
| irish                    | ANALYZER     |
| keyword                  | ANALYZER     |
| mapping                  | CHAR_FILTER  |
| pattern_replace          | CHAR_FILTER  |
| htmlStrip                | CHAR_FILTER  |
| html_strip               | CHAR_FILTER  |
| limit                    | TOKEN_FILTER |
| delimited_payload_filter | TOKEN_FILTER |
| synonym                  | TOKEN_FILTER |
| keep                     | TOKEN_FILTER |
| pattern_capture          | TOKEN_FILTER |
| pattern_replace          | TOKEN_FILTER |
| dictionary_decompounder  | TOKEN_FILTER |
| hyphenation_decompounder | TOKEN_FILTER |
| keyword_marker           | TOKEN_FILTER |
| stemmer_override         | TOKEN_FILTER |
| hunspell                 | TOKEN_FILTER |
| cjk_bigram               | TOKEN_FILTER |
| cjk_width                | TOKEN_FILTER |
| czech_stem               | TOKEN_FILTER |
| type_as_payload          | TOKEN_FILTER |
| nGram                    | TOKEN_FILTER |
| stemmer                  | TOKEN_FILTER |
| dutch_stem               | TOKEN_FILTER |
| edgeNGram                | TOKEN_FILTER |
| keyword_repeat           | TOKEN_FILTER |
| unique                   | TOKEN_FILTER |
| elision                  | TOKEN_FILTER |
| snowball                 | TOKEN_FILTER |
| arabic_normalization     | TOKEN_FILTER |
| kstem                    | TOKEN_FILTER |
| length                   | TOKEN_FILTER |
| brazilian_stem           | TOKEN_FILTER |
| lowercase                | TOKEN_FILTER |
| classic                  | TOKEN_FILTER |
| russian_stem             | TOKEN_FILTER |
| ngram                    | TOKEN_FILTER |
| porter_stem              | TOKEN_FILTER |
| german_stem              | TOKEN_FILTER |
| common_grams             | TOKEN_FILTER |
| trim                     | TOKEN_FILTER |
| french_stem              | TOKEN_FILTER |
| standard                 | TOKEN_FILTER |
| truncate                 | TOKEN_FILTER |
| stop                     | TOKEN_FILTER |
| arabic_stem              | TOKEN_FILTER |
| reverse                  | TOKEN_FILTER |
| word_delimiter           | TOKEN_FILTER |
| persian_normalization    | TOKEN_FILTER |
| shingle                  | TOKEN_FILTER |
| asciifolding             | TOKEN_FILTER |
| edge_ngram               | TOKEN_FILTER |
| letter                   | TOKENIZER    |
| nGram                    | TOKENIZER    |
| edgeNGram                | TOKENIZER    |
| whitespace               | TOKENIZER    |
| uax_url_email            | TOKENIZER    |
| pattern                  | TOKENIZER    |
| path_hierarchy           | TOKENIZER    |
| lowercase                | TOKENIZER    |
| classic                  | TOKENIZER    |
| ngram                    | TOKENIZER    |
| standard                 | TOKENIZER    |
| keyword                  | TOKENIZER    |
| edge_ngram               | TOKENIZER    |
+--------------------------+--------------+
SELECT 105 rows in set (0.007 sec)
```
