### PR TITLE
disabled auto-create index setting

### DIFF
--- a/sql/src/main/java/io/crate/plugin/SQLPlugin.java
+++ b/sql/src/main/java/io/crate/plugin/SQLPlugin.java
@@ -88,6 +88,10 @@ public class SQLPlugin extends AbstractPlugin {
         // Set default analyzer
         settingsBuilder.put("index.analysis.analyzer.default.type", "keyword");
 
+        // Never allow implicit creation of an index, even on partitioned tables we are creating
+        // partitions explicitly
+        settingsBuilder.put("action.auto_create_index", false);
+
         return settingsBuilder.build();
     }
 

--- a/sql/src/test/java/io/crate/executor/transport/BaseTransportExecutorTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/BaseTransportExecutorTest.java
@@ -44,6 +44,7 @@ import org.junit.After;
 import org.junit.Before;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -98,4 +99,13 @@ public class BaseTransportExecutorTest extends SQLTransportIntegrationTest {
         executor = null;
         docSchemaInfo = null;
     }
+
+    protected ESGetNode newGetNode(String tableName, List<Symbol> outputs, String singleStringKey, int executionNodeId) {
+        return newGetNode(tableName, outputs, Collections.singletonList(singleStringKey), executionNodeId);
+    }
+
+    protected ESGetNode newGetNode(String tableName, List<Symbol> outputs, List<String> singleStringKeys, int executionNodeId) {
+        return newGetNode(docSchemaInfo.getTableInfo(tableName), outputs, singleStringKeys, executionNodeId);
+    }
+
 }

--- a/sql/src/test/java/io/crate/executor/transport/SymbolBasedTransportShardUpsertActionTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/SymbolBasedTransportShardUpsertActionTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to CRATE.IO GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.executor.transport;
+
+import io.crate.jobs.JobContextService;
+import io.crate.metadata.Functions;
+import io.crate.metadata.ReferenceIdent;
+import io.crate.metadata.ReferenceInfo;
+import io.crate.metadata.TableIdent;
+import io.crate.planner.RowGranularity;
+import io.crate.planner.symbol.Reference;
+import io.crate.test.integration.CrateUnitTest;
+import io.crate.types.DataTypes;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.index.TransportIndexAction;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.action.shard.ShardStateAction;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.indices.IndexMissingException;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+
+public class SymbolBasedTransportShardUpsertActionTest extends CrateUnitTest {
+
+    static class TestingTransportShardUpsertAction extends SymbolBasedTransportShardUpsertAction {
+
+        public TestingTransportShardUpsertAction(Settings settings,
+                                                 ThreadPool threadPool,
+                                                 ClusterService clusterService,
+                                                 TransportService transportService,
+                                                 ActionFilters actionFilters,
+                                                 TransportIndexAction indexAction,
+                                                 IndicesService indicesService,
+                                                 JobContextService jobContextService,
+                                                 ShardStateAction shardStateAction,
+                                                 Functions functions) {
+            super(settings, threadPool, clusterService, transportService, actionFilters,
+                    jobContextService, indexAction, indicesService, shardStateAction, functions);
+        }
+
+        @Override
+        protected IndexResponse indexItem(SymbolBasedShardUpsertRequest request,
+                                          SymbolBasedShardUpsertRequest.Item item,
+                                          ShardId shardId,
+                                          boolean tryInsertFirst,
+                                          int retryCount) throws ElasticsearchException {
+            throw new IndexMissingException(new Index(request.index()));
+        }
+    }
+
+    private SymbolBasedTransportShardUpsertAction transportShardUpsertAction;
+
+    @Before
+    public void prepare() throws Exception {
+        transportShardUpsertAction = new TestingTransportShardUpsertAction(
+                ImmutableSettings.EMPTY,
+                mock(ThreadPool.class),
+                mock(ClusterService.class),
+                mock(TransportService.class),
+                mock(ActionFilters.class),
+                mock(TransportIndexAction.class),
+                mock(IndicesService.class),
+                mock(JobContextService.class),
+                mock(ShardStateAction.class),
+                mock(Functions.class)
+                );
+    }
+
+    @Test
+    public void testIndexMissingExceptionWhileProcessingItemsResultsInFailure() throws Exception {
+        TableIdent charactersIdent = new TableIdent(null, "characters");
+        final Reference idRef = new Reference(new ReferenceInfo(
+                new ReferenceIdent(charactersIdent, "id"), RowGranularity.DOC, DataTypes.SHORT));
+
+        ShardId shardId = new ShardId("characters", 0);
+        final SymbolBasedShardUpsertRequest request = new SymbolBasedShardUpsertRequest(
+                new ShardId("characters", 0), null, new Reference[]{idRef});
+        request.add(1, "1", null, new Object[]{1}, null, null);
+
+        ShardUpsertResponse response = transportShardUpsertAction.processRequestItems(
+                shardId, request);
+
+        assertThat(response.failures().size(), is(1));
+        assertThat(response.failures().get(0).message(), is("IndexMissingException[[characters] missing]"));
+    }
+}

--- a/sql/src/test/java/io/crate/executor/transport/TransportExecutorTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/TransportExecutorTest.java
@@ -29,41 +29,37 @@ import io.crate.analyze.OrderBy;
 import io.crate.analyze.WhereClause;
 import io.crate.core.collections.Bucket;
 import io.crate.executor.Job;
-import io.crate.executor.RowCountResult;
 import io.crate.executor.Task;
 import io.crate.executor.TaskResult;
 import io.crate.executor.transport.task.KillTask;
-import io.crate.executor.transport.task.SymbolBasedUpsertByIdTask;
 import io.crate.executor.transport.task.elasticsearch.ESDeleteByQueryTask;
 import io.crate.executor.transport.task.elasticsearch.ESGetTask;
 import io.crate.metadata.*;
 import io.crate.metadata.doc.DocSysColumns;
 import io.crate.metadata.doc.DocTableInfo;
