### PR TITLE
fix: throw correct exception if one uses any other operator than `=`

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for Crate
 Unreleased
 ==========
 
+ - fix: throw correct exception if `_version` is misused in WHERE clause
+
  - improved string lookup performance for group queries and global aggregates
 
  - fix: throw correct exception if one uses `_version` in a select statements

--- a/sql/src/main/java/io/crate/analyze/where/WhereClauseValidator.java
+++ b/sql/src/main/java/io/crate/analyze/where/WhereClauseValidator.java
@@ -1,0 +1,93 @@
+package io.crate.analyze.where;
+
+
+import io.crate.analyze.WhereClause;
+import io.crate.operation.operator.EqOperator;
+import io.crate.operation.operator.GteOperator;
+import io.crate.operation.predicate.NotPredicate;
+import io.crate.planner.symbol.Function;
+import io.crate.planner.symbol.Reference;
+import io.crate.planner.symbol.Symbol;
+import io.crate.planner.symbol.SymbolVisitor;
+import io.crate.sql.tree.ComparisonExpression;
+
+import java.util.Locale;
+import java.util.Stack;
+
+public class WhereClauseValidator {
+
+    private static final Visitor visitor = new Visitor();
+
+    public Symbol validate(WhereClause whereClause) {
+        return visitor.process(whereClause.query(), new Visitor.Context());
+    }
+
+    private static class Visitor extends SymbolVisitor<Visitor.Context, Symbol> {
+
+        public static class Context {
+
+            public final Stack<Function> functions = new Stack();
+        }
+
+        private final static String _SCORE = "_score";
+
+        private final static String _VERSION = "_version";
+
+        private final static String VERSION_ERROR = "Filtering \"_version\" in WHERE clause only works using the \"=\" operator, checking for a numeric value";
+
+        private final static String SCORE_ERROR = String.format(Locale.ENGLISH,
+                "System column '%s' can only be used within a '%s' comparison without any surrounded predicate",
+                _SCORE, ComparisonExpression.Type.GREATER_THAN_OR_EQUAL.getValue());
+
+        @Override
+        public Symbol visitReference(Reference reference, Context context) {
+            String columnName = reference.info().ident().columnIdent().name();
+            if(columnName.equalsIgnoreCase(_VERSION)){
+                validateSysReference(context, EqOperator.NAME, VERSION_ERROR);
+            } else if(columnName.equalsIgnoreCase(_SCORE)){
+                validateSysReference(context, GteOperator.NAME, SCORE_ERROR);
+            }
+            return super.visitReference(reference, context);
+        }
+
+        @Override
+        public Symbol visitFunction(Function function, Context context){
+            context.functions.push(function);
+            continueTraversal(function, context);
+            context.functions.pop();
+            return function;
+        }
+
+        private Function continueTraversal(Function symbol, Context context) {
+            for (Symbol argument : symbol.arguments()) {
+                process(argument, context);
+            }
+            return symbol;
+        }
+
+        private boolean insideNotPredicate(Context context){
+            for(Function function : context.functions){
+                if(function.info().ident().name().equals(NotPredicate.NAME)){
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private void validateSysReference(Context context, String requiredFunctionName, String error) {
+            if(context.functions.isEmpty()){
+                throw new UnsupportedOperationException(error);
+            }
+            Function function = context.functions.lastElement();
+            if(!function.info().ident().name().equalsIgnoreCase(requiredFunctionName)
+                    || insideNotPredicate(context)) {
+                throw new UnsupportedOperationException(error);
+            }
+            assert function.arguments().size() == 2;
+            Symbol right = function.arguments().get(1);
+            if(!right.symbolType().isValueSymbol()){
+                throw new UnsupportedOperationException(error);
+            }
+        }
+    }
+}

--- a/sql/src/test/java/io/crate/analyze/SelectAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectAnalyzerTest.java
@@ -1785,6 +1785,13 @@ public class SelectAnalyzerTest extends BaseAnalyzerTest {
     }
 
     @Test
+    public void testScoreReferenceComparisonWithColumn() throws Exception {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("System column '_score' can only be used within a '>=' comparison without any surrounded predicate");
+        analyze("select * from users where \"_score\" >= id");
+    }
+
+    @Test
     public void testScoreReferenceInvalidNotPredicate() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
         expectedException.expectMessage("System column '_score' can only be used within a '>=' comparison without any surrounded predicate");
@@ -1794,21 +1801,21 @@ public class SelectAnalyzerTest extends BaseAnalyzerTest {
     @Test
     public void testScoreReferenceInvalidLikePredicate() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("System column '_score' cannot be used within a predicate");
+        expectedException.expectMessage("System column '_score' can only be used within a '>=' comparison without any surrounded predicate");
         analyze("select * from users where \"_score\" in (0.9)");
     }
 
     @Test
     public void testScoreReferenceInvalidNullPredicate() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("System column '_score' cannot be used within a predicate");
+        expectedException.expectMessage("System column '_score' can only be used within a '>=' comparison without any surrounded predicate");
         analyze("select * from users where \"_score\" is null");
     }
 
     @Test
     public void testScoreReferenceInvalidNotNullPredicate() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("System column '_score' cannot be used within a predicate");
+        expectedException.expectMessage("System column '_score' can only be used within a '>=' comparison without any surrounded predicate");
         analyze("select * from users where \"_score\" is not null");
     }
 

--- a/sql/src/test/java/io/crate/analyze/WhereClauseValidatorTest.java
+++ b/sql/src/test/java/io/crate/analyze/WhereClauseValidatorTest.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.analyze;
+
+import io.crate.metadata.MetaDataModule;
+import io.crate.metadata.ReferenceInfos;
+import io.crate.metadata.sys.MetaDataSysModule;
+import io.crate.metadata.table.SchemaInfo;
+import io.crate.operation.aggregation.impl.AggregationImplModule;
+import io.crate.operation.operator.OperatorModule;
+import io.crate.operation.predicate.PredicateModule;
+import io.crate.operation.scalar.ScalarFunctionModule;
+import org.elasticsearch.common.inject.Module;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class WhereClauseValidatorTest extends BaseAnalyzerTest {
+
+    static {
+        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
+    }
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    static class TestMetaDataModule extends MetaDataModule {
+
+        @Override
+        protected void bindSchemas() {
+            super.bindSchemas();
+            SchemaInfo schemaInfo = mock(SchemaInfo.class);
+            when(schemaInfo.getTableInfo(TEST_DOC_TABLE_IDENT.name())).thenReturn(userTableInfo);
+            schemaBinder.addBinding(ReferenceInfos.DEFAULT_SCHEMA_NAME).toInstance(schemaInfo);
+        }
+
+    }
+
+    @Override
+    protected List<Module> getModules() {
+        List<Module> modules = super.getModules();
+        modules.addAll(Arrays.<Module>asList(
+                new TestModule(),
+                new TestMetaDataModule(),
+                new MetaDataSysModule(),
+                new OperatorModule(),
+                new AggregationImplModule(),
+                new PredicateModule(),
+                new ScalarFunctionModule()
+        ));
+        return modules;
+    }
+
+    @Test
+    public void testUpdateWhereVersionUsingWrongOperator() throws Exception {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage(
+                "Filtering \"_version\" in WHERE clause only works using the \"=\" operator, checking for a numeric value");
+        analyze("update users set col2 = ? where col2 = ? and \"_version\" >= ?",
+                new Object[]{"already in panic", "don't panic", 3});
+    }
+
+    @Test
+    public void testUpdateWhereVersionIsColumn() throws Exception {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage(
+                "Filtering \"_version\" in WHERE clause only works using the \"=\" operator, checking for a numeric value");
+        analyze("update users set col2 = ? where _version = id",
+                new Object[]{1});
+    }
+
+    @Test
+    public void testUpdateWhereVersionInOperatorColumn() throws Exception {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage(
+                "Filtering \"_version\" in WHERE clause only works using the \"=\" operator, checking for a numeric value");
+        analyze("update users set col2 = ? where _version in (1,2,3)",
+                new Object[]{1});
+    }
+
+    @Test
+    public void testUpdateWhereVersionAddition() throws Exception {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage(
+                "Filtering \"_version\" in WHERE clause only works using the \"=\" operator, checking for a numeric value");
+        analyze("update users set col2 = ? where _version + 1 = 2",
+                new Object[]{1});
+    }
+
+    @Test
+    public void testSelectWhereVersionAddition() throws Exception {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage(
+                "Filtering \"_version\" in WHERE clause only works using the \"=\" operator, checking for a numeric value");
+        analyze("Select * from users where id = 1 and _version + 1 = 2");
+    }
+
+    @Test
+    public void testSelectWhereVersionNotPredicate() throws Exception {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage(
+                "Filtering \"_version\" in WHERE clause only works using the \"=\" operator, checking for a numeric value");
+        analyze("update users set col2 = ? where not (_version = 1 and col1 = 1)",
+                new Object[]{1});
+    }
+
+    @Test
+    public void testSelectWhereVersionIsNullPredicate() throws Exception {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage(
+                "Filtering \"_version\" in WHERE clause only works using the \"=\" operator, checking for a numeric value");
+        analyze("update users set col2 = ? where _version is null",
+                new Object[]{1});
+    }
+}

--- a/sql/src/test/java/io/crate/integrationtests/VersionHandlingIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/VersionHandlingIntegrationTest.java
@@ -203,4 +203,5 @@ public class VersionHandlingIntegrationTest extends SQLTransportIntegrationTest 
         expectedException.expectMessage("\"_version\" column is not valid in the WHERE clause of a SELECT statement");
         execute("select _version from test where col1 = 1 and _version = 50");
     }
+
 }


### PR DESCRIPTION
to compare the `_version` field