### PR TITLE
analyze LikePredicate without depending on Reference/Field.target()

### DIFF
--- a/sql/src/main/java/io/crate/metadata/FunctionIdent.java
+++ b/sql/src/main/java/io/crate/metadata/FunctionIdent.java
@@ -23,6 +23,7 @@ package io.crate.metadata;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Ordering;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -41,6 +42,14 @@ public class FunctionIdent implements Comparable<FunctionIdent>, Streamable {
 
     public FunctionIdent() {
 
+    }
+
+    public static FunctionIdent of(String name, DataType dataType) {
+        return new FunctionIdent(name, ImmutableList.of(dataType));
+    }
+
+    public static FunctionIdent of(String name, DataType type1, DataType type2) {
+        return new FunctionIdent(name, ImmutableList.of(type1, type2));
     }
 
     public FunctionIdent(String name, List<DataType> argumentTypes) {

--- a/sql/src/test/java/io/crate/analyze/SelectAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectAnalyzerTest.java
@@ -1443,7 +1443,7 @@ public class SelectAnalyzerTest extends BaseAnalyzerTest {
     @Test
     public void testRegexpMatchInvalidArg() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("type of \"users.floats\" doesn't match type of \"'foo'\" and cannot be cast implicitly");
+        expectedException.expectMessage("'foo' cannot be cast to type float");
         analyze("select * from users where floats ~ 'foo'");
     }
 

--- a/sql/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
@@ -306,7 +306,7 @@ public class UpdateAnalyzerTest extends BaseAnalyzerTest {
     @Test
     public void testUpdateWithWrongParameters() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("type of \"users.other_id\" doesn't match type of \"[1, 2, 3]\" and cannot be cast implicitly");
+        expectedException.expectMessage("[1, 2, 3] cannot be cast to type long");
 
         analyze("update users set name=?, friends=? where other_id=?",
                 new Object[]{


### PR DESCRIPTION
In order to remove `.target()` on `Field` the ExpressionAnalyzer may not use
that property anymore.

This changes the like analyzation to only use the types which is enough anyway
(normalizeInputForReference does a lot more is it can also handles objects and
stuff which is only relevant for insert)