### PR TITLE
fix keep-alive edge-case

### DIFF
--- a/sql/src/main/java/io/crate/action/job/TransportKeepAliveAction.java
+++ b/sql/src/main/java/io/crate/action/job/TransportKeepAliveAction.java
@@ -85,7 +85,7 @@ public class TransportKeepAliveAction implements NodeAction<KeepAliveRequest, Tr
         JobExecutionContext context = jobContextService.getContextOrNull(request.jobId());
         if (context != null) {
             LOGGER.trace("keeping JobExecutionContext {} alive ", context);
-            context.keepAlive();
+            context.externalKeepAlive();
         } else {
             LOGGER.trace("no JobExecutionContext found for jobId {}", request.jobId());
         }

--- a/sql/src/main/java/io/crate/jobs/AbstractExecutionSubContext.java
+++ b/sql/src/main/java/io/crate/jobs/AbstractExecutionSubContext.java
@@ -151,4 +151,11 @@ public abstract class AbstractExecutionSubContext implements ExecutionSubContext
 
     }
 
+    /**
+     * by default is PASSIVE, as it does not trigger keep alive on execution context itself
+     */
+    @Override
+    public SubContextMode subContextMode() {
+        return SubContextMode.PASSIVE;
+    }
 }

--- a/sql/src/main/java/io/crate/jobs/ExecutionSubContext.java
+++ b/sql/src/main/java/io/crate/jobs/ExecutionSubContext.java
@@ -21,9 +21,36 @@
 
 package io.crate.jobs;
 
+import com.google.common.base.Predicate;
+
 import javax.annotation.Nullable;
 
 public interface ExecutionSubContext {
+
+    public static final Predicate<ExecutionSubContext> IS_ACTIVE_PREDICATE = new Predicate<ExecutionSubContext>() {
+        @Override
+        public boolean apply(@Nullable ExecutionSubContext input) {
+            return input != null && input.subContextMode() == SubContextMode.ACTIVE;
+        }
+    };
+
+    /**
+     * enum for the current mode of a ExecutionSubContext.
+     * Might be static or changing dynamically
+     * (e.g. becoming active when a data was received and is currently consumed).
+     */
+    public static enum SubContextMode {
+        /**
+         * an active subcontext is active itself,
+         * keeping its execution context alive.
+         */
+        ACTIVE,
+        /**
+         * a passive subcontext usually idles waiting for data.
+         * it might need external keep alives in order to not be shut down.
+         */
+        PASSIVE
+    }
 
     /**
      * Set the {@link KeepAliveListener} on this subcontext. This is required to be set before
@@ -58,4 +85,9 @@ public interface ExecutionSubContext {
     SubExecutionContextFuture future();
 
     int id();
+
+    /**
+     * get the current state in respect to keep-alive handling
+     */
+    SubContextMode subContextMode();
 }

--- a/sql/src/main/java/io/crate/jobs/JobExecutionContext.java
+++ b/sql/src/main/java/io/crate/jobs/JobExecutionContext.java
@@ -22,6 +22,7 @@
 package io.crate.jobs;
 
 import com.google.common.base.Throwables;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
@@ -62,6 +63,16 @@ public class JobExecutionContext implements KeepAliveListener {
     @Override
     public void keepAlive() {
         this.lastAccessTime = threadPool.estimatedTimeInMillis();
+    }
+
+    /**
+     * only triggers keepAlive internally if no {@linkplain ExecutionSubContext.SubContextMode#ACTIVE}
+     * subcontexts are available.
+     */
+    public void externalKeepAlive() {
+        if (!Iterables.any(subContexts.values(), ExecutionSubContext.IS_ACTIVE_PREDICATE)) {
+            keepAlive();
+        }
     }
 
     public static class Builder {

--- a/sql/src/main/java/io/crate/operation/collect/JobCollectContext.java
+++ b/sql/src/main/java/io/crate/operation/collect/JobCollectContext.java
@@ -197,4 +197,15 @@ public class JobCollectContext extends AbstractExecutionSubContext implements Ex
     public SharedShardContexts sharedShardContexts() {
         return sharedShardContexts;
     }
+
+
+    /**
+     * active by default, because as long its operation is running
+     * it is keeping the local execution context alive itself
+     * and does not need external keep alives.
+     */
+    @Override
+    public SubContextMode subContextMode() {
+        return SubContextMode.ACTIVE;
+    }
 }

--- a/sql/src/test/java/io/crate/jobs/JobExecutionContextTest.java
+++ b/sql/src/test/java/io/crate/jobs/JobExecutionContextTest.java
@@ -46,6 +46,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.elasticsearch.test.ElasticsearchTestCase.assertBusy;
 import static org.hamcrest.core.Is.is;
@@ -218,5 +219,40 @@ public class JobExecutionContextTest extends CrateUnitTest {
         public String name() {
             return "SlowKilLExecutionSubContext";
         }
+    }
+
+    private static class KeepAliveSubContext extends AbstractExecutionSubContext {
+
+        final AtomicReference<SubContextMode> subContextMode = new AtomicReference<>(SubContextMode.PASSIVE);
+
+        protected KeepAliveSubContext() {
+            super(0);
+        }
+
+        @Override
+        public String name() {
+            return "keep-alive";
+        }
+
+        @Override
+        public SubContextMode subContextMode() {
+            return subContextMode.get();
+        }
+    }
+
+    @Test
+    public void testExternalKeepAlive() throws Exception {
+        JobExecutionContext.Builder builder =
+                new JobExecutionContext.Builder(UUID.randomUUID(), threadPool, mock(StatsTables.class));
+        KeepAliveSubContext subContext = new KeepAliveSubContext();
+        builder.addSubContext(subContext);
+        JobExecutionContext executionContext = spy(builder.build());
+        executionContext.externalKeepAlive();
+        verify(executionContext, times(1)).keepAlive();
+
+        subContext.subContextMode.set(ExecutionSubContext.SubContextMode.ACTIVE);
+        executionContext.externalKeepAlive();
+        // no further call done
+        verify(executionContext, times(1)).keepAlive();
     }
 }

