### PR TITLE
use lower shardQueueSize for OrderedDocCollector's

### DIFF
--- a/sql/src/main/java/io/crate/operation/Paging.java
+++ b/sql/src/main/java/io/crate/operation/Paging.java
@@ -35,14 +35,6 @@ public class Paging {
         return getWeightedPageSize(limit, weight, OVERHEAD_FACTOR);
     }
 
-    public static int getShardPageSize(@Nullable Integer limit, int numTotalShards) {
-        return getWeightedPageSize(
-                limit,
-                1.0d/ Math.max(1, numTotalShards),
-                Math.pow(OVERHEAD_FACTOR, 2)
-        );
-    }
-
     private static int getWeightedPageSize(@Nullable Integer limit, double weight, double overheadFactor) {
         Integer limitOrPageSize = firstNonNull(limit, PAGE_SIZE);
         if (1.0 / weight > limitOrPageSize) {

--- a/sql/src/main/java/io/crate/operation/collect/collectors/OrderedDocCollector.java
+++ b/sql/src/main/java/io/crate/operation/collect/collectors/OrderedDocCollector.java
@@ -136,7 +136,7 @@ public class OrderedDocCollector implements Callable<NumberedIterable<Row>>, Aut
             LOGGER.trace("searchMore but EXHAUSTED");
             return empty;
         }
-        LOGGER.trace("searchMore from [{}]", lastDoc);
+        LOGGER.debug("searchMore from [{}]", lastDoc);
         TopDocs topDocs = searcher.searchAfter(lastDoc, query(lastDoc), null, batchSize, sort, doDocsScores, false);
         return scoreDocToIterable(topDocs.scoreDocs);
     }

--- a/sql/src/main/java/io/crate/planner/consumer/QueryAndFetchConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/QueryAndFetchConsumer.java
@@ -181,7 +181,6 @@ public class QueryAndFetchConsumer implements Consumer {
                 List<Symbol> allOutputs = toInputColumns(toCollect);
                 List<Symbol> finalOutputs = toInputColumns(outputSymbols);
 
-                int limit = firstNonNull(querySpec.limit(), Constants.DEFAULT_SELECT_LIMIT);
 
                 CollectPhaseOrderedProjectionBuilderContext projectionBuilderContext =
                         new CollectPhaseOrderedProjectionBuilderContext(querySpec, orderByInputColumns, allOutputs);
@@ -200,6 +199,7 @@ public class QueryAndFetchConsumer implements Consumer {
 
                 // MERGE
                 if (context.rootRelation() == table) {
+                    int limit = firstNonNull(querySpec.limit(), Constants.DEFAULT_SELECT_LIMIT);
                     TopNProjection tnp = new TopNProjection(limit, querySpec.offset());
                     tnp.outputs(finalOutputs);
                     if (orderBy == null) {

--- a/sql/src/test/java/io/crate/operation/PagingTest.java
+++ b/sql/src/test/java/io/crate/operation/PagingTest.java
@@ -29,28 +29,10 @@ import static org.junit.Assert.assertThat;
 public class PagingTest {
 
     @Test
-    public void testGetShardPageSize() throws Exception {
-        int shardPageSize = Paging.getShardPageSize(10_000, 16);
-        assertThat(shardPageSize, is(1406));
-    }
-
-    @Test
     public void testGetNodePageSize() throws Exception {
         double weight = 1.0d / 8.0d;
         int pageSize = Paging.getWeightedPageSize(10_000, weight);
         assertThat(pageSize, is(1875));
-    }
-
-    @Test
-    public void testNumShardsGreaterLimit() throws Exception {
-        int shardPageSize = Paging.getShardPageSize(10, 16);
-        assertThat(shardPageSize, is(10));
-    }
-
-    @Test
-    public void testZeroShards() throws Exception {
-        int shardPageSize = Paging.getShardPageSize(10, 0);
-        assertThat(shardPageSize, is(10));
     }
 
     @Test


### PR DESCRIPTION
This should increase the performance of most ordered queries as the number of
rows which have to be sorted per shard is smaller.

Simple benchmark:

    SELECT "pageURL" FROM rankings_cj ORDER BY "pageURL" LIMIT 1 OFFSET 10000
       previous: 0.314 now: 0.239

    SELECT "sourceIP" FROM uservisits_cj ORDER BY "sourceIP" LIMIT 1 OFFSET 50000
       previous: 1.013 now: 0.663