### PR TITLE
fix group by with multiple group by keys and no order by but limit

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,9 @@ Unreleased
 
 NOTE: Upgrading from 0.47 or earlier versions requires a full cluster restart
 
+ - Fixed an issue that caused GROUP BY queries with multiple group keys, no
+   order by and limit to hang.
+
  - Increased performance of ``hostname`` and ``id`` expression for ``sys.nodes`` table
 
 2015/04/28 0.48.3

--- a/sql/src/main/java/io/crate/operation/projectors/GroupingProjector.java
+++ b/sql/src/main/java/io/crate/operation/projectors/GroupingProjector.java
@@ -357,14 +357,13 @@ public class GroupingProjector implements Projector, RowDownstreamHandle {
             // 2nd level
             ramAccountingContext.addBytes(RamAccountingContext.roundUp(12 +
                     (keyInputs.size() + aggregators.length) * 4));
-            //Object[][] rows = new Object[result.size()][keyInputs.size() + aggregators.length];
             RowN row = new RowN(keyInputs.size() + aggregators.length);
             for (Map.Entry<List<Object>, Object[]> entry : result.entrySet()) {
                 Object[] cells = new Object[row.size()];
                 transformToRow(entry, cells, aggregators);
                 row.cells(cells);
                 if (!downstream.setNextRow(row)){
-                    return;
+                    break;
                 }
             }
             downstream.finish();

--- a/sql/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
@@ -69,6 +69,17 @@ public class GroupByAggregateTest extends SQLTransportIntegrationTest {
         assertEquals(34, response.rows()[1][0]);
     }
 
+    @Test
+    public void testNonDistributedGroupByWithManyKeysNoOrderByAndLimit() throws Exception {
+        execute("create table t (name string, x int) clustered by (name) with (number_of_replicas = 0)");
+        ensureYellow();
+
+        execute("insert into t (name, x) values ('Marvin', 1), ('Trillian', 1), ('Ford', 1), ('Arthur', 1)");
+        execute("refresh table t");
+
+        execute("select count(*), name from t group by name, x limit 2");
+        assertThat(response.rowCount(), is(2L));
+    }
 
     @Test
     public void testGroupByOnClusteredByColumnPartOfPrimaryKey() throws Exception {


### PR DESCRIPTION
finish on the downstream was never called if downstream.setNextRow returned
false