### PR TITLE
IteratorPageDownstream: avoid emitting another row in finish

### DIFF
--- a/sql/src/main/java/io/crate/operation/merge/IteratorPageDownstream.java
+++ b/sql/src/main/java/io/crate/operation/merge/IteratorPageDownstream.java
@@ -60,6 +60,7 @@ public class IteratorPageDownstream implements PageDownstream, RowUpstream {
     private volatile PageConsumeListener pausedListener;
     private volatile Iterator<Row> pausedIterator;
     private volatile boolean pendingPause;
+    private boolean downstreamWantsMore = true;
 
     public IteratorPageDownstream(RowReceiver rowReceiver,
                                   PagingIterator<Row> pagingIterator,
@@ -100,6 +101,7 @@ public class IteratorPageDownstream implements PageDownstream, RowUpstream {
                 return wantMore;
             }
             if (!wantMore) {
+                downstreamWantsMore = false;
                 listener.finish();
                 return false;
             }
@@ -157,7 +159,9 @@ public class IteratorPageDownstream implements PageDownstream, RowUpstream {
     @Override
     public void finish() {
         if (finished.compareAndSet(false, true)) {
-            consumeRemaining();
+            if (downstreamWantsMore) {
+                consumeRemaining();
+            }
             rowReceiver.finish();
         }
     }

--- a/sql/src/test/java/io/crate/testing/CollectingRowReceiver.java
+++ b/sql/src/test/java/io/crate/testing/CollectingRowReceiver.java
@@ -49,6 +49,10 @@ public class CollectingRowReceiver implements RowReceiver {
         return new PausingReceiver(pauseAfter);
     }
 
+    public static CollectingRowReceiver withLimit(int limit) {
+        return new LimitingReceiver(limit);
+    }
+
     public CollectingRowReceiver() {
     }
 
@@ -102,6 +106,27 @@ public class CollectingRowReceiver implements RowReceiver {
                     "Didn't receive fail or finish. Upstream was \"" + upstream + "\"");
             timeoutException.initCause(e);
             throw timeoutException;
+        }
+    }
+
+    private static class LimitingReceiver extends CollectingRowReceiver {
+
+        private final int limit;
+        private int numRows = 0;
+
+        public LimitingReceiver(int limit) {
+            this.limit = limit;
+        }
+
+        @Override
+        public boolean setNextRow(Row row) {
+            boolean wantsMore = super.setNextRow(row);
+            numRows++;
+            //noinspection SimplifiableIfStatement
+            if (numRows >= limit) {
+                return false;
+            }
+            return wantsMore;
         }
     }
 


### PR DESCRIPTION
calling finish() on the IteratorPageDownstream would always send the
rowReceiver at most one more row if the iterator wasn't exhausted. (which is
the case if the downstream returned false on a setNextRow call).