### PR TITLE
cast to correct type after value extraction from source

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed an issue that could cause the response to contain the wrong types
+   (e.g. integer instead of long)
+
  - Fix: Sorting on a scalar with a column containing NULL values as
    argument no longer throws an NPE
 

--- a/sql/src/main/java/io/crate/executor/transport/SymbolBasedTransportShardUpsertAction.java
+++ b/sql/src/main/java/io/crate/executor/transport/SymbolBasedTransportShardUpsertAction.java
@@ -347,8 +347,8 @@ public class SymbolBasedTransportShardUpsertAction extends TransportShardReplica
             return new FieldExtractor<GetResult>() {
                 @Override
                 public Object extract(GetResult getResult) {
-                    return XContentMapValues.extractValue(
-                            reference.info().ident().columnIdent().fqn(), getResult.sourceAsMap());
+                    return reference.valueType().value(XContentMapValues.extractValue(
+                            reference.info().ident().columnIdent().fqn(), getResult.sourceAsMap()));
                 }
             };
         }

--- a/sql/src/main/java/io/crate/executor/transport/TransportShardUpsertAction.java
+++ b/sql/src/main/java/io/crate/executor/transport/TransportShardUpsertAction.java
@@ -415,8 +415,8 @@ public class TransportShardUpsertAction extends TransportShardReplicationOperati
             return new FieldExtractor<GetResult>() {
                 @Override
                 public Object extract(GetResult getResult) {
-                    return XContentMapValues.extractValue(
-                            reference.info().ident().columnIdent().fqn(), getResult.sourceAsMap());
+                    return reference.valueType().value(XContentMapValues.extractValue(
+                            reference.info().ident().columnIdent().fqn(), getResult.sourceAsMap()));
                 }
             };
         }

--- a/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/ESFieldExtractor.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/ESFieldExtractor.java
@@ -21,10 +21,11 @@
 
 package io.crate.executor.transport.task.elasticsearch;
 
-import io.crate.metadata.PartitionName;
 import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.PartitionName;
 import io.crate.metadata.ReferenceInfo;
 import io.crate.planner.symbol.Reference;
+import io.crate.types.DataType;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.search.SearchHit;
 
