### PR TITLE
Add a "run" task similar to the runDebug target

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -207,6 +207,14 @@ task(runDebug, dependsOn: 'classes', type: JavaExec) {
     maxHeapSize = '512m'
 }
 
+task(run, dependsOn: 'classes', type: JavaExec) {
+    main = 'io.crate.bootstrap.CrateF'
+    debug = false
+    classpath = sourceSets.main.runtimeClasspath
+    maxHeapSize = '512m'
+    systemProperties System.getProperties()
+}
+
 test {
 
     testLogging {


### PR DESCRIPTION
Example usage: ./gradlew run -Des.path.home=$(pwd)/sandbox/crate_1/
Note that all system properties are copied, thus -D on the gradle command line will work.
