### PR TITLE
make setNextRow in FilterProjector synchronized

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed a rare race condition that could cause the ``having`` clause to filter
+   incorrectly.
+
  - Fix: ``alter table add column`` didn't work correctly on partitioned tables.
 
  - Added cast function for timestamp type

--- a/sql/src/main/java/io/crate/operation/projectors/FilterProjector.java
+++ b/sql/src/main/java/io/crate/operation/projectors/FilterProjector.java
@@ -51,7 +51,7 @@ public class FilterProjector implements Projector {
     }
 
     @Override
-    public boolean setNextRow(Object... row) {
+    public synchronized boolean setNextRow(Object... row) {
         for (CollectExpression<?> collectExpression : collectExpressions) {
             collectExpression.setNextRow(row);
         }


### PR DESCRIPTION
Fixes a race conditation where rows weren't filtered but should have been. (Or
the other way around).

The collectorExpression/condition that is used there contains shared state and
setNextRow is called from different threads.

testHavingGroupByNonDistributed failed about 3 times in 800 runs.
