### PR TITLE
make sure DistributingDownstream doesn't get stuck

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed a possible race condition that could lead to queries getting stuck
+   (Only affected SELECT queries with a limit/offset > 500000) 
+
  - Fix: Crate won't start properly if a plugin loading error occurs
    (e.g. through a misconfigured plugin)
 

--- a/sql/src/main/java/io/crate/executor/transport/ExecutionPhasesTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/ExecutionPhasesTask.java
@@ -245,7 +245,9 @@ public class ExecutionPhasesTask extends JobTask {
                 pageDownstreamContext.setBucket(bucketIdx, bucket, true, new PageResultListener() {
                     @Override
                     public void needMore(boolean needMore) {
-                        // can't page with directResult
+                        if (needMore) {
+                            LOGGER.warn("requested more data but directResponse doesn't support paging");
+                        }
                     }
 
                     @Override

--- a/sql/src/main/java/io/crate/executor/transport/distributed/DistributingDownstream.java
+++ b/sql/src/main/java/io/crate/executor/transport/distributed/DistributingDownstream.java
@@ -226,6 +226,7 @@ public class DistributingDownstream implements RowReceiver {
 
         public void sendRequest(Bucket bucket, boolean isLast) {
             if (finished) {
+                requestsPending.decrementAndGet();
                 return;
             }
             keepAliveTimer.reset();


### PR DESCRIPTION
If one downstream doesn't need more data but another one does
`pendingRequests` is still increased by 2 but never got decreased for the
downstream that is already finished. This would then cause a deadlock.