### PR TITLE
add kill method to CrateCollector and remove JobCollectContext from doCollect

### DIFF
--- a/sql/src/main/java/io/crate/operation/collect/CrateCollector.java
+++ b/sql/src/main/java/io/crate/operation/collect/CrateCollector.java
@@ -25,5 +25,6 @@ import io.crate.operation.RowUpstream;
 
 public interface CrateCollector extends RowUpstream {
 
-    void doCollect(JobCollectContext jobCollectContext);
+    void doCollect();
+    void kill();
 }

--- a/sql/src/main/java/io/crate/operation/collect/JobQueryShardContext.java
+++ b/sql/src/main/java/io/crate/operation/collect/JobQueryShardContext.java
@@ -34,7 +34,7 @@ import org.elasticsearch.search.internal.SearchContext;
 import java.util.ArrayList;
 import java.util.List;
 
-public class JobQueryShardContext implements ExecutionSubContext, ExecutionState {
+public class JobQueryShardContext implements ExecutionSubContext {
 
     private final IndexShard indexShard;
     private final int jobSearchContextId;
@@ -45,8 +45,6 @@ public class JobQueryShardContext implements ExecutionSubContext, ExecutionState
     private EngineSearcherDelegate engineSearcherDelegate;
     private Engine.Searcher engineSearcher;
     private CrateSearchContext searchContext;
-
-    private volatile boolean isKilled = false;
 
     public JobQueryShardContext(IndexShard indexShard,
                                 int jobSearchContextId,
@@ -99,13 +97,7 @@ public class JobQueryShardContext implements ExecutionSubContext, ExecutionState
 
     @Override
     public void kill() {
-        isKilled = true;
         close();
-    }
-
-    @Override
-    public boolean isKilled() {
-        return isKilled;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/operation/collect/NoopCrateCollector.java
+++ b/sql/src/main/java/io/crate/operation/collect/NoopCrateCollector.java
@@ -24,8 +24,6 @@ package io.crate.operation.collect;
 import io.crate.operation.RowDownstream;
 import io.crate.operation.RowDownstreamHandle;
 
-import java.util.concurrent.CancellationException;
-
 public class NoopCrateCollector implements CrateCollector {
 
     private RowDownstreamHandle downstream;
@@ -35,11 +33,11 @@ public class NoopCrateCollector implements CrateCollector {
     }
 
     @Override
-    public void doCollect(JobCollectContext jobCollectContext) {
-        if (jobCollectContext.isKilled()) {
-            downstream.fail(new CancellationException());
-        } else {
-            downstream.finish();
-        }
+    public void doCollect() {
+        downstream.finish();
+    }
+
+    @Override
+    public void kill() {
     }
 }

--- a/sql/src/main/java/io/crate/operation/collect/ShardCollectService.java
+++ b/sql/src/main/java/io/crate/operation/collect/ShardCollectService.java
@@ -120,7 +120,7 @@ public class ShardCollectService {
      *
      * @param collectNode describes the collectOperation
      * @param projectorChain the shard projector chain to get the downstream from
-     * @return collector wrapping different collect implementations, call {@link io.crate.operation.collect.CrateCollector#doCollect(JobCollectContext)} )} to start
+     * @return collector wrapping different collect implementations, call {@link io.crate.operation.collect.CrateCollector#doCollect()} )} to start
      * collecting with this collector
      */
     public CrateCollector getCollector(CollectNode collectNode,
@@ -196,7 +196,8 @@ public class ShardCollectService {
                                     collectNode,
                                     functions,
                                     downstream,
-                                    shardContext);
+                                    shardContext,
+                                    jobCollectContext.ramAccountingContext());
                         } catch (Throwable t) {
                             if (localContext != null) {
                                 localContext.close();

--- a/sql/src/main/java/io/crate/operation/collect/ShardProjectorChain.java
+++ b/sql/src/main/java/io/crate/operation/collect/ShardProjectorChain.java
@@ -26,7 +26,6 @@ import com.google.common.collect.Lists;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.jobs.ExecutionState;
 import io.crate.operation.RowDownstream;
-import io.crate.operation.projectors.ProjectionToProjectorVisitor;
 import io.crate.operation.projectors.Projector;
 import io.crate.operation.projectors.ProjectorFactory;
 import io.crate.planner.RowGranularity;

--- a/sql/src/main/java/io/crate/operation/collect/blobs/BlobDocCollector.java
+++ b/sql/src/main/java/io/crate/operation/collect/blobs/BlobDocCollector.java
@@ -33,6 +33,7 @@ import io.crate.operation.collect.JobCollectContext;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.CancellationException;
 
 public class BlobDocCollector implements CrateCollector {
 
@@ -42,6 +43,7 @@ public class BlobDocCollector implements CrateCollector {
     private final Input<Boolean> condition;
 
     private RowDownstreamHandle downstream;
+    private volatile boolean killed;
 
     public BlobDocCollector(
             BlobShard blobShard,
@@ -57,8 +59,8 @@ public class BlobDocCollector implements CrateCollector {
     }
 
     @Override
-    public void doCollect(JobCollectContext jobCollectContext) {
-        BlobContainer.FileVisitor fileVisitor = new FileListingsFileVisitor(jobCollectContext);
+    public void doCollect() {
+        BlobContainer.FileVisitor fileVisitor = new FileListingsFileVisitor();
         try {
             blobShard.blobContainer().walkFiles(null, fileVisitor);
             downstream.finish();
@@ -67,18 +69,20 @@ public class BlobDocCollector implements CrateCollector {
         }
     }
 
+    @Override
+    public void kill() {
+        killed = true;
+    }
+
     private class FileListingsFileVisitor implements BlobContainer.FileVisitor {
 
         private final InputRow row = new InputRow(inputs);
-        private JobCollectContext jobCollectContext;
-
-        public FileListingsFileVisitor(JobCollectContext jobCollectContext) {
-            this.jobCollectContext = jobCollectContext;
-        }
 
         @Override
         public boolean visit(File file) throws IOException {
-            jobCollectContext.interruptIfKilled();
+            if (killed) {
+                throw new CancellationException();
+            }
             for (BlobCollectorExpression expression : expressions) {
                 expression.setNextBlob(file);
             }

--- a/sql/src/main/java/io/crate/operation/projectors/FlatProjectorChain.java
+++ b/sql/src/main/java/io/crate/operation/projectors/FlatProjectorChain.java
@@ -22,14 +22,12 @@
 package io.crate.operation.projectors;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.jobs.ExecutionState;
 import io.crate.operation.RowDownstream;
 import io.crate.planner.projection.Projection;
 
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;

--- a/sql/src/main/java/io/crate/operation/projectors/ProjectionToProjectorVisitor.java
+++ b/sql/src/main/java/io/crate/operation/projectors/ProjectionToProjectorVisitor.java
@@ -24,7 +24,6 @@ package io.crate.operation.projectors;
 import io.crate.analyze.EvaluatingNormalizer;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.executor.transport.TransportActionProvider;
-import io.crate.jobs.ExecutionState;
 import io.crate.metadata.ColumnIdent;
 import io.crate.operation.ImplementationSymbolVisitor;
 import io.crate.operation.Input;

--- a/sql/src/test/java/io/crate/operation/collect/LuceneDocCollectorTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/LuceneDocCollectorTest.java
@@ -164,7 +164,7 @@ public class LuceneDocCollectorTest extends SQLTransportIntegrationTest {
     public void testLimitWithoutOrder() throws Exception{
         collectingProjector.rows.clear();
         LuceneDocCollector docCollector = createDocCollector(null, 15, orderBy.orderBySymbols());
-        docCollector.doCollect(jobCollectContext);
+        docCollector.doCollect();
         assertThat(collectingProjector.rows.size(), is(15));
     }
 
@@ -172,7 +172,7 @@ public class LuceneDocCollectorTest extends SQLTransportIntegrationTest {
     public void testOrderedWithLimit() throws Exception{
         collectingProjector.rows.clear();
         LuceneDocCollector docCollector = createDocCollector(orderBy, 15, orderBy.orderBySymbols());
-        docCollector.doCollect(jobCollectContext);
+        docCollector.doCollect();
         assertThat(collectingProjector.rows.size(), is(15));
         assertThat(((BytesRef)collectingProjector.rows.get(0)[0]).utf8ToString(), is("Austria") );
         assertThat(((BytesRef)collectingProjector.rows.get(1)[0]).utf8ToString(), is("Germany") );
@@ -184,7 +184,7 @@ public class LuceneDocCollectorTest extends SQLTransportIntegrationTest {
     public void testOrderedWithLimitHigherThanPageSize() throws Exception{
         collectingProjector.rows.clear();
         LuceneDocCollector docCollector = createDocCollector(orderBy, PAGE_SIZE + 5, orderBy.orderBySymbols());
-        docCollector.doCollect(jobCollectContext);
+        docCollector.doCollect();
         assertThat(collectingProjector.rows.size(), is(PAGE_SIZE + 5));
         assertThat(((BytesRef)collectingProjector.rows.get(0)[0]).utf8ToString(), is("Austria") );
         assertThat(((BytesRef)collectingProjector.rows.get(1)[0]).utf8ToString(), is("Germany") );
@@ -196,7 +196,7 @@ public class LuceneDocCollectorTest extends SQLTransportIntegrationTest {
     public void testOrderedWithoutLimit() throws Exception {
         collectingProjector.rows.clear();
         LuceneDocCollector docCollector = createDocCollector(orderBy, null, orderBy.orderBySymbols(), WhereClause.MATCH_ALL, 1);
-        docCollector.doCollect(jobCollectContext);
+        docCollector.doCollect();
         assertThat(collectingProjector.rows.size(), is(NUMBER_OF_DOCS));
         assertThat(((BytesRef)collectingProjector.rows.get(0)[0]).utf8ToString(), is("Austria") );
         assertThat(((BytesRef)collectingProjector.rows.get(1)[0]).utf8ToString(), is("Germany") );
@@ -211,7 +211,7 @@ public class LuceneDocCollectorTest extends SQLTransportIntegrationTest {
         Reference ref = new Reference(new ReferenceInfo(ident, RowGranularity.DOC, DataTypes.STRING));
         OrderBy orderBy = new OrderBy(ImmutableList.of((Symbol)ref), new boolean[]{false}, new Boolean[]{true});
         LuceneDocCollector docCollector = createDocCollector(orderBy, null, orderBy.orderBySymbols(), WhereClause.MATCH_ALL, 1);
-        docCollector.doCollect(jobCollectContext);
+        docCollector.doCollect();
         assertThat(collectingProjector.rows.size(), is(NUMBER_OF_DOCS));
         assertThat(collectingProjector.rows.get(0)[0], is(nullValue()));
         assertThat(collectingProjector.rows.get(1)[0], is(nullValue()));
@@ -228,7 +228,7 @@ public class LuceneDocCollectorTest extends SQLTransportIntegrationTest {
         Reference ref = new Reference(new ReferenceInfo(ident, RowGranularity.DOC, DataTypes.STRING));
         OrderBy orderBy = new OrderBy(ImmutableList.of((Symbol)ref), new boolean[]{true}, new Boolean[]{false});
         LuceneDocCollector docCollector = createDocCollector(orderBy, null, orderBy.orderBySymbols(), WhereClause.MATCH_ALL, 1);
-        docCollector.doCollect(jobCollectContext);
+        docCollector.doCollect();
         assertThat(collectingProjector.rows.size(), is(NUMBER_OF_DOCS));
         assertThat(collectingProjector.rows.get(NUMBER_OF_DOCS - 1)[0], is(nullValue()));
         assertThat(collectingProjector.rows.get(NUMBER_OF_DOCS - 2)[0], is(nullValue()));
@@ -245,7 +245,7 @@ public class LuceneDocCollectorTest extends SQLTransportIntegrationTest {
         Reference ref = new Reference(new ReferenceInfo(ident, RowGranularity.DOC, DataTypes.STRING));
         OrderBy orderBy = new OrderBy(ImmutableList.of((Symbol)ref), new boolean[]{true}, new Boolean[]{true});
         LuceneDocCollector docCollector = createDocCollector(orderBy, null, orderBy.orderBySymbols(), WhereClause.MATCH_ALL, 1);
-        docCollector.doCollect(jobCollectContext);
+        docCollector.doCollect();
         assertThat(collectingProjector.rows.size(), is(NUMBER_OF_DOCS));
         assertThat(collectingProjector.rows.get(0)[0], is(nullValue()));
         assertThat(collectingProjector.rows.get(1)[0], is(nullValue()));
@@ -267,7 +267,7 @@ public class LuceneDocCollectorTest extends SQLTransportIntegrationTest {
         OrderBy orderBy = new OrderBy(ImmutableList.of((Symbol)population), new boolean[]{true}, new Boolean[]{true});
 
         LuceneDocCollector docCollector = createDocCollector(orderBy, null, ImmutableList.of((Symbol)countries));
-        docCollector.doCollect(jobCollectContext);
+        docCollector.doCollect();
         assertThat(collectingProjector.rows.size(), is(NUMBER_OF_DOCS));
         assertThat(collectingProjector.rows.get(0).length, is(1));
         assertThat(((BytesRef)collectingProjector.rows.get(NUMBER_OF_DOCS - 6)[0]).utf8ToString(), is("USA") );
@@ -291,7 +291,7 @@ public class LuceneDocCollectorTest extends SQLTransportIntegrationTest {
 
         OrderBy orderBy = new OrderBy(ImmutableList.of((Symbol)scalarFunction), new boolean[]{false}, new Boolean[]{false});
         LuceneDocCollector docCollector = createDocCollector(orderBy, null, ImmutableList.of((Symbol)population));
-        docCollector.doCollect(jobCollectContext);
+        docCollector.doCollect();
         assertThat(collectingProjector.rows.size(), is(NUMBER_OF_DOCS));
         assertThat(((Integer)collectingProjector.rows.get(NUMBER_OF_DOCS - 2)[0]), is(1) );
         assertThat(((Integer)collectingProjector.rows.get(NUMBER_OF_DOCS - 1)[0]), is(0) );
@@ -347,7 +347,7 @@ public class LuceneDocCollectorTest extends SQLTransportIntegrationTest {
         JobCollectContext jobCollectContext = jobContextService.getContext(node.jobId()).getSubContext(node.executionNodeId());
         LuceneDocCollector collector = (LuceneDocCollector)shardCollectService.getCollector(node, projectorChain, jobCollectContext, 0);
         collector.pageSize(1);
-        collector.doCollect(jobCollectContext);
+        collector.doCollect();
         assertThat(collectingProjector.rows.size(), is(8));
 
         String expected = "1| 0\n" +
@@ -372,7 +372,7 @@ public class LuceneDocCollectorTest extends SQLTransportIntegrationTest {
         node.orderBy(orderBy);
         collector = (LuceneDocCollector)shardCollectService.getCollector(node, projectorChain, jobCollectContext, 0);
         collector.pageSize(1);
-        collector.doCollect(jobCollectContext);
+        collector.doCollect();
 
         expected = "1| NULL\n" +
                    "1| NULL\n" +
@@ -399,7 +399,7 @@ public class LuceneDocCollectorTest extends SQLTransportIntegrationTest {
         );
         WhereClause whereClause = new WhereClause(function);
         LuceneDocCollector docCollector = createDocCollector(null, null, orderBy.orderBySymbols(), whereClause, PAGE_SIZE);
-        docCollector.doCollect(jobCollectContext);
+        docCollector.doCollect();
         assertThat(collectingProjector.rows.size(), is(0));
 
         // where _score = 1.0
@@ -411,7 +411,7 @@ public class LuceneDocCollectorTest extends SQLTransportIntegrationTest {
         );
         whereClause = new WhereClause(function);
         docCollector = createDocCollector(null, null, orderBy.orderBySymbols(), whereClause, PAGE_SIZE);
-        docCollector.doCollect(jobCollectContext);
+        docCollector.doCollect();
         assertThat(collectingProjector.rows.size(), is(NUMBER_OF_DOCS));
     }
 }

--- a/sql/src/test/java/io/crate/operation/collect/SimpleOneRowCollectorTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/SimpleOneRowCollectorTest.java
@@ -50,7 +50,7 @@ public class SimpleOneRowCollectorTest extends CrateUnitTest {
                 Collections.<CollectExpression<?>>emptySet(),
                 downstream
         );
-        collector.doCollect(mock(JobCollectContext.class));
+        collector.doCollect();
         verify(handle, times(1)).setNextRow(any(InputRow.class));
         verify(handle, times(1)).finish();
     }

--- a/sql/src/test/java/io/crate/operation/collect/files/BlobDocCollectorTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/files/BlobDocCollectorTest.java
@@ -111,7 +111,7 @@ public class BlobDocCollectorTest extends CrateUnitTest {
         );
 
         projector.startProjection(mock(ExecutionState.class));
-        collector.doCollect(mock(JobCollectContext.class));
+        collector.doCollect();
         return projector;
     }
 

--- a/sql/src/test/java/io/crate/operation/collect/files/FileReadingCollectorTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/files/FileReadingCollectorTest.java
@@ -251,7 +251,7 @@ public class FileReadingCollectorTest extends CrateUnitTest {
                 0
         );
         projector.startProjection(mock(ExecutionState.class));
-        collector.doCollect(mock(JobCollectContext.class));
+        collector.doCollect();
         return projector;
     }
 

--- a/sql/src/test/java/org/elasticsearch/action/bulk/BulkShardProcessorTest.java
+++ b/sql/src/test/java/org/elasticsearch/action/bulk/BulkShardProcessorTest.java
@@ -27,8 +27,6 @@ import io.crate.executor.transport.ShardUpsertRequest;
 import io.crate.executor.transport.ShardUpsertResponse;
 import io.crate.executor.transport.TransportActionProvider;
 import io.crate.jobs.ExecutionState;
-import io.crate.jobs.JobContextService;
-import io.crate.jobs.JobExecutionContext;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.ReferenceInfo;
 import io.crate.metadata.TableIdent;
@@ -55,7 +53,6 @@ import org.elasticsearch.index.shard.ShardId;
 import org.junit.Test;
 import org.mockito.*;
 
-import java.lang.reflect.Field;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/stresstest/src/test/java/io/crate/benchmark/LuceneDocCollectorBenchmark.java
+++ b/stresstest/src/test/java/io/crate/benchmark/LuceneDocCollectorBenchmark.java
@@ -251,7 +251,7 @@ public class LuceneDocCollectorBenchmark extends BenchmarkBase {
     public void testLuceneDocCollectorOrderedWithScrollingPerformance() throws Exception{
         collectingProjector.rows.clear();
         LuceneDocCollector docCollector = createDocCollector(orderBy, null, orderBy.orderBySymbols());
-        docCollector.doCollect(jobCollectContext);
+        docCollector.doCollect();
         collectingProjector.finish();
         MatcherAssert.assertThat(collectingProjector.rows.size(), CoreMatchers.is(NUMBER_OF_DOCUMENTS));
     }
@@ -260,7 +260,7 @@ public class LuceneDocCollectorBenchmark extends BenchmarkBase {
     @Test
     public void testLuceneDocCollectorOrderedWithoutScrollingPerformance() throws Exception{
         LuceneDocCollector docCollector = createDocCollector(orderBy, NUMBER_OF_DOCUMENTS, orderBy.orderBySymbols());
-        docCollector.doCollect(jobCollectContext);
+        docCollector.doCollect();
         collectingProjector.finish();
     }
 
@@ -281,7 +281,7 @@ public class LuceneDocCollectorBenchmark extends BenchmarkBase {
         topNProjector.downstream(collectingProjector);
         topNProjector.startProjection(jobCollectContext);
         LuceneDocCollector docCollector = createDocCollector(null, null, topNProjector, ImmutableList.of((Symbol) reference));
-        docCollector.doCollect(jobCollectContext);
+        docCollector.doCollect();
         topNProjector.doFinish();
         collectingProjector.finish();
     }
@@ -290,7 +290,7 @@ public class LuceneDocCollectorBenchmark extends BenchmarkBase {
     @Test
     public void testLuceneDocCollectorUnorderedPerformance() throws Exception{
         LuceneDocCollector docCollector = createDocCollector(null, null, ImmutableList.of((Symbol) reference));
-        docCollector.doCollect(jobCollectContext);
+        docCollector.doCollect();
         collectingProjector.finish();
     }
 


### PR DESCRIPTION
a first step towards removing the circular referencing of Context/Collector.