### PR TITLE
use BooleanFilter instead of BooleanQuery to pre-filter in array equals case

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Improved performance of queries that use the equals operator on arrays
+
  - COPY FROM now skips rows with the same primary key instead of overriding them
 
 2015/02/06 0.47.0

--- a/core/src/main/java/io/crate/Version.java
+++ b/core/src/main/java/io/crate/Version.java
@@ -34,7 +34,7 @@ public class Version {
     // the (internal) format of the id is there so we can easily do after/before checks on the id
 
 
-    public static final boolean SNAPSHOT = false;
+    public static final boolean SNAPSHOT = true;
     public static final Version CURRENT = new Version(470099, SNAPSHOT, org.elasticsearch.Version.V_1_4_2);
 
     static {

--- a/sql/src/main/java/io/crate/lucene/QueryBuilderHelper.java
+++ b/sql/src/main/java/io/crate/lucene/QueryBuilderHelper.java
@@ -4,6 +4,7 @@ import io.crate.types.CollectionType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.apache.lucene.index.Term;
+import org.apache.lucene.queries.TermFilter;
 import org.apache.lucene.search.*;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.lucene.BytesRefs;
@@ -50,6 +51,10 @@ public abstract class QueryBuilderHelper {
 
     public abstract Filter rangeFilter(String columnName, Object from, Object to, boolean includeLower, boolean includeUpper);
     public abstract Query rangeQuery(String columnName, Object from, Object to, boolean includeLower, boolean includeUpper);
+
+    public Filter eqFilter(String columnName, Object value) {
+        return rangeFilter(columnName, value, value, true, true);
+    }
 
     public Query eq(String columnName, Object value) {
         return rangeQuery(columnName, value, value, true, true);
@@ -183,6 +188,11 @@ public abstract class QueryBuilderHelper {
         @Override
         public Query eq(String columnName, Object value) {
             return new TermQuery(new Term(columnName, (BytesRef)value));
+        }
+
+        @Override
+        public Filter eqFilter(String columnName, Object value) {
+            return new TermFilter(new Term(columnName, (BytesRef) value));
         }
 
         @Override

--- a/sql/src/test/java/io/crate/lucene/LuceneQueryBuilderTest.java
+++ b/sql/src/test/java/io/crate/lucene/LuceneQueryBuilderTest.java
@@ -36,11 +36,13 @@ import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.SetType;
+import org.apache.lucene.queries.BooleanFilter;
 import org.apache.lucene.sandbox.queries.regex.RegexQuery;
 import org.apache.lucene.search.*;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.inject.ModulesBuilder;
 import org.elasticsearch.common.lucene.search.MatchNoDocsQuery;
+import org.elasticsearch.common.lucene.search.XConstantScoreQuery;
 import org.elasticsearch.index.cache.IndexCache;
 import org.elasticsearch.search.internal.SearchContext;
 import org.junit.Before;
@@ -99,6 +101,14 @@ public class LuceneQueryBuilderTest extends RandomizedTest {
                 createReference("x", longArray),
                 Literal.newLiteral(longArray, new Object[] { 10L, null, 20L }))));
         assertThat(query, instanceOf(FilteredQuery.class));
+        FilteredQuery filteredQuery = (FilteredQuery) query;
+
+        assertThat(filteredQuery.getFilter(), instanceOf(BooleanFilter.class));
+        assertThat(filteredQuery.getQuery(), instanceOf(XConstantScoreQuery.class));
+
+        BooleanFilter filter = (BooleanFilter) filteredQuery.getFilter();
+        assertThat(filter.clauses().get(0).getFilter(), instanceOf(BooleanFilter.class)); // booleanFilter with terms filter
+        assertThat(filter.clauses().get(1).getFilter(), instanceOf(Filter.class)); // generic function filter
     }
 
     @Test


### PR DESCRIPTION
This way the execution order can be controlled (first BooleanFilter with
TermFilter to pre-filter the result and then apply the genericFunctionFilter
only on the results that are remaining)

This way it is a lot faster and also has the advantage that there is no
"MaxBooleanClause" limit.