### PR TITLE
use only 1 map for subContexts in JobExecutionContext

### DIFF
--- a/sql/src/main/java/io/crate/action/job/ContextPreparer.java
+++ b/sql/src/main/java/io/crate/action/job/ContextPreparer.java
@@ -178,7 +178,7 @@ public class ContextPreparer {
             Futures.addCallback(downstream.result(), new OperationFinishedStatsTablesCallback<Bucket>(
                     node.executionNodeId(), statsTables, context.ramAccountingContext));
 
-            context.contextBuilder.addPageDownstreamContext(node.executionNodeId(), pageDownstreamContext);
+            context.contextBuilder.addSubContext(node.executionNodeId(), pageDownstreamContext);
             return null;
         }
 
@@ -196,7 +196,7 @@ public class ContextPreparer {
                     context.ramAccountingContext,
                     downstream
             );
-            context.contextBuilder.addCollectContext(node.executionNodeId(), jobCollectContext);
+            context.contextBuilder.addSubContext(node.executionNodeId(), jobCollectContext);
             if (!node.keepContextForFetcher()) {
                 downstream.result().addListener(new Runnable() {
                     @Override

--- a/sql/src/main/java/io/crate/action/job/ExecutionNodeOperationStarter.java
+++ b/sql/src/main/java/io/crate/action/job/ExecutionNodeOperationStarter.java
@@ -89,7 +89,7 @@ public class ExecutionNodeOperationStarter implements RowUpstream {
 
         @Override
         public Void visitCollectNode(final CollectNode collectNode, final JobExecutionContext context) {
-            final JobCollectContext collectContext = context.getCollectContext(collectNode.executionNodeId());
+            final JobCollectContext collectContext = context.getSubContext(collectNode.executionNodeId());
             threadPool.executor(COLLECT_EXECUTOR).execute(new Runnable() {
                 @Override
                 public void run() {

--- a/sql/src/main/java/io/crate/executor/transport/ExecutionNodesTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/ExecutionNodesTask.java
@@ -201,7 +201,7 @@ public class ExecutionNodesTask extends JobTask {
         Collection<ExecutionNode> localExecutionNodes = nodesByServer.remove(localNodeId);
 
         JobExecutionContext.Builder builder = jobContextService.newBuilder(jobId());
-        builder.addPageDownstreamContext(mergeNode.executionNodeId(), finalLocalMerge);
+        builder.addSubContext(mergeNode.executionNodeId(), finalLocalMerge);
 
         if (localExecutionNodes == null || localExecutionNodes.isEmpty()) {
             // only the local merge happens locally so it is enough to just create that context.

--- a/sql/src/main/java/io/crate/executor/transport/merge/TransportDistributedResultAction.java
+++ b/sql/src/main/java/io/crate/executor/transport/merge/TransportDistributedResultAction.java
@@ -110,7 +110,7 @@ public class TransportDistributedResultAction implements NodeAction<DistributedR
             return;
         }
 
-        PageDownstreamContext pageDownstreamContext = context.getPageDownstreamContext(request.executionNodeId());
+        PageDownstreamContext pageDownstreamContext = context.getSubContextOrNull(request.executionNodeId());
         if (pageDownstreamContext == null) {
             // this is currently sometimes the case when upstreams send failures more than once
             listener.onFailure(new IllegalStateException(String.format(Locale.ENGLISH,

--- a/sql/src/main/java/io/crate/jobs/ExecutionSubContext.java
+++ b/sql/src/main/java/io/crate/jobs/ExecutionSubContext.java
@@ -22,5 +22,7 @@
 package io.crate.jobs;
 
 public interface ExecutionSubContext {
+
     void addCallback(ContextCallback contextCallback);
+    void close();
 }

--- a/sql/src/main/java/io/crate/jobs/PageDownstreamContext.java
+++ b/sql/src/main/java/io/crate/jobs/PageDownstreamContext.java
@@ -170,6 +170,11 @@ public class PageDownstreamContext implements ExecutionSubContext {
         callbacks.add(contextCallback);
     }
 
+    @Override
+    public void close() {
+        finish();
+    }
+
     private class ResultListenerBridgingConsumeListener implements PageConsumeListener {
 
         @Override

--- a/sql/src/main/java/io/crate/operation/collect/MapSideDataCollectOperation.java
+++ b/sql/src/main/java/io/crate/operation/collect/MapSideDataCollectOperation.java
@@ -241,7 +241,7 @@ public class MapSideDataCollectOperation implements CollectOperation, RowUpstrea
         context = jobContextService.getContext(collectNode.jobId().get());
         JobCollectContext jobCollectContext;
         try {
-            jobCollectContext = context.getCollectContext(collectNode.executionNodeId());
+            jobCollectContext = context.getSubContext(collectNode.executionNodeId());
         } catch (IllegalArgumentException e) {
             downstream.registerUpstream(this).finish();
             return;

--- a/sql/src/main/java/io/crate/operation/fetch/NodeFetchOperation.java
+++ b/sql/src/main/java/io/crate/operation/fetch/NodeFetchOperation.java
@@ -119,7 +119,7 @@ public class NodeFetchOperation implements RowUpstream {
         int numShards = shardBuckets.size();
 
         JobExecutionContext jobExecutionContext = jobContextService.getContext(jobId);
-        JobCollectContext jobCollectContext = jobExecutionContext.getCollectContext(executionNodeId);
+        JobCollectContext jobCollectContext = jobExecutionContext.getSubContext(executionNodeId);
 
         RowDownstream upstreamsRowMerger = new PositionalRowMerger(rowDownstream, toFetchReferences.size());
 

--- a/sql/src/test/java/io/crate/jobs/JobExecutionContextTest.java
+++ b/sql/src/test/java/io/crate/jobs/JobExecutionContextTest.java
@@ -55,12 +55,12 @@ public class JobExecutionContextTest extends CrateUnitTest {
     @Test
     public void testAddTheSameContextTwiceThrowsAnError() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("PageDownstreamContext for 1 already added");
+        expectedException.expectMessage("ExecutionSubContext for 1 already added");
 
         JobExecutionContext.Builder builder = new JobExecutionContext.Builder(UUID.randomUUID(), threadPool);
 
-        builder.addPageDownstreamContext(1, mock(PageDownstreamContext.class));
-        builder.addPageDownstreamContext(1, mock(PageDownstreamContext.class));
+        builder.addSubContext(1, mock(PageDownstreamContext.class));
+        builder.addSubContext(1, mock(PageDownstreamContext.class));
     }
 
     @Test
@@ -69,12 +69,12 @@ public class JobExecutionContextTest extends CrateUnitTest {
         expectedException.expectMessage("subContext 1 is already present");
 
         JobExecutionContext.Builder builder = new JobExecutionContext.Builder(UUID.randomUUID(), threadPool);
-        builder.addPageDownstreamContext(1, mock(PageDownstreamContext.class));
+        builder.addSubContext(1, mock(PageDownstreamContext.class));
 
         JobExecutionContext firstContext = builder.build();
 
         builder = new JobExecutionContext.Builder(UUID.randomUUID(), threadPool);
-        builder.addPageDownstreamContext(1, mock(PageDownstreamContext.class));
+        builder.addSubContext(1, mock(PageDownstreamContext.class));
 
         firstContext.merge(builder.build());
     }

--- a/sql/src/test/java/io/crate/operation/collect/LocalDataCollectTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/LocalDataCollectTest.java
@@ -542,7 +542,7 @@ public class LocalDataCollectTest extends CrateUnitTest {
     private Bucket getBucket(CollectNode collectNode) throws InterruptedException, ExecutionException {
         CollectingProjector cd = new CollectingProjector();
         JobExecutionContext.Builder builder = jobContextService.newBuilder(collectNode.jobId().get());
-        builder.addCollectContext(
+        builder.addSubContext(
                 collectNode.executionNodeId(),
                 new JobCollectContext(collectNode.jobId().get(), RAM_ACCOUNTING_CONTEXT, cd));
         jobContextService.createOrMergeContext(builder);

--- a/sql/src/test/java/io/crate/operation/collect/LuceneDocCollectorTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/LuceneDocCollectorTest.java
@@ -155,7 +155,7 @@ public class LuceneDocCollectorTest extends SQLTransportIntegrationTest {
         int jobSearchContextId = 0;
         JobExecutionContext.Builder builder = jobContextService.newBuilder(jobId);
         JobCollectContext collectContext = new JobCollectContext(jobId, RAM_ACCOUNTING_CONTEXT, collectingProjector);
-        builder.addCollectContext(node.executionNodeId(), collectContext);
+        builder.addSubContext(node.executionNodeId(), collectContext);
         jobContextService.createOrMergeContext(builder);
         collectContext.registerJobContextId(shardId, jobSearchContextId);
         LuceneDocCollector collector = (LuceneDocCollector)shardCollectService.getCollector(node, projectorChain, collectContext, 0);
@@ -342,7 +342,7 @@ public class LuceneDocCollectorTest extends SQLTransportIntegrationTest {
         node.maxRowGranularity(RowGranularity.DOC);
 
         JobExecutionContext.Builder builder = jobContextService.newBuilder(node.jobId().get());
-        builder.addCollectContext(node.executionNodeId(),
+        builder.addSubContext(node.executionNodeId(),
                 new JobCollectContext(node.jobId().get(), RAM_ACCOUNTING_CONTEXT, collectingProjector));
         jobContextService.createOrMergeContext(builder);
 
@@ -350,7 +350,7 @@ public class LuceneDocCollectorTest extends SQLTransportIntegrationTest {
         when(projectorChain.newShardDownstreamProjector(any(ProjectionToProjectorVisitor.class))).thenReturn(collectingProjector);
 
         int jobSearchContextId = 0;
-        JobCollectContext jobCollectContext = jobContextService.getContext(node.jobId().get()).getCollectContext(node.executionNodeId());
+        JobCollectContext jobCollectContext = jobContextService.getContext(node.jobId().get()).getSubContext(node.executionNodeId());
         ShardId shardId = new ShardId("test", 0);
         jobCollectContext.registerJobContextId(shardId, jobSearchContextId);
         LuceneDocCollector collector = (LuceneDocCollector)shardCollectService.getCollector(node, projectorChain, jobCollectContext, 0);

--- a/sql/src/test/java/io/crate/operation/fetch/NodeFetchOperationTest.java
+++ b/sql/src/test/java/io/crate/operation/fetch/NodeFetchOperationTest.java
@@ -94,7 +94,7 @@ public class NodeFetchOperationTest extends CrateUnitTest {
     public void testFetchOperationNoLuceneDocCollector() throws Exception {
         UUID jobId = UUID.randomUUID();
         JobExecutionContext.Builder builder = jobContextService.newBuilder(jobId);
-        builder.addCollectContext(1, new JobCollectContext(jobId, RAM_ACCOUNTING_CONTEXT, new CollectingProjector()));
+        builder.addSubContext(1, new JobCollectContext(jobId, RAM_ACCOUNTING_CONTEXT, new CollectingProjector()));
         jobContextService.createOrMergeContext(builder);
 
         NodeFetchOperation nodeFetchOperation = new NodeFetchOperation(

--- a/stresstest/src/test/java/io/crate/benchmark/LuceneDocCollectorBenchmark.java
+++ b/stresstest/src/test/java/io/crate/benchmark/LuceneDocCollectorBenchmark.java
@@ -201,7 +201,7 @@ public class LuceneDocCollectorBenchmark extends BenchmarkBase {
         int jobSearchContextId = 0;
         JobExecutionContext.Builder builder = jobContextService.newBuilder(jobId);
         JobCollectContext collectContext = new JobCollectContext(jobId, RAM_ACCOUNTING_CONTEXT, collectingProjector);
-        builder.addCollectContext(node.executionNodeId(), collectContext);
+        builder.addSubContext(node.executionNodeId(), collectContext);
         collectContext.registerJobContextId(shardId, jobSearchContextId);
         LuceneDocCollector collector = (LuceneDocCollector)shardCollectService.getCollector(node, projectorChain, collectContext, 0);
         collector.pageSize(PAGE_SIZE);


### PR DESCRIPTION
to make it easier to use it for other SubContext implementations