### PR TITLE
allow no-limit at nested (paged) QTF and NestedLoop

### DIFF
--- a/sql/src/main/java/io/crate/analyze/QueriedTable.java
+++ b/sql/src/main/java/io/crate/analyze/QueriedTable.java
@@ -114,25 +114,24 @@ public class QueriedTable implements QueriedRelation {
             throw new IllegalArgumentException("a querySpec needs to have some outputs in order to create a new sub-relation");
         }
         List<Symbol> splitOutputs = Lists.newArrayList(splitForRelation(tableRelation, outputs).splitSymbols());
-        boolean pullDownLimit = true;
 
         OrderBy orderBy = querySpec.orderBy();
         if (orderBy != null) {
-            pullDownLimit = splitOrderBy(tableRelation, querySpec, splitQuerySpec, splitOutputs, orderBy);
+            splitOrderBy(tableRelation, querySpec, splitQuerySpec, splitOutputs, orderBy);
         }
 
         WhereClause where = querySpec.where();
         if (where != null && where.hasQuery()) {
-            pullDownLimit = splitWhereClause(tableRelation, querySpec, splitQuerySpec, splitOutputs, pullDownLimit, where);
+            splitWhereClause(tableRelation, querySpec, splitQuerySpec, splitOutputs, where);
         } else {
             splitQuerySpec.where(WhereClause.MATCH_ALL);
         }
 
-        if (pullDownLimit) {
-            Integer limit = querySpec.limit();
-            if (limit != null) {
-                splitQuerySpec.limit(limit + querySpec.offset());
-            }
+        // pull down limit = limit + offset, offset=0 by default
+        Integer limit = querySpec.limit();
+        if (limit != null) {
+            splitQuerySpec.limit(limit + querySpec.offset());
+            splitQuerySpec.offset(0);
         }
         splitQuerySpec.outputs(splitOutputs);
         List<OutputName> outputNames = new ArrayList<>(splitOutputs.size());
@@ -165,11 +164,10 @@ public class QueriedTable implements QueriedRelation {
         }
     }
 
