### PR TITLE
remove rowCount from TaskResult interface.

### DIFF
--- a/sql/src/main/java/io/crate/action/sql/TransportSQLAction.java
+++ b/sql/src/main/java/io/crate/action/sql/TransportSQLAction.java
@@ -25,7 +25,6 @@ import io.crate.analyze.Analysis;
 import io.crate.analyze.Analyzer;
 import io.crate.executor.BytesRefUtils;
 import io.crate.executor.Executor;
-import io.crate.executor.QueryResult;
 import io.crate.executor.TaskResult;
 import io.crate.executor.transport.ResponseForwarder;
 import io.crate.operation.collect.StatsTables;
@@ -93,12 +92,13 @@ public class TransportSQLAction extends TransportBaseSQLAction<SQLRequest, SQLRe
         TaskResult taskResult = result.get(0);
         Object[][] rows = taskResult.rows();
         long rowCount = 0;
-        if (expectsAffectedRows && taskResult instanceof QueryResult) {
+        if (expectsAffectedRows) {
             if (rows.length >= 1 && rows[0].length >= 1) {
                 rowCount = ((Number) rows[0][0]).longValue();
             }
+            rows = TaskResult.EMPTY_ROWS;
         } else {
-            rowCount = taskResult.rowCount();
+            rowCount = rows.length;
         }
         BytesRefUtils.ensureStringTypesAreStrings(outputTypes, rows);
         return new SQLResponse(

--- a/sql/src/main/java/io/crate/action/sql/TransportSQLBulkAction.java
+++ b/sql/src/main/java/io/crate/action/sql/TransportSQLBulkAction.java
@@ -84,11 +84,12 @@ public class TransportSQLBulkAction extends TransportBaseSQLAction<SQLBulkReques
                                                        boolean expectsAffectedRows,
                                                        long requestCreationTime,
                                                        boolean includeTypesOnResponse) {
+        assert expectsAffectedRows : "bulk operations only works with statements that return rowcounts";
         SQLBulkResponse.Result[] results = new SQLBulkResponse.Result[result.size()];
         for (int i = 0, resultSize = result.size(); i < resultSize; i++) {
             TaskResult taskResult = result.get(i);
             assert taskResult instanceof RowCountResult : "Query operation not supported with bulk requests";
-            results[i] = new SQLBulkResponse.Result(taskResult.errorMessage(), taskResult.rowCount());
+            results[i] = new SQLBulkResponse.Result(taskResult.errorMessage(), (Long) taskResult.rows()[0][0]);
         }
         return new SQLBulkResponse(outputNames, results, requestCreationTime, dataTypes, includeTypesOnResponse);
     }

--- a/sql/src/main/java/io/crate/executor/QueryResult.java
+++ b/sql/src/main/java/io/crate/executor/QueryResult.java
@@ -33,9 +33,4 @@ public class QueryResult extends TaskResult {
     public Object[][] rows() {
         return rows;
     }
-
-    @Override
-    public long rowCount() {
-        return rows.length;
-    }
 }

--- a/sql/src/main/java/io/crate/executor/RowCountResult.java
+++ b/sql/src/main/java/io/crate/executor/RowCountResult.java
@@ -27,16 +27,15 @@ import javax.annotation.Nullable;
 
 public class RowCountResult extends TaskResult {
 
-    private final long rowCount;
     @Nullable private final Throwable error;
+    private final Object[][] rows;
 
     public RowCountResult(long rowCount) {
-        this.rowCount = rowCount;
-        this.error = null;
+        this(rowCount, null);
     }
 
     private RowCountResult(long rowCount, Throwable throwable) {
-        this.rowCount = rowCount;
+        this.rows = new Object[][] { new Object[] { rowCount }};
         this.error = throwable;
     }
 
@@ -46,12 +45,7 @@ public class RowCountResult extends TaskResult {
     
     @Override
     public Object[][] rows() {
-        return EMPTY_ROWS;
-    }
-
-    @Override
-    public long rowCount() {
-        return rowCount;
+        return rows;
     }
 
     @Nullable

--- a/sql/src/main/java/io/crate/executor/TaskResult.java
+++ b/sql/src/main/java/io/crate/executor/TaskResult.java
@@ -25,7 +25,7 @@ import javax.annotation.Nullable;
 
 public abstract class TaskResult {
 
-    protected static final Object[][] EMPTY_ROWS = new Object[0][];
+    public static final Object[][] EMPTY_ROWS = new Object[0][];
 
     public static final RowCountResult ZERO = new RowCountResult(0L);
     public static final RowCountResult ONE_ROW = new RowCountResult(1L);
@@ -34,13 +34,7 @@ public abstract class TaskResult {
 
     public static final QueryResult EMPTY_RESULT = new QueryResult(EMPTY_ROWS);
 
-    public TaskResult() {
-
-    }
-
     public abstract Object[][] rows();
-
-    public abstract long rowCount();
 
     /**
      * can be set in bulk operations to set the error for a single operation

--- a/sql/src/test/java/io/crate/executor/transport/TransportExecutorDDLTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/TransportExecutorDDLTest.java
@@ -124,8 +124,8 @@ public class TransportExecutorDDLTest extends SQLTransportIntegrationTest {
         TaskResult taskResult = listenableFuture.get().get(0);
         Object[][] objects = listenableFuture.get().get(0).rows();
 
-        assertThat(taskResult.rowCount(), is(1L));
-        assertThat(objects.length, is(0));
+        assertThat(((Long) taskResult.rows()[0][0]), is(1L));
+        assertThat(objects.length, is(1));
 
         execute("select * from information_schema.tables where table_name = 'test' and number_of_replicas = 0 and number_of_shards = 2");
         assertThat(response.rowCount(), is(1L));
@@ -156,8 +156,8 @@ public class TransportExecutorDDLTest extends SQLTransportIntegrationTest {
         TaskResult taskResult = listenableFuture.get().get(0);
         Object[][] objects = listenableFuture.get().get(0).rows();
 
-        assertThat(taskResult.rowCount(), is(1L));
-        assertThat(objects.length, is(0));
+        assertThat(((Long) taskResult.rows()[0][0]), is(1L));
+        assertThat(objects.length, is(1));
 
         execute("select * from information_schema.tables where table_name = 'test' and number_of_replicas = 0 and number_of_shards = 2");
         assertThat(response.rowCount(), is(1L));
@@ -192,8 +192,8 @@ public class TransportExecutorDDLTest extends SQLTransportIntegrationTest {
         TaskResult taskResult = listenableFuture.get().get(0);
         Object[][] objects = listenableFuture.get().get(0).rows();
 
-        assertThat(taskResult.rowCount(), is(1L));
-        assertThat(objects.length, is(0));
+        assertThat(((Long) taskResult.rows()[0][0]), is(1L));
+        assertThat(objects.length, is(1));
 
         execute("select * from information_schema.tables where table_name = 'test' and number_of_replicas = 0 and number_of_shards = 2");
         assertThat(response.rowCount(), is(1L));
@@ -225,8 +225,8 @@ public class TransportExecutorDDLTest extends SQLTransportIntegrationTest {
         ListenableFuture<List<TaskResult>> listenableFuture = Futures.allAsList(futures);
         TaskResult taskResult = listenableFuture.get().get(0);
         Object[][] objects = listenableFuture.get().get(0).rows();
-        assertThat(taskResult.rowCount(), is(1L));
-        assertThat(objects.length, is(0));
+        assertThat(((Long) taskResult.rows()[0][0]), is(1L));
+        assertThat(objects.length, is(1));
 
         execute("select * from information_schema.tables where table_name = 't'");
         assertThat(response.rowCount(), is(0L));
@@ -253,8 +253,8 @@ public class TransportExecutorDDLTest extends SQLTransportIntegrationTest {
         ListenableFuture<List<TaskResult>> listenableFuture = Futures.allAsList(futures);
         TaskResult taskResult = listenableFuture.get().get(0);
         Object[][] objects = listenableFuture.get().get(0).rows();
-        assertThat(taskResult.rowCount(), is(1L));
-        assertThat(objects.length, is(0));
+        assertThat(((Long) taskResult.rows()[0][0]), is(1L));
+        assertThat(objects.length, is(1));
 
         execute("select * from information_schema.tables where table_name = 't'");
         assertThat(response.rowCount(), is(0L));
@@ -287,8 +287,8 @@ public class TransportExecutorDDLTest extends SQLTransportIntegrationTest {
         ListenableFuture<List<TaskResult>> listenableFuture = Futures.allAsList(futures);
         TaskResult taskResult = listenableFuture.get().get(0);
         Object[][] objects = listenableFuture.get().get(0).rows();
-        assertThat(taskResult.rowCount(), is(1L));
-        assertThat(objects.length, is(0));
+        assertThat(((Long) taskResult.rows()[0][0]), is(1L));
+        assertThat(objects.length, is(1));
         assertEquals("panic", client().admin().cluster().prepareState().execute().actionGet().getState().metaData().persistentSettings().get(persistentSetting));
 
         // Update transient only
@@ -306,8 +306,8 @@ public class TransportExecutorDDLTest extends SQLTransportIntegrationTest {
         listenableFuture = Futures.allAsList(futures);
         taskResult = listenableFuture.get().get(0);
         objects = listenableFuture.get().get(0).rows();
-        assertThat(taskResult.rowCount(), is(1L));
-        assertThat(objects.length, is(0));
+        assertThat(((Long) taskResult.rows()[0][0]), is(1L));
+        assertThat(objects.length, is(1));
         assertEquals("123", client().admin().cluster().prepareState().execute().actionGet().getState().metaData().transientSettings().get(transientSetting));
 
         // Update persistent & transient
@@ -328,8 +328,8 @@ public class TransportExecutorDDLTest extends SQLTransportIntegrationTest {
         listenableFuture = Futures.allAsList(futures);
         taskResult = listenableFuture.get().get(0);
         objects = listenableFuture.get().get(0).rows();
-        assertThat(taskResult.rowCount(), is(1L));
-        assertThat(objects.length, is(0));
+        assertThat(((Long) taskResult.rows()[0][0]), is(1L));
+        assertThat(objects.length, is(1));
         assertEquals("normal", client().admin().cluster().prepareState().execute().actionGet().getState().metaData().persistentSettings().get(persistentSetting));
         assertEquals("243", client().admin().cluster().prepareState().execute().actionGet().getState().metaData().transientSettings().get(transientSetting));
     }
@@ -382,8 +382,8 @@ public class TransportExecutorDDLTest extends SQLTransportIntegrationTest {
         ListenableFuture<List<TaskResult>> listenableFuture = Futures.allAsList(futures);
         TaskResult taskResult = listenableFuture.get().get(0);
         Object[][] objects = listenableFuture.get().get(0).rows();
-        assertThat(taskResult.rowCount(), is(1L));
-        assertThat(objects.length, is(0));
+        assertThat(((Long) taskResult.rows()[0][0]), is(1L));
+        assertThat(objects.length, is(1));
 
         refresh();
 

--- a/sql/src/test/java/io/crate/executor/transport/TransportExecutorTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/TransportExecutorTest.java
@@ -461,8 +461,8 @@ public class TransportExecutorTest extends SQLTransportIntegrationTest {
         task.start();
         TaskResult taskResult = task.result().get(0).get();
         Object[][] rows = taskResult.rows();
-        assertThat(rows.length, is(0));
-        assertThat(taskResult.rowCount(), is(-1L));
+        assertThat(rows.length, is(1));
+        assertThat(((Long) rows[0][0]), is(-1L));
 
         // verify deletion
         DocTableInfo characters = docSchemaInfo.getTableInfo("characters");
@@ -497,8 +497,8 @@ public class TransportExecutorTest extends SQLTransportIntegrationTest {
         List<ListenableFuture<TaskResult>> result = executor.execute(job);
         TaskResult taskResult = result.get(0).get();
         Object[][] rows = taskResult.rows();
-        assertThat(rows.length, is(0));
-        assertThat(taskResult.rowCount(), is(1L));
+        assertThat(rows.length, is(1));
+        assertThat(((Long) rows[0][0]), is(1L));
 
         // verify deletion
         ImmutableList<Symbol> outputs = ImmutableList.<Symbol>of(id_ref, name_ref);
@@ -538,8 +538,8 @@ public class TransportExecutorTest extends SQLTransportIntegrationTest {
         List<ListenableFuture<TaskResult>> result = executor.execute(job);
         TaskResult taskResult = result.get(0).get();
         Object[][] rows = taskResult.rows();
-        assertThat(rows.length, is(0));
-        assertThat(taskResult.rowCount(), is(1L));
+        assertThat(rows.length, is(1));
+        assertThat(((Long) rows[0][0]), is(1L));
 
 
         // verify insertion
@@ -585,8 +585,8 @@ public class TransportExecutorTest extends SQLTransportIntegrationTest {
         List<ListenableFuture<TaskResult>> result = executor.execute(job);
         TaskResult taskResult = result.get(0).get();
         Object[][] indexResult = taskResult.rows();
-        assertThat(indexResult.length, is(0));
-        assertThat(taskResult.rowCount(), is(1L));
+        assertThat(indexResult.length, is(1));
+        assertThat(((Long) indexResult[0][0]), is(1L));
 
         refresh();
 
@@ -655,9 +655,9 @@ public class TransportExecutorTest extends SQLTransportIntegrationTest {
 
         List<ListenableFuture<TaskResult>> result = executor.execute(job);
         TaskResult taskResult = result.get(0).get();
-        assertThat(taskResult.rowCount(), is(2L));
-        Object[][] rows = result.get(0).get().rows();
-        assertThat(rows.length, is(0));
+        Object[][] rows = taskResult.rows();
+        assertThat(((Long) rows[0][0]), is(2L));
+        assertThat(rows.length, is(1));
 
         // verify insertion
 
@@ -702,8 +702,8 @@ public class TransportExecutorTest extends SQLTransportIntegrationTest {
         TaskResult taskResult = result.get(0).get();
         Object[][] rows = taskResult.rows();
 
-        assertThat(rows.length, is(0));
-        assertThat(taskResult.rowCount(), is(1L));
+        assertThat(rows.length, is(1));
+        assertThat(((Long) rows[0][0]), is(1L));
 
         // verify update
         ImmutableList<Symbol> outputs = ImmutableList.<Symbol>of(id_ref, name_ref);
@@ -756,7 +756,7 @@ public class TransportExecutorTest extends SQLTransportIntegrationTest {
         assertThat(job.tasks().get(0), instanceOf(ESUpdateByQueryTask.class));
         List<ListenableFuture<TaskResult>> result = executor.execute(job);
         assertThat(result.get(0).get().errorMessage(), is(nullValue()));
-        assertThat(result.get(0).get().rowCount(), is(1L));
+        assertThat(((Long) result.get(0).get().rows()[0][0]), is(1L));
 
         List<Symbol> outputs = Arrays.<Symbol>asList(id_ref, name_ref, version_ref);
         ESGetNode getNode = newGetNode("characters", outputs, "1");
@@ -805,7 +805,7 @@ public class TransportExecutorTest extends SQLTransportIntegrationTest {
         Job job = executor.newJob(plan);
         assertThat(job.tasks().get(0), instanceOf(ESUpdateByQueryTask.class));
         List<ListenableFuture<TaskResult>> result = executor.execute(job);
-        assertThat(result.get(0).get().rowCount(), is(2L));
+        assertThat(((Long) result.get(0).get().rows()[0][0]), is(2L));
 
         refresh();
 


### PR DESCRIPTION
Tasks will now always write the rowCount into the rows and there is only one
place where the extraction of the rowCount is done (in the transport where the
SQLResponse is built).
