### PR TITLE
don't unwrap symbols in ExpressionAnalyzer

### DIFF
--- a/sql/src/main/java/io/crate/planner/symbol/Field.java
+++ b/sql/src/main/java/io/crate/planner/symbol/Field.java
@@ -22,6 +22,7 @@
 package io.crate.planner.symbol;
 
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Predicate;
 import io.crate.analyze.WhereClause;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.types.DataType;
@@ -136,6 +137,12 @@ public class Field extends Symbol {
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(Field.class).add("target", target).add("relation", relation).toString();
+    }
+
+    @Deprecated
+    public static boolean symbolOrTarget(Symbol left, Predicate<Symbol> dynamicReferencePredicate) {
+        return dynamicReferencePredicate.apply(left) ||
+                (left instanceof Field && dynamicReferencePredicate.apply(((Field) left).target()));
     }
 
     private static class UnwrappingVisitor extends SymbolVisitor<Void, Symbol>

--- a/sql/src/test/java/io/crate/analyze/SelectAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectAnalyzerTest.java
@@ -1324,7 +1324,7 @@ public class SelectAnalyzerTest extends BaseAnalyzerTest {
         assertThat(havingFunction.arguments().get(0), isFunction("max"));
         Function maxFunction = (Function)havingFunction.arguments().get(0);
 
-        assertThat(maxFunction.arguments().get(0), isReference("bytes"));
+        assertThat(unwrap(maxFunction.arguments().get(0)), isReference("bytes"));
         TestingHelpers.assertLiteralSymbol(havingFunction.arguments().get(1), (byte) 4, DataTypes.BYTE);
     }
 


### PR DESCRIPTION
In case of functions those were changed inplace and the fields got lost. But
they're required in the Planner later on.
