### PR TITLE
fix used diskspace

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for Crate Data
 Unreleased
 ==========
 
+ - fix: return used disk space in bytes
+
  - changed sys.nodes.fs column to contain stats about all mounted disks,
    total disk stats and node data path locations
 

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/fs/NodeFsDisksExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/fs/NodeFsDisksExpression.java
@@ -106,7 +106,7 @@ class NodeFsDisksExpression extends SysNodeObjectArrayReference {
             childImplementations.put(USED, new ChildExpression<Long>(USED) {
                 @Override
                 public Long value() {
-                    return usage.getUsed();
+                    return usage.getUsed()*1024;
                 }
             });
             childImplementations.put(AVAILABLE, new ChildExpression<Long>(AVAILABLE) {


### PR DESCRIPTION
according to the [sigar api](http://www.hyperic.com/support/docs/sigar/org/hyperic/sigar/FileSystemUsage.html#getUsed%28%29) `getUsed()` should return a size in bytes, however, the returned value does not match with the bytes value. however it does match with the kbytes value.

any ideas?
