### PR TITLE
testing: always use waitForMappingUpdateOnAll

### DIFF
--- a/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
@@ -95,6 +95,11 @@ public abstract class SQLTransportIntegrationTest extends ElasticsearchIntegrati
         return ImmutableSettings.builder().put("number_of_replicas", 0).build();
     }
 
+    @Override
+    public void waitForConcreteMappingsOnAll(String index, String type, String... fieldNames) throws Exception {
+        waitForMappingUpdateOnAll(index, fieldNames);
+    }
+
     @After
     public void assertNoJobExecutionContextAreLeftOpen() throws Exception {
         final Field activeContexts = JobContextService.class.getDeclaredField("activeContexts");


### PR DESCRIPTION
the waitForConcreteMappingsOnAll from the ES integration test class doesn't
wait for the Schema/TableInfo caches to be invalidated and might still lead to
flaky tests.

waitForMappingUpdateOnAll operates on ReferenceInfos and therefore waits for
the caches to be invalidated.