### PR TITLE
selecting error from sys.jobs_log caused

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fix: selecting error from sys.jobs_log caused a NPE in some cases
+
  - Fix: If a query would fail because a shard starts to relocate during
    query time, the query is retried now
 

--- a/sql/src/main/java/io/crate/operation/reference/sys/job/SysJobLogExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/job/SysJobLogExpression.java
@@ -64,10 +64,11 @@ public abstract class SysJobLogExpression<T> extends RowContextCollectorExpressi
             .add(new SysJobLogExpression<BytesRef>(ERROR) {
                 @Override
                 public BytesRef value() {
-                    if (row.errorMessage() == null) {
+                    String err = row.errorMessage();
+                    if (err == null) {
                         return null;
                     }
-                    return new BytesRef(row.errorMessage());
+                    return new BytesRef(err);
                 }
             })
             .build();


### PR DESCRIPTION
a NPE in some rare cases