### PR TITLE
extract Schemas interface from ReferenceInfos

### DIFF
--- a/sql/src/main/java/io/crate/analyze/AbstractDropTableAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/AbstractDropTableAnalyzedStatement.java
@@ -23,20 +23,20 @@ package io.crate.analyze;
 
 import io.crate.exceptions.SchemaUnknownException;
 import io.crate.exceptions.TableUnknownException;
-import io.crate.metadata.ReferenceInfos;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.TableIdent;
 import io.crate.metadata.table.TableInfo;
 
 public abstract class AbstractDropTableAnalyzedStatement extends AbstractDDLAnalyzedStatement {
 
-    protected final ReferenceInfos referenceInfos;
+    protected final Schemas schemas;
     protected final boolean dropIfExists;
 
     protected TableInfo tableInfo;
     protected boolean noop;
 
-    public AbstractDropTableAnalyzedStatement(ReferenceInfos referenceInfos, boolean dropIfExists) {
-        this.referenceInfos = referenceInfos;
+    public AbstractDropTableAnalyzedStatement(Schemas schemas, boolean dropIfExists) {
+        this.schemas = schemas;
         this.dropIfExists = dropIfExists;
     }
 
@@ -54,7 +54,7 @@ public abstract class AbstractDropTableAnalyzedStatement extends AbstractDDLAnal
 
     public void table(TableIdent tableIdent) {
         try {
-            tableInfo = referenceInfos.getWritableTable(tableIdent);
+            tableInfo = schemas.getWritableTable(tableIdent);
         } catch (SchemaUnknownException | TableUnknownException e) {
             if (dropIfExists) {
                 noop = true;

--- a/sql/src/main/java/io/crate/analyze/AddColumnAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/AddColumnAnalyzedStatement.java
@@ -21,23 +21,23 @@
 
 package io.crate.analyze;
 
-import io.crate.metadata.ReferenceInfos;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.TableIdent;
 import io.crate.metadata.table.TableInfo;
 
 public class AddColumnAnalyzedStatement extends AbstractDDLAnalyzedStatement {
 
-    private final ReferenceInfos referenceInfos;
+    private final Schemas schemas;
     private TableInfo tableInfo;
     private AnalyzedTableElements analyzedTableElements;
     private boolean newPrimaryKeys = false;
 
-    protected AddColumnAnalyzedStatement(ReferenceInfos referenceInfos) {
-        this.referenceInfos = referenceInfos;
+    protected AddColumnAnalyzedStatement(Schemas schemas) {
+        this.schemas = schemas;
     }
 
     public void table(TableIdent tableIdent) {
-        tableInfo = referenceInfos.getWritableTable(tableIdent);
+        tableInfo = schemas.getWritableTable(tableIdent);
     }
 
     public TableInfo table() {

--- a/sql/src/main/java/io/crate/analyze/AlterBlobTableAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/AlterBlobTableAnalyzedStatement.java
@@ -21,23 +21,23 @@
 
 package io.crate.analyze;
 
-import io.crate.metadata.ReferenceInfos;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.TableIdent;
 import io.crate.metadata.blob.BlobSchemaInfo;
 import io.crate.metadata.table.TableInfo;
 
 public class AlterBlobTableAnalyzedStatement extends AbstractDDLAnalyzedStatement {
 
-    private final ReferenceInfos referenceInfos;
+    private final Schemas schemas;
     private TableInfo tableInfo;
 
-    public AlterBlobTableAnalyzedStatement(ReferenceInfos referenceInfos) {
-        this.referenceInfos = referenceInfos;
+    public AlterBlobTableAnalyzedStatement(Schemas schemas) {
+        this.schemas = schemas;
     }
 
     public void table(TableIdent tableIdent) {
         assert BlobSchemaInfo.NAME.equals(tableIdent.schema());
-        tableInfo = referenceInfos.getTableInfo(tableIdent);
+        tableInfo = schemas.getTableInfo(tableIdent);
     }
 
     public TableInfo table() {

--- a/sql/src/main/java/io/crate/analyze/AlterBlobTableAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/AlterBlobTableAnalyzer.java
@@ -21,7 +21,7 @@
 
 package io.crate.analyze;
 
-import io.crate.metadata.ReferenceInfos;
+import io.crate.metadata.Schemas;
 import io.crate.sql.tree.AlterBlobTable;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
@@ -30,16 +30,16 @@ import org.elasticsearch.common.inject.Singleton;
 public class AlterBlobTableAnalyzer extends BlobTableAnalyzer<AlterBlobTableAnalyzedStatement> {
 
     private static final TablePropertiesAnalyzer TABLE_PROPERTIES_ANALYZER = new TablePropertiesAnalyzer();
-    private final ReferenceInfos referenceInfos;
+    private final Schemas schemas;
 
     @Inject
-    public AlterBlobTableAnalyzer(ReferenceInfos referenceInfos) {
-        this.referenceInfos = referenceInfos;
+    public AlterBlobTableAnalyzer(Schemas schemas) {
+        this.schemas = schemas;
     }
 
     @Override
     public AlterBlobTableAnalyzedStatement visitAlterBlobTable(AlterBlobTable node, Analysis analysis) {
-        AlterBlobTableAnalyzedStatement statement = new AlterBlobTableAnalyzedStatement(referenceInfos);
+        AlterBlobTableAnalyzedStatement statement = new AlterBlobTableAnalyzedStatement(schemas);
 
         statement.table(tableToIdent(node.table()));
 

--- a/sql/src/main/java/io/crate/analyze/AlterTableAddColumnAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/AlterTableAddColumnAnalyzer.java
@@ -36,13 +36,13 @@ import java.util.List;
 @Singleton
 public class AlterTableAddColumnAnalyzer extends DefaultTraversalVisitor<AddColumnAnalyzedStatement, Analysis> {
 
-    private final ReferenceInfos referenceInfos;
+    private final Schemas schemas;
     private final FulltextAnalyzerResolver fulltextAnalyzerResolver;
 
     @Inject
-    public AlterTableAddColumnAnalyzer(ReferenceInfos referenceInfos,
+    public AlterTableAddColumnAnalyzer(Schemas schemas,
                                        FulltextAnalyzerResolver fulltextAnalyzerResolver) {
-        this.referenceInfos = referenceInfos;
+        this.schemas = schemas;
         this.fulltextAnalyzerResolver = fulltextAnalyzerResolver;
     }
 
@@ -59,7 +59,7 @@ public class AlterTableAddColumnAnalyzer extends DefaultTraversalVisitor<AddColu
 
     @Override
     public AddColumnAnalyzedStatement visitAlterTableAddColumnStatement(AlterTableAddColumn node, Analysis analysis) {
-        AddColumnAnalyzedStatement statement = new AddColumnAnalyzedStatement(referenceInfos);
+        AddColumnAnalyzedStatement statement = new AddColumnAnalyzedStatement(schemas);
         setTableAndPartitionName(node.table(), statement, analysis.parameterContext());
 
         statement.analyzedTableElements(TableElementsAnalyzer.analyze(

--- a/sql/src/main/java/io/crate/analyze/AlterTableAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/AlterTableAnalyzedStatement.java
@@ -23,7 +23,7 @@ package io.crate.analyze;
 
 import com.google.common.base.Optional;
 import io.crate.metadata.PartitionName;
-import io.crate.metadata.ReferenceInfos;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.TableIdent;
 import io.crate.metadata.table.TableInfo;
 
@@ -31,17 +31,17 @@ import javax.annotation.Nullable;
 
 public class AlterTableAnalyzedStatement extends AbstractDDLAnalyzedStatement {
 
-    private final ReferenceInfos referenceInfos;
+    private final Schemas schemas;
     private TableInfo tableInfo;
     private Optional<PartitionName> partitionName = Optional.absent();
     private boolean excludePartitions = false;
 
-    public AlterTableAnalyzedStatement(ReferenceInfos referenceInfos) {
-        this.referenceInfos = referenceInfos;
+    public AlterTableAnalyzedStatement(Schemas schemas) {
+        this.schemas = schemas;
     }
 
     public void table(TableIdent tableIdent) {
-        tableInfo = referenceInfos.getWritableTable(tableIdent);
+        tableInfo = schemas.getWritableTable(tableIdent);
     }
 
     public TableInfo table() {

--- a/sql/src/main/java/io/crate/analyze/AlterTableAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/AlterTableAnalyzer.java
@@ -22,7 +22,7 @@
 package io.crate.analyze;
 
 import io.crate.metadata.PartitionName;
-import io.crate.metadata.ReferenceInfos;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.TableIdent;
 import io.crate.sql.tree.*;
 import org.elasticsearch.common.inject.Inject;
@@ -32,11 +32,11 @@ import org.elasticsearch.common.inject.Singleton;
 public class AlterTableAnalyzer extends DefaultTraversalVisitor<AlterTableAnalyzedStatement, Analysis> {
 
     private static final TablePropertiesAnalyzer TABLE_PROPERTIES_ANALYZER = new TablePropertiesAnalyzer();
-    private final ReferenceInfos referenceInfos;
+    private final Schemas schemas;
 
     @Inject
-    public AlterTableAnalyzer(ReferenceInfos referenceInfos) {
-        this.referenceInfos = referenceInfos;
+    public AlterTableAnalyzer(Schemas schemas) {
+        this.schemas = schemas;
     }
 
     @Override
@@ -51,7 +51,7 @@ public class AlterTableAnalyzer extends DefaultTraversalVisitor<AlterTableAnalyz
     @Override
     public AlterTableAnalyzedStatement visitAlterTable(AlterTable node, Analysis analysis) {
 
-        AlterTableAnalyzedStatement statement = new AlterTableAnalyzedStatement(referenceInfos);
+        AlterTableAnalyzedStatement statement = new AlterTableAnalyzedStatement(schemas);
         setTableAndPartitionName(node.table(), statement, analysis);
 
         TableParameterInfo tableParameterInfo = statement.table().tableParameterInfo();

--- a/sql/src/main/java/io/crate/analyze/AnalysisMetaData.java
+++ b/sql/src/main/java/io/crate/analyze/AnalysisMetaData.java
@@ -22,8 +22,8 @@
 package io.crate.analyze;
 
 import io.crate.metadata.Functions;
-import io.crate.metadata.ReferenceInfos;
 import io.crate.metadata.ReferenceResolver;
+import io.crate.metadata.Schemas;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
 
@@ -34,15 +34,15 @@ import javax.annotation.concurrent.ThreadSafe;
 public class AnalysisMetaData {
 
     private final Functions functions;
-    private final ReferenceInfos referenceInfos;
+    private final Schemas schemas;
     private final ReferenceResolver referenceResolver;
 
     @Inject
     public AnalysisMetaData(Functions functions,
-                            ReferenceInfos referenceInfos,
+                            Schemas schemas,
                             ReferenceResolver referenceResolver) {
         this.functions = functions;
-        this.referenceInfos = referenceInfos;
+        this.schemas = schemas;
         this.referenceResolver = referenceResolver;
     }
 
@@ -50,8 +50,8 @@ public class AnalysisMetaData {
         return functions;
     }
 
-    public ReferenceInfos referenceInfos() {
-        return referenceInfos;
+    public Schemas referenceInfos() {
+        return schemas;
     }
 
     public ReferenceResolver referenceResolver() {

--- a/sql/src/main/java/io/crate/analyze/CreateBlobTableAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/CreateBlobTableAnalyzedStatement.java
@@ -22,7 +22,7 @@
 package io.crate.analyze;
 
 import io.crate.exceptions.TableAlreadyExistsException;
-import io.crate.metadata.ReferenceInfos;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.TableIdent;
 
 public class CreateBlobTableAnalyzedStatement extends AbstractDDLAnalyzedStatement {
@@ -42,9 +42,9 @@ public class CreateBlobTableAnalyzedStatement extends AbstractDDLAnalyzedStateme
         return tableIdent;
     }
 
-    public void table(TableIdent tableIdent, ReferenceInfos referenceInfos) {
+    public void table(TableIdent tableIdent, Schemas schemas) {
         tableIdent.validate();
-        if (referenceInfos.tableExists(tableIdent)) {
+        if (schemas.tableExists(tableIdent)) {
             throw new TableAlreadyExistsException(tableIdent);
         }
         this.tableIdent = tableIdent;

--- a/sql/src/main/java/io/crate/analyze/CreateBlobTableStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateBlobTableStatementAnalyzer.java
@@ -23,7 +23,7 @@ package io.crate.analyze;
 
 import io.crate.Constants;
 import io.crate.analyze.expressions.ExpressionToNumberVisitor;
-import io.crate.metadata.ReferenceInfos;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.TableIdent;
 import io.crate.sql.tree.ClusteredBy;
 import io.crate.sql.tree.CreateBlobTable;
@@ -35,18 +35,18 @@ import org.elasticsearch.common.inject.Singleton;
 public class CreateBlobTableStatementAnalyzer extends BlobTableAnalyzer<CreateBlobTableAnalyzedStatement> {
 
     private static final TablePropertiesAnalyzer TABLE_PROPERTIES_ANALYZER = new TablePropertiesAnalyzer();
-    private final ReferenceInfos referenceInfos;
+    private final Schemas schemas;
 
     @Inject
-    public CreateBlobTableStatementAnalyzer(ReferenceInfos referenceInfos) {
-        this.referenceInfos = referenceInfos;
+    public CreateBlobTableStatementAnalyzer(Schemas schemas) {
+        this.schemas = schemas;
     }
 
     @Override
     public CreateBlobTableAnalyzedStatement visitCreateBlobTable(CreateBlobTable node, Analysis analysis) {
         CreateBlobTableAnalyzedStatement statement = new CreateBlobTableAnalyzedStatement();
         TableIdent tableIdent = tableToIdent(node.name());
-        statement.table(tableIdent, referenceInfos);
+        statement.table(tableIdent, schemas);
 
         if (node.clusteredBy().isPresent()) {
             ClusteredBy clusteredBy = node.clusteredBy().get();

--- a/sql/src/main/java/io/crate/analyze/CreateTableAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/CreateTableAnalyzedStatement.java
@@ -42,11 +42,11 @@ public class CreateTableAnalyzedStatement extends AbstractDDLAnalyzedStatement {
         this.fulltextAnalyzerResolver = fulltextAnalyzerResolver;
     }
 
-    public void table(TableIdent tableIdent, boolean ifNotExists, ReferenceInfos referenceInfos) {
+    public void table(TableIdent tableIdent, boolean ifNotExists, Schemas schemas) {
         tableIdent.validate();
         if (ifNotExists) {
-            noOp = referenceInfos.tableExists(tableIdent);
-        } else if (referenceInfos.tableExists(tableIdent)) {
+            noOp = schemas.tableExists(tableIdent);
+        } else if (schemas.tableExists(tableIdent)) {
             throw new TableAlreadyExistsException(tableIdent);
         }
         this.ifNotExists = ifNotExists;

--- a/sql/src/main/java/io/crate/analyze/CreateTableStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateTableStatementAnalyzer.java
@@ -23,10 +23,7 @@ package io.crate.analyze;
 import io.crate.Constants;
 import io.crate.analyze.expressions.ExpressionToNumberVisitor;
 import io.crate.analyze.expressions.ExpressionToStringVisitor;
-import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.FulltextAnalyzerResolver;
-import io.crate.metadata.ReferenceInfos;
-import io.crate.metadata.TableIdent;
+import io.crate.metadata.*;
 import io.crate.sql.tree.*;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.inject.Inject;
@@ -40,7 +37,7 @@ public class CreateTableStatementAnalyzer extends DefaultTraversalVisitor<Create
 
     private static final TablePropertiesAnalyzer TABLE_PROPERTIES_ANALYZER = new TablePropertiesAnalyzer();
     private static final String CLUSTERED_BY_IN_PARTITIONED_ERROR = "Cannot use CLUSTERED BY column in PARTITIONED BY clause";
-    private final ReferenceInfos referenceInfos;
+    private final Schemas schemas;
     private final FulltextAnalyzerResolver fulltextAnalyzerResolver;
 
     class Context {
@@ -58,9 +55,9 @@ public class CreateTableStatementAnalyzer extends DefaultTraversalVisitor<Create
     }
 
     @Inject
-    public CreateTableStatementAnalyzer(ReferenceInfos referenceInfos,
+    public CreateTableStatementAnalyzer(Schemas schemas,
                                         FulltextAnalyzerResolver fulltextAnalyzerResolver) {
-        this.referenceInfos = referenceInfos;
+        this.schemas = schemas;
         this.fulltextAnalyzerResolver = fulltextAnalyzerResolver;
     }
 
@@ -100,7 +97,7 @@ public class CreateTableStatementAnalyzer extends DefaultTraversalVisitor<Create
 
     private void setTableIdent(CreateTable node, Context context) {
         TableIdent tableIdent = TableIdent.of(node.name(), context.analysis.parameterContext().defaultSchema());
-        context.statement.table(tableIdent, node.ifNotExists(), referenceInfos);
+        context.statement.table(tableIdent, node.ifNotExists(), schemas);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/analyze/DropBlobTableAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/DropBlobTableAnalyzedStatement.java
@@ -21,12 +21,12 @@
 
 package io.crate.analyze;
 
-import io.crate.metadata.ReferenceInfos;
+import io.crate.metadata.Schemas;
 
 public class DropBlobTableAnalyzedStatement extends AbstractDropTableAnalyzedStatement {
 
-    public DropBlobTableAnalyzedStatement(ReferenceInfos referenceInfos, boolean ignoreNonExistentTable) {
-        super(referenceInfos, ignoreNonExistentTable);
+    public DropBlobTableAnalyzedStatement(Schemas schemas, boolean ignoreNonExistentTable) {
+        super(schemas, ignoreNonExistentTable);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/analyze/DropBlobTableStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/DropBlobTableStatementAnalyzer.java
@@ -21,7 +21,7 @@
 
 package io.crate.analyze;
 
-import io.crate.metadata.ReferenceInfos;
+import io.crate.metadata.Schemas;
 import io.crate.sql.tree.DropBlobTable;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
@@ -29,16 +29,16 @@ import org.elasticsearch.common.inject.Singleton;
 @Singleton
 public class DropBlobTableStatementAnalyzer extends BlobTableAnalyzer<DropBlobTableAnalyzedStatement> {
 
-    private final ReferenceInfos referenceInfos;
+    private final Schemas schemas;
 
     @Inject
-    public DropBlobTableStatementAnalyzer(ReferenceInfos referenceInfos) {
-        this.referenceInfos = referenceInfos;
+    public DropBlobTableStatementAnalyzer(Schemas schemas) {
+        this.schemas = schemas;
     }
 
     @Override
     public DropBlobTableAnalyzedStatement visitDropBlobTable(DropBlobTable node, Analysis analysis) {
-        DropBlobTableAnalyzedStatement statement = new DropBlobTableAnalyzedStatement(referenceInfos, node.ignoreNonExistentTable());
+        DropBlobTableAnalyzedStatement statement = new DropBlobTableAnalyzedStatement(schemas, node.ignoreNonExistentTable());
         statement.table(tableToIdent(node.table()));
         return statement;
     }

--- a/sql/src/main/java/io/crate/analyze/DropTableStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/DropTableStatementAnalyzer.java
@@ -21,7 +21,7 @@
 
 package io.crate.analyze;
 
-import io.crate.metadata.ReferenceInfos;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.TableIdent;
 import io.crate.sql.tree.DefaultTraversalVisitor;
 import io.crate.sql.tree.DropTable;
@@ -32,16 +32,16 @@ import org.elasticsearch.common.inject.Singleton;
 @Singleton
 public class DropTableStatementAnalyzer extends DefaultTraversalVisitor<DropTableAnalyzedStatement, Analysis> {
 
-    private final ReferenceInfos referenceInfos;
+    private final Schemas schemas;
 
     @Inject
-    protected DropTableStatementAnalyzer(ReferenceInfos referenceInfos) {
-        this.referenceInfos = referenceInfos;
+    protected DropTableStatementAnalyzer(Schemas schemas) {
+        this.schemas = schemas;
     }
 
     @Override
     public DropTableAnalyzedStatement visitDropTable(DropTable node, Analysis context) {
-        DropTableAnalyzedStatement statement = new DropTableAnalyzedStatement(referenceInfos, node.ignoreNonExistentTable());
+        DropTableAnalyzedStatement statement = new DropTableAnalyzedStatement(schemas, node.ignoreNonExistentTable());
         statement.table(TableIdent.of(node.table(), context.parameterContext().defaultSchema()));
         return statement;
     }

--- a/sql/src/main/java/io/crate/analyze/RefreshTableAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/RefreshTableAnalyzedStatement.java
@@ -23,25 +23,24 @@ package io.crate.analyze;
 
 import io.crate.exceptions.PartitionUnknownException;
 import io.crate.metadata.PartitionName;
-import io.crate.metadata.ReferenceInfos;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.TableIdent;
 import io.crate.metadata.table.TableInfo;
 
-import javax.annotation.Nullable;
 import java.util.*;
 
 public class RefreshTableAnalyzedStatement extends AbstractDDLAnalyzedStatement {
 
-    private final ReferenceInfos referenceInfos;
+    private final Schemas schemas;
     private final Set<TableInfo> tableInfos = new HashSet<>();
     private final Map<TableInfo, PartitionName> partitions = new HashMap<>();
 
-    protected RefreshTableAnalyzedStatement(ReferenceInfos referenceInfos){
-        this.referenceInfos = referenceInfos;
+    protected RefreshTableAnalyzedStatement(Schemas schemas){
+        this.schemas = schemas;
     }
 
     public TableInfo table(TableIdent tableIdent) {
-        TableInfo tableInfo = referenceInfos.getWritableTable(tableIdent);
+        TableInfo tableInfo = schemas.getWritableTable(tableIdent);
         tableInfos.add(tableInfo);
         return tableInfo;
     }

--- a/sql/src/main/java/io/crate/analyze/RefreshTableAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/RefreshTableAnalyzer.java
@@ -21,7 +21,7 @@
 
 package io.crate.analyze;
 
-import io.crate.metadata.ReferenceInfos;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.TableIdent;
 import io.crate.metadata.table.TableInfo;
 import io.crate.sql.tree.*;
@@ -33,11 +33,11 @@ import java.util.List;
 @Singleton
 public class RefreshTableAnalyzer extends DefaultTraversalVisitor<RefreshTableAnalyzedStatement, Analysis> {
 
-    private final ReferenceInfos referenceInfos;
+    private final Schemas schemas;
 
     @Inject
-    public RefreshTableAnalyzer(ReferenceInfos referenceInfos) {
-        this.referenceInfos = referenceInfos;
+    public RefreshTableAnalyzer(Schemas schemas) {
+        this.schemas = schemas;
     }
 
     public RefreshTableAnalyzedStatement analyze(Node node, Analysis analysis) {
@@ -47,7 +47,7 @@ public class RefreshTableAnalyzer extends DefaultTraversalVisitor<RefreshTableAn
 
     @Override
     public RefreshTableAnalyzedStatement visitRefreshStatement(RefreshStatement node, Analysis analysis) {
-        RefreshTableAnalyzedStatement statement = new RefreshTableAnalyzedStatement(referenceInfos);
+        RefreshTableAnalyzedStatement statement = new RefreshTableAnalyzedStatement(schemas);
         for (Table nodeTable : node.tables()) {
             TableIdent tableIdent = TableIdent.of(nodeTable, analysis.parameterContext().defaultSchema());
             TableInfo tableInfo = statement.table(tableIdent);

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -87,7 +87,7 @@ public class ExpressionAnalyzer {
     private final EvaluatingNormalizer normalizer;
     private final FieldProvider fieldProvider;
     private final Functions functions;
-    private final ReferenceInfos referenceInfos;
+    private final Schemas schemas;
     private final ParameterContext parameterContext;
     private boolean forWrite = false;
 
@@ -95,7 +95,7 @@ public class ExpressionAnalyzer {
                               ParameterContext parameterContext,
                               FieldProvider fieldProvider) {
         functions = analysisMetaData.functions();
-        referenceInfos = analysisMetaData.referenceInfos();
+        schemas = analysisMetaData.referenceInfos();
         this.parameterContext = parameterContext;
         this.fieldProvider = fieldProvider;
         this.innerAnalyzer = new InnerExpressionAnalyzer();
@@ -259,7 +259,7 @@ public class ExpressionAnalyzer {
     private Map<String, Object> normalizeObjectValue(Map<String, Object> value, ReferenceInfo info, boolean forWrite) {
         for (Map.Entry<String, Object> entry : value.entrySet()) {
             ColumnIdent nestedIdent = ColumnIdent.getChild(info.ident().columnIdent(), entry.getKey());
-            TableInfo tableInfo = referenceInfos.getTableInfo(info.ident().tableIdent());
+            TableInfo tableInfo = schemas.getTableInfo(info.ident().tableIdent());
             ReferenceInfo nestedInfo = tableInfo.getReferenceInfo(nestedIdent);
             if (nestedInfo == null) {
                 if (info.columnPolicy() == ColumnPolicy.IGNORED) {

--- a/sql/src/main/java/io/crate/metadata/MetaDataModule.java
+++ b/sql/src/main/java/io/crate/metadata/MetaDataModule.java
@@ -51,7 +51,6 @@ public class MetaDataModule extends AbstractModule {
 
     protected void bindSchemas() {
         schemaBinder = MapBinder.newMapBinder(binder(), String.class, SchemaInfo.class);
-        bind(ReferenceInfos.class).asEagerSingleton();
+        bind(Schemas.class).to(ReferenceInfos.class).asEagerSingleton();
     }
-
 }

--- a/sql/src/main/java/io/crate/metadata/PartitionName.java
+++ b/sql/src/main/java/io/crate/metadata/PartitionName.java
@@ -79,7 +79,7 @@ public class PartitionName {
     }
 
     public PartitionName(@Nullable String schemaName, String tableName, List<BytesRef> values) {
-        this.schemaName = ReferenceInfos.DEFAULT_SCHEMA_NAME.equals(schemaName) ? null : schemaName;
+        this.schemaName = Schemas.DEFAULT_SCHEMA_NAME.equals(schemaName) ? null : schemaName;
         this.tableName = tableName;
         this.values = values;
     }
@@ -204,7 +204,7 @@ public class PartitionName {
         assert tableName != null;
 
         String[] splitted = split(partitionTableName);
-        assert (splitted[0] == null && (schemaName == null || schemaName.equals(ReferenceInfos.DEFAULT_SCHEMA_NAME)))
+        assert (splitted[0] == null && (schemaName == null || schemaName.equals(Schemas.DEFAULT_SCHEMA_NAME)))
                 || (splitted[0] != null && splitted[0].equals(schemaName))
                 || splitted[1].equals(tableName) : String.format(
                 Locale.ENGLISH, "%s no partition of table %s", partitionTableName, tableName);
@@ -240,7 +240,7 @@ public class PartitionName {
         if (!indexNamePartsPredicate.apply(splitted)) {
             return false;
         } else if (splitted.size() == 4) {
-            return (schemaName == null || schemaName.equals(ReferenceInfos.DEFAULT_SCHEMA_NAME)) && splitted.get(2).equals(tableName);
+            return (schemaName == null || schemaName.equals(Schemas.DEFAULT_SCHEMA_NAME)) && splitted.get(2).equals(tableName);
         } else if (splitted.size() == 5) {
             return schemaName != null && schemaName.equals(splitted.get(0)) && splitted.get(3).equals(tableName);
         }
@@ -285,7 +285,7 @@ public class PartitionName {
      * compute the template name (used with partitioned tables) from a given schema and table name
      */
     public static String templateName(@Nullable String schemaName, String tableName) {
-        if (schemaName == null || schemaName.equals(ReferenceInfos.DEFAULT_SCHEMA_NAME)) {
+        if (schemaName == null || schemaName.equals(Schemas.DEFAULT_SCHEMA_NAME)) {
             return DOT_JOINER.join(PARTITIONED_TABLE_PREFIX, tableName, "");
         } else {
             return DOT_JOINER.join(schemaName, PARTITIONED_TABLE_PREFIX, tableName, "");
@@ -306,13 +306,13 @@ public class PartitionName {
      */
     public static String schemaName(String partitionOrTemplateName) {
         String schema = PartitionName.split(partitionOrTemplateName)[0];
-        return schema == null ? ReferenceInfos.DEFAULT_SCHEMA_NAME : schema;
+        return schema == null ? Schemas.DEFAULT_SCHEMA_NAME : schema;
     }
 
     public static Tuple<String, String> schemaAndTableName(String partitionOrTemplateName) {
         String[] splitted = PartitionName.split(partitionOrTemplateName);
         return new Tuple<>(
-                MoreObjects.firstNonNull(splitted[0], ReferenceInfos.DEFAULT_SCHEMA_NAME),
+                MoreObjects.firstNonNull(splitted[0], Schemas.DEFAULT_SCHEMA_NAME),
                 splitted[1]
         );
     }

--- a/sql/src/main/java/io/crate/metadata/ReferenceInfos.java
+++ b/sql/src/main/java/io/crate/metadata/ReferenceInfos.java
@@ -47,17 +47,13 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 
 @Singleton
-public class ReferenceInfos implements Iterable<SchemaInfo>, ClusterStateListener {
+public class ReferenceInfos implements ClusterStateListener, Schemas {
 
     private final static ESLogger LOGGER = Loggers.getLogger(ReferenceInfos.class);
-
-    public static final Pattern SCHEMA_PATTERN = Pattern.compile("^([^.]+)\\.(.+)");
-    public static final String DEFAULT_SCHEMA_NAME = "doc";
 
     private final ClusterService clusterService;
     private final TransportPutIndexTemplateAction transportPutIndexTemplateAction;
@@ -79,6 +75,7 @@ public class ReferenceInfos implements Iterable<SchemaInfo>, ClusterStateListene
         clusterService.add(this);
     }
 
+    @Override
     public TableInfo getWritableTable(TableIdent tableIdent) {
         TableInfo tableInfo = getTableInfo(tableIdent);
         if ((tableInfo.schemaInfo().systemSchema() && !tableInfo.schemaInfo().name().equals(BlobSchemaInfo.NAME))) {
@@ -101,6 +98,7 @@ public class ReferenceInfos implements Iterable<SchemaInfo>, ClusterStateListene
      * @throws io.crate.exceptions.TableUnknownException if table given in <code>ident</code> does
      *         not exist in the given schema
      */
+    @Override
     public TableInfo getTableInfo(TableIdent ident) {
         SchemaInfo schemaInfo = getSchemaInfo(ident);
         TableInfo info;
@@ -196,6 +194,7 @@ public class ReferenceInfos implements Iterable<SchemaInfo>, ClusterStateListene
         return true;
     }
 
+    @Override
     public boolean tableExists(TableIdent tableIdent) {
         SchemaInfo schemaInfo = schemas.get(firstNonNull(tableIdent.schema(), DEFAULT_SCHEMA_NAME));
         if (schemaInfo == null) {

--- a/sql/src/main/java/io/crate/metadata/Schemas.java
+++ b/sql/src/main/java/io/crate/metadata/Schemas.java
@@ -1,12 +1,12 @@
 /*
- * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * Licensed to Crate.IO GmbH ("Crate") under one or more contributor
  * license agreements.  See the NOTICE file distributed with this work for
  * additional information regarding copyright ownership.  Crate licenses
  * this file to you under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.  You may
  * obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
@@ -19,18 +19,21 @@
  * software solely pursuant to the terms of the relevant commercial agreement.
  */
 
-package io.crate.analyze;
+package io.crate.metadata;
 
-import io.crate.metadata.Schemas;
+import io.crate.metadata.table.SchemaInfo;
+import io.crate.metadata.table.TableInfo;
 
-public class DropTableAnalyzedStatement extends AbstractDropTableAnalyzedStatement {
+import java.util.regex.Pattern;
 
-    public DropTableAnalyzedStatement(Schemas schemas, boolean ignoreNonExistentTable) {
-        super(schemas, ignoreNonExistentTable);
-    }
+public interface Schemas extends Iterable<SchemaInfo> {
 
-    @Override
-    public <C, R> R accept(AnalyzedStatementVisitor<C, R> analyzedStatementVisitor, C context) {
-        return analyzedStatementVisitor.visitDropTableStatement(this, context);
-    }
+    Pattern SCHEMA_PATTERN = Pattern.compile("^([^.]+)\\.(.+)");
+    String DEFAULT_SCHEMA_NAME = "doc";
+
+    TableInfo getWritableTable(TableIdent tableIdent);
+
+    TableInfo getTableInfo(TableIdent ident);
+
+    boolean tableExists(TableIdent tableIdent);
 }

--- a/sql/src/main/java/io/crate/metadata/TableIdent.java
+++ b/sql/src/main/java/io/crate/metadata/TableIdent.java
@@ -83,7 +83,7 @@ public class TableIdent implements Comparable<TableIdent>, Streamable {
     }
 
     public String fqn() {
-        if (schema == null || schema.equalsIgnoreCase(ReferenceInfos.DEFAULT_SCHEMA_NAME)) {
+        if (schema == null || schema.equalsIgnoreCase(Schemas.DEFAULT_SCHEMA_NAME)) {
             return name;
         }
         return String.format("%s.%s", schema, name);

--- a/sql/src/main/java/io/crate/metadata/doc/DocSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/doc/DocSchemaInfo.java
@@ -38,7 +38,7 @@ import io.crate.blob.v2.BlobIndices;
 import io.crate.exceptions.TableUnknownException;
 import io.crate.exceptions.UnhandledServerException;
 import io.crate.metadata.PartitionName;
-import io.crate.metadata.ReferenceInfos;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.TableIdent;
 import io.crate.metadata.table.SchemaInfo;
 import io.crate.metadata.table.TableInfo;
@@ -73,7 +73,7 @@ public class DocSchemaInfo implements SchemaInfo, ClusterStateListener {
             if (BlobIndices.isBlobIndex(input)) {
                 return false;
             }
-            return !ReferenceInfos.SCHEMA_PATTERN.matcher(input).matches();
+            return !Schemas.SCHEMA_PATTERN.matcher(input).matches();
         }
     };
 
@@ -103,7 +103,7 @@ public class DocSchemaInfo implements SchemaInfo, ClusterStateListener {
                          ThreadPool threadPool,
                          TransportPutIndexTemplateAction transportPutIndexTemplateAction) {
         executorService = (ExecutorService) threadPool.executor(ThreadPool.Names.SUGGEST);
-        schemaName = ReferenceInfos.DEFAULT_SCHEMA_NAME;
+        schemaName = Schemas.DEFAULT_SCHEMA_NAME;
         this.clusterService = clusterService;
         clusterService.add(this);
         this.transportPutIndexTemplateAction = transportPutIndexTemplateAction;
@@ -136,7 +136,7 @@ public class DocSchemaInfo implements SchemaInfo, ClusterStateListener {
             @Nullable
             @Override
             public TableInfo apply(String input) {
-                Matcher matcher = ReferenceInfos.SCHEMA_PATTERN.matcher(input);
+                Matcher matcher = Schemas.SCHEMA_PATTERN.matcher(input);
                 if (matcher.matches()) {
                     input = matcher.group(2);
                 }
@@ -150,7 +150,7 @@ public class DocSchemaInfo implements SchemaInfo, ClusterStateListener {
                 if (BlobIndices.isBlobIndex(input)) {
                     return false;
                 }
-                Matcher matcher = ReferenceInfos.SCHEMA_PATTERN.matcher(input);
+                Matcher matcher = Schemas.SCHEMA_PATTERN.matcher(input);
                 return (matcher.matches() && matcher.group(1).equals(schemaName)) ;
             }
         };

--- a/sql/src/main/java/io/crate/metadata/doc/MetaDataDocModule.java
+++ b/sql/src/main/java/io/crate/metadata/doc/MetaDataDocModule.java
@@ -21,7 +21,7 @@
 
 package io.crate.metadata.doc;
 
-import io.crate.metadata.ReferenceInfos;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.table.SchemaInfo;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.inject.multibindings.MapBinder;
@@ -37,7 +37,7 @@ public class MetaDataDocModule extends AbstractModule {
     @Override
     protected void configure() {
         schemaBinder = MapBinder.newMapBinder(binder(), String.class, SchemaInfo.class);
-        schemaBinder.addBinding(ReferenceInfos.DEFAULT_SCHEMA_NAME).to(DocSchemaInfo.class).asEagerSingleton();
+        schemaBinder.addBinding(Schemas.DEFAULT_SCHEMA_NAME).to(DocSchemaInfo.class).asEagerSingleton();
 
         migrations = MapBinder.newMapBinder(binder(), String.class, LocalGatewayMetaMigrator.LocalGatewayMetaDataMigration.class);
         migrations.addBinding("crate-arraymapper").to(ArrayMapperMetaMigration.class).asEagerSingleton();

--- a/sql/src/main/java/io/crate/metadata/shard/ShardReferenceResolver.java
+++ b/sql/src/main/java/io/crate/metadata/shard/ShardReferenceResolver.java
@@ -43,7 +43,7 @@ public class ShardReferenceResolver extends AbstractReferenceResolver {
 
     @Inject
     public ShardReferenceResolver(Index index,
-                                  ReferenceInfos referenceInfos,
+                                  Schemas schemas,
                                   ClusterService clusterService,
                                   final Map<ReferenceIdent, ReferenceImplementation> globalImplementations,
                                   final Map<ReferenceIdent, ShardReferenceImplementation> shardImplementations) {
@@ -55,7 +55,7 @@ public class ShardReferenceResolver extends AbstractReferenceResolver {
             TableIdent tableIdent = new TableIdent(PartitionName.schemaName(index.name()), PartitionName.tableName(index.name()));
             // check if alias exists
             if (clusterService.state().metaData().hasConcreteIndex(tableIdent.esName())) {
-                TableInfo info = referenceInfos.getTableInfo(tableIdent);
+                TableInfo info = schemas.getTableInfo(tableIdent);
                 assert info.isPartitioned();
                 int i = 0;
                 int numPartitionedColumns = info.partitionedByColumns().size();

--- a/sql/src/main/java/io/crate/metadata/shard/unassigned/UnassignedShard.java
+++ b/sql/src/main/java/io/crate/metadata/shard/unassigned/UnassignedShard.java
@@ -2,7 +2,7 @@ package io.crate.metadata.shard.unassigned;
 
 import io.crate.metadata.PartitionName;
 import io.crate.blob.v2.BlobIndices;
-import io.crate.metadata.ReferenceInfos;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.blob.BlobSchemaInfo;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.cluster.ClusterService;
@@ -44,12 +44,12 @@ public class UnassignedShard {
                 orphanedPartition = true;
             }
         } else {
-            Matcher matcher = ReferenceInfos.SCHEMA_PATTERN.matcher(index);
+            Matcher matcher = Schemas.SCHEMA_PATTERN.matcher(index);
             if (matcher.matches()) {
                 this.schemaName = matcher.group(1);
                 tableName = matcher.group(2);
             } else {
-                this.schemaName = ReferenceInfos.DEFAULT_SCHEMA_NAME;
+                this.schemaName = Schemas.DEFAULT_SCHEMA_NAME;
                 tableName = index;
             }
         }

--- a/sql/src/main/java/io/crate/operation/collect/InformationSchemaCollectService.java
+++ b/sql/src/main/java/io/crate/operation/collect/InformationSchemaCollectService.java
@@ -49,7 +49,7 @@ public class InformationSchemaCollectService implements CollectService {
 
     @Inject
     protected InformationSchemaCollectService(Functions functions,
-                                              ReferenceInfos referenceInfos,
+                                              Schemas schemas,
                                               InformationDocLevelReferenceResolver refResolver,
                                               FulltextAnalyzerResolver ftResolver,
                                               ClusterService clusterService) {
@@ -57,7 +57,7 @@ public class InformationSchemaCollectService implements CollectService {
         RoutineInfos routineInfos = new RoutineInfos(ftResolver);
         this.docInputSymbolVisitor = new CollectInputSymbolVisitor<>(functions, refResolver);
 
-        Iterable<TableInfo> tablesIterable = FluentIterable.from(referenceInfos)
+        Iterable<TableInfo> tablesIterable = FluentIterable.from(schemas)
                 .transformAndConcat(new Function<SchemaInfo, Iterable<TableInfo>>() {
                     @Nullable
                     @Override
@@ -103,7 +103,7 @@ public class InformationSchemaCollectService implements CollectService {
                 .put("information_schema.table_constraints", tableConstraintsIterable)
                 .put("information_schema.table_partitions", tablePartitionsIterable)
                 .put("information_schema.routines", routinesIterable)
-                .put("information_schema.schemata", referenceInfos).build();
+                .put("information_schema.schemata", schemas).build();
     }
 
     class ColumnsIterator implements Iterator<ColumnContext>, Iterable<ColumnContext> {

--- a/sql/src/main/java/io/crate/operation/reference/information/InformationColumnsExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/information/InformationColumnsExpression.java
@@ -21,8 +21,8 @@
 
 package io.crate.operation.reference.information;
 
-import io.crate.metadata.ReferenceInfos;
 import io.crate.metadata.RowContextCollectorExpression;
+import io.crate.metadata.Schemas;
 import org.apache.lucene.util.BytesRef;
 
 
@@ -31,7 +31,7 @@ public abstract class InformationColumnsExpression<T>
 
     public static class ColumnsSchemaNameExpression extends InformationColumnsExpression<BytesRef> {
 
-        static final BytesRef DOC_SCHEMA_INFO = new BytesRef(ReferenceInfos.DEFAULT_SCHEMA_NAME);
+        static final BytesRef DOC_SCHEMA_INFO = new BytesRef(Schemas.DEFAULT_SCHEMA_NAME);
 
         @Override
         public BytesRef value() {

--- a/sql/src/main/java/io/crate/operation/reference/information/InformationDocLevelReferenceResolver.java
+++ b/sql/src/main/java/io/crate/operation/reference/information/InformationDocLevelReferenceResolver.java
@@ -41,7 +41,7 @@ import java.util.Map;
 public class InformationDocLevelReferenceResolver implements DocLevelReferenceResolver<RowCollectExpression<?, ?>> {
 
     private final Map<TableIdent, Map<ColumnIdent, RowCollectExpressionFactory>> factoryMap;
-    private final BytesRef DOC_SCHEMA_INFO = new BytesRef(ReferenceInfos.DEFAULT_SCHEMA_NAME);
+    private final BytesRef DOC_SCHEMA_INFO = new BytesRef(Schemas.DEFAULT_SCHEMA_NAME);
 
     @Inject
     public InformationDocLevelReferenceResolver() {

--- a/sql/src/main/java/io/crate/operation/reference/information/InformationTablePartitionsExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/information/InformationTablePartitionsExpression.java
@@ -21,8 +21,8 @@
 package io.crate.operation.reference.information;
 
 import io.crate.metadata.PartitionInfo;
-import io.crate.metadata.ReferenceInfos;
 import io.crate.metadata.RowContextCollectorExpression;
+import io.crate.metadata.Schemas;
 import org.apache.lucene.util.BytesRef;
 
 import java.util.Map;
@@ -39,7 +39,7 @@ public abstract class InformationTablePartitionsExpression<T>
 
     public static class PartitionsSchemaNameExpression extends InformationTablePartitionsExpression<BytesRef> {
 
-        private final BytesRef DOC_SCHEMA_INFO = new BytesRef(ReferenceInfos.DEFAULT_SCHEMA_NAME);
+        private final BytesRef DOC_SCHEMA_INFO = new BytesRef(Schemas.DEFAULT_SCHEMA_NAME);
 
         @Override
         public BytesRef value() {

--- a/sql/src/main/java/io/crate/operation/reference/sys/shard/ShardSchemaNameExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/shard/ShardSchemaNameExpression.java
@@ -21,7 +21,7 @@
 
 package io.crate.operation.reference.sys.shard;
 
-import io.crate.metadata.ReferenceInfos;
+import io.crate.metadata.Schemas;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.index.shard.ShardId;
@@ -31,13 +31,13 @@ import java.util.regex.Matcher;
 public class ShardSchemaNameExpression extends SysShardExpression<BytesRef> {
 
     public static final String NAME = "schema_name";
-    private static final BytesRef DOC_SCHEMA_NAME = new BytesRef(ReferenceInfos.DEFAULT_SCHEMA_NAME);
+    private static final BytesRef DOC_SCHEMA_NAME = new BytesRef(Schemas.DEFAULT_SCHEMA_NAME);
     private final BytesRef schemaName;
 
     @Inject
     public ShardSchemaNameExpression(ShardId shardId) {
         String indexName = shardId.getIndex();
-        Matcher matcher = ReferenceInfos.SCHEMA_PATTERN.matcher(indexName);
+        Matcher matcher = Schemas.SCHEMA_PATTERN.matcher(indexName);
         if (matcher.matches()) {
             schemaName = new BytesRef(matcher.group(1));
         } else {

--- a/sql/src/main/java/io/crate/operation/reference/sys/shard/ShardTableNameExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/shard/ShardTableNameExpression.java
@@ -21,7 +21,7 @@
 package io.crate.operation.reference.sys.shard;
 
 import io.crate.metadata.PartitionName;
-import io.crate.metadata.ReferenceInfos;
+import io.crate.metadata.Schemas;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.index.shard.ShardId;
@@ -41,7 +41,7 @@ public class ShardTableNameExpression extends SysShardExpression<BytesRef> {
         } catch (IllegalArgumentException e) {
             // no partition
         }
-        Matcher matcher = ReferenceInfos.SCHEMA_PATTERN.matcher(tableName);
+        Matcher matcher = Schemas.SCHEMA_PATTERN.matcher(tableName);
         if (matcher.matches()) {
             tableName = matcher.group(2);
         }

--- a/sql/src/main/java/io/crate/planner/symbol/SymbolFormatter.java
+++ b/sql/src/main/java/io/crate/planner/symbol/SymbolFormatter.java
@@ -23,7 +23,7 @@ package io.crate.planner.symbol;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
-import io.crate.metadata.ReferenceInfos;
+import io.crate.metadata.Schemas;
 import org.apache.lucene.util.BytesRef;
 
 import javax.annotation.Nullable;
@@ -91,7 +91,7 @@ public class SymbolFormatter extends SymbolVisitor<Void, String> {
     public String visitReference(Reference symbol, Void context) {
         StringBuilder builder = new StringBuilder();
         String schema = symbol.info().ident().tableIdent().schema();
-        if (schema != null && !schema.equals(ReferenceInfos.DEFAULT_SCHEMA_NAME)) {
+        if (schema != null && !schema.equals(Schemas.DEFAULT_SCHEMA_NAME)) {
             builder.append(symbol.info().ident().tableIdent().schema()).append(".");
         }
         return builder.append(symbol.info().ident().tableIdent().name())

--- a/sql/src/test/java/io/crate/analyze/AlterTableAddColumnAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/AlterTableAddColumnAnalyzerTest.java
@@ -24,7 +24,7 @@ package io.crate.analyze;
 import io.crate.core.collections.StringObjectMaps;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.MetaDataModule;
-import io.crate.metadata.ReferenceInfos;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.sys.MetaDataSysModule;
 import io.crate.metadata.table.SchemaInfo;
 import io.crate.sql.parser.ParsingException;
@@ -59,7 +59,7 @@ public class AlterTableAddColumnAnalyzerTest extends BaseAnalyzerTest {
             when(schemaInfo.getTableInfo(TEST_DOC_TABLE_IDENT_CLUSTERED_BY_ONLY.name()))
                     .thenReturn(userTableInfoClusteredByOnly);
             when(schemaInfo.getTableInfo(DEEPLY_NESTED_TABLE_IDENT.name())).thenReturn(DEEPLY_NESTED_TABLE_INFO);
-            schemaBinder.addBinding(ReferenceInfos.DEFAULT_SCHEMA_NAME).toInstance(schemaInfo);
+            schemaBinder.addBinding(Schemas.DEFAULT_SCHEMA_NAME).toInstance(schemaInfo);
         }
     }
 

--- a/sql/src/test/java/io/crate/analyze/BaseAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/BaseAnalyzerTest.java
@@ -62,7 +62,7 @@ public abstract class BaseAnalyzerTest extends CrateUnitTest {
             .put("nodeOne", TreeMapBuilder.<String, List<Integer>>newMapBuilder().put("t1", Arrays.asList(1, 2)).map())
             .put("nodeTow", TreeMapBuilder.<String, List<Integer>>newMapBuilder().put("t1", Arrays.asList(3, 4)).map())
             .map());
-    static final TableIdent TEST_DOC_TABLE_IDENT = new TableIdent(ReferenceInfos.DEFAULT_SCHEMA_NAME, "users");
+    static final TableIdent TEST_DOC_TABLE_IDENT = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "users");
     static final TableInfo userTableInfo = TestingTableInfo.builder(TEST_DOC_TABLE_IDENT, RowGranularity.DOC, shardRouting)
             .add("id", DataTypes.LONG, null)
             .add("other_id", DataTypes.LONG, null)
@@ -84,7 +84,7 @@ public abstract class BaseAnalyzerTest extends CrateUnitTest {
             .addPrimaryKey("id")
             .clusteredBy("id")
             .build();
-    static final TableIdent TEST_DOC_TABLE_IDENT_MULTI_PK = new TableIdent(ReferenceInfos.DEFAULT_SCHEMA_NAME, "users_multi_pk");
+    static final TableIdent TEST_DOC_TABLE_IDENT_MULTI_PK = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "users_multi_pk");
     static final TableInfo userTableInfoMultiPk = TestingTableInfo.builder(TEST_DOC_TABLE_IDENT_MULTI_PK, RowGranularity.DOC, shardRouting)
             .add("id", DataTypes.LONG, null)
             .add("name", DataTypes.STRING, null)
@@ -95,7 +95,7 @@ public abstract class BaseAnalyzerTest extends CrateUnitTest {
             .addPrimaryKey("name")
             .clusteredBy("id")
             .build();
-    static final TableIdent TEST_DOC_TABLE_IDENT_CLUSTERED_BY_ONLY = new TableIdent(ReferenceInfos.DEFAULT_SCHEMA_NAME, "users_clustered_by_only");
+    static final TableIdent TEST_DOC_TABLE_IDENT_CLUSTERED_BY_ONLY = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "users_clustered_by_only");
     static final TableInfo userTableInfoClusteredByOnly = TestingTableInfo.builder(TEST_DOC_TABLE_IDENT_CLUSTERED_BY_ONLY, RowGranularity.DOC, shardRouting)
             .add("id", DataTypes.LONG, null)
             .add("name", DataTypes.STRING, null)
@@ -104,13 +104,13 @@ public abstract class BaseAnalyzerTest extends CrateUnitTest {
             .add("friends", new ArrayType(DataTypes.OBJECT), null, ColumnPolicy.DYNAMIC)
             .clusteredBy("id")
             .build();
-    static final TableIdent TEST_DOC_TABLE_REFRESH_INTERVAL_BY_ONLY = new TableIdent(ReferenceInfos.DEFAULT_SCHEMA_NAME, "user_refresh_interval");
+    static final TableIdent TEST_DOC_TABLE_REFRESH_INTERVAL_BY_ONLY = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "user_refresh_interval");
     static final TableInfo userTableInfoRefreshIntervalByOnly = TestingTableInfo.builder(TEST_DOC_TABLE_REFRESH_INTERVAL_BY_ONLY, RowGranularity.DOC, shardRouting)
             .add("id", DataTypes.LONG, null)
             .add("content", DataTypes.STRING, null)
             .clusteredBy("id")
             .build();
-    static final TableIdent NESTED_PK_TABLE_IDENT = new TableIdent(ReferenceInfos.DEFAULT_SCHEMA_NAME, "nested_pk");
+    static final TableIdent NESTED_PK_TABLE_IDENT = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "nested_pk");
     static final TableInfo nestedPkTableInfo = TestingTableInfo.builder(NESTED_PK_TABLE_IDENT, RowGranularity.DOC, shardRouting)
             .add("id", DataTypes.LONG, null)
             .add("o", DataTypes.OBJECT, null, ColumnPolicy.DYNAMIC)
@@ -119,7 +119,7 @@ public abstract class BaseAnalyzerTest extends CrateUnitTest {
             .addPrimaryKey("o.b")
             .clusteredBy("o.b")
             .build();
-    static final TableIdent TEST_PARTITIONED_TABLE_IDENT = new TableIdent(ReferenceInfos.DEFAULT_SCHEMA_NAME, "parted");
+    static final TableIdent TEST_PARTITIONED_TABLE_IDENT = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "parted");
     static final TableInfo TEST_PARTITIONED_TABLE_INFO = new TestingTableInfo.Builder(
             TEST_PARTITIONED_TABLE_IDENT, RowGranularity.DOC, new Routing())
             .add("id", DataTypes.INTEGER, null)
@@ -132,7 +132,7 @@ public abstract class BaseAnalyzerTest extends CrateUnitTest {
                     new PartitionName("parted", Arrays.asList(new BytesRef("1395961200000"))).stringValue(),
                     new PartitionName("parted", new ArrayList<BytesRef>(){{add(null);}}).stringValue())
             .build();
-    static final TableIdent TEST_MULTIPLE_PARTITIONED_TABLE_IDENT = new TableIdent(ReferenceInfos.DEFAULT_SCHEMA_NAME, "multi_parted");
+    static final TableIdent TEST_MULTIPLE_PARTITIONED_TABLE_IDENT = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "multi_parted");
     static final TableInfo TEST_MULTIPLE_PARTITIONED_TABLE_INFO = new TestingTableInfo.Builder(
             TEST_MULTIPLE_PARTITIONED_TABLE_IDENT, RowGranularity.DOC, new Routing())
             .add("id", DataTypes.INTEGER, null)
@@ -146,7 +146,7 @@ public abstract class BaseAnalyzerTest extends CrateUnitTest {
                     new PartitionName("multi_parted", Arrays.asList(new BytesRef("1395961200000"), new BytesRef("-100"))).stringValue(),
                     new PartitionName("multi_parted", Arrays.asList(null, new BytesRef("-100"))).stringValue())
             .build();
-    static final TableIdent TEST_NESTED_PARTITIONED_TABLE_IDENT = new TableIdent(ReferenceInfos.DEFAULT_SCHEMA_NAME, "nested_parted");
+    static final TableIdent TEST_NESTED_PARTITIONED_TABLE_IDENT = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "nested_parted");
     static final TableInfo TEST_NESTED_PARTITIONED_TABLE_INFO = new TestingTableInfo.Builder(
             TEST_NESTED_PARTITIONED_TABLE_IDENT, RowGranularity.DOC, new Routing())
             .add("id", DataTypes.INTEGER, null)
@@ -159,7 +159,7 @@ public abstract class BaseAnalyzerTest extends CrateUnitTest {
                     new PartitionName("nested_parted", Arrays.asList(new BytesRef("1395961200000"), new BytesRef("Ford"))).stringValue(),
                     new PartitionName("nested_parted", Arrays.asList(null, new BytesRef("Zaphod"))).stringValue())
             .build();
-    static final TableIdent TEST_DOC_TRANSACTIONS_TABLE_IDENT = new TableIdent(ReferenceInfos.DEFAULT_SCHEMA_NAME, "transactions");
+    static final TableIdent TEST_DOC_TRANSACTIONS_TABLE_IDENT = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "transactions");
     static final TableInfo TEST_DOC_TRANSACTIONS_TABLE_INFO = new TestingTableInfo.Builder(
             TEST_DOC_TRANSACTIONS_TABLE_IDENT, RowGranularity.DOC, new Routing())
             .add("id", DataTypes.LONG, null)
@@ -168,7 +168,7 @@ public abstract class BaseAnalyzerTest extends CrateUnitTest {
             .add("amount", DataTypes.DOUBLE, null)
             .add("timestamp", DataTypes.TIMESTAMP, null)
             .build();
-    static final TableIdent DEEPLY_NESTED_TABLE_IDENT = new TableIdent(ReferenceInfos.DEFAULT_SCHEMA_NAME, "deeply_nested");
+    static final TableIdent DEEPLY_NESTED_TABLE_IDENT = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "deeply_nested");
     static final TableInfo DEEPLY_NESTED_TABLE_INFO = new TestingTableInfo.Builder(
             DEEPLY_NESTED_TABLE_IDENT, RowGranularity.DOC, new Routing())
             .add("details", DataTypes.OBJECT, null, ColumnPolicy.DYNAMIC)
@@ -184,19 +184,19 @@ public abstract class BaseAnalyzerTest extends CrateUnitTest {
             .add("tags", DataTypes.LONG, Arrays.asList("metadata", "id"))
             .build();
 
-    public static final TableIdent IGNORED_NESTED_TABLE_IDENT = new TableIdent(ReferenceInfos.DEFAULT_SCHEMA_NAME, "ignored_nested");
+    public static final TableIdent IGNORED_NESTED_TABLE_IDENT = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "ignored_nested");
     public static final TableInfo IGNORED_NESTED_TABLE_INFO = new TestingTableInfo.Builder(
                 IGNORED_NESTED_TABLE_IDENT, RowGranularity.DOC, new Routing())
                 .add("details", DataTypes.OBJECT, null, ColumnPolicy.IGNORED)
                 .build();
 
-    static final TableIdent TEST_DOC_LOCATIONS_TABLE_IDENT = new TableIdent(ReferenceInfos.DEFAULT_SCHEMA_NAME, "locations");
+    static final TableIdent TEST_DOC_LOCATIONS_TABLE_IDENT = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "locations");
     static final TableInfo TEST_DOC_LOCATIONS_TABLE_INFO = TestingTableInfo.builder(TEST_DOC_LOCATIONS_TABLE_IDENT, RowGranularity.DOC, shardRouting)
             .add("id", DataTypes.LONG, null)
             .add("loc", DataTypes.GEO_POINT, null)
             .build();
 
-    static final TableInfo TEST_CLUSTER_BY_STRING_TABLE_INFO = TestingTableInfo.builder(new TableIdent(ReferenceInfos.DEFAULT_SCHEMA_NAME, "bystring"), RowGranularity.DOC, shardRouting)
+    static final TableInfo TEST_CLUSTER_BY_STRING_TABLE_INFO = TestingTableInfo.builder(new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "bystring"), RowGranularity.DOC, shardRouting)
             .add("name", DataTypes.STRING, null)
             .add("score", DataTypes.DOUBLE, null)
             .addPrimaryKey("name")
@@ -310,12 +310,12 @@ public abstract class BaseAnalyzerTest extends CrateUnitTest {
 
     protected AnalyzedStatement analyze(String statement, Object[] params) {
         return analyzer.analyze(SqlParser.createStatement(statement),
-                new ParameterContext(params, new Object[0][], ReferenceInfos.DEFAULT_SCHEMA_NAME)).analyzedStatement();
+                new ParameterContext(params, new Object[0][], Schemas.DEFAULT_SCHEMA_NAME)).analyzedStatement();
     }
 
     protected AnalyzedStatement analyze(String statement, Object[][] bulkArgs) {
         return analyzer.analyze(SqlParser.createStatement(statement),
-                new ParameterContext(new Object[0], bulkArgs, ReferenceInfos.DEFAULT_SCHEMA_NAME)).analyzedStatement();
+                new ParameterContext(new Object[0], bulkArgs, Schemas.DEFAULT_SCHEMA_NAME)).analyzedStatement();
     }
 
     protected List<Module> getModules() {

--- a/sql/src/test/java/io/crate/analyze/CopyAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CopyAnalyzerTest.java
@@ -26,7 +26,7 @@ import io.crate.exceptions.PartitionUnknownException;
 import io.crate.exceptions.SchemaUnknownException;
 import io.crate.exceptions.TableUnknownException;
 import io.crate.metadata.MetaDataModule;
-import io.crate.metadata.ReferenceInfos;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.sys.MetaDataSysModule;
 import io.crate.metadata.table.SchemaInfo;
 import io.crate.operation.operator.OperatorModule;
@@ -62,7 +62,7 @@ public class CopyAnalyzerTest extends BaseAnalyzerTest {
             SchemaInfo schemaInfo = mock(SchemaInfo.class);
             when(schemaInfo.getTableInfo(TEST_DOC_TABLE_IDENT.name())).thenReturn(userTableInfo);
             when(schemaInfo.getTableInfo(TEST_PARTITIONED_TABLE_IDENT.name())).thenReturn(TEST_PARTITIONED_TABLE_INFO);
-            schemaBinder.addBinding(ReferenceInfos.DEFAULT_SCHEMA_NAME).toInstance(schemaInfo);
+            schemaBinder.addBinding(Schemas.DEFAULT_SCHEMA_NAME).toInstance(schemaInfo);
         }
     }
 

--- a/sql/src/test/java/io/crate/analyze/CreateAlterPartitionedTableAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateAlterPartitionedTableAnalyzerTest.java
@@ -22,10 +22,7 @@
 package io.crate.analyze;
 
 import io.crate.exceptions.ColumnUnknownException;
-import io.crate.metadata.FulltextAnalyzerResolver;
-import io.crate.metadata.MetaDataModule;
-import io.crate.metadata.PartitionName;
-import io.crate.metadata.ReferenceInfos;
+import io.crate.metadata.*;
 import io.crate.metadata.information.MetaDataInformationModule;
 import io.crate.metadata.sys.MetaDataSysModule;
 import io.crate.metadata.table.SchemaInfo;
@@ -74,7 +71,7 @@ public class CreateAlterPartitionedTableAnalyzerTest extends BaseAnalyzerTest {
             when(schemaInfo.getTableInfo(TEST_DOC_TABLE_REFRESH_INTERVAL_BY_ONLY.name())).thenReturn(userTableInfoRefreshIntervalByOnly);
             when(schemaInfo.getTableInfo(TEST_PARTITIONED_TABLE_IDENT.name())).thenReturn(TEST_PARTITIONED_TABLE_INFO);
             when(schemaInfo.getTableInfo(TEST_MULTIPLE_PARTITIONED_TABLE_IDENT.name())).thenReturn(TEST_MULTIPLE_PARTITIONED_TABLE_INFO);
-            schemaBinder.addBinding(ReferenceInfos.DEFAULT_SCHEMA_NAME).toInstance(schemaInfo);
+            schemaBinder.addBinding(Schemas.DEFAULT_SCHEMA_NAME).toInstance(schemaInfo);
         }
     }
 

--- a/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -70,7 +70,7 @@ public class CreateAlterTableStatementAnalyzerTest extends BaseAnalyzerTest {
             SchemaInfo schemaInfo = mock(SchemaInfo.class);
             when(schemaInfo.getTableInfo(TEST_DOC_TABLE_IDENT.name())).thenReturn(userTableInfo);
             when(schemaInfo.getTableInfo(TEST_DOC_TABLE_REFRESH_INTERVAL_BY_ONLY.name())).thenReturn(userTableInfoRefreshIntervalByOnly);
-            schemaBinder.addBinding(ReferenceInfos.DEFAULT_SCHEMA_NAME).toInstance(schemaInfo);
+            schemaBinder.addBinding(Schemas.DEFAULT_SCHEMA_NAME).toInstance(schemaInfo);
         }
     }
 

--- a/sql/src/test/java/io/crate/analyze/CreateAnalyzerAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateAnalyzerAnalyzerTest.java
@@ -22,7 +22,7 @@
 package io.crate.analyze;
 
 import io.crate.metadata.MetaDataModule;
-import io.crate.metadata.ReferenceInfos;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.information.MetaDataInformationModule;
 import io.crate.metadata.sys.MetaDataSysModule;
 import io.crate.metadata.table.SchemaInfo;
@@ -49,7 +49,7 @@ public class CreateAnalyzerAnalyzerTest extends BaseAnalyzerTest {
             super.bindSchemas();
             SchemaInfo schemaInfo = mock(SchemaInfo.class);
             when(schemaInfo.getTableInfo(TEST_DOC_TABLE_IDENT.name())).thenReturn(userTableInfo);
-            schemaBinder.addBinding(ReferenceInfos.DEFAULT_SCHEMA_NAME).toInstance(schemaInfo);
+            schemaBinder.addBinding(Schemas.DEFAULT_SCHEMA_NAME).toInstance(schemaInfo);
         }
     }
 

--- a/sql/src/test/java/io/crate/analyze/DeleteAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/DeleteAnalyzerTest.java
@@ -24,7 +24,7 @@ package io.crate.analyze;
 import io.crate.analyze.relations.TableRelation;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.MetaDataModule;
-import io.crate.metadata.ReferenceInfos;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.sys.MetaDataSysModule;
 import io.crate.metadata.table.SchemaInfo;
 import io.crate.metadata.table.TableInfo;
@@ -58,7 +58,7 @@ public class DeleteAnalyzerTest extends BaseAnalyzerTest {
             when(schemaInfo.getTableInfo(TEST_DOC_TABLE_IDENT.name())).thenReturn(userTableInfo);
             when(schemaInfo.getTableInfo(TEST_PARTITIONED_TABLE_IDENT.name()))
                     .thenReturn(TEST_PARTITIONED_TABLE_INFO);
-            schemaBinder.addBinding(ReferenceInfos.DEFAULT_SCHEMA_NAME).toInstance(schemaInfo);
+            schemaBinder.addBinding(Schemas.DEFAULT_SCHEMA_NAME).toInstance(schemaInfo);
         }
     }
 

--- a/sql/src/test/java/io/crate/analyze/DropBlobTableAnalyzedStatementTest.java
+++ b/sql/src/test/java/io/crate/analyze/DropBlobTableAnalyzedStatementTest.java
@@ -23,7 +23,7 @@ package io.crate.analyze;
 
 
 import io.crate.exceptions.TableUnknownException;
-import io.crate.metadata.ReferenceInfos;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.TableIdent;
 import io.crate.metadata.blob.BlobSchemaInfo;
 import io.crate.test.integration.CrateUnitTest;
@@ -38,22 +38,22 @@ public class DropBlobTableAnalyzedStatementTest extends CrateUnitTest {
 
     public static final String IRRELEVANT = "Irrelevant";
 
-    private ReferenceInfos referenceInfos;
+    private Schemas schemas;
 
     private DropBlobTableAnalyzedStatement dropBlobTableAnalyzedStatement;
 
 
     @Before
     public void prepare() {
-        referenceInfos = mock(ReferenceInfos.class);
+        schemas = mock(Schemas.class);
     }
 
     @Test
     public void testDeletingNoExistingTableSetsNoopIfIgnoreNonExistentTablesIsSet() throws Exception {
         TableIdent tableIdent = new TableIdent(BlobSchemaInfo.NAME, IRRELEVANT);
-        when(referenceInfos.getWritableTable(tableIdent)).thenThrow(new TableUnknownException(tableIdent));
+        when(schemas.getWritableTable(tableIdent)).thenThrow(new TableUnknownException(tableIdent));
 
-        dropBlobTableAnalyzedStatement = new DropBlobTableAnalyzedStatement(referenceInfos, true);
+        dropBlobTableAnalyzedStatement = new DropBlobTableAnalyzedStatement(schemas, true);
         dropBlobTableAnalyzedStatement.table(tableIdent);
         assertThat(dropBlobTableAnalyzedStatement.noop(), is(true));
     }
@@ -63,9 +63,9 @@ public class DropBlobTableAnalyzedStatementTest extends CrateUnitTest {
         expectedException.expect(TableUnknownException.class);
         expectedException.expectMessage("Table 'blob.Irrelevant' unknown");
         TableIdent tableIdent = new TableIdent(BlobSchemaInfo.NAME, IRRELEVANT);
-        when(referenceInfos.getWritableTable(tableIdent)).thenThrow(new TableUnknownException(tableIdent));
+        when(schemas.getWritableTable(tableIdent)).thenThrow(new TableUnknownException(tableIdent));
 
-        dropBlobTableAnalyzedStatement = new DropBlobTableAnalyzedStatement(referenceInfos, false);
+        dropBlobTableAnalyzedStatement = new DropBlobTableAnalyzedStatement(schemas, false);
         dropBlobTableAnalyzedStatement.table(tableIdent);
     }
 }

--- a/sql/src/test/java/io/crate/analyze/DropTableAnalyzedStatementTest.java
+++ b/sql/src/test/java/io/crate/analyze/DropTableAnalyzedStatementTest.java
@@ -23,7 +23,7 @@ package io.crate.analyze;
 
 
 import io.crate.exceptions.TableUnknownException;
-import io.crate.metadata.ReferenceInfos;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.TableIdent;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.TableInfo;
@@ -39,13 +39,13 @@ public class DropTableAnalyzedStatementTest extends CrateUnitTest {
 
     public static final String IRRELEVANT = "Irrelevant";
 
-    private ReferenceInfos referenceInfos;
+    private Schemas schemas;
 
     private DropTableAnalyzedStatement dropTableAnalyzedStatement;
 
     @Before
     public void prepare() {
-        referenceInfos = mock(ReferenceInfos.class);
+        schemas = mock(Schemas.class);
     }
 
     @Test
@@ -54,18 +54,18 @@ public class DropTableAnalyzedStatementTest extends CrateUnitTest {
         expectedException.expectMessage(String.format("Table '%s.%s' unknown", IRRELEVANT, IRRELEVANT));
 
         TableIdent tableIdent = new TableIdent(IRRELEVANT, IRRELEVANT);
-        when(referenceInfos.getWritableTable(tableIdent)).thenThrow(new TableUnknownException(tableIdent));
+        when(schemas.getWritableTable(tableIdent)).thenThrow(new TableUnknownException(tableIdent));
 
-        dropTableAnalyzedStatement = new DropTableAnalyzedStatement(referenceInfos, false);
+        dropTableAnalyzedStatement = new DropTableAnalyzedStatement(schemas, false);
         dropTableAnalyzedStatement.table(tableIdent);
     }
 
     @Test
     public void unknownTableSetsNoopIfIgnoreNonExistentTablesIsSet() throws Exception {
         TableIdent tableIdent = new TableIdent(IRRELEVANT, IRRELEVANT);
-        when(referenceInfos.getWritableTable(tableIdent)).thenThrow(new TableUnknownException(tableIdent));
+        when(schemas.getWritableTable(tableIdent)).thenThrow(new TableUnknownException(tableIdent));
 
-        dropTableAnalyzedStatement = new DropTableAnalyzedStatement(referenceInfos, true);
+        dropTableAnalyzedStatement = new DropTableAnalyzedStatement(schemas, true);
         dropTableAnalyzedStatement.table(tableIdent);
 
         assertThat(dropTableAnalyzedStatement.noop(), is(true));
@@ -79,7 +79,7 @@ public class DropTableAnalyzedStatementTest extends CrateUnitTest {
 
         TableIdent tableIdent = new TableIdent(IRRELEVANT, IRRELEVANT);
 
-        dropTableAnalyzedStatement = new DropTableAnalyzedStatement(referenceInfos, true);
+        dropTableAnalyzedStatement = new DropTableAnalyzedStatement(schemas, true);
 
         dropTableAnalyzedStatement.table(tableIdent);
         assertThat(dropTableAnalyzedStatement.noop(), is(false));

--- a/sql/src/test/java/io/crate/analyze/DropTableAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/DropTableAnalyzerTest.java
@@ -24,7 +24,7 @@ package io.crate.analyze;
 import io.crate.exceptions.SchemaUnknownException;
 import io.crate.exceptions.TableUnknownException;
 import io.crate.metadata.MetaDataModule;
-import io.crate.metadata.ReferenceInfos;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.information.MetaDataInformationModule;
 import io.crate.metadata.sys.MetaDataSysModule;
 import io.crate.metadata.table.SchemaInfo;
@@ -52,7 +52,7 @@ public class DropTableAnalyzerTest extends BaseAnalyzerTest {
             super.bindSchemas();
             SchemaInfo schemaInfo = mock(SchemaInfo.class);
             when(schemaInfo.getTableInfo(TEST_DOC_TABLE_IDENT.name())).thenReturn(userTableInfo);
-            schemaBinder.addBinding(ReferenceInfos.DEFAULT_SCHEMA_NAME).toInstance(schemaInfo);
+            schemaBinder.addBinding(Schemas.DEFAULT_SCHEMA_NAME).toInstance(schemaInfo);
         }
     }
 

--- a/sql/src/test/java/io/crate/analyze/ExpressionAnalyzerNormalizeTest.java
+++ b/sql/src/test/java/io/crate/analyze/ExpressionAnalyzerNormalizeTest.java
@@ -158,7 +158,7 @@ public class ExpressionAnalyzerNormalizeTest extends CrateUnitTest {
             super.bindSchemas();
             SchemaInfo schemaInfo = mock(SchemaInfo.class);
             when(schemaInfo.getTableInfo(TEST_TABLE_IDENT.name())).thenReturn(userTableInfo);
-            schemaBinder.addBinding(ReferenceInfos.DEFAULT_SCHEMA_NAME).toInstance(schemaInfo);
+            schemaBinder.addBinding(Schemas.DEFAULT_SCHEMA_NAME).toInstance(schemaInfo);
         }
     }
 

--- a/sql/src/test/java/io/crate/analyze/InsertFromSubQueryAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/InsertFromSubQueryAnalyzerTest.java
@@ -23,7 +23,7 @@ package io.crate.analyze;
 
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.metadata.MetaDataModule;
-import io.crate.metadata.ReferenceInfos;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.sys.MetaDataSysModule;
 import io.crate.metadata.table.SchemaInfo;
 import io.crate.operation.aggregation.impl.AggregationImplModule;
@@ -65,7 +65,7 @@ public class InsertFromSubQueryAnalyzerTest extends BaseAnalyzerTest {
                     .thenReturn(TEST_PARTITIONED_TABLE_INFO);
             when(schemaInfo.getTableInfo(TEST_NESTED_PARTITIONED_TABLE_IDENT.name()))
                     .thenReturn(TEST_NESTED_PARTITIONED_TABLE_INFO);
-            schemaBinder.addBinding(ReferenceInfos.DEFAULT_SCHEMA_NAME).toInstance(schemaInfo);
+            schemaBinder.addBinding(Schemas.DEFAULT_SCHEMA_NAME).toInstance(schemaInfo);
         }
     }
 

--- a/sql/src/test/java/io/crate/analyze/InsertFromValuesAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/InsertFromValuesAnalyzerTest.java
@@ -84,7 +84,7 @@ public class InsertFromValuesAnalyzerTest extends BaseAnalyzerTest {
                     .thenReturn(DEEPLY_NESTED_TABLE_INFO);
             when(schemaInfo.getTableInfo(NESTED_CLUSTERED_TABLE_IDENT.name()))
                     .thenReturn(NESTED_CLUSTERED_TABLE_INFO);
-            schemaBinder.addBinding(ReferenceInfos.DEFAULT_SCHEMA_NAME).toInstance(schemaInfo);
+            schemaBinder.addBinding(Schemas.DEFAULT_SCHEMA_NAME).toInstance(schemaInfo);
         }
 
         @Override

--- a/sql/src/test/java/io/crate/analyze/RefreshAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/RefreshAnalyzerTest.java
@@ -21,9 +21,6 @@
 
 package io.crate.analyze;
 
-import com.google.common.base.Function;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Multimaps;
 import io.crate.exceptions.TableUnknownException;
 import io.crate.metadata.*;
 import io.crate.metadata.blob.BlobSchemaInfo;
@@ -38,7 +35,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import javax.annotation.Nullable;
 import java.util.*;
 
 import static org.hamcrest.Matchers.contains;
@@ -71,7 +67,7 @@ public class RefreshAnalyzerTest extends BaseAnalyzerTest {
                     .thenReturn(TEST_PARTITIONED_TABLE_INFO);
             when(docSchemaInfo.getTableInfo(TEST_DOC_TABLE_IDENT.name())).thenReturn(userTableInfo);
 
-            schemaBinder.addBinding(ReferenceInfos.DEFAULT_SCHEMA_NAME).toInstance(docSchemaInfo);
+            schemaBinder.addBinding(Schemas.DEFAULT_SCHEMA_NAME).toInstance(docSchemaInfo);
         }
     }
 

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -30,7 +30,7 @@ import io.crate.exceptions.ColumnUnknownException;
 import io.crate.exceptions.UnsupportedFeatureException;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.MetaDataModule;
-import io.crate.metadata.ReferenceInfos;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.sys.MetaDataSysModule;
 import io.crate.metadata.sys.SysNodesTableInfo;
 import io.crate.metadata.table.SchemaInfo;
@@ -42,7 +42,6 @@ import io.crate.operation.predicate.IsNullPredicate;
 import io.crate.operation.predicate.MatchPredicate;
 import io.crate.operation.predicate.NotPredicate;
 import io.crate.operation.predicate.PredicateModule;
-import io.crate.operation.reference.sys.node.SysNodeExpressionModule;
 import io.crate.operation.scalar.ScalarFunctionModule;
 import io.crate.operation.scalar.SubscriptFunction;
 import io.crate.operation.scalar.arithmetic.AddFunction;
@@ -107,7 +106,7 @@ public class SelectStatementAnalyzerTest extends BaseAnalyzerTest {
                     .thenReturn(TEST_DOC_LOCATIONS_TABLE_INFO);
             when(schemaInfo.getTableInfo(TEST_CLUSTER_BY_STRING_TABLE_INFO.ident().name()))
                     .thenReturn(TEST_CLUSTER_BY_STRING_TABLE_INFO);
-            schemaBinder.addBinding(ReferenceInfos.DEFAULT_SCHEMA_NAME).toInstance(schemaInfo);
+            schemaBinder.addBinding(Schemas.DEFAULT_SCHEMA_NAME).toInstance(schemaInfo);
         }
 
         @Override

--- a/sql/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
@@ -68,7 +68,7 @@ public class UpdateAnalyzerTest extends BaseAnalyzerTest {
             .add("other_obj", DataTypes.OBJECT, null)
             .clusteredBy("obj.name").build();
 
-    private final static TableIdent TEST_ALIAS_TABLE_IDENT = new TableIdent(ReferenceInfos.DEFAULT_SCHEMA_NAME, "alias");
+    private final static TableIdent TEST_ALIAS_TABLE_IDENT = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "alias");
     private final static TableInfo TEST_ALIAS_TABLE_INFO = new TestingTableInfo.Builder(
             TEST_ALIAS_TABLE_IDENT, RowGranularity.DOC, new Routing())
             .add("bla", DataTypes.STRING, null)
@@ -86,7 +86,7 @@ public class UpdateAnalyzerTest extends BaseAnalyzerTest {
                     .thenReturn(TEST_PARTITIONED_TABLE_INFO);
             when(schemaInfo.getTableInfo(DEEPLY_NESTED_TABLE_IDENT.name())).thenReturn(DEEPLY_NESTED_TABLE_INFO);
             when(schemaInfo.getTableInfo(NESTED_CLUSTERED_BY_TABLE_IDENT.name())).thenReturn(NESTED_CLUSTERED_BY_TABLE_INFO);
-            schemaBinder.addBinding(ReferenceInfos.DEFAULT_SCHEMA_NAME).toInstance(schemaInfo);
+            schemaBinder.addBinding(Schemas.DEFAULT_SCHEMA_NAME).toInstance(schemaInfo);
         }
 
         @Override
@@ -116,12 +116,12 @@ public class UpdateAnalyzerTest extends BaseAnalyzerTest {
 
     protected UpdateAnalyzedStatement analyze(String statement, Object[] params) {
         return (UpdateAnalyzedStatement) analyzer.analyze(SqlParser.createStatement(statement),
-                new ParameterContext(params, new Object[0][], ReferenceInfos.DEFAULT_SCHEMA_NAME)).analyzedStatement();
+                new ParameterContext(params, new Object[0][], Schemas.DEFAULT_SCHEMA_NAME)).analyzedStatement();
     }
 
     protected UpdateAnalyzedStatement analyze(String statement, Object[][] bulkArgs) {
         return (UpdateAnalyzedStatement) analyzer.analyze(SqlParser.createStatement(statement),
-                new ParameterContext(new Object[0], bulkArgs, ReferenceInfos.DEFAULT_SCHEMA_NAME)).analyzedStatement();
+                new ParameterContext(new Object[0], bulkArgs, Schemas.DEFAULT_SCHEMA_NAME)).analyzedStatement();
     }
 
     @Test
@@ -192,7 +192,7 @@ public class UpdateAnalyzerTest extends BaseAnalyzerTest {
         UpdateAnalyzedStatement statement = analyze("update users set name='Trillian'");
         UpdateAnalyzedStatement.NestedAnalyzedStatement statement1 = statement.nestedStatements().get(0);
         assertThat(statement1.assignments().size(), is(1));
-        assertThat(((TableRelation) statement.sourceRelation()).tableInfo().ident(), is(new TableIdent(ReferenceInfos.DEFAULT_SCHEMA_NAME, "users")));
+        assertThat(((TableRelation) statement.sourceRelation()).tableInfo().ident(), is(new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "users")));
 
         Reference ref = statement1.assignments().keySet().iterator().next();
         assertThat(ref.info().ident().tableIdent().name(), is("users"));

--- a/sql/src/test/java/io/crate/analyze/where/WhereClauseAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/where/WhereClauseAnalyzerTest.java
@@ -107,7 +107,7 @@ public class WhereClauseAnalyzerTest extends CrateUnitTest {
             super.bindSchemas();
             bind(ThreadPool.class).toInstance(threadPool);
             SchemaInfo schemaInfo = mock(SchemaInfo.class);
-            when(schemaInfo.name()).thenReturn(ReferenceInfos.DEFAULT_SCHEMA_NAME);
+            when(schemaInfo.name()).thenReturn(Schemas.DEFAULT_SCHEMA_NAME);
             when(schemaInfo.getTableInfo("users")).thenReturn(
                     TestingTableInfo.builder(new TableIdent("doc", "users"), RowGranularity.DOC, twoNodeRouting)
                             .add("id", DataTypes.STRING, null)
@@ -170,13 +170,13 @@ public class WhereClauseAnalyzerTest extends CrateUnitTest {
                             .add("friends", new ArrayType(DataTypes.OBJECT), null, ColumnPolicy.DYNAMIC)
                             .clusteredBy("id")
                             .build());
-            schemaBinder.addBinding(ReferenceInfos.DEFAULT_SCHEMA_NAME).toInstance(schemaInfo);
+            schemaBinder.addBinding(Schemas.DEFAULT_SCHEMA_NAME).toInstance(schemaInfo);
         }
     }
 
     private DeleteAnalyzedStatement analyzeDelete(String stmt, Object[][] bulkArgs) {
         return (DeleteAnalyzedStatement) analyzer.analyze(SqlParser.createStatement(stmt),
-                new ParameterContext(new Object[0], bulkArgs, ReferenceInfos.DEFAULT_SCHEMA_NAME)).analyzedStatement();
+                new ParameterContext(new Object[0], bulkArgs, Schemas.DEFAULT_SCHEMA_NAME)).analyzedStatement();
     }
 
     private DeleteAnalyzedStatement analyzeDelete(String stmt) {
@@ -185,12 +185,12 @@ public class WhereClauseAnalyzerTest extends CrateUnitTest {
 
     private UpdateAnalyzedStatement analyzeUpdate(String stmt) {
         return (UpdateAnalyzedStatement) analyzer.analyze(SqlParser.createStatement(stmt),
-                new ParameterContext(new Object[0], new Object[0][], ReferenceInfos.DEFAULT_SCHEMA_NAME)).analyzedStatement();
+                new ParameterContext(new Object[0], new Object[0][], Schemas.DEFAULT_SCHEMA_NAME)).analyzedStatement();
     }
 
     private WhereClause analyzeSelect(String stmt, Object... args) {
         SelectAnalyzedStatement statement = (SelectAnalyzedStatement) analyzer.analyze(SqlParser.createStatement(stmt),
-                new ParameterContext(args, new Object[0][], ReferenceInfos.DEFAULT_SCHEMA_NAME)).analyzedStatement();
+                new ParameterContext(args, new Object[0][], Schemas.DEFAULT_SCHEMA_NAME)).analyzedStatement();
         return statement.relation().querySpec().where();
     }
 

--- a/sql/src/test/java/io/crate/executor/transport/TransportExecutorTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/TransportExecutorTest.java
@@ -309,14 +309,14 @@ public class TransportExecutorTest extends BaseTransportExecutorTest {
 
         Reference id_ref = new Reference(new ReferenceInfo(
                 new ReferenceIdent(
-                        new TableIdent(ReferenceInfos.DEFAULT_SCHEMA_NAME, "searchf"),
+                        new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "searchf"),
                         "id"),
                 RowGranularity.DOC,
                 DataTypes.INTEGER
         ));
         Reference date_ref = new Reference(new ReferenceInfo(
                 new ReferenceIdent(
-                        new TableIdent(ReferenceInfos.DEFAULT_SCHEMA_NAME, "searchf"),
+                        new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "searchf"),
                         "date"),
                 RowGranularity.DOC,
                 DataTypes.TIMESTAMP

--- a/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
@@ -29,10 +29,8 @@ import io.crate.action.sql.parser.SQLXContentSourceParser;
 import io.crate.jobs.JobContextService;
 import io.crate.jobs.JobExecutionContext;
 import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.ReferenceInfos;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.TableIdent;
-import io.crate.metadata.doc.DocSchemaInfo;
-import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.TableInfo;
 import io.crate.plugin.CrateCorePlugin;
 import io.crate.testing.SQLTransportExecutor;
@@ -227,9 +225,9 @@ public abstract class SQLTransportIntegrationTest extends ElasticsearchIntegrati
         assertBusy(new Runnable() {
             @Override
             public void run() {
-                Iterable<ReferenceInfos> referenceInfosIterable = internalCluster().getInstances(ReferenceInfos.class);
-                for (ReferenceInfos referenceInfos : referenceInfosIterable) {
-                    TableInfo tableInfo = referenceInfos.getTableInfo(tableIdent);
+                Iterable<Schemas> referenceInfosIterable = internalCluster().getInstances(Schemas.class);
+                for (Schemas schemas : referenceInfosIterable) {
+                    TableInfo tableInfo = schemas.getTableInfo(tableIdent);
                     assertThat(tableInfo, Matchers.notNullValue());
                     for (String fieldName : fieldNames) {
                         ColumnIdent columnIdent = ColumnIdent.fromPath(fieldName);

--- a/sql/src/test/java/io/crate/metadata/PartitionNameTest.java
+++ b/sql/src/test/java/io/crate/metadata/PartitionNameTest.java
@@ -242,7 +242,7 @@ public class PartitionNameTest extends CrateUnitTest {
     public void splitTemplateName() throws Exception {
         assertThat(PartitionName.split(PartitionName.templateName("schema", "t")), arrayContaining("schema", "t", ""));
         assertThat(PartitionName.split(PartitionName.templateName(null, "t")), arrayContaining(null, "t", ""));
-        assertThat(PartitionName.split(PartitionName.templateName(ReferenceInfos.DEFAULT_SCHEMA_NAME, "t")), arrayContaining(null, "t", ""));
+        assertThat(PartitionName.split(PartitionName.templateName(Schemas.DEFAULT_SCHEMA_NAME, "t")), arrayContaining(null, "t", ""));
     }
 
     @Test
@@ -294,7 +294,7 @@ public class PartitionNameTest extends CrateUnitTest {
                 is("081620j2")
         );
         Assert.assertThat(
-                PartitionName.ident(new PartitionName(ReferenceInfos.DEFAULT_SCHEMA_NAME, "table", new ArrayList<BytesRef>() {{
+                PartitionName.ident(new PartitionName(Schemas.DEFAULT_SCHEMA_NAME, "table", new ArrayList<BytesRef>() {{
                     add(null);
                 }}).stringValue()),
                 is("0400")
@@ -308,7 +308,7 @@ public class PartitionNameTest extends CrateUnitTest {
                         new PartitionName("table", Arrays.asList(new BytesRef("xxx")))));
         assertTrue(
                 new PartitionName(null, "table", Arrays.asList(new BytesRef("xxx"))).equals(
-                        new PartitionName(ReferenceInfos.DEFAULT_SCHEMA_NAME, "table", Arrays.asList(new BytesRef("xxx")))));
+                        new PartitionName(Schemas.DEFAULT_SCHEMA_NAME, "table", Arrays.asList(new BytesRef("xxx")))));
         assertFalse(
                 new PartitionName("table", Arrays.asList(new BytesRef("xxx"))).equals(
                         new PartitionName("schema", "table", Arrays.asList(new BytesRef("xxx")))));

--- a/sql/src/test/java/io/crate/metadata/ReferenceInfosITest.java
+++ b/sql/src/test/java/io/crate/metadata/ReferenceInfosITest.java
@@ -40,11 +40,11 @@ import static org.hamcrest.core.Is.is;
 @ElasticsearchIntegrationTest.ClusterScope(numDataNodes = 2, numClientNodes = 0)
 public class ReferenceInfosITest extends SQLTransportIntegrationTest {
 
-    private ReferenceInfos referenceInfos;
+    private Schemas schemas;
 
     @Before
     public void setUpService() {
-        referenceInfos = internalCluster().getInstance(ReferenceInfos.class);
+        schemas = internalCluster().getInstance(Schemas.class);
     }
 
     @Test
@@ -56,7 +56,7 @@ public class ReferenceInfosITest extends SQLTransportIntegrationTest {
                 ") clustered into 10 shards with (number_of_replicas=1)");
         ensureYellow();
 
-        DocTableInfo ti = (DocTableInfo) referenceInfos.getTableInfo(new TableIdent(null, "t1"));
+        DocTableInfo ti = (DocTableInfo) schemas.getTableInfo(new TableIdent(null, "t1"));
         assertThat(ti.ident().name(), is("t1"));
 
         assertThat(ti.columns().size(), is(3));
@@ -88,8 +88,8 @@ public class ReferenceInfosITest extends SQLTransportIntegrationTest {
         client().admin().indices().aliases(request).actionGet();
         ensureGreen();
 
-        TableInfo terminatorTable = referenceInfos.getTableInfo(new TableIdent(null, "terminator"));
-        TableInfo entsafterTable = referenceInfos.getTableInfo(new TableIdent(null, "entsafter"));
+        TableInfo terminatorTable = schemas.getTableInfo(new TableIdent(null, "terminator"));
+        TableInfo entsafterTable = schemas.getTableInfo(new TableIdent(null, "entsafter"));
         assertNotNull(terminatorTable);
         assertFalse(terminatorTable.isAlias());
 
@@ -107,7 +107,7 @@ public class ReferenceInfosITest extends SQLTransportIntegrationTest {
         client().admin().indices().aliases(request).actionGet();
         ensureYellow();
 
-        TableInfo entsafterTable = referenceInfos.getTableInfo(new TableIdent(null, "entsafter"));
+        TableInfo entsafterTable = schemas.getTableInfo(new TableIdent(null, "entsafter"));
         assertNotNull(entsafterTable);
         assertThat(entsafterTable.concreteIndices().length, is(2));
         assertThat(Arrays.asList(entsafterTable.concreteIndices()), containsInAnyOrder("terminator", "transformer"));
@@ -116,7 +116,7 @@ public class ReferenceInfosITest extends SQLTransportIntegrationTest {
 
     @Test
     public void testNodesTable() throws Exception {
-        TableInfo ti = referenceInfos.getTableInfo(new TableIdent("sys", "nodes"));
+        TableInfo ti = schemas.getTableInfo(new TableIdent("sys", "nodes"));
         Routing routing = ti.getRouting(null, null);
         assertTrue(routing.hasLocations());
         assertEquals(2, routing.nodes().size());
@@ -131,7 +131,7 @@ public class ReferenceInfosITest extends SQLTransportIntegrationTest {
         execute("create table t3 (id int primary key) clustered into 8 shards with(number_of_replicas=0)");
         ensureYellow();
 
-        TableInfo ti = referenceInfos.getTableInfo(new TableIdent("sys", "shards"));
+        TableInfo ti = schemas.getTableInfo(new TableIdent("sys", "shards"));
         Routing routing = ti.getRouting(null, null);
 
         Set<String> tables = new HashSet<>();
@@ -149,7 +149,7 @@ public class ReferenceInfosITest extends SQLTransportIntegrationTest {
 
     @Test
     public void testClusterTable() throws Exception {
-        TableInfo ti = referenceInfos.getTableInfo(new TableIdent("sys", "cluster"));
+        TableInfo ti = schemas.getTableInfo(new TableIdent("sys", "cluster"));
         assertTrue(ti.getRouting(null, null).locations().containsKey(TableInfo.NULL_NODE_ID));
     }
 }

--- a/sql/src/test/java/io/crate/metadata/ReferenceInfosTest.java
+++ b/sql/src/test/java/io/crate/metadata/ReferenceInfosTest.java
@@ -75,8 +75,8 @@ public class ReferenceInfosTest {
         SchemaInfo schemaInfo = schemaInfoMock(tableIdent);
         when(schemaInfo.systemSchema()).thenReturn(true);
 
-        ReferenceInfos referenceInfos = getReferenceInfos(schemaInfo);
-        referenceInfos.getWritableTable(tableIdent);
+        Schemas schemas = getReferenceInfos(schemaInfo);
+        schemas.getWritableTable(tableIdent);
     }
 
     @Test
@@ -88,8 +88,8 @@ public class ReferenceInfosTest {
         SchemaInfo schemaInfo = schemaInfoMock(tableIdent);
         when(schemaInfo.systemSchema()).thenReturn(false);
 
-        ReferenceInfos referenceInfos = getReferenceInfos(schemaInfo);
-        referenceInfos.getWritableTable(tableIdent);
+        Schemas schemas = getReferenceInfos(schemaInfo);
+        schemas.getWritableTable(tableIdent);
     }
 
     private SchemaInfo schemaInfoMock(TableIdent tableIdent) {
@@ -103,7 +103,7 @@ public class ReferenceInfosTest {
         return schemaInfo;
     }
 
-    private ReferenceInfos getReferenceInfos(SchemaInfo schemaInfo) {
+    private Schemas getReferenceInfos(SchemaInfo schemaInfo) {
         Map<String, SchemaInfo> builtInSchema = new HashMap<>();
         builtInSchema.put(schemaInfo.name(), schemaInfo);
 

--- a/sql/src/test/java/io/crate/operation/collect/DocLevelCollectTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/DocLevelCollectTest.java
@@ -191,7 +191,7 @@ public class DocLevelCollectTest extends SQLTransportIntegrationTest {
     @Test
     public void testCollectWithPartitionedColumns() throws Exception {
         Routing routing = docSchemaInfo.getTableInfo(PARTITIONED_TABLE_NAME).getRouting(WhereClause.MATCH_ALL, null);
-        TableIdent tableIdent = new TableIdent(ReferenceInfos.DEFAULT_SCHEMA_NAME, PARTITIONED_TABLE_NAME);
+        TableIdent tableIdent = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, PARTITIONED_TABLE_NAME);
         CollectPhase collectNode = getCollectNode(
                 Arrays.<Symbol>asList(
                         new Reference(new ReferenceInfo(new ReferenceIdent(tableIdent, "id"),

--- a/sql/src/test/java/io/crate/operation/collect/LocalDataCollectTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/LocalDataCollectTest.java
@@ -202,7 +202,7 @@ public class LocalDataCollectTest extends CrateUnitTest {
             functionBinder = MapBinder.newMapBinder(binder(), FunctionIdent.class, FunctionImplementation.class);
             functionBinder.addBinding(TestFunction.ident).toInstance(new TestFunction());
             bind(Functions.class).asEagerSingleton();
-            bind(ReferenceInfos.class).toInstance(mock(ReferenceInfos.class));
+            bind(Schemas.class).toInstance(mock(Schemas.class));
             bind(ThreadPool.class).toInstance(testThreadPool);
 
             BulkRetryCoordinator bulkRetryCoordinator = mock(BulkRetryCoordinator.class);

--- a/sql/src/test/java/io/crate/operation/reference/sys/SysShardsExpressionsTest.java
+++ b/sql/src/test/java/io/crate/operation/reference/sys/SysShardsExpressionsTest.java
@@ -65,7 +65,7 @@ public class SysShardsExpressionsTest extends CrateUnitTest {
 
     private Injector injector;
     private ReferenceResolver resolver;
-    private ReferenceInfos referenceInfos;
+    private Schemas schemas;
 
     private String indexName = "wikipedia_de";
     private static ThreadPool threadPool = new ThreadPool("testing");
@@ -81,7 +81,7 @@ public class SysShardsExpressionsTest extends CrateUnitTest {
                 new SysShardExpressionModule()
         ).createInjector();
         resolver = injector.getInstance(ShardReferenceResolver.class);
-        referenceInfos = injector.getInstance(ReferenceInfos.class);
+        schemas = injector.getInstance(Schemas.class);
     }
 
     @AfterClass
@@ -153,7 +153,7 @@ public class SysShardsExpressionsTest extends CrateUnitTest {
     @Test
     public void testShardInfoLookup() throws Exception {
         ReferenceInfo info = SysShardsTableInfo.INFOS.get(new ColumnIdent("id"));
-        assertEquals(info, referenceInfos.getTableInfo(SysShardsTableInfo.IDENT).getReferenceInfo(info.ident().columnIdent()));
+        assertEquals(info, schemas.getTableInfo(SysShardsTableInfo.IDENT).getReferenceInfo(info.ident().columnIdent()));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/reference/sys/TestGlobalSysExpressions.java
+++ b/sql/src/test/java/io/crate/operation/reference/sys/TestGlobalSysExpressions.java
@@ -52,7 +52,6 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -65,7 +64,7 @@ public class TestGlobalSysExpressions extends CrateUnitTest {
 
     private Injector injector;
     private ReferenceResolver resolver;
-    private ReferenceInfos referenceInfos;
+    private Schemas schemas;
 
     private static final ReferenceInfo LOAD_INFO = SysNodesTableInfo.INFOS.get(new ColumnIdent("load"));
     private static final ReferenceInfo LOAD1_INFO = SysNodesTableInfo.INFOS.get(new ColumnIdent("load", "1"));
@@ -81,7 +80,7 @@ public class TestGlobalSysExpressions extends CrateUnitTest {
                 new MetaDataSysModule()
         ).createInjector();
         resolver = injector.getInstance(ReferenceResolver.class);
-        referenceInfos = injector.getInstance(ReferenceInfos.class);
+        schemas = injector.getInstance(Schemas.class);
     }
 
     @After
@@ -131,7 +130,7 @@ public class TestGlobalSysExpressions extends CrateUnitTest {
     @Test
     public void testInfoLookup() throws Exception {
         ReferenceIdent ident = LOAD_INFO.ident();
-        TableInfo sysNodesTableInfo = referenceInfos.getTableInfo(SysNodesTableInfo.IDENT);
+        TableInfo sysNodesTableInfo = schemas.getTableInfo(SysNodesTableInfo.IDENT);
         assertEquals(LOAD_INFO, sysNodesTableInfo.getReferenceInfo(ident.columnIdent()));
 
         ident = LOAD1_INFO.ident();

--- a/sql/src/test/java/io/crate/planner/PlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/PlannerTest.java
@@ -155,7 +155,7 @@ public class PlannerTest extends CrateUnitTest {
         protected void bindSchemas() {
             super.bindSchemas();
             SchemaInfo schemaInfo = mock(SchemaInfo.class);
-            TableIdent userTableIdent = new TableIdent(ReferenceInfos.DEFAULT_SCHEMA_NAME, "users");
+            TableIdent userTableIdent = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "users");
             TableInfo userTableInfo = TestingTableInfo.builder(userTableIdent, RowGranularity.DOC, shardRouting)
                     .add("name", DataTypes.STRING, null)
                     .add("id", DataTypes.LONG, null)
@@ -165,16 +165,16 @@ public class PlannerTest extends CrateUnitTest {
                     .addPrimaryKey("id")
                     .clusteredBy("id")
                     .build();
-            when(userTableInfo.schemaInfo().name()).thenReturn(ReferenceInfos.DEFAULT_SCHEMA_NAME);
-            TableIdent charactersTableIdent = new TableIdent(ReferenceInfos.DEFAULT_SCHEMA_NAME, "characters");
+            when(userTableInfo.schemaInfo().name()).thenReturn(Schemas.DEFAULT_SCHEMA_NAME);
+            TableIdent charactersTableIdent = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "characters");
             TableInfo charactersTableInfo = TestingTableInfo.builder(charactersTableIdent, RowGranularity.DOC, shardRouting)
                     .add("name", DataTypes.STRING, null)
                     .add("id", DataTypes.STRING, null)
                     .addPrimaryKey("id")
                     .clusteredBy("id")
                     .build();
-            when(charactersTableInfo.schemaInfo().name()).thenReturn(ReferenceInfos.DEFAULT_SCHEMA_NAME);
-            TableIdent partedTableIdent = new TableIdent(ReferenceInfos.DEFAULT_SCHEMA_NAME, "parted");
+            when(charactersTableInfo.schemaInfo().name()).thenReturn(Schemas.DEFAULT_SCHEMA_NAME);
+            TableIdent partedTableIdent = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "parted");
             TableInfo partedTableInfo = TestingTableInfo.builder(partedTableIdent, RowGranularity.DOC, partedRouting)
                     .add("name", DataTypes.STRING, null)
                     .add("id", DataTypes.STRING, null)
@@ -188,8 +188,8 @@ public class PlannerTest extends CrateUnitTest {
                     .addPrimaryKey("date")
                     .clusteredBy("id")
                     .build();
-            when(partedTableInfo.schemaInfo().name()).thenReturn(ReferenceInfos.DEFAULT_SCHEMA_NAME);
-            TableIdent emptyPartedTableIdent = new TableIdent(ReferenceInfos.DEFAULT_SCHEMA_NAME, "empty_parted");
+            when(partedTableInfo.schemaInfo().name()).thenReturn(Schemas.DEFAULT_SCHEMA_NAME);
+            TableIdent emptyPartedTableIdent = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "empty_parted");
             TableInfo emptyPartedTableInfo = TestingTableInfo.builder(partedTableIdent, RowGranularity.DOC, shardRouting)
                     .add("name", DataTypes.STRING, null)
                     .add("id", DataTypes.STRING, null)
@@ -198,7 +198,7 @@ public class PlannerTest extends CrateUnitTest {
                     .addPrimaryKey("date")
                     .clusteredBy("id")
                     .build();
-            TableIdent multiplePartitionedTableIdent= new TableIdent(ReferenceInfos.DEFAULT_SCHEMA_NAME, "multi_parted");
+            TableIdent multiplePartitionedTableIdent= new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "multi_parted");
             TableInfo multiplePartitionedTableInfo = new TestingTableInfo.Builder(
                     multiplePartitionedTableIdent, RowGranularity.DOC, new Routing())
                     .add("id", DataTypes.INTEGER, null)
@@ -212,7 +212,7 @@ public class PlannerTest extends CrateUnitTest {
                             new PartitionName("multi_parted", Arrays.asList(new BytesRef("1395961200000"), new BytesRef("-100"))).stringValue(),
                             new PartitionName("multi_parted", Arrays.asList(null, new BytesRef("-100"))).stringValue())
                     .build();
-            TableIdent clusteredByParitionedIdent = new TableIdent(ReferenceInfos.DEFAULT_SCHEMA_NAME, "clustered_parted");
+            TableIdent clusteredByParitionedIdent = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "clustered_parted");
             TableInfo clusteredByPartitionedTableInfo = new TestingTableInfo.Builder(
                     multiplePartitionedTableIdent, RowGranularity.DOC, clusteredPartedRouting)
                     .add("id", DataTypes.INTEGER, null)
@@ -223,7 +223,7 @@ public class PlannerTest extends CrateUnitTest {
                             new PartitionName("clustered_parted", Arrays.asList(new BytesRef("1395874800000"))).stringValue(),
                             new PartitionName("clustered_parted", Arrays.asList(new BytesRef("1395961200000"))).stringValue())
                     .build();
-            when(emptyPartedTableInfo.schemaInfo().name()).thenReturn(ReferenceInfos.DEFAULT_SCHEMA_NAME);
+            when(emptyPartedTableInfo.schemaInfo().name()).thenReturn(Schemas.DEFAULT_SCHEMA_NAME);
             when(schemaInfo.getTableInfo(charactersTableIdent.name())).thenReturn(charactersTableInfo);
             when(schemaInfo.getTableInfo(userTableIdent.name())).thenReturn(userTableInfo);
             when(schemaInfo.getTableInfo(partedTableIdent.name())).thenReturn(partedTableInfo);
@@ -231,7 +231,7 @@ public class PlannerTest extends CrateUnitTest {
             when(schemaInfo.getTableInfo(multiplePartitionedTableIdent.name())).thenReturn(multiplePartitionedTableInfo);
             when(schemaInfo.getTableInfo(clusteredByParitionedIdent.name())).thenReturn(clusteredByPartitionedTableInfo);
             when(schemaInfo.getTableInfo(BaseAnalyzerTest.IGNORED_NESTED_TABLE_IDENT.name())).thenReturn(BaseAnalyzerTest.IGNORED_NESTED_TABLE_INFO);
-            schemaBinder.addBinding(ReferenceInfos.DEFAULT_SCHEMA_NAME).toInstance(schemaInfo);
+            schemaBinder.addBinding(Schemas.DEFAULT_SCHEMA_NAME).toInstance(schemaInfo);
             schemaBinder.addBinding(SysSchemaInfo.NAME).toInstance(mockSysSchemaInfo());
             schemaBinder.addBinding(BlobSchemaInfo.NAME).toInstance(mockBlobSchemaInfo());
         }
@@ -282,17 +282,17 @@ public class PlannerTest extends CrateUnitTest {
 
     private Plan plan(String statement) {
         return planner.plan(analyzer.analyze(SqlParser.createStatement(statement),
-                new ParameterContext(new Object[0], new Object[0][], ReferenceInfos.DEFAULT_SCHEMA_NAME)), UUID.randomUUID());
+                new ParameterContext(new Object[0], new Object[0][], Schemas.DEFAULT_SCHEMA_NAME)), UUID.randomUUID());
     }
 
     private Plan plan(String statement, Object[] args) {
         return planner.plan(analyzer.analyze(SqlParser.createStatement(statement),
-                new ParameterContext(args, new Object[0][], ReferenceInfos.DEFAULT_SCHEMA_NAME)), UUID.randomUUID());
+                new ParameterContext(args, new Object[0][], Schemas.DEFAULT_SCHEMA_NAME)), UUID.randomUUID());
     }
 
     private Plan plan(String statement, Object[][] bulkArgs) {
         return planner.plan(analyzer.analyze(SqlParser.createStatement(statement),
-                new ParameterContext(new Object[0], bulkArgs, ReferenceInfos.DEFAULT_SCHEMA_NAME)), UUID.randomUUID());
+                new ParameterContext(new Object[0], bulkArgs, Schemas.DEFAULT_SCHEMA_NAME)), UUID.randomUUID());
     }
 
     @Test
@@ -1440,7 +1440,7 @@ public class PlannerTest extends CrateUnitTest {
         assertThat(toCollect.get(0), isFunction("toLong"));
         assertThat(((Function) toCollect.get(0)).arguments().get(0), isReference("_doc['id']"));
         assertThat((Reference) toCollect.get(1), equalTo(new Reference(new ReferenceInfo(
-                new ReferenceIdent(new TableIdent(ReferenceInfos.DEFAULT_SCHEMA_NAME, "parted"), "date"), RowGranularity.PARTITION, DataTypes.TIMESTAMP))));
+                new ReferenceIdent(new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "parted"), "date"), RowGranularity.PARTITION, DataTypes.TIMESTAMP))));
     }
 
     @Test


### PR DESCRIPTION
ReferenceInfos is one of those classes that pulls in a lot of cluster
dependencies which is annoying for analyzer/planner unit tests because it has
to be mocked.

Extracting the interface will allow us to write a "static" stub Schemas class
which can be used in tests.