### PR TITLE
add retry logic to ESBulkIndexTask

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate Data
 Unreleased
 ==========
 
+ - fix: insert statements with a large number of multi-values didn't insert all
+   rows if the internal threading queues run full.
+
  - fix: fix npe in partition clause analysis with null value
 
  - improved error messages

--- a/sql/src/main/java/io/crate/executor/transport/TransportExecutor.java
+++ b/sql/src/main/java/io/crate/executor/transport/TransportExecutor.java
@@ -260,7 +260,7 @@ public class TransportExecutor implements Executor {
         @Override
         public Void visitESIndexNode(ESIndexNode node, Job context) {
             if (node.sourceMaps().size() > 1) {
-                context.addTask(new ESBulkIndexTask(transportBulkAction, node));
+                context.addTask(new ESBulkIndexTask(threadPool, transportBulkAction, node));
             } else {
                 context.addTask(new ESIndexTask(transportIndexAction, node));
             }

--- a/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/ESBulkIndexTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/ESBulkIndexTask.java
@@ -21,6 +21,8 @@
 
 package io.crate.executor.transport.task.elasticsearch;
 
+import com.carrotsearch.hppc.IntArrayList;
+import com.carrotsearch.hppc.cursors.IntCursor;
 import com.google.common.util.concurrent.SettableFuture;
 import io.crate.planner.node.dml.ESIndexNode;
 import org.elasticsearch.action.ActionListener;
@@ -29,11 +31,17 @@ import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.bulk.TransportBulkAction;
 import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class ESBulkIndexTask extends AbstractESIndexTask {
 
+    private final static AtomicInteger currentDelay = new AtomicInteger(0);
     private final TransportBulkAction bulkAction;
     private final BulkRequest request;
     private final ActionListener<BulkResponse> listener;
@@ -41,21 +49,68 @@ public class ESBulkIndexTask extends AbstractESIndexTask {
     static class BulkIndexResponseListener implements ActionListener<BulkResponse> {
 
         private final SettableFuture<Object[][]> result;
+        private final long initialRowsAffected;
+        private final ThreadPool threadPool;
+        private final TransportBulkAction bulkAction;
+        private final BulkRequest request;
+        private final ESLogger logger = Loggers.getLogger(getClass());
 
-        BulkIndexResponseListener(SettableFuture<Object[][]> result) {
+        BulkIndexResponseListener(ThreadPool threadPool,
+                                  TransportBulkAction bulkAction,
+                                  BulkRequest request,
+                                  SettableFuture<Object[][]> result,
+                                  long initialRowsAffected) {
+            this.threadPool = threadPool;
+            this.bulkAction = bulkAction;
+            this.request = request;
             this.result = result;
+            this.initialRowsAffected = initialRowsAffected;
         }
 
         @Override
         public void onResponse(BulkResponse bulkItemResponses) {
             BulkItemResponse[] responses = bulkItemResponses.getItems();
-            long rowsAffected = 0L;
+            long rowsAffected = initialRowsAffected;
+            IntArrayList toRetry = new IntArrayList();
+            String lastFailure = null;
+
             for (BulkItemResponse response : responses) {
                 if (!response.isFailed()) {
                     rowsAffected++;
+                } else if (response.getFailureMessage().startsWith("EsRejectedExecution")) {
+                    toRetry.add(response.getItemId());
+                } else {
+                    lastFailure = response.getFailureMessage();
                 }
             }
-            result.set(new Object[][]{new Object[]{rowsAffected}});
+
+            if (!toRetry.isEmpty()) {
+                logger.debug("%s requests failed due to full queue.. retrying", toRetry.size());
+                final BulkRequest bulkRequest = new BulkRequest();
+                for (IntCursor intCursor : toRetry) {
+                    bulkRequest.add(request.requests().get(intCursor.value));
+                }
+
+                final long currentRowsAffected = rowsAffected;
+                threadPool.schedule(TimeValue.timeValueSeconds(currentDelay.incrementAndGet()),
+                        ThreadPool.Names.SAME, new Runnable() {
+                            @Override
+                            public void run() {
+                                bulkAction.execute(bulkRequest, new BulkIndexResponseListener(
+                                        threadPool,
+                                        bulkAction,
+                                        bulkRequest,
+                                        result,
+                                        currentRowsAffected));
+                            }
+                        });
+            } else if (lastFailure == null) {
+                currentDelay.set(0);
+                result.set(new Object[][]{new Object[]{rowsAffected}});
+            } else {
+                currentDelay.set(0);
+                result.setException(new RuntimeException(lastFailure));
+            }
         }
 
         @Override
@@ -64,7 +119,8 @@ public class ESBulkIndexTask extends AbstractESIndexTask {
         }
     }
 
-    public ESBulkIndexTask(TransportBulkAction bulkAction,
+    public ESBulkIndexTask(ThreadPool threadPool,
+                           TransportBulkAction bulkAction,
                            ESIndexNode node) {
         super(node);
         this.bulkAction = bulkAction;
@@ -79,7 +135,7 @@ public class ESBulkIndexTask extends AbstractESIndexTask {
                     node.routingValues().get(i));
             this.request.add(indexRequest);
         }
-        this.listener = new BulkIndexResponseListener(result);
+        this.listener = new BulkIndexResponseListener(threadPool, bulkAction, request, result, 0L);
     }
 
     @Override

--- a/sql/src/test/java/io/crate/executor/transport/task/elasticsearch/BulkIndexResponseListenerTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/task/elasticsearch/BulkIndexResponseListenerTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.executor.transport.task.elasticsearch;
+
+import com.google.common.util.concurrent.SettableFuture;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.bulk.BulkItemResponse;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.bulk.TransportBulkAction;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+public class BulkIndexResponseListenerTest {
+
+    @Test
+    public void testRetryLogic() throws Throwable {
+
+        /**
+         * simulate a bulkRequest where one response contains a EsRejected Failure
+         */
+
+        TransportBulkAction bulkAction = mock(TransportBulkAction.class);
+        ThreadPool threadPool = new ThreadPool(ImmutableSettings.EMPTY, null);
+
+        SettableFuture<Object[][]> result = SettableFuture.create();
+        BulkRequest bulkRequest = new BulkRequest();
+        IndexRequest request1 = new IndexRequest("dummy", "default", "1");
+        request1.source("foo", "bar");
+        IndexRequest request2 = new IndexRequest("dummy", "default", "2");
+        request2.source("foo", "bla");
+        bulkRequest.add(request1);
+        bulkRequest.add(request2);
+        ESBulkIndexTask.BulkIndexResponseListener responseListener = new ESBulkIndexTask.BulkIndexResponseListener(
+                threadPool, bulkAction, bulkRequest, result, 0
+        );
+
+        // this is the retry with only 1 requests instead of both
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                BulkRequest request = (BulkRequest) invocation.getArguments()[0];
+                assertEquals(1, request.requests().size());
+
+                ESBulkIndexTask.BulkIndexResponseListener listener =
+                        (ESBulkIndexTask.BulkIndexResponseListener) invocation.getArguments()[1];
+
+                listener.onResponse(new BulkResponse(
+                        new BulkItemResponse[]{
+                                new BulkItemResponse(1, IndexRequest.OpType.CREATE.name(),
+                                        new IndexResponse("dummy", "default", "2", 1L, true))
+                        }, 100L));
+                return null;
+            }
+        }).when(bulkAction).execute(any(BulkRequest.class), any(ActionListener.class));
+
+
+        BulkResponse responses = new BulkResponse(
+                new BulkItemResponse[] {
+                        new BulkItemResponse(0, IndexRequest.OpType.CREATE.name(),
+                                new IndexResponse("dummy", "default", "1", 1L, true)),
+                        new BulkItemResponse(1, IndexRequest.OpType.CREATE.name(),
+                                new BulkItemResponse.Failure("dummy", "default", "2", new EsRejectedExecutionException()))
+                }, 200L
+        );
+        responseListener.onResponse(responses);
+
+
+        Object[][] objects = result.get();
+        assertThat((Long)objects[0][0], is(2L));
+    }
+}


### PR DESCRIPTION
if the Bulk ThreadPool queue runs full requests are
   rejected. This retry logic avoids losing inserts.
