### PR TITLE
don't recalc duration on duration() calls

### DIFF
--- a/sql/src/main/java/io/crate/action/sql/SQLBaseResponse.java
+++ b/sql/src/main/java/io/crate/action/sql/SQLBaseResponse.java
@@ -51,6 +51,7 @@ public abstract class SQLBaseResponse extends ActionResponse implements ToXConte
     protected DataType[] colTypes;
     protected boolean includeTypes;
     protected long requestStartedTime;
+    protected Long duration;
 
     public SQLBaseResponse() {} // used for serialization
 
@@ -82,10 +83,13 @@ public abstract class SQLBaseResponse extends ActionResponse implements ToXConte
     }
 
     public long duration() {
-        if (requestStartedTime > 0) {
-            return System.currentTimeMillis()- requestStartedTime;
+        if (duration == null) {
+            if (requestStartedTime > 0) {
+                duration = System.currentTimeMillis() - requestStartedTime;
+            }
+            duration = -1L;
         }
-        return -1;
+        return duration;
     }
 
     protected void writeSharedAttributes(XContentBuilder builder) throws IOException {


### PR DESCRIPTION
The RestSqlActionTests where flaky because duration() was called multiple
times and changed in-between.

Would be even better to set the duration in the ctor but then we would have to
break backward compatibility because we would have to change the serialization
from writeVLong to writeLong
