### PR TITLE
fix: composite index must only work with `string` typed columns,

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate Data
 Unreleased
 ==========
 
+- fix: composite index must only work with `string` typed columns,
+  also defining it using the `plain` method must result in `keyword` analyzer
+
 - fix: using non-equality comparison of a partition column within
   `AND` expressions results in empty row set
 

--- a/sql/src/main/java/io/crate/analyze/AnalyzedTableElements.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedTableElements.java
@@ -37,6 +37,7 @@ public class AnalyzedTableElements {
     List<AnalyzedColumnDefinition> partitionedByColumns = new ArrayList<>();
     List<AnalyzedColumnDefinition> columns = new ArrayList<>();
     Set<ColumnIdent> columnIdents = new HashSet<>();
+    Map<ColumnIdent, String> columnTypes = new HashMap<>();
     List<String> primaryKeys;
     List<List<String>> partitionedBy;
 
@@ -109,6 +110,7 @@ public class AnalyzedTableElements {
         }
 
         columnIdents.add(column.ident());
+        columnTypes.put(column.ident(), column.dataType());
         for (AnalyzedColumnDefinition child : column.children()) {
             expandColumn(child);
         }
@@ -138,6 +140,7 @@ public class AnalyzedTableElements {
         }
         columnIdents.add(analyzedColumnDefinition.ident());
         columns.add(analyzedColumnDefinition);
+        columnTypes.put(analyzedColumnDefinition.ident(), analyzedColumnDefinition.dataType());
     }
 
     public Settings settings() {
@@ -183,6 +186,9 @@ public class AnalyzedTableElements {
             ColumnIdent columnIdent = ColumnIdent.fromPath(entry.getKey());
             if (!columnIdents.contains(columnIdent)) {
                 throw new ColumnUnknownException(columnIdent.sqlFqn());
+            }
+            if (!columnTypes.get(columnIdent).equalsIgnoreCase("string")) {
+                throw new IllegalArgumentException("INDEX definition only support 'string' typed source columns");
             }
         }
     }


### PR DESCRIPTION
also defining it using the `plain` method must result in `keyword` analyzer
