### PR TITLE
FileReadingCollector, force UTF8 for string to bytes conversion

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fix: Force UTF8 encoding in file reading collector to avoid JVM's default encoding settings
+
  - Added support for the ``std_dev``, ``variance`` and ``geometric_mean``
    aggregation functions
 

--- a/sql/src/main/java/io/crate/operation/collect/files/FileReadingCollector.java
+++ b/sql/src/main/java/io/crate/operation/collect/files/FileReadingCollector.java
@@ -170,7 +170,7 @@ public class FileReadingCollector implements CrateCollector {
 
                 try {
                     while ((line = reader.readLine()) != null) {
-                        collectorContext.lineContext().rawSource(line.getBytes());
+                        collectorContext.lineContext().rawSource(line.getBytes(StandardCharsets.UTF_8));
                         newRow = new Object[inputs.size()];
                         for (LineCollectorExpression expression : collectorExpressions) {
                             expression.setNextLine(line);

--- a/sql/src/test/java/io/crate/operation/collect/files/FileReadingCollectorTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/files/FileReadingCollectorTest.java
@@ -36,6 +36,7 @@ import io.crate.metadata.Functions;
 import io.crate.operation.projectors.CollectingProjector;
 import io.crate.operation.reference.file.FileLineReferenceResolver;
 import io.crate.types.DataTypes;
+import org.apache.lucene.util.AbstractRandomizedTest;
 import org.apache.lucene.util.BytesRef;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -56,7 +57,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 
-public class FileReadingCollectorTest {
+public class FileReadingCollectorTest extends AbstractRandomizedTest {
 
     private static File tmpFile;
     private static File tmpFileGz;
@@ -80,7 +81,7 @@ public class FileReadingCollectorTest {
     }
 
     @Before
-    public void setUp() throws Exception {
+    public void prepare() throws Exception {
         Functions functions = new Functions(
                 ImmutableMap.<FunctionIdent, FunctionImplementation>of(),
                 ImmutableMap.<String, DynamicFunctionResolver>of()


### PR DESCRIPTION
Added StandardEncoding.UTF_8 when reading file line by line to ensure correct encoding (independent of local JVM settings)