### PR TITLE
fix: add sys.nodes and sys.cluster expressions to UnassignedShardsReferenceResolver

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate Data
 Unreleased
 ==========
 
+ - fix: queries like "select sys.nodes.name, * from sys.shards" now also work
+   correctly if there are unassigned shards
+
  - feature: implemented partitioned tables
 
  - feature: added table 'information_schema.table_partitions'

--- a/sql/src/main/java/io/crate/analyze/DataStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/DataStatementAnalyzer.java
@@ -21,6 +21,7 @@
 
 package io.crate.analyze;
 
+import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -41,6 +42,7 @@ import io.crate.sql.tree.StringLiteral;
 import org.apache.lucene.util.BytesRef;
 
 import java.util.*;
+
 
 abstract class DataStatementAnalyzer<T extends AbstractDataAnalysis> extends AbstractStatementAnalyzer<Symbol, T> {
 
@@ -160,7 +162,10 @@ abstract class DataStatementAnalyzer<T extends AbstractDataAnalysis> extends Abs
         SubscriptContext subscriptContext = new SubscriptContext();
         node.accept(visitor, subscriptContext);
         ReferenceIdent ident = new ReferenceIdent(
-                context.table().ident(), subscriptContext.column(), subscriptContext.parts());
+                Objects.firstNonNull(subscriptContext.tableIdent(), context.table().ident()),
+                subscriptContext.column(),
+                subscriptContext.parts()
+        );
         return context.allocateReference(ident);
     }
 

--- a/sql/src/main/java/io/crate/analyze/SubscriptContext.java
+++ b/sql/src/main/java/io/crate/analyze/SubscriptContext.java
@@ -21,6 +21,8 @@
 
 package io.crate.analyze;
 
