### PR TITLE
make sure FetchContext is closed if FetchProjector receives fail

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,11 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed an issue that was introduced in 0.52.0 which could cause a
+   FetchContext to remain open longer than necessary in an error case.
+   This could then lead to failures if an attempt was made to move shards to
+   which the FetchContext hold onto.
+
  - Added initial limited cross-join support
 
  - Updated crate/elasticsearch for improved logging on graceful shutdown errors

--- a/sql/src/main/java/io/crate/operation/projectors/FetchProjector.java
+++ b/sql/src/main/java/io/crate/operation/projectors/FetchProjector.java
@@ -300,8 +300,12 @@ public class FetchProjector extends AbstractProjector {
             boolean first = failure.compareAndSet(null, throwable);
             switch (stage.get()) {
                 case INIT:
+                    throw new IllegalStateException("Shouldn't call fail on projection if projection hasn't been prepared");
                 case COLLECT:
-                    if (!first) return;
+                    if (first) {
+                        sendRequests();
+                        return;
+                    }
                 case FETCH:
                     if (remainingRequests.get() > 0) return;
             }


### PR DESCRIPTION
In some cases the FetchContext wouldn't be closed correctly
(until the Reaper closed it).

For example in the following scenario with 3 nodes:

    T       N1                      N2                  H

    1                                               send job requests
    2   created context
    3                             create context
    4                             failure
    5                                               fetchProjector.fail
    6  context isn't closed
