### PR TITLE
Add sql query circuit breaker.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /docs/eggs
 /docs/out
 /docs/clients/out
+/reports

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Add sql query breaker which will terminate a query execution if too
+   much memory will be consumened.
+
  - Fixed NPE which could occure on a shard failure while collecting
    distributed (e.g. group by query)
 

--- a/app/src/main/dist/config/crate.yml
+++ b/app/src/main/dist/config/crate.yml
@@ -110,7 +110,6 @@
 # location to disable it, set the following:
 # node.max_local_storage_nodes: 1
 
-
 #################################### Table ####################################
 
 # You can set a number of options (such as shard/replica options, mapping
@@ -572,6 +571,21 @@
 # your cluster. To execute such queries more failsafe even with slower hardware
 # increase this timeout
 #insert_by_query.request_timeout: 1m
+
+########################## SQL Query Circuit Breaker ##########################
+
+# The query circuit breaker allows estimation of needed memory required by
+# a query.
+
+# Specifies the limit for the query breaker.
+#
+# crate.breaker.query.limit: 60%
+
+# A constant that all query data estimations are multiplied with to
+# determine a final estimation.
+#
+# crate.breaker.query.overhead: 1.0.3
+
 
 ################################### UDC ###################################
 

--- a/core/src/main/java/io/crate/types/DataTypes.java
+++ b/core/src/main/java/io/crate/types/DataTypes.java
@@ -38,6 +38,10 @@ public class DataTypes {
 
     private final static ESLogger logger = Loggers.getLogger(DataTypes.class);
 
+    /**
+     * While adding new types here, please aware the {@link io.crate.breaker.SizeEstimatorFactory}
+     */
+    @SuppressWarnings("JavadocReference")
     public final static UndefinedType UNDEFINED = UndefinedType.INSTANCE;
     public final static NotSupportedType NOT_SUPPORTED = NotSupportedType.INSTANCE;
 

--- a/docs/configuration.txt
+++ b/docs/configuration.txt
@@ -128,6 +128,26 @@ Ports
   of the node is not directly reachable from outside, e.g. running it
   behind a firewall or inside a Docker container.
 
+Query Circuit Breaker
+---------------------
+
+The Query circuit breaker will keep track of the used memory during
+the execution of a query. If a query consumes too much memory or if
+the cluster is already near its memory limit it will terminate the
+query to ensure the cluster keeps working.
+
+**crate.breaker.query.limit**
+  | *Runtime:*   ``no``
+
+  Specifies the limit for the query breaker, defaults to ``60%`` of
+  the JVM HEAP.
+
+**crate.breaker.query.overhead**
+  | *Runtime:*   ``no``
+
+  A constant that all data estimations are multiplied with to
+  determine a final estimation. Defaults to ``1.03``.
+
 .. _conf-cluster-settings:
 
 Cluster Wide Settings

--- a/docs/sql/system.txt
+++ b/docs/sql/system.txt
@@ -550,12 +550,12 @@ operation is listed on each node it is being executed on.
 In order to see on which nodes the operations are being executed the
 ``sys.nodes.name`` expression can be used in the query::
 
-    cr> select sys.nodes.name, job_id, name from sys.operations order by name limit 1;
-    +----------------+--------...-+---------+
-    | sys.nodes.name | job_id     | name    |
-    +----------------+--------...-+---------+
-    | crate          | ...        | collect |
-    +----------------+--------...-+---------+
+    cr> select sys.nodes.name, job_id, name, used_bytes from sys.operations order by name limit 1;
+    +----------------+--------...-+---------+------------+
+    | sys.nodes.name | job_id     | name    | used_bytes |
+    +----------------+--------...-+---------+------------+
+    | crate          | ...        | collect | ...        |
+    +----------------+--------...-+---------+------------+
     SELECT 1 row in set (... sec)
 
 Logs

--- a/sql/src/main/java/io/crate/action/sql/TransportBaseSQLAction.java
+++ b/sql/src/main/java/io/crate/action/sql/TransportBaseSQLAction.java
@@ -287,6 +287,8 @@ public abstract class TransportBaseSQLAction<TRequest extends SQLBaseRequest, TR
              * Here we unwrap it to get the original exception.
              */
             return e.getCause();
+        } else if (e instanceof org.elasticsearch.common.breaker.CircuitBreakingException) {
+            return new CircuitBreakingException(e.getMessage());
         }
         return e;
     }

--- a/sql/src/main/java/io/crate/breaker/BytesRefSizeEstimator.java
+++ b/sql/src/main/java/io/crate/breaker/BytesRefSizeEstimator.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.breaker;
+
+import org.apache.lucene.util.BytesRef;
+
+import javax.annotation.Nullable;
+
+public class BytesRefSizeEstimator extends SizeEstimator<BytesRef> {
+    @Override
+    public long estimateSize(@Nullable BytesRef value) {
+        if (value == null) {
+            return 8;
+        }
+        long bytes = value.length;
+        // 64 bytes for miscellaneous overhead
+        bytes += 64;
+        return bytes;
+    }
+}

--- a/sql/src/main/java/io/crate/breaker/CircuitBreakerModule.java
+++ b/sql/src/main/java/io/crate/breaker/CircuitBreakerModule.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.breaker;
+
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.inject.AbstractModule;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
+
+public class CircuitBreakerModule extends AbstractModule {
+
+    public static final String QUERY_CIRCUIT_BREAKER_LIMIT_SETTING = "crate.breaker.query.limit";
+    public static final String QUERY_CIRCUIT_BREAKER_OVERHEAD_SETTING = "crate.breaker.query.overhead";
+    public static final String DEFAULT_CIRCUIT_BREAKER_LIMIT = "60%";
+    public static final double DEFAULT_CIRCUIT_BREAKER_OVERHEAD_CONSTANT = 1.03;
+
+
+    private final Settings settings;
+
+    public CircuitBreakerModule(Settings settings) {
+        this.settings = settings;
+    }
+
+    @Override
+    protected void configure() {
+        ByteSizeValue memoryLimit = settings.getAsMemory(
+                QUERY_CIRCUIT_BREAKER_LIMIT_SETTING,
+                DEFAULT_CIRCUIT_BREAKER_LIMIT);
+        double overhead = settings.getAsDouble(
+                QUERY_CIRCUIT_BREAKER_OVERHEAD_SETTING,
+                DEFAULT_CIRCUIT_BREAKER_OVERHEAD_CONSTANT);
+
+        ESLogger logger = Loggers.getLogger(QueryOperationCircuitBreaker.class);
+
+        bind(CircuitBreaker.class).annotatedWith(QueryOperationCircuitBreaker.class)
+                .toInstance(new MemoryCircuitBreaker(memoryLimit, overhead, logger));
+    }
+}