-import io.crate.metadata.table.TableInfo;
-import io.crate.operation.aggregation.impl.CountAggregation;
 import io.crate.operation.operator.EqOperator;
 import io.crate.operation.projectors.TopN;
 import io.crate.operation.scalar.DateTruncFunction;
 import io.crate.planner.*;
 import io.crate.planner.node.dml.ESDeleteByQueryNode;
-import io.crate.planner.node.dml.SymbolBasedUpsertByIdNode;
-import io.crate.planner.node.dml.Upsert;
-import io.crate.planner.node.dql.*;
+import io.crate.planner.node.dql.CollectPhase;
+import io.crate.planner.node.dql.ESGetNode;
+import io.crate.planner.node.dql.MergePhase;
+import io.crate.planner.node.dql.QueryThenFetch;
 import io.crate.planner.node.management.KillPlan;
-import io.crate.planner.projection.*;
+import io.crate.planner.projection.FetchProjection;
+import io.crate.planner.projection.MergeProjection;
+import io.crate.planner.projection.Projection;
+import io.crate.planner.projection.TopNProjection;
 import io.crate.planner.symbol.*;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
-import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.cluster.routing.operation.plain.Preference;
-import org.elasticsearch.common.collect.MapBuilder;
-import org.elasticsearch.search.SearchHits;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
 
 import static io.crate.testing.TestingHelpers.isRow;
 import static java.util.Arrays.asList;
