### PR TITLE
ensure current_timestamp is evaluated only once per statement

### DIFF
--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalysisContext.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalysisContext.java
@@ -21,15 +21,25 @@
 
 package io.crate.analyze.expressions;
 
+import io.crate.analyze.EvaluatingNormalizer;
 import io.crate.metadata.FunctionInfo;
+import io.crate.operation.scalar.timestamp.CurrentTimestampFunction;
 import io.crate.planner.symbol.Function;
+import io.crate.planner.symbol.Literal;
 import io.crate.planner.symbol.Symbol;
+import io.crate.sql.tree.CurrentTime;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 public class ExpressionAnalysisContext {
+
+    /**
+     * currentTime should be evaluated only once per query/statement.
+     * This map is used to
+     */
+    private final Map<CurrentTime, Literal> allocatedCurrentTimestamps = new HashMap<>();
 
     private final Map<Function, Function> functionSymbols = new HashMap<>();
     public boolean hasAggregates = false;
@@ -49,5 +59,20 @@ public class ExpressionAnalysisContext {
         } else {
             return existingFunction;
         }
+    }
+
+    /**
+     * allocate a new function for the currentTime node or re-use an already evaluated one to ensure
+     * currentTime evaluation is global per query.
+     *
+     * TODO: once sub-selects are implemented need to take care to re-use the ExpressionAnalysisContext...
+     */
+    public Symbol allocateCurrentTime(CurrentTime node, List<Symbol> args, EvaluatingNormalizer normalizer) {
+        Literal literal = allocatedCurrentTimestamps.get(node);
+        if (literal == null) {
+            literal = (Literal)normalizer.normalize(allocateFunction(CurrentTimestampFunction.INFO, args));
+            allocatedCurrentTimestamps.put(node, literal);
+        }
+        return literal;
     }
 }

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -369,7 +369,7 @@ public class ExpressionAnalyzer {
             List<Symbol> args = Lists.<Symbol>newArrayList(
                     Literal.newLiteral(node.getPrecision().or(CurrentTimestampFunction.DEFAULT_PRECISION))
             );
-            return context.allocateFunction(CurrentTimestampFunction.INFO, args);
+            return context.allocateCurrentTime(node, args, normalizer);
         }
 
         @Override


### PR DESCRIPTION
selectWhereEqualCurrentTimestamp() was flaky because that was not the case.