### PR TITLE
invalidate cache on create table table exists check

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,9 @@ Unreleased
 
 NOTE: Upgrading from 0.49 or earlier versions requires a full cluster restart
 
+ - Fixed a race condition that could cause a `CREATE TABLE` statement
+   immediately after a `DROP TABLE` statement to fail.
+
  - Fixed a minor memory leak that occurred if custom schemas were deleted.
 
  - Fixed incorrect comparison in query by IP type

--- a/sql/src/main/java/io/crate/metadata/ReferenceInfos.java
+++ b/sql/src/main/java/io/crate/metadata/ReferenceInfos.java
@@ -200,6 +200,7 @@ public class ReferenceInfos implements Iterable<SchemaInfo>, ClusterStateListene
         if (schemaInfo == null) {
             return false;
         }
+        schemaInfo.invalidateTableCache(tableIdent.name());
         TableInfo tableInfo = schemaInfo.getTableInfo(tableIdent.name());
         //noinspection RedundantIfStatement
         if (tableInfo == null || isOrphanedAlias(tableInfo)) {

--- a/sql/src/main/java/io/crate/metadata/blob/BlobSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/blob/BlobSchemaInfo.java
@@ -116,6 +116,11 @@ public class BlobSchemaInfo implements SchemaInfo, ClusterStateListener {
     }
 
     @Override
+    public void invalidateTableCache(String tableName) {
+        cache.invalidate(tableName);
+    }
+
+    @Override
     public void clusterChanged(ClusterChangedEvent event) {
         if (event.metaDataChanged()) {
             cache.invalidateAll();

--- a/sql/src/main/java/io/crate/metadata/doc/DocSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/doc/DocSchemaInfo.java
@@ -223,6 +223,11 @@ public class DocSchemaInfo implements SchemaInfo, ClusterStateListener {
     }
 
     @Override
+    public void invalidateTableCache(String tableName) {
+        cache.invalidate(tableName);
+    }
+
+    @Override
     public void clusterChanged(ClusterChangedEvent event) {
         if (event.metaDataChanged() && cache.size() > 0) {
             cache.invalidateAll(event.indicesDeleted());

--- a/sql/src/main/java/io/crate/metadata/information/InformationSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/information/InformationSchemaInfo.java
@@ -62,6 +62,11 @@ public class InformationSchemaInfo implements SchemaInfo {
     }
 
     @Override
+    public void invalidateTableCache(String tableName) {
+
+    }
+
+    @Override
     public Iterator<? extends TableInfo> iterator() {
         return tableInfoMap.values().iterator();
     }

--- a/sql/src/main/java/io/crate/metadata/sys/SysSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysSchemaInfo.java
@@ -69,6 +69,11 @@ public class SysSchemaInfo implements SchemaInfo {
     }
 
     @Override
+    public void invalidateTableCache(String tableName) {
+
+    }
+
+    @Override
     public Iterator<? extends TableInfo> iterator() {
         return tableInfos.values().iterator();
     }

--- a/sql/src/main/java/io/crate/metadata/table/SchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/table/SchemaInfo.java
@@ -31,4 +31,6 @@ public interface SchemaInfo<T extends TableInfo> extends Iterable<T>, AutoClosea
     String name();
 
     boolean systemSchema();
+
+    void invalidateTableCache(String tableName);
 }


### PR DESCRIPTION
Otherwise the cache invalidation is "too lazy" and a script like the following
might run into an "table already exists error":

    conn = connect('localhost:4200')
    c = conn.cursor()
    c.execute('drop table if exists user')
    while True:
        c.execute('create table user (id int primary key, name string)')
        c.execute('drop table user')

This should also fix the flaky doc-test suite.