@@ -71,21 +67,6 @@ import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.Is.is;
 
 public class TransportExecutorTest extends BaseTransportExecutorTest {
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
-    @Before
-    public void setup() {
-    }
-
-    protected ESGetNode newGetNode(String tableName, List<Symbol> outputs, String singleStringKey, int executionNodeId) {
-        return newGetNode(tableName, outputs, Collections.singletonList(singleStringKey), executionNodeId);
-    }
-
-    protected ESGetNode newGetNode(String tableName, List<Symbol> outputs, List<String> singleStringKeys, int executionNodeId) {
-        return newGetNode(docSchemaInfo.getTableInfo(tableName), outputs, singleStringKeys, executionNodeId);
-    }
 
     @Test
     public void testESGetTask() throws Exception {
@@ -438,311 +419,6 @@ public class TransportExecutorTest extends BaseTransportExecutorTest {
         // verify deletion
         execute("select * from characters where id = 2");
         assertThat(response.rowCount(), is(0L));
-    }
-
-    @Test
-    public void testInsertWithSymbolBasedUpsertByIdTask() throws Exception {
-        execute("create table characters (id int primary key, name string)");
-        ensureGreen();
-
-        /* insert into characters (id, name) values (99, 'Marvin'); */
-        Planner.Context ctx = new Planner.Context(clusterService(), UUID.randomUUID());
-        SymbolBasedUpsertByIdNode updateNode = new SymbolBasedUpsertByIdNode(
-                ctx.nextExecutionPhaseId(),
-                false,
-                false,
-                null,
-                new Reference[]{idRef, nameRef});
-        updateNode.add("characters", "99", "99", null, null, new Object[]{99, new BytesRef("Marvin")});
-
-        Plan plan = new IterablePlan(ctx.jobId(), updateNode);
-        Job job = executor.newJob(plan);
-        assertThat(job.tasks().get(0), instanceOf(SymbolBasedUpsertByIdTask.class));
-
-        List<? extends ListenableFuture<TaskResult>> result = executor.execute(job);
-        TaskResult taskResult = result.get(0).get();
-        Bucket rows = taskResult.rows();
-        assertThat(rows, contains(isRow(1L)));
-
-        // verify insertion
-        ImmutableList<Symbol> outputs = ImmutableList.<Symbol>of(idRef, nameRef);
-        ESGetNode getNode = newGetNode("characters", outputs, "99", ctx.nextExecutionPhaseId());
-        plan = new IterablePlan(UUID.randomUUID(), getNode);
-        job = executor.newJob(plan);
-        result = executor.execute(job);
-        Bucket objects = result.get(0).get().rows();
-
-        assertThat(objects, contains(isRow(99, "Marvin")));
-    }
-
-    @Test
-    public void testInsertIntoPartitionedTableWithSymbolBasedUpsertByIdTask() throws Exception {
-        execute("create table parted (" +
-                "  id int, " +
-                "  name string, " +
-                "  date timestamp" +
-                ") partitioned by (date)");
-        ensureGreen();
-
-        /* insert into parted (id, name, date) values(0, 'Trillian', 13959981214861); */
-        Planner.Context ctx = new Planner.Context(clusterService(), UUID.randomUUID());
-        SymbolBasedUpsertByIdNode updateNode = new SymbolBasedUpsertByIdNode(
-                ctx.nextExecutionPhaseId(),
-                true,
-                false,
-                null,
-                new Reference[]{idRef, nameRef});
-
-        PartitionName partitionName = new PartitionName("parted", Arrays.asList(new BytesRef("13959981214861")));
-        updateNode.add(partitionName.stringValue(), "123", "123", null, null, new Object[]{0L, new BytesRef("Trillian")});
-
-        Plan plan = new IterablePlan(ctx.jobId(), updateNode);
-        Job job = executor.newJob(plan);
-        assertThat(job.tasks().get(0), instanceOf(SymbolBasedUpsertByIdTask.class));
-
-        List<? extends ListenableFuture<TaskResult>> result = executor.execute(job);
-        TaskResult taskResult = result.get(0).get();
-        Bucket indexResult = taskResult.rows();
-        assertThat(indexResult, contains(isRow(1L)));
-
-        refresh();
-
-        assertTrue(
-                client().admin().indices().prepareExists(partitionName.stringValue())
-                        .execute().actionGet().isExists()
-        );
-        assertTrue(
-                client().admin().indices().prepareAliasesExist("parted")
-                        .execute().actionGet().exists()
-        );
-        SearchHits hits = client().prepareSearch(partitionName.stringValue())
-                .setTypes(Constants.DEFAULT_MAPPING_TYPE)
-                .addFields("id", "name")
-                .setQuery(new MapBuilder<String, Object>()
-                                .put("match_all", new HashMap<String, Object>())
-                                .map()
-                ).execute().actionGet().getHits();
-        assertThat(hits.getTotalHits(), is(1L));
-        assertThat((Integer) hits.getHits()[0].field("id").getValues().get(0), is(0));
-        assertThat((String) hits.getHits()[0].field("name").getValues().get(0), is("Trillian"));
-    }
-
-    @Test
-    public void testInsertMultiValuesWithSymbolBasedUpsertByIdTask() throws Exception {
-        execute("create table characters (id int primary key, name string)");
-        ensureGreen();
-
-        /* insert into characters (id, name) values (99, 'Marvin'), (42, 'Deep Thought'); */
-        Planner.Context ctx = new Planner.Context(clusterService(), UUID.randomUUID());
-        SymbolBasedUpsertByIdNode updateNode = new SymbolBasedUpsertByIdNode(
-                ctx.nextExecutionPhaseId(),
-                false,
-                false,
-                null,
-                new Reference[]{idRef, nameRef});
-
-        updateNode.add("characters", "99", "99", null, null, new Object[]{99, new BytesRef("Marvin")});
-        updateNode.add("characters", "42", "42", null, null, new Object[]{42, new BytesRef("Deep Thought")});
-
-        Plan plan = new IterablePlan(ctx.jobId(), updateNode);
-        Job job = executor.newJob(plan);
-        assertThat(job.tasks().get(0), instanceOf(SymbolBasedUpsertByIdTask.class));
-
-        List<? extends ListenableFuture<TaskResult>> result = executor.execute(job);
-        TaskResult taskResult = result.get(0).get();
-        Bucket rows = taskResult.rows();
-        assertThat(rows, contains(isRow(2L)));
-
-        // verify insertion
-        ImmutableList<Symbol> outputs = ImmutableList.<Symbol>of(idRef, nameRef);
-        ESGetNode getNode = newGetNode("characters", outputs, Arrays.asList("99", "42"), ctx.nextExecutionPhaseId());
-        plan = new IterablePlan(UUID.randomUUID(), getNode);
-        job = executor.newJob(plan);
-        result = executor.execute(job);
-        Bucket objects = result.get(0).get().rows();
-
-        assertThat(objects, contains(
-                isRow(99, "Marvin"),
-                isRow(42, "Deep Thought")
-        ));
-    }
-
-    @Test
-    public void testUpdateWithSymbolBasedUpsertByIdTask() throws Exception {
-        setup.setUpCharacters();
-
-        // update characters set name='Vogon lyric fan' where id=1
-        Planner.Context ctx = new Planner.Context(clusterService(), UUID.randomUUID());
-        SymbolBasedUpsertByIdNode updateNode = new SymbolBasedUpsertByIdNode(
-                ctx.nextExecutionPhaseId(), false, false, new String[]{nameRef.ident().columnIdent().fqn()}, null);
-        updateNode.add("characters", "1", "1", new Symbol[]{Literal.newLiteral("Vogon lyric fan")}, null);
-        Plan plan = new IterablePlan(ctx.jobId(), updateNode);
-
-        Job job = executor.newJob(plan);
-        assertThat(job.tasks().get(0), instanceOf(SymbolBasedUpsertByIdTask.class));
-        List<? extends ListenableFuture<TaskResult>> result = executor.execute(job);
-        TaskResult taskResult = result.get(0).get();
-        Bucket rows = taskResult.rows();
-        assertThat(rows, contains(isRow(1L)));
-
-        // verify update
-        ImmutableList<Symbol> outputs = ImmutableList.<Symbol>of(idRef, nameRef);
-        ESGetNode getNode = newGetNode("characters", outputs, "1", ctx.nextExecutionPhaseId());
-        plan = new IterablePlan(UUID.randomUUID(), getNode);
-        job = executor.newJob(plan);
-        result = executor.execute(job);
-        Bucket objects = result.get(0).get().rows();
-
-        assertThat(objects, contains(isRow(1, "Vogon lyric fan")));
-    }
-
-    @Test
-    public void testInsertOnDuplicateWithSymbolBasedUpsertByIdTask() throws Exception {
-        setup.setUpCharacters();
-        /* insert into characters (id, name, female) values (5, 'Zaphod Beeblebrox', false)
-           on duplicate key update set name = 'Zaphod Beeblebrox'; */
-        Object[] missingAssignments = new Object[]{5, new BytesRef("Zaphod Beeblebrox"), false};
-        Planner.Context ctx = new Planner.Context(clusterService(), UUID.randomUUID());
-        SymbolBasedUpsertByIdNode updateNode = new SymbolBasedUpsertByIdNode(
-                ctx.nextExecutionPhaseId(),
-                false,
-                false,
-                new String[]{nameRef.ident().columnIdent().fqn()},
-                new Reference[]{idRef, nameRef, femaleRef});
-
-        updateNode.add("characters", "5", "5", new Symbol[]{Literal.newLiteral("Zaphod Beeblebrox")}, null, missingAssignments);
-        Plan plan = new IterablePlan(UUID.randomUUID(), updateNode);
-        Job job = executor.newJob(plan);
-        assertThat(job.tasks().get(0), instanceOf(SymbolBasedUpsertByIdTask.class));
-        List<? extends ListenableFuture<TaskResult>> result = executor.execute(job);
-        TaskResult taskResult = result.get(0).get();
-        Bucket rows = taskResult.rows();
-        assertThat(rows, contains(isRow(1L)));
-
-        // verify insert
-        ImmutableList<Symbol> outputs = ImmutableList.<Symbol>of(idRef, nameRef, femaleRef);
-        ESGetNode getNode = newGetNode("characters", outputs, "5", ctx.nextExecutionPhaseId());
-        plan = new IterablePlan(UUID.randomUUID(), getNode);
-        job = executor.newJob(plan);
-        result = executor.execute(job);
-        Bucket objects = result.get(0).get().rows();
-        assertThat(objects, contains(isRow(5, "Zaphod Beeblebrox", false)));
-
-    }
-
-    @Test
-    public void testUpdateOnDuplicateWithSymbolBasedUpsertByIdTask() throws Exception {
-        setup.setUpCharacters();
-        /* insert into characters (id, name, female) values (1, 'Zaphod Beeblebrox', false)
-           on duplicate key update set name = 'Zaphod Beeblebrox'; */
-        Object[] missingAssignments = new Object[]{1, new BytesRef("Zaphod Beeblebrox"), true};
-        Planner.Context ctx = new Planner.Context(clusterService(), UUID.randomUUID());
-        SymbolBasedUpsertByIdNode updateNode = new SymbolBasedUpsertByIdNode(
-                ctx.nextExecutionPhaseId(),
-                false,
-                false,
-                new String[]{femaleRef.ident().columnIdent().fqn()},
-                new Reference[]{idRef, nameRef, femaleRef});
-        updateNode.add("characters", "1", "1", new Symbol[]{Literal.newLiteral(true)}, null, missingAssignments);
-        Plan plan = new IterablePlan(ctx.jobId(), updateNode);
-        Job job = executor.newJob(plan);
-        assertThat(job.tasks().get(0), instanceOf(SymbolBasedUpsertByIdTask.class));
-        List<? extends ListenableFuture<TaskResult>> result = executor.execute(job);
-        TaskResult taskResult = result.get(0).get();
-        Bucket rows = taskResult.rows();
-        assertThat(rows, contains(isRow(1L)));
-
-        // verify update
-        ImmutableList<Symbol> outputs = ImmutableList.<Symbol>of(idRef, nameRef, femaleRef);
-        ESGetNode getNode = newGetNode("characters", outputs, "1", ctx.nextExecutionPhaseId());
-        plan = new IterablePlan(UUID.randomUUID(), getNode);
-        job = executor.newJob(plan);
-        result = executor.execute(job);
-        Bucket objects = result.get(0).get().rows();
-
-        assertThat(objects, contains(isRow(1, "Arthur", true)));
-    }
-
-    @Test
-    public void testBulkUpdateByQueryTask() throws Exception {
-        setup.setUpCharacters();
-        /* update characters set name 'Zaphod Beeblebrox' where female = false
-           update characters set name 'Zaphod Beeblebrox' where female = true
-         */
-
-        List<Plan> childNodes = new ArrayList<>();
-        Planner.Context plannerContext = new Planner.Context(clusterService(), UUID.randomUUID());
-
-        TableInfo tableInfo = docSchemaInfo.getTableInfo("characters");
-        Reference uidReference = new Reference(
-                new ReferenceInfo(
-                        new ReferenceIdent(tableInfo.ident(), "_uid"),
-                        RowGranularity.DOC, DataTypes.STRING));
-
-        // 1st collect and merge nodes
-        Function whereClause1 = new Function(new FunctionInfo(
-                new FunctionIdent(EqOperator.NAME, Arrays.<DataType>asList(DataTypes.BOOLEAN, DataTypes.BOOLEAN)),
-                DataTypes.BOOLEAN),
-                Arrays.<Symbol>asList(femaleRef, Literal.newLiteral(true)));
-
-        UpdateProjection updateProjection = new UpdateProjection(
-                new InputColumn(0, DataTypes.STRING),
-                new String[]{"name"},
-                new Symbol[]{Literal.newLiteral("Zaphod Beeblebrox")},
-                null);
-
-        CollectPhase collectNode1 = PlanNodeBuilder.collect(
-                plannerContext.jobId(),
-                tableInfo,
-                plannerContext,
-                new WhereClause(whereClause1),
-                ImmutableList.<Symbol>of(uidReference),
-                ImmutableList.<Projection>of(updateProjection),
-                null,
-                Preference.PRIMARY.type()
-        );
-        MergePhase mergeNode1 = PlanNodeBuilder.localMerge(
-                plannerContext.jobId(),
-                ImmutableList.<Projection>of(CountAggregation.PARTIAL_COUNT_AGGREGATION_PROJECTION), collectNode1,
-                plannerContext);
-        childNodes.add(new CollectAndMerge(collectNode1, mergeNode1, UUID.randomUUID()));
-
-        // 2nd collect and merge nodes
-        Function whereClause2 = new Function(new FunctionInfo(
-                new FunctionIdent(EqOperator.NAME, Arrays.<DataType>asList(DataTypes.BOOLEAN, DataTypes.BOOLEAN)),
-                DataTypes.BOOLEAN),
-                Arrays.<Symbol>asList(femaleRef, Literal.newLiteral(true)));
-
-        CollectPhase collectNode2 = PlanNodeBuilder.collect(
-                plannerContext.jobId(),
-                tableInfo,
-                plannerContext,
-                new WhereClause(whereClause2),
-                ImmutableList.<Symbol>of(uidReference),
-                ImmutableList.<Projection>of(updateProjection),
-                null,
-                Preference.PRIMARY.type()
-        );
-        MergePhase mergeNode2 = PlanNodeBuilder.localMerge(
-                plannerContext.jobId(),
-                ImmutableList.<Projection>of(CountAggregation.PARTIAL_COUNT_AGGREGATION_PROJECTION), collectNode2,
-                plannerContext);
-        childNodes.add(new CollectAndMerge(collectNode2, mergeNode2, UUID.randomUUID()));
-
-        Upsert plan = new Upsert(childNodes, UUID.randomUUID());
-        Job job = executor.newJob(plan);
-
-        assertThat(job.tasks().size(), is(1));
-        assertThat(job.tasks().get(0), instanceOf(ExecutionPhasesTask.class));
-        List<? extends ListenableFuture<TaskResult>> results = executor.execute(job);
-        assertThat(results.size(), is(2));
-
-        for (int i = 0; i < results.size(); i++) {
-            TaskResult result = results.get(i).get();
-            assertThat(result, instanceOf(RowCountResult.class));
-            // each of the bulk request hits 2 records
-            assertThat(((RowCountResult)result).rowCount(), is(2L));
-        }
     }
 
     @Test

--- a/sql/src/test/java/io/crate/executor/transport/TransportExecutorUpsertTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/TransportExecutorUpsertTest.java
@@ -1,0 +1,368 @@
+/*
+ * Licensed to CRATE.IO GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.executor.transport;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.crate.Constants;
+import io.crate.analyze.WhereClause;
+import io.crate.core.collections.Bucket;
+import io.crate.executor.Job;
+import io.crate.executor.RowCountResult;
+import io.crate.executor.TaskResult;
+import io.crate.executor.transport.task.SymbolBasedUpsertByIdTask;
+import io.crate.metadata.*;
+import io.crate.metadata.table.TableInfo;
+import io.crate.operation.aggregation.impl.CountAggregation;
+import io.crate.operation.operator.EqOperator;
+import io.crate.planner.*;
+import io.crate.planner.node.dml.SymbolBasedUpsertByIdNode;
+import io.crate.planner.node.dml.Upsert;
+import io.crate.planner.node.dql.CollectAndMerge;
+import io.crate.planner.node.dql.CollectPhase;
+import io.crate.planner.node.dql.ESGetNode;
+import io.crate.planner.node.dql.MergePhase;
+import io.crate.planner.projection.Projection;
+import io.crate.planner.projection.UpdateProjection;
+import io.crate.planner.symbol.*;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.cluster.routing.operation.plain.Preference;
+import org.elasticsearch.common.collect.MapBuilder;
+import org.elasticsearch.search.SearchHits;
+import org.junit.Test;
+
+import java.util.*;
+
+import static io.crate.testing.TestingHelpers.isRow;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.core.Is.is;
+
+public class TransportExecutorUpsertTest extends BaseTransportExecutorTest {
+
+    @Test
+    public void testInsertWithSymbolBasedUpsertByIdTask() throws Exception {
+        execute("create table characters (id int primary key, name string)");
+        ensureGreen();
+
+        /* insert into characters (id, name) values (99, 'Marvin'); */
+        Planner.Context ctx = new Planner.Context(clusterService(), UUID.randomUUID());
+        SymbolBasedUpsertByIdNode updateNode = new SymbolBasedUpsertByIdNode(
+                ctx.nextExecutionPhaseId(),
+                false,
+                false,
+                null,
+                new Reference[]{idRef, nameRef});
+        updateNode.add("characters", "99", "99", null, null, new Object[]{99, new BytesRef("Marvin")});
+
+        Plan plan = new IterablePlan(ctx.jobId(), updateNode);
+        Job job = executor.newJob(plan);
+        assertThat(job.tasks().get(0), instanceOf(SymbolBasedUpsertByIdTask.class));
+
+        List<? extends ListenableFuture<TaskResult>> result = executor.execute(job);
+        TaskResult taskResult = result.get(0).get();
+        Bucket rows = taskResult.rows();
+        assertThat(rows, contains(isRow(1L)));
+
+        // verify insertion
+        ImmutableList<Symbol> outputs = ImmutableList.<Symbol>of(idRef, nameRef);
+        ESGetNode getNode = newGetNode("characters", outputs, "99", ctx.nextExecutionPhaseId());
+        plan = new IterablePlan(UUID.randomUUID(), getNode);
+        job = executor.newJob(plan);
+        result = executor.execute(job);
+        Bucket objects = result.get(0).get().rows();
+
+        assertThat(objects, contains(isRow(99, "Marvin")));
+    }
+
+    @Test
+    public void testInsertIntoPartitionedTableWithSymbolBasedUpsertByIdTask() throws Exception {
+        execute("create table parted (" +
+                "  id int, " +
+                "  name string, " +
+                "  date timestamp" +
+                ") partitioned by (date)");
+        ensureGreen();
+
+        /* insert into parted (id, name, date) values(0, 'Trillian', 13959981214861); */
+        Planner.Context ctx = new Planner.Context(clusterService(), UUID.randomUUID());
+        SymbolBasedUpsertByIdNode updateNode = new SymbolBasedUpsertByIdNode(
+                ctx.nextExecutionPhaseId(),
+                true,
+                false,
+                null,
+                new Reference[]{idRef, nameRef});
+
+        PartitionName partitionName = new PartitionName("parted", Arrays.asList(new BytesRef("13959981214861")));
+        updateNode.add(partitionName.stringValue(), "123", "123", null, null, new Object[]{0L, new BytesRef("Trillian")});
+
+        Plan plan = new IterablePlan(ctx.jobId(), updateNode);
+        Job job = executor.newJob(plan);
+        assertThat(job.tasks().get(0), instanceOf(SymbolBasedUpsertByIdTask.class));
+
+        List<? extends ListenableFuture<TaskResult>> result = executor.execute(job);
+        TaskResult taskResult = result.get(0).get();
+        Bucket indexResult = taskResult.rows();
+        assertThat(indexResult, contains(isRow(1L)));
+
+        refresh();
+
+        assertTrue(
+                client().admin().indices().prepareExists(partitionName.stringValue())
+                        .execute().actionGet().isExists()
+        );
+        assertTrue(
+                client().admin().indices().prepareAliasesExist("parted")
+                        .execute().actionGet().exists()
+        );
+        SearchHits hits = client().prepareSearch(partitionName.stringValue())
+                .setTypes(Constants.DEFAULT_MAPPING_TYPE)
+                .addFields("id", "name")
+                .setQuery(new MapBuilder<String, Object>()
+                                .put("match_all", new HashMap<String, Object>())
+                                .map()
+                ).execute().actionGet().getHits();
+        assertThat(hits.getTotalHits(), is(1L));
+        assertThat((Integer) hits.getHits()[0].field("id").getValues().get(0), is(0));
+        assertThat((String) hits.getHits()[0].field("name").getValues().get(0), is("Trillian"));
+    }
+
+    @Test
+    public void testInsertMultiValuesWithSymbolBasedUpsertByIdTask() throws Exception {
+        execute("create table characters (id int primary key, name string)");
+        ensureGreen();
+
+        /* insert into characters (id, name) values (99, 'Marvin'), (42, 'Deep Thought'); */
+        Planner.Context ctx = new Planner.Context(clusterService(), UUID.randomUUID());
+        SymbolBasedUpsertByIdNode updateNode = new SymbolBasedUpsertByIdNode(
+                ctx.nextExecutionPhaseId(),
+                false,
+                false,
+                null,
+                new Reference[]{idRef, nameRef});
+
+        updateNode.add("characters", "99", "99", null, null, new Object[]{99, new BytesRef("Marvin")});
+        updateNode.add("characters", "42", "42", null, null, new Object[]{42, new BytesRef("Deep Thought")});
+
+        Plan plan = new IterablePlan(ctx.jobId(), updateNode);
+        Job job = executor.newJob(plan);
+        assertThat(job.tasks().get(0), instanceOf(SymbolBasedUpsertByIdTask.class));
+
+        List<? extends ListenableFuture<TaskResult>> result = executor.execute(job);
+        TaskResult taskResult = result.get(0).get();
+        Bucket rows = taskResult.rows();
+        assertThat(rows, contains(isRow(2L)));
+
+        // verify insertion
+        ImmutableList<Symbol> outputs = ImmutableList.<Symbol>of(idRef, nameRef);
+        ESGetNode getNode = newGetNode("characters", outputs, Arrays.asList("99", "42"), ctx.nextExecutionPhaseId());
+        plan = new IterablePlan(UUID.randomUUID(), getNode);
+        job = executor.newJob(plan);
+        result = executor.execute(job);
+        Bucket objects = result.get(0).get().rows();
+
+        assertThat(objects, contains(
+                isRow(99, "Marvin"),
+                isRow(42, "Deep Thought")
+        ));
+    }
+
+    @Test
+    public void testUpdateWithSymbolBasedUpsertByIdTask() throws Exception {
+        setup.setUpCharacters();
+
+        // update characters set name='Vogon lyric fan' where id=1
+        Planner.Context ctx = new Planner.Context(clusterService(), UUID.randomUUID());
+        SymbolBasedUpsertByIdNode updateNode = new SymbolBasedUpsertByIdNode(
+                ctx.nextExecutionPhaseId(), false, false, new String[]{nameRef.ident().columnIdent().fqn()}, null);
+        updateNode.add("characters", "1", "1", new Symbol[]{Literal.newLiteral("Vogon lyric fan")}, null);
+        Plan plan = new IterablePlan(ctx.jobId(), updateNode);
+
+        Job job = executor.newJob(plan);
+        assertThat(job.tasks().get(0), instanceOf(SymbolBasedUpsertByIdTask.class));
+        List<? extends ListenableFuture<TaskResult>> result = executor.execute(job);
+        TaskResult taskResult = result.get(0).get();
+        Bucket rows = taskResult.rows();
+        assertThat(rows, contains(isRow(1L)));
+
+        // verify update
+        ImmutableList<Symbol> outputs = ImmutableList.<Symbol>of(idRef, nameRef);
+        ESGetNode getNode = newGetNode("characters", outputs, "1", ctx.nextExecutionPhaseId());
+        plan = new IterablePlan(UUID.randomUUID(), getNode);
+        job = executor.newJob(plan);
+        result = executor.execute(job);
+        Bucket objects = result.get(0).get().rows();
+
+        assertThat(objects, contains(isRow(1, "Vogon lyric fan")));
+    }
+
+    @Test
+    public void testInsertOnDuplicateWithSymbolBasedUpsertByIdTask() throws Exception {
+        setup.setUpCharacters();
+        /* insert into characters (id, name, female) values (5, 'Zaphod Beeblebrox', false)
+           on duplicate key update set name = 'Zaphod Beeblebrox'; */
+        Object[] missingAssignments = new Object[]{5, new BytesRef("Zaphod Beeblebrox"), false};
+        Planner.Context ctx = new Planner.Context(clusterService(), UUID.randomUUID());
+        SymbolBasedUpsertByIdNode updateNode = new SymbolBasedUpsertByIdNode(
+                ctx.nextExecutionPhaseId(),
+                false,
+                false,
+                new String[]{nameRef.ident().columnIdent().fqn()},
+                new Reference[]{idRef, nameRef, femaleRef});
+
+        updateNode.add("characters", "5", "5", new Symbol[]{Literal.newLiteral("Zaphod Beeblebrox")}, null, missingAssignments);
+        Plan plan = new IterablePlan(UUID.randomUUID(), updateNode);
+        Job job = executor.newJob(plan);
+        assertThat(job.tasks().get(0), instanceOf(SymbolBasedUpsertByIdTask.class));
+        List<? extends ListenableFuture<TaskResult>> result = executor.execute(job);
+        TaskResult taskResult = result.get(0).get();
+        Bucket rows = taskResult.rows();
+        assertThat(rows, contains(isRow(1L)));
+
+        // verify insert
+        ImmutableList<Symbol> outputs = ImmutableList.<Symbol>of(idRef, nameRef, femaleRef);
+        ESGetNode getNode = newGetNode("characters", outputs, "5", ctx.nextExecutionPhaseId());
+        plan = new IterablePlan(UUID.randomUUID(), getNode);
+        job = executor.newJob(plan);
+        result = executor.execute(job);
+        Bucket objects = result.get(0).get().rows();
+        assertThat(objects, contains(isRow(5, "Zaphod Beeblebrox", false)));
+
+    }
+
+    @Test
+    public void testUpdateOnDuplicateWithSymbolBasedUpsertByIdTask() throws Exception {
+        setup.setUpCharacters();
+        /* insert into characters (id, name, female) values (1, 'Zaphod Beeblebrox', false)
+           on duplicate key update set name = 'Zaphod Beeblebrox'; */
+        Object[] missingAssignments = new Object[]{1, new BytesRef("Zaphod Beeblebrox"), true};
+        Planner.Context ctx = new Planner.Context(clusterService(), UUID.randomUUID());
+        SymbolBasedUpsertByIdNode updateNode = new SymbolBasedUpsertByIdNode(
+                ctx.nextExecutionPhaseId(),
+                false,
+                false,
+                new String[]{femaleRef.ident().columnIdent().fqn()},
+                new Reference[]{idRef, nameRef, femaleRef});
+        updateNode.add("characters", "1", "1", new Symbol[]{Literal.newLiteral(true)}, null, missingAssignments);
+        Plan plan = new IterablePlan(ctx.jobId(), updateNode);
+        Job job = executor.newJob(plan);
+        assertThat(job.tasks().get(0), instanceOf(SymbolBasedUpsertByIdTask.class));
+        List<? extends ListenableFuture<TaskResult>> result = executor.execute(job);
+        TaskResult taskResult = result.get(0).get();
+        Bucket rows = taskResult.rows();
+        assertThat(rows, contains(isRow(1L)));
+
+        // verify update
+        ImmutableList<Symbol> outputs = ImmutableList.<Symbol>of(idRef, nameRef, femaleRef);
+        ESGetNode getNode = newGetNode("characters", outputs, "1", ctx.nextExecutionPhaseId());
+        plan = new IterablePlan(UUID.randomUUID(), getNode);
+        job = executor.newJob(plan);
+        result = executor.execute(job);
+        Bucket objects = result.get(0).get().rows();
+
+        assertThat(objects, contains(isRow(1, "Arthur", true)));
+    }
+
+    @Test
+    public void testBulkUpdateByQueryTask() throws Exception {
+        setup.setUpCharacters();
+        /* update characters set name 'Zaphod Beeblebrox' where female = false
+           update characters set name 'Zaphod Beeblebrox' where female = true
+         */
+
+        List<Plan> childNodes = new ArrayList<>();
+        Planner.Context plannerContext = new Planner.Context(clusterService(), UUID.randomUUID());
+
+        TableInfo tableInfo = docSchemaInfo.getTableInfo("characters");
+        Reference uidReference = new Reference(
+                new ReferenceInfo(
+                        new ReferenceIdent(tableInfo.ident(), "_uid"),
+                        RowGranularity.DOC, DataTypes.STRING));
+
+        // 1st collect and merge nodes
+        Function whereClause1 = new Function(new FunctionInfo(
+                new FunctionIdent(EqOperator.NAME, Arrays.<DataType>asList(DataTypes.BOOLEAN, DataTypes.BOOLEAN)),
+                DataTypes.BOOLEAN),
+                Arrays.<Symbol>asList(femaleRef, Literal.newLiteral(true)));
+
+        UpdateProjection updateProjection = new UpdateProjection(
+                new InputColumn(0, DataTypes.STRING),
+                new String[]{"name"},
+                new Symbol[]{Literal.newLiteral("Zaphod Beeblebrox")},
+                null);
+
+        CollectPhase collectNode1 = PlanNodeBuilder.collect(
+                plannerContext.jobId(),
+                tableInfo,
+                plannerContext,
+                new WhereClause(whereClause1),
+                ImmutableList.<Symbol>of(uidReference),
+                ImmutableList.<Projection>of(updateProjection),
+                null,
+                Preference.PRIMARY.type()
+        );
+        MergePhase mergeNode1 = PlanNodeBuilder.localMerge(
+                plannerContext.jobId(),
+                ImmutableList.<Projection>of(CountAggregation.PARTIAL_COUNT_AGGREGATION_PROJECTION), collectNode1,
+                plannerContext);
+        childNodes.add(new CollectAndMerge(collectNode1, mergeNode1, UUID.randomUUID()));
+
+        // 2nd collect and merge nodes
+        Function whereClause2 = new Function(new FunctionInfo(
+                new FunctionIdent(EqOperator.NAME, Arrays.<DataType>asList(DataTypes.BOOLEAN, DataTypes.BOOLEAN)),
+                DataTypes.BOOLEAN),
+                Arrays.<Symbol>asList(femaleRef, Literal.newLiteral(true)));
+
+        CollectPhase collectNode2 = PlanNodeBuilder.collect(
+                plannerContext.jobId(),
+                tableInfo,
+                plannerContext,
+                new WhereClause(whereClause2),
+                ImmutableList.<Symbol>of(uidReference),
+                ImmutableList.<Projection>of(updateProjection),
+                null,
+                Preference.PRIMARY.type()
+        );
+        MergePhase mergeNode2 = PlanNodeBuilder.localMerge(
+                plannerContext.jobId(),
+                ImmutableList.<Projection>of(CountAggregation.PARTIAL_COUNT_AGGREGATION_PROJECTION), collectNode2,
+                plannerContext);
+        childNodes.add(new CollectAndMerge(collectNode2, mergeNode2, UUID.randomUUID()));
+
+        Upsert plan = new Upsert(childNodes, UUID.randomUUID());
+        Job job = executor.newJob(plan);
+
+        assertThat(job.tasks().size(), is(1));
+        assertThat(job.tasks().get(0), instanceOf(ExecutionPhasesTask.class));
+        List<? extends ListenableFuture<TaskResult>> results = executor.execute(job);
+        assertThat(results.size(), is(2));
+
+        for (int i = 0; i < results.size(); i++) {
+            TaskResult result = results.get(i).get();
+            assertThat(result, instanceOf(RowCountResult.class));
+            // each of the bulk request hits 2 records
+            assertThat(((RowCountResult)result).rowCount(), is(2L));
+        }
+    }
+}

