### PR TITLE
Fix: Changed output of column names in error

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fix: Changed output of column names in error messages to subscript notation,
+   so the correct notation to address columns in sql is reflected
+
  - Fix: correctly plan group by queries using HAVING clause
 
  - Fix: Using CLUSTERED BY Column in PARTITIONED BY clause threw

--- a/sql/src/main/java/io/crate/analyze/AbstractDataAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/AbstractDataAnalyzedStatement.java
@@ -143,22 +143,22 @@ public abstract class AbstractDataAnalyzedStatement extends AnalyzedStatement {
                     }
                     reference = tableInfo.getDynamic(ident.columnIdent(), forWrite);
                     if (reference == null) {
-                        throw new ColumnUnknownException(ident.columnIdent().fqn());
+                        throw new ColumnUnknownException(ident.columnIdent().sqlFqn());
                     }
                     info = reference.info();
                 }
             }
             if (info.granularity().finerThan(table.rowGranularity())) {
                 throw new UnsupportedOperationException(String.format(Locale.ENGLISH,
-                        "Cannot resolve reference '%s.%s', reason: finer granularity than table '%s'",
-                        info.ident().tableIdent().fqn(), info.ident().columnIdent().fqn(), table.ident().fqn()));
+                        "Cannot resolve reference %s.%s, reason: finer granularity than table '%s'",
+                        info.ident().tableIdent().fqn(), info.ident().columnIdent().sqlFqn(), table.ident().fqn()));
             }
             if (reference == null) {
                 reference = new Reference(info);
             }
             referenceSymbols.put(info.ident(), reference);
         } else if (unique) {
-            throw new IllegalArgumentException(String.format(Locale.ENGLISH, "reference '%s' repeated", ident.columnIdent().fqn()));
+            throw new IllegalArgumentException(String.format(Locale.ENGLISH, "reference %s repeated", ident.columnIdent().sqlFqn()));
         }
         return reference;
     }
