### PR TITLE
fix possible deadlock in NestedLoopOperation

### DIFF
--- a/sql/src/main/java/io/crate/operation/join/NestedLoopOperation.java
+++ b/sql/src/main/java/io/crate/operation/join/NestedLoopOperation.java
@@ -198,8 +198,8 @@ public class NestedLoopOperation implements RowUpstream {
                 case LEAD_ELECTION:
                     if (leadAcquired.compareAndSet(false, true)) {
                         lastRow = row;
-                        state.set(State.PAUSED);
                         upstream.pause();
+                        state.set(State.PAUSED);
                         return true;
                     } else {
                         rightState = waitForStateChange(right.state);
@@ -214,15 +214,15 @@ public class NestedLoopOperation implements RowUpstream {
             switch (rightState) {
                 case PAUSED:
                     lastRow = row;
-                    state.set(State.PAUSED);
                     upstream.pause();
+                    state.set(State.PAUSED);
                     return right.resume(rightState);
                 case FINISHED:
                     //noinspection SimplifiableIfStatement
                     if (right.receivedRows && downstreamWantsMore) {
                         lastRow = row;
-                        state.set(State.PAUSED);
                         upstream.pause();
+                        state.set(State.PAUSED);
                         return right.resume(rightState);
                     }
                     return false;
@@ -277,9 +277,9 @@ public class NestedLoopOperation implements RowUpstream {
             switch (leftState) {
                 case LEAD_ELECTION:
                     if (leadAcquired.compareAndSet(false, true)) {
-                        state.set(State.PAUSED);
                         lastRow = rightRow;
                         upstream.pause();
+                        state.set(State.PAUSED);
                         return true;
                     } else {
                         return handlePauseOrFinished(rightRow, waitForStateChange(left.state));


### PR DESCRIPTION
the state was changed before upstream.pause() was called which could cause the
other side to call resume BEFORE the upstream.pause() call was made which
would cause the resume to become a noop and the NL operation to become
deadlocked.