### PR TITLE
fix LuceneQueryBuilder for "x = null" where x is numeric or boolean

### DIFF
--- a/sql/src/main/java/io/crate/lucene/QueryBuilderHelper.java
+++ b/sql/src/main/java/io/crate/lucene/QueryBuilderHelper.java
@@ -8,6 +8,8 @@ import org.apache.lucene.queries.TermFilter;
 import org.apache.lucene.search.*;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.lucene.BytesRefs;
+import org.elasticsearch.common.lucene.search.MatchNoDocsFilter;
+import org.elasticsearch.common.lucene.search.Queries;
 
 public abstract class QueryBuilderHelper {
 
@@ -53,10 +55,16 @@ public abstract class QueryBuilderHelper {
     public abstract Query rangeQuery(String columnName, Object from, Object to, boolean includeLower, boolean includeUpper);
 
     public Filter eqFilter(String columnName, Object value) {
+        if (value == null) {
+            return new MatchNoDocsFilter();
+        }
         return rangeFilter(columnName, value, value, true, true);
     }
 
     public Query eq(String columnName, Object value) {
+        if (value == null) {
+            return Queries.newMatchNoDocsQuery();
+        }
         return rangeQuery(columnName, value, value, true, true);
     }
 
@@ -77,6 +85,9 @@ public abstract class QueryBuilderHelper {
 
         @Override
         public Query eq(String columnName, Object value) {
+            if (value == null) {
+                return Queries.newMatchNoDocsQuery();
+            }
             return new TermQuery(new Term(columnName, value == true ? "T" : "F"));
         }
     }
@@ -187,11 +198,17 @@ public abstract class QueryBuilderHelper {
 
         @Override
         public Query eq(String columnName, Object value) {
+            if (value == null) {
+                return Queries.newMatchNoDocsQuery();
+            }
             return new TermQuery(new Term(columnName, (BytesRef)value));
         }
 
         @Override
         public Filter eqFilter(String columnName, Object value) {
+            if (value == null) {
+                return new MatchNoDocsFilter();
+            }
             return new TermFilter(new Term(columnName, (BytesRef) value));
         }
 

--- a/sql/src/test/java/io/crate/lucene/LuceneQueryBuilderTest.java
+++ b/sql/src/test/java/io/crate/lucene/LuceneQueryBuilderTest.java
@@ -79,6 +79,20 @@ public class LuceneQueryBuilderTest extends CrateUnitTest {
     }
 
     @Test
+    public void testWhereRefEqNullWithDifferentTypes() throws Exception {
+        for (DataType type : DataTypes.PRIMITIVE_TYPES) {
+            Reference foo = createReference("foo", type);
+            Query query = convert(whereClause(EqOperator.NAME, foo, Literal.newLiteral(type, null)));
+
+            // must always become a MatchNoDocsQuery
+            // string: term query with null would cause NPE
+            // int/numeric: rangeQuery from null to null would match all
+            // bool:  term would match false too because of the condition in the eq query builder
+            assertThat(query, instanceOf(MatchNoDocsQuery.class));
+        }
+    }
+
+    @Test
     public void testWhereRefEqRef() throws Exception {
         Reference foo = createReference("foo", DataTypes.STRING);
         Query query = convert(whereClause(EqOperator.NAME, foo, foo));


### PR DESCRIPTION
This actually isn't a problem in 0.48 because the "= null" case is handled
during normalization or analysis. But it is a problem in 0.47 for "where x in
(null)" where this will result in a Range query from null to null which
matches everything