### PR TITLE
remove rowGranularity from Analysis/AnalyzedStatement

### DIFF
--- a/sql/src/main/java/io/crate/planner/PlanNodeBuilder.java
+++ b/sql/src/main/java/io/crate/planner/PlanNodeBuilder.java
@@ -47,7 +47,7 @@ class PlanNodeBuilder {
                                            ImmutableList<Projection> projections) {
         CollectNode node = new CollectNode("distributing collect", analysis.table().getRouting(analysis.whereClause()));
         node.whereClause(analysis.whereClause());
-        node.maxRowGranularity(analysis.rowGranularity());
+        node.maxRowGranularity(analysis.table().rowGranularity());
         node.downStreamNodes(downstreamNodes);
         node.toCollect(toCollect);
         node.projections(projections);
@@ -111,7 +111,7 @@ class PlanNodeBuilder {
         CollectNode node = new CollectNode("collect", routing);
         node.whereClause(analysis.whereClause());
         node.toCollect(toCollect);
-        node.maxRowGranularity(analysis.rowGranularity());
+        node.maxRowGranularity(analysis.table().rowGranularity());
         node.projections(projections);
         node.isPartitioned(analysis.table().isPartitioned());
         setOutputTypes(node);

--- a/sql/src/main/java/io/crate/planner/Planner.java
+++ b/sql/src/main/java/io/crate/planner/Planner.java
@@ -635,8 +635,7 @@ public class Planner extends AnalyzedStatementVisitor<Planner.Context, Plan> {
     }
 
     private void groupBy(SelectAnalyzedStatement analysis, Plan plan, Context context) {
-
-        if (analysis.rowGranularity().ordinal() < RowGranularity.DOC.ordinal()
+        if (analysis.table().rowGranularity().ordinal() < RowGranularity.DOC.ordinal()
                 || !requiresDistribution(analysis)) {
             nonDistributedGroupBy(analysis, plan, context);
         } else if (context.indexWriterProjection.isPresent()) {
@@ -695,7 +694,7 @@ public class Planner extends AnalyzedStatementVisitor<Planner.Context, Plan> {
         boolean groupedByClusteredPk = groupedByClusteredColumnOrPrimaryKeys(analysis);
 
         int numAggregationSteps = 2;
-        if (analysis.rowGranularity() == RowGranularity.DOC) {
+        if (analysis.table().rowGranularity() == RowGranularity.DOC) {
             /**
              * this is only the case if the group by key is the clustered by column.
              * collectNode has row-authority and there is no need to group again on the handler node
@@ -1090,7 +1089,7 @@ public class Planner extends AnalyzedStatementVisitor<Planner.Context, Plan> {
 
                 WhereClause whereClause = statement.whereClause();
                 if (!context.indexWriterProjection.isPresent()
-                        && statement.rowGranularity().ordinal() >= RowGranularity.DOC.ordinal() &&
+                        && statement.table().rowGranularity().ordinal() >= RowGranularity.DOC.ordinal() &&
                         statement.table().getRouting(whereClause).hasLocations() &&
                         statement.table().schemaInfo().name().equals(DocSchemaInfo.NAME)) {
 

--- a/sql/src/test/java/io/crate/analyze/DeleteAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/DeleteAnalyzerTest.java
@@ -89,7 +89,7 @@ public class DeleteAnalyzerTest extends BaseAnalyzerTest {
         DeleteAnalyzedStatement.NestedDeleteAnalyzedStatement analysis = analyze("delete from users where name='Trillian'");
         assertEquals(TEST_DOC_TABLE_IDENT, analysis.table().ident());
 
-        assertThat(analysis.rowGranularity(), is(RowGranularity.DOC));
+        assertThat(analysis.table().rowGranularity(), is(RowGranularity.DOC));
 
         Function whereClause = (Function)analysis.whereClause().query();
         assertEquals(EqOperator.NAME, whereClause.info().ident().name());

--- a/sql/src/test/java/io/crate/analyze/SelectAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectAnalyzerTest.java
@@ -176,7 +176,7 @@ public class SelectAnalyzerTest extends BaseAnalyzerTest {
 
         assertFalse(analysis.hasGroupBy());
         assertTrue(analysis.orderBy().isSorted());
-        assertThat(analysis.rowGranularity(), is(RowGranularity.NODE));
+        assertThat(analysis.table().rowGranularity(), is(RowGranularity.NODE));
 
         assertEquals(1, analysis.outputSymbols().size());
         assertEquals(1, analysis.orderBy().orderBySymbols().size());
@@ -235,7 +235,7 @@ public class SelectAnalyzerTest extends BaseAnalyzerTest {
         assertEquals(analysis.table().ident(), SysNodesTableInfo.IDENT);
         assertNull(analysis.limit());
 
-        assertThat(analysis.rowGranularity(), is(RowGranularity.NODE));
+        assertThat(analysis.table().rowGranularity(), is(RowGranularity.NODE));
         assertTrue(analysis.hasGroupBy());
         assertEquals(2, analysis.outputSymbols().size());
         assertEquals(1, analysis.groupBy().size());
@@ -252,7 +252,7 @@ public class SelectAnalyzerTest extends BaseAnalyzerTest {
 
         assertFalse(analysis.hasGroupBy());
 
-        assertThat(analysis.rowGranularity(), is(RowGranularity.NODE));
+        assertThat(analysis.table().rowGranularity(), is(RowGranularity.NODE));
 
         assertEquals(SysNodesTableInfo.IDENT, analysis.table().ident());
         assertEquals(1, analysis.outputSymbols().size());
@@ -266,7 +266,7 @@ public class SelectAnalyzerTest extends BaseAnalyzerTest {
         SelectAnalyzedStatement analysis =  analyze("select avg(load['5']) from sys.nodes");
         assertEquals(SysNodesTableInfo.IDENT, analysis.table().ident());
 
-        assertThat(analysis.rowGranularity(), is(RowGranularity.NODE));
+        assertThat(analysis.table().rowGranularity(), is(RowGranularity.NODE));
 
         assertFalse(analysis.hasGroupBy());
         assertEquals(1, analysis.outputSymbols().size());
@@ -298,7 +298,7 @@ public class SelectAnalyzerTest extends BaseAnalyzerTest {
                 "where load['1'] = 1.2 or 1 >= load['5']");
         assertEquals(SysNodesTableInfo.IDENT, analysis.table().ident());
 
-        assertThat(analysis.rowGranularity(), is(RowGranularity.NODE));
+        assertThat(analysis.table().rowGranularity(), is(RowGranularity.NODE));
 
         assertFalse(analysis.hasGroupBy());
 
@@ -656,7 +656,7 @@ public class SelectAnalyzerTest extends BaseAnalyzerTest {
     @Test
     public void testGranularityWithSingleAggregation() throws Exception {
         SelectAnalyzedStatement analysis = analyze("select count(*) from sys.nodes");
-        assertThat(analysis.rowGranularity(), is(RowGranularity.NODE));
+        assertThat(analysis.table().rowGranularity(), is(RowGranularity.NODE));
     }
 
     @Test
@@ -2016,5 +2016,12 @@ public class SelectAnalyzerTest extends BaseAnalyzerTest {
         assertThat(analysis.whereClause().clusteredBy().get(), is("a,b,c"));
         assertThat(analysis.ids().size(), is(1));
         assertThat(analysis.ids().get(0), is("a,b,c"));
+    }
+
+    @Test
+    public void testShardGranularityFromNodeGranularityTable() throws Exception {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("Cannot resolve reference 'sys.shards.id', reason: finer granularity than table 'sys.nodes'");
+        analyze("select sys.shards.id from sys.nodes");
     }
 }


### PR DESCRIPTION
It is not allowed to have a column with a finer granularity then the table has
in the query. So it is unnecessary to keep track of the max rowGranularity
because tableInfo.rowGranularity() will always have the max rowGranularity.
