### PR TITLE
check killed state also in GroupingProjector

### DIFF
--- a/sql/src/main/java/io/crate/executor/transport/distributed/ResultProviderBase.java
+++ b/sql/src/main/java/io/crate/executor/transport/distributed/ResultProviderBase.java
@@ -23,6 +23,7 @@ package io.crate.executor.transport.distributed;
 
 import com.google.common.util.concurrent.SettableFuture;
 import io.crate.core.collections.Bucket;
+import io.crate.jobs.ExecutionState;
 import io.crate.operation.RowDownstream;
 import io.crate.operation.RowDownstreamHandle;
 import io.crate.operation.RowUpstream;
@@ -34,8 +35,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 public abstract class ResultProviderBase implements ResultProvider {
 
     private final SettableFuture<Bucket> result = SettableFuture.create();
-    protected final AtomicInteger remainingUpstreams = new AtomicInteger(0);
     private final AtomicBoolean failed = new AtomicBoolean(false);
+
+    protected final AtomicInteger remainingUpstreams = new AtomicInteger(0);
+    protected ExecutionState executionState;
 
     @Override
     public RowDownstreamHandle registerUpstream(RowUpstream upstream) {
@@ -44,7 +47,8 @@ public abstract class ResultProviderBase implements ResultProvider {
     }
 
     @Override
-    public void startProjection() {
+    public void startProjection(ExecutionState executionState) {
+        this.executionState = executionState;
     }
 
     /**

--- a/sql/src/main/java/io/crate/jobs/ExecutionState.java
+++ b/sql/src/main/java/io/crate/jobs/ExecutionState.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.  You may
  * obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
@@ -19,28 +19,9 @@
  * software solely pursuant to the terms of the relevant commercial agreement.
  */
 
-package io.crate.operation.projectors;
+package io.crate.jobs;
 
-import io.crate.jobs.ExecutionState;
-import io.crate.operation.RowDownstream;
-import io.crate.operation.RowUpstream;
-import io.crate.planner.projection.Projection;
+public interface ExecutionState {
 
-
-/**
- * Operation interface for {@link Projection} instances.
- */
-public interface Projector extends RowDownstream, RowUpstream {
-
-    /**
-     * initialization hook which gets called before execution
-     */
-    void startProjection(ExecutionState executionState);
-
-    /**
-     * sets the downstream of this projector
-     *
-     * @param downstream the downstream to be used
-     */
-    void downstream(RowDownstream downstream);
+    boolean isKilled();
 }

--- a/sql/src/main/java/io/crate/jobs/PageDownstreamContext.java
+++ b/sql/src/main/java/io/crate/jobs/PageDownstreamContext.java
@@ -36,7 +36,7 @@ import java.util.BitSet;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public class PageDownstreamContext implements ExecutionSubContext {
+public class PageDownstreamContext implements ExecutionSubContext, ExecutionState {
 
     private static final ESLogger LOGGER = Loggers.getLogger(PageDownstreamContext.class);
 
@@ -51,6 +51,7 @@ public class PageDownstreamContext implements ExecutionSubContext {
     private final ArrayList<PageResultListener> listeners = new ArrayList<>();
     private final ArrayList<ContextCallback> callbacks = new ArrayList<>(1);
     private final AtomicBoolean closed = new AtomicBoolean(false);
+    private volatile boolean isKilled = false;
 
 
     public PageDownstreamContext(String name,
@@ -188,6 +189,7 @@ public class PageDownstreamContext implements ExecutionSubContext {
 
     @Override
     public void kill() {
+        isKilled = true;
         if (!closed.getAndSet(true)) {
             CancellationException cancellationException = new CancellationException();
             for (ContextCallback contextCallback : callbacks) {
@@ -202,6 +204,11 @@ public class PageDownstreamContext implements ExecutionSubContext {
     @Override
     public String name() {
         return name;
+    }
+
+    @Override
+    public boolean isKilled() {
+        return isKilled;
     }
 
     private class ResultListenerBridgingConsumeListener implements PageConsumeListener {

--- a/sql/src/main/java/io/crate/operation/QueryResultRowDownstream.java
+++ b/sql/src/main/java/io/crate/operation/QueryResultRowDownstream.java
@@ -26,6 +26,7 @@ import io.crate.core.collections.CollectionBucket;
 import io.crate.core.collections.Row;
 import io.crate.executor.QueryResult;
 import io.crate.executor.TaskResult;
+import io.crate.jobs.ExecutionState;
 import io.crate.operation.projectors.Projector;
 
 import java.util.ArrayList;
@@ -72,7 +73,7 @@ public class QueryResultRowDownstream implements Projector {
     }
 
     @Override
-    public void startProjection() {
+    public void startProjection(ExecutionState executionState) {
 
     }
 

--- a/sql/src/main/java/io/crate/operation/collect/JobCollectContext.java
+++ b/sql/src/main/java/io/crate/operation/collect/JobCollectContext.java
@@ -25,6 +25,7 @@ import com.google.common.base.Function;
 import io.crate.action.sql.query.CrateSearchContext;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.jobs.ContextCallback;
+import io.crate.jobs.ExecutionState;
 import io.crate.jobs.ExecutionSubContext;
 import io.crate.operation.RowDownstream;
 import io.crate.operation.RowDownstreamHandle;
@@ -44,7 +45,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public class JobCollectContext implements ExecutionSubContext, RowUpstream {
+public class JobCollectContext implements ExecutionSubContext, RowUpstream, ExecutionState {
 
     private final UUID id;
     private final CollectNode collectNode;

--- a/sql/src/main/java/io/crate/operation/collect/MapSideDataCollectOperation.java
+++ b/sql/src/main/java/io/crate/operation/collect/MapSideDataCollectOperation.java
@@ -255,7 +255,7 @@ public class MapSideDataCollectOperation implements CollectOperation, RowUpstrea
                                     localRowDownStream,
                                     node.jobId()
                             );
-                            projectorChain.startProjections();
+                            projectorChain.startProjections(jobCollectContext);
                             localRowDownStream = projectorChain.firstProjector();
                         }
                         CrateCollector collector = collectService.getCollector(localCollectNode, localRowDownStream); // calls projector.registerUpstream()
@@ -421,7 +421,7 @@ public class MapSideDataCollectOperation implements CollectOperation, RowUpstrea
         }
 
         // start the projection
-        projectorChain.startProjections();
+        projectorChain.startProjections(jobCollectContext);
         try {
             LOGGER.trace("starting {} shardCollectors...", numShards);
             return runCollectThreaded(collectNode, shardCollectors, jobCollectContext);

--- a/sql/src/main/java/io/crate/operation/collect/ShardingProjector.java
+++ b/sql/src/main/java/io/crate/operation/collect/ShardingProjector.java
@@ -22,6 +22,7 @@
 package io.crate.operation.collect;
 
 import io.crate.core.collections.Row;
+import io.crate.jobs.ExecutionState;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Functions;
 import io.crate.operation.*;
@@ -70,7 +71,7 @@ public class ShardingProjector implements Projector, RowDownstreamHandle {
     }
 
     @Override
-    public void startProjection() {
+    public void startProjection(ExecutionState executionState) {
         visitorContext = new VisitorContext();
         if (routingSymbol != null ) {
             routingInput = visitor.process(routingSymbol, visitorContext);

--- a/sql/src/main/java/io/crate/operation/fetch/PositionalRowMerger.java
+++ b/sql/src/main/java/io/crate/operation/fetch/PositionalRowMerger.java
@@ -22,6 +22,7 @@
 package io.crate.operation.fetch;
 
 import io.crate.core.collections.Row;
+import io.crate.jobs.ExecutionState;
 import io.crate.operation.RowDownstream;
 import io.crate.operation.RowDownstreamHandle;
 import io.crate.operation.RowUpstream;
@@ -107,7 +108,7 @@ public class PositionalRowMerger implements Projector, RowDownstreamHandle {
     }
 
     @Override
-    public void startProjection() {
+    public void startProjection(ExecutionState executionState) {
     }
 
     @Override

--- a/sql/src/main/java/io/crate/operation/merge/BucketMerger.java
+++ b/sql/src/main/java/io/crate/operation/merge/BucketMerger.java
@@ -39,6 +39,5 @@ public interface BucketMerger extends PageDownstream, RowUpstream {
      *
      * @param downstream the downstream to be used
      */
-    public void downstream(RowDownstream downstream);
-
+    void downstream(RowDownstream downstream);
 }

--- a/sql/src/main/java/io/crate/operation/projectors/AbstractIndexWriterProjector.java
+++ b/sql/src/main/java/io/crate/operation/projectors/AbstractIndexWriterProjector.java
@@ -34,6 +34,7 @@ import io.crate.core.collections.Row1;
 import io.crate.executor.transport.ShardUpsertRequest;
 import io.crate.executor.transport.ShardUpsertResponse;
 import io.crate.executor.transport.TransportActionProvider;
+import io.crate.jobs.ExecutionState;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.TableIdent;
@@ -166,9 +167,9 @@ public abstract class AbstractIndexWriterProjector implements
     }
 
     @Override
-    public void startProjection() {
+    public void startProjection(ExecutionState executionState) {
         assert bulkShardProcessor != null : "must create a BulkShardProcessor first";
-        shardingProjector.startProjection();
+        shardingProjector.startProjection(executionState);
     }
 
     protected abstract Row updateRow(Row row);

--- a/sql/src/main/java/io/crate/operation/projectors/AggregationProjector.java
+++ b/sql/src/main/java/io/crate/operation/projectors/AggregationProjector.java
@@ -27,6 +27,7 @@ import io.crate.core.collections.Bucket;
 import io.crate.core.collections.Row;
 import io.crate.core.collections.RowN;
 import io.crate.executor.transport.distributed.ResultProviderBase;
+import io.crate.jobs.ExecutionState;
 import io.crate.operation.AggregationContext;
 import io.crate.operation.RowDownstream;
 import io.crate.operation.RowUpstream;
@@ -67,7 +68,7 @@ public class AggregationProjector extends ResultProviderBase implements Projecto
     }
 
     @Override
-    public void startProjection() {
+    public void startProjection(ExecutionState executionState) {
         for (CollectExpression<?> collectExpression : collectExpressions) {
             collectExpression.startCollect();
         }

--- a/sql/src/main/java/io/crate/operation/projectors/FetchProjector.java
+++ b/sql/src/main/java/io/crate/operation/projectors/FetchProjector.java
@@ -27,6 +27,7 @@ import com.carrotsearch.hppc.LongArrayList;
 import io.crate.core.collections.Row;
 import io.crate.core.collections.RowN;
 import io.crate.executor.transport.*;
+import io.crate.jobs.ExecutionState;
 import io.crate.metadata.Functions;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.ReferenceInfo;
@@ -147,7 +148,7 @@ public class FetchProjector implements Projector, RowDownstreamHandle {
     }
 
     @Override
-    public void startProjection() {
+    public void startProjection(ExecutionState executionState) {
         collectDocIdExpression.startCollect();
 
         if (remainingUpstreams.get() <= 0) {

--- a/sql/src/main/java/io/crate/operation/projectors/FilterProjector.java
+++ b/sql/src/main/java/io/crate/operation/projectors/FilterProjector.java
@@ -22,6 +22,7 @@
 package io.crate.operation.projectors;
 
 import io.crate.core.collections.Row;
+import io.crate.jobs.ExecutionState;
 import io.crate.operation.Input;
 import io.crate.operation.RowDownstream;
 import io.crate.operation.RowDownstreamHandle;
@@ -47,7 +48,7 @@ public class FilterProjector implements Projector, RowDownstreamHandle {
     }
 
     @Override
-    public void startProjection() {
+    public void startProjection(ExecutionState executionState) {
     }
 
     @Override

--- a/sql/src/main/java/io/crate/operation/projectors/FlatProjectorChain.java
+++ b/sql/src/main/java/io/crate/operation/projectors/FlatProjectorChain.java
@@ -25,6 +25,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import io.crate.breaker.RamAccountingContext;
+import io.crate.jobs.ExecutionState;
 import io.crate.operation.RowDownstream;
 import io.crate.planner.projection.Projection;
 
@@ -43,7 +44,7 @@ import java.util.UUID;
  * Usage:
  * <ul>
  * <li> construct it,
- * <li> call {@linkplain #startProjections()},
+ * <li> call {@linkplain #startProjections(ExecutionState)},
  * <li> get the first projector using {@linkplain #firstProjector()}
  * <li> feed data to it,
  * <li> wait for the result of  your custom downstream
@@ -58,9 +59,9 @@ public class FlatProjectorChain {
         this.projectors = projectors;
     }
 
-    public void startProjections() {
+    public void startProjections(ExecutionState executionState) {
         for (Projector projector : Lists.reverse(projectors)) {
-            projector.startProjection();
+            projector.startProjection(executionState);
         }
     }
 
@@ -70,7 +71,7 @@ public class FlatProjectorChain {
 
     /**
      * No ResultProvider will be added.
-     * if <code>downstream</code> is a Projector, {@linkplain io.crate.operation.projectors.Projector#startProjection()} will not be called
+     * if <code>downstream</code> is a Projector, {@linkplain Projector#startProjection(ExecutionState)} will not be called
      * by this FlatProjectorChain.
      */
     public static FlatProjectorChain withAttachedDownstream(final ProjectorFactory projectorFactory,

--- a/sql/src/main/java/io/crate/operation/projectors/MergeProjector.java
+++ b/sql/src/main/java/io/crate/operation/projectors/MergeProjector.java
@@ -24,6 +24,7 @@ package io.crate.operation.projectors;
 import com.google.common.collect.Ordering;
 import io.crate.core.collections.Row;
 import io.crate.core.collections.RowN;
+import io.crate.jobs.ExecutionState;
 import io.crate.operation.RowDownstream;
 import io.crate.operation.RowDownstreamHandle;
 import io.crate.operation.RowUpstream;
@@ -56,7 +57,7 @@ public class MergeProjector implements Projector  {
     }
 
     @Override
-    public void startProjection() {
+    public void startProjection(ExecutionState executionState) {
         if (remainingUpstreams.get() == 0) {
             upstreamFinished();
         }

--- a/sql/src/main/java/io/crate/operation/projectors/NoOpProjector.java
+++ b/sql/src/main/java/io/crate/operation/projectors/NoOpProjector.java
@@ -22,6 +22,7 @@
 package io.crate.operation.projectors;
 
 import io.crate.core.collections.Row;
+import io.crate.jobs.ExecutionState;
 import io.crate.operation.RowDownstream;
 import io.crate.operation.RowDownstreamHandle;
 import io.crate.operation.RowUpstream;
@@ -40,7 +41,7 @@ public class NoOpProjector implements Projector, RowDownstreamHandle {
     }
 
     @Override
-    public void startProjection() {
+    public void startProjection(ExecutionState executionState) {
 
     }
 

--- a/sql/src/main/java/io/crate/operation/projectors/ProjectionToProjectorVisitor.java
+++ b/sql/src/main/java/io/crate/operation/projectors/ProjectionToProjectorVisitor.java
@@ -24,6 +24,7 @@ package io.crate.operation.projectors;
 import io.crate.analyze.EvaluatingNormalizer;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.executor.transport.TransportActionProvider;
+import io.crate.jobs.ExecutionState;
 import io.crate.metadata.ColumnIdent;
 import io.crate.operation.ImplementationSymbolVisitor;
 import io.crate.operation.Input;

--- a/sql/src/main/java/io/crate/operation/projectors/SimpleTopNProjector.java
+++ b/sql/src/main/java/io/crate/operation/projectors/SimpleTopNProjector.java
@@ -24,6 +24,7 @@ package io.crate.operation.projectors;
 import com.google.common.base.Preconditions;
 import io.crate.Constants;
 import io.crate.core.collections.Row;
+import io.crate.jobs.ExecutionState;
 import io.crate.operation.*;
 import io.crate.operation.collect.CollectExpression;
 
@@ -64,7 +65,7 @@ public class SimpleTopNProjector implements Projector, RowUpstream, RowDownstrea
     }
 
     @Override
-    public void startProjection() {
+    public void startProjection(ExecutionState executionState) {
     }
 
     @Override

--- a/sql/src/main/java/io/crate/operation/projectors/SortingTopNProjector.java
+++ b/sql/src/main/java/io/crate/operation/projectors/SortingTopNProjector.java
@@ -27,6 +27,7 @@ import io.crate.core.collections.ArrayBucket;
 import io.crate.core.collections.Bucket;
 import io.crate.core.collections.Row;
 import io.crate.executor.transport.distributed.ResultProviderBase;
+import io.crate.jobs.ExecutionState;
 import io.crate.operation.Input;
 import io.crate.operation.RowDownstream;
 import io.crate.operation.RowDownstreamHandle;
@@ -89,8 +90,8 @@ public class SortingTopNProjector extends ResultProviderBase {
     }
 
     @Override
-    public void startProjection() {
-        super.startProjection();
+    public void startProjection(ExecutionState executionState) {
+        super.startProjection(executionState);
         synchronized (this){
             if (pq==null) {
                 pq = new RowPriorityQueue<>(maxSize, comparators);

--- a/sql/src/main/java/io/crate/operation/projectors/UpdateProjector.java
+++ b/sql/src/main/java/io/crate/operation/projectors/UpdateProjector.java
@@ -28,6 +28,7 @@ import io.crate.core.collections.Row1;
 import io.crate.executor.transport.ShardUpsertResponse;
 import io.crate.executor.transport.SymbolBasedShardUpsertRequest;
 import io.crate.executor.transport.TransportActionProvider;
+import io.crate.jobs.ExecutionState;
 import io.crate.metadata.settings.CrateSettings;
 import io.crate.operation.RowDownstream;
 import io.crate.operation.RowDownstreamHandle;
@@ -98,7 +99,7 @@ public class UpdateProjector implements Projector, RowDownstreamHandle {
     }
 
     @Override
-    public void startProjection() {
+    public void startProjection(ExecutionState executionState) {
     }
 
     @Override

--- a/sql/src/main/java/io/crate/operation/projectors/WriterProjector.java
+++ b/sql/src/main/java/io/crate/operation/projectors/WriterProjector.java
@@ -26,6 +26,7 @@ import io.crate.core.collections.Row1;
 import io.crate.exceptions.UnhandledServerException;
 import io.crate.exceptions.UnsupportedFeatureException;
 import io.crate.exceptions.ValidationException;
+import io.crate.jobs.ExecutionState;
 import io.crate.metadata.ColumnIdent;
 import io.crate.operation.Input;
 import io.crate.operation.RowDownstream;
@@ -138,7 +139,7 @@ public class WriterProjector implements Projector, RowDownstreamHandle {
     }
 
     @Override
-    public void startProjection() {
+    public void startProjection(ExecutionState executionState) {
         counter.set(0);
         try {
             output.open();

--- a/sql/src/test/java/io/crate/operation/collect/HandlerSideLevelCollectTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/HandlerSideLevelCollectTest.java
@@ -26,6 +26,7 @@ import io.crate.analyze.WhereClause;
 import io.crate.core.collections.Bucket;
 import io.crate.core.collections.TreeMapBuilder;
 import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.jobs.ExecutionState;
 import io.crate.metadata.*;
 import io.crate.metadata.information.InformationSchemaInfo;
 import io.crate.metadata.sys.SysClusterTableInfo;
@@ -84,7 +85,7 @@ public class HandlerSideLevelCollectTest extends SQLTransportIntegrationTest {
 
     private Bucket collect(CollectNode collectNode) throws InterruptedException, java.util.concurrent.ExecutionException {
         CollectingProjector collectingProjector = new CollectingProjector();
-        collectingProjector.startProjection();
+        collectingProjector.startProjection(mock(ExecutionState.class));
         operation.collect(collectNode, collectingProjector, mock(JobCollectContext.class));
         return collectingProjector.result().get();
     }

--- a/sql/src/test/java/io/crate/operation/collect/LocalDataCollectTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/LocalDataCollectTest.java
@@ -547,7 +547,7 @@ public class LocalDataCollectTest extends CrateUnitTest {
                 new JobCollectContext(collectNode.jobId(), collectNode, operation, RAM_ACCOUNTING_CONTEXT, cd);
         builder.addSubContext(collectNode.executionNodeId(), jobCollectContext);
         JobExecutionContext context = jobContextService.createContext(builder);
-        cd.startProjection();
+        cd.startProjection(jobCollectContext);
         operation.collect(collectNode, cd, jobCollectContext);
         return cd.result().get();
     }

--- a/sql/src/test/java/io/crate/operation/collect/MapSideDataCollectOperationTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/MapSideDataCollectOperationTest.java
@@ -24,6 +24,7 @@ package io.crate.operation.collect;
 import com.google.common.collect.ImmutableMap;
 import io.crate.core.collections.TreeMapBuilder;
 import io.crate.executor.transport.TransportActionProvider;
+import io.crate.jobs.ExecutionState;
 import io.crate.metadata.*;
 import io.crate.testing.CollectingProjector;
 import io.crate.operation.projectors.ResultProvider;
@@ -146,7 +147,7 @@ public class MapSideDataCollectOperationTest {
         collectNode.jobId(UUID.randomUUID());
         PlanNodeBuilder.setOutputTypes(collectNode);
         CollectingProjector cd = new CollectingProjector();
-        cd.startProjection();
+        cd.startProjection(mock(ExecutionState.class));
         collectOperation.collect(collectNode, cd, mock(JobCollectContext.class));
         assertThat(cd.result().get(), contains(
                 isRow("Arthur", 38),

--- a/sql/src/test/java/io/crate/operation/collect/ShardProjectorChainTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/ShardProjectorChainTest.java
@@ -24,6 +24,7 @@ package io.crate.operation.collect;
 import com.google.common.collect.ImmutableList;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.executor.transport.TransportActionProvider;
+import io.crate.jobs.ExecutionState;
 import io.crate.metadata.Functions;
 import io.crate.metadata.MetaDataModule;
 import io.crate.metadata.ReferenceResolver;
@@ -87,7 +88,7 @@ public class ShardProjectorChainTest extends CrateUnitTest {
 
     private RowDownstream finalDownstream() {
         CollectingProjector projector = new CollectingProjector();
-        projector.startProjection();
+        projector.startProjection(mock(ExecutionState.class));
         return projector;
     }
 

--- a/sql/src/test/java/io/crate/operation/collect/ShardingProjectorTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/ShardingProjectorTest.java
@@ -24,6 +24,7 @@ package io.crate.operation.collect;
 import com.google.common.collect.ImmutableList;
 import io.crate.core.collections.Row;
 import io.crate.core.collections.RowN;
+import io.crate.jobs.ExecutionState;
 import io.crate.metadata.ColumnIdent;
 import io.crate.planner.symbol.InputColumn;
 import io.crate.planner.symbol.Symbol;
@@ -33,6 +34,7 @@ import org.junit.Test;
 import java.util.List;
 
 import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.mock;
 
 public class ShardingProjectorTest extends CrateUnitTest {
 
@@ -49,7 +51,7 @@ public class ShardingProjectorTest extends CrateUnitTest {
     public void testNoPrimaryKeyNoRouting() {
         ShardingProjector shardingProjector =
                 new ShardingProjector(ImmutableList.<ColumnIdent>of(), ImmutableList.<Symbol>of(), null);
-        shardingProjector.startProjection();
+        shardingProjector.startProjection(mock(ExecutionState.class));
         shardingProjector.setNextRow(row());
 
         // auto-generated id, no special routing
@@ -61,7 +63,7 @@ public class ShardingProjectorTest extends CrateUnitTest {
     public void testNoPrimaryKeyButRouting() {
         ShardingProjector shardingProjector =
                 new ShardingProjector(ImmutableList.<ColumnIdent>of(), ImmutableList.<Symbol>of(), new InputColumn(1));
-        shardingProjector.startProjection();
+        shardingProjector.startProjection(mock(ExecutionState.class));
         shardingProjector.setNextRow(row(1, "hoschi"));
 
         // auto-generated id, special routing
@@ -74,7 +76,7 @@ public class ShardingProjectorTest extends CrateUnitTest {
         List<Symbol> primaryKeySymbols = ImmutableList.<Symbol>of(new InputColumn(0), new InputColumn(1));
         ShardingProjector shardingProjector =
                 new ShardingProjector(ImmutableList.<ColumnIdent>of(), primaryKeySymbols, null);
-        shardingProjector.startProjection();
+        shardingProjector.startProjection(mock(ExecutionState.class));
         shardingProjector.setNextRow(row(1, "hoschi"));
 
         // compound encoded id, no special routing
@@ -87,7 +89,7 @@ public class ShardingProjectorTest extends CrateUnitTest {
         List<Symbol> primaryKeySymbols = ImmutableList.<Symbol>of(new InputColumn(1), new InputColumn(0));
         ShardingProjector shardingProjector =
                 new ShardingProjector(ImmutableList.<ColumnIdent>of(), primaryKeySymbols, new InputColumn(1));
-        shardingProjector.startProjection();
+        shardingProjector.startProjection(mock(ExecutionState.class));
         shardingProjector.setNextRow(row(1, "hoschi"));
 
         // compound encoded id, special routing
@@ -100,7 +102,7 @@ public class ShardingProjectorTest extends CrateUnitTest {
         List<Symbol> primaryKeySymbols = ImmutableList.<Symbol>of(new InputColumn(1), new InputColumn(0));
         ShardingProjector shardingProjector =
                 new ShardingProjector(ImmutableList.<ColumnIdent>of(), primaryKeySymbols, new InputColumn(1));
-        shardingProjector.startProjection();
+        shardingProjector.startProjection(mock(ExecutionState.class));
 
         shardingProjector.setNextRow(row(1, "hoschi"));
         assertThat(shardingProjector.id(), is("AgZob3NjaGkBMQ=="));
@@ -116,7 +118,7 @@ public class ShardingProjectorTest extends CrateUnitTest {
         List<Symbol> primaryKeySymbols = ImmutableList.<Symbol>of(new InputColumn(2));
         ShardingProjector shardingProjector =
                 new ShardingProjector(ImmutableList.of(ID_IDENT), primaryKeySymbols, new InputColumn(1));
-        shardingProjector.startProjection();
+        shardingProjector.startProjection(mock(ExecutionState.class));
         shardingProjector.setNextRow(row(1, "hoschi", null));
 
         // generated _id, special routing
@@ -132,7 +134,7 @@ public class ShardingProjectorTest extends CrateUnitTest {
         List<Symbol> primaryKeySymbols = ImmutableList.<Symbol>of(new InputColumn(0));
         ShardingProjector shardingProjector =
                 new ShardingProjector(ImmutableList.<ColumnIdent>of(), primaryKeySymbols, null);
-        shardingProjector.startProjection();
+        shardingProjector.startProjection(mock(ExecutionState.class));
         shardingProjector.setNextRow(row(new Object[] { null }));
     }
 
@@ -144,7 +146,7 @@ public class ShardingProjectorTest extends CrateUnitTest {
         List<Symbol> primaryKeySymbols = ImmutableList.<Symbol>of(new InputColumn(1), new InputColumn(0));
         ShardingProjector shardingProjector =
                 new ShardingProjector(ImmutableList.<ColumnIdent>of(), primaryKeySymbols, new InputColumn(1));
-        shardingProjector.startProjection();
+        shardingProjector.startProjection(mock(ExecutionState.class));
         shardingProjector.setNextRow(row(1, null));
     }
 }

--- a/sql/src/test/java/io/crate/operation/collect/files/BlobDocCollectorTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/files/BlobDocCollectorTest.java
@@ -24,6 +24,7 @@ package io.crate.operation.collect.files;
 import io.crate.blob.BlobContainer;
 import io.crate.blob.v2.BlobShard;
 import io.crate.core.collections.Bucket;
+import io.crate.jobs.ExecutionState;
 import io.crate.operation.Input;
 import io.crate.operation.collect.JobCollectContext;
 import io.crate.operation.collect.blobs.BlobCollectorExpression;
@@ -109,7 +110,7 @@ public class BlobDocCollectorTest extends CrateUnitTest {
                 projector
         );
 
-        projector.startProjection();
+        projector.startProjection(mock(ExecutionState.class));
         collector.doCollect(mock(JobCollectContext.class));
         return projector;
     }

--- a/sql/src/test/java/io/crate/operation/collect/files/FileReadingCollectorTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/files/FileReadingCollectorTest.java
@@ -32,6 +32,7 @@ import com.google.common.collect.ImmutableMap;
 import io.crate.core.collections.Bucket;
 import io.crate.core.collections.Row;
 import io.crate.external.S3ClientHelper;
+import io.crate.jobs.ExecutionState;
 import io.crate.metadata.DynamicFunctionResolver;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
@@ -249,7 +250,7 @@ public class FileReadingCollectorTest extends CrateUnitTest {
                 1,
                 0
         );
-        projector.startProjection();
+        projector.startProjection(mock(ExecutionState.class));
         collector.doCollect(mock(JobCollectContext.class));
         return projector;
     }

--- a/sql/src/test/java/io/crate/operation/merge/SortingBucketMergerTest.java
+++ b/sql/src/test/java/io/crate/operation/merge/SortingBucketMergerTest.java
@@ -29,6 +29,7 @@ import com.google.common.util.concurrent.SettableFuture;
 import io.crate.core.collections.ArrayBucket;
 import io.crate.core.collections.Bucket;
 import io.crate.core.collections.BucketPage;
+import io.crate.jobs.ExecutionState;
 import io.crate.operation.Input;
 import io.crate.operation.PageConsumeListener;
 import io.crate.operation.collect.CollectExpression;
@@ -48,6 +49,7 @@ import java.util.concurrent.Executor;
 import static io.crate.testing.TestingHelpers.createPage;
 import static io.crate.testing.TestingHelpers.isSorted;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
 
 
 @SuppressWarnings("unchecked")
@@ -60,7 +62,7 @@ public class SortingBucketMergerTest extends CrateUnitTest {
         final SortingBucketMerger merger = new SortingBucketMerger(
                 buckets, new int[] { 0 }, new boolean[] { false }, new Boolean[] { nullsFirst }, Optional.<Executor>absent());
         merger.downstream(collectingProjector);
-        collectingProjector.startProjection();
+        collectingProjector.startProjection(mock(ExecutionState.class));
 
         final Iterator<BucketPage> pageIter = Iterators.forArray(pages);
         if (pageIter.hasNext()) {
@@ -394,8 +396,8 @@ public class SortingBucketMergerTest extends CrateUnitTest {
                 bucketMerger.downstream(topN);
                 CollectingProjector collectingProjector = new CollectingProjector();
                 topN.downstream(collectingProjector);
-                collectingProjector.startProjection();
-                topN.startProjection();
+                collectingProjector.startProjection(mock(ExecutionState.class));
+                topN.startProjection(mock(ExecutionState.class));
                 bucketMerger.nextPage(page1, new PageConsumeListener() {
                     @Override
                     public void needMore() {
@@ -433,7 +435,7 @@ public class SortingBucketMergerTest extends CrateUnitTest {
         final SortingBucketMerger merger = new SortingBucketMerger(
                 2, new int[]{1, 0}, new boolean[]{false, true}, new Boolean[]{null, true}, Optional.<Executor>absent());
         merger.downstream(collectingProjector);
-        collectingProjector.startProjection();
+        collectingProjector.startProjection(mock(ExecutionState.class));
         BucketPage page1 = createPage(
                 Arrays.asList(
                         new Object[]{"A", "0"},

--- a/sql/src/test/java/io/crate/operation/projectors/GroupingProjectorTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/GroupingProjectorTest.java
@@ -13,6 +13,7 @@ import io.crate.operation.Input;
 import io.crate.operation.aggregation.AggregationFunction;
 import io.crate.operation.aggregation.impl.AggregationImplModule;
 import io.crate.operation.collect.CollectExpression;
+import io.crate.operation.collect.JobCollectContext;
 import io.crate.planner.symbol.Aggregation;
 import io.crate.planner.symbol.Symbol;
 import io.crate.test.integration.CrateUnitTest;
@@ -30,6 +31,7 @@ import java.util.concurrent.ExecutionException;
 
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.mock;
 
 public class GroupingProjectorTest extends CrateUnitTest {
 
@@ -74,7 +76,7 @@ public class GroupingProjectorTest extends CrateUnitTest {
 
         Row emptyRow = new RowN(new Object[]{});
 
-        projector.startProjection();
+        projector.startProjection(mock(JobCollectContext.class));
         projector.setNextRow(emptyRow);
         projector.setNextRow(emptyRow);
         projector.setNextRow(emptyRow);

--- a/sql/src/test/java/io/crate/operation/projectors/IndexWriterProjectorTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/IndexWriterProjectorTest.java
@@ -25,6 +25,7 @@ import io.crate.core.collections.Bucket;
 import io.crate.core.collections.RowN;
 import io.crate.executor.transport.TransportActionProvider;
 import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.jobs.ExecutionState;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.ReferenceInfo;
@@ -51,6 +52,7 @@ import java.util.Arrays;
 import static io.crate.testing.TestingHelpers.isRow;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.mock;
 
 public class IndexWriterProjectorTest extends SQLTransportIntegrationTest {
 
@@ -89,7 +91,7 @@ public class IndexWriterProjectorTest extends SQLTransportIntegrationTest {
                 false
         );
         indexWriter.registerUpstream(null);
-        indexWriter.startProjection();
+        indexWriter.startProjection(mock(ExecutionState.class));
         indexWriter.downstream(collectingProjector);
 
         Thread t1 = new Thread(new Runnable() {

--- a/sql/src/test/java/io/crate/operation/projectors/IndexWriterProjectorUnitTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/IndexWriterProjectorUnitTest.java
@@ -24,6 +24,7 @@ package io.crate.operation.projectors;
 import com.google.common.collect.ImmutableList;
 import io.crate.core.collections.RowN;
 import io.crate.executor.transport.TransportActionProvider;
+import io.crate.jobs.ExecutionState;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.ReferenceInfo;
@@ -134,7 +135,7 @@ public class IndexWriterProjectorUnitTest extends CrateUnitTest {
         );
         indexWriter.downstream(collectingProjector);
         indexWriter.registerUpstream(null);
-        indexWriter.startProjection();
+        indexWriter.startProjection(mock(ExecutionState.class));
         indexWriter.setNextRow(new RowN(new Object[]{new BytesRef("{\"y\": \"x\"}"), null}));
         indexWriter.finish();
     }

--- a/sql/src/test/java/io/crate/operation/projectors/MergeProjectorTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/MergeProjectorTest.java
@@ -24,6 +24,7 @@ package io.crate.operation.projectors;
 import com.google.common.collect.ImmutableList;
 import io.crate.core.collections.Row;
 import io.crate.core.collections.RowN;
+import io.crate.jobs.ExecutionState;
 import io.crate.operation.RowDownstreamHandle;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.testing.CollectingProjector;
@@ -38,6 +39,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
 
 public class MergeProjectorTest extends CrateUnitTest {
 
@@ -61,7 +63,7 @@ public class MergeProjectorTest extends CrateUnitTest {
         RowDownstreamHandle handle3 = projector.registerUpstream(null);
 
         projector.downstream(collectingProjector);
-        projector.startProjection();
+        projector.startProjection(mock(ExecutionState.class));
 
         handle1.setNextRow(spare(1));
         handle1.setNextRow(spare(3));
@@ -159,7 +161,7 @@ public class MergeProjectorTest extends CrateUnitTest {
         RowDownstreamHandle handle2 = projector.registerUpstream(null);
 
         projector.downstream(collectingProjector);
-        projector.startProjection();
+        projector.startProjection(mock(ExecutionState.class));
 
         handle1.setNextRow(spare(1));
         handle2.setNextRow(spare(1));
@@ -197,7 +199,7 @@ public class MergeProjectorTest extends CrateUnitTest {
         RowDownstreamHandle handle2 = projector.registerUpstream(null);
         RowDownstreamHandle handle3 = projector.registerUpstream(null);
         projector.downstream(collectingProjector);
-        projector.startProjection();
+        projector.startProjection(mock(ExecutionState.class));
 
         handle1.setNextRow(spare(4));
         handle3.setNextRow(spare(4));
@@ -241,7 +243,7 @@ public class MergeProjectorTest extends CrateUnitTest {
         final ExecutorService executorService = Executors.newScheduledThreadPool(numUpstreams);
 
         projector.downstream(collectingProjector);
-        projector.startProjection();
+        projector.startProjection(mock(ExecutionState.class));
 
         // register upstreams
         List<RowDownstreamHandle> downstreamHandles = new ArrayList<>(numUpstreams);

--- a/sql/src/test/java/io/crate/operation/projectors/ProjectionToProjectorVisitorTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/ProjectionToProjectorVisitorTest.java
@@ -27,6 +27,7 @@ import io.crate.core.collections.Bucket;
 import io.crate.core.collections.Row;
 import io.crate.core.collections.RowN;
 import io.crate.executor.transport.TransportActionProvider;
+import io.crate.jobs.ExecutionState;
 import io.crate.metadata.*;
 import io.crate.operation.ImplementationSymbolVisitor;
 import io.crate.operation.RowDownstreamHandle;
@@ -141,7 +142,7 @@ public class ProjectionToProjectorVisitorTest extends CrateUnitTest {
         projector.downstream(collectingProjector);
         assertThat(projector, instanceOf(SimpleTopNProjector.class));
 
-        projector.startProjection();
+        projector.startProjection(mock(ExecutionState.class));
         int i;
         for (i = 0; i < 20; i++) {
             if (!handle.setNextRow(spare(42))) {
@@ -167,7 +168,7 @@ public class ProjectionToProjectorVisitorTest extends CrateUnitTest {
         RowDownstreamHandle handle = projector.registerUpstream(null);
         assertThat(projector, instanceOf(SortingTopNProjector.class));
 
-        projector.startProjection();
+        projector.startProjection(mock(ExecutionState.class));
         int i;
         for (i = 20; i > 0; i--) {
             if (!handle.setNextRow(spare(i % 4, i))) {
@@ -204,7 +205,7 @@ public class ProjectionToProjectorVisitorTest extends CrateUnitTest {
         assertThat(projector, instanceOf(AggregationProjector.class));
 
 
-        projector.startProjection();
+        projector.startProjection(mock(ExecutionState.class));
         handle.setNextRow(spare("foo", 10));
         handle.setNextRow(spare("bar", 20));
         handle.finish();
@@ -237,11 +238,11 @@ public class ProjectionToProjectorVisitorTest extends CrateUnitTest {
                 new InputColumn(2, DataTypes.DOUBLE), new InputColumn(3, DataTypes.LONG)));
         SortingTopNProjector topNProjector = (SortingTopNProjector) visitor.create(topNProjection, RAM_ACCOUNTING_CONTEXT, UUID.randomUUID());
         projector.downstream(topNProjector);
-        topNProjector.startProjection();
+        topNProjector.startProjection(mock(ExecutionState.class));
 
         assertThat(projector, instanceOf(GroupingProjector.class));
 
-        projector.startProjection();
+        projector.startProjection(mock(ExecutionState.class));
         BytesRef human = new BytesRef("human");
         BytesRef vogon = new BytesRef("vogon");
         BytesRef male = new BytesRef("male");
@@ -276,7 +277,7 @@ public class ProjectionToProjectorVisitorTest extends CrateUnitTest {
         projector.downstream(collectingProjector);
         assertThat(projector, instanceOf(FilterProjector.class));
 
-        projector.startProjection();
+        projector.startProjection(mock(ExecutionState.class));
         handle.setNextRow(spare("human", 2));
         handle.setNextRow(spare("vogon", 1));
 
@@ -308,7 +309,7 @@ public class ProjectionToProjectorVisitorTest extends CrateUnitTest {
         RowDownstreamHandle handle2 = projector.registerUpstream(null);
         RowDownstreamHandle handle3 = projector.registerUpstream(null);
 
-        projector.startProjection();
+        projector.startProjection(mock(ExecutionState.class));
 
         handle1.setNextRow(row(5, 1, 1));
         handle2.setNextRow(row(0, 1, 2));

--- a/sql/src/test/java/io/crate/operation/projectors/SortingTopNProjectorTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/SortingTopNProjectorTest.java
@@ -24,6 +24,7 @@ package io.crate.operation.projectors;
 import io.crate.core.collections.Bucket;
 import io.crate.core.collections.Row;
 import io.crate.core.collections.RowN;
+import io.crate.jobs.ExecutionState;
 import io.crate.operation.Input;
 import io.crate.operation.collect.CollectExpression;
 import io.crate.operation.collect.InputCollectExpression;
@@ -37,6 +38,7 @@ import static io.crate.testing.TestingHelpers.isNullRow;
 import static io.crate.testing.TestingHelpers.isRow;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.mock;
 
 public class SortingTopNProjectorTest extends CrateUnitTest {
 
@@ -65,7 +67,7 @@ public class SortingTopNProjectorTest extends CrateUnitTest {
                 TopN.NO_LIMIT,
                 TopN.NO_OFFSET);
         projector.registerUpstream(null);
-        projector.startProjection();
+        projector.startProjection(mock(ExecutionState.class));
         int i;
         for (i = 10; i > 0; i--) {   // 10 --> 1
             if (!projector.setNextRow(spare(i))) {
@@ -106,7 +108,7 @@ public class SortingTopNProjectorTest extends CrateUnitTest {
                 projector.downstream(collector);
             }
 
-            projector.startProjection();
+            projector.startProjection(mock(ExecutionState.class));
             projector.setNextRow(spare(1));
             projector.setNextRow(spare(2));
             projector.setNextRow(spare(3));
@@ -143,7 +145,7 @@ public class SortingTopNProjectorTest extends CrateUnitTest {
                 30
         );
         projector.registerUpstream(null);
-        projector.startProjection();
+        projector.startProjection(mock(ExecutionState.class));
         for (int i = 0; i < 10; i++) {
             if (!projector.setNextRow(spare(i))) {
                 break;
@@ -166,7 +168,7 @@ public class SortingTopNProjectorTest extends CrateUnitTest {
                 TopN.NO_LIMIT,
                 5);
         projector.registerUpstream(null);
-        projector.startProjection();
+        projector.startProjection(mock(ExecutionState.class));
         int i;
         for (i = 10; i > 0; i--) {   // 10 --> 1
             if (!projector.setNextRow(spare(i))) {
@@ -197,7 +199,7 @@ public class SortingTopNProjectorTest extends CrateUnitTest {
                 3,
                 5);
         projector.registerUpstream(null);
-        projector.startProjection();
+        projector.startProjection(mock(ExecutionState.class));
         int i;
         for (i = 10; i > 0; i--) {   // 10 --> 1
             projector.setNextRow(spare(i));
@@ -227,7 +229,7 @@ public class SortingTopNProjectorTest extends CrateUnitTest {
                 100,
                 0);
         projector.registerUpstream(null);
-        projector.startProjection();
+        projector.startProjection(mock(ExecutionState.class));
         projector.setNextRow(spare(1));
         projector.setNextRow(spare(new Object[]{null}));
         projector.finish();
@@ -248,7 +250,7 @@ public class SortingTopNProjectorTest extends CrateUnitTest {
                 100,
                 0);
         projector.registerUpstream(null);
-        projector.startProjection();
+        projector.startProjection(mock(ExecutionState.class));
         projector.setNextRow(spare(1));
         projector.setNextRow(spare(new Object[]{null}));
         projector.finish();
@@ -269,7 +271,7 @@ public class SortingTopNProjectorTest extends CrateUnitTest {
                 100,
                 0);
         projector.registerUpstream(null);
-        projector.startProjection();
+        projector.startProjection(mock(ExecutionState.class));
         projector.setNextRow(spare(1));
         projector.setNextRow(spare(new Object[]{null}));
         projector.finish();
@@ -290,7 +292,7 @@ public class SortingTopNProjectorTest extends CrateUnitTest {
                 100,
                 0);
         projector.registerUpstream(null);
-        projector.startProjection();
+        projector.startProjection(mock(ExecutionState.class));
         projector.setNextRow(spare(1));
         projector.setNextRow(spare(new Object[]{null}));
         projector.finish();
@@ -311,7 +313,7 @@ public class SortingTopNProjectorTest extends CrateUnitTest {
                 3,
                 5);
         projector.registerUpstream(null);
-        projector.startProjection();
+        projector.startProjection(mock(ExecutionState.class));
         int i;
         for (i = 0; i < 10; i++) {   // 0 --> 9
             projector.setNextRow(spare(i));
@@ -360,7 +362,7 @@ public class SortingTopNProjectorTest extends CrateUnitTest {
                 TopN.NO_LIMIT,
                 TopN.NO_OFFSET);
         projector.registerUpstream(null);
-        projector.startProjection();
+        projector.startProjection(mock(ExecutionState.class));
         int i;
         for (i = 0; i < 7; i++) {
             projector.setNextRow(spare(i, i % 4));

--- a/sql/src/test/java/io/crate/operation/projectors/WriterProjectorTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/WriterProjectorTest.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableSet;
 import io.crate.core.collections.Bucket;
 import io.crate.core.collections.Row1;
 import io.crate.exceptions.UnhandledServerException;
+import io.crate.jobs.ExecutionState;
 import io.crate.metadata.ColumnIdent;
 import io.crate.operation.collect.CollectExpression;
 import io.crate.test.integration.CrateUnitTest;
@@ -49,6 +50,7 @@ import java.util.concurrent.Executors;
 import static io.crate.testing.TestingHelpers.isRow;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.mock;
 
 public class WriterProjectorTest extends CrateUnitTest {
 
@@ -74,7 +76,7 @@ public class WriterProjectorTest extends CrateUnitTest {
         ResultProvider downstream = new CollectingProjector();
         projector.downstream(downstream);
 
-        projector.startProjection();
+        projector.startProjection(mock(ExecutionState.class));
 
         projector.registerUpstream(null);
         for (int i = 0; i < 5; i++) {
@@ -121,7 +123,7 @@ public class WriterProjectorTest extends CrateUnitTest {
         );
         CollectingProjector downstream = new CollectingProjector();
         projector.downstream(downstream);
-        projector.startProjection();
+        projector.startProjection(mock(ExecutionState.class));
         projector.registerUpstream(null);
         projector.finish();
         downstream.result().get();
@@ -144,7 +146,7 @@ public class WriterProjectorTest extends CrateUnitTest {
         );
         CollectingProjector downstream = new CollectingProjector();
         projector.downstream(downstream);
-        projector.startProjection();
+        projector.startProjection(mock(ExecutionState.class));
         projector.registerUpstream(null);
         projector.finish();
         downstream.result().get();

--- a/sql/src/test/java/org/elasticsearch/action/bulk/BulkShardProcessorTest.java
+++ b/sql/src/test/java/org/elasticsearch/action/bulk/BulkShardProcessorTest.java
@@ -26,6 +26,9 @@ import io.crate.core.collections.RowN;
 import io.crate.executor.transport.ShardUpsertRequest;
 import io.crate.executor.transport.ShardUpsertResponse;
 import io.crate.executor.transport.TransportActionProvider;
+import io.crate.jobs.ExecutionState;
+import io.crate.jobs.JobContextService;
+import io.crate.jobs.JobExecutionContext;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.ReferenceInfo;
 import io.crate.metadata.TableIdent;
@@ -52,9 +55,8 @@ import org.elasticsearch.index.shard.ShardId;
 import org.junit.Test;
 import org.mockito.*;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.lang.reflect.Field;
+import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -80,6 +82,7 @@ public class BulkShardProcessorTest extends CrateUnitTest {
     @Mock(answer = Answers.RETURNS_MOCKS)
     ClusterService clusterService;
 
+
     @Test
     public void testNonEsRejectedExceptionDoesNotResultInRetryButAborts() throws Throwable {
         expectedException.expect(RuntimeException.class);
@@ -103,7 +106,7 @@ public class BulkShardProcessorTest extends CrateUnitTest {
                 ImmutableList.<Symbol>of(new InputColumn(0, IntegerType.INSTANCE)),
                 null
         );
-        shardingProjector.startProjection();
+        shardingProjector.startProjection(mock(ExecutionState.class));
 
         BulkRetryCoordinator bulkRetryCoordinator = new BulkRetryCoordinator(
                 ImmutableSettings.EMPTY
@@ -175,7 +178,7 @@ public class BulkShardProcessorTest extends CrateUnitTest {
                 ImmutableList.<Symbol>of(new InputColumn(0, IntegerType.INSTANCE)),
                 null
         );
-        shardingProjector.startProjection();
+        shardingProjector.startProjection(mock(ExecutionState.class));
 
         TransportActionProvider transportActionProvider = mock(TransportActionProvider.class, Answers.RETURNS_DEEP_STUBS.get());
         when(transportActionProvider.transportShardUpsertActionDelegate()).thenReturn(transportShardUpsertActionDelegate);

--- a/stresstest/src/test/java/io/crate/benchmark/GroupingProjectorBenchmark.java
+++ b/stresstest/src/test/java/io/crate/benchmark/GroupingProjectorBenchmark.java
@@ -24,6 +24,7 @@ package io.crate.benchmark;
 import com.carrotsearch.junitbenchmarks.BenchmarkRule;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.core.collections.Row;
+import io.crate.jobs.ExecutionState;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Functions;
@@ -52,6 +53,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+
+import static org.mockito.Mockito.mock;
 
 public class GroupingProjectorBenchmark {
 
@@ -104,7 +107,7 @@ public class GroupingProjectorBenchmark {
                 Arrays.<DataType>asList(DataTypes.STRING), keyInputs, collectExpressions, aggregations, RAM_ACCOUNTING_CONTEXT);
 
         groupingProjector.registerUpstream(null);
-        groupingProjector.startProjection();
+        groupingProjector.startProjection(mock(ExecutionState.class));
 
         List<BytesRef> keys = new ArrayList<>(Locale.getISOCountries().length);
         for (String s : Locale.getISOCountries()) {
@@ -142,7 +145,7 @@ public class GroupingProjectorBenchmark {
                 Arrays.<DataType>asList(DataTypes.INTEGER), keyInputs, collectExpressions, aggregations, RAM_ACCOUNTING_CONTEXT);
 
         groupingProjector.registerUpstream(null);
-        groupingProjector.startProjection();
+        groupingProjector.startProjection(mock(ExecutionState.class));
 
         SpareRow row = new SpareRow();
         for (int i = 0; i < 20_000_000; i++) {

--- a/stresstest/src/test/java/io/crate/benchmark/LuceneDocCollectorBenchmark.java
+++ b/stresstest/src/test/java/io/crate/benchmark/LuceneDocCollectorBenchmark.java
@@ -31,6 +31,7 @@ import io.crate.Constants;
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.WhereClause;
 import io.crate.breaker.RamAccountingContext;
+import io.crate.jobs.ExecutionState;
 import io.crate.jobs.JobContextService;
 import io.crate.jobs.JobExecutionContext;
 import io.crate.metadata.ReferenceIdent;
@@ -282,7 +283,7 @@ public class LuceneDocCollectorBenchmark extends BenchmarkBase {
                 0
         );
         topNProjector.downstream(collectingProjector);
-        topNProjector.startProjection();
+        topNProjector.startProjection(jobCollectContext);
         LuceneDocCollector docCollector = createDocCollector(null, null, topNProjector, ImmutableList.of((Symbol) reference));
         docCollector.doCollect(jobCollectContext);
         topNProjector.doFinish();


### PR DESCRIPTION
finish() in the GroupingProjector is rather expensive. So in case of a KILL
ALL it has to abort, otherwise the cluster load might stay high for quite some
time.