### PR TITLE
include subContexts values in JobExecutionContext toString

### DIFF
--- a/sql/src/main/java/io/crate/jobs/JobExecutionContext.java
+++ b/sql/src/main/java/io/crate/jobs/JobExecutionContext.java
@@ -237,8 +237,8 @@ public class JobExecutionContext implements KeepAliveListener {
     @Override
     public String toString() {
         return "JobExecutionContext{" +
-                "jobId=" + jobId +
-                ", activeSubContexts=" + numSubContexts.get() +
+                "id=" + jobId +
+                ", subContexts=" + subContexts.values() +
                 ", closed=" + closed +
                 '}';
     }

--- a/sql/src/main/java/io/crate/operation/collect/JobCollectContext.java
+++ b/sql/src/main/java/io/crate/operation/collect/JobCollectContext.java
@@ -28,10 +28,10 @@ import com.google.common.util.concurrent.Futures;
 import io.crate.action.job.SharedShardContexts;
 import io.crate.action.sql.query.CrateSearchContext;
 import io.crate.breaker.RamAccountingContext;
-import io.crate.operation.projectors.ListenableRowReceiver;
-import io.crate.jobs.ExecutionState;
 import io.crate.jobs.AbstractExecutionSubContext;
+import io.crate.jobs.ExecutionState;
 import io.crate.jobs.KeepAliveListener;
+import io.crate.operation.projectors.ListenableRowReceiver;
 import io.crate.operation.projectors.RowReceiver;
 import io.crate.operation.projectors.RowReceivers;
 import io.crate.planner.node.dql.CollectPhase;
@@ -40,7 +40,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Locale;
-import java.util.concurrent.CancellationException;
 
 public class JobCollectContext extends AbstractExecutionSubContext implements ExecutionState {
 
@@ -151,7 +150,6 @@ public class JobCollectContext extends AbstractExecutionSubContext implements Ex
         return "JobCollectContext{" +
                 "searchContexts=" + searchContexts +
                 ", closed=" + future.closed() +
-                ", keepAliveListener=" + keepAliveListener +
                 '}';
     }
 


### PR DESCRIPTION
We use the toString() on the JobExecutionContex to debug errors if a context
hasn't been removed. For that case it is crucial to include the subContexts so
that we can see which subContext got stuck.

Removed the keepAliveListener from the JobCollectContext toString() because it
is actually the JobExecutionContext and it would cause an infinite recursion.