### PR TITLE
fix settings on partitioned tables

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fix: number_of_shards and number_of_replicas are now correctly applied
+   through the whole lifetime of a partitioned table and its partitions
+
  - Added columns ``number_of_shards`` and ``number_of_replicas`` to
    table ``information_schema.table_partitions``
 

--- a/sql/src/main/java/io/crate/metadata/doc/DocIndexMetaData.java
+++ b/sql/src/main/java/io/crate/metadata/doc/DocIndexMetaData.java
@@ -52,7 +52,6 @@ public class DocIndexMetaData {
     public static final ColumnIdent ID_IDENT = new ColumnIdent(ID);
     private final IndexMetaData metaData;
 
-
     private final MappingMetaData defaultMappingMetaData;
     private final Map<String, Object> defaultMappingMap;
 
@@ -477,12 +476,16 @@ public class DocIndexMetaData {
         } else if (thisIsCreatedFromTemplate) {
             if (this.references.size() < other.references.size()) {
                 // this is older, update template and return other
-                updateTemplate(other, transportPutIndexTemplateAction);
-                return other;
+                // settings in template are always authoritative for table information about
+                // number_of_shards and number_of_replicas
+                updateTemplate(other, transportPutIndexTemplateAction, this.metaData.settings());
+                // merge the new mapping with the template settings
+                return new DocIndexMetaData(IndexMetaData.builder(other.metaData).settings(this.metaData.settings()).build(), other.ident).build();
             } else if (references().size() == other.references().size() &&
                     !references().keySet().equals(other.references().keySet())) {
                 XContentHelper.update(defaultMappingMap, other.defaultMappingMap, false);
-                updateTemplate(this, transportPutIndexTemplateAction);
+                // update the template with new information
+                updateTemplate(this, transportPutIndexTemplateAction, this.metaData.settings());
                 return this;
             }
             // other is older, just return this
@@ -493,11 +496,13 @@ public class DocIndexMetaData {
     }
 
     private void updateTemplate(DocIndexMetaData md,
-                                TransportPutIndexTemplateAction transportPutIndexTemplateAction) {
+                                TransportPutIndexTemplateAction transportPutIndexTemplateAction,
+                                Settings updateSettings) {
         String templateName = PartitionName.templateName(ident.schema(), ident.name());
         PutIndexTemplateRequest request = new PutIndexTemplateRequest(templateName)
                 .mapping(Constants.DEFAULT_MAPPING_TYPE, md.defaultMappingMap)
                 .create(false)
+                .settings(updateSettings)
                 .template(templateName + "*");
         for (String alias : md.aliases()) {
             request = request.alias(new Alias(alias));

--- a/sql/src/test/java/io/crate/metadata/doc/DocIndexMetaDataTest.java
+++ b/sql/src/test/java/io/crate/metadata/doc/DocIndexMetaDataTest.java
@@ -1131,8 +1131,8 @@ public class DocIndexMetaDataTest extends RandomizedTest {
                     .endObject()
                 .endObject();
         Settings templateSettings =  ImmutableSettings.builder()
-                .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 1)
-                .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 5)
+                .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 2)
+                .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 6)
                 .build();
         IndexMetaData metaData = getIndexMetaData("test1", builder, templateSettings, null);
         DocIndexMetaData md = newMeta(metaData, "test1");
@@ -1153,8 +1153,8 @@ public class DocIndexMetaDataTest extends RandomizedTest {
         assertThat(partitionMD.concreteIndexName(), is(partitionName.stringValue()));
         DocIndexMetaData merged = md.merge(partitionMD, mock(TransportPutIndexTemplateAction.class), true);
 
-        assertThat(merged.numberOfReplicas(), is(BytesRefs.toBytesRef(1)));
-        assertThat(merged.numberOfShards(), is(5));
+        assertThat(merged.numberOfReplicas(), is(BytesRefs.toBytesRef(2)));
+        assertThat(merged.numberOfShards(), is(6));
     }
 
     @Test


### PR DESCRIPTION
they were screwed when merging docindexmetadata from a partitioned table template and its partition indices