### PR TITLE
use debug logging in TransportCloseContextNodeAction

### DIFF
--- a/sql/src/main/java/io/crate/executor/transport/TransportCloseContextNodeAction.java
+++ b/sql/src/main/java/io/crate/executor/transport/TransportCloseContextNodeAction.java
@@ -106,8 +106,8 @@ public class TransportCloseContextNodeAction implements NodeAction<NodeCloseCont
                 } else if (LOGGER.isInfoEnabled()) {
                     LOGGER.info("Couldn't find ExecutionSubContext for {}/{}", request.jobId(), request.executionPhaseId());
                 }
-            } else if (LOGGER.isInfoEnabled()){
-                LOGGER.info("Couldn't find JobExecutionContext for jobId: {}", request.jobId());
+            } else if (LOGGER.isDebugEnabled()){
+                LOGGER.debug("Couldn't find JobExecutionContext for jobId: {}", request.jobId());
             }
             statsTables.operationFinished(request.executionPhaseId(), null, 0L);
             response.onResponse(new NodeCloseContextResponse());


### PR DESCRIPTION
that the context doesn't exist is often the case and fills up the logs quite a
lot.