### PR TITLE
catch exceptions frmo mergeOperation.finished() in LocalMergeTask

### DIFF
--- a/sql/src/main/java/io/crate/executor/task/LocalMergeTask.java
+++ b/sql/src/main/java/io/crate/executor/task/LocalMergeTask.java
@@ -148,17 +148,13 @@ public class LocalMergeTask extends JobTask {
 
                     try {
                         shouldContinue = mergeOperation.addRows(rows.rows());
-                    } catch (Throwable ex) {
-                        ramAccountingContext.close();
-                        statsTables.operationFinished(operationId, Exceptions.messageOf(ex),
-                                ramAccountingContext.totalBytes());
-                        result.setException(ex);
-                        logger.error("Failed to add rows", ex);
-                        return;
-                    }
 
-                    if (countdown.decrementAndGet() == 0 || !shouldContinue) {
-                        mergeOperation.finished();
+                        if (countdown.decrementAndGet() == 0 || !shouldContinue) {
+                            mergeOperation.finished();
+                        }
+                    } catch (Throwable ex) {
+                        onFailure(ex);
+                        logger.error("Failed to add rows", ex);
                     }
                 }
 


### PR DESCRIPTION
mergeOperation.finished() can fail too (not really at runtime, but during
development...) this caused tests to hang now they error correctly.