### PR TITLE
move validators into their own package

### DIFF
--- a/sql/src/main/java/io/crate/analyze/validator/GroupBySymbolValidator.java
+++ b/sql/src/main/java/io/crate/analyze/validator/GroupBySymbolValidator.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.analyze.validator;
+
+import io.crate.metadata.ReferenceInfo;
+import io.crate.planner.symbol.*;
+import io.crate.types.DataTypes;
+
+public class GroupBySymbolValidator {
+
+    private final static InnerValidator INNER_VALIDATOR = new InnerValidator();
+
+    public static void validate(Symbol symbol) throws IllegalArgumentException, UnsupportedOperationException {
+        INNER_VALIDATOR.process(symbol, null);
+    }
+
+    private static class InnerValidator extends SymbolVisitor<Void, Void> {
+
+        @Override
+        public Void visitDynamicReference(DynamicReference symbol, Void context) {
+            throw new IllegalArgumentException(
+                    SymbolFormatter.format("unknown column '%s' not allowed in GROUP BY", symbol));
+        }
+
+        @Override
+        public Void visitReference(Reference symbol, Void context) {
+            if (!DataTypes.PRIMITIVE_TYPES.contains(symbol.valueType())) {
+                throw new IllegalArgumentException(
+                        String.format("Cannot GROUP BY '%s': invalid data type '%s'",
+                                SymbolFormatter.format(symbol),
+                                symbol.valueType()));
+            } else if (symbol.info().indexType() == ReferenceInfo.IndexType.ANALYZED) {
+                throw new IllegalArgumentException(
+                        String.format("Cannot GROUP BY '%s': grouping on analyzed/fulltext columns is not possible",
+                                SymbolFormatter.format(symbol)));
+            } else if (symbol.info().indexType() == ReferenceInfo.IndexType.NO) {
+                throw new IllegalArgumentException(
+                        String.format("Cannot GROUP BY '%s': grouping on non-indexed columns is not possible",
+                                SymbolFormatter.format(symbol)));
+            }
+            return null;
+        }
+
+        @Override
+        public Void visitFunction(Function symbol, Void context) {
+            switch (symbol.info().type()) {
+                case SCALAR:
+                    break;
+                case AGGREGATE:
+                    throw new IllegalArgumentException("Aggregate functions are not allowed in GROUP BY");
+                case PREDICATE:
+                    throw new UnsupportedOperationException(String.format(
+                            "%s predicate cannot be used in a GROUP BY clause", symbol.info().ident().name()));
+                default:
+                    throw new UnsupportedOperationException(
+                            String.format("FunctionInfo.Type %s not handled", symbol.info().type()));
+            }
+            return null;
+        }
+
+        @Override
+        protected Void visitSymbol(Symbol symbol, Void context) {
+            throw new UnsupportedOperationException(
+                    String.format("Cannot GROUP BY for '%s'", SymbolFormatter.format(symbol))
+            );
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/analyze/validator/HavingSymbolValidator.java
+++ b/sql/src/main/java/io/crate/analyze/validator/HavingSymbolValidator.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.analyze.validator;
+
+import io.crate.metadata.FunctionInfo;
+import io.crate.planner.symbol.*;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+public class HavingSymbolValidator {
+
+    private final static InnerValidator INNER_VALIDATOR = new InnerValidator();
+
+    public static void validate(Symbol symbol, @Nullable List<Symbol> groupBySymbols) throws IllegalArgumentException {
+        INNER_VALIDATOR.process(symbol, new HavingContext(groupBySymbols));
+    }
+
+    static class HavingContext {
+        @Nullable
+        private final List<Symbol> groupBySymbols;
+
+        private boolean insideAggregation = false;
+
+        public HavingContext(@Nullable List<Symbol> groupBySymbols) {
+            this.groupBySymbols = groupBySymbols;
+        }
+    }
+
+    private static class InnerValidator extends SymbolVisitor<HavingContext, Void> {
+
+        @Override
+        public Void visitReference(Reference symbol, HavingContext context) {
+            if (!context.insideAggregation && (context.groupBySymbols == null || !context.groupBySymbols.contains(symbol))) {
+                throw new IllegalArgumentException(
+                        SymbolFormatter.format("Cannot use reference %s outside of an Aggregation in HAVING clause. " +
+                                "Only GROUP BY keys allowed here.", symbol));
+            }
+            return null;
+        }
+
+        @Override
+        public Void visitFunction(Function symbol, HavingContext context) {
+            if (symbol.info().type().equals(FunctionInfo.Type.AGGREGATE)) {
+                context.insideAggregation = true;
+            }
+            for (Symbol argument : symbol.arguments()) {
+                process(argument, context);
+            }
+            context.insideAggregation = false;
+            return null;
+        }
+
+        @Override
+        protected Void visitSymbol(Symbol symbol, HavingContext context) {
+            return null;
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/analyze/validator/SelectSymbolValidator.java
+++ b/sql/src/main/java/io/crate/analyze/validator/SelectSymbolValidator.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.analyze.validator;
+
+import io.crate.metadata.ReferenceInfo;
+import io.crate.planner.symbol.*;
+
+import java.util.List;
+
+public class SelectSymbolValidator {
+
+    private final static InnerValidator INNER_VALIDATOR = new InnerValidator();
+
+    public static void validate(List<Symbol> symbols, boolean selectFromFieldCache) {
+        for (Symbol symbol : symbols) {
+            INNER_VALIDATOR.process(symbol, new SelectContext(selectFromFieldCache));
+        }
+    }
+
+    static class SelectContext {
+        private boolean selectFromFieldCache;
+
+        public SelectContext(boolean selectFromFieldCache) {
+            this.selectFromFieldCache = selectFromFieldCache;
+        }
+    }
+
+    private static class InnerValidator extends SymbolVisitor<SelectSymbolValidator.SelectContext, Void> {
+
+        @Override
+        public Void visitReference(Reference symbol, SelectContext context) {
+            if (context.selectFromFieldCache) {
+                if (symbol.info().indexType() == ReferenceInfo.IndexType.ANALYZED) {
+                    throw new IllegalArgumentException(
+                            String.format("Cannot select analyzed column '%s' " +
+                                            "within grouping or aggregations",
+                                    SymbolFormatter.format(symbol)));
+                } else if (symbol.info().indexType() == ReferenceInfo.IndexType.NO) {
+                    throw new IllegalArgumentException(
+                            String.format("Cannot select non-indexed column '%s' " +
+                                            "within grouping or aggregations",
+                                    SymbolFormatter.format(symbol)));
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public Void visitFunction(Function symbol, SelectContext context) {
+            switch (symbol.info().type()) {
+                case SCALAR:
+                    break;
+                case AGGREGATE:
+                    context.selectFromFieldCache = true;
+                    break;
+                case PREDICATE:
+                    throw new UnsupportedOperationException(String.format(
+                            "%s predicate cannot be selected", symbol.info().ident().name()));
+                default:
+                    throw new UnsupportedOperationException(String.format(
+                            "FunctionInfo.Type %s not handled", symbol.info().type()));
+            }
+            for (Symbol arg : symbol.arguments()) {
+                process(arg, context);
+            }
+            return null;
+        }
+
+        @Override
+        public Void visitSymbol(Symbol symbol, SelectContext context) {
+            return null;
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/analyze/validator/SortSymbolValidator.java
+++ b/sql/src/main/java/io/crate/analyze/validator/SortSymbolValidator.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.analyze.validator;
+
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.ReferenceInfo;
+import io.crate.planner.symbol.*;
+import io.crate.types.DataTypes;
+
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * validate that sortSymbols don't contain partition by columns
+ */
+public class SortSymbolValidator {
+
+    private final static InnerValidator INNER_VALIDATOR = new InnerValidator();
+
+    public static void validate(Symbol symbol, List<ColumnIdent> partitionedByColumns) throws UnsupportedOperationException {
+        INNER_VALIDATOR.process(symbol, new SortContext(partitionedByColumns));
+    }
+
+    static class SortContext {
+
+        private boolean inFunction;
+        private List<ColumnIdent> partitionedByColumns;
+
+        public SortContext(List<ColumnIdent> partitionedByColumns) {
+            this.partitionedByColumns = partitionedByColumns;
+            this.inFunction = false;
+        }
+    }
+
+    private static class InnerValidator extends SymbolVisitor<SortContext, Void> {
+
+        @Override
+        public Void visitFunction(Function symbol, SortContext context) {
+            if (!context.inFunction  && !DataTypes.PRIMITIVE_TYPES.contains(symbol.valueType())) {
+                throw new UnsupportedOperationException(
+                        String.format(Locale.ENGLISH,
+                                "Cannot ORDER BY '%s': invalid return type '%s'.",
+                                SymbolFormatter.format(symbol),
+                                symbol.valueType())
+                );
+            }
+            if (symbol.info().type() == FunctionInfo.Type.PREDICATE) {
+                throw new UnsupportedOperationException(String.format(
+                        "%s predicate cannot be used in an ORDER BY clause", symbol.info().ident().name()));
+            }
+
+            try {
+                context.inFunction = true;
+                for (Symbol arg : symbol.arguments()) {
+                    process(arg, context);
+                }
+            } finally {
+                context.inFunction = false;
+            }
+            return null;
+        }
+
+        @Override
+        public Void visitReference(Reference symbol, SortContext context) {
+            if (context.partitionedByColumns.contains(symbol.info().ident().columnIdent())) {
+                throw new UnsupportedOperationException(
+                        SymbolFormatter.format(
+                                "cannot use partitioned column %s in ORDER BY clause",
+                                symbol));
+            }
+            // if we are in a function, we do not need to check the data type.
+            // the function will do that for us.
+            if (!context.inFunction && !DataTypes.PRIMITIVE_TYPES.contains(symbol.info().type())) {
+                throw new UnsupportedOperationException(
+                        String.format(Locale.ENGLISH,
+                                "Cannot ORDER BY '%s': invalid data type '%s'.",
+                                SymbolFormatter.format(symbol),
+                                symbol.valueType())
+                );
+            } else if (symbol.info().indexType() == ReferenceInfo.IndexType.ANALYZED) {
+                throw new UnsupportedOperationException(
+                        String.format("Cannot ORDER BY '%s': sorting on analyzed/fulltext columns is not possible",
+                                SymbolFormatter.format(symbol)));
+            } else if (symbol.info().indexType() == ReferenceInfo.IndexType.NO) {
+                throw new UnsupportedOperationException(
+                        String.format("Cannot ORDER BY '%s': sorting on non-indexed columns is not possible",
+                                SymbolFormatter.format(symbol)));
+            }
+            return null;
+        }
+
+        @Override
+        public Void visitDynamicReference(DynamicReference symbol, SortContext context) {
+            throw new UnsupportedOperationException(
+                    SymbolFormatter.format("Cannot order by \"%s\". The column doesn't exist.", symbol));
+        }
+
+        @Override
+        public Void visitSymbol(Symbol symbol, SortContext context) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
also hides the visitor in internal classes to have a cleaner public interface.
