### PR TITLE
leaverage ordinal fieldcache capabilities for better performance

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for Crate
 Unreleased
 ==========
 
+ - improved string lookup performance for group queries and global aggregates
+
  - fix: throw correct exception if one uses `_version` in a select statements
    where clause
 


### PR DESCRIPTION
performance on groups
===

master:
==

```
GroupByBenchmark.testGroupByAnyPerformance: [measured 1000 out of 1010 rounds, threads: 1 (sequential)]
 round: 0.16 [+- 0.01], round.block: 0.00 [+- 0.00], 
 round.gc: 0.00 [+- 0.00], GC.calls: 677, GC.time: 1.57, 
 time.total: 186.05, time.warmup: 30.95, time.bench: 155.10
````

dobe/bytesrefperf:
== 

```
GroupByBenchmark.testGroupByAnyPerformance: [measured 1000 out of 1010 rounds, threads: 1 (sequential)]
 round: 0.09 [+- 0.00], round.block: 0.00 [+- 0.00]
 round.gc: 0.00 [+- 0.00],  GC.calls: 171, GC.time: 0.37,
 time.total: 117.26, time.warmup: 30.77, time.bench: 86.49
```