### PR TITLE
add getSafe to functions; rename getColumnInfo to getReferenceInfo

### DIFF
--- a/sql/src/main/java/io/crate/analyze/AbstractDataAnalysis.java
+++ b/sql/src/main/java/io/crate/analyze/AbstractDataAnalysis.java
@@ -20,7 +20,6 @@
  */
 package io.crate.analyze;
 
-import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
@@ -217,7 +216,7 @@ public abstract class AbstractDataAnalysis extends Analysis {
                               Predicate<ReferenceInfo> parentMatchPredicate) {
         ColumnIdent parent = info.ident().columnIdent().getParent();
         while (parent != null) {
-            ReferenceInfo parentInfo = table.getColumnInfo(parent);
+            ReferenceInfo parentInfo = table.getReferenceInfo(parent);
             if (parentMatchPredicate.apply(parentInfo)) {
                 return true;
             }
@@ -227,23 +226,11 @@ public abstract class AbstractDataAnalysis extends Analysis {
     }
 
     public FunctionInfo getFunctionInfo(FunctionIdent ident) {
-        FunctionImplementation implementation = functions.get(ident);
-        if (implementation == null) {
-            throw new UnsupportedOperationException(
-                    String.format("unknown function: %s(%s)", ident.name(),
-                            Joiner.on(", ").join(ident.argumentTypes())));
-        }
-        return implementation.info();
+        return functions.getSafe(ident).info();
     }
 
     public FunctionImplementation getFunctionImplementation(FunctionIdent ident) {
-        FunctionImplementation implementation = functions.get(ident);
-        if (implementation == null) {
-            throw new UnsupportedOperationException(
-                    String.format("unknown function: %s(%s)", ident.name(),
-                            Joiner.on(", ").join(ident.argumentTypes())));
-        }
-        return implementation;
+        return functions.getSafe(ident);
     }
 
     public Collection<Reference> references() {
@@ -421,7 +408,7 @@ public abstract class AbstractDataAnalysis extends Analysis {
     private Map<String, Object> normalizeObjectValue(Map<String, Object> value, ReferenceInfo info) {
         for (Map.Entry<String, Object> entry : value.entrySet()) {
             ColumnIdent nestedIdent = ColumnIdent.getChild(info.ident().columnIdent(), entry.getKey());
-            ReferenceInfo nestedInfo = table.getColumnInfo(nestedIdent);
+            ReferenceInfo nestedInfo = table.getReferenceInfo(nestedIdent);
             if (nestedInfo == null) {
                 if (info.objectType() == ReferenceInfo.ObjectType.IGNORED) {
                     continue;

--- a/sql/src/main/java/io/crate/analyze/AlterTableAddColumnAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/AlterTableAddColumnAnalyzer.java
@@ -68,7 +68,7 @@ public class AlterTableAddColumnAnalyzer extends AbstractStatementAnalyzer<Void,
 
     private void ensureColumnLeafsAreNew(AnalyzedColumnDefinition column, TableInfo tableInfo) {
         if ((!column.isObjectExtension() || column.children().isEmpty())
-                && tableInfo.getColumnInfo(column.ident()) != null) {
+                && tableInfo.getReferenceInfo(column.ident()) != null) {
             throw new IllegalArgumentException(String.format(
                     "The table \"%s\" already has a column named \"%s\"",
                     tableInfo.ident().name(),
@@ -84,7 +84,7 @@ public class AlterTableAddColumnAnalyzer extends AbstractStatementAnalyzer<Void,
             if (pkIdent.name().equals("_id")) {
                 continue;
             }
-            ReferenceInfo pkInfo = context.table().getColumnInfo(pkIdent);
+            ReferenceInfo pkInfo = context.table().getReferenceInfo(pkIdent);
             assert pkInfo != null;
 
             AnalyzedColumnDefinition pkColumn = new AnalyzedColumnDefinition(null);

--- a/sql/src/main/java/io/crate/metadata/Functions.java
+++ b/sql/src/main/java/io/crate/metadata/Functions.java
@@ -21,9 +21,9 @@
 
 package io.crate.metadata;
 
+import com.google.common.base.Joiner;
 import org.elasticsearch.common.inject.Inject;
 
-import java.util.Collection;
 import java.util.Map;
 
 public class Functions {
@@ -38,6 +38,28 @@ public class Functions {
         this.functionResolvers = functionResolvers;
     }
 
+    /**
+     * <p>
+     *     returns the functionImplementation for the given ident.
+     * </p>
+     *
+     * same as {@link #get(FunctionIdent)} but will throw an UnsupportedOperationException
+     * if no implementation is found.
+     */
+    public FunctionImplementation getSafe(FunctionIdent ident)
+            throws IllegalArgumentException, UnsupportedOperationException {
+        FunctionImplementation implementation = get(ident);
+        if (implementation == null) {
+            throw new UnsupportedOperationException(
+                    String.format("unknown function: %s(%s)", ident.name(),
+                            Joiner.on(", ").join(ident.argumentTypes())));
+        }
+        return implementation;
+    }
+
+    /**
+     * returns the functionImplementation for the given ident.
+     */
     public FunctionImplementation get(FunctionIdent ident) throws IllegalArgumentException {
         FunctionImplementation implementation = functionImplementations.get(ident);
         if (implementation != null) {
@@ -49,9 +71,5 @@ public class Functions {
             return dynamicResolver.getForTypes(ident.argumentTypes());
         }
         return null;
-    }
-
-    public Collection<FunctionImplementation> functions() {
-        return functionImplementations.values();
     }
 }

--- a/sql/src/main/java/io/crate/metadata/ReferenceIdent.java
+++ b/sql/src/main/java/io/crate/metadata/ReferenceIdent.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.List;
 
@@ -48,7 +49,7 @@ public class ReferenceIdent implements Comparable<ReferenceIdent>, Streamable {
         this(tableIdent, new ColumnIdent(column));
     }
 
-    public ReferenceIdent(TableIdent tableIdent, String column, List<String> path) {
+    public ReferenceIdent(TableIdent tableIdent, String column, @Nullable List<String> path) {
         this(tableIdent, new ColumnIdent(column, path));
     }
 

--- a/sql/src/main/java/io/crate/metadata/ReferenceInfos.java
+++ b/sql/src/main/java/io/crate/metadata/ReferenceInfos.java
@@ -83,7 +83,7 @@ public class ReferenceInfos implements Iterable<SchemaInfo>{
     public ReferenceInfo getReferenceInfo(ReferenceIdent ident) {
         TableInfo tableInfo = getTableInfo(ident.tableIdent());
         if (tableInfo != null) {
-            return tableInfo.getColumnInfo(ident.columnIdent());
+            return tableInfo.getReferenceInfo(ident.columnIdent());
         }
         return null;
     }

--- a/sql/src/main/java/io/crate/metadata/blob/BlobTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/blob/BlobTableInfo.java
@@ -89,7 +89,7 @@ public class BlobTableInfo implements TableInfo {
 
     @Nullable
     @Override
-    public ReferenceInfo getColumnInfo(ColumnIdent columnIdent) {
+    public ReferenceInfo getReferenceInfo(ColumnIdent columnIdent) {
         return INFOS.get(columnIdent);
     }
 

--- a/sql/src/main/java/io/crate/metadata/doc/DocTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/doc/DocTableInfo.java
@@ -119,7 +119,7 @@ public class DocTableInfo implements TableInfo {
      */
     @Override
     @Nullable
-    public ReferenceInfo getColumnInfo(ColumnIdent columnIdent) {
+    public ReferenceInfo getReferenceInfo(ColumnIdent columnIdent) {
         return references.get(columnIdent);
     }
 
@@ -132,7 +132,7 @@ public class DocTableInfo implements TableInfo {
             ReferenceInfo parentInfo = null;
 
             while (parentIdent != null) {
-                parentInfo = getColumnInfo(parentIdent);
+                parentInfo = getReferenceInfo(parentIdent);
                 if (parentInfo != null) {
                     break;
                 }

--- a/sql/src/main/java/io/crate/metadata/information/InformationTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/information/InformationTableInfo.java
@@ -64,7 +64,7 @@ public class InformationTableInfo extends AbstractTableInfo {
 
     @Nullable
     @Override
-    public ReferenceInfo getColumnInfo(ColumnIdent columnIdent) {
+    public ReferenceInfo getReferenceInfo(ColumnIdent columnIdent) {
         return references.get(columnIdent);
     }
 

--- a/sql/src/main/java/io/crate/metadata/sys/SysClusterTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysClusterTableInfo.java
@@ -318,7 +318,7 @@ public class SysClusterTableInfo extends SysTableInfo {
     }
 
     @Override
-    public ReferenceInfo getColumnInfo(ColumnIdent columnIdent) {
+    public ReferenceInfo getReferenceInfo(ColumnIdent columnIdent) {
         return INFOS.get(columnIdent);
     }
 

--- a/sql/src/main/java/io/crate/metadata/sys/SysJobsLogTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysJobsLogTableInfo.java
@@ -66,7 +66,7 @@ public class SysJobsLogTableInfo extends SysTableInfo {
 
     @Nullable
     @Override
-    public ReferenceInfo getColumnInfo(ColumnIdent columnIdent) {
+    public ReferenceInfo getReferenceInfo(ColumnIdent columnIdent) {
         return INFOS.get(columnIdent);
     }
 

--- a/sql/src/main/java/io/crate/metadata/sys/SysJobsTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysJobsTableInfo.java
@@ -63,7 +63,7 @@ public class SysJobsTableInfo extends SysTableInfo {
     }
 
     @Override
-    public ReferenceInfo getColumnInfo(ColumnIdent columnIdent) {
+    public ReferenceInfo getReferenceInfo(ColumnIdent columnIdent) {
         return INFOS.get(columnIdent);
     }
 

--- a/sql/src/main/java/io/crate/metadata/sys/SysNodesTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysNodesTableInfo.java
@@ -148,7 +148,7 @@ public class SysNodesTableInfo extends SysTableInfo {
     }
 
     @Override
-    public ReferenceInfo getColumnInfo(ColumnIdent columnIdent) {
+    public ReferenceInfo getReferenceInfo(ColumnIdent columnIdent) {
         return INFOS.get(columnIdent);
     }
 

--- a/sql/src/main/java/io/crate/metadata/sys/SysOperationsLogTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysOperationsLogTableInfo.java
@@ -71,7 +71,7 @@ public class SysOperationsLogTableInfo extends SysTableInfo {
 
     @Nullable
     @Override
-    public ReferenceInfo getColumnInfo(ColumnIdent columnIdent) {
+    public ReferenceInfo getReferenceInfo(ColumnIdent columnIdent) {
         return columnInfo(columnIdent);
     }
 

--- a/sql/src/main/java/io/crate/metadata/sys/SysOperationsTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysOperationsTableInfo.java
@@ -67,7 +67,7 @@ public class SysOperationsTableInfo extends SysTableInfo {
 
     @Nullable
     @Override
-    public ReferenceInfo getColumnInfo(ColumnIdent columnIdent) {
+    public ReferenceInfo getReferenceInfo(ColumnIdent columnIdent) {
         return columnInfo(columnIdent);
     }
 

--- a/sql/src/main/java/io/crate/metadata/sys/SysShardsTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysShardsTableInfo.java
@@ -76,7 +76,7 @@ public class SysShardsTableInfo extends SysTableInfo {
     }
 
     @Override
-    public ReferenceInfo getColumnInfo(ColumnIdent columnIdent) {
+    public ReferenceInfo getReferenceInfo(ColumnIdent columnIdent) {
         return INFOS.get(columnIdent);
     }
 

--- a/sql/src/main/java/io/crate/metadata/table/TableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/table/TableInfo.java
@@ -44,7 +44,7 @@ public interface TableInfo extends Iterable<ReferenceInfo> {
      * returns null if this table contains no such column.
      */
     @Nullable
-    public ReferenceInfo getColumnInfo(ColumnIdent columnIdent);
+    public ReferenceInfo getReferenceInfo(ColumnIdent columnIdent);
 
     /**
      * returns the top level columns of this table with predictable order

--- a/sql/src/main/java/io/crate/planner/Planner.java
+++ b/sql/src/main/java/io/crate/planner/Planner.java
@@ -231,14 +231,14 @@ public class Planner extends AnalysisVisitor<Planner.Context, Plan> {
             Reference sourceRef;
             if (analysis.table().isPartitioned() && analysis.partitionIdent() == null) {
                 // table is partitioned, insert partitioned columns into the output
-                sourceRef = new Reference(analysis.table().getColumnInfo(DocSysColumns.DOC));
+                sourceRef = new Reference(analysis.table().getReferenceInfo(DocSysColumns.DOC));
                 Map<ColumnIdent, Symbol> overwrites = new HashMap<>();
                 for (ReferenceInfo referenceInfo : analysis.table().partitionedByColumns()) {
                     overwrites.put(referenceInfo.ident().columnIdent(), new Reference(referenceInfo));
                 }
                 projection.overwrites(overwrites);
             } else {
-                sourceRef = new Reference(analysis.table().getColumnInfo(DocSysColumns.RAW));
+                sourceRef = new Reference(analysis.table().getReferenceInfo(DocSysColumns.RAW));
             }
             contextBuilder = contextBuilder.output(ImmutableList.<Symbol>of(sourceRef));
         }
@@ -292,29 +292,29 @@ public class Planner extends AnalysisVisitor<Planner.Context, Plan> {
         // add primaryKey columns
         for (ColumnIdent primaryKey : analysis.table().primaryKey()) {
             toCollect.add(
-                    new Reference(analysis.table().getColumnInfo(primaryKey))
+                    new Reference(analysis.table().getReferenceInfo(primaryKey))
             );
         }
 
         // add partitioned columns (if not part of primaryKey)
         for (String partitionedColumn : partitionedByNames) {
             toCollect.add(
-                    new Reference(analysis.table().getColumnInfo(ColumnIdent.fromPath(partitionedColumn)))
+                    new Reference(analysis.table().getReferenceInfo(ColumnIdent.fromPath(partitionedColumn)))
             );
         }
 
         // add clusteredBy column (if not part of primaryKey)
         if (clusteredByPrimaryKeyIdx == -1) {
             toCollect.add(
-                    new Reference(analysis.table().getColumnInfo(analysis.table().clusteredBy()))
+                    new Reference(analysis.table().getReferenceInfo(analysis.table().clusteredBy()))
             );
         }
 
         // finally add _raw or _doc
         if (analysis.table().isPartitioned() && analysis.partitionIdent() == null) {
-            toCollect.add(new Reference(analysis.table().getColumnInfo(DocSysColumns.DOC)));
+            toCollect.add(new Reference(analysis.table().getReferenceInfo(DocSysColumns.DOC)));
         } else {
-            toCollect.add(new Reference(analysis.table().getColumnInfo(DocSysColumns.RAW)));
+            toCollect.add(new Reference(analysis.table().getReferenceInfo(DocSysColumns.RAW)));
         }
 
         DiscoveryNodes allNodes = clusterService.state().nodes();

--- a/sql/src/test/java/io/crate/analyze/AnalysisTest.java
+++ b/sql/src/test/java/io/crate/analyze/AnalysisTest.java
@@ -174,7 +174,7 @@ public class AnalysisTest {
     @SuppressWarnings("unchecked")
     public void testNormalizeDynamicEmptyObjectLiteral() throws Exception {
         SelectAnalysis analysis = (SelectAnalysis)getAnalysis();
-        ReferenceInfo objInfo = userTableInfo.getColumnInfo(new ColumnIdent("dyn_empty"));
+        ReferenceInfo objInfo = userTableInfo.getReferenceInfo(new ColumnIdent("dyn_empty"));
         Map<String, Object> map = new HashMap<>();
         map.put("time", "2014-02-16T00:00:01");
         map.put("false", true);
@@ -187,7 +187,7 @@ public class AnalysisTest {
     @Test( expected = ColumnValidationException.class)
     public void testNormalizeObjectLiteralInvalidNested() throws Exception {
         SelectAnalysis analysis = (SelectAnalysis)getAnalysis();
-        ReferenceInfo objInfo = userTableInfo.getColumnInfo(new ColumnIdent("dyn"));
+        ReferenceInfo objInfo = userTableInfo.getReferenceInfo(new ColumnIdent("dyn"));
         Map<String, Object> map = new HashMap<>();
         map.put("d", "2014-02-16T00:00:01");
         analysis.normalizeInputForReference(Literal.newLiteral(map), new Reference(objInfo));
@@ -196,7 +196,7 @@ public class AnalysisTest {
     @Test
     public void testNormalizeObjectLiteralConvertFromString() throws Exception {
         SelectAnalysis analysis = (SelectAnalysis)getAnalysis();
-        ReferenceInfo objInfo = userTableInfo.getColumnInfo(new ColumnIdent("dyn"));
+        ReferenceInfo objInfo = userTableInfo.getReferenceInfo(new ColumnIdent("dyn"));
         Map<String, Object> map = new HashMap<>();
         map.put("d", "2.9");
 
@@ -208,7 +208,7 @@ public class AnalysisTest {
     @Test
     public void testNormalizeObjectLiteral() throws Exception {
         SelectAnalysis analysis = (SelectAnalysis)getAnalysis();
-        ReferenceInfo objInfo = userTableInfo.getColumnInfo(new ColumnIdent("dyn"));
+        ReferenceInfo objInfo = userTableInfo.getReferenceInfo(new ColumnIdent("dyn"));
         Map<String, Object> map = new HashMap<String, Object>() {{
             put("d", 2.9d);
             put("inner_strict", new HashMap<String, Object>(){{
@@ -230,7 +230,7 @@ public class AnalysisTest {
     @Test
     public void testNormalizeDynamicObjectLiteralWithAdditionalColumn() throws Exception {
         SelectAnalysis analysis = (SelectAnalysis)getAnalysis();
-        ReferenceInfo objInfo = userTableInfo.getColumnInfo(new ColumnIdent("dyn"));
+        ReferenceInfo objInfo = userTableInfo.getReferenceInfo(new ColumnIdent("dyn"));
         Map<String, Object> map = new HashMap<>();
         map.put("d", 2.9d);
         map.put("half", "1.45");
@@ -241,7 +241,7 @@ public class AnalysisTest {
     @Test(expected = ColumnUnknownException.class)
     public void testNormalizeStrictObjectLiteralWithAdditionalColumn() throws Exception {
         SelectAnalysis analysis = (SelectAnalysis)getAnalysis();
-        ReferenceInfo objInfo = userTableInfo.getColumnInfo(new ColumnIdent("strict"));
+        ReferenceInfo objInfo = userTableInfo.getReferenceInfo(new ColumnIdent("strict"));
         Map<String, Object> map = new HashMap<>();
         map.put("inner_d", 2.9d);
         map.put("half", "1.45");
@@ -251,7 +251,7 @@ public class AnalysisTest {
     @Test(expected = ColumnUnknownException.class)
     public void testNormalizeStrictObjectLiteralWithAdditionalNestedColumn() throws Exception {
         SelectAnalysis analysis = (SelectAnalysis)getAnalysis();
-        ReferenceInfo objInfo = userTableInfo.getColumnInfo(new ColumnIdent("strict"));
+        ReferenceInfo objInfo = userTableInfo.getReferenceInfo(new ColumnIdent("strict"));
         Map<String, Object> map = new HashMap<>();
         map.put("inner_d", 2.9d);
         map.put("inner_map", new HashMap<String, Object>(){{
@@ -263,7 +263,7 @@ public class AnalysisTest {
     @Test(expected = ColumnUnknownException.class)
     public void testNormalizeNestedStrictObjectLiteralWithAdditionalColumn() throws Exception {
         SelectAnalysis analysis = (SelectAnalysis)getAnalysis();
-        ReferenceInfo objInfo = userTableInfo.getColumnInfo(new ColumnIdent("dyn"));
+        ReferenceInfo objInfo = userTableInfo.getReferenceInfo(new ColumnIdent("dyn"));
 
         Map<String, Object> map = new HashMap<>();
         map.put("inner_strict", new HashMap<String, Object>(){{
@@ -277,7 +277,7 @@ public class AnalysisTest {
     @Test
     public void testNormalizeDynamicNewColumnTimestamp() throws Exception {
         SelectAnalysis analysis = (SelectAnalysis)getAnalysis();
-        ReferenceInfo objInfo = userTableInfo.getColumnInfo(new ColumnIdent("dyn"));
+        ReferenceInfo objInfo = userTableInfo.getReferenceInfo(new ColumnIdent("dyn"));
         Map<String, Object> map = new HashMap<String, Object>() {{
             put("time", "1970-01-01T00:00:00");
         }};
@@ -291,7 +291,7 @@ public class AnalysisTest {
     @Test
     public void testNormalizeIgnoredNewColumnTimestamp() throws Exception {
         SelectAnalysis analysis = (SelectAnalysis)getAnalysis();
-        ReferenceInfo objInfo = userTableInfo.getColumnInfo(new ColumnIdent("ignored"));
+        ReferenceInfo objInfo = userTableInfo.getReferenceInfo(new ColumnIdent("ignored"));
         Map<String, Object> map = new HashMap<String, Object>() {{
             put("time", "1970-01-01T00:00:00");
         }};
@@ -305,7 +305,7 @@ public class AnalysisTest {
     @Test
     public void testNormalizeDynamicNewColumnNoTimestamp() throws Exception {
         SelectAnalysis analysis = (SelectAnalysis)getAnalysis();
-        ReferenceInfo objInfo = userTableInfo.getColumnInfo(new ColumnIdent("ignored"));
+        ReferenceInfo objInfo = userTableInfo.getReferenceInfo(new ColumnIdent("ignored"));
         Map<String, Object> map = new HashMap<String, Object>() {{
             put("no_time", "1970");
         }};
@@ -319,7 +319,7 @@ public class AnalysisTest {
     @Test
     public void testNormalizeStringToNumberColumn() throws Exception {
         SelectAnalysis analysis = (SelectAnalysis)getAnalysis();
-        ReferenceInfo objInfo = userTableInfo.getColumnInfo(new ColumnIdent("d"));
+        ReferenceInfo objInfo = userTableInfo.getReferenceInfo(new ColumnIdent("d"));
         Literal<BytesRef> stringDoubleLiteral = Literal.newLiteral("298.444");
         Literal literal = analysis.normalizeInputForReference(stringDoubleLiteral, new Reference(objInfo));
         assertLiteralSymbol(literal, 298.444d);

--- a/sql/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
@@ -274,16 +274,16 @@ public class UpdateAnalyzerTest extends BaseAnalyzerTest {
                         new Object[]{"Jeltz", 0, friends, "9"});
         assertThat(analysis.assignments().size(), is(3));
         assertLiteralSymbol(
-                analysis.assignments().get(new Reference(userTableInfo.getColumnInfo(new ColumnIdent("name")))),
+                analysis.assignments().get(new Reference(userTableInfo.getReferenceInfo(new ColumnIdent("name")))),
                 "Jeltz"
         );
         assertLiteralSymbol(
-                analysis.assignments().get(new Reference(userTableInfo.getColumnInfo(new ColumnIdent("friends")))),
+                analysis.assignments().get(new Reference(userTableInfo.getReferenceInfo(new ColumnIdent("friends")))),
                 friends,
                 new ArrayType(DataTypes.OBJECT)
         );
         assertLiteralSymbol(
-                analysis.assignments().get(new Reference(userTableInfo.getColumnInfo(new ColumnIdent("other_id")))),
+                analysis.assignments().get(new Reference(userTableInfo.getReferenceInfo(new ColumnIdent("other_id")))),
                 0L
         );
 
@@ -309,7 +309,7 @@ public class UpdateAnalyzerTest extends BaseAnalyzerTest {
                 new Object[]{ new Map[0], 0 });
 
         Literal friendsLiteral = (Literal)analysis.assignments().get(
-                new Reference(userTableInfo.getColumnInfo(new ColumnIdent("friends"))));
+                new Reference(userTableInfo.getReferenceInfo(new ColumnIdent("friends"))));
         assertThat(friendsLiteral.valueType().id(), is(ArrayType.ID));
         assertEquals(DataTypes.OBJECT, ((ArrayType)friendsLiteral.valueType()).innerType());
         assertThat(((Object[])friendsLiteral.value()).length, is(0));

--- a/sql/src/test/java/io/crate/metadata/blob/BlobTableInfoTest.java
+++ b/sql/src/test/java/io/crate/metadata/blob/BlobTableInfoTest.java
@@ -47,7 +47,7 @@ public class BlobTableInfoTest {
 
     @Test
     public void testGetColumnInfo() throws Exception {
-        ReferenceInfo foobar = info.getColumnInfo(new ColumnIdent("digest"));
+        ReferenceInfo foobar = info.getReferenceInfo(new ColumnIdent("digest"));
         assertNotNull(foobar);
         assertEquals(DataTypes.STRING, foobar.type());
 

--- a/sql/src/test/java/io/crate/metadata/doc/DocTableInfoTest.java
+++ b/sql/src/test/java/io/crate/metadata/doc/DocTableInfoTest.java
@@ -39,7 +39,7 @@ public class DocTableInfoTest {
                 ImmutableList.<ColumnIdent>of(),
                 ImmutableList.<PartitionName>of());
 
-        ReferenceInfo foobar = info.getColumnInfo(new ColumnIdent("foobar"));
+        ReferenceInfo foobar = info.getReferenceInfo(new ColumnIdent("foobar"));
         assertNull(foobar);
         DynamicReference reference = info.getDynamic(new ColumnIdent("foobar"));
         assertNotNull(reference);
@@ -84,7 +84,7 @@ public class DocTableInfoTest {
 
         try {
             ColumnIdent columnIdent = new ColumnIdent("foobar", Arrays.asList("foo", "bar"));
-            assertNull(info.getColumnInfo(columnIdent));
+            assertNull(info.getReferenceInfo(columnIdent));
             info.getDynamic(columnIdent);
             fail();
         } catch (ColumnUnknownException e) {
@@ -92,13 +92,13 @@ public class DocTableInfoTest {
         }
         try {
             ColumnIdent columnIdent = new ColumnIdent("foobar", Arrays.asList("foo"));
-            assertNull(info.getColumnInfo(columnIdent));
+            assertNull(info.getReferenceInfo(columnIdent));
             info.getDynamic(columnIdent);
             fail();
         } catch (ColumnUnknownException e) {
 
         }
-        ReferenceInfo colInfo = info.getColumnInfo(new ColumnIdent("foobar"));
+        ReferenceInfo colInfo = info.getReferenceInfo(new ColumnIdent("foobar"));
         assertNotNull(colInfo);
     }
 }

--- a/sql/src/test/java/io/crate/metadata/table/TestingTableInfo.java
+++ b/sql/src/test/java/io/crate/metadata/table/TestingTableInfo.java
@@ -233,7 +233,7 @@ public class TestingTableInfo extends AbstractTableInfo {
     }
 
     @Override
-    public ReferenceInfo getColumnInfo(ColumnIdent columnIdent) {
+    public ReferenceInfo getReferenceInfo(ColumnIdent columnIdent) {
         return references.get(columnIdent);
     }
 
@@ -307,7 +307,7 @@ public class TestingTableInfo extends AbstractTableInfo {
     public DynamicReference getDynamic(ColumnIdent ident) {
         if (!ident.isColumn()) {
             ColumnIdent parentIdent = ident.getParent();
-            ReferenceInfo parentInfo = getColumnInfo(parentIdent);
+            ReferenceInfo parentInfo = getReferenceInfo(parentIdent);
             if (parentInfo != null && parentInfo.objectType() == ReferenceInfo.ObjectType.STRICT) {
                 throw new ColumnUnknownException(ident().name(), ident.fqn());
             }


### PR DESCRIPTION
Moves the null check logic from the AbstractDataAnalysis into the Functions
class as both getFunctionInfo and getFunctionImplementation will probably be
removed in the upcoming relations change.

Renamed getColumnInfo to getReferenceInfo as it actually returns a
ReferenceInfo.
