### PR TITLE
Array functions module

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -14,6 +14,10 @@ Unreleased
 
  - Updated crate/elasticsearch for improved logging on graceful shutdown errors
 
+ - Added ``array_cat``, ``array_unique`` and ``array_difference`` scalar functions.
+   Also modified ``concat`` function to resolve to ``array_cat`` when ``concat``
+   function is called with 2 array args, so the operator ``||`` will work with arrays.
+
 2015/10/13 0.52.0
 =================
 

--- a/docs/sql/scalar.txt
+++ b/docs/sql/scalar.txt
@@ -835,6 +835,163 @@ Examples
     +---------------------+--------------+
     SELECT 5 rows in set (... sec)
 
+
+Array Functions
+===============
+
+array_cat(first_array, second_array) returns array
+-------------------------------------------------------------------------
+
+The ``array_cat`` function concatenates two arrays into one array
+
+::
+
+    cr> select array_cat([1,2,3],[3,4,5,6]) from sys.cluster;
+    +-------------------------------+
+    | array_cat([1,2,3], [3,4,5,6]) |
+    +-------------------------------+
+    | [1, 2, 3, 3, 4, 5, 6]         |
+    +-------------------------------+
+    SELECT 1 row in set (... sec)
+
+
+It can be used to append elements to array fields
+
+::
+
+    cr> create table array_cat_example (list array(integer));
+    CREATE OK (... sec)
+
+::
+
+    cr> insert into array_cat_example (list) values ([1,2,3]);
+    INSERT OK, 1 row affected (... sec)
+
+.. Hidden: refresh array_cat_example
+
+    cr> refresh table array_cat_example
+    REFRESH OK (... sec)
+
+::
+
+    cr> update array_cat_example set list = array_cat(list, [4, 5, 6]);
+    UPDATE OK, 1 row affected (... sec)
+
+.. Hidden: refresh array_cat_example
+
+    cr> refresh table array_cat_example
+    REFRESH OK (... sec)
+
+::
+
+    cr> select * from array_cat_example;
+    +--------------------+
+    | list               |
+    +--------------------+
+    | [1, 2, 3, 4, 5, 6] |
+    +--------------------+
+    SELECT 1 row in set (... sec)
+
+
+.. note:: Appending to arrays with array_cat in updates is handy, but unfortunately not isolated. We use optimistic concurrency control to ensure that your update operation used the latest state of the row. But only 3 retry attempts are made by fetching the newest version again and if they all fail, the query fails.
+
+
+You can also use the concat operator ``||`` with arrays
+
+::
+
+    cr> select [1,2,3] || [4,5,6] || [7,8,9] from sys.cluster;
+    +-------------------------------------------+
+    | concat(concat([1,2,3], [4,5,6]), [7,8,9]) |
+    +-------------------------------------------+
+    | [1, 2, 3, 4, 5, 6, 7, 8, 9]               |
+    +-------------------------------------------+
+    SELECT 1 row in set (... sec)
+
+
+array_unique(first_array, [ second_array]) returns array
+-------------------------------------------------------------------
+
+The ``array_unique`` function merges two arrays into one array with unique elements
+
+::
+
+    cr> select array_unique([1,2,3],[3,4,5,6]) from sys.cluster;
+    +----------------------------------+
+    | array_unique([1,2,3], [3,4,5,6]) |
+    +----------------------------------+
+    | [1, 2, 3, 4, 5, 6]               |
+    +----------------------------------+
+    SELECT 1 row in set (... sec)
+
+
+It can be used with one argument
+
+::
+
+    cr> select array_unique([1,2,3,3,4,5,6,7,5,6,9,10]) from sys.cluster;
+    +------------------------------------------+
+    | array_unique([1,2,3,3,4,5,6,7,5,6,9,10]) |
+    +------------------------------------------+
+    | [1, 2, 3, 4, 5, 6, 7, 9, 10]             |
+    +------------------------------------------+
+    SELECT 1 row in set (... sec)
+
+
+array_difference(first_array, second_array) returns array
+-------------------------------------------------------------------
+
+The ``array_difference`` function removes elements from the first array that are contained in the second array.
+
+::
+
+    cr> select array_difference([1,2,3,4,5,6,7,8,9,10],[2,3,6,9,15]) from sys.cluster;
+    +--------------------------------------------------------+
+    | array_difference([1,2,3,4,5,6,7,8,9,10], [2,3,6,9,15]) |
+    +--------------------------------------------------------+
+    | [1, 4, 5, 7, 8, 10]                                    |
+    +--------------------------------------------------------+
+    SELECT 1 row in set (... sec)
+
+
+It can be used to remove elements from array fields.
+
+::
+
+    cr> create table array_difference_example (list array(integer));
+    CREATE OK (... sec)
+
+::
+
+    cr> insert into array_difference_example (list) values ([1,2,3,4,5,6,7,8,9,10]);
+    INSERT OK, 1 row affected (... sec)
+
+.. Hidden: refresh array_difference_example
+
+    cr> refresh table array_difference_example
+    REFRESH OK (... sec)
+
+::
+
+    cr> update array_difference_example set list = array_difference(list, [6]);
+    UPDATE OK, 1 row affected (... sec)
+
+.. Hidden: refresh array_difference_example
+
+    cr> refresh table array_difference_example
+    REFRESH OK (... sec)
+
+::
+
+    cr> select * from array_difference_example;
+    +------------------------------+
+    | list                         |
+    +------------------------------+
+    | [1, 2, 3, 4, 5, 7, 8, 9, 10] |
+    +------------------------------+
+    SELECT 1 row in set (... sec)
+
+
 .. rubric:: Footnotes
 
 .. [#MySQL-Docs] http://dev.mysql.com/doc/refman/5.6/en/date-and-time-functions.html#function_date-format

--- a/sql/src/main/java/io/crate/operation/scalar/ArrayCatFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/ArrayCatFunction.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.operation.scalar;
+
+import com.google.common.base.Preconditions;
+import io.crate.metadata.*;
+import io.crate.operation.Input;
+import io.crate.planner.symbol.Function;
+import io.crate.planner.symbol.Literal;
+import io.crate.planner.symbol.Symbol;
+import io.crate.types.DataType;
+import io.crate.types.ArrayType;
+import io.crate.types.DataTypes;
+
+import java.util.List;
+import java.util.Locale;
+
+public class ArrayCatFunction extends Scalar<Object[], Object> {
+
+    public static final String NAME = "array_cat";
+    private FunctionInfo functionInfo;
+
+    public static FunctionInfo createInfo(List<DataType> types) {
+        ArrayType arrayType = (ArrayType) types.get(0);
+        if(arrayType.innerType().equals(DataTypes.UNDEFINED)){
+            arrayType = (ArrayType) types.get(1);
+        }
+        return new FunctionInfo(new FunctionIdent(NAME, types), arrayType);
+    }
+
+    public static void register(ScalarFunctionModule module) {
+        module.register(NAME, new Resolver());
+    }
+
+    protected ArrayCatFunction(FunctionInfo functionInfo) {
+        this.functionInfo = functionInfo;
+    }
+
+    @Override
+    public FunctionInfo info() {
+        return functionInfo;
+    }
+
+    @Override
+    public Symbol normalizeSymbol(Function symbol) {
+        if (anyNonLiterals(symbol.arguments())) {
+            return symbol;
+        }
+
+
+        Input[] argList = new Input[symbol.arguments().size()];
+        int counter = 0;
+        for(Symbol argSymbol : symbol.arguments()){
+            Input input  = (Input) argSymbol;
+            argList[counter++] = input;
+        }
+
+        return Literal.newLiteral(evaluate(argList), this.info().returnType());
+    }
+
+    @Override
+    public Object[] evaluate(Input[] args) {
+        int counter = 0;
+        for(Input array : args){
+            if(array == null || array.value() == null){
+                continue;
+            }
+            Object[] arg = (Object[]) array.value();
+            counter += arg.length;
+        }
+
+        DataType innerType = ((ArrayType) this.info().returnType()).innerType();
+
+        Object[] resultArray = new Object[counter];
+        counter = 0;
+        for(Input array : args){
+            if(array == null || array.value() == null){
+                continue;
+            }
+            Object[] arg = (Object[]) array.value();
+            for(Object element: arg){
+                resultArray[counter++] = innerType.value(element);
+            }
+        }
+
+        return resultArray;
+    }
+
+
+    private static class Resolver implements DynamicFunctionResolver {
+
+        @Override
+        public FunctionImplementation<Function> getForTypes(List<DataType> dataTypes) throws IllegalArgumentException {
+            Preconditions.checkArgument(dataTypes.size() == 2, "array_cat function requires 2 arguments");
+
+            for (int i = 0; i < dataTypes.size(); i++) {
+                Preconditions.checkArgument(dataTypes.get(i) instanceof ArrayType, String.format(Locale.ENGLISH,
+                        "Argument %d of the array_cat function cannot be converted to array", i + 1));
+            }
+
+            DataType innerType0 = ((ArrayType) dataTypes.get(0)).innerType();
+            DataType innerType1 = ((ArrayType) dataTypes.get(1)).innerType();
+
+            Preconditions.checkArgument(!innerType0.equals(DataTypes.UNDEFINED) || !innerType1.equals(DataTypes.UNDEFINED),
+                    "One of the arguments of the array_cat function can be of undefined inner type, but not both");
+
+            if(!innerType0.equals(DataTypes.UNDEFINED)){
+                Preconditions.checkArgument(innerType1.isConvertableTo(innerType0),
+                        String.format(Locale.ENGLISH,
+                                "Second argument's inner type (%s) of the array_cat function cannot be converted to the first argument's inner type (%s)",
+                                innerType1,innerType0));
+            }
+
+            return new ArrayCatFunction(createInfo(dataTypes));
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/operation/scalar/ArrayDifferenceFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/ArrayDifferenceFunction.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.operation.scalar;
+
+import com.google.common.base.Preconditions;
+import io.crate.metadata.*;
+import io.crate.operation.Input;
+import io.crate.planner.symbol.Function;
+import io.crate.planner.symbol.Literal;
+import io.crate.planner.symbol.Symbol;
+import io.crate.types.ArrayType;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+import org.elasticsearch.common.Nullable;
+import com.google.common.base.Optional;
+
+import java.util.*;
+
+public class ArrayDifferenceFunction extends Scalar<Object[], Object> {
+
+    public static final String NAME = "array_difference";
+    private FunctionInfo functionInfo;
+    private final Optional<Set<Object>> optionalSubtractSet;
+
+    private static FunctionInfo createInfo(List<DataType> types) {
+        ArrayType arrayType = (ArrayType) types.get(0);
+        if(arrayType.innerType().equals(DataTypes.UNDEFINED)){
+            arrayType = (ArrayType) types.get(1);
+        }
+        return new FunctionInfo(new FunctionIdent(NAME, types), arrayType);
+    }
+
+    public static void register(ScalarFunctionModule module) {
+        module.register(NAME, new Resolver());
+    }
+
+    protected ArrayDifferenceFunction(FunctionInfo functionInfo, @Nullable Set<Object> subtractSet) {
+        this.functionInfo = functionInfo;
+        optionalSubtractSet = Optional.fromNullable(subtractSet);
+    }
+
+    @Override
+    public FunctionInfo info() {
+        return functionInfo;
+    }
+
+    @Override
+    public Symbol normalizeSymbol(Function symbol) {
+        if (anyNonLiterals(symbol.arguments())) {
+            return symbol;
+        }
+
+        Input[] argList = new Input[symbol.arguments().size()];
+        int counter = 0;
+        for(Symbol argSymbol : symbol.arguments()){
+            Input input  = (Input) argSymbol;
+            argList[counter++] = input;
+        }
+
+        return Literal.newLiteral(evaluate(argList), this.info().returnType());
+    }
+
+    @Override
+    public Scalar<Object[], Object> compile(List<Symbol> arguments) {
+
+        Symbol symbol = arguments.get(1);
+        if(symbol == null){
+            return this;
+        }
+
+        if (!symbol.symbolType().isValueSymbol()) {
+            // arguments are no values, we can't compile
+            return this;
+        }
+
+        Input input = (Input) symbol;
+        if(input.value() == null){
+            return this;
+        }
+
+        DataType innerType = ((ArrayType) this.info().returnType()).innerType();
+        Object[] array = (Object[]) input.value();
+        Set<Object> subtractSet = new HashSet<>();
+        if(array.length > 0){
+            for(Object element : array){
+                subtractSet.add(innerType.value(element));
+            }
+        }
+
+        return new ArrayDifferenceFunction(this.functionInfo, subtractSet);
+    }
+
+    @Override
+    public Object[] evaluate(Input[] args) {
+
+        if(args[0] == null || args[0].value() == null){
+            return null;
+        }
+
+        DataType innerType = ((ArrayType) this.info().returnType()).innerType();
+        Set<Object> localSubtractSet;
+        if(!optionalSubtractSet.isPresent()){
+            localSubtractSet = new HashSet<>();
+            for(int i = 1; i < args.length; i++){
+                if(args[i] == null || args[i].value() == null){
+                    continue;
+                }
+                Object[] array = (Object[]) args[i].value();
+                for(Object element : array){
+                    localSubtractSet.add(innerType.value(element));
+                }
+            }
+        }else{
+            localSubtractSet = optionalSubtractSet.get();
+        }
+
+        Object[] originalArray = (Object[]) args[0].value();
+        List<Object> resultList   = new ArrayList<>(originalArray.length);
+        for(int i = 0; i < originalArray.length; i++){
+            Object element = innerType.value(originalArray[i]);
+            if(!localSubtractSet.contains(element)){
+                resultList.add(element);
+            }
+        }
+
+        return resultList.toArray();
+    }
+
+
+    private static class Resolver implements DynamicFunctionResolver {
+
+        @Override
+        public FunctionImplementation<Function> getForTypes(List<DataType> dataTypes) throws IllegalArgumentException {
+            Preconditions.checkArgument(dataTypes.size() == 2, "array_difference function requires 2 arguments");
+
+            for (int i = 0; i < dataTypes.size(); i++) {
+                Preconditions.checkArgument(dataTypes.get(i) instanceof ArrayType, String.format(Locale.ENGLISH,
+                        "Argument %d of the array_difference function cannot be converted to array", i + 1));
+            }
+
+            DataType innerType0 = ((ArrayType) dataTypes.get(0)).innerType();
+            DataType innerType1 = ((ArrayType) dataTypes.get(1)).innerType();
+
+            Preconditions.checkArgument(!innerType0.equals(DataTypes.UNDEFINED) || !innerType1.equals(DataTypes.UNDEFINED),
+                    "One of the arguments of the array_difference function can be of undefined inner type, but not both");
+
+            if(!innerType0.equals(DataTypes.UNDEFINED)){
+                Preconditions.checkArgument(innerType1.isConvertableTo(innerType0),
+                        String.format(Locale.ENGLISH,
+                                "Second argument's inner type (%s) of the array_difference function cannot be converted to the first argument's inner type (%s)",
+                                innerType1,innerType0));
+            }
+
+            return new ArrayDifferenceFunction(createInfo(dataTypes), null);
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/operation/scalar/ArrayUniqueFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/ArrayUniqueFunction.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.operation.scalar;
+
+import com.google.common.base.Preconditions;
+import io.crate.metadata.*;
+import io.crate.operation.Input;
+import io.crate.planner.symbol.Function;
+import io.crate.planner.symbol.Literal;
+import io.crate.planner.symbol.Symbol;
+import io.crate.types.ArrayType;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+public class ArrayUniqueFunction extends Scalar<Object[], Object> {
+
+    public static final String NAME = "array_unique";
+    private FunctionInfo functionInfo;
+
+    private static FunctionInfo createInfo(List<DataType> types) {
+        ArrayType arrayType = (ArrayType) types.get(0);
+        if(arrayType.innerType().equals(DataTypes.UNDEFINED) && types.size() == 2){
+            arrayType = (ArrayType) types.get(1);
+        }
+        return new FunctionInfo(new FunctionIdent(NAME, types), arrayType);
+    }
+
+    public static void register(ScalarFunctionModule module) {
+        module.register(NAME, new Resolver());
+    }
+
+    protected ArrayUniqueFunction(FunctionInfo functionInfo) {
+        this.functionInfo = functionInfo;
+    }
+
+    @Override
+    public FunctionInfo info() {
+        return functionInfo;
+    }
+
+    @Override
+    public Symbol normalizeSymbol(Function symbol) {
+        if (anyNonLiterals(symbol.arguments())) {
+            return symbol;
+        }
+
+        Input[] argList = new Input[symbol.arguments().size()];
+        int counter = 0;
+        for(Symbol argSymbol : symbol.arguments()){
+            Input input  = (Input) argSymbol;
+            argList[counter++] = input;
+        }
+
+        return Literal.newLiteral(evaluate(argList), this.info().returnType());
+    }
+
+    @Override
+    public Object[] evaluate(Input[] args) {
+
+        DataType innerType   = ((ArrayType)this.info().returnType()).innerType();
+        Set<Object> uniqueSet = new LinkedHashSet<>();
+        for(Input array : args){
+            if(array == null || array.value() == null){
+                continue;
+            }
+            Object[] arg = (Object[]) array.value();
+            for(Object element: arg){
+                uniqueSet.add(innerType.value(element));
+            }
+        }
+
+        return uniqueSet.toArray();
+    }
+
+
+    private static class Resolver implements DynamicFunctionResolver {
+
+        @Override
+        public FunctionImplementation<Function> getForTypes(List<DataType> dataTypes) throws IllegalArgumentException {
+            Preconditions.checkArgument(dataTypes.size() >= 1 && dataTypes.size() <= 2, "array_unique function requires one or two arguments");
+
+            for (int i = 0; i < dataTypes.size(); i++) {
+                Preconditions.checkArgument(dataTypes.get(i) instanceof ArrayType, String.format(Locale.ENGLISH,
+                        "Argument %d of the array_unique function cannot be converted to array", i + 1));
+            }
+
+            if(dataTypes.size() == 2){
+                DataType innerType0 = ((ArrayType) dataTypes.get(0)).innerType();
+                DataType innerType1 = ((ArrayType) dataTypes.get(1)).innerType();
+
+                Preconditions.checkArgument(!innerType0.equals(DataTypes.UNDEFINED) || !innerType1.equals(DataTypes.UNDEFINED),
+                        "One of the arguments of the array_unique function can be of undefined inner type, but not both");
+
+                if(!innerType0.equals(DataTypes.UNDEFINED)){
+                    Preconditions.checkArgument(innerType1.isConvertableTo(innerType0),
+                            String.format(Locale.ENGLISH,
+                                    "Second argument's inner type (%s) of the array_unique function cannot be converted to the first argument's inner type (%s)",
+                                    innerType1,innerType0));
+                }
+            }else if(dataTypes.size() == 1){
+                DataType innerType = ((ArrayType) dataTypes.get(0)).innerType();
+                Preconditions.checkArgument(!innerType.equals(DataTypes.UNDEFINED),
+                        "When used with only one argument, the inner type of the array argument cannot be undefined");
+            }
+
+            return new ArrayUniqueFunction(createInfo(dataTypes));
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/operation/scalar/ScalarFunctionModule.java
+++ b/sql/src/main/java/io/crate/operation/scalar/ScalarFunctionModule.java
@@ -90,6 +90,10 @@ public class ScalarFunctionModule extends AbstractModule {
 
         ConcatFunction.register(this);
 
+        ArrayCatFunction.register(this);
+        ArrayDifferenceFunction.register(this);
+        ArrayUniqueFunction.register(this);
+
         // bind all registered functions and resolver
         // by doing it here instead of the register functions, plugins can also use the
         // register functions in their onModule(...) hooks

--- a/sql/src/test/java/io/crate/operation/scalar/ArrayCatFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/ArrayCatFunctionTest.java
@@ -1,0 +1,240 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.operation.scalar;
+
+import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.Scalar;
+import io.crate.operation.Input;
+import io.crate.planner.symbol.Function;
+import io.crate.planner.symbol.Literal;
+import io.crate.planner.symbol.Symbol;
+import io.crate.testing.TestingHelpers;
+import io.crate.types.ArrayType;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+import org.apache.lucene.util.BytesRef;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.Matchers.is;
+
+public class ArrayCatFunctionTest extends AbstractScalarFunctionsTest {
+
+    private static final ArrayType arrayOfIntegerType    = new ArrayType(DataTypes.INTEGER);
+    private static final ArrayType arrayOfLongType       = new ArrayType(DataTypes.LONG);
+    private static final ArrayType arrayOfStringType     = new ArrayType(DataTypes.STRING);
+    private static final ArrayType arrayOfBooleanType    = new ArrayType(DataTypes.BOOLEAN);
+    private static final ArrayType arrayOfIpType         = new ArrayType(DataTypes.IP);
+    private static final ArrayType arrayOfUndefinedType  = new ArrayType(DataTypes.UNDEFINED);
+
+    private ArrayCatFunction getFunction(ArrayType... args) {
+        List<DataType> argumentTypes = new ArrayList<>(args.length);
+        for (int i = 0; i < args.length; i++) {
+            argumentTypes.add(args[i]);
+        }
+        ArrayCatFunction function = ((ArrayCatFunction) functions.get(new FunctionIdent(ArrayCatFunction.NAME, argumentTypes)));
+        return function;
+    }
+
+    private void assertEval(Object[] expected, Literal ... args) {
+        List<DataType> argumentTypes = new ArrayList<>(args.length);
+        Input[] inputs = new Input[args.length];
+        for (int i = 0; i < args.length; i++) {
+            inputs[i] = args[i];
+            argumentTypes.add(args[i].valueType());
+        }
+        Scalar scalar = ((Scalar) functions.get(new FunctionIdent(ArrayCatFunction.NAME, argumentTypes)));
+        Object[] evaluate = (Object[]) scalar.evaluate(inputs);
+        assertThat(evaluate, is(expected));
+    }
+
+    @Test
+    public void testNormalizeWithValueSymbols() throws Exception {
+        ArrayCatFunction function = getFunction(arrayOfIntegerType, arrayOfIntegerType);
+
+        Symbol symbol = function.normalizeSymbol(new Function(function.info(), Arrays.<Symbol>asList(
+                Literal.newLiteral(new Integer[]{10, 20}, arrayOfIntegerType),
+                Literal.newLiteral(new Integer[]{10, 30}, arrayOfIntegerType)
+        )));
+
+        TestingHelpers.assertLiteralSymbol(symbol, new Integer[]{10, 20, 10, 30}, arrayOfIntegerType);
+    }
+
+    @Test
+    public void testNormalizeWithRefs() throws Exception {
+        ArrayCatFunction function = getFunction(arrayOfIntegerType, arrayOfIntegerType);
+
+        Function functionSymbol = new Function(function.info(), Arrays.<Symbol>asList(
+                TestingHelpers.createReference("foo", arrayOfIntegerType),
+                Literal.newLiteral(new Integer[]{10, 30}, arrayOfIntegerType)
+        ));
+        Function symbol = (Function) function.normalizeSymbol(functionSymbol);
+        assertThat(symbol, Matchers.sameInstance(functionSymbol));
+    }
+
+    @Test
+    public void testNullArguments() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Argument 2 of the array_cat function cannot be converted to array");
+        assertEval(
+                null,
+                Literal.newLiteral(new Object[]{1, 2, 3}, arrayOfIntegerType),
+                Literal.NULL);
+    }
+
+    @Test
+    public void testNullArgumentsWithoutCheckingForArrays() throws Exception {
+        ArrayCatFunction function = getFunction(arrayOfIntegerType, arrayOfIntegerType);
+
+        Input[] inputs = new Input[]{
+                Literal.NULL,
+                null
+        };
+
+        Object[] expected = new Object[] {};
+        Object[] evaluate = function.evaluate(inputs);
+        assertThat(evaluate, is(expected));
+    }
+
+    @Test
+    public void testZeroArguments() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("array_cat function requires 2 arguments");
+        assertEval(null);
+    }
+
+    @Test
+    public void testOneArgument() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("array_cat function requires 2 arguments");
+        assertEval(new Object[]{}, Literal.newLiteral(new Object[]{1}, new ArrayType(DataTypes.INTEGER)));
+    }
+
+    @Test
+    public void testThreeArguments() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("array_cat function requires 2 arguments");
+        assertEval(new Object[]{},
+                Literal.newLiteral(new Object[]{1}, new ArrayType(DataTypes.INTEGER)),
+                Literal.newLiteral(new Object[]{2}, new ArrayType(DataTypes.INTEGER)),
+                Literal.newLiteral(new Object[]{3}, new ArrayType(DataTypes.INTEGER)));
+    }
+
+    @Test
+    public void testDifferentConvertableInnerTypes() throws Exception {
+        assertEval(
+                new Object[]{1, 1},
+                Literal.newLiteral(new Object[]{1},  arrayOfIntegerType),
+                Literal.newLiteral(new Object[]{1L}, arrayOfLongType));
+    }
+
+    @Test
+    public void testStringToNumberCast() throws Exception {
+        assertEval(
+                new Object[]{1, 2},
+                Literal.newLiteral(new Object[]{1},      arrayOfIntegerType),
+                Literal.newLiteral(new Object[]{"2"},    arrayOfStringType));
+    }
+
+    @Test
+    public void testNumberToStringCast() throws Exception {
+        assertEval(
+                new Object[]{new BytesRef("2"), new BytesRef("1")},
+                Literal.newLiteral(new Object[]{"2"},    arrayOfStringType),
+                Literal.newLiteral(new Object[]{1},      arrayOfIntegerType));
+    }
+
+    @Test
+    public void testConvertNonNumericStringToNumber() throws Exception {
+        expectedException.expect(NumberFormatException.class);
+        assertEval(
+                null,
+                Literal.newLiteral(new Object[]{1},              arrayOfIntegerType),
+                Literal.newLiteral(new Object[]{"foo","bar"},    arrayOfStringType));
+    }
+
+    @Test
+    public void testDifferentUnconvertableInnerTypes() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Second argument's inner type (ip) of the array_cat function cannot be converted to the first argument's inner type (boolean)");
+        assertEval(
+                null,
+                Literal.newLiteral(new Object[]{true},                       arrayOfBooleanType),
+                Literal.newLiteral(new Object[]{new BytesRef("127.0.0.1")},  arrayOfIpType));
+
+    }
+
+    @Test
+    public void testNullElements() throws Exception {
+        assertEval(
+                new Object[]{1, null, 3, null, 2, 3},
+                Literal.newLiteral(new Object[]{1, null, 3}, arrayOfIntegerType),
+                Literal.newLiteral(new Object[]{null, 2, 3}, arrayOfIntegerType));
+    }
+
+    @Test
+    public void testTwoIntegerArguments() throws Exception {
+        assertEval(
+                new Object[]{1,2,2,3},
+                Literal.newLiteral(new Object[]{1,2}, arrayOfIntegerType),
+                Literal.newLiteral(new Object[]{2,3}, arrayOfIntegerType));
+    }
+
+    @Test
+    public void testTwoLongArguments() throws Exception {
+        assertEval(
+                new Object[]{44L,55L,55L,66L},
+                Literal.newLiteral(new Object[]{44L, 55L}, arrayOfLongType),
+                Literal.newLiteral(new Object[]{55L, 66L}, arrayOfLongType));
+    }
+
+    @Test
+    public void testTwoStringArguments() throws Exception {
+        assertEval(
+                new Object[]{new BytesRef("foo"),new BytesRef("bar"),new BytesRef("bar"),new BytesRef("baz")},
+                Literal.newLiteral(new Object[]{"foo","bar"}, arrayOfStringType),
+                Literal.newLiteral(new Object[]{"bar","baz"}, arrayOfStringType));
+    }
+
+    @Test
+    public void testEmptyArrayAndIntegerArray() throws Exception {
+        assertEval(
+                new Object[]{1,2},
+                Literal.newLiteral(new Object[]{},      arrayOfUndefinedType),
+                Literal.newLiteral(new Object[]{1,2},   arrayOfIntegerType));
+    }
+
+    @Test
+    public void testEmptyArrays() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("One of the arguments of the array_cat function can be of undefined inner type, but not both");
+        assertEval(null,
+                Literal.newLiteral(new Object[]{}, arrayOfUndefinedType),
+                Literal.newLiteral(new Object[]{}, arrayOfUndefinedType));
+    }
+}

--- a/sql/src/test/java/io/crate/operation/scalar/ArrayDifferenceFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/ArrayDifferenceFunctionTest.java
@@ -1,0 +1,345 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.operation.scalar;
+
+import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.Scalar;
+import io.crate.operation.Input;
+import io.crate.planner.symbol.Function;
+import io.crate.planner.symbol.Literal;
+import io.crate.planner.symbol.Symbol;
+import io.crate.testing.TestingHelpers;
+import io.crate.types.ArrayType;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+import org.apache.lucene.util.BytesRef;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import java.util.*;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+
+public class ArrayDifferenceFunctionTest extends AbstractScalarFunctionsTest {
+
+    private static final ArrayType arrayOfIntegerType    = new ArrayType(DataTypes.INTEGER);
+    private static final ArrayType arrayOfLongType       = new ArrayType(DataTypes.LONG);
+    private static final ArrayType arrayOfStringType     = new ArrayType(DataTypes.STRING);
+    private static final ArrayType arrayOfBooleanType    = new ArrayType(DataTypes.BOOLEAN);
+    private static final ArrayType arrayOfIpType         = new ArrayType(DataTypes.IP);
+    private static final ArrayType arrayOfUndefinedType  = new ArrayType(DataTypes.UNDEFINED);
+
+    private ArrayDifferenceFunction getFunction(ArrayType... args) {
+        List<DataType> argumentTypes = new ArrayList<>(args.length);
+        for (int i = 0; i < args.length; i++) {
+            argumentTypes.add(args[i]);
+        }
+        ArrayDifferenceFunction function = ((ArrayDifferenceFunction) functions.get(new FunctionIdent(ArrayDifferenceFunction.NAME, argumentTypes)));
+        return function;
+    }
+
+    private void assertEval(Object[] expected, Literal ... args) {
+        List<DataType> argumentTypes = new ArrayList<>(args.length);
+        Input[] inputs = new Input[args.length];
+        for (int i = 0; i < args.length; i++) {
+            inputs[i] = args[i];
+            argumentTypes.add(args[i].valueType());
+        }
+        Scalar scalar = ((Scalar) functions.get(new FunctionIdent(ArrayDifferenceFunction.NAME, argumentTypes)));
+        Object[] evaluate = (Object[]) scalar.evaluate(inputs);
+        assertThat(evaluate, is(expected));
+    }
+
+    @Test
+    public void testCompileWithValues() throws Exception {
+        List<DataType> argumentTypes = Arrays.<DataType>asList(arrayOfIntegerType, arrayOfIntegerType);
+        List<Symbol> arguments = Arrays.<Symbol>asList(
+                Literal.newLiteral(new Object[]{1, 2, 3},arrayOfIntegerType),
+                Literal.newLiteral(new Object[]{3, 4, 5}, arrayOfIntegerType)
+        );
+
+        Scalar function = ((ArrayDifferenceFunction) functions.get(new FunctionIdent(ArrayDifferenceFunction.NAME, argumentTypes)));
+        Scalar compiled = function.compile(arguments);
+
+        assertThat(compiled, instanceOf(ArrayDifferenceFunction.class));
+    }
+
+    @Test
+    public void testCompileWithRefs() throws Exception {
+        DataType type = new ArrayType(DataTypes.INTEGER);
+        List<DataType> argumentTypes = Arrays.<DataType>asList(type, type);
+        List<Symbol> arguments = Arrays.<Symbol>asList(
+                Literal.newLiteral(new Object[]{1, 2, 3},type),
+                TestingHelpers.createReference("foo", type)
+        );
+
+        Scalar function = ((ArrayDifferenceFunction) functions.get(new FunctionIdent(ArrayDifferenceFunction.NAME, argumentTypes)));
+        Scalar compiled = function.compile(arguments);
+
+        assertThat(compiled, sameInstance(function));
+    }
+
+    @Test
+    public void testCompileWithNullArgs() throws Exception {
+        List<DataType> argumentTypes = Arrays.<DataType>asList(arrayOfIntegerType, arrayOfIntegerType);
+        List<Symbol> arguments = Arrays.<Symbol>asList(
+                Literal.newLiteral(new Object[]{1, 2, 3},arrayOfIntegerType),
+                null
+        );
+
+        Scalar function = ((ArrayDifferenceFunction) functions.get(new FunctionIdent(ArrayDifferenceFunction.NAME, argumentTypes)));
+        Scalar compiled = function.compile(arguments);
+
+        assertThat(compiled, sameInstance(function));
+    }
+
+    @Test
+    public void testCompileWithNullArgValues() throws Exception {
+        List<DataType> argumentTypes = Arrays.<DataType>asList(arrayOfIntegerType, arrayOfIntegerType);
+        List<Symbol> arguments = Arrays.<Symbol>asList(
+                Literal.newLiteral(new Object[]{1, 2, 3}, arrayOfIntegerType),
+                Literal.NULL
+        );
+
+        Scalar function = ((ArrayDifferenceFunction) functions.get(new FunctionIdent(ArrayDifferenceFunction.NAME, argumentTypes)));
+        Scalar compiled = function.compile(arguments);
+
+        assertThat(compiled, sameInstance(function));
+    }
+
+    @Test
+    public void testCompiledEvaluation() throws Exception {
+        Literal arg1 = Literal.newLiteral(new Object[]{1, 2, 3},arrayOfIntegerType);
+        Literal arg2 = Literal.newLiteral(new Object[]{3, 4, 5}, arrayOfIntegerType);
+
+        List<DataType> argumentTypes = Arrays.<DataType>asList(arrayOfIntegerType, arrayOfIntegerType);
+        List<Symbol>   arguments     = Arrays.<Symbol>asList(arg1, arg2);
+        Input[]        inputs        = new Input[]{ arg1, arg2};
+
+        ArrayDifferenceFunction function = (ArrayDifferenceFunction) functions.get(new FunctionIdent(ArrayDifferenceFunction.NAME, argumentTypes));
+        ArrayDifferenceFunction compiled = (ArrayDifferenceFunction) function.compile(arguments);
+        assertThat(compiled, instanceOf(ArrayDifferenceFunction.class));
+
+        Object[] evaluate = compiled.evaluate(inputs);
+        Object[] expected = new Object[] {1, 2};
+        assertThat(evaluate, is(expected));
+    }
+
+    @Test
+    public void testNormalizeWithValueSymbols() throws Exception {
+        ArrayType type = new ArrayType(DataTypes.INTEGER);
+        ArrayDifferenceFunction function = getFunction(type, type);
+
+        Symbol symbol = function.normalizeSymbol(new Function(function.info(), Arrays.<Symbol>asList(
+                Literal.newLiteral(new Integer[]{10, 20}, type),
+                Literal.newLiteral(new Integer[]{10, 30}, type)
+        )));
+
+        TestingHelpers.assertLiteralSymbol(symbol, new Integer[]{20}, type);
+    }
+
+    @Test
+    public void testNormalizeWithRefs() throws Exception {
+        ArrayType type = new ArrayType(DataTypes.INTEGER);
+        ArrayDifferenceFunction function = getFunction(type, type);
+
+        Function functionSymbol = new Function(function.info(), Arrays.<Symbol>asList(
+                TestingHelpers.createReference("foo", type),
+                Literal.newLiteral(new Integer[]{10, 30}, type)
+        ));
+        Function symbol = (Function) function.normalizeSymbol(functionSymbol);
+        assertThat(symbol, Matchers.sameInstance(functionSymbol));
+    }
+
+    @Test
+    public void testNullArguments() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Argument 2 of the array_difference function cannot be converted to array");
+        assertEval(null,
+                Literal.newLiteral(new Object[]{1}, arrayOfIntegerType),
+                Literal.NULL);
+    }
+
+    @Test
+    public void testNullArgumentsWithoutCheckingForArrays() throws Exception {
+        ArrayDifferenceFunction function = getFunction(arrayOfIntegerType, arrayOfIntegerType);
+
+        Input[] inputs = new Input[]{
+                Literal.NULL,
+                null
+        };
+
+        Object[] expected = null;
+        Object[] evaluate = function.evaluate(inputs);
+        assertThat(evaluate, is(expected));
+    }
+
+    @Test
+    public void testNullFirstArgumentWithoutCheckingForArrays() throws Exception {
+        ArrayDifferenceFunction function = getFunction(arrayOfIntegerType, arrayOfIntegerType);
+
+        Input[] inputs = new Input[]{
+                null,
+                Literal.newLiteral(new Object[]{22, 33, 44}, arrayOfIntegerType)
+        };
+
+        Object[] evaluate = function.evaluate(inputs);
+        assertNull(evaluate);
+    }
+
+    @Test
+    public void testNullValueFirstArgumentWithoutCheckingForArrays() throws Exception {
+        ArrayDifferenceFunction function = getFunction(arrayOfIntegerType, arrayOfIntegerType);
+
+        Input[] inputs = new Input[]{
+                Literal.NULL,
+                Literal.newLiteral(new Object[]{22, 33, 44}, arrayOfIntegerType)
+        };
+
+        Object[] evaluate = function.evaluate(inputs);
+        assertNull(evaluate);
+    }
+
+    @Test
+    public void testNullSecondArgumentWithoutCheckingForArrays() throws Exception {
+        ArrayDifferenceFunction function = getFunction(arrayOfIntegerType, arrayOfIntegerType);
+
+        Input[] inputs = new Input[]{
+                Literal.newLiteral(new Object[]{22, 33, 44}, arrayOfIntegerType),
+                null
+        };
+
+        Object[] evaluate = function.evaluate(inputs);
+        assertThat(evaluate, is(new Object[]{22, 33, 44}));
+    }
+
+    @Test
+    public void testNullValueSecondArgumentWithoutCheckingForArrays() throws Exception {
+        ArrayDifferenceFunction function = getFunction(arrayOfIntegerType, arrayOfIntegerType);
+
+        Input[] inputs = new Input[]{
+                Literal.newLiteral(new Object[]{22, 33, 44}, arrayOfIntegerType),
+                Literal.NULL
+        };
+
+        Object[] evaluate = function.evaluate(inputs);
+        assertThat(evaluate, is(new Object[]{22, 33, 44}));
+    }
+
+    @Test
+    public void testZeroArguments() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("array_difference function requires 2 arguments");
+        assertEval(null);
+    }
+
+    @Test
+    public void testOneArgument() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("array_difference function requires 2 arguments");
+        assertEval(null,
+                Literal.newLiteral(new Object[]{1}, arrayOfIntegerType));
+    }
+
+    @Test
+    public void testDifferentBuConvertableInnerTypes() throws Exception {
+        assertEval(new Object[]{},
+                Literal.newLiteral(new Object[]{1},  arrayOfIntegerType),
+                Literal.newLiteral(new Object[]{1L}, arrayOfLongType));
+    }
+
+    @Test
+    public void testConvertNonNumericStringToNumber() throws Exception {
+        expectedException.expect(NumberFormatException.class);
+        assertEval(
+                null,
+                Literal.newLiteral(new Object[]{1},              arrayOfIntegerType),
+                Literal.newLiteral(new Object[]{"foo","bar"},    arrayOfStringType));
+    }
+
+    @Test
+    public void testDifferentUnconvertableInnerTypes() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Second argument's inner type (ip) of the array_difference function cannot be converted to the first argument's inner type (boolean)");
+        assertEval(
+                null,
+                Literal.newLiteral(new Object[]{true},                       arrayOfBooleanType),
+                Literal.newLiteral(new Object[]{new BytesRef("127.0.0.1")},  arrayOfIpType));
+
+    }
+
+    @Test
+    public void testNullElements() throws Exception {
+        assertEval(
+                new Object[]{1},
+                Literal.newLiteral(new Object[]{1,null,3},  arrayOfIntegerType),
+                Literal.newLiteral(new Object[]{null, 2,3}, arrayOfIntegerType));
+        assertEval(
+                new Object[]{1, null, 2, null},
+                Literal.newLiteral(new Object[]{1, null, 3, 2, null},  arrayOfIntegerType),
+                Literal.newLiteral(new Object[]{3},                    arrayOfIntegerType));
+    }
+
+    @Test
+    public void testTwoIntegerArguments() throws Exception {
+        assertEval(
+                new Object[]{1},
+                Literal.newLiteral(new Object[]{1,2}, arrayOfIntegerType),
+                Literal.newLiteral(new Object[]{2,3}, arrayOfIntegerType));
+    }
+
+    @Test
+    public void testTwoLongArguments() throws Exception {
+        assertEval(
+                new Object[]{44L},
+                Literal.newLiteral(new Object[]{44L, 55L}, arrayOfLongType),
+                Literal.newLiteral(new Object[]{55L, 66L}, arrayOfLongType));
+    }
+
+    @Test
+    public void testTwoStringArguments() throws Exception {
+        assertEval(
+                new Object[]{new BytesRef("foo")},
+                Literal.newLiteral(new Object[]{"foo","bar"}, arrayOfStringType),
+                Literal.newLiteral(new Object[]{"bar","baz"}, arrayOfStringType));
+    }
+
+    @Test
+    public void testEmptyArrayAndIntegerArray() throws Exception {
+        assertEval(
+                new Object[]{},
+                Literal.newLiteral(new Object[]{},    arrayOfUndefinedType),
+                Literal.newLiteral(new Object[]{1,2}, arrayOfIntegerType));
+    }
+
+    @Test
+    public void testEmptyArrays() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("One of the arguments of the array_difference function can be of undefined inner type, but not both");
+        assertEval(null,
+                Literal.newLiteral(new Object[]{}, arrayOfUndefinedType),
+                Literal.newLiteral(new Object[]{}, arrayOfUndefinedType));
+    }
+}

