### PR TITLE
fix delete/drop errors on partitioned tables

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,10 @@ Unreleased
 
 NOTE: Upgrading from 0.49 or earlier versions requires a full cluster restart
 
+ - Fixed an error that could occur if the same ``delete from
+   <partitoned_table>`` or ``drop table <partitioned_table>`` statement is
+   executed concurrently
+
  - Added the ``KILL ALL`` statement which can be used to cancel running
    operations
 

--- a/sql/src/main/java/io/crate/executor/transport/task/DropTableTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/DropTableTask.java
@@ -33,6 +33,7 @@ import org.elasticsearch.action.admin.indices.delete.TransportDeleteIndexAction;
 import org.elasticsearch.action.admin.indices.template.delete.DeleteIndexTemplateRequest;
 import org.elasticsearch.action.admin.indices.template.delete.DeleteIndexTemplateResponse;
 import org.elasticsearch.action.admin.indices.template.delete.TransportDeleteIndexTemplateAction;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.indices.IndexTemplateMissingException;
@@ -97,7 +98,11 @@ public class DropTableTask extends AbstractChainedTask {
     }
 
     private void deleteESIndex(String indexOrAlias) {
-        deleteIndexAction.execute(new DeleteIndexRequest(indexOrAlias), new ActionListener<DeleteIndexResponse>() {
+        DeleteIndexRequest deleteIndexRequest = new DeleteIndexRequest(indexOrAlias);
+        if (tableInfo.isPartitioned()) {
+            deleteIndexRequest.indicesOptions(IndicesOptions.lenientExpandOpen());
+        }
+        deleteIndexAction.execute(deleteIndexRequest, new ActionListener<DeleteIndexResponse>() {
             @Override
             public void onResponse(DeleteIndexResponse response) {
                 if (!response.isAcknowledged()) {

--- a/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/ESDeleteIndexTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/ESDeleteIndexTask.java
@@ -74,7 +74,16 @@ public class ESDeleteIndexTask extends AbstractChainedTask {
         super(jobId);
         this.transport = transport;
         this.request = new DeleteIndexRequest(node.indices());
-        this.request.indicesOptions(IndicesOptions.strictExpandOpen());
+        if (node.indices().length > 1) {
+            /**
+             * table is partitioned, in case of concurrent "delete from partitions"
+             * it could be that some partitions are already deleted,
+             * so ignore it if some are missing
+             */
+            this.request.indicesOptions(IndicesOptions.lenientExpandOpen());
+        } else {
+            this.request.indicesOptions(IndicesOptions.strictExpandOpen());
+        }
         this.listener = new DeleteIndexListener(result, node.indices().length > 1);
     }
 

--- a/sql/src/main/java/io/crate/metadata/doc/DocTableInfoBuilder.java
+++ b/sql/src/main/java/io/crate/metadata/doc/DocTableInfoBuilder.java
@@ -80,12 +80,7 @@ public class DocTableInfoBuilder {
         if (metaData.getTemplates().containsKey(templateName)) {
             docIndexMetaData = buildDocIndexMetaDataFromTemplate(ident.esName(), templateName);
             createdFromTemplate = true;
-            try {
-                concreteIndices = metaData.concreteIndices(IndicesOptions.strictExpandOpen(), ident.esName());
-            } catch(IndexMissingException e) {
-                // no partition created yet
-                concreteIndices = new String[]{};
-            }
+            concreteIndices = metaData.concreteIndices(IndicesOptions.lenientExpandOpen(), ident.esName());
         } else {
             try {
                 concreteIndices = metaData.concreteIndices(IndicesOptions.strictExpandOpen(), ident.esName());
@@ -98,8 +93,7 @@ public class DocTableInfoBuilder {
             }
         }
 
-        if ((!createdFromTemplate && concreteIndices.length == 1)
-                || !checkAliasSchema) {
+        if ((!createdFromTemplate && concreteIndices.length == 1) || !checkAliasSchema) {
             return docIndexMetaData;
         }
         for (int i = 0; i < concreteIndices.length; i++) {

--- a/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -1058,9 +1058,7 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
         assertEquals(1L, response.rowCount());
 
         execute("delete from quotes"); // this will delete all partitions
-        ensureGreen();
         execute("delete from quotes"); // this should still work even though only the template exists
-        ensureGreen();
 
         execute("drop table quotes");
         assertEquals(1L, response.rowCount());


### PR DESCRIPTION
could occur with concurrent deletes or if metaData across nodes are not
up2date