### PR TITLE
return number of jobs killed in JobContextService.killAll()

### DIFF
--- a/sql/src/main/java/io/crate/jobs/JobContextService.java
+++ b/sql/src/main/java/io/crate/jobs/JobContextService.java
@@ -129,7 +129,9 @@ public class JobContextService extends AbstractLifecycleComponent<JobContextServ
         writeLock.lock();
         try {
             for (JobExecutionContext jobExecutionContext : activeContexts.values()) {
-                numKilled += jobExecutionContext.kill();
+                jobExecutionContext.kill();
+                 // don't use  numKilled = activeContext.size() because the content of activeContexts could change
+                numKilled++;
             }
             assert activeContexts.size() == 0 :
                     "after killing all contexts they should have been removed from the map due to the callbacks";


### PR DESCRIPTION
instead of number of operations.