### PR TITLE
fixed a race condition in bulk index creation

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,8 +5,12 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed a race condition that could cause the re-creation of an already
+   existing table partition and therefore potential dataloss when creating
+   a lot of partitions simultaniously using COPY FROM or bulk inserts.
+
  - Fixed a race condition that could cause COPY FROM operations to get stuck if
-   shards were to be relocated. 
+   shards were to be relocated.
 
  - Throw an exception when someone attempts to change non-runtime changeable
    settings

--- a/sql/src/main/java/org/elasticsearch/action/admin/indices/create/TransportBulkCreateIndicesAction.java
+++ b/sql/src/main/java/org/elasticsearch/action/admin/indices/create/TransportBulkCreateIndicesAction.java
@@ -337,6 +337,128 @@ public class TransportBulkCreateIndicesAction
         return b;
     }
 
+    protected ClusterState executeCreateIndices(ClusterState currentState,
+                                                BulkCreateIndicesRequest request) throws Exception {
+        /**
+         * This code is more or less the same as the stuff in {@link MetaDataCreateIndexService}
+         * but optimized for bulk operation without separate mapping/alias/index settings.
+         */
+
+        List<String> indicesToCreate = new ArrayList<>(request.indices().size());
+        String removalReason = null;
+        String testIndex = null;
+        try {
+            validateAndFilterExistingIndices(currentState, indicesToCreate, request);
+            if (indicesToCreate.isEmpty()) {
+                return currentState;
+            }
+
+            Map<String, IndexMetaData.Custom> customs = Maps.newHashMap();
+            Map<String, Map<String, Object>> mappings = Maps.newHashMap();
+            Map<String, AliasMetaData> templatesAliases = Maps.newHashMap();
+            List<String> templateNames = Lists.newArrayList();
+
+            List<IndexTemplateMetaData> templates = findTemplates(request, currentState, indexTemplateFilter);
+            applyTemplates(customs, mappings, templatesAliases, templateNames, templates);
+            File mappingsDir = new File(environment.configFile(), "mappings");
+            if (mappingsDir.isDirectory()) {
+                addMappingFromMappingsFile(mappings, mappingsDir, request);
+            }
+
+            Settings indexSettings = createIndexSettings(currentState, templates);
+
+            testIndex = indicesToCreate.get(0);
+            indicesService.createIndex(testIndex, indexSettings, clusterService.localNode().id());
+
+            // now add the mappings
+            IndexService indexService = indicesService.indexServiceSafe(testIndex);
+            MapperService mapperService = indexService.mapperService();
+            // first, add the default mapping
+            if (mappings.containsKey(MapperService.DEFAULT_MAPPING)) {
+                try {
+                    mapperService.merge(MapperService.DEFAULT_MAPPING, new CompressedString(XContentFactory.jsonBuilder().map(mappings.get(MapperService.DEFAULT_MAPPING)).string()), false);
+                } catch (Exception e) {
+                    removalReason = "failed on parsing default mapping on index creation";
+                    throw new MapperParsingException("mapping [" + MapperService.DEFAULT_MAPPING + "]", e);
+                }
+            }
+            for (Map.Entry<String, Map<String, Object>> entry : mappings.entrySet()) {
+                if (entry.getKey().equals(MapperService.DEFAULT_MAPPING)) {
+                    continue;
+                }
+                try {
+                    // apply the default here, its the first time we parse it
+                    mapperService.merge(entry.getKey(), new CompressedString(XContentFactory.jsonBuilder().map(entry.getValue()).string()), true);
+                } catch (Exception e) {
+                    removalReason = "failed on parsing mappings on index creation";
+                    throw new MapperParsingException("mapping [" + entry.getKey() + "]", e);
+                }
+            }
+
+            IndexQueryParserService indexQueryParserService = indexService.queryParserService();
+            for (AliasMetaData aliasMetaData : templatesAliases.values()) {
+                if (aliasMetaData.filter() != null) {
+                    aliasValidator.validateAliasFilter(aliasMetaData.alias(), aliasMetaData.filter().uncompressed(), indexQueryParserService);
+                }
+            }
+
+            // now, update the mappings with the actual source
+            Map<String, MappingMetaData> mappingsMetaData = Maps.newHashMap();
+            for (DocumentMapper mapper : mapperService.docMappers(true)) {
+                MappingMetaData mappingMd = new MappingMetaData(mapper);
+                mappingsMetaData.put(mapper.type(), mappingMd);
+            }
+
+            MetaData.Builder newMetaDataBuilder = MetaData.builder(currentState.metaData());
+            for (String index : indicesToCreate) {
+                final IndexMetaData.Builder indexMetaDataBuilder =
+                        IndexMetaData.builder(index).settings(indexSettings);
+
+                for (MappingMetaData mappingMd : mappingsMetaData.values()) {
+                    indexMetaDataBuilder.putMapping(mappingMd);
+                }
+                for (AliasMetaData aliasMetaData : templatesAliases.values()) {
+                    indexMetaDataBuilder.putAlias(aliasMetaData);
+                }
+                for (Map.Entry<String, IndexMetaData.Custom> customEntry : customs.entrySet()) {
+                    indexMetaDataBuilder.putCustom(customEntry.getKey(), customEntry.getValue());
+                }
+                indexMetaDataBuilder.state(IndexMetaData.State.OPEN);
+
+                final IndexMetaData indexMetaData;
+                try {
+                    indexMetaData = indexMetaDataBuilder.build();
+                } catch (Exception e) {
+                    removalReason = "failed to build index metadata";
+                    throw e;
+                }
+                logger.info("[{}] creating index, cause [bulk], templates {}, shards [{}]/[{}], mappings {}",
+                        index, templateNames, indexMetaData.numberOfShards(), indexMetaData.numberOfReplicas(), mappings.keySet());
+
+                indexService.indicesLifecycle().beforeIndexAddedToCluster(new Index(index), indexMetaData.settings());
+                newMetaDataBuilder.put(indexMetaData, false);
+            }
+            MetaData newMetaData = newMetaDataBuilder.build();
+
+            ClusterState updatedState = ClusterState.builder(currentState).metaData(newMetaData).build();
+            RoutingTable.Builder routingTableBuilder = RoutingTable.builder(updatedState.routingTable());
+            for (String index : indicesToCreate) {
+                routingTableBuilder.addAsNew(updatedState.metaData().index(index));
+            }
+            RoutingAllocation.Result routingResult = allocationService.reroute(
+                    ClusterState.builder(updatedState).routingTable(routingTableBuilder).build());
+            updatedState = ClusterState.builder(updatedState).routingResult(routingResult).build();
+
+            removalReason = "cleaning up after validating index on master";
+            return updatedState;
+        } finally {
+            if (testIndex != null) {
+                // index was partially created - need to clean up
+                indicesService.deleteIndex(testIndex, removalReason != null ? removalReason : "failed to create index");
+            }
+        }
+    }
+
     private void createIndices(final BulkCreateIndicesRequest request,
                                final Map<Semaphore, Collection<String>> lockedIndices,
                                ActionListener<ClusterStateUpdateResponse> listener) {
@@ -368,124 +490,7 @@ public class TransportBulkCreateIndicesAction
 
             @Override
             public ClusterState execute(ClusterState currentState) throws Exception {
-                /**
-                 * This code is more or less the same as the stuff in {@link MetaDataCreateIndexService}
-                 * but optimized for bulk operation without separate mapping/alias/index settings.
-                 */
-
-                List<String> indicesToCreate = new ArrayList<>(request.indices().size());
-                String removalReason = null;
-                String testIndex = null;
-                try {
-                    validateAndFilterExistingIndices(currentState, indicesToCreate, request);
-                    if (indicesToCreate.isEmpty()) {
-                        return currentState;
-                    }
-
-                    Map<String, IndexMetaData.Custom> customs = Maps.newHashMap();
-                    Map<String, Map<String, Object>> mappings = Maps.newHashMap();
-                    Map<String, AliasMetaData> templatesAliases = Maps.newHashMap();
-                    List<String> templateNames = Lists.newArrayList();
-
-                    List<IndexTemplateMetaData> templates = findTemplates(request, currentState, indexTemplateFilter);
-                    applyTemplates(customs, mappings, templatesAliases, templateNames, templates);
-                    File mappingsDir = new File(environment.configFile(), "mappings");
-                    if (mappingsDir.isDirectory()) {
-                        addMappingFromMappingsFile(mappings, mappingsDir, request);
-                    }
-
-                    Settings indexSettings = createIndexSettings(currentState, templates);
-
-                    testIndex = indicesToCreate.get(0);
-                    indicesService.createIndex(testIndex, indexSettings, clusterService.localNode().id());
-
-                    // now add the mappings
-                    IndexService indexService = indicesService.indexServiceSafe(testIndex);
-                    MapperService mapperService = indexService.mapperService();
-                    // first, add the default mapping
-                    if (mappings.containsKey(MapperService.DEFAULT_MAPPING)) {
-                        try {
-                            mapperService.merge(MapperService.DEFAULT_MAPPING, new CompressedString(XContentFactory.jsonBuilder().map(mappings.get(MapperService.DEFAULT_MAPPING)).string()), false);
-                        } catch (Exception e) {
-                            removalReason = "failed on parsing default mapping on index creation";
-                            throw new MapperParsingException("mapping [" + MapperService.DEFAULT_MAPPING + "]", e);
-                        }
-                    }
-                    for (Map.Entry<String, Map<String, Object>> entry : mappings.entrySet()) {
-                        if (entry.getKey().equals(MapperService.DEFAULT_MAPPING)) {
-                            continue;
-                        }
-                        try {
-                            // apply the default here, its the first time we parse it
-                            mapperService.merge(entry.getKey(), new CompressedString(XContentFactory.jsonBuilder().map(entry.getValue()).string()), true);
-                        } catch (Exception e) {
-                            removalReason = "failed on parsing mappings on index creation";
-                            throw new MapperParsingException("mapping [" + entry.getKey() + "]", e);
-                        }
-                    }
-
-                    IndexQueryParserService indexQueryParserService = indexService.queryParserService();
-                    for (AliasMetaData aliasMetaData : templatesAliases.values()) {
-                        if (aliasMetaData.filter() != null) {
-                            aliasValidator.validateAliasFilter(aliasMetaData.alias(), aliasMetaData.filter().uncompressed(), indexQueryParserService);
-                        }
-                    }
-
-                    // now, update the mappings with the actual source
-                    Map<String, MappingMetaData> mappingsMetaData = Maps.newHashMap();
-                    for (DocumentMapper mapper : mapperService.docMappers(true)) {
-                        MappingMetaData mappingMd = new MappingMetaData(mapper);
-                        mappingsMetaData.put(mapper.type(), mappingMd);
-                    }
-
-                    MetaData.Builder newMetaDataBuilder = MetaData.builder(currentState.metaData());
-                    for (String index : indicesToCreate) {
-                        final IndexMetaData.Builder indexMetaDataBuilder =
-                                IndexMetaData.builder(index).settings(indexSettings);
-
-                        for (MappingMetaData mappingMd : mappingsMetaData.values()) {
-                            indexMetaDataBuilder.putMapping(mappingMd);
-                        }
-                        for (AliasMetaData aliasMetaData : templatesAliases.values()) {
-                            indexMetaDataBuilder.putAlias(aliasMetaData);
-                        }
-                        for (Map.Entry<String, IndexMetaData.Custom> customEntry : customs.entrySet()) {
-                            indexMetaDataBuilder.putCustom(customEntry.getKey(), customEntry.getValue());
-                        }
-                        indexMetaDataBuilder.state(IndexMetaData.State.OPEN);
-
-                        final IndexMetaData indexMetaData;
-                        try {
-                            indexMetaData = indexMetaDataBuilder.build();
-                        } catch (Exception e) {
-                            removalReason = "failed to build index metadata";
-                            throw e;
-                        }
-                        logger.info("[{}] creating index, cause [bulk], templates {}, shards [{}]/[{}], mappings {}",
-                                index, templateNames, indexMetaData.numberOfShards(), indexMetaData.numberOfReplicas(), mappings.keySet());
-
-                        indexService.indicesLifecycle().beforeIndexAddedToCluster(new Index(index), indexMetaData.settings());
-                        newMetaDataBuilder.put(indexMetaData, false);
-                    }
-                    MetaData newMetaData = newMetaDataBuilder.build();
-
-                    ClusterState updatedState = ClusterState.builder(currentState).metaData(newMetaData).build();
-                    RoutingTable.Builder routingTableBuilder = RoutingTable.builder(updatedState.routingTable());
-                    for (String index : request.indices()) {
-                        routingTableBuilder.addAsNew(updatedState.metaData().index(index));
-                    }
-                    RoutingAllocation.Result routingResult = allocationService.reroute(
-                            ClusterState.builder(updatedState).routingTable(routingTableBuilder).build());
-                    updatedState = ClusterState.builder(updatedState).routingResult(routingResult).build();
-
-                    removalReason = "cleaning up after validating index on master";
-                    return updatedState;
-                } finally {
-                    if (testIndex != null) {
-                        // index was partially created - need to clean up
-                        indicesService.deleteIndex(testIndex, removalReason != null ? removalReason : "failed to create index");
-                    }
-                }
+                return executeCreateIndices(currentState, request);
             }
         });
 

