### PR TITLE
fix NPE if _score is selected with order by

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed a NPE that was thrown if a SELECT statement contained `_score` in the
+   result columns and an ORDER BY clause.
+
  - Fix: selecting error from sys.jobs_log caused a NPE in some cases
 
  - Fix: If a query would fail because a shard starts to relocate during

--- a/sql/src/main/java/io/crate/operation/reference/doc/lucene/ScoreCollectorExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/doc/lucene/ScoreCollectorExpression.java
@@ -45,8 +45,15 @@ public class ScoreCollectorExpression extends
         return score;
     }
 
+    public void score(float score) {
+        this.score = score;
+    }
+
     @Override
     public void setNextDocId(int doc) {
+        if (scorer == null) {
+            return;
+        }
         try {
             score = scorer.score();
         } catch (IOException e) {

--- a/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -946,8 +946,6 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
         execute("create table quotes (quote string, " +
                 "index quote_ft using fulltext(quote)) with (number_of_replicas = 0)");
         ensureYellow();
-        assertTrue(client().admin().indices().exists(new IndicesExistsRequest("quotes"))
-                .actionGet().isExists());
 
         execute("insert into quotes values (?), (?)",
                 new Object[]{"Would it save you a lot of time if I just gave up and went mad now?",
@@ -957,6 +955,11 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
 
         execute("select quote, \"_score\" from quotes where match(quote_ft, 'time') " +
                 "and \"_score\" >= 0.98");
+        assertEquals(1L, response.rowCount());
+        assertThat((Float) response.rows()[0][1], greaterThanOrEqualTo(0.98f));
+
+        execute("select quote, \"_score\" from quotes where match(quote_ft, 'time') " +
+                "and \"_score\" >= 0.98 order by quote ");
         assertEquals(1L, response.rowCount());
         assertThat((Float) response.rows()[0][1], greaterThanOrEqualTo(0.98f));
     }


### PR DESCRIPTION
In the `searchWithOrderBy` method the scorer isn't set on 
LuceneCollectorExpression so the ScoreCollectorExpression caused an NPE.

Also removed the minimumScore check in `collect`: The ContextIndexSearcher
wraps the LuceneDocCollector inside a MinimumScoreCollector so the
minimumScore filter was already applied in some cases. (For the other cases 
ContextIndexSearcher.Stage.MAIN_QUERY had to be set)

This change was made because having rowCount++ before the minScore filter
looked like a bug but turned out to work fine (because of the
MinimumScoreCollector)