### PR TITLE
tweak logging in NestedLoopOperation

### DIFF
--- a/sql/src/main/java/io/crate/operation/merge/IteratorPageDownstream.java
+++ b/sql/src/main/java/io/crate/operation/merge/IteratorPageDownstream.java
@@ -91,7 +91,9 @@ public class IteratorPageDownstream implements PageDownstream, RowUpstream {
     @Override
     public void repeat() {
         if (finished.compareAndSet(true, false)) {
+            assert downstreamWantsMore : "downstream doesn't want more but still called repeat";
             LOGGER.trace("received repeat: {}", rowReceiver);
+
             paused.set(false);
             if (processBuckets(pagingIterator.repeat().iterator(), PageConsumeListener.NO_OP_LISTENER)) {
                 consumeRemaining();


### PR DESCRIPTION
Removed the trace log on each right row because that happens
really often and doesn't really provide any insight.

Added some more "state change" log entries instead. As those
are way more interesting.