### PR TITLE
optimize single row upsert by bypassing bulk shard processor

### DIFF
--- a/sql/src/main/java/io/crate/executor/transport/TransportShardUpsertAction.java
+++ b/sql/src/main/java/io/crate/executor/transport/TransportShardUpsertAction.java
@@ -305,6 +305,7 @@ public class TransportShardUpsertAction extends TransportShardReplicationOperati
      *
      * TODO: detect NOOP
      */
+    @SuppressWarnings("unchecked")
     private void updateSourceByPaths(Map<String, Object> source, Map<String, Object> changes) {
         for (Map.Entry<String, Object> changesEntry : changes.entrySet()) {
             if (changesEntry.getKey().contains(".")) {

--- a/sql/src/main/java/io/crate/executor/transport/task/UpsertByIdTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/UpsertByIdTask.java
@@ -25,15 +25,29 @@ import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
+import io.crate.Constants;
 import io.crate.executor.JobTask;
 import io.crate.executor.RowCountResult;
 import io.crate.executor.TaskResult;
+import io.crate.executor.transport.ShardUpsertRequest;
+import io.crate.executor.transport.ShardUpsertResponse;
 import io.crate.planner.node.dml.UpsertByIdNode;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
 import org.elasticsearch.action.admin.indices.create.TransportCreateIndexAction;
 import org.elasticsearch.action.bulk.BulkShardProcessor;
 import org.elasticsearch.action.bulk.TransportShardUpsertActionDelegate;
+import org.elasticsearch.action.support.AutoCreateIndex;
 import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.engine.DocumentMissingException;
+import org.elasticsearch.index.engine.VersionConflictEngineException;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.indices.IndexAlreadyExistsException;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -44,9 +58,16 @@ import java.util.UUID;
 
 public class UpsertByIdTask extends JobTask {
 
-    private final BulkShardProcessor bulkShardProcessor;
+    private final TransportShardUpsertActionDelegate transportShardUpsertActionDelegate;
+    private final TransportCreateIndexAction transportCreateIndexAction;
+    private final ClusterService clusterService;
     private final UpsertByIdNode node;
-    private final ArrayList<ListenableFuture<TaskResult>> resultList;
+    private final List<ListenableFuture<TaskResult>> resultList;
+    private final AutoCreateIndex autoCreateIndex;
+    @Nullable
+    private BulkShardProcessor bulkShardProcessor;
+
+    private final ESLogger logger = Loggers.getLogger(getClass());
 
     public UpsertByIdTask(UUID jobId,
                           ClusterService clusterService,
@@ -55,10 +76,100 @@ public class UpsertByIdTask extends JobTask {
                           TransportCreateIndexAction transportCreateIndexAction,
                           UpsertByIdNode node) {
         super(jobId);
-
+        this.transportShardUpsertActionDelegate = transportShardUpsertActionDelegate;
+        this.transportCreateIndexAction = transportCreateIndexAction;
+        this.clusterService = clusterService;
         this.node = node;
+        autoCreateIndex = new AutoCreateIndex(settings);
 
-        this.bulkShardProcessor = new BulkShardProcessor(
+        if (node.items().size() == 1) {
+            // skip useless usage of bulk processor if only 1 item in statement
+            // and instead create upsert request directly on start()
+            resultList = new ArrayList<>(1);
+            resultList.add(SettableFuture.<TaskResult>create());
+        } else {
+            resultList = initializeBulkShardProcessor(settings);
+        }
+
+    }
+
+    @Override
+    public void start() {
+        if (node.items().size() == 1) {
+            // directly execute upsert request without usage of bulk processor
+            @SuppressWarnings("unchecked")
+            SettableFuture<TaskResult> futureResult = (SettableFuture)resultList.get(0);
+            UpsertByIdNode.Item item = node.items().get(0);
+            if (node.isPartitionedTable()
+                    && autoCreateIndex.shouldAutoCreate(item.index(), clusterService.state())) {
+                createIndexAndExecuteUpsertRequest(item, futureResult);
+            } else {
+                executeUpsertRequest(item, futureResult);
+            }
+
+        } else if (bulkShardProcessor != null) {
+            for (UpsertByIdNode.Item item : node.items()) {
+                bulkShardProcessor.add(
+                        item.index(),
+                        item.id(),
+                        item.updateAssignments(),
+                        item.insertValues(),
+                        item.routing(),
+                        item.version());
+            }
+            bulkShardProcessor.close();
+        }
+    }
+
+    private void executeUpsertRequest(final UpsertByIdNode.Item item, final SettableFuture futureResult) {
+        ShardId shardId = clusterService.operationRouting().indexShards(
+                clusterService.state(),
+                item.index(),
+                Constants.DEFAULT_MAPPING_TYPE,
+                item.id(),
+                item.routing()
+        ).shardId();
+
+        ShardUpsertRequest upsertRequest = new ShardUpsertRequest(shardId, node.updateColumns(), node.insertColumns());
+        upsertRequest.continueOnError(false);
+        upsertRequest.add(0, item.id(), item.updateAssignments(), item.insertValues(), item.version(), item.routing());
+
+        transportShardUpsertActionDelegate.execute(upsertRequest, new ActionListener<ShardUpsertResponse>() {
+            @Override
+            public void onResponse(ShardUpsertResponse updateResponse) {
+                int location = updateResponse.locations().get(0);
+                if (updateResponse.responses().get(location) != null) {
+                    futureResult.set(TaskResult.ONE_ROW);
+                } else {
+                    ShardUpsertResponse.Failure failure = updateResponse.failures().get(location);
+                    if (logger.isDebugEnabled()) {
+                        if (failure.versionConflict()) {
+                            logger.debug("Upsert of document with id {} failed because of a version conflict", failure.id());
+                        } else {
+                            logger.debug("Upsert of document with id {} failed {}", failure.id(), failure.message());
+                        }
+                    }
+                    futureResult.set(TaskResult.ZERO);
+                }
+            }
+
+            @Override
+            public void onFailure(Throwable e) {
+                e = ExceptionsHelper.unwrapCause(e);
+                if (item.insertValues() == null
+                        && (e instanceof DocumentMissingException
+                        || e instanceof VersionConflictEngineException)) {
+                    // on updates, set affected row to 0 if document is not found or version conflicted
+                    futureResult.set(TaskResult.ZERO);
+                } else {
+                    futureResult.setException(e);
+                }
+            }
+        });
+    }
+
+    private List<ListenableFuture<TaskResult>> initializeBulkShardProcessor(Settings settings) {
+        bulkShardProcessor = new BulkShardProcessor(
                 clusterService,
                 settings,
                 transportShardUpsertActionDelegate,
@@ -69,12 +180,10 @@ public class UpsertByIdTask extends JobTask {
                 node.updateColumns(),
                 node.insertColumns());
 
-
         if (!node.isBulkRequest()) {
             final SettableFuture<TaskResult> futureResult = SettableFuture.create();
-            resultList = new ArrayList<>(1);
+            List<ListenableFuture<TaskResult>> resultList = new ArrayList<>(1);
             resultList.add(futureResult);
-
             Futures.addCallback(bulkShardProcessor.result(), new FutureCallback<BitSet>() {
                 @Override
                 public void onSuccess(@Nullable BitSet result) {
@@ -90,12 +199,14 @@ public class UpsertByIdTask extends JobTask {
                     futureResult.setException(t);
                 }
             });
+            return resultList;
         } else {
             final int numResults = node.items().size();
-            resultList = new ArrayList<>(numResults);
+            final List<ListenableFuture<TaskResult>> resultList = new ArrayList<>(numResults);
             for (int i = 0; i < numResults; i++) {
                 resultList.add(SettableFuture.<TaskResult>create());
             }
+
             Futures.addCallback(bulkShardProcessor.result(), new FutureCallback<BitSet>() {
                 @Override
                 public void onSuccess(@Nullable BitSet result) {
@@ -127,23 +238,33 @@ public class UpsertByIdTask extends JobTask {
                     setAllToFailed(t);
                 }
             });
+            return resultList;
         }
-
     }
 
-    @Override
-    public void start() {
-        for (UpsertByIdNode.Item item : node.items()) {
-            bulkShardProcessor.add(
-                    item.index(),
-                    item.id(),
-                    item.updateAssignments(),
-                    item.insertValues(),
-                    item.routing(),
-                    item.version());
-        }
-        bulkShardProcessor.close();
+    private void createIndexAndExecuteUpsertRequest(final UpsertByIdNode.Item item,
+                                                    final SettableFuture futureResult) {
+        transportCreateIndexAction.execute(
+                new CreateIndexRequest(item.index()).cause("upsert single item"),
+                new ActionListener<CreateIndexResponse>() {
+            @Override
+            public void onResponse(CreateIndexResponse createIndexResponse) {
+                executeUpsertRequest(item, futureResult);
+            }
+
+            @Override
+            public void onFailure(Throwable e) {
+                e = ExceptionsHelper.unwrapCause(e);
+                if (e instanceof IndexAlreadyExistsException) {
+                    executeUpsertRequest(item, futureResult);
+                } else {
+                    futureResult.setException(e);
+                }
+
+            }
+        });
     }
+
 
     @Override
     public List<ListenableFuture<TaskResult>> result() {

--- a/sql/src/test/java/io/crate/executor/transport/TransportExecutorTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/TransportExecutorTest.java
@@ -472,7 +472,7 @@ public class TransportExecutorTest extends BaseTransportExecutorTest {
     }
 
     @Test
-    public void testESIndexPartitionedTableTask() throws Exception {
+    public void testInsertIntoPartitionedTableWithUpsertByIdTask() throws Exception {
         execute("create table parted (" +
                 "  id int, " +
                 "  name string, " +

--- a/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -2438,15 +2438,6 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
         ensureGreen();
         execute("insert into t (name, score) values ('Ford', 1.2)");
     }
-
-    //TODO: remove once branch 'relation' is merged
-    @Test
-    public void testUpdateByPrimaryKeyUnknownDocument() {
-        execute("create table test (id int primary key, message string)");
-        ensureGreen();
-        execute("update test set message='b' where id = 1");
-        assertEquals(0, response.rowCount());
-    }
 }
 
 


### PR DESCRIPTION
InsertBenchmark.testInsertSingleApi: [measured 100 out of 101 rounds, threads: 1 (sequential)]
     round: 0.05 [+- 0.03], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 28, GC.time: 0.24, time.total: 11.75, time.warmup: 7.18, time.bench: 4.57

InsertBenchmark.testInsertSingleSql: [measured 100 out of 101 rounds, threads: 1 (sequential)]
     round: 0.05 [+- 0.03], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 47, GC.time: 0.29, time.total: 4.99, time.warmup: 0.30, time.bench: 4.69
