### PR TITLE
fix keep alive timer starting when sending node could not be determined

### DIFF
--- a/sql/src/main/java/io/crate/action/job/TransportJobAction.java
+++ b/sql/src/main/java/io/crate/action/job/TransportJobAction.java
@@ -118,14 +118,14 @@ public class TransportJobAction implements NodeAction<JobRequest, JobResponse> {
         } else {
             String nodeId = nodeId(request.remoteAddress());
             final KeepAliveTimers.ResettableTimer keepAliveTimer;
-            if (nodeId != null) {
+            if (nodeId == null) {
+                // assuming local node in this case
+                LOGGER.debug("Could not determine direct response node for address [{}]. Assuming local node. Not starting keep alive timer.", request.remoteAddress());
+                keepAliveTimer = null;
+            } else {
                 keepAliveTimer = keepAliveTimers.forJobOnNode(request.jobId(), nodeId);
                 keepAliveTimer.start();
-            } else {
-                LOGGER.warn("could not determine direct response node for address {}. not starting keepalive timer.", request.remoteAddress());
-                keepAliveTimer = null;
             }
-
             Futures.addCallback(Futures.allAsList(directResponseFutures), new FutureCallback<List<Bucket>>() {
                 @Override
                 public void onSuccess(List<Bucket> buckets) {


### PR DESCRIPTION
in this case the request was executed locally, so we do not neet to start the timer