### PR TITLE
fixed SHOW CREATE TABLE statement if nested objects exists

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,10 @@ Changes for Crate
 
 Unreleased
 ==========
- 
+
+ - Fixed a bug in SHOW CREATE TABLE statement that leads to a wrong table 
+   schema if the table contains nested objects
+
  - Fixed an issue that causes a ClosedChannelException during BLOB download
 
  - Fix: Prevent NPE in COPY FROM and INSERT FROM SUBQUERY queries

--- a/sql/src/main/java/io/crate/analyze/MetaDataToASTNodeResolver.java
+++ b/sql/src/main/java/io/crate/analyze/MetaDataToASTNodeResolver.java
@@ -69,6 +69,9 @@ public class MetaDataToASTNodeResolver {
                 if (ident.isSystemColumn()) continue;
                 if (parent != null && !ident.isChildOf(parent)) continue;
                 if (parent == null && !ident.path().isEmpty()) continue;
+                if (parent != null) {
+                    if (ident.getParent().compareTo(parent) > 0) continue;
+                }
 
                 ColumnType columnType = null;
                 if (info.type().equals(DataTypes.OBJECT)) {

--- a/sql/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -86,7 +86,7 @@ public class ShowIntegrationTest extends SQLTransportIntegrationTest {
                 " col_arr_obj_a array(object)," +
                 " col_arr_obj_b array(object(strict) as (id int))," +
                 " col_obj_a object," +
-                " col_obj_b object(dynamic) as (arr array(integer), obj object)" +
+                " col_obj_b object(dynamic) as (arr array(integer), obj object(strict) as (id int, name string))" +
                 ")");
         execute("show create table test");
         assertRow("CREATE TABLE IF NOT EXISTS \"doc\".\"test\" (\n" +
@@ -98,7 +98,10 @@ public class ShowIntegrationTest extends SQLTransportIntegrationTest {
                 "   \"col_obj_a\" OBJECT (DYNAMIC),\n" +
                 "   \"col_obj_b\" OBJECT (DYNAMIC) AS (\n" +
                 "      \"arr\" ARRAY(INTEGER),\n" +
-                "      \"obj\" OBJECT (DYNAMIC)\n" +
+                "      \"obj\" OBJECT (STRICT) AS (\n" +
+                "         \"id\" INTEGER,\n" +
+                "         \"name\" STRING\n" +
+                "      )\n" +
                 "   )\n" +
                 ")\n");
 


### PR DESCRIPTION
Fixed a bug in SHOW CREATE TABLE statement that leads to a wrong table
schema if the table contains nested objects