### PR TITLE
refactored abstract expression base classes

### DIFF
--- a/sql/src/main/java/io/crate/metadata/ReferenceImplementation.java
+++ b/sql/src/main/java/io/crate/metadata/ReferenceImplementation.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.  You may
  * obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
@@ -21,7 +21,9 @@
 
 package io.crate.metadata;
 
-public interface ReferenceImplementation {
+import io.crate.operation.Input;
+
+public interface ReferenceImplementation<T> extends Input<T> {
 
     /**
      * Returns an implementation for a child.

--- a/sql/src/main/java/io/crate/metadata/RowContextCollectorExpression.java
+++ b/sql/src/main/java/io/crate/metadata/RowContextCollectorExpression.java
@@ -23,7 +23,7 @@ package io.crate.metadata;
 
 import io.crate.operation.Input;
 
-public abstract class RowContextCollectorExpression<R, T> implements ReferenceImplementation, Input<T> {
+public abstract class RowContextCollectorExpression<R, T> implements ReferenceImplementation<T> {
 
     protected final ReferenceInfo info;
     protected R row;

--- a/sql/src/main/java/io/crate/metadata/SimpleObjectExpression.java
+++ b/sql/src/main/java/io/crate/metadata/SimpleObjectExpression.java
@@ -19,16 +19,16 @@
  * software solely pursuant to the terms of the relevant commercial agreement.
  */
 
-package io.crate.metadata.sys;
+package io.crate.metadata;
 
 import io.crate.metadata.ReferenceImplementation;
 import io.crate.operation.Input;
 
 /**
- * Base class for system expressions. Implementations of system expressions should inherit from it.
+ * Base class for expressions. Implementations of expressions should inherit from it.
  * @param <T> The returnType of the expression
  */
-public abstract class SysExpression<T> implements ReferenceImplementation, Input<T> {
+public abstract class SimpleObjectExpression<T> implements ReferenceImplementation<T> {
 
     @Override
     public ReferenceImplementation getChildImplementation(String name) {

--- a/sql/src/main/java/io/crate/metadata/information/RowCollectExpression.java
+++ b/sql/src/main/java/io/crate/metadata/information/RowCollectExpression.java
@@ -29,7 +29,7 @@ import io.crate.operation.Input;
  * Base class for information_schema expressions.
  * @param <T> The returnType of the expression
  */
-public abstract class RowCollectExpression<R, T> implements ReferenceImplementation, Input<T> {
+public abstract class RowCollectExpression<R, T> implements ReferenceImplementation<T> {
 
     protected final ReferenceInfo info;
     protected R row;

--- a/sql/src/main/java/io/crate/metadata/shard/ShardReferenceImplementation.java
+++ b/sql/src/main/java/io/crate/metadata/shard/ShardReferenceImplementation.java
@@ -23,5 +23,5 @@ package io.crate.metadata.shard;
 
 import io.crate.metadata.ReferenceImplementation;
 
-public interface ShardReferenceImplementation extends ReferenceImplementation {
+public interface ShardReferenceImplementation<T> extends ReferenceImplementation<T> {
 }

--- a/sql/src/main/java/io/crate/metadata/shard/blob/BlobShardReferenceImplementation.java
+++ b/sql/src/main/java/io/crate/metadata/shard/blob/BlobShardReferenceImplementation.java
@@ -23,5 +23,5 @@ package io.crate.metadata.shard.blob;
 
 import io.crate.metadata.ReferenceImplementation;
 
-public interface BlobShardReferenceImplementation extends ReferenceImplementation {
+public interface BlobShardReferenceImplementation<T> extends ReferenceImplementation<T> {
 }

--- a/sql/src/main/java/io/crate/metadata/shard/unassigned/UnassignedShardCollectorExpression.java
+++ b/sql/src/main/java/io/crate/metadata/shard/unassigned/UnassignedShardCollectorExpression.java
@@ -7,7 +7,7 @@ import io.crate.metadata.ReferenceInfo;
 import io.crate.metadata.sys.SysShardsTableInfo;
 import io.crate.operation.Input;
 
-public abstract class UnassignedShardCollectorExpression<T> implements ReferenceImplementation, Input<T> {
+public abstract class UnassignedShardCollectorExpression<T> implements ReferenceImplementation<T> {
 
     private final ReferenceInfo info;
     protected UnassignedShard row;

--- a/sql/src/main/java/io/crate/operation/reference/NestedObjectExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/NestedObjectExpression.java
@@ -19,30 +19,32 @@
  * software solely pursuant to the terms of the relevant commercial agreement.
  */
 
-package io.crate.operation.reference.sys;
+package io.crate.operation.reference;
 
 import io.crate.metadata.ReferenceImplementation;
-import io.crate.metadata.sys.SysExpression;
 import org.apache.lucene.util.BytesRef;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-public abstract class SysObjectReference extends SysExpression<Map<String, Object>>
-        implements ReferenceImplementation {
+public abstract class NestedObjectExpression implements ReferenceImplementation<Map<String, Object>> {
 
-    protected final Map<String, SysExpression> childImplementations = new HashMap<>();
+    protected final Map<String, ReferenceImplementation> childImplementations = new HashMap<>();
+
+    public Map<String, ReferenceImplementation> getChildImplementations() {
+        return childImplementations;
+    }
 
     @Override
-    public SysExpression getChildImplementation(String name) {
+    public ReferenceImplementation getChildImplementation(String name) {
         return childImplementations.get(name);
     }
 
     @Override
     public Map<String,Object> value() {
         Map<String, Object> map = new HashMap<>();
-        for (Map.Entry<String, SysExpression> e : childImplementations.entrySet()) {
+        for (Map.Entry<String, ReferenceImplementation> e : childImplementations.entrySet()) {
             Object value = e.getValue().value();
 
             // convert nested columns of type e.getValue().value() to String here
@@ -54,4 +56,5 @@ public abstract class SysObjectReference extends SysExpression<Map<String, Objec
         }
         return Collections.unmodifiableMap(map);
     }
+
 }

--- a/sql/src/main/java/io/crate/operation/reference/partitioned/PartitionedColumnExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/partitioned/PartitionedColumnExpression.java
@@ -27,7 +27,7 @@ import io.crate.metadata.shard.ShardReferenceImplementation;
 import io.crate.operation.Input;
 import org.apache.lucene.util.BytesRef;
 
-public class PartitionedColumnExpression implements Input, ShardReferenceImplementation {
+public class PartitionedColumnExpression implements ShardReferenceImplementation {
 
     private final Object value;
 

--- a/sql/src/main/java/io/crate/operation/reference/sys/SysClusterObjectReference.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/SysClusterObjectReference.java
@@ -22,10 +22,10 @@
 package io.crate.operation.reference.sys;
 
 import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.ReferenceInfo;
 import io.crate.metadata.sys.SysClusterTableInfo;
+import io.crate.operation.reference.NestedObjectExpression;
 
-public abstract class SysClusterObjectReference extends SysObjectReference {
+public abstract class SysClusterObjectReference extends NestedObjectExpression {
 
     protected SysClusterObjectReference(String name) {
         this(new ColumnIdent(name));

--- a/sql/src/main/java/io/crate/operation/reference/sys/SysNodeObjectReference.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/SysNodeObjectReference.java
@@ -1,8 +1,9 @@
 package io.crate.operation.reference.sys;
 
+import io.crate.operation.reference.NestedObjectExpression;
 import io.crate.operation.reference.sys.node.SysNodeExpression;
 
-public abstract class SysNodeObjectReference extends SysObjectReference {
+public abstract class SysNodeObjectReference extends NestedObjectExpression {
 
     protected abstract class ChildExpression<T> extends SysNodeExpression<T> {
 

--- a/sql/src/main/java/io/crate/operation/reference/sys/SysStaticObjectArrayReference.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/SysStaticObjectArrayReference.java
@@ -21,15 +21,17 @@
 
 package io.crate.operation.reference.sys;
 
+import io.crate.operation.reference.NestedObjectExpression;
+
 import java.util.ArrayList;
 import java.util.List;
 
 public abstract class SysStaticObjectArrayReference extends SysObjectArrayReference {
 
-    protected final List<SysObjectReference> childImplementations = new ArrayList<>();
+    protected final List<NestedObjectExpression> childImplementations = new ArrayList<>();
 
     @Override
-    protected List<SysObjectReference> getChildImplementations() {
+    protected List<NestedObjectExpression> getChildImplementations() {
         return childImplementations;
     }
 

--- a/sql/src/main/java/io/crate/operation/reference/sys/cluster/SysClusterExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/cluster/SysClusterExpression.java
@@ -23,13 +23,10 @@ package io.crate.operation.reference.sys.cluster;
 
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.ReferenceImplementation;
-import io.crate.metadata.ReferenceInfo;
 import io.crate.metadata.sys.SysClusterTableInfo;
-import io.crate.metadata.sys.SysExpression;
-import org.elasticsearch.common.Preconditions;
+import io.crate.metadata.SimpleObjectExpression;
 
-public abstract class SysClusterExpression<T> extends SysExpression<T> implements ReferenceImplementation {
-
+public abstract class SysClusterExpression<T> extends SimpleObjectExpression<T> {
 
     protected SysClusterExpression(String name) {
         this(new ColumnIdent(name));

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/NodeSysExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/NodeSysExpression.java
@@ -25,12 +25,12 @@ import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.ReferenceImplementation;
 import io.crate.metadata.ReferenceInfo;
 import io.crate.metadata.ReferenceResolver;
-import io.crate.metadata.sys.SysExpression;
+import io.crate.metadata.SimpleObjectExpression;
 import io.crate.metadata.sys.SysNodesTableInfo;
-import io.crate.operation.reference.sys.SysObjectReference;
+import io.crate.operation.reference.NestedObjectExpression;
 import org.elasticsearch.common.inject.Inject;
 
-public class NodeSysExpression extends SysObjectReference {
+public class NodeSysExpression extends NestedObjectExpression {
 
     private final SysNodesTableInfo tableInfo;
     private final ReferenceResolver resolver;
@@ -42,7 +42,7 @@ public class NodeSysExpression extends SysObjectReference {
         for (ReferenceInfo info : tableInfo.columns()) {
             childImplementations.put(
                     info.ident().columnIdent().name(),
-                    (SysExpression) resolver.getImplementation(info.ident()));
+                    resolver.getImplementation(info.ident()));
         }
     }
 

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/SysNodeExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/SysNodeExpression.java
@@ -22,8 +22,8 @@
 package io.crate.operation.reference.sys.node;
 
 import io.crate.metadata.ReferenceImplementation;
-import io.crate.metadata.sys.SysExpression;
+import io.crate.metadata.SimpleObjectExpression;
 
-public abstract class SysNodeExpression<T> extends SysExpression<T> implements ReferenceImplementation {
+public abstract class SysNodeExpression<T> extends SimpleObjectExpression<T> {
 
 }

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/fs/NodeFsDataExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/fs/NodeFsDataExpression.java
@@ -25,7 +25,7 @@ import com.google.common.collect.ImmutableList;
 import io.crate.metadata.ColumnIdent;
 import io.crate.operation.reference.sys.SysNodeObjectReference;
 import io.crate.operation.reference.sys.SysNodeStaticObjectArrayReference;
-import io.crate.operation.reference.sys.SysObjectReference;
+import io.crate.operation.reference.NestedObjectExpression;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
@@ -52,7 +52,7 @@ public class NodeFsDataExpression extends SysNodeStaticObjectArrayReference {
     }
 
     @Override
-    protected List<SysObjectReference> getChildImplementations() {
+    protected List<NestedObjectExpression> getChildImplementations() {
         if (childImplementations.isEmpty()) {
             addChildImplementations();
         }

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/fs/NodeFsDisksExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/fs/NodeFsDisksExpression.java
@@ -25,7 +25,7 @@ import com.google.common.collect.ImmutableList;
 import io.crate.metadata.ColumnIdent;
 import io.crate.operation.reference.sys.SysNodeObjectArrayReference;
 import io.crate.operation.reference.sys.SysNodeObjectReference;
-import io.crate.operation.reference.sys.SysObjectReference;
+import io.crate.operation.reference.NestedObjectExpression;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
@@ -50,8 +50,8 @@ public class NodeFsDisksExpression extends SysNodeObjectArrayReference {
     }
 
     @Override
-    protected List<SysObjectReference> getChildImplementations() {
-        List<SysObjectReference> diskRefs;
+    protected List<NestedObjectExpression> getChildImplementations() {
+        List<NestedObjectExpression> diskRefs;
         if (sigarService.sigarAvailable()) {
             try {
                 FileSystem[] fileSystems = sigarService.sigar().getFileSystemList();

--- a/sql/src/main/java/io/crate/operation/reference/sys/shard/SysShardExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/shard/SysShardExpression.java
@@ -22,8 +22,8 @@
 package io.crate.operation.reference.sys.shard;
 
 import io.crate.metadata.shard.ShardReferenceImplementation;
-import io.crate.metadata.sys.SysExpression;
+import io.crate.metadata.SimpleObjectExpression;
 
-public abstract class SysShardExpression<T> extends SysExpression<T> implements ShardReferenceImplementation {
+public abstract class SysShardExpression<T> extends SimpleObjectExpression<T> {
 
 }

--- a/sql/src/main/java/io/crate/operation/reference/sys/shard/blob/BlobShardIdExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/shard/blob/BlobShardIdExpression.java
@@ -26,7 +26,7 @@ import io.crate.operation.reference.sys.shard.ShardIdExpression;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.index.shard.ShardId;
 
-public class BlobShardIdExpression extends ShardIdExpression implements BlobShardReferenceImplementation {
+public class BlobShardIdExpression extends ShardIdExpression implements BlobShardReferenceImplementation<Integer> {
 
     @Inject
     public BlobShardIdExpression(ShardId shardId) {

--- a/sql/src/main/java/io/crate/operation/reference/sys/shard/blob/BlobShardNumDocsExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/shard/blob/BlobShardNumDocsExpression.java
@@ -26,7 +26,7 @@ import io.crate.metadata.shard.blob.BlobShardReferenceImplementation;
 import io.crate.operation.reference.sys.shard.SysShardExpression;
 import org.elasticsearch.common.inject.Inject;
 
-public class BlobShardNumDocsExpression extends SysShardExpression<Long> implements BlobShardReferenceImplementation {
+public class BlobShardNumDocsExpression extends SysShardExpression<Long> implements BlobShardReferenceImplementation<Long> {
     public static final String NAME = "num_docs";
 
     private final BlobShard blobShard;

--- a/sql/src/main/java/io/crate/operation/reference/sys/shard/blob/BlobShardPartitionIdentExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/shard/blob/BlobShardPartitionIdentExpression.java
@@ -26,7 +26,7 @@ import io.crate.operation.reference.sys.shard.SysShardExpression;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.inject.Inject;
 
-public class BlobShardPartitionIdentExpression extends SysShardExpression<BytesRef> implements BlobShardReferenceImplementation {
+public class BlobShardPartitionIdentExpression extends SysShardExpression<BytesRef> implements BlobShardReferenceImplementation<BytesRef> {
 
     public static final String NAME = "partition_ident";
     private static final BytesRef value = new BytesRef("");

--- a/sql/src/main/java/io/crate/operation/reference/sys/shard/blob/BlobShardPartitionOrphanedExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/shard/blob/BlobShardPartitionOrphanedExpression.java
@@ -25,7 +25,7 @@ import io.crate.metadata.shard.blob.BlobShardReferenceImplementation;
 import io.crate.operation.reference.sys.shard.SysShardExpression;
 import org.elasticsearch.common.inject.Inject;
 
-public class BlobShardPartitionOrphanedExpression extends SysShardExpression<Boolean> implements BlobShardReferenceImplementation {
+public class BlobShardPartitionOrphanedExpression extends SysShardExpression<Boolean> implements BlobShardReferenceImplementation<Boolean> {
 
     public static final String NAME = "orphan_partition";
 

--- a/sql/src/main/java/io/crate/operation/reference/sys/shard/blob/BlobShardPrimaryExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/shard/blob/BlobShardPrimaryExpression.java
@@ -26,7 +26,7 @@ import io.crate.operation.reference.sys.shard.ShardPrimaryExpression;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.index.shard.IndexShard;
 
-public class BlobShardPrimaryExpression extends ShardPrimaryExpression implements BlobShardReferenceImplementation {
+public class BlobShardPrimaryExpression extends ShardPrimaryExpression implements BlobShardReferenceImplementation<Boolean> {
 
     @Inject
     public BlobShardPrimaryExpression(IndexShard indexShard) {

--- a/sql/src/main/java/io/crate/operation/reference/sys/shard/blob/BlobShardRelocatingNodeExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/shard/blob/BlobShardRelocatingNodeExpression.java
@@ -23,10 +23,11 @@ package io.crate.operation.reference.sys.shard.blob;
 
 import io.crate.metadata.shard.blob.BlobShardReferenceImplementation;
 import io.crate.operation.reference.sys.shard.ShardRelocatingNodeExpression;
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.index.shard.IndexShard;
 
-public class BlobShardRelocatingNodeExpression extends ShardRelocatingNodeExpression implements BlobShardReferenceImplementation {
+public class BlobShardRelocatingNodeExpression extends ShardRelocatingNodeExpression implements BlobShardReferenceImplementation<BytesRef> {
 
     @Inject
     public BlobShardRelocatingNodeExpression(IndexShard indexShard) {

--- a/sql/src/main/java/io/crate/operation/reference/sys/shard/blob/BlobShardSchemaNameExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/shard/blob/BlobShardSchemaNameExpression.java
@@ -26,7 +26,7 @@ import io.crate.metadata.shard.blob.BlobShardReferenceImplementation;
 import io.crate.operation.reference.sys.shard.SysShardExpression;
 import org.apache.lucene.util.BytesRef;
 
-public class BlobShardSchemaNameExpression extends SysShardExpression<BytesRef> implements BlobShardReferenceImplementation {
+public class BlobShardSchemaNameExpression extends SysShardExpression<BytesRef> implements BlobShardReferenceImplementation<BytesRef> {
 
     public static final String NAME = "schema_name";
     public static final BytesRef BLOB_SCHEMA_NAME = new BytesRef(BlobSchemaInfo.NAME);

--- a/sql/src/main/java/io/crate/operation/reference/sys/shard/blob/BlobShardSizeExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/shard/blob/BlobShardSizeExpression.java
@@ -30,7 +30,7 @@ import org.elasticsearch.common.inject.Inject;
 
 import java.util.concurrent.TimeUnit;
 
-public class BlobShardSizeExpression extends SysShardExpression<Long> implements BlobShardReferenceImplementation {
+public class BlobShardSizeExpression extends SysShardExpression<Long> implements BlobShardReferenceImplementation<Long> {
 
     public static final String NAME = "size";
 

--- a/sql/src/main/java/io/crate/operation/reference/sys/shard/blob/BlobShardStateExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/shard/blob/BlobShardStateExpression.java
@@ -23,10 +23,11 @@ package io.crate.operation.reference.sys.shard.blob;
 
 import io.crate.metadata.shard.blob.BlobShardReferenceImplementation;
 import io.crate.operation.reference.sys.shard.ShardStateExpression;
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.index.shard.IndexShard;
 
-public class BlobShardStateExpression extends ShardStateExpression implements BlobShardReferenceImplementation {
+public class BlobShardStateExpression extends ShardStateExpression implements BlobShardReferenceImplementation<BytesRef> {
 
     @Inject
     public BlobShardStateExpression(IndexShard indexShard) {

--- a/sql/src/main/java/io/crate/operation/reference/sys/shard/blob/BlobShardTableNameExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/shard/blob/BlobShardTableNameExpression.java
@@ -28,7 +28,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.index.shard.ShardId;
 
-public class BlobShardTableNameExpression extends SysShardExpression<BytesRef> implements BlobShardReferenceImplementation {
+public class BlobShardTableNameExpression extends SysShardExpression<BytesRef> implements BlobShardReferenceImplementation<BytesRef> {
 
     public static final String NAME = "table_name";
 

--- a/sql/src/test/java/io/crate/analyze/EvaluatingNormalizerTest.java
+++ b/sql/src/test/java/io/crate/analyze/EvaluatingNormalizerTest.java
@@ -2,7 +2,7 @@ package io.crate.analyze;
 
 import com.google.common.collect.ImmutableList;
 import io.crate.metadata.*;
-import io.crate.metadata.sys.SysExpression;
+import io.crate.metadata.SimpleObjectExpression;
 import io.crate.operation.operator.AndOperator;
 import io.crate.operation.operator.EqOperator;
 import io.crate.operation.operator.OperatorModule;
@@ -41,7 +41,7 @@ public class EvaluatingNormalizerTest extends CrateUnitTest {
         ReferenceIdent dummyLoadIdent = new ReferenceIdent(new TableIdent("test", "dummy"), "load");
         dummyLoadInfo = new ReferenceInfo(dummyLoadIdent, RowGranularity.NODE, DataTypes.DOUBLE);
 
-        referenceImplementationMap.put(dummyLoadIdent, new SysExpression<Double>() {
+        referenceImplementationMap.put(dummyLoadIdent, new SimpleObjectExpression<Double>() {
             @Override
             public Double value() {
                 return 0.08;

--- a/sql/src/test/java/io/crate/metadata/PartitionReferenceResolverTest.java
+++ b/sql/src/test/java/io/crate/metadata/PartitionReferenceResolverTest.java
@@ -38,6 +38,11 @@ public class PartitionReferenceResolverTest extends CrateUnitTest {
         ReferenceIdent ident = new ReferenceIdent(new TableIdent("doc", "foo"), "bar");
         when(fallbackRefResolver.getImplementation(ident)).thenReturn(new ReferenceImplementation() {
             @Override
+            public Object value() {
+                return null;
+            }
+
+            @Override
             public ReferenceImplementation getChildImplementation(String name) {
                 return null;
             }

--- a/sql/src/test/java/io/crate/operation/collect/LocalDataCollectTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/LocalDataCollectTest.java
@@ -120,7 +120,7 @@ import static org.mockito.Mockito.when;
 public class LocalDataCollectTest extends CrateUnitTest {
 
 
-    static class TestExpression implements ReferenceImplementation, Input<Integer> {
+    static class TestExpression implements ReferenceImplementation<Integer> {
         public static final ReferenceIdent ident = new ReferenceIdent(new TableIdent("default", "collect"), "truth");
         public static final ReferenceInfo info = new ReferenceInfo(ident, RowGranularity.NODE, DataTypes.INTEGER);
 
@@ -159,7 +159,7 @@ public class LocalDataCollectTest extends CrateUnitTest {
         }
     }
 
-    static class ShardIdExpression extends SysShardExpression<Integer> {
+    static class ShardIdExpression extends SysShardExpression<Integer> implements ShardReferenceImplementation<Integer> {
 
         private final ShardId shardId;
 

--- a/sql/src/test/java/io/crate/operation/reference/sys/SysExpressionsBytesRefTest.java
+++ b/sql/src/test/java/io/crate/operation/reference/sys/SysExpressionsBytesRefTest.java
@@ -21,7 +21,9 @@
 
 package io.crate.operation.reference.sys;
 
-import io.crate.metadata.sys.SysExpression;
+import io.crate.metadata.ReferenceImplementation;
+import io.crate.metadata.SimpleObjectExpression;
+import io.crate.operation.reference.NestedObjectExpression;
 import io.crate.test.integration.CrateUnitTest;
 import org.apache.lucene.util.BytesRef;
 import org.junit.Test;
@@ -32,7 +34,7 @@ import static org.hamcrest.Matchers.*;
 
 public class SysExpressionsBytesRefTest extends CrateUnitTest {
 
-    static class BytesRefNullSysExpression extends SysExpression<BytesRef> {
+    static class BytesRefNullSysExpression extends SimpleObjectExpression<BytesRef> {
 
         @Override
         public BytesRef value() {
@@ -41,7 +43,7 @@ public class SysExpressionsBytesRefTest extends CrateUnitTest {
 
     }
 
-    static class NullFieldSysObjectReference extends SysObjectReference {
+    static class NullFieldSysObjectReference extends NestedObjectExpression {
 
         protected NullFieldSysObjectReference() {
             childImplementations.put("n", new BytesRefNullSysExpression());
@@ -60,7 +62,7 @@ public class SysExpressionsBytesRefTest extends CrateUnitTest {
     @Test
     public void testSysObjectReferenceNull() throws Exception {
         NullFieldSysObjectReference nullRef = new NullFieldSysObjectReference();
-        SysExpression n = nullRef.getChildImplementation("n");
+        ReferenceImplementation n = nullRef.getChildImplementation("n");
         assertThat(n, instanceOf(BytesRefNullSysExpression.class));
 
         Map<String, Object> value = nullRef.value();

--- a/sql/src/test/java/io/crate/operation/reference/sys/SysShardsExpressionsTest.java
+++ b/sql/src/test/java/io/crate/operation/reference/sys/SysShardsExpressionsTest.java
@@ -26,7 +26,7 @@ import io.crate.metadata.shard.MetaDataShardModule;
 import io.crate.metadata.shard.ShardReferenceResolver;
 import io.crate.metadata.sys.MetaDataSysModule;
 import io.crate.metadata.sys.SysClusterTableInfo;
-import io.crate.metadata.sys.SysExpression;
+import io.crate.metadata.SimpleObjectExpression;
 import io.crate.metadata.sys.SysShardsTableInfo;
 import io.crate.operation.reference.sys.cluster.SysClusterExpressionModule;
 import io.crate.operation.reference.sys.shard.*;
@@ -49,7 +49,6 @@ import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.*;
 import org.elasticsearch.index.store.StoreStats;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
@@ -161,28 +160,28 @@ public class SysShardsExpressionsTest extends CrateUnitTest {
     public void testClusterExpression() throws Exception {
         // Looking up cluster wide expressions must work too
         ReferenceIdent ident = new ReferenceIdent(SysClusterTableInfo.IDENT, "name");
-        SysExpression<BytesRef> name = (SysExpression<BytesRef>) resolver.getImplementation(ident);
+        SimpleObjectExpression<BytesRef> name = (SimpleObjectExpression<BytesRef>) resolver.getImplementation(ident);
         assertEquals(new BytesRef("crate"), name.value());
     }
 
     @Test
     public void testId() throws Exception {
         ReferenceIdent ident = new ReferenceIdent(SysShardsTableInfo.IDENT, "id");
-        SysExpression<Integer> shardExpression = (SysExpression<Integer>) resolver.getImplementation(ident);
+        SimpleObjectExpression<Integer> shardExpression = (SimpleObjectExpression<Integer>) resolver.getImplementation(ident);
         assertEquals(new Integer(1), shardExpression.value());
     }
 
     @Test
     public void testSize() throws Exception {
         ReferenceIdent ident = new ReferenceIdent(SysShardsTableInfo.IDENT, "size");
-        SysExpression<Long> shardExpression = (SysExpression<Long>) resolver.getImplementation(ident);
+        SimpleObjectExpression<Long> shardExpression = (SimpleObjectExpression<Long>) resolver.getImplementation(ident);
         assertEquals(new Long(123456), shardExpression.value());
     }
 
     @Test
     public void testNumDocs() throws Exception {
         ReferenceIdent ident = new ReferenceIdent(SysShardsTableInfo.IDENT, "num_docs");
-        SysExpression<Long> shardExpression = (SysExpression<Long>) resolver.getImplementation(ident);
+        SimpleObjectExpression<Long> shardExpression = (SimpleObjectExpression<Long>) resolver.getImplementation(ident);
         assertEquals(new Long(654321), shardExpression.value());
 
         // second call should throw Exception
@@ -192,28 +191,28 @@ public class SysShardsExpressionsTest extends CrateUnitTest {
     @Test
     public void testState() throws Exception {
         ReferenceIdent ident = new ReferenceIdent(SysShardsTableInfo.IDENT, "state");
-        SysExpression<BytesRef> shardExpression = (SysExpression<BytesRef>) resolver.getImplementation(ident);
+        SimpleObjectExpression<BytesRef> shardExpression = (SimpleObjectExpression<BytesRef>) resolver.getImplementation(ident);
         assertEquals(new BytesRef("STARTED"), shardExpression.value());
     }
 
     @Test
     public void testPrimary() throws Exception {
         ReferenceIdent ident = new ReferenceIdent(SysShardsTableInfo.IDENT, "primary");
-        SysExpression<BytesRef> shardExpression = (SysExpression<BytesRef>) resolver.getImplementation(ident);
+        SimpleObjectExpression<BytesRef> shardExpression = (SimpleObjectExpression<BytesRef>) resolver.getImplementation(ident);
         assertEquals(true, shardExpression.value());
     }
 
     @Test
     public void testRelocatingNode() throws Exception {
         ReferenceIdent ident = new ReferenceIdent(SysShardsTableInfo.IDENT, "relocating_node");
-        SysExpression<BytesRef> shardExpression = (SysExpression<BytesRef>) resolver.getImplementation(ident);
+        SimpleObjectExpression<BytesRef> shardExpression = (SimpleObjectExpression<BytesRef>) resolver.getImplementation(ident);
         assertEquals(new BytesRef("node_X"), shardExpression.value());
     }
 
     @Test
     public void testTableName() throws Exception {
         ReferenceIdent ident = new ReferenceIdent(SysShardsTableInfo.IDENT, ShardTableNameExpression.NAME);
-        SysExpression<BytesRef> shardExpression = (SysExpression<BytesRef>) resolver.getImplementation(ident);
+        SimpleObjectExpression<BytesRef> shardExpression = (SimpleObjectExpression<BytesRef>) resolver.getImplementation(ident);
         assertEquals(new BytesRef("wikipedia_de"), shardExpression.value());
     }
 
@@ -223,7 +222,7 @@ public class SysShardsExpressionsTest extends CrateUnitTest {
         indexName = PartitionName.PARTITIONED_TABLE_PREFIX + ".wikipedia_de._1";
         prepare();
         ReferenceIdent ident = new ReferenceIdent(SysShardsTableInfo.IDENT, ShardTableNameExpression.NAME);
-        SysExpression<BytesRef> shardExpression = (SysExpression<BytesRef>) resolver.getImplementation(ident);
+        SimpleObjectExpression<BytesRef> shardExpression = (SimpleObjectExpression<BytesRef>) resolver.getImplementation(ident);
         assertEquals(new BytesRef("wikipedia_de"), shardExpression.value());
 
         // reset indexName
@@ -235,7 +234,7 @@ public class SysShardsExpressionsTest extends CrateUnitTest {
         indexName = PartitionName.PARTITIONED_TABLE_PREFIX + ".wikipedia_de._1";
         prepare();
         ReferenceIdent ident = new ReferenceIdent(SysShardsTableInfo.IDENT, ShardPartitionIdentExpression.NAME);
-        SysExpression<BytesRef> shardExpression = (SysExpression<BytesRef>) resolver.getImplementation(ident);
+        SimpleObjectExpression<BytesRef> shardExpression = (SimpleObjectExpression<BytesRef>) resolver.getImplementation(ident);
         assertEquals(new BytesRef("_1"), shardExpression.value());
 
         // reset indexName
@@ -246,7 +245,7 @@ public class SysShardsExpressionsTest extends CrateUnitTest {
     public void testPartitionIdentOfNonPartition() throws Exception {
         // expression should return NULL on non partitioned tables
         ReferenceIdent ident = new ReferenceIdent(SysShardsTableInfo.IDENT, ShardPartitionIdentExpression.NAME);
-        SysExpression<BytesRef> shardExpression = (SysExpression<BytesRef>) resolver.getImplementation(ident);
+        SimpleObjectExpression<BytesRef> shardExpression = (SimpleObjectExpression<BytesRef>) resolver.getImplementation(ident);
         assertEquals(new BytesRef(""), shardExpression.value());
     }
 
@@ -255,7 +254,7 @@ public class SysShardsExpressionsTest extends CrateUnitTest {
         indexName = PartitionName.PARTITIONED_TABLE_PREFIX + ".wikipedia_de._1";
         prepare();
         ReferenceIdent ident = new ReferenceIdent(SysShardsTableInfo.IDENT, ShardPartitionOrphanedExpression.NAME);
-        SysExpression<Boolean> shardExpression = (SysExpression<Boolean>) resolver.getImplementation(ident);
+        SimpleObjectExpression<Boolean> shardExpression = (SimpleObjectExpression<Boolean>) resolver.getImplementation(ident);
         assertEquals(true, shardExpression.value());
 
         // reset indexName
@@ -265,7 +264,7 @@ public class SysShardsExpressionsTest extends CrateUnitTest {
     @Test
     public void testSchemaName() throws Exception {
         ReferenceIdent ident = new ReferenceIdent(SysShardsTableInfo.IDENT, ShardSchemaNameExpression.NAME);
-        SysExpression<BytesRef> shardExpression = (SysExpression<BytesRef>) resolver.getImplementation(ident);
+        SimpleObjectExpression<BytesRef> shardExpression = (SimpleObjectExpression<BytesRef>) resolver.getImplementation(ident);
         assertEquals(new BytesRef("doc"), shardExpression.value());
     }
 
@@ -274,7 +273,7 @@ public class SysShardsExpressionsTest extends CrateUnitTest {
         indexName = "my_schema.wikipedia_de";
         prepare();
         ReferenceIdent ident = new ReferenceIdent(SysShardsTableInfo.IDENT, ShardSchemaNameExpression.NAME);
-        SysExpression<BytesRef> shardExpression = (SysExpression<BytesRef>) resolver.getImplementation(ident);
+        SimpleObjectExpression<BytesRef> shardExpression = (SimpleObjectExpression<BytesRef>) resolver.getImplementation(ident);
         assertEquals(new BytesRef("my_schema"), shardExpression.value());
         // reset indexName
         indexName = "wikipedia_de";
@@ -286,7 +285,7 @@ public class SysShardsExpressionsTest extends CrateUnitTest {
         indexName = "my_schema.wikipedia_de";
         prepare();
         ReferenceIdent ident = new ReferenceIdent(SysShardsTableInfo.IDENT, ShardTableNameExpression.NAME);
-        SysExpression<BytesRef> shardExpression = (SysExpression<BytesRef>) resolver.getImplementation(ident);
+        SimpleObjectExpression<BytesRef> shardExpression = (SimpleObjectExpression<BytesRef>) resolver.getImplementation(ident);
         assertEquals(new BytesRef("wikipedia_de"), shardExpression.value());
 
         // reset indexName

--- a/sql/src/test/java/io/crate/operation/reference/sys/TestGlobalSysExpressions.java
+++ b/sql/src/test/java/io/crate/operation/reference/sys/TestGlobalSysExpressions.java
@@ -26,10 +26,11 @@ import io.crate.metadata.*;
 import io.crate.metadata.settings.CrateSettings;
 import io.crate.metadata.sys.MetaDataSysModule;
 import io.crate.metadata.sys.SysClusterTableInfo;
-import io.crate.metadata.sys.SysExpression;
+import io.crate.metadata.SimpleObjectExpression;
 import io.crate.metadata.sys.SysNodesTableInfo;
 import io.crate.metadata.table.TableInfo;
 import io.crate.operation.Input;
+import io.crate.operation.reference.NestedObjectExpression;
 import io.crate.operation.reference.sys.cluster.ClusterSettingsExpression;
 import io.crate.operation.reference.sys.node.NodeLoadExpression;
 import io.crate.test.integration.CrateUnitTest;
@@ -138,19 +139,19 @@ public class TestGlobalSysExpressions extends CrateUnitTest {
     @Test
     public void testChildImplementationLookup() throws Exception {
         ReferenceIdent ident = new ReferenceIdent(SysNodesTableInfo.IDENT, "load");
-        SysObjectReference load = (SysObjectReference) resolver.getImplementation(ident);
+        NestedObjectExpression load = (NestedObjectExpression) resolver.getImplementation(ident);
 
         Input ci = load.getChildImplementation("1");
         assertEquals(1D, ci.value());
 
-        SysExpression<Double> l1 = (SysExpression<Double>) resolver.getImplementation(LOAD1_INFO.ident());
+        SimpleObjectExpression<Double> l1 = (SimpleObjectExpression<Double>) resolver.getImplementation(LOAD1_INFO.ident());
         assertTrue(ci == l1);
     }
 
     @Test
     public void testClusterSettings() throws Exception {
         ReferenceIdent ident = new ReferenceIdent(SysClusterTableInfo.IDENT, ClusterSettingsExpression.NAME);
-        SysObjectReference settingsExpression = (SysObjectReference) resolver.getImplementation(ident);
+        NestedObjectExpression settingsExpression = (NestedObjectExpression) resolver.getImplementation(ident);
 
         Map settings = settingsExpression.value();
 

--- a/sql/src/test/java/io/crate/operation/reference/sys/TestSysNodesExpressions.java
+++ b/sql/src/test/java/io/crate/operation/reference/sys/TestSysNodesExpressions.java
@@ -27,9 +27,10 @@ import io.crate.Version;
 import io.crate.metadata.GlobalReferenceResolver;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.ReferenceResolver;
-import io.crate.metadata.sys.SysExpression;
+import io.crate.metadata.SimpleObjectExpression;
 import io.crate.metadata.sys.SysNodesTableInfo;
 import io.crate.operation.Input;
+import io.crate.operation.reference.NestedObjectExpression;
 import io.crate.operation.reference.sys.node.NodeVersionExpression;
 import io.crate.operation.reference.sys.node.SysNodeExpression;
 import io.crate.operation.reference.sys.node.SysNodeExpressionModule;
@@ -75,7 +76,6 @@ import org.mockito.stubbing.Answer;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -307,7 +307,7 @@ public class TestSysNodesExpressions extends CrateUnitTest {
     public void testLoad() throws Exception {
 
         ReferenceIdent ident = new ReferenceIdent(SysNodesTableInfo.IDENT, "load");
-        SysObjectReference load = (SysObjectReference) resolver.getImplementation(ident);
+        NestedObjectExpression load = (NestedObjectExpression) resolver.getImplementation(ident);
 
         Map<String, Object> v = load.value();
         assertNull(v.get("something"));
@@ -327,7 +327,7 @@ public class TestSysNodesExpressions extends CrateUnitTest {
     public void testWindowsLoad() throws Exception {
         onWindows = true;
         ReferenceIdent ident = new ReferenceIdent(SysNodesTableInfo.IDENT, "load");
-        SysObjectReference load = (SysObjectReference) resolver.getImplementation(ident);
+        NestedObjectExpression load = (NestedObjectExpression) resolver.getImplementation(ident);
         Map<String, Object> windowsValue = load.value();
         assertNull(windowsValue.get("1"));
         assertNull(windowsValue.get("5"));
@@ -338,28 +338,28 @@ public class TestSysNodesExpressions extends CrateUnitTest {
     @Test
     public void testName() throws Exception {
         ReferenceIdent ident = new ReferenceIdent(SysNodesTableInfo.IDENT, "name");
-        SysExpression<String> name = (SysExpression<String>) resolver.getImplementation(ident);
+        SimpleObjectExpression<String> name = (SimpleObjectExpression<String>) resolver.getImplementation(ident);
         assertEquals(new BytesRef("node 1"), name.value());
     }
 
     @Test
     public void testId() throws Exception {
         ReferenceIdent ident = new ReferenceIdent(SysNodesTableInfo.IDENT, "id");
-        SysExpression<BytesRef> id = (SysExpression<BytesRef>) resolver.getImplementation(ident);
+        SimpleObjectExpression<BytesRef> id = (SimpleObjectExpression<BytesRef>) resolver.getImplementation(ident);
         assertEquals(new BytesRef("node-id-1"), id.value());
     }
 
     @Test
     public void testHostname() throws Exception {
         ReferenceIdent ident = new ReferenceIdent(SysNodesTableInfo.IDENT, "hostname");
-        SysExpression<BytesRef> hostname = (SysExpression<BytesRef>) resolver.getImplementation(ident);
+        SimpleObjectExpression<BytesRef> hostname = (SimpleObjectExpression<BytesRef>) resolver.getImplementation(ident);
         assertEquals(new BytesRef("localhost"), hostname.value());
     }
 
     @Test
     public void testRestUrl() throws Exception {
         ReferenceIdent ident = new ReferenceIdent(SysNodesTableInfo.IDENT, "rest_url");
-        SysExpression<BytesRef> http_addr = (SysExpression<BytesRef>) resolver.getImplementation(ident);
+        SimpleObjectExpression<BytesRef> http_addr = (SimpleObjectExpression<BytesRef>) resolver.getImplementation(ident);
         assertEquals(new BytesRef("http://localhost:44200"), http_addr.value());
     }
 
@@ -367,7 +367,7 @@ public class TestSysNodesExpressions extends CrateUnitTest {
     public void testPorts() throws Exception {
 
         ReferenceIdent ident = new ReferenceIdent(SysNodesTableInfo.IDENT, "port");
-        SysObjectReference port = (SysObjectReference) resolver.getImplementation(ident);
+        NestedObjectExpression port = (NestedObjectExpression) resolver.getImplementation(ident);
 
         Map<String, Object> v = port.value();
         assertEquals(44200, v.get("http"));
@@ -378,7 +378,7 @@ public class TestSysNodesExpressions extends CrateUnitTest {
     public void testMemory() throws Exception {
 
         ReferenceIdent ident = new ReferenceIdent(SysNodesTableInfo.IDENT, "mem");
-        SysObjectReference mem = (SysObjectReference) resolver.getImplementation(ident);
+        NestedObjectExpression mem = (NestedObjectExpression) resolver.getImplementation(ident);
 
         Map<String, Object> v = mem.value();
 
@@ -393,7 +393,7 @@ public class TestSysNodesExpressions extends CrateUnitTest {
     public void testHeap() throws Exception {
 
         ReferenceIdent ident = new ReferenceIdent(SysNodesTableInfo.IDENT, "heap");
-        SysObjectReference heap = (SysObjectReference) resolver.getImplementation(ident);
+        NestedObjectExpression heap = (NestedObjectExpression) resolver.getImplementation(ident);
 
         Map<String, Object> v = heap.value();
 
@@ -405,7 +405,7 @@ public class TestSysNodesExpressions extends CrateUnitTest {
     @Test
     public void testFs() throws Exception {
         ReferenceIdent ident = new ReferenceIdent(SysNodesTableInfo.IDENT, NodeFsExpression.NAME);
-        SysObjectReference fs = (SysObjectReference) resolver.getImplementation(ident);
+        NestedObjectExpression fs = (NestedObjectExpression) resolver.getImplementation(ident);
 
         Map<String, Object> v = fs.value();
         String total = mapToSortedString((Map<String, Object>) v.get("total"));
@@ -429,7 +429,7 @@ public class TestSysNodesExpressions extends CrateUnitTest {
         assertThat((String)((Map<String, Object>)data[1]).get("path"), is(resolveCanonicalPath("/bar")));
 
         ident = new ReferenceIdent(SysNodesTableInfo.IDENT, NodeFsExpression.NAME, ImmutableList.of(NodeFsDataExpression.NAME, "dev"));
-        SysExpression<Object[]> fsData = (SysExpression<Object[]>)resolver.getImplementation(ident);
+        SimpleObjectExpression<Object[]> fsData = (SimpleObjectExpression<Object[]>)resolver.getImplementation(ident);
         for (Object arrayElement : fsData.value()) {
             assertThat(arrayElement, instanceOf(BytesRef.class));
         }
@@ -440,7 +440,7 @@ public class TestSysNodesExpressions extends CrateUnitTest {
     public void testFsWithoutSigar() throws Exception {
         sigarAvailable = false;
         ReferenceIdent ident = new ReferenceIdent(SysNodesTableInfo.IDENT, NodeFsExpression.NAME);
-        SysObjectReference fs = (SysObjectReference) resolver.getImplementation(ident);
+        NestedObjectExpression fs = (NestedObjectExpression) resolver.getImplementation(ident);
 
         Map<String, Object> v = fs.value();
         assertThat(mapToSortedString((Map<String, Object>) v.get("total")),
@@ -469,7 +469,7 @@ public class TestSysNodesExpressions extends CrateUnitTest {
     public void testVersion() throws Exception {
 
         ReferenceIdent ident = new ReferenceIdent(SysNodesTableInfo.IDENT, "version");
-        SysObjectReference version = (SysObjectReference) resolver.getImplementation(ident);
+        NestedObjectExpression version = (NestedObjectExpression) resolver.getImplementation(ident);
 
         Map<String, Object> v = version.value();
         assertEquals(Version.CURRENT.number(), v.get("number"));
@@ -481,7 +481,7 @@ public class TestSysNodesExpressions extends CrateUnitTest {
     @Test
     public void testNetwork() throws Exception {
         ReferenceIdent ident = new ReferenceIdent(SysNodesTableInfo.IDENT, "network");
-        SysObjectReference networkRef = (SysObjectReference) resolver.getImplementation(ident);
+        NestedObjectExpression networkRef = (NestedObjectExpression) resolver.getImplementation(ident);
 
         Map<String, Object> networkStats = networkRef.value();
         assertThat(mapToSortedString(networkStats),
@@ -494,7 +494,7 @@ public class TestSysNodesExpressions extends CrateUnitTest {
     @Test
     public void testNetworkTCP() throws Exception {
         ReferenceIdent ident = new ReferenceIdent(SysNodesTableInfo.IDENT, "network", Collections.singletonList("tcp"));
-        SysObjectReference tcpRef = (SysObjectReference) resolver.getImplementation(ident);
+        NestedObjectExpression tcpRef = (NestedObjectExpression) resolver.getImplementation(ident);
 
         Map<String, Object> tcpStats = tcpRef.value();
 
@@ -508,7 +508,7 @@ public class TestSysNodesExpressions extends CrateUnitTest {
     @Test
     public void testCpu() throws Exception {
         ReferenceIdent ident = new ReferenceIdent(SysNodesTableInfo.IDENT, "os");
-        SysObjectReference os = (SysObjectReference)resolver.getImplementation(ident);
+        NestedObjectExpression os = (NestedObjectExpression)resolver.getImplementation(ident);
 
         Map<String, Object> v = os.value();
         assertEquals(3600000L, v.get("uptime"));
@@ -525,7 +525,7 @@ public class TestSysNodesExpressions extends CrateUnitTest {
     @Test
     public void testProcess() throws Exception {
         ReferenceIdent ident = new ReferenceIdent(SysNodesTableInfo.IDENT, "process");
-        SysObjectReference processRef = (SysObjectReference)resolver.getImplementation(ident);
+        NestedObjectExpression processRef = (NestedObjectExpression)resolver.getImplementation(ident);
 
         Map<String, Object> v = processRef.value();
         assertEquals(42L, (long) v.get("open_file_descriptors"));
@@ -535,7 +535,7 @@ public class TestSysNodesExpressions extends CrateUnitTest {
     @Test
     public void testNestedBytesRefExpressionsString() throws Exception {
         ReferenceIdent ident = new ReferenceIdent(SysNodesTableInfo.IDENT, "version");
-        SysObjectReference version = (SysObjectReference) resolver.getImplementation(ident);
+        NestedObjectExpression version = (NestedObjectExpression) resolver.getImplementation(ident);
 
         ident = new ReferenceIdent(SysNodesTableInfo.IDENT, "version", Collections.singletonList("number"));
         SysNodeExpression<BytesRef> versionNumber = (SysNodeExpression<BytesRef>)resolver.getImplementation(ident);


### PR DESCRIPTION
`io.crate.metadata.sys.SysExpression -> io.crate.metadata.SimpleObjectExpression`
and
`io.crate.operation.reference.sys.SysObjectReference -> io.crate.operation.reference.NestedObjectExpression`