### PR TITLE
remove single bucket optimization from SortingBucketMerger

### DIFF
--- a/sql/src/main/java/io/crate/operation/PageDownstreamFactory.java
+++ b/sql/src/main/java/io/crate/operation/PageDownstreamFactory.java
@@ -87,7 +87,7 @@ public class PageDownstreamFactory {
         }
 
         PageDownstream pageDownstream;
-        if (mergeNode.sortedInputOutput()) {
+        if (mergeNode.sortedInputOutput() && mergeNode.numUpstreams() > 1) {
             pageDownstream = new SortingBucketMerger(
                     rowDownstream,
                     mergeNode.numUpstreams(),

--- a/sql/src/main/java/io/crate/operation/merge/SortingBucketMerger.java
+++ b/sql/src/main/java/io/crate/operation/merge/SortingBucketMerger.java
@@ -116,20 +116,16 @@ public class SortingBucketMerger implements PageDownstream, RowUpstream {
             @Override
             public void onSuccess(List<Bucket> buckets) {
                 try {
-                    if (numBuckets == 1) {
-                        emitSingleBucket(buckets.get(0));
-                    } else {
-                        ArrayList<Iterator<Row>> bucketIts = new ArrayList<>(numBuckets);
-                        for (int i = 0; i < buckets.size(); i++) {
-                            Iterator<Row> remainingBucketIt = remainingBucketIts[i];
-                            if (remainingBucketIt == null) {
-                                bucketIts.add(buckets.get(i).iterator());
-                            } else {
-                                bucketIts.add(Iterators.concat(remainingBucketIt, buckets.get(i).iterator()));
-                            }
+                    ArrayList<Iterator<Row>> bucketIts = new ArrayList<>(numBuckets);
+                    for (int i = 0; i < buckets.size(); i++) {
+                        Iterator<Row> remainingBucketIt = remainingBucketIts[i];
+                        if (remainingBucketIt == null) {
+                            bucketIts.add(buckets.get(i).iterator());
+                        } else {
+                            bucketIts.add(Iterators.concat(remainingBucketIt, buckets.get(i).iterator()));
                         }
-                        emitBuckets(bucketIts);
                     }
+                    emitBuckets(bucketIts);
                 } catch (Throwable t) {
                     downstream.fail(t);
                 } finally {
@@ -305,15 +301,6 @@ public class SortingBucketMerger implements PageDownstream, RowUpstream {
                 }
             }
             bi = (bi+1) % numBuckets;
-        }
-    }
-
-    private void emitSingleBucket(Bucket bucket) {
-        for (Row row : bucket) {
-            if (!emit(row)) {
-                wantMore.set(false);
-                return;
-            }
         }
     }
 


### PR DESCRIPTION
instead it is possible to use the NonSortingBucketMerger who does the same
thing.