### PR TITLE
removed SysNodeExpressions from GlobalReferenceResolver

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,10 @@ Unreleased
 
 NOTE: Upgrading from 0.49 or earlier versions requires a full cluster restart
 
+ - Fix: make sure sys.nodes expressions that utilize os/process/network/jvm
+   services use the same stats probe per row; previously values derived from
+   these services could have been from different probes
+
  - Fix: Stats table log entry was missing for delete-by-query statements.
 
  - Fix: made it possible to filter on all types of table settings

--- a/sql/src/main/java/io/crate/metadata/GlobalReferenceResolver.java
+++ b/sql/src/main/java/io/crate/metadata/GlobalReferenceResolver.java
@@ -21,7 +21,6 @@
 
 package io.crate.metadata;
 
-import io.crate.operation.reference.sys.node.NodeSysExpression;
 import org.elasticsearch.common.inject.Inject;
 
 import java.util.Map;
@@ -29,10 +28,6 @@ import java.util.Map;
 public class GlobalReferenceResolver extends AbstractReferenceResolver {
 
     private final Map<ReferenceIdent, ReferenceImplementation> implementations;
-
-    @Inject
-    private NodeSysExpression nodeSysExpression;
-
 
     @Inject
     public GlobalReferenceResolver(
@@ -44,14 +39,4 @@ public class GlobalReferenceResolver extends AbstractReferenceResolver {
         return implementations;
     }
 
-    @Override
-    public ReferenceImplementation getImplementation(ReferenceIdent ident) {
-        ReferenceImplementation impl = super.getImplementation(ident);
-        if (impl != null){
-            return impl;
-        } else if (nodeSysExpression != null){
-            return nodeSysExpression.getImplementation(ident);
-        }
-        return null;
-    }
 }

--- a/sql/src/main/java/io/crate/operation/reference/NestedObjectExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/NestedObjectExpression.java
@@ -22,7 +22,6 @@
 package io.crate.operation.reference;
 
 import io.crate.metadata.ReferenceImplementation;
-import io.crate.metadata.RowCollectExpression;
 import org.apache.lucene.util.BytesRef;
 
 import java.util.Collections;

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/NodeHeapExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/NodeHeapExpression.java
@@ -22,8 +22,7 @@
 package io.crate.operation.reference.sys.node;
 
 import io.crate.operation.reference.sys.SysNodeObjectReference;
-import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.monitor.jvm.JvmService;
+import org.elasticsearch.monitor.jvm.JvmStats;
 
 public class NodeHeapExpression extends SysNodeObjectReference {
 
@@ -36,31 +35,27 @@ public class NodeHeapExpression extends SysNodeObjectReference {
     public static final String FREE = "free";
     public static final String USED = "used";
 
-    private final JvmService jvmService;
-
-    @Inject
-    public NodeHeapExpression(JvmService jvmService) {
-        this.jvmService = jvmService;
-        addChildImplementations();
+    public NodeHeapExpression(JvmStats stats) {
+        addChildImplementations(stats);
     }
 
-    private void addChildImplementations() {
+    private void addChildImplementations(final JvmStats stats) {
         childImplementations.put(FREE, new HeapExpression() {
             @Override
             public Long value() {
-                return jvmService.stats().mem().getHeapMax().bytes() - jvmService.stats().mem().getHeapUsed().bytes();
+                return stats.mem().getHeapMax().bytes() - stats.mem().getHeapUsed().bytes();
             }
         });
         childImplementations.put(USED, new HeapExpression() {
             @Override
             public Long value() {
-                return jvmService.stats().mem().getHeapUsed().bytes();
+                return stats.mem().getHeapUsed().bytes();
             }
         });
         childImplementations.put(MAX, new HeapExpression() {
             @Override
             public Long value() {
-                return jvmService.stats().mem().getHeapMax().bytes();
+                return stats.mem().getHeapMax().bytes();
             }
         });
     }

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/NodeHostnameExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/NodeHostnameExpression.java
@@ -24,7 +24,6 @@ package io.crate.operation.reference.sys.node;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.common.inject.Inject;
 
 public class NodeHostnameExpression extends SysNodeExpression<BytesRef> {
 
@@ -32,7 +31,6 @@ public class NodeHostnameExpression extends SysNodeExpression<BytesRef> {
 
     private final ClusterService clusterService;
 
-    @Inject
     public NodeHostnameExpression(ClusterService clusterService) {
         this.clusterService = clusterService;
     }

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/NodeIdExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/NodeIdExpression.java
@@ -24,7 +24,6 @@ package io.crate.operation.reference.sys.node;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.common.inject.Inject;
 
 
 public class NodeIdExpression extends SysNodeExpression<BytesRef> {
@@ -34,7 +33,6 @@ public class NodeIdExpression extends SysNodeExpression<BytesRef> {
     private final ClusterService clusterService;
     private BytesRef value;
 
-    @Inject
     public NodeIdExpression(ClusterService clusterService) {
         this.clusterService = clusterService;
     }

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/NodeLoadExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/NodeLoadExpression.java
@@ -22,8 +22,7 @@
 package io.crate.operation.reference.sys.node;
 
 import io.crate.operation.reference.sys.SysNodeObjectReference;
-import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.monitor.os.OsService;
+import org.elasticsearch.monitor.os.OsStats;
 
 public class NodeLoadExpression extends SysNodeObjectReference {
 
@@ -33,28 +32,26 @@ public class NodeLoadExpression extends SysNodeObjectReference {
     public static final String FIVE = "5";
     public static final String FIFTEEN = "15";
 
-    private final OsService osService;
-
-    @Inject
-    public NodeLoadExpression(OsService osService) {
-        this.osService = osService;
-        childImplementations.put(ONE, new LoadExpression(0));
-        childImplementations.put(FIVE, new LoadExpression(1));
-        childImplementations.put(FIFTEEN, new LoadExpression(2));
+    public NodeLoadExpression(OsStats os) {
+        childImplementations.put(ONE, new LoadExpression(os, 0));
+        childImplementations.put(FIVE, new LoadExpression(os, 1));
+        childImplementations.put(FIFTEEN, new LoadExpression(os, 2));
     }
 
     class LoadExpression extends SysNodeExpression<Double> {
 
         private final int idx;
+        private final OsStats stats;
 
-        LoadExpression(int idx) {
+        LoadExpression(OsStats stats, int idx) {
             this.idx = idx;
+            this.stats = stats;
         }
 
         @Override
         public Double value() {
             try {
-                return osService.stats().loadAverage()[idx];
+                return stats.loadAverage()[idx];
             } catch (IndexOutOfBoundsException e) {
                 return null;
             }

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/NodeMemoryExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/NodeMemoryExpression.java
@@ -22,8 +22,7 @@
 package io.crate.operation.reference.sys.node;
 
 import io.crate.operation.reference.sys.SysNodeObjectReference;
-import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.monitor.os.OsService;
+import org.elasticsearch.monitor.os.OsStats;
 
 public class NodeMemoryExpression extends SysNodeObjectReference {
 
@@ -37,37 +36,33 @@ public class NodeMemoryExpression extends SysNodeObjectReference {
     public static final String FREE_PERCENT = "free_percent";
     public static final String USED_PERCENT = "used_percent";
 
-    private final OsService osService;
-
-    @Inject
-    public NodeMemoryExpression(OsService osService) {
-        this.osService = osService;
-        addChildImplementations();
+    public NodeMemoryExpression(OsStats stats) {
+        addChildImplementations(stats);
     }
 
-    private void addChildImplementations() {
+    private void addChildImplementations(final OsStats stats) {
         childImplementations.put(FREE, new MemoryExpression() {
             @Override
             public Long value() {
-                return osService.stats().mem().actualFree().bytes();
+                return stats.mem().actualFree().bytes();
             }
         });
         childImplementations.put(USED, new MemoryExpression() {
             @Override
             public Long value() {
-                return osService.stats().mem().actualUsed().bytes();
+                return stats.mem().actualUsed().bytes();
             }
         });
         childImplementations.put(FREE_PERCENT, new MemoryExpression() {
             @Override
             public Short value() {
-                return osService.stats().mem().freePercent();
+                return stats.mem().freePercent();
             }
         });
         childImplementations.put(USED_PERCENT, new MemoryExpression() {
             @Override
             public Short value() {
-                return osService.stats().mem().usedPercent();
+                return stats.mem().usedPercent();
             }
         });
     }

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/NodeNameExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/NodeNameExpression.java
@@ -22,7 +22,6 @@
 package io.crate.operation.reference.sys.node;
 
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.discovery.Discovery;
 
 public class NodeNameExpression extends SysNodeExpression<BytesRef> {
@@ -31,7 +30,6 @@ public class NodeNameExpression extends SysNodeExpression<BytesRef> {
     private final Discovery discovery;
     private BytesRef value = null;
 
-    @Inject
     public NodeNameExpression(Discovery discovery) {
         this.discovery = discovery;
     }

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/NodeNetworkExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/NodeNetworkExpression.java
@@ -23,16 +23,16 @@ package io.crate.operation.reference.sys.node;
 
 import io.crate.operation.reference.sys.SysNodeObjectReference;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.monitor.network.NetworkService;
+import org.elasticsearch.monitor.network.NetworkStats;
 
 public class NodeNetworkExpression extends SysNodeObjectReference {
 
     public static final String NAME = "network";
 
     @Inject
-    public NodeNetworkExpression(NetworkService networkService) {
+    public NodeNetworkExpression(NetworkStats stats) {
         childImplementations.put(NodeNetworkTCPExpression.NAME,
-                new NodeNetworkTCPExpression(networkService));
+                new NodeNetworkTCPExpression(stats));
     }
 
 

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/NodeNetworkTCPExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/NodeNetworkTCPExpression.java
@@ -22,15 +22,15 @@
 package io.crate.operation.reference.sys.node;
 
 import io.crate.operation.reference.sys.SysNodeObjectReference;
-import org.elasticsearch.monitor.network.NetworkService;
+import org.elasticsearch.monitor.network.NetworkStats;
 
 class NodeNetworkTCPExpression extends SysNodeObjectReference {
 
     public static final String NAME = "tcp";
 
-    public NodeNetworkTCPExpression(NetworkService networkService) {
-        childImplementations.put(TCPConnectionsExpression.NAME, new TCPConnectionsExpression(networkService));
-        childImplementations.put(TCPPacketsExpression.NAME, new TCPPacketsExpression(networkService));
+    public NodeNetworkTCPExpression(NetworkStats stats) {
+        childImplementations.put(TCPConnectionsExpression.NAME, new TCPConnectionsExpression(stats));
+        childImplementations.put(TCPPacketsExpression.NAME, new TCPPacketsExpression(stats));
     }
 
     static class TCPConnectionsExpression extends SysNodeObjectReference {
@@ -43,48 +43,44 @@ class NodeNetworkTCPExpression extends SysNodeObjectReference {
         private static final String DROPPED = "dropped";
         private static final String EMBRYONIC_DROPPED = "embryonic_dropped";
 
-        private final NetworkService networkService;
-
-        protected TCPConnectionsExpression(NetworkService networkService) {
-            this.networkService = networkService;
-            addChildImplementations();
+        protected TCPConnectionsExpression(NetworkStats stats) {
+            addChildImplementations(stats);
         }
 
-        private void addChildImplementations() {
+        private void addChildImplementations(final NetworkStats stats) {
             childImplementations.put(INITIATED, new TCPConnectionsChildExpression() {
                 @Override
                 public Long value() {
-                    return networkService.stats().tcp().activeOpens();
+                    return stats.tcp().activeOpens();
                 }
             });
             childImplementations.put(ACCEPTED, new TCPConnectionsChildExpression() {
                 @Override
                 public Long value() {
-                    return networkService.stats().tcp().passiveOpens();
+                    return stats.tcp().passiveOpens();
                 }
             });
             childImplementations.put(CURR_ESTABLISHED, new TCPConnectionsChildExpression() {
                 @Override
                 public Long value() {
-                    return networkService.stats().tcp().currEstab();
+                    return stats.tcp().currEstab();
                 }
             });
             childImplementations.put(DROPPED, new TCPConnectionsChildExpression() {
                 @Override
                 public Long value() {
-                    return networkService.stats().tcp().estabResets();
+                    return stats.tcp().estabResets();
                 }
             });
             childImplementations.put(EMBRYONIC_DROPPED, new TCPConnectionsChildExpression() {
                 @Override
                 public Long value() {
-                    return networkService.stats().tcp().attemptFails();
+                    return stats.tcp().attemptFails();
                 }
             });
         }
 
         private abstract class TCPConnectionsChildExpression extends SysNodeExpression<Long> {
-
         }
     }
 
@@ -98,48 +94,44 @@ class NodeNetworkTCPExpression extends SysNodeObjectReference {
         private static final String ERRORS_RECEIVED = "errors_received";
         private static final String RST_SENT = "rst_sent";
 
-        private final NetworkService networkService;
-
-        protected TCPPacketsExpression(NetworkService networkService) {
-            this.networkService = networkService;
-            addChildImplementations();
+        protected TCPPacketsExpression(NetworkStats stats) {
+            addChildImplementations(stats);
         }
 
-        private void addChildImplementations() {
+        private void addChildImplementations(final NetworkStats stats) {
             childImplementations.put(SENT, new TCPPacketsChildExpression() {
                 @Override
                 public Long value() {
-                    return networkService.stats().tcp().outSegs();
+                    return stats.tcp().outSegs();
                 }
             });
             childImplementations.put(RECEIVED, new TCPPacketsChildExpression() {
                 @Override
                 public Long value() {
-                    return networkService.stats().tcp().inSegs();
+                    return stats.tcp().inSegs();
                 }
             });
             childImplementations.put(RETRANSMITTED, new TCPPacketsChildExpression() {
                 @Override
                 public Long value() {
-                    return networkService.stats().tcp().retransSegs();
+                    return stats.tcp().retransSegs();
                 }
             });
             childImplementations.put(ERRORS_RECEIVED, new TCPPacketsChildExpression() {
                 @Override
                 public Long value() {
-                    return networkService.stats().tcp().inErrs();
+                    return stats.tcp().inErrs();
                 }
             });
             childImplementations.put(RST_SENT, new TCPPacketsChildExpression() {
                 @Override
                 public Long value() {
-                    return networkService.stats().tcp().outRsts();
+                    return stats.tcp().outRsts();
                 }
             });
         }
 
         private abstract class TCPPacketsChildExpression extends SysNodeExpression<Long> {
-
         }
 
     }

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/NodeOsCpuExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/NodeOsCpuExpression.java
@@ -24,7 +24,6 @@ package io.crate.operation.reference.sys.node;
 import io.crate.operation.reference.sys.SysNodeObjectReference;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.monitor.os.OsStats;
-import org.elasticsearch.node.service.NodeService;
 
 public class NodeOsCpuExpression extends SysNodeObjectReference {
 
@@ -39,19 +38,15 @@ public class NodeOsCpuExpression extends SysNodeObjectReference {
     public static final String USAGE = "used";
     public static final String STOLEN = "stolen";
 
-    private final NodeService nodeService;
-
     @Inject
-    public NodeOsCpuExpression(NodeService nodeService) {
-        this.nodeService = nodeService;
-        addChildImplementations();
+    public NodeOsCpuExpression(OsStats stats) {
+        addChildImplementations(stats);
     }
 
-    private void addChildImplementations() {
+    private void addChildImplementations(final OsStats os) {
         childImplementations.put(SYS, new CpuExpression() {
             @Override
             public Short value() {
-                OsStats os = nodeService.stats().getOs();
                 if (os != null) {
                     return os.cpu().sys();
                 } else {
@@ -62,7 +57,6 @@ public class NodeOsCpuExpression extends SysNodeObjectReference {
         childImplementations.put(USER, new CpuExpression() {
             @Override
             public Short value() {
-                OsStats os = nodeService.stats().getOs();
                 if (os != null) {
                     return os.cpu().user();
                 } else {
@@ -73,7 +67,6 @@ public class NodeOsCpuExpression extends SysNodeObjectReference {
         childImplementations.put(IDLE, new CpuExpression() {
             @Override
             public Short value() {
-                OsStats os = nodeService.stats().getOs();
                 if (os != null) {
                     return os.cpu().idle();
                 } else {
@@ -84,7 +77,6 @@ public class NodeOsCpuExpression extends SysNodeObjectReference {
         childImplementations.put(USAGE, new CpuExpression() {
             @Override
             public Short value() {
-                OsStats os = nodeService.stats().getOs();
                 if (os != null) {
                     return (short) (os.cpu().sys() + os.cpu().user());
                 } else {
@@ -95,7 +87,6 @@ public class NodeOsCpuExpression extends SysNodeObjectReference {
         childImplementations.put(STOLEN, new CpuExpression() {
             @Override
             public Short value() {
-                OsStats os = nodeService.stats().getOs();
                 if (os != null) {
                     return os.cpu().stolen();
                 } else {

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/NodeOsExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/NodeOsExpression.java
@@ -22,8 +22,7 @@
 package io.crate.operation.reference.sys.node;
 
 import io.crate.operation.reference.sys.SysNodeObjectReference;
-import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.node.service.NodeService;
+import org.elasticsearch.monitor.os.OsStats;
 
 
 public class NodeOsExpression extends SysNodeObjectReference {
@@ -31,25 +30,20 @@ public class NodeOsExpression extends SysNodeObjectReference {
     public static final String NAME = "os";
 
     abstract class OsExpression extends SysNodeExpression<Object> {
-
     }
 
     public static final String UPTIME = "uptime";
     public static final String TIMESTAMP = "timestamp";
 
-    private final NodeService nodeService;
-
-    @Inject
-    public NodeOsExpression(NodeService nodeService) {
-        this.nodeService = nodeService;
-        addChildImplementations();
+    public NodeOsExpression(OsStats stats) {
+        addChildImplementations(stats);
     }
 
-    private void addChildImplementations() {
+    private void addChildImplementations(final OsStats os) {
         childImplementations.put(UPTIME, new OsExpression() {
             @Override
             public Long value() {
-                return nodeService.stats().getOs().uptime().millis();
+                return os.uptime().millis();
             }
         });
         childImplementations.put(TIMESTAMP, new OsExpression() {
@@ -59,7 +53,7 @@ public class NodeOsExpression extends SysNodeObjectReference {
             }
         });
         childImplementations.put(NodeOsCpuExpression.NAME,
-                new NodeOsCpuExpression(nodeService));
+                new NodeOsCpuExpression(os));
     }
 
 }

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/NodePortExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/NodePortExpression.java
@@ -22,7 +22,6 @@
 package io.crate.operation.reference.sys.node;
 
 import io.crate.operation.reference.sys.SysNodeObjectReference;
-import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.node.service.NodeService;
@@ -40,7 +39,6 @@ public class NodePortExpression extends SysNodeObjectReference {
 
     private final NodeService nodeService;
 
-    @Inject
     public NodePortExpression(NodeService nodeService) {
         this.nodeService = nodeService;
         addChildImplementations();

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/NodeProcessExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/NodeProcessExpression.java
@@ -22,10 +22,8 @@
 package io.crate.operation.reference.sys.node;
 
 import io.crate.operation.reference.sys.SysNodeObjectReference;
-import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.monitor.process.ProcessInfo;
 import org.elasticsearch.monitor.process.ProcessStats;
-import org.elasticsearch.node.service.NodeService;
 
 public class NodeProcessExpression extends SysNodeObjectReference {
 
@@ -37,19 +35,15 @@ public class NodeProcessExpression extends SysNodeObjectReference {
     public static final String OPEN_FILE_DESCRIPTORS = "open_file_descriptors";
     public static final String MAX_OPEN_FILE_DESCRIPTORS = "max_open_file_descriptors";
 
-    private final NodeService nodeService;
 
-    @Inject
-    protected NodeProcessExpression(final NodeService nodeService) {
-        this.nodeService = nodeService;
-        addChildImplementations();
+    public NodeProcessExpression(ProcessInfo processInfo, ProcessStats processStats) {
+        addChildImplementations(processInfo, processStats);
     }
 
-    private void addChildImplementations() {
+    private void addChildImplementations(final ProcessInfo processInfo, final ProcessStats processStats) {
         childImplementations.put(OPEN_FILE_DESCRIPTORS, new ProcessExpression() {
             @Override
             public Long value() {
-                ProcessStats processStats = nodeService.stats().getProcess();
                 if (processStats != null) {
                     return processStats.getOpenFileDescriptors();
                 } else { return -1L; }
@@ -58,7 +52,6 @@ public class NodeProcessExpression extends SysNodeObjectReference {
         childImplementations.put(MAX_OPEN_FILE_DESCRIPTORS, new ProcessExpression() {
             @Override
             public Long value() {
-                ProcessInfo processInfo = nodeService.info().getProcess();
                 if (processInfo != null) {
                     return processInfo.getMaxFileDescriptors();
                 } else { return -1L; }

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/NodeRestUrlExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/NodeRestUrlExpression.java
@@ -23,7 +23,6 @@ package io.crate.operation.reference.sys.node;
 
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.cluster.ClusterService;
-import org.elasticsearch.common.inject.Inject;
 
 public class NodeRestUrlExpression extends SysNodeExpression<BytesRef> {
 
@@ -31,7 +30,6 @@ public class NodeRestUrlExpression extends SysNodeExpression<BytesRef> {
 
     private final ClusterService clusterService;
 
-    @Inject
     public NodeRestUrlExpression(ClusterService clusterService) {
         this.clusterService = clusterService;
     }

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/NodeSysExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/NodeSysExpression.java
@@ -21,39 +21,89 @@
 
 package io.crate.operation.reference.sys.node;
 
-import io.crate.metadata.ReferenceIdent;
-import io.crate.metadata.ReferenceImplementation;
-import io.crate.metadata.ReferenceInfo;
-import io.crate.metadata.ReferenceResolver;
-import io.crate.metadata.SimpleObjectExpression;
-import io.crate.metadata.sys.SysNodesTableInfo;
+import io.crate.metadata.*;
 import io.crate.operation.reference.NestedObjectExpression;
+import io.crate.operation.reference.sys.node.fs.NodeFsExpression;
+import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.discovery.Discovery;
+import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.monitor.jvm.JvmService;
+import org.elasticsearch.monitor.network.NetworkService;
+import org.elasticsearch.monitor.os.OsService;
+import org.elasticsearch.monitor.os.OsStats;
+import org.elasticsearch.monitor.sigar.SigarService;
+import org.elasticsearch.node.service.NodeService;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import java.util.Arrays;
+import java.util.Collection;
 
 public class NodeSysExpression extends NestedObjectExpression {
 
-    private final SysNodesTableInfo tableInfo;
-    private final ReferenceResolver resolver;
+    private final NodeService nodeService;
+    private final OsService osService;
+    private final JvmService jvmService;
+    private final NetworkService networkService;
+
+    private static final Collection EXPRESSIONS_WITH_OS_STATS = Arrays.asList(
+            NodeMemoryExpression.NAME,
+            NodeLoadExpression.NAME,
+            NodeOsExpression.NAME
+    );
 
     @Inject
-    public NodeSysExpression(SysNodesTableInfo tableInfo, ReferenceResolver resolver) {
-        this.tableInfo = tableInfo;
-        this.resolver = resolver;
-        for (ReferenceInfo info : tableInfo.columns()) {
-            childImplementations.put(
-                    info.ident().columnIdent().name(),
-                    resolver.getImplementation(info.ident()));
-        }
+    public NodeSysExpression(ClusterService clusterService,
+                             SigarService sigarService,
+                             OsService osService,
+                             NodeService nodeService,
+                             JvmService jvmService,
+                             NetworkService networkService,
+                             NodeEnvironment nodeEnvironment,
+                             Discovery discovery,
+                             ThreadPool threadPool) {
+        this.nodeService = nodeService;
+        this.osService = osService;
+        this.jvmService = jvmService;
+        this.networkService = networkService;
+        childImplementations.put(NodeFsExpression.NAME,
+                new NodeFsExpression(sigarService, nodeEnvironment));
+        childImplementations.put(NodeHostnameExpression.NAME,
+                new NodeHostnameExpression(clusterService));
+        childImplementations.put(NodeRestUrlExpression.NAME,
+                new NodeRestUrlExpression(clusterService));
+        childImplementations.put(NodeIdExpression.NAME,
+                new NodeIdExpression(clusterService));
+        childImplementations.put(NodeNameExpression.NAME,
+                new NodeNameExpression(discovery));
+        childImplementations.put(NodePortExpression.NAME,
+                new NodePortExpression(nodeService));
+        childImplementations.put(NodeVersionExpression.NAME,
+                new NodeVersionExpression());
+        childImplementations.put(NodeThreadPoolsExpression.NAME,
+                new NodeThreadPoolsExpression(threadPool));
     }
 
-    public ReferenceImplementation getImplementation(ReferenceIdent ident) {
-        if (!tableInfo.tableColumn().name().equals(ident.columnIdent().name())) {
-            return null;
+    @Override
+    public ReferenceImplementation getChildImplementation(String name) {
+        if (EXPRESSIONS_WITH_OS_STATS.contains(name)) {
+            OsStats osStats = osService.stats();
+            if (NodeMemoryExpression.NAME.equals(name)) {
+                return new NodeMemoryExpression(osStats);
+            } else if (NodeLoadExpression.NAME.equals(name)) {
+                return new NodeLoadExpression(osStats);
+            } else if (NodeOsExpression.NAME.equals(name)) {
+                return new NodeOsExpression(osStats);
+            }
+        } else if (NodeProcessExpression.NAME.equals(name)) {
+            return new NodeProcessExpression(nodeService.info().getProcess(),
+                    nodeService.stats().getProcess());
+        } else if (NodeHeapExpression.NAME.equals(name)) {
+            return new NodeHeapExpression(jvmService.stats());
+        } else if (NodeNetworkExpression.NAME.equals(name)) {
+            return new NodeNetworkExpression(networkService.stats());
         }
-        if (ident.columnIdent().isColumn()) {
-            return this;
-        } else {
-            return resolver.getImplementation(tableInfo.tableColumn().getImplementationIdent(ident));
-        }
+        return super.getChildImplementation(name);
     }
+
 }

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/NodeSysReferenceResolver.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/NodeSysReferenceResolver.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.operation.reference.sys.node;
+
+import io.crate.metadata.ReferenceIdent;
+import io.crate.metadata.ReferenceImplementation;
+import io.crate.metadata.ReferenceResolver;
+import io.crate.metadata.sys.SysNodesTableInfo;
+import io.crate.metadata.sys.SysSchemaInfo;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class NodeSysReferenceResolver implements ReferenceResolver {
+
+    private NodeSysExpression nodeSysExpression;
+    private final Map<String, ReferenceImplementation> expressionCache = new HashMap();
+
+    public NodeSysReferenceResolver(NodeSysExpression nodeSysExpression) {
+        this.nodeSysExpression = nodeSysExpression;
+    }
+
+    private ReferenceImplementation getCachedImplementation(String name) {
+        ReferenceImplementation impl = expressionCache.get(name);
+        if (impl == null) {
+            impl = nodeSysExpression.getChildImplementation(name);
+            expressionCache.put(name, impl);
+        }
+        return impl;
+    }
+
+    @Override
+    public ReferenceImplementation getImplementation(ReferenceIdent ident) {
+        if (SysNodesTableInfo.IDENT.equals(ident.tableIdent())) {
+            ReferenceImplementation impl = getCachedImplementation(ident.columnReferenceIdent().columnIdent().name());
+            if (impl != null) {
+                for (String part : ident.columnIdent().path()) {
+                    impl = impl.getChildImplementation(part);
+                }
+            }
+            return impl;
+        } else if (SysNodesTableInfo.SYS_COL_NAME.equals(ident.columnIdent().name())) {
+            if (ident.columnIdent().isColumn()) {
+                return nodeSysExpression;
+            }
+            ReferenceImplementation impl = null;
+            for (String part : ident.columnIdent().path()) {
+                if (impl == null) {
+                    impl = getCachedImplementation(part);
+                } else {
+                    impl = impl.getChildImplementation(part);
+                }
+            }
+            return impl;
+        }
+        return null;
+    }
+}
+

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/NodeThreadPoolsExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/NodeThreadPoolsExpression.java
@@ -22,7 +22,6 @@
 package io.crate.operation.reference.sys.node;
 
 import io.crate.operation.reference.sys.SysNodeStaticObjectArrayReference;
-import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.threadpool.ThreadPool;
 
 public class NodeThreadPoolsExpression extends SysNodeStaticObjectArrayReference {
@@ -31,7 +30,6 @@ public class NodeThreadPoolsExpression extends SysNodeStaticObjectArrayReference
 
     private final ThreadPool threadPool;
 
-    @Inject
     protected NodeThreadPoolsExpression(ThreadPool threadPool) {
         super(NAME);
         this.threadPool = threadPool;

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/SysNodeExpressionModule.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/SysNodeExpressionModule.java
@@ -21,45 +21,18 @@
 
 package io.crate.operation.reference.sys.node;
 
-import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.ReferenceImplementation;
-import io.crate.metadata.ReferenceInfo;
-import io.crate.metadata.sys.SysNodesTableInfo;
-import io.crate.operation.reference.sys.node.fs.NodeFsExpression;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.inject.multibindings.MapBinder;
 
-import java.util.Map;
-
 public class SysNodeExpressionModule extends AbstractModule {
 
-    private Map<ColumnIdent, ReferenceInfo> infos;
     private MapBinder<ReferenceIdent, ReferenceImplementation> refBinder;
-
-    private void bindExpr(String name, Class clazz) {
-        refBinder.addBinding(infos.get(new ColumnIdent(name)).ident()).to(clazz).asEagerSingleton();
-    }
 
     @Override
     protected void configure() {
         refBinder = MapBinder.newMapBinder(binder(), ReferenceIdent.class, ReferenceImplementation.class);
-        infos = SysNodesTableInfo.INFOS;
         bind(NodeSysExpression.class).asEagerSingleton();
-
-        bindExpr(NodeFsExpression.NAME, NodeFsExpression.class);
-        bindExpr(NodeHostnameExpression.NAME, NodeHostnameExpression.class);
-        bindExpr(NodeRestUrlExpression.NAME, NodeRestUrlExpression.class);
-        bindExpr(NodeIdExpression.NAME, NodeIdExpression.class);
-        bindExpr(NodeLoadExpression.NAME, NodeLoadExpression.class);
-        bindExpr(NodeMemoryExpression.NAME, NodeMemoryExpression.class);
-        bindExpr(NodeNameExpression.NAME, NodeNameExpression.class);
-        bindExpr(NodePortExpression.NAME, NodePortExpression.class);
-        bindExpr(NodeHeapExpression.NAME, NodeHeapExpression.class);
-        bindExpr(NodeVersionExpression.NAME, NodeVersionExpression.class);
-        bindExpr(NodeThreadPoolsExpression.NAME, NodeThreadPoolsExpression.class);
-        bindExpr(NodeNetworkExpression.NAME, NodeNetworkExpression.class);
-        bindExpr(NodeOsExpression.NAME, NodeOsExpression.class);
-        bindExpr(NodeProcessExpression.NAME, NodeProcessExpression.class);
     }
 }

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/fs/NodeFsExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/fs/NodeFsExpression.java
@@ -22,7 +22,6 @@
 package io.crate.operation.reference.sys.node.fs;
 
 import io.crate.operation.reference.sys.SysNodeObjectReference;
-import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.monitor.sigar.SigarService;
 
@@ -30,7 +29,6 @@ public class NodeFsExpression extends SysNodeObjectReference {
 
     public static final String NAME = "fs";
 
-    @Inject
     public NodeFsExpression(SigarService sigarService,
                             NodeEnvironment nodeEnvironment) {
         childImplementations.put(NodeFsTotalExpression.NAME, new NodeFsTotalExpression(sigarService));

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -42,7 +42,7 @@ import io.crate.operation.predicate.IsNullPredicate;
 import io.crate.operation.predicate.MatchPredicate;
 import io.crate.operation.predicate.NotPredicate;
 import io.crate.operation.predicate.PredicateModule;
-import io.crate.operation.reference.sys.node.NodeLoadExpression;
+import io.crate.operation.reference.sys.node.SysNodeExpressionModule;
 import io.crate.operation.scalar.ScalarFunctionModule;
 import io.crate.operation.scalar.SubscriptFunction;
 import io.crate.operation.scalar.arithmetic.AddFunction;
@@ -58,6 +58,8 @@ import io.crate.types.DataTypes;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.inject.Module;
+import org.elasticsearch.monitor.network.NetworkService;
+import org.elasticsearch.node.service.NodeService;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.IsInstanceOf;
 import org.junit.Test;
@@ -81,10 +83,10 @@ public class SelectStatementAnalyzerTest extends BaseAnalyzerTest {
     static class TestMetaDataModule extends MetaDataModule {
 
         @Override
-        protected void bindReferences() {
-            super.bindReferences();
-            referenceBinder.addBinding(LOAD_INFO.ident()).to(NodeLoadExpression.class).asEagerSingleton();
-            referenceBinder.addBinding(CLUSTER_NAME_INFO.ident()).toInstance(new ClusterNameExpression());
+        protected void configure() {
+            super.configure();
+            bind(NetworkService.class).toInstance(mock(NetworkService.class));
+            bind(NodeService.class).toInstance(mock(NodeService.class));
         }
 
         @Override

--- a/sql/src/test/java/io/crate/operation/collect/MapSideDataCollectOperationTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/MapSideDataCollectOperationTest.java
@@ -26,6 +26,7 @@ import io.crate.core.collections.TreeMapBuilder;
 import io.crate.executor.transport.TransportActionProvider;
 import io.crate.jobs.ExecutionState;
 import io.crate.metadata.*;
+import io.crate.operation.reference.sys.node.NodeSysExpression;
 import io.crate.testing.CollectingProjector;
 import io.crate.operation.projectors.ResultProvider;
 import io.crate.operation.projectors.ResultProviderFactory;
@@ -94,13 +95,13 @@ public class MapSideDataCollectOperationTest {
         NodeSettingsService nodeSettingsService = mock(NodeSettingsService.class);
 
         MapSideDataCollectOperation collectOperation = new MapSideDataCollectOperation(
-
                 clusterService,
                 ImmutableSettings.EMPTY,
                 mock(TransportActionProvider.class, Answers.RETURNS_DEEP_STUBS.get()),
                 mock(BulkRetryCoordinatorPool.class),
                 functions,
                 referenceResolver,
+                mock(NodeSysExpression.class),
                 indicesService,
                 new ThreadPool(ImmutableSettings.builder().put("name", getClass().getName()).build(), null),
                 new CollectServiceResolver(discoveryService,

--- a/sql/src/test/java/io/crate/operation/reference/sys/SysNodesExpressionsTest.java
+++ b/sql/src/test/java/io/crate/operation/reference/sys/SysNodesExpressionsTest.java
@@ -31,9 +31,7 @@ import io.crate.metadata.SimpleObjectExpression;
 import io.crate.metadata.sys.SysNodesTableInfo;
 import io.crate.operation.Input;
 import io.crate.operation.reference.NestedObjectExpression;
-import io.crate.operation.reference.sys.node.NodeVersionExpression;
-import io.crate.operation.reference.sys.node.SysNodeExpression;
-import io.crate.operation.reference.sys.node.SysNodeExpressionModule;
+import io.crate.operation.reference.sys.node.*;
 import io.crate.operation.reference.sys.node.fs.NodeFsDataExpression;
 import io.crate.operation.reference.sys.node.fs.NodeFsExpression;
 import io.crate.test.integration.CrateUnitTest;
@@ -82,11 +80,12 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static io.crate.testing.TestingHelpers.mapToSortedString;
+import static io.crate.testing.TestingHelpers.newMockedThreadPool;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.*;
 
-public class TestSysNodesExpressions extends CrateUnitTest {
+public class SysNodesExpressionsTest extends CrateUnitTest {
 
     /**
      * Resolve canonical path (platform independent)
@@ -283,10 +282,9 @@ public class TestSysNodesExpressions extends CrateUnitTest {
             when(jvmService.stats()).thenReturn(jvmStats);
             bind(JvmService.class).toInstance(jvmService);
 
-            bind(ReferenceResolver.class).to(GlobalReferenceResolver.class).asEagerSingleton();
-
             ThreadPool threadPool = new ThreadPool(getClass().getName());
             bind(ThreadPool.class).toInstance(threadPool);
+
         }
     }
 
@@ -296,7 +294,7 @@ public class TestSysNodesExpressions extends CrateUnitTest {
                 new TestModule(),
                 new SysNodeExpressionModule()
         ).createInjector();
-        resolver = injector.getInstance(ReferenceResolver.class);
+        resolver = new NodeSysReferenceResolver(injector.getInstance(NodeSysExpression.class));
     }
 
     @After

--- a/sql/src/test/java/io/crate/operation/reference/sys/TestGlobalSysExpressions.java
+++ b/sql/src/test/java/io/crate/operation/reference/sys/TestGlobalSysExpressions.java
@@ -52,6 +52,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -116,10 +117,11 @@ public class TestGlobalSysExpressions extends CrateUnitTest {
             bind(ClusterService.class).toInstance(clusterService);
             bind(TransportPutIndexTemplateAction.class).toInstance(mock(TransportPutIndexTemplateAction.class));
 
+            NodeLoadExpression loadExpr = new NodeLoadExpression(osStats);
+
             MapBinder<ReferenceIdent, ReferenceImplementation> b = MapBinder
                     .newMapBinder(binder(), ReferenceIdent.class, ReferenceImplementation.class);
-            b.addBinding(SysNodesTableInfo.INFOS.get(new ColumnIdent("load")).ident()).to(
-                    NodeLoadExpression.class).asEagerSingleton();
+            b.addBinding(SysNodesTableInfo.INFOS.get(new ColumnIdent("load")).ident()).toInstance(loadExpr);
 
             b.addBinding(SysClusterTableInfo.INFOS.get(new ColumnIdent("settings")).ident()).to(
                     ClusterSettingsExpression.class).asEagerSingleton();

--- a/sql/src/test/java/io/crate/testing/SQLTransportExecutor.java
+++ b/sql/src/test/java/io/crate/testing/SQLTransportExecutor.java
@@ -44,6 +44,7 @@ public class SQLTransportExecutor {
 
     private static final ESLogger LOGGER = Loggers.getLogger(SQLTransportExecutor.class);
     private final ClientProvider clientProvider;
+    private static final Long REQUEST_TIMEOUT = 5L;
 
     public static SQLTransportExecutor create(final TestCluster testCluster) {
         return new SQLTransportExecutor(new ClientProvider() {
@@ -59,23 +60,23 @@ public class SQLTransportExecutor {
     }
 
     public SQLResponse exec(String statement) {
-        return execute(statement, new Object[0]).actionGet(5, TimeUnit.SECONDS);
+        return execute(statement, new Object[0]).actionGet(REQUEST_TIMEOUT, TimeUnit.SECONDS);
     }
 
     public SQLResponse exec(String statement, Object... params) {
-        return execute(statement, params).actionGet(5, TimeUnit.SECONDS);
+        return execute(statement, params).actionGet(REQUEST_TIMEOUT, TimeUnit.SECONDS);
     }
 
     public SQLResponse exec(SQLRequest request) {
-        return execute(request).actionGet(5, TimeUnit.SECONDS);
+        return execute(request).actionGet(REQUEST_TIMEOUT, TimeUnit.SECONDS);
     }
 
     public SQLBulkResponse exec(String statement, Object[][] bulkArgs) {
-        return execute(statement, bulkArgs).actionGet(5, TimeUnit.SECONDS);
+        return execute(statement, bulkArgs).actionGet(REQUEST_TIMEOUT, TimeUnit.SECONDS);
     }
 
     public SQLBulkResponse exec(SQLBulkRequest request) {
-        return execute(request).actionGet(5, TimeUnit.SECONDS);
+        return execute(request).actionGet(REQUEST_TIMEOUT, TimeUnit.SECONDS);
     }
 
     public ActionFuture<SQLResponse> execute(String statement, Object[] params) {


### PR DESCRIPTION
also instantiate expressions that use os/network/jvm/process stats on demand and cache them in the resolver in order to be able to re-use the OS and process probes and achieve atomic os/process queries