### PR TITLE
fixed a bug where job gets listed in sys.jobs

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed a bug where a job entry wasn't cleaned up on any parser/analyzer errors.
+   
  - Fixed an issue that caused queries on blob tables to cause a
    NullPointerException if the filter in the WHERE CLAUSE resulted in a
    ``null`` value.

--- a/sql/src/main/java/io/crate/action/sql/TransportBaseSQLAction.java
+++ b/sql/src/main/java/io/crate/action/sql/TransportBaseSQLAction.java
@@ -209,6 +209,7 @@ public abstract class TransportBaseSQLAction<TRequest extends SQLBaseRequest, TR
         } catch (Throwable e) {
             logger.debug("Error executing SQLRequest", e);
             sendResponse(listener, buildSQLActionException(e));
+            statsTables.jobFinished(jobId, e.getMessage());
         }
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -1952,6 +1952,21 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
                 "the Sun Zarss, the planet Preliumtarn of the famed Sevorbeupstry and Quentulus Quazgar Mountains." +
                 "\",\"race\":null}| 3\n");
     }
+
+    @Test
+    public void testUnknownTableJobGetsRemoved() throws Exception {
+        execute("set global stats.enabled=true");
+        try {
+            execute("select * from foobar");
+        } catch (SQLActionException e) {
+            assertEquals(e.getMessage(), "Table 'foobar' unknown");
+            execute("select stmt from sys.jobs");
+            assertEquals(response.rowCount(), 1L);
+            assertEquals(response.rows()[0][0], "select stmt from sys.jobs");
+        } finally {
+            execute("reset global stats.enabled");
+        }
+    }
 }
 
 


### PR DESCRIPTION
if "unknown table" exception occurred the select-job doesn't get removed from sys.jobs