### PR TITLE
remove visitField from FieldReplacingVisitor

### DIFF
--- a/sql/src/main/java/io/crate/analyze/QueriedTable.java
+++ b/sql/src/main/java/io/crate/analyze/QueriedTable.java
@@ -298,16 +298,6 @@ public class QueriedTable implements QueriedRelation {
         }
 
         @Override
-        public Symbol visitField(Field field, FieldReplacingCtx context) {
-            // need to check relation identity for fields to not replace fields of other relations in the self-join case
-            // (otherTableRelation.equals(thisTableRelation) would result in true...
-            if (field.relation() == context.relation) {
-                return super.visitField(field, context);
-            }
-            return field;
-        }
-
-        @Override
         protected Symbol visitSymbol(Symbol symbol, FieldReplacingCtx context) {
             Field field = context.get(symbol);
             if (field != null) {


### PR DESCRIPTION
no need to take extra care of Fields as .equals() is self-join aware since
bc437a16f650162ebe6b383044c273792850fcfd