### PR TITLE
- Fix: fixed an issue which caused that some settings are

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fix: fixed an issue which caused that some settings are not selectable
+   if they are not set
+
  - Fix: fixed an issue which caused TypeConversion errors if a setting was
    selected which represents a byte size
    (e.g. indices[‘store’][‘throttle’][‘my_bytes_per_sec’])

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,10 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fix: fixed an issue which caused TypeConversion errors if a setting was
+   selected which represents a byte size
+   (e.g. indices[‘store’][‘throttle’][‘my_bytes_per_sec’])
+
  - Added support for unicast host discovery via EC2 API
 
  - BREAKING CHANGE

--- a/docs/sql/system.txt
+++ b/docs/sql/system.txt
@@ -121,11 +121,11 @@ currently applied cluster settings.
     | settings['indices']                                                               | object    |
     | settings['indices']['recovery']                                                   | object    |
     | settings['indices']['recovery']['concurrent_streams']                             | integer   |
-    | settings['indices']['recovery']['file_chunk_size']                                | long      |
+    | settings['indices']['recovery']['file_chunk_size']                                | string    |
     | settings['indices']['recovery']['translog_ops']                                   | integer   |
-    | settings['indices']['recovery']['translog_size']                                  | long      |
+    | settings['indices']['recovery']['translog_size']                                  | string    |
     | settings['indices']['recovery']['compress']                                       | boolean   |
-    | settings['indices']['recovery']['max_bytes_per_sec']                              | long      |
+    | settings['indices']['recovery']['max_bytes_per_sec']                              | string    |
     | settings['indices']['recovery']['retry_delay_state_sync']                         | string    |
     | settings['indices']['recovery']['retry_delay_network']                            | string    |
     | settings['indices']['recovery']['internal_action_timeout']                        | string    |
@@ -134,7 +134,7 @@ currently applied cluster settings.
     | settings['indices']['store']                                                      | object    |
     | settings['indices']['store']['throttle']                                          | object    |
     | settings['indices']['store']['throttle']['type']                                  | string    |
-    | settings['indices']['store']['throttle']['max_bytes_per_sec']                     | long      |
+    | settings['indices']['store']['throttle']['max_bytes_per_sec']                     | string    |
     | settings['indices']['fielddata']                                                  | object    |
     | settings['indices']['fielddata']['breaker']                                       | object    |
     | settings['indices']['fielddata']['breaker']['limit']                              | string    |

