### PR TITLE
count operation: expose Futures for the callableList

### DIFF
--- a/sql/src/main/java/io/crate/jobs/CountContext.java
+++ b/sql/src/main/java/io/crate/jobs/CountContext.java
@@ -23,6 +23,7 @@ package io.crate.jobs;
 
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
 import io.crate.analyze.WhereClause;
 import io.crate.core.collections.Row1;
 import io.crate.operation.RowDownstream;
@@ -59,7 +60,8 @@ public class CountContext implements RowUpstream, ExecutionSubContext {
 
     public void start() {
         try {
-            Futures.addCallback(countOperation.count(indexShardMap, whereClause), new FutureCallback<Long>() {
+            ListenableFuture<Long> countFuture = countOperation.count(indexShardMap, whereClause);
+            Futures.addCallback(countFuture, new FutureCallback<Long>() {
                 @Override
                 public void onSuccess(@Nullable Long result) {
                     rowDownstreamHandle.setNextRow(new Row1(result));

--- a/sql/src/main/java/io/crate/operation/count/CountOperation.java
+++ b/sql/src/main/java/io/crate/operation/count/CountOperation.java
@@ -34,5 +34,5 @@ public interface CountOperation {
 
     ListenableFuture<Long> count(Map<String, ? extends Collection<Integer>> indexShardMap,
                                  WhereClause whereClause) throws IOException, InterruptedException;
-    long count(String index, int shardId, WhereClause whereClause) throws IOException;
+    long count(String index, int shardId, WhereClause whereClause) throws IOException, InterruptedException;
 }


### PR DESCRIPTION
This commit changes the countOperation execution to expose a Future which
wraps the underlying Futures which actually present tasks that are being
executed by the underlying threads.

This way if the future is cancelled the threads have
``interrupted` set and can terminate early.