### PR TITLE
create copy of function at lucene query converter so original referenced function will be untouched

### DIFF
--- a/sql/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
+++ b/sql/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
@@ -794,7 +794,7 @@ public class LuceneQueryBuilder {
             // reason1: analyzed columns or columns with index off wouldn't work
             //   substr(n, 1, 1) in the case of n => analyzed would throw an error because n would be an array
             // reason2: would have to load each value into the field cache
-            DocReferenceConverter.convertIf(function, Predicates.<Reference>alwaysTrue());
+            function = (Function)DocReferenceConverter.convertIf(function, Predicates.<Reference>alwaysTrue());
 
             final CollectInputSymbolVisitor.Context ctx = inputSymbolVisitor.process(function);
             assert ctx.topLevelInputs().size() == 1;

--- a/sql/src/main/java/io/crate/metadata/DocReferenceConverter.java
+++ b/sql/src/main/java/io/crate/metadata/DocReferenceConverter.java
@@ -109,12 +109,11 @@ public class DocReferenceConverter {
 
         @Override
         public Symbol visitFunction(Function symbol, Predicate<Reference> predicate) {
-            int idx = 0;
+            List<Symbol> arguments = new ArrayList<>(symbol.arguments().size());
             for (Symbol argument : symbol.arguments()) {
-                symbol.setArgument(idx, process(argument, predicate));
-                idx++;
+                arguments.add(process(argument, predicate));
             }
-            return symbol;
+            return new Function(symbol.info(), arguments);
         }
 
         @Override


### PR DESCRIPTION
fixes issues related to update assignments using same function reference