### PR TITLE
Fix: In some cases a ``DROP TABLE`` statment does

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,10 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fix: In some cases a ``DROP TABLE`` statment does not delete all
+   partitions. Now it's possible to repeat the statement in order
+   to delete the orphaned partitions.
+
  - Added the IF NOT EXISTS clause to the CREATE TABLE statement
 
 2015/05/07 0.49.0


### PR DESCRIPTION
not delete all partitions. Now it's possible to repeat the  statement in order to delete the orphaned
partitions.