### PR TITLE
fix Listener leak in ReferenceInfos / custom DocSchemaInfo

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,8 @@ Unreleased
 
 NOTE: Upgrading from 0.49 or earlier versions requires a full cluster restart
 
+ - Fixed a minor memory leak that occurred if custom schemas were deleted.
+
  - Fixed incorrect comparison in query by IP type
 
  - Added ``probe_timestamp`` child expressions for os, process, heap, mem, and

--- a/sql/src/main/java/io/crate/metadata/blob/BlobSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/blob/BlobSchemaInfo.java
@@ -135,4 +135,9 @@ public class BlobSchemaInfo implements SchemaInfo, ClusterStateListener {
                 .filter(BlobIndices.indicesFilter)
                 .transform(BlobIndices.stripPrefix);
     }
+
+    @Override
+    public void close() throws Exception {
+        clusterService.remove(this);
+    }
 }

--- a/sql/src/main/java/io/crate/metadata/doc/DocSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/doc/DocSchemaInfo.java
@@ -131,6 +131,7 @@ public class DocSchemaInfo implements SchemaInfo, ClusterStateListener {
         clusterService.add(this);
         this.transportPutIndexTemplateAction = transportPutIndexTemplateAction;
 
+
         this.tableInfoFunction = new Function<String, TableInfo>() {
             @Nullable
             @Override
@@ -302,5 +303,10 @@ public class DocSchemaInfo implements SchemaInfo, ClusterStateListener {
     @Override
     public Iterator<TableInfo> iterator() {
         return Iterators.transform(tableNames().iterator(), tableInfoFunction);
+    }
+
+    @Override
+    public void close() throws Exception {
+        clusterService.remove(this);
     }
 }

--- a/sql/src/main/java/io/crate/metadata/information/InformationSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/information/InformationSchemaInfo.java
@@ -65,4 +65,9 @@ public class InformationSchemaInfo implements SchemaInfo {
     public Iterator<? extends TableInfo> iterator() {
         return tableInfoMap.values().iterator();
     }
+
+    @Override
+    public void close() throws Exception {
+
+    }
 }

--- a/sql/src/main/java/io/crate/metadata/sys/SysSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysSchemaInfo.java
@@ -72,4 +72,9 @@ public class SysSchemaInfo implements SchemaInfo {
     public Iterator<? extends TableInfo> iterator() {
         return tableInfos.values().iterator();
     }
+
+    @Override
+    public void close() throws Exception {
+
+    }
 }

--- a/sql/src/main/java/io/crate/metadata/table/SchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/table/SchemaInfo.java
@@ -23,7 +23,7 @@ package io.crate.metadata.table;
 
 import javax.annotation.Nullable;
 
-public interface SchemaInfo<T extends TableInfo> extends Iterable<T> {
+public interface SchemaInfo<T extends TableInfo> extends Iterable<T>, AutoCloseable {
 
     @Nullable
     TableInfo getTableInfo(String name);


### PR DESCRIPTION
The listeners that are registered in the DocSchemaInfo were never removed,
causing a memory leak.