### PR TITLE
changed the help text for the "cluster.graceful_stop.min_availability…

### DIFF
--- a/app/src/main/dist/config/crate.yml
+++ b/app/src/main/dist/config/crate.yml
@@ -29,7 +29,7 @@
 #
 # The minimum data availability the cluster needs to ensure when a certain node
 # is shut down. By default the cluster ensures availability of primary shards
-# but not replicas. Other options are "all" and "none".
+# but not replicas. Other options are "full" and "none".
 #
 # cluster.graceful_stop.min_availability: primaries
 #


### PR DESCRIPTION
…: " setting from 'all' to the correct 'full'