### PR TITLE
Require DataType of grouping keys in GroupProjector

### DIFF
--- a/sql/src/main/java/io/crate/action/sql/DDLAnalysisDispatcher.java
+++ b/sql/src/main/java/io/crate/action/sql/DDLAnalysisDispatcher.java
@@ -174,7 +174,7 @@ public class DDLAnalysisDispatcher extends AnalysisVisitor<Void, ListenableFutur
                 Aggregation.Step.PARTIAL);
         Aggregation countAggregationFinal = new Aggregation(
                 CountAggregation.COUNT_STAR_FUNCTION,
-                ImmutableList.<Symbol>of(new InputColumn(0)),
+                ImmutableList.<Symbol>of(new InputColumn(0, DataTypes.LONG)),
                 Aggregation.Step.PARTIAL,
                 Aggregation.Step.FINAL);
 

--- a/sql/src/main/java/io/crate/operation/AbstractImplementationSymbolVisitor.java
+++ b/sql/src/main/java/io/crate/operation/AbstractImplementationSymbolVisitor.java
@@ -70,7 +70,7 @@ public abstract class AbstractImplementationSymbolVisitor<C extends AbstractImpl
         return context;
     }
 
-    public C process(List<Symbol> symbols) {
+    public C process(List<? extends Symbol> symbols) {
         C context = newContext();
         for (Symbol symbol : symbols) {
             context.add(process(symbol, context));

--- a/sql/src/main/java/io/crate/operation/projectors/ProjectionToProjectorVisitor.java
+++ b/sql/src/main/java/io/crate/operation/projectors/ProjectionToProjectorVisitor.java
@@ -27,6 +27,7 @@ import io.crate.metadata.ColumnIdent;
 import io.crate.operation.ImplementationSymbolVisitor;
 import io.crate.operation.Input;
 import io.crate.operation.collect.CollectExpression;
+import io.crate.planner.DataTypeVisitor;
 import io.crate.planner.projection.*;
 import io.crate.planner.symbol.Aggregation;
 import io.crate.planner.symbol.Literal;
@@ -128,6 +129,7 @@ public class ProjectionToProjectorVisitor extends ProjectionVisitor<Void, Projec
             symbolVisitor.process(aggregation, symbolContext);
         }
         return new GroupingProjector(
+                DataTypeVisitor.fromSymbols(projection.keys()),
                 keyInputs,
                 symbolContext.collectExpressions().toArray(new CollectExpression[symbolContext.collectExpressions().size()]),
                 symbolContext.aggregations()

--- a/sql/src/main/java/io/crate/planner/DataTypeVisitor.java
+++ b/sql/src/main/java/io/crate/planner/DataTypeVisitor.java
@@ -26,6 +26,9 @@ import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.UndefinedType;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class DataTypeVisitor extends SymbolVisitor<Void, DataType> {
 
     private static final DataTypeVisitor INSTANCE = new DataTypeVisitor();
@@ -33,6 +36,14 @@ public class DataTypeVisitor extends SymbolVisitor<Void, DataType> {
 
     public static DataType fromSymbol(Symbol symbol) {
         return INSTANCE.process(symbol, null);
+    }
+
+    public static List<DataType> fromSymbols(List<? extends Symbol> keys) {
+        List<DataType> types = new ArrayList<>(keys.size());
+        for (Symbol key : keys) {
+            types.add(fromSymbol(key));
+        }
+        return types;
     }
 
     @Override
@@ -45,7 +56,7 @@ public class DataTypeVisitor extends SymbolVisitor<Void, DataType> {
 
     @Override
     public DataType visitInputColumn(InputColumn inputColumn, Void context) {
-        return null;
+        return inputColumn.valueType();
     }
 
     @Override
@@ -82,4 +93,5 @@ public class DataTypeVisitor extends SymbolVisitor<Void, DataType> {
     protected DataType visitSymbol(Symbol symbol, Void context) {
         throw new UnsupportedOperationException(SymbolFormatter.format("Unable to get DataType from symbol: %s", symbol));
     }
+
 }

--- a/sql/src/main/java/io/crate/planner/PlannerContext.java
+++ b/sql/src/main/java/io/crate/planner/PlannerContext.java
@@ -22,6 +22,7 @@
 package io.crate.planner;
 
 import io.crate.planner.symbol.Aggregation;
+import io.crate.planner.symbol.DataTypeSymbol;
 import io.crate.planner.symbol.InputColumn;
 import io.crate.planner.symbol.Symbol;
 
@@ -31,7 +32,7 @@ public class PlannerContext {
 
     final int numGroupKeys;
     List<Aggregation> aggregations = new ArrayList<>();
-    List<Symbol> groupBy;
+    List<DataTypeSymbol> groupBy;
     Aggregation.Step[] steps;
     int stepIdx = 0;
     Symbol parent;
@@ -63,10 +64,10 @@ public class PlannerContext {
         return steps[stepIdx];
     }
 
-    Symbol allocateToCollect(Symbol symbol) {
+    DataTypeSymbol allocateToCollect(Symbol symbol) {
         InputColumn inputColumn = toCollectAllocation.get(symbol);
         if (inputColumn == null) {
-            inputColumn = new InputColumn(toCollectAllocation.size());
+            inputColumn = new InputColumn(toCollectAllocation.size(), DataTypeVisitor.fromSymbol(symbol));
             toCollectAllocation.put(symbol, inputColumn);
         }
         return inputColumn;

--- a/sql/src/main/java/io/crate/planner/PlannerContextBuilder.java
+++ b/sql/src/main/java/io/crate/planner/PlannerContextBuilder.java
@@ -61,7 +61,7 @@ public class PlannerContextBuilder {
         this.ignoreOrderBy = ignoreOrderBy;
     }
 
-    public List<Symbol> groupBy() {
+    public List<DataTypeSymbol> groupBy() {
         return context.groupBy;
     }
 
@@ -103,7 +103,9 @@ public class PlannerContextBuilder {
                 } else if (context.numGroupKeys > 0 && splitSymbol.symbolType() != SymbolType.INPUT_COLUMN) {
                     // in case the symbol was an aggregation function it is replaced directly.
                     // this wasn't the case so the symbol must be a group by
-                    resolvedSymbol = new InputColumn(context.originalGroupBy.indexOf(splitSymbol));
+                    resolvedSymbol = new InputColumn(
+                            context.originalGroupBy.indexOf(splitSymbol),
+                            DataTypeVisitor.fromSymbol(splitSymbol));
                 } else if (splitSymbol.symbolType() == SymbolType.INPUT_COLUMN) {
                     resolvedSymbol = splitSymbol;
                 } else if(symbol.symbolType().isValueSymbol()){
@@ -137,7 +139,7 @@ public class PlannerContextBuilder {
             for (Aggregation aggregation : context.aggregations) {
                 context.aggregations.set(i, new Aggregation(
                         aggregation.functionInfo(),
-                        Arrays.<Symbol>asList(new InputColumn(idx)),
+                        Arrays.<Symbol>asList(new InputColumn(idx, null)),
                         aggregation.toStep(), context.step()));
                 i++;
                 idx++;
@@ -145,8 +147,8 @@ public class PlannerContextBuilder {
         }
 
         int idx = 0;
-        for (Symbol symbol : context.groupBy) {
-            context.groupBy.set(idx, new InputColumn(idx));
+        for (DataTypeSymbol symbol : context.groupBy) {
+            context.groupBy.set(idx, new InputColumn(idx, symbol.valueType()));
             idx++;
         }
     }
@@ -206,7 +208,7 @@ public class PlannerContextBuilder {
     public List<Symbol> passThroughOrderBy() {
         List<Symbol> orderBy = new ArrayList<>();
         for (Symbol symbol : context.orderBy) {
-            orderBy.add(new InputColumn(context.outputs.indexOf(symbol)));
+            orderBy.add(new InputColumn(context.outputs.indexOf(symbol), DataTypeVisitor.fromSymbol(symbol)));
         }
 
         return orderBy;
@@ -219,7 +221,7 @@ public class PlannerContextBuilder {
     public List<Symbol> passThroughOutputs() {
         List<Symbol> outputs = new ArrayList<>();
         for (int i = 0; i < context.outputs.size(); i++) {
-            outputs.add(new InputColumn(i));
+            outputs.add(new InputColumn(i, DataTypeVisitor.fromSymbol(context.outputs.get(i))));
         }
         return outputs;
     }

--- a/sql/src/main/java/io/crate/planner/projection/AbstractIndexWriterProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/AbstractIndexWriterProjection.java
@@ -104,15 +104,15 @@ public abstract class AbstractIndexWriterProjection extends Projection {
                                    int clusteredByIdx) {
         this.idSymbols = new ArrayList<>(primaryKeys.size());
         for (int primaryKeyIndex : primaryKeyIndices) {
-            idSymbols.add(new InputColumn(primaryKeyIndex));
+            idSymbols.add(new InputColumn(primaryKeyIndex, null));
         }
 
         this.partitionedBySymbols = new ArrayList<>(partitionedByIndices.length);
         for (int partitionByIndex : partitionedByIndices) {
-            partitionedBySymbols.add(new InputColumn(partitionByIndex));
+            partitionedBySymbols.add(new InputColumn(partitionByIndex, null));
         }
         if (clusteredByIdx >= 0) {
-            clusteredBySymbol = new InputColumn(clusteredByIdx);
+            clusteredBySymbol = new InputColumn(clusteredByIdx, null);
         }
     }
 

--- a/sql/src/main/java/io/crate/planner/projection/ColumnIndexWriterProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/ColumnIndexWriterProjection.java
@@ -77,7 +77,7 @@ public class ColumnIndexWriterProjection extends AbstractIndexWriterProjection {
 
         for (int i = 0; i < columns.size(); i++) {
             if (!partitionedByIndices.contains(i)) {
-                this.columnSymbols.add(new InputColumn(i));
+                this.columnSymbols.add(new InputColumn(i, null));
             } else {
                 columnIdents.remove(i);
             }

--- a/sql/src/main/java/io/crate/planner/projection/GroupProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/GroupProjection.java
@@ -23,6 +23,7 @@ package io.crate.planner.projection;
 
 import io.crate.planner.RowGranularity;
 import io.crate.planner.symbol.Aggregation;
+import io.crate.planner.symbol.DataTypeSymbol;
 import io.crate.planner.symbol.Symbol;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -33,7 +34,7 @@ import java.util.List;
 
 public class GroupProjection extends Projection {
 
-    List<Symbol> keys;
+    List<DataTypeSymbol> keys;
     List<Aggregation> values;
     List<Symbol> outputs;
 
@@ -49,16 +50,16 @@ public class GroupProjection extends Projection {
     public GroupProjection() {
     }
 
-    public GroupProjection(List<Symbol> keys, List<Aggregation> values) {
+    public GroupProjection(List<DataTypeSymbol> keys, List<Aggregation> values) {
         this.keys = keys;
         this.values = values;
     }
 
-    public List<Symbol> keys() {
+    public List<DataTypeSymbol> keys() {
         return keys;
     }
 
-    public void keys(List<Symbol> keys) {
+    public void keys(List<DataTypeSymbol> keys) {
         this.keys = keys;
     }
 
@@ -83,7 +84,8 @@ public class GroupProjection extends Projection {
     @Override
     public List<? extends Symbol> outputs() {
         if (outputs == null) {
-            outputs = new ArrayList<>(keys);
+            outputs = new ArrayList<>(keys.size() + values.size());
+            outputs.addAll(keys);
             outputs.addAll(values);
         }
         return outputs;
@@ -94,7 +96,7 @@ public class GroupProjection extends Projection {
         int size = in.readVInt();
         keys = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
-            keys.add(Symbol.fromStream(in));
+            keys.add((DataTypeSymbol) Symbol.fromStream(in));
         }
         size = in.readVInt();
         values = new ArrayList<>(size);

--- a/sql/src/main/java/io/crate/planner/projection/SourceIndexWriterProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/SourceIndexWriterProjection.java
@@ -24,6 +24,7 @@ package io.crate.planner.projection;
 import io.crate.metadata.ColumnIdent;
 import io.crate.planner.symbol.InputColumn;
 import io.crate.planner.symbol.Symbol;
+import io.crate.types.DataTypes;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -88,7 +89,7 @@ public class SourceIndexWriterProjection extends AbstractIndexWriterProjection {
         }
 
         generateSymbols(pkIndices, partitionedByIndices, clusteredByIdx);
-        rawSourceSymbol = new InputColumn(currentInputIndex);
+        rawSourceSymbol = new InputColumn(currentInputIndex, DataTypes.STRING);
     }
 
     @Override

--- a/sql/src/test/java/io/crate/executor/task/LocalMergeTaskTest.java
+++ b/sql/src/test/java/io/crate/executor/task/LocalMergeTaskTest.java
@@ -39,6 +39,7 @@ import io.crate.planner.projection.GroupProjection;
 import io.crate.planner.projection.Projection;
 import io.crate.planner.projection.TopNProjection;
 import io.crate.planner.symbol.Aggregation;
+import io.crate.planner.symbol.DataTypeSymbol;
 import io.crate.planner.symbol.InputColumn;
 import io.crate.planner.symbol.Symbol;
 import io.crate.types.DataType;
@@ -90,7 +91,7 @@ public class LocalMergeTaskTest {
         minAggFunction = (AggregationFunction<MinimumAggregation.MinimumAggState>) functions.get(minAggIdent);
 
         groupProjection = new GroupProjection();
-        groupProjection.keys(Arrays.<Symbol>asList(new InputColumn(0)));
+        groupProjection.keys(Arrays.<DataTypeSymbol>asList(new InputColumn(0, DataTypes.INTEGER)));
         groupProjection.values(Arrays.asList(
                 new Aggregation(minAggFunction.info(), Arrays.<Symbol>asList(new InputColumn(1)), Aggregation.Step.PARTIAL, Aggregation.Step.FINAL)
         ));

--- a/sql/src/test/java/io/crate/executor/transport/TransportExecutorTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/TransportExecutorTest.java
@@ -375,7 +375,7 @@ public class TransportExecutorTest extends SQLTransportIntegrationTest {
         mergeNode.inputTypes(Arrays.<DataType>asList(DataTypes.INTEGER, DataTypes.TIMESTAMP));
         mergeNode.outputTypes(Arrays.<DataType>asList(DataTypes.INTEGER, DataTypes.TIMESTAMP));
         TopNProjection topN = new TopNProjection(2, TopN.NO_OFFSET);
-        topN.outputs(Arrays.asList(new InputColumn(0), function));
+        topN.outputs(Arrays.<Symbol>asList(new InputColumn(0), function));
         mergeNode.projections(Arrays.<Projection>asList(topN));
         Plan plan = new Plan();
         plan.add(node);

--- a/sql/src/test/java/io/crate/executor/transport/merge/DistributedResultRequestTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/merge/DistributedResultRequestTest.java
@@ -155,7 +155,9 @@ public class DistributedResultRequestTest {
         dummyMergeNode.contextId(contextId);
         dummyMergeNode.inputTypes(Arrays.<DataType>asList(DataTypes.INTEGER, DataTypes.STRING));
         TopNProjection topNProjection = new TopNProjection(10, 0);
-        topNProjection.outputs(Arrays.<Symbol>asList(new InputColumn(0), new InputColumn(1)));
+        topNProjection.outputs(Arrays.<Symbol>asList(
+                new InputColumn(0, DataTypes.INTEGER),
+                new InputColumn(1, DataTypes.INTEGER)));
         dummyMergeNode.projections(Arrays.<Projection>asList(topNProjection));
 
         DistributedRequestContextManager contextManager =

--- a/sql/src/test/java/io/crate/executor/transport/task/DistributedMergeTaskTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/task/DistributedMergeTaskTest.java
@@ -15,6 +15,7 @@ import io.crate.planner.node.dql.MergeNode;
 import io.crate.planner.projection.GroupProjection;
 import io.crate.planner.projection.TopNProjection;
 import io.crate.planner.symbol.Aggregation;
+import io.crate.planner.symbol.DataTypeSymbol;
 import io.crate.planner.symbol.InputColumn;
 import io.crate.planner.symbol.Symbol;
 import io.crate.test.integration.CrateIntegrationTest;
@@ -54,7 +55,7 @@ public class DistributedMergeTaskTest extends SQLTransportIntegrationTest {
         mergeNode.inputTypes(Arrays.<DataType>asList(DataTypes.UNDEFINED, DataTypes.STRING));
 
         GroupProjection groupProjection = new GroupProjection();
-        groupProjection.keys(Arrays.<Symbol>asList(new InputColumn(1)));
+        groupProjection.keys(Arrays.<DataTypeSymbol>asList(new InputColumn(1, DataTypes.STRING)));
         groupProjection.values(Arrays.asList(
                 new Aggregation(
                         countAggregation.info(),
@@ -68,7 +69,7 @@ public class DistributedMergeTaskTest extends SQLTransportIntegrationTest {
         topNProjection.outputs(Arrays.<Symbol>asList(new InputColumn(0), new InputColumn(1)));
 
         mergeNode.projections(Arrays.asList(groupProjection, topNProjection));
-        mergeNode.outputTypes(Arrays.<DataType>asList(DataTypes.STRING, DataTypes.UNDEFINED));
+        mergeNode.outputTypes(Arrays.<DataType>asList(DataTypes.STRING, DataTypes.LONG));
 
         Streamer<?>[] mapperOutputStreamer = new Streamer[] {
                 new AggregationStateStreamer(countAggregation),

--- a/sql/src/test/java/io/crate/operation/ImplementationSymbolVisitorTest.java
+++ b/sql/src/test/java/io/crate/operation/ImplementationSymbolVisitorTest.java
@@ -27,10 +27,7 @@ import io.crate.operation.aggregation.impl.AverageAggregation;
 import io.crate.operation.aggregation.impl.CountAggregation;
 import io.crate.operation.collect.CollectExpression;
 import io.crate.planner.RowGranularity;
-import io.crate.planner.symbol.Aggregation;
-import io.crate.planner.symbol.Function;
-import io.crate.planner.symbol.InputColumn;
-import io.crate.planner.symbol.Symbol;
+import io.crate.planner.symbol.*;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.elasticsearch.common.inject.AbstractModule;
@@ -127,7 +124,7 @@ public class ImplementationSymbolVisitorTest {
         Function multiply = new Function(
                 MultiplyFunction.INFO, Arrays.<Symbol>asList(new InputColumn(1))
         );
-        List<Symbol> keys = Arrays.asList(new InputColumn(0), multiply);
+        List<DataTypeSymbol> keys = Arrays.asList(new InputColumn(0, DataTypes.LONG), multiply);
 
         ImplementationSymbolVisitor.Context context = visitor.process(keys);
         assertThat(context.collectExpressions().size(), is(2));
@@ -155,7 +152,7 @@ public class ImplementationSymbolVisitorTest {
         Function multiply = new Function(
                 MultiplyFunction.INFO, Arrays.<Symbol>asList(new InputColumn(1))
         );
-        List<Symbol> keys = Arrays.asList(new InputColumn(0), multiply);
+        List<DataTypeSymbol> keys = Arrays.asList(new InputColumn(0, DataTypes.LONG), multiply);
 
 
         // values: [ count(in(0)) ]

--- a/sql/src/test/java/io/crate/operation/collect/ShardProjectorChainTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/ShardProjectorChainTest.java
@@ -36,10 +36,7 @@ import io.crate.planner.RowGranularity;
 import io.crate.planner.projection.GroupProjection;
 import io.crate.planner.projection.Projection;
 import io.crate.planner.projection.TopNProjection;
-import io.crate.planner.symbol.Aggregation;
-import io.crate.planner.symbol.InputColumn;
-import io.crate.planner.symbol.Literal;
-import io.crate.planner.symbol.Symbol;
+import io.crate.planner.symbol.*;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.inject.Injector;
 import org.elasticsearch.common.inject.ModulesBuilder;
@@ -105,7 +102,7 @@ public class ShardProjectorChainTest {
     public void testWithShardProjections() throws Exception {
         TopNProjection topN = new TopNProjection(0, 1);
         GroupProjection groupProjection = new GroupProjection(
-                Arrays.<Symbol>asList(Literal.newLiteral(true)),
+                Arrays.<DataTypeSymbol>asList(Literal.newLiteral(true)),
                 Arrays.asList(countAggregation()));
         groupProjection.setRequiredGranularity(RowGranularity.SHARD);
         ShardProjectorChain chain = new ShardProjectorChain(2, ImmutableList.of(groupProjection, topN), projectionToProjectorVisitor);
@@ -126,11 +123,11 @@ public class ShardProjectorChainTest {
     public void testWith2ShardProjections() throws Exception {
         TopNProjection topN = new TopNProjection(0, 1);
         GroupProjection groupProjection1 = new GroupProjection(
-                Arrays.<Symbol>asList(Literal.newLiteral(true)),
+                Arrays.<DataTypeSymbol>asList(Literal.newLiteral(true)),
                 Arrays.asList(countAggregation()));
         groupProjection1.setRequiredGranularity(RowGranularity.SHARD);
         GroupProjection groupProjection2 = new GroupProjection(
-                Arrays.<Symbol>asList(Literal.newLiteral(true)),
+                Arrays.<DataTypeSymbol>asList(Literal.newLiteral(true)),
                 Arrays.asList(countAggregation()));
         groupProjection2.setRequiredGranularity(RowGranularity.SHARD);
         ShardProjectorChain chain = new ShardProjectorChain(2, ImmutableList.of(groupProjection1, groupProjection2, topN), projectionToProjectorVisitor);
@@ -152,7 +149,7 @@ public class ShardProjectorChainTest {
     public void testWithoutShardProjections() throws Exception {
         TopNProjection topN = new TopNProjection(0, 1);
         GroupProjection groupProjection = new GroupProjection(
-                Arrays.<Symbol>asList(Literal.newLiteral(true)),
+                Arrays.<DataTypeSymbol>asList(Literal.newLiteral(true)),
                 Arrays.asList(countAggregation()));
         ShardProjectorChain chain = new ShardProjectorChain(2, ImmutableList.of(groupProjection, topN), projectionToProjectorVisitor);
 
@@ -190,7 +187,7 @@ public class ShardProjectorChainTest {
     public void testZeroShards() throws Exception {
         TopNProjection topN = new TopNProjection(0, 1);
         GroupProjection groupProjection = new GroupProjection(
-                Arrays.<Symbol>asList(Literal.newLiteral(true)),
+                Arrays.<DataTypeSymbol>asList(Literal.newLiteral(true)),
                 Arrays.asList(countAggregation()));
         ShardProjectorChain chain = new ShardProjectorChain(0, ImmutableList.of(groupProjection, topN), projectionToProjectorVisitor);
 

--- a/sql/src/test/java/io/crate/operation/merge/MergeOperationTest.java
+++ b/sql/src/test/java/io/crate/operation/merge/MergeOperationTest.java
@@ -34,6 +34,7 @@ import io.crate.planner.projection.GroupProjection;
 import io.crate.planner.projection.Projection;
 import io.crate.planner.projection.TopNProjection;
 import io.crate.planner.symbol.Aggregation;
+import io.crate.planner.symbol.DataTypeSymbol;
 import io.crate.planner.symbol.InputColumn;
 import io.crate.planner.symbol.Symbol;
 import io.crate.types.DataType;
@@ -84,9 +85,10 @@ public class MergeOperationTest {
         minAggFunction = (AggregationFunction<MinimumAggregation.MinimumAggState>) functions.get(minAggIdent);
 
         groupProjection = new GroupProjection();
-        groupProjection.keys(Arrays.<Symbol>asList(new InputColumn(0)));
+        groupProjection.keys(Arrays.<DataTypeSymbol>asList(new InputColumn(0, DataTypes.INTEGER)));
         groupProjection.values(Arrays.asList(
-                new Aggregation(minAggInfo, Arrays.<Symbol>asList(new InputColumn(1)), Aggregation.Step.PARTIAL, Aggregation.Step.FINAL)
+                new Aggregation(minAggInfo, Arrays.<Symbol>asList(new InputColumn(1)),
+                        Aggregation.Step.PARTIAL, Aggregation.Step.FINAL)
         ));
     }
 

--- a/sql/src/test/java/io/crate/operation/projectors/GroupingProjectorTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/GroupingProjectorTest.java
@@ -17,6 +17,7 @@ import io.crate.types.DataTypes;
 import org.elasticsearch.common.inject.ModulesBuilder;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.concurrent.ExecutionException;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -51,6 +52,7 @@ public class GroupingProjectorTest {
 
         AggregationContext[] aggregations = new AggregationContext[] { aggregationContext };
         GroupingProjector projector = new GroupingProjector(
+                Arrays.asList(DataTypes.STRING),
                 keys,
                 new CollectExpression[0],
                 aggregations

--- a/sql/src/test/java/io/crate/operation/projectors/ProjectionToProjectorVisitorTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/ProjectionToProjectorVisitorTest.java
@@ -187,7 +187,7 @@ public class ProjectionToProjectorVisitorTest {
         //         in(0)  in(1)      in(0),      in(2)
         // select  race, avg(age), count(race), gender  ... group by race, gender
         GroupProjection projection = new GroupProjection();
-        projection.keys(Arrays.<Symbol>asList(new InputColumn(0), new InputColumn(2)));
+        projection.keys(Arrays.<DataTypeSymbol>asList(new InputColumn(0, DataTypes.STRING), new InputColumn(2, DataTypes.STRING)));
         projection.values(Arrays.asList(
                 new Aggregation(avgInfo, Arrays.<Symbol>asList(new InputColumn(1)), Aggregation.Step.ITER, Aggregation.Step.FINAL),
                 new Aggregation(countInfo, Arrays.<Symbol>asList(new InputColumn(0)), Aggregation.Step.ITER, Aggregation.Step.FINAL)

--- a/sql/src/test/java/io/crate/planner/node/MergeNodeTest.java
+++ b/sql/src/test/java/io/crate/planner/node/MergeNodeTest.java
@@ -30,6 +30,7 @@ import io.crate.planner.node.dql.MergeNode;
 import io.crate.planner.projection.GroupProjection;
 import io.crate.planner.projection.TopNProjection;
 import io.crate.planner.symbol.Aggregation;
+import io.crate.planner.symbol.DataTypeSymbol;
 import io.crate.planner.symbol.Reference;
 import io.crate.planner.symbol.Symbol;
 import io.crate.testing.TestingHelpers;
@@ -57,7 +58,7 @@ public class MergeNodeTest {
 
         Reference nameRef = TestingHelpers.createReference("name", DataTypes.STRING);
         GroupProjection groupProjection = new GroupProjection();
-        groupProjection.keys(Arrays.<Symbol>asList(nameRef));
+        groupProjection.keys(Arrays.<DataTypeSymbol>asList(nameRef));
         groupProjection.values(Arrays.asList(
                 new Aggregation(
                         new FunctionInfo(new FunctionIdent(CountAggregation.NAME, ImmutableList.<DataType>of()), DataTypes.LONG),

--- a/sql/src/test/java/io/crate/planner/node/PlanNodeStreamerVisitorTest.java
+++ b/sql/src/test/java/io/crate/planner/node/PlanNodeStreamerVisitorTest.java
@@ -36,10 +36,7 @@ import io.crate.planner.projection.AggregationProjection;
 import io.crate.planner.projection.GroupProjection;
 import io.crate.planner.projection.Projection;
 import io.crate.planner.projection.TopNProjection;
-import io.crate.planner.symbol.Aggregation;
-import io.crate.planner.symbol.InputColumn;
-import io.crate.planner.symbol.Literal;
-import io.crate.planner.symbol.Symbol;
+import io.crate.planner.symbol.*;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.elasticsearch.common.inject.Injector;
@@ -169,7 +166,7 @@ public class PlanNodeStreamerVisitorTest {
         MergeNode mergeNode = new MergeNode("mörtsch", 2);
         mergeNode.inputTypes(Arrays.<DataType>asList(DataTypes.STRING, DataTypes.UNDEFINED));
         GroupProjection groupProjection = new GroupProjection(
-                Arrays.<Symbol>asList(Literal.newLiteral("key")),
+                Arrays.<DataTypeSymbol>asList(Literal.newLiteral("key")),
                 Arrays.asList(new Aggregation(
                         countInfo,
                         ImmutableList.<Symbol>of(),

--- a/sql/src/test/java/io/crate/planner/projection/GroupProjectionTest.java
+++ b/sql/src/test/java/io/crate/planner/projection/GroupProjectionTest.java
@@ -27,6 +27,7 @@ import io.crate.metadata.FunctionInfo;
 import io.crate.operation.aggregation.impl.CountAggregation;
 import io.crate.planner.RowGranularity;
 import io.crate.planner.symbol.Aggregation;
+import io.crate.planner.symbol.DataTypeSymbol;
 import io.crate.planner.symbol.Reference;
 import io.crate.planner.symbol.Symbol;
 import io.crate.types.DataType;
@@ -49,7 +50,7 @@ public class GroupProjectionTest {
     public void testStreaming() throws Exception {
         GroupProjection p = new GroupProjection();
         p.keys(
-                ImmutableList.<Symbol>of(
+                ImmutableList.<DataTypeSymbol>of(
                         createReference("foo", DataTypes.STRING),
                         createReference("bar", DataTypes.SHORT)
                 ));
@@ -69,7 +70,7 @@ public class GroupProjectionTest {
     public void testStreaming2() throws Exception {
         Reference nameRef = createReference("name", DataTypes.STRING);
         GroupProjection groupProjection = new GroupProjection();
-        groupProjection.keys(Arrays.<Symbol>asList(nameRef));
+        groupProjection.keys(Arrays.<DataTypeSymbol>asList(nameRef));
         groupProjection.values(Arrays.asList(
                 new Aggregation(
                         new FunctionInfo(new FunctionIdent(CountAggregation.NAME, ImmutableList.<DataType>of()), DataTypes.LONG),
@@ -94,7 +95,7 @@ public class GroupProjectionTest {
     public void testStreamingGranularity() throws Exception {
         GroupProjection p = new GroupProjection();
         p.keys(
-                ImmutableList.<Symbol>of(
+                ImmutableList.<DataTypeSymbol>of(
                         createReference("foo", DataTypes.STRING),
                         createReference("bar", DataTypes.SHORT)
                 ));


### PR DESCRIPTION
GroupingProjector now takes the key dataTypes as argument. Currently the types
are un-used. But they will be used in the future for circuit-breaker and
probably type based optimizations.
