### PR TITLE
Nodesettingstest - windows

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -2,3 +2,4 @@
 /data/
 /logs/
 /plugins/
+/config

--- a/app/config/crate.yml
+++ b/app/config/crate.yml
@@ -1,1 +1,0 @@
-../src/main/dist/config/crate.yml

--- a/app/config/logging.yml
+++ b/app/config/logging.yml
@@ -1,1 +1,0 @@
-../src/main/dist/config/logging.yml


### PR DESCRIPTION
I've removed the app/config symlinks from git index, instead I'm dynamically copying needed (default) configuration form the src/main/dist/config directory where it is needed (to app/config).

AFAIK, those symlinks' only purpose was to serve as default configuration for these NodeSettingsTests, so by copying them manually we achieve exactly the same goal, to have a "default" configuration for the tests.

Please let me know if this solution is OK for you guys or if you have a better one!

Thanks