### PR TITLE
fix custom blob path deletion handling

### DIFF
--- a/blob/src/main/java/io/crate/blob/BlobEnvironment.java
+++ b/blob/src/main/java/io/crate/blob/BlobEnvironment.java
@@ -127,31 +127,21 @@ public class BlobEnvironment {
      * Check if a given blob data path contains no indices and non crate related path
      */
     public boolean isCustomBlobPathEmpty(File root) {
-        if (root != null && root.exists()) {
-            if (root.isDirectory()) {
-                File[] children = root.listFiles();
-                if (children != null) {
-                    boolean empty = true;
-                    for (File aChildren : children) {
-                        if (aChildren.isDirectory()
-                                && aChildren.getName().equals("nodes")) {
-                            for (File nodeFolder : aChildren.listFiles()) {
-                                if (nodeFolder.isDirectory()
-                                        && new File(nodeFolder, "indices").list().length > 0) {
-                                    empty = false;
-                                }
-                            }
-                        } else if (aChildren.getName().equals(clusterName.value())) {
-                            empty = isCustomBlobPathEmpty(aChildren);
-                        } else {
-                            return false;
-                        }
-                    }
-                    return empty;
-                }
-            }
+        return isCustomBlobPathEmpty(root, true);
+    }
+
+    private boolean isCustomBlobPathEmpty(File file, boolean isRoot) {
+        if (file == null || !file.exists() || !file.isDirectory()) {
+            return false;
+        }
+        File[] children = file.listFiles();
+        if (children == null || children.length == 0) {
+            return true;
+        }
+        //noinspection SimplifiableIfStatement
+        if (isRoot && children.length == 1 && children[0].getName().equals("indices")) {
+            return isCustomBlobPathEmpty(children[0], false);
         }
         return false;
     }
-
 }

--- a/blob/src/test/java/io/crate/integrationtests/CustomBlobPathTest.java
+++ b/blob/src/test/java/io/crate/integrationtests/CustomBlobPathTest.java
@@ -145,7 +145,7 @@ public class CustomBlobPathTest extends ElasticsearchIntegrationTest {
         assertFalse(loc2.exists());
 
         assertThat(tempBlobPath.exists(), is(true));
-        // TODO: add assertion that the folder is empty
+        assertThat(tempBlobPath.listFiles().length, is(0));
 
         blobIndices.createBlobTable("test", indexSettings).get();
         ensureGreen();


### PR DESCRIPTION
previous logic was to delete the whole custom path folder, but the "is empty"
detection didn't work so nothing ever happened.

Fixes the "is empty" detection and changed the behaviour to only delete sub
folders within that custom path.