--- a/sql/src/test/java/org/elasticsearch/action/admin/indices/create/TransportBulkCreateIndicesActionTest.java
+++ b/sql/src/test/java/org/elasticsearch/action/admin/indices/create/TransportBulkCreateIndicesActionTest.java
@@ -25,6 +25,10 @@ import com.google.common.collect.ImmutableList;
 import io.crate.integrationtests.SQLTransportIntegrationTest;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsResponse;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
+import org.elasticsearch.common.collect.ImmutableOpenIntMap;
+import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.indices.InvalidIndexNameException;
 import org.junit.After;
 import org.junit.Before;
@@ -104,6 +108,25 @@ public class TransportBulkCreateIndicesActionTest extends SQLTransportIntegratio
                 .indices().prepareExists("index1", "index2", "index3", "index4")
                 .execute().actionGet();
         assertThat(indicesExistsResponse.isExists(), is(true));
+    }
+
+    @Test
+    public void testRoutingOfIndicesIsNotOverridden() throws Exception {
+        cluster().client().admin().indices()
+                .prepareCreate("index_0")
+                .setSettings(ImmutableSettings.builder().put("number_of_shards", 1).put("number_of_replicas", 0))
+                .execute().actionGet();
+        ensureYellow("index_0");
+
+        ClusterState currentState = internalCluster().clusterService().state();
+
+        BulkCreateIndicesRequest request = new BulkCreateIndicesRequest(
+                Arrays.asList("index_0", "index_1"),
+                UUID.randomUUID());
+        currentState = action.executeCreateIndices(currentState, request);
+
+        ImmutableOpenIntMap<IndexShardRoutingTable> newRouting = currentState.routingTable().indicesRouting().get("index_0").getShards();
+        assertTrue("[index_0][0] must be started already", newRouting.get(0).primaryShard().started());
     }
 
     @Test


### PR DESCRIPTION
that could cause the re-creation of an already existing table partition.

in this case the data that was already inserted into the previously
created shards of the affected partition is lost.

this may happen when creating a lot of partitions simultaniously,
e.g. using multiple parallel COPY FROM statements or or bulk inserts.

see: https://github.com/crate/crate/pull/2697/files#diff-6a84bae9eb8daa49b156e6e0058cceb8R445