### PR TITLE
- testConversionWithNonAsciiCharacter unicode fix

### DIFF
--- a/core/src/test/java/io/crate/types/LongTypeTest.java
+++ b/core/src/test/java/io/crate/types/LongTypeTest.java
@@ -47,7 +47,7 @@ public class LongTypeTest {
     @Test
     public void testConversionWithNonAsciiCharacter() throws Exception {
         expectedException.expect(NumberFormatException.class);
-        expectedException.expectMessage("π");
+        expectedException.expectMessage("\u03C0"); // "π" GREEK SMALL LETTER PI
         assertBytesRefParsing("\u03C0", 0L);
     }
 


### PR DESCRIPTION
In my windows environment, this test failed with following message:

java.lang.AssertionError: 
Expected: (an instance of java.lang.NumberFormatException and exception with message a string containing "Ï€")
     but: exception with message a string containing "Ï€" message was "π"

Therefore, I've changed the expected message to unicode as well!

Thanks