### PR TITLE
fix: always return rowcount, even when it's not ascertenaible.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate Data
 Unreleased
 ==========
 
+- fix: always return rowcount, even when it's not ascertenaible.
+  In this cases -1 is returned.
+
 - fix: composite index must only work with `string` typed columns,
   also defining it using the `plain` method must result in `keyword` analyzer
 

--- a/docs/sql/rest.txt
+++ b/docs/sql/rest.txt
@@ -74,6 +74,11 @@ The same query using question marks as placeholders looks like this::
       "duration" : ...
     }
 
+.. note::
+
+    With some queries the row count is not ascertainable. In this cases
+    rowcount is -1.
+
 Column Types
 ============
 

--- a/sql/src/main/java/io/crate/action/sql/SQLResponse.java
+++ b/sql/src/main/java/io/crate/action/sql/SQLResponse.java
@@ -102,9 +102,7 @@ public class SQLResponse extends ActionResponse implements ToXContent, SQLResult
             }
         }
         builder.endArray();
-        if (hasRowCount()) {
-            builder.field(Fields.ROWCOUNT, rowCount());
-        }
+        builder.field(Fields.ROWCOUNT, rowCount());
         builder.field(Fields.DURATION, duration());
 
         return builder;

--- a/sql/src/test/java/io/crate/module/sql/test/SQLResponseTest.java
+++ b/sql/src/test/java/io/crate/module/sql/test/SQLResponseTest.java
@@ -70,7 +70,7 @@ public class SQLResponseTest extends TestCase {
         });
         //System.out.println(json(r));
         JSONAssert.assertEquals(
-                "{\"cols\":[\"some\",\"thing\"],\"rows\":[[\"one\",\"two\"],[\"three\",\"four\"]],\"duration\":-1}",
+                "{\"cols\":[\"some\",\"thing\"],\"rows\":[[\"one\",\"two\"],[\"three\",\"four\"]],\"rowcount\":-1, \"duration\":-1}",
                 json(r), true);
     }
 
@@ -82,8 +82,9 @@ public class SQLResponseTest extends TestCase {
                 new Object[]{"one", "two"},
                 new Object[]{"three", "four"},
         });
+        // If no rowcount is set, -1 is returned
         JSONAssert.assertEquals(
-                "{\"cols\":[\"some\",\"thing\"],\"rows\":[[\"one\",\"two\"],[\"three\",\"four\"]],\"duration\":-1}",
+                "{\"cols\":[\"some\",\"thing\"],\"rows\":[[\"one\",\"two\"],[\"three\",\"four\"]],\"rowcount\":-1,\"duration\":-1}",
                 json(r), true);
 
         r.rowCount(2L);


### PR DESCRIPTION
In this cases -1 is returned.
