### PR TITLE
change the operationId on sys.operations to be an int

### DIFF
--- a/sql/src/main/java/io/crate/breaker/RamAccountingContext.java
+++ b/sql/src/main/java/io/crate/breaker/RamAccountingContext.java
@@ -25,7 +25,7 @@ import io.crate.planner.node.ExecutionNode;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 
-import java.util.UUID;
+import java.util.Locale;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class RamAccountingContext {
@@ -41,8 +41,9 @@ public class RamAccountingContext {
     private volatile boolean closed = false;
     private volatile boolean tripped = false;
 
-    public static RamAccountingContext forExecutionNode(CircuitBreaker breaker, ExecutionNode executionNode, UUID operationId) {
-        String ramAccountingContextId = String.format("%s: %s", executionNode.name(), operationId.toString());
+    public static RamAccountingContext forExecutionNode(CircuitBreaker breaker, ExecutionNode executionNode) {
+        String ramAccountingContextId = String.format(Locale.ENGLISH, "%s: %d",
+                executionNode.name(), executionNode.executionNodeId());
         return new RamAccountingContext(ramAccountingContextId, breaker);
     }
 

--- a/sql/src/main/java/io/crate/executor/callbacks/OperationFinishedStatsTablesCallback.java
+++ b/sql/src/main/java/io/crate/executor/callbacks/OperationFinishedStatsTablesCallback.java
@@ -32,11 +32,11 @@ import java.util.UUID;
 
 public class OperationFinishedStatsTablesCallback<T> implements FutureCallback<T> {
 
-    private final UUID operationId;
+    private final int operationId;
     private final StatsTables statsTables;
     private final RamAccountingContext ramAccountingContext;
 
-    public OperationFinishedStatsTablesCallback(UUID operationId,
+    public OperationFinishedStatsTablesCallback(int operationId,
                                                 StatsTables statsTables,
                                                 RamAccountingContext ramAccountingContext) {
         this.operationId = operationId;

--- a/sql/src/main/java/io/crate/executor/task/LocalCollectTask.java
+++ b/sql/src/main/java/io/crate/executor/task/LocalCollectTask.java
@@ -63,9 +63,7 @@ public class LocalCollectTask extends JobTask {
         this.resultList = new ArrayList<>(1);
         this.result = SettableFuture.create();
         resultList.add(result);
-        ramAccountingContext = new RamAccountingContext(
-                String.format("%s: %s", collectNode.name(), jobId),
-                circuitBreaker);
+        ramAccountingContext = RamAccountingContext.forExecutionNode(circuitBreaker, collectNode);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/executor/transport/ExecutionNodesTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/ExecutionNodesTask.java
@@ -224,10 +224,10 @@ public class ExecutionNodesTask extends JobTask {
     }
 
     private RamAccountingContext trackOperation(ExecutionNode executionNode, String operationName) {
-        UUID operationId = UUID.randomUUID();
-        RamAccountingContext ramAccountingContext = RamAccountingContext.forExecutionNode(circuitBreaker, executionNode, operationId);
-        statsTables.operationStarted(operationId, jobId(), operationName);
-        Futures.addCallback(result, new OperationFinishedStatsTablesCallback<>(operationId, statsTables, ramAccountingContext));
+        RamAccountingContext ramAccountingContext = RamAccountingContext.forExecutionNode(circuitBreaker, executionNode);
+        statsTables.operationStarted(executionNode.executionNodeId(), jobId(), operationName);
+        Futures.addCallback(result, new OperationFinishedStatsTablesCallback<>(
+                executionNode.executionNodeId(), statsTables, ramAccountingContext));
         return ramAccountingContext;
     }
 
@@ -358,7 +358,9 @@ public class ExecutionNodesTask extends JobTask {
             if (node.keepContextForFetcher()) {
                 LOGGER.trace("closing job context {} on {} nodes", node.jobId().get(), nodeIds.size());
                 for (final String nodeId : nodeIds) {
-                    transportCloseContextNodeAction.execute(nodeId, new NodeCloseContextRequest(node.jobId().get()), new ActionListener<NodeCloseContextResponse>() {
+                    transportCloseContextNodeAction.execute(nodeId,
+                            new NodeCloseContextRequest(node.jobId().get(), node.executionNodeId()),
+                            new ActionListener<NodeCloseContextResponse>() {
                         @Override
                         public void onResponse(NodeCloseContextResponse nodeCloseContextResponse) {
                         }

--- a/sql/src/main/java/io/crate/executor/transport/NodeCloseContextRequest.java
+++ b/sql/src/main/java/io/crate/executor/transport/NodeCloseContextRequest.java
@@ -31,26 +31,29 @@ import java.util.UUID;
 public class NodeCloseContextRequest extends TransportRequest {
 
     private UUID jobId;
+    private int executionNodeId;
 
     public NodeCloseContextRequest() {
     }
 
-    public NodeCloseContextRequest(UUID jobId) {
+    public NodeCloseContextRequest(UUID jobId, int executionNodeId) {
         this.jobId = jobId;
-    }
-
-    public void jobId(UUID jobId) {
-        this.jobId = jobId;
+        this.executionNodeId = executionNodeId;
     }
 
     public UUID jobId() {
         return jobId;
     }
 
+    public int executionNodeId() {
+        return executionNodeId;
+    }
+
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
         jobId = new UUID(in.readLong(), in.readLong());
+        executionNodeId = in.readVInt();
     }
 
     @Override
@@ -58,5 +61,6 @@ public class NodeCloseContextRequest extends TransportRequest {
         super.writeTo(out);
         out.writeLong(jobId.getMostSignificantBits());
         out.writeLong(jobId.getLeastSignificantBits());
+        out.writeVInt(executionNodeId);
     }
 }

--- a/sql/src/main/java/io/crate/executor/transport/TransportCloseContextNodeAction.java
+++ b/sql/src/main/java/io/crate/executor/transport/TransportCloseContextNodeAction.java
@@ -90,15 +90,15 @@ public class TransportCloseContextNodeAction implements NodeAction<NodeCloseCont
     @Override
     public void nodeOperation(final NodeCloseContextRequest request,
                               final ActionListener<NodeCloseContextResponse> response) {
-        final UUID operationId = UUID.randomUUID();
-        statsTables.operationStarted(operationId, request.jobId(), "closeContext");
+        statsTables.operationStarted(request.executionNodeId(), request.jobId(), "closeContext");
 
+        // TODO: don't close the whole context but just the given executionNodeId
         try {
             jobContextService.closeContext(request.jobId());
-            statsTables.operationFinished(operationId, null, 0);
+            statsTables.operationFinished(request.executionNodeId(), null, 0);
             response.onResponse(new NodeCloseContextResponse());
         } catch (Exception e) {
-            statsTables.operationFinished(operationId, Exceptions.messageOf(e), 0);
+            statsTables.operationFinished(request.executionNodeId(), Exceptions.messageOf(e), 0);
             response.onFailure(e);
         }
     }

--- a/sql/src/main/java/io/crate/operation/collect/StatsTables.java
+++ b/sql/src/main/java/io/crate/operation/collect/StatsTables.java
@@ -52,7 +52,7 @@ import java.util.concurrent.atomic.AtomicReference;
 public class StatsTables {
 
     protected final Map<UUID, JobContext> jobsTable = new ConcurrentHashMap<>();
-    protected final Map<UUID, OperationContext> operationsTable = new ConcurrentHashMap<>();
+    protected final Map<Integer, OperationContext> operationsTable = new ConcurrentHashMap<>();
     protected final AtomicReference<BlockingQueue<JobContextLog>> jobsLog = new AtomicReference<>();
     protected final AtomicReference<BlockingQueue<OperationContextLog>> operationsLog = new AtomicReference<>();
     private final static NoopQueue<OperationContextLog> NOOP_OPERATIONS_LOG = NoopQueue.instance();
@@ -149,7 +149,7 @@ public class StatsTables {
         jobContextLogs.offer(new JobContextLog(jobContext, errorMessage));
     }
 
-    public void operationStarted(UUID operationId, UUID jobId, String name) {
+    public void operationStarted(int operationId, UUID jobId, String name) {
         if (isEnabled()) {
             operationsTable.put(
                     operationId,
@@ -157,7 +157,7 @@ public class StatsTables {
         }
     }
 
-    public void operationFinished(@Nullable UUID operationId, @Nullable String errorMessage, long usedBytes) {
+    public void operationFinished(@Nullable Integer operationId, @Nullable String errorMessage, long usedBytes) {
         if (operationId == null || !isEnabled()) {
             return;
         }

--- a/sql/src/main/java/io/crate/operation/projectors/FetchProjector.java
+++ b/sql/src/main/java/io/crate/operation/projectors/FetchProjector.java
@@ -308,7 +308,9 @@ public class FetchProjector implements Projector, RowDownstreamHandle {
         if (closeContexts || bulkSize > NO_BULK_REQUESTS) {
             LOGGER.trace("closing job context {} on {} nodes", jobId, numNodes);
             for (final String nodeId : executionNodes) {
-                transportCloseContextNodeAction.execute(nodeId, new NodeCloseContextRequest(jobId), new ActionListener<NodeCloseContextResponse>() {
+                transportCloseContextNodeAction.execute(nodeId,
+                        new NodeCloseContextRequest(jobId, executionNodeId),
+                        new ActionListener<NodeCloseContextResponse>() {
                     @Override
                     public void onResponse(NodeCloseContextResponse nodeCloseContextResponse) {
                     }

--- a/sql/src/main/java/io/crate/operation/reference/sys/operation/OperationContext.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/operation/OperationContext.java
@@ -25,13 +25,13 @@ import java.util.UUID;
 
 public class OperationContext {
 
-    public UUID id;
+    public int id;
     public UUID jobId;
     public String name;
     public long started;
     public long usedBytes;
 
-    public OperationContext(UUID id, UUID jobId, String name, long started) {
+    public OperationContext(int id, UUID jobId, String name, long started) {
         this.id = id;
         this.jobId = jobId;
         this.name = name;

--- a/sql/src/main/java/io/crate/operation/reference/sys/operation/OperationContextLog.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/operation/OperationContextLog.java
@@ -37,7 +37,7 @@ public class OperationContextLog {
         this.ended = System.currentTimeMillis();
     }
 
-    public UUID id() {
+    public int id() {
         return operationContext.id;
     }
 

--- a/sql/src/main/java/io/crate/operation/reference/sys/operation/SysOperationExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/operation/SysOperationExpression.java
@@ -34,7 +34,7 @@ public abstract class SysOperationExpression<T> extends RowContextCollectorExpre
             .add(new SysOperationExpression<BytesRef>(SysOperationsTableInfo.ColumnNames.ID) {
                 @Override
                 public BytesRef value() {
-                    return new BytesRef(row.id.toString());
+                    return new BytesRef(Integer.toString(row.id));
                 }
             })
             .add(new SysOperationExpression<BytesRef>(SysOperationsTableInfo.ColumnNames.JOB_ID) {

--- a/sql/src/main/java/io/crate/operation/reference/sys/operation/SysOperationLogExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/operation/SysOperationLogExpression.java
@@ -34,7 +34,7 @@ public abstract class SysOperationLogExpression<T> extends RowContextCollectorEx
             .add(new SysOperationLogExpression<BytesRef>(SysOperationsLogTableInfo.ColumnNames.ID) {
                 @Override
                 public BytesRef value() {
-                    return new BytesRef(row.id().toString());
+                    return new BytesRef(Integer.toString(row.id()));
                 }
             })
             .add(new SysOperationLogExpression<BytesRef>(SysOperationsLogTableInfo.ColumnNames.JOB_ID) {

--- a/sql/src/test/java/io/crate/operation/collect/StatsTablesTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/StatsTablesTest.java
@@ -90,9 +90,9 @@ public class StatsTablesTest extends CrateUnitTest {
 
 
         stats.operationsLog.get().add(new OperationContextLog(
-                new OperationContext(UUID.randomUUID(), UUID.randomUUID(), "foo", 2L), null));
+                new OperationContext(1, UUID.randomUUID(), "foo", 2L), null));
         stats.operationsLog.get().add(new OperationContextLog(
-                new OperationContext(UUID.randomUUID(), UUID.randomUUID(), "foo", 3L), null));
+                new OperationContext(1, UUID.randomUUID(), "foo", 3L), null));
 
         stats.listener.onRefreshSettings(ImmutableSettings.builder()
                 .put(CrateSettings.STATS_ENABLED.settingName(), true)


### PR DESCRIPTION
Externally it is still a string as before (so no breaking change).

But internally it will use the executionNodeId. This is actually a more
meaningful information in regards to what kind of operation is running.

In addition the random UUID generation isn't necessary anymore.