### PR TITLE
WriterProjector: remove open()/close() from Output

### DIFF
--- a/sql/src/main/java/io/crate/operation/projectors/writer/Output.java
+++ b/sql/src/main/java/io/crate/operation/projectors/writer/Output.java
@@ -24,15 +24,16 @@ package io.crate.operation.projectors.writer;
 import com.google.common.base.Preconditions;
 import org.elasticsearch.common.settings.Settings;
 
+import java.io.IOException;
 import java.io.OutputStream;
 
 public abstract class Output {
 
-    public abstract void open() throws java.io.IOException;
-
-    public abstract void close() throws java.io.IOException;
-
-    public abstract OutputStream getOutputStream();
+    /**
+     * calling this method creates & acquires an OutputStream which must be closed by the caller if it is no longer needed
+     * @throws IOException in case the Output can't be created (e.g. due to file permission errors or something like that)
+     */
+    public abstract OutputStream acquireOutputStream() throws IOException;
 
     protected boolean parseCompression(Settings settings) {
         String compressionType = settings.get("compression");

--- a/sql/src/main/java/io/crate/operation/projectors/writer/OutputFile.java
+++ b/sql/src/main/java/io/crate/operation/projectors/writer/OutputFile.java
@@ -34,7 +34,6 @@ import java.util.zip.GZIPOutputStream;
 public class OutputFile extends Output {
 
     private final String path;
-    private OutputStream os;
     private final boolean overwrite;
     private final boolean compression;
 
@@ -46,7 +45,7 @@ public class OutputFile extends Output {
     }
 
     @Override
-    public void open() throws IOException {
+    public OutputStream acquireOutputStream() throws IOException {
         File outFile = new File(path);
         if (outFile.exists()){
             if (!overwrite){
@@ -56,22 +55,10 @@ public class OutputFile extends Output {
                 throw new IOException("Output path is a directory: " + path);
             }
         }
-        os = new FileOutputStream(outFile);
+        OutputStream os = new FileOutputStream(outFile);
         if (compression) {
             os = new GZIPOutputStream(os);
         }
-    }
-
-    @Override
-    public void close() throws IOException {
-        if (os != null) { // if open failed os is null here
-            os.close();
-            os = null;
-        }
-    }
-
-    @Override
-    public OutputStream getOutputStream() {
         return os;
     }
 }

--- a/sql/src/main/java/io/crate/operation/projectors/writer/OutputS3.java
+++ b/sql/src/main/java/io/crate/operation/projectors/writer/OutputS3.java
@@ -49,7 +49,6 @@ public class OutputS3 extends Output {
     private final ExecutorService executorService;
     private final URI uri;
     private final boolean compression;
-    private OutputStream outputStream;
 
     public OutputS3(ExecutorService executorService, URI uri, Settings settings) {
         this.executorService = executorService;
@@ -58,23 +57,11 @@ public class OutputS3 extends Output {
     }
 
     @Override
-    public void open() throws IOException {
-        outputStream = new S3OutputStream(executorService, uri, new S3ClientHelper());
+    public OutputStream acquireOutputStream() throws IOException {
+        OutputStream outputStream = new S3OutputStream(executorService, uri, new S3ClientHelper());
         if (compression) {
             outputStream = new GZIPOutputStream(outputStream);
         }
-    }
-
-    @Override
-    public void close() throws IOException {
-        if (outputStream != null) {
-            outputStream.close();
-            outputStream = null;
-        }
-    }
-
-    @Override
-    public OutputStream getOutputStream() {
         return outputStream;
     }
 


### PR DESCRIPTION
OutputStream is already closable so the close on output is a abit redundant.
And it is usually the case that whoever acquires something is also responsible
for closing it.