--- a/sql/src/test/java/io/crate/operation/scalar/ArrayUniqueFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/ArrayUniqueFunctionTest.java
@@ -1,0 +1,221 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.operation.scalar;
+
+import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.Scalar;
+import io.crate.operation.Input;
+import io.crate.planner.symbol.Function;
+import io.crate.planner.symbol.Literal;
+import io.crate.planner.symbol.Symbol;
+import io.crate.testing.TestingHelpers;
+import io.crate.types.ArrayType;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+import org.apache.lucene.util.BytesRef;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.Matchers.is;
+
+public class ArrayUniqueFunctionTest extends AbstractScalarFunctionsTest {
+
+    private static final ArrayType arrayOfIntegerType    = new ArrayType(DataTypes.INTEGER);
+    private static final ArrayType arrayOfLongType       = new ArrayType(DataTypes.LONG);
+    private static final ArrayType arrayOfStringType     = new ArrayType(DataTypes.STRING);
+    private static final ArrayType arrayOfBooleanType    = new ArrayType(DataTypes.BOOLEAN);
+    private static final ArrayType arrayOfIpType         = new ArrayType(DataTypes.IP);
+    private static final ArrayType arrayOfUndefinedType  = new ArrayType(DataTypes.UNDEFINED);
+
+    private ArrayUniqueFunction getFunction(ArrayType... args) {
+        List<DataType> argumentTypes = new ArrayList<>(args.length);
+        for (int i = 0; i < args.length; i++) {
+            argumentTypes.add(args[i]);
+        }
+        ArrayUniqueFunction function = ((ArrayUniqueFunction) functions.get(new FunctionIdent(ArrayUniqueFunction.NAME, argumentTypes)));
+        return function;
+    }
+
+    private void assertEval(Object[] expected, Literal ... args) {
+        List<DataType> argumentTypes = new ArrayList<>(args.length);
+        Input[] inputs = new Input[args.length];
+        for (int i = 0; i < args.length; i++) {
+            inputs[i] = args[i];
+            argumentTypes.add(args[i].valueType());
+        }
+        Scalar scalar = ((Scalar) functions.get(new FunctionIdent(ArrayUniqueFunction.NAME, argumentTypes)));
+        Object[] evaluate = (Object[]) scalar.evaluate(inputs);
+        assertThat(evaluate, is(expected));
+    }
+
+    @Test
+    public void testNormalizeWithValueSymbols() throws Exception {
+        ArrayUniqueFunction function = getFunction(arrayOfIntegerType, arrayOfIntegerType);
+
+        Symbol symbol = function.normalizeSymbol(new Function(function.info(), Arrays.<Symbol>asList(
+                Literal.newLiteral(new Integer[]{10, 20}, arrayOfIntegerType),
+                Literal.newLiteral(new Integer[]{10, 30}, arrayOfIntegerType)
+        )));
+
+        TestingHelpers.assertLiteralSymbol(symbol, new Integer[]{10, 20, 30}, arrayOfIntegerType);
+    }
+
+    @Test
+    public void testNormalizeWithRefs() throws Exception {
+        ArrayUniqueFunction function = getFunction(arrayOfIntegerType, arrayOfIntegerType);
+
+        Function functionSymbol = new Function(function.info(), Arrays.<Symbol>asList(
+                TestingHelpers.createReference("foo", arrayOfIntegerType),
+                Literal.newLiteral(new Integer[]{10, 30}, arrayOfIntegerType)
+        ));
+        Function symbol = (Function) function.normalizeSymbol(functionSymbol);
+        assertThat(symbol, Matchers.sameInstance(functionSymbol));
+    }
+
+    @Test
+    public void testNullArguments() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Argument 2 of the array_unique function cannot be converted to array");
+        assertEval(null, Literal.newLiteral(new Object[]{1}, arrayOfIntegerType), Literal.NULL);
+    }
+
+    @Test
+    public void testNullArgumentsWithoutCheckingForArrays() throws Exception {
+        ArrayUniqueFunction function = getFunction(arrayOfIntegerType, arrayOfIntegerType);
+
+        Input[] inputs = new Input[]{
+                null,
+                Literal.NULL
+        };
+
+        Object[] expected = new Object[]{};
+        Object[] evaluate = function.evaluate(inputs);
+        assertThat(evaluate, is(expected));
+    }
+
+    @Test
+    public void testZeroArguments() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("array_unique function requires one or two arguments");
+        assertEval(null);
+    }
+
+    @Test
+    public void testOneArgument() throws Exception {
+        assertEval(
+                new Object[]{new BytesRef("foo"), new BytesRef("bar"), new BytesRef("baz")},
+                Literal.newLiteral(new Object[]{"foo", "bar", "baz", "baz"}, arrayOfStringType));
+    }
+
+    @Test
+    public void testDifferentButConvertableInnerTypes() throws Exception {
+       assertEval(
+                new Object[]{1},
+                Literal.newLiteral(new Object[]{1},  arrayOfIntegerType),
+                Literal.newLiteral(new Object[]{1L}, arrayOfLongType));
+    }
+
+    @Test
+    public void testConvertNonNumericStringToNumber() throws Exception {
+        expectedException.expect(NumberFormatException.class);
+        assertEval(
+                null,
+                Literal.newLiteral(new Object[]{1},              arrayOfIntegerType),
+                Literal.newLiteral(new Object[]{"foo","bar"},    arrayOfStringType));
+    }
+
+    @Test
+    public void testDifferentUnconvertableInnerTypes() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Second argument's inner type (ip) of the array_unique function cannot be converted to the first argument's inner type (boolean)");
+        assertEval(
+                null,
+                Literal.newLiteral(new Object[]{true},                       arrayOfBooleanType),
+                Literal.newLiteral(new Object[]{new BytesRef("127.0.0.1")},  arrayOfIpType));
+
+    }
+
+    @Test
+    public void testNullElements() throws Exception {
+        assertEval(
+                new Object[]{1, null, 3, 2},
+                Literal.newLiteral(new Object[]{1, null, 3}, arrayOfIntegerType),
+                Literal.newLiteral(new Object[]{null, 2, 3}, arrayOfIntegerType));
+    }
+
+    @Test
+    public void testTwoIntegerArguments() throws Exception {
+        assertEval(
+                new Object[]{1,2,3},
+                Literal.newLiteral(new Object[]{1,2}, arrayOfIntegerType),
+                Literal.newLiteral(new Object[]{2,3}, arrayOfIntegerType));
+    }
+
+    @Test
+    public void testTwoLongArguments() throws Exception {
+        assertEval(
+                new Object[]{44L, 55L, 66L},
+                Literal.newLiteral(new Object[]{44L, 55L}, arrayOfLongType),
+                Literal.newLiteral(new Object[]{55L, 66L}, arrayOfLongType));
+    }
+
+    @Test
+    public void testTwoStringArguments() throws Exception {
+        assertEval(
+                new Object[]{new BytesRef("foo"),new BytesRef("bar"),new BytesRef("baz")},
+                Literal.newLiteral(new Object[]{"foo","bar"}, arrayOfStringType),
+                Literal.newLiteral(new Object[]{"bar","baz"}, arrayOfStringType));
+    }
+
+    @Test
+    public void testEmptyArrayAndIntegerArray() throws Exception {
+        assertEval(
+                new Object[]{111, 222, 333},
+                Literal.newLiteral(new Object[]{},              arrayOfUndefinedType),
+                Literal.newLiteral(new Object[]{111, 222, 333}, arrayOfIntegerType));
+    }
+
+
+
+    @Test
+    public void testEmptyArrays() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("One of the arguments of the array_unique function can be of undefined inner type, but not both");
+        assertEval(new Object[]{},
+                Literal.newLiteral(new Object[]{}, arrayOfUndefinedType),
+                Literal.newLiteral(new Object[]{}, arrayOfUndefinedType));
+    }
+
+    @Test
+    public void testEmptyArray() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("When used with only one argument, the inner type of the array argument cannot be undefined");
+        assertEval(
+                null,
+                Literal.newLiteral(new Object[]{}, arrayOfUndefinedType));
+    }
+}