-    private static boolean splitWhereClause(TableRelation tableRelation,
+    private static void splitWhereClause(TableRelation tableRelation,
                                             QuerySpec querySpec,
                                             QuerySpec splitQuerySpec,
                                             List<Symbol> splitOutputs,
-                                            boolean pullDownLimit,
                                             WhereClause where) {
         QuerySplitter.SplitQueries splitQueries = QuerySplitter.splitForRelation(tableRelation, where.query());
         if (splitQueries.relationQuery() != null) {
@@ -179,27 +177,22 @@ public class QueriedTable implements QueriedRelation {
             SplitContext splitContext = splitForRelation(tableRelation, splitQueries.remainingQuery());
             assert splitContext.directSplit.isEmpty();
             splitOutputs.addAll(splitContext.mixedSplit);
-            pullDownLimit = pullDownLimit && splitContext.mixedSplit.isEmpty();
         } else {
             splitQuerySpec.where(WhereClause.MATCH_ALL);
         }
-        return pullDownLimit;
     }
 
-    private static boolean splitOrderBy(TableRelation tableRelation,
+    private static void splitOrderBy(TableRelation tableRelation,
                                         QuerySpec querySpec,
                                         QuerySpec splitQuerySpec,
                                         List<Symbol> splitOutputs,
                                         OrderBy orderBy) {
-        boolean pullDownLimit;
         SplitContext splitContext = splitForRelation(tableRelation, orderBy.orderBySymbols());
         addAllNew(splitOutputs, splitContext.mixedSplit);
-        pullDownLimit = splitContext.mixedSplit.isEmpty();
 
         if (!splitContext.directSplit.isEmpty()) {
             rewriteOrderBy(querySpec, splitQuerySpec, splitContext);
         }
-        return pullDownLimit;
     }
 
     /**

--- a/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/ESQueryBuilder.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/ESQueryBuilder.java
@@ -22,6 +22,7 @@
 package io.crate.executor.transport.task.elasticsearch;
 
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.spatial4j.core.context.jts.JtsSpatialContext;
@@ -29,6 +30,7 @@ import com.spatial4j.core.shape.Shape;
 import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.Envelope;
 import com.vividsolutions.jts.geom.Geometry;
+import io.crate.Constants;
 import io.crate.analyze.WhereClause;
 import io.crate.core.StringUtils;
 import io.crate.metadata.ColumnIdent;
@@ -183,7 +185,7 @@ public class ESQueryBuilder {
         }
 
         builder.field("from", node.offset());
-        builder.field("size", node.limit());
+        builder.field("size", MoreObjects.firstNonNull(node.limit(), Constants.DEFAULT_SELECT_LIMIT));
 
         builder.endObject();
         return builder.bytes();

--- a/sql/src/main/java/io/crate/operation/join/nestedloop/FetchedPagingNestedLoopStrategy.java
+++ b/sql/src/main/java/io/crate/operation/join/nestedloop/FetchedPagingNestedLoopStrategy.java
@@ -46,11 +46,6 @@ class FetchedPagingNestedLoopStrategy extends OneShotNestedLoopStrategy {
     }
 
     @Override
-    public int rowsToProduce(Optional<PageInfo> pageInfo) {
-        return nestedLoopOperation.limit() + nestedLoopOperation.offset();
-    }
-
-    @Override
     public void onFirstJoin(JoinContext joinContext) {
         // we can close the context as we produced ALL results in one batch
         try {

--- a/sql/src/main/java/io/crate/operation/join/nestedloop/NestedLoopOperation.java
+++ b/sql/src/main/java/io/crate/operation/join/nestedloop/NestedLoopOperation.java
@@ -147,10 +147,6 @@ public class NestedLoopOperation implements ProjectorUpstream {
         return this.offset;
     }
 
-    private boolean hasOffset() {
-        return this.offset > 0;
-    }
-
     private boolean needsToFetchAllForPaging() {
         return !this.projections.isEmpty();
     }

--- a/sql/src/main/java/io/crate/operation/join/nestedloop/OneShotNestedLoopStrategy.java
+++ b/sql/src/main/java/io/crate/operation/join/nestedloop/OneShotNestedLoopStrategy.java
@@ -29,6 +29,7 @@ import io.crate.executor.PageableTaskResult;
 import io.crate.executor.QueryResult;
 import io.crate.executor.TaskResult;
 import io.crate.operation.projectors.Projector;
+import io.crate.operation.projectors.TopN;
 
 import java.io.IOException;
 import java.util.concurrent.Executor;
@@ -194,6 +195,9 @@ class OneShotNestedLoopStrategy implements NestedLoopStrategy {
 
     @Override
     public int rowsToProduce(Optional<PageInfo> pageInfo) {
+        if (nestedLoopOperation.limit() == TopN.NO_LIMIT) {
+            return TopN.NO_LIMIT;
+        }
         return nestedLoopOperation.limit() + nestedLoopOperation.offset();
     }
 

--- a/sql/src/main/java/io/crate/planner/PlanPrinter.java
+++ b/sql/src/main/java/io/crate/planner/PlanPrinter.java
@@ -218,12 +218,12 @@ public class PlanPrinter extends PlanVisitor<PlanPrinter.PrintContext, Void> {
 
             context.print("left");
             context.indent();
-            visitPlan(node.left(), context);
+            PlanPrinter.this.process(node.left(), context);
             context.dedent();
 
             context.print("right");
             context.indent();
-            visitPlan(node.right(), context);
+            PlanPrinter.this.process(node.right(), context);
             context.dedent();
 
             context.print("outputTypes: %s", node.outputTypes());

--- a/sql/src/main/java/io/crate/planner/consumer/CrossJoinConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/CrossJoinConsumer.java
@@ -164,10 +164,22 @@ public class CrossJoinConsumer implements Consumer {
                     return null;
                 }
                 TableRelation tableRelation = (TableRelation) analyzedRelation;
-                QueriedTable queriedTable = QueriedTable.newSubRelation(entry.getKey(), tableRelation, statement.querySpec());
+                final QueriedTable queriedTable = QueriedTable.newSubRelation(entry.getKey(), tableRelation, statement.querySpec());
                 queriedTable.normalize(analysisMetaData);
-                queriedTables.add(queriedTable);
                 where = statement.querySpec().where();
+                orderBy = statement.querySpec().orderBy();
+                // erase limit and offset if this relation is part of remaining query or of remaining order by
+                queriedTables.add(queriedTable);
+
+            }
+            boolean hasRemainingQuery = where.hasQuery() && !(where.query() instanceof Literal);
+            boolean hasRemainingOrderBy = orderBy != null && orderBy.isSorted();
+            // erase
+            if (hasRemainingQuery || hasRemainingOrderBy) {
+                for (QueriedTable queriedTable : queriedTables) {
+                    queriedTable.querySpec().limit(null);
+                    queriedTable.querySpec().offset(TopN.NO_OFFSET);
+                }
             }
 
             int rootLimit = MoreObjects.firstNonNull(statement.querySpec().limit(), Constants.DEFAULT_SELECT_LIMIT);
@@ -181,14 +193,14 @@ public class CrossJoinConsumer implements Consumer {
             });
 
             // get new remaining order by
-            orderBy = statement.querySpec().orderBy();
-            boolean pushDownLimit = orderBy == null || !orderBy.isSorted();
-            NestedLoopNode nestedLoopNode = toNestedLoop(statement, queriedTables, rootLimit, statement.querySpec().offset(), pushDownLimit);
+
+            boolean pushDownLimit = !hasRemainingOrderBy && !hasRemainingQuery;
+            NestedLoopNode nestedLoopNode = toNestedLoop(queriedTables, rootLimit, statement.querySpec().offset(), pushDownLimit);
             List<Symbol> queriedTablesOutputs = getAllOutputs(queriedTables);
 
             ImmutableList.Builder<Projection> projectionBuilder = ImmutableList.builder();
 
-            if (where.hasQuery() && !(where.query() instanceof Literal)) {
+            if (hasRemainingQuery) {
                 Symbol filter = replaceFieldsWithInputColumns(where.query(), queriedTablesOutputs);
                 projectionBuilder.add(new FilterProjection(filter));
             }
@@ -283,7 +295,7 @@ public class CrossJoinConsumer implements Consumer {
          *
          * The queriedTables must be ordered in such a way that the left node of the NL will always be the one to order by ("leftOuterLoop = true")
          */
-        private NestedLoopNode toNestedLoop(MultiSourceSelect statement, List<QueriedTable> queriedTables, int limit, int offset, boolean pushDownLimit) {
+        private NestedLoopNode toNestedLoop(List<QueriedTable> queriedTables, int limit, int offset, boolean pushDownLimit) {
             Iterator<QueriedTable> iterator = queriedTables.iterator();
             NestedLoopNode nl = null;
             Plan left;
@@ -294,11 +306,13 @@ public class CrossJoinConsumer implements Consumer {
 
             while (iterator.hasNext()) {
                 QueriedTable next = iterator.next();
-                int currentLimit = iterator.hasNext() ? nestedLimit : limit;
-                int currentOffset = iterator.hasNext() ? nestedOffset : offset;
+                int currentLimit;
+                int currentOffset;
                 if (nl == null) {
                     assert iterator.hasNext();
                     QueriedTable second = iterator.next();
+                    currentLimit = iterator.hasNext() ? nestedLimit : limit;
+                    currentOffset = iterator.hasNext() ? nestedOffset : offset;
 
                     left = consumingPlanner.plan(next);
                     right = consumingPlanner.plan(second);
@@ -309,6 +323,8 @@ public class CrossJoinConsumer implements Consumer {
                             .addAll(left.outputTypes())
                             .addAll(right.outputTypes()).build());
                 } else {
+                    currentLimit = iterator.hasNext() ? nestedLimit : limit;
+                    currentOffset = iterator.hasNext() ? nestedOffset : offset;
                     NestedLoopNode lastNL = nl;
                     right = consumingPlanner.plan(next);
                     assert right != null;

--- a/sql/src/main/java/io/crate/planner/consumer/QueryThenFetchConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/QueryThenFetchConsumer.java
@@ -84,6 +84,7 @@ public class QueryThenFetchConsumer implements Consumer {
                     return new NoopPlannedAnalyzedRelation(table);
                 }
             }
+
             OrderBy orderBy = table.querySpec().orderBy();
             if (orderBy == null){
                 return new QueryThenFetchNode(

--- a/sql/src/main/java/io/crate/planner/node/dql/QueryThenFetchNode.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/QueryThenFetchNode.java
@@ -25,7 +25,6 @@ package io.crate.planner.node.dql;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
-import io.crate.Constants;
 import io.crate.analyze.WhereClause;
 import io.crate.metadata.ReferenceInfo;
 import io.crate.metadata.Routing;
@@ -40,7 +39,9 @@ import java.util.List;
 public class QueryThenFetchNode extends ESDQLPlanNode {
 
     private final List<Symbol> orderBy;
-    private final int limit;
+
+    @Nullable
+    private final Integer limit;
     private final int offset;
     private final boolean[] reverseFlags;
     private final WhereClause whereClause;
@@ -80,7 +81,7 @@ public class QueryThenFetchNode extends ESDQLPlanNode {
         this.whereClause = whereClause;
         this.outputs = outputs;
 
-        this.limit = MoreObjects.firstNonNull(limit, Constants.DEFAULT_SELECT_LIMIT);
+        this.limit = limit;
         this.offset = MoreObjects.firstNonNull(offset, 0);
 
         this.partitionBy = MoreObjects.firstNonNull(partitionBy, ImmutableList.<ReferenceInfo>of());
@@ -91,8 +92,13 @@ public class QueryThenFetchNode extends ESDQLPlanNode {
         return routing;
     }
 
-    public int limit() {
+    @Nullable
+    public Integer limit() {
         return limit;
+    }
+
+    public int limitOr(int ifNull) {
+        return MoreObjects.firstNonNull(limit, ifNull);
     }
 
     public int offset() {
@@ -134,21 +140,5 @@ public class QueryThenFetchNode extends ESDQLPlanNode {
                 .add("whereClause", whereClause())
                 .add("partitionBy", partitionBy)
                 .toString();
-    }
-
-    public static QueryThenFetchNode withLimitAndOffset(QueryThenFetchNode oldNode,
-                                                        int newOffset,
-                                                        int newLimit) {
-        return new QueryThenFetchNode(
-                oldNode.routing(),
-                oldNode.outputs(),
-                oldNode.orderBy(),
-                oldNode.reverseFlags(),
-                oldNode.nullsFirst(),
-                newLimit,
-                newOffset,
-                oldNode.whereClause(),
-                oldNode.partitionBy()
-        );
     }
 }

--- a/sql/src/test/java/io/crate/operation/join/nestedloop/NestedLoopOperationTest.java
+++ b/sql/src/test/java/io/crate/operation/join/nestedloop/NestedLoopOperationTest.java
@@ -604,5 +604,17 @@ public class NestedLoopOperationTest {
             assertPagedFullNestedLoop(left, right);
         }
     }
+
+    @Test
+    public void testBiggerLimitThanDefaultPageSize() throws Exception {
+        Object[][] left = randomRows(NestedLoopOperation.MAX_PAGE_SIZE + 10, 1);
+        Object[][] right = randomRows(10, 1);
+
+        assertNestedLoop(left, right, NestedLoopOperation.MAX_PAGE_SIZE*2, 10, NestedLoopOperation.MAX_PAGE_SIZE*2);
+
+        if (nestedLoopPaged) {
+            assertPagedFullNestedLoop(left, right);
+        }
+    }
 }
 


### PR DESCRIPTION
we need to fetch as much as the parent relation needs if we have e.g.:

* order by symbol with references to more than one table e.g. t1.count + t2.count
* where clause with "join condition"

so we need to allow selecting with no-limit at all internally.