### PR TITLE
correctly handle null values and nested objects

### DIFF
--- a/sql/src/test/java/io/crate/integrationtests/Setup.java
+++ b/sql/src/test/java/io/crate/integrationtests/Setup.java
@@ -22,6 +22,7 @@
 package io.crate.integrationtests;
 
 import io.crate.Constants;
+import io.crate.action.sql.SQLResponse;
 import io.crate.testing.SQLTransportExecutor;
 import org.elasticsearch.common.settings.ImmutableSettings;
 
@@ -31,6 +32,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static com.google.common.collect.Maps.newHashMap;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 public class Setup {
 
@@ -265,12 +268,13 @@ public class Setup {
                 "  tags array(string)" +
                 ") with (number_of_replicas=0)");
         transportExecutor.ensureGreen();
-        transportExecutor.exec("insert into any_table (id, temps, names, tags) values (?,?,?,?), (?,?,?,?), (?,?,?,?), (?,?,?,?)",
+        SQLResponse response = transportExecutor.exec("insert into any_table (id, temps, names, tags) values (?,?,?,?), (?,?,?,?), (?,?,?,?), (?,?,?,?)",
                         1, Arrays.asList(0L, 0L, 0L), Arrays.asList("Dornbirn", "Berlin", "St. Margrethen"), Arrays.asList("cool"),
                         2, Arrays.asList(0, 1, -1), Arrays.asList("Dornbirn", "Dornbirn", "Dornbirn"), Arrays.asList("cool", null),
                         3, Arrays.asList(42, -42), Arrays.asList("Hangelsberg", "Berlin"), Arrays.asList("kuhl", "cool"),
                         4, null, null, Arrays.asList("kuhl", null)
                 );
+        assertThat(response.rowCount(), is(4L));
         transportExecutor.refresh("any_table");
     }
 


### PR DESCRIPTION
- support parsing null values
- reset path in ParseContext after traversing into ObjectMapper during parsing of document source
