### PR TITLE
L/remove return type symbol formatter

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate Data
 unreleased
 ==========
 
+ - error messages will no longer show the 'return type' of a function and
+   aggregation
+
  - support global DISTINCT select statements
 
  - ``PARTITIONED BY`` parser support

--- a/sql/src/main/java/io/crate/planner/symbol/SymbolFormatter.java
+++ b/sql/src/main/java/io/crate/planner/symbol/SymbolFormatter.java
@@ -62,13 +62,13 @@ public class SymbolFormatter extends SymbolVisitor<Void, String> {
 
     @Override
     public String visitAggregation(Aggregation symbol, Void context) {
-        return format("%s %s(%s)", symbol.functionInfo().returnType(),
+        return format("%s(%s)",
                 symbol.functionIdent().name(), argJoiner.join(symbol.functionIdent().argumentTypes()));
     }
 
     @Override
     public String visitFunction(Function symbol, Void context) {
-        return format("%s %s(%s)", symbol.info().returnType(),
+        return format("%s(%s)",
                 symbol.info().ident().name(), argJoiner.join(symbol.info().ident().argumentTypes()));
     }
 

--- a/sql/src/test/java/io/crate/operation/collect/LocalDataCollectTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/LocalDataCollectTest.java
@@ -335,7 +335,7 @@ public class LocalDataCollectTest {
     public void testUnknownFunction() throws Exception {
         // will be wrapped somewhere above
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Cannot find implementation for function boolean unknown()");
+        expectedException.expectMessage("Cannot find implementation for function unknown()");
 
         CollectNode collectNode = new CollectNode("unknownFunction", testRouting);
         Function unknownFunction = new Function(

--- a/sql/src/test/java/io/crate/planner/symbol/SymbolFormatterTest.java
+++ b/sql/src/test/java/io/crate/planner/symbol/SymbolFormatterTest.java
@@ -45,7 +45,7 @@ public class SymbolFormatterTest {
         Function f = new Function(new FunctionInfo(
                 new FunctionIdent("foo", Arrays.asList(DataType.STRING, DataType.DOUBLE)), DataType.DOUBLE, false),
                 Arrays.<Symbol>asList(new StringLiteral("bar"), new DoubleLiteral(3.4)));
-        assertFormat(f, "double foo(string, double)");
+        assertFormat(f, "foo(string, double)");
     }
 
     @Test
@@ -53,7 +53,7 @@ public class SymbolFormatterTest {
         Function f = new Function(new FunctionInfo(
                 new FunctionIdent("baz", ImmutableList.<DataType>of()), DataType.DOUBLE, false),
                 ImmutableList.<Symbol>of());
-        assertFormat(f, "double baz()");
+        assertFormat(f, "baz()");
     }
 
     @Test
@@ -62,7 +62,7 @@ public class SymbolFormatterTest {
                 new FunctionIdent("agg", Arrays.asList(DataType.INTEGER)), DataType.LONG, true
         ), Arrays.<Symbol>asList(new IntegerLiteral(-127)), Aggregation.Step.ITER, Aggregation.Step.PARTIAL);
 
-        assertFormat(a, "long agg(integer)");
+        assertFormat(a, "agg(integer)");
     }
 
     @Test
@@ -135,7 +135,7 @@ public class SymbolFormatterTest {
         Function f = new Function(new FunctionInfo(
                 new FunctionIdent("foo", Arrays.asList(DataType.STRING, DataType.NULL)), DataType.DOUBLE, false),
                 Arrays.<Symbol>asList(new StringLiteral("bar"), new DoubleLiteral(3.4)));
-        assertThat(SymbolFormatter.format("This Symbol is formatted %s", f), is("This Symbol is formatted double foo(string, null)"));
+        assertThat(SymbolFormatter.format("This Symbol is formatted %s", f), is("This Symbol is formatted foo(string, null)"));
     }
 
     @Test


### PR DESCRIPTION
We (@dobe and me) once discussed, that the SymbolFormatter shouldn't use the 'return type' of an aggregation or function. This will result in cleaner error messages.

(Also, I want to use the SymbolFormatter in #591 to generate the information_schema.routines table. But I've decided to remove the return type in this separate pull request).
