### PR TITLE
gradle: remove outputs.files from ANTLR3 task

### DIFF
--- a/sql-parser/build.gradle
+++ b/sql-parser/build.gradle
@@ -33,7 +33,6 @@ task generateWithANTLR3(type:Exec) {
     if (Os.isFamily(Os.FAMILY_WINDOWS)) {
         outputPath = 'src/main/java/io/crate/sql/parser';
     }
-    outputs.files(fileTree(dir: 'src/main/java/io/crate/sql/parser', include: '**/Statement*.java').files)
     commandLine = ['java', '-cp',  configurations.antlr3.getAsPath(), 'org.antlr.Tool', '-o', outputPath, 'src/main/java/io/crate/sql/parser/Statement.g', 'src/main/java/io/crate/sql/parser/StatementBuilder.g']
 }
 


### PR DESCRIPTION
`./gradlew clean compileJava` no longer re-created the parser