--- a/sql/src/main/java/io/crate/metadata/settings/CrateSettings.java
+++ b/sql/src/main/java/io/crate/metadata/settings/CrateSettings.java
@@ -405,6 +405,16 @@ public class CrateSettings {
         public String name() { return "include"; }
 
         @Override
+        public List<Setting> children() {
+            return ImmutableList.<Setting>of(
+                    ROUTING_ALLOCATION_INCLUDE_IP,
+                    ROUTING_ALLOCATION_INCLUDE_HOST,
+                    ROUTING_ALLOCATION_INCLUDE_ID,
+                    ROUTING_ALLOCATION_INCLUDE_NAME
+            );
+        }
+
+        @Override
         public Setting parent() {
             return ROUTING_ALLOCATION;
         }
@@ -453,6 +463,16 @@ public class CrateSettings {
     public static final NestedSetting ROUTING_ALLOCATION_EXCLUDE = new NestedSetting() {
         @Override
         public String name() { return "exclude"; }
+
+        @Override
+        public List<Setting> children() {
+            return ImmutableList.<Setting>of(
+                    ROUTING_ALLOCATION_EXCLUDE_IP,
+                    ROUTING_ALLOCATION_EXCLUDE_HOST,
+                    ROUTING_ALLOCATION_EXCLUDE_ID,
+                    ROUTING_ALLOCATION_EXCLUDE_NAME
+            );
+        }
 
         @Override
         public Setting parent() {
@@ -504,6 +524,16 @@ public class CrateSettings {
     public static final NestedSetting ROUTING_ALLOCATION_REQUIRE = new NestedSetting() {
         @Override
         public String name() { return "require"; }
+
+        @Override
+        public List<Setting> children() {
+            return ImmutableList.<Setting>of(
+                    ROUTING_ALLOCATION_REQUIRE_IP,
+                    ROUTING_ALLOCATION_REQUIRE_HOST,
+                    ROUTING_ALLOCATION_REQUIRE_ID,
+                    ROUTING_ALLOCATION_REQUIRE_NAME
+            );
+        }
 
         @Override
         public Setting parent() {

--- a/sql/src/main/java/io/crate/metadata/sys/SysClusterTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysClusterTableInfo.java
@@ -250,19 +250,19 @@ public class SysClusterTableInfo extends SysTableInfo {
         register(ClusterSettingsExpression.NAME, DataTypes.INTEGER, ImmutableList.of(CrateSettings.INDICES.name(),
                 CrateSettings.INDICES_RECOVERY.name(),
                 CrateSettings.INDICES_RECOVERY_CONCURRENT_STREAMS.name()));
-        register(ClusterSettingsExpression.NAME, DataTypes.LONG, ImmutableList.of(CrateSettings.INDICES.name(),
+        register(ClusterSettingsExpression.NAME, DataTypes.STRING, ImmutableList.of(CrateSettings.INDICES.name(),
                 CrateSettings.INDICES_RECOVERY.name(),
                 CrateSettings.INDICES_RECOVERY_FILE_CHUNK_SIZE.name()));
         register(ClusterSettingsExpression.NAME, DataTypes.INTEGER, ImmutableList.of(CrateSettings.INDICES.name(),
                 CrateSettings.INDICES_RECOVERY.name(),
                 CrateSettings.INDICES_RECOVERY_TRANSLOG_OPS.name()));
-        register(ClusterSettingsExpression.NAME, DataTypes.LONG, ImmutableList.of(CrateSettings.INDICES.name(),
+        register(ClusterSettingsExpression.NAME, DataTypes.STRING, ImmutableList.of(CrateSettings.INDICES.name(),
                 CrateSettings.INDICES_RECOVERY.name(),
                 CrateSettings.INDICES_RECOVERY_TRANSLOG_SIZE.name()));
         register(ClusterSettingsExpression.NAME, DataTypes.BOOLEAN, ImmutableList.of(CrateSettings.INDICES.name(),
                 CrateSettings.INDICES_RECOVERY.name(),
                 CrateSettings.INDICES_RECOVERY_COMPRESS.name()));
-        register(ClusterSettingsExpression.NAME, DataTypes.LONG, ImmutableList.of(CrateSettings.INDICES.name(),
+        register(ClusterSettingsExpression.NAME, DataTypes.STRING, ImmutableList.of(CrateSettings.INDICES.name(),
                 CrateSettings.INDICES_RECOVERY.name(),
                 CrateSettings.INDICES_RECOVERY_MAX_BYTES_PER_SEC.name()));
         register(ClusterSettingsExpression.NAME, DataTypes.STRING, ImmutableList.of(CrateSettings.INDICES.name(),
@@ -290,7 +290,7 @@ public class SysClusterTableInfo extends SysTableInfo {
                 CrateSettings.INDICES_STORE.name(),
                 CrateSettings.INDICES_STORE_THROTTLE.name(),
                 CrateSettings.INDICES_STORE_THROTTLE_TYPE.name()));
-        register(ClusterSettingsExpression.NAME, DataTypes.LONG, ImmutableList.of(CrateSettings.INDICES.name(),
+        register(ClusterSettingsExpression.NAME, DataTypes.STRING, ImmutableList.of(CrateSettings.INDICES.name(),
                 CrateSettings.INDICES_STORE.name(),
                 CrateSettings.INDICES_STORE_THROTTLE.name(),
                 CrateSettings.INDICES_STORE_THROTTLE_MAX_BYTES_PER_SEC.name()));

--- a/sql/src/test/java/io/crate/integrationtests/CrateSettingsIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/CrateSettingsIntegrationTest.java
@@ -1,0 +1,16 @@
+package io.crate.integrationtests;
+
+
+import io.crate.action.sql.SQLResponse;
+import org.junit.Test;
+
+public class CrateSettingsIntegrationTest extends SQLTransportIntegrationTest {
+
+    @Test
+    public void testAllSettingsAreSelectable() throws Exception {
+        SQLResponse res = execute("select schema_name, table_name, column_name from information_schema.columns where column_name like 'settings%'");
+        for (Object[] row : res.rows()) {
+            execute(String.format("select %s from %s.%s ", row[2], row[0], row[1]));
+        }
+    }
+}


### PR DESCRIPTION
  not selectable if they are not set

- Fix: fixed an issue which caused TypeConversion errors
  if a setting was selected which represents a byte size
  (e.g. indices[‘store’][‘throttle’][‘my_bytes_per_sec’])