### PR TITLE
use correct RamAccountingContext for shard projectors/collectors

### DIFF
--- a/sql/src/main/java/io/crate/operation/collect/ShardCollectService.java
+++ b/sql/src/main/java/io/crate/operation/collect/ShardCollectService.java
@@ -140,13 +140,7 @@ public class ShardCollectService {
     public CrateCollector getCollector(CollectNode collectNode,
                                        ShardProjectorChain projectorChain) throws Exception {
         CollectNode normalizedCollectNode = collectNode.normalize(shardNormalizer);
-        UUID jobId = null;
-        if (collectNode.jobId().isPresent()) {
-            jobId = collectNode.jobId().get();
-        }
-        String ramAccountingContextId = String.format("%s: %s", collectNode.id(), jobId);
-        RamAccountingContext ramAccountingContext = new RamAccountingContext(ramAccountingContextId, circuitBreaker);
-        Projector downstream = projectorChain.newShardDownstreamProjector(projectorVisitor, ramAccountingContext);
+        Projector downstream = projectorChain.newShardDownstreamProjector(projectorVisitor);
 
         if (normalizedCollectNode.whereClause().noMatch()) {
             return CrateCollector.NOOP;

--- a/sql/src/main/java/io/crate/operation/collect/ShardProjectorChain.java
+++ b/sql/src/main/java/io/crate/operation/collect/ShardProjectorChain.java
@@ -26,14 +26,12 @@ import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.operation.projectors.CollectingProjector;
-import io.crate.operation.projectors.ResultProvider;
 import io.crate.operation.projectors.ProjectionToProjectorVisitor;
 import io.crate.operation.projectors.Projector;
+import io.crate.operation.projectors.ResultProvider;
 import io.crate.planner.RowGranularity;
 import io.crate.planner.projection.Projection;
-import org.elasticsearch.search.facet.FacetExecutor;
 
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -71,6 +69,7 @@ import java.util.List;
 public class ShardProjectorChain implements ResultProvider {
 
     private final List<Projection> projections;
+    private final RamAccountingContext ramAccountingContext;
     protected final List<Projector> shardProjectors;
     protected final List<Projector> nodeProjectors;
     private Projector firstNodeProjector;
@@ -83,6 +82,7 @@ public class ShardProjectorChain implements ResultProvider {
                                ProjectionToProjectorVisitor nodeProjectorVisitor,
                                RamAccountingContext ramAccountingContext) {
         this.projections = projections;
+        this.ramAccountingContext = ramAccountingContext;
         nodeProjectors = new ArrayList<>();
 
         if (projections.size() == 0) {
@@ -142,8 +142,7 @@ public class ShardProjectorChain implements ResultProvider {
      * @param projectorVisitor the visitor to create projections out of a projection
      * @return a new projector connected to the internal chain
      */
-    public Projector newShardDownstreamProjector(ProjectionToProjectorVisitor projectorVisitor,
-                                                 RamAccountingContext ramAccountingContext) {
+    public Projector newShardDownstreamProjector(ProjectionToProjectorVisitor projectorVisitor) {
         if (shardProjectionsIndex < 0) {
             return firstNodeProjector;
         }

--- a/sql/src/test/java/io/crate/operation/collect/ShardProjectorChainTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/ShardProjectorChainTest.java
@@ -140,8 +140,8 @@ public class ShardProjectorChainTest {
         assertThat(chain.nodeProjectors.get(0), is(instanceOf(SimpleTopNProjector.class)));
         assertThat(chain.shardProjectors.size(), is(0));
 
-        Projector projector1 = chain.newShardDownstreamProjector(projectionToProjectorVisitor, RAM_ACCOUNTING_CONTEXT);
-        Projector projector2 = chain.newShardDownstreamProjector(projectionToProjectorVisitor, RAM_ACCOUNTING_CONTEXT);
+        Projector projector1 = chain.newShardDownstreamProjector(projectionToProjectorVisitor);
+        Projector projector2 = chain.newShardDownstreamProjector(projectionToProjectorVisitor);
         assertThat(projector1, is(instanceOf(GroupingProjector.class)));
         assertThat(projector2, is(instanceOf(GroupingProjector.class)));
 
@@ -170,8 +170,8 @@ public class ShardProjectorChainTest {
         assertThat(chain.nodeProjectors.get(1), is(instanceOf(SimpleTopNProjector.class)));
         assertThat(chain.shardProjectors.size(), is(0));
 
-        Projector projector1 = chain.newShardDownstreamProjector(projectionToProjectorVisitor, RAM_ACCOUNTING_CONTEXT);
-        Projector projector2 = chain.newShardDownstreamProjector(projectionToProjectorVisitor, RAM_ACCOUNTING_CONTEXT);
+        Projector projector1 = chain.newShardDownstreamProjector(projectionToProjectorVisitor);
+        Projector projector2 = chain.newShardDownstreamProjector(projectionToProjectorVisitor);
         assertThat(projector1, is(instanceOf(GroupingProjector.class)));
         assertThat(projector2, is(instanceOf(GroupingProjector.class)));
 
@@ -195,8 +195,8 @@ public class ShardProjectorChainTest {
         assertThat(chain.nodeProjectors.get(1), is(instanceOf(SimpleTopNProjector.class)));
         assertThat(chain.shardProjectors.size(), is(0));
 
-        Projector projector1 = chain.newShardDownstreamProjector(projectionToProjectorVisitor, RAM_ACCOUNTING_CONTEXT);
-        Projector projector2 = chain.newShardDownstreamProjector(projectionToProjectorVisitor, RAM_ACCOUNTING_CONTEXT);
+        Projector projector1 = chain.newShardDownstreamProjector(projectionToProjectorVisitor);
+        Projector projector2 = chain.newShardDownstreamProjector(projectionToProjectorVisitor);
         assertThat(projector1, is(instanceOf(GroupingProjector.class)));
         assertThat(projector2, is(instanceOf(GroupingProjector.class)));
 
@@ -212,8 +212,8 @@ public class ShardProjectorChainTest {
         assertThat(chain.nodeProjectors.get(0), is(instanceOf(CollectingProjector.class)));
         assertThat(chain.shardProjectors.size(), is(0));
 
-        Projector projector1 = chain.newShardDownstreamProjector(projectionToProjectorVisitor, RAM_ACCOUNTING_CONTEXT);
-        Projector projector2 = chain.newShardDownstreamProjector(projectionToProjectorVisitor, RAM_ACCOUNTING_CONTEXT);
+        Projector projector1 = chain.newShardDownstreamProjector(projectionToProjectorVisitor);
+        Projector projector2 = chain.newShardDownstreamProjector(projectionToProjectorVisitor);
         assertThat(projector1, is(instanceOf(CollectingProjector.class)));
         assertThat(projector2, is(instanceOf(CollectingProjector.class)));
 
@@ -234,8 +234,8 @@ public class ShardProjectorChainTest {
         assertThat(chain.nodeProjectors.get(1), is(instanceOf(SimpleTopNProjector.class)));
         assertThat(chain.shardProjectors.size(), is(0));
 
-        Projector projector1 = chain.newShardDownstreamProjector(projectionToProjectorVisitor, RAM_ACCOUNTING_CONTEXT);
-        Projector projector2 = chain.newShardDownstreamProjector(projectionToProjectorVisitor, RAM_ACCOUNTING_CONTEXT);
+        Projector projector1 = chain.newShardDownstreamProjector(projectionToProjectorVisitor);
+        Projector projector2 = chain.newShardDownstreamProjector(projectionToProjectorVisitor);
         assertThat(projector1, is(instanceOf(GroupingProjector.class)));
         assertThat(projector2, is(instanceOf(GroupingProjector.class)));
 


### PR DESCRIPTION
As things currently work each collector and projector need to use a shared
RamAccountingContext that is global per operation per node.

(Because one collector will also check the RamAccountingContext to see if
another collector tripped and abort collecting)

This was wrong but didn't really cause any issues as the only shard projectors
that are currently used don't account anyway.