### PR TITLE
fix TopRowUpstream race condition which can lead to a deadlock

### DIFF
--- a/sql/src/main/java/io/crate/operation/collect/collectors/TopRowUpstream.java
+++ b/sql/src/main/java/io/crate/operation/collect/collectors/TopRowUpstream.java
@@ -87,7 +87,12 @@ public class TopRowUpstream implements RowUpstream, ExecutionState {
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }
-            return true;
+            // double check after lock has been acquired. Resume could have changed pendingPause before the lock was acquired
+            if (pendingPause) {
+                return true;
+            } else {
+                pauseLock.unlock();
+            }
         }
         return false;
     }


### PR DESCRIPTION
follow up to e0fd62cdddca140316ec66c5384f4881240b3df4 which didn't fix the
deadlock completely