### PR TITLE
remove Comparable implementation from Idents

### DIFF
--- a/sql/src/main/java/io/crate/metadata/ReferenceIdent.java
+++ b/sql/src/main/java/io/crate/metadata/ReferenceIdent.java
@@ -22,7 +22,6 @@
 package io.crate.metadata;
 
 import com.google.common.base.Objects;
-import com.google.common.collect.ComparisonChain;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
@@ -31,7 +30,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.List;
 
-public class ReferenceIdent implements Comparable<ReferenceIdent>, Streamable {
+public class ReferenceIdent implements Streamable {
 
     private TableIdent tableIdent;
     private ColumnIdent columnIdent;
@@ -96,15 +95,6 @@ public class ReferenceIdent implements Comparable<ReferenceIdent>, Streamable {
     public String toString() {
         return String.format("<RefIdent: %s->%s>", tableIdent, columnIdent);
     }
-
-    @Override
-    public int compareTo(ReferenceIdent o) {
-        return ComparisonChain.start()
-                .compare(tableIdent, o.tableIdent)
-                .compare(columnIdent, o.columnIdent)
-                .result();
-    }
-
 
     @Override
     public void readFrom(StreamInput in) throws IOException {

--- a/sql/src/main/java/io/crate/metadata/ReferenceInfo.java
+++ b/sql/src/main/java/io/crate/metadata/ReferenceInfo.java
@@ -24,7 +24,6 @@ package io.crate.metadata;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ComparisonChain;
 import io.crate.metadata.table.ColumnPolicy;
 import io.crate.planner.RowGranularity;
 import io.crate.types.DataType;
@@ -35,7 +34,7 @@ import org.elasticsearch.common.io.stream.Streamable;
 
 import java.io.IOException;
 
-public class ReferenceInfo implements Comparable<ReferenceInfo>, Streamable {
+public class ReferenceInfo implements Streamable {
 
     public static class Builder {
         private ReferenceIdent ident;
@@ -175,17 +174,6 @@ public class ReferenceInfo implements Comparable<ReferenceInfo>, Streamable {
         }
         helper.add("index type", indexType.toString());
         return helper.toString();
-    }
-
-    @Override
-    public int compareTo(ReferenceInfo o) {
-        return ComparisonChain.start()
-                .compare(granularity, o.granularity)
-                .compare(ident, o.ident)
-                .compare(type, o.type)
-                .compare(columnPolicy.ordinal(), o.columnPolicy.ordinal())
-                .compare(indexType.ordinal(), o.indexType.ordinal())
-                .result();
     }
 
     @Override

--- a/sql/src/main/java/io/crate/metadata/TableIdent.java
+++ b/sql/src/main/java/io/crate/metadata/TableIdent.java
@@ -23,7 +23,6 @@ package io.crate.metadata;
 
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.ImmutableSet;
 import io.crate.exceptions.InvalidSchemaNameException;
 import io.crate.exceptions.InvalidTableNameException;
@@ -37,7 +36,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 
-public class TableIdent implements Comparable<TableIdent>, Streamable {
+public class TableIdent implements Streamable {
 
     private static final Set<String> INVALID_TABLE_NAME_CHARACTERS = ImmutableSet.of(".");
 
@@ -137,14 +136,6 @@ public class TableIdent implements Comparable<TableIdent>, Streamable {
             return name;
         }
         return String.format("%s.%s", schema, name);
-    }
-
-    @Override
-    public int compareTo(TableIdent o) {
-        return ComparisonChain.start()
-                .compare(schema, o.schema)
-                .compare(name, o.name)
-                .result();
     }
 
     @Override


### PR DESCRIPTION
it is not used and the TableIdent compareTo resulted in warnings due to the
schema being nullable.