### PR TITLE
copy bytes in StreamBucket.Builder build()

### DIFF
--- a/sql/src/main/java/io/crate/executor/transport/StreamBucket.java
+++ b/sql/src/main/java/io/crate/executor/transport/StreamBucket.java
@@ -89,7 +89,7 @@ public class StreamBucket implements Bucket, Streamable {
         }
 
         public void reset() {
-            out.reset();
+            out = new BytesStreamOutput(size); // next bucket is probably going to have the same size
             size = 0;
         }
     }


### PR DESCRIPTION
babb0cee5458c19e78e228224fd592ba66dd4d7d broke the StreamBucket.

If the StreamBucket is sent to the same node the writeTo/readFrom aren't
executed so the bytes aren't copied.

And `BytesStreamOutput.reset` resizes the bytesArray if it grew larger than
1024 which will also result in failures.