### PR TITLE
increase limits in select-limit-order benchmark

### DIFF
--- a/sql/src/test/java/io/crate/benchmark/SelectLimitOrderBenchmark.java
+++ b/sql/src/test/java/io/crate/benchmark/SelectLimitOrderBenchmark.java
@@ -51,8 +51,8 @@ import static org.junit.Assert.assertEquals;
 @BenchmarkMethodChart(filePrefix = "benchmark-select-limit-order")
 public class SelectLimitOrderBenchmark extends BenchmarkBase {
 
-    public static final int BENCHMARK_ROUNDS = 100;
-    public static final int NUMBER_OF_DOCUMENTS = 200_000;
+    public static final int BENCHMARK_ROUNDS = 10;
+    public static final int NUMBER_OF_DOCUMENTS = 1_200_000;
     public static final String INDEX_NAME = "bench_select_limit_order";
 
     private String[] generatedStrings;
@@ -155,42 +155,38 @@ public class SelectLimitOrderBenchmark extends BenchmarkBase {
 
     @BenchmarkOptions(benchmarkRounds = BENCHMARK_ROUNDS, warmupRounds = 1)
     @Test
-    public void benchLimit1000_ES() throws Exception {
-        Integer limit = 1000;
+    public void benchLimit1000000_ES() throws Exception {
+        Integer limit = 1_000_000;
         Integer offset = 0;
         boolean orderBy = false;
-        // run bench multiple times per round, otherwise resulting numbers are too small to compare
-        runESBenchmark(10, limit, offset, orderBy);
+        runESBenchmark(1, limit, offset, orderBy);
     }
 
     @BenchmarkOptions(benchmarkRounds = BENCHMARK_ROUNDS, warmupRounds = 1)
     @Test
-    public void benchLimit1000_SQL() throws Exception {
-        Integer limit = 1000;
+    public void benchLimit1000000_SQL() throws Exception {
+        Integer limit = 1_000_000;
         Integer offset = 0;
         boolean orderBy = false;
-        // run bench multiple times per round, otherwise resulting numbers are too small to compare
-        runSQLBenchmark(10, limit, offset, orderBy);
+        runSQLBenchmark(1, limit, offset, orderBy);
     }
 
     @BenchmarkOptions(benchmarkRounds = BENCHMARK_ROUNDS, warmupRounds = 1)
     @Test
-    public void benchLimit1000Order_ES() throws Exception {
-        Integer limit = 1000;
+    public void benchLimit1000000Order_ES() throws Exception {
+        Integer limit = 1_000_000;
         Integer offset = 0;
         boolean orderBy = true;
-        // run bench multiple times per round, otherwise resulting numbers are too small to compare
-        runESBenchmark(10, limit, offset, orderBy);
+        runESBenchmark(1, limit, offset, orderBy);
     }
 
     @BenchmarkOptions(benchmarkRounds = BENCHMARK_ROUNDS, warmupRounds = 1)
     @Test
-    public void benchLimit1000Order_SQL() throws Exception {
-        Integer limit = 1000;
+    public void benchLimit1000000Order_SQL() throws Exception {
+        Integer limit = 1_000_000;
         Integer offset = 0;
         boolean orderBy = true;
-        // run bench multiple times per round, otherwise resulting numbers are too small to compare
-        runSQLBenchmark(10, limit, offset, orderBy);
+        runSQLBenchmark(1, limit, offset, orderBy);
     }
 
     @BenchmarkOptions(benchmarkRounds = BENCHMARK_ROUNDS, warmupRounds = 1)


### PR DESCRIPTION
SelectLimitOrderBenchmark.benchLimit1000000_SQL: [measured 10 out of 11 rounds, threads: 1 (sequential)]
 round: 13.77 [+- 1.02], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 122, GC.time: 75.86, time.total: 200.90, time.warmup: 63.24, time.bench: 137.66

SelectLimitOrderBenchmark.benchLimit1000000_ES: [measured 10 out of 11 rounds, threads: 1 (sequential)]
 round: 3.94 [+- 0.17], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 36, GC.time: 16.61, time.total: 43.03, time.warmup: 3.61, time.bench: 39.42


SelectLimitOrderBenchmark.benchLimit1000000Order_SQL: [measured 10 out of 11 rounds, threads: 1 (sequential)]
 round: 29.42 [+- 2.66], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 188, GC.time: 224.89, time.total: 325.03, time.warmup: 30.85, time.bench: 294.18

SelectLimitOrderBenchmark.benchLimit1000000Order_ES: [measured 10 out of 11 rounds, threads: 1 (sequential)]
 round: 8.21 [+- 0.87], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 67, GC.time: 49.88, time.total: 90.71, time.warmup: 8.58, time.bench: 82.13


SelectLimitOrderBenchmark.benchLimit100Offset100000Order_SQL: [measured 10 out of 11 rounds, threads: 1 (sequential)]
 round: 0.74 [+- 0.22], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 7, GC.time: 2.04, time.total: 9.06, time.warmup: 1.62, time.bench: 7.44

SelectLimitOrderBenchmark.benchLimit100Offset100000Order_ES: [measured 10 out of 11 rounds, threads: 1 (sequential)]
 round: 0.70 [+- 0.19], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 6, GC.time: 1.58, time.total: 8.38, time.warmup: 1.42, time.bench: 6.96

