### PR TITLE
allocate routing in planner/planner context

### DIFF
--- a/sql/src/main/java/io/crate/planner/PlanNodeBuilder.java
+++ b/sql/src/main/java/io/crate/planner/PlanNodeBuilder.java
@@ -54,7 +54,7 @@ public class PlanNodeBuilder {
                                                    WhereClause whereClause,
                                                    List<Symbol> toCollect,
                                                    ImmutableList<Projection> projections) {
-        Routing routing = tableInfo.getRouting(whereClause, null);
+        Routing routing = plannerContext.allocateRouting(tableInfo, whereClause, null);
         plannerContext.allocateJobSearchContextIds(routing);
         CollectPhase node = new CollectPhase(
                 jobId,
@@ -148,7 +148,7 @@ public class PlanNodeBuilder {
                                        @Nullable String routingPreference,
                                        @Nullable OrderBy orderBy,
                                        @Nullable Integer limit) {
-        Routing routing = tableInfo.getRouting(whereClause, routingPreference);
+        Routing routing = plannerContext.allocateRouting(tableInfo, whereClause, routingPreference);
         return collect(jobId, tableInfo, plannerContext, whereClause, routing, toCollect, projections, partitionIdent, orderBy, limit);
     }
 

--- a/sql/src/main/java/io/crate/planner/consumer/CountConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/CountConsumer.java
@@ -76,7 +76,7 @@ public class CountConsumer implements Consumer {
             }
 
             TableInfo tableInfo = table.tableRelation().tableInfo();
-            Routing routing = tableInfo.getRouting(querySpec.where(), null);
+            Routing routing = context.plannerContext().allocateRouting(tableInfo, querySpec.where(), null);
             Planner.Context plannerContext = context.plannerContext();
             CountPhase countNode = new CountPhase(plannerContext.jobId(), plannerContext.nextExecutionPhaseId(), routing, querySpec.where());
             MergePhase mergeNode = new MergePhase(

--- a/sql/src/main/java/io/crate/planner/consumer/NonDistributedGroupByConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/NonDistributedGroupByConsumer.java
@@ -87,7 +87,7 @@ public class NonDistributedGroupByConsumer implements Consumer {
                 return null;
             }
 
-            Routing routing = tableInfo.getRouting(table.querySpec().where(), null);
+            Routing routing = context.plannerContext().allocateRouting(tableInfo, table.querySpec().where(), null);
             if (routing.hasLocations() && routing.locations().size()>1) {
                 return null;
             }
@@ -100,7 +100,7 @@ public class NonDistributedGroupByConsumer implements Consumer {
             if (table.querySpec().groupBy() == null) {
                 return null;
             }
-            Routing routing = table.tableRelation().tableInfo().getRouting(table.querySpec().where(), null);
+            Routing routing = context.plannerContext().allocateRouting(table.tableRelation().tableInfo(), table.querySpec().where(), null);
             return nonDistributedGroupBy(table, routing, context);
         }
 


### PR DESCRIPTION
In order to ensure that the routing per table/whereClause/preference pair is
always the same per statement.

This will be important for self-joins, otherwise it could happen that one
table uses replica shards and the other one uses primaries or different
replica shards.