### PR TITLE
Fixed a rare bug which could cause a MapperParsingException

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ -  Fixed a rare bug which could cause a MapperParsingException if one creates
+    a new dynamic array concurrently
+
 2015/07/16 0.49.6
 =================
 

--- a/sql/src/test/java/io/crate/integrationtests/ColumnPolicyIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ColumnPolicyIntegrationTest.java
@@ -158,9 +158,7 @@ public class ColumnPolicyIntegrationTest extends SQLTransportIntegrationTest {
                 ") with (column_policy='dynamic', number_of_replicas=0)");
         ensureYellow();
         execute("insert into dynamic_table (new, meta) values(['a', 'b', 'c'], 'hello')");
-        execute("refresh table dynamic_table");
         execute("insert into dynamic_table (new) values(['d', 'e', 'f'])");
-        refresh();
         waitNoPendingTasksOnAll();
         Map<String, Object> sourceMap = getSourceMap("dynamic_table");
         assertThat(String.valueOf(nestedValue(sourceMap, "properties.new.type")), is("array"));


### PR DESCRIPTION
if one creates a new dynamic array