### PR TITLE
use global cluster scope in TransportSQLAction test to prevent a faulty ...

### DIFF
--- a/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -49,7 +49,7 @@ import static com.google.common.collect.Maps.newHashMap;
 import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilder;
 import static org.hamcrest.Matchers.*;
 
-@CrateIntegrationTest.ClusterScope(scope = CrateIntegrationTest.Scope.SUITE, numNodes = 2)
+@CrateIntegrationTest.ClusterScope(scope = CrateIntegrationTest.Scope.GLOBAL)
 @Seed("991C1014D4833E6C:1CDD059F87E0920F")
 public class TransportSQLActionTest extends SQLTransportIntegrationTest {
 


### PR DESCRIPTION
...behaviour on some machines.
