### PR TITLE
clean up code in Task

### DIFF
--- a/sql/src/main/java/io/crate/breaker/RamAccountingContext.java
+++ b/sql/src/main/java/io/crate/breaker/RamAccountingContext.java
@@ -21,9 +21,11 @@
 
 package io.crate.breaker;
 
+import io.crate.planner.node.ExecutionNode;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class RamAccountingContext {
@@ -38,6 +40,11 @@ public class RamAccountingContext {
     private final AtomicLong flushBuffer = new AtomicLong(0);
     private volatile boolean closed = false;
     private volatile boolean tripped = false;
+
+    public static RamAccountingContext forExecutionNode(CircuitBreaker breaker, ExecutionNode executionNode, UUID operationId) {
+        String ramAccountingContextId = String.format("%s: %s", executionNode.name(), operationId.toString());
+        return new RamAccountingContext(ramAccountingContextId, breaker);
+    }
 
     public RamAccountingContext(String contextId, CircuitBreaker breaker) {
         this.contextId = contextId;

--- a/sql/src/main/java/io/crate/executor/callbacks/OperationFinishedStatsTablesCallback.java
+++ b/sql/src/main/java/io/crate/executor/callbacks/OperationFinishedStatsTablesCallback.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.executor.callbacks;
+
+import com.google.common.util.concurrent.FutureCallback;
+import io.crate.breaker.RamAccountingContext;
+import io.crate.exceptions.Exceptions;
+import io.crate.operation.collect.StatsTables;
+
+import javax.annotation.Nonnull;
+import java.util.UUID;
+
+
+public class OperationFinishedStatsTablesCallback<T> implements FutureCallback<T> {
+
+    private final UUID operationId;
+    private final StatsTables statsTables;
+    private final RamAccountingContext ramAccountingContext;
+
+    public OperationFinishedStatsTablesCallback(UUID operationId,
+                                                StatsTables statsTables,
+                                                RamAccountingContext ramAccountingContext) {
+        this.operationId = operationId;
+        this.statsTables = statsTables;
+        this.ramAccountingContext = ramAccountingContext;
+    }
+
+    @Override
+    public void onSuccess(T result) {
+        statsTables.operationFinished(operationId, null, ramAccountingContext.totalBytes());
+        ramAccountingContext.close();
+    }
+
+    @Override
+    public void onFailure(@Nonnull Throwable t) {
+        statsTables.operationFinished(operationId, Exceptions.messageOf(t), ramAccountingContext.totalBytes());
+        ramAccountingContext.close();
+    }
+}

--- a/sql/src/main/java/io/crate/executor/transport/TransportExecutor.java
+++ b/sql/src/main/java/io/crate/executor/transport/TransportExecutor.java
@@ -251,24 +251,24 @@ public class TransportExecutor implements Executor, TaskExecutor {
             if (node.isRouted()) {
                 return singleTask(
                     new RemoteCollectTask(
-                        jobId,
-                        node,
-                        transportActionProvider.transportJobInitAction(),
-                        transportActionProvider.transportCloseContextNodeAction(),
-                        streamerVisitor,
-                        handlerSideDataCollectOperation,
-                        globalProjectionToProjectionVisitor,
-                        statsTables,
-                        circuitBreaker
+                            jobId,
+                            node,
+                            transportActionProvider.transportJobInitAction(),
+                            transportActionProvider.transportCloseContextNodeAction(),
+                            streamerVisitor,
+                            handlerSideDataCollectOperation,
+                            globalProjectionToProjectionVisitor,
+                            statsTables,
+                            circuitBreaker
                     )
                 );
             } else {
                 return singleTask(
                         new LocalCollectTask(
-                            jobId,
-                            handlerSideDataCollectOperation,
-                            node,
-                            circuitBreaker
+                                jobId,
+                                handlerSideDataCollectOperation,
+                                node,
+                                circuitBreaker
                         )
                 );
             }
@@ -290,6 +290,7 @@ public class TransportExecutor implements Executor, TaskExecutor {
                 return singleTask(new LocalMergeTask(
                         jobId,
                         pageDownstreamFactory,
+                        jobContextService,
                         node,
                         statsTables,
                         circuitBreaker, threadPool));


### PR DESCRIPTION
moved code from the CTOR in ExecutionNodesTask to the start() method to be
able to inject the downstream later on