### PR TITLE
make NestedLoop use paging on its child relations if possible

### DIFF
--- a/core/src/main/java/io/crate/core/bigarray/AbstractMultiArrayBigArray.java
+++ b/core/src/main/java/io/crate/core/bigarray/AbstractMultiArrayBigArray.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.core.bigarray;
+
+import com.google.common.base.Preconditions;
+
+import java.util.Locale;
+
+/**
+ * ObjectArray that is Iterable and backed by multiple custom array implementations
+ * @param <T> the type of element this array contains in several backing arrays
+ * @param <ArrayType> the actual type of backing array. e.g. T[] for native arrays
+ */
+public abstract class AbstractMultiArrayBigArray<T, ArrayType> implements IterableBigArray<T> {
+
+    protected final ArrayType[] backingArrays;
+    protected final long offset;
+    protected final long size;
+
+    /**
+     * create a bigarray instance using n numbers of backing arrays
+     * with
+     *
+     * @param offset a starting offset that starts to count at the beginning
+     *               of all the backing arrays.
+     *               Using {@linkplain #get(long)} will get the element at offset + the given argument
+     *               in the underlying row of backingArrays.
+     * @param size how many elements of the underlying backingArrays this array references
+     * @param backingArrays a variable number ( > 0 ) of arrays that back this bigarray instance
+     */
+    @SafeVarargs
+    public AbstractMultiArrayBigArray(long offset, long size, ArrayType ... backingArrays) {
+        long arraysSize = arraysSize(backingArrays);
+        Preconditions.checkArgument(backingArrays.length > 0, "empty backing arrays");
+        Preconditions.checkArgument(offset <= arraysSize, "offset exceeds backing arrays");
+        this.backingArrays = backingArrays;
+        this.offset = offset;
+        this.size = Math.min(size, arraysSize);
+    }
+
+    public abstract long arrayLength(ArrayType array);
+
+    protected abstract T getValue(long backingArraysIdx, long curArrayIdx);
+
+    protected abstract T setValue(long backingArraysIdx, long curArrayIdx, T value);
+
+    protected void assertIsInt(long l) {
+        assert l == (int)l : "long value exceeds int range";
+    }
+
+    protected long arraysSize(ArrayType[] arrays) {
+        long count = 0L;
+        for (ArrayType array : arrays) {
+            count += arrayLength(array);
+        }
+        return count;
+    }
+
+    protected long[] arraysIdx(ArrayType[] arrays, long index) {
+        int arrayIdx = 0;
+        long accumulatedSize = 0L;
+
+        long curArrayLen;
+        while (arrayIdx < arrays.length) {
+            curArrayLen = arrayLength(arrays[arrayIdx]);
+            if (accumulatedSize + curArrayLen > index) {
+                break;
+            }
+            accumulatedSize += curArrayLen;
+            arrayIdx++;
+        }
+
+        long curIdx = (int) (accumulatedSize > 0 ? (index-accumulatedSize) : index);
+        return new long[]{arrayIdx, curIdx};
+    }
+
+    protected long[] arraysIdx(long index) {
+        return arraysIdx(backingArrays, index+offset);
+    }
+
+
+    @Override
+    public T get(long index) {
+        if (index >= size || index < 0) {
+            throw new ArrayIndexOutOfBoundsException(
+                    String.format(Locale.ENGLISH, "index %d exceeds bounds of backing arrays", index));
+        }
+        long[] indices = arraysIdx(index);
+        return getValue(indices[0], indices[1]);
+    }
+
+    @Override
+    public T set(long index, T value) {
+        if (index > size) {
+            throw new ArrayIndexOutOfBoundsException(
+                    String.format(Locale.ENGLISH, "index %d exceeds bounds of backing arrays", index));
+        }
+        long[] indices = arraysIdx(index);
+        return setValue(indices[0], indices[1], value);
+    }
+
+    @Override
+    public long size() {
+        return size;
+    }
+}

