### PR TITLE
avoid NPEs when selecting hidden columns

### DIFF
--- a/sql/src/main/java/io/crate/analyze/relations/DocTableRelation.java
+++ b/sql/src/main/java/io/crate/analyze/relations/DocTableRelation.java
@@ -21,11 +21,13 @@
 
 package io.crate.analyze.relations;
 
+import com.google.common.collect.ImmutableSet;
 import io.crate.analyze.OrderBy;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Path;
 import io.crate.metadata.ReferenceInfo;
+import io.crate.metadata.doc.DocSysColumns;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.planner.symbol.*;
 
@@ -33,6 +35,7 @@ import javax.annotation.Nullable;
 
 public class DocTableRelation extends AbstractTableRelation<DocTableInfo> {
 
+    private static ImmutableSet<ColumnIdent> HIDDEN_COLUMNS = ImmutableSet.of(DocSysColumns.DOCID);
     private final static SortValidator SORT_VALIDATOR = new SortValidator();
 
     private static class SortValidator extends SymbolVisitor<DocTableRelation, Void> {
@@ -87,6 +90,9 @@ public class DocTableRelation extends AbstractTableRelation<DocTableInfo> {
 
     private Field getField(Path path, boolean forWrite) {
         ColumnIdent ci = getColumnIdentSafe(path);
+        if (HIDDEN_COLUMNS.contains(ci)) {
+            return null;
+        }
         ReferenceInfo referenceInfo = tableInfo.getReferenceInfo(ci);
         if (referenceInfo == null) {
             referenceInfo = tableInfo.indexColumn(ci);

--- a/sql/src/main/java/io/crate/planner/consumer/QueryThenFetchConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/QueryThenFetchConsumer.java
@@ -127,6 +127,7 @@ public class QueryThenFetchConsumer implements Consumer {
 
             Collection<FetchSource> fetchSources = ImmutableList.of(
                     new FetchSource(
+                            table.tableRelation().tableInfo().ident(),
                             table.tableRelation().tableInfo().partitionedByColumns(),
                             ImmutableList.of(fetchPushDown.docIdField()),
                             fetchPushDown.fetchRefs()

--- a/sql/src/main/java/io/crate/planner/node/fetch/FetchSource.java
+++ b/sql/src/main/java/io/crate/planner/node/fetch/FetchSource.java
@@ -22,7 +22,6 @@
 
 package io.crate.planner.node.fetch;
 
-import com.google.common.collect.Iterables;
 import io.crate.metadata.ReferenceInfo;
 import io.crate.metadata.TableIdent;
 import io.crate.planner.symbol.Field;
@@ -39,20 +38,15 @@ public class FetchSource {
     private final TableIdent tableIdent;
     private final boolean fetchRequired;
 
-    public FetchSource(List<ReferenceInfo> partitionedByColumns, Collection<Field> docIdFields, Collection<Reference> references) {
+    public FetchSource(TableIdent tableIdent,
+                       List<ReferenceInfo> partitionedByColumns,
+                       Collection<Field> docIdFields,
+                       Collection<Reference> references) {
         this.partitionedByColumns = partitionedByColumns;
         this.docIdFields = docIdFields;
         this.references = references;
-        if (!references.isEmpty()) {
-            fetchRequired = true;
-            //noinspection ConstantConditions
-            this.tableIdent = Iterables.getFirst(references, null).ident().tableIdent();
-        } else {
-            ReferenceInfo info = Iterables.getFirst(partitionedByColumns, null);
-            assert info != null;
-            fetchRequired = false;
-            this.tableIdent = info.ident().tableIdent();
-        }
+        this.tableIdent = tableIdent;
+        this.fetchRequired = !references.isEmpty();
     }
 
     public boolean fetchRequired() {

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -1671,4 +1671,40 @@ public class SelectStatementAnalyzerTest extends BaseAnalyzerTest {
 
         analyze("select * from sys.nodes, sys.nodes");
     }
+
+    @Test
+    public void testSelectHiddenColumn() throws Exception {
+        expectedException.expect(ColumnUnknownException.class);
+        expectedException.expectMessage("Column _docid unknown");
+        analyze("select _docid + 1 from users");
+    }
+
+    @Test
+    public void testOrderByHiddenColumn() throws Exception {
+        expectedException.expect(ColumnUnknownException.class);
+        expectedException.expectMessage("Column _docid unknown");
+        analyze("select * from users order by _docid");
+
+    }
+
+    @Test
+    public void testWhereHiddenColumn() throws Exception {
+        expectedException.expect(ColumnUnknownException.class);
+        expectedException.expectMessage("Column _docid unknown");
+        analyze("select * from users where _docid = 0");
+    }
+
+    @Test
+    public void testGroupByHiddenColumn() throws Exception {
+        expectedException.expect(ColumnUnknownException.class);
+        expectedException.expectMessage("Column _docid unknown");
+        analyze("select count(*) from users group by _docid");
+    }
+
+    @Test
+    public void testHavingHiddenColumn() throws Exception {
+        expectedException.expect(ColumnUnknownException.class);
+        expectedException.expectMessage("Column _docid unknown");
+        analyze("select count(*) from users group by id having _docid > 0");
+    }
 }


### PR DESCRIPTION
and restrict access to hidden columns like _docid