### PR TITLE
fix collecting unassigned shards

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,12 +7,13 @@ Unreleased
 
 NOTE: Upgrading from 0.49 or earlier versions requires a full cluster restart
 
- - Added new table settings that can be set on ``CREATE TABLE``
-   and changed/reset with ``ALTER TABLE``.
+ - Fix: Handle concurrently dropped partitions while collecting rows
 
  - Fix: Updated es/upstream to prevent errors caused by too many cluster
    state updates when dropping tables with a huge amount of partitions
 
+ - Added new table settings that can be set on ``CREATE TABLE``
+   and changed/reset with ``ALTER TABLE``.
 
  - Fixed an issue that caused a node stop to always take up at least 10 seconds
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,9 @@ Unreleased
 
 NOTE: Upgrading from 0.49 or earlier versions requires a full cluster restart
 
+ - Fix: Do not throw exception on querying `sys.shards` while
+   unassigned shards are changing
+
  - Fix: Handle concurrently dropped partitions while collecting rows
 
  - Fix: Updated es/upstream to prevent errors caused by too many cluster

--- a/sql/src/main/java/io/crate/executor/transport/ExecutionNodesTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/ExecutionNodesTask.java
@@ -206,7 +206,7 @@ public class ExecutionNodesTask extends JobTask {
             Collection<ExecutionNode> executionNodes = entry.getValue();
 
             if (serverNodeId.equals(TableInfo.NULL_NODE_ID)) {
-                handlerSideCollect(executionNodes, pageDownstreamContexts);
+                handlerSideCollect(idx, executionNodes, pageDownstreamContexts);
             } else {
                 JobRequest request = new JobRequest(jobId(), executionNodes);
                 if (hasDirectResponse) {
@@ -249,23 +249,26 @@ public class ExecutionNodesTask extends JobTask {
         }
     }
 
-    private void handlerSideCollect(Collection<ExecutionNode> executionNodes,
+    private void handlerSideCollect(final int bucketIdx,
+                                    Collection<ExecutionNode> executionNodes,
                                     List<PageDownstreamContext> pageDownstreamContexts) {
         assert executionNodes.size() == 1 && pageDownstreamContexts.size() == 1
                 : "handlerSideCollect is only possible with 1 collectNode";
         ExecutionNode onlyElement = Iterables.getOnlyElement(executionNodes);
         assert onlyElement instanceof CollectNode : "handlerSideCollect is only possible with 1 collectNode";
 
+        LOGGER.trace("calling handlerSideCollect for job {}", jobId());
+
         final PageDownstreamContext pageDownstreamContext = pageDownstreamContexts.get(0);
         CollectNode collectNode = ((CollectNode) onlyElement);
         RamAccountingContext ramAccountingContext = trackOperation(collectNode,
-                "handlerSide collect", results.get(0));
+                "handlerSide collect", results.size() > 1 ? results.get(bucketIdx) : results.get(0));
 
         CollectingProjector collectingProjector = new CollectingProjector();
         Futures.addCallback(collectingProjector.result(), new FutureCallback<Bucket>() {
             @Override
             public void onSuccess(Bucket result) {
-                pageDownstreamContext.setBucket(0, result, true, new PageResultListener() {
+                pageDownstreamContext.setBucket(bucketIdx, result, true, new PageResultListener() {
                     @Override
                     public void needMore(boolean needMore) {
                         // can't page
@@ -273,14 +276,14 @@ public class ExecutionNodesTask extends JobTask {
 
                     @Override
                     public int buckedIdx() {
-                        return 0;
+                        return bucketIdx;
                     }
                 });
             }
 
             @Override
             public void onFailure(@Nonnull Throwable t) {
-                pageDownstreamContext.failure(0, t);
+                pageDownstreamContext.failure(bucketIdx, t);
             }
         });
 

--- a/sql/src/main/java/io/crate/jobs/PageDownstreamContext.java
+++ b/sql/src/main/java/io/crate/jobs/PageDownstreamContext.java
@@ -89,7 +89,8 @@ public class PageDownstreamContext implements ExecutionSubContext {
         synchronized (lock) {
             LOGGER.trace("setBucket: {}", bucketIdx);
             if (allFuturesSet.get(bucketIdx)) {
-                throw new IllegalStateException("May not set the same bucket of a page more than once");
+                pageDownstream.fail(new IllegalStateException("May not set the same bucket of a page more than once"));
+                return;
             }
 
             if (pageEmpty()) {
@@ -114,7 +115,8 @@ public class PageDownstreamContext implements ExecutionSubContext {
         synchronized (lock) {
             LOGGER.trace("failure: bucket: {} {}", bucketIdx, throwable);
             if (allFuturesSet.get(bucketIdx)) {
-                throw new IllegalStateException("May not set the same bucket of a page more than once");
+                pageDownstream.fail(new IllegalStateException("May not set the same bucket %d of a page more than once"));
+                return;
             }
             if (pageEmpty()) {
                 LOGGER.trace("calling nextPage");


### PR DESCRIPTION
Fixes a internal invalid state which causes a query on system tables failure, while lots of shards were assigned(create table/partition/add-replica-nodes) or un-assigned (drop table/partition/remove-nodes) concurrently.
TableUnkownExceptions in such a scenario also do not bubble anymore on system tables.