### PR TITLE
use partition ident in copy from

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,9 @@ Unreleased
    non existent column or for a non existent partition value led to
    deletion of all partitions of the queried table
 
+ - Fix: Copy from using the PARTITION clause imported into a ``null`` partition
+   instead of using the partition clause. 
+
  - All scalar functions can now be used in the WHERE clause in SELECT
    statements and they may be nested without limitations. In addition it is now
    possible to compare one scalar function to another.

--- a/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/ESQueryBuilder.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/ESQueryBuilder.java
@@ -125,7 +125,6 @@ public class ESQueryBuilder {
             visitor.process(whereClause.query(), context);
         } else {
             context.builder.field("match_all", Collections.emptyMap());
-
         }
         context.builder.endObject();
     }

--- a/sql/src/main/java/io/crate/operation/projectors/AbstractIndexWriterProjector.java
+++ b/sql/src/main/java/io/crate/operation/projectors/AbstractIndexWriterProjector.java
@@ -80,7 +80,8 @@ public abstract class AbstractIndexWriterProjector implements Projector {
                                            @Nullable ColumnIdent clusteredBy,
                                            @Nullable Input<?> routingInput,
                                            CollectExpression<?>[] collectExpressions,
-                                           @Nullable Integer bulkActions) {
+                                           @Nullable Integer bulkActions,
+                                           boolean autoCreateIndices) {
         this.tableName = tableName;
         this.primaryKeys = primaryKeys;
         this.collectExpressions = collectExpressions;
@@ -93,7 +94,7 @@ public abstract class AbstractIndexWriterProjector implements Projector {
                 settings,
                 transportShardBulkAction,
                 transportCreateIndexAction,
-                partitionedByInputs.size() > 0, // autoCreate indices if this is a partitioned table
+                autoCreateIndices,
                 false,
                 Objects.firstNonNull(bulkActions, 100)
         );

--- a/sql/src/main/java/io/crate/operation/projectors/ColumnIndexWriterProjector.java
+++ b/sql/src/main/java/io/crate/operation/projectors/ColumnIndexWriterProjector.java
@@ -61,11 +61,12 @@ public class ColumnIndexWriterProjector extends AbstractIndexWriterProjector {
                                          List<ColumnIdent> columnIdents,
                                          List<Input<?>> columnInputs,
                                          CollectExpression<?>[] collectExpressions,
-                                         @Nullable Integer bulkActions) {
+                                         @Nullable Integer bulkActions,
+                                         boolean autoCreateIndices) {
         super(clusterService, settings, transportShardBulkAction,
                 transportCreateIndexAction, tableName, primaryKeys, idInputs,
                 partitionedByInputs, routingIdent, routingInput, collectExpressions,
-                bulkActions);
+                bulkActions, autoCreateIndices);
         assert columnIdents.size() == columnInputs.size();
         this.columnIdents = columnIdents;
         this.columnInputs = columnInputs;

--- a/sql/src/main/java/io/crate/operation/projectors/IndexWriterProjector.java
+++ b/sql/src/main/java/io/crate/operation/projectors/IndexWriterProjector.java
@@ -65,11 +65,12 @@ public class IndexWriterProjector extends AbstractIndexWriterProjector {
                                 CollectExpression<?>[] collectExpressions,
                                 @Nullable Integer bulkActions,
                                 @Nullable String[] includes,
-                                @Nullable String[] excludes) {
+                                @Nullable String[] excludes,
+                                boolean autoCreateIndices) {
         super(clusterService, settings, transportShardBulkAction,
                 transportCreateIndexAction, tableName, primaryKeys, idInputs, partitionedByInputs,
                 routingIdent, routingInput,
-                collectExpressions, bulkActions);
+                collectExpressions, bulkActions, autoCreateIndices);
         this.sourceInput = sourceInput;
         this.includes = includes;
         this.excludes = excludes;

--- a/sql/src/main/java/io/crate/operation/projectors/ProjectionToProjectorVisitor.java
+++ b/sql/src/main/java/io/crate/operation/projectors/ProjectionToProjectorVisitor.java
@@ -226,7 +226,8 @@ public class ProjectionToProjectorVisitor extends ProjectionVisitor<Void, Projec
                 symbolContext.collectExpressions().toArray(new CollectExpression[symbolContext.collectExpressions().size()]),
                 projection.bulkActions(),
                 projection.includes(),
-                projection.excludes()
+                projection.excludes(),
+                projection.autoCreateIndices()
         );
     }
 
