### PR TITLE
fix NullPointerException in OutputFile

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate Data
 Unreleased
 ==========
 
+ - fixed a NullPointerException that could occur using the COPY TO statement if
+   the target directory doesn't exist.
+
 2014/04/07 0.35.0
 =================
 

--- a/sql/src/main/java/io/crate/operation/projectors/writer/OutputFile.java
+++ b/sql/src/main/java/io/crate/operation/projectors/writer/OutputFile.java
@@ -71,8 +71,10 @@ public class OutputFile extends Output {
 
     @Override
     public void close() throws IOException {
-        os.close();
-        os = null;
+        if (os != null) { // if open failed os is null here
+            os.close();
+            os = null;
+        }
     }
 
     @Override


### PR DESCRIPTION
the NPE hided other errors that occured in open() (like 
FileNotFoundExceptions)
