### PR TITLE
do not shutdown executor in OutputS3

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed an issue that caused ``COPY TO .. s3`` statements to leave the cluster
+   in a broken state.
+
  - Fixed a deadlock that could occur if queries with high offset or limit were
    executed concurrently
 

--- a/sql/src/main/java/io/crate/operation/projectors/writer/OutputS3.java
+++ b/sql/src/main/java/io/crate/operation/projectors/writer/OutputS3.java
@@ -178,7 +178,6 @@ public class OutputS3 extends Output {
                             multipartUpload.getUploadId(),
                             etags)
             );
-            executorService.shutdown();
             super.close();
         }
     }


### PR DESCRIPTION
The executorService doesn't belong to the OutputS3 so it isn't allowed to shut
it down.

Currently it is actually the generic threadpool and closing it fucks up the
whole cluster.