### PR TITLE
throw a meaningful error if is null is used on a function

### DIFF
--- a/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/ESQueryBuilder.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/ESQueryBuilder.java
@@ -698,7 +698,8 @@ public class ESQueryBuilder {
                 Preconditions.checkArgument(function.arguments().size() == 1);
 
                 Symbol arg = function.arguments().get(0);
-                Preconditions.checkArgument(arg.symbolType() == SymbolType.REFERENCE);
+                Preconditions.checkArgument(arg.symbolType() == SymbolType.REFERENCE,
+                        "IS NULL only works on columns, not on functions or other expressions");
 
                 Reference reference = (Reference) arg;
                 String columnName = reference.info().ident().columnIdent().fqn();

--- a/sql/src/test/java/io/crate/executor/transport/task/elasticsearch/ESQueryBuilderTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/task/elasticsearch/ESQueryBuilderTest.java
@@ -913,4 +913,15 @@ public class ESQueryBuilderTest extends CrateUnitTest {
         generator.convert(new WhereClause(whereClause));
     }
 
+    @Test
+    public void testIsNullOnFunctionThrowsMeaningfulError() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("IS NULL only works on columns, not on functions or other expressions");
+
+        Function query = createFunction(IsNullPredicate.NAME, DataTypes.BOOLEAN,
+                createFunction(EqOperator.NAME, DataTypes.BOOLEAN,
+                        createReference("x", DataTypes.INTEGER), Literal.newLiteral(10)));
+
+        generator.convert(new WhereClause(query));
+    }
 }


### PR DESCRIPTION
In the ESQueryBuilder since there is no "generic function" fallback