### PR TITLE
split/move sort symbol validation

### DIFF
--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -30,7 +30,7 @@ import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.relations.select.SelectAnalyzer;
 import io.crate.analyze.validator.GroupBySymbolValidator;
 import io.crate.analyze.validator.HavingSymbolValidator;
-import io.crate.analyze.validator.SortSymbolValidator;
+import io.crate.analyze.validator.SemanticSortValidator;
 import io.crate.exceptions.AmbiguousColumnAliasException;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.TableIdent;
@@ -190,7 +190,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
             SortItem sortItem = orderBy.get(i);
             Expression sortKey = sortItem.getSortKey();
             Symbol symbol = symbolFromSelectOutputReferenceOrExpression(sortKey, selectAnalysis, "ORDER BY");
-            SortSymbolValidator.validate(symbol, null);
+            SemanticSortValidator.validate(symbol);
 
             symbols.add(symbol);
             switch (sortItem.getNullOrdering()) {

--- a/sql/src/main/java/io/crate/analyze/validator/SemanticSortValidator.java
+++ b/sql/src/main/java/io/crate/analyze/validator/SemanticSortValidator.java
@@ -21,36 +21,29 @@
 
 package io.crate.analyze.validator;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.collect.ImmutableList;
-import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.ReferenceInfo;
 import io.crate.planner.symbol.*;
 import io.crate.types.DataTypes;
 
-import javax.annotation.Nullable;
-import java.util.List;
 import java.util.Locale;
 
 /**
- * validate that sortSymbols don't contain partition by columns
+ * rudimentary sort symbol validation that can be used during analysis.
+ *
+ * validates only types and that there are no predicates.
  */
-public class SortSymbolValidator {
+public class SemanticSortValidator {
 
     private final static InnerValidator INNER_VALIDATOR = new InnerValidator();
 
-    public static void validate(Symbol symbol, @Nullable List<ColumnIdent> partitionedByColumns) throws UnsupportedOperationException {
-        INNER_VALIDATOR.process(symbol, new SortContext(partitionedByColumns));
+    public static void validate(Symbol symbol) throws UnsupportedOperationException {
+        INNER_VALIDATOR.process(symbol, new SortContext());
     }
 
     static class SortContext {
-
-        private final List<ColumnIdent> partitionedByColumns;
         private boolean inFunction;
 
-        public SortContext(List<ColumnIdent> partitionedByColumns) {
-            this.partitionedByColumns = MoreObjects.firstNonNull(partitionedByColumns, ImmutableList.<ColumnIdent>of());
+        public SortContext() {
             this.inFunction = false;
         }
     }
@@ -71,7 +64,6 @@ public class SortSymbolValidator {
                 throw new UnsupportedOperationException(String.format(
                         "%s predicate cannot be used in an ORDER BY clause", symbol.info().ident().name()));
             }
-
             try {
                 context.inFunction = true;
                 for (Symbol arg : symbol.arguments()) {
@@ -84,48 +76,17 @@ public class SortSymbolValidator {
         }
 
         @Override
-        public Void visitReference(Reference symbol, SortContext context) {
-            if (context.partitionedByColumns.contains(symbol.info().ident().columnIdent())) {
-                throw new UnsupportedOperationException(
-                        SymbolFormatter.format(
-                                "cannot use partitioned column %s in ORDER BY clause",
-                                symbol));
-            }
-
+        public Void visitField(Field field, SortContext context) {
             // if we are in a function, we do not need to check the data type.
             // the function will do that for us.
-            if (!context.inFunction && !DataTypes.PRIMITIVE_TYPES.contains(symbol.info().type())) {
+            if (!context.inFunction && !DataTypes.PRIMITIVE_TYPES.contains(field.valueType())) {
                 throw new UnsupportedOperationException(
                         String.format(Locale.ENGLISH,
                                 "Cannot ORDER BY '%s': invalid data type '%s'.",
-                                SymbolFormatter.format(symbol),
-                                symbol.valueType())
+                                SymbolFormatter.format(field),
+                                field.valueType())
                 );
-            } else if (symbol.info().indexType() == ReferenceInfo.IndexType.ANALYZED) {
-                throw new UnsupportedOperationException(
-                        String.format("Cannot ORDER BY '%s': sorting on analyzed/fulltext columns is not possible",
-                                SymbolFormatter.format(symbol)));
-            } else if (symbol.info().indexType() == ReferenceInfo.IndexType.NO) {
-                throw new UnsupportedOperationException(
-                        String.format("Cannot ORDER BY '%s': sorting on non-indexed columns is not possible",
-                                SymbolFormatter.format(symbol)));
             }
-            return null;
-        }
-
-        @Override
-        public Void visitField(Field field, SortContext context) {
-            return process(field.target(), context);
-        }
-
-        @Override
-        public Void visitDynamicReference(DynamicReference symbol, SortContext context) {
-            throw new UnsupportedOperationException(
-                    SymbolFormatter.format("Cannot order by \"%s\". The column doesn't exist.", symbol));
-        }
-
-        @Override
-        public Void visitSymbol(Symbol symbol, SortContext context) {
             return null;
         }
     }

--- a/sql/src/main/java/io/crate/planner/v2/DistributedGroupByConsumer.java
+++ b/sql/src/main/java/io/crate/planner/v2/DistributedGroupByConsumer.java
@@ -109,7 +109,7 @@ public class DistributedGroupByConsumer implements Consumer {
             }
             PlannerContextBuilder contextBuilder = new PlannerContextBuilder(2, tableRelation.resolve(statement.groupBy()))
                     .output(tableRelation.resolve(statement.outputSymbols()))
-                    .orderBy(tableRelation.resolve(statement.orderBy().orderBySymbols()));
+                    .orderBy(tableRelation.resolveAndValidateOrderBy(statement.orderBy().orderBySymbols()));
 
             Symbol havingClause = null;
             if(statement.havingClause() != null){

--- a/sql/src/main/java/io/crate/planner/v2/ESGetConsumer.java
+++ b/sql/src/main/java/io/crate/planner/v2/ESGetConsumer.java
@@ -103,7 +103,7 @@ public class ESGetConsumer implements Consumer {
                     statement.outputTypes(),
                     whereClauseContext.ids(),
                     whereClauseContext.routingValues(),
-                    tableRelation.resolve(statement.orderBy().orderBySymbols()),
+                    tableRelation.resolveAndValidateOrderBy(statement.orderBy().orderBySymbols()),
                     statement.orderBy().reverseFlags(),
                     statement.orderBy().nullsFirst(),
                     statement.limit(),

--- a/sql/src/main/java/io/crate/planner/v2/GlobalAggregateConsumer.java
+++ b/sql/src/main/java/io/crate/planner/v2/GlobalAggregateConsumer.java
@@ -39,8 +39,6 @@ import io.crate.planner.symbol.Symbol;
 import java.util.ArrayList;
 import java.util.List;
 
-import static io.crate.planner.symbol.Field.unwrap;
-
 public class GlobalAggregateConsumer implements Consumer {
 
     private final Visitor visitor;
@@ -81,7 +79,7 @@ public class GlobalAggregateConsumer implements Consumer {
             return null;
         }
         // global aggregate: collect and partial aggregate on C and final agg on H
-        PlannerContextBuilder contextBuilder = new PlannerContextBuilder(2).output(unwrap(statement.outputSymbols()));
+        PlannerContextBuilder contextBuilder = new PlannerContextBuilder(2).output(tableRelation.resolve(statement.outputSymbols()));
 
         // havingClause could be a Literal or Function.
         // if its a Literal and value is false, we'll never reach this point (no match),

--- a/sql/src/main/java/io/crate/planner/v2/InsertFromSubQueryConsumer.java
+++ b/sql/src/main/java/io/crate/planner/v2/InsertFromSubQueryConsumer.java
@@ -183,7 +183,7 @@ public class InsertFromSubQueryConsumer implements Consumer {
             List<Symbol> groupBy = tableRelation.resolve(analysis.groupBy());
             PlannerContextBuilder contextBuilder = new PlannerContextBuilder(2, groupBy, ignoreSorting)
                     .output(tableRelation.resolve(analysis.outputSymbols()))
-                    .orderBy(tableRelation.resolve(analysis.orderBy().orderBySymbols()));
+                    .orderBy(tableRelation.resolveAndValidateOrderBy(analysis.orderBy().orderBySymbols()));
 
             Symbol havingClause = null;
             if(analysis.havingClause() != null){
@@ -229,7 +229,7 @@ public class InsertFromSubQueryConsumer implements Consumer {
                 TopNProjection topN = new TopNProjection(
                         firstNonNull(analysis.limit(), Constants.DEFAULT_SELECT_LIMIT) + analysis.offset(),
                         0,
-                        tableRelation.resolve(analysis.orderBy().orderBySymbols()),
+                        tableRelation.resolveAndValidateOrderBy(analysis.orderBy().orderBySymbols()),
                         analysis.orderBy().reverseFlags(),
                         analysis.orderBy().nullsFirst()
                 );

--- a/sql/src/main/java/io/crate/planner/v2/NonDistributedGroupByConsumer.java
+++ b/sql/src/main/java/io/crate/planner/v2/NonDistributedGroupByConsumer.java
@@ -140,7 +140,7 @@ public class NonDistributedGroupByConsumer implements Consumer {
         PlannerContextBuilder contextBuilder =
                 new PlannerContextBuilder(numAggregationSteps, groupBy, ignoreSorting)
                         .output(tableRelation.resolve(analysis.outputSymbols()))
-                        .orderBy(tableRelation.resolve(analysis.orderBy().orderBySymbols()));
+                        .orderBy(tableRelation.resolveAndValidateOrderBy(analysis.orderBy().orderBySymbols()));
 
         Symbol havingClause = null;
         if(analysis.havingClause() != null){

--- a/sql/src/main/java/io/crate/planner/v2/ReduceOnCollectorGroupByConsumer.java
+++ b/sql/src/main/java/io/crate/planner/v2/ReduceOnCollectorGroupByConsumer.java
@@ -140,7 +140,7 @@ public class ReduceOnCollectorGroupByConsumer implements Consumer {
         PlannerContextBuilder contextBuilder =
                 new PlannerContextBuilder(numAggregationSteps, groupBy, ignoreSorting)
                         .output(tableRelation.resolve(analysis.outputSymbols()))
-                        .orderBy(tableRelation.resolve(analysis.orderBy().orderBySymbols()));
+                        .orderBy(tableRelation.resolveAndValidateOrderBy(analysis.orderBy().orderBySymbols()));
         Symbol havingClause = null;
         if(analysis.havingClause() != null){
             havingClause = tableRelation.resolve(analysis.havingClause());

--- a/sql/src/test/java/io/crate/analyze/SelectAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectAnalyzerTest.java
@@ -951,20 +951,6 @@ public class SelectAnalyzerTest extends BaseAnalyzerTest {
     }
 
     @Test
-    public void testOrderByOnAnalyzed() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("Cannot ORDER BY 'users.text': sorting on analyzed/fulltext columns is not possible");
-        analyze("select text from users u order by 1");
-    }
-
-    @Test
-    public void testOrderByOnIndexOff() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("Cannot ORDER BY 'users.no_index': sorting on non-indexed columns is not possible");
-        analyze("select no_index from users u order by 1");
-    }
-
-    @Test
     public void testArithmeticPlus() throws Exception {
         SelectAnalyzedStatement analysis = analyze("select load['1'] + load['5'] from sys.nodes");
         assertThat(((Function) analysis.outputSymbols().get(0)).info().ident().name(), is(AddFunction.NAME));
@@ -1626,12 +1612,5 @@ public class SelectAnalyzerTest extends BaseAnalyzerTest {
         assertThat(symbols.size(), is(2));
         assertThat(unwrap(symbols.get(0)), isReference("id"));
         assertThat(symbols.get(1), isFunction("abs"));
-    }
-
-    @Test
-    public void testSortOnUnknownColumn() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("Cannot order by \"users.o['unknown_column']\". The column doesn't exist.");
-        analyze("select name from users order by o['unknown_column']");
     }
 }


### PR DESCRIPTION
validation that requires data from a Reference can only be done in the Planner
/Consumer by using the Relation that owns the Field.

This is a further preparation to remove .target() from Field. Once that is
done Reference's aren't available anymore during analysis.