### PR TITLE
do not create a JobExecutionContext if the given builder is empty

### DIFF
--- a/sql/src/main/java/io/crate/jobs/JobContextService.java
+++ b/sql/src/main/java/io/crate/jobs/JobContextService.java
@@ -96,7 +96,11 @@ public class JobContextService extends AbstractLifecycleComponent<JobContextServ
         return new JobExecutionContext.Builder(jobId, threadPool);
     }
 
+    @Nullable
     public JobExecutionContext createOrMergeContext(JobExecutionContext.Builder contextBuilder) {
+        if (contextBuilder.isEmpty()) {
+            return null;
+        }
         final UUID jobId = contextBuilder.jobId();
         JobExecutionContext newContext = contextBuilder.build();
 

--- a/sql/src/main/java/io/crate/jobs/JobExecutionContext.java
+++ b/sql/src/main/java/io/crate/jobs/JobExecutionContext.java
@@ -82,6 +82,10 @@ public class JobExecutionContext {
             }
         }
 
+        boolean isEmpty() {
+            return collectContextMap.isEmpty() && pageDownstreamContextMap.isEmpty();
+        }
+
         public UUID jobId() {
             return jobId;
         }
@@ -95,6 +99,7 @@ public class JobExecutionContext {
                     pageDownstreamContextMap
             );
         }
+
     }
 
     private JobExecutionContext(UUID jobId,

--- a/sql/src/test/java/io/crate/jobs/JobContextServiceTest.java
+++ b/sql/src/test/java/io/crate/jobs/JobContextServiceTest.java
@@ -78,6 +78,12 @@ public class JobContextServiceTest extends CrateUnitTest {
     }
 
     @Test
+    public void testCreateCallWithEmptyBuilderReturnsNull() throws Exception {
+        JobExecutionContext.Builder builder = jobContextService.newBuilder(UUID.randomUUID());
+        assertThat(jobContextService.createOrMergeContext(builder), nullValue());
+    }
+
+    @Test
     public void testAccessContext() throws Exception {
         JobExecutionContext ctx1 = getJobExecutionContextWithOneActiveSubContext(jobContextService);
         assertThat(ctx1.lastAccessTime(), is(-1L));


### PR DESCRIPTION
the close-callbacks would never fire and the context wouldn't be cleaned up