### PR TITLE
let upstream phases send keepalives to their downstreams

### DIFF
--- a/sql/src/main/java/io/crate/action/job/TransportKeepAliveAction.java
+++ b/sql/src/main/java/io/crate/action/job/TransportKeepAliveAction.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.action.job;
+
+import io.crate.executor.transport.DefaultTransportResponseHandler;
+import io.crate.executor.transport.NodeAction;
+import io.crate.executor.transport.NodeActionRequestHandler;
+import io.crate.executor.transport.Transports;
+import io.crate.jobs.JobContextService;
+import io.crate.jobs.JobExecutionContext;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportResponse;
+import org.elasticsearch.transport.TransportService;
+
+@Singleton
+public class TransportKeepAliveAction implements NodeAction<KeepAliveRequest, TransportResponse.Empty> {
+
+    private static final ESLogger LOGGER = Loggers.getLogger(TransportKeepAliveAction.class);
+    public static final String ACTION_NAME = "crate/sql/job/keep_alive";
+    private static final String EXECUTOR = ThreadPool.Names.SAME;
+
+    private final JobContextService jobContextService;
+    private final Transports transports;
+
+    @Inject
+    public TransportKeepAliveAction(TransportService transportService,
+                                    Transports transports,
+                                    JobContextService jobContextService) {
+        this.jobContextService = jobContextService;
+        this.transports = transports;
+        transportService.registerHandler(ACTION_NAME, new NodeActionRequestHandler<KeepAliveRequest, TransportResponse.Empty>(this) {
+            @Override
+            public KeepAliveRequest newInstance() {
+                return new KeepAliveRequest();
+            }
+        });
+    }
+
+    public void keepAlive(String node, final KeepAliveRequest request, final ActionListener<TransportResponse.Empty> listener) {
+        transports.executeLocalOrWithTransport(this, node, request, listener, new DefaultTransportResponseHandler<TransportResponse.Empty>(listener) {
+            @Override
+            public TransportResponse.Empty newInstance() {
+                return TransportResponse.Empty.INSTANCE;
+            }
+        });
+    }
+
+    @Override
+    public String actionName() {
+        return ACTION_NAME;
+    }
+
+    @Override
+    public String executorName() {
+        return EXECUTOR;
+    }
+
+    @Override
+    public void nodeOperation(KeepAliveRequest request, ActionListener<TransportResponse.Empty> listener) {
+        JobExecutionContext context = jobContextService.getContextOrNull(request.jobId());
+        if (context != null) {
+            LOGGER.trace("keeping JobExecutionContext {} alive ", context);
+            context.keepAlive();
+        } else {
+            LOGGER.trace("no JobExecutionContext found for jobId {}", request.jobId());
+        }
+        listener.onResponse(TransportResponse.Empty.INSTANCE);
+    }
+
+}

--- a/sql/src/main/java/io/crate/executor/transport/TransportExecutorModule.java
+++ b/sql/src/main/java/io/crate/executor/transport/TransportExecutorModule.java
@@ -22,6 +22,7 @@
 package io.crate.executor.transport;
 
 import io.crate.action.job.TransportJobAction;
+import io.crate.action.job.TransportKeepAliveAction;
 import io.crate.executor.Executor;
 import io.crate.executor.transport.distributed.TransportDistributedResultAction;
 import io.crate.executor.transport.kill.TransportKillAllNodeAction;
