### PR TITLE
support functions in select-list on queries that do pk lookups

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,10 @@ Changes for Crate Data
 Unreleased
 ==========
 
+ - Added support for scalar functions within the select column list and ORDER
+   BY clause for SELECT statements that get optimized to do
+   primary-key-lookups.
+
  - Fix: raise an error if an array is inserted into an objects
    field which is not of type array
 

--- a/sql/src/main/java/io/crate/action/sql/TransportBaseSQLAction.java
+++ b/sql/src/main/java/io/crate/action/sql/TransportBaseSQLAction.java
@@ -385,6 +385,12 @@ public abstract class TransportBaseSQLAction<TRequest extends SQLBaseRequest, TR
             if (stackTrace1.length > 0) {
                 message = String.format("NPE in %s", stackTrace1[0]);
             }
+        } else if (e instanceof ArrayIndexOutOfBoundsException) {
+            // in case of ArrayIndexOutOfBoundsExceptions the message is just the index number ...
+            StackTraceElement[] stackTrace1 = e.getStackTrace();
+            if (stackTrace1.length > 0) {
+                message = String.format("ArrayIndexOutOfBoundsException in %s", stackTrace1[0]);
+            }
         }
         if (logger.isTraceEnabled()) {
             message = Objects.firstNonNull(message, stackTrace.toString());

--- a/sql/src/main/java/io/crate/operation/projectors/FlatProjectorChain.java
+++ b/sql/src/main/java/io/crate/operation/projectors/FlatProjectorChain.java
@@ -44,14 +44,12 @@ import java.util.List;
  */
 public class FlatProjectorChain {
 
-    private final ProjectionToProjectorVisitor projectorVisitor;
     private Projector firstProjector;
     private final List<Projector> projectors;
     private ResultProvider lastProjector;
 
     public FlatProjectorChain(List<Projection> projections, ProjectionToProjectorVisitor projectorVisitor) {
         projectors = new ArrayList<>();
-        this.projectorVisitor = projectorVisitor;
         if (projections.size() == 0) {
             firstProjector = new CollectingProjector();
             lastProjector = (ResultProvider)firstProjector;

--- a/sql/src/main/java/io/crate/operation/projectors/Projector.java
+++ b/sql/src/main/java/io/crate/operation/projectors/Projector.java
@@ -40,7 +40,6 @@ public interface Projector extends ProjectorUpstream {
      *
      * This method must be thread safe.
      *
-     * @param row
      * @return false if this projection does not need any more rows, true otherwise.
      */
     public boolean setNextRow(Object ... row);

--- a/sql/src/main/java/io/crate/planner/Planner.java
+++ b/sql/src/main/java/io/crate/planner/Planner.java
@@ -116,10 +116,10 @@ public class Planner extends AnalysisVisitor<Planner.Context, Plan> {
             globalAggregates(analysis, plan, context);
         } else {
             WhereClause whereClause = analysis.whereClause();
-            if (analysis.rowGranularity().ordinal() >= RowGranularity.DOC.ordinal() &&
+            if (!context.indexWriterProjection.isPresent()
+                && analysis.rowGranularity().ordinal() >= RowGranularity.DOC.ordinal() &&
                     analysis.table().getRouting(whereClause).hasLocations() &&
-                    (analysis.table().ident().schema() == null || analysis.table().ident().schema().equals(DocSchemaInfo.NAME))
-                    && (analysis.isLimited() || analysis.ids().size() > 0 || !context.indexWriterProjection.isPresent())) {
+                    analysis.table().schemaInfo().name().equals(DocSchemaInfo.NAME)) {
 
                     if (analysis.ids().size() > 0
                             && analysis.routingValues().size() > 0
@@ -479,10 +479,7 @@ public class Planner extends AnalysisVisitor<Planner.Context, Plan> {
     }
 
     private void ESGet(SelectAnalysis analysis, Plan plan, Context context) {
-        PlannerContextBuilder contextBuilder = new PlannerContextBuilder()
-                .output(analysis.outputSymbols())
-                .orderBy(analysis.sortSymbols());
-
+        assert !context.indexWriterProjection.isPresent() : "shouldn't use ESGet with indexWriterProjection";
         String indexName;
         if (analysis.table().isPartitioned()) {
             assert analysis.whereClause().partitions().size() == 1 : "ambiguous partitions for ESGet";
@@ -490,34 +487,19 @@ public class Planner extends AnalysisVisitor<Planner.Context, Plan> {
         } else {
             indexName = analysis.table().ident().name();
         }
-
         ESGetNode getNode = new ESGetNode(
                 indexName,
+                analysis.outputSymbols(),
+                extractDataTypes(analysis.outputSymbols()),
                 analysis.ids(),
                 analysis.routingValues(),
+                analysis.sortSymbols(),
+                analysis.reverseFlags(),
+                analysis.nullsFirst(),
+                analysis.limit(),
+                analysis.offset(),
                 analysis.table().partitionedByColumns());
-        getNode.outputs(contextBuilder.toCollect());
-        getNode.outputTypes(extractDataTypes(analysis.outputSymbols()));
         plan.add(getNode);
-
-        // handle sorting, limit and offset
-        if (analysis.isSorted() || analysis.limit() != null
-                || analysis.offset() > 0
-                || context.indexWriterProjection.isPresent()) {
-            TopNProjection tnp = new TopNProjection(
-                    Objects.firstNonNull(analysis.limit(), Constants.DEFAULT_SELECT_LIMIT),
-                    analysis.offset(),
-                    contextBuilder.orderBy(),
-                    analysis.reverseFlags(),
-                    analysis.nullsFirst()
-            );
-            tnp.outputs(contextBuilder.outputs());
-            ImmutableList.Builder<Projection> projectionBuilder = ImmutableList.<Projection>builder().add(tnp);
-            if (context.indexWriterProjection.isPresent()) {
-                projectionBuilder.add(context.indexWriterProjection.get());
-            }
-            plan.add(PlanNodeBuilder.localMerge(projectionBuilder.build(), getNode));
-        }
     }
 
     private void normalSelect(SelectAnalysis analysis, Plan plan, Context context) {
@@ -1091,7 +1073,7 @@ public class Planner extends AnalysisVisitor<Planner.Context, Plan> {
     }
 
 
-    static List<DataType> extractDataTypes(List<Symbol> symbols) {
+    public static List<DataType> extractDataTypes(List<Symbol> symbols) {
         List<DataType> types = new ArrayList<>(symbols.size());
         for (Symbol symbol : symbols) {
             types.add(DataTypeVisitor.fromSymbol(symbol));

--- a/sql/src/main/java/io/crate/planner/node/dql/ESGetNode.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/ESGetNode.java
@@ -25,9 +25,10 @@ import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import io.crate.metadata.ReferenceInfo;
 import io.crate.planner.node.PlanVisitor;
+import io.crate.planner.symbol.Symbol;
+import io.crate.types.DataType;
 import org.elasticsearch.common.Nullable;
 
-import java.util.Arrays;
 import java.util.List;
 
 
@@ -36,27 +37,38 @@ public class ESGetNode extends ESDQLPlanNode implements DQLPlanNode {
     private final String index;
     private final List<String> ids;
     private final List<String> routingValues;
+    private final List<Symbol> sortSymbols;
+    private final boolean[] reverseFlags;
+    private final Boolean[] nullsFirst;
+    private final Integer limit;
+    private final int offset;
     private final List<ReferenceInfo> partitionBy;
 
+    private final static boolean[] EMPTY_REVERSE_FLAGS = new boolean[0];
+    private final static Boolean[] EMPTY_NULLS_FIRST = new Boolean[0];
+
     public ESGetNode(String index,
+                     List<Symbol> outputs,
+                     List<DataType> outputTypes,
                      List<String> ids,
                      List<String> routingValues,
+                     @Nullable List<Symbol> sortSymbols,
+                     @Nullable boolean[] reverseFlags,
+                     @Nullable Boolean[] nullsFirst,
+                     @Nullable Integer limit,
+                     int offset,
                      @Nullable List<ReferenceInfo> partitionBy) {
         this.index = index;
+        this.outputs = outputs;
+        outputTypes(outputTypes);
         this.ids = ids;
         this.routingValues = routingValues;
-        this.partitionBy = Objects.firstNonNull(partitionBy,
-                ImmutableList.<ReferenceInfo>of());
-    }
-
-    public ESGetNode(String index,
-                     List<String> ids,
-                     List<String> routingValues) {
-        this(index, ids, routingValues, null);
-    }
-
-    public ESGetNode(String index, String id, String routingValue) {
-        this(index, Arrays.asList(id), Arrays.asList(routingValue), null);
+        this.sortSymbols = Objects.firstNonNull(sortSymbols, ImmutableList.<Symbol>of());
+        this.reverseFlags = Objects.firstNonNull(reverseFlags, EMPTY_REVERSE_FLAGS);
+        this.nullsFirst = Objects.firstNonNull(nullsFirst, EMPTY_NULLS_FIRST);
+        this.limit = limit;
+        this.offset = offset;
+        this.partitionBy = Objects.firstNonNull(partitionBy, ImmutableList.<ReferenceInfo>of());
     }
 
     public String index() {
@@ -75,6 +87,28 @@ public class ESGetNode extends ESDQLPlanNode implements DQLPlanNode {
     public List<String> routingValues() {
         return routingValues;
     }
+
+    @Nullable
+    public Integer limit() {
+        return limit;
+    }
+
+    public int offset() {
+        return offset;
+    }
+
+    public List<Symbol> sortSymbols() {
+        return sortSymbols;
+    }
+
+    public boolean[] reverseFlags() {
+        return reverseFlags;
+    }
+
+    public Boolean[] nullsFirst() {
+        return nullsFirst;
+    }
+
 
     public List<ReferenceInfo> partitionBy() {
         return partitionBy;

--- a/sql/src/test/java/io/crate/integrationtests/WherePKIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/WherePKIntegrationTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.integrationtests;
+
+import io.crate.test.integration.CrateIntegrationTest;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+
+@CrateIntegrationTest.ClusterScope(scope = CrateIntegrationTest.Scope.GLOBAL)
+public class WherePKIntegrationTest extends SQLTransportIntegrationTest {
+
+    @Test
+    public void testWherePkColInWithLimit() throws Exception {
+        execute("create table users (" +
+                "   id int primary key," +
+                "   name string" +
+                ") clustered into 2 shards with (number_of_replicas = 0)");
+        ensureGreen();
+        execute("insert into users (id, name) values (?, ?)", new Object[][] {
+                new Object[] { 1, "Arthur" },
+                new Object[] { 2, "Trillian" },
+                new Object[] { 3, "Marvin" },
+                new Object[] { 4, "Slartibartfast" },
+        });
+        execute("refresh table users");
+
+        execute("select name from users where id in (1, 3, 4) order by name desc limit 2");
+        assertThat(response.rowCount(), is(2L));
+        assertThat((String) response.rows()[0][0], is("Slartibartfast"));
+        assertThat((String) response.rows()[1][0], is("Marvin"));
+    }
+
+    @Test
+    public void testWherePKWithFunctionInOutputsAndOrderBy() throws Exception {
+        execute("create table users (" +
+                "   id int primary key," +
+                "   name string" +
+                ") clustered into 2 shards with (number_of_replicas = 0)");
+        ensureGreen();
+        execute("insert into users (id, name) values (?, ?)", new Object[][]{
+                new Object[]{1, "Arthur"},
+                new Object[]{2, "Trillian"},
+                new Object[]{3, "Marvin"},
+                new Object[]{4, "Slartibartfast"},
+        });
+        execute("refresh table users");
+        execute("select substr(name, 1, 1) from users where id in (1, 2, 3) order by substr(name, 1, 1) desc");
+        assertThat(response.rowCount(), is(3L));
+        assertThat((String) response.rows()[0][0], is("T"));
+        assertThat((String) response.rows()[1][0], is("M"));
+        assertThat((String) response.rows()[2][0], is("A"));
+    }
+
+    @Test
+    public void testWherePKWithOrderBySymbolThatIsMissingInSelectList() throws Exception {
+        execute("create table users (" +
+                "   id int primary key," +
+                "   name string" +
+                ") clustered into 2 shards with (number_of_replicas = 0)");
+        ensureGreen();
+        execute("insert into users (id, name) values (?, ?)", new Object[][]{
+                new Object[]{1, "Arthur"},
+                new Object[]{2, "Trillian"},
+                new Object[]{3, "Marvin"},
+                new Object[]{4, "Slartibartfast"},
+        });
+        execute("refresh table users");
+        execute("select name from users where id in (1, 2, 3) order by id desc");
+        assertThat(response.rowCount(), is(3L));
+        assertThat((String) response.rows()[0][0], is("Marvin"));
+        assertThat((String) response.rows()[1][0], is("Trillian"));
+        assertThat((String) response.rows()[2][0], is("Arthur"));
+    }
+
+    @Test
+    public void testWherePkColLimit0() throws Exception {
+        execute("create table users (id int primary key, name string) " +
+                "clustered into 1 shards with (number_of_replicas = 0)");
+        ensureGreen();
+        execute("insert into users (id, name) values (1, 'Arthur')");
+        execute("refresh table users");
+        execute("select name from users where id = 1 limit 0");
+        assertThat(response.rowCount(), is(0L));
+    }
+}


### PR DESCRIPTION
Also made the ESGetTask standalone so it doesn't require an additional
MergeTask.

In addition the plan for insert from query has changed so that it will always
use QueryAndFetch to avoid handler round-trips.
