### PR TITLE
instantiate certain aggregation dataypes on node start, not on first use

### DIFF
--- a/sql/src/main/java/io/crate/operation/aggregation/impl/AverageAggregation.java
+++ b/sql/src/main/java/io/crate/operation/aggregation/impl/AverageAggregation.java
@@ -43,6 +43,10 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
     public static final String NAME = NAMES[0];
     private final FunctionInfo info;
 
+    static {
+        DataTypes.register(AverageStateType.ID, AverageStateType.INSTANCE);
+    }
+
     /**
      * register as "avg" and "mean"
      */
@@ -96,10 +100,6 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
 
         public static final int ID = 1024;
         private static final AverageStateType INSTANCE = new AverageStateType();
-
-        private AverageStateType() {
-            DataTypes.register(ID, this);
-        }
 
         @Override
         public int id() {

--- a/sql/src/main/java/io/crate/operation/aggregation/impl/GeometricMeanAggregation.java
+++ b/sql/src/main/java/io/crate/operation/aggregation/impl/GeometricMeanAggregation.java
@@ -46,6 +46,10 @@ public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanA
 
     public static final String NAME = "geometric_mean";
 
+    static {
+        DataTypes.register(GeometricMeanStateType.ID, GeometricMeanStateType.INSTANCE);
+    }
+
     public static void register(AggregationImplModule mod) {
         for (DataType<?> t : DataTypes.NUMERIC_PRIMITIVE_TYPES) {
             mod.register(new GeometricMeanAggregation(new FunctionInfo(
@@ -115,10 +119,6 @@ public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanA
 
         public static final GeometricMeanStateType INSTANCE = new GeometricMeanStateType();
         public static final int ID = 4096;
-
-        private GeometricMeanStateType() {
-            DataTypes.register(ID, this);
-        }
 
         @Override
         public int id() {

--- a/sql/src/main/java/io/crate/operation/aggregation/impl/StandardDeviationAggregation.java
+++ b/sql/src/main/java/io/crate/operation/aggregation/impl/StandardDeviationAggregation.java
@@ -44,6 +44,9 @@ public class StandardDeviationAggregation extends AggregationFunction<StandardDe
 
     public static final String NAME = "stddev";
 
+    static {
+        DataTypes.register(StdDevStateType.ID, StdDevStateType.INSTANCE);
+    }
 
     public static void register(AggregationImplModule mod) {
         for (DataType<?> t : DataTypes.NUMERIC_PRIMITIVE_TYPES) {
@@ -84,10 +87,6 @@ public class StandardDeviationAggregation extends AggregationFunction<StandardDe
 
         public static final StdDevStateType INSTANCE = new StdDevStateType();
         public static final int ID = 8192;
-
-        private StdDevStateType() {
-            DataTypes.register(ID, this);
-        }
 
         @Override
         public int id() {

--- a/sql/src/main/java/io/crate/operation/aggregation/impl/VarianceAggregation.java
+++ b/sql/src/main/java/io/crate/operation/aggregation/impl/VarianceAggregation.java
@@ -45,6 +45,10 @@ public class VarianceAggregation extends AggregationFunction<VarianceAggregation
 
     public static final String NAME = "variance";
 
+    static {
+        DataTypes.register(VarianceStateType.ID, VarianceStateType.INSTANCE);
+    }
+
     public static void register(AggregationImplModule mod) {
         for (DataType<?> t : DataTypes.NUMERIC_PRIMITIVE_TYPES) {
             mod.register(new VarianceAggregation(new FunctionInfo(
@@ -84,10 +88,6 @@ public class VarianceAggregation extends AggregationFunction<VarianceAggregation
 
         public static final VarianceStateType INSTANCE = new VarianceStateType();
         public static final int ID = 2048;
-
-        private VarianceStateType() {
-            DataTypes.register(ID, this);
-        }
 
         @Override
         public int id() {


### PR DESCRIPTION
which has caused a NullPointerException when one or more nodes in the cluster
have not used the datatype before