### PR TITLE
run response actionListener in SAME ThreadPool

### DIFF
--- a/sql/src/main/java/io/crate/action/job/TransportJobAction.java
+++ b/sql/src/main/java/io/crate/action/job/TransportJobAction.java
@@ -71,7 +71,7 @@ public class TransportJobAction implements NodeAction<JobRequest, JobResponse> {
 
     public void execute(String node, final JobRequest request, final ActionListener<JobResponse> listener) {
         transports.executeLocalOrWithTransport(this, node, request, listener,
-                new DefaultTransportResponseHandler<JobResponse>(listener, EXECUTOR) {
+                new DefaultTransportResponseHandler<JobResponse>(listener) {
                     @Override
                     public JobResponse newInstance() {
                         return new JobResponse();

--- a/sql/src/main/java/io/crate/executor/transport/DefaultTransportResponseHandler.java
+++ b/sql/src/main/java/io/crate/executor/transport/DefaultTransportResponseHandler.java
@@ -21,7 +21,10 @@
 
 package io.crate.executor.transport;
 
+import com.google.common.base.MoreObjects;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.BaseTransportResponseHandler;
 import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportResponse;
@@ -32,9 +35,21 @@ public abstract class DefaultTransportResponseHandler<TResponse extends Transpor
     private final ActionListener<TResponse> listener;
     private final String executor;
 
-    protected DefaultTransportResponseHandler(ActionListener<TResponse> listener, String executor) {
+    /**
+     * Creates a ResponseHandler that passes the response or exception to the given listener.
+     * onResponse/onFailure will be executed using the SAME threadPool
+     */
+    protected DefaultTransportResponseHandler(ActionListener<TResponse> listener) {
+        this(listener, null);
+    }
+
+     /**
+     * Creates a ResponseHandler that passes the response or exception to the given listener.
+     * onResponse/onFailure will be executed using the given executor or SAME if the executor is null
+     */
+    protected DefaultTransportResponseHandler(ActionListener<TResponse> listener, @Nullable String executor) {
         this.listener = listener;
-        this.executor = executor;
+        this.executor = MoreObjects.firstNonNull(executor, ThreadPool.Names.SAME);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/executor/transport/TransportCloseContextNodeAction.java
+++ b/sql/src/main/java/io/crate/executor/transport/TransportCloseContextNodeAction.java
@@ -73,7 +73,7 @@ public class TransportCloseContextNodeAction implements NodeAction<NodeCloseCont
             NodeCloseContextRequest request,
             ActionListener<NodeCloseContextResponse> listener) {
         transports.executeLocalOrWithTransport(this, targetNode, request, listener,
-                new DefaultTransportResponseHandler<NodeCloseContextResponse>(listener, executorName()) {
+                new DefaultTransportResponseHandler<NodeCloseContextResponse>(listener) {
                     @Override
                     public NodeCloseContextResponse newInstance() {
                         return new NodeCloseContextResponse();

--- a/sql/src/main/java/io/crate/executor/transport/TransportFetchNodeAction.java
+++ b/sql/src/main/java/io/crate/executor/transport/TransportFetchNodeAction.java
@@ -89,7 +89,7 @@ public class TransportFetchNodeAction implements NodeAction<NodeFetchRequest, No
             final NodeFetchRequest request,
             ActionListener<NodeFetchResponse> listener) {
         transports.executeLocalOrWithTransport(this, targetNode, request, listener,
-                new DefaultTransportResponseHandler<NodeFetchResponse>(listener, executorName()) {
+                new DefaultTransportResponseHandler<NodeFetchResponse>(listener, ThreadPool.Names.SUGGEST) {
             @Override
             public NodeFetchResponse newInstance() {
                 return new NodeFetchResponse(outputStreamers(request.toFetchReferences()));

--- a/sql/src/main/java/io/crate/executor/transport/kill/TransportKillAllNodeAction.java
+++ b/sql/src/main/java/io/crate/executor/transport/kill/TransportKillAllNodeAction.java
@@ -56,7 +56,7 @@ public class TransportKillAllNodeAction implements NodeAction<KillAllRequest, Ki
 
     public void execute(String targetNode, KillAllRequest request, ActionListener<KillResponse> listener) {
         transports.executeLocalOrWithTransport(this, targetNode, request, listener,
-                new DefaultTransportResponseHandler<KillResponse>(listener, executorName()) {
+                new DefaultTransportResponseHandler<KillResponse>(listener) {
             @Override
             public KillResponse newInstance() {
                 return new KillResponse(0);

--- a/sql/src/main/java/io/crate/executor/transport/kill/TransportKillJobsNodeAction.java
+++ b/sql/src/main/java/io/crate/executor/transport/kill/TransportKillJobsNodeAction.java
@@ -96,7 +96,7 @@ public class TransportKillJobsNodeAction implements NodeAction<KillJobsRequest, 
             }
         };
         DefaultTransportResponseHandler<KillResponse> transportResponseHandler =
-                new DefaultTransportResponseHandler<KillResponse>(killResponseActionListener, executorName()) {
+                new DefaultTransportResponseHandler<KillResponse>(killResponseActionListener) {
             @Override
             public KillResponse newInstance() {
                 return new KillResponse(0);

--- a/sql/src/test/java/io/crate/executor/transport/TransportsTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/TransportsTest.java
@@ -96,7 +96,7 @@ public class TransportsTest extends CrateUnitTest {
         NodeAction nodeAction = mock(NodeAction.class);
         when(nodeAction.executorName()).thenReturn(executorName);
         transports.executeLocalOrWithTransport(nodeAction, "noop_id", mock(TransportRequest.class), listener,
-                new DefaultTransportResponseHandler(listener, executorName) {
+                new DefaultTransportResponseHandler(listener) {
             @Override
             public TransportResponse newInstance() {
                 return mock(TransportResponse.class);


### PR DESCRIPTION
usually the onResponse operation is very cheap and can run on the IO/caller
thread directly.

If the response operation is expensive the listener should be wrapped into a
ThreadedActionListener or a different ResponseHandler should be used.

This avoids EsRejectedExecutionExceptions which can cause queries to get stuck
as the response could be swallowed.