### PR TITLE
optimize usage of PartitionName and clean up its interface

### DIFF
--- a/sql/src/main/java/io/crate/action/sql/DDLStatementDispatcher.java
+++ b/sql/src/main/java/io/crate/action/sql/DDLStatementDispatcher.java
@@ -307,7 +307,7 @@ public class DDLStatementDispatcher extends AnalyzedStatementVisitor<UUID, Liste
                 indexNames = tableInfo.concreteIndices();
             } else {
                 // single partition
-                indexNames = new String[] { partitionName.stringValue() };
+                indexNames = new String[] { partitionName.asIndexName() };
             }
         } else {
             indexNames = new String[] { tableInfo.ident().esName() };
@@ -372,7 +372,7 @@ public class DDLStatementDispatcher extends AnalyzedStatementVisitor<UUID, Liste
                     tableSettingsInfo.partitionTableSettingsInfo().supportedInternalSettings());
 
             if (analysis.partitionName().isPresent()) {
-                String index = analysis.partitionName().get().stringValue();
+                String index = analysis.partitionName().get().asIndexName();
                 results.add(updateMapping(analysis.tableParameter().mappings(), index));
                 results.add(updateSettings(parameterWithFilteredSettings, index));
             } else {

--- a/sql/src/main/java/io/crate/action/sql/TransportBaseSQLAction.java
+++ b/sql/src/main/java/io/crate/action/sql/TransportBaseSQLAction.java
@@ -52,7 +52,6 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.cluster.ClusterService;
-import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.inject.Provider;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexShardMissingException;
@@ -324,8 +323,8 @@ public abstract class TransportBaseSQLAction<TRequest extends SQLBaseRequest, TR
             }
             return new InvalidTableNameException(((InvalidIndexNameException) e).index().getName(), e);
         } else if (e instanceof InvalidIndexTemplateException) {
-            Tuple<String, String> schemaAndTable = PartitionName.schemaAndTableName(((InvalidIndexTemplateException) e).name());
-            return new InvalidTableNameException(new TableIdent(schemaAndTable.v1(), schemaAndTable.v2()).fqn(), e);
+            PartitionName partitionName = PartitionName.fromIndexOrTemplate(((InvalidIndexTemplateException) e).name());
+            return new InvalidTableNameException(new TableIdent(partitionName.schema(), partitionName.tableName()).fqn(), e);
         } else if (e instanceof IndexMissingException) {
             return new TableUnknownException(((IndexMissingException) e).index().name(), e);
         } else if (e instanceof org.elasticsearch.common.breaker.CircuitBreakingException) {

--- a/sql/src/main/java/io/crate/analyze/CopyStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CopyStatementAnalyzer.java
@@ -152,7 +152,13 @@ public class CopyStatementAnalyzer extends DefaultTraversalVisitor<CopyAnalyzedS
 
     private boolean partitionExists(DocTableInfo table, @Nullable String partitionIdent) {
         if (table.isPartitioned() && partitionIdent != null) {
-            return table.partitions().contains(PartitionName.fromPartitionIdent(table.ident().schema(), table.ident().name(), partitionIdent));
+            for (PartitionName partitionName : table.partitions()) {
+                if (partitionName.schema().equals(table.ident().schema())
+                        && partitionName.tableName().equals(table.ident().name())
+                        && partitionName.ident().equals(partitionIdent)) {
+                    return true;
+                }
+            }
         }
         return false;
     }

--- a/sql/src/main/java/io/crate/analyze/InsertFromValuesAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/InsertFromValuesAnalyzedStatement.java
@@ -87,7 +87,7 @@ public class InsertFromValuesAnalyzedStatement extends AbstractInsertAnalyzedSta
                 values.add(BytesRefs.toBytesRef(map.get(columnName)));
             }
             PartitionName partitionName = new PartitionName(tableInfo().ident().schema(), tableInfo().ident().name(), values);
-            partitionValues.add(partitionName.stringValue());
+            partitionValues.add(partitionName.asIndexName());
         }
         return partitionValues;
     }

--- a/sql/src/main/java/io/crate/analyze/RefreshTableAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/RefreshTableAnalyzer.java
@@ -75,7 +75,7 @@ public class RefreshTableAnalyzer extends DefaultTraversalVisitor<RefreshTableAn
                 if (!docTableInfo.partitions().contains(partitionName)) {
                     throw new PartitionUnknownException(tableInfo.ident().fqn(), partitionName.ident());
                 }
-                indexNames.add(partitionName.stringValue());
+                indexNames.add(partitionName.asIndexName());
             }
         }
         return new RefreshTableAnalyzedStatement(indexNames);

--- a/sql/src/main/java/io/crate/analyze/where/WhereClauseAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/where/WhereClauseAnalyzer.java
@@ -188,7 +188,7 @@ public class WhereClauseAnalyzer {
                     partitions = new ArrayList<>();
                     queryPartitionMap.put(normalized, partitions);
                 }
-                partitions.add(Literal.newLiteral(partitionName.stringValue()));
+                partitions.add(Literal.newLiteral(partitionName.asIndexName()));
             }
         }
 

