### PR TITLE
Excluding log4j from client

### DIFF
--- a/client/build.gradle
+++ b/client/build.gradle
@@ -24,6 +24,7 @@ dependencies {
         exclude group: 'com.tdunning'
         exclude group: 'commons-cli'
         exclude group: 'org.slf4j'
+        exclude group: 'log4j'
     }
     // needed by ES Version class - keep up to date with es dependencies
     compile 'org.apache.lucene:lucene-core:4.10.4'


### PR DESCRIPTION
Fixes #2591 Excluding log4j dependency from crate-client in order to enable the usage of slf4j.

