### PR TITLE
Added ``os_info`` column to ``sys.nodes`` table.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,10 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Added ``os_info`` column to ``sys.nodes`` table.
+   Currently the column only lists the number of available processors in the JVM
+   (which is usually equal to the number of cores of the CPU).
+
  - Improved retry logic of EC2 unicast host discovery mechanism
 
  - Fixed a deadlock that could occur if queries with high offset or limit were

--- a/sql/src/main/java/io/crate/metadata/sys/SysNodesTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysNodesTableInfo.java
@@ -121,6 +121,9 @@ public class SysNodesTableInfo extends SysTableInfo {
         register("os", DataTypes.SHORT, ImmutableList.of("cpu", "used"));
         register("os", DataTypes.SHORT, ImmutableList.of("cpu", "stolen"));
 
+        register("os_info", DataTypes.OBJECT, null);
+        register("os_info", DataTypes.INTEGER, ImmutableList.of("available_processors"));
+
         register("process", DataTypes.OBJECT, null);
         register("process", DataTypes.LONG, ImmutableList.of("open_file_descriptors"));
         register("process", DataTypes.LONG, ImmutableList.of("max_open_file_descriptors"));

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/NodeOsInfoExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/NodeOsInfoExpression.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to Crate.IO GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.operation.reference.sys.node;
+
+import io.crate.operation.reference.sys.SysNodeObjectReference;
+import org.elasticsearch.monitor.os.OsInfo;
+
+public class NodeOsInfoExpression extends SysNodeObjectReference {
+
+    public static final String NAME = "os_info";
+    private static final String AVAILABLE_PROCESSORS = "available_processors";
+
+    abstract class OsInfoExpression extends SysNodeExpression<Object> {
+    }
+
+    public NodeOsInfoExpression(OsInfo info) {
+        addChildImplementations(info);
+    }
+
+    private void addChildImplementations(final OsInfo info) {
+        childImplementations.put(AVAILABLE_PROCESSORS, new OsInfoExpression() {
+            @Override
+            public Integer value() {
+                return info.availableProcessors();
+            }
+        });
+    }
+
+}
+

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/NodeSysExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/NodeSysExpression.java
@@ -30,6 +30,7 @@ import org.elasticsearch.discovery.Discovery;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.monitor.jvm.JvmService;
 import org.elasticsearch.monitor.network.NetworkService;
+import org.elasticsearch.monitor.os.OsInfo;
 import org.elasticsearch.monitor.os.OsService;
 import org.elasticsearch.monitor.os.OsStats;
 import org.elasticsearch.monitor.sigar.SigarService;
@@ -82,6 +83,8 @@ public class NodeSysExpression extends NestedObjectExpression {
                 new NodeVersionExpression());
         childImplementations.put(NodeThreadPoolsExpression.NAME,
                 new NodeThreadPoolsExpression(threadPool));
+        childImplementations.put(NodeOsInfoExpression.NAME,
+                new NodeOsInfoExpression(osService.info()));
     }
 
     @Override

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -273,8 +273,8 @@ public class SelectStatementAnalyzerTest extends BaseAnalyzerTest {
         List<String> outputNames = outputNames(analysis.relation());
         assertThat(outputNames.get(0), is("id"));
         assertThat(outputNames.get(1), is("id"));
-        assertThat(outputNames.size(), is(15));
-        assertThat(analysis.relation().querySpec().outputs().size(), is(15));
+        assertThat(outputNames.size(), is(16));
+        assertThat(analysis.relation().querySpec().outputs().size(), is(16));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -435,7 +435,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultColumns() throws Exception {
         execute("select * from information_schema.columns order by schema_name, table_name");
-        assertEquals(283L, response.rowCount());
+        assertEquals(285L, response.rowCount());
     }
 
     @Test
@@ -555,7 +555,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
         execute("select max(ordinal_position) from information_schema.columns");
         assertEquals(1, response.rowCount());
 
-        short max_ordinal = 89;
+        short max_ordinal = 91;
         assertEquals(max_ordinal, response.rows()[0][0]);
 
         execute("create table t1 (id integer, col1 string)");

--- a/sql/src/test/java/io/crate/operation/reference/sys/SysNodesExpressionsTest.java
+++ b/sql/src/test/java/io/crate/operation/reference/sys/SysNodesExpressionsTest.java
@@ -57,6 +57,7 @@ import org.elasticsearch.monitor.jvm.JvmStats;
 import org.elasticsearch.monitor.network.NetworkProbe;
 import org.elasticsearch.monitor.network.NetworkService;
 import org.elasticsearch.monitor.network.NetworkStats;
+import org.elasticsearch.monitor.os.OsInfo;
 import org.elasticsearch.monitor.os.OsService;
 import org.elasticsearch.monitor.os.OsStats;
 import org.elasticsearch.monitor.process.ProcessInfo;
@@ -139,6 +140,10 @@ public class SysNodesExpressionsTest extends CrateUnitTest {
             when(mem.actualUsed()).thenReturn(byteSizeValue);
             when(mem.usedPercent()).thenReturn((short) 22);
             when(mem.freePercent()).thenReturn((short) 78);
+
+            OsInfo osInfo = mock(OsInfo.class);
+            when(osService.info()).thenReturn(osInfo);
+            when(osInfo.availableProcessors()).thenReturn(4);
 
             bind(OsService.class).toInstance(osService);
 
@@ -537,6 +542,16 @@ public class SysNodesExpressionsTest extends CrateUnitTest {
         cpuObj.put("system", 1000L);
         cpuObj.put("user", 500L);
         assertEquals(cpuObj, v.get("cpu"));
+    }
+
+    @Test
+    public void testOsInfo() throws Exception {
+        ReferenceIdent ident = new ReferenceIdent(SysNodesTableInfo.IDENT, "os_info");
+        NestedObjectExpression ref = (NestedObjectExpression) resolver.getImplementation(ident);
+
+        Map<String, Object> v = ref.value();
+        int cores = (int) v.get("available_processors");
+        assertEquals(4, cores);
     }
 
     @Test


### PR DESCRIPTION
Currently the column only lists the number of available processors in the JVM
which is usually equal to the number of cores of the CPU.