### PR TITLE
fix eq on array literals, disallow eq on other array comparisons

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,10 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Comparing arrays now works correctly for literals and comparing an array
+   field to an array literal will result in a correct
+   UnsupportedOperationException.
+
  - Support `INSERT ... ON DUPLICATE KEY UPDATE` statement
 
  - Fix: Improved value validation for nested primary key and clustered by

--- a/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/ESQueryBuilder.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/ESQueryBuilder.java
@@ -586,7 +586,9 @@ public class ESQueryBuilder {
                 }
 
                 assert left.symbolType() == SymbolType.REFERENCE || left.symbolType() == SymbolType.DYNAMIC_REFERENCE;
-
+                if (DataTypes.isCollectionType(left.valueType()) && DataTypes.isCollectionType(right.valueType())) {
+                    throw new UnsupportedOperationException("Cannot compare two arrays");
+                }
 
                 Object value;
                 if (Symbol.isLiteral(right, DataTypes.STRING)) {

--- a/sql/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
+++ b/sql/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
@@ -344,6 +344,9 @@ public class LuceneQueryBuilder {
                     return null;
                 }
 
+                if (DataTypes.isCollectionType(tuple.v1().valueType()) && DataTypes.isCollectionType(tuple.v2().valueType())) {
+                    throw new UnsupportedFeatureException("Cannot compare two arrays");
+                }
                 String columnName = tuple.v1().info().ident().columnIdent().fqn();
                 QueryBuilderHelper builder = QueryBuilderHelper.forType(tuple.v1().valueType());
                 return builder.eq(columnName, tuple.v2().value());

--- a/sql/src/test/java/io/crate/executor/transport/task/elasticsearch/ESQueryBuilderTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/task/elasticsearch/ESQueryBuilderTest.java
@@ -859,6 +859,18 @@ public class ESQueryBuilderTest {
     }
 
     @Test
+    public void testEqOnTwoArrayShouldFail() throws Exception {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("Cannot compare two arrays");
+
+        DataType intArray = new ArrayType(DataTypes.INTEGER);
+        generator.convert(new WhereClause(createFunction(EqOperator.NAME, DataTypes.BOOLEAN,
+                createReference("a", intArray),
+                Literal.newLiteral(intArray, new Object[] { 10, 20})
+        )));
+    }
+
+    @Test
     public void testWhereNumericScalarEqNumericScalar() throws Exception {
         /**
          * round(a) = round(b) isn't supported

--- a/sql/src/test/java/io/crate/operation/operator/EqOperatorTest.java
+++ b/sql/src/test/java/io/crate/operation/operator/EqOperatorTest.java
@@ -1,5 +1,6 @@
 package io.crate.operation.operator;
 
+import com.carrotsearch.randomizedtesting.RandomizedTest;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.crate.metadata.FunctionIdent;
@@ -10,6 +11,7 @@ import io.crate.operation.operator.input.ObjectInput;
 import io.crate.planner.symbol.Function;
 import io.crate.planner.symbol.Literal;
 import io.crate.planner.symbol.Symbol;
+import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.elasticsearch.common.inject.ModulesBuilder;
@@ -19,11 +21,12 @@ import org.junit.Test;
 import java.util.Arrays;
 
 import static io.crate.testing.TestingHelpers.assertLiteralSymbol;
+import static io.crate.testing.TestingHelpers.createFunction;
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.*;
 
-public class EqOperatorTest {
+public class EqOperatorTest extends RandomizedTest {
 
     static {
         ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
@@ -36,14 +39,14 @@ public class EqOperatorTest {
         functions = new ModulesBuilder().add(new OperatorModule()).createInjector().getInstance(Functions.class);
     }
 
-    private EqOperator getOp(DataType dataType) {
-        return (EqOperator) functions.get(
+    private CmpOperator getOp(DataType dataType) {
+        return (CmpOperator) functions.get(
                 new FunctionIdent(EqOperator.NAME, ImmutableList.of(dataType, dataType)));
     }
 
     @Test
     public void testNormalizeSymbol() {
-        EqOperator op = getOp(DataTypes.INTEGER);
+        CmpOperator op = getOp(DataTypes.INTEGER);
 
         Function function = new Function(
                 op.info(), Arrays.<Symbol>asList(Literal.newLiteral(2), Literal.newLiteral(2)));
@@ -53,8 +56,117 @@ public class EqOperatorTest {
     }
 
     @Test
+    public void testEqArrayLeftSideIsNull_RightSideNull() throws Exception {
+        ArrayType intIntArray = new ArrayType(new ArrayType(DataTypes.INTEGER));
+        CmpOperator op = getOp(intIntArray);
+        Object[][] values = new Object[][] {
+                new Object[] { 1, 1},
+                new Object[] { 10 }
+        };
+        Function function = createFunction(EqOperator.NAME, DataTypes.BOOLEAN,
+                Literal.newLiteral(intIntArray, null),
+                Literal.newLiteral(intIntArray, values));
+        assertLiteralSymbol(op.normalizeSymbol(function), null, DataTypes.BOOLEAN);
+
+        function = createFunction(EqOperator.NAME, DataTypes.BOOLEAN,
+                Literal.newLiteral(intIntArray, values),
+                Literal.newLiteral(intIntArray, null));
+        assertLiteralSymbol(op.normalizeSymbol(function), null, DataTypes.BOOLEAN);
+
+        assertThat(eq(intIntArray, null, values), nullValue());
+        assertThat(eq(intIntArray, values, null), nullValue());
+    }
+
+    @Test
+    public void testNormalizeEvalNestedIntArrayIsTrueIfEquals() throws Exception {
+        ArrayType intIntArray = new ArrayType(new ArrayType(DataTypes.INTEGER));
+        CmpOperator op = getOp(intIntArray);
+
+        Object[][] left = new Object[][] {
+                new Object[] { 1, 1},
+                new Object[] { 10 }
+        };
+        Object[][] right = new Object[][] {
+                new Object[] { 1, 1},
+                new Object[] { 10 }
+        };
+        Function function = createFunction(EqOperator.NAME, DataTypes.BOOLEAN,
+                Literal.newLiteral(intIntArray, left),
+                Literal.newLiteral(intIntArray, right));
+
+        assertLiteralSymbol(op.normalizeSymbol(function), true);
+        assertThat(eq(intIntArray, left, right), is(true));
+    }
+
+    @Test
+    public void testNormalizeEvalNestedIntArrayIsFalseIfNotEquals() throws Exception {
+        ArrayType intIntArray = new ArrayType(new ArrayType(DataTypes.INTEGER));
+        CmpOperator op = getOp(intIntArray);
+
+        Object[][] left = new Object[][] {
+                new Object[] { 1 },
+                new Object[] { 10 }
+        };
+        Object[][] right = new Object[][] {
+                new Object[] { 1, 1},
+                new Object[] { 10 }
+        };
+        Function function = createFunction(EqOperator.NAME, DataTypes.BOOLEAN,
+                Literal.newLiteral(intIntArray, left),
+                Literal.newLiteral(intIntArray, right));
+
+        assertLiteralSymbol(op.normalizeSymbol(function), false);
+        assertThat(eq(intIntArray, left, right), is(false));
+    }
+
+    @Test
+    public void testNormalizeAndEvalTwoEqualArraysShouldReturnTrueLiteral() throws Exception {
+        ArrayType intArray = new ArrayType(DataTypes.INTEGER);
+        CmpOperator op = getOp(intArray);
+
+        Object[] left = new Object[] { 1, 1, 10 };
+        Object[] right = new Object[] { 1, 1, 10 };
+        Function function = createFunction(EqOperator.NAME, DataTypes.BOOLEAN,
+                Literal.newLiteral(intArray, left),
+                Literal.newLiteral(intArray, right));
+
+        assertLiteralSymbol(op.normalizeSymbol(function), true);
+        assertThat(eq(intArray, left, right), is(true));
+    }
+
+    @Test
+    public void testNormalizeAndEvalTwoNotEqualArraysShouldReturnFalse() throws Exception {
+        ArrayType intArray = new ArrayType(DataTypes.INTEGER);
+        CmpOperator op = getOp(intArray);
+
+        Object[] left = new Object[] { 1, 1, 10 };
+        Object[] right = new Object[] { 1, 10 };
+        Function function = createFunction(EqOperator.NAME, DataTypes.BOOLEAN,
+                Literal.newLiteral(intArray, left),
+                Literal.newLiteral(intArray, right));
+
+        assertLiteralSymbol(op.normalizeSymbol(function), false);
+        assertThat(eq(intArray, left, right), is(false));
+    }
+
+    @Test
+    public void testNormalizeAndEvalTwoArraysWithSameLengthButDifferentValuesShouldReturnFalse() throws Exception {
+        ArrayType intArray = new ArrayType(DataTypes.INTEGER);
+        CmpOperator op = getOp(intArray);
+
+        Object[] left = new Object[] { 1, 1, 10 };
+        Object[] right = new Object[] { 1, 2, 10 };
+        Function function = createFunction(EqOperator.NAME, DataTypes.BOOLEAN,
+                Literal.newLiteral(intArray, left),
+                Literal.newLiteral(intArray, right));
+
+        assertLiteralSymbol(op.normalizeSymbol(function), false);
+        assertThat(eq(intArray, left, right), is(false));
+    }
+
+    @Test
     public void testNormalizeSymbolWithNullLiteral() {
-        EqOperator op = getOp(DataTypes.INTEGER);
+        CmpOperator op = getOp(DataTypes.INTEGER);
         Function function = new Function(
                 op.info(), Arrays.<Symbol>asList(Literal.NULL, Literal.NULL));
         Literal result = (Literal)op.normalizeSymbol(function);
@@ -64,7 +176,7 @@ public class EqOperatorTest {
 
     @Test
     public void testNormalizeSymbolWithOneNullLiteral() {
-        EqOperator op = getOp(DataTypes.INTEGER);
+        CmpOperator op = getOp(DataTypes.INTEGER);
         Function function = new Function(
                 op.info(), Arrays.<Symbol>asList(Literal.newLiteral(2), Literal.NULL));
         Literal result = (Literal)op.normalizeSymbol(function);
@@ -74,7 +186,7 @@ public class EqOperatorTest {
 
     @Test
     public void testNormalizeSymbolNeq() {
-        EqOperator op = getOp(DataTypes.INTEGER);
+        CmpOperator op = getOp(DataTypes.INTEGER);
 
         Function function = new Function(
                 op.info(), Arrays.<Symbol>asList(Literal.newLiteral(2), Literal.newLiteral(4)));
@@ -85,7 +197,7 @@ public class EqOperatorTest {
 
     @Test
     public void testNormalizeSymbolNonLiteral() {
-        EqOperator op = getOp(DataTypes.INTEGER);
+        CmpOperator op = getOp(DataTypes.INTEGER);
         Function f1 = new Function(
                 new FunctionInfo(
                         new FunctionIdent("dummy_function", Arrays.<DataType>asList(DataTypes.INTEGER)),
@@ -112,7 +224,7 @@ public class EqOperatorTest {
     }
 
     private Boolean eq(DataType type, Object left, Object right) {
-        EqOperator op = getOp(type);
+        CmpOperator op = getOp(type);
         return op.evaluate(new Input[] {new ObjectInput(left),new ObjectInput(right) });
     }
 


### PR DESCRIPTION
previously

 where [1, 2, 3] = [1, 1, 1]

did match because only the size of the arrays was used for comparison.

and where a_field = [1, 2, 3] failed with a ClassCastException. Now it returns
an error that it isn't supported