### PR TITLE
fix guice injection error if HttpServer is disabled

### DIFF
--- a/sql/src/main/java/io/crate/operation/reference/sys/node/NodePortExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/NodePortExpression.java
@@ -27,7 +27,6 @@ import io.crate.operation.reference.sys.SysNodeObjectReference;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
-import org.elasticsearch.http.HttpServer;
 import org.elasticsearch.node.service.NodeService;
 
 
@@ -46,13 +45,11 @@ public class NodePortExpression extends SysNodeObjectReference {
     public static final String TRANSPORT = "transport";
 
     private final NodeService nodeService;
-    private final HttpServer httpServer;
 
     @Inject
-    public NodePortExpression(NodeService nodeService, HttpServer httpServer) {
+    public NodePortExpression(NodeService nodeService) {
         super(NAME);
         this.nodeService = nodeService;
-        this.httpServer = httpServer;
         addChildImplementations();
     }
 
@@ -60,8 +57,10 @@ public class NodePortExpression extends SysNodeObjectReference {
         childImplementations.put(HTTP, new PortExpression(HTTP) {
             @Override
             public Integer value() {
-
-                return portFromAddress(httpServer.info().address().publishAddress()); //nodeService.stats().getNode().attributes().get("http_address"));
+                if (nodeService.info().getHttp() == null) {
+                    return null;
+                }
+                return portFromAddress(nodeService.info().getHttp().address().publishAddress());
             }
         });
         childImplementations.put(TRANSPORT, new PortExpression(TRANSPORT) {

--- a/sql/src/test/java/io/crate/operation/reference/sys/TestSysNodesExpressions.java
+++ b/sql/src/test/java/io/crate/operation/reference/sys/TestSysNodesExpressions.java
@@ -51,7 +51,6 @@ import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.discovery.Discovery;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.http.HttpInfo;
-import org.elasticsearch.http.HttpServer;
 import org.elasticsearch.monitor.jvm.JvmService;
 import org.elasticsearch.monitor.jvm.JvmStats;
 import org.elasticsearch.monitor.network.NetworkService;
@@ -235,15 +234,13 @@ public class TestSysNodesExpressions {
                 e.printStackTrace();
             }
 
-            HttpServer httpServer = mock(HttpServer.class);
             HttpInfo httpInfo = mock(HttpInfo.class);
+            when(nodeInfo.getHttp()).thenReturn(httpInfo);
             BoundTransportAddress boundTransportAddress = new BoundTransportAddress(
                     new InetSocketTransportAddress("localhost", 44200),
                     new InetSocketTransportAddress("localhost", 44200)
             );
             when(httpInfo.address()).thenReturn(boundTransportAddress);
-            when(httpServer.info()).thenReturn(httpInfo);
-            bind(HttpServer.class).toInstance(httpServer);
 
             JvmService jvmService = mock(JvmService.class);
             JvmStats jvmStats = mock(JvmStats.class);

--- a/sql/src/test/java/io/crate/operation/reference/sys/node/NodePortExpressionTest.java
+++ b/sql/src/test/java/io/crate/operation/reference/sys/node/NodePortExpressionTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.operation.reference.sys.node;
+
+import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
+import org.elasticsearch.node.service.NodeService;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class NodePortExpressionTest {
+
+    @Test
+    public void testNoHttpServerAvailable() throws Exception {
+        NodeService nodeService = mock(NodeService.class);
+        NodeInfo nodeInfo = mock(NodeInfo.class);
+        when(nodeService.info()).thenReturn(nodeInfo);
+        when(nodeInfo.getHttp()).thenReturn(null);
+
+
+        NodePortExpression nodePortExpression = new NodePortExpression(nodeService);
+        Object value = nodePortExpression.getChildImplementation(NodePortExpression.HTTP).value();
+        assertThat(value, Matchers.nullValue());
+    }
+}


### PR DESCRIPTION
if http.enabled is set to false a node will be started
   without HttpServer bound and guice will throw error
   because it is used in the NodePortExpression