--- a/sql/src/test/java/io/crate/jobs/PageDownstreamContextTest.java
+++ b/sql/src/test/java/io/crate/jobs/PageDownstreamContextTest.java
@@ -22,10 +22,15 @@
 package io.crate.jobs;
 
 import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.SettableFuture;
 import io.crate.Streamer;
 import io.crate.breaker.RamAccountingContext;
+import io.crate.core.collections.Bucket;
+import io.crate.core.collections.BucketPage;
 import io.crate.core.collections.Row1;
 import io.crate.core.collections.SingleRowBucket;
+import io.crate.operation.PageConsumeListener;
 import io.crate.operation.PageDownstream;
 import io.crate.operation.PageResultListener;
 import io.crate.operation.projectors.FlatProjectorChain;
@@ -37,7 +42,9 @@ import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import java.util.List;
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.hamcrest.Matchers.is;
@@ -95,5 +102,72 @@ public class PageDownstreamContextTest extends CrateUnitTest {
         ctx.kill(null);
         assertThat(throwable.get(), Matchers.instanceOf(CancellationException.class));
         verify(downstream, times(1)).fail(any(CancellationException.class));
+    }
+
+    @Test
+    public void testActiveWhileProcessingPage() throws Exception {
+        PageDownstream downstream = mock(PageDownstream.class);
+        final SettableFuture<Void> pageCompleteFuture = SettableFuture.create();
+        final CountDownLatch pageConsumeLatch = new CountDownLatch(1);
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                BucketPage bucketPage = (BucketPage)invocation.getArguments()[0];
+                final PageConsumeListener listener = (PageConsumeListener)invocation.getArguments()[1];
+                Futures.addCallback(
+                        Futures.allAsList(bucketPage.buckets()),
+                        new FutureCallback<List<Bucket>>() {
+                            @Override
+                            public void onSuccess(List<Bucket> result) {
+                                try {
+                                    pageConsumeLatch.await();
+                                    listener.finish();
+                                } catch (InterruptedException e) {
+                                    fail("interrupted while waiting on page result");
+                                }
+                                pageCompleteFuture.set(null);
+                            }
+
+                            @Override
+                            public void onFailure(Throwable t) {
+                                pageCompleteFuture.setException(t);
+                                listener.finish();
+                            }
+                        }
+                );
+                return null;
+            }
+        }).when(downstream).nextPage(any(BucketPage.class), any(PageConsumeListener.class));
+        final PageResultListener resultListener = mock(PageResultListener.class);
+        final PageDownstreamContext ctx = new PageDownstreamContext(1, "dummy", downstream, new Streamer[0], RAM_ACCOUNTING_CONTEXT, 2, mock(FlatProjectorChain.class));
+
+
+        // check passive by default
+        assertThat(ctx.subContextMode(), is(ExecutionSubContext.SubContextMode.PASSIVE));
+
+        // set first bucket
+        ctx.setBucket(0, new SingleRowBucket(new Row1("foo")), false, resultListener);
+
+        // check active until page is set
+        assertThat(ctx.subContextMode(), is(ExecutionSubContext.SubContextMode.ACTIVE));
+
+        // set second bucket
+        // in a thread because we block in the consumelistener to check the state while consuming
+        Thread setBucketThread2 = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                ctx.setBucket(1, new SingleRowBucket(new Row1("bar")), true, resultListener);
+            }
+        });
+        setBucketThread2.start();
+
+        // check active while page is processed
+        assertThat(ctx.subContextMode(), is(ExecutionSubContext.SubContextMode.ACTIVE));
+        pageConsumeLatch.countDown();
+
+        setBucketThread2.join(100);
+        Thread.sleep(100);
+        // check closed is back to passive
+        assertThat(ctx.subContextMode(), is(ExecutionSubContext.SubContextMode.PASSIVE));
     }
 }


### PR DESCRIPTION
where two nodes are downstream of each other for a certain query
and if one gets stuck, the job did not get killed
because both nodes kept each other alive.

Now keep alive requests to different nodes are only sent
when the local context is not stuck, so the other waiting context times out and gets killed