### PR TITLE
implemented insert plan proposal

### DIFF
--- a/sql/src/main/java/io/crate/analyze/InsertFromSubQueryAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/InsertFromSubQueryAnalyzedStatement.java
@@ -24,7 +24,6 @@ package io.crate.analyze;
 import com.google.common.collect.ImmutableList;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.AnalyzedRelationVisitor;
-import io.crate.analyze.relations.QueriedRelation;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.metadata.Path;
 import io.crate.metadata.table.TableInfo;
@@ -35,15 +34,19 @@ import java.util.List;
 
 public class InsertFromSubQueryAnalyzedStatement extends AbstractInsertAnalyzedStatement implements AnalyzedRelation {
 
-    private final QueriedRelation subQueryRelation;
+    private AnalyzedRelation subQueryRelation;
 
-    public InsertFromSubQueryAnalyzedStatement(QueriedRelation subQueryRelation, TableInfo targetTableInfo) {
+    public InsertFromSubQueryAnalyzedStatement(AnalyzedRelation subQueryRelation, TableInfo targetTableInfo) {
         tableInfo(targetTableInfo);
         this.subQueryRelation = subQueryRelation;
     }
 
-    public QueriedRelation subQueryRelation() {
+    public AnalyzedRelation subQueryRelation() {
         return this.subQueryRelation;
+    }
+
+    public void subQueryRelation(AnalyzedRelation subQueryRelation) {
+        this.subQueryRelation = subQueryRelation;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/analyze/relations/PlannedAnalyzedRelation.java
+++ b/sql/src/main/java/io/crate/analyze/relations/PlannedAnalyzedRelation.java
@@ -22,6 +22,8 @@
 package io.crate.analyze.relations;
 
 import io.crate.planner.Plan;
+import io.crate.planner.node.dql.DQLPlanNode;
+import io.crate.planner.projection.Projection;
 
 public interface PlannedAnalyzedRelation extends AnalyzedRelation {
 
@@ -29,5 +31,11 @@ public interface PlannedAnalyzedRelation extends AnalyzedRelation {
      * Returns a plan for this relation.
      */
     public Plan plan();
+
+    public void addProjection(Projection projection);
+
+    public boolean resultIsDistributed();
+
+    public DQLPlanNode resultNode();
 
 }

--- a/sql/src/main/java/io/crate/planner/PlanNodeBuilder.java
+++ b/sql/src/main/java/io/crate/planner/PlanNodeBuilder.java
@@ -82,7 +82,7 @@ public class PlanNodeBuilder {
      * calculates the outputTypes using the projections and input types.
      * must be called after projections have been set.
      */
-    static void setOutputTypes(CollectNode node) {
+    public static void setOutputTypes(CollectNode node) {
         if (node.projections().isEmpty()) {
             node.outputTypes(Symbols.extractTypes(node.toCollect()));
         } else {
@@ -96,7 +96,7 @@ public class PlanNodeBuilder {
      * <p/>
      * must be called after projections have been set
      */
-    static void connectTypes(DQLPlanNode previousNode, DQLPlanNode nextNode) {
+    public static void connectTypes(DQLPlanNode previousNode, DQLPlanNode nextNode) {
         nextNode.inputTypes(previousNode.outputTypes());
         nextNode.outputTypes(Planner.extractDataTypes(nextNode.projections(), nextNode.inputTypes()));
     }

--- a/sql/src/main/java/io/crate/planner/PlanVisitor.java
+++ b/sql/src/main/java/io/crate/planner/PlanVisitor.java
@@ -21,6 +21,7 @@
 
 package io.crate.planner;
 
+import io.crate.planner.node.dml.InsertFromSubQuery;
 import io.crate.planner.node.dml.QueryAndFetch;
 import io.crate.planner.node.dml.Upsert;
 import io.crate.planner.node.dql.DistributedGroupBy;
@@ -63,6 +64,10 @@ public class PlanVisitor<C, R> {
     }
 
     public R visitDistributedGroupBy(DistributedGroupBy node, C context) {
+        return visitPlan(node, context);
+    }
+
+    public R visitInsertByQuery(InsertFromSubQuery node, C context) {
         return visitPlan(node, context);
     }
 }

--- a/sql/src/main/java/io/crate/planner/Planner.java
+++ b/sql/src/main/java/io/crate/planner/Planner.java
@@ -87,10 +87,10 @@ public class Planner extends AnalyzedStatementVisitor<Planner.Context, Plan> {
     }
 
     @Inject
-    public Planner(ClusterService clusterService, AnalysisMetaData analysisMetaData) {
+    public Planner(ClusterService clusterService, AnalysisMetaData analysisMetaData, ConsumingPlanner consumingPlanner) {
         this.clusterService = clusterService;
         this.functions = analysisMetaData.functions();
-        this.consumingPlanner = new ConsumingPlanner(analysisMetaData);
+        this.consumingPlanner = consumingPlanner;
     }
 
     /**

--- a/sql/src/main/java/io/crate/planner/consumer/ConsumerContext.java
+++ b/sql/src/main/java/io/crate/planner/consumer/ConsumerContext.java
@@ -36,8 +36,8 @@ public class ConsumerContext {
         this.rootRelation = rootRelation;
     }
 
-    public void rootRelation(AnalyzedRelation rootRelation) {
-        this.rootRelation = rootRelation;
+    public void rootRelation(AnalyzedRelation relation) {
+        this.rootRelation = relation;
     }
 
     public AnalyzedRelation rootRelation() {

--- a/sql/src/main/java/io/crate/planner/consumer/ESGetConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/ESGetConsumer.java
@@ -21,10 +21,7 @@
 
 package io.crate.planner.consumer;
 
-import io.crate.analyze.AnalysisMetaData;
-import io.crate.analyze.OrderBy;
-import io.crate.analyze.QueriedTable;
-import io.crate.analyze.WhereClause;
+import io.crate.analyze.*;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.AnalyzedRelationVisitor;
 import io.crate.analyze.relations.PlannedAnalyzedRelation;
@@ -82,6 +79,10 @@ public class ESGetConsumer implements Consumer {
             }
 
             if (!whereClause.primaryKeys().isPresent()) {
+                return null;
+            }
+
+            if (tableInfo.schemaInfo().systemSchema()) {
                 return null;
             }
 

--- a/sql/src/main/java/io/crate/planner/consumer/QueryThenFetchConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/QueryThenFetchConsumer.java
@@ -21,10 +21,7 @@
 
 package io.crate.planner.consumer;
 
-import io.crate.analyze.AnalysisMetaData;
-import io.crate.analyze.OrderBy;
-import io.crate.analyze.QueriedTable;
-import io.crate.analyze.WhereClause;
+import io.crate.analyze.*;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.AnalyzedRelationVisitor;
 import io.crate.analyze.relations.PlannedAnalyzedRelation;

--- a/sql/src/main/java/io/crate/planner/node/NoopPlannedAnalyzedRelation.java
+++ b/sql/src/main/java/io/crate/planner/node/NoopPlannedAnalyzedRelation.java
@@ -28,6 +28,8 @@ import io.crate.exceptions.ColumnUnknownException;
 import io.crate.metadata.Path;
 import io.crate.planner.NoopPlan;
 import io.crate.planner.Plan;
+import io.crate.planner.node.dql.DQLPlanNode;
+import io.crate.planner.projection.Projection;
 import io.crate.planner.symbol.Field;
 
 import javax.annotation.Nullable;
@@ -67,5 +69,19 @@ public class NoopPlannedAnalyzedRelation implements PlannedAnalyzedRelation {
         return relation.fields();
     }
 
+    @Override
+    public void addProjection(Projection projection) {
+        throw new UnsupportedOperationException("addingProjection not supported");
+    }
+
+    @Override
+    public boolean resultIsDistributed() {
+        throw new UnsupportedOperationException("resultIsDistributed is not supported");
+    }
+
+    @Override
+    public DQLPlanNode resultNode() {
+        throw new UnsupportedOperationException("resultNode is not supported");
+    }
 
 }

--- a/sql/src/main/java/io/crate/planner/node/dml/DMLPlanNode.java
+++ b/sql/src/main/java/io/crate/planner/node/dml/DMLPlanNode.java
@@ -72,4 +72,9 @@ public abstract class DMLPlanNode implements DQLPlanNode {
     public void outputTypes(List<DataType> outputTypes) {
         throw new UnsupportedOperationException("outputTypes cannot be modified on DMLPlanNodes");
     }
+
+    @Override
+    public void addProjection(Projection projection) {
+        throw new UnsupportedOperationException("addProjection is not supported on DMLPLanNodes");
+    }
 }

--- a/sql/src/main/java/io/crate/planner/node/dml/QueryAndFetch.java
+++ b/sql/src/main/java/io/crate/planner/node/dml/QueryAndFetch.java
@@ -1,14 +1,17 @@
 package io.crate.planner.node.dml;
 
 
-import io.crate.analyze.relations.PlannedAnalyzedRelation;
 import io.crate.analyze.relations.AnalyzedRelationVisitor;
+import io.crate.analyze.relations.PlannedAnalyzedRelation;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.metadata.Path;
 import io.crate.planner.Plan;
+import io.crate.planner.PlanNodeBuilder;
 import io.crate.planner.PlanVisitor;
 import io.crate.planner.node.dql.CollectNode;
+import io.crate.planner.node.dql.DQLPlanNode;
 import io.crate.planner.node.dql.MergeNode;
+import io.crate.planner.projection.Projection;
 import io.crate.planner.symbol.Field;
 
 import javax.annotation.Nullable;
@@ -17,9 +20,9 @@ import java.util.List;
 public class QueryAndFetch implements PlannedAnalyzedRelation, Plan {
 
     private final CollectNode collectNode;
-    private final MergeNode localMergeNode;
+    private MergeNode localMergeNode;
 
-    public QueryAndFetch(CollectNode collectNode, MergeNode localMergeNode){
+    public QueryAndFetch(CollectNode collectNode, @Nullable MergeNode localMergeNode){
         this.collectNode = collectNode;
         this.localMergeNode = localMergeNode;
     }
@@ -61,5 +64,26 @@ public class QueryAndFetch implements PlannedAnalyzedRelation, Plan {
     @Override
     public Plan plan() {
         return this;
+    }
+
+    @Override
+    public void addProjection(Projection projection) {
+        DQLPlanNode node = resultNode();
+        node.addProjection(projection);
+        if (node instanceof CollectNode) {
+            PlanNodeBuilder.setOutputTypes((CollectNode)node);
+        } else if (node instanceof MergeNode) {
+            PlanNodeBuilder.connectTypes(collectNode, node);
+        }
+    }
+
+    @Override
+    public boolean resultIsDistributed() {
+        return localMergeNode == null;
+    }
+
+    @Override
+    public DQLPlanNode resultNode() {
+        return localMergeNode == null ? collectNode : localMergeNode;
     }
 }

--- a/sql/src/main/java/io/crate/planner/node/dml/Upsert.java
+++ b/sql/src/main/java/io/crate/planner/node/dml/Upsert.java
@@ -21,13 +21,14 @@
 
 package io.crate.planner.node.dml;
 
-import io.crate.analyze.relations.PlannedAnalyzedRelation;
 import io.crate.analyze.relations.AnalyzedRelationVisitor;
+import io.crate.analyze.relations.PlannedAnalyzedRelation;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.metadata.Path;
 import io.crate.planner.Plan;
 import io.crate.planner.PlanVisitor;
 import io.crate.planner.node.dql.DQLPlanNode;
+import io.crate.planner.projection.Projection;
 import io.crate.planner.symbol.Field;
 
 import javax.annotation.Nullable;
@@ -75,4 +76,20 @@ public class Upsert implements PlannedAnalyzedRelation, Plan {
     public Plan plan() {
         return this;
     }
+
+    @Override
+    public void addProjection(Projection projection) {
+        throw new UnsupportedOperationException("adding projection not supported");
+    }
+
+    @Override
+    public boolean resultIsDistributed() {
+        throw new UnsupportedOperationException("resultIsDistributed is not supported");
+    }
+
+    @Override
+    public DQLPlanNode resultNode() {
+        throw new UnsupportedOperationException("resultNode is not supported");
+    }
+
 }

--- a/sql/src/main/java/io/crate/planner/node/dql/AbstractDQLPlanNode.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/AbstractDQLPlanNode.java
@@ -58,8 +58,20 @@ public abstract class AbstractDQLPlanNode implements DQLPlanNode, Streamable {
         return projections != null && projections.size() > 0;
     }
 
+    @Override
     public List<Projection> projections() {
         return projections;
+    }
+
+    public void projections(List<Projection> projections) {
+        this.projections = projections;
+    }
+
+    @Override
+    public void addProjection(Projection projection) {
+        List<Projection> projections = new ArrayList<>(this.projections);
+        projections.add(projection);
+        this.projections = ImmutableList.copyOf(projections);
     }
 
     public Optional<Projection> finalProjection() {
@@ -70,9 +82,6 @@ public abstract class AbstractDQLPlanNode implements DQLPlanNode, Streamable {
         }
     }
 
-    public void projections(List<Projection> projections) {
-        this.projections = projections;
-    }
 
     public void outputTypes(List<DataType> outputTypes) {
         this.outputTypes = outputTypes;

--- a/sql/src/main/java/io/crate/planner/node/dql/DQLPlanNode.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/DQLPlanNode.java
@@ -11,6 +11,7 @@ public interface DQLPlanNode extends PlanNode {
 
     boolean hasProjections();
     List<Projection> projections();
+    void addProjection(Projection projection);
 
     Set<String> executionNodes();
 

--- a/sql/src/main/java/io/crate/planner/node/dql/DistributedGroupBy.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/DistributedGroupBy.java
@@ -21,12 +21,14 @@
 
 package io.crate.planner.node.dql;
 
-import io.crate.analyze.relations.PlannedAnalyzedRelation;
 import io.crate.analyze.relations.AnalyzedRelationVisitor;
+import io.crate.analyze.relations.PlannedAnalyzedRelation;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.metadata.Path;
 import io.crate.planner.Plan;
+import io.crate.planner.PlanNodeBuilder;
 import io.crate.planner.PlanVisitor;
+import io.crate.planner.projection.Projection;
 import io.crate.planner.symbol.Field;
 
 import javax.annotation.Nullable;
@@ -36,9 +38,9 @@ public class DistributedGroupBy implements PlannedAnalyzedRelation, Plan {
 
     private final CollectNode collectNode;
     private final MergeNode reducerMergeNode;
-    private final MergeNode localMergeNode;
+    private MergeNode localMergeNode;
 
-    public DistributedGroupBy(CollectNode collectNode, MergeNode reducerMergeNode, MergeNode localMergeNode) {
+    public DistributedGroupBy(CollectNode collectNode, MergeNode reducerMergeNode, @Nullable MergeNode localMergeNode) {
         this.collectNode = collectNode;
         this.reducerMergeNode = reducerMergeNode;
         this.localMergeNode = localMergeNode;
@@ -86,4 +88,26 @@ public class DistributedGroupBy implements PlannedAnalyzedRelation, Plan {
     public Plan plan() {
         return this;
     }
+
+    @Override
+    public void addProjection(Projection projection) {
+        DQLPlanNode node = resultNode();
+        node.addProjection(projection);
+        if (node instanceof CollectNode) {
+            PlanNodeBuilder.setOutputTypes((CollectNode)node);
+        } else if (node instanceof MergeNode) {
+            PlanNodeBuilder.connectTypes(reducerMergeNode, node);
+        }
+    }
+
+    @Override
+    public boolean resultIsDistributed() {
+        return localMergeNode == null;
+    }
+
+    @Override
+    public @Nullable DQLPlanNode resultNode() {
+        return localMergeNode != null ? localMergeNode : reducerMergeNode;
+    }
+
 }

--- a/sql/src/main/java/io/crate/planner/node/dql/ESDQLPlanNode.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/ESDQLPlanNode.java
@@ -104,6 +104,21 @@ public abstract class ESDQLPlanNode implements DQLPlanNode, PlannedAnalyzedRelat
     }
 
     @Override
+    public void addProjection(Projection projection) {
+        throw new UnsupportedOperationException("addProjection not supported on ESDQLPlanNode");
+    }
+
+    @Override
+    public boolean resultIsDistributed() {
+        throw new UnsupportedOperationException("resultIsDistributed is not supported on ESDQLPlanNode");
+    }
+
+    @Override
+    public DQLPlanNode resultNode() {
+        throw new UnsupportedOperationException("resultNode is not supported on ESDQLPLanNode");
+    }
+
+    @Override
     public Plan plan() {
         return new IterablePlan(this);
     }

--- a/sql/src/main/java/io/crate/planner/node/dql/NonDistributedGroupBy.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/NonDistributedGroupBy.java
@@ -21,12 +21,13 @@
 package io.crate.planner.node.dql;
 
 
-import io.crate.analyze.relations.PlannedAnalyzedRelation;
 import io.crate.analyze.relations.AnalyzedRelationVisitor;
+import io.crate.analyze.relations.PlannedAnalyzedRelation;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.metadata.Path;
 import io.crate.planner.Plan;
 import io.crate.planner.PlanVisitor;
+import io.crate.planner.projection.Projection;
 import io.crate.planner.symbol.Field;
 
 import javax.annotation.Nullable;
@@ -35,7 +36,7 @@ import java.util.List;
 public class NonDistributedGroupBy implements PlannedAnalyzedRelation, Plan {
 
     private final CollectNode collectNode;
-    private final MergeNode localMergeNode;
+    private MergeNode localMergeNode;
 
     public NonDistributedGroupBy(CollectNode collectNode, MergeNode localMergeNode){
         this.collectNode = collectNode;
@@ -80,4 +81,20 @@ public class NonDistributedGroupBy implements PlannedAnalyzedRelation, Plan {
     public Plan plan() {
         return this;
     }
+
+    @Override
+    public void addProjection(Projection projection) {
+        this.resultNode().addProjection(projection);
+    }
+
+    @Override
+    public boolean resultIsDistributed() {
+        return localMergeNode == null;
+    }
+
+    @Override
+    public DQLPlanNode resultNode() {
+        return localMergeNode == null ? collectNode : localMergeNode;
+    }
+
 }

--- a/sql/src/test/java/io/crate/analyze/InsertFromSubQueryAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/InsertFromSubQueryAnalyzerTest.java
@@ -85,7 +85,7 @@ public class InsertFromSubQueryAnalyzerTest extends BaseAnalyzerTest {
 
     private void assertCompatibleColumns(InsertFromSubQueryAnalyzedStatement statement) {
 
-        List<Symbol> outputSymbols = statement.subQueryRelation().querySpec().outputs();
+        List<Symbol> outputSymbols = ((QueriedTable)statement.subQueryRelation()).querySpec().outputs();
         assertThat(statement.columns().size(), is(outputSymbols.size()));
 
         for (int i = 0; i < statement.columns().size(); i++) {
@@ -189,7 +189,7 @@ public class InsertFromSubQueryAnalyzerTest extends BaseAnalyzerTest {
                         ")");
 
 
-        List<Symbol> outputSymbols = statement.subQueryRelation().querySpec().outputs();
+        List<Symbol> outputSymbols = ((QueriedTable)statement.subQueryRelation()).querySpec().outputs();
         assertThat(statement.columns().size(), is(outputSymbols.size()));
         assertThat(outputSymbols.get(1), instanceOf(Function.class));
         Function castFunction = (Function)outputSymbols.get(1);

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -816,15 +816,15 @@ public class SelectStatementAnalyzerTest extends BaseAnalyzerTest {
         assertEquals("u", actualAnalysisColAliased.tableAlias());
         assertEquals("u", actualAnalysisOptionalAs.tableAlias());
         assertEquals(
-                ((Function)expectedanalysis.relation().querySpec().where().query()).arguments().get(0),
-                ((Function)actualanalysis.relation().querySpec().where().query()).arguments().get(0)
+                ((Function)expectedanalysis.rootRelation().querySpec().where().query()).arguments().get(0),
+                ((Function)actualanalysis.rootRelation().querySpec().where().query()).arguments().get(0)
         );
         assertEquals(
-                ((Function)expectedanalysis.relation().querySpec().where().query()).arguments().get(0),
+                ((Function)expectedanalysis.rootRelation().querySpec().where().query()).arguments().get(0),
                 ((Function)actualAnalysisColAliased.whereClause().query()).arguments().get(0)
         );
         assertEquals(
-                ((Function) expectedanalysis.relation().querySpec().where().query()).arguments().get(0),
+                ((Function) expectedanalysis.rootRelation().querySpec().where().query()).arguments().get(0),
                 ((Function) actualAnalysisOptionalAs.whereClause().query()).arguments().get(0)
         );
     }


### PR DESCRIPTION
made handling of indexWriterProjection more generic and moved it to insertFromSubQueryConsumer,
so inner consumers don’t have to handle it.