### PR TITLE
remove cloud.aws.region setting completely

### DIFF
--- a/docs/best_practice/ec2_setup.txt
+++ b/docs/best_practice/ec2_setup.txt
@@ -9,7 +9,7 @@ When running Crate in a cloud environment such as `Amazon EC2`_ (Elastic Cloud
 Compute) you usually face the problem that Crate's default discovery mechanism
 does not work out of the box.
 
-Luckily, Crate has multiple mechanisms for unicast host discovery built in,
+Luckily, Crate has several built-in mechanisms for unicast host discovery,
 also one for EC2. EC2 discovery uses the `EC2 API`_ to look up other EC2 hosts
 that are then used as unicast hosts for node discovery (see
 :ref:`conf_discovery`).
@@ -23,17 +23,22 @@ that are then used as unicast hosts for node discovery (see
 Basic Configuration
 ===================
 
-First, to activate EC2 discovery **simply set the discovery type to "ec2"**::
+The most important step for EC2 discovery is that you have the launch your EC2
+instances within the same security group. The rules of that security group must
+at least allow traffic on Crate's transport port (default ``4300``). This will
+allow Crate to accept and respond to pings from other Crate instances with the
+same cluster name and form a cluster.
+
+Once you have your instances running and Crate installed, you can enable the
+EC2 discovery by **simply setting the discovery type to "ec2"**::
 
   discovery.type: ec2
 
-The following settings allow you to control EC2 discovery once it is enabled.
+However, in order to be able to use the EC2 API, Crate must `sign the requests`_
+using AWS credentials consisting of an access key and a secret key.
 
 Authentication
 --------------
-
-In order to be able to use the EC2 API, Crate must `sign the requests`_ using
-AWS credentials consisting of an access key and a secret key.
 
 For that it is recommended to create a separate user that has only the necessary
 permissions to describe instances. These permissions are attached to the user
@@ -77,47 +82,19 @@ You could also provide them as system properties or as settings in the
   Note that the env variables need to be provided for the user that runs the
   Crate process, which is usually the user ``crate`` in production.
 
-Define Region
--------------
-
-Once authenticated you'll need to set the region you're operating within. **By
-default, the region in which the EC2 instance is running in will be used and
-you don't need to define it separately!**
-
-However, if this region differs from the region that you want to use for
-discovery, you'd need to set it manyally, e.g. when your instances
-are running in ``eu-west-1`` your setting would be::
-
-  cloud.aws.region: eu-west-1
-
-You can find the available region setting values :ref:`here <discovery_ec2_region>`.
+Now you are ready to start your Crate instances and they will discovery each
+other automatically. Note that all Crate instances of the same region will join
+the cluster as long as their cluster name is equal and they are able to "talk"
+to each other over the transport port.
 
 
-Host Addressing
----------------
-
-By default the discovery mechanism uses the private IP of the instances to
-communicate with each other. This makes sense especially when your instances
-run in a VPN and traffic is only allowed within the private network.
-
-If you prefer private DNS addressing, the setting
-:ref:`discovery.ec2.host_type <discovery_ec2_host_type>` can control how the
-hosts are addressed.
-However, you shall never set it to ``public_ip`` or ``public_dns`` due to
-security reasons.
-
-
-Filter Instances
+Production Setup
 ================
 
-Filter by Security Group
-------------------------
-
-The most obvious way of filtering instances is by their security group. When
-launching multiple EC2 instances for a cluster, you will want to separate the
-instances from other instances by assigning them a separate security group with
-custom firewall rules. These rules must at least allow traffic on Crate's
-transport port (``4200`` by default).
+For a production setup the best way to filter instances for discovery is via
+security group. This requires that you create a separate security group for
+each cluster and allow TCP traffic on transport port ``4300`` (or other, if set
+to a different port) only from within the group.
 
  .. image:: ../_static/ec2-discovery-security-groups.png
     :alt: Assign security group on instance launch
@@ -131,7 +108,17 @@ For example when you launch your instances with the security group
 
   discovery.ec2.groups: sg-crate-demo
 
+The combination with the unique cluster name makes the production setup very
+simple yet secure.
+
 See also :ref:`discovery.ec2.groups <discovery_ec2_groups>`.
+
+
+Optional Filters
+================
+
+Sometimes however, you will want to have a more flexible setup. In this case
+there are a few other settings that can be set.
 
 Filter by Tags
 --------------

--- a/docs/configuration.txt
+++ b/docs/configuration.txt
@@ -566,21 +566,6 @@ Note that the AWS credentials can also be provided by environment variables
 ``AWS_ACCESS_KEY_ID`` and ``AWS_SECRET_KEY`` or via system properties
 ``aws.accessKeyId`` and ``aws.secretKey``.
 
-.. _discovery_ec2_region:
-
-**cloud.aws.region**
-  | *Runtime:*  ``no``
-  | *Default:*  ``Current region of the EC2 instance``
-  | *Available Values:*: ``us-east (us-east-1)``, ``us-west (us-west-1)``,
-                         ``us-west-1``, ``us-west-2``,
-                         ``ap-southeast (ap-southeast-1)``, ``ap-southeast-1``,
-                         ``ap-southeast-2``, ``ap-northeast (ap-northeast-1)``,
-                         ``eu-west (eu-west-1)``, ``eu-central (eu-central-1)``,
-                         ``sa-east (sa-east-1)``, ``cn-north (cn-north-1)``
-
-  Defines the region in which the API call is performed and nodes can be looked
-  up.
-
 Following settings control the discovery:
 
 .. _discovery_ec2_groups:


### PR DESCRIPTION
and use current region of the instance instead
also documented that in the best practice

see: https://github.com/crate/elasticsearch-cloud-aws/pull/2