### PR TITLE
test utf-8 encoding in copy from

### DIFF
--- a/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -21,7 +21,6 @@
 
 package io.crate.integrationtests;
 
-import com.carrotsearch.randomizedtesting.annotations.Seed;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import io.crate.Constants;
@@ -66,7 +65,6 @@ import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.Is.is;
 
 @CrateIntegrationTest.ClusterScope(scope = CrateIntegrationTest.Scope.GLOBAL)
-@Seed("991C1014D4833E6C:1CDD059F87E0920F")
 public class TransportSQLActionTest extends SQLTransportIntegrationTest {
 
 
@@ -2348,6 +2346,9 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
         execute("select * from quotes");
         assertEquals(3L, response.rowCount());
         assertThat(response.rows()[0].length, is(2));
+
+        execute("select quote from quotes where id = 1");
+        assertThat((String) response.rows()[0][0], is("Don't pañic."));
     }
 
     @Test

--- a/sql/src/test/resources/essetup/data/copy/test_copy_from.json
+++ b/sql/src/test/resources/essetup/data/copy/test_copy_from.json
@@ -1,3 +1,3 @@
-{"id": 1, "quote": "Don't panic"}
+{"id": 1, "quote": "Don't pañic."}
 {"id": 2, "quote": "Would it save you a lot of time if I just gave up and went mad now?"}
 {"id": 3, "quote": "Time is an illusion. Lunchtime doubly so."}


### PR DESCRIPTION
(the test would fail sometimes due to the charset randomization if the
FileReader wasn't using utf-8 explicitly)
