### PR TITLE
support long getopt options in bin/crate

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate Data
 Unreleased
 ==========
 
+ - the ``bin/crate`` executable now supports setting configuration options by
+   prefixing them with double dashes. For example: ``bin/crate --node.name=foobar``
+
  - updated crash to 0.10.0
 
  - added having support for global aggregate

--- a/app/src/main/dist/bin/crate
+++ b/app/src/main/dist/bin/crate
@@ -138,6 +138,22 @@ launch_service()
     return $execval
 }
 
+# Parse any long getopt options and put them into properties before calling getopt below
+# Be dash compatible to make sure running under ubuntu works
+ARGV=""
+while [ $# -gt 0 ]
+do
+    case $1 in
+      --*=*) properties="$properties -Des.${1#--}"
+           shift 1
+           ;;
+      --*) properties="$properties -Des.${1#--}=$2"
+           shift 2
+           ;;
+      *) ARGV="$ARGV $1" ; shift
+    esac
+done
+
 # Parse any command line options.
 args=`getopt vdhp:D:X: "$@"`
 eval set -- "$args"


### PR DESCRIPTION
e.g. bin/crate --node.name=foobar
