### PR TITLE
Create .mailmap to suppress duplicates in git shortlog

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,12 @@
+<christian.haudum@gmail.com> <christian@rjdj.me>
+<matthias@crate.io> <matthiasfelsche@m7f6.de>
+<matthias@crate.io> <matthiaswahl@m7w3.de>
+<matthias@crate.io> <mfelsche@users.noreply.github.com>
+<matthias@crate.io> <wahl@crate-technology.com>
+<matthias@crate.io> <wahl@crate.io>
+Bernd Dorn <bernddorn@gmail.com>
+Bernhard Kuzel <bernhard.kuzel@gmail.com>
+Lukas Ender <hello@lukasender.at>
+Mathias Fussenegger <f.mathias@zignar.net>
+Mathias Fussenegger <f.mathias@zignar.net> <mfussenegger@users.noreply.github.com>
+Philipp Bogensberger <philipp@crate.io> <bogensberger@lovelysystems.com>


### PR DESCRIPTION
Without `.mailmap`:

```
$ git shortlog -se master | wc -l
25
```

With `.mailmap`:

```
$ git shortlog -se master | wc -l
13
```
