### PR TITLE
avoid unnecessary boxing/object creation in type conversions

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,11 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Breaking Change:
+   Made string to boolean casts more strict. Mixed case strings like 'tRuE'
+   won't convert anymore.
+   Also improved the performance of those type casts.
+
  - Fixed an issue that could cause `COPY FROM` to ignore a primary key
    constraint leading to duplicate rows.
    This could happen if a table has multiple primary keys and clustered by is

--- a/core/src/main/java/io/crate/types/BytesRefs2.java
+++ b/core/src/main/java/io/crate/types/BytesRefs2.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to Crate.IO GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.types;
+
+import org.apache.lucene.util.BytesRef;
+
+public class BytesRefs2 {
+
+    private BytesRefs2() {}
+
+    public static final BytesRef LOWER_SHORT_TRUE = new BytesRef("t");
+    public static final BytesRef UPPER_SHORT_TRUE= new BytesRef("T");
+    public static final BytesRef LOWER_SHORT_FALSE = new BytesRef("f");
+    public static final BytesRef UPPER_SHORT_FALSE = new BytesRef("F");
+
+    public static final BytesRef LOWER_TRUE = new BytesRef("true");
+    public static final BytesRef UPPER_TRUE= new BytesRef("TRUE");
+    public static final BytesRef LOWER_FALSE = new BytesRef("false");
+    public static final BytesRef UPPER_FALSE = new BytesRef("FALSE");
+}

--- a/core/src/main/java/io/crate/types/LongType.java
+++ b/core/src/main/java/io/crate/types/LongType.java
@@ -73,7 +73,7 @@ public class
      *
      * mostly copied from {@link Long#parseLong(String s, int radix)}
      */
-    private long parseLong(BytesRef value) {
+    private static long parseLong(BytesRef value) {
         assert value != null : "value must not be null";
         boolean negative = false;
         long result = 0;

--- a/core/src/main/java/io/crate/types/StringType.java
+++ b/core/src/main/java/io/crate/types/StringType.java
@@ -35,6 +35,7 @@ public class StringType extends DataType<BytesRef> implements DataTypeFactory, S
 
     public static final int ID = 4;
     public static final StringType INSTANCE = new StringType();
+
     protected StringType() {}
 
     @Override
@@ -64,11 +65,7 @@ public class StringType extends DataType<BytesRef> implements DataTypeFactory, S
             return new BytesRef((String)value);
         }
         if (value instanceof Boolean) {
-            if ((boolean)value) {
-                return new BytesRef("t");
-            } else {
-                return new BytesRef("f");
-            }
+            return (Boolean) value ? BytesRefs2.LOWER_SHORT_TRUE : BytesRefs2.LOWER_SHORT_FALSE;
         }
         if (value instanceof Map || value.getClass().isArray()) {
             throw new IllegalArgumentException(

--- a/core/src/main/java/io/crate/types/TimestampType.java
+++ b/core/src/main/java/io/crate/types/TimestampType.java
@@ -48,7 +48,7 @@ public class TimestampType extends LongType implements Streamer<Long>, DataTypeF
             return null;
         }
         if (value instanceof BytesRef) {
-            return valueFromString(((BytesRef)value).utf8ToString());
+            return valueFromString(((BytesRef) value).utf8ToString());
         }
         if (value instanceof String) {
             return valueFromString((String) value);
@@ -69,7 +69,7 @@ public class TimestampType extends LongType implements Streamer<Long>, DataTypeF
 
     private Long valueFromString(String s) {
         try {
-            return new Long(s);
+            return Long.valueOf(s);
         } catch (NumberFormatException e) {
             return TimestampFormat.parseTimestampString(s);
         }

--- a/core/src/test/java/io/crate/types/DataTypesTest.java
+++ b/core/src/test/java/io/crate/types/DataTypesTest.java
@@ -39,7 +39,7 @@ public class DataTypesTest extends CrateUnitTest {
     @Test
     public void testConvertBooleanToString() {
         BytesRef value = DataTypes.STRING.value(true);
-        assertEquals(new BytesRef("t"), value);
+        assertEquals(BytesRefs2.LOWER_SHORT_TRUE, value);
     }
 
     @Test
@@ -189,11 +189,15 @@ public class DataTypesTest extends CrateUnitTest {
         DataTypes.LONG.value("hello");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = ClassCastException.class)
     public void testConvertToUnsupportedBooleanConversion() {
         DataTypes.BOOLEAN.value("hello");
     }
 
+    @Test(expected = ClassCastException.class)
+    public void testConvertUnsupportedBytesRefToBoolean() throws Exception {
+        DataTypes.BOOLEAN.value(new BytesRef("foo"));
+    }
 
     @Test(expected = ClassCastException.class)
     public void testConvertBooleanToLong() {

--- a/sql/src/main/java/io/crate/analyze/SettingsAppliers.java
+++ b/sql/src/main/java/io/crate/analyze/SettingsAppliers.java
@@ -60,7 +60,7 @@ public class SettingsAppliers {
                 settingsBuilder.put(name, validate(value));
             } catch (InvalidSettingValueContentException e) {
                 throw new IllegalArgumentException(e.getMessage());
-            } catch (IllegalArgumentException e) {
+            } catch (ClassCastException | IllegalArgumentException e) {
                 throw invalidException(e);
             }
         }

--- a/sql/src/test/java/io/crate/operation/scalar/cast/ToBooleanFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/cast/ToBooleanFunctionTest.java
@@ -84,8 +84,8 @@ public class ToBooleanFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testNormalizeInvalidString() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("cannot cast 'hello' to boolean");
+        expectedException.expect(ClassCastException.class);
+        expectedException.expectMessage("Can't cast 'hello' to boolean");
         TestingHelpers.assertLiteralSymbol(normalize("hello", DataTypes.STRING), 123L);
     }
 }


### PR DESCRIPTION
Converting boolean true to bytesRef:

    Before:     0.19
    After:      0.00

Convert strings to boolean:

    Before:     0.29 [+- 0.01]
    After:      0.11 [+- 0.01]

Convert bytesRefs to boolean (with the string optimization already applied):
(this has also a behaviour change in that mixed cased string like TrUe won't convert. So maybe this part should be reverted.)

    Before:     0.09 [+- 0.01]
    After:      0.04 [+- 0.00]