### PR TITLE
remove limit handling from CrateDocCollector

### DIFF
--- a/sql/src/main/java/io/crate/operation/collect/ShardCollectService.java
+++ b/sql/src/main/java/io/crate/operation/collect/ShardCollectService.java
@@ -210,7 +210,6 @@ public class ShardCollectService {
                     searchContext,
                     executor,
                     jobCollectContext.keepAliveListener(),
-                    collectNode,
                     jobCollectContext.queryPhaseRamAccountingContext(),
                     projectorChain.newShardDownstreamProjector(projectorVisitor),
                     docCtx.topLevelInputs(),

--- a/sql/src/main/java/io/crate/planner/consumer/QueryAndFetchConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/QueryAndFetchConsumer.java
@@ -297,13 +297,9 @@ public class QueryAndFetchConsumer implements Consumer {
         @Override
         public List<Projection> visitQueriedDocTable(QueriedDocTable table,
                                                      CollectPhaseOrderedProjectionBuilderContext context) {
-            if (context.orderBy == null) {
-                return ImmutableList.of();
-            } else {
-                TopNProjection topNProjection = new TopNProjection(context.offset + context.limit, 0);
-                topNProjection.outputs(context.allOutputs);
-                return ImmutableList.<Projection>of(topNProjection);
-            }
+            TopNProjection topNProjection = new TopNProjection(context.offset + context.limit, 0);
+            topNProjection.outputs(context.allOutputs);
+            return ImmutableList.<Projection>of(topNProjection);
         }
 
         @Override


### PR DESCRIPTION
Instead a topN projection is added to handle the limit.

In a follow up commit the limit on the collectPhase will be changed to a
nodePageSize which is no longer a hard limit but instead a hint that may be
used by the collectors and the DistributingDownstream.