--- a/sql/src/main/java/io/crate/executor/transport/task/CreateTableTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/CreateTableTask.java
@@ -145,10 +145,7 @@ public class CreateTableTask extends AbstractChainedTask {
     private void deleteOrphans(final CreateTableResponseListener listener) {
         if (clusterService.state().metaData().aliases().containsKey(planNode.tableIdent().fqn())
                 && PartitionName.isPartition(
-                clusterService.state().metaData().aliases().get(planNode.tableIdent().fqn()).keysIt().next(),
-                planNode.tableIdent().schema(),
-                planNode.tableIdent().name())
-                ) {
+                clusterService.state().metaData().aliases().get(planNode.tableIdent().fqn()).keysIt().next())) {
             logger.debug("Deleting orphaned partitions with alias: {}", planNode.tableIdent().fqn());
             deleteIndexAction.execute(new DeleteIndexRequest(planNode.tableIdent().fqn()), new ActionListener<DeleteIndexResponse>() {
                 @Override

--- a/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/ESGetTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/ESGetTask.java
@@ -156,7 +156,7 @@ public class ESGetTask extends JobTask implements RowUpstream {
 
     public static String indexName(DocTableInfo tableInfo, Optional<List<BytesRef>> values) {
         if (tableInfo.isPartitioned()) {
-            return new PartitionName(tableInfo.ident(), values.get()).stringValue();
+            return new PartitionName(tableInfo.ident(), values.get()).asIndexName();
         } else {
             return tableInfo.ident().esName();
         }

--- a/sql/src/main/java/io/crate/metadata/PartitionInfos.java
+++ b/sql/src/main/java/io/crate/metadata/PartitionInfos.java
@@ -62,7 +62,7 @@ public class PartitionInfos implements Iterable<PartitionInfo> {
         @Override
         public PartitionInfo apply(@Nullable ObjectObjectCursor<String, IndexMetaData> input) {
             assert input != null;
-            PartitionName partitionName = PartitionName.fromStringSafe(input.key);
+            PartitionName partitionName = PartitionName.fromIndexOrTemplate(input.key);
             try {
                 Map<String, Object> valuesMap = buildValuesMap(partitionName, input.value.mapping(Constants.DEFAULT_MAPPING_TYPE));
                 BytesRef numberOfReplicas = NumberOfReplicas.fromSettings(input.value.settings());

--- a/sql/src/main/java/io/crate/metadata/ReferenceInfos.java
+++ b/sql/src/main/java/io/crate/metadata/ReferenceInfos.java
@@ -226,7 +226,7 @@ public class ReferenceInfos implements ClusterStateListener, Schemas {
 
             boolean isPartitionAlias = true;
             for (String index : table.concreteIndices()) {
-                if (!PartitionName.isPartition(index, table.ident().schema(), table.ident().name())) {
+                if (!PartitionName.isPartition(index)) {
                     isPartitionAlias = false;
                     break;
                 }

--- a/sql/src/main/java/io/crate/metadata/doc/DocTableInfoBuilder.java
+++ b/sql/src/main/java/io/crate/metadata/doc/DocTableInfoBuilder.java
@@ -144,9 +144,10 @@ public class DocTableInfoBuilder {
         List<PartitionName> partitions = new ArrayList<>();
         if (md.partitionedBy().size() > 0) {
             for(String index : concreteIndices) {
-                if (PartitionName.isPartition(index, ident.schema(), ident.name())) {
+                if (PartitionName.isPartition(index)) {
                     try {
-                        PartitionName partitionName = PartitionName.fromString(index, ident.schema(), ident.name());
+                        PartitionName partitionName = PartitionName.fromIndexOrTemplate(index);
+                        assert partitionName.schema().equals(ident.schema()) && ident.name().equals(partitionName.tableName());
                         partitions.add(partitionName);
                     } catch (IllegalArgumentException e) {
                         // ignore

--- a/sql/src/main/java/io/crate/metadata/shard/unassigned/UnassignedShard.java
+++ b/sql/src/main/java/io/crate/metadata/shard/unassigned/UnassignedShard.java
@@ -37,9 +37,10 @@ public class UnassignedShard {
             this.schemaName = BlobSchemaInfo.NAME;
             tableName = BlobIndices.STRIP_PREFIX.apply(index);
         } else if (PartitionName.isPartition(index)) {
-            schemaName = PartitionName.schemaName(index);
-            tableName = PartitionName.tableName(index);
-            ident = PartitionName.ident(index);
+            PartitionName partitionName = PartitionName.fromIndexOrTemplate(index);
+            schemaName = partitionName.schema();
+            tableName = partitionName.tableName();
+            ident = partitionName.ident();
             if (!clusterService.state().metaData().hasConcreteIndex(tableName)) {
                 orphanedPartition = true;
             }

--- a/sql/src/main/java/io/crate/operation/projectors/AbstractIndexWriterProjector.java
+++ b/sql/src/main/java/io/crate/operation/projectors/AbstractIndexWriterProjector.java
@@ -124,7 +124,7 @@ public abstract class AbstractIndexWriterProjector extends RowDownstreamAndHandl
                     .build(new CacheLoader<List<BytesRef>, String>() {
                         @Override
                         public String load(@Nonnull List<BytesRef> key) throws Exception {
-                            return new PartitionName(tableIdent, key).stringValue();
+                            return new PartitionName(tableIdent, key).asIndexName();
                         }
                     });
         } else {
@@ -247,7 +247,7 @@ public abstract class AbstractIndexWriterProjector extends RowDownstreamAndHandl
                 throw ExceptionsHelper.convertToRuntime(e);
             }
         } else if (partitionIdent != null) {
-            return PartitionName.fromPartitionIdent(tableIdent.schema(), tableIdent.name(), partitionIdent).stringValue();
+            return PartitionName.indexName(tableIdent.schema(), tableIdent.name(), partitionIdent);
         } else {
             return tableIdent.esName();
         }

--- a/sql/src/main/java/io/crate/operation/projectors/FetchProjector.java
+++ b/sql/src/main/java/io/crate/operation/projectors/FetchProjector.java
@@ -251,7 +251,7 @@ public class FetchProjector extends RowDownstreamAndHandle implements Projector 
         Row partitionValuesRow = null;
         if (!partitionedBy.isEmpty() && PartitionName.isPartition(index)) {
             Object[] partitionValues;
-            List<BytesRef> partitionRowValues = PartitionName.fromStringSafe(index).values();
+            List<BytesRef> partitionRowValues = PartitionName.fromIndexOrTemplate(index).values();
             partitionValues = new Object[partitionRowValues.size()];
             for (int i = 0; i < partitionRowValues.size(); i++) {
                 partitionValues[i] = partitionedBy.get(i).type().value(partitionRowValues.get(i));

--- a/sql/src/main/java/io/crate/operation/reference/information/InformationTablePartitionsExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/information/InformationTablePartitionsExpression.java
@@ -43,7 +43,7 @@ public abstract class InformationTablePartitionsExpression<T>
 
         @Override
         public BytesRef value() {
-            String schemaName = row.name().schemaName();
+            String schemaName = row.name().schemaOrNull();
             if (schemaName == null) {
                 return DOC_SCHEMA_INFO;
             }

--- a/sql/src/main/java/io/crate/operation/reference/sys/shard/ShardPartitionIdentExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/shard/ShardPartitionIdentExpression.java
@@ -36,7 +36,7 @@ public class ShardPartitionIdentExpression extends SimpleObjectExpression<BytesR
     @Inject
     public ShardPartitionIdentExpression(ShardId shardId) {
         if (PartitionName.isPartition(shardId.getIndex())) {
-            value = new BytesRef(PartitionName.ident(shardId.getIndex()));
+            value = new BytesRef(PartitionName.fromIndexOrTemplate(shardId.getIndex()).ident());
         } else {
             value = EMPTY;
         }

--- a/sql/src/main/java/io/crate/operation/reference/sys/shard/ShardPartitionOrphanedExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/shard/ShardPartitionOrphanedExpression.java
@@ -41,9 +41,9 @@ public class ShardPartitionOrphanedExpression extends SimpleObjectExpression<Boo
         this.clusterService = clusterService;
         isPartition = PartitionName.isPartition(shardId.getIndex());
         if (isPartition) {
-            String[] parts = PartitionName.split(shardId.getIndex());
-            String schema = parts[0];
-            String tableName = parts[1];
+            PartitionName partitionName = PartitionName.fromIndexOrTemplate(shardId.getIndex());
+            String schema = partitionName.schemaOrNull();
+            String tableName = partitionName.tableName();
             if (schema == null) {
                 aliasName = tableName;
             } else {

--- a/sql/src/main/java/io/crate/operation/reference/sys/shard/ShardTableNameExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/shard/ShardTableNameExpression.java
@@ -39,7 +39,7 @@ public class ShardTableNameExpression extends SimpleObjectExpression<BytesRef> i
     public ShardTableNameExpression(ShardId shardId) {
         String index = shardId.getIndex();
         if (PartitionName.isPartition(index)) {
-            value = new BytesRef(PartitionName.tableName(index));
+            value = new BytesRef(PartitionName.fromIndexOrTemplate(index).tableName());
         } else {
             Matcher matcher = Schemas.SCHEMA_PATTERN.matcher(index);
             if (matcher.matches()) {

--- a/sql/src/main/java/io/crate/planner/Planner.java
+++ b/sql/src/main/java/io/crate/planner/Planner.java
@@ -290,8 +290,8 @@ public class Planner extends AnalyzedStatementVisitor<Planner.Context, Plan> {
 
         Routing routing = tableInfo.getRouting(WhereClause.MATCH_ALL, null);
         if (partitionIdent != null) {
-            routing = Routing.filter(routing, PartitionName.fromPartitionIdent(
-                    tableInfo.schemaInfo().name(), tableInfo.ident().name(), partitionIdent).stringValue());
+            routing = Routing.filter(routing, PartitionName.indexName(
+                    tableInfo.schemaInfo().name(), tableInfo.ident().name(), partitionIdent));
         }
         CollectPhase collectPhase = new CollectPhase(
                 context.jobId(),
@@ -343,10 +343,9 @@ public class Planner extends AnalyzedStatementVisitor<Planner.Context, Plan> {
         } else {
             assert table.isPartitioned() : "table must be partitioned if partitionIdent is set";
             // partitionIdent is present -> possible to index raw source into concrete es index
-            PartitionName partitionName = PartitionName.fromPartitionIdent(table.ident().schema(), table.ident().name(), analysis.partitionIdent());
-            partitionValues = partitionName.values();
 
-            partitionIdent = partitionName.ident();
+            partitionValues = PartitionName.decodeIdent(analysis.partitionIdent());
+            partitionIdent = analysis.partitionIdent();
             partitionedByNames = Collections.emptyList();
         }
 
@@ -613,7 +612,7 @@ public class Planner extends AnalyzedStatementVisitor<Planner.Context, Plan> {
             indices = new String[tableInfo.partitions().size()];
             int i = 0;
             for (PartitionName partitionName: tableInfo.partitions()) {
-                indices[i] = partitionName.stringValue();
+                indices[i] = partitionName.asIndexName();
                 i++;
             }
         } else {

--- a/sql/src/main/java/io/crate/planner/consumer/UpdateConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/UpdateConsumer.java
@@ -189,7 +189,7 @@ public class UpdateConsumer implements Consumer {
             for (DocKeys.DocKey key : whereClause.docKeys().get()) {
                 String index;
                 if (key.partitionValues().isPresent()) {
-                    index = new PartitionName(tableInfo.ident(), key.partitionValues().get()).stringValue();
+                    index = new PartitionName(tableInfo.ident(), key.partitionValues().get()).asIndexName();
                 } else {
                     index = indices[0];
                 }

--- a/sql/src/test/java/io/crate/analyze/BaseAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/BaseAnalyzerTest.java
@@ -127,9 +127,9 @@ public abstract class BaseAnalyzerTest extends CrateUnitTest {
             .add("obj", DataTypes.OBJECT, null, ColumnPolicy.DYNAMIC)
             // add 3 partitions/simulate already done inserts
             .addPartitions(
-                    new PartitionName("parted", Arrays.asList(new BytesRef("1395874800000"))).stringValue(),
-                    new PartitionName("parted", Arrays.asList(new BytesRef("1395961200000"))).stringValue(),
-                    new PartitionName("parted", new ArrayList<BytesRef>(){{add(null);}}).stringValue())
+                    new PartitionName("parted", Arrays.asList(new BytesRef("1395874800000"))).asIndexName(),
+                    new PartitionName("parted", Arrays.asList(new BytesRef("1395961200000"))).asIndexName(),
+                    new PartitionName("parted", new ArrayList<BytesRef>(){{add(null);}}).asIndexName())
             .build();
     static final TableIdent TEST_MULTIPLE_PARTITIONED_TABLE_IDENT = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "multi_parted");
     static final TableInfo TEST_MULTIPLE_PARTITIONED_TABLE_INFO = new TestingTableInfo.Builder(
@@ -141,9 +141,9 @@ public abstract class BaseAnalyzerTest extends CrateUnitTest {
             .add("obj", DataTypes.STRING, Arrays.asList("name"), true)
             // add 3 partitions/simulate already done inserts
             .addPartitions(
-                    new PartitionName("multi_parted", Arrays.asList(new BytesRef("1395874800000"), new BytesRef("0"))).stringValue(),
-                    new PartitionName("multi_parted", Arrays.asList(new BytesRef("1395961200000"), new BytesRef("-100"))).stringValue(),
-                    new PartitionName("multi_parted", Arrays.asList(null, new BytesRef("-100"))).stringValue())
+                    new PartitionName("multi_parted", Arrays.asList(new BytesRef("1395874800000"), new BytesRef("0"))).asIndexName(),
+                    new PartitionName("multi_parted", Arrays.asList(new BytesRef("1395961200000"), new BytesRef("-100"))).asIndexName(),
+                    new PartitionName("multi_parted", Arrays.asList(null, new BytesRef("-100"))).asIndexName())
             .build();
     static final TableIdent TEST_NESTED_PARTITIONED_TABLE_IDENT = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "nested_parted");
     static final TableInfo TEST_NESTED_PARTITIONED_TABLE_INFO = new TestingTableInfo.Builder(
@@ -154,9 +154,9 @@ public abstract class BaseAnalyzerTest extends CrateUnitTest {
             .add("obj", DataTypes.STRING, Arrays.asList("name"), true)
                     // add 3 partitions/simulate already done inserts
             .addPartitions(
-                    new PartitionName("nested_parted", Arrays.asList(new BytesRef("1395874800000"), new BytesRef("Trillian"))).stringValue(),
-                    new PartitionName("nested_parted", Arrays.asList(new BytesRef("1395961200000"), new BytesRef("Ford"))).stringValue(),
-                    new PartitionName("nested_parted", Arrays.asList(null, new BytesRef("Zaphod"))).stringValue())
+                    new PartitionName("nested_parted", Arrays.asList(new BytesRef("1395874800000"), new BytesRef("Trillian"))).asIndexName(),
+                    new PartitionName("nested_parted", Arrays.asList(new BytesRef("1395961200000"), new BytesRef("Ford"))).asIndexName(),
+                    new PartitionName("nested_parted", Arrays.asList(null, new BytesRef("Zaphod"))).asIndexName())
             .build();
     static final TableIdent TEST_DOC_TRANSACTIONS_TABLE_IDENT = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "transactions");
     static final TableInfo TEST_DOC_TRANSACTIONS_TABLE_INFO = new TestingTableInfo.Builder(

--- a/sql/src/test/java/io/crate/analyze/CopyAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CopyAnalyzerTest.java
@@ -59,6 +59,7 @@ public class CopyAnalyzerTest extends BaseAnalyzerTest {
         protected void bindSchemas() {
             super.bindSchemas();
             SchemaInfo schemaInfo = mock(SchemaInfo.class);
+            when(schemaInfo.name()).thenReturn(Schemas.DEFAULT_SCHEMA_NAME);
             when(schemaInfo.getTableInfo(TEST_DOC_TABLE_IDENT.name())).thenReturn(userTableInfo);
             when(schemaInfo.getTableInfo(TEST_PARTITIONED_TABLE_IDENT.name())).thenReturn(TEST_PARTITIONED_TABLE_INFO);
             schemaBinder.addBinding(Schemas.DEFAULT_SCHEMA_NAME).toInstance(schemaInfo);
@@ -100,7 +101,7 @@ public class CopyAnalyzerTest extends BaseAnalyzerTest {
     public void testCopyFromPartitionedTablePARTITIONKeywordValidArgs() throws Exception {
         CopyAnalyzedStatement analysis = (CopyAnalyzedStatement) analyze(
                 "copy parted partition (date=1395874800000) from '/some/distant/file.ext'");
-        String parted = new PartitionName("parted", Arrays.asList(new BytesRef("1395874800000"))).encodeIdent();
+        String parted = new PartitionName("parted", Arrays.asList(new BytesRef("1395874800000"))).ident();
         assertThat(analysis.partitionIdent(), equalTo(parted));
     }
 
@@ -177,7 +178,7 @@ public class CopyAnalyzerTest extends BaseAnalyzerTest {
     @Test
     public void testCopyToFileWithPartitionClause() throws Exception {
         CopyAnalyzedStatement analysis = (CopyAnalyzedStatement) analyze("copy parted partition (date=1395874800000) to '/blah.txt'");
-        String parted = new PartitionName("parted", Arrays.asList(new BytesRef("1395874800000"))).encodeIdent();
+        String parted = new PartitionName("parted", Arrays.asList(new BytesRef("1395874800000"))).ident();
         assertThat(analysis.partitionIdent(), is(parted));
     }
 
@@ -185,7 +186,7 @@ public class CopyAnalyzerTest extends BaseAnalyzerTest {
     public void testCopyToDirectoryithPartitionClause() throws Exception {
         CopyAnalyzedStatement analysis = (CopyAnalyzedStatement) analyze("copy parted partition (date=1395874800000) to directory '/tmp'");
         assertThat(analysis.directoryUri(), is(true));
-        String parted = new PartitionName("parted", Arrays.asList(new BytesRef("1395874800000"))).encodeIdent();
+        String parted = new PartitionName("parted", Arrays.asList(new BytesRef("1395874800000"))).ident();
         assertThat(analysis.partitionIdent(), is(parted));
     }
 

--- a/sql/src/test/java/io/crate/analyze/InsertFromValuesAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/InsertFromValuesAnalyzerTest.java
@@ -503,11 +503,11 @@ public class InsertFromValuesAnalyzerTest extends BaseAnalyzerTest {
 
     private void validateBulkIndexPartitionedTableAnalysis(InsertFromValuesAnalyzedStatement analysis) {
         assertThat(analysis.generatePartitions(), contains(
-                new PartitionName("parted", Arrays.asList(new BytesRef("13963670051500"))).stringValue(),
-                new PartitionName("parted", Arrays.asList(new BytesRef("0"))).stringValue(),
+                new PartitionName("parted", Arrays.asList(new BytesRef("13963670051500"))).asIndexName(),
+                new PartitionName("parted", Arrays.asList(new BytesRef("0"))).asIndexName(),
                 new PartitionName("parted", new ArrayList<BytesRef>() {{
                     add(null);
-                }}).stringValue()
+                }}).asIndexName()
         ));
         assertThat(analysis.sourceMaps().size(), is(3));
 
@@ -546,8 +546,8 @@ public class InsertFromValuesAnalyzerTest extends BaseAnalyzerTest {
                         2, "2014-05-21", new MapBuilder<String, Object>().put("name", "Arthur").map()
                 });
         assertThat(analysis.generatePartitions(), contains(
-                new PartitionName("nested_parted", Arrays.asList(new BytesRef("0"), new BytesRef("Zaphod"))).stringValue(),
-                new PartitionName("nested_parted", Arrays.asList(new BytesRef("1400630400000"), new BytesRef("Arthur"))).stringValue()
+                new PartitionName("nested_parted", Arrays.asList(new BytesRef("0"), new BytesRef("Zaphod"))).asIndexName(),
+                new PartitionName("nested_parted", Arrays.asList(new BytesRef("1400630400000"), new BytesRef("Arthur"))).asIndexName()
 
         ));
         assertThat(analysis.sourceMaps().size(), is(2));

--- a/sql/src/test/java/io/crate/analyze/PartitionPropertiesAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/PartitionPropertiesAnalyzerTest.java
@@ -63,6 +63,6 @@ public class PartitionPropertiesAnalyzerTest extends BaseAnalyzerTest {
                         new QualifiedNameReference(new QualifiedName("name")),
                         new StringLiteral("foo"))),
                 new Object[0]);
-        assertThat(partitionName.stringValue(), is(".partitioned.users.0426crrf"));
+        assertThat(partitionName.asIndexName(), is(".partitioned.users.0426crrf"));
     }
 }

--- a/sql/src/test/java/io/crate/analyze/where/WhereClauseAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/where/WhereClauseAnalyzerTest.java
@@ -122,11 +122,11 @@ public class WhereClauseAnalyzerTest extends CrateUnitTest {
                             .add("date", DataTypes.TIMESTAMP, null, true)
                             .add("obj", DataTypes.OBJECT, null, ColumnPolicy.IGNORED)
                             .addPartitions(
-                                    new PartitionName("parted", Arrays.asList(new BytesRef("1395874800000"))).stringValue(),
-                                    new PartitionName("parted", Arrays.asList(new BytesRef("1395961200000"))).stringValue(),
+                                    new PartitionName("parted", Arrays.asList(new BytesRef("1395874800000"))).asIndexName(),
+                                    new PartitionName("parted", Arrays.asList(new BytesRef("1395961200000"))).asIndexName(),
                                     new PartitionName("parted", new ArrayList<BytesRef>() {{
                                         add(null);
-                                    }}).stringValue())
+                                    }}).asIndexName())
                             .build());
             when(schemaInfo.getTableInfo("parted_pk")).thenReturn(
                     TestingTableInfo.builder(new TableIdent("doc", "parted"), twoNodeRouting)
@@ -136,11 +136,11 @@ public class WhereClauseAnalyzerTest extends CrateUnitTest {
                             .add("date", DataTypes.TIMESTAMP, null, true)
                             .add("obj", DataTypes.OBJECT, null, ColumnPolicy.IGNORED)
                             .addPartitions(
-                                    new PartitionName("parted_pk", Arrays.asList(new BytesRef("1395874800000"))).stringValue(),
-                                    new PartitionName("parted_pk", Arrays.asList(new BytesRef("1395961200000"))).stringValue(),
+                                    new PartitionName("parted_pk", Arrays.asList(new BytesRef("1395874800000"))).asIndexName(),
+                                    new PartitionName("parted_pk", Arrays.asList(new BytesRef("1395961200000"))).asIndexName(),
                                     new PartitionName("parted_pk", new ArrayList<BytesRef>() {{
                                         add(null);
-                                    }}).stringValue())
+                                    }}).asIndexName())
                             .build());
             when(schemaInfo.getTableInfo("bystring")).thenReturn(
                     TestingTableInfo.builder(new TableIdent("doc", "bystring"), twoNodeRouting)
@@ -240,7 +240,7 @@ public class WhereClauseAnalyzerTest extends CrateUnitTest {
         assertThat(whereClause.hasQuery(), is(false));
         assertThat(whereClause.noMatch(), is(false));
         assertThat(whereClause.partitions(),
-                Matchers.contains(new PartitionName("parted", Arrays.asList(new BytesRef("1395874800000"))).stringValue()));
+                Matchers.contains(new PartitionName("parted", Arrays.asList(new BytesRef("1395874800000"))).asIndexName()));
     }
 
     @Test
@@ -260,7 +260,7 @@ public class WhereClauseAnalyzerTest extends CrateUnitTest {
         assertThat(whereClause.hasQuery(), is(false));
         assertThat(whereClause.noMatch(), is(false));
         assertThat(whereClause.partitions(),
-                Matchers.contains(new PartitionName("parted", Arrays.asList(new BytesRef("1395874800000"))).stringValue()));
+                Matchers.contains(new PartitionName("parted", Arrays.asList(new BytesRef("1395874800000"))).asIndexName()));
     }
 
     @Test
@@ -272,7 +272,7 @@ public class WhereClauseAnalyzerTest extends CrateUnitTest {
         assertThat(nestedAnalyzedStatement.whereClause().noMatch(), is(false));
 
         assertEquals(ImmutableList.of(
-                        new PartitionName("parted", Arrays.asList(new BytesRef("1395874800000"))).stringValue()),
+                        new PartitionName("parted", Arrays.asList(new BytesRef("1395874800000"))).asIndexName()),
                 nestedAnalyzedStatement.whereClause().partitions()
         );
     }
@@ -491,11 +491,11 @@ public class WhereClauseAnalyzerTest extends CrateUnitTest {
 
     @Test
     public void testSelectFromPartitionedTable() throws Exception {
-        String partition1 = new PartitionName("parted", Arrays.asList(new BytesRef("1395874800000"))).stringValue();
-        String partition2 = new PartitionName("parted", Arrays.asList(new BytesRef("1395961200000"))).stringValue();
+        String partition1 = new PartitionName("parted", Arrays.asList(new BytesRef("1395874800000"))).asIndexName();
+        String partition2 = new PartitionName("parted", Arrays.asList(new BytesRef("1395961200000"))).asIndexName();
         String partition3 = new PartitionName("parted", new ArrayList<BytesRef>() {{
             add(null);
-        }}).stringValue();
+        }}).asIndexName();
 
         WhereClause whereClause = analyzeSelectWhere("select id, name from parted where date = 1395874800000");
         assertEquals(ImmutableList.of(partition1), whereClause.partitions());

--- a/sql/src/test/java/io/crate/executor/transport/TransportExecutorDDLTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/TransportExecutorDDLTest.java
@@ -149,7 +149,7 @@ public class TransportExecutorDDLTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testCreateTableWithOrphanedPartitions() throws Exception {
-        String partitionName = new PartitionName("test", Arrays.asList(new BytesRef("foo"))).stringValue();
+        String partitionName = new PartitionName("test", Arrays.asList(new BytesRef("foo"))).asIndexName();
         client().admin().indices().prepareCreate(partitionName)
                 .addMapping(Constants.DEFAULT_MAPPING_TYPE, TEST_PARTITIONED_MAPPING)
                 .setSettings(TEST_SETTINGS)
@@ -181,7 +181,7 @@ public class TransportExecutorDDLTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testCreateTableWithOrphanedAlias() throws Exception {
-        String partitionName = new PartitionName("test", Arrays.asList(new BytesRef("foo"))).stringValue();
+        String partitionName = new PartitionName("test", Arrays.asList(new BytesRef("foo"))).asIndexName();
         client().admin().indices().prepareCreate(partitionName)
                 .addMapping(Constants.DEFAULT_MAPPING_TYPE, TEST_PARTITIONED_MAPPING)
                 .setSettings(TEST_SETTINGS)
@@ -227,7 +227,7 @@ public class TransportExecutorDDLTest extends SQLTransportIntegrationTest {
         execute("select * from information_schema.table_partitions where table_name = 't'");
         assertThat(response.rowCount(), is(1L));
 
-        String partitionName = new PartitionName("t", ImmutableList.of(new BytesRef("1"))).stringValue();
+        String partitionName = new PartitionName("t", ImmutableList.of(new BytesRef("1"))).asIndexName();
         ESDeletePartitionNode deleteIndexNode = new ESDeletePartitionNode(partitionName);
         Plan plan = new IterablePlan(UUID.randomUUID(), deleteIndexNode);
 
@@ -256,7 +256,7 @@ public class TransportExecutorDDLTest extends SQLTransportIntegrationTest {
         assertThat(response.rowCount(), is(1L));
         ensureYellow();
 
-        String partitionName = new PartitionName("t", ImmutableList.of(new BytesRef("1"))).stringValue();
+        String partitionName = new PartitionName("t", ImmutableList.of(new BytesRef("1"))).asIndexName();
         assertTrue(client().admin().indices().prepareClose(partitionName).execute().actionGet().isAcknowledged());
 
         ESDeletePartitionNode deleteIndexNode = new ESDeletePartitionNode(partitionName);

--- a/sql/src/test/java/io/crate/executor/transport/TransportExecutorUpsertTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/TransportExecutorUpsertTest.java
@@ -119,7 +119,7 @@ public class TransportExecutorUpsertTest extends BaseTransportExecutorTest {
                 new Reference[]{idRef, nameRef});
 
         PartitionName partitionName = new PartitionName("parted", Arrays.asList(new BytesRef("13959981214861")));
-        updateNode.add(partitionName.stringValue(), "123", "123", null, null, new Object[]{0L, new BytesRef("Trillian")});
+        updateNode.add(partitionName.asIndexName(), "123", "123", null, null, new Object[]{0L, new BytesRef("Trillian")});
 
         Plan plan = new IterablePlan(ctx.jobId(), updateNode);
         Job job = executor.newJob(plan);
@@ -133,14 +133,14 @@ public class TransportExecutorUpsertTest extends BaseTransportExecutorTest {
         refresh();
 
         assertTrue(
-                client().admin().indices().prepareExists(partitionName.stringValue())
+                client().admin().indices().prepareExists(partitionName.asIndexName())
                         .execute().actionGet().isExists()
         );
         assertTrue(
                 client().admin().indices().prepareAliasesExist("parted")
                         .execute().actionGet().exists()
         );
-        SearchHits hits = client().prepareSearch(partitionName.stringValue())
+        SearchHits hits = client().prepareSearch(partitionName.asIndexName())
                 .setTypes(Constants.DEFAULT_MAPPING_TYPE)
                 .addFields("id", "name")
                 .setQuery(new MapBuilder<String, Object>()

--- a/sql/src/test/java/io/crate/integrationtests/ColumnPolicyIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ColumnPolicyIntegrationTest.java
@@ -393,7 +393,7 @@ public class ColumnPolicyIntegrationTest extends SQLTransportIntegrationTest {
         execute("refresh table numbers");
 
         MappingMetaData partitionMetaData = clusterService().state().metaData().indices()
-                .get(new PartitionName("numbers", Arrays.asList(new BytesRef("true"))).stringValue())
+                .get(new PartitionName("numbers", Arrays.asList(new BytesRef("true"))).asIndexName())
                 .getMappings().get(Constants.DEFAULT_MAPPING_TYPE);
         assertThat(String.valueOf(partitionMetaData.getSourceAsMap().get("dynamic")), is(ColumnPolicy.STRICT.value()));
 
@@ -429,7 +429,7 @@ public class ColumnPolicyIntegrationTest extends SQLTransportIntegrationTest {
         execute("refresh table numbers");
 
         MappingMetaData partitionMetaData = clusterService().state().metaData().indices()
-                .get(new PartitionName("numbers", Arrays.asList(new BytesRef("true"))).stringValue())
+                .get(new PartitionName("numbers", Arrays.asList(new BytesRef("true"))).asIndexName())
                 .getMappings().get(Constants.DEFAULT_MAPPING_TYPE);
         assertThat(String.valueOf(partitionMetaData.getSourceAsMap().get("dynamic")), is(ColumnPolicy.STRICT.value()));
 
@@ -465,7 +465,7 @@ public class ColumnPolicyIntegrationTest extends SQLTransportIntegrationTest {
         execute("refresh table numbers");
 
         MappingMetaData partitionMetaData = clusterService().state().metaData().indices()
-                .get(new PartitionName("numbers", Collections.singletonList(new BytesRef("true"))).stringValue())
+                .get(new PartitionName("numbers", Collections.singletonList(new BytesRef("true"))).asIndexName())
                 .getMappings().get(Constants.DEFAULT_MAPPING_TYPE);
         assertThat(String.valueOf(partitionMetaData.getSourceAsMap().get("dynamic")), is("true"));
 
@@ -548,13 +548,13 @@ public class ColumnPolicyIntegrationTest extends SQLTransportIntegrationTest {
         execute("alter table dynamic_table set (column_policy = 'strict')");
         waitNoPendingTasksOnAll();
         MappingMetaData partitionMetaData = clusterService().state().metaData().indices()
-                .get(new PartitionName("dynamic_table", Arrays.asList(new BytesRef("10.0"))).stringValue())
+                .get(new PartitionName("dynamic_table", Arrays.asList(new BytesRef("10.0"))).asIndexName())
                 .getMappings().get(Constants.DEFAULT_MAPPING_TYPE);
         assertThat(String.valueOf(partitionMetaData.getSourceAsMap().get("dynamic")), is(ColumnPolicy.STRICT.value()));
         execute("alter table dynamic_table reset (column_policy)");
         waitNoPendingTasksOnAll();
         partitionMetaData = clusterService().state().metaData().indices()
-                .get(new PartitionName("dynamic_table", Arrays.asList(new BytesRef("10.0"))).stringValue())
+                .get(new PartitionName("dynamic_table", Arrays.asList(new BytesRef("10.0"))).asIndexName())
                 .getMappings().get(Constants.DEFAULT_MAPPING_TYPE);
         assertThat(String.valueOf(partitionMetaData.getSourceAsMap().get("dynamic")), is(String.valueOf(ColumnPolicy.DYNAMIC.mappingValue())));
     }
@@ -595,17 +595,17 @@ public class ColumnPolicyIntegrationTest extends SQLTransportIntegrationTest {
         ensureYellow();
 
         MappingMetaData partitionMetaData = clusterService().state().metaData().indices()
-                .get(new PartitionName("dynamic_table", Arrays.asList(new BytesRef("10.0"))).stringValue())
+                .get(new PartitionName("dynamic_table", Arrays.asList(new BytesRef("10.0"))).asIndexName())
                 .getMappings().get(Constants.DEFAULT_MAPPING_TYPE);
         assertThat(String.valueOf(partitionMetaData.getSourceAsMap().get("dynamic")), is(String.valueOf(ColumnPolicy.DYNAMIC.mappingValue())));
 
         partitionMetaData = clusterService().state().metaData().indices()
-                .get(new PartitionName("dynamic_table", Arrays.asList(new BytesRef("5.0"))).stringValue())
+                .get(new PartitionName("dynamic_table", Arrays.asList(new BytesRef("5.0"))).asIndexName())
                 .getMappings().get(Constants.DEFAULT_MAPPING_TYPE);
         assertThat(String.valueOf(partitionMetaData.getSourceAsMap().get("dynamic")), is(String.valueOf(ColumnPolicy.DYNAMIC.mappingValue())));
 
         partitionMetaData = clusterService().state().metaData().indices()
-                .get(new PartitionName("dynamic_table", Arrays.asList(new BytesRef("3.0"))).stringValue())
+                .get(new PartitionName("dynamic_table", Arrays.asList(new BytesRef("3.0"))).asIndexName())
                 .getMappings().get(Constants.DEFAULT_MAPPING_TYPE);
         assertThat(String.valueOf(partitionMetaData.getSourceAsMap().get("dynamic")), is(String.valueOf(ColumnPolicy.DYNAMIC.mappingValue())));
     }

--- a/sql/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -541,7 +541,7 @@ public class DDLIntegrationTest extends SQLTransportIntegrationTest {
         execute("insert into quotes (id, quote, date) values (?, ?, ?)",
                 new Object[]{3, "Time is a illusion. Lunchtime doubles so", 1495961200000L}
         );
-        String partition = new PartitionName("quotes", Arrays.asList(new BytesRef("1495961200000"))).stringValue();
+        String partition = new PartitionName("quotes", Arrays.asList(new BytesRef("1495961200000"))).asIndexName();
         GetSettingsResponse settingsResponse = client().admin().indices().prepareGetSettings(partition).execute().get();
         assertThat(settingsResponse.getSetting(partition, IndexMetaData.SETTING_NUMBER_OF_SHARDS), is("5"));
     }

--- a/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -181,7 +181,7 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
         ensureYellow();
 
         for (String id : ImmutableList.of("1", "2", "3")) {
-            String partitionName = new PartitionName("quotes", ImmutableList.of(new BytesRef(id))).stringValue();
+            String partitionName = new PartitionName("quotes", ImmutableList.of(new BytesRef(id))).asIndexName();
             assertNotNull(client().admin().cluster().prepareState().execute().actionGet()
                     .getState().metaData().indices().get(partitionName));
             assertNotNull(client().admin().cluster().prepareState().execute().actionGet()
@@ -272,7 +272,7 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
 
         String partitionName = new PartitionName("parted",
                 Arrays.asList(new BytesRef(String.valueOf(13959981214861L)))
-        ).stringValue();
+        ).asIndexName();
         MetaData metaData = client().admin().cluster().prepareState().execute().actionGet()
                 .getState().metaData();
         assertNotNull(metaData.indices().get(partitionName).aliases().get("parted"));
@@ -292,7 +292,7 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
     private void validateInsertPartitionedTable() {
         String partitionName = new PartitionName("parted",
                 Arrays.asList(new BytesRef(String.valueOf(13959981214861L)))
-        ).stringValue();
+        ).asIndexName();
         assertTrue(internalCluster().clusterService().state().metaData().hasIndex(partitionName));
         assertNotNull(client().admin().cluster().prepareState().execute().actionGet()
                 .getState().metaData().indices().get(partitionName).aliases().get("parted"));
@@ -302,7 +302,7 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
                 is(1L)
         );
 
-        partitionName = new PartitionName("parted", Arrays.asList(new BytesRef(String.valueOf(0L)))).stringValue();
+        partitionName = new PartitionName("parted", Arrays.asList(new BytesRef(String.valueOf(0L)))).asIndexName();
         assertTrue(internalCluster().clusterService().state().metaData().hasIndex(partitionName));
         assertNotNull(client().admin().cluster().prepareState().execute().actionGet()
                 .getState().metaData().indices().get(partitionName).aliases().get("parted"));
@@ -314,7 +314,7 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
 
         List<BytesRef> nullList = new ArrayList<>();
         nullList.add(null);
-        partitionName = new PartitionName("parted", nullList).stringValue();
+        partitionName = new PartitionName("parted", nullList).asIndexName();
         assertTrue(internalCluster().clusterService().state().metaData().hasIndex(partitionName));
         assertNotNull(client().admin().cluster().prepareState().execute().actionGet()
                 .getState().metaData().indices().get(partitionName).aliases().get("parted"));
@@ -372,7 +372,7 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
         refresh();
         String partitionName = new PartitionName("parted",
                 Arrays.asList(new BytesRef("Ford"), new BytesRef(String.valueOf(13959981214861L)))
-        ).stringValue();
+        ).asIndexName();
         assertNotNull(client().admin().cluster().prepareState().execute().actionGet()
                 .getState().metaData().indices().get(partitionName).aliases().get("parted"));
         assertThat(
@@ -449,7 +449,7 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
         ensureYellow();
         refresh();
         String partitionName = new PartitionName("parted",
-                Arrays.asList(new BytesRef("Trillian"), null)).stringValue();
+                Arrays.asList(new BytesRef("Trillian"), null)).asIndexName();
         assertNotNull(client().admin().cluster().prepareState().execute().actionGet()
                 .getState().metaData().indices().get(partitionName).aliases().get("parted"));
 
@@ -473,7 +473,7 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
         ensureYellow();
         refresh();
         String partitionName = new PartitionName("parted",
-                Arrays.asList(new BytesRef("Trillian"), new BytesRef(dateValue.toString()))).stringValue();
+                Arrays.asList(new BytesRef("Trillian"), new BytesRef(dateValue.toString()))).asIndexName();
         assertNotNull(client().admin().cluster().prepareState().execute().actionGet()
                 .getState().metaData().indices().get(partitionName).aliases().get("parted"));
     }
@@ -1283,8 +1283,8 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
         assertThat(templateSettings.get(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS), is("1-all"));
 
         List<String> partitions = ImmutableList.of(
-                new PartitionName("quotes", Arrays.asList(new BytesRef("1395874800000"))).stringValue(),
-                new PartitionName("quotes", Arrays.asList(new BytesRef("1395961200000"))).stringValue()
+                new PartitionName("quotes", Arrays.asList(new BytesRef("1395874800000"))).asIndexName(),
+                new PartitionName("quotes", Arrays.asList(new BytesRef("1395961200000"))).asIndexName()
         );
         Thread.sleep(1000);
         GetSettingsResponse settingsResponse = client().admin().indices().prepareGetSettings(
@@ -1348,8 +1348,8 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
         assertThat(templateSettings.get(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS), is("false"));
 
         List<String> partitions = ImmutableList.of(
-                new PartitionName("quotes", Arrays.asList(new BytesRef("1395874800000"))).stringValue(),
-                new PartitionName("quotes", Arrays.asList(new BytesRef("1395961200000"))).stringValue()
+                new PartitionName("quotes", Arrays.asList(new BytesRef("1395874800000"))).asIndexName(),
+                new PartitionName("quotes", Arrays.asList(new BytesRef("1395961200000"))).asIndexName()
         );
         Thread.sleep(1000);
         GetSettingsResponse settingsResponse = client().admin().indices().prepareGetSettings(
@@ -1381,8 +1381,8 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
         execute("alter table quotes partition (date=1395874800000) set (number_of_replicas=1)");
         ensureYellow();
         List<String> partitions = ImmutableList.of(
-                new PartitionName("quotes", Arrays.asList(new BytesRef("1395874800000"))).stringValue(),
-                new PartitionName("quotes", Arrays.asList(new BytesRef("1395961200000"))).stringValue()
+                new PartitionName("quotes", Arrays.asList(new BytesRef("1395874800000"))).asIndexName(),
+                new PartitionName("quotes", Arrays.asList(new BytesRef("1395961200000"))).asIndexName()
         );
 
         GetSettingsResponse settingsResponse = client().admin().indices().prepareGetSettings(
@@ -1574,13 +1574,13 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
         execute("refresh table dynamic_table");
         ensureGreen();
         MappingMetaData partitionMetaData = clusterService().state().metaData().indices()
-                .get(new PartitionName("dynamic_table", Arrays.asList(new BytesRef("10.0"))).stringValue())
+                .get(new PartitionName("dynamic_table", Arrays.asList(new BytesRef("10.0"))).asIndexName())
                 .getMappings().get(Constants.DEFAULT_MAPPING_TYPE);
         assertThat(String.valueOf(partitionMetaData.getSourceAsMap().get("_meta")), Matchers.is("{partitioned_by=[[score, double]]}"));
         execute("alter table dynamic_table set (column_policy= 'dynamic')");
         waitNoPendingTasksOnAll();
         partitionMetaData = clusterService().state().metaData().indices()
-                .get(new PartitionName("dynamic_table", Arrays.asList(new BytesRef("10.0"))).stringValue())
+                .get(new PartitionName("dynamic_table", Arrays.asList(new BytesRef("10.0"))).asIndexName())
                 .getMappings().get(Constants.DEFAULT_MAPPING_TYPE);
         assertThat(String.valueOf(partitionMetaData.getSourceAsMap().get("_meta")), Matchers.is("{partitioned_by=[[score, double]]}"));
     }
@@ -1781,8 +1781,8 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
         assertThat(templateSettings.get(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS), is("0-all"));
 
         List<String> partitions = ImmutableList.of(
-                new PartitionName("quotes", Arrays.asList(new BytesRef("1395874800000"))).stringValue(),
-                new PartitionName("quotes", Arrays.asList(new BytesRef("1395961200000"))).stringValue()
+                new PartitionName("quotes", Arrays.asList(new BytesRef("1395874800000"))).asIndexName(),
+                new PartitionName("quotes", Arrays.asList(new BytesRef("1395961200000"))).asIndexName()
         );
         Thread.sleep(1000);
         GetSettingsResponse settingsResponse = client().admin().indices().prepareGetSettings(
@@ -2011,7 +2011,7 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
         t.start();
 
         PartitionName partitionName = new PartitionName("t", Collections.singletonList(new BytesRef("a")));
-        final String indexName = partitionName.stringValue();
+        final String indexName = partitionName.asIndexName();
 
         ClusterService clusterService = internalCluster().getInstance(ClusterService.class);
         DiscoveryNodes nodes = clusterService.state().nodes();

--- a/sql/src/test/java/io/crate/metadata/PartitionInfosTest.java
+++ b/sql/src/test/java/io/crate/metadata/PartitionInfosTest.java
@@ -66,7 +66,7 @@ public class PartitionInfosTest  extends CrateUnitTest {
     public void testPartitionWithoutMapping() throws Exception {
         Map<String, IndexMetaData> indices = new HashMap<>();
         PartitionName partitionName = new PartitionName("test1", ImmutableList.of(new BytesRef("foo")));
-        indices.put(partitionName.stringValue(), IndexMetaData.builder(partitionName.stringValue()).numberOfShards(10).numberOfReplicas(4).build());
+        indices.put(partitionName.asIndexName(), IndexMetaData.builder(partitionName.asIndexName()).numberOfShards(10).numberOfReplicas(4).build());
         Iterable<PartitionInfo> partitioninfos = new PartitionInfos(mockService(indices));
         assertThat(partitioninfos.iterator().hasNext(), is(false));
     }
@@ -76,15 +76,15 @@ public class PartitionInfosTest  extends CrateUnitTest {
         Map<String, IndexMetaData> indices = new HashMap<>();
         PartitionName partitionName = new PartitionName("test1", ImmutableList.of(new BytesRef("foo")));
         IndexMetaData indexMetaData = IndexMetaData
-                .builder(partitionName.stringValue())
+                .builder(partitionName.asIndexName())
                 .putMapping(Constants.DEFAULT_MAPPING_TYPE, "{\"_meta\":{\"partitioned_by\":[[\"col\", \"string\"]]}}")
                 .numberOfShards(10)
                 .numberOfReplicas(4).build();
-        indices.put(partitionName.stringValue(), indexMetaData);
+        indices.put(partitionName.asIndexName(), indexMetaData);
         Iterable<PartitionInfo> partitioninfos = new PartitionInfos(mockService(indices));
         Iterator<PartitionInfo> iter = partitioninfos.iterator();
         PartitionInfo partitioninfo = iter.next();
-        assertThat(partitioninfo.name().stringValue(), is(partitionName.stringValue()));
+        assertThat(partitioninfo.name().asIndexName(), is(partitionName.asIndexName()));
         assertThat(partitioninfo.numberOfShards(), is(10));
         assertThat(partitioninfo.numberOfReplicas().utf8ToString(), is("4"));
         assertThat(partitioninfo.values(), hasEntry("col", (Object)"foo"));
@@ -96,15 +96,15 @@ public class PartitionInfosTest  extends CrateUnitTest {
         Map<String, IndexMetaData> indices = new HashMap<>();
         PartitionName partitionName = new PartitionName("test1", ImmutableList.of(new BytesRef("foo"), new BytesRef("1")));
         IndexMetaData indexMetaData = IndexMetaData
-                .builder(partitionName.stringValue())
+                .builder(partitionName.asIndexName())
                 .putMapping(Constants.DEFAULT_MAPPING_TYPE, "{\"_meta\":{\"partitioned_by\":[[\"col\", \"string\"], [\"col2\", \"integer\"]]}}")
                 .numberOfShards(10)
                 .numberOfReplicas(4).build();
-        indices.put(partitionName.stringValue(), indexMetaData);
+        indices.put(partitionName.asIndexName(), indexMetaData);
         Iterable<PartitionInfo> partitioninfos = new PartitionInfos(mockService(indices));
         Iterator<PartitionInfo> iter = partitioninfos.iterator();
         PartitionInfo partitioninfo = iter.next();
-        assertThat(partitioninfo.name().stringValue(), is(partitionName.stringValue()));
+        assertThat(partitioninfo.name().asIndexName(), is(partitionName.asIndexName()));
         assertThat(partitioninfo.numberOfShards(), is(10));
         assertThat(partitioninfo.numberOfReplicas().utf8ToString(), is("4"));
         assertThat(partitioninfo.values(), hasEntry("col", (Object)"foo"));

--- a/sql/src/test/java/io/crate/metadata/PartitionNameTest.java
+++ b/sql/src/test/java/io/crate/metadata/PartitionNameTest.java
@@ -24,11 +24,9 @@ package io.crate.metadata;
 import com.google.common.collect.ImmutableList;
 import io.crate.test.integration.CrateUnitTest;
 import org.apache.lucene.util.BytesRef;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.core.Is.is;
@@ -39,11 +37,10 @@ public class PartitionNameTest extends CrateUnitTest {
     public void testSingleColumn() throws Exception {
         PartitionName partitionName = new PartitionName("test", ImmutableList.of(new BytesRef("1")));
 
-        assertTrue(partitionName.isValid());
         assertThat(partitionName.values().size(), is(1));
         assertEquals(ImmutableList.of(new BytesRef("1")), partitionName.values());
 
-        PartitionName partitionName1 = PartitionName.fromString(partitionName.stringValue(), null, "test");
+        PartitionName partitionName1 = PartitionName.fromIndexOrTemplate(partitionName.asIndexName());
         assertEquals(partitionName.values(), partitionName1.values());
     }
 
@@ -51,35 +48,21 @@ public class PartitionNameTest extends CrateUnitTest {
     public void testSingleColumnSchema() throws Exception {
         PartitionName partitionName = new PartitionName("schema", "test", ImmutableList.of(new BytesRef("1")));
 
-        assertTrue(partitionName.isValid());
         assertThat(partitionName.values().size(), is(1));
         assertEquals(ImmutableList.of(new BytesRef("1")), partitionName.values());
 
-        PartitionName partitionName1 = PartitionName.fromString(partitionName.stringValue(), "schema", "test");
+        PartitionName partitionName1 = PartitionName.fromIndexOrTemplate(partitionName.asIndexName());
         assertEquals(partitionName.values(), partitionName1.values());
-    }
-
-    @Test
-    public void testWithoutValue() throws Exception {
-        PartitionName partitionName = new PartitionName("test", ImmutableList.<BytesRef>of());
-        assertFalse(partitionName.isValid());
-    }
-
-    @Test
-    public void testWithoutValueSchema() throws Exception {
-        PartitionName partitionName = new PartitionName("schema", "test", ImmutableList.<BytesRef>of());
-        assertFalse(partitionName.isValid());
     }
 
     @Test
     public void testMultipleColumns() throws Exception {
         PartitionName partitionName = new PartitionName("test", ImmutableList.of(new BytesRef("1"), new BytesRef("foo")));
 
-        assertTrue(partitionName.isValid());
         assertThat(partitionName.values().size(), is(2));
         assertEquals(ImmutableList.of(new BytesRef("1"), new BytesRef("foo")), partitionName.values());
 
-        PartitionName partitionName1 = PartitionName.fromString(partitionName.stringValue(), null, "test");
+        PartitionName partitionName1 = PartitionName.fromIndexOrTemplate(partitionName.asIndexName());
         assertEquals(partitionName.values(), partitionName1.values());
     }
 
@@ -87,11 +70,10 @@ public class PartitionNameTest extends CrateUnitTest {
     public void testMultipleColumnsSchema() throws Exception {
         PartitionName partitionName = new PartitionName("schema", "test", ImmutableList.of(new BytesRef("1"), new BytesRef("foo")));
 
-        assertTrue(partitionName.isValid());
         assertThat(partitionName.values().size(), is(2));
         assertEquals(ImmutableList.of(new BytesRef("1"), new BytesRef("foo")), partitionName.values());
 
-        PartitionName partitionName1 = PartitionName.fromString(partitionName.stringValue(), "schema", "test");
+        PartitionName partitionName1 = PartitionName.fromIndexOrTemplate(partitionName.asIndexName());
         assertEquals(partitionName.values(), partitionName1.values());
     }
 
@@ -101,11 +83,10 @@ public class PartitionNameTest extends CrateUnitTest {
             add(null);
         }});
 
-        assertTrue(partitionName.isValid());
         assertThat(partitionName.values().size(), is(1));
         assertEquals(null, partitionName.values().get(0));
 
-        PartitionName partitionName1 = PartitionName.fromString(partitionName.stringValue(), null, "test");
+        PartitionName partitionName1 = PartitionName.fromIndexOrTemplate(partitionName.asIndexName());
         assertEquals(partitionName.values(), partitionName1.values());
     }
 
@@ -115,11 +96,10 @@ public class PartitionNameTest extends CrateUnitTest {
             add(null);
         }});
 
-        assertTrue(partitionName.isValid());
         assertThat(partitionName.values().size(), is(1));
         assertEquals(null, partitionName.values().get(0));
 
-        PartitionName partitionName1 = PartitionName.fromString(partitionName.stringValue(), "schema", "test");
+        PartitionName partitionName1 = PartitionName.fromIndexOrTemplate(partitionName.asIndexName());
         assertEquals(partitionName.values(), partitionName1.values());
     }
 
@@ -127,24 +107,23 @@ public class PartitionNameTest extends CrateUnitTest {
     public void testEmptyStringValue() throws Exception {
         PartitionName partitionName = new PartitionName("test", ImmutableList.of(new BytesRef("")));
 
-        assertTrue(partitionName.isValid());
         assertThat(partitionName.values().size(), is(1));
         assertEquals(ImmutableList.of(new BytesRef("")), partitionName.values());
 
-        PartitionName partitionName1 = PartitionName.fromString(partitionName.stringValue(), null, "test");
+        PartitionName partitionName1 = PartitionName.fromIndexOrTemplate(partitionName.asIndexName());
         assertEquals(partitionName.values(), partitionName1.values());
     }
 
     @Test
     public void testPartitionNameNotFromTable() throws Exception {
         String partitionName = PartitionName.PARTITIONED_TABLE_PREFIX + ".test1._1";
-        assertFalse(PartitionName.tableName(partitionName).equals("test"));
+        assertFalse(PartitionName.fromIndexOrTemplate(partitionName).tableName().equals("test"));
     }
 
     @Test
     public void testPartitionNameNotFromSchema() throws Exception {
         String partitionName = "schema1." + PartitionName.PARTITIONED_TABLE_PREFIX + ".test1._1";
-        assertFalse(PartitionName.schemaName(partitionName).equals("schema"));
+        assertFalse(PartitionName.fromIndexOrTemplate(partitionName).schemaOrNull().equals("schema"));
     }
 
     @Test
@@ -153,87 +132,49 @@ public class PartitionNameTest extends CrateUnitTest {
         expectedException.expectMessage("Invalid partition ident: 1");
 
         String partitionName = PartitionName.PARTITIONED_TABLE_PREFIX + ".test.1";
-        PartitionName.fromString(partitionName, null, "test");
+        PartitionName.fromIndexOrTemplate(partitionName).values();
     }
 
     @Test
     public void testIsPartition() throws Exception {
-        assertFalse(
-                PartitionName.isPartition("test", null, "test")
-        );
-        assertFalse(
-                PartitionName.isPartition("test", "schema", "test")
-        );
+        assertFalse(PartitionName.isPartition("test"));
 
-        assertTrue(PartitionName.isPartition(
-                PartitionName.PARTITIONED_TABLE_PREFIX + ".test.", null, "test"
-        ));
-        assertTrue(PartitionName.isPartition(
-                "schema." + PartitionName.PARTITIONED_TABLE_PREFIX + ".test.", "schema", "test"
-        ));
+        assertTrue(PartitionName.isPartition(PartitionName.PARTITIONED_TABLE_PREFIX + ".test."));
+        assertTrue(PartitionName.isPartition("schema." + PartitionName.PARTITIONED_TABLE_PREFIX + ".test."));
 
-        assertFalse(
-                PartitionName.isPartition(
-                        PartitionName.PARTITIONED_TABLE_PREFIX + ".tast.djfhjhdgfjy",
-                        null,
-                        "test"
-                )
-        );
-        assertFalse(
-                PartitionName.isPartition(
-                        "schema." + PartitionName.PARTITIONED_TABLE_PREFIX + ".tast.djfhjhdgfjy",
-                        "schema",
-                        "test"
-                )
-        );
-        assertFalse(
-                PartitionName.isPartition(
-                        "schama." + PartitionName.PARTITIONED_TABLE_PREFIX + ".test.djfhjhdgfjy",
-                        "schema",
-                        "test"
-                )
-        );
-
-        assertFalse(
-                PartitionName.isPartition("partitioned.test.dshhjfgjsdh", null, "test")
-        );
-        assertFalse(
-                PartitionName.isPartition("schema.partitioned.test.dshhjfgjsdh", "schema", "test")
-        );
-        assertFalse(
-                PartitionName.isPartition(".test.dshhjfgjsdh", null, "test")
-        );
-        assertFalse(
-                PartitionName.isPartition("schema.test.dshhjfgjsdh", "schema", "test")
-        );
+        assertFalse(PartitionName.isPartition("partitioned.test.dshhjfgjsdh"));
+        assertFalse(PartitionName.isPartition("schema.partitioned.test.dshhjfgjsdh"));
+        assertFalse(PartitionName.isPartition(".test.dshhjfgjsdh"));
+        assertFalse(PartitionName.isPartition("schema.test.dshhjfgjsdh"));
         assertTrue(PartitionName.isPartition(".partitioned.test.dshhjfgjsdh"));
         assertTrue(PartitionName.isPartition("schema..partitioned.test.dshhjfgjsdh"));
     }
 
+    /*
     @Test
     public void testSplit() throws Exception {
         String[] splitted = PartitionName.split(
-                new PartitionName("t", Arrays.asList(new BytesRef("a"), new BytesRef("b"))).stringValue());
+                new PartitionName("t", Arrays.asList(new BytesRef("a"), new BytesRef("b"))).asIndexName());
         assertThat(splitted, arrayContaining(null, "t", "081620j2"));
 
-        splitted = PartitionName.split(new PartitionName(null, "t", Arrays.asList(new BytesRef("a"), new BytesRef("b"))).stringValue());
+        splitted = PartitionName.split(new PartitionName(null, "t", Arrays.asList(new BytesRef("a"), new BytesRef("b"))).asIndexName());
         assertThat(splitted, arrayContaining(null, "t", "081620j2"));
 
-        splitted = PartitionName.split(new PartitionName("schema", "t", Arrays.asList(new BytesRef("a"), new BytesRef("b"))).stringValue());
+        splitted = PartitionName.split(new PartitionName("schema", "t", Arrays.asList(new BytesRef("a"), new BytesRef("b"))).asIndexName());
         assertThat(splitted, arrayContaining("schema", "t", "081620j2"));
 
         splitted = PartitionName.split(
-                new PartitionName("t", Arrays.asList(null, new BytesRef("b"))).stringValue());
+                new PartitionName("t", Arrays.asList(null, new BytesRef("b"))).asIndexName());
         assertThat(splitted, arrayContaining(null, "t", "08004og"));
 
         splitted = PartitionName.split(
                 new PartitionName("t", new ArrayList<BytesRef>() {{
                     add(null);
-                }}).stringValue());
+                }}).asIndexName());
         assertThat(splitted, arrayContaining(null, "t", "0400"));
 
         splitted = PartitionName.split(
-                new PartitionName("t", Arrays.asList(new BytesRef("hoschi"))).stringValue());
+                new PartitionName("t", Arrays.asList(new BytesRef("hoschi"))).asIndexName());
         assertThat(splitted, arrayContaining(null, "t", "043mgrrjcdk6i"));
 
     }
@@ -290,13 +231,13 @@ public class PartitionNameTest extends CrateUnitTest {
     @Test
     public void testIdent() throws Exception {
         Assert.assertThat(
-                PartitionName.ident(new PartitionName("table", ImmutableList.of(new BytesRef("a"), new BytesRef("b"))).stringValue()),
+                PartitionName.ident(new PartitionName("table", ImmutableList.of(new BytesRef("a"), new BytesRef("b"))).asIndexName()),
                 is("081620j2")
         );
         Assert.assertThat(
                 PartitionName.ident(new PartitionName(Schemas.DEFAULT_SCHEMA_NAME, "table", new ArrayList<BytesRef>() {{
                     add(null);
-                }}).stringValue()),
+                }}).asIndexName()),
                 is("0400")
         );
     }
@@ -313,6 +254,7 @@ public class PartitionNameTest extends CrateUnitTest {
                 new PartitionName("table", Arrays.asList(new BytesRef("xxx"))).equals(
                         new PartitionName("schema", "table", Arrays.asList(new BytesRef("xxx")))));
         PartitionName name = new PartitionName(null, "table", Arrays.asList(new BytesRef("xxx")));
-        assertTrue(name.equals(PartitionName.fromStringSafe(name.stringValue())));
+        assertTrue(name.equals(PartitionName.fromIndexOrTemplate(name.asIndexName())));
     }
+    */
 }

--- a/sql/src/test/java/io/crate/metadata/doc/DocIndexMetaDataTest.java
+++ b/sql/src/test/java/io/crate/metadata/doc/DocIndexMetaDataTest.java
@@ -48,7 +48,6 @@ import java.util.concurrent.TimeUnit;
 import static io.crate.testing.TestingHelpers.newMockedThreadPool;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -1160,13 +1159,13 @@ public class DocIndexMetaDataTest extends CrateUnitTest {
                 .build();
         AliasMetaData aliasMetaData = AliasMetaData.newAliasMetaDataBuilder("test1")
                 .build();
-        IndexMetaData partitionMetaData = getIndexMetaData(partitionName.stringValue(), builder,
+        IndexMetaData partitionMetaData = getIndexMetaData(partitionName.asIndexName(), builder,
                partitionSettings, aliasMetaData);
-        DocIndexMetaData partitionMD = newMeta(partitionMetaData, partitionName.stringValue());
+        DocIndexMetaData partitionMD = newMeta(partitionMetaData, partitionName.asIndexName());
         assertThat(partitionMD.aliases().size(), is(1));
         assertThat(partitionMD.aliases(), hasItems("test1"));
         assertThat(partitionMD.isAlias(), is(false));
-        assertThat(partitionMD.concreteIndexName(), is(partitionName.stringValue()));
+        assertThat(partitionMD.concreteIndexName(), is(partitionName.asIndexName()));
         DocIndexMetaData merged = md.merge(partitionMD, mock(TransportPutIndexTemplateAction.class), true);
 
         assertThat(merged.numberOfReplicas(), is(BytesRefs.toBytesRef(2)));

--- a/sql/src/test/java/io/crate/metadata/table/TestingTableInfo.java
+++ b/sql/src/test/java/io/crate/metadata/table/TestingTableInfo.java
@@ -209,7 +209,7 @@ public class TestingTableInfo extends DocTableInfo {
 
         public Builder addPartitions(String... partitionNames) {
             for (String partitionName : partitionNames) {
-                PartitionName partition = PartitionName.fromString(partitionName, ident.schema(), ident.name());
+                PartitionName partition = PartitionName.fromIndexOrTemplate(partitionName);
                 partitions.add(partition);
             }
             return this;

--- a/sql/src/test/java/io/crate/planner/PlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/PlannerTest.java
@@ -178,9 +178,9 @@ public class PlannerTest extends CrateUnitTest {
                     .add("id", DataTypes.STRING, null)
                     .add("date", DataTypes.TIMESTAMP, null, true)
                     .addPartitions(
-                            new PartitionName("parted", new ArrayList<BytesRef>(){{add(null);}}).stringValue(), // TODO: invalid partition: null not valid as part of primary key
-                            new PartitionName("parted", Arrays.asList(new BytesRef("0"))).stringValue(),
-                            new PartitionName("parted", Arrays.asList(new BytesRef("123"))).stringValue()
+                            new PartitionName("parted", new ArrayList<BytesRef>(){{add(null);}}).asIndexName(), // TODO: invalid partition: null not valid as part of primary key
+                            new PartitionName("parted", Arrays.asList(new BytesRef("0"))).asIndexName(),
+                            new PartitionName("parted", Arrays.asList(new BytesRef("123"))).asIndexName()
                     )
                     .addPrimaryKey("id")
                     .addPrimaryKey("date")
@@ -206,9 +206,9 @@ public class PlannerTest extends CrateUnitTest {
                     .add("obj", DataTypes.STRING, Arrays.asList("name"), true)
                             // add 3 partitions/simulate already done inserts
                     .addPartitions(
-                            new PartitionName("multi_parted", Arrays.asList(new BytesRef("1395874800000"), new BytesRef("0"))).stringValue(),
-                            new PartitionName("multi_parted", Arrays.asList(new BytesRef("1395961200000"), new BytesRef("-100"))).stringValue(),
-                            new PartitionName("multi_parted", Arrays.asList(null, new BytesRef("-100"))).stringValue())
+                            new PartitionName("multi_parted", Arrays.asList(new BytesRef("1395874800000"), new BytesRef("0"))).asIndexName(),
+                            new PartitionName("multi_parted", Arrays.asList(new BytesRef("1395961200000"), new BytesRef("-100"))).asIndexName(),
+                            new PartitionName("multi_parted", Arrays.asList(null, new BytesRef("-100"))).asIndexName())
                     .build();
             TableIdent clusteredByParitionedIdent = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "clustered_parted");
             TableInfo clusteredByPartitionedTableInfo = new TestingTableInfo.Builder(
@@ -218,8 +218,8 @@ public class PlannerTest extends CrateUnitTest {
                     .add("city", DataTypes.STRING, null)
                     .clusteredBy("city")
                     .addPartitions(
-                            new PartitionName("clustered_parted", Arrays.asList(new BytesRef("1395874800000"))).stringValue(),
-                            new PartitionName("clustered_parted", Arrays.asList(new BytesRef("1395961200000"))).stringValue())
+                            new PartitionName("clustered_parted", Arrays.asList(new BytesRef("1395874800000"))).asIndexName(),
+                            new PartitionName("clustered_parted", Arrays.asList(new BytesRef("1395961200000"))).asIndexName())
                     .build();
             when(emptyPartedTableInfo.schemaInfo().name()).thenReturn(Schemas.DEFAULT_SCHEMA_NAME);
             when(schemaInfo.getTableInfo(charactersTableIdent.name())).thenReturn(charactersTableInfo);
@@ -375,7 +375,7 @@ public class PlannerTest extends CrateUnitTest {
         assertThat(getNode.tableInfo().ident().name(), is("parted"));
         assertThat(getNode.docKeys().getOnlyKey(), isDocKey("one", 0L));
 
-        //is(new PartitionName("parted", Arrays.asList(new BytesRef("0"))).stringValue()));
+        //is(new PartitionName("parted", Arrays.asList(new BytesRef("0"))).asIndexName()));
         assertEquals(DataTypes.STRING, getNode.outputTypes().get(0));
         assertEquals(DataTypes.TIMESTAMP, getNode.outputTypes().get(1));
     }
@@ -648,7 +648,7 @@ public class PlannerTest extends CrateUnitTest {
             indices.addAll(entry.getValue().keySet());
         }
         assertThat(indices, Matchers.contains(
-                new PartitionName("parted", Arrays.asList(new BytesRef("123"))).stringValue()));
+                new PartitionName("parted", Arrays.asList(new BytesRef("123"))).asIndexName()));
 
         assertTrue(collectPhase.whereClause().hasQuery());
 
@@ -1827,8 +1827,8 @@ public class PlannerTest extends CrateUnitTest {
         indices = Planner.indices(TestingTableInfo.builder(custom, shardRouting)
                 .add("id", DataTypes.INTEGER, null)
                 .add("date", DataTypes.TIMESTAMP, null, true)
-                .addPartitions(new PartitionName(custom, Arrays.asList(new BytesRef("0"))).stringValue())
-                .addPartitions(new PartitionName(custom, Arrays.asList(new BytesRef("12345"))).stringValue())
+                .addPartitions(new PartitionName(custom, Arrays.asList(new BytesRef("0"))).asIndexName())
+                .addPartitions(new PartitionName(custom, Arrays.asList(new BytesRef("12345"))).asIndexName())
                 .build(), WhereClause.MATCH_ALL);
         assertThat(indices, arrayContainingInAnyOrder("custom..partitioned.table.04130", "custom..partitioned.table.04332chj6gqg"));
     }


### PR DESCRIPTION
There were various places where a indexName was parsed multiple times to get
schema and tableName.

A lot of the functionality of PartitionName was also kinda duplicated with a
slightly different interface. This is now more generic and more flexible.