### PR TITLE
fix group by on string columns - redistribution was broken

### DIFF
--- a/sql/src/test/java/io/crate/operation/collect/ModuloBucketingIteratorTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/ModuloBucketingIteratorTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.operation.collect;
+
+import org.apache.lucene.util.BytesRef;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class ModuloBucketingIteratorTest {
+
+    @Test
+    public void testBytesRefHashing() throws Exception {
+
+        ModuloBucketingIterator moduloBucketingIterator =
+                new ModuloBucketingIterator(4, null);
+
+        int bucket = moduloBucketingIterator.getBucket(new Object[]{new BytesRef("foo")});
+        assertThat(bucket, is(2));
+    }
+}


### PR DESCRIPTION
due to BytesRef hashCode change in lucene which is now different by default
accross different jvms.
