### PR TITLE
don't recheck distribution requirement in DistributedGroupByConsumer

### DIFF
--- a/sql/src/main/java/io/crate/planner/consumer/DistributedGroupByConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/DistributedGroupByConsumer.java
@@ -103,10 +103,6 @@ public class DistributedGroupByConsumer implements Consumer {
 
             Routing routing = tableInfo.getRouting(whereClause, null);
 
-            if (!GroupByConsumer.requiresDistribution(tableInfo, routing)) {
-                return table;
-            }
-
             GroupByConsumer.validateGroupBySymbols(table.tableRelation(), table.querySpec().groupBy());
             PlannerContextBuilder contextBuilder = new PlannerContextBuilder(2,
                     table.querySpec().groupBy())

--- a/sql/src/main/java/io/crate/planner/consumer/GlobalAggregateConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/GlobalAggregateConsumer.java
@@ -103,10 +103,15 @@ public class GlobalAggregateConsumer implements Consumer {
         }
     }
 
+    private static boolean noGroupBy(List<Symbol> groupBy) {
+        return groupBy == null || groupBy.isEmpty();
+    }
+
     public static PlannedAnalyzedRelation globalAggregates(QueriedTable table,
                                                            TableRelation tableRelation,
                                                            WhereClauseContext whereClauseContext,
                                                            ColumnIndexWriterProjection indexWriterProjection){
+        assert noGroupBy(table.querySpec().groupBy()) : "must not have group by clause for global aggregate queries";
         validateAggregationOutputs(tableRelation, table.querySpec().outputs());
         // global aggregate: collect and partial aggregate on C and final agg on H
         PlannerContextBuilder contextBuilder = new PlannerContextBuilder(2).output(

--- a/sql/src/test/java/io/crate/integrationtests/Setup.java
+++ b/sql/src/test/java/io/crate/integrationtests/Setup.java
@@ -148,7 +148,7 @@ public class Setup {
             " details object," +
             " details_ignored object(ignored)" +
             ")", numericType));
-        transportExecutor.ensureGreen();
+        transportExecutor.ensureYellow();
 
         Map<String, String> details = newHashMap();
         details.put("job", "Sandwitch Maker");


### PR DESCRIPTION
In some cases if shards are still initializing the requiresDistribution()
method might change its result between two calls.

This can lead to the NonDistributedConsumer believing that distribution is
required and the DistributedConsumer believing that it isn't.

To fix that just check once in the NonDistributedConsumer and rely on the
order of the Consumers.

In the worst case this will execute a query that could be non-distributed in a
distributed way.