--- a/core/src/main/java/io/crate/core/bigarray/AbstractMultiArrayIterator.java
+++ b/core/src/main/java/io/crate/core/bigarray/AbstractMultiArrayIterator.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.core.bigarray;
+
+import com.google.common.collect.AbstractIterator;
+
+public abstract class AbstractMultiArrayIterator<T, ArrayType> extends AbstractIterator<T> {
+
+    protected final ArrayType[] backingArrays;
+    protected final long endOffset;
+    protected final int arraysLen;
+
+    protected long backingArraysIdx;
+    protected long curArrayIdx;
+    protected long curOffset;
+
+    public AbstractMultiArrayIterator(AbstractMultiArrayBigArray<T, ArrayType> bigArray,
+                                      long offset,
+                                      long size,
+                                      ArrayType[] backingArrays) {
+        this.backingArrays = backingArrays;
+        this.arraysLen = backingArrays.length;
+        this.endOffset = offset + size;
+        this.curOffset = offset;
+
+        long[] offsetIndices = bigArray.arraysIdx(backingArrays, offset);
+        this.backingArraysIdx = offsetIndices[0];
+        this.curArrayIdx = offsetIndices[1];
+    }
+
+    protected void assertIsInt(long l) {
+        assert l == (int)l : "long value exceeds int range";
+    }
+
+    private boolean switchArray() {
+        backingArraysIdx++;
+        curArrayIdx = 0;
+        if (backingArraysIdx >= arraysLen) {
+            return false;
+        }
+        // advance through 0 length arrays
+        while (getArrayLength(backingArraysIdx) == 0) {
+            backingArraysIdx++;
+            if (backingArraysIdx >= arraysLen) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public abstract long getArrayLength(long idx);
+
+    public abstract T getValue(long backingArraysIdx, long curArrayIdx);
+
+    @Override
+    protected T computeNext() {
+        T value;
+        if (backingArraysIdx < arraysLen && curArrayIdx >= getArrayLength(backingArraysIdx)) {
+            if (!switchArray()) {
+                endOfData();
+                return null;
+            }
+        }
+        if (curOffset >= endOffset) {
+            endOfData();
+            return null;
+        }
+        value = getValue(backingArraysIdx, curArrayIdx);
+        curArrayIdx++;
+        curOffset++;
+        return value;
+    }
+}

--- a/core/src/main/java/io/crate/core/bigarray/IterableBigArray.java
+++ b/core/src/main/java/io/crate/core/bigarray/IterableBigArray.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.core.bigarray;
+
+import org.elasticsearch.common.util.ObjectArray;
+
+public interface IterableBigArray<T> extends ObjectArray<T>, Iterable<T> {
+}

--- a/core/src/main/java/io/crate/core/bigarray/MultiBigArrayIterator.java
+++ b/core/src/main/java/io/crate/core/bigarray/MultiBigArrayIterator.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.core.bigarray;
+
+import org.elasticsearch.common.util.ObjectArray;
+
+public class MultiBigArrayIterator<T> extends AbstractMultiArrayIterator<T, ObjectArray<T>> {
+
+    public MultiBigArrayIterator(MultiObjectArrayBigArray<T> bigArray,
+                                 long offset,
+                                 long size,
+                                 ObjectArray<T>[] backingArrays) {
+        super(bigArray, offset, size, backingArrays);
+
+    }
+
+    @Override
+    public long getArrayLength(long idx) {
+        assertIsInt(idx);
+        return backingArrays[(int)idx].size();
+    }
+
+    @Override
+    public T getValue(long backingArraysIdx, long curArrayIdx) {
+        assertIsInt(backingArraysIdx);
+        return backingArrays[(int)backingArraysIdx].get(curArrayIdx);
+    }
+}

--- a/core/src/main/java/io/crate/core/bigarray/MultiNativeArrayBigArray.java
+++ b/core/src/main/java/io/crate/core/bigarray/MultiNativeArrayBigArray.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.core.bigarray;
+
+import org.elasticsearch.ElasticsearchException;
+
+import java.util.Iterator;
+
+public class MultiNativeArrayBigArray<T> extends AbstractMultiArrayBigArray<T, T[]> {
+
+    @SafeVarargs
+    public MultiNativeArrayBigArray(long offset, long size, T[]... backingArrays) {
+        super(offset, size, backingArrays);
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        return 0; // TODO
+    }
+
+    @Override
+    public void close() throws ElasticsearchException {
+        // lalala!
+    }
+
+    @Override
+    public long arrayLength(T[] array) {
+        return array.length;
+    }
+
+    @Override
+    protected T getValue(long backingArraysIdx, long curArrayIdx) {
+        assertIsInt(backingArraysIdx);
+        assertIsInt(curArrayIdx);
+        return backingArrays[(int)backingArraysIdx][(int)curArrayIdx];
+    }
+
+    @Override
+    protected T setValue(long backingArraysIdx, long curArrayIdx, T value) {
+        assertIsInt(backingArraysIdx);
+        assertIsInt(curArrayIdx);
+        T old = backingArrays[(int)backingArraysIdx][(int)curArrayIdx];
+        backingArrays[(int)backingArraysIdx][(int)curArrayIdx] = value;
+        return old;
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return new MultiNativeArrayIterator<>(this, offset, size, backingArrays);
+    }
+}

--- a/core/src/main/java/io/crate/core/bigarray/MultiNativeArrayIterator.java
+++ b/core/src/main/java/io/crate/core/bigarray/MultiNativeArrayIterator.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.core.bigarray;
+
+public class MultiNativeArrayIterator<T> extends AbstractMultiArrayIterator<T, T[]> {
+
+    public MultiNativeArrayIterator(MultiNativeArrayBigArray<T> bigArray,
+                                    long offset,
+                                    long size,
+                                    T[][] backingArrays) {
+        super(bigArray, offset, size, backingArrays);
+    }
+
+    @Override
+    public long getArrayLength(long idx) {
+        assertIsInt(idx);
+        return backingArrays[(int)idx].length;
+    }
+
+    @Override
+    public T getValue(long backingArraysIdx, long curArrayIdx) {
+        assertIsInt(backingArraysIdx);
+        assertIsInt(curArrayIdx);
+        return backingArrays[(int)backingArraysIdx][(int)curArrayIdx];
+    }
+}

--- a/core/src/main/java/io/crate/core/bigarray/MultiObjectArrayBigArray.java
+++ b/core/src/main/java/io/crate/core/bigarray/MultiObjectArrayBigArray.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.core.bigarray;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.lease.Releasables;
+import org.elasticsearch.common.util.ObjectArray;
+
+import java.util.Iterator;
+
+public class MultiObjectArrayBigArray<T> extends AbstractMultiArrayBigArray<T, ObjectArray<T>> {
+
+    @SafeVarargs
+    public MultiObjectArrayBigArray(long offset, long size, ObjectArray<T>... backingArrays) {
+        super(offset, size, backingArrays);
+    }
+
+    @Override
+    public long arrayLength(ObjectArray<T> array) {
+        return array.size();
+    }
+
+    @Override
+    protected T getValue(long backingArraysIdx, long curArrayIdx) {
+        assertIsInt(backingArraysIdx);
+        return backingArrays[(int)backingArraysIdx].get(curArrayIdx);
+    }
+
+    @Override
+    protected T setValue(long backingArraysIdx, long curArrayIdx, T value) {
+        assertIsInt(backingArraysIdx);
+        return backingArrays[(int)backingArraysIdx].set(curArrayIdx, value);
+    }
+
+    @Override
+    public long ramBytesUsed() {
+        long used = 24; // initial offset
+        for (ObjectArray<T> array : backingArrays) {
+            used += array.ramBytesUsed();
+        }
+        return used;
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return new MultiBigArrayIterator<>(this, offset, size(), backingArrays);
+    }
+
+    @Override
+    public void close() throws ElasticsearchException {
+        Releasables.close(backingArrays);
+    }
+}

--- a/core/src/test/java/io/crate/core/bigarray/NativeObjectArrayBigArrayTest.java
+++ b/core/src/test/java/io/crate/core/bigarray/NativeObjectArrayBigArrayTest.java
@@ -1,0 +1,245 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.core.bigarray;
+
+import org.hamcrest.Matchers;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class NativeObjectArrayBigArrayTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private Object[][] createArray(int length) {
+        Object[][] backingArray = new Object[length][];
+        for (int i = 0; i< length; i++) {
+            backingArray[i] = new Object[] { i };
+        }
+        return backingArray;
+    }
+
+    @Test
+    public void testSingleArrayZeroSize() throws Exception {
+        Object[][] backingArray = createArray(10);
+
+        MultiNativeArrayBigArray<Object[]> bigArray = new MultiNativeArrayBigArray<Object[]>(0, 0, backingArray);
+        assertThat(bigArray.size(), is(0L));
+
+        expectedException.expect(ArrayIndexOutOfBoundsException.class);
+        expectedException.expectMessage("index 0 exceeds bounds of backing arrays");
+
+        bigArray.get(0L);
+    }
+
+    @Test
+    public void testSingleArrayOffsetExceedsBound() throws Exception {
+        Object[][] backingArray = createArray(10);
+        MultiNativeArrayBigArray<Object[]> bigArray = new MultiNativeArrayBigArray<Object[]>(10, 0, backingArray);
+        assertThat(bigArray.size(), is(0L));
+
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("offset exceeds backing arrays");
+
+        new MultiNativeArrayBigArray<Object[]>(11, 1, backingArray);
+    }
+
+    @Test
+    public void testSingleArrayZeroSizeWithBigOffset() throws Exception {
+        Object[][] backingArray = createArray(10);
+        MultiNativeArrayBigArray<Object[]> bigArray = new MultiNativeArrayBigArray<Object[]>(10, 0, backingArray);
+        assertThat(bigArray.size(), is(0L));
+    }
+
+    @Test
+    public void testSingleArraySizeOne() throws Exception {
+        Object[][] backingArray = createArray(10);
+        MultiNativeArrayBigArray<Object[]> bigArray = new MultiNativeArrayBigArray<Object[]>(9, 1, backingArray);
+        assertThat(bigArray.size(), is(1L));
+
+        Object[] row = bigArray.get(0L);
+        assertThat(row, Matchers.<Object>arrayContaining(9));
+
+        expectedException.expect(ArrayIndexOutOfBoundsException.class);
+        expectedException.expectMessage("index 1 exceeds bounds of backing arrays");
+
+        bigArray.get(1L);
+    }
+
+    @Test
+    public void testSingleArraySmallSize() throws Exception {
+        Object[][] backingArray = createArray(10);
+        MultiNativeArrayBigArray<Object[]> bigArray = new MultiNativeArrayBigArray<Object[]>(0, 5, backingArray);
+        assertThat(bigArray.size(), is(5L));
+
+        Object[] row = bigArray.get(0L);
+        assertThat(row, Matchers.<Object>arrayContaining(0));
+
+        int i = 0;
+        for (Object[] element : bigArray) {
+            assertThat(element[0], Matchers.<Object>is(i));
+            i++;
+        }
+        assertThat(i, is(5));
+
+    }
+
+    @Test
+    public void testNegativeIndex() throws Exception {
+        Object[][] backingArray = createArray(10);
+        MultiNativeArrayBigArray<Object[]> bigArray = new MultiNativeArrayBigArray<Object[]>(0, 10, backingArray);
+        assertThat(bigArray.size(), is(10L));
+
+        expectedException.expect(ArrayIndexOutOfBoundsException.class);
+        expectedException.expectMessage("index -19 exceeds bounds of backing arrays");
+
+        bigArray.get(-19L);
+    }
+
+    @Test
+    public void testMultipleArrays() throws Exception {
+        Object[][] backingArray1 = createArray(7);
+        Object[][] backingArray2 = createArray(10);
+        MultiNativeArrayBigArray<Object[]> bigArray = new MultiNativeArrayBigArray<>(0, 17, backingArray1, backingArray2);
+        assertThat(bigArray.size(), is(17L));
+        int i = 0;
+        for (; i < 7; i++) {
+            assertThat(bigArray.get(i), is(Matchers.<Object>arrayContaining(i)));
+        }
+        int j = 0;
+        for (; i < 17; i++) {
+            assertThat(bigArray.get(i), is(Matchers.<Object>arrayContaining(j++)));
+        }
+
+        expectedException.expect(ArrayIndexOutOfBoundsException.class);
+        expectedException.expectMessage("index 17 exceeds bounds of backing arrays");
+        bigArray.get(i);
+    }
+
+    @Test
+    public void testNullSizeArray() throws Exception {
+        Object[][] backingArray1 = createArray(1);
+        Object[][] backingArray2 = createArray(0);
+        Object[][] backingArray3 = createArray(9);
+        MultiNativeArrayBigArray<Object[]> bigArray = new MultiNativeArrayBigArray<>(
+                0, 10,
+                backingArray1,
+                backingArray2,
+                backingArray3);
+        assertThat(bigArray.size(), is(10L));
+        assertThat(bigArray.get(0L), is(Matchers.<Object>arrayContaining(0)));
+
+        for (int i=1; i < 9; i++) {
+            assertThat(bigArray.get(i), is(Matchers.<Object>arrayContaining(i-1)));
+        }
+
+        Object[] iterResults = new Object[(int)bigArray.size()];
+        int iter = 0;
+        for (Object[] row : bigArray) {
+            iterResults[iter++] = row[0];
+        }
+        assertThat(iterResults, is(Matchers.<Object>arrayContaining(0, 0, 1, 2, 3, 4, 5, 6, 7, 8)));
+
+        bigArray = new MultiNativeArrayBigArray<>(
+                1, 9,
+                backingArray1,
+                backingArray2,
+                backingArray3);
+        assertThat(bigArray.size(), is(9L));
+        for (int i=0; i < 9; i++) {
+            assertThat(bigArray.get(i), is(Matchers.<Object>arrayContaining(i)));
+        }
+
+        iterResults = new Object[(int)bigArray.size()];
+        int iter2 = 0;
+        for (Object[] row : bigArray) {
+            iterResults[iter2++] = row[0];
+        }
+        assertThat(iterResults, is(Matchers.<Object>arrayContaining(0, 1, 2, 3, 4, 5, 6, 7, 8)));
+
+    }
+
+    @Test
+    public void testSet() throws Exception {
+        Object[][] backingArray1 = createArray(1);
+        Object[][] backingArray2 = createArray(0);
+        Object[][] backingArray3 = createArray(9);
+        MultiNativeArrayBigArray<Object[]> bigArray = new MultiNativeArrayBigArray<>(
+                0, 10,
+                backingArray1,
+                backingArray2,
+                backingArray3);
+        assertThat(bigArray.size(), is(10L));
+        assertThat(bigArray.get(0L), is(Matchers.<Object>arrayContaining(0)));
+
+        Object[] empty = new Object[0];
+        for (int i=1; i < 9; i++) {
+            assertThat(bigArray.set(i, empty), is(Matchers.<Object>arrayContaining(i-1)));
+        }
+        for (int i=1; i < 9; i++) {
+            assertThat(bigArray.get(i), is(empty));
+        }
+    }
+
+    @Test
+    public void testIterator() throws Exception {
+        Object[][] backingArray = createArray(10);
+        MultiNativeArrayBigArray<Object[]> bigArray = new MultiNativeArrayBigArray<Object[]>(0, 10, backingArray);
+        int i = 0;
+        for (Object[] row : bigArray) {
+            assertThat(row, is(Matchers.<Object>arrayContaining(i++)));
+        }
+        assertThat(i, is(10));
+
+        bigArray = new MultiNativeArrayBigArray<Object[]>(5, 5, backingArray);
+
+        i = 5;
+        for (Object[] row : bigArray) {
+            assertThat(row, is(Matchers.<Object>arrayContaining(i++)));
+        }
+        assertThat(i, is(10));
+
+        bigArray = new MultiNativeArrayBigArray<Object[]>(5, 2, backingArray);
+
+        i = 5;
+        for (Object[] row : bigArray) {
+            assertThat(row, is(Matchers.<Object>arrayContaining(i++)));
+        }
+        assertThat(i, is(7));
+
+        bigArray = new MultiNativeArrayBigArray<Object[]>(0, 0, new Object[0][]);
+        assertThat(bigArray.iterator().hasNext(), is(false));
+
+        bigArray = new MultiNativeArrayBigArray<>(0, 20, new Object[0][], backingArray, backingArray);
+        i = 0;
+        for (Object[] row : bigArray) {
+            assertThat(row, is(Matchers.<Object>arrayContaining(i%10)));
+            i++;
+        }
+        assertThat(i, is(20));
+    }
+
+}

--- a/sql/src/main/java/io/crate/action/sql/query/CrateResultSorter.java
+++ b/sql/src/main/java/io/crate/action/sql/query/CrateResultSorter.java
@@ -110,6 +110,11 @@ public class CrateResultSorter {
 
         // Need to use the length of the resultsArr array, since the slots will be based on the position in the resultsArr array
         TopDocs[] shardTopDocs = new TopDocs[resultsArr.length()];
+        if (firstResult.includeFetch()) {
+            // if we did both query and fetch on the same go, we have fetched all the docs from each shards already, use them...
+            // this is also important since we shortcut and fetch only docs from "from" and up to "size"
+            limit *= sortedResults.length;
+        }
         for (AtomicArray.Entry<? extends QuerySearchResultProvider> sortedResult : sortedResults) {
             TopDocs topDocs = sortedResult.value.queryResult().topDocs();
             // the 'index' field is the position in the resultsArr atomic array

--- a/sql/src/main/java/io/crate/action/sql/query/CrateResultSorter.java
+++ b/sql/src/main/java/io/crate/action/sql/query/CrateResultSorter.java
@@ -44,7 +44,7 @@ public class CrateResultSorter {
      * copied from SearchPhaseController, to manually set offset
      *
      * @param resultsArr Shard result holder
-     * @param offset the number of results to skipd
+     * @param offset the number of results to skip
      * @param limit the number of results to return at max
      */
     public ScoreDoc[] sortDocs(AtomicArray<? extends QuerySearchResultProvider> resultsArr, int offset, int limit) throws IOException {
@@ -110,11 +110,6 @@ public class CrateResultSorter {
 
         // Need to use the length of the resultsArr array, since the slots will be based on the position in the resultsArr array
         TopDocs[] shardTopDocs = new TopDocs[resultsArr.length()];
-        if (firstResult.includeFetch()) {
-            // if we did both query and fetch on the same go, we have fetched all the docs from each shards already, use them...
-            // this is also important since we shortcut and fetch only docs from "from" and up to "size"
-            limit *= sortedResults.length;
-        }
         for (AtomicArray.Entry<? extends QuerySearchResultProvider> sortedResult : sortedResults) {
             TopDocs topDocs = sortedResult.value.queryResult().topDocs();
             // the 'index' field is the position in the resultsArr atomic array

--- a/sql/src/main/java/io/crate/executor/BigArrayPage.java
+++ b/sql/src/main/java/io/crate/executor/BigArrayPage.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.executor;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.AbstractIterator;
+import org.elasticsearch.common.util.ObjectArray;
+
+import java.util.Iterator;
+
+public class BigArrayPage implements Page {
+
+    private class ObjectArrayIterator<T> extends AbstractIterator<T>{
+
+        private final ObjectArray<T> array;
+        private final long limit;
+        private long position;
+
+        ObjectArrayIterator(ObjectArray<T> array, long start, long limit) {
+            this.array = array;
+            this.limit = start+limit;
+            this.position = start;
+        }
+
+        @Override
+        protected T computeNext() {
+            if (position > limit-1) {
+                endOfData();
+                return null;
+            }
+            try {
+                return this.array.get(position++);
+            } catch (ArrayIndexOutOfBoundsException e) {
+                endOfData();
+                return null;
+            }
+        }
+    }
+
+    private final ObjectArray<Object[]> page;
+    private final long start;
+    private final long size;
+
+    public BigArrayPage(ObjectArray<Object[]> page) {
+        this(page, 0, page.size());
+    }
+
+    public BigArrayPage(ObjectArray<Object[]> page, long start, long size) {
+        Preconditions.checkArgument(start <= page.size(), "start exceeds page");
+        this.page = page;
+        this.start = start;
+        this.size = Math.min(size, page.size() - start);
+    }
+
+    @Override
+    public long size() {
+        return size;
+    }
+
+    @Override
+    public Iterator<Object[]> iterator() {
+        return new ObjectArrayIterator<>(page, start, size);
+    }
+}

--- a/sql/src/main/java/io/crate/executor/ObjectArrayPage.java
+++ b/sql/src/main/java/io/crate/executor/ObjectArrayPage.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.executor;
+
+import com.google.common.base.Preconditions;
+import io.crate.core.collections.ArrayIterator;
+
+import java.util.Iterator;
+
+public class ObjectArrayPage implements Page {
+
+    private final int start;
+    private final int size;
+    private final Object[][] pageSource;
+
+    public ObjectArrayPage(Object[][] pageSource, int start, int size) {
+        Preconditions.checkArgument(start <= pageSource.length, "start exceeds page");
+        this.start = start;
+        this.size = Math.min(size, pageSource.length - start);
+        this.pageSource = pageSource;
+    }
+
+    public ObjectArrayPage(Object[][] pageSource) {
+        this(pageSource, 0, pageSource.length);
+    }
+
+    @Override
+    public Iterator<Object[]> iterator() {
+        return new ArrayIterator(pageSource, start, start +  size);
+    }
+
+    @Override
+    public long size() {
+        return size;
+    }
+}

--- a/sql/src/main/java/io/crate/executor/Page.java
+++ b/sql/src/main/java/io/crate/executor/Page.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.executor;
+
+import java.util.Collections;
+import java.util.Iterator;
+
+/**
+ * a Page represents a couple of rows
+ */
+public interface Page extends Iterable<Object[]> {
+
+    /**
+     * The number of rows that this page actually contains.
+     * Might be less that the requested size
+     */
+    public long size();
+
+    public static final Page EMPTY = new Page() {
+        @Override
+        public long size() {
+            return 0;
+        }
+
+        @Override
+        public Iterator<Object[]> iterator() {
+            return Collections.emptyIterator();
+        }
+    };
+}

--- a/sql/src/main/java/io/crate/executor/PageInfo.java
+++ b/sql/src/main/java/io/crate/executor/PageInfo.java
@@ -53,6 +53,10 @@ public class PageInfo {
         return new PageInfo(position+size, nextSize);
     }
 
+    public PageInfo nextPage() {
+        return new PageInfo(position+size, size);
+    }
+
     public static PageInfo fromStream(StreamInput in) throws IOException {
         return new PageInfo(in.readVInt(), in.readVInt());
     }

--- a/sql/src/main/java/io/crate/executor/PageableTask.java
+++ b/sql/src/main/java/io/crate/executor/PageableTask.java
@@ -24,10 +24,10 @@ package io.crate.executor;
 /**
  * A task that is able to return paged results.
  * By contract it should return implementations of
- * {@linkplain io.crate.executor.PagableTaskResult} (nested in futures)
+ * {@linkplain PageableTaskResult} (nested in futures)
  * on {@linkplain #result()}.
  */
-public interface PagableTask extends Task {
+public interface PageableTask extends Task {
 
     /**
      * Start a paged execution.

--- a/sql/src/main/java/io/crate/executor/PageableTaskResult.java
+++ b/sql/src/main/java/io/crate/executor/PageableTaskResult.java
@@ -34,11 +34,11 @@ import java.util.NoSuchElementException;
  * asynchronously.
  *
  */
-public interface PagableTaskResult extends TaskResult, Closeable {
+public interface PageableTaskResult extends TaskResult, Closeable {
 
-    public static final PagableTaskResult EMPTY_PAGABLE_RESULT = new PagableTaskResult() {
+    public static final PageableTaskResult EMPTY_PAGABLE_RESULT = new PageableTaskResult() {
         @Override
-        public ListenableFuture<PagableTaskResult> fetch(PageInfo pageInfo) {
+        public ListenableFuture<PageableTaskResult> fetch(PageInfo pageInfo) {
             return Futures.immediateFailedFuture(new NoSuchElementException());
         }
 
@@ -65,7 +65,7 @@ public interface PagableTaskResult extends TaskResult, Closeable {
      * @param pageInfo identifying the page to fetch
      * @return a future holding the result of fetching the next page
      */
-    ListenableFuture<PagableTaskResult> fetch(PageInfo pageInfo);
+    ListenableFuture<PageableTaskResult> fetch(PageInfo pageInfo);
 
 
     /**

--- a/sql/src/main/java/io/crate/executor/PageableTaskResult.java
+++ b/sql/src/main/java/io/crate/executor/PageableTaskResult.java
@@ -43,8 +43,13 @@ public interface PageableTaskResult extends TaskResult, Closeable {
         }
 
         @Override
+        public Page page() {
+            return Page.EMPTY;
+        }
+
+        @Override
         public Object[][] rows() {
-            return TaskResult.EMPTY_ROWS;
+            throw new UnsupportedOperationException("rows() is not supported on PageableTaskResut");
         }
 
         @Nullable
@@ -67,6 +72,19 @@ public interface PageableTaskResult extends TaskResult, Closeable {
      */
     ListenableFuture<PageableTaskResult> fetch(PageInfo pageInfo);
 
+
+    /**
+     *
+     * <strong>
+     *     Use this instead of {@linkplain #rows()}!
+     * </strong>
+     * <p>
+     *
+     * Get the page that was fetched with this task result.
+     * It might contain less rows than requested.
+     * @return a Page you can iterate over to get the rows it consists of
+     */
+    Page page();
 
     /**
      * Must be called after paging is done

--- a/sql/src/main/java/io/crate/executor/SinglePageTaskResult.java
+++ b/sql/src/main/java/io/crate/executor/SinglePageTaskResult.java
@@ -26,24 +26,17 @@ import com.google.common.util.concurrent.ListenableFuture;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
-import java.util.Arrays;
 
 public class SinglePageTaskResult implements PageableTaskResult {
 
-    private final Object[][] rows;
+    private final Page page;
 
     public SinglePageTaskResult(Object[][] rows) {
-        this.rows = rows;
+        this.page = new ObjectArrayPage(rows);
     }
 
-    public SinglePageTaskResult(Object[][] rows, PageInfo pageInfo) {
-        if (pageInfo.position() != 0 || pageInfo.size() < rows.length) {
-            // TODO: use a row representation that hides the underlying array stuff
-            // so we could do this more efficiently
-            this.rows = Arrays.copyOfRange(rows, pageInfo.position(), pageInfo.position() + pageInfo.size());
-        } else {
-            this.rows = rows;
-        }
+    public SinglePageTaskResult(Object[][] rows, int start, int end) {
+        this.page = new ObjectArrayPage(rows, start, end);
     }
 
     @Override
@@ -52,8 +45,13 @@ public class SinglePageTaskResult implements PageableTaskResult {
     }
 
     @Override
+    public Page page() {
+        return page;
+    }
+
+    @Override
     public Object[][] rows() {
-        return rows;
+        throw new UnsupportedOperationException("rows() not supported on SinglePageTaskResult");
     }
 
     @Nullable

--- a/sql/src/main/java/io/crate/executor/SinglePageTaskResult.java
+++ b/sql/src/main/java/io/crate/executor/SinglePageTaskResult.java
@@ -27,7 +27,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.NoSuchElementException;
 
-public class SinglePageTaskResult implements PagableTaskResult {
+public class SinglePageTaskResult implements PageableTaskResult {
 
     private final Object[][] rows;
 
@@ -36,7 +36,7 @@ public class SinglePageTaskResult implements PagableTaskResult {
     }
 
     @Override
-    public ListenableFuture<PagableTaskResult> fetch(PageInfo pageInfo) {
+    public ListenableFuture<PageableTaskResult> fetch(PageInfo pageInfo) {
         throw new NoSuchElementException();
     }
 
@@ -51,7 +51,7 @@ public class SinglePageTaskResult implements PagableTaskResult {
         return null;
     }
 
-    public static PagableTaskResult singlePage(Object[][] rows) {
+    public static PageableTaskResult singlePage(Object[][] rows) {
         return new SinglePageTaskResult(rows);
     }
 

--- a/sql/src/main/java/io/crate/executor/transport/TransportExecutor.java
+++ b/sql/src/main/java/io/crate/executor/transport/TransportExecutor.java
@@ -56,6 +56,7 @@ import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Provider;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.search.controller.SearchPhaseController;
 import org.elasticsearch.threadpool.ThreadPool;
 
@@ -85,6 +86,8 @@ public class TransportExecutor implements Executor, TaskExecutor {
 
     private final CrateResultSorter crateResultSorter;
 
+    private final BigArrays bigArrays;
+
     @Inject
     public TransportExecutor(Settings settings,
                              TransportActionProvider transportActionProvider,
@@ -97,7 +100,8 @@ public class TransportExecutor implements Executor, TaskExecutor {
                              StatsTables statsTables,
                              ClusterService clusterService,
                              CrateCircuitBreakerService breakerService,
-                             CrateResultSorter crateResultSorter) {
+                             CrateResultSorter crateResultSorter,
+                             BigArrays bigArrays) {
         this.settings = settings;
         this.transportActionProvider = transportActionProvider;
         this.handlerSideDataCollectOperation = handlerSideDataCollectOperation;
@@ -108,6 +112,7 @@ public class TransportExecutor implements Executor, TaskExecutor {
         this.statsTables = statsTables;
         this.clusterService = clusterService;
         this.crateResultSorter = crateResultSorter;
+        this.bigArrays = bigArrays;
         this.visitor = new Visitor();
         this.circuitBreaker = breakerService.getBreaker(CrateCircuitBreakerService.QUERY_BREAKER);
         this.globalImplementationSymbolVisitor = new ImplementationSymbolVisitor(
@@ -259,6 +264,7 @@ public class TransportExecutor implements Executor, TaskExecutor {
                     transportActionProvider.searchServiceTransportAction(),
                     searchPhaseControllerProvider.get(),
                     threadPool,
+                    bigArrays,
                     crateResultSorter));
         }
 

--- a/sql/src/main/java/io/crate/executor/transport/TransportExecutor.java
+++ b/sql/src/main/java/io/crate/executor/transport/TransportExecutor.java
@@ -264,13 +264,20 @@ public class TransportExecutor implements Executor, TaskExecutor {
 
         @Override
         public ImmutableList<Task> visitNestedLoopNode(NestedLoopNode node, UUID jobId) {
-            return singleTask(new NestedLoopTask(
+            // TODO: optimize for outer and inner being the same relation
+            List<Task> outerTasks = node.outer().accept(this, jobId);
+            List<Task> innerTasks = node.inner().accept(this, jobId);
+            return singleTask(
+                    new NestedLoopTask(
                         jobId,
                         clusterService.localNode().id(),
                         node,
+                        outerTasks,
+                        innerTasks,
                         TransportExecutor.this,
                         globalProjectionToProjectionVisitor,
-                        circuitBreaker));
+                        circuitBreaker)
+            );
         }
 
         @Override

--- a/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/QueryThenFetchTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/QueryThenFetchTask.java
@@ -431,6 +431,7 @@ public class QueryThenFetchTask extends JobTask implements PageableTask {
             this.queryFetchResults = new AtomicArray<>(numShards);
         }
 
+
         @Override
         public ListenableFuture<PageableTaskResult> fetch(final PageInfo pageInfo) {
             final AtomicInteger numOps = new AtomicInteger(numShards);
@@ -505,7 +506,7 @@ public class QueryThenFetchTask extends JobTask implements PageableTask {
 
         @Override
         public void close() throws IOException {
-            releaseScrollContexts(queryFetchResults);
+            releaseAllContexts();
         }
     }
 
@@ -528,11 +529,11 @@ public class QueryThenFetchTask extends JobTask implements PageableTask {
         }
     }
 
-    private void releaseScrollContexts(AtomicArray<QueryFetchSearchResult> firstResults) {
-        for (AtomicArray.Entry<QueryFetchSearchResult> entry : firstResults.asList()) {
-            DiscoveryNode node = nodes.get(entry.value.queryResult().shardTarget().nodeId());
+    private void releaseAllContexts() {
+        for (Map.Entry<SearchShardTarget, Long> entry : searchContextIds.entrySet()) {
+            DiscoveryNode node = nodes.get(entry.getKey().nodeId());
             if (node != null) {
-                searchServiceTransportAction.sendFreeContext(node, entry.value.queryResult().id(), EMPTY_SEARCH_REQUEST);
+                searchServiceTransportAction.sendFreeContext(node, entry.getValue(), EMPTY_SEARCH_REQUEST);
             }
         }
     }

--- a/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/QueryThenFetchTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/QueryThenFetchTask.java
@@ -74,7 +74,7 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
-public class QueryThenFetchTask extends JobTask implements PagableTask {
+public class QueryThenFetchTask extends JobTask implements PageableTask {
 
     private static final TimeValue DEFAULT_KEEP_ALIVE = TimeValue.timeValueMinutes(5L);
     private final ESLogger logger = Loggers.getLogger(this.getClass());
@@ -217,7 +217,7 @@ public class QueryThenFetchTask extends JobTask implements PagableTask {
         requests = prepareRequests(references, pageInfo);
 
         if (!routing.hasLocations() || requests.size() == 0) {
-            result.set(PagableTaskResult.EMPTY_PAGABLE_RESULT);
+            result.set(PageableTaskResult.EMPTY_PAGABLE_RESULT);
         }
 
         state.blocks().globalBlockedRaiseException(ClusterBlockLevel.READ);
@@ -419,10 +419,10 @@ public class QueryThenFetchTask extends JobTask implements PagableTask {
         }
     }
 
-    class QTFScrollTaskResult implements PagableTaskResult {
+    class QTFScrollTaskResult implements PageableTaskResult {
 
         private final Object[][] rows;
-        private final SettableFuture<PagableTaskResult> future;
+        private final SettableFuture<PageableTaskResult> future;
         private final AtomicArray<QueryFetchSearchResult> queryFetchResults;
 
         public QTFScrollTaskResult(Object[][] rows) {
@@ -432,7 +432,7 @@ public class QueryThenFetchTask extends JobTask implements PagableTask {
         }
 
         @Override
-        public ListenableFuture<PagableTaskResult> fetch(final PageInfo pageInfo) {
+        public ListenableFuture<PageableTaskResult> fetch(final PageInfo pageInfo) {
             final AtomicInteger numOps = new AtomicInteger(numShards);
 
             final Scroll scroll = new Scroll(keepAlive.or(DEFAULT_KEEP_ALIVE));
@@ -461,7 +461,7 @@ public class QueryThenFetchTask extends JobTask implements PagableTask {
                                             final Object[][] rows = toRows(hits, extractors);
 
                                             if (rows.length == 0) {
-                                                future.set(PagableTaskResult.EMPTY_PAGABLE_RESULT);
+                                                future.set(PageableTaskResult.EMPTY_PAGABLE_RESULT);
                                                 close();
                                             } else {
                                                 future.set(new QTFScrollTaskResult(rows));

--- a/sql/src/main/java/io/crate/operation/join/CollectingPageableTaskIterable.java
+++ b/sql/src/main/java/io/crate/operation/join/CollectingPageableTaskIterable.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.operation.join;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import io.crate.executor.PageInfo;
+import io.crate.executor.PageableTaskResult;
+import io.crate.executor.SinglePageTaskResult;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.*;
+
+/**
+ * iterable over a PageableTask
+ * that gathers the pages it fetches.
+ *
+ * The iterator it returns iterates over all the pages
+ */
+public class CollectingPageableTaskIterable extends RelationIterable {
+
+    private PageableTaskResult currentTaskResult;
+    private List<Object[][]> pages;
+
+    public CollectingPageableTaskIterable(PageableTaskResult taskResult, PageInfo pageInfo) {
+        super(pageInfo);
+        this.currentTaskResult = taskResult;
+        this.pages = new LinkedList<>();
+        this.pages.add(
+                taskResult.rows()
+        );
+    }
+
+    @Override
+    public Iterator<Object[]> iterator() {
+        return Iterators.concat(Lists.transform(pages, new Function<Object[][], Iterator<Object[]>>() {
+            @Nullable
+            @Override
+            public Iterator<Object[]> apply(@Nullable Object[][] input) {
+                if (input == null) {
+                    return Collections.emptyIterator();
+                } else {
+                    return Iterators.forArray(input);
+                }
+            }
+        }).iterator());
+    }
+
+    @Override
+    public ListenableFuture<Void> fetchPage(PageInfo pageInfo) throws NoSuchElementException {
+        this.pageInfo(pageInfo);
+
+        if (isComplete()) {
+            return Futures.immediateFuture(null);
+        }
+
+        final SettableFuture<Void> future = SettableFuture.create();
+        Futures.addCallback(currentTaskResult.fetch(pageInfo), new FutureCallback<PageableTaskResult>() {
+            @Override
+            public void onSuccess(@Nullable PageableTaskResult result) {
+                if (result == null) {
+                    throw new IllegalArgumentException("PageableTaskResult is null");
+                }
+                pages.add(result.rows());
+                future.set(null);
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                future.setException(t);
+            }
+        });
+        return future;
+    }
+
+    @Override
+    public boolean isComplete() {
+        // last page length is 0
+        return currentTaskResult instanceof SinglePageTaskResult ||
+                (!pages.isEmpty() && pages.get(pages.size()-1).length == 0);
+    }
+
+    @Override
+    public void close() throws IOException {
+        currentTaskResult.close();
+    }
+}

--- a/sql/src/main/java/io/crate/operation/join/FetchedRowsIterable.java
+++ b/sql/src/main/java/io/crate/operation/join/FetchedRowsIterable.java
@@ -19,55 +19,45 @@
  * software solely pursuant to the terms of the relevant commercial agreement.
  */
 
-package io.crate.executor;
+package io.crate.operation.join;
 
+import com.google.common.collect.Iterators;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import io.crate.executor.PageInfo;
+import io.crate.executor.TaskResult;
 
-import javax.annotation.Nullable;
 import java.io.IOException;
-import java.util.Arrays;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
 
-public class SinglePageTaskResult implements PageableTaskResult {
+class FetchedRowsIterable extends RelationIterable {
 
     private final Object[][] rows;
 
-    public SinglePageTaskResult(Object[][] rows) {
-        this.rows = rows;
-    }
-
-    public SinglePageTaskResult(Object[][] rows, PageInfo pageInfo) {
-        if (pageInfo.position() != 0 || pageInfo.size() < rows.length) {
-            // TODO: use a row representation that hides the underlying array stuff
-            // so we could do this more efficiently
-            this.rows = Arrays.copyOfRange(rows, pageInfo.position(), pageInfo.position() + pageInfo.size());
-        } else {
-            this.rows = rows;
-        }
+    public FetchedRowsIterable(TaskResult taskResult, PageInfo pageInfo) {
+        super(pageInfo);
+        this.rows = taskResult.rows();
     }
 
     @Override
-    public ListenableFuture<PageableTaskResult> fetch(PageInfo pageInfo) {
-        return Futures.immediateFuture(PageableTaskResult.EMPTY_PAGABLE_RESULT);
+    public Iterator<Object[]> iterator() {
+        return Iterators.forArray(rows);
     }
 
     @Override
-    public Object[][] rows() {
-        return rows;
+    public ListenableFuture<Void> fetchPage(PageInfo pageInfo) throws NoSuchElementException {
+        this.pageInfo(pageInfo);
+        return Futures.immediateFuture(null);
     }
 
-    @Nullable
     @Override
-    public String errorMessage() {
-        return null;
-    }
-
-    public static PageableTaskResult singlePage(Object[][] rows) {
-        return new SinglePageTaskResult(rows);
+    public boolean isComplete() {
+        return currentPageInfo().position() >= rows.length;
     }
 
     @Override
     public void close() throws IOException {
-        // boomshakalakka!
+        // ayayayayayaaaay!
     }
 }

--- a/sql/src/main/java/io/crate/operation/join/NestedLoopOperation.java
+++ b/sql/src/main/java/io/crate/operation/join/NestedLoopOperation.java
@@ -267,7 +267,7 @@ public class NestedLoopOperation implements ProjectorUpstream {
 
         int rowsToProduce = limit + offset;
         int outerPageSize = 1;
-        final PageInfo outerPageInfo = new PageInfo(0, 1);
+        final PageInfo outerPageInfo = new PageInfo(0, outerPageSize);
         List<ListenableFuture<TaskResult>> outerResults = executeChildTasks(outerRelationTasks, Optional.of(outerPageInfo));
         assert outerResults.size() == 1;
         final PageInfo innerPageInfo = new PageInfo(0, rowsToProduce/outerPageSize);

--- a/sql/src/main/java/io/crate/operation/join/RelationIterable.java
+++ b/sql/src/main/java/io/crate/operation/join/RelationIterable.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.operation.join;
+
+import com.google.common.collect.Iterators;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.crate.executor.PageInfo;
+import io.crate.executor.PageableTaskResult;
+import io.crate.executor.TaskResult;
+
+import java.io.Closeable;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+abstract class RelationIterable implements Iterable<Object[]>, Closeable {
+
+    private PageInfo pageInfo;
+
+    protected RelationIterable(PageInfo pageInfo) {
+        this.pageInfo = pageInfo;
+    }
+
+    public abstract ListenableFuture<Void> fetchPage(PageInfo pageInfo) throws NoSuchElementException;
+
+    public abstract boolean isComplete();
+
+    public PageInfo currentPageInfo() {
+        return pageInfo;
+    }
+
+    protected void pageInfo(PageInfo pageInfo) {
+        this.pageInfo = pageInfo;
+    }
+
+    public Iterator<Object[]> forCurrentPage() {
+        Iterator<Object[]> iter = iterator();
+        Iterators.advance(iter, currentPageInfo().position());
+        return iter;
+    }
+
+    static RelationIterable forTaskResult(TaskResult taskResult, PageInfo pageInfo, boolean collecting) {
+        if (taskResult instanceof PageableTaskResult) {
+            if (collecting) {
+                return new CollectingPageableTaskIterable((PageableTaskResult) taskResult, pageInfo);
+            } else {
+                return new SinglePagePageableTaskIterable((PageableTaskResult)taskResult, pageInfo);
+            }
+        } else {
+            return new FetchedRowsIterable(taskResult, pageInfo);
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/planner/projection/TopNProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/TopNProjection.java
@@ -21,7 +21,7 @@
 
 package io.crate.planner.projection;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import io.crate.planner.symbol.Symbol;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -63,9 +63,9 @@ public class TopNProjection extends Projection {
 
     public TopNProjection(int limit, int offset, @Nullable List<Symbol> orderBy, @Nullable boolean[] reverseFlags, @Nullable Boolean[] nullsFirst) {
         this(limit, offset);
-        this.orderBy = Objects.firstNonNull(orderBy, ImmutableList.<Symbol>of());
-        this.reverseFlags = Objects.firstNonNull(reverseFlags, new boolean[0]);
-        this.nullsFirst = Objects.firstNonNull(nullsFirst, new Boolean[0]);
+        this.orderBy = MoreObjects.firstNonNull(orderBy, ImmutableList.<Symbol>of());
+        this.reverseFlags = MoreObjects.firstNonNull(reverseFlags, new boolean[0]);
+        this.nullsFirst = MoreObjects.firstNonNull(nullsFirst, new Boolean[0]);
         assert this.orderBy.size() == this.reverseFlags.length : "reverse flags length does not match orderBy items count";
         assert this.nullsFirst.length == this.reverseFlags.length;
     }

--- a/sql/src/test/java/io/crate/executor/BigArrayPageTest.java
+++ b/sql/src/test/java/io/crate/executor/BigArrayPageTest.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.executor;
+
+import com.google.common.collect.Iterators;
+import org.elasticsearch.cache.recycler.PageCacheRecycler;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.ObjectArray;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class BigArrayPageTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private BigArrays bigArrays;
+
+    @Before
+    public void prepare() {
+        PageCacheRecycler pageCacheRecycler = new PageCacheRecycler(ImmutableSettings.EMPTY, new ThreadPool(getClass().getName()));
+        bigArrays = new BigArrays(ImmutableSettings.EMPTY, pageCacheRecycler, null);
+    }
+
+    @Test
+    public void testEmptyArray() throws Exception {
+        BigArrayPage page = new BigArrayPage(bigArrays.<Object[]>newObjectArray(0), 0, 0);
+        assertThat(page.size(), is(0L));
+        assertThat(page.iterator().hasNext(), is(false));
+
+        page = new BigArrayPage(bigArrays.<Object[]>newObjectArray(0), 0, 10);
+        assertThat(page.size(), is(0L));
+        assertThat(page.iterator().hasNext(), is(false));
+    }
+
+    @Test
+    public void testBigArray() throws Exception {
+        ObjectArray<Object[]> pageSource = bigArrays.newObjectArray(100);
+        for (long i = 0; i < pageSource.size(); i++) {
+            pageSource.set(i, new Object[]{ i });
+        }
+        BigArrayPage page = new BigArrayPage(pageSource, 0, 10);
+        assertThat(page.size(), is(10L));
+        assertThat(Iterators.size(page.iterator()), is(10));
+
+        page = new BigArrayPage(pageSource, 10, 10);
+        assertThat(page.size(), is(10L));
+        assertThat(Iterators.size(page.iterator()), is(10));
+
+        page = new BigArrayPage(pageSource, 0, 100);
+        assertThat(page.size(), is(100L));
+        assertThat(Iterators.size(page.iterator()), is(100));
+
+        page = new BigArrayPage(pageSource, 10, 100);
+        assertThat(page.size(), is(90L));
+        assertThat(Iterators.size(page.iterator()), is(90));
+
+        page = new BigArrayPage(pageSource);
+        assertThat(page.size(), is(100L));
+        assertThat(Iterators.size(page.iterator()), is(100));
+    }
+
+    @Test
+    public void testExceed() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("start exceeds page");
+        new BigArrayPage(bigArrays.<Object[]>newObjectArray(2), 3, 1);
+    }
+}

--- a/sql/src/test/java/io/crate/executor/ObjectArrayPageTest.java
+++ b/sql/src/test/java/io/crate/executor/ObjectArrayPageTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.executor;
+
+import com.google.common.collect.Iterators;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class ObjectArrayPageTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testEmptyObjectArray() throws Exception {
+        ObjectArrayPage page = new ObjectArrayPage(new Object[0][], 0, 0);
+        assertThat(page.size(), is(0L));
+        assertThat(page.iterator().hasNext(), is(false));
+
+        page = new ObjectArrayPage(new Object[0][], 0, 10);
+        assertThat(page.size(), is(0L));
+        assertThat(page.iterator().hasNext(), is(false));
+    }
+
+    @Test
+    public void testBigObjectArray() throws Exception {
+        Object[][] pageSource = new Object[100][];
+        for (int i = 0; i < pageSource.length; i++) {
+            pageSource[i] = new Object[] { i };
+        }
+        ObjectArrayPage page = new ObjectArrayPage(pageSource, 0, 10);
+        assertThat(page.size(), is(10L));
+        assertThat(Iterators.size(page.iterator()), is(10));
+
+        page = new ObjectArrayPage(pageSource, 10, 10);
+        assertThat(page.size(), is(10L));
+        assertThat(Iterators.size(page.iterator()), is(10));
+
+        page = new ObjectArrayPage(pageSource, 0, 100);
+        assertThat(page.size(), is(100L));
+        assertThat(Iterators.size(page.iterator()), is(100));
+
+        page = new ObjectArrayPage(pageSource, 10, 100);
+        assertThat(page.size(), is(90L));
+        assertThat(Iterators.size(page.iterator()), is(90));
+
+        page = new ObjectArrayPage(pageSource);
+        assertThat(page.size(), is(100L));
+        assertThat(Iterators.size(page.iterator()), is(100));
+    }
+
+    @Test
+    public void testExceed() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("start exceeds page");
+        new ObjectArrayPage(new Object[2][], 3, 1);
+    }
+
+
+}

--- a/sql/src/test/java/io/crate/executor/transport/BaseTransportExecutorTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/BaseTransportExecutorTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.executor.transport;
+
+import com.google.common.collect.ImmutableList;
+import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.integrationtests.Setup;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.ReferenceIdent;
+import io.crate.metadata.ReferenceInfo;
+import io.crate.metadata.TableIdent;
+import io.crate.metadata.doc.DocSchemaInfo;
+import io.crate.planner.RowGranularity;
+import io.crate.planner.node.dql.ESGetNode;
+import io.crate.planner.symbol.Reference;
+import io.crate.planner.symbol.Symbol;
+import io.crate.planner.symbol.Symbols;
+import io.crate.test.integration.CrateIntegrationTest;
+import io.crate.test.integration.CrateTestCluster;
+import io.crate.testing.TestingHelpers;
+import io.crate.types.DataTypes;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterService;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.Arrays;
+import java.util.List;
+
+@CrateIntegrationTest.ClusterScope(scope = CrateIntegrationTest.Scope.GLOBAL)
+public class BaseTransportExecutorTest extends SQLTransportIntegrationTest {
+
+    Setup setup = new Setup(sqlExecutor);
+
+    static {
+        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
+    }
+
+    ClusterService clusterService;
+    ClusterName clusterName;
+    TransportExecutor executor;
+    DocSchemaInfo docSchemaInfo;
+
+    TableIdent charactersIdent = new TableIdent(null, "characters");
+    TableIdent booksIdent = new TableIdent(null, "books");
+
+    Reference idRef = new Reference(new ReferenceInfo(
+            new ReferenceIdent(charactersIdent, "id"), RowGranularity.DOC, DataTypes.INTEGER));
+    Reference nameRef = new Reference(new ReferenceInfo(
+            new ReferenceIdent(charactersIdent, "name"), RowGranularity.DOC, DataTypes.STRING));
+    Reference femaleRef = TestingHelpers.createReference(charactersIdent.name(), new ColumnIdent("female"), DataTypes.BOOLEAN);
+    Reference versionRef = new Reference(new ReferenceInfo(
+            new ReferenceIdent(charactersIdent, "_version"), RowGranularity.DOC, DataTypes.LONG));
+
+    Reference booksIdRef = new Reference(new ReferenceInfo(
+            new ReferenceIdent(booksIdent, "id"), RowGranularity.DOC, DataTypes.INTEGER));
+    Reference titleRef = new Reference(new ReferenceInfo(
+            new ReferenceIdent(booksIdent, "title"), RowGranularity.DOC, DataTypes.STRING));
+    Reference authorRef = new Reference(new ReferenceInfo(
+            new ReferenceIdent(booksIdent, "author"), RowGranularity.DOC, DataTypes.STRING));
+
+    TableIdent partedTable = new TableIdent(null, "parted");
+    Reference partedIdRef = new Reference(new ReferenceInfo(
+            new ReferenceIdent(partedTable, "id"), RowGranularity.DOC, DataTypes.INTEGER));
+    Reference partedNameRef = new Reference(new ReferenceInfo(
+            new ReferenceIdent(partedTable, "name"), RowGranularity.DOC, DataTypes.STRING));
+    Reference partedDateRef = new Reference(new ReferenceInfo(
+            new ReferenceIdent(partedTable, "date"), RowGranularity.DOC, DataTypes.TIMESTAMP));
+
+    protected static ESGetNode newGetNode(String index, List<Symbol> outputs, String id) {
+        return newGetNode(index, outputs, Arrays.asList(id));
+    }
+
+    protected static ESGetNode newGetNode(String index, List<Symbol> outputs, List<String> ids) {
+        return new ESGetNode(
+                index,
+                outputs,
+                Symbols.extractTypes(outputs),
+                ids,
+                ids,
+                ImmutableList.<Symbol>of(),
+                new boolean[0],
+                new Boolean[0],
+                null,
+                0,
+                null
+        );
+    }
+
+    @Before
+    public void transportSetUp() {
+        CrateTestCluster cluster = cluster();
+        executor = cluster.getInstance(TransportExecutor.class);
+
+        docSchemaInfo = cluster.getInstance(DocSchemaInfo.class);
+    }
+
+    @After
+    public void transportTearDown() {
+        executor = null;
+        docSchemaInfo = null;
+    }
+}

--- a/sql/src/test/java/io/crate/executor/transport/TransportExecutorPagingTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/TransportExecutorPagingTest.java
@@ -1,0 +1,374 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.executor.transport;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.crate.Constants;
+import io.crate.analyze.WhereClause;
+import io.crate.executor.*;
+import io.crate.executor.task.join.NestedLoopTask;
+import io.crate.executor.transport.task.elasticsearch.QueryThenFetchTask;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.planner.node.dql.QueryThenFetchNode;
+import io.crate.planner.node.dql.join.NestedLoopNode;
+import io.crate.planner.projection.Projection;
+import io.crate.planner.projection.TopNProjection;
+import io.crate.planner.symbol.InputColumn;
+import io.crate.planner.symbol.Symbol;
+import io.crate.testing.TestingHelpers;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+import org.elasticsearch.common.unit.TimeValue;
+import org.junit.After;
+import org.junit.Test;
+
+import java.io.Closeable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.core.Is.is;
+
+public class TransportExecutorPagingTest extends BaseTransportExecutorTest {
+
+    static {
+        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
+    }
+
+    private Closeable closeMeWhenDone;
+
+    @After
+    public void freeResources() throws Exception {
+        if (closeMeWhenDone != null) {
+            closeMeWhenDone.close();
+        }
+    }
+
+    @Test
+    public void testPagedQueryThenFetch() throws Exception {
+        setup.setUpCharacters();
+        DocTableInfo characters = docSchemaInfo.getTableInfo("characters");
+
+        QueryThenFetchNode qtfNode = new QueryThenFetchNode(
+                characters.getRouting(WhereClause.MATCH_ALL),
+                Arrays.<Symbol>asList(idRef, nameRef, femaleRef),
+                Arrays.<Symbol>asList(nameRef, idRef),
+                new boolean[]{false, false},
+                new Boolean[]{null, null},
+                5,
+                0,
+                WhereClause.MATCH_ALL,
+                null
+        );
+
+        List<Task> tasks = executor.newTasks(qtfNode, UUID.randomUUID());
+        assertThat(tasks.size(), is(1));
+        QueryThenFetchTask qtfTask = (QueryThenFetchTask)tasks.get(0);
+        PageInfo pageInfo = PageInfo.firstPage(2);
+        qtfTask.setKeepAlive(TimeValue.timeValueSeconds(10));
+
+        qtfTask.start(pageInfo);
+        List<ListenableFuture<TaskResult>> results = qtfTask.result();
+        assertThat(results.size(), is(1));
+        ListenableFuture<TaskResult> resultFuture = results.get(0);
+
+        TaskResult result = resultFuture.get();
+        assertThat(result, instanceOf(PageableTaskResult.class));
+        closeMeWhenDone = (PageableTaskResult)result;
+        assertThat(TestingHelpers.printedTable(result.rows()), is(
+                "1| Arthur| false\n" +
+                        "4| Arthur| true\n"
+        ));
+        ListenableFuture<PageableTaskResult> nextPageResultFuture = ((PageableTaskResult)result).fetch(pageInfo.nextPage(2));
+        PageableTaskResult nextPageResult = nextPageResultFuture.get();
+        closeMeWhenDone = nextPageResult;
+        assertThat(TestingHelpers.printedTable(nextPageResult.rows()), is(
+                "2| Ford| false\n" +
+                        "3| Trillian| true\n"
+        ));
+
+        Object[][] nextRows = nextPageResult.fetch(pageInfo.nextPage(2)).get().rows();
+        assertThat(nextRows.length, is(0));
+
+    }
+
+    @Test
+    public void testPagedQueryThenFetchWithOffset() throws Exception {
+        setup.setUpCharacters();
+        DocTableInfo characters = docSchemaInfo.getTableInfo("characters");
+
+        QueryThenFetchNode qtfNode = new QueryThenFetchNode(
+                characters.getRouting(WhereClause.MATCH_ALL),
+                Arrays.<Symbol>asList(idRef, nameRef, femaleRef),
+                Arrays.<Symbol>asList(nameRef, idRef),
+                new boolean[]{false, false},
+                new Boolean[]{null, null},
+                5,
+                0,
+                WhereClause.MATCH_ALL,
+                null
+        );
+
+        List<Task> tasks = executor.newTasks(qtfNode, UUID.randomUUID());
+        assertThat(tasks.size(), is(1));
+        QueryThenFetchTask qtfTask = (QueryThenFetchTask)tasks.get(0);
+        PageInfo pageInfo = new PageInfo(1, 2);
+        qtfTask.setKeepAlive(TimeValue.timeValueSeconds(10));
+        qtfTask.start(pageInfo);
+        List<ListenableFuture<TaskResult>> results = qtfTask.result();
+        assertThat(results.size(), is(1));
+        ListenableFuture<TaskResult> resultFuture = results.get(0);
+        TaskResult result = resultFuture.get();
+        assertThat(result, instanceOf(PageableTaskResult.class));
+        closeMeWhenDone = (PageableTaskResult)result;
+        assertThat(TestingHelpers.printedTable(result.rows()), is(
+                "4| Arthur| true\n" +
+                        "2| Ford| false\n"
+        ));
+        ListenableFuture<PageableTaskResult> nextPageResultFuture = ((PageableTaskResult)result).fetch(pageInfo.nextPage(2));
+        PageableTaskResult nextPageResult = nextPageResultFuture.get();
+        closeMeWhenDone = nextPageResult;
+        assertThat(TestingHelpers.printedTable(nextPageResult.rows()), is(
+                "3| Trillian| true\n"
+        ));
+
+        Object[][] nextRows = nextPageResult.fetch(pageInfo.nextPage(2)).get().rows();
+        assertThat(nextRows.length, is(0));
+    }
+
+    @Test
+    public void testPagedQueryThenFetchWithoutSorting() throws Exception {
+        setup.setUpCharacters();
+        DocTableInfo characters = docSchemaInfo.getTableInfo("characters");
+
+        QueryThenFetchNode qtfNode = new QueryThenFetchNode(
+                characters.getRouting(WhereClause.MATCH_ALL),
+                Arrays.<Symbol>asList(idRef, nameRef, femaleRef),
+                null,
+                null,
+                null,
+                5,
+                0,
+                WhereClause.MATCH_ALL,
+                null
+        );
+
+        List<Task> tasks = executor.newTasks(qtfNode, UUID.randomUUID());
+        assertThat(tasks.size(), is(1));
+        QueryThenFetchTask qtfTask = (QueryThenFetchTask)tasks.get(0);
+        PageInfo pageInfo = new PageInfo(1, 2);
+        qtfTask.setKeepAlive(TimeValue.timeValueSeconds(10));
+        qtfTask.start(pageInfo);
+        List<ListenableFuture<TaskResult>> results = qtfTask.result();
+        assertThat(results.size(), is(1));
+
+        ListenableFuture<TaskResult> resultFuture = results.get(0);
+        TaskResult result = resultFuture.get();
+        assertThat(result, instanceOf(PageableTaskResult.class));
+        closeMeWhenDone = (PageableTaskResult)result;
+
+        assertThat(result.rows().length, is(2));
+
+        ListenableFuture<PageableTaskResult> nextPageResultFuture = ((PageableTaskResult)result).fetch(pageInfo.nextPage(2));
+        PageableTaskResult nextPageResult = nextPageResultFuture.get();
+        closeMeWhenDone = nextPageResult;
+        assertThat(nextPageResult.rows().length, is(1));
+
+        PageableTaskResult furtherPageResult = nextPageResult.fetch(pageInfo.nextPage(2)).get();
+        closeMeWhenDone = furtherPageResult;
+        assertThat(furtherPageResult.rows().length, is(0));
+    }
+
+    @Test
+    public void testNestedLoopBothSidesPageableNoLimit() throws Exception {
+        setup.setUpCharacters();
+        setup.setUpBooks();
+
+        DocTableInfo characters = docSchemaInfo.getTableInfo("characters");
+
+        QueryThenFetchNode leftNode = new QueryThenFetchNode(
+                characters.getRouting(WhereClause.MATCH_ALL),
+                Arrays.<Symbol>asList(idRef, nameRef, femaleRef),
+                Arrays.<Symbol>asList(nameRef, femaleRef),
+                new boolean[]{false, true},
+                new Boolean[]{null, null},
+                5,
+                0,
+                WhereClause.MATCH_ALL,
+                null
+        );
+        leftNode.outputTypes(ImmutableList.of(
+                        idRef.info().type(),
+                        nameRef.info().type(),
+                        femaleRef.info().type())
+        );
+
+        DocTableInfo books = docSchemaInfo.getTableInfo("books");
+        QueryThenFetchNode rightNode = new QueryThenFetchNode(
+                books.getRouting(WhereClause.MATCH_ALL),
+                Arrays.<Symbol>asList(titleRef),
+                Arrays.<Symbol>asList(titleRef),
+                new boolean[]{false},
+                new Boolean[]{null},
+                null,
+                null,
+                WhereClause.MATCH_ALL,
+                null
+        );
+        rightNode.outputTypes(ImmutableList.of(
+                        authorRef.info().type())
+        );
+
+        TopNProjection projection = new TopNProjection(Constants.DEFAULT_SELECT_LIMIT, 0);
+        projection.outputs(ImmutableList.<Symbol>of(
+                new InputColumn(0, DataTypes.INTEGER),
+                new InputColumn(1, DataTypes.STRING),
+                new InputColumn(2, DataTypes.BOOLEAN),
+                new InputColumn(3, DataTypes.STRING)
+        ));
+        List<DataType> outputTypes = ImmutableList.of(
+                idRef.info().type(),
+                nameRef.info().type(),
+                femaleRef.info().type(),
+                titleRef.info().type());
+
+
+        // SELECT characters.id, characters.name, characters.female, books.title
+        // FROM characters CROSS JOIN books
+        // ORDER BY character.name, character.female, books.title
+        NestedLoopNode node = new NestedLoopNode(leftNode, rightNode, true, Constants.DEFAULT_SELECT_LIMIT, 0);
+        node.projections(ImmutableList.<Projection>of(projection));
+        node.outputTypes(outputTypes);
+
+        List<Task> tasks = executor.newTasks(node, UUID.randomUUID());
+        assertThat(tasks.size(), is(1));
+        assertThat(tasks.get(0), instanceOf(NestedLoopTask.class));
+
+        NestedLoopTask nestedLoopTask = (NestedLoopTask) tasks.get(0);
+
+        List<ListenableFuture<TaskResult>> results = nestedLoopTask.result();
+        assertThat(results.size(), is(1));
+        nestedLoopTask.start();
+        TaskResult result = results.get(0).get();
+        assertThat(result, instanceOf(QueryResult.class));
+        assertThat(TestingHelpers.printedTable(result.rows()), is(
+                "4| Arthur| true| Life, the Universe and Everything\n" +
+                        "4| Arthur| true| The Hitchhiker's Guide to the Galaxy\n" +
+                        "4| Arthur| true| The Restaurant at the End of the Universe\n" +
+                        "1| Arthur| false| Life, the Universe and Everything\n" +
+                        "1| Arthur| false| The Hitchhiker's Guide to the Galaxy\n" +
+                        "1| Arthur| false| The Restaurant at the End of the Universe\n" +
+                        "2| Ford| false| Life, the Universe and Everything\n" +
+                        "2| Ford| false| The Hitchhiker's Guide to the Galaxy\n" +
+                        "2| Ford| false| The Restaurant at the End of the Universe\n" +
+                        "3| Trillian| true| Life, the Universe and Everything\n" +
+                        "3| Trillian| true| The Hitchhiker's Guide to the Galaxy\n" +
+                        "3| Trillian| true| The Restaurant at the End of the Universe\n"));
+    }
+
+    @Test
+    public void testNestedLoopBothSidesPageableLimitAndOffset() throws Exception {
+        setup.setUpCharacters();
+        setup.setUpBooks();
+
+        DocTableInfo characters = docSchemaInfo.getTableInfo("characters");
+
+        QueryThenFetchNode leftNode = new QueryThenFetchNode(
+                characters.getRouting(WhereClause.MATCH_ALL),
+                Arrays.<Symbol>asList(idRef, nameRef, femaleRef),
+                Arrays.<Symbol>asList(nameRef, femaleRef),
+                new boolean[]{false, true},
+                new Boolean[]{null, null},
+                5,
+                0,
+                WhereClause.MATCH_ALL,
+                null
+        );
+        leftNode.outputTypes(ImmutableList.of(
+                        idRef.info().type(),
+                        nameRef.info().type(),
+                        femaleRef.info().type())
+        );
+
+        DocTableInfo books = docSchemaInfo.getTableInfo("books");
+        QueryThenFetchNode rightNode = new QueryThenFetchNode(
+                books.getRouting(WhereClause.MATCH_ALL),
+                Arrays.<Symbol>asList(titleRef),
+                Arrays.<Symbol>asList(titleRef),
+                new boolean[]{false},
+                new Boolean[]{null},
+                null,
+                null,
+                WhereClause.MATCH_ALL,
+                null
+        );
+        rightNode.outputTypes(ImmutableList.of(
+                        authorRef.info().type())
+        );
+
+        TopNProjection projection = new TopNProjection(10, 1);
+        projection.outputs(ImmutableList.<Symbol>of(
+                new InputColumn(0, DataTypes.INTEGER),
+                new InputColumn(1, DataTypes.STRING),
+                new InputColumn(2, DataTypes.BOOLEAN),
+                new InputColumn(3, DataTypes.STRING)
+        ));
+        List<DataType> outputTypes = ImmutableList.of(
+                idRef.info().type(),
+                nameRef.info().type(),
+                femaleRef.info().type(),
+                titleRef.info().type());
+
+
+        // SELECT characters.id, characters.name, characters.female, books.title
+        // FROM characters CROSS JOIN books
+        // ORDER BY character.name, character.female, books.title
+        NestedLoopNode node = new NestedLoopNode(leftNode, rightNode, true, 10, 1);
+        node.projections(ImmutableList.<Projection>of(projection));
+        node.outputTypes(outputTypes);
+
+        List<Task> tasks = executor.newTasks(node, UUID.randomUUID());
+        assertThat(tasks.size(), is(1));
+        assertThat(tasks.get(0), instanceOf(NestedLoopTask.class));
+
+        NestedLoopTask nestedLoopTask = (NestedLoopTask) tasks.get(0);
+
+        List<ListenableFuture<TaskResult>> results = nestedLoopTask.result();
+        assertThat(results.size(), is(1));
+        nestedLoopTask.start();
+        TaskResult result = results.get(0).get();
+        assertThat(result, instanceOf(QueryResult.class));
+        assertThat(TestingHelpers.printedTable(result.rows()), is(
+                "4| Arthur| true| The Hitchhiker's Guide to the Galaxy\n" +
+                        "4| Arthur| true| The Restaurant at the End of the Universe\n" +
+                        "1| Arthur| false| Life, the Universe and Everything\n" +
+                        "1| Arthur| false| The Hitchhiker's Guide to the Galaxy\n" +
+                        "1| Arthur| false| The Restaurant at the End of the Universe\n" +
+                        "2| Ford| false| Life, the Universe and Everything\n" +
+                        "2| Ford| false| The Hitchhiker's Guide to the Galaxy\n" +
+                        "2| Ford| false| The Restaurant at the End of the Universe\n" +
+                        "3| Trillian| true| Life, the Universe and Everything\n" +
+                        "3| Trillian| true| The Hitchhiker's Guide to the Galaxy\n"));
+    }
+}

--- a/sql/src/test/java/io/crate/executor/transport/TransportExecutorTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/TransportExecutorTest.java
@@ -30,9 +30,7 @@ import io.crate.analyze.WhereClause;
 import io.crate.executor.*;
 import io.crate.executor.task.join.NestedLoopTask;
 import io.crate.executor.transport.task.elasticsearch.*;
-import io.crate.integrationtests.SQLTransportIntegrationTest;
 import io.crate.metadata.*;
-import io.crate.metadata.doc.DocSchemaInfo;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.sys.SysClusterTableInfo;
 import io.crate.metadata.sys.SysNodesTableInfo;
@@ -52,7 +50,6 @@ import io.crate.planner.node.dql.join.NestedLoopNode;
 import io.crate.planner.projection.Projection;
 import io.crate.planner.projection.TopNProjection;
 import io.crate.planner.symbol.*;
-import io.crate.test.integration.CrateIntegrationTest;
 import io.crate.test.integration.CrateTestCluster;
 import io.crate.testing.TestingHelpers;
 import io.crate.types.DataType;
@@ -65,7 +62,6 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.collect.MapBuilder;
-import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.search.SearchHits;
@@ -81,8 +77,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.number.OrderingComparison.greaterThan;
 
-@CrateIntegrationTest.ClusterScope(scope = CrateIntegrationTest.Scope.GLOBAL)
-public class TransportExecutorTest extends SQLTransportIntegrationTest {
+public class TransportExecutorTest extends BaseTransportExecutorTest {
 
     static {
         ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
@@ -90,110 +85,21 @@ public class TransportExecutorTest extends SQLTransportIntegrationTest {
 
     private ClusterService clusterService;
     private ClusterName clusterName;
-    private TransportExecutor executor;
-    private DocSchemaInfo docSchemaInfo;
-
-    TableIdent charactersIdent = new TableIdent(null, "characters");
-    TableIdent booksIdent = new TableIdent(null, "books");
-
-    Reference idRef = new Reference(new ReferenceInfo(
-            new ReferenceIdent(charactersIdent, "id"), RowGranularity.DOC, DataTypes.INTEGER));
-    Reference nameRef = new Reference(new ReferenceInfo(
-            new ReferenceIdent(charactersIdent, "name"), RowGranularity.DOC, DataTypes.STRING));
-    Reference femaleRef = TestingHelpers.createReference(charactersIdent.name(), new ColumnIdent("female"), DataTypes.BOOLEAN);
-    Reference versionRef = new Reference(new ReferenceInfo(
-            new ReferenceIdent(charactersIdent, "_version"), RowGranularity.DOC, DataTypes.LONG));
-
-    Reference booksIdRef = new Reference(new ReferenceInfo(
-            new ReferenceIdent(booksIdent, "id"), RowGranularity.DOC, DataTypes.INTEGER));
-    Reference titleRef = new Reference(new ReferenceInfo(
-            new ReferenceIdent(booksIdent, "title"), RowGranularity.DOC, DataTypes.STRING));
-    Reference authorRef = new Reference(new ReferenceInfo(
-            new ReferenceIdent(booksIdent, "author"), RowGranularity.DOC, DataTypes.STRING));
-
-    TableIdent partedTable = new TableIdent(null, "parted");
-    Reference partedIdRef = new Reference(new ReferenceInfo(
-            new ReferenceIdent(partedTable, "id"), RowGranularity.DOC, DataTypes.INTEGER));
-    Reference partedNameRef = new Reference(new ReferenceInfo(
-            new ReferenceIdent(partedTable, "name"), RowGranularity.DOC, DataTypes.STRING));
-    Reference partedDateRef = new Reference(new ReferenceInfo(
-            new ReferenceIdent(partedTable, "date"), RowGranularity.DOC, DataTypes.TIMESTAMP));
-
-    private static ESGetNode newGetNode(String index, List<Symbol> outputs, String id) {
-        return newGetNode(index, outputs, Arrays.asList(id));
-    }
-
-    private static ESGetNode newGetNode(String index, List<Symbol> outputs, List<String> ids) {
-        return new ESGetNode(
-                index,
-                outputs,
-                Symbols.extractTypes(outputs),
-                ids,
-                ids,
-                ImmutableList.<Symbol>of(),
-                new boolean[0],
-                new Boolean[0],
-                null,
-                0,
-                null
-        );
-    }
 
     @Before
-    public void transportSetUp() {
+    public void setup() {
         CrateTestCluster cluster = cluster();
         clusterService = cluster.getInstance(ClusterService.class);
         clusterName = cluster.getInstance(ClusterName.class);
-        executor = cluster.getInstance(TransportExecutor.class);
-
-        docSchemaInfo = cluster.getInstance(DocSchemaInfo.class);
     }
 
     @After
-    public void transportTearDown() {
+    public void teardown() {
         clusterService = null;
         clusterName = null;
-        executor = null;
-        docSchemaInfo = null;
     }
 
-    private void insertCharacters() {
-        execute("create table characters (id int primary key, name string, female boolean)");
-        ensureGreen();
-        execute("insert into characters (id, name, female) values (?, ?, ?)",
-                new Object[][]{
-                    new Object[] { 1, "Arthur", false},
-                    new Object[] { 2, "Ford", false},
-                    new Object[] { 3, "Trillian", true},
-                    new Object[] { 4, "Arthur", true}
-                }
-        );
-        refresh();
-    }
 
-    private void insertBooks() {
-        execute("create table books (id int primary key, title string, author string)");
-        ensureGreen();
-        execute("insert into books (id, title, author) values (?, ?, ?)", new Object[][]{
-                new Object[] { 1, "The Hitchhiker's Guide to the Galaxy", "Douglas Adams"},
-                new Object[] { 2, "The Restaurant at the End of the Universe", "Douglas Adams"},
-                new Object[] { 3, "Life, the Universe and Everything", "Douglas Adams"}
-        });
-        refresh();
-    }
-
-    private void createPartitionedTable() {
-        execute("create table parted (id int, name string, date timestamp) partitioned by (date)");
-        ensureGreen();
-        execute("insert into parted (id, name, date) values (?, ?, ?), (?, ?, ?), (?, ?, ?)",
-                new Object[]{
-                        1, "Trillian", null,
-                        2, null, 0L,
-                        3, "Ford", 1396388720242L
-                });
-        ensureGreen();
-        refresh();
-    }
 
     @Test
     public void testRemoteCollectTask() throws Exception {
@@ -252,7 +158,7 @@ public class TransportExecutorTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testESGetTask() throws Exception {
-        insertCharacters();
+        setup.setUpCharacters();
 
         ImmutableList<Symbol> outputs = ImmutableList.<Symbol>of(idRef, nameRef);
         ESGetNode node = newGetNode("characters", outputs, "2");
@@ -269,7 +175,7 @@ public class TransportExecutorTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testESGetTaskWithDynamicReference() throws Exception {
-        insertCharacters();
+        setup.setUpCharacters();
 
         ImmutableList<Symbol> outputs = ImmutableList.<Symbol>of(idRef, new DynamicReference(
                 new ReferenceIdent(new TableIdent(null, "characters"), "foo"), RowGranularity.DOC));
@@ -287,7 +193,7 @@ public class TransportExecutorTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testESMultiGet() throws Exception {
-        insertCharacters();
+        setup.setUpCharacters();
         ImmutableList<Symbol> outputs = ImmutableList.<Symbol>of(idRef, nameRef);
         ESGetNode node = newGetNode("characters", outputs, asList("1", "2"));
         Plan plan = new Plan();
@@ -301,7 +207,7 @@ public class TransportExecutorTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testESSearchTask() throws Exception {
-        insertCharacters();
+        setup.setUpCharacters();
 
         DocTableInfo characters = docSchemaInfo.getTableInfo("characters");
 
@@ -338,7 +244,7 @@ public class TransportExecutorTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testESSearchTaskWithFilter() throws Exception {
-        insertCharacters();
+        setup.setUpCharacters();
 
         Function whereClause = new Function(new FunctionInfo(
                 new FunctionIdent(EqOperator.NAME, Arrays.<DataType>asList(DataTypes.STRING, DataTypes.STRING)),
@@ -434,7 +340,7 @@ public class TransportExecutorTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testESSearchTaskPartitioned() throws Exception {
-        createPartitionedTable();
+        setup.setUpPartitionedTableWithName();
         // get partitions
         ImmutableOpenMap<String, List<AliasMetaData>> aliases =
                 client().admin().indices().prepareGetAliases().addAliases("parted")
@@ -475,7 +381,7 @@ public class TransportExecutorTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testESDeleteByQueryTask() throws Exception {
-        insertCharacters();
+        setup.setUpCharacters();
 
         Function whereClause = new Function(new FunctionInfo(
                 new FunctionIdent(EqOperator.NAME, Arrays.<DataType>asList(DataTypes.STRING, DataTypes.STRING)),
@@ -520,7 +426,7 @@ public class TransportExecutorTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testESDeleteTask() throws Exception {
-        insertCharacters();
+        setup.setUpCharacters();
 
         ESDeleteNode node = new ESDeleteNode("characters", "2", "2", Optional.<Long>absent());
         Plan plan = new Plan();
@@ -644,7 +550,7 @@ public class TransportExecutorTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testESCountTask() throws Exception {
-        insertCharacters();
+        setup.setUpCharacters();
         Plan plan = new Plan();
         WhereClause whereClause = new WhereClause(null, false);
         plan.add(new ESCountNode(new String[]{"characters"}, whereClause));
@@ -711,7 +617,7 @@ public class TransportExecutorTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testESUpdateByIdTask() throws Exception {
-        insertCharacters();
+        setup.setUpCharacters();
 
         // update characters set name='Vogon lyric fan' where id=1
         WhereClause whereClause = new WhereClause(null, false);
@@ -753,7 +659,7 @@ public class TransportExecutorTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testUpdateByQueryTaskWithVersion() throws Exception {
-        insertCharacters();
+        setup.setUpCharacters();
 
         // do update
         Function whereClauseFunction = new Function(AndOperator.INFO, Arrays.<Symbol>asList(
@@ -807,7 +713,7 @@ public class TransportExecutorTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testUpdateByQueryTask() throws Exception {
-        insertCharacters();
+        setup.setUpCharacters();
 
         Function whereClause = new Function(OrOperator.INFO, Arrays.<Symbol>asList(
                 new Function(new FunctionInfo(
@@ -876,8 +782,8 @@ public class TransportExecutorTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testNestedLoopTask() throws Exception {
-        insertCharacters();
-        insertBooks();
+        setup.setUpCharacters();
+        setup.setUpBooks();
 
         DocTableInfo characters = docSchemaInfo.getTableInfo("characters");
 
@@ -995,8 +901,8 @@ public class TransportExecutorTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testNestedLoopMixedSorting() throws Exception {
-        insertCharacters();
-        insertBooks();
+        setup.setUpCharacters();
+        setup.setUpBooks();
 
         DocTableInfo characters = docSchemaInfo.getTableInfo("characters");
 
@@ -1069,139 +975,5 @@ public class TransportExecutorTest extends SQLTransportIntegrationTest {
                         "4| Arthur| true| Douglas Adams\n" +
                         "1| Arthur| false| Douglas Adams\n" +
                         "1| Arthur| false| Douglas Adams\n"));
-    }
-
-    @Test
-    public void testPagedQueryThenFetch() throws Exception {
-        insertCharacters();
-        DocTableInfo characters = docSchemaInfo.getTableInfo("characters");
-
-        QueryThenFetchNode qtfNode = new QueryThenFetchNode(
-                characters.getRouting(WhereClause.MATCH_ALL),
-                Arrays.<Symbol>asList(idRef, nameRef, femaleRef),
-                Arrays.<Symbol>asList(nameRef, idRef),
-                new boolean[]{false, false},
-                new Boolean[]{null, null},
-                5,
-                0,
-                WhereClause.MATCH_ALL,
-                null
-        );
-
-        List<Task> tasks = executor.newTasks(qtfNode, UUID.randomUUID());
-        assertThat(tasks.size(), is(1));
-        QueryThenFetchTask qtfTask = (QueryThenFetchTask)tasks.get(0);
-        PageInfo pageInfo = PageInfo.firstPage(2);
-        qtfTask.setKeepAlive(TimeValue.timeValueSeconds(10));
-
-        qtfTask.start(pageInfo);
-        List<ListenableFuture<TaskResult>> results = qtfTask.result();
-        assertThat(results.size(), is(1));
-        ListenableFuture<TaskResult> resultFuture = results.get(0);
-        TaskResult result = resultFuture.get();
-        assertThat(result, instanceOf(PageableTaskResult.class));
-        assertThat(TestingHelpers.printedTable(result.rows()), is(
-                "1| Arthur| false\n" +
-                "4| Arthur| true\n"
-                ));
-        ListenableFuture<PageableTaskResult> nextPageResultFuture = ((PageableTaskResult)result).fetch(pageInfo.nextPage(2));
-        PageableTaskResult nextPageResult = nextPageResultFuture.get();
-        assertThat(TestingHelpers.printedTable(nextPageResult.rows()), is(
-                "2| Ford| false\n" +
-                "3| Trillian| true\n"
-        ));
-
-        Object[][] nextRows = nextPageResult.fetch(pageInfo.nextPage(2)).get().rows();
-        assertThat(nextRows.length, is(0));
-
-        // finally close it
-        nextPageResult.close();
-    }
-
-    @Test
-    public void testPagedQueryThenFetchWithOffset() throws Exception {
-        insertCharacters();
-        DocTableInfo characters = docSchemaInfo.getTableInfo("characters");
-
-        QueryThenFetchNode qtfNode = new QueryThenFetchNode(
-                characters.getRouting(WhereClause.MATCH_ALL),
-                Arrays.<Symbol>asList(idRef, nameRef, femaleRef),
-                Arrays.<Symbol>asList(nameRef, idRef),
-                new boolean[]{false, false},
-                new Boolean[]{null, null},
-                5,
-                0,
-                WhereClause.MATCH_ALL,
-                null
-        );
-
-        List<Task> tasks = executor.newTasks(qtfNode, UUID.randomUUID());
-        assertThat(tasks.size(), is(1));
-        QueryThenFetchTask qtfTask = (QueryThenFetchTask)tasks.get(0);
-        PageInfo pageInfo = new PageInfo(1, 2);
-        qtfTask.setKeepAlive(TimeValue.timeValueSeconds(10));
-        qtfTask.start(pageInfo);
-        List<ListenableFuture<TaskResult>> results = qtfTask.result();
-        assertThat(results.size(), is(1));
-        ListenableFuture<TaskResult> resultFuture = results.get(0);
-        TaskResult result = resultFuture.get();
-        assertThat(result, instanceOf(PageableTaskResult.class));
-        assertThat(TestingHelpers.printedTable(result.rows()), is(
-                "4| Arthur| true\n" +
-                "2| Ford| false\n"
-        ));
-        ListenableFuture<PageableTaskResult> nextPageResultFuture = ((PageableTaskResult)result).fetch(pageInfo.nextPage(2));
-        PageableTaskResult nextPageResult = nextPageResultFuture.get();
-        assertThat(TestingHelpers.printedTable(nextPageResult.rows()), is(
-                "3| Trillian| true\n"
-        ));
-
-        Object[][] nextRows = nextPageResult.fetch(pageInfo.nextPage(2)).get().rows();
-        assertThat(nextRows.length, is(0));
-
-        // finally close it
-        nextPageResult.close();
-    }
-
-    @Test
-    public void testPagedQueryThenFetchWithoutSorting() throws Exception {
-        insertCharacters();
-        DocTableInfo characters = docSchemaInfo.getTableInfo("characters");
-
-        QueryThenFetchNode qtfNode = new QueryThenFetchNode(
-                characters.getRouting(WhereClause.MATCH_ALL),
-                Arrays.<Symbol>asList(idRef, nameRef, femaleRef),
-                null,
-                null,
-                null,
-                5,
-                0,
-                WhereClause.MATCH_ALL,
-                null
-        );
-
-        List<Task> tasks = executor.newTasks(qtfNode, UUID.randomUUID());
-        assertThat(tasks.size(), is(1));
-        QueryThenFetchTask qtfTask = (QueryThenFetchTask)tasks.get(0);
-        PageInfo pageInfo = new PageInfo(1, 2);
-        qtfTask.setKeepAlive(TimeValue.timeValueSeconds(10));
-        qtfTask.start(pageInfo);
-        List<ListenableFuture<TaskResult>> results = qtfTask.result();
-        assertThat(results.size(), is(1));
-
-        ListenableFuture<TaskResult> resultFuture = results.get(0);
-        TaskResult result = resultFuture.get();
-        assertThat(result, instanceOf(PageableTaskResult.class));
-
-        assertThat(result.rows().length, is(2));
-
-        ListenableFuture<PageableTaskResult> nextPageResultFuture = ((PageableTaskResult)result).fetch(pageInfo.nextPage(2));
-        PageableTaskResult nextPageResult = nextPageResultFuture.get();
-        assertThat(nextPageResult.rows().length, is(1));
-
-        PageableTaskResult furtherPageResult = nextPageResult.fetch(pageInfo.nextPage(2)).get();
-        assertThat(furtherPageResult.rows().length, is(0));
-
-        furtherPageResult.close();
     }
 }

--- a/sql/src/test/java/io/crate/executor/transport/TransportExecutorTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/TransportExecutorTest.java
@@ -1099,13 +1099,13 @@ public class TransportExecutorTest extends SQLTransportIntegrationTest {
         assertThat(results.size(), is(1));
         ListenableFuture<TaskResult> resultFuture = results.get(0);
         TaskResult result = resultFuture.get();
-        assertThat(result, instanceOf(PagableTaskResult.class));
+        assertThat(result, instanceOf(PageableTaskResult.class));
         assertThat(TestingHelpers.printedTable(result.rows()), is(
                 "1| Arthur| false\n" +
                 "4| Arthur| true\n"
                 ));
-        ListenableFuture<PagableTaskResult> nextPageResultFuture = ((PagableTaskResult)result).fetch(pageInfo.nextPage(2));
-        PagableTaskResult nextPageResult = nextPageResultFuture.get();
+        ListenableFuture<PageableTaskResult> nextPageResultFuture = ((PageableTaskResult)result).fetch(pageInfo.nextPage(2));
+        PageableTaskResult nextPageResult = nextPageResultFuture.get();
         assertThat(TestingHelpers.printedTable(nextPageResult.rows()), is(
                 "2| Ford| false\n" +
                 "3| Trillian| true\n"
@@ -1145,13 +1145,13 @@ public class TransportExecutorTest extends SQLTransportIntegrationTest {
         assertThat(results.size(), is(1));
         ListenableFuture<TaskResult> resultFuture = results.get(0);
         TaskResult result = resultFuture.get();
-        assertThat(result, instanceOf(PagableTaskResult.class));
+        assertThat(result, instanceOf(PageableTaskResult.class));
         assertThat(TestingHelpers.printedTable(result.rows()), is(
                 "4| Arthur| true\n" +
                 "2| Ford| false\n"
         ));
-        ListenableFuture<PagableTaskResult> nextPageResultFuture = ((PagableTaskResult)result).fetch(pageInfo.nextPage(2));
-        PagableTaskResult nextPageResult = nextPageResultFuture.get();
+        ListenableFuture<PageableTaskResult> nextPageResultFuture = ((PageableTaskResult)result).fetch(pageInfo.nextPage(2));
+        PageableTaskResult nextPageResult = nextPageResultFuture.get();
         assertThat(TestingHelpers.printedTable(nextPageResult.rows()), is(
                 "3| Trillian| true\n"
         ));
@@ -1191,15 +1191,15 @@ public class TransportExecutorTest extends SQLTransportIntegrationTest {
 
         ListenableFuture<TaskResult> resultFuture = results.get(0);
         TaskResult result = resultFuture.get();
-        assertThat(result, instanceOf(PagableTaskResult.class));
+        assertThat(result, instanceOf(PageableTaskResult.class));
 
         assertThat(result.rows().length, is(2));
 
-        ListenableFuture<PagableTaskResult> nextPageResultFuture = ((PagableTaskResult)result).fetch(pageInfo.nextPage(2));
-        PagableTaskResult nextPageResult = nextPageResultFuture.get();
+        ListenableFuture<PageableTaskResult> nextPageResultFuture = ((PageableTaskResult)result).fetch(pageInfo.nextPage(2));
+        PageableTaskResult nextPageResult = nextPageResultFuture.get();
         assertThat(nextPageResult.rows().length, is(1));
 
-        PagableTaskResult furtherPageResult = nextPageResult.fetch(pageInfo.nextPage(2)).get();
+        PageableTaskResult furtherPageResult = nextPageResult.fetch(pageInfo.nextPage(2)).get();
         assertThat(furtherPageResult.rows().length, is(0));
 
         furtherPageResult.close();

--- a/sql/src/test/java/io/crate/executor/transport/task/elasticsearch/QueryThenFetchTaskTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/task/elasticsearch/QueryThenFetchTaskTest.java
@@ -42,6 +42,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
 import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.search.action.SearchServiceListener;
@@ -112,6 +113,7 @@ public class QueryThenFetchTaskTest {
                 searchServiceTransportAction,
                 searchPhaseController,
                 new ThreadPool("testpool"),
+                mock(BigArrays.class),
                 crateResultSorter);
     }
 
@@ -139,6 +141,7 @@ public class QueryThenFetchTaskTest {
                 mock(SearchServiceTransportAction.class),
                 mock(SearchPhaseController.class),
                 mock(ThreadPool.class),
+                mock(BigArrays.class),
                 crateResultSorter);
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/Setup.java
+++ b/sql/src/test/java/io/crate/integrationtests/Setup.java
@@ -299,4 +299,42 @@ public class Setup {
                 ") with (number_of_replicas=0)");
         transportExecutor.ensureGreen();
     }
+
+    public void setUpCharacters() {
+        transportExecutor.exec("create table characters (id int primary key, name string, female boolean)");
+        transportExecutor.ensureGreen();
+        transportExecutor.exec("insert into characters (id, name, female) values (?, ?, ?)",
+                new Object[][]{
+                        new Object[] { 1, "Arthur", false},
+                        new Object[] { 2, "Ford", false},
+                        new Object[] { 3, "Trillian", true},
+                        new Object[] { 4, "Arthur", true}
+                }
+        );
+        transportExecutor.refresh("characters");
+    }
+
+    public void setUpBooks() {
+        transportExecutor.exec("create table books (id int primary key, title string, author string)");
+        transportExecutor.ensureGreen();
+        transportExecutor.exec("insert into books (id, title, author) values (?, ?, ?)", new Object[][]{
+                new Object[] { 1, "The Hitchhiker's Guide to the Galaxy", "Douglas Adams"},
+                new Object[] { 2, "The Restaurant at the End of the Universe", "Douglas Adams"},
+                new Object[] { 3, "Life, the Universe and Everything", "Douglas Adams"}
+        });
+        transportExecutor.refresh("books");
+    }
+
+    public void setUpPartitionedTableWithName() {
+        transportExecutor.exec("create table parted (id int, name string, date timestamp) partitioned by (date)");
+        transportExecutor.ensureGreen();
+        transportExecutor.exec("insert into parted (id, name, date) values (?, ?, ?), (?, ?, ?), (?, ?, ?)",
+                new Object[]{
+                        1, "Trillian", null,
+                        2, null, 0L,
+                        3, "Ford", 1396388720242L
+                });
+        transportExecutor.ensureGreen();
+        transportExecutor.refresh("parted");
+    }
 }

--- a/sql/src/test/java/io/crate/testing/TestingHelpers.java
+++ b/sql/src/test/java/io/crate/testing/TestingHelpers.java
@@ -21,6 +21,7 @@
 
 package io.crate.testing;
 
+import io.crate.executor.Page;
 import io.crate.metadata.*;
 import io.crate.planner.RowGranularity;
 import io.crate.planner.symbol.*;
@@ -56,9 +57,17 @@ public class TestingHelpers {
      * @return a string representing a table
      */
     public static String printedTable(Object[][] result) {
+        return printRows(Arrays.asList(result));
+    }
+
+    public static String printedPage(Page page) {
+        return printRows(page);
+    }
+
+    public static String printRows(Iterable<Object[]> rows) {
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         PrintStream out = new PrintStream(os);
-        for (Object[] row : result) {
+        for (Object[] row : rows) {
             boolean first = true;
             for (Object o : row) {
                 if (!first) {


### PR DESCRIPTION
* introduce Page class hiding implementation details of batches of rows
* fix some Paging issue with QueryThenFetchTask, which might return more rows than requested, but we want a PageableTaskResult to always return the requested size maximum