--- a/sql/src/test/java/io/crate/executor/transport/TransportShardUpsertActionTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/TransportShardUpsertActionTest.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to CRATE.IO GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.executor.transport;
+
+import com.google.common.collect.Lists;
+import io.crate.core.collections.RowN;
+import io.crate.jobs.JobContextService;
+import io.crate.metadata.Functions;
+import io.crate.metadata.ReferenceIdent;
+import io.crate.metadata.ReferenceInfo;
+import io.crate.metadata.TableIdent;
+import io.crate.planner.RowGranularity;
+import io.crate.planner.symbol.InputColumn;
+import io.crate.planner.symbol.Reference;
+import io.crate.planner.symbol.Symbol;
+import io.crate.test.integration.CrateUnitTest;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+import io.crate.types.ShortType;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.index.TransportIndexAction;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.action.shard.ShardStateAction;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.indices.IndexMissingException;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+
+public class TransportShardUpsertActionTest extends CrateUnitTest {
+
+    static class TestingTransportShardUpsertAction extends TransportShardUpsertAction {
+
+        public TestingTransportShardUpsertAction(Settings settings,
+                                                 ThreadPool threadPool,
+                                                 ClusterService clusterService,
+                                                 TransportService transportService,
+                                                 ActionFilters actionFilters,
+                                                 TransportIndexAction indexAction,
+                                                 IndicesService indicesService,
+                                                 JobContextService jobContextService,
+                                                 ShardStateAction shardStateAction,
+                                                 Functions functions) {
+            super(settings, threadPool, clusterService, transportService, actionFilters,
+                    indexAction, indicesService, jobContextService, shardStateAction, functions);
+        }
+
+        @Override
+        protected IndexResponse indexItem(ShardUpsertRequest request,
+                                          ShardUpsertRequest.Item item,
+                                          ShardId shardId,
+                                          SymbolToFieldExtractorContext extractorContextUpdate,
+                                          SymbolToInputContext implContextInsert,
+                                          boolean tryInsertFirst,
+                                          int retryCount) throws ElasticsearchException {
+            throw new IndexMissingException(new Index(request.index()));
+        }
+    }
+
+    private TransportShardUpsertAction transportShardUpsertAction;
+
+    @Before
+    public void prepare() throws Exception {
+        transportShardUpsertAction = new TestingTransportShardUpsertAction(
+                ImmutableSettings.EMPTY,
+                mock(ThreadPool.class),
+                mock(ClusterService.class),
+                mock(TransportService.class),
+                mock(ActionFilters.class),
+                mock(TransportIndexAction.class),
+                mock(IndicesService.class),
+                mock(JobContextService.class),
+                mock(ShardStateAction.class),
+                mock(Functions.class)
+                );
+    }
+
+    @Test
+    public void testIndexMissingExceptionWhileProcessingItemsResultsInFailure() throws Exception {
+        TableIdent charactersIdent = new TableIdent(null, "characters");
+
+        final Reference idRef = new Reference(new ReferenceInfo(
+                new ReferenceIdent(charactersIdent, "id"), RowGranularity.DOC, DataTypes.SHORT));
+        DataType[] dataTypes = new DataType[]{ ShortType.INSTANCE };
+        Lists.newArrayList(0);
+        List<Integer> rowIndicesToStream = Lists.newArrayList(0);
+        Map<Reference, Symbol> insertAssignments = new HashMap<Reference, Symbol>(){{
+            put(idRef, new InputColumn(0));
+        }};
+
+        ShardId shardId = new ShardId("characters", 0);
+        ShardUpsertRequest request = new ShardUpsertRequest(
+                shardId,
+                dataTypes,
+                rowIndicesToStream,
+                null,
+                insertAssignments);
+        request.add(1, "1", new RowN(new Object[]{1}), null, null);
+
+        ShardUpsertResponse response = transportShardUpsertAction.processRequestItems(
+                shardId,
+                request,
+                mock(TransportShardUpsertAction.SymbolToFieldExtractorContext.class),
+                mock(TransportShardUpsertAction.SymbolToInputContext.class),
+                System.nanoTime() + 10);
+
+        assertThat(response.failures().size(), is(1));
+        assertThat(response.failures().get(0).message(), is("IndexMissingException[[characters] missing]"));
+    }
+}

