### PR TITLE
remove unnecessary type cast in EvaluatingNormalizer

### DIFF
--- a/sql/src/main/java/io/crate/analyze/EvaluatingNormalizer.java
+++ b/sql/src/main/java/io/crate/analyze/EvaluatingNormalizer.java
@@ -89,7 +89,7 @@ public class EvaluatingNormalizer extends SymbolVisitor<Void, Symbol> {
 
         Input input = (Input) referenceResolver.getImplementation(symbol.info().ident());
         if (input != null) {
-            return Literal.newLiteral(symbol.info().type(), symbol.info().type().value(input.value()));
+            return Literal.newLiteral(symbol.info().type(), input.value());
         }
 
         if (logger.isTraceEnabled()) {


### PR DESCRIPTION
the value returned from a ReferenceImplementation must always match the
columns type.