@@ -263,7 +264,8 @@ public class ProjectionToProjectorVisitor extends ProjectionVisitor<Void, Projec
                 projection.columnIdents(),
                 columnInputs,
                 symbolContext.collectExpressions().toArray(new CollectExpression[symbolContext.collectExpressions().size()]),
-                projection.bulkActions()
+                projection.bulkActions(),
+                projection.autoCreateIndices()
         );
     }
 

--- a/sql/src/main/java/io/crate/planner/Planner.java
+++ b/sql/src/main/java/io/crate/planner/Planner.java
@@ -29,11 +29,13 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import io.crate.Constants;
+import io.crate.PartitionName;
 import io.crate.analyze.*;
 import io.crate.exceptions.UnhandledServerException;
 import io.crate.metadata.*;
 import io.crate.metadata.doc.DocSchemaInfo;
 import io.crate.metadata.doc.DocSysColumns;
+import io.crate.metadata.table.TableInfo;
 import io.crate.operation.aggregation.impl.CountAggregation;
 import io.crate.operation.aggregation.impl.SumAggregation;
 import io.crate.operation.projectors.TopN;
@@ -160,7 +162,8 @@ public class Planner extends AnalysisVisitor<Planner.Context, Plan> {
                 analysis.partitionedByIndices(),
                 analysis.routingColumn(),
                 analysis.routingColumnIndex(),
-                ImmutableSettings.EMPTY // TODO: define reasonable writersettings
+                ImmutableSettings.EMPTY, // TODO: define reasonable writersettings
+                analysis.table().isPartitioned()
         );
 
         SelectAnalysis subQueryAnalysis = analysis.subQueryAnalysis();
