### PR TITLE
implement ProjectedNode

### DIFF
--- a/sql/src/main/java/io/crate/planner/Planner.java
+++ b/sql/src/main/java/io/crate/planner/Planner.java
@@ -438,7 +438,7 @@ public class Planner extends AnalyzedStatementVisitor<Planner.Context, Plan> {
         plan.add(indexNode);
     }
 
-    static List<DataType> extractDataTypes(List<Projection> projections, @Nullable List<DataType> inputTypes) {
+    public static List<DataType> extractDataTypes(List<Projection> projections, @Nullable List<DataType> inputTypes) {
         if (projections.size() == 0){
             return inputTypes;
         }

--- a/sql/src/main/java/io/crate/planner/consumer/InsertFromSubQueryConsumerV2.java
+++ b/sql/src/main/java/io/crate/planner/consumer/InsertFromSubQueryConsumerV2.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.consumer;
+
+
+import com.google.common.collect.Lists;
+import io.crate.analyze.InsertFromSubQueryAnalyzedStatement;
+import io.crate.analyze.relations.AnalyzedRelation;
+import io.crate.analyze.relations.PlannedAnalyzedRelation;
+import io.crate.metadata.ColumnIdent;
+import io.crate.planner.node.PlanNode;
+import io.crate.planner.node.PlanNodeVisitor;
+import io.crate.planner.node.ProjectedNode;
+import io.crate.planner.node.dml.InsertNode;
+import io.crate.planner.node.dml.QueryAndFetchNode;
+import io.crate.planner.projection.*;
+import io.crate.planner.symbol.Reference;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.settings.ImmutableSettings;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+
+
+public class InsertFromSubQueryConsumerV2 implements Consumer {
+
+    private final static RelationVisitor RELATION_VISITOR = new RelationVisitor();
+    private final static PlanVisitor PLAN_VISITOR = new PlanVisitor();
+
+    @Override
+    public boolean consume(AnalyzedRelation rootRelation, ConsumerContext context) {
+        AnalyzedRelation relation = RELATION_VISITOR.process(context.rootRelation(), context);
+        if (relation == null) {
+            return false;
+        }
+        context.rootRelation(relation);
+        return true;
+    }
+
+    private static class RelationVisitor extends io.crate.analyze.relations.RelationVisitor<ConsumerContext, AnalyzedRelation> {
+
+        @Override
+        public AnalyzedRelation visitInsertFromQuery(InsertFromSubQueryAnalyzedStatement insertFromSubQueryAnalyzedStatement, ConsumerContext context) {
+            if (!(insertFromSubQueryAnalyzedStatement.subQueryRelation() instanceof PlanNode)) {
+                return insertFromSubQueryAnalyzedStatement;
+            }
+            PlanNode subQueryRelation = (PlanNode)insertFromSubQueryAnalyzedStatement.subQueryRelation();
+
+            List<ColumnIdent> columns = Lists.transform(insertFromSubQueryAnalyzedStatement.columns(), new com.google.common.base.Function<Reference, ColumnIdent>() {
+                @Nullable
+                @Override
+                public ColumnIdent apply(@Nullable Reference input) {
+                    if (input == null) {
+                        return null;
+                    }
+                    return input.info().ident().columnIdent();
+                }
+            });
+            ColumnIndexWriterProjection indexWriterProjection = new ColumnIndexWriterProjection(
+                    insertFromSubQueryAnalyzedStatement.tableInfo().ident().name(),
+                    insertFromSubQueryAnalyzedStatement.tableInfo().primaryKey(),
+                    columns,
+                    insertFromSubQueryAnalyzedStatement.primaryKeyColumnIndices(),
+                    insertFromSubQueryAnalyzedStatement.partitionedByIndices(),
+                    insertFromSubQueryAnalyzedStatement.routingColumn(),
+                    insertFromSubQueryAnalyzedStatement.routingColumnIndex(),
+                    ImmutableSettings.EMPTY,
+                    insertFromSubQueryAnalyzedStatement.tableInfo().isPartitioned()
+            );
+
+            return PLAN_VISITOR.process(subQueryRelation, indexWriterProjection);
+        }
+
+        @Override
+        protected AnalyzedRelation visitAnalyzedRelation(AnalyzedRelation relation, ConsumerContext context) {
+            return null;
+        }
+
+    }
+
+    static class PlanVisitor extends PlanNodeVisitor<ColumnIndexWriterProjection, PlannedAnalyzedRelation> {
+
+        @Override
+        public PlannedAnalyzedRelation visitQueryAndFetchNode(QueryAndFetchNode node, ColumnIndexWriterProjection projection) {
+            assert node.localMergeNode() == null : "QueryAndFetchNode must not hold a local merge node for a insert-by-query plan";
+            ProjectedNode projectedNode = new ProjectedNode(node, projection);
+            return new InsertNode(Arrays.asList(node, projectedNode));
+        }
+
+        @Override
+        protected PlannedAnalyzedRelation visitPlanNode(PlanNode node, ColumnIndexWriterProjection projection) {
+            throw new UnsupportedOperationException(String.format(Locale.ENGLISH, "PlanNode %s not supported", node.toString()));
+        }
+    }
+
+}

--- a/sql/src/main/java/io/crate/planner/node/PlanNode.java
+++ b/sql/src/main/java/io/crate/planner/node/PlanNode.java
@@ -1,6 +1,7 @@
 package io.crate.planner.node;
 
 
+import io.crate.planner.projection.Projection;
 import io.crate.types.DataType;
 
 import java.util.List;
@@ -8,6 +9,8 @@ import java.util.List;
 public interface PlanNode {
 
     public <C, R> R accept(PlanNodeVisitor<C, R> visitor, C context);
+
+    void addProjection(Projection projection);
 
     List<DataType> outputTypes();
     void outputTypes(List<DataType> outputTypes);

--- a/sql/src/main/java/io/crate/planner/node/PlanNodeVisitor.java
+++ b/sql/src/main/java/io/crate/planner/node/PlanNodeVisitor.java
@@ -124,4 +124,12 @@ public class PlanNodeVisitor<C, R> {
     public R visitQueryAndFetchNode(QueryAndFetchNode node, C context){
         return visitPlanNode(node, context);
     }
+
+    public R visitInsertNode(InsertNode node, C context){
+        return visitPlanNode(node, context);
+    }
+
+    public R visitProjectedNode(ProjectedNode node, C context){
+        return visitPlanNode(node, context);
+    }
 }

--- a/sql/src/main/java/io/crate/planner/node/ddl/CreateTableNode.java
+++ b/sql/src/main/java/io/crate/planner/node/ddl/CreateTableNode.java
@@ -24,6 +24,7 @@ package io.crate.planner.node.ddl;
 import com.google.common.base.Optional;
 import io.crate.metadata.TableIdent;
 import io.crate.planner.node.PlanNodeVisitor;
+import io.crate.planner.projection.Projection;
 import org.elasticsearch.common.settings.Settings;
 
 import javax.annotation.Nullable;
@@ -92,5 +93,10 @@ public class CreateTableNode extends DDLPlanNode {
     @Override
     public <C, R> R accept(PlanNodeVisitor<C, R> visitor, C context) {
         return visitor.visitCreateTableNode(this, context);
+    }
+
+    @Override
+    public void addProjection(Projection projection) {
+        throw new UnsupportedOperationException("addProjection not supported");
     }
 }

--- a/sql/src/main/java/io/crate/planner/node/ddl/DropTableNode.java
+++ b/sql/src/main/java/io/crate/planner/node/ddl/DropTableNode.java
@@ -23,6 +23,7 @@ package io.crate.planner.node.ddl;
 
 import io.crate.metadata.table.TableInfo;
 import io.crate.planner.node.PlanNodeVisitor;
+import io.crate.planner.projection.Projection;
 
 public class DropTableNode extends DDLPlanNode {
 
@@ -40,5 +41,10 @@ public class DropTableNode extends DDLPlanNode {
     @Override
     public <C, R> R accept(PlanNodeVisitor<C, R> visitor, C context) {
         return visitor.visitDropTableNode(this, context);
+    }
+
+    @Override
+    public void addProjection(Projection projection) {
+        throw new UnsupportedOperationException("addProjection not supported");
     }
 }

--- a/sql/src/main/java/io/crate/planner/node/ddl/ESClusterUpdateSettingsNode.java
+++ b/sql/src/main/java/io/crate/planner/node/ddl/ESClusterUpdateSettingsNode.java
@@ -22,6 +22,7 @@
 package io.crate.planner.node.ddl;
 
 import io.crate.planner.node.PlanNodeVisitor;
+import io.crate.planner.projection.Projection;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 
@@ -82,5 +83,10 @@ public class ESClusterUpdateSettingsNode extends DDLPlanNode {
     @Override
     public <C, R> R accept(PlanNodeVisitor<C, R> visitor, C context) {
         return visitor.visitESClusterUpdateSettingsNode(this, context);
+    }
+
+    @Override
+    public void addProjection(Projection projection) {
+        throw new UnsupportedOperationException("addProjection not supported");
     }
 }

--- a/sql/src/main/java/io/crate/planner/node/ddl/ESCreateTemplateNode.java
+++ b/sql/src/main/java/io/crate/planner/node/ddl/ESCreateTemplateNode.java
@@ -22,6 +22,7 @@
 package io.crate.planner.node.ddl;
 
 import io.crate.planner.node.PlanNodeVisitor;
+import io.crate.planner.projection.Projection;
 import org.elasticsearch.common.settings.Settings;
 
 import javax.annotation.Nullable;
@@ -79,5 +80,10 @@ public class ESCreateTemplateNode extends DDLPlanNode {
     @Override
     public <C, R> R accept(PlanNodeVisitor<C, R> visitor, C context) {
         return visitor.visitESCreateTemplateNode(this, context);
+    }
+
+    @Override
+    public void addProjection(Projection projection) {
+        throw new UnsupportedOperationException("addProjection not supported");
     }
 }

--- a/sql/src/main/java/io/crate/planner/node/ddl/ESDeleteIndexNode.java
+++ b/sql/src/main/java/io/crate/planner/node/ddl/ESDeleteIndexNode.java
@@ -22,6 +22,7 @@
 package io.crate.planner.node.ddl;
 
 import io.crate.planner.node.PlanNodeVisitor;
+import io.crate.planner.projection.Projection;
 
 public class ESDeleteIndexNode extends DDLPlanNode {
 
@@ -49,5 +50,10 @@ public class ESDeleteIndexNode extends DDLPlanNode {
     @Override
     public <C, R> R accept(PlanNodeVisitor<C, R> visitor, C context) {
         return visitor.visitESDeleteIndexNode(this, context);
+    }
+
+    @Override
+    public void addProjection(Projection projection) {
+        throw new UnsupportedOperationException("addProjection not supported");
     }
 }

--- a/sql/src/main/java/io/crate/planner/node/dml/ESDeleteByQueryNode.java
+++ b/sql/src/main/java/io/crate/planner/node/dml/ESDeleteByQueryNode.java
@@ -23,6 +23,7 @@ package io.crate.planner.node.dml;
 
 import io.crate.analyze.WhereClause;
 import io.crate.planner.node.PlanNodeVisitor;
+import io.crate.planner.projection.Projection;
 
 public class ESDeleteByQueryNode extends DMLPlanNode {
 
@@ -47,4 +48,10 @@ public class ESDeleteByQueryNode extends DMLPlanNode {
     public <C, R> R accept(PlanNodeVisitor<C, R> visitor, C context) {
         return visitor.visitESDeleteByQueryNode(this, context);
     }
+
+    @Override
+    public void addProjection(Projection projection) {
+        throw new UnsupportedOperationException("addProjection not supported");
+    }
+
 }

--- a/sql/src/main/java/io/crate/planner/node/dml/ESDeleteNode.java
+++ b/sql/src/main/java/io/crate/planner/node/dml/ESDeleteNode.java
@@ -23,6 +23,7 @@ package io.crate.planner.node.dml;
 
 import com.google.common.base.Optional;
 import io.crate.planner.node.PlanNodeVisitor;
+import io.crate.planner.projection.Projection;
 
 public class ESDeleteNode extends DMLPlanNode {
 
@@ -53,6 +54,11 @@ public class ESDeleteNode extends DMLPlanNode {
     @Override
     public <C, R> R accept(PlanNodeVisitor<C, R> visitor, C context) {
         return visitor.visitESDeleteNode(this, context);
+    }
+
+    @Override
+    public void addProjection(Projection projection) {
+        throw new UnsupportedOperationException("addProjection not supported");
     }
 
     public Optional<Long> version() {

--- a/sql/src/main/java/io/crate/planner/node/dml/ESIndexNode.java
+++ b/sql/src/main/java/io/crate/planner/node/dml/ESIndexNode.java
@@ -22,6 +22,7 @@
 package io.crate.planner.node.dml;
 
 import io.crate.planner.node.PlanNodeVisitor;
+import io.crate.planner.projection.Projection;
 import org.elasticsearch.common.bytes.BytesReference;
 
 import javax.annotation.Nullable;
@@ -77,6 +78,11 @@ public class ESIndexNode extends DMLPlanNode {
     @Override
     public <C, R> R accept(PlanNodeVisitor<C, R> visitor, C context) {
         return visitor.visitESIndexNode(this, context);
+    }
+
+    @Override
+    public void addProjection(Projection projection) {
+        throw new UnsupportedOperationException("addProjection not supported");
     }
 
     /**

--- a/sql/src/main/java/io/crate/planner/node/dml/InsertNode.java
+++ b/sql/src/main/java/io/crate/planner/node/dml/InsertNode.java
@@ -19,7 +19,7 @@
  * software solely pursuant to the terms of the relevant commercial agreement.
  */
 
-package io.crate.planner.node.dql;
+package io.crate.planner.node.dml;
 
 import io.crate.analyze.relations.PlannedAnalyzedRelation;
 import io.crate.analyze.relations.RelationVisitor;
@@ -29,42 +29,27 @@ import io.crate.planner.node.PlanNode;
 import io.crate.planner.node.PlanNodeVisitor;
 import io.crate.planner.projection.Projection;
 import io.crate.planner.symbol.Field;
-import io.crate.types.DataType;
 
 import javax.annotation.Nullable;
 import java.util.List;
 
-public class GlobalAggregateNode implements PlannedAnalyzedRelation, PlanNode {
+public class InsertNode extends DMLPlanNode implements PlannedAnalyzedRelation {
 
-    private final CollectNode collectNode;
-    private final MergeNode mergeNode;
+    private final List<PlanNode> nodes;
 
-    public GlobalAggregateNode(CollectNode collectNode, MergeNode mergeNode) {
-        this.collectNode = collectNode;
-        this.mergeNode = mergeNode;
+    public InsertNode(List<PlanNode> nodes) {
+        this.nodes = nodes;
     }
 
-    public CollectNode collectNode() {
-        return collectNode;
-    }
-
-    public MergeNode mergeNode() {
-        return mergeNode;
+    public List<PlanNode> nodes() {
+        return nodes;
     }
 
     @Override
-    public <C, R> R accept(PlanNodeVisitor<C, R> visitor, C context) {
-        return visitor.visitGlobalAggregateNode(this, context);
-    }
-
-    @Override
-    public List<DataType> outputTypes() {
-        return mergeNode.outputTypes();
-    }
-
-    @Override
-    public void outputTypes(List<DataType> outputTypes) {
-        throw new UnsupportedOperationException("outputTypes(outputTypes) not supported on GlobalAggregateNode");
+    public void addProjection(Projection projection) {
+        if (!nodes.isEmpty()) {
+            nodes.get(nodes.size() - 1).addProjection(projection);
+        }
     }
 
     @Override
@@ -75,21 +60,21 @@ public class GlobalAggregateNode implements PlannedAnalyzedRelation, PlanNode {
     @Nullable
     @Override
     public Field getField(Path path) {
-        throw new UnsupportedOperationException("getField not supported on GlobalAggregateNode");
+        throw new UnsupportedOperationException("getField is not supported");
     }
 
     @Override
     public Field getWritableField(Path path) throws UnsupportedOperationException, ColumnUnknownException {
-        throw new UnsupportedOperationException("getWritableField not supported on GlobalAggregateNode");
+        throw new UnsupportedOperationException("getWritableField is not supported");
     }
 
     @Override
     public List<Field> fields() {
-        throw new UnsupportedOperationException("fields not supported on GlobalAggregateNode");
+        throw new UnsupportedOperationException("fields is not supported");
     }
 
     @Override
-    public void addProjection(Projection projection) {
-        throw new UnsupportedOperationException("addProjection not supported");
+    public <C, R> R accept(PlanNodeVisitor<C, R> visitor, C context) {
+        return visitor.visitInsertNode(this, context);
     }
 }

--- a/sql/src/main/java/io/crate/planner/node/dml/QueryAndFetchNode.java
+++ b/sql/src/main/java/io/crate/planner/node/dml/QueryAndFetchNode.java
@@ -9,6 +9,7 @@ import io.crate.planner.node.PlanNode;
 import io.crate.planner.node.PlanNodeVisitor;
 import io.crate.planner.node.dql.CollectNode;
 import io.crate.planner.node.dql.MergeNode;
+import io.crate.planner.projection.Projection;
 import io.crate.planner.symbol.Field;
 import io.crate.types.DataType;
 
@@ -18,11 +19,16 @@ import java.util.List;
 public class QueryAndFetchNode implements PlannedAnalyzedRelation, PlanNode {
 
     private final CollectNode collectNode;
+    @Nullable
     private final MergeNode localMergeNode;
 
-    public QueryAndFetchNode(CollectNode collectNode, MergeNode localMergeNode){
+    public QueryAndFetchNode(CollectNode collectNode, @Nullable MergeNode localMergeNode){
         this.collectNode = collectNode;
         this.localMergeNode = localMergeNode;
+    }
+
+    public QueryAndFetchNode(CollectNode collectNode) {
+        this(collectNode, null);
     }
 
     @Override
@@ -61,10 +67,16 @@ public class QueryAndFetchNode implements PlannedAnalyzedRelation, PlanNode {
         throw new UnsupportedOperationException("set outputTypes is not supported");
     }
 
+    @Override
+    public void addProjection(Projection projection) {
+        collectNode.addProjection(projection);
+    }
+
     public CollectNode collectNode() {
         return collectNode;
     }
 
+    @Nullable
     public MergeNode localMergeNode(){
         return localMergeNode;
     }

--- a/sql/src/main/java/io/crate/planner/node/dml/UpdateByIdExecutionNode.java
+++ b/sql/src/main/java/io/crate/planner/node/dml/UpdateByIdExecutionNode.java
@@ -23,6 +23,7 @@ package io.crate.planner.node.dml;
 
 import com.google.common.base.Optional;
 import io.crate.planner.node.PlanNodeVisitor;
+import io.crate.planner.projection.Projection;
 import io.crate.planner.symbol.Symbol;
 
 import java.util.Map;
@@ -70,5 +71,10 @@ public class UpdateByIdExecutionNode extends DMLPlanNode {
     @Override
     public <C, R> R accept(PlanNodeVisitor<C, R> visitor, C context) {
         return visitor.visitUpdateByIdExecutionNode(this, context);
+    }
+
+    @Override
+    public void addProjection(Projection projection) {
+        throw new UnsupportedOperationException("addProjection not supported");
     }
 }

--- a/sql/src/main/java/io/crate/planner/node/dml/UpdateNode.java
+++ b/sql/src/main/java/io/crate/planner/node/dml/UpdateNode.java
@@ -27,6 +27,7 @@ import io.crate.exceptions.ColumnUnknownException;
 import io.crate.metadata.Path;
 import io.crate.planner.node.PlanNodeVisitor;
 import io.crate.planner.node.dql.DQLPlanNode;
+import io.crate.planner.projection.Projection;
 import io.crate.planner.symbol.Field;
 
 import javax.annotation.Nullable;
@@ -68,5 +69,10 @@ public class UpdateNode extends DMLPlanNode implements PlannedAnalyzedRelation {
     @Override
     public <C, R> R accept(PlanNodeVisitor<C, R> visitor, C context) {
         return visitor.visitUpdateNode(this, context);
+    }
+
+    @Override
+    public void addProjection(Projection projection) {
+        throw new UnsupportedOperationException("addProjection not supported");
     }
 }

--- a/sql/src/main/java/io/crate/planner/node/dql/AbstractDQLPlanNode.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/AbstractDQLPlanNode.java
@@ -24,6 +24,7 @@ package io.crate.planner.node.dql;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
+import io.crate.planner.Planner;
 import io.crate.planner.projection.Projection;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -60,6 +61,12 @@ public abstract class AbstractDQLPlanNode implements DQLPlanNode, Streamable {
 
     public List<Projection> projections() {
         return projections;
+    }
+
+    @Override
+    public void addProjection(Projection projection) {
+        projections.add(projection);
+        outputTypes(Planner.extractDataTypes(projections, outputTypes()));
     }
 
     public Optional<Projection> finalProjection() {

--- a/sql/src/main/java/io/crate/planner/node/dql/DistributedGroupByNode.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/DistributedGroupByNode.java
@@ -27,6 +27,7 @@ import io.crate.exceptions.ColumnUnknownException;
 import io.crate.metadata.Path;
 import io.crate.planner.node.PlanNode;
 import io.crate.planner.node.PlanNodeVisitor;
+import io.crate.planner.projection.Projection;
 import io.crate.planner.symbol.Field;
 import io.crate.types.DataType;
 
@@ -83,6 +84,11 @@ public class DistributedGroupByNode implements PlannedAnalyzedRelation, PlanNode
 
     public CollectNode collectNode() {
         return collectNode;
+    }
+
+    @Override
+    public void addProjection(Projection projection) {
+        throw new UnsupportedOperationException("addProjection not supported");
     }
 
     public MergeNode reducerMergeNode() {

--- a/sql/src/main/java/io/crate/planner/node/dql/ESCountNode.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/ESCountNode.java
@@ -23,6 +23,7 @@ package io.crate.planner.node.dql;
 
 import io.crate.analyze.WhereClause;
 import io.crate.planner.node.PlanNodeVisitor;
+import io.crate.planner.projection.Projection;
 import io.crate.types.DataType;
 import io.crate.types.LongType;
 
@@ -58,4 +59,8 @@ public class ESCountNode extends ESDQLPlanNode {
         return outputTypes;
     }
 
+    @Override
+    public void addProjection(Projection projection) {
+        throw new UnsupportedOperationException("addProjection not supported");
+    }
 }

--- a/sql/src/main/java/io/crate/planner/node/dql/ESGetNode.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/ESGetNode.java
@@ -25,6 +25,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import io.crate.metadata.ReferenceInfo;
 import io.crate.planner.node.PlanNodeVisitor;
+import io.crate.planner.projection.Projection;
 import io.crate.planner.symbol.Symbol;
 import io.crate.types.DataType;
 import org.elasticsearch.common.Nullable;
@@ -123,4 +124,10 @@ public class ESGetNode extends ESDQLPlanNode implements DQLPlanNode {
                 .add("partitionBy", partitionBy)
                 .toString();
     }
+
+    @Override
+    public void addProjection(Projection projection) {
+        throw new UnsupportedOperationException("addProjection not supported");
+    }
+
 }

--- a/sql/src/main/java/io/crate/planner/node/dql/NonDistributedGroupByNode.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/NonDistributedGroupByNode.java
@@ -27,6 +27,7 @@ import io.crate.exceptions.ColumnUnknownException;
 import io.crate.metadata.Path;
 import io.crate.planner.node.PlanNode;
 import io.crate.planner.node.PlanNodeVisitor;
+import io.crate.planner.projection.Projection;
 import io.crate.planner.symbol.Field;
 import io.crate.types.DataType;
 
@@ -77,6 +78,11 @@ public class NonDistributedGroupByNode implements PlannedAnalyzedRelation, PlanN
     @Override
     public void outputTypes(List<DataType> outputTypes) {
         throw new UnsupportedOperationException("set outputTypes is not supported");
+    }
+
+    @Override
+    public void addProjection(Projection projection) {
+        throw new UnsupportedOperationException("addProjection not supported");
     }
 
     public MergeNode localMergeNode() {

--- a/sql/src/main/java/io/crate/planner/node/dql/QueryThenFetchNode.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/QueryThenFetchNode.java
@@ -30,6 +30,7 @@ import io.crate.analyze.WhereClause;
 import io.crate.metadata.ReferenceInfo;
 import io.crate.metadata.Routing;
 import io.crate.planner.node.PlanNodeVisitor;
+import io.crate.planner.projection.Projection;
 import io.crate.planner.symbol.Symbol;
 import io.crate.planner.symbol.Symbols;
 import org.elasticsearch.common.Nullable;
@@ -122,6 +123,11 @@ public class QueryThenFetchNode extends ESDQLPlanNode {
     @Override
     public <C, R> R accept(PlanNodeVisitor<C, R> visitor, C context) {
         return visitor.visitQueryThenFetchNode(this, context);
+    }
+
+    @Override
+    public void addProjection(Projection projection) {
+        throw new UnsupportedOperationException("addProjection not supported");
     }
 
     @Override

--- a/sql/src/test/java/io/crate/planner/consumer/InsertFromSubQueryConsumerV2Test.java
+++ b/sql/src/test/java/io/crate/planner/consumer/InsertFromSubQueryConsumerV2Test.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.planner.consumer;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
+import io.crate.analyze.InsertFromSubQueryAnalyzedStatement;
+import io.crate.analyze.WhereClause;
+import io.crate.analyze.relations.TableRelation;
+import io.crate.metadata.ReferenceInfo;
+import io.crate.metadata.Routing;
+import io.crate.metadata.TableIdent;
+import io.crate.metadata.table.TableInfo;
+import io.crate.metadata.table.TestingTableInfo;
+import io.crate.planner.RowGranularity;
+import io.crate.planner.node.ProjectedNode;
+import io.crate.planner.node.dml.InsertNode;
+import io.crate.planner.node.dml.QueryAndFetchNode;
+import io.crate.planner.node.dql.CollectNode;
+import io.crate.planner.projection.ColumnIndexWriterProjection;
+import io.crate.planner.symbol.Field;
+import io.crate.planner.symbol.Reference;
+import io.crate.planner.symbol.Symbol;
+import io.crate.types.DataTypes;
+import org.junit.Test;
+
+import javax.annotation.Nullable;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class InsertFromSubQueryConsumerV2Test {
+
+    static {
+        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
+    }
+
+    private static final TableIdent TEST_TABLE_IDENT = new TableIdent(null, "test");
+    private static final TableInfo TEST_TABLE_INFO = TestingTableInfo.builder(TEST_TABLE_IDENT, RowGranularity.DOC, new Routing())
+            .add("id", DataTypes.LONG, null)
+            .add("name", DataTypes.STRING, null)
+            .addPrimaryKey("id")
+            .clusteredBy("id")
+            .build();
+    private static final TableRelation TEST_TABLE_RELATION = new TableRelation(TEST_TABLE_INFO);
+
+    @Test
+    public void testQueryAndFetchSubQuery() throws Exception {
+        Routing routing = TEST_TABLE_INFO.getRouting(WhereClause.MATCH_ALL, null);
+        CollectNode collectNode = new CollectNode("collect", routing);
+
+        collectNode.toCollect(Lists.transform(TEST_TABLE_RELATION.fields(), new Function<Field, Symbol>() {
+            @Nullable
+            @Override
+            public Symbol apply(Field input) {
+                return input;
+            }
+        }));
+        QueryAndFetchNode queryAndFetchNode = new QueryAndFetchNode(collectNode);
+
+        InsertFromSubQueryAnalyzedStatement statement =
+                new InsertFromSubQueryAnalyzedStatement(queryAndFetchNode, TEST_TABLE_INFO);
+        statement.columns(Lists.transform(Lists.newArrayList(TEST_TABLE_INFO.columns()), new Function<ReferenceInfo, Reference>() {
+            @Nullable
+            @Override
+            public Reference apply(@Nullable ReferenceInfo input) {
+                return new Reference(input);
+            }
+        }));
+
+        ConsumerContext consumerContext = new ConsumerContext(statement);
+        Consumer consumer = new InsertFromSubQueryConsumerV2();
+        consumer.consume(consumerContext.rootRelation(), consumerContext);
+
+        assertThat(consumerContext.rootRelation(), instanceOf(InsertNode.class));
+
+        InsertNode insertNode = (InsertNode)consumerContext.rootRelation();
+        assertThat(insertNode.nodes().size(), is(2));
+
+        assertThat(insertNode.nodes().get(0), instanceOf(QueryAndFetchNode.class));
+        assertThat(insertNode.nodes().get(1), instanceOf(ProjectedNode.class));
+
+        ProjectedNode projectedNode = (ProjectedNode)insertNode.nodes().get(1);
+        assertThat(projectedNode.node(), is(insertNode.nodes().get(0)));
+        assertThat(projectedNode.projection(), instanceOf(ColumnIndexWriterProjection.class));
+    }
+}


### PR DESCRIPTION
add new insert-by-subquery consumer variant which 
only supports already planned subQuery relations
and adding a ProjectedNode including the writer projection