+import io.crate.metadata.TableIdent;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -28,6 +30,7 @@ public class SubscriptContext {
 
     private String column;
     private List<String> parts = new ArrayList<>();
+    private TableIdent tableIdent;
 
     public String column() {
         return column;
@@ -43,5 +46,13 @@ public class SubscriptContext {
 
     public void add(String part) {
         parts.add(0, part);
+    }
+
+    public void tableIdent(TableIdent tableIdent) {
+        this.tableIdent = tableIdent;
+    }
+
+    public TableIdent tableIdent() {
+        return tableIdent;
     }
 }

--- a/sql/src/main/java/io/crate/analyze/SubscriptVisitor.java
+++ b/sql/src/main/java/io/crate/analyze/SubscriptVisitor.java
@@ -22,7 +22,10 @@
 package io.crate.analyze;
 
 import com.google.common.base.Preconditions;
+import io.crate.metadata.TableIdent;
 import io.crate.sql.tree.*;
+
+import java.util.List;
 
 
 public class SubscriptVisitor extends AstVisitor<Void, SubscriptContext> {
@@ -47,6 +50,15 @@ public class SubscriptVisitor extends AstVisitor<Void, SubscriptContext> {
 
     @Override
     protected Void visitQualifiedNameReference(QualifiedNameReference node, SubscriptContext context) {
+        List<String> parts = node.getName().getParts();
+        switch (parts.size()) {
+            case 3:
+                context.tableIdent(new TableIdent(parts.get(0), parts.get(1)));
+                break;
+            case 2:
+                context.tableIdent(new TableIdent(null, parts.get(0)));
+                break;
+        }
         context.column(node.getSuffix().getSuffix());
         return null;
     }

--- a/sql/src/main/java/io/crate/metadata/shard/unassigned/UnassignedShardCollectorExpression.java
+++ b/sql/src/main/java/io/crate/metadata/shard/unassigned/UnassignedShardCollectorExpression.java
@@ -16,6 +16,10 @@ public abstract class UnassignedShardCollectorExpression<T> implements Reference
         this.info = SysShardsTableInfo.INFOS.get(new ColumnIdent(name));
     }
 
+    protected UnassignedShardCollectorExpression(ReferenceInfo info) {
+        this.info = info;
+    }
+
     @Override
     public ReferenceImplementation getChildImplementation(String name) {
         return null;

--- a/sql/src/main/java/io/crate/operation/collect/UnassignedShardsCollectService.java
+++ b/sql/src/main/java/io/crate/operation/collect/UnassignedShardsCollectService.java
@@ -54,10 +54,12 @@ public class UnassignedShardsCollectService implements CollectService {
 
     @Inject
     @SuppressWarnings("unchecked")
-    public UnassignedShardsCollectService(Functions functions, ClusterService clusterService) {
+    public UnassignedShardsCollectService(Functions functions,
+                                          ClusterService clusterService,
+                                          UnassignedShardsReferenceResolver unassignedShardsReferenceResolver) {
         this.inputSymbolVisitor = new CollectInputSymbolVisitor<Input<?>>(
             functions,
-            (DocLevelReferenceResolver)new UnassignedShardsReferenceResolver()
+            (DocLevelReferenceResolver)unassignedShardsReferenceResolver
         );
         this.clusterService = clusterService;
     }

--- a/sql/src/main/java/io/crate/operation/reference/sys/shard/unassigned/UnassignedShardsReferenceResolver.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/shard/unassigned/UnassignedShardsReferenceResolver.java
@@ -1,11 +1,16 @@
 package io.crate.operation.reference.sys.shard.unassigned;
 
-import com.google.common.collect.ImmutableList;
+import io.crate.metadata.ReferenceIdent;
+import io.crate.metadata.ReferenceImplementation;
 import io.crate.metadata.ReferenceInfo;
 import io.crate.metadata.shard.unassigned.UnassignedShardCollectorExpression;
+import io.crate.metadata.sys.SysClusterTableInfo;
+import io.crate.metadata.sys.SysNodesTableInfo;
 import io.crate.operation.reference.DocLevelReferenceResolver;
+import io.crate.operation.reference.sys.cluster.SysClusterExpression;
 import io.crate.operation.reference.sys.shard.*;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.inject.Inject;
 
 import javax.annotation.Nullable;
 import java.util.HashMap;
@@ -13,75 +18,113 @@ import java.util.Map;
 
 public class UnassignedShardsReferenceResolver implements DocLevelReferenceResolver<UnassignedShardCollectorExpression<?>> {
 
-    private static final ImmutableList<UnassignedShardCollectorExpression<?>> IMPLEMENTATIONS =
-        ImmutableList.<UnassignedShardCollectorExpression<?>>builder()
-        .add(new UnassignedShardCollectorExpression<BytesRef>(ShardSchemaNameExpression.NAME) {
+    private static final Map<ReferenceInfo, UnassignedShardCollectorExpression<?>> IMPLEMENTATIONS = new HashMap<>();
+    private final Map<ReferenceIdent, ReferenceImplementation> referenceImplementations;
+
+    private static void register(UnassignedShardCollectorExpression<?> collectorExpression) {
+        IMPLEMENTATIONS.put(collectorExpression.info(), collectorExpression);
+    }
+
+    static {
+        register(new UnassignedShardCollectorExpression<BytesRef>(ShardSchemaNameExpression.NAME) {
             @Override
             public BytesRef value() {
                 return new BytesRef(this.row.schemaName());
             }
-        })
-        .add(new UnassignedShardCollectorExpression<BytesRef>(ShardTableNameExpression.NAME) {
+        });
+        register(new UnassignedShardCollectorExpression<BytesRef>(ShardTableNameExpression.NAME) {
             @Override
             public BytesRef value() {
                 return new BytesRef(this.row.tableName());
             }
-        })
-        .add(new UnassignedShardCollectorExpression<BytesRef>(ShardPartitionIdentExpression.NAME) {
+        });
+        register(new UnassignedShardCollectorExpression<BytesRef>(ShardPartitionIdentExpression.NAME) {
             @Override
             public BytesRef value() {
                 return new BytesRef(this.row.partitionIdent());
             }
-        })
-        .add(new UnassignedShardCollectorExpression<Integer>(ShardIdExpression.NAME) {
+        });
+        register(new UnassignedShardCollectorExpression<Integer>(ShardIdExpression.NAME) {
             @Override
             public Integer value() {
                 return this.row.id();
             }
-        })
-        .add(new UnassignedShardCollectorExpression<Long>(ShardNumDocsExpression.NAME) {
+        });
+        register(new UnassignedShardCollectorExpression<Long>(ShardNumDocsExpression.NAME) {
             @Override
             public Long value() {
                 return 0L;
             }
-        })
-        .add(new UnassignedShardCollectorExpression<Boolean>(ShardPrimaryExpression.NAME) {
+        });
+        register(new UnassignedShardCollectorExpression<Boolean>(ShardPrimaryExpression.NAME) {
             @Override
             public Boolean value() {
                 return row.primary();
             }
-        })
-        .add(new UnassignedShardCollectorExpression<BytesRef>(ShardRelocatingNodeExpression.NAME) {
+        });
+        register(new UnassignedShardCollectorExpression<BytesRef>(ShardRelocatingNodeExpression.NAME) {
             @Override
             public BytesRef value() {
                 return null;
             }
-        })
-        .add(new UnassignedShardCollectorExpression<Long>(ShardSizeExpression.NAME) {
+        });
+        register(new UnassignedShardCollectorExpression<Long>(ShardSizeExpression.NAME) {
             @Override
             public Long value() {
                 return 0L;
             }
-        })
-        .add(new UnassignedShardCollectorExpression<BytesRef>(ShardStateExpression.NAME) {
+        });
+        register(new UnassignedShardCollectorExpression<BytesRef>(ShardStateExpression.NAME) {
             @Override
             public BytesRef value() {
                 return new BytesRef("UNASSIGNED");
             }
-        }).build();
+        });
 
-    private final Map<ReferenceInfo, UnassignedShardCollectorExpression<?>> implementations;
-
-    public UnassignedShardsReferenceResolver() {
-        implementations = new HashMap<>(IMPLEMENTATIONS.size());
-        for (UnassignedShardCollectorExpression<?> implementation : IMPLEMENTATIONS) {
-            implementations.put(implementation.info(), implementation);
+        for (ReferenceInfo referenceInfo : SysNodesTableInfo.INFOS.values()) {
+            register(nullExpression(referenceInfo));
         }
+    }
+
+    @Inject
+    public UnassignedShardsReferenceResolver(Map<ReferenceIdent, ReferenceImplementation> referenceImplementations) {
+        this.referenceImplementations = referenceImplementations;
     }
 
     @Nullable
     @Override
     public UnassignedShardCollectorExpression<?> getImplementation(ReferenceInfo info) {
-        return implementations.get(info);
+        UnassignedShardCollectorExpression<?> expression = IMPLEMENTATIONS.get(info);
+        if (expression == null
+            && info.ident().tableIdent().equals(SysClusterTableInfo.IDENT)) {
+            final ReferenceImplementation referenceImplementation = referenceImplementations.get(info.ident());
+            if (referenceImplementation == null) {
+                return null;
+            }
+            assert referenceImplementation instanceof SysClusterExpression;
+            return new UnassignedShardCollectorExpression<Object>(info) {
+                @Override
+                public Object value() {
+                    return ((SysClusterExpression)referenceImplementation).value();
+                }
+            };
+        }
+        return expression;
+    }
+
+    private static <T> NullUnassignedShardCollectorExpression<T> nullExpression(ReferenceInfo info) {
+        return new NullUnassignedShardCollectorExpression<>(info);
+    }
+
+    static class NullUnassignedShardCollectorExpression<T> extends UnassignedShardCollectorExpression<T> {
+
+        protected NullUnassignedShardCollectorExpression(ReferenceInfo info) {
+            super(info);
+        }
+
+        @Override
+        public T value() {
+            return null;
+        }
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/TransportSQLActionSingleNodeTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TransportSQLActionSingleNodeTest.java
@@ -49,6 +49,12 @@ public class TransportSQLActionSingleNodeTest extends SQLTransportIntegrationTes
         assertThat(response.rowCount(), is(1L));
         assertEquals(1, response.cols().length);
         assertThat((Long) response.rows()[0][0], is(expectedUnassignedShards));
+
+
+        // test that cluster and node expressions are also available for unassigned shards
+        execute("select sys.cluster.name, sys.nodes.name, sys.nodes.port['http'] from sys.shards where table_name = 'locations'");
+        assertThat(response.rowCount(), is(20L));
+        assertThat((String)response.rows()[0][0], is(cluster().clusterName()));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/collect/UnassignedShardsCollectServiceUnitTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/UnassignedShardsCollectServiceUnitTest.java
@@ -35,7 +35,7 @@ public class UnassignedShardsCollectServiceUnitTest {
     @Test
     public void testIsPrimaryAllShardsUnassinged() throws Exception {
         UnassignedShardsCollectService.UnassignedShardIteratorContext context =
-                new UnassignedShardsCollectService(null, null).new UnassignedShardIteratorContext();
+                new UnassignedShardsCollectService(null, null, null).new UnassignedShardIteratorContext();
         // Set<ShardId> must be instantiated but empty,
         // which means: no primary shards available; all shards unassigned for a specific table name and shard id
         context.seenPrimaries = new HashSet<>();


### PR DESCRIPTION
this way a query like  select sys.nodes.name, \* from sys.shards also works if
there are unassigned shards.
