### PR TITLE
let gradle link es sources, not compiled class files (at least for main sources)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,18 @@ allprojects {
     tasks.withType(Javadoc) {
         failOnError = false
     }
+
+    tasks.withType(Test) {
+        doFirst {
+            // move lucene-test-framework to the beginning of the classpath
+            // for cli ./gradlew use
+            def cp = project.sourceSets.test.runtimeClasspath
+            def testFrameworkEntry = cp.find({it.name.contains("lucene-test-framework")})
+            if (testFrameworkEntry != null) {
+                project.sourceSets.test.runtimeClasspath = files(testFrameworkEntry) + cp.filter({ !it.name.contains("lucene-test-framework") })
+            }
+        }
+    }
 }
 
 configure(subprojects.findAll {it.name != 'es'}) {
@@ -156,21 +168,26 @@ subprojects {
                 // when calling tests from intellij
                 withXml {
                     def node = it.asNode()
-                    def testingNode = node.component.orderEntry.find {
-                        it.@'module-name' == 'testing'
-                    }
 
-                    if (testingNode != null) {
-                        def parent = testingNode.parent()
-                        def newNode = new Node(parent, testingNode.name(), testingNode.attributes())
-                        parent.remove(testingNode)
-                        parent.children().add(4, newNode)
+                    def testFramework = node.component.orderEntry.find {
+                        it.@'type' == 'module-library' && it.library.CLASSES.root.find {
+                            it.@'url'.contains('lucene-test-framework')
+                        }
+                    }
+                    if (testFramework != null) {
+                        println "moving test framework"
+                        def parent = testFramework.parent()
+                        def newNode = new Node(parent, testFramework.name(), testFramework.attributes(), testFramework.value())
+                        parent.remove(testFramework)
+                        parent.children().add(5, newNode)
                     }
                 }
             }
         }
     }
 }
+
+
 
 def jvmTestFlags = ['-ea']
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -12,12 +12,14 @@ dependencies {
     compile project(':es')
     compile 'commons-codec:commons-codec:1.9'
     compile 'org.apache.xbean:xbean-finder:4.2'
+
     testCompile project(':testing')
 }
 
 test {
-    testLogging.exceptionFormat = 'full'
+    outputs.upToDateWhen { false }
 
+    testLogging.exceptionFormat = 'full'
     jacoco {
         excludes = [
                 "*Test*"

--- a/es/build.gradle
+++ b/es/build.gradle
@@ -5,7 +5,10 @@ repositories {
     mavenCentral()
 }
 
-configurations { lucenetest }
+configurations {
+    lucenetest
+    testOutput.extendsFrom (testCompile, lucenetest)
+}
 
 idea {
     module {
@@ -84,10 +87,10 @@ dependencies {
     lucenetest ('junit:junit:4.11') {
         exclude group: 'org.hamcrest', module: 'hamcrest-core'
     }
-    lucenetest ('org.apache.lucene:lucene-codecs:4.10.4') {
+    lucenetest ('org.apache.lucene:lucene-test-framework:4.10.4') {
         exclude group: 'junit', module: 'junit'
     }
-    lucenetest ('org.apache.lucene:lucene-test-framework:4.10.4') {
+    lucenetest ('org.apache.lucene:lucene-codecs:4.10.4') {
         exclude group: 'junit', module: 'junit'
     }
     lucenetest ('com.carrotsearch.randomizedtesting:randomizedtesting-runner:2.1.11') {
@@ -98,6 +101,15 @@ dependencies {
 
 sourceSets.test.compileClasspath = configurations.lucenetest + sourceSets.test.compileClasspath
 sourceSets.test.runtimeClasspath = configurations.lucenetest + sourceSets.test.runtimeClasspath
+
+task testJar (type: Jar, dependsOn: testClasses) {
+    from sourceSets.test.output
+    classifier = 'test'
+}
+
+artifacts {
+    testOutput testJar
+}
 
 test {
     enabled = false

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -4,8 +4,19 @@ archivesBaseName = 'crate-testing'
 
 configurations {
     all*.exclude group: 'org.elasticsearch'
+    ideaConf
 }
 
+
+idea {
+    module {
+        // ensure es dependencies are available in intellij as well
+        def esProject = parent.project.subprojects.find({it.name == 'es'})
+        scopes.COMPILE.plus += [configurations.ideaConf]
+        scopes.COMPILE.plus.add(0, esProject.configurations.lucenetest)
+        scopes.COMPILE.plus.add(0, esProject.configurations.testOutput)
+    }
+}
 evaluationDependsOn(':es')
 
 dependencies {
@@ -14,7 +25,17 @@ dependencies {
     }
     compile 'org.codehaus.jackson:jackson-mapper-asl:1.9.13'
     compile 'org.apache.commons:commons-lang3:3.3.2'
-    compile project(':es').sourceSets.test.runtimeClasspath
+    // es test classes
+    compile project(path: ':es', configuration: 'testOutput')
+
+    // idea cannot handle project dependencies with different configurations
+    // so we have to declare the compiled test sources here
+    // and add them above so idea sees them
+    ideaConf project(':es').sourceSets.test.output
+
+    // main dependencies and es.jar
+    compile project(':es')
+
 }
 
 test {


### PR DESCRIPTION
so development is easier.
idea or the gradle idea plugin are not able to link different configurations of module dependencies, unfortunately.
so we only can link to the main sources, not the test ones