### PR TITLE
avoid long running queries to be killed by the job context reaper

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed an issue that could kill long running queries on shards with few
+   segments containing huge amounts of documents
+
  - Fixed an issue that could cause `COPY FROM` to ignore a primary key
    constraint leading to duplicate rows.
    This could happen if a table has multiple primary keys and clustered by is

--- a/sql/src/main/java/io/crate/jobs/JobExecutionContext.java
+++ b/sql/src/main/java/io/crate/jobs/JobExecutionContext.java
@@ -275,6 +275,7 @@ public class JobExecutionContext {
 
         @Override
         public void keepAlive() {
+            LOGGER.trace("trigger keepAlive on context for execution phase {}", executionPhaseId);
             lastAccessTime = threadPool.estimatedTimeInMillis();
         }
     }

--- a/sql/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
+++ b/sql/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
@@ -74,6 +74,8 @@ import org.elasticsearch.common.geo.GeoDistance;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.lucene.docset.MatchDocIdSet;
 import org.elasticsearch.common.lucene.search.Queries;
@@ -98,6 +100,7 @@ import static io.crate.operation.scalar.regex.RegexMatcher.isPcrePattern;
 @Singleton
 public class LuceneQueryBuilder {
 
+    private static final ESLogger LOGGER = Loggers.getLogger(LuceneQueryBuilder.class);
     private final static Visitor VISITOR = new Visitor();
     private final CollectInputSymbolVisitor<LuceneCollectorExpression<?>> inputSymbolVisitor;
 
@@ -117,6 +120,11 @@ public class LuceneQueryBuilder {
             ctx.query = Queries.newMatchAllQuery();
         } else {
             ctx.query = VISITOR.process(whereClause.query(), ctx);
+        }
+        if (LOGGER.isTraceEnabled()) {
+            if (whereClause.hasQuery()) {
+                LOGGER.trace("WHERE CLAUSE [{}] -> LUCENE QUERY [{}] ", SymbolFormatter.format(whereClause.query()), ctx.query);
+            }
         }
         return ctx;
     }

--- a/sql/src/main/java/io/crate/operation/collect/JobCollectContext.java
+++ b/sql/src/main/java/io/crate/operation/collect/JobCollectContext.java
@@ -162,7 +162,7 @@ public class JobCollectContext implements ExecutionSubContext, RowUpstream, Exec
             try {
                 closeFuture.get();
             } catch (Throwable e) {
-                LOGGER.warn("Error while waiting for already running close {}", e);
+                LOGGER.warn("Error while waiting for already running close {}", e, id);
             }
         }
     }

--- a/sql/src/main/java/io/crate/operation/collect/LuceneDocCollector.java
+++ b/sql/src/main/java/io/crate/operation/collect/LuceneDocCollector.java
@@ -154,6 +154,12 @@ public class LuceneDocCollector extends Collector implements CrateCollector, Row
                             ramAccountingContext.limit()));
         }
 
+        if (rowCount % KEEP_ALIVE_AFTER_ROWS == 0) {
+            // trigger keep-alive only every KEEP_ALIVE_AFTER_ROWS
+            // as it uses too much volatile stuff to do it more often
+            keepAliveListener.keepAlive();
+        }
+
         if (skipDoc(doc)) {
             return;
         }
@@ -190,12 +196,6 @@ public class LuceneDocCollector extends Collector implements CrateCollector, Row
         }
         internalCollectContext.lastCollected.doc = doc;
         internalCollectContext.lastDocBase = currentDocBase;
-
-        if (rowCount % KEEP_ALIVE_AFTER_ROWS == 0) {
-            // trigger keep-alive only every KEEP_ALIVE_AFTER_ROWS
-            // as it uses too much volatile stuff to do it more often
-            keepAliveListener.keepAlive();
-        }
     }
 
 

