### PR TITLE
make use of compile for date_format

### DIFF
--- a/sql/src/main/java/io/crate/operation/scalar/TimestampFormatter.java
+++ b/sql/src/main/java/io/crate/operation/scalar/TimestampFormatter.java
@@ -23,7 +23,6 @@ package io.crate.operation.scalar;
 
 import com.carrotsearch.hppc.CharObjectMap;
 import com.carrotsearch.hppc.CharObjectOpenHashMap;
-import com.google.common.base.Charsets;
 import org.apache.lucene.util.BytesRef;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -41,14 +40,6 @@ public class TimestampFormatter {
     private interface FormatTimestampPartFunction {
         public String format(DateTime timestamp);
     }
-
-    private static final byte[] ST = "st".getBytes(Charsets.UTF_8);
-    private static final byte[] ND = "nd".getBytes(Charsets.UTF_8);
-    private static final byte[] RD = "rd".getBytes(Charsets.UTF_8);
-    private static final byte[] TH = "th".getBytes(Charsets.UTF_8);
-    private static final byte[] AM = "AM".getBytes(Charsets.UTF_8);
-    private static final byte[] PM = "AM".getBytes(Charsets.UTF_8);
-
 
     private final static Locale LOCALE = Locale.ENGLISH;
     private final static CharObjectMap<FormatTimestampPartFunction> PART_FORMATTERS = new CharObjectOpenHashMap<>();

--- a/sql/src/test/java/io/crate/operation/scalar/DateFormatFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/DateFormatFunctionTest.java
@@ -64,10 +64,7 @@ public class DateFormatFunctionTest extends AbstractScalarFunctionsTest {
     
     public Object evaluateForArgs(List<Symbol> args) {
         Function function = createFunction(DateFormatFunction.NAME, DataTypes.STRING, args);
-        Scalar impl = (Scalar)functions.get(function.info().ident());
-        if (randomBoolean()) {
-            impl = impl.compile(function.arguments());
-        }
+        Scalar impl = ((Scalar)functions.get(function.info().ident())).compile(function.arguments());
         Input[] inputs = new Input[args.size()];
         for (int i = 0; i < args.size(); i++) {
             inputs[i] = (Input)args.get(i);

--- a/stresstest/src/test/java/io/crate/benchmark/DateFormatFunctionBench.java
+++ b/stresstest/src/test/java/io/crate/benchmark/DateFormatFunctionBench.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.benchmark;
+
+import com.carrotsearch.junitbenchmarks.BenchmarkOptions;
+import com.carrotsearch.junitbenchmarks.BenchmarkRule;
+import com.google.common.collect.ImmutableList;
+import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.Scalar;
+import io.crate.operation.Input;
+import io.crate.operation.scalar.DateFormatFunction;
+import io.crate.planner.symbol.Literal;
+import io.crate.planner.symbol.Symbol;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+import org.apache.lucene.util.BytesRef;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class DateFormatFunctionBench {
+
+    private static final int BENCHMARK_ROUNDS = 100;
+    private static final int ITERATIONS = 1_000_000;
+
+    @Rule
+    public TestRule benchmarkRun = new BenchmarkRule();
+
+    Scalar<BytesRef, Object> singleArgument;
+    Scalar<BytesRef, Object> twoArgFunction;
+    Scalar<BytesRef, Object> withTimeZone;
+
+    List<Symbol> singleArgs = Collections.<Symbol>singletonList(
+            Literal.newLiteral(DataTypes.TIMESTAMP, 0L)
+    );
+    Input<Object>[] singleArgInputs = singleArgs.toArray(new Input[1]);
+    List<Symbol> twoArgs = Arrays.<Symbol>asList(
+            Literal.newLiteral("%Y-%m-%d &H:%i:%S"),
+            Literal.newLiteral(DataTypes.TIMESTAMP, 0L)
+    );
+    Input<Object>[] twoArgInputs = twoArgs.toArray(new Input[2]);
+    List<Symbol> threeArgs = Arrays.<Symbol>asList(
+            Literal.newLiteral("%Y-%m-%d &H:%i:%S"),
+            Literal.newLiteral("Europe/Rome"),
+            Literal.newLiteral(DataTypes.TIMESTAMP, 0L)
+    );
+    Input<Object>[] threeArgInputs = threeArgs.toArray(new Input[3]);
+
+
+    @Before
+    public void prepare() {
+        singleArgument = new DateFormatFunction(new FunctionInfo(
+                new FunctionIdent(DateFormatFunction.NAME, ImmutableList.<DataType>of(DataTypes.TIMESTAMP)),
+                DataTypes.STRING,
+                FunctionInfo.Type.SCALAR,
+                true
+        )).compile(singleArgs);
+        twoArgFunction = new DateFormatFunction(new FunctionInfo(
+                new FunctionIdent(DateFormatFunction.NAME, ImmutableList.<DataType>of(DataTypes.STRING, DataTypes.TIMESTAMP)),
+                DataTypes.STRING,
+                FunctionInfo.Type.SCALAR,
+                true
+        )).compile(twoArgs);
+        withTimeZone = new DateFormatFunction(new FunctionInfo(
+                new FunctionIdent(DateFormatFunction.NAME, ImmutableList.<DataType>of(DataTypes.STRING, DataTypes.STRING, DataTypes.TIMESTAMP)),
+                DataTypes.STRING,
+                FunctionInfo.Type.SCALAR,
+                true
+        )).compile(threeArgs);
+    }
+
+    @BenchmarkOptions(benchmarkRounds = BENCHMARK_ROUNDS, warmupRounds = 10)
+    @Test
+    public void testDateFormatSingleArg() throws Exception {
+        for (int i = 0; i < ITERATIONS; i++) {
+            singleArgument.evaluate(singleArgInputs);
+        }
+    }
+
+    @BenchmarkOptions(benchmarkRounds = BENCHMARK_ROUNDS, warmupRounds = 10)
+    @Test
+    public void testDateFormatTwoArgs() throws Exception {
+        for (int i = 0; i < ITERATIONS; i++) {
+            twoArgFunction.evaluate(twoArgInputs);
+        }
+    }
+
+    @BenchmarkOptions(benchmarkRounds = BENCHMARK_ROUNDS, warmupRounds = 10)
+    @Test
+    public void testDateFormatThreeArgs() throws Exception {
+        for (int i = 0; i < ITERATIONS; i++) {
+            withTimeZone.evaluate(threeArgInputs);
+        }
+    }
+}


### PR DESCRIPTION
unfortunately it doesn't speed up execution:

### COMPILE

```
DateFormatFunctionBench.testDateFormatTwoArgs: [measured 100 out of 110 rounds, threads: 1 (sequential)]
 round: 0.06 [+- 0.01], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 30, GC.time: 0.02, time.total: 7.25, time.warmup: 1.03, time.bench: 6.22
DateFormatFunctionBench.testDateFormatThreeArgs: [measured 100 out of 110 rounds, threads: 1 (sequential)]
 round: 0.07 [+- 0.00], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 126, GC.time: 0.06, time.total: 7.22, time.warmup: 0.69, time.bench: 6.53
DateFormatFunctionBench.testDateFormatSingleArg: [measured 100 out of 110 rounds, threads: 1 (sequential)]
 round: 0.08 [+- 0.00], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 160, GC.time: 0.08, time.total: 9.01, time.warmup: 0.82, time.bench: 8.19

DateFormatFunctionBench.testDateFormatTwoArgs: [measured 100 out of 110 rounds, threads: 1 (sequential)]
 round: 0.62 [+- 0.01], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 1265, GC.time: 0.58, time.total: 68.81, time.warmup: 6.62, time.bench: 62.19
DateFormatFunctionBench.testDateFormatThreeArgs: [measured 100 out of 110 rounds, threads: 1 (sequential)]
 round: 0.67 [+- 0.03], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 1355, GC.time: 0.63, time.total: 74.01, time.warmup: 6.67, time.bench: 67.34
DateFormatFunctionBench.testDateFormatSingleArg: [measured 100 out of 110 rounds, threads: 1 (sequential)]
 round: 0.81 [+- 0.01], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 1541, GC.time: 0.75, time.total: 89.59, time.warmup: 8.21, time.bench: 81.38
```

### MASTER

```
DateFormatFunctionBench.testDateFormatTwoArgs: [measured 100 out of 110 rounds, threads: 1 (sequential)]
 round: 0.06 [+- 0.01], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 30, GC.time: 0.02, time.total: 7.24, time.warmup: 1.06, time.bench: 6.18
DateFormatFunctionBench.testDateFormatThreeArgs: [measured 100 out of 110 rounds, threads: 1 (sequential)]
 round: 0.07 [+- 0.00], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 123, GC.time: 0.06, time.total: 7.41, time.warmup: 0.71, time.bench: 6.70
DateFormatFunctionBench.testDateFormatSingleArg: [measured 100 out of 110 rounds, threads: 1 (sequential)]
 round: 0.08 [+- 0.00], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 164, GC.time: 0.08, time.total: 9.09, time.warmup: 0.83, time.bench: 8.26
 
DateFormatFunctionBench.testDateFormatTwoArgs: [measured 100 out of 110 rounds, threads: 1 (sequential)]
 round: 0.62 [+- 0.01], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 1194, GC.time: 0.56, time.total: 68.52, time.warmup: 6.60, time.bench: 61.92
DateFormatFunctionBench.testDateFormatThreeArgs: [measured 100 out of 110 rounds, threads: 1 (sequential)]
 round: 0.68 [+- 0.01], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 1278, GC.time: 0.63, time.total: 74.66, time.warmup: 6.89, time.bench: 67.77
DateFormatFunctionBench.testDateFormatSingleArg: [measured 100 out of 110 rounds, threads: 1 (sequential)]
 round: 0.82 [+- 0.02], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 1451, GC.time: 0.75, time.total: 89.80, time.warmup: 8.10, time.bench: 81.70
```