### PR TITLE
updated crash to 0.9.13 which includes the following changes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,11 @@ Changes for Crate Data
 Unreleased
 ==========
 
+ - updated crash to 0.9.13 which includes the following changes
+
+    - fix: avoid stripping arbitrative whitespaces from
+      commands passed via stdin
+
  - fix: with a very large number of shards, queries on ``sys.shards`` could
    overflow the threadpools.
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -71,7 +71,7 @@ distZip {
 ext {
     downloadDir = new File(buildDir, 'downloads')
     plugin_crateadmin_version = '0.8.4'
-    crash_version = '0.9.12'
+    crash_version = '0.9.13'
 }
 
 evaluationDependsOn(':es')

--- a/docs/versions.cfg
+++ b/docs/versions.cfg
@@ -1,6 +1,6 @@
 [versions]
 crate = 0.10.2
-crash = 0.9.12
+crash = 0.9.13
 Jinja2 = 2.7.1
 MarkupSafe = 0.18
 Pygments = 1.6


### PR DESCRIPTION
- fix: avoid stripping arbitrative whitespaces from
  commands passed via stdin
