### PR TITLE
fix context unavailable race condition in FetchProjector

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed a race condition that could cause queries with a high limit to fail
+   due to a missing job context.
+
  - Updated crate-admin to 0.14.2 which includes the following changes:
     
     - added support for line breaks in console result table

--- a/sql/src/main/java/io/crate/executor/transport/TransportShardUpsertAction.java
+++ b/sql/src/main/java/io/crate/executor/transport/TransportShardUpsertAction.java
@@ -81,7 +81,6 @@ import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CancellationException;

--- a/sql/src/main/java/io/crate/operation/collect/MapSideDataCollectOperation.java
+++ b/sql/src/main/java/io/crate/operation/collect/MapSideDataCollectOperation.java
@@ -61,6 +61,7 @@ import org.elasticsearch.indices.IndexMissingException;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.threadpool.ThreadPool;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.*;
 import java.util.concurrent.Callable;
@@ -221,8 +222,8 @@ public class MapSideDataCollectOperation implements CollectOperation, RowUpstrea
                     }
 
                     @Override
-                    public void onFailure(Throwable t) {
-                        jobCollectContext.close();
+                    public void onFailure(@Nonnull Throwable t) {
+                        jobCollectContext.closeDueToFailure(t);
                     }
                 });
 

--- a/sql/src/main/java/io/crate/operation/projectors/FetchProjector.java
+++ b/sql/src/main/java/io/crate/operation/projectors/FetchProjector.java
@@ -197,6 +197,7 @@ public class FetchProjector implements Projector, RowDownstreamHandle {
         if (remainingUpstreams.decrementAndGet() == 0) {
             // flush all remaining buckets
             Iterator<NodeBucket> it = nodeBuckets.values().iterator();
+            remainingRequests.set(nodeBuckets.size());
             while (it.hasNext()) {
                 flushNodeBucket(it.next());
                 it.remove();
@@ -246,7 +247,6 @@ public class FetchProjector implements Projector, RowDownstreamHandle {
     private void flushNodeBucket(final NodeBucket nodeBucket) {
         // every request must increase downstream upstream counter
         downstream.registerUpstream(this);
-        remainingRequests.incrementAndGet();
 
         NodeFetchRequest request = new NodeFetchRequest();
         request.jobId(jobId);


### PR DESCRIPTION
Could be that ContextClose requests where made while fetch requests were
pending