### PR TITLE
change timeValue cluster settings to string type

### DIFF
--- a/docs/sql/system.txt
+++ b/docs/sql/system.txt
@@ -78,13 +78,13 @@ currently applied cluster settings.
     | settings['discovery']                                                             | object    |
     | settings['discovery']['zen']                                                      | object    |
     | settings['discovery']['zen']['minimum_master_nodes']                              | integer   |
-    | settings['discovery']['zen']['ping_timeout']                                      | long      |
-    | settings['discovery']['zen']['publish_timeout']                                   | long      |
+    | settings['discovery']['zen']['ping_timeout']                                      | string    |
+    | settings['discovery']['zen']['publish_timeout']                                   | string    |
     | settings['cluster']                                                               | object    |
     | settings['cluster']['graceful_stop']                                              | object    |
     | settings['cluster']['graceful_stop']['min_availability']                          | string    |
     | settings['cluster']['graceful_stop']['reallocate']                                | boolean   |
-    | settings['cluster']['graceful_stop']['timeout']                                   | long      |
+    | settings['cluster']['graceful_stop']['timeout']                                   | string    |
     | settings['cluster']['graceful_stop']['force']                                     | boolean   |
     | settings['cluster']['routing']                                                    | object    |
     | settings['cluster']['routing']['allocation']                                      | object    |
@@ -136,7 +136,7 @@ currently applied cluster settings.
     | settings['indices']['fielddata']['breaker']['overhead']                           | double    |
     | settings['cluster']['info']                                                       | object    |
     | settings['cluster']['info']['update']                                             | object    |
-    | settings['cluster']['info']['update']['interval']                                 | long      |
+    | settings['cluster']['info']['update']['interval']                                 | string    |
     +-----------------------------------------------------------------------------------+-----------+
     SELECT 67 rows in set (... sec)
 

--- a/sql/src/main/java/io/crate/metadata/sys/SysClusterTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysClusterTableInfo.java
@@ -69,10 +69,10 @@ public class SysClusterTableInfo extends SysTableInfo {
         register("settings", DataTypes.INTEGER, ImmutableList.of(CrateSettings.DISCOVERY.name(),
                 CrateSettings.DISCOVERY_ZEN.name(),
                 CrateSettings.DISCOVERY_ZEN_MIN_MASTER_NODES.name()));
-        register("settings", DataTypes.LONG, ImmutableList.of(CrateSettings.DISCOVERY.name(),
+        register("settings", DataTypes.STRING, ImmutableList.of(CrateSettings.DISCOVERY.name(),
                 CrateSettings.DISCOVERY_ZEN.name(),
                 CrateSettings.DISCOVERY_ZEN_PING_TIMEOUT.name()));
-        register("settings", DataTypes.LONG, ImmutableList.of(CrateSettings.DISCOVERY.name(),
+        register("settings", DataTypes.STRING, ImmutableList.of(CrateSettings.DISCOVERY.name(),
                 CrateSettings.DISCOVERY_ZEN.name(),
                 CrateSettings.DISCOVERY_ZEN_PUBLISH_TIMEOUT.name()));
 
@@ -86,7 +86,7 @@ public class SysClusterTableInfo extends SysTableInfo {
         register("settings", DataTypes.BOOLEAN, ImmutableList.of(CrateSettings.CLUSTER.name(),
                 CrateSettings.GRACEFUL_STOP.name(),
                 CrateSettings.GRACEFUL_STOP_REALLOCATE.name()));
-        register("settings", DataTypes.LONG, ImmutableList.of(CrateSettings.CLUSTER.name(),
+        register("settings", DataTypes.STRING, ImmutableList.of(CrateSettings.CLUSTER.name(),
                 CrateSettings.GRACEFUL_STOP.name(),
                 CrateSettings.GRACEFUL_STOP_TIMEOUT.name()));
         register("settings", DataTypes.BOOLEAN, ImmutableList.of(CrateSettings.CLUSTER.name(),
@@ -298,7 +298,7 @@ public class SysClusterTableInfo extends SysTableInfo {
         register("settings", DataTypes.OBJECT, ImmutableList.of(CrateSettings.CLUSTER.name(),
                 CrateSettings.CLUSTER_INFO.name(),
                 CrateSettings.CLUSTER_INFO_UPDATE.name()));
-        register("settings", DataTypes.LONG, ImmutableList.of(CrateSettings.CLUSTER.name(),
+        register("settings", DataTypes.STRING, ImmutableList.of(CrateSettings.CLUSTER.name(),
                 CrateSettings.CLUSTER_INFO.name(),
                 CrateSettings.CLUSTER_INFO_UPDATE.name(),
                 CrateSettings.CLUSTER_INFO_UPDATE_INTERVAL.name()));


### PR DESCRIPTION
LONG is wrong as they contain the unit. For example '30m' isn't a number