### PR TITLE
disabled auto-create index setting

### DIFF
--- a/sql/src/main/java/io/crate/plugin/SQLPlugin.java
+++ b/sql/src/main/java/io/crate/plugin/SQLPlugin.java
@@ -88,6 +88,10 @@ public class SQLPlugin extends AbstractPlugin {
         // Set default analyzer
         settingsBuilder.put("index.analysis.analyzer.default.type", "keyword");
 
+        // Never allow implicit creation of an index, even on partitioned tables we are creating
+        // partitions explicitly
+        settingsBuilder.put("action.auto_create_index", false);
+
         return settingsBuilder.build();
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/KillIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/KillIntegrationTest.java
@@ -61,11 +61,6 @@ public class KillIntegrationTest extends SQLTransportIntegrationTest {
                 ") with (number_of_replicas=1)");
         ensureYellow();
         assertGotCancelled("insert into new_employees (select * from employees)", null);
-
-        // if the insert is killed there will still be pending insert operations,
-        // the refresh seems to block long enough that those operations can be finished,
-        // otherwise the test would be flaky.
-        refresh();
     }
 
     private void assertGotCancelled(final String statement, @Nullable final Object[] params) throws Exception {


### PR DESCRIPTION
as we always create indices explicitly, auto-creation of indices should never occur.
this will also fix flaky tests, where inserts were still happening after an table was dropped 