### PR TITLE
remove equals implementation from KillJobsRequest

### DIFF
--- a/sql/src/main/java/io/crate/executor/transport/kill/KillJobsRequest.java
+++ b/sql/src/main/java/io/crate/executor/transport/kill/KillJobsRequest.java
@@ -67,12 +67,4 @@ public class KillJobsRequest extends TransportRequest {
             out.writeLong(job.getLeastSignificantBits());
         }
     }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        KillJobsRequest that = (KillJobsRequest)o;
-        return that.toKill().equals(this.toKill());
-    }
 }

--- a/sql/src/test/java/io/crate/executor/transport/kill/KillJobsRequestTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/kill/KillJobsRequestTest.java
@@ -46,7 +46,6 @@ public class KillJobsRequestTest extends CrateUnitTest {
         KillJobsRequest r2 = new KillJobsRequest();
         r2.readFrom(in);
 
-        assertThat(r, equalTo(r2));
         assertThat(r.toKill(), equalTo(r2.toKill()));
     }
 }


### PR DESCRIPTION
Because object equality is enough for KillJobsRequest and hashCode wasn't
implemented which could result in strange behaviours.