### PR TITLE
Fix: Querying the information_schema caused a NPE if

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fix: Querying the information_schema caused a NPE if there was an orphaned partition
+
  - Fix: Order by ``_raw`` and/or ``_id`` did not work.
 
  - Upgraded Elasticsearch to 1.7.2

--- a/sql/src/main/java/io/crate/metadata/doc/DocSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/doc/DocSchemaInfo.java
@@ -33,7 +33,6 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.Iterators;
-import com.google.common.collect.Lists;
 import com.google.common.collect.UnmodifiableIterator;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.crate.blob.v2.BlobIndices;
@@ -169,12 +168,7 @@ public class DocSchemaInfo implements SchemaInfo, ClusterStateListener {
                     return null;
                 }
                 if (PartitionName.isPartition(input)) {
-                    PartitionName partitionName = PartitionName.fromIndexOrTemplate(input);
-                    if (partitionName.schema().equals(schemaName)) {
-                        return partitionName.tableName();
-                    } else {
-                        return null;
-                    }
+                    return null;
                 }
                 return input;
             }

--- a/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -1009,7 +1009,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
         ensureGreen();
         execute("select table_name from information_schema.tables where 'date' = ANY (partitioned_by)");
         assertThat(response.rowCount(), is(1L));
-        assertThat((String)response.rows()[0][0], is("any1"));
+        assertThat((String) response.rows()[0][0], is("any1"));
     }
 
     @Test
@@ -1056,7 +1056,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
                 "where schema_name ~ '[a-z]+o[a-z]' order by schema_name");
         assertThat(response.rowCount(), is(2L));
         assertThat((String)response.rows()[0][0], is("blob"));
-        assertThat((String)response.rows()[1][0], is("doc"));
+        assertThat((String) response.rows()[1][0], is("doc"));
     }
 
     @Test
@@ -1071,5 +1071,12 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
         execute("select * from information_schema.schemata order by schema_name asc");
         assertThat(response.rowCount(), is(4L));
         assertThat(TestingHelpers.getColumn(response.rows(), 0), is(Matchers.<Object>arrayContaining("blob", "doc", "information_schema", "sys")));
+    }
+
+    @Test
+    public void testOrphanedPartition() throws Exception {
+        prepareCreate(".partitioned.foo.04138").execute().get();
+        execute("select table_name from information_schema.tables where schema_name='doc'");
+        assertThat(response.rowCount(), is(0L));
     }
 }


### PR DESCRIPTION
there was an orphaned partition