@@ -35,6 +36,7 @@ public class TransportExecutorModule extends AbstractModule {
         bind(Executor.class).to(TransportExecutor.class).asEagerSingleton();
 
         bind(TransportJobAction.class).asEagerSingleton();
+        bind(TransportKeepAliveAction.class).asEagerSingleton();
         bind(TransportDistributedResultAction.class).asEagerSingleton();
         bind(SymbolBasedTransportShardUpsertAction.class).asEagerSingleton();
         bind(TransportShardUpsertAction.class).asEagerSingleton();

--- a/sql/src/main/java/io/crate/executor/transport/distributed/DistributingDownstream.java
+++ b/sql/src/main/java/io/crate/executor/transport/distributed/DistributingDownstream.java
@@ -26,6 +26,7 @@ import io.crate.Streamer;
 import io.crate.core.collections.Bucket;
 import io.crate.core.collections.Row;
 import io.crate.jobs.ExecutionState;
+import io.crate.jobs.KeepAliveTimers;
 import io.crate.operation.RowUpstream;
 import io.crate.operation.projectors.Requirement;
 import io.crate.operation.projectors.Requirements;
@@ -64,6 +65,7 @@ public class DistributingDownstream implements RowReceiver {
     private final byte inputId;
     private final int bucketIdx;
     private final TransportDistributedResultAction transportDistributedResultAction;
+    private final KeepAliveTimers keepAliveTimers;
     private final Streamer<?>[] streamers;
     private final int pageSize;
     private RowUpstream upstream;
@@ -84,6 +86,7 @@ public class DistributingDownstream implements RowReceiver {
                                   int bucketIdx,
                                   Collection<String> downstreamNodeIds,
                                   TransportDistributedResultAction transportDistributedResultAction,
+                                  KeepAliveTimers keepAliveTimers,
                                   Streamer<?>[] streamers,
                                   int pageSize) {
         this.jobId = jobId;
@@ -92,6 +95,7 @@ public class DistributingDownstream implements RowReceiver {
         this.inputId = inputId;
         this.bucketIdx = bucketIdx;
         this.transportDistributedResultAction = transportDistributedResultAction;
+        this.keepAliveTimers = keepAliveTimers;
         this.streamers = streamers;
         this.pageSize = pageSize;
 
@@ -175,11 +179,18 @@ public class DistributingDownstream implements RowReceiver {
                 downstream.forwardFailure(throwable);
             }
         }
+        // finally close downstreams
+        for (Downstream downstream : downstreams) {
+            downstream.close();
+        }
     }
 
     @Override
     public void prepare(ExecutionState executionState) {
-
+        // start timer for each downstream
+        for (Downstream downstream : downstreams) {
+            downstream.prepare();
+        }
     }
 
     @Override
@@ -187,17 +198,25 @@ public class DistributingDownstream implements RowReceiver {
         upstream = rowUpstream;
     }
 
-    private class Downstream implements ActionListener<DistributedResultResponse> {
+    private class Downstream implements ActionListener<DistributedResultResponse>, AutoCloseable {
 
         private final String node;
+        private final KeepAliveTimers.ResettableTimer keepAliveTimer;
         private boolean finished = false;
+
 
         public Downstream(String node) {
             this.node = node;
+            keepAliveTimer = keepAliveTimers.forJobOnNode(jobId, node);
+        }
+
+        public void prepare() {
+            keepAliveTimer.start();
         }
 
         public void forwardFailure(Throwable throwable) {
             LOGGER.trace("Sending failure to {}", node);
+            keepAliveTimer.cancel();
             transportDistributedResultAction.pushResult(
                     node,
                     new DistributedResultRequest(jobId, targetExecutionPhaseId, inputId, bucketIdx, streamers, throwable),
@@ -209,6 +228,7 @@ public class DistributingDownstream implements RowReceiver {
             if (finished) {
                 return;
             }
+            keepAliveTimer.reset();
             LOGGER.trace("Sending request to {}", node);
             transportDistributedResultAction.pushResult(
                     node,
@@ -261,6 +281,11 @@ public class DistributingDownstream implements RowReceiver {
                 }
                 resume();
             }
+        }
+
+        @Override
+        public void close() {
+            keepAliveTimer.cancel();
         }
     }
 }

--- a/sql/src/main/java/io/crate/jobs/KeepAliveTimers.java
+++ b/sql/src/main/java/io/crate/jobs/KeepAliveTimers.java
@@ -85,6 +85,23 @@ public class KeepAliveTimers {
     }
 
 
+    /**
+     * A timer that executes a given runnable periodically with a given delay if
+     * the delay duration was exceeded since the last reset.
+     *
+     * Execution example:
+     *
+     * ResettableTimer timer = new ResettableTimer(threadPool, new Runnable { System.out.println("hello world"); }, TimeValue.timeValueMillis(100));
+     * timer.start();
+     *
+     * t+100 -> no reset yet -> "hello world"
+     *
+     * t+150 -> another thread calls reset()
+     *
+     * t+200 -> only 50 ms since last reset
+     *
+     * t+300 -> 150 ms since last reset -> "hello world"
+     */
     public static class ResettableTimer {
         private final Runnable runnable;
         private final TimeValue delay;

--- a/sql/src/main/java/io/crate/jobs/KeepAliveTimers.java
+++ b/sql/src/main/java/io/crate/jobs/KeepAliveTimers.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.jobs;
+
+import io.crate.action.job.KeepAliveRequest;
+import io.crate.action.job.TransportKeepAliveAction;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportResponse;
+
+import java.util.UUID;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+@Singleton
+public class KeepAliveTimers {
+
+    private static final ESLogger LOGGER = Loggers.getLogger(KeepAliveTimers.class);
+
+    private final ThreadPool threadPool;
+    private final TimeValue maxKeepAliveTime;
+    private final TransportKeepAliveAction transportKeepAliveAction;
+
+    @Inject
+    public KeepAliveTimers(ThreadPool threadPool,
+                           @JobContextService.JobKeepAlive TimeValue maxKeepAliveTime,
+                           TransportKeepAliveAction transportKeepAliveAction) {
+        this.threadPool = threadPool;
+        this.maxKeepAliveTime = maxKeepAliveTime;
+        this.transportKeepAliveAction = transportKeepAliveAction;
+    }
+
+    public ResettableTimer forJobOnNode(final UUID jobId, final String nodeId) {
+        return forRunnable(new Runnable() {
+            @Override
+            public void run() {
+                transportKeepAliveAction.keepAlive(nodeId, new KeepAliveRequest(jobId), new ActionListener<TransportResponse.Empty>() {
+                    @Override
+                    public void onResponse(TransportResponse.Empty empty) {
+                        LOGGER.trace("keep alive for job [{}] on downstream [{}] finished successfully", jobId, nodeId);
+                    }
+
+                    @Override
+                    public void onFailure(Throwable e) {
+                        LOGGER.trace("keep alive for job [{}] on downstream [{}] failed", e,jobId, nodeId);
+                    }
+                });
+            }
+        });
+    }
+
+    public ResettableTimer forRunnable(Runnable runnable) {
+        TimeValue delay = TimeValue.timeValueMillis(Math.max(1, maxKeepAliveTime.millis() / 3));
+        return forRunnable(runnable, delay);
+    }
+
+    public ResettableTimer forRunnable(Runnable runnable, TimeValue delay) {
+        return new ResettableTimer(threadPool, runnable, delay);
+    }
+
+
+    public static class ResettableTimer {
+        private final Runnable runnable;
+        private final TimeValue delay;
+        private final AtomicReference<ScheduledFuture<?>> futureHolder = new AtomicReference<>();
+        private final AtomicLong lastReset = new AtomicLong(-1L);
+        private final ThreadPool threadPool;
+
+        public ResettableTimer(ThreadPool threadPool, Runnable runnable, TimeValue delay) {
+            this.threadPool = threadPool;
+            this.runnable = runnable;
+            this.delay = delay;
+        }
+
+        public void start() {
+            LOGGER.trace("starting ResettableTimer with delay of {}", this.delay);
+            final long started = threadPool.estimatedTimeInMillis();
+            lastReset.set(started);
+            futureHolder.set(threadPool.scheduleWithFixedDelay(new Runnable() {
+                @Override
+                public void run() {
+                    long notAccessed = threadPool.estimatedTimeInMillis() - lastReset.get();
+                    if (notAccessed >= delay.millis()){
+                        // execute action only when delay expired since last reset
+                        LOGGER.trace("not accessed in {}ms, running keep alive runnable", notAccessed);
+                        runnable.run();
+                    } else {
+                        LOGGER.trace("not accessed in {}ms. will only execute keep alive runnable after {}ms", notAccessed, delay.millis());
+                    }
+
+                }
+            }, delay));
+        }
+
+        public void reset() {
+            lastReset.set(threadPool.estimatedTimeInMillis());
+        }
+
+        public void cancel() {
+            ScheduledFuture<?> future = futureHolder.getAndSet(null);
+            if (future != null) {
+                future.cancel(true);
+            }
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/operation/projectors/InternalRowDownstreamFactory.java
+++ b/sql/src/main/java/io/crate/operation/projectors/InternalRowDownstreamFactory.java
@@ -24,6 +24,7 @@ package io.crate.operation.projectors;
 import com.google.common.collect.Lists;
 import io.crate.Streamer;
 import io.crate.executor.transport.distributed.*;
+import io.crate.jobs.KeepAliveTimers;
 import io.crate.operation.NodeOperation;
 import io.crate.planner.distribution.DistributionInfo;
 import io.crate.planner.node.ExecutionPhases;
@@ -41,12 +42,15 @@ public class InternalRowDownstreamFactory implements RowDownstreamFactory {
 
     private final ClusterService clusterService;
     private final TransportDistributedResultAction transportDistributedResultAction;
+    private final KeepAliveTimers keepAliveTimers;
 
     @Inject
     public InternalRowDownstreamFactory(ClusterService clusterService,
-                                        TransportDistributedResultAction transportDistributedResultAction) {
+                                        TransportDistributedResultAction transportDistributedResultAction,
+                                        KeepAliveTimers keepAliveTimers) {
         this.clusterService = clusterService;
         this.transportDistributedResultAction = transportDistributedResultAction;
+        this.keepAliveTimers = keepAliveTimers;
     }
 
     public RowReceiver createDownstream(NodeOperation nodeOperation,
@@ -87,6 +91,7 @@ public class InternalRowDownstreamFactory implements RowDownstreamFactory {
                 bucketIdx,
                 nodeOperation.downstreamNodes(),
                 transportDistributedResultAction,
+                keepAliveTimers,
                 streamers,
                 pageSize
         );

--- a/sql/src/test/java/io/crate/executor/transport/distributed/DistributingDownstreamTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/distributed/DistributingDownstreamTest.java
@@ -24,42 +24,73 @@ package io.crate.executor.transport.distributed;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.*;
 import io.crate.Streamer;
+import io.crate.action.job.KeepAliveRequest;
+import io.crate.action.job.TransportKeepAliveAction;
 import io.crate.core.collections.Bucket;
 import io.crate.core.collections.Row;
 import io.crate.core.collections.Row1;
 import io.crate.executor.transport.Transports;
+import io.crate.jobs.ExecutionState;
 import io.crate.jobs.JobContextService;
+import io.crate.jobs.KeepAliveTimers;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.testing.RowSender;
 import io.crate.types.DataTypes;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportResponse;
 import org.elasticsearch.transport.TransportService;
 import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Answers;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 
 import static org.hamcrest.core.Is.is;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.*;
 
 public class DistributingDownstreamTest extends CrateUnitTest {
 
     private ListeningExecutorService executorService;
+    private ScheduledExecutorService scheduledExecutorService;
+    private ThreadPool threadPool;
 
     @Override
     @Before
     public void setUp() throws Exception {
         super.setUp();
         executorService = MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(3));
+        scheduledExecutorService = Executors.newScheduledThreadPool(1);
+        // need to mock here, as we cannot set estimated_time_interval via settings due to ES ThreadPool bug
+        threadPool = mock(ThreadPool.class);
+        when(threadPool.executor(anyString())).thenReturn(executorService);
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                return System.currentTimeMillis();
+            }
+        }).when(threadPool).estimatedTimeInMillis();
+        when(threadPool.scheduleWithFixedDelay(any(Runnable.class), any(TimeValue.class))).thenAnswer(new Answer<ScheduledFuture<?>>() {
+            @Override
+            public ScheduledFuture<?> answer(InvocationOnMock invocation) throws Throwable {
+
+                Runnable runnable = (Runnable)invocation.getArguments()[0];
+                TimeValue interval = (TimeValue)invocation.getArguments()[1];
+                return scheduledExecutorService.scheduleWithFixedDelay(runnable, interval.millis(), interval.millis(), TimeUnit.MILLISECONDS);
+            }
+        });
     }
 
     @Override
@@ -68,6 +99,7 @@ public class DistributingDownstreamTest extends CrateUnitTest {
         super.tearDown();
         executorService.shutdown();
         executorService.awaitTermination(1, TimeUnit.SECONDS);
+        scheduledExecutorService.shutdownNow();
     }
 
     @Test
@@ -115,6 +147,7 @@ public class DistributingDownstreamTest extends CrateUnitTest {
                 0,
                 ImmutableList.of("n1"),
                 transportDistributedResultAction,
+                mock(KeepAliveTimers.class, Answers.RETURNS_MOCKS.get()),
                 streamers,
                 pageSize
         );
@@ -135,5 +168,37 @@ public class DistributingDownstreamTest extends CrateUnitTest {
         assertThat(receivedRows.size(), is(52));
         assertThat(task1.numPauses(), Matchers.greaterThan(0));
         assertThat(task1.numResumes(), Matchers.greaterThan(0));
+    }
+
+    @Test
+    public void testDownstreamKeepAlive() throws Exception {
+        TransportKeepAliveAction transportKeepAliveAction = mock(TransportKeepAliveAction.class);
+        final CountDownLatch countDownLatch = new CountDownLatch(3);
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                countDownLatch.countDown();
+                ActionListener<TransportResponse.Empty> actionListener = (ActionListener<TransportResponse.Empty>) invocation.getArguments()[2];
+                actionListener.onResponse(TransportResponse.Empty.INSTANCE);
+                return null;
+            }
+        }).when(transportKeepAliveAction).keepAlive(anyString(), Mockito.any(KeepAliveRequest.class), Mockito.<ActionListener<TransportResponse.Empty>>any());
+        KeepAliveTimers keepAliveTimers = new KeepAliveTimers(threadPool, TimeValue.timeValueMillis(10), transportKeepAliveAction);
+        Streamer[] streamers = new Streamer[] {DataTypes.STRING.streamer() };
+        int pageSize = 10;
+        final DistributingDownstream distributingDownstream = new DistributingDownstream(
+                UUID.randomUUID(),
+                new BroadcastingBucketBuilder(streamers, 1),
+                1,
+                (byte) 0,
+                0,
+                ImmutableList.of("n1"),
+                mock(TransportDistributedResultAction.class),
+                keepAliveTimers,
+                streamers,
+                pageSize
+        );
+        distributingDownstream.prepare(mock(ExecutionState.class));
+        countDownLatch.await(1, TimeUnit.SECONDS);
     }
 }

--- a/sql/src/test/java/io/crate/executor/transport/distributed/InternalRowDownstreamFactoryTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/distributed/InternalRowDownstreamFactoryTest.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.crate.analyze.WhereClause;
 import io.crate.core.collections.TreeMapBuilder;
+import io.crate.jobs.KeepAliveTimers;
 import io.crate.metadata.Routing;
 import io.crate.operation.NodeOperation;
 import io.crate.operation.Paging;
@@ -56,7 +57,9 @@ public class InternalRowDownstreamFactoryTest extends CrateUnitTest {
     public void before() {
         rowDownstreamFactory = new InternalRowDownstreamFactory(
                 new NoopClusterService(),
-                mock(TransportDistributedResultAction.class));
+                mock(TransportDistributedResultAction.class),
+                mock(KeepAliveTimers.class)
+        );
     }
 
     private RowReceiver createDownstream(Set<String> downstreamExecutionNodes) {

--- a/sql/src/test/java/io/crate/jobs/KeepAliveTimersTest.java
+++ b/sql/src/test/java/io/crate/jobs/KeepAliveTimersTest.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.jobs;
+
+import com.google.common.util.concurrent.SettableFuture;
+import io.crate.action.job.TransportKeepAliveAction;
+import io.crate.test.integration.CrateUnitTest;
+import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.util.concurrent.*;
+
+import static org.mockito.Mockito.*;
+
+public class KeepAliveTimersTest extends CrateUnitTest {
+
+    static {
+        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
+    }
+
+    private static final TimeValue TEST_DELAY = TimeValue.timeValueMillis(100);
+
+    private ThreadPool threadPool;
+    private ScheduledExecutorService scheduledExecutorService;
+    private TransportKeepAliveAction transportKeepAliveAction;
+
+    @Before
+    public void prepare() throws Exception {
+        scheduledExecutorService = Executors.newScheduledThreadPool(2);
+
+        // need to mock here, as we cannot set estimated_time_interval via settings due to ES ThreadPool bug
+        threadPool = mock(ThreadPool.class);
+        when(threadPool.estimatedTimeInMillis()).thenAnswer(new Answer<Long>() {
+            @Override
+            public Long answer(InvocationOnMock invocation) throws Throwable {
+                return System.currentTimeMillis();
+            }
+        });
+        when(threadPool.scheduleWithFixedDelay(any(Runnable.class), any(TimeValue.class))).thenAnswer(new Answer<ScheduledFuture<?>>() {
+            @Override
+            public ScheduledFuture<?> answer(InvocationOnMock invocation) throws Throwable {
+                Runnable runnable = (Runnable)invocation.getArguments()[0];
+                TimeValue interval = (TimeValue)invocation.getArguments()[1];
+                return scheduledExecutorService.scheduleWithFixedDelay(runnable, interval.getMillis(), interval.getMillis(), TimeUnit.MILLISECONDS);
+            }
+        });
+        transportKeepAliveAction = mock(TransportKeepAliveAction.class);
+    }
+
+    @After
+    public void cleanup() throws Exception {
+        scheduledExecutorService.shutdownNow();
+    }
+
+    @Test
+    public void testKeepAliveRunnableWithoutResetIsCalled() throws Exception {
+        Tuple<SettableFuture<Void>, KeepAliveTimers.ResettableTimer> futureAndTimer = getTimer(TimeValue.timeValueMillis(10));
+        KeepAliveTimers.ResettableTimer timer = futureAndTimer.v2();
+        SettableFuture<Void> future = futureAndTimer.v1();
+        timer.start();
+        future.get(50, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    public void testKeepAliveRunnableWithHighDelayNotCalled() throws Exception {
+        Tuple<SettableFuture<Void>, KeepAliveTimers.ResettableTimer> futureAndTimer = getTimer(TimeValue.timeValueMillis(100));
+        KeepAliveTimers.ResettableTimer timer = futureAndTimer.v2();
+        SettableFuture<Void> future = futureAndTimer.v1();
+        timer.start();
+        expectedException.expect(TimeoutException.class);
+        future.get(100, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    public void testKeepAliveRunnableNotCalledWithManyResets() throws Exception {
+        Tuple<SettableFuture<Void>, KeepAliveTimers.ResettableTimer> futureAndTimer = getTimer(TimeValue.timeValueMillis(50));
+        final KeepAliveTimers.ResettableTimer timer = futureAndTimer.v2();
+        SettableFuture<Void> future = futureAndTimer.v1();
+
+        timer.start();
+        scheduledExecutorService.scheduleWithFixedDelay(new Runnable() {
+            @Override
+            public void run() {
+                timer.reset();
+            }
+        }, 10, 10, TimeUnit.MILLISECONDS);
+        expectedException.expect(TimeoutException.class);
+        future.get(100, TimeUnit.MILLISECONDS);
+    }
+
+    private Tuple<SettableFuture<Void>, KeepAliveTimers.ResettableTimer> getTimer(TimeValue timerDelay) {
+        KeepAliveTimers keepAliveTimers = new KeepAliveTimers(threadPool, TEST_DELAY, transportKeepAliveAction);
+        final SettableFuture<Void> future = SettableFuture.create();
+        final KeepAliveTimers.ResettableTimer timer = keepAliveTimers.forRunnable(new Runnable() {
+            @Override
+            public void run() {
+                future.set(null);
+            }
+        }, timerDelay);
+        return new Tuple<>(future, timer);
+    }
+
+    @Test
+    public void testCanceledBeforeExecution() throws Exception {
+        Tuple<SettableFuture<Void>, KeepAliveTimers.ResettableTimer> futureAndTimer = getTimer(TimeValue.timeValueMillis(50));
+        final KeepAliveTimers.ResettableTimer timer = futureAndTimer.v2();
+        SettableFuture<Void> future = futureAndTimer.v1();
+        timer.start();
+
+        scheduledExecutorService.schedule(new Runnable() {
+            @Override
+            public void run() {
+                timer.cancel();
+            }
+        }, 10, TimeUnit.MILLISECONDS);
+        expectedException.expect(TimeoutException.class);
+        future.get(100, TimeUnit.MILLISECONDS);
+
+    }
+}

--- a/sql/src/test/java/io/crate/jobs/KeepAliveTimersTest.java
+++ b/sql/src/test/java/io/crate/jobs/KeepAliveTimersTest.java
@@ -130,17 +130,12 @@ public class KeepAliveTimersTest extends CrateUnitTest {
 
     @Test
     public void testCanceledBeforeExecution() throws Exception {
-        Tuple<SettableFuture<Void>, KeepAliveTimers.ResettableTimer> futureAndTimer = getTimer(TimeValue.timeValueMillis(50));
+        Tuple<SettableFuture<Void>, KeepAliveTimers.ResettableTimer> futureAndTimer = getTimer(TimeValue.timeValueSeconds(1));
         final KeepAliveTimers.ResettableTimer timer = futureAndTimer.v2();
         SettableFuture<Void> future = futureAndTimer.v1();
         timer.start();
-
-        scheduledExecutorService.schedule(new Runnable() {
-            @Override
-            public void run() {
-                timer.cancel();
-            }
-        }, 10, TimeUnit.MILLISECONDS);
+        Thread.sleep(10);
+        timer.cancel();
         expectedException.expect(TimeoutException.class);
         future.get(100, TimeUnit.MILLISECONDS);
 

--- a/sql/src/test/java/io/crate/jobs/KeepAliveTimersTest.java
+++ b/sql/src/test/java/io/crate/jobs/KeepAliveTimersTest.java
@@ -22,7 +22,6 @@
 
 package io.crate.jobs;
 
-import com.carrotsearch.randomizedtesting.annotations.Repeat;
 import com.google.common.util.concurrent.SettableFuture;
 import io.crate.action.job.TransportKeepAliveAction;
 import io.crate.test.integration.CrateUnitTest;
@@ -39,7 +38,6 @@ import java.util.concurrent.*;
 
 import static org.mockito.Mockito.*;
 
-@Repeat(iterations=100)
 public class KeepAliveTimersTest extends CrateUnitTest {
 
     static {
@@ -54,7 +52,7 @@ public class KeepAliveTimersTest extends CrateUnitTest {
 
     @Before
     public void prepare() throws Exception {
-        scheduledExecutorService = Executors.newScheduledThreadPool(2);
+        scheduledExecutorService = Executors.newScheduledThreadPool(1);
 
         // need to mock here, as we cannot set estimated_time_interval via settings due to ES ThreadPool bug
         threadPool = mock(ThreadPool.class);
@@ -86,7 +84,7 @@ public class KeepAliveTimersTest extends CrateUnitTest {
         KeepAliveTimers.ResettableTimer timer = futureAndTimer.v2();
         SettableFuture<Void> future = futureAndTimer.v1();
         timer.start();
-        future.get(50, TimeUnit.MILLISECONDS);
+        future.get(100, TimeUnit.MILLISECONDS);
     }
 
     @Test
@@ -111,9 +109,9 @@ public class KeepAliveTimersTest extends CrateUnitTest {
             public void run() {
                 timer.reset();
             }
-        }, 10, 10, TimeUnit.MILLISECONDS);
+        }, 0, 10, TimeUnit.MILLISECONDS);
         expectedException.expect(TimeoutException.class);
-        future.get(100, TimeUnit.MILLISECONDS);
+        future.get(200, TimeUnit.MILLISECONDS);
     }
 
     private Tuple<SettableFuture<Void>, KeepAliveTimers.ResettableTimer> getTimer(TimeValue timerDelay) {
@@ -138,6 +136,5 @@ public class KeepAliveTimersTest extends CrateUnitTest {
         timer.cancel();
         expectedException.expect(TimeoutException.class);
         future.get(100, TimeUnit.MILLISECONDS);
-
     }
 }

--- a/sql/src/test/java/io/crate/jobs/KeepAliveTimersTest.java
+++ b/sql/src/test/java/io/crate/jobs/KeepAliveTimersTest.java
@@ -22,6 +22,7 @@
 
 package io.crate.jobs;
 
+import com.carrotsearch.randomizedtesting.annotations.Repeat;
 import com.google.common.util.concurrent.SettableFuture;
 import io.crate.action.job.TransportKeepAliveAction;
 import io.crate.test.integration.CrateUnitTest;
@@ -38,6 +39,7 @@ import java.util.concurrent.*;
 
 import static org.mockito.Mockito.*;
 
+@Repeat(iterations=100)
 public class KeepAliveTimersTest extends CrateUnitTest {
 
     static {
@@ -89,7 +91,7 @@ public class KeepAliveTimersTest extends CrateUnitTest {
 
     @Test
     public void testKeepAliveRunnableWithHighDelayNotCalled() throws Exception {
-        Tuple<SettableFuture<Void>, KeepAliveTimers.ResettableTimer> futureAndTimer = getTimer(TimeValue.timeValueMillis(100));
+        Tuple<SettableFuture<Void>, KeepAliveTimers.ResettableTimer> futureAndTimer = getTimer(TimeValue.timeValueMillis(500));
         KeepAliveTimers.ResettableTimer timer = futureAndTimer.v2();
         SettableFuture<Void> future = futureAndTimer.v1();
         timer.start();

--- a/stresstest/src/test/java/io/crate/stress/LongRunningQueriesIntegrationTest.java
+++ b/stresstest/src/test/java/io/crate/stress/LongRunningQueriesIntegrationTest.java
@@ -35,14 +35,14 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 @TimeoutSuite(millis = 30 * 20 * TimeUnits.MINUTE)
-@TestLogging("io.crate.jobs.JobExecutionContext:TRACE")
+@TestLogging("io.crate.jobs.JobExecutionContext:TRACE,io.crate.jobs.KeepAliveTimers:TRACE")
 @ElasticsearchIntegrationTest.ClusterScope (numDataNodes = 2)
 public class LongRunningQueriesIntegrationTest extends SQLTransportIntegrationTest {
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
-    private static final int ROWS = 1_500_000;
+    private static final int ROWS = 500_000;
     private static final TimeValue TIMEOUT = TimeValue.timeValueSeconds(2_500);
 
     @Override


### PR DESCRIPTION
so their downstream contexts won't be killed by the reaper when the upstream phase takes very long to produce a result