### PR TITLE
fixed regexp_matches and regexp_replace

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,12 @@ Changes for Crate Data
 Unreleased
 ==========
 
+ - improved error messages for ``regexp_matches`` and ``regexp_replace scalar``
+   function when arguments are of wrong type
+
+ - fix: ``regexp_matches`` with column ident as input raised exception
+   when used in IS (NOT) NULL predicate
+
  - added missing _id collector expression so _id can also be used in
    'insert from query' statements
 

--- a/sql/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
+++ b/sql/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
@@ -286,8 +286,9 @@ public class LuceneQueryBuilder {
                 assert input != null;
                 assert input.arguments().size() == 1;
                 Symbol arg = input.arguments().get(0);
-                checkArgument(arg.symbolType() == SymbolType.REFERENCE);
-
+                if (arg.symbolType() != SymbolType.REFERENCE) {
+                    return null;
+                }
                 Reference reference = (Reference)arg;
 
                 String columnName = reference.info().ident().columnIdent().fqn();

--- a/sql/src/main/java/io/crate/operation/scalar/regex/MatchesFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/regex/MatchesFunction.java
@@ -128,10 +128,10 @@ public class MatchesFunction extends Scalar<BytesRef[], Object> implements Dynam
         assert (args.length > 1 && args.length < 4);
         Object val = args[0].value();
         final Object patternValue = args[1].value();
-        assert patternValue instanceof BytesRef;
         if (val == null || patternValue == null) {
             return null;
         }
+        assert patternValue instanceof BytesRef;
         // value can be a string if e.g. result is retrieved by ESSearchTask
         if (val instanceof String) {
             val = new BytesRef((String)val);
@@ -163,7 +163,7 @@ public class MatchesFunction extends Scalar<BytesRef[], Object> implements Dynam
                         "[%s] Function implementation not found for argument types %s",
                         NAME, Arrays.toString(dataTypes.toArray())));
         if (dataTypes.size() == 3) {
-            Preconditions.checkArgument(dataTypes.get(2) == DataTypes.STRING);
+            Preconditions.checkArgument(dataTypes.get(2) == DataTypes.STRING, "flags must be of type string");
         }
         return new MatchesFunction(createInfo(dataTypes));
     }

--- a/sql/src/main/java/io/crate/operation/scalar/regex/ReplaceFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/regex/ReplaceFunction.java
@@ -160,11 +160,12 @@ public class ReplaceFunction extends Scalar<BytesRef, Object> implements Dynamic
 
     @Override
     public FunctionImplementation<Function> getForTypes(List<DataType> dataTypes) throws IllegalArgumentException {
-        Preconditions.checkArgument(dataTypes.size() >= 3 && dataTypes.size() <= 4
-                && dataTypes.get(0) == DataTypes.STRING && dataTypes.get(1) == DataTypes.STRING
-                && dataTypes.get(2) == DataTypes.STRING);
+        Preconditions.checkArgument(dataTypes.size() >= 3 && dataTypes.size() <= 4);
+        Preconditions.checkArgument(dataTypes.get(0) == DataTypes.STRING, "source argument must be of type string");
+        Preconditions.checkArgument(dataTypes.get(1) == DataTypes.STRING, "pattern argument must be of type string");
+        Preconditions.checkArgument(dataTypes.get(2) == DataTypes.STRING, "replace argument must be of type string");
         if (dataTypes.size() == 4) {
-            Preconditions.checkArgument(dataTypes.get(3) == DataTypes.STRING);
+            Preconditions.checkArgument(dataTypes.get(3) == DataTypes.STRING, "flags must be of type string");
         }
         return new ReplaceFunction(createInfo(dataTypes));
     }

--- a/sql/src/test/java/io/crate/integrationtests/RegexpIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/RegexpIntegrationTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.integrationtests;
+
+import io.crate.test.integration.CrateIntegrationTest;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.hamcrest.core.Is.is;
+
+@CrateIntegrationTest.ClusterScope(scope = CrateIntegrationTest.Scope.GLOBAL)
+public class RegexpIntegrationTest extends SQLTransportIntegrationTest {
+
+    static {
+        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
+    }
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testRegexpMatchesIsNull() throws Exception {
+        execute("create table regex_test (i integer, s string) with (number_of_replicas=0)");
+        ensureGreen();
+        execute("insert into regex_test(i, s) values (?, ?)", new Object[][]{
+                new Object[]{1, "foo is first"},
+                new Object[]{2, "bar is second"},
+                new Object[]{3, "foobar is great"},
+                new Object[]{4, "crate is greater"},
+                new Object[]{5, "foo"},
+                new Object[]{6, null}
+        });
+        refresh();
+        execute("select i from regex_test where regexp_matches(s, 'is') is not null");
+        assertThat(response.rowCount(), is(4L));
+        execute("select i from regex_test where regexp_matches(s, 'is') is null");
+        assertThat(response.rowCount(), is(2L));
+    }
+
+    @Test
+    public void testRegexpReplaceIsNull() throws Exception {
+        execute("create table regex_test (i integer, s string) with (number_of_replicas=0)");
+        ensureGreen();
+        execute("insert into regex_test(i, s) values (?, ?)", new Object[][]{
+                new Object[]{1, "foo is first"},
+                new Object[]{2, "bar is second"},
+                new Object[]{3, "foobar is great"},
+                new Object[]{4, "crate is greater"},
+                new Object[]{5, "foo"},
+                new Object[]{6, null}
+        });
+        refresh();
+        execute("select i from regex_test where regexp_replace(s, 'is', 'was') is not null");
+        assertThat(response.rowCount(), is(5L));
+        execute("select i from regex_test where regexp_replace(s, 'is', 'was') is null");
+        assertThat(response.rowCount(), is(1L));
+    }
+
+}
+
+


### PR DESCRIPTION
when used in IS (NOT) NULL predicate
and provide error message when regex_matches arguments are of incorrect type
