### PR TITLE
remove sqlalchemy dependency

### DIFF
--- a/docs/buildout.cfg
+++ b/docs/buildout.cfg
@@ -11,7 +11,7 @@ recipe = zc.recipe.egg:script
 relative-paths = true
 entry-points=test=zope.testrunner:run
 eggs = zope.testrunner
-       crate [test, sqlalchemy]
+       crate [test]
        crash
        zc.customdoctests
 initialization=

--- a/docs/versions.cfg
+++ b/docs/versions.cfg
@@ -2,7 +2,6 @@
 Babel = 1.3
 Jinja2 = 2.7.3
 MarkupSafe = 0.23
-SQLAlchemy = 1.0.0
 Sphinx = 1.3.1
 alabaster = 0.7.6
 appdirs = 1.4.0
@@ -13,7 +12,6 @@ crate-docs-theme = 0.4.1
 docutils = 0.12
 lovely.testlayers = 0.6.0
 mock = 1.0.1
-mr.developer = 1.34
 pytz = 2015.4
 snowballstemmer = 1.2.0
 sphinx-rtd-theme = 0.1.8


### PR DESCRIPTION
We only need the crate testlayer to run the doctests. SQLAlchemy isn't needed