### PR TITLE
fix: throw correct exception if one uses `_version`

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - fix: throw correct exception if one uses `_version` without primary key
+   in a select statements where clause
+
  - Optimized memory estimates for min()/max() aggregates for the CircuitBreaker
 
  - improved speed of Alter table settings in partitioned tables

--- a/sql/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
+++ b/sql/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
@@ -30,6 +30,7 @@ import com.spatial4j.core.shape.Shape;
 import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.Geometry;
 import io.crate.analyze.WhereClause;
+import io.crate.exceptions.UnsupportedFeatureException;
 import io.crate.lucene.match.MatchQueryBuilder;
 import io.crate.lucene.match.MultiMatchQueryBuilder;
 import io.crate.metadata.DocReferenceConverter;
@@ -754,7 +755,7 @@ public class LuceneQueryBuilder {
                 }
                 String unsupportedMessage = Context.UNSUPPORTED_FIELDS.get(columnName);
                 if (unsupportedMessage != null) {
-                    throw new UnsupportedOperationException(unsupportedMessage);
+                    throw new UnsupportedFeatureException(unsupportedMessage);
                 }
             }
             return false;


### PR DESCRIPTION
without primary key in a select statements where 
clause