### PR TITLE
don't eagerly close the JobCollectContext/SearchContext if there were no rows

### DIFF
--- a/sql/src/main/java/io/crate/operation/collect/JobCollectContext.java
+++ b/sql/src/main/java/io/crate/operation/collect/JobCollectContext.java
@@ -78,7 +78,6 @@ public class JobCollectContext implements ExecutionSubContext, RowUpstream, Exec
         this.queryPhaseRamAccountingContext = queryPhaseRamAccountingContext;
         this.downstream = new RowDownstream() {
 
-            final AtomicLong rowCount = new AtomicLong();
             final AtomicInteger numUpstreams = new AtomicInteger();
 
             @Override
@@ -89,7 +88,6 @@ public class JobCollectContext implements ExecutionSubContext, RowUpstream, Exec
 
                     @Override
                     public boolean setNextRow(Row row) {
-                        rowCount.incrementAndGet();
                         return rowDownstreamHandle.setNextRow(row);
                     }
 
@@ -97,7 +95,7 @@ public class JobCollectContext implements ExecutionSubContext, RowUpstream, Exec
                     public void finish() {
                         rowDownstreamHandle.finish();
                         if (numUpstreams.decrementAndGet() == 0) {
-                            if (rowCount.get() == 0 || !collectPhase.keepContextForFetcher()) {
+                            if (!collectPhase.keepContextForFetcher()) {
                                 close();
                             }
                         }

--- a/sql/src/main/java/io/crate/operation/collect/LuceneDocCollector.java
+++ b/sql/src/main/java/io/crate/operation/collect/LuceneDocCollector.java
@@ -161,7 +161,7 @@ public class LuceneDocCollector extends Collector implements CrateCollector, Row
             e.setNextDocId(doc);
         }
         boolean wantMore = downstream.setNextRow(inputRow);
-        if (!wantMore || (limit != null && rowCount == limit)) {
+        if (!wantMore || (limit != null && rowCount >= limit)) {
             // no more rows required, we can stop here
             throw new CollectionFinishedEarlyException();
         }
@@ -216,9 +216,6 @@ public class LuceneDocCollector extends Collector implements CrateCollector, Row
             searchContext.close();
             downstream.fail(e);
         } finally {
-            if (rowCount == 0) {
-                searchContext.close();
-            }
             searchContext.searcher().finishStage(ContextIndexSearcher.Stage.MAIN_QUERY);
             assert SearchContext.current() == searchContext;
             searchContext.clearReleasables(SearchContext.Lifetime.PHASE);


### PR DESCRIPTION
The searchContext will be closed indirectly if the JobCollectContext is
closed.

The JobCollectContext is closed after the Fetch and once we've a separate
FetchContext it can always be closed immediately anyway.