### PR TITLE
fix: using non-equality comparsion of a partition ident within `AND` ...

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,12 @@
 Changes for Crate Data
 ======================
 
+Unreleased
+==========
+
+- fix: using non-equality comparison of a partition column within
+  `AND` expressions results in empty row set
+
 2014/07/29 0.41.0
 =================
 

--- a/sql/src/test/java/io/crate/analyze/SelectAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectAnalyzerTest.java
@@ -999,6 +999,10 @@ public class SelectAnalyzerTest extends BaseAnalyzerTest {
         assertTrue(analysis.whereClause().hasQuery());
         assertFalse(analysis.noMatch());
 
+        analysis = (SelectAnalysis)analyze("select id, name from parted where 1395874700000 < date and date < 1395961200001");
+        assertThat(analysis.whereClause().partitions(), containsInAnyOrder(partition1, partition2));
+        assertFalse(analysis.whereClause().hasQuery());
+        assertFalse(analysis.noMatch());
     }
 
     @Test


### PR DESCRIPTION
... expressions results in empty row set