--- a/sql/src/main/java/io/crate/breaker/ConstSizeEstimator.java
+++ b/sql/src/main/java/io/crate/breaker/ConstSizeEstimator.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.breaker;
+
+import javax.annotation.Nullable;
+
+public class ConstSizeEstimator extends SizeEstimator<Object> {
+
+    private final long size;
+
+    public ConstSizeEstimator(long size) {
+        this.size = size;
+    }
+
+    @Override
+    public long estimateSize(@Nullable Object value) {
+        if (value == null) {
+            return 8;
+        }
+        return size;
+    }
+
+    @Override
+    public long estimateSize(@Nullable Object oldValue, @Nullable Object newValue) {
+        return estimateSize(newValue);
+    }
+}

--- a/sql/src/main/java/io/crate/breaker/MemoryCircuitBreaker.java
+++ b/sql/src/main/java/io/crate/breaker/MemoryCircuitBreaker.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.breaker;
+
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.unit.ByteSizeValue;
+
+public class MemoryCircuitBreaker extends org.elasticsearch.common.breaker.MemoryCircuitBreaker {
+
+    private final ESLogger logger;
+
+    public MemoryCircuitBreaker(ByteSizeValue limit, double overheadConstant, ESLogger logger) {
+        super(limit, overheadConstant, logger);
+        this.logger = logger;
+    }
+
+    @Override
+    public void circuitBreak(String label, long bytesNeeded) throws CircuitBreakingException {
+        try {
+            super.circuitBreak(label, bytesNeeded);
+        } catch (CircuitBreakingException e) {
+            final String message = "Too much HEAP memory used by [" + label + "], usage would be larger than limit of [" +
+                    getLimit() + "/" + new ByteSizeValue(getLimit()) + "]";
+            logger.debug(message);
+            throw new CircuitBreakingException(message);
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/breaker/QueryOperationCircuitBreaker.java
+++ b/sql/src/main/java/io/crate/breaker/QueryOperationCircuitBreaker.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.breaker;
+
+import org.elasticsearch.common.inject.BindingAnnotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@BindingAnnotation
+@Target({FIELD, PARAMETER})
+@Retention(RUNTIME)
+@Documented
+public @interface QueryOperationCircuitBreaker {
+}

--- a/sql/src/main/java/io/crate/breaker/RamAccountingContext.java
+++ b/sql/src/main/java/io/crate/breaker/RamAccountingContext.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.breaker;
+
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+public class RamAccountingContext {
+
+    // Flush every 5mb
+    public static long FLUSH_BUFFER_SIZE = 1024 * 1024 * 5;
+
+    private final String contextId;
+    private final CircuitBreaker breaker;
+
+    private final AtomicLong totalBytes = new AtomicLong(0);
+    private final AtomicLong flushBuffer = new AtomicLong(0);
+    private volatile boolean closed = false;
+    private volatile boolean tripped = false;
+
+    public RamAccountingContext(String contextId, CircuitBreaker breaker) {
+        this.contextId = contextId;
+        this.breaker = breaker;
+    }
+
+    /**
+     * Add bytes to the context and maybe break
+     *
+     * @param bytes bytes to be added to
+     * @throws CircuitBreakingException
+     */
+    public void addBytes(long bytes) throws CircuitBreakingException {
+        if (closed) {
+            return;
+        }
+        if (bytes == 0) {
+            return;
+        }
+        long currentFlushBuffer = flushBuffer.addAndGet(bytes);
+        if (currentFlushBuffer >= FLUSH_BUFFER_SIZE) {
+            flush(currentFlushBuffer);
+        }
+    }
+
+    /**
+     * Flush the {@code bytes} to the breaker, incrementing the total
+     * bytes and adjusting the buffer.
+
+     * @param bytes long value of bytes to be flushed to the breaker
+     * @throws CircuitBreakingException
+     */
+    private void flush(long bytes) throws CircuitBreakingException {
+        if (bytes == 0) {
+            return;
+        }
+        try {
+            breaker.addEstimateBytesAndMaybeBreak(bytes, contextId);
+        } catch (CircuitBreakingException e) {
+            // since we've already created the data, we need to
+            // add it so closing the context re-adjusts properly
+            breaker.addWithoutBreaking(bytes);
+            tripped = true;
+            // re-throw the original exception
+            throw e;
+        }
+        totalBytes.addAndGet(bytes);
+        flushBuffer.addAndGet(-bytes);
+    }
+
+    /**
+     * @return the total number of bytes that have been aggregated
+     */
+    public long totalBytes() {
+        return totalBytes.get();
+    }
+
+    /**
+     * Close the context and adjust the breaker.
+     * A remaining flush buffer will not be flushed to avoid breaking on close.
+     * (all ram operations expected to be finished at this point)
+     */
+    public void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        if (totalBytes.get() != 0) {
+            breaker.addWithoutBreaking(-totalBytes.get());
+        }
+        totalBytes.addAndGet(flushBuffer.getAndSet(0));
+    }
+
+    public boolean trippedBreaker() {
+        return tripped;
+    }
+}

--- a/sql/src/main/java/io/crate/breaker/SizeEstimator.java
+++ b/sql/src/main/java/io/crate/breaker/SizeEstimator.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.breaker;
+
+import javax.annotation.Nullable;
+
+public abstract class SizeEstimator<T> {
+    public abstract long estimateSize(@Nullable T value);
+
+    public long estimateSize(@Nullable T oldValue, @Nullable T newValue) {
+        return estimateSize(newValue) - estimateSize(oldValue);
+    }
+}

--- a/sql/src/main/java/io/crate/breaker/SizeEstimatorFactory.java
+++ b/sql/src/main/java/io/crate/breaker/SizeEstimatorFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.breaker;
+
+import io.crate.types.*;
+
+public class SizeEstimatorFactory {
+
+    public static <T> SizeEstimator<T> create(DataType type) {
+        switch (type.id()) {
+            case StringType.ID:
+            case IpType.ID:
+                return (SizeEstimator<T>)new BytesRefSizeEstimator();
+            case GeoPointType.ID:
+                return (SizeEstimator<T>)new ConstSizeEstimator(16);
+            default:
+                return (SizeEstimator<T>)new ConstSizeEstimator(8);
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/exceptions/CircuitBreakingException.java
+++ b/sql/src/main/java/io/crate/exceptions/CircuitBreakingException.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.exceptions;
+
+public class CircuitBreakingException extends UnhandledServerException {
+
+    public CircuitBreakingException(String message) {
+        super(message);
+    }
+
+    @Override
+    public int errorCode() {
+        return 0;
+    }
+}

--- a/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/ESGetTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/ESGetTask.java
@@ -162,7 +162,8 @@ public class ESGetTask implements Task<QueryResult> {
             topNProjection.outputs(genInputColumns(node.outputs().size()));
             projectorChain = new FlatProjectorChain(
                     Arrays.<Projection>asList(topNProjection),
-                    projectionToProjectorVisitor
+                    projectionToProjectorVisitor,
+                    null
             );
         }
         return projectorChain;

--- a/sql/src/main/java/io/crate/metadata/sys/SysOperationsLogTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysOperationsLogTableInfo.java
@@ -36,10 +36,12 @@ import java.util.*;
 public class SysOperationsLogTableInfo extends SysTableInfo {
 
     public static class ColumnNames {
+        public static final String ID = "id";
         public static final String JOB_ID = "job_id";
         public static final String NAME = "name";
         public static final String STARTED = "started";
         public static final String ENDED = "ended";
+        public static final String USED_BYTES = "used_bytes";
         public static final String ERROR = "error";
     }
 
@@ -57,10 +59,12 @@ public class SysOperationsLogTableInfo extends SysTableInfo {
     }
 
     static {
+        register(ColumnNames.ID, DataTypes.STRING);
         register(ColumnNames.JOB_ID, DataTypes.STRING);
         register(ColumnNames.NAME, DataTypes.STRING);
         register(ColumnNames.STARTED, DataTypes.TIMESTAMP);
         register(ColumnNames.ENDED, DataTypes.TIMESTAMP);
+        register(ColumnNames.USED_BYTES, DataTypes.LONG);
         register(ColumnNames.ERROR, DataTypes.STRING);
     }
 

--- a/sql/src/main/java/io/crate/metadata/sys/SysOperationsTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysOperationsTableInfo.java
@@ -36,9 +36,11 @@ import java.util.*;
 public class SysOperationsTableInfo extends SysTableInfo {
 
     public static class ColumnNames {
+        public final static String ID = "id";
         public final static String JOB_ID = "job_id";
         public final static String NAME = "name";
         public final static String STARTED = "started";
+        public final static String USED_BYTES = "used_bytes";
     }
 
     public static final TableIdent IDENT = new TableIdent(SCHEMA, "operations");
@@ -55,9 +57,11 @@ public class SysOperationsTableInfo extends SysTableInfo {
     }
 
     static {
+        register(ColumnNames.ID, DataTypes.STRING);
         register(ColumnNames.JOB_ID, DataTypes.STRING);
         register(ColumnNames.NAME, DataTypes.STRING);
         register(ColumnNames.STARTED, DataTypes.TIMESTAMP);
+        register(ColumnNames.USED_BYTES, DataTypes.LONG);
     }
 
     @Inject

--- a/sql/src/main/java/io/crate/operation/DownstreamOperationFactory.java
+++ b/sql/src/main/java/io/crate/operation/DownstreamOperationFactory.java
@@ -21,9 +21,10 @@
 
 package io.crate.operation;
 
+import io.crate.breaker.RamAccountingContext;
 import io.crate.planner.node.dql.AbstractDQLPlanNode;
 
 public interface DownstreamOperationFactory<TPlanNode extends AbstractDQLPlanNode> {
 
-    public DownstreamOperation create(TPlanNode node);
+    public DownstreamOperation create(TPlanNode node, RamAccountingContext ramAccountingContext);
 }

--- a/sql/src/main/java/io/crate/operation/aggregation/AggregationCollector.java
+++ b/sql/src/main/java/io/crate/operation/aggregation/AggregationCollector.java
@@ -21,6 +21,7 @@
 
 package io.crate.operation.aggregation;
 
+import io.crate.breaker.RamAccountingContext;
 import io.crate.operation.Input;
 import io.crate.operation.collect.RowCollector;
 import io.crate.planner.symbol.Aggregation;
@@ -72,8 +73,8 @@ public class AggregationCollector implements RowCollector {
     }
 
 
-    public boolean startCollect() {
-        aggregationState = fromImpl.startCollect();
+    public boolean startCollect(RamAccountingContext ramAccountingContext) {
+        aggregationState = fromImpl.startCollect(ramAccountingContext);
         return true;
     }
 
@@ -96,8 +97,8 @@ public class AggregationCollector implements RowCollector {
 
     abstract class FromImpl {
 
-        public AggregationState startCollect() {
-            return aggregationFunction.newState();
+        public AggregationState startCollect(RamAccountingContext ramAccountingContext) {
+            return aggregationFunction.newState(ramAccountingContext);
         }
 
         public abstract boolean processRow();

--- a/sql/src/main/java/io/crate/operation/aggregation/AggregationFunction.java
+++ b/sql/src/main/java/io/crate/operation/aggregation/AggregationFunction.java
@@ -21,13 +21,14 @@
 
 package io.crate.operation.aggregation;
 
+import io.crate.breaker.RamAccountingContext;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.operation.Input;
 import io.crate.planner.symbol.Function;
 import io.crate.planner.symbol.Symbol;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
 
 public abstract class AggregationFunction<T extends AggregationState> implements FunctionImplementation<Function> {
-
 
     /**
      * Apply the columnValue to the argument AggState using the logic in this AggFunction
@@ -36,7 +37,7 @@ public abstract class AggregationFunction<T extends AggregationState> implements
      * @param args  the arguments according to FunctionInfo.argumentTypes
      * @return false if we do not need any further iteration for this state
      */
-    public abstract boolean iterate(T state, Input... args);
+    public abstract boolean iterate(T state, Input... args)  throws CircuitBreakingException;
 
 
     /**
@@ -44,11 +45,12 @@ public abstract class AggregationFunction<T extends AggregationState> implements
      *
      * @return a new state instance
      */
-    public abstract T newState();
+    public abstract T newState(RamAccountingContext ramAccountingContext);
 
 
     @Override
     public Symbol normalizeSymbol(Function symbol) {
         return symbol;
     }
+
 }

--- a/sql/src/main/java/io/crate/operation/aggregation/VariableSizeAggregationState.java
+++ b/sql/src/main/java/io/crate/operation/aggregation/VariableSizeAggregationState.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.operation.aggregation;
+
+import io.crate.breaker.RamAccountingContext;
+import io.crate.breaker.SizeEstimator;
+
+public abstract class VariableSizeAggregationState<T extends AggregationState> extends AggregationState<T> {
+
+    protected final SizeEstimator sizeEstimator;
+
+    public VariableSizeAggregationState(
+            RamAccountingContext ramAccountingContext,
+            SizeEstimator sizeEstimator) {
+        super(ramAccountingContext);
+        this.sizeEstimator = sizeEstimator;
+    }
+}

--- a/sql/src/main/java/io/crate/operation/aggregation/impl/CountAggregation.java
+++ b/sql/src/main/java/io/crate/operation/aggregation/impl/CountAggregation.java
@@ -22,6 +22,7 @@
 package io.crate.operation.aggregation.impl;
 
 import com.google.common.collect.ImmutableList;
+import io.crate.breaker.RamAccountingContext;
 import io.crate.metadata.DynamicFunctionResolver;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
@@ -63,9 +64,7 @@ public class CountAggregation extends AggregationFunction<CountAggregation.Count
             } else {
                 return new CountAggregation(
                         new FunctionInfo(new FunctionIdent(NAME, dataTypes),
-                                DataTypes.LONG, FunctionInfo.Type.AGGREGATE),
-                        true
-                );
+                                DataTypes.LONG, FunctionInfo.Type.AGGREGATE), true);
             }
         }
     }
@@ -78,6 +77,12 @@ public class CountAggregation extends AggregationFunction<CountAggregation.Count
     public static class CountAggState extends AggregationState<CountAggState> {
 
         public long value = 0;
+
+        public CountAggState(RamAccountingContext ramAccountingContext) {
+            super(ramAccountingContext);
+            // long value
+            ramAccountingContext.addBytes(8);
+        }
 
         @Override
         public Object value() {
@@ -119,8 +124,8 @@ public class CountAggregation extends AggregationFunction<CountAggregation.Count
     }
 
     @Override
-    public CountAggState newState() {
-        return new CountAggState();
+    public CountAggState newState(RamAccountingContext ramAccountingContext) {
+        return new CountAggState(ramAccountingContext);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/operation/aggregation/impl/SumAggregation.java
+++ b/sql/src/main/java/io/crate/operation/aggregation/impl/SumAggregation.java
@@ -22,6 +22,7 @@
 package io.crate.operation.aggregation.impl;
 
 import com.google.common.collect.ImmutableList;
+import io.crate.breaker.RamAccountingContext;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
 import io.crate.operation.Input;
@@ -54,6 +55,11 @@ public class SumAggregation extends AggregationFunction<SumAggregation.SumAggSta
     public static class SumAggState extends AggregationState<SumAggState> {
 
         private Double value = null; // sum that aggregates nothing returns null, not 0.0
+
+        public SumAggState(RamAccountingContext ramAccountingContext) {
+            super(ramAccountingContext);
+            ramAccountingContext.addBytes(8);
+        }
 
         @Override
         public Object value() {
@@ -105,8 +111,8 @@ public class SumAggregation extends AggregationFunction<SumAggregation.SumAggSta
     }
 
     @Override
-    public SumAggState newState() {
-        return new SumAggState();
+    public SumAggState newState(RamAccountingContext ramAccountingContext) {
+        return new SumAggState(ramAccountingContext);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/operation/collect/AbstractRowCollector.java
+++ b/sql/src/main/java/io/crate/operation/collect/AbstractRowCollector.java
@@ -21,9 +21,11 @@
 
 package io.crate.operation.collect;
 
+import io.crate.breaker.RamAccountingContext;
+
 public abstract class AbstractRowCollector<T> implements RowCollector<T> {
-    public T collect() {
-        if (startCollect()) {
+    public T collect(RamAccountingContext ramAccountingContext) {
+        if (startCollect(ramAccountingContext)) {
             boolean carryOn;
             do {
                 carryOn = processRow();

--- a/sql/src/main/java/io/crate/operation/collect/CollectOperation.java
+++ b/sql/src/main/java/io/crate/operation/collect/CollectOperation.java
@@ -22,8 +22,9 @@
 package io.crate.operation.collect;
 
 import com.google.common.util.concurrent.ListenableFuture;
+import io.crate.breaker.RamAccountingContext;
 import io.crate.planner.node.dql.CollectNode;
 
 public interface CollectOperation<T> {
-    public ListenableFuture<T> collect(CollectNode collectNode);
+    public ListenableFuture<T> collect(CollectNode collectNode, RamAccountingContext ramAccountingContext);
 }

--- a/sql/src/main/java/io/crate/operation/collect/CollectionAbortedException.java
+++ b/sql/src/main/java/io/crate/operation/collect/CollectionAbortedException.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.operation.collect;
+
+import java.io.IOException;
+
+/**
+ * Throw this exception inside a {@link org.apache.lucene.search.Collector#collect} in order to
+ * abort the collection. Throwing a {@link org.apache.lucene.search.CollectionTerminatedException}
+ * will cause the IndexSearcher to stop collecting the current leaf (segment) but continuing with
+ * the next leaf (segment).
+ */
+public class CollectionAbortedException extends IOException {
+}

--- a/sql/src/main/java/io/crate/operation/collect/CrateCollector.java
+++ b/sql/src/main/java/io/crate/operation/collect/CrateCollector.java
@@ -21,6 +21,7 @@
 
 package io.crate.operation.collect;
 
+import io.crate.breaker.RamAccountingContext;
 import io.crate.operation.ProjectorUpstream;
 import io.crate.operation.projectors.Projector;
 
@@ -28,7 +29,7 @@ public interface CrateCollector extends ProjectorUpstream {
 
     public static final CrateCollector NOOP = new CrateCollector() {
         @Override
-        public void doCollect() {
+        public void doCollect(RamAccountingContext ramAccountingContext) {
         }
 
         @Override
@@ -42,5 +43,5 @@ public interface CrateCollector extends ProjectorUpstream {
         }
     };
 
-    public void doCollect() throws Exception;
+    public void doCollect(RamAccountingContext ramAccountingContext) throws Exception;
 }

--- a/sql/src/main/java/io/crate/operation/collect/RowCollector.java
+++ b/sql/src/main/java/io/crate/operation/collect/RowCollector.java
@@ -21,6 +21,8 @@
 
 package io.crate.operation.collect;
 
+import io.crate.breaker.RamAccountingContext;
+
 public interface RowCollector<T> {
 
     /**
@@ -28,7 +30,7 @@ public interface RowCollector<T> {
      *
      * @return false if no colletion is needed
      */
-    public boolean startCollect();
+    public boolean startCollect(RamAccountingContext ramAccountingContext);
 
     /**
      * Tells the collector to process the current row

--- a/sql/src/main/java/io/crate/operation/collect/SimpleOneRowCollector.java
+++ b/sql/src/main/java/io/crate/operation/collect/SimpleOneRowCollector.java
@@ -21,9 +21,11 @@
 
 package io.crate.operation.collect;
 
+import io.crate.breaker.RamAccountingContext;
 import io.crate.operation.Input;
 import io.crate.operation.projectors.Projector;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 
@@ -47,7 +49,7 @@ public class SimpleOneRowCollector extends AbstractRowCollector<Object[]> implem
     }
 
     @Override
-    public boolean startCollect() {
+    public boolean startCollect(RamAccountingContext ramAccountingContext) {
         for (CollectExpression<?> collectExpression : collectExpressions) {
             collectExpression.startCollect();
         }
@@ -73,8 +75,8 @@ public class SimpleOneRowCollector extends AbstractRowCollector<Object[]> implem
     }
 
     @Override
-    public void doCollect() {
-        collect();
+    public void doCollect(RamAccountingContext ramAccountingContext) throws IOException {
+        collect(ramAccountingContext);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/operation/collect/StatsTables.java
+++ b/sql/src/main/java/io/crate/operation/collect/StatsTables.java
@@ -153,11 +153,11 @@ public class StatsTables {
         if (isEnabled()) {
             operationsTable.put(
                     operationId,
-                    new OperationContext(jobId, name, System.currentTimeMillis()));
+                    new OperationContext(operationId, jobId, name, System.currentTimeMillis()));
         }
     }
 
-    public void operationFinished(@Nullable UUID operationId, @Nullable String errorMessage) {
+    public void operationFinished(@Nullable UUID operationId, @Nullable String errorMessage, @Nullable long usedBytes) {
         if (operationId == null || !isEnabled()) {
             return;
         }
@@ -167,6 +167,7 @@ public class StatsTables {
             // been enabled before the finish
             return;
         }
+        operationContext.usedBytes = usedBytes;
         BlockingQueue<OperationContextLog> operationContextLogs = operationsLog.get();
         operationContextLogs.offer(new OperationContextLog(operationContext, errorMessage));
     }

--- a/sql/src/main/java/io/crate/operation/collect/UnexpectedCollectionTerminatedException.java
+++ b/sql/src/main/java/io/crate/operation/collect/UnexpectedCollectionTerminatedException.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.operation.collect;
+
+import java.io.IOException;
+
+public class UnexpectedCollectionTerminatedException extends IOException {
+
+    public UnexpectedCollectionTerminatedException(String message) {
+        super(message);
+    }
+}

--- a/sql/src/main/java/io/crate/operation/collect/blobs/BlobDocCollector.java
+++ b/sql/src/main/java/io/crate/operation/collect/blobs/BlobDocCollector.java
@@ -23,6 +23,7 @@ package io.crate.operation.collect.blobs;
 
 import io.crate.blob.BlobContainer;
 import io.crate.blob.v2.BlobShard;
+import io.crate.breaker.RamAccountingContext;
 import io.crate.operation.Input;
 import io.crate.operation.collect.CrateCollector;
 import io.crate.operation.projectors.Projector;
@@ -53,7 +54,7 @@ public class BlobDocCollector implements CrateCollector {
     }
 
     @Override
-    public void doCollect() throws Exception {
+    public void doCollect(RamAccountingContext ramAccountingContext) throws Exception {
         BlobContainer.FileVisitor fileVisitor = new FileListingsFileVisitor();
         try {
             blobShard.blobContainer().walkFiles(null, fileVisitor);

--- a/sql/src/main/java/io/crate/operation/collect/files/FileReadingCollector.java
+++ b/sql/src/main/java/io/crate/operation/collect/files/FileReadingCollector.java
@@ -26,10 +26,11 @@ import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.crate.breaker.RamAccountingContext;
 import io.crate.operation.Input;
+import io.crate.operation.collect.CollectionAbortedException;
 import io.crate.operation.collect.CrateCollector;
 import io.crate.operation.projectors.Projector;
-import org.apache.lucene.search.CollectionTerminatedException;
 
 import javax.annotation.Nullable;
 import java.io.BufferedReader;
@@ -140,7 +141,7 @@ public class FileReadingCollector implements CrateCollector {
     }
 
     @Override
-    public void doCollect() throws IOException, CollectionTerminatedException {
+    public void doCollect(RamAccountingContext ramAccountingContext) throws IOException {
         FileInput fileInput = getFileInput();
         if (fileInput == null) {
             if (downstream != null) {
@@ -179,7 +180,7 @@ public class FileReadingCollector implements CrateCollector {
                             newRow[i++] = input.value();
                         }
                         if (!downstream.setNextRow(newRow)) {
-                            throw new CollectionTerminatedException();
+                            throw new CollectionAbortedException();
                         }
                     }
                 } finally {

--- a/sql/src/main/java/io/crate/operation/merge/MergeOperation.java
+++ b/sql/src/main/java/io/crate/operation/merge/MergeOperation.java
@@ -22,6 +22,7 @@
 package io.crate.operation.merge;
 
 import com.google.common.util.concurrent.ListenableFuture;
+import io.crate.breaker.RamAccountingContext;
 import io.crate.executor.transport.TransportActionProvider;
 import io.crate.operation.DownstreamOperation;
 import io.crate.operation.ImplementationSymbolVisitor;
@@ -48,13 +49,15 @@ public class MergeOperation implements DownstreamOperation {
     public MergeOperation(ClusterService clusterService,
                           Settings settings,
                           TransportActionProvider transportActionProvider,
-                          ImplementationSymbolVisitor symbolVisitor, MergeNode mergeNode) {
+                          ImplementationSymbolVisitor symbolVisitor, MergeNode mergeNode,
+                          RamAccountingContext ramAccountingContext) {
         projectorChain = new FlatProjectorChain(mergeNode.projections(),
                 new ProjectionToProjectorVisitor(
                         clusterService,
                         settings,
                         transportActionProvider,
-                        symbolVisitor)
+                        symbolVisitor),
+                ramAccountingContext
         );
         downstream(projectorChain.firstProjector());
         this.numUpstreams = mergeNode.numUpstreams();

--- a/sql/src/main/java/io/crate/operation/projectors/AggregationProjector.java
+++ b/sql/src/main/java/io/crate/operation/projectors/AggregationProjector.java
@@ -21,6 +21,7 @@
 
 package io.crate.operation.projectors;
 
+import io.crate.breaker.RamAccountingContext;
 import io.crate.operation.AggregationContext;
 import io.crate.operation.ProjectorUpstream;
 import io.crate.operation.aggregation.AggregationCollector;
@@ -40,7 +41,8 @@ public class AggregationProjector implements Projector {
     private final AtomicReference<Throwable> upstreamFailure = new AtomicReference<>(null);
 
     public AggregationProjector(Set<CollectExpression<?>> collectExpressions,
-                                AggregationContext[] aggregations) {
+                                AggregationContext[] aggregations,
+                                RamAccountingContext ramAccountingContext) {
 
         row = new Object[aggregations.length];
         this.collectExpressions = collectExpressions;
@@ -53,7 +55,7 @@ public class AggregationProjector implements Projector {
             );
             // startCollect creates the aggregationState. In case of the AggregationProjector
             // we only want to have 1 global state not 1 state per node/shard or even document.
-            aggregationCollectors[i].startCollect();
+            aggregationCollectors[i].startCollect(ramAccountingContext);
         }
     }
 

--- a/sql/src/main/java/io/crate/operation/projectors/FlatProjectorChain.java
+++ b/sql/src/main/java/io/crate/operation/projectors/FlatProjectorChain.java
@@ -23,6 +23,7 @@ package io.crate.operation.projectors;
 
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.ListenableFuture;
+import io.crate.breaker.RamAccountingContext;
 import io.crate.planner.projection.Projection;
 
 import java.util.ArrayList;
@@ -48,7 +49,9 @@ public class FlatProjectorChain {
     private final List<Projector> projectors;
     private ResultProvider lastProjector;
 
-    public FlatProjectorChain(List<Projection> projections, ProjectionToProjectorVisitor projectorVisitor) {
+    public FlatProjectorChain(List<Projection> projections,
+                              ProjectionToProjectorVisitor projectorVisitor,
+                              RamAccountingContext ramAccountingContext) {
         projectors = new ArrayList<>();
         if (projections.size() == 0) {
             firstProjector = new CollectingProjector();
@@ -57,7 +60,7 @@ public class FlatProjectorChain {
         } else {
             Projector previousProjector = null;
             for (Projection projection : projections) {
-                Projector projector = projectorVisitor.process(projection);
+                Projector projector = projectorVisitor.process(projection, ramAccountingContext);
                 projectors.add(projector);
                 if (previousProjector != null) {
                     previousProjector.downstream(projector);

--- a/sql/src/main/java/io/crate/operation/reference/sys/operation/OperationContext.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/operation/OperationContext.java
@@ -25,11 +25,14 @@ import java.util.UUID;
 
 public class OperationContext {
 
+    public UUID id;
     public UUID jobId;
     public String name;
     public long started;
+    public long usedBytes;
 
-    public OperationContext(UUID jobId, String name, long started) {
+    public OperationContext(UUID id, UUID jobId, String name, long started) {
+        this.id = id;
         this.jobId = jobId;
         this.name = name;
         this.started = started;

--- a/sql/src/main/java/io/crate/operation/reference/sys/operation/OperationContextLog.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/operation/OperationContextLog.java
@@ -37,6 +37,10 @@ public class OperationContextLog {
         this.ended = System.currentTimeMillis();
     }
 
+    public UUID id() {
+        return operationContext.id;
+    }
+
     public UUID jobId() {
         return operationContext.jobId;
     }
@@ -51,6 +55,10 @@ public class OperationContextLog {
 
     public long ended() {
         return ended;
+    }
+
+    public long usedBytes() {
+        return  operationContext.usedBytes;
     }
 
     @Nullable

--- a/sql/src/main/java/io/crate/operation/reference/sys/operation/SysOperationExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/operation/SysOperationExpression.java
@@ -31,6 +31,12 @@ public abstract class SysOperationExpression<T> extends RowContextCollectorExpre
 
     public static final ImmutableList<SysOperationExpression<?>> IMPLEMENTATIONS =
             ImmutableList.<SysOperationExpression<?>>builder()
+            .add(new SysOperationExpression<BytesRef>(SysOperationsTableInfo.ColumnNames.ID) {
+                @Override
+                public BytesRef value() {
+                    return new BytesRef(row.id.toString());
+                }
+            })
             .add(new SysOperationExpression<BytesRef>(SysOperationsTableInfo.ColumnNames.JOB_ID) {
                 @Override
                 public BytesRef value() {
@@ -47,6 +53,15 @@ public abstract class SysOperationExpression<T> extends RowContextCollectorExpre
                 @Override
                 public Long value() {
                     return row.started;
+                }
+            })
+            .add(new SysOperationExpression<Long>(SysOperationsTableInfo.ColumnNames.USED_BYTES) {
+                @Override
+                public Long value() {
+                    if (row.usedBytes == 0) {
+                        return null;
+                    }
+                    return row.usedBytes;
                 }
             }).build();
 

--- a/sql/src/main/java/io/crate/operation/reference/sys/operation/SysOperationLogExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/operation/SysOperationLogExpression.java
@@ -31,6 +31,12 @@ public abstract class SysOperationLogExpression<T> extends RowContextCollectorEx
 
     public static final ImmutableList<SysOperationLogExpression<?>> IMPLEMENTATIONS =
             ImmutableList.<SysOperationLogExpression<?>>builder()
+            .add(new SysOperationLogExpression<BytesRef>(SysOperationsLogTableInfo.ColumnNames.ID) {
+                @Override
+                public BytesRef value() {
+                    return new BytesRef(row.id().toString());
+                }
+            })
             .add(new SysOperationLogExpression<BytesRef>(SysOperationsLogTableInfo.ColumnNames.JOB_ID) {
                 @Override
                 public BytesRef value() {
@@ -53,6 +59,15 @@ public abstract class SysOperationLogExpression<T> extends RowContextCollectorEx
                 @Override
                 public Long value() {
                     return row.ended();
+                }
+            })
+            .add(new SysOperationLogExpression<Long>(SysOperationsLogTableInfo.ColumnNames.USED_BYTES) {
+                @Override
+                public Long value() {
+                    if (row.usedBytes() == 0) {
+                        return null;
+                    }
+                    return row.usedBytes();
                 }
             })
             .add(new SysOperationLogExpression<BytesRef>(SysOperationsLogTableInfo.ColumnNames.ERROR) {

--- a/sql/src/main/java/io/crate/planner/node/AggregationStateStreamer.java
+++ b/sql/src/main/java/io/crate/planner/node/AggregationStateStreamer.java
@@ -21,9 +21,10 @@
 
 package io.crate.planner.node;
 
+import io.crate.Streamer;
+import io.crate.breaker.RamAccountingContext;
 import io.crate.operation.aggregation.AggregationFunction;
 import io.crate.operation.aggregation.AggregationState;
-import io.crate.Streamer;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -35,14 +36,17 @@ import java.io.IOException;
 public class AggregationStateStreamer implements Streamer<AggregationState> {
 
     private final AggregationFunction aggregationFunction;
+    private final RamAccountingContext ramAccountingContext;
 
-    public AggregationStateStreamer(AggregationFunction aggregationFunction) {
+    public AggregationStateStreamer(AggregationFunction aggregationFunction,
+                                    RamAccountingContext ramAccountingContext) {
         this.aggregationFunction = aggregationFunction;
+        this.ramAccountingContext = ramAccountingContext;
     }
 
     @Override
     public AggregationState<?> readValueFrom(StreamInput in) throws IOException {
-        AggregationState<?> aggState = this.aggregationFunction.newState();
+        AggregationState<?> aggState = this.aggregationFunction.newState(ramAccountingContext);
         aggState.readFrom(in);
         return aggState;
     }

--- a/sql/src/main/java/io/crate/plugin/SQLPlugin.java
+++ b/sql/src/main/java/io/crate/plugin/SQLPlugin.java
@@ -27,6 +27,7 @@ import io.crate.action.sql.SQLAction;
 import io.crate.action.sql.SQLBulkAction;
 import io.crate.action.sql.TransportSQLAction;
 import io.crate.action.sql.TransportSQLBulkAction;
+import io.crate.breaker.CircuitBreakerModule;
 import io.crate.executor.transport.TransportExecutorModule;
 import io.crate.executor.transport.task.elasticsearch.facet.UpdateFacetParser;
 import io.crate.metadata.MetaDataModule;
@@ -110,6 +111,7 @@ public class SQLPlugin extends AbstractPlugin {
         if (!settings.getAsBoolean("node.client", false)) {
             modules.add(SQLModule.class);
 
+            modules.add(CircuitBreakerModule.class);
             modules.add(TransportExecutorModule.class);
             modules.add(CollectOperationModule.class);
             modules.add(MetaDataModule.class);

--- a/sql/src/test/java/io/crate/breaker/SizeEstimatorTest.java
+++ b/sql/src/test/java/io/crate/breaker/SizeEstimatorTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.breaker;
+
+import io.crate.types.DataTypes;
+import org.apache.lucene.util.BytesRef;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class SizeEstimatorTest {
+
+    @Test
+    public void testBytesRef() throws Exception {
+        SizeEstimator sizeEstimator = SizeEstimatorFactory.create(DataTypes.STRING);
+        assertThat(sizeEstimator.estimateSize(null), is(8L));
+        assertThat(sizeEstimator.estimateSize(new BytesRef("hello")), is(69L));
+        assertThat(sizeEstimator.estimateSize(new BytesRef("hello"), new BytesRef("hello world")), is(6L));
+    }
+
+    @Test
+    public void testConstant() throws Exception {
+        SizeEstimator sizeEstimator = SizeEstimatorFactory.create(DataTypes.BYTE);
+        assertThat(sizeEstimator.estimateSize(null), is(8L));
+        assertThat(sizeEstimator.estimateSize(new Byte("100")), is(8L));
+        assertThat(sizeEstimator.estimateSize(new Byte("100"), new Byte("42")), is(8L));
+    }
+
+    @Test
+    public void testGeoPoint() throws Exception {
+        SizeEstimator sizeEstimator = SizeEstimatorFactory.create(DataTypes.GEO_POINT);
+        assertThat(sizeEstimator.estimateSize(null), is(8L));
+        assertThat(sizeEstimator.estimateSize(new Double[]{1.0d, 2.0d}), is(16L));
+        assertThat(sizeEstimator.estimateSize(new Double[]{1.0d, 2.0d}, null), is(8L));
+    }
+
+}

--- a/sql/src/test/java/io/crate/integrationtests/GroupByAggregateBreakerTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/GroupByAggregateBreakerTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.integrationtests;
+
+import io.crate.action.sql.SQLActionException;
+import io.crate.breaker.CircuitBreakerModule;
+import io.crate.breaker.RamAccountingContext;
+import io.crate.test.integration.CrateIntegrationTest;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+@CrateIntegrationTest.ClusterScope(scope = CrateIntegrationTest.Scope.SUITE)
+public class GroupByAggregateBreakerTest extends SQLTransportIntegrationTest {
+
+    static {
+        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
+    }
+
+
+    private Setup setup = new Setup(sqlExecutor);
+    private boolean setUpDone = false;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        RamAccountingContext.FLUSH_BUFFER_SIZE = 24;
+        return ImmutableSettings.builder()
+                .put(CircuitBreakerModule.QUERY_CIRCUIT_BREAKER_LIMIT_SETTING, 512)
+                .build();
+    }
+
+    @Before
+    public void initTestData() {
+        if (!setUpDone) {
+            this.setup.setUpEmployees();
+            setUpDone = true;
+        }
+    }
+
+    @Test
+    public void selectGroupByWithBreaking() throws Exception {
+        expectedException.expect(SQLActionException.class);
+        expectedException.expectMessage(Matchers.startsWith("Too much HEAP memory used by [distributing collect:"));
+        execute("select name, department, max(income), min(age) from employees group by name, department order by 3");
+    }
+}

--- a/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -427,7 +427,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultColumns() throws Exception {
         execute("select * from information_schema.columns order by schema_name, table_name");
-        assertEquals(196L, response.rowCount());
+        assertEquals(200L, response.rowCount());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/TransportSQLActionClassLifecycleTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TransportSQLActionClassLifecycleTest.java
@@ -651,7 +651,7 @@ public class TransportSQLActionClassLifecycleTest extends ClassLifecycleIntegrat
 
         List<String> names = new ArrayList<>();
         for (Object[] objects : resp.rows()) {
-            names.add((String)objects[1]);
+            names.add((String)objects[2]);
         }
         assertTrue(names.contains("distributing collect"));
         assertTrue(names.contains("distributed merge"));

--- a/sql/src/test/java/io/crate/operation/aggregation/impl/ArbitraryAggregationTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/impl/ArbitraryAggregationTest.java
@@ -26,6 +26,7 @@ import io.crate.metadata.FunctionIdent;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+import org.apache.lucene.util.BytesRef;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.isOneOf;
@@ -86,7 +87,7 @@ public class ArbitraryAggregationTest extends AggregationTest {
 
     @Test
     public void testString() throws Exception {
-        Object[][] data = new Object[][]{{"Youri"}, {"Ruben"}};
+        Object[][] data = new Object[][]{{new BytesRef("Youri")}, {new BytesRef("Ruben")}};
         Object[][] result = executeAggregation(DataTypes.STRING, data);
 
         assertThat(result[0][0], isOneOf(data[0][0], data[1][0]));

--- a/sql/src/test/java/io/crate/operation/aggregation/impl/MaximumAggregationTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/impl/MaximumAggregationTest.java
@@ -26,6 +26,7 @@ import io.crate.metadata.FunctionIdent;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+import org.apache.lucene.util.BytesRef;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -79,9 +80,10 @@ public class MaximumAggregationTest extends AggregationTest {
 
     @Test
     public void testString() throws Exception {
-        Object[][] result = executeAggregation(DataTypes.STRING, new Object[][]{{"Youri"}, {"Ruben"}});
+        Object[][] result = executeAggregation(DataTypes.STRING,
+                new Object[][]{{new BytesRef("Youri")}, {new BytesRef("Ruben")}});
 
-        assertEquals("Youri", result[0][0]);
+        assertEquals(new BytesRef("Youri"), result[0][0]);
     }
 
     @Test(expected = NullPointerException.class)

--- a/sql/src/test/java/io/crate/operation/aggregation/impl/MinimumAggregationTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/impl/MinimumAggregationTest.java
@@ -26,6 +26,7 @@ import io.crate.metadata.FunctionIdent;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+import org.apache.lucene.util.BytesRef;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -79,9 +80,10 @@ public class MinimumAggregationTest extends AggregationTest {
 
     @Test
     public void testString() throws Exception {
-        Object[][] result = executeAggregation(DataTypes.STRING, new Object[][]{{"Youri"}, {"Ruben"}});
+        Object[][] result = executeAggregation(DataTypes.STRING,
+                new Object[][]{{new BytesRef("Youri")}, {new BytesRef("Ruben")}});
 
-        assertEquals("Ruben", result[0][0]);
+        assertEquals(new BytesRef("Ruben"), result[0][0]);
     }
 
     @Test(expected = NullPointerException.class)

--- a/sql/src/test/java/io/crate/operation/collect/DocLevelCollectTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/DocLevelCollectTest.java
@@ -139,7 +139,7 @@ public class DocLevelCollectTest extends SQLTransportIntegrationTest {
         collectNode.toCollect(Arrays.<Symbol>asList(testDocLevelReference, underscoreRawReference, underscoreIdReference));
         collectNode.maxRowGranularity(RowGranularity.DOC);
 
-        Object[][] result = operation.collect(collectNode).get();
+        Object[][] result = operation.collect(collectNode, null).get();
         assertThat(result.length, is(2));
 
         assertThat(result[0].length, is(3));
@@ -165,7 +165,7 @@ public class DocLevelCollectTest extends SQLTransportIntegrationTest {
                 Arrays.<Symbol>asList(testDocLevelReference, Literal.newLiteral(2)))
         ));
 
-        Object[][] result = operation.collect(collectNode).get();
+        Object[][] result = operation.collect(collectNode, null).get();
         assertThat(result.length, is(1));
         assertThat(result[0].length, is(1));
         assertThat((Integer) result[0][0], is(2));
@@ -185,7 +185,7 @@ public class DocLevelCollectTest extends SQLTransportIntegrationTest {
         ));
         collectNode.maxRowGranularity(RowGranularity.DOC);
 
-        Object[][] result = operation.collect(collectNode).get();
+        Object[][] result = operation.collect(collectNode, null).get();
 
         assertThat(result.length, is(2));
         assertThat(result[0].length, is(4));
@@ -218,7 +218,7 @@ public class DocLevelCollectTest extends SQLTransportIntegrationTest {
         collectNode.maxRowGranularity(RowGranularity.DOC);
         collectNode.isPartitioned(true);
 
-        Object[][] result = operation.collect(collectNode).get();
+        Object[][] result = operation.collect(collectNode, null).get();
         assertThat(result.length, is(2));
         assertThat((Integer)result[0][0], isOneOf(1,2));
         assertThat((Integer)result[1][0], isOneOf(1,2));

--- a/sql/src/test/java/io/crate/operation/collect/HandlerSideLevelCollectTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/HandlerSideLevelCollectTest.java
@@ -73,7 +73,7 @@ public class HandlerSideLevelCollectTest extends SQLTransportIntegrationTest {
         Reference clusterNameRef = new Reference(SysClusterTableInfo.INFOS.get(new ColumnIdent("name")));
         collectNode.toCollect(Arrays.<Symbol>asList(clusterNameRef));
         collectNode.maxRowGranularity(RowGranularity.CLUSTER);
-        Object[][] result = operation.collect(collectNode).get();
+        Object[][] result = operation.collect(collectNode, null).get();
         assertThat(result.length, is(1));
         assertTrue(((BytesRef) result[0][0]).utf8ToString().startsWith("shared-"));
     }
@@ -101,7 +101,7 @@ public class HandlerSideLevelCollectTest extends SQLTransportIntegrationTest {
         collectNode.whereClause(new WhereClause(whereClause));
         collectNode.toCollect(toCollect);
         collectNode.maxRowGranularity(RowGranularity.DOC);
-        Object[][] result = operation.collect(collectNode).get();
+        Object[][] result = operation.collect(collectNode, null).get();
         System.out.println(TestingHelpers.printedTable(result));
         assertEquals("sys| shards| 1| 0| NULL| NULL| NULL\n", TestingHelpers.printedTable(result));
     }
@@ -122,7 +122,7 @@ public class HandlerSideLevelCollectTest extends SQLTransportIntegrationTest {
         }
         collectNode.toCollect(toCollect);
         collectNode.maxRowGranularity(RowGranularity.DOC);
-        Object[][] result = operation.collect(collectNode).get();
+        Object[][] result = operation.collect(collectNode, null).get();
 
 
         String expected = "sys| cluster| id| 1| string\n" +
@@ -135,7 +135,7 @@ public class HandlerSideLevelCollectTest extends SQLTransportIntegrationTest {
 
         // second time - to check if the internal iterator resets
         System.out.println(TestingHelpers.printedTable(result));
-        result = operation.collect(collectNode).get();
+        result = operation.collect(collectNode, null).get();
         assertTrue(TestingHelpers.printedTable(result).startsWith(expected));
     }
 

--- a/sql/src/test/java/io/crate/operation/collect/MapSideDataCollectOperationTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/MapSideDataCollectOperationTest.java
@@ -114,7 +114,7 @@ public class MapSideDataCollectOperationTest {
                 null,
                 false
         );
-        ListenableFuture<Object[][]> resultFuture = collectOperation.collect(collectNode);
+        ListenableFuture<Object[][]> resultFuture = collectOperation.collect(collectNode, null);
         Object[][] objects = resultFuture.get();
 
         assertThat((String)objects[0][0], is("Arthur"));

--- a/sql/src/test/java/io/crate/operation/collect/SimpleOneRowCollectorTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/SimpleOneRowCollectorTest.java
@@ -46,7 +46,7 @@ public class SimpleOneRowCollectorTest {
                 Collections.<CollectExpression<?>>emptySet(),
                 downStream
         );
-        collector.doCollect();
+        collector.doCollect(null);
         verify(downStream, never()).startProjection();
         verify(downStream, times(1)).setNextRow(true, new BytesRef("foo"));
         verify(downStream, times(1)).upstreamFinished();

--- a/sql/src/test/java/io/crate/operation/collect/StatsTablesTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/StatsTablesTest.java
@@ -90,9 +90,9 @@ public class StatsTablesTest {
 
 
         stats.operationsLog.get().add(new OperationContextLog(
-                new OperationContext(UUID.randomUUID(), "foo", 2L), null));
+                new OperationContext(UUID.randomUUID(), UUID.randomUUID(), "foo", 2L), null));
         stats.operationsLog.get().add(new OperationContextLog(
-                new OperationContext(UUID.randomUUID(), "foo", 3L), null));
+                new OperationContext(UUID.randomUUID(), UUID.randomUUID(), "foo", 3L), null));
 
         stats.listener.onRefreshSettings(ImmutableSettings.builder()
                 .put(CrateSettings.STATS_ENABLED.settingName(), true)

--- a/sql/src/test/java/io/crate/operation/collect/files/BlobDocCollectorTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/files/BlobDocCollectorTest.java
@@ -108,7 +108,7 @@ public class BlobDocCollectorTest {
         );
 
         projector.startProjection();
-        collector.doCollect();
+        collector.doCollect(null);
         return projector;
     }
 

--- a/sql/src/test/java/io/crate/operation/collect/files/FileReadingCollectorTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/files/FileReadingCollectorTest.java
@@ -193,7 +193,7 @@ public class FileReadingCollectorTest {
                 0
         );
         projector.startProjection();
-        collector.doCollect();
+        collector.doCollect(null);
         return projector;
     }
 }


### PR DESCRIPTION
This adds a sql query circuit breaker which tries to estimate the amount of memory needed by a certain operation of a query to prevent a OutOfMemory exception.
It raises a CircuitBreakingException if the limit exceeded.
The default limit is 60% of the available HEAP.

The limit can be configured using the `crate.breaker.query.limit` and related `crate.breaker.query.overhead` settings.
