### PR TITLE
fix compilation error on jdk8: ensure the compiler doesn't complain

### DIFF
--- a/sql/src/main/java/io/crate/operation/collect/ShardCollectService.java
+++ b/sql/src/main/java/io/crate/operation/collect/ShardCollectService.java
@@ -35,6 +35,7 @@ import io.crate.operation.Input;
 import io.crate.operation.collect.blobs.BlobDocCollector;
 import io.crate.operation.projectors.ProjectionToProjectorVisitor;
 import io.crate.operation.projectors.Projector;
+import io.crate.operation.reference.DocLevelReferenceResolver;
 import io.crate.operation.reference.doc.blob.BlobReferenceResolver;
 import io.crate.operation.reference.doc.lucene.LuceneDocLevelReferenceResolver;
 import io.crate.planner.RowGranularity;
@@ -98,9 +99,11 @@ public class ShardCollectService {
 
         this.blobIndices = blobIndices;
         isBlobShard = BlobIndices.isBlobShard(this.shardId);
+
+        DocLevelReferenceResolver<? extends Input<?>> resolver = (isBlobShard ? BlobReferenceResolver.INSTANCE : LuceneDocLevelReferenceResolver.INSTANCE);
         this.docInputSymbolVisitor = new CollectInputSymbolVisitor<>(
                 functions,
-                (isBlobShard ? BlobReferenceResolver.INSTANCE : LuceneDocLevelReferenceResolver.INSTANCE)
+                resolver
         );
         this.shardImplementationSymbolVisitor = new ImplementationSymbolVisitor(
                 (isBlobShard ? blobShardReferenceResolver :referenceResolver),

--- a/sql/src/main/java/io/crate/planner/Planner.java
+++ b/sql/src/main/java/io/crate/planner/Planner.java
@@ -24,6 +24,7 @@ package io.crate.planner;
 import com.carrotsearch.hppc.procedures.ObjectProcedure;
 import com.google.common.base.Objects;
 import com.google.common.base.*;
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;


### PR DESCRIPTION
As promised. here's the PR for compiling under java 8. There's also a PR for `crate/elasticsearch` at https://github.com/crate/elasticsearch/pull/7
