### PR TITLE
call buildSQLActionException in all sendResponse paths

### DIFF
--- a/sql/src/main/java/io/crate/action/sql/TransportBaseSQLAction.java
+++ b/sql/src/main/java/io/crate/action/sql/TransportBaseSQLAction.java
@@ -222,7 +222,7 @@ public abstract class TransportBaseSQLAction<TRequest extends SQLBaseRequest, TR
                         );
                     }
                 } catch (Throwable e) {
-                    sendResponse(listener, e);
+                    sendResponse(listener, buildSQLActionException(e));
                     return;
                 }
 


### PR DESCRIPTION
One code path to sendResponse(.., e) missed the call to 
buildSQLActionException and resulted in error messages that in some cases
aren't very helpful.