### PR TITLE
use TermsFilter for ANY/IN with numeric literals

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,7 @@ Changes for Crate
 Unreleased
 ==========
 
- - Optimized queries that use ``IN`` or ``ANY`` on fields of type ``string``
+ - Optimized queries that use ``IN`` or ``ANY``
 
  - Fix: Option http.enabled=false caused UDC module to crash on startup
 

--- a/sql/src/main/java/io/crate/lucene/TermBuilder.java
+++ b/sql/src/main/java/io/crate/lucene/TermBuilder.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.lucene;
+
+import io.crate.types.*;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.BytesRefBuilder;
+import org.apache.lucene.util.NumericUtils;
+import org.elasticsearch.index.mapper.core.BooleanFieldMapper.Values;
+
+public abstract class TermBuilder<T> {
+
+    private static final IntegerTermBuilder INTEGER_TERM_BUILDER = new IntegerTermBuilder();
+    private static final ByteTermBuilder BYTE_TERM_BUILDER = new ByteTermBuilder();
+    private static final ShortTermBuilder SHORT_TERM_BUILDER = new ShortTermBuilder();
+    private static final LongTermBuilder LONG_TERM_BUILDER = new LongTermBuilder();
+    private static final BooleanTermBuilder BOOLEAN_TERM_BUILDER = new BooleanTermBuilder();
+    private static final DoubleTermBuilder DOUBLE_TERM_BUILDER = new DoubleTermBuilder();
+    private static final FloatTermBuilder FLOAT_TERM_BUILDER = new FloatTermBuilder();
+    private static final StringTermBuilder STRING_TERM_BUILDER = new StringTermBuilder();
+
+    public static TermBuilder forType(DataType dataType) {
+        while (dataType instanceof CollectionType) {
+            dataType = ((CollectionType) dataType).innerType();
+        }
+
+        switch (dataType.id()) {
+            case BooleanType.ID:
+                return BOOLEAN_TERM_BUILDER;
+            case IntegerType.ID:
+                return INTEGER_TERM_BUILDER;
+            case ByteType.ID:
+                return BYTE_TERM_BUILDER;
+            case ShortType.ID:
+                return SHORT_TERM_BUILDER;
+            case LongType.ID:
+            case TimestampType.ID:
+            case IpType.ID:
+                return LONG_TERM_BUILDER;
+            case FloatType.ID:
+                return FLOAT_TERM_BUILDER;
+            case DoubleType.ID:
+                return DOUBLE_TERM_BUILDER;
+            case StringType.ID:
+                return STRING_TERM_BUILDER;
+            default:
+                throw new UnsupportedOperationException(String.format("type %s not supported", dataType));
+        }
+    }
+
+    public abstract BytesRef term(T value);
+
+    static class IntegerTermBuilder extends TermBuilder<Integer> {
+        @Override
+        public BytesRef term(Integer value) {
+            BytesRefBuilder builder = new BytesRefBuilder();
+            NumericUtils.intToPrefixCoded(value, 0, builder);
+            return builder.get();
+        }
+
+        public BytesRef term(Byte value) {
+            return term(value.intValue());
+        }
+
+        public BytesRef term(Short value) {
+            return term(value.intValue());
+        }
+    }
+
+    static class ByteTermBuilder extends TermBuilder<Byte> {
+        @Override
+        public BytesRef term(Byte value) {
+            return INTEGER_TERM_BUILDER.term(value.intValue());
+        }
+    }
+
+    static class ShortTermBuilder extends TermBuilder<Short> {
+        @Override
+        public BytesRef term(Short value) {
+            return INTEGER_TERM_BUILDER.term(value.intValue());
+        }
+    }
+
+    static class LongTermBuilder extends TermBuilder<Long> {
+        @Override
+        public BytesRef term(Long value) {
+            BytesRefBuilder builder = new BytesRefBuilder();
+            NumericUtils.longToPrefixCoded(value, 0, builder);
+            return builder.get();
+        }
+    }
+
+    static class DoubleTermBuilder extends TermBuilder<Double> {
+        @Override
+        public BytesRef term(Double value) {
+            long longValue = NumericUtils.doubleToSortableLong(value);
+            BytesRefBuilder bytesRef = new BytesRefBuilder();
+            NumericUtils.longToPrefixCoded(longValue, 0, bytesRef);
+            return bytesRef.get();
+        }
+    }
+
+    static class FloatTermBuilder extends TermBuilder<Float> {
+        @Override
+        public BytesRef term(Float value) {
+            int intValue = NumericUtils.floatToSortableInt(value);
+            BytesRefBuilder bytesRef = new BytesRefBuilder();
+            NumericUtils.intToPrefixCoded(intValue, 0, bytesRef);
+            return bytesRef.get();
+        }
+    }
+
+    static class BooleanTermBuilder extends TermBuilder<Boolean> {
+        @Override
+        public BytesRef term(Boolean value) {
+            if (value == null) {
+                return Values.FALSE;
+            }
+            return value ? Values.TRUE : Values.FALSE;
+        }
+    }
+
+    static class StringTermBuilder extends TermBuilder<BytesRef> {
+        @Override
+        public BytesRef term(BytesRef value) {
+            return value;
+        }
+    }
+}

