### PR TITLE
testing: fix more flaky dynamic mapping update tests

### DIFF
--- a/sql/src/test/java/io/crate/integrationtests/ObjectColumnTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ObjectColumnTest.java
@@ -87,7 +87,8 @@ public class ObjectColumnTest extends SQLTransportIntegrationTest {
                         authorMap
                 });
         refresh();
-        executeWithRetryOnUnknownColumn("select title, author, author['dead'] from ot order by title");
+        waitForMappingUpdateOnAll("ot", "author.dead");
+        execute("select title, author, author['dead'] from ot order by title");
         assertEquals(2, response.rowCount());
         assertEquals("Life, the Universe and Everything", response.rows()[0][0]);
         assertEquals(authorMap, response.rows()[0][1]);
@@ -141,7 +142,8 @@ public class ObjectColumnTest extends SQLTransportIntegrationTest {
         execute("update ot set author['job']='Writer' " +
                 "where author['name']['first_name']='Douglas' and author['name']['last_name']='Adams'");
         refresh();
-        executeWithRetryOnUnknownColumn("select author, author['job'] from ot " +
+        waitForMappingUpdateOnAll("ot", "author.job");
+        execute("select author, author['job'] from ot " +
                 "where author['name']['first_name']='Douglas' and author['name']['last_name']='Adams'");
         assertEquals(1, response.rowCount());
         assertEquals(
@@ -201,8 +203,8 @@ public class ObjectColumnTest extends SQLTransportIntegrationTest {
                         authorMap
                 });
         refresh();
-        ensureYellow(); // ensure mapping change is distributed
-        executeWithRetryOnUnknownColumn("select author from ot where author['dead']=true");
+        waitForMappingUpdateOnAll("ot", "author.dead");
+        execute("select author from ot where author['dead']=true");
         assertEquals(1, response.rowCount());
         assertEquals(authorMap, response.rows()[0][0]);
     }
@@ -259,7 +261,8 @@ public class ObjectColumnTest extends SQLTransportIntegrationTest {
                 }
         );
         refresh();
-        executeWithRetryOnUnknownColumn("select title, author['dead'] from ot order by author['dead'] desc");
+        waitForMappingUpdateOnAll("ot", "author.dead");
+        execute("select title, author['dead'] from ot order by author['dead'] desc");
         assertEquals(3, response.rowCount());
         assertEquals("The Hitchhiker's Guide to the Galaxy", response.rows()[0][0]);
         assertNull(response.rows()[0][1]);
@@ -279,8 +282,8 @@ public class ObjectColumnTest extends SQLTransportIntegrationTest {
                 "('I''m addicted to kite', {name='Youri', addresses=[{city='Dirksland', country='NL'}]})");
         execute("refresh table test");
 
-        waitNoPendingTasksOnAll();
-        executeWithRetryOnUnknownColumn("select message, person['name'], person['addresses']['city'] from test " +
+        waitForMappingUpdateOnAll("test", "person.name");
+        execute("select message, person['name'], person['addresses']['city'] from test " +
                 "where person['name'] = 'Youri'");
 
         assertEquals(1L, response.rowCount());

--- a/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
@@ -174,34 +174,6 @@ public abstract class SQLTransportIntegrationTest extends ElasticsearchIntegrati
     }
 
     /**
-     * executes the given statement and if a column unknown exception occurs it will retry up to 10 times
-     */
-    public SQLResponse executeWithRetryOnUnknownColumn(String statement) {
-        SQLActionException lastException = null;
-        int retry = 1;
-        while (retry < 4000) {
-            try {
-                response = execute(statement);
-                return response;
-            } catch (SQLActionException e) {
-                lastException = e;
-                String message = e.getMessage();
-                if (message.startsWith("Column") && message.endsWith("unknown")) {
-                    try {
-                        Thread.sleep(retry);
-                    } catch (InterruptedException e1) {
-                        // ignore
-                    }
-                    retry = retry * 2;
-                } else {
-                    throw e;
-                }
-            }
-        }
-        throw lastException;
-    }
-
-    /**
      * Execute an SQL Statement on a random node of the cluster
      *
      * @param stmt the SQL Statement

--- a/sql/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
@@ -294,17 +294,6 @@ public class SQLTypeMappingTest extends SQLTransportIntegrationTest {
     }
 
     @Test
-    public void testInsertNewColumn() throws Exception {
-        setUpSimple();
-        execute("insert into t1 (id, new_col) values (?,?)", new Object[]{0, "1970-01-01"});
-        refresh();
-
-        // schema update is async; retry if new column isn't available immediately
-        executeWithRetryOnUnknownColumn("select id, new_col from t1 where id=0");
-        assertEquals(0L, response.rows()[0][1]);
-    }
-
-    @Test
     public void testInsertNewObjectColumn() throws Exception {
         setUpSimple();
         execute("insert into t1 (id, new_col) values (?,?)", new Object[]{
@@ -318,7 +307,8 @@ public class SQLTypeMappingTest extends SQLTransportIntegrationTest {
         });
         refresh();
 
-        SQLResponse response = executeWithRetryOnUnknownColumn("select id, new_col from t1 where id=0");
+        waitForMappingUpdateOnAll("t1", "new_col");
+        SQLResponse response = execute("select id, new_col from t1 where id=0");
         @SuppressWarnings("unchecked")
         Map<String, Object> mapped = (Map<String, Object>)response.rows()[0][1];
         assertEquals(0, mapped.get("a_date"));

--- a/sql/src/test/java/io/crate/integrationtests/UpdateIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/UpdateIntegrationTest.java
@@ -211,7 +211,8 @@ public class UpdateIntegrationTest extends SQLTransportIntegrationTest {
         assertEquals(1, response.rowCount());
         refresh();
 
-        executeWithRetryOnUnknownColumn("select coolness['x'], coolness['y'] from test");
+        waitForMappingUpdateOnAll("test", "coolness.x");
+        execute("select coolness['x'], coolness['y'] from test");
         assertEquals(1, response.rowCount());
         assertEquals("3", response.rows()[0][0]);
         assertEquals(2L, response.rows()[0][1]);


### PR DESCRIPTION
Replaces executeWithRetryOnUnknownColumn with waitForMappingUpdateOnAll calls
because the former doesn't ensure that the mapping is updated on ALL nodes.

A second query after the first one that used executeWithRetryOnUnknownColumn
might still fail if it hit another node that hadn't updated the mapping yet.

Also removed `testInsertNewColumn` because
`testInsertNewColumnTableDynamic` tests the same.