### PR TITLE
unwrap ExecutionException to improve error reporting

### DIFF
--- a/sql/src/main/java/io/crate/action/sql/TransportSQLAction.java
+++ b/sql/src/main/java/io/crate/action/sql/TransportSQLAction.java
@@ -42,6 +42,7 @@ import org.elasticsearch.action.search.ReduceSearchPhaseException;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.UncategorizedExecutionException;
 import org.elasticsearch.index.engine.DocumentAlreadyExistsException;
 import org.elasticsearch.indices.IndexAlreadyExistsException;
 import org.elasticsearch.indices.IndexMissingException;
@@ -204,10 +205,14 @@ public class TransportSQLAction extends TransportAction<SQLRequest, SQLResponse>
      * @return
      */
     public Throwable esToCrateException(Throwable e) {
-        if (e instanceof RemoteTransportException || e instanceof UncheckedExecutionException) {
+        if (e instanceof RemoteTransportException || e instanceof UncheckedExecutionException || e instanceof UncategorizedExecutionException) {
             // if its a transport exception get the real cause throwable
             e = e.getCause();
         }
+        if (e instanceof ExecutionException) {
+            e = e.getCause();
+        }
+
         if (e instanceof IllegalArgumentException || e instanceof ParsingException) {
             return new SQLParseException(e.getMessage(), (Exception)e);
         } else if (e instanceof UnsupportedOperationException) {


### PR DESCRIPTION
e.g. instead of

```
SQLActionException[Failed execution]
```

the user will now get

```
SQLActionException[com.amazonaws.services.s3.model.AmazonS3Exception:
```

   Status Code: 403, AWS Service: Amazon S3, AWS Request ID:
   6F27AB0AB5FE3155, AWS Error Code: SignatureDoesNotMatch ...
