### PR TITLE
build booleanQuery with TermQueries for "where X in (...)"

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fix performance regression on ``SELECT`` queries which use the ``IN``
+   operator in the ``WHERE`` clause.
+
  - Updated crate-admin to 0.10.0 which includes following changes:
 
     - added hint to console: press shift+enter to submit query


### PR DESCRIPTION
the commit 61f0e8c773449b26866f179feedba54665f32cc2 together with
8ead30b6816e96b50f3040ee65908b12ea577081 caused a performance regression for
WHERE x IN as it used table scan
/ source lookups instead of utilizing the lucene index.
