### PR TITLE
- Fixed a threading issue in DistributingDownstreams

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed a rare race condition that could cause some queries with offset + limit higher
+   than 1_000_000 to return too few rows
+
  - Fixed an issue that could cause concurrent queries on information_schema or
    sys tables to return inconsistent results
 

--- a/sql/src/main/java/io/crate/executor/transport/distributed/DistributedResultRequest.java
+++ b/sql/src/main/java/io/crate/executor/transport/distributed/DistributedResultRequest.java
@@ -50,11 +50,23 @@ public class DistributedResultRequest extends TransportRequest {
     public DistributedResultRequest() {
     }
 
-    public DistributedResultRequest(UUID jobId, int executionPhaseId, int bucketIdx, Streamer<?>[] streamers) {
+    private DistributedResultRequest(UUID jobId, int executionPhaseId, int bucketIdx, Streamer<?>[] streamers) {
         this.jobId = jobId;
         this.executionPhaseId = executionPhaseId;
         this.bucketIdx = bucketIdx;
         this.streamers = streamers;
+    }
+
+    public DistributedResultRequest(UUID jobId, int executionPhaseId, int bucketIdx, Streamer<?>[] streamers, Bucket rows,
+                                    boolean isLast) {
+        this(jobId, executionPhaseId, bucketIdx, streamers);
+        this.rows = rows;
+        this.isLast = isLast;
+    }
+
+    public DistributedResultRequest(UUID jobId, int executionPhaseId, int bucketIdx, Streamer<?>[] streamers, Throwable throwable) {
+        this(jobId, executionPhaseId, bucketIdx, streamers);
+        this.throwable = throwable;
     }
 
     public UUID jobId() {
@@ -88,20 +100,12 @@ public class DistributedResultRequest extends TransportRequest {
         return rows;
     }
 
-    public void rows(Bucket rows) {
-        this.rows = rows;
-    }
-
     public boolean isLast() {
         return isLast;
     }
 
     public void isLast(boolean isLast) {
         this.isLast = isLast;
-    }
-
-    public void throwable(Throwable throwable) {
-        this.throwable = throwable;
     }
 
     @Nullable

--- a/sql/src/test/java/io/crate/executor/transport/merge/DistributedResultRequestTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/merge/DistributedResultRequestTest.java
@@ -36,6 +36,7 @@ import java.util.UUID;
 import static io.crate.testing.TestingHelpers.isNullRow;
 import static io.crate.testing.TestingHelpers.isRow;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
 
 public class DistributedResultRequestTest extends CrateUnitTest {
 
@@ -48,8 +49,7 @@ public class DistributedResultRequestTest extends CrateUnitTest {
         };
         UUID uuid = UUID.randomUUID();
 
-        DistributedResultRequest r1 = new DistributedResultRequest(uuid, 1, 1, streamers);
-        r1.rows(new ArrayBucket(rows));
+        DistributedResultRequest r1 = new DistributedResultRequest(uuid, 1, 1, streamers, new ArrayBucket(rows), false);
 
         BytesStreamOutput out = new BytesStreamOutput();
         r1.writeTo(out);
@@ -60,6 +60,7 @@ public class DistributedResultRequestTest extends CrateUnitTest {
         assertTrue(r2.rowsCanBeRead());
 
         assertEquals(r1.rows().size(), r2.rows().size());
+        assertThat(r1.isLast(), is(r2.isLast()));
 
         assertThat(r2.rows(), contains(isRow("ab"), isNullRow(), isRow("cd")));
     }


### PR DESCRIPTION
that could cause some queries to return too few rows
- Prevent DistributingDownstreams to send needless
empty requests