### PR TITLE
change failure handling in PageDownstreamContext

### DIFF
--- a/sql/src/main/java/io/crate/executor/transport/ExecutionNodesTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/ExecutionNodesTask.java
@@ -202,7 +202,7 @@ public class ExecutionNodesTask extends JobTask {
 
             @Override
             public void onFailure(@Nonnull Throwable t) {
-                pageDownstreamContext.failure(t);
+                pageDownstreamContext.failure(0, t);
             }
         });
 
@@ -314,13 +314,13 @@ public class ExecutionNodesTask extends JobTask {
                     }
                 });
             } else {
-                pageDownstreamContext.failure(new IllegalStateException("expected directResponse but didn't get one"));
+                pageDownstreamContext.failure(bucketIdx, new IllegalStateException("expected directResponse but didn't get one"));
             }
         }
 
         @Override
         public void onFailure(Throwable e) {
-            pageDownstreamContext.failure(e);
+            pageDownstreamContext.failure(bucketIdx, e);
         }
     }
 

--- a/sql/src/main/java/io/crate/executor/transport/merge/TransportDistributedResultAction.java
+++ b/sql/src/main/java/io/crate/executor/transport/merge/TransportDistributedResultAction.java
@@ -114,7 +114,7 @@ public class TransportDistributedResultAction implements NodeAction<DistributedR
             Throwable throwable = request.throwable();
             if (throwable != null) {
                 listener.onResponse(new DistributedResultResponse(false));
-                pageDownstreamContext.failure(throwable);
+                pageDownstreamContext.failure(request.bucketIdx(), throwable);
             } else {
                 request.streamers(pageDownstreamContext.streamer());
                 pageDownstreamContext.setBucket(

--- a/sql/src/main/java/io/crate/jobs/ContextCallback.java
+++ b/sql/src/main/java/io/crate/jobs/ContextCallback.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.jobs;
+
+public interface ContextCallback {
+    void onClose();
+}

--- a/sql/src/main/java/io/crate/jobs/ExecutionSubContext.java
+++ b/sql/src/main/java/io/crate/jobs/ExecutionSubContext.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.jobs;
+
+public interface ExecutionSubContext {
+    void addCallback(ContextCallback contextCallback);
+}


### PR DESCRIPTION
In the next couple commits the context handling will be changed so that the
PageDownstreamContext will destroy itself if is is finished/failed. In order
for that to work finish/fail must not be called until all upstreams are done 
sending requests.