### PR TITLE
invalidate DocTableInfo cache if single partition is altered

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,10 @@ Changes for Crate Data
 Unreleased
 ==========
 
+ - fix: The table schema of partitioned table is now correctly invalidated if a
+   single partition has been modified using the ALTER TABLE statement with the
+   PARTITION clause.
+
  - COPY FROM now always assumes that the files it reads are encoded using UTF-8
    instead of relying on the system default.
 

--- a/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -4140,8 +4140,8 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
 
         execute("insert into t (id, date, name) values (2, '2014-01-01', 100)"); // insert integer as name
         refresh();
-        ensureGreen();
         execute("select name from t where id = 2 and date = '2014-01-01'");
+
         assertThat((String) response.rows()[0][0], is("100")); // is returned as string
 
         execute("alter table t add name2 string"); // now template is also updated


### PR DESCRIPTION
this fixes the testAlterTableAddColumnOnPartitionedTable test
