### PR TITLE
Let doctests use an IPv4 address

### DIFF
--- a/docs/src/crate/ports.py
+++ b/docs/src/crate/ports.py
@@ -2,14 +2,15 @@
 
 import socket
 
-def public_ip():
+def public_ipv4():
     """
     take first public interface
     sorted by getaddrinfo - see RFC 3484
-    should have the real public ip as first
+    should have the real public IPv4 address as first address.
+    At the moment the test layer is not able to handle v6 addresses
     """
     for addrinfo in socket.getaddrinfo(socket.gethostname(), None):
-        if addrinfo[1] in (socket.SOCK_STREAM, socket.SOCK_DGRAM):
+        if addrinfo[1] in (socket.SOCK_STREAM, socket.SOCK_DGRAM) and addrinfo[0] == socket.AF_INET:
             return addrinfo[4][0]
 
 

--- a/docs/src/crate/process_test.py
+++ b/docs/src/crate/process_test.py
@@ -7,7 +7,7 @@ import socket
 from crate.testing.layer import CrateLayer
 from crate.client.http import Client
 from .paths import crate_path
-from .ports import public_ip, random_available_port
+from .ports import public_ipv4, random_available_port
 from lovely.testlayers.layer import CascadedLayer
 
 
@@ -37,7 +37,7 @@ class GracefulStopTest(unittest.TestCase):
         for i in range(num_servers):
             layer = GracefulStopCrateLayer(self.node_name(i),
                            crate_path(),
-                           host=public_ip(),
+                           host=public_ipv4(),
                            port=random_available_port(),
                            transport_port=random_available_port(),
                            multicast=True,


### PR DESCRIPTION
Make sure the python doctests let their crate servers bind to an
IPv4 address when they start.