### PR TITLE
keep thread pool open until all pending requests are done

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed an issue that could cause bulk inserts to get stalled.
+
  - Restricted allowed characters in column names
 
 2014/12/17 0.46.0


### PR DESCRIPTION
If a pending request is Rejected after close() has been called it is
re-scheduled. This re-scheduling fails if the threadPool has been shutdown.
