### PR TITLE
close reference to file header in DigestBlob on commit

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fix: Close headFileChannel in DigestBlob on commit
+
  - Added case-insensitive regex operator ~*
 
  - Support PCRE compatible regular expressions

--- a/blob/src/main/java/io/crate/blob/DigestBlob.java
+++ b/blob/src/main/java/io/crate/blob/DigestBlob.java
@@ -162,6 +162,14 @@ public class DigestBlob {
             file.delete();
             throw new DigestMismatchException(digest, contentDigest);
         }
+        // release headFileChannel
+        if(null != headFileChannel){
+            try {
+                headFileChannel.close();
+            } catch (IOException e) {
+                // probably already closed!
+            }
+        }
         File newFile = container.getFile(digest);
         file.renameTo(newFile);
         return newFile;

--- a/blob/src/test/java/io/crate/DigestBlobTests.java
+++ b/blob/src/test/java/io/crate/DigestBlobTests.java
@@ -114,9 +114,12 @@ public class DigestBlobTests {
         FileInputStream stream = new FileInputStream(digestBlob.file());
         stream.read(buffer, 0, 15);
         assertEquals("ABCDEFGHIJKLMNO", new BytesArray(buffer).toUtf8().trim());
+        stream.close();
+
         File file = digestBlob.commit();
         assertTrue(file.exists());
-        file.delete();
+        // just in case any references to file left
+        assertTrue(file.delete());
     }
 
     @Test
@@ -139,9 +142,12 @@ public class DigestBlobTests {
         FileInputStream stream = new FileInputStream(digestBlob.file());
         stream.read(buffer, 0, 15);
         assertEquals("ABCDEFGHIJKLMNO", new BytesArray(buffer).toUtf8().trim());
+        stream.close();
+
         File file = digestBlob.commit();
         assertTrue(file.exists());
-        file.delete();
+        // just in case any references to file left
+        assertTrue(file.delete());
     }
 
 }


### PR DESCRIPTION
This caused some tests to fail on Windows (testDigestBlobResumeHeadAndAddContent and testResumeDigestBlobAddHeadAfterContent)!

Please review and let me know if that file channel was left open on purpose, but from what I understand, after commit, there shouldn't be any internal references, should there?