### PR TITLE
QAF: include offset in limit of collectPhase

### DIFF
--- a/sql/src/main/java/io/crate/planner/consumer/QueryAndFetchConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/QueryAndFetchConsumer.java
@@ -265,7 +265,7 @@ public class QueryAndFetchConsumer implements Consumer {
             this.allOutputs = allOutputs;
             this.orderBy = querySpec.orderBy();
             this.offset = querySpec.offset();
-            this.limit = firstNonNull(querySpec.limit(), Constants.DEFAULT_SELECT_LIMIT);;
+            this.limit = firstNonNull(querySpec.limit(), Constants.DEFAULT_SELECT_LIMIT) + querySpec.offset();
         }
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -30,7 +30,6 @@ import io.crate.action.sql.SQLBulkResponse;
 import io.crate.exceptions.Exceptions;
 import io.crate.exceptions.TableUnknownException;
 import io.crate.executor.TaskResult;
-import io.crate.metadata.TableIdent;
 import io.crate.planner.Plan;
 import io.crate.testing.TestingHelpers;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthStatus;


### PR DESCRIPTION
testSqlRequestWithLimitAndOffset failed due to that since 
85e059fd4d8bcc88bf16ec773e40d05f5d646f43

Before that commit there were no QAF plans for doc tables with limit/offset so
the bug didn't really occur.