--- a/sql/src/test/java/io/crate/integrationtests/KillIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/KillIntegrationTest.java
@@ -23,8 +23,6 @@ package io.crate.integrationtests;
 
 import io.crate.action.sql.SQLActionException;
 import io.crate.exceptions.Exceptions;
-import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.common.settings.Settings;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -49,19 +47,6 @@ public class KillIntegrationTest extends SQLTransportIntegrationTest {
 
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-    @Override
-    protected Settings nodeSettings(int nodeOrdinal) {
-        ImmutableSettings.Builder builder = ImmutableSettings.builder();
-        builder.put(super.nodeSettings(nodeOrdinal));
-
-        // disable auto-creation of indexes because this can lead to flaky killAll tests
-        // if a insert is killed, pending insert operations could still exists and
-        // would re-create the table after it was dropped by test cleanUp routines
-        builder.put("action.auto_create_index", false);
-
-        return builder.build();
-    }
 
     @Test
     public void testKillInsertFromSubQuery() throws Exception {


### PR DESCRIPTION
because we always create indices explicitly, auto-creation of indices should never occur.
this will also fix flaky tests, where inserts were still happening after an table was dropped

also ensure that upsert actions will not throw an exception if an index is missing while inserting/updating documents. instead create a failure, failures will not increase the row count. 