### PR TITLE
switch to container(docker) based travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: java
 jdk:
   - openjdk7
-
+sudo: false
 env:
   global:
-    _JAVA_OPTIONS="-Xmx1g -XX:MaxPermSize=256m -XX:MaxDirectMemorySize=1g"
+    _JAVA_OPTIONS="-Xmx1g -XX:MaxPermSize=256m"
 
 notifications:
   email: false


### PR DESCRIPTION
this gives us 2 dedicated cores and 4 GB of memory, see http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/
