### PR TITLE
fixed id generation on `COPY FROM`

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,14 @@
 Changes for Crate Data
 ======================
 
+Unreleased
+==========
+
+ - fix: id generation on import via `COPY FROM` were wrong if multiple
+   primary key constraints and clustered-by were used.
+   WARNING: records must be re-imported otherwise queries with filter
+   on primary key columns will not match any record
+
 2014/05/23 0.38.2
 =================
 

--- a/sql/src/main/java/io/crate/analyze/AbstractDataAnalysis.java
+++ b/sql/src/main/java/io/crate/analyze/AbstractDataAnalysis.java
@@ -521,7 +521,7 @@ public abstract class AbstractDataAnalysis extends Analysis {
     protected void addIdAndRouting(Boolean create, List<String> primaryKeyValues, String clusteredByValue) {
 
         ColumnIdent clusteredBy = table().clusteredBy();
-        Id id = new Id(table().primaryKey(), primaryKeyValues, clusteredBy == null ? null : clusteredBy, create);
+        Id id = new Id(table().primaryKey(), primaryKeyValues, clusteredBy, create);
         if (id.isValid()) {
             String idString = id.stringValue();
             ids.add(idString);

--- a/sql/src/main/java/io/crate/analyze/Id.java
+++ b/sql/src/main/java/io/crate/analyze/Id.java
@@ -61,7 +61,8 @@ public class Id implements Streamable {
                     return;
                 }
                 if (primaryKeys.get(i).equals(clusteredBy)) {
-                    // clusteredBy value must always be first
+                    // clusteredBy value must always be first,
+                    // so it can be extracted from id later on
                     values.add(0, primaryKeyValue);
                 } else {
                     values.add(primaryKeyValue);

--- a/sql/src/main/java/io/crate/operation/projectors/IndexWriterProjector.java
+++ b/sql/src/main/java/io/crate/operation/projectors/IndexWriterProjector.java
@@ -196,12 +196,14 @@ public class IndexWriterProjector implements Projector {
         });
 
         Object routing = routingInput.value();
-        String clusteredByValue = null;
+        String clusteredByValue;
+        ColumnIdent clusteredByColumn = null;
         if (routing != null) {
             clusteredByValue = routing.toString();
+            clusteredByColumn = primaryKeys.get(primaryKeyValues.indexOf(clusteredByValue));
             indexRequest.routing(clusteredByValue);
         }
-        Id id = new Id(primaryKeys, primaryKeyValues, clusteredByValue != null ? ColumnIdent.fromPath(clusteredByValue) : null, true);
+        Id id = new Id(primaryKeys, primaryKeyValues, clusteredByColumn, true);
         indexRequest.id(id.stringValue());
         return indexRequest;
     }


### PR DESCRIPTION
bug only affected imports on tables with multiple primary key constraints and clustered-by definition
