### PR TITLE
make crate compile- and testable when offline

### DIFF
--- a/sql/build.gradle
+++ b/sql/build.gradle
@@ -15,7 +15,10 @@ dependencies {
     compile project(':core')
     compile project(':blob')
     compile project(':sql-parser')
-    compile 'com.amazonaws:aws-java-sdk-s3:1.9.34'
+    compile ('com.amazonaws:aws-java-sdk-s3:1.9.34') {
+        // es provides a compatible version
+        exclude group: 'joda-time', module: 'joda-time'
+    }
     compile 'org.apache.commons:commons-math3:3.4.1'
     testCompile project(':testing')
     testCompile 'org.skyscreamer:jsonassert:1.2.0'


### PR DESCRIPTION
removed dependency that could not resolved when offline because it is
never downloaded because there is already a newer version of the same
package