### PR TITLE
add group vs arbitrary benchmark

### DIFF
--- a/sql/src/test/java/io/crate/benchmark/GroupByArbitraryBenchmark.java
+++ b/sql/src/test/java/io/crate/benchmark/GroupByArbitraryBenchmark.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.benchmark;
+
+import com.carrotsearch.junitbenchmarks.BenchmarkOptions;
+import com.carrotsearch.junitbenchmarks.BenchmarkRule;
+import com.carrotsearch.junitbenchmarks.annotation.AxisRange;
+import com.carrotsearch.junitbenchmarks.annotation.BenchmarkHistoryChart;
+import com.carrotsearch.junitbenchmarks.annotation.BenchmarkMethodChart;
+import com.carrotsearch.junitbenchmarks.annotation.LabelType;
+import io.crate.action.sql.SQLAction;
+import io.crate.action.sql.SQLRequest;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+
+import java.io.IOException;
+import java.util.Random;
+
+@AxisRange(min = 0)
+@BenchmarkHistoryChart(filePrefix="benchmark-groupby-arbitrary-history", labelWith = LabelType.CUSTOM_KEY)
+@BenchmarkMethodChart(filePrefix = "benchmark-groupby-arbitrary")
+public class GroupByArbitraryBenchmark extends BenchmarkBase {
+
+    public static final int NUMBER_OF_DOCUMENTS = 500_000;
+    public static final int BENCHMARK_ROUNDS = 100;
+
+    public static SQLRequest groupRequest = new SQLRequest(String.format("select continent, \"countryName\" from %s group by 1, 2 ", INDEX_NAME));
+    public static SQLRequest arbitraryRequest = new SQLRequest(String.format("select continent, arbitrary(\"countryName\") from %s group by 1", INDEX_NAME));
+
+
+    static {
+        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
+    }
+
+    @Rule
+    public TestRule benchmarkRun = RuleChain.outerRule(new BenchmarkRule()).around(super.ruleChain);
+
+    @Override
+    public boolean importData() {
+        return false;
+    }
+
+    @Override
+    public boolean generateData() {
+        return true;
+    }
+
+    @Override
+    protected int numberOfDocuments() {
+        return NUMBER_OF_DOCUMENTS;
+    }
+
+    @Override
+    protected byte[] generateRowSource() throws IOException {
+        Random random = getRandom();
+        byte[] buffer = new byte[32];
+        random.nextBytes(buffer);
+        return XContentFactory.jsonBuilder()
+                .startObject()
+                .field("areaInSqKm", random.nextFloat())
+                .field("continent", new BytesArray(buffer, 0, 4).toUtf8())
+                .field("countryCode", new BytesArray(buffer, 4, 8).toUtf8())
+                .field("countryName", new BytesArray(buffer, 8, 24).toUtf8())
+                .field("population", random.nextInt(Integer.MAX_VALUE))
+                .endObject()
+                .bytes().toBytes();
+    }
+
+    @BenchmarkOptions(benchmarkRounds = BENCHMARK_ROUNDS, warmupRounds = 10)
+    @Test
+    public void testGroup() {
+        getClient(false).execute(SQLAction.INSTANCE, groupRequest).actionGet();
+    }
+
+    @BenchmarkOptions(benchmarkRounds = BENCHMARK_ROUNDS, warmupRounds = 10)
+    @Test
+    public void testArbitrary() {
+        getClient(false).execute(SQLAction.INSTANCE, arbitraryRequest).actionGet();
+    }
+}


### PR DESCRIPTION
GroupByArbitraryBenchmark.testArbitrary: [measured 100 out of 110 rounds, threads: 1 (sequential)]
round: 0.25 [+- 0.01], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 11, GC.time: 0.02, time.total: 65.80, time.warmup: 40.38, time.bench: 25.42

GroupByArbitraryBenchmark.testGroup: [measured 100 out of 110 rounds, threads: 1 (sequential)]
round: 0.29 [+- 0.01], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 21, GC.time: 0.05, time.total: 31.66, time.warmup: 2.91, time.bench: 28.75
