### PR TITLE
remove repeat requirement from left side of the NestedLoopOperation

### DIFF
--- a/sql/src/main/java/io/crate/operation/join/NestedLoopOperation.java
+++ b/sql/src/main/java/io/crate/operation/join/NestedLoopOperation.java
@@ -245,7 +245,7 @@ public class NestedLoopOperation implements RowUpstream {
 
         @Override
         public Set<Requirement> requirements() {
-            return Requirements.add(downstream.requirements(), Requirement.REPEAT);
+            return downstream.requirements();
         }
     }
 


### PR DESCRIPTION
this was just there because the old SortingRowMerger had a race condition
where it would send rows even though it was paused.