### PR TITLE
Expose close() in CrateClient

### DIFF
--- a/client/src/main/java/io/crate/client/CrateClient.java
+++ b/client/src/main/java/io/crate/client/CrateClient.java
@@ -122,4 +122,7 @@ public class CrateClient {
         return settings;
     }
 
+    public void close() {
+        internalClient.close();
+    }
 }

--- a/client/src/main/java/io/crate/client/InternalCrateClient.java
+++ b/client/src/main/java/io/crate/client/InternalCrateClient.java
@@ -97,4 +97,8 @@ public class InternalCrateClient {
     public void addTransportAddress(TransportAddress transportAddress) {
         nodesService.addTransportAddresses(transportAddress);
     }
+
+    public void close() {
+        nodesService.close();
+    }
 }


### PR DESCRIPTION
This just exposes the `close()` method in `TransportClientNodesService` to safely close down any network connections from the client.