@@ -255,65 +258,80 @@ public class Planner extends AnalysisVisitor<Planner.Context, Plan> {
     }
 
     private void copyFromPlan(CopyAnalysis analysis, Plan plan) {
-        int clusteredByPrimaryKeyIdx = analysis.table().primaryKey().indexOf(analysis.table().clusteredBy());
+        /**
+         * copy from has two "modes":
+         *
+         * 1: non-partitioned tables or partitioned tables with partition ident --> import into single es index
+         *    -> collect raw source and import as is
+         *
+         * 2: partitioned table without partition ident
+         *    -> collect document and partition by values
+         *    -> exclude partitioned by columns from document
+         *    -> insert into es index (partition determined by partition by value)
+         */
+
+        TableInfo table = analysis.table();
+        int clusteredByPrimaryKeyIdx = table.primaryKey().indexOf(analysis.table().clusteredBy());
         List<String> partitionedByNames;
-        String tableName = analysis.table().ident().name();
+        List<ColumnIdent> partitionByColumns;
+        String tableName;
+
         if (analysis.partitionIdent() == null) {
-            partitionedByNames = Lists.newArrayList(
-                    Lists.transform(analysis.table().partitionedBy(), ColumnIdent.GET_FQN_NAME_FUNCTION)
-            );
+            tableName = table.ident().name();
+            if (table.isPartitioned()) {
+                partitionedByNames = Lists.newArrayList(
+                        Lists.transform(table.partitionedBy(), ColumnIdent.GET_FQN_NAME_FUNCTION));
+                partitionByColumns = table.partitionedBy();
+            } else {
+                partitionedByNames = Collections.emptyList();
+                partitionByColumns = Collections.emptyList();
+            }
         } else {
-            /*
-             * if there is a partitionIdent in the analysis this means that the file doesn't include
-             * the partition ident in the rows.
-             *
-             * Therefore there is no need to exclude the partition columns from the source and
-             * it is possible to import into the partitioned index directly.
-             */
-            partitionedByNames = Arrays.asList();
+            assert table.isPartitioned() : "table must be partitioned if partitionIdent is set";
+            // partitionIdent is present -> possible to index raw source into concrete es index
+            tableName = PartitionName.fromPartitionIdent(table.ident().name(), analysis.partitionIdent()).stringValue();
+            partitionedByNames = Collections.emptyList();
+            partitionByColumns = Collections.emptyList();
         }
-        List<Projection> projections = Arrays.<Projection>asList(new SourceIndexWriterProjection(
+
+        SourceIndexWriterProjection sourceIndexWriterProjection = new SourceIndexWriterProjection(
                 tableName,
-                analysis.table().primaryKey(),
-                analysis.table().partitionedBy(),
-                analysis.table().clusteredBy(),
+                table.primaryKey(),
+                partitionByColumns,
+                table.clusteredBy(),
                 clusteredByPrimaryKeyIdx,
                 analysis.settings(),
                 null,
-                partitionedByNames.size() > 0 ? partitionedByNames.toArray(new String[partitionedByNames.size()]) : null
-        ));
-
-        partitionedByNames.removeAll(Lists.transform(analysis.table().primaryKey(), ColumnIdent.GET_FQN_NAME_FUNCTION));
-
-        int referencesSize = analysis.table().primaryKey().size() + partitionedByNames.size() + 1;
+                partitionedByNames.size() > 0 ? partitionedByNames.toArray(new String[partitionedByNames.size()]) : null,
+                table.isPartitioned() // autoCreateIndices
+        );
+        List<Projection> projections = Arrays.<Projection>asList(sourceIndexWriterProjection);
+        partitionedByNames.removeAll(Lists.transform(table.primaryKey(), ColumnIdent.GET_FQN_NAME_FUNCTION));
+        int referencesSize = table.primaryKey().size() + partitionedByNames.size() + 1;
         referencesSize = clusteredByPrimaryKeyIdx == -1 ? referencesSize + 1 : referencesSize;
+
         List<Symbol> toCollect = new ArrayList<>(referencesSize);
         // add primaryKey columns
-        for (ColumnIdent primaryKey : analysis.table().primaryKey()) {
-            toCollect.add(
-                    new Reference(analysis.table().getReferenceInfo(primaryKey))
-            );
+        for (ColumnIdent primaryKey : table.primaryKey()) {
+            toCollect.add(new Reference(table.getReferenceInfo(primaryKey)));
         }
 
         // add partitioned columns (if not part of primaryKey)
         for (String partitionedColumn : partitionedByNames) {
             toCollect.add(
-                    new Reference(analysis.table().getReferenceInfo(ColumnIdent.fromPath(partitionedColumn)))
+                    new Reference(table.getReferenceInfo(ColumnIdent.fromPath(partitionedColumn)))
             );
         }
-
         // add clusteredBy column (if not part of primaryKey)
         if (clusteredByPrimaryKeyIdx == -1) {
             toCollect.add(
-                    new Reference(analysis.table().getReferenceInfo(analysis.table().clusteredBy()))
-            );
+                    new Reference(table.getReferenceInfo(table.clusteredBy())));
         }
-
         // finally add _raw or _doc
-        if (analysis.table().isPartitioned() && analysis.partitionIdent() == null) {
-            toCollect.add(new Reference(analysis.table().getReferenceInfo(DocSysColumns.DOC)));
+        if (table.isPartitioned() && analysis.partitionIdent() == null) {
+            toCollect.add(new Reference(table.getReferenceInfo(DocSysColumns.DOC)));
         } else {
-            toCollect.add(new Reference(analysis.table().getReferenceInfo(DocSysColumns.RAW)));
+            toCollect.add(new Reference(table.getReferenceInfo(DocSysColumns.RAW)));
         }
 
         DiscoveryNodes allNodes = clusterService.state().nodes();

--- a/sql/src/main/java/io/crate/planner/projection/AbstractIndexWriterProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/AbstractIndexWriterProjection.java
@@ -55,15 +55,19 @@ public abstract class AbstractIndexWriterProjection extends Projection {
     protected List<Symbol> partitionedBySymbols;
     protected @Nullable Symbol clusteredBySymbol;
 
+    protected boolean autoCreateIndices;
+
     protected AbstractIndexWriterProjection() {}
 
     protected AbstractIndexWriterProjection(String tableName,
                                             List<ColumnIdent> primaryKeys,
                                             @Nullable ColumnIdent clusteredByColumn,
-                                            Settings settings) {
+                                            Settings settings,
+                                            boolean autoCreateIndices) {
         this.tableName = tableName;
         this.primaryKeys = primaryKeys;
         this.clusteredByColumn = clusteredByColumn;
+        this.autoCreateIndices = autoCreateIndices;
 
         this.bulkActions = settings.getAsInt(BULK_SIZE, BULK_SIZE_DEFAULT);
         Preconditions.checkArgument(bulkActions > 0, "\"bulk_size\" must be greater than 0.");
@@ -85,6 +89,10 @@ public abstract class AbstractIndexWriterProjection extends Projection {
 
     public List<Symbol> partitionedBySymbols() {
         return partitionedBySymbols;
+    }
+
+    public boolean autoCreateIndices() {
+        return autoCreateIndices;
     }
 
     /**
@@ -189,6 +197,7 @@ public abstract class AbstractIndexWriterProjection extends Projection {
             clusteredByColumn = ident;
         }
         bulkActions = in.readVInt();
+        autoCreateIndices = in.readBoolean();
     }
 
     @Override
@@ -221,5 +230,6 @@ public abstract class AbstractIndexWriterProjection extends Projection {
             clusteredByColumn.writeTo(out);
         }
         out.writeVInt(bulkActions);
+        out.writeBoolean(autoCreateIndices);
     }
 }

--- a/sql/src/main/java/io/crate/planner/projection/ColumnIndexWriterProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/ColumnIndexWriterProjection.java
@@ -67,8 +67,9 @@ public class ColumnIndexWriterProjection extends AbstractIndexWriterProjection {
                                        IntSet partitionedByIndices,
                                        @Nullable ColumnIdent clusteredByColumn,
                                        int clusteredByIndex,
-                                       Settings settings) {
-        super(tableName, primaryKeys, clusteredByColumn, settings);
+                                       Settings settings,
+                                       boolean autoCreateIndices) {
+        super(tableName, primaryKeys, clusteredByColumn, settings, autoCreateIndices);
         generateSymbols(primaryKeyIndices.toArray(), partitionedByIndices.toArray(), clusteredByIndex);
 
         this.columnIdents = Lists.newArrayList(columns);

--- a/sql/src/main/java/io/crate/planner/projection/SourceIndexWriterProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/SourceIndexWriterProjection.java
@@ -60,8 +60,9 @@ public class SourceIndexWriterProjection extends AbstractIndexWriterProjection {
                                        int clusteredByIdx,
                                        Settings settings,
                                        @Nullable String[] includes,
-                                       @Nullable String[] excludes) {
-        super(tableName, primaryKeys, clusteredByColumn, settings);
+                                       @Nullable String[] excludes,
+                                       boolean autoCreateIndices) {
+        super(tableName, primaryKeys, clusteredByColumn, settings, autoCreateIndices);
 
         this.includes = includes;
         this.excludes = excludes;

--- a/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -2373,9 +2373,24 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
         String filePath = Joiner.on(File.separator).join(copyFilePath, "test_copy_from.json");
         execute("copy quotes partition (date=1400507539938) from ?", new Object[]{filePath});
         refresh();
-        execute("select count(*) from quotes");
-        assertEquals(1L, response.rowCount());
-        assertThat((Long) response.rows()[0][0], is(3L));
+        execute("select id, date, quote from quotes order by id asc");
+        assertEquals(3L, response.rowCount());
+        assertThat((Integer) response.rows()[0][0], is(1));
+        assertThat((Long) response.rows()[0][1], is(1400507539938L));
+        assertThat((String) response.rows()[0][2], is("Don't pañic."));
+
+        execute("select count(*) from information_schema.table_partitions where table_name = 'quotes'");
+        assertThat((Long) response.rows()[0][0], is(1L));
+
+        execute("copy quotes partition (date=1800507539938) from ?", new Object[]{filePath});
+        refresh();
+
+        execute("select partition_ident from information_schema.table_partitions " +
+                "where table_name = 'quotes' " +
+                "order by partition_ident");
+        assertThat(response.rowCount(), is(2L));
+        assertThat((String) response.rows()[0][0], is("04732d1g60qj0dpl6csjicpo"));
+        assertThat((String) response.rows()[1][0], is("04732e1g60qj0dpl6csjicpo"));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/projectors/IndexWriterProjectorTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/IndexWriterProjectorTest.java
@@ -68,7 +68,8 @@ public class IndexWriterProjectorTest extends SQLTransportIntegrationTest {
                 sourceInput,
                 collectExpressions,
                 20,
-                null, null
+                null, null,
+                false
         );
         indexWriter.registerUpstream(null);
         indexWriter.startProjection();

--- a/sql/src/test/java/io/crate/operation/projectors/IndexWriterProjectorUnitTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/IndexWriterProjectorUnitTest.java
@@ -83,7 +83,8 @@ public class IndexWriterProjectorUnitTest {
                 sourceInput,
                 collectExpressions,
                 20,
-                null, null
+                null, null,
+                false
         );
         indexWriter.downstream(collectingProjector);
         indexWriter.registerUpstream(null);
@@ -120,7 +121,8 @@ public class IndexWriterProjectorUnitTest {
                 sourceInput,
                 collectExpressions,
                 20,
-                null, null
+                null, null,
+                false
         );
         indexWriter.downstream(collectingProjector);
         indexWriter.registerUpstream(null);


### PR DESCRIPTION
was ignored before and import was done into `null` partition.

This fixes https://github.com/crate/crate/issues/1215
