### PR TITLE
mark ShardCollectService as Singleton

### DIFF
--- a/sql/src/main/java/io/crate/operation/collect/ShardCollectService.java
+++ b/sql/src/main/java/io/crate/operation/collect/ShardCollectService.java
@@ -43,6 +43,7 @@ import io.crate.planner.symbol.Literal;
 import org.elasticsearch.action.bulk.BulkRetryCoordinatorPool;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.engine.Engine;
@@ -51,6 +52,7 @@ import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.threadpool.ThreadPool;
 
+@Singleton
 public class ShardCollectService {
 
     private final CollectInputSymbolVisitor<?> docInputSymbolVisitor;


### PR DESCRIPTION
it's bound to the shard injector and we don't want to re-create it each time a
shard collector is retrieved.