@@ -348,7 +348,7 @@ public abstract class AbstractDataAnalyzedStatement extends AnalyzedStatement {
         if (dataType != null
                 && DataTypes.isCollectionType(dataType)
                 && DataTypes.isCollectionType(((CollectionType)dataType).innerType())) {
-            throw new ColumnValidationException(columnIdent.fqn(),
+            throw new ColumnValidationException(columnIdent.sqlFqn(),
                     String.format(Locale.ENGLISH, "Invalid datatype '%s'", dataType));
         }
     }
@@ -393,7 +393,7 @@ public abstract class AbstractDataAnalyzedStatement extends AnalyzedStatement {
                 DynamicReference dynamicReference = tableInfo.getDynamic(nestedIdent, forWrite);
                 DataType type = DataTypes.guessType(entry.getValue(), false);
                 if (type == null) {
-                    throw new ColumnValidationException(info.ident().columnIdent().fqn(), "Invalid value");
+                    throw new ColumnValidationException(info.ident().columnIdent().sqlFqn(), "Invalid value");
                 }
                 dynamicReference.valueType(type);
                 nestedInfo = dynamicReference.info();
@@ -432,7 +432,7 @@ public abstract class AbstractDataAnalyzedStatement extends AnalyzedStatement {
             }
             return info.type().value(primitiveValue);
         } catch (Exception e) {
-            throw new ColumnValidationException(info.ident().columnIdent().fqn(),
+            throw new ColumnValidationException(info.ident().columnIdent().sqlFqn(),
                     String.format("Invalid %s",
                             info.type().getName()
                     )

--- a/sql/src/main/java/io/crate/analyze/AnalyzedTableElements.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedTableElements.java
@@ -169,8 +169,9 @@ public class AnalyzedTableElements {
 
     private void validatePrimaryKeys() {
         for (String additionalPrimaryKey : additionalPrimaryKeys) {
-            if (!columnIdents.contains(ColumnIdent.fromPath(additionalPrimaryKey))) {
-                throw new ColumnUnknownException(additionalPrimaryKey);
+            ColumnIdent columnIdent = ColumnIdent.fromPath(additionalPrimaryKey);
+            if (!columnIdents.contains(columnIdent)) {
+                throw new ColumnUnknownException(columnIdent.sqlFqn());
             }
         }
     }
@@ -179,7 +180,7 @@ public class AnalyzedTableElements {
         for (Map.Entry<String, Set<String>> entry : copyToMap.entrySet()) {
             ColumnIdent columnIdent = ColumnIdent.fromPath(entry.getKey());
             if (!columnIdents.contains(columnIdent)) {
-                throw new ColumnUnknownException(columnIdent.fqn());
+                throw new ColumnUnknownException(columnIdent.sqlFqn());
             }
             if (!columnTypes.get(columnIdent).equalsIgnoreCase("string")) {
                 throw new IllegalArgumentException("INDEX definition only support 'string' typed source columns");
@@ -261,7 +262,7 @@ public class AnalyzedTableElements {
             if (skipIfNotFound) {
                 return;
             }
-            throw new ColumnUnknownException(partitionedByIdent.fqn());
+            throw new ColumnUnknownException(partitionedByIdent.sqlFqn());
         }
         if (columnDefinition.dataType().equals("object")) {
             throw new IllegalArgumentException(String.format(Locale.ENGLISH,

--- a/sql/src/main/java/io/crate/analyze/InsertFromValuesAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/InsertFromValuesAnalyzer.java
@@ -120,7 +120,7 @@ public class InsertFromValuesAnalyzer extends AbstractInsertAnalyzer<InsertFromV
             try {
                 valuesSymbol = context.normalizeInputForReference(valuesSymbol, column, true);
             } catch (IllegalArgumentException | UnsupportedOperationException e) {
-                throw new ColumnValidationException(column.info().ident().columnIdent().fqn(), e);
+                throw new ColumnValidationException(column.info().ident().columnIdent().sqlFqn(), e);
             }
             try {
                 Object value = ((Input) valuesSymbol).value();

--- a/sql/src/main/java/io/crate/analyze/PartitionPropertiesAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/PartitionPropertiesAnalyzer.java
@@ -72,7 +72,7 @@ public class PartitionPropertiesAnalyzer {
                 values[idx] = converted == null ? null : DataTypes.STRING.value(converted);
             } catch (IndexOutOfBoundsException ex) {
                 throw new IllegalArgumentException(
-                        String.format("\"%s\" is no known partition column", entry.getKey().fqn()));
+                        String.format("\"%s\" is no known partition column", entry.getKey().sqlFqn()));
             }
         }
         return new PartitionName(tableInfo.ident().name(), Arrays.asList(values));

--- a/sql/src/main/java/io/crate/analyze/UpdateAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/UpdateAnalyzedStatement.java
@@ -123,7 +123,7 @@ public class UpdateAnalyzedStatement extends AbstractDataAnalyzedStatement {
 
         public void addAssignment(Reference reference, Symbol value) {
             if (assignments.containsKey(reference)) {
-                throw new IllegalArgumentException(String.format(Locale.ENGLISH, "reference repeated %s", reference.info().ident().columnIdent().fqn()));
+                throw new IllegalArgumentException(String.format(Locale.ENGLISH, "reference repeated %s", reference.info().ident().columnIdent().sqlFqn()));
             }
             if (!reference.info().ident().tableIdent().equals(table().ident())) {
                 throw new UnsupportedOperationException("cannot update references from other tables.");

--- a/sql/src/main/java/io/crate/analyze/UpdateStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/UpdateStatementAnalyzer.java
@@ -84,7 +84,7 @@ public class UpdateStatementAnalyzer extends AbstractStatementAnalyzer<Symbol, U
                     try {
                         updateValue = context.normalizeInputForReference(value, reference, true);
                     } catch(IllegalArgumentException|UnsupportedOperationException e) {
-                        throw new ColumnValidationException(ident.fqn(), e);
+                        throw new ColumnValidationException(ident.sqlFqn(), e);
                     }
 
                     if (context.table.clusteredBy() != null) {

--- a/sql/src/main/java/io/crate/exceptions/ColumnUnknownException.java
+++ b/sql/src/main/java/io/crate/exceptions/ColumnUnknownException.java
@@ -24,11 +24,11 @@ package io.crate.exceptions;
 public class ColumnUnknownException extends ResourceUnknownException {
 
     public ColumnUnknownException(String columnName) {
-        super(String.format("Column '%s' unknown", columnName));
+        super(String.format("Column %s unknown", columnName));
     }
 
     public ColumnUnknownException(String columnName, Throwable e) {
-        super(String.format("Column '%s' unknown", columnName), e);
+        super(String.format("Column %s unknown", columnName), e);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/metadata/table/AbstractTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/table/AbstractTableInfo.java
@@ -94,18 +94,18 @@ public abstract class AbstractTableInfo implements TableInfo {
             if (parentInfo != null) {
                 switch (parentInfo.columnPolicy()) {
                     case STRICT:
-                        throw new ColumnUnknownException(ident.fqn());
+                        throw new ColumnUnknownException(ident.sqlFqn());
                     case IGNORED:
                         parentIsIgnored = true;
                         break;
                 }
             }
         } else if(forWrite == false && columnPolicy() != ColumnPolicy.IGNORED) {
-            throw new ColumnUnknownException(ident.fqn());
+            throw new ColumnUnknownException(ident.sqlFqn());
         } else {
             switch (columnPolicy()) {
                 case STRICT:
-                    throw new ColumnUnknownException(ident.fqn());
+                    throw new ColumnUnknownException(ident.sqlFqn());
                 case IGNORED:
                     parentIsIgnored = true;
                     break;

--- a/sql/src/test/java/io/crate/analyze/InsertFromValuesAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/InsertFromValuesAnalyzerTest.java
@@ -355,7 +355,7 @@ public class InsertFromValuesAnalyzerTest extends BaseAnalyzerTest {
     @Test
     public void testInsertInvalidObjectArrayFieldInObjectArray() throws Exception {
         expectedException.expect(ColumnValidationException.class);
-        expectedException.expectMessage("Validation failed for tags.metadata.id: Invalid long");
+        expectedException.expectMessage("Validation failed for tags['metadata']['id']: Invalid long");
         analyze("insert into deeply_nested (tags) " +
                 "values (" +
                 "  [" +

--- a/sql/src/test/java/io/crate/analyze/SelectAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectAnalyzerTest.java
@@ -1971,14 +1971,14 @@ public class SelectAnalyzerTest extends BaseAnalyzerTest {
     @Test
     public void testFunctionArgumentsCantBeAliases() throws Exception {
         expectedException.expect(ColumnUnknownException.class);
-        expectedException.expectMessage("Column 'n' unknown");
+        expectedException.expectMessage("Column n unknown");
         analyze("select name as n, substr(n, 1, 1) from users");
     }
 
     @Test
     public void testSubscriptOnAliasShouldntWork() throws Exception {
         expectedException.expect(ColumnUnknownException.class);
-        expectedException.expectMessage("Column 'n' unknown");
+        expectedException.expectMessage("Column n unknown");
         analyze("select name as n, n[1] from users");
     }
 
@@ -2021,7 +2021,7 @@ public class SelectAnalyzerTest extends BaseAnalyzerTest {
     @Test
     public void testShardGranularityFromNodeGranularityTable() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("Cannot resolve reference 'sys.shards.id', reason: finer granularity than table 'sys.nodes'");
+        expectedException.expectMessage("Cannot resolve reference sys.shards.id, reason: finer granularity than table 'sys.nodes'");
         analyze("select sys.shards.id from sys.nodes");
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/ColumnPolicyIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ColumnPolicyIntegrationTest.java
@@ -92,7 +92,7 @@ public class ColumnPolicyIntegrationTest extends SQLTransportIntegrationTest {
         assertThat(response.rows()[0], is(Matchers.<Object>arrayContaining(1, "Ford")));
 
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("Column 'boo' unknown");
+        expectedException.expectMessage("Column boo unknown");
         execute("insert into strict_table (id, name, boo) values (2, 'Trillian', true)");
     }
 
@@ -112,7 +112,7 @@ public class ColumnPolicyIntegrationTest extends SQLTransportIntegrationTest {
         assertThat(response.rows()[0], is(Matchers.<Object>arrayContaining(1, "Ford")));
 
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("Column 'boo' unknown");
+        expectedException.expectMessage("Column boo unknown");
         execute("update strict_table set name='Trillian', boo=true where id=1");
     }
 
@@ -275,7 +275,7 @@ public class ColumnPolicyIntegrationTest extends SQLTransportIntegrationTest {
                 });
         execute("refresh table books");
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("Column 'author.name.middle_name' unknown");
+        expectedException.expectMessage("Column author['name']['middle_name'] unknown");
         authorMap = new HashMap<String, Object>(){{
             put("name", new HashMap<String, Object>(){{
                 put("first_name", "Douglas");
@@ -409,7 +409,7 @@ public class ColumnPolicyIntegrationTest extends SQLTransportIntegrationTest {
         assertThat(String.valueOf(partitionMetaData.getSourceAsMap().get("dynamic")), is(ColumnPolicy.STRICT.value()));
 
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("Column 'perfect' unknown");
+        expectedException.expectMessage("Column perfect unknown");
         execute("insert into numbers (num, odd, prime, perfect) values (?, ?, ?, ?)",
                 new Object[]{28, true, false, true});
     }
@@ -445,7 +445,7 @@ public class ColumnPolicyIntegrationTest extends SQLTransportIntegrationTest {
         assertThat(String.valueOf(partitionMetaData.getSourceAsMap().get("dynamic")), is(ColumnPolicy.STRICT.value()));
 
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("Column 'perfect' unknown");
+        expectedException.expectMessage("Column perfect unknown");
         execute("update numbers set num=?, perfect=? where num=6",
                 new Object[]{28, true});
     }
@@ -523,7 +523,7 @@ public class ColumnPolicyIntegrationTest extends SQLTransportIntegrationTest {
         execute("alter table dynamic_table set (column_policy = 'strict')");
         waitNoPendingTasksOnAll();
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("Column 'new_col' unknown");
+        expectedException.expectMessage("Column new_col unknown");
         execute("insert into dynamic_table (id, score, new_col) values (1, 4656234.345, 'hello')");
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/ObjectColumnTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ObjectColumnTest.java
@@ -121,7 +121,7 @@ public class ObjectColumnTest extends SQLTransportIntegrationTest {
     @Test
     public void testAddColumnToStrictObject() throws Exception {
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("Column 'author.name.middle_name' unknown");
+        expectedException.expectMessage("Column author['name']['middle_name'] unknown");
 
         Map<String, Object> authorMap = new HashMap<String, Object>(){{
             put("name", new HashMap<String, Object>(){{
@@ -180,7 +180,7 @@ public class ObjectColumnTest extends SQLTransportIntegrationTest {
     @Test
     public void updateToStrictObject() throws Exception {
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("Column 'author.name.middle_name' unknown");
+        expectedException.expectMessage("Column author['name']['middle_name'] unknown");
 
         execute("update ot set author['name']['middle_name']='Noel' " +
                 "where author['name']['first_name']='Douglas' and author['name']['last_name']='Adams'");

--- a/sql/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
@@ -182,7 +182,7 @@ public class SQLTypeMappingTest extends SQLTransportIntegrationTest {
     public void testInvalidInsertIntoObject() throws Exception {
 
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("Validation failed for object_field.created: Invalid timestamp");
+        expectedException.expectMessage("Validation failed for object_field['created']: Invalid timestamp");
 
         setUpObjectTable();
         execute("insert into test12 (object_field, strict_field) values (?,?)", new Object[]{
@@ -290,7 +290,7 @@ public class SQLTypeMappingTest extends SQLTransportIntegrationTest {
         refresh();
         waitNoPendingTasksOnAll();
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("Validation failed for o.a: Invalid string");
+        expectedException.expectMessage("Validation failed for o['a']: Invalid string");
         execute("insert into t1 values ({a=['123', '456']})");
     }
 
@@ -363,7 +363,7 @@ public class SQLTypeMappingTest extends SQLTransportIntegrationTest {
     public void testInsertNewColumnToStrictObject() throws Exception {
 
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("Column 'strict_field.another_new_col' unknown");
+        expectedException.expectMessage("Column strict_field['another_new_col'] unknown");
 
         setUpObjectTable();
         Map<String, Object> strictContent = new HashMap<String, Object>(){{

--- a/sql/src/test/java/io/crate/integrationtests/SysShardsTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysShardsTest.java
@@ -267,7 +267,7 @@ public class SysShardsTest extends ClassLifecycleIntegrationTest {
     @Test
     public void testGroupByUnknownOrderBy() throws Exception {
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("Column 'lol' unknown");
+        expectedException.expectMessage("Column lol unknown");
         transportExecutor.exec(
             "select sum(num_docs), table_name from sys.shards group by table_name order by lol");
     }
@@ -275,7 +275,7 @@ public class SysShardsTest extends ClassLifecycleIntegrationTest {
     @Test
     public void testGroupByUnknownWhere() throws Exception {
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("Column 'lol' unknown");
+        expectedException.expectMessage("Column lol unknown");
         transportExecutor.exec(
             "select sum(num_docs), table_name from sys.shards where lol='funky' group by table_name");
     }
@@ -283,7 +283,7 @@ public class SysShardsTest extends ClassLifecycleIntegrationTest {
     @Test
     public void testGlobalAggregateUnknownWhere() throws Exception {
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("Column 'lol' unknown");
+        expectedException.expectMessage("Column lol unknown");
         transportExecutor.exec(
             "select sum(num_docs) from sys.shards where lol='funky'");
     }

--- a/sql/src/test/java/io/crate/metadata/table/TestingTableInfo.java
+++ b/sql/src/test/java/io/crate/metadata/table/TestingTableInfo.java
@@ -299,7 +299,7 @@ public class TestingTableInfo extends AbstractTableInfo {
             ColumnIdent parentIdent = ident.getParent();
             ReferenceInfo parentInfo = getReferenceInfo(parentIdent);
             if (parentInfo != null && parentInfo.columnPolicy() == ColumnPolicy.STRICT) {
-                throw new ColumnUnknownException(ident.fqn());
+                throw new ColumnUnknownException(ident.sqlFqn());
             }
         }
         return new DynamicReference(new ReferenceIdent(ident(), ident), rowGranularity());


### PR DESCRIPTION
messages to subscript notation, so the correct 
notation to address columns in sql is reflected