--- a/sql/src/test/java/io/crate/lucene/LuceneQueryBuilderTest.java
+++ b/sql/src/test/java/io/crate/lucene/LuceneQueryBuilderTest.java
@@ -170,10 +170,8 @@ public class LuceneQueryBuilderTest extends CrateUnitTest {
                         foo,
                         Literal.newLiteral(dataType, Sets.newHashSet(1, 3))));
         Query query = convert(whereClause);
-        assertThat(query, instanceOf(BooleanQuery.class));
-        for (BooleanClause booleanClause : (BooleanQuery) query) {
-            assertThat(booleanClause.getQuery(), instanceOf(NumericRangeQuery.class));
-        }
+        assertThat(query, instanceOf(FilteredQuery.class));
+        assertThat(((FilteredQuery)query).getFilter(), instanceOf(TermsFilter.class));
     }
 
     @Test
@@ -220,7 +218,7 @@ public class LuceneQueryBuilderTest extends CrateUnitTest {
         Literal doubleArrayLiteral = Literal.newLiteral(new Object[]{-1.5d, 0.0d, 1.5d}, new ArrayType(DataTypes.DOUBLE));
         Query query = convert(whereClause(AnyEqOperator.NAME, ref, doubleArrayLiteral));
         assertThat(query, instanceOf(FilteredQuery.class));
-        assertThat(((FilteredQuery)query).getFilter(), instanceOf(BooleanFilter.class));
+        assertThat(((FilteredQuery)query).getFilter(), instanceOf(TermsFilter.class));
     }
 
     @Test

