### PR TITLE
BulkRetryCoordinator: remove InterruptedException from releaseWriteLock

### DIFF
--- a/sql/src/main/java/org/elasticsearch/action/bulk/BulkRetryCoordinator.java
+++ b/sql/src/main/java/org/elasticsearch/action/bulk/BulkRetryCoordinator.java
@@ -128,11 +128,7 @@ public class BulkRetryCoordinator {
         @Override
         public void onResponse(Response response) {
             currentDelay.set(0);
-            try {
-                retryLock.releaseWriteLock();
-            } catch (InterruptedException e) {
-                Thread.interrupted();
-            }
+            retryLock.releaseWriteLock();
             listener.onResponse(response);
         }
 
@@ -167,7 +163,7 @@ public class BulkRetryCoordinator {
             writeLock.acquire();
         }
 
-        public void releaseWriteLock() throws InterruptedException {
+        public void releaseWriteLock() {
             if (activeWriters.decrementAndGet() == 0) {
                 // unlock all readers
                 readLock.release(waitingReaders.getAndSet(0)+1);

--- a/sql/src/main/java/org/elasticsearch/action/bulk/SymbolBasedBulkShardProcessor.java
+++ b/sql/src/main/java/org/elasticsearch/action/bulk/SymbolBasedBulkShardProcessor.java
@@ -468,11 +468,7 @@ public class SymbolBasedBulkShardProcessor<Request extends BulkProcessorRequest,
         } else {
             if (repeatingRetry) {
                 // release failed retry
-                try {
-                    coordinator.retryLock().releaseWriteLock();
-                } catch (InterruptedException ex) {
-                    Thread.interrupted();
-                }
+                coordinator.retryLock().releaseWriteLock();
             }
             for (IntCursor intCursor : request.itemIndices()) {
                 synchronized (responsesLock) {


### PR DESCRIPTION
release() on a Semaphore can't cause an InterruptedException.