--- a/sql/src/test/java/io/crate/integrationtests/FetchOperationIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/FetchOperationIntegrationTest.java
@@ -109,7 +109,7 @@ public class FetchOperationIntegrationTest extends SQLTransportIntegrationTest {
         sqlExecutor.exec("create table characters (id int primary key, name string) " +
                 "clustered into 2 shards with(number_of_replicas=0)");
         sqlExecutor.ensureYellowOrGreen();
-        sqlExecutor.exec("insert into characters (id, name) values (?, ?)",
+        sqlExecutor.execBulk("insert into characters (id, name) values (?, ?)",
                 new Object[][]{
                         new Object[]{1, "Arthur"},
                         new Object[]{2, "Ford"},

--- a/sql/src/test/java/io/crate/integrationtests/LongRunningQueriesIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/LongRunningQueriesIntegrationTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.integrationtests;
+
+import io.crate.action.sql.SQLResponse;
+import io.crate.jobs.JobContextService;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.junit.annotations.TestLogging;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+@TestLogging("io.crate.jobs.JobExecutionContext:TRACE")
+@ElasticsearchIntegrationTest.ClusterScope (numDataNodes = 2)
+public class LongRunningQueriesIntegrationTest extends SQLTransportIntegrationTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private static final long ORIGINAL_KEEP_ALIVE = JobContextService.KEEP_ALIVE;
+    private static final long TEST_KEEP_ALIVE = TimeValue.timeValueSeconds(2).millis();
+    private static final int ROWS = 4;
+    private static final TimeValue TIMEOUT = TimeValue.timeValueSeconds(20);
+
+
+    @Override
+    public SQLResponse execute(String stmt) {
+        return super.execute(stmt, TIMEOUT);
+    }
+
+    @Override
+    public SQLResponse execute(String stmt, Object[] args) {
+        return super.execute(stmt, args, TIMEOUT);
+    }
+
+    @Before
+    public void prepare() {
+        JobContextService.KEEP_ALIVE = TEST_KEEP_ALIVE;
+    }
+
+    @After
+    public void cleanup() {
+        JobContextService.KEEP_ALIVE = ORIGINAL_KEEP_ALIVE;
+    }
+
+    @Test
+    public void testLongQueryThenFetchContextIsNotReapedWhileInCollector() throws Exception {
+        execute("create table longt (id int, duration long) clustered into 1 shards with (number_of_replicas=0)");
+        ensureYellow();
+        Object[][] args = new Object[ROWS][];
+        for (int i = 0; i < ROWS; i++) {
+            args[i] = new Object[]{i, 1000};
+        }
+        execute("insert into longt (id, duration) values (?, ?)", args);
+        execute("refresh table longt");
+
+        // sleep for 4 seconds, 2 seconds more than KEEP_ALIVE
+        // where clause is evaluated in LuceneDocCollector
+        execute("select duration from longt where sleep(duration) = true");
+    }
+
+    @Test
+    public void testLongQueryThenFetchContextIsNotReapedWhileInCollectorWithoutMatches() throws Exception {
+        execute("create table longt (id int, duration long) clustered into 1 shards with (number_of_replicas=0)");
+        ensureYellow();
+        Object[][] args = new Object[ROWS][];
+        for (int i = 0; i < ROWS; i++) {
+            args[i] = new Object[]{i, 1000};
+        }
+        execute("insert into longt (id, duration) values (?, ?)", args);
+        execute("refresh table longt");
+
+        // sleep for 4 seconds, 3 seconds more than KEEP_ALIVE
+        // where clause is evaluated in LuceneDocCollector
+        execute("select duration from longt where sleep(duration) = false");
+    }
+
+    @TestLogging("io.crate.jobs.JobExecutionContext:TRACE")
+    @Test
+    public void testLongQueryThenFetchContextIsNotReapedWhileInFetchProjector() throws Exception {
+        execute("create table longt (id int, duration long) clustered into 1 shards with (number_of_replicas=0)");
+        ensureYellow();
+        Object[][] args = new Object[ROWS][];
+        for (int i = 0; i < ROWS; i++) {
+            args[i] = new Object[]{i, 1000};
+        }
+        execute("insert into longt (id, duration) values (?, ?)", args);
+        execute("refresh table longt");
+
+        // sleep for 4 seconds, 3 seconds more than KEEP_ALIVE
+        // duration will be fetched in FetchProjector and sleep will be executed
+        // there (localMerge)
+        execute("select sleep(duration) from longt");
+    }
+}

--- a/sql/src/test/java/io/crate/integrationtests/QueryThenFetchIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/QueryThenFetchIntegrationTest.java
@@ -54,9 +54,9 @@ public class QueryThenFetchIntegrationTest extends SQLTransportIntegrationTest {
         execute("select * from t order by substr(name, 1, 1) = 'M', b");
         assertThat(TestingHelpers.printedTable(response.rows()), is(
                 "1| Trillian\n" +
-                "2| Arthur\n" +
-                "0| Marvin\n" +
-                "3| Max\n"));
+                        "2| Arthur\n" +
+                        "0| Marvin\n" +
+                        "3| Max\n"));
     }
 
     @Test
@@ -114,7 +114,7 @@ public class QueryThenFetchIntegrationTest extends SQLTransportIntegrationTest {
         execute("insert into t (x) values (?)", bulkArgs);
         execute("refresh table t");
 
-        Long limit = new Long(docCount-1);
+        Long limit = new Long(docCount - 1);
         execute("select * from t limit ?", new Object[]{limit});
         assertThat(response.rowCount(), is(limit));
 

--- a/sql/src/test/java/io/crate/integrationtests/RegexpIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/RegexpIntegrationTest.java
@@ -252,7 +252,6 @@ public class RegexpIntegrationTest extends SQLTransportIntegrationTest {
         execute("select * from sys.shards where table_name ~* 'LOCATIONS'");
         assertThat(response.rowCount(), is(2L));
         assertThat((String) response.rows()[0][1], is("locations"));
-
     }
 
 }

--- a/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
@@ -239,7 +239,7 @@ public abstract class SQLTransportIntegrationTest extends ElasticsearchIntegrati
      * @return the SQLResponse
      */
     public SQLResponse execute(String stmt, Object[] args, TimeValue timeout) {
-        response = sqlExecutor.exec(stmt, timeout, args);
+        response = sqlExecutor.exec(stmt, args, timeout);
         return response;
     }
 
@@ -266,8 +266,20 @@ public abstract class SQLTransportIntegrationTest extends ElasticsearchIntegrati
      * @return the SQLResponse
      */
     public SQLBulkResponse execute(String stmt, Object[][] bulkArgs) {
-        return sqlExecutor.exec(stmt, bulkArgs);
+        return sqlExecutor.execBulk(stmt, bulkArgs);
     }
+
+    /**
+     * Execute an SQL Statement on a random node of the cluster
+     *
+     * @param stmt the SQL Statement
+     * @param bulkArgs the bulk arguments of the statement
+     * @return the SQLResponse
+     */
+    public SQLBulkResponse execute(String stmt, Object[][] bulkArgs, TimeValue timeout) {
+        return sqlExecutor.execBulk(stmt, bulkArgs, timeout);
+    }
+
 
     /**
      * Execute an SQL Statement on a random node of the cluster

--- a/sql/src/test/java/io/crate/integrationtests/Setup.java
+++ b/sql/src/test/java/io/crate/integrationtests/Setup.java
@@ -130,7 +130,7 @@ public class Setup {
                         "13",  "End of the Galaxy", "2013-07-16",  "Galaxy",  6,  "The end of the Galaxy.%", null
                 }
         };
-        transportExecutor.exec(insertStmt, rows);
+        transportExecutor.execBulk(insertStmt, rows);
     }
 
     public void groupBySetup() throws Exception {
@@ -303,12 +303,12 @@ public class Setup {
     public void setUpCharacters() {
         transportExecutor.exec("create table characters (id int primary key, name string, female boolean, details object)");
         transportExecutor.ensureGreen();
-        transportExecutor.exec("insert into characters (id, name, female) values (?, ?, ?)",
+        transportExecutor.execBulk("insert into characters (id, name, female) values (?, ?, ?)",
                 new Object[][]{
-                        new Object[] { 1, "Arthur", false},
-                        new Object[] { 2, "Ford", false},
-                        new Object[] { 3, "Trillian", true},
-                        new Object[] { 4, "Arthur", true}
+                        new Object[]{1, "Arthur", false},
+                        new Object[]{2, "Ford", false},
+                        new Object[]{3, "Trillian", true},
+                        new Object[]{4, "Arthur", true}
                 }
         );
         transportExecutor.refresh("characters");
@@ -317,11 +317,11 @@ public class Setup {
     public void setUpPartitionedTableWithName() {
         transportExecutor.exec("create table parted (id int, name string, date timestamp) partitioned by (date)");
         transportExecutor.ensureGreen();
-        transportExecutor.exec("insert into parted (id, name, date) values (?, ?, ?), (?, ?, ?), (?, ?, ?)",
-                new Object[]{
-                        1, "Trillian", null,
-                        2, null, 0L,
-                        3, "Ford", 1396388720242L
+        transportExecutor.execBulk("insert into parted (id, name, date) values (?, ?, ?)",
+                new Object[][]{
+                        {1, "Trillian", null},
+                        {2, null, 0L},
+                        {3, "Ford", 1396388720242L}
                 });
         transportExecutor.ensureGreen();
         transportExecutor.refresh("parted");

--- a/sql/src/test/java/io/crate/testing/SQLTransportExecutor.java
+++ b/sql/src/test/java/io/crate/testing/SQLTransportExecutor.java
@@ -73,13 +73,21 @@ public class SQLTransportExecutor {
         return exec(new SQLRequest(statement, params));
     }
 
+    public SQLResponse exec(String statement, TimeValue timeout, Object... params) {
+        return exec(new SQLRequest(statement, params), timeout);
+    }
+
     public SQLBulkResponse exec(String statement, Object[][] bulkArgs) {
         return exec(new SQLBulkRequest(statement, bulkArgs));
     }
 
     public SQLResponse exec(SQLRequest request) {
+        return exec(request, REQUEST_TIMEOUT);
+    }
+
+    public SQLResponse exec(SQLRequest request, TimeValue timeout) {
         try {
-            return execute(request).actionGet(REQUEST_TIMEOUT);
+            return execute(request).actionGet(timeout);
         } catch (ElasticsearchTimeoutException e) {
             LOGGER.error("Timeout on SQL statement: {}", e, request.stmt());
             throw e;

--- a/sql/src/test/java/io/crate/testing/SQLTransportExecutor.java
+++ b/sql/src/test/java/io/crate/testing/SQLTransportExecutor.java
@@ -73,12 +73,16 @@ public class SQLTransportExecutor {
         return exec(new SQLRequest(statement, params));
     }
 
-    public SQLResponse exec(String statement, TimeValue timeout, Object... params) {
+    public SQLResponse exec(String statement, Object[] params, TimeValue timeout) {
         return exec(new SQLRequest(statement, params), timeout);
     }
 
-    public SQLBulkResponse exec(String statement, Object[][] bulkArgs) {
-        return exec(new SQLBulkRequest(statement, bulkArgs));
+    public SQLBulkResponse execBulk(String statement, Object[][] bulkArgs) {
+        return exec(new SQLBulkRequest(statement, bulkArgs), REQUEST_TIMEOUT);
+    }
+
+    public SQLBulkResponse execBulk(String statement, Object[][] bulkArgs, TimeValue timeout) {
+        return exec(new SQLBulkRequest(statement, bulkArgs), timeout);
     }
 
     public SQLResponse exec(SQLRequest request) {
@@ -95,8 +99,12 @@ public class SQLTransportExecutor {
     }
 
     public SQLBulkResponse exec(SQLBulkRequest request) {
+        return exec(request, REQUEST_TIMEOUT);
+    }
+
+    public SQLBulkResponse exec(SQLBulkRequest request, TimeValue timeout) {
         try {
-            return execute(request).actionGet(REQUEST_TIMEOUT);
+            return execute(request).actionGet(timeout);
         } catch (ElasticsearchTimeoutException e) {
             LOGGER.error("Timeout on SQL statement: {}", e, request.stmt());
             throw e;


### PR DESCRIPTION
this happened if a long running query (or ordering) was executed inside the LuceneDocCollector
when a shard had very few segments with a huge amount of documents
so the keepalive time was not updated during execution.

Benchmark results remained roughly the same.