### PR TITLE
made crash posix compatible

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for Crate Data
 Unreleased
 ==========
 
+ - made ``bin/crash`` posix compatible
+
  - improved substr function to not copy underlying byte array
 
 2014/07/15 0.40.1

--- a/app/src/main/dist/bin/crash
+++ b/app/src/main/dist/bin/crash
@@ -3,14 +3,14 @@
 PYTHON_EXECUTABLE=
 for PYTHON in python python2 python3
 do
-    if [[ -e `which ${PYTHON}` ]]
+    if [ -e "`which ${PYTHON}`" ]
     then
         PYTHON_EXECUTABLE=`which ${PYTHON}`
         break
     fi
 done
 
-if [[ ! -e ${PYTHON_EXECUTABLE} ]]; then
+if [ ! -e "${PYTHON_EXECUTABLE}" ]; then
     echo "No python executable found. Please install python in order to use crash"
     exit 1
 fi


### PR DESCRIPTION
came up using dash, which is the default /bin/sh on debian (and derivatives) and does not support '[['.
Turns out '[[' is not POSIX.
