### PR TITLE
disable filter cache in genericFunctionQuery

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,8 @@ Changes for Crate
 Unreleased
 ==========
 
- - Improved performance of queries that use the equals operator on arrays
+ - Improved performance of queries that use generic scalar functions (like
+   equals comparison on arrays)
 
  - COPY FROM now skips rows with the same primary key instead of overriding them
 

--- a/sql/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
+++ b/sql/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
@@ -900,7 +900,7 @@ public class LuceneQueryBuilder {
             for (LuceneCollectorExpression expression : expressions) {
                 expression.startCollect(collectorContext);
             }
-            Filter filter = new Filter() {
+            return new Filter() {
                 @Override
                 public DocIdSet getDocIdSet(AtomicReaderContext context, Bits acceptDocs) throws IOException {
                     for (LuceneCollectorExpression expression : expressions) {
@@ -919,7 +919,6 @@ public class LuceneQueryBuilder {
                     );
                 }
             };
-            return indexCache.filter().cache(filter);
         }
 
         private Query genericFunctionQuery(Function function) {


### PR DESCRIPTION
improves performance of queries like:

    where x = 1 and slowfunction(x, y)