### PR TITLE
Fix flaky test in TypeConversionTest

### DIFF
--- a/core/src/test/java/io/crate/types/TypeConversionTest.java
+++ b/core/src/test/java/io/crate/types/TypeConversionTest.java
@@ -91,7 +91,9 @@ public class TypeConversionTest extends CrateUnitTest {
 
         for (Byte byteVal : bytes(10)) {
             for (DataType t : DataTypes.ALLOWED_CONVERSIONS.get(DataTypes.BYTE.id())) {
-                byteVal = t.equals(DataTypes.IP) ? (byte) Math.abs(byteVal) : byteVal;
+                if (t.equals(DataTypes.IP)) {
+                    byteVal = (byte) Math.abs(byteVal == Byte.MIN_VALUE ? byteVal >> 1 : byteVal);
+                }
                 t.value(byteVal);
             }
         }


### PR DESCRIPTION
abs byte value for -128 relults in -128 which fails for iptype.value