### PR TITLE
fix egde case in doc test setup

### DIFF
--- a/docs/src/crate/process_test.py
+++ b/docs/src/crate/process_test.py
@@ -7,7 +7,7 @@ import socket
 from crate.testing.layer import CrateLayer
 from crate.client.http import Client
 from .paths import crate_path
-from .ports import public_ipv4, GLOBAL_PORT_POOL
+from .ports import GLOBAL_PORT_POOL
 from lovely.testlayers.layer import CascadedLayer
 
 
@@ -45,11 +45,10 @@ class GracefulStopTest(unittest.TestCase):
         self.clients = []
         self.node_names = []
         for i in range(num_servers):
-            host = public_ipv4()
             layer = GracefulStopCrateLayer(self.node_name(i),
                            crate_path(),
-                           host=host,
-                           port=GLOBAL_PORT_POOL.get(host),
+                           host='0.0.0.0',
+                           port=GLOBAL_PORT_POOL.get(),
                            transport_port=GLOBAL_PORT_POOL.get(),
                            multicast=True,
                            cluster_name=self.__class__.__name__)


### PR DESCRIPTION
use '0.0.0.0' as bind host in order to prevent binding to interface that
does not support multicast