### PR TITLE
re-use TopRowUpstream in IteratorPageDownstream

### DIFF
--- a/sql/src/test/java/io/crate/operation/merge/IteratorPageDownstreamTest.java
+++ b/sql/src/test/java/io/crate/operation/merge/IteratorPageDownstreamTest.java
@@ -181,7 +181,7 @@ public class IteratorPageDownstreamTest extends CrateUnitTest {
         pageDownstream.nextPage(new BucketPage(ImmutableList.of(b1)), PAGE_CONSUME_LISTENER);
         pageDownstream.nextPage(new BucketPage(ImmutableList.of(b1)), PAGE_CONSUME_LISTENER);
         pageDownstream.finish();
-        pageDownstream.repeat();
+        rowReceiver.repeatUpstream();
         pageDownstream.finish();
         assertThat(TestingHelpers.printedTable(rowReceiver.result()), is(
                 "a\n" +
@@ -216,11 +216,11 @@ public class IteratorPageDownstreamTest extends CrateUnitTest {
         ));
         pageDownstream.nextPage(new BucketPage(ImmutableList.of(b1)), PAGE_CONSUME_LISTENER);
         assertThat(rowReceiver.rows.size(), is(2));
-        pageDownstream.resume(false);
+        rowReceiver.resumeUpstream(false);
         assertThat(rowReceiver.rows.size(), is(3));
 
         pageDownstream.finish();
-        pageDownstream.repeat();
+        rowReceiver.repeatUpstream();
 
         assertThat(TestingHelpers.printedTable(rowReceiver.result()), is(
                 "a\n" +
@@ -229,7 +229,5 @@ public class IteratorPageDownstreamTest extends CrateUnitTest {
                 "a\n" +
                 "b\n" +
                 "c\n"));
-
-
     }
 }

--- a/sql/src/test/java/io/crate/testing/CollectingRowReceiver.java
+++ b/sql/src/test/java/io/crate/testing/CollectingRowReceiver.java
@@ -122,6 +122,10 @@ public class CollectingRowReceiver implements RowReceiver {
         }
     }
 
+    public void repeatUpstream() {
+        upstream.repeat();
+    }
+
     private static class LimitingReceiver extends CollectingRowReceiver {
 
         private final int limit;


### PR DESCRIPTION
The TopRowUpstream handles some race conditions that the 
IteratorPageDownstream didn't handle.