@@ -43,9 +44,11 @@ public abstract class ESFieldExtractor implements FieldExtractor<SearchHit> {
     public static class Source extends ESFieldExtractor {
 
         private final ColumnIdent ident;
+        private final DataType type;
 
-        public Source(ColumnIdent ident) {
+        public Source(ColumnIdent ident, DataType type) {
             this.ident = ident;
+            this.type = type;
         }
 
         @Override
@@ -92,13 +95,13 @@ public abstract class ESFieldExtractor implements FieldExtractor<SearchHit> {
             }
             Object top = source.get(ident.name());
             if (ident.isColumn()) {
-                return top;
+                return type.value(top);
             }
             if (top==null){
                 return null;
             }
             Object result = down(top, 0);
-            return result == NOT_FOUND ? null : result;
+            return result == NOT_FOUND ? null : type.value(result);
         }
     }
 

--- a/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/ESGetTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/ESGetTask.java
@@ -342,7 +342,7 @@ public class ESGetTask extends JobTask {
     static class GetResponseFieldExtractorFactory implements FieldExtractorFactory<GetResponse, GetResponseContext> {
 
         @Override
-        public FieldExtractor<GetResponse> build(Reference reference, final GetResponseContext context) {
+        public FieldExtractor<GetResponse> build(final Reference reference, final GetResponseContext context) {
             final String field = reference.info().ident().columnIdent().fqn();
             if (field.equals("_version")) {
                 return new FieldExtractor<GetResponse>() {
@@ -373,8 +373,9 @@ public class ESGetTask extends JobTask {
             return new FieldExtractor<GetResponse>() {
                 @Override
                 public Object extract(GetResponse response) {
-                    assert response.getSourceAsMap() != null;
-                    return XContentMapValues.extractValue(field, response.getSourceAsMap());
+                    Map<String, Object> sourceAsMap = response.getSourceAsMap();
+                    assert sourceAsMap != null;
+                    return reference.valueType().value(XContentMapValues.extractValue(field, sourceAsMap));
                 }
             };
         }

--- a/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/QueryThenFetchTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/QueryThenFetchTask.java
@@ -215,7 +215,7 @@ public class QueryThenFetchTask extends JobTask implements PageableTask {
             } else if (context.partitionBy.contains(field.info())) {
                 return new ESFieldExtractor.PartitionedByColumnExtractor(field, context.partitionBy);
             } else {
-                return new ESFieldExtractor.Source(columnIdent);
+                return new ESFieldExtractor.Source(columnIdent, field.valueType());
             }
         }
     }

--- a/sql/src/test/java/io/crate/executor/transport/PagingTasksTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/PagingTasksTest.java
@@ -524,7 +524,7 @@ public class PagingTasksTest extends BaseTransportExecutorTest {
         int numRows = randomIntBetween(1, 4096);
         Object[][] bulkArgs = new Object[numRows][];
         for (int l = 0; l < numRows; l++) {
-            bulkArgs[l] = new Object[]{l};
+            bulkArgs[l] = new Object[]{ (long)l};
         }
         sqlExecutor.exec("insert into ids values (?)", bulkArgs);
         sqlExecutor.refresh("ids");

--- a/sql/src/test/java/io/crate/integrationtests/ArithmeticIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ArithmeticIntegrationTest.java
@@ -179,11 +179,11 @@ public class ArithmeticIntegrationTest extends SQLTransportIntegrationTest {
 
         execute("select x, base, log(x, base) from t where log(x, base) = 2.0 order by x");
         assertThat(response.rowCount(), is(2L));
-        assertThat((Integer) response.rows()[0][0], is(9));
-        assertThat((Integer) response.rows()[0][1], is(3));
+        assertThat((Long) response.rows()[0][0], is(9L));
+        assertThat((Long) response.rows()[0][1], is(3L));
         assertThat((Double) response.rows()[0][2], is(2.0));
-        assertThat((Integer) response.rows()[1][0], is(144));
-        assertThat((Integer) response.rows()[1][1], is(12));
+        assertThat((Long) response.rows()[1][0], is(144L));
+        assertThat((Long) response.rows()[1][1], is(12L));
         assertThat((Double) response.rows()[1][2], is(2.0));
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/ColumnPolicyIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ColumnPolicyIntegrationTest.java
@@ -24,8 +24,8 @@ package io.crate.integrationtests;
 import com.google.common.base.Joiner;
 import com.google.common.base.Predicate;
 import io.crate.Constants;
-import io.crate.metadata.PartitionName;
 import io.crate.action.sql.SQLActionException;
+import io.crate.metadata.PartitionName;
 import io.crate.metadata.table.ColumnPolicy;
 import io.crate.test.integration.CrateIntegrationTest;
 import io.crate.testing.TestingHelpers;
@@ -43,9 +43,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import javax.annotation.Nullable;
-import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -189,10 +187,7 @@ public class ColumnPolicyIntegrationTest extends SQLTransportIntegrationTest {
         assertEquals(1L, response.rowCount());
         assertArrayEquals(new String[]{"person['name']", "person['addresses']['city']"},
                 response.cols());
-        assertArrayEquals(new Object[]{"Ford",
-                new ArrayList<String>() {{
-                    add("West Country");
-                }}},
+        assertArrayEquals(new Object[]{"Ford", new Object[] { "West Country" }},
                 response.rows()[0]
         );
     }

--- a/sql/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
@@ -21,7 +21,6 @@
 
 package io.crate.integrationtests;
 
-import com.carrotsearch.randomizedtesting.annotations.Repeat;
 import io.crate.Constants;
 import io.crate.action.sql.SQLActionException;
 import io.crate.action.sql.SQLResponse;
@@ -36,8 +35,7 @@ import org.junit.rules.ExpectedException;
 import java.util.HashMap;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.closeTo;
-import static org.hamcrest.Matchers.isIn;
+import static org.hamcrest.Matchers.*;
 
 @CrateIntegrationTest.ClusterScope(scope = CrateIntegrationTest.Scope.GLOBAL)
 public class GroupByAggregateTest extends SQLTransportIntegrationTest {

--- a/sql/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
@@ -30,9 +30,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.*;
@@ -115,7 +113,7 @@ public class InsertIntoIntegrationTest extends SQLTransportIntegrationTest {
         assertEquals(3.402f, ((Number) response.rows()[0][3]).floatValue(), 0.002f);
         assertEquals(2147483647, response.rows()[0][4]);
         assertEquals(9223372036854775807L, response.rows()[0][5]);
-        assertEquals(32767, response.rows()[0][6]);
+        assertEquals((short) 32767, response.rows()[0][6]);
         assertEquals("Youri", response.rows()[0][7]);
 
         assertEquals(true, response.rows()[1][0]);
@@ -124,7 +122,7 @@ public class InsertIntoIntegrationTest extends SQLTransportIntegrationTest {
         assertEquals(3.402f, ((Number) response.rows()[1][3]).floatValue(), 0.002f);
         assertEquals(2147483647, response.rows()[1][4]);
         assertEquals(9223372036854775807L, response.rows()[1][5]);
-        assertEquals(32767, response.rows()[1][6]);
+        assertEquals((short)32767, response.rows()[1][6]);
         assertEquals("Youri", response.rows()[1][7]);
     }
 
@@ -159,31 +157,31 @@ public class InsertIntoIntegrationTest extends SQLTransportIntegrationTest {
         refresh();
 
         execute("select * from test");
-        assertEquals(true, ((List<Boolean>) response.rows()[0][0]).get(0));
-        assertEquals(false, ((List<Boolean>) response.rows()[0][0]).get(1));
+        assertEquals(true, ((Object[]) response.rows()[0][0])[0]);
+        assertEquals(false, ((Object[]) response.rows()[0][0])[1]);
 
-        assertThat(((List<Long>) response.rows()[0][1]).get(0), is(1378849903000L));
-        assertThat(((List<Long>) response.rows()[0][1]).get(1), is(1384120303000L));
+        assertThat(((Long) ((Object[]) response.rows()[0][1])[0]), is(1378849903000L));
+        assertThat(((Long) ((Object[]) response.rows()[0][1])[1]), is(1384120303000L));
 
-        assertThat(((List<Double>) response.rows()[0][2]).get(0), is(1.79769313486231570e+308));
-        assertThat(((List<Double>) response.rows()[0][2]).get(1), is(1.69769313486231570e+308));
+        assertThat(((Double) ((Object[]) response.rows()[0][2])[0]), is(1.79769313486231570e+308));
+        assertThat(((Double) ((Object[]) response.rows()[0][2])[1]), is(1.69769313486231570e+308));
 
 
-        assertEquals(3.402f, ((Number) ((List) response.rows()[0][3]).get(0)).floatValue(), 0.002f);
-        assertEquals(3.403f, ((Number) ((List) response.rows()[0][3]).get(1)).floatValue(), 0.002f);
-        assertThat(((List<Float>) response.rows()[0][3]).get(2), nullValue());
+        assertEquals(3.402f, ((Number) ((Object[]) response.rows()[0][3])[0]).floatValue(), 0.002f);
+        assertEquals(3.403f, ((Number) ((Object[]) response.rows()[0][3])[1]).floatValue(), 0.002f);
+        assertThat(((Object[]) response.rows()[0][3])[2], nullValue());
 
-        assertThat(((List<Integer>) response.rows()[0][4]).get(0), is(2147483647));
-        assertThat(((List<Integer>) response.rows()[0][4]).get(1), is(234583));
+        assertThat(((Integer) ((Object[]) response.rows()[0][4])[0]), is(2147483647));
+        assertThat(((Integer) ((Object[]) response.rows()[0][4])[1]), is(234583));
 
-        assertThat(((List<Long>) response.rows()[0][5]).get(0), is(9223372036854775807L));
-        assertThat(((List<Integer>) response.rows()[0][5]).get(1), is(4));
+        assertThat(((Long) ((Object[]) response.rows()[0][5])[0]), is(9223372036854775807L));
+        assertThat(((Long) ((Object[]) response.rows()[0][5])[1]), is(4L));
 
-        assertThat(((List<Integer>) response.rows()[0][6]).get(0), is(32767));
-        assertThat(((List<Integer>) response.rows()[0][6]).get(1), is(2));
+        assertThat(((Short) ((Object[]) response.rows()[0][6])[0]), is((short) 32767));
+        assertThat(((Short) ((Object[]) response.rows()[0][6])[1]), is((short) 2));
 
-        assertThat(((List<String>) response.rows()[0][7]).get(0), is("Youri"));
-        assertThat(((List<String>) response.rows()[0][7]).get(1), is("Juri"));
+        assertThat(((String) ((Object[]) response.rows()[0][7])[0]), is("Youri"));
+        assertThat(((String) ((Object[]) response.rows()[0][7])[1]), is("Juri"));
     }
 
     @Test
@@ -300,8 +298,10 @@ public class InsertIntoIntegrationTest extends SQLTransportIntegrationTest {
         execute("select id, details from test");
         assertEquals(1, response.rowCount());
         assertEquals(1, response.rows()[0][0]);
-        assertThat(response.rows()[0][1], instanceOf(List.class));
-        assertThat(((List) response.rows()[0][1]).size(), is(0));
+
+        assertThat(response.rows()[0][1], instanceOf(Object[].class));
+        Object[] details = ((Object[]) response.rows()[0][1]);
+        assertThat(details.length, is(0));
     }
 
     @Test
@@ -448,10 +448,14 @@ public class InsertIntoIntegrationTest extends SQLTransportIntegrationTest {
         execute("refresh table users");
         execute("select friends, name from users order by id");
         assertThat(response.rowCount(), is(2L));
-        assertNull((((ArrayList) response.rows()[0][0]).get(0)));
-        assertThat(((String) ((ArrayList) response.rows()[0][0]).get(1)), is("gedöns"));
+
+        Object[] friends = (Object[]) response.rows()[0][0];
+        assertThat(friends[0], nullValue());
+        assertThat(((String) friends[1]), is("gedöns"));
         assertThat((String)response.rows()[0][1], is("björk"));
-        assertNull((((ArrayList) response.rows()[1][0]).get(0)));
+
+        friends = ((Object[]) response.rows()[1][0]);
+        assertNull(friends[0]);
     }
 
     @Test
@@ -519,6 +523,10 @@ public class InsertIntoIntegrationTest extends SQLTransportIntegrationTest {
         execute("refresh table locations2");
         execute("select * from locations2 order by id");
         assertThat(response.rowCount(), is(13L));
+
+        for (int i = 0; i < rowsOriginal.length; i++) {
+            rowsOriginal[i][5] =  (long)((int)rowsOriginal[i][5]);
+        }
         assertThat(response.rows(), is(rowsOriginal));
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/ObjectColumnTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ObjectColumnTest.java
@@ -30,7 +30,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -289,10 +288,8 @@ public class ObjectColumnTest extends SQLTransportIntegrationTest {
         assertEquals(1L, response.rowCount());
         assertArrayEquals(new String[]{"message", "person['name']", "person['addresses']['city']"},
                 response.cols());
-        assertArrayEquals(new Object[]{"I'm addicted to kite", "Youri",
-                        new ArrayList<String>() {{
-                            add("Dirksland");
-                        }}},
+        assertArrayEquals(
+                new Object[]{"I'm addicted to kite", "Youri", new Object[] { "Dirksland" }},
                 response.rows()[0]
         );
     }

--- a/sql/src/test/java/io/crate/integrationtests/QueryThenFetchIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/QueryThenFetchIntegrationTest.java
@@ -59,4 +59,17 @@ public class QueryThenFetchIntegrationTest extends SQLTransportIntegrationTest {
 
         execute("select format('%d', s) from t");
     }
+
+    @Test
+    public void testTestWithTimestampThatIsInIntegerRange() throws Exception {
+        execute("create table t (ts timestamp) clustered into 1 shards with (number_of_replicas = 0)");
+        ensureYellow();
+        execute("insert into t (ts) values (0)");
+        execute("insert into t (ts) values (1425980155)");
+        execute("refresh table t");
+
+        execute("select extract(day from ts) from t order by 1");
+        assertThat((Integer) response.rows()[0][0], is(1));
+        assertThat((Integer) response.rows()[1][0], is(17));
+    }
 }

--- a/sql/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
@@ -89,13 +89,13 @@ public class SQLTypeMappingTest extends SQLTransportIntegrationTest {
 
         assertEquals(1, response.rows()[0][0]);
         assertEquals("With", response.rows()[0][1]);
-        assertEquals(0, response.rows()[0][2]);
-        assertEquals(127, response.rows()[0][3]);
+        assertEquals(0L, response.rows()[0][2]);
+        assertEquals((byte) 127, response.rows()[0][3]);
 
         assertEquals(2, response.rows()[1][0]);
         assertEquals("Without", response.rows()[1][1]);
-        assertEquals(3600000, response.rows()[1][2]);
-        assertEquals(-128, response.rows()[1][3]);
+        assertEquals(3600000L, response.rows()[1][2]);
+        assertEquals((byte) -128, response.rows()[1][3]);
     }
 
     public void setUpObjectTable() throws IOException {
@@ -161,7 +161,7 @@ public class SQLTypeMappingTest extends SQLTransportIntegrationTest {
         response = execute("select object_field['created'], object_field['size'], " +
                 "no_dynamic_field['dynamic_again']['field'] from test12");
         assertEquals(1384819200000L, response.rows()[0][0]);
-        assertEquals(127, response.rows()[0][1]);
+        assertEquals((byte) 127, response.rows()[0][1]);
         assertEquals(1384790145289L, response.rows()[0][2]);
     }
 
@@ -257,8 +257,8 @@ public class SQLTypeMappingTest extends SQLTransportIntegrationTest {
                 "object_field, ip_field from t1 where id=0");
         assertEquals(1, response.rowCount());
         assertEquals(0, response.rows()[0][0]);
-        assertEquals(127, response.rows()[0][1]);
-        assertEquals(-32768, response.rows()[0][2]);
+        assertEquals((byte) 127, response.rows()[0][1]);
+        assertEquals((short)-32768, response.rows()[0][2]);
         assertEquals(0x7fffffff, response.rows()[0][3]);
         assertEquals(0x8000000000000000L, response.rows()[0][4]);
         assertEquals(1.0f, ((Number) response.rows()[0][5]).floatValue(), 0.01f);
@@ -320,7 +320,7 @@ public class SQLTypeMappingTest extends SQLTransportIntegrationTest {
             }
         }
         assertNotNull(response);
-        assertEquals(0, response.rows()[0][1]);
+        assertEquals(0L, response.rows()[0][1]);
     }
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -34,6 +34,7 @@ import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsReques
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.hamcrest.Matchers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -500,7 +501,7 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
         execute(
                 "select i from test where i > 10");
         assertEquals(1, response.rowCount());
-        assertEquals(20, response.rows()[0][0]);
+        assertEquals(20L, response.rows()[0][0]);
     }
 
 
@@ -522,11 +523,11 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
         execute("select id, strings, integers from t1");
         assertThat(response.rowCount(), is(1L));
         assertThat((Integer) response.rows()[0][0], is(1));
-        assertThat(((List<String>) response.rows()[0][1]).get(0), is("foo"));
-        assertThat(((List<String>) response.rows()[0][1]).get(1), is("bar"));
-        assertThat(((List<Integer>) response.rows()[0][2]).get(0), is(1));
-        assertThat(((List<Integer>) response.rows()[0][2]).get(1), is(2));
-        assertThat(((List<Integer>) response.rows()[0][2]).get(2), is(3));
+        assertThat(((String) ((Object[]) response.rows()[0][1])[0]), is("foo"));
+        assertThat(((String) ((Object[]) response.rows()[0][1])[1]), is("bar"));
+        assertThat(((Integer) ((Object[]) response.rows()[0][2])[0]), is(1));
+        assertThat(((Integer) ((Object[]) response.rows()[0][2])[1]), is(2));
+        assertThat(((Integer) ((Object[]) response.rows()[0][2])[2]), is(3));
     }
 
     @Test
@@ -542,8 +543,8 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
 
         execute("select details['names'] from t1");
         assertThat(response.rowCount(), is(1L));
-        assertThat(((List<String>) response.rows()[0][0]).get(0), is("Arthur"));
-        assertThat(((List<String>) response.rows()[0][0]).get(1), is("Trillian"));
+        assertThat(((String) ((Object[]) response.rows()[0][0])[0]), is("Arthur"));
+        assertThat(((String) ((Object[]) response.rows()[0][0])[1]), is("Trillian"));
     }
 
     @Test
@@ -606,9 +607,9 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
         execute("select id, strings from t1");
         assertThat(response.rowCount(), is(1L));
         assertThat((Integer) response.rows()[0][0], is(1));
-        assertThat(((List<String>) response.rows()[0][1]).get(0), is("foo"));
-        assertThat(((List<String>) response.rows()[0][1]).get(1), is((String) null));
-        assertThat(((List<String>) response.rows()[0][1]).get(2), is("bar"));
+        assertThat(((String) ((Object[]) response.rows()[0][1])[0]), is("foo"));
+        assertThat(((Object[]) response.rows()[0][1])[1], nullValue());
+        assertThat(((String) ((Object[]) response.rows()[0][1])[2]), is("bar"));
     }
 
     @Test
@@ -634,21 +635,21 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
         execute("select objects from t1");
         assertThat(response.rowCount(), is(1L));
 
-        List<Map<String, Object>> objResults = (List<Map<String, Object>>) response.rows()[0][0];
-        Map<String, Object> obj1Result = objResults.get(0);
+        Object[] objResults = ((Object[]) response.rows()[0][0]);
+        Map<String, Object> obj1Result = ((Map) objResults[0]);
         assertThat((String) obj1Result.get("name"), is("foo"));
         assertThat((Integer) obj1Result.get("age"), is(1));
 
-        Map<String, Object> obj2Result = objResults.get(1);
+        Map<String, Object> obj2Result = ((Map) objResults[1]);
         assertThat((String) obj2Result.get("name"), is("bar"));
         assertThat((Integer) obj2Result.get("age"), is(2));
 
         execute("select objects['name'] from t1");
         assertThat(response.rowCount(), is(1L));
 
-        List<String> names = (List<String>) response.rows()[0][0];
-        assertThat(names.get(0), is("foo"));
-        assertThat(names.get(1), is("bar"));
+        String[] names = Arrays.copyOf(((Object[]) response.rows()[0][0]), 2, String[].class);
+        assertThat(names[0], is("foo"));
+        assertThat(names[1], is("bar"));
 
         execute("select objects['name'] from t1 where ? = ANY (objects['name'])", new Object[]{"foo"});
         assertThat(response.rowCount(), is(1L));
@@ -1455,11 +1456,9 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
         execute("select p from geo_point_table order by id desc");
 
         assertThat(response.rowCount(), is(2L));
-        assertThat((List<Double>) response.rows()[0][0], is(Arrays.asList(57.22, 7.12)));
-        assertThat((List<Double>) response.rows()[1][0], is(Arrays.asList(47.22, 12.09)));
+        assertThat(((Double[]) response.rows()[0][0]), Matchers.arrayContaining(57.22, 7.12));
+        assertThat(((Double[]) response.rows()[1][0]), Matchers.arrayContaining(47.22, 12.09));
     }
-
-
 
     @Test
     public void testGroupByOnIpType() throws Exception {
@@ -1518,14 +1517,14 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
 
         // queries
         execute("select p from t where distance(p, 'POINT (11 21)') > 0.0");
-        List<Double> row = (List<Double>) response.rows()[0][0];
-        assertThat(row.get(0), is(10.0d));
-        assertThat(row.get(1), is(20.0d));
+        Double[] row = Arrays.copyOf((Object[])response.rows()[0][0], 2, Double[].class);
+        assertThat(row[0], is(10.0d));
+        assertThat(row[1], is(20.0d));
 
         execute("select p from t where distance(p, 'POINT (11 21)') < 10.0");
-        row = (List<Double>) response.rows()[0][0];
-        assertThat(row.get(0), is(11.0d));
-        assertThat(row.get(1), is(21.0d));
+        row = Arrays.copyOf((Object[])response.rows()[0][0], 2, Double[].class);
+        assertThat(row[0], is(11.0d));
+        assertThat(row[1], is(21.0d));
 
         execute("select p from t where distance(p, 'POINT (11 21)') < 10.0 or distance(p, 'POINT (11 21)') > 10.0");
         assertThat(response.rowCount(), is(2L));
@@ -1682,28 +1681,6 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
         assertThat(response.rowCount(), is(2L));
         assertThat((Integer) response.rows()[0][0], is(1));
         assertThat((Integer) response.rows()[1][0], is(2));
-    }
-
-    @Test
-    public void testSelectWhereArithmeticScalarTwoReferenceArgs() throws Exception {
-        execute("create table t (x long, base long) clustered into 1 shards with (number_of_replicas=0)");
-        ensureYellow();
-        execute("insert into t (x, base) values (?, ?), (?, ?), (?, ?)", new Object[]{
-                144L, 12L, // 2
-                65536L, 2L, // 16
-                9L, 3L, // 2
-                700L, 3L // 5.9630...
-        });
-        execute("refresh table t");
-
-        execute("select x, base, log(x, base) from t where log(x, base) = 2.0 order by x");
-        assertThat(response.rowCount(), is(2L));
-        assertThat((Integer) response.rows()[0][0], is(9));
-        assertThat((Integer) response.rows()[0][1], is(3));
-        assertThat((Double) response.rows()[0][2], is(2.0));
-        assertThat((Integer) response.rows()[1][0], is(144));
-        assertThat((Integer) response.rows()[1][1], is(12));
-        assertThat((Double) response.rows()[1][2], is(2.0));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/WherePKIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/WherePKIntegrationTest.java
@@ -28,7 +28,6 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import java.util.Arrays;
-import java.util.List;
 
 import static org.hamcrest.core.Is.is;
 
@@ -124,7 +123,8 @@ public class WherePKIntegrationTest extends SQLTransportIntegrationTest {
         assertThat(response.rowCount(), is(1L));
         assertThat((String) response.rows()[0][0], is("123"));
         //noinspection unchecked
-        assertThat((List<String>) response.rows()[0][1], Matchers.contains("small", "blue"));
+        String[] tags = Arrays.copyOf((Object[])response.rows()[0][1], 2, String[].class);
+        assertThat(tags, Matchers.arrayContaining("small", "blue"));
     }
 
     @Test


### PR DESCRIPTION
otherwise functions that are registered to specific types might fail.

for example extract(day from ts) expects ts to be a long. In
   case the timestamp is in the integer range it received a
   Integer instead and failed.