--- a/stresstest/src/test/java/io/crate/benchmark/BenchmarkBase.java
+++ b/stresstest/src/test/java/io/crate/benchmark/BenchmarkBase.java
@@ -165,8 +165,14 @@ public class BenchmarkBase {
                     for (int i=0; i < numDocsToCreate; i+=1000) {
                         bulkRequest.requests().clear();
                         try {
-                            byte[] source = generateRowSource();
+                            byte[] source = null;
+                            if (!generateNewRowForEveryDocument()) {
+                                source = generateRowSource();
+                            }
                             for (int j=0; j<1000;j++) {
+                                if (generateNewRowForEveryDocument()) {
+                                    source = generateRowSource();
+                                }
                                 IndexRequest indexRequest = new IndexRequest(tableName, "default", String.valueOf(i+j) + String.valueOf(Thread.currentThread().getId()));
                                 indexRequest.source(source);
                                 bulkRequest.add(indexRequest);
@@ -191,6 +197,10 @@ public class BenchmarkBase {
 
     protected byte[] generateRowSource() throws IOException {
         return new byte[0];
+    }
+
+    protected boolean generateNewRowForEveryDocument() {
+        return false;
     }
 
     protected Random getRandom() {

--- a/stresstest/src/test/java/io/crate/benchmark/InNumericBenchmark.java
+++ b/stresstest/src/test/java/io/crate/benchmark/InNumericBenchmark.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.benchmark;
+
+import com.carrotsearch.junitbenchmarks.BenchmarkOptions;
+import com.carrotsearch.junitbenchmarks.BenchmarkRule;
+import com.carrotsearch.junitbenchmarks.annotation.AxisRange;
+import com.carrotsearch.junitbenchmarks.annotation.BenchmarkHistoryChart;
+import com.carrotsearch.junitbenchmarks.annotation.BenchmarkMethodChart;
+import com.carrotsearch.junitbenchmarks.annotation.LabelType;
+import com.google.common.base.Joiner;
+import io.crate.action.sql.SQLResponse;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+
+import java.io.IOException;
+import java.util.Random;
+import java.util.Vector;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+@AxisRange(min = 0)
+@BenchmarkHistoryChart(filePrefix="benchmark-in-numeric-history", labelWith = LabelType.CUSTOM_KEY)
+@BenchmarkMethodChart(filePrefix = "benchmark-in-numeric")
+public class InNumericBenchmark extends BenchmarkBase {
+
+    public static final int BENCHMARK_ROUNDS = 100;
+    public static final int NUMBER_OF_DOCUMENTS = 100_000;
+    public static final String INDEX_NAME = "bench_in_numeric";
+
+    static {
+        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
+    }
+
+    static AtomicInteger VALUE = new AtomicInteger(0);
+    static Vector<Integer> VALUES = new Vector<>();
+
+    @Rule
+    public TestRule benchmarkRun = RuleChain.outerRule(new BenchmarkRule()).around(super.ruleChain);
+
+
+    @Override
+    protected void createTable() {
+        execute("create table " + INDEX_NAME +
+                " (int_val int, long_val long) " +
+                "clustered into 4 shards with (number_of_replicas=0)");
+        client().admin().cluster().prepareHealth(INDEX_NAME).setWaitForGreenStatus().execute().actionGet();
+    }
+
+    @Override
+    protected String tableName() {
+        return INDEX_NAME;
+    }
+
+    @Override
+    public boolean generateData() {
+        return true;
+    }
+
+    @Override
+    protected int numberOfDocuments() {
+        return NUMBER_OF_DOCUMENTS;
+    }
+
+    @Override
+    protected byte[] generateRowSource() throws IOException {
+        Random random = getRandom();
+
+        int value = VALUE.getAndIncrement();
+        VALUES.add(value);
+
+        return XContentFactory.jsonBuilder()
+                .startObject()
+                .field("int_val", value)
+                .field("long_val", random.nextLong())
+                .endObject()
+                .bytes().toBytes();
+    }
+
+    @BenchmarkOptions(benchmarkRounds = BENCHMARK_ROUNDS, warmupRounds = 1)
+    @Test
+    public void testSelectIn500() throws Exception {
+        String statement = "select * from " + INDEX_NAME + " where int_val in (" +
+                Joiner.on(",").join(VALUES.subList(0, 500)) + ")";
+        SQLResponse response = execute(statement);
+        assertThat(response.rowCount(), is(500L));
+    }
+
+    @BenchmarkOptions(benchmarkRounds = BENCHMARK_ROUNDS, warmupRounds = 1)
+    @Test
+    public void testSelectIn2K() throws Exception {
+        String statement = "select * from " + INDEX_NAME + " where int_val in (" +
+                Joiner.on(",").join(VALUES.subList(0, 2000)) + ")";
+        SQLResponse response = execute(statement);
+        assertThat(response.rowCount(), is(2000L));
+    }
+
+    @BenchmarkOptions(benchmarkRounds = BENCHMARK_ROUNDS, warmupRounds = 1)
+    @Test
+    public void testSelectIn8K() throws Exception {
+        String statement = "select * from " + INDEX_NAME + " where int_val in (" +
+                Joiner.on(",").join(VALUES.subList(0, 8000)) + ")";
+        SQLResponse response = execute(statement);
+        assertThat(response.rowCount(), is(8000L));
+    }
+}


### PR DESCRIPTION
Master
----------

InNumericBenchmark.testSelectIn500: [measured 100 out of 101 rounds, threads: 1 (sequential)]
round: 0.03 [+- 0.02], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 30, GC.time: 0.09, time.total: 24.84, time.warmup: 21.35, time.bench: 3.49
InNumericBenchmark.testSelectIn2K: [measured 100 out of 101 rounds, threads: 1 (sequential)]
round: 0.11 [+- 0.00], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 113, GC.time: 0.24, time.total: 11.11, time.warmup: 0.23, time.bench: 10.88
InNumericBenchmark.testSelectIn8K: [measured 100 out of 101 rounds, threads: 1 (sequential)]
round: 0.44 [+- 0.03], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 464, GC.time: 2.16, time.total: 44.35, time.warmup: 0.78, time.bench: 43.57

WITH TERMSFILTER
------------------------------

InNumericBenchmark.testSelectIn500: [measured 100 out of 101 rounds, threads: 1 (sequential)]
round: 0.01 [+- 0.01], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 2, GC.time: 0.02, time.total: 24.82, time.warmup: 23.40, time.bench: 1.42
InNumericBenchmark.testSelectIn2K: [measured 100 out of 101 rounds, threads: 1 (sequential)]
round: 0.03 [+- 0.00], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 8, GC.time: 0.04, time.total: 3.60, time.warmup: 0.14, time.bench: 3.46
InNumericBenchmark.testSelectIn8K: [measured 100 out of 101 rounds, threads: 1 (sequential)]
round: 0.12 [+- 0.01], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 27, GC.time: 0.07, time.total: 12.65, time.warmup: 0.44, time.bench: 12.21