### PR DESCRIPTION
Related to issue: support append to array on update (set array_field += new_element) #2566

```
Array Functions
=================

array_merge(first_array, second_array, [ third_array , ... ]) returns array
-------------------------------------------------------------------

The ``array_merge`` function merges one or more arrays into one array

::

    cr> select array_merge([1,2,3],[3,4,5,6],[7,9,10]) from sys.cluster;
    +-------------------------------------------+
    | array_merge([1,2,3], [3,4,5,6], [7,9,10]) |
    +-------------------------------------------+
    | [1, 2, 3, 3, 4, 5, 6, 7, 9, 10]           |
    +-------------------------------------------+
    SELECT 1 row in set (0.004 sec)


It can be used to append elements to array fields

    cr> create table array_merge_example (list array(integer));
    CREATE OK (0.384 sec)
    cr> insert into array_merge_example (list) values ([1,2,3]);
    INSERT OK, 1 row affected (0.303 sec)
    cr> update array_merge_example set list = array_merge(list,[4,5,6]);
    UPDATE OK, 1 row affected (0.372 sec)
    cr> select * from array_merge_example;
    +--------------------+
    | list               |
    +--------------------+
    | [1, 2, 3, 4, 5, 6] |
    +--------------------+
    SELECT 1 row in set (0.037 sec)

array_unique(first_array, [ second_array , ... ]) returns array
-------------------------------------------------------------------

The ``array_unique`` function merges one or more arrays into one array with unique elements

::

    cr> select array_unique([1,2,3],[3,4,5,6],[7,9,10]) from sys.cluster;
    +--------------------------------------------+
    | array_unique([1,2,3], [3,4,5,6], [7,9,10]) |
    +--------------------------------------------+
    | [1, 2, 3, 4, 5, 6, 7, 9, 10]               |
    +--------------------------------------------+
    SELECT 1 row in set (0.007 sec)


It can be used with one argument

    cr> select array_unique([1,2,3,3,4,5,6,7,5,6,9,10]) from sys.cluster;
    +------------------------------------------+
    | array_unique([1,2,3,3,4,5,6,7,5,6,9,10]) |
    +------------------------------------------+
    | [1, 2, 3, 4, 5, 6, 7, 9, 10]             |
    +------------------------------------------+
    SELECT 1 row in set (0.009 sec)

array_subtract(first_array, second_array, [ third_array , ... ]) returns array
-------------------------------------------------------------------

The ``array_subtract`` function subtracts elements from the first array

::

    cr> select array_subtract([1,2,3,4,5,6,7,8,9,10],[2,3],[6,9],[15]) from sys.cluster;
    +------------------------------------------------------------+
    | array_subtract([1,2,3,4,5,6,7,8,9,10], [2,3], [6,9], [15]) |
    +------------------------------------------------------------+
    | [1, 4, 5, 7, 8, 10]                                        |
    +------------------------------------------------------------+
    SELECT 1 row in set (0.009 sec)


It can be used to remove elements from array fields

    cr> insert into array_subtract_example (list) values ([1,2,3,4,5,6,7,8,9,10]);
    INSERT OK, 1 row affected (0.015 sec)
    cr> update array_subtract_example set list = array_subtract(list,[6]);
    UPDATE OK, 1 row affected (0.017 sec)
    cr> select * from array_subtract_example;
    +------------------------------+
    | list                         |
    +------------------------------+
    | [1, 2, 3, 4, 5, 7, 8, 9, 10] |
    +------------------------------+
    SELECT 1 row in set (0.009 sec)
```