### PR TITLE
remove RowDownstream interface from NL operation

### DIFF
--- a/sql/src/main/java/io/crate/jobs/NestedLoopContext.java
+++ b/sql/src/main/java/io/crate/jobs/NestedLoopContext.java
@@ -80,7 +80,8 @@ public class NestedLoopContext implements DownstreamExecutionSubContext, Executi
 
         // left context
         if (nestedLoopPhase.leftMergePhase() != null) {
-            leftDownstreamContext = createPageDownstreamContext(nestedLoopPhase.leftMergePhase());
+            leftDownstreamContext = createPageDownstreamContext(nestedLoopPhase.leftMergePhase(),
+                    nestedLoopOperation.leftDownStream());
             leftDownstreamContext.addCallback(new RemoveContextCallback(0));
             activeSubContexts.incrementAndGet();
         } else {
@@ -88,7 +89,8 @@ public class NestedLoopContext implements DownstreamExecutionSubContext, Executi
         }
         // right context
         if (nestedLoopPhase.rightMergePhase() != null) {
-            rightDownstreamContext = createPageDownstreamContext(nestedLoopPhase.rightMergePhase());
+            rightDownstreamContext = createPageDownstreamContext(nestedLoopPhase.rightMergePhase(),
+                    nestedLoopOperation.rightDownStream());
             rightDownstreamContext.addCallback(new RemoveContextCallback(1));
             activeSubContexts.incrementAndGet();
         } else {
@@ -96,7 +98,6 @@ public class NestedLoopContext implements DownstreamExecutionSubContext, Executi
         }
 
     }
-
 
     @Override
     public void addCallback(ContextCallback contextCallback) {
@@ -192,11 +193,12 @@ public class NestedLoopContext implements DownstreamExecutionSubContext, Executi
         return false;
     }
 
-    private PageDownstreamContext createPageDownstreamContext(MergePhase phase) {
+    private PageDownstreamContext createPageDownstreamContext(MergePhase phase,
+                                                              RowDownstream rowDownstream) {
         Tuple<PageDownstream, FlatProjectorChain> pageDownstreamProjectorChain =
                 pageDownstreamFactory.createMergeNodePageDownstream(
                         phase,
-                        nestedLoopOperation,
+                        rowDownstream,
                         true,
                         ramAccountingContext,
                         Optional.of(threadPool.executor(ThreadPool.Names.SEARCH)));

--- a/sql/src/main/java/io/crate/operation/SingleUpstreamRowDownstream.java
+++ b/sql/src/main/java/io/crate/operation/SingleUpstreamRowDownstream.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to CRATE.IO GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.operation;
+
+public class SingleUpstreamRowDownstream implements RowDownstream {
+
+    private final RowDownstreamHandle rowDownstreamHandle;
+    private RowUpstream upstream;
+    private volatile boolean upstreamRegistered = false;
+
+    public SingleUpstreamRowDownstream(RowDownstreamHandle rowDownstreamHandle) {
+        this.rowDownstreamHandle = rowDownstreamHandle;
+    }
+
+    @Override
+    public RowDownstreamHandle registerUpstream(RowUpstream upstream) {
+        assert upstreamRegistered == false : "An upstream is already registered, only support 1 upstream";
+        upstreamRegistered = true;
+        this.upstream = upstream;
+        return rowDownstreamHandle;
+    }
+
+    public RowUpstream upstream() {
+        return upstream;
+    }
+}


### PR DESCRIPTION
NL operation has now 2 concrete methods for
resolving left & right row downstreams