### PR TITLE
use table stats to decide which side of NL to broadcast

### DIFF
--- a/sql/src/main/java/io/crate/action/sql/TransportSQLAction.java
+++ b/sql/src/main/java/io/crate/action/sql/TransportSQLAction.java
@@ -41,6 +41,7 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Provider;
+import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.BaseTransportRequestHandler;
@@ -51,6 +52,7 @@ import javax.annotation.Nullable;
 import java.util.List;
 
 
+@Singleton
 public class TransportSQLAction extends TransportBaseSQLAction<SQLRequest, SQLResponse> {
 
     @Inject

--- a/sql/src/main/java/io/crate/planner/TableStatsService.java
+++ b/sql/src/main/java/io/crate/planner/TableStatsService.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner;
+
+
+import com.carrotsearch.hppc.ObjectLongMap;
+import com.carrotsearch.hppc.ObjectLongOpenHashMap;
+import io.crate.action.sql.SQLRequest;
+import io.crate.action.sql.SQLResponse;
+import io.crate.action.sql.TransportSQLAction;
+import io.crate.metadata.TableIdent;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.component.AbstractComponent;
+import org.elasticsearch.common.inject.BindingAnnotation;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Provider;
+import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Singleton
+public class TableStatsService extends AbstractComponent implements Runnable {
+
+    private static final SQLRequest REQUEST = new SQLRequest(
+            "select cast(sum(num_docs) as long), schema_name, table_name from sys.shards group by 2, 3");
+    private final Provider<TransportSQLAction> transportSQLAction;
+    private volatile ObjectLongMap<TableIdent> tableStats = null;
+
+    @BindingAnnotation
+    @Target({ ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD })
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface StatsUpdateInterval {}
+
+    @Inject
+    public TableStatsService(Settings settings,
+                             ThreadPool threadPool,
+                             @StatsUpdateInterval TimeValue updateInterval,
+                             Provider<TransportSQLAction> transportSQLAction) {
+        super(settings);
+        this.transportSQLAction = transportSQLAction;
+        threadPool.scheduleWithFixedDelay(this, updateInterval);
+    }
+
+    @Override
+    public void run() {
+        updateStats();
+    }
+
+    private void updateStats() {
+        transportSQLAction.get().execute(
+                REQUEST,
+                new ActionListener<SQLResponse>() {
+
+                    @Override
+                    public void onResponse(SQLResponse sqlResponse) {
+                        tableStats = statsFromResponse(sqlResponse);
+                    }
+
+                    @Override
+                    public void onFailure(Throwable e) {
+                        logger.error("error retrieving table stats", e);
+                    }
+                });
+    }
+
+    private static ObjectLongMap<TableIdent> statsFromResponse(SQLResponse sqlResponse) {
+        ObjectLongMap<TableIdent> newStats = new ObjectLongOpenHashMap<>((int) sqlResponse.rowCount());
+        for (Object[] row : sqlResponse.rows()) {
+            newStats.put(new TableIdent((String) row[1], (String) row[2]), (long) row[0]);
+        }
+        return newStats;
+    }
+
+    /**
+     * Returns the number of docs a table has.
+     *
+     * <p>
+     * The returned number isn't an accurate real-time value but a cached value that is periodically updated
+     * </p>
+     * Returns -1 if the table isn't in the cache
+     */
+    public long numDocs(TableIdent tableIdent) {
+        ObjectLongMap<TableIdent> stats = tableStats;
+        if (stats == null) {
+            stats = statsFromResponse(transportSQLAction.get().execute(REQUEST).actionGet(30, TimeUnit.SECONDS));
+            tableStats = stats;
+        }
+        if (stats.containsKey(tableIdent)) {
+            return stats.get(tableIdent);
+        }
+        return -1;
+    }
+}

--- a/sql/src/main/java/io/crate/plugin/SQLModule.java
+++ b/sql/src/main/java/io/crate/plugin/SQLModule.java
@@ -23,8 +23,10 @@ package io.crate.plugin;
 
 import io.crate.action.sql.DDLStatementDispatcher;
 import io.crate.metadata.FulltextAnalyzerResolver;
+import io.crate.planner.TableStatsService;
 import io.crate.service.SQLService;
 import org.elasticsearch.common.inject.AbstractModule;
+import org.elasticsearch.common.unit.TimeValue;
 
 
 public class SQLModule extends AbstractModule {
@@ -34,5 +36,7 @@ public class SQLModule extends AbstractModule {
         bind(SQLService.class).asEagerSingleton();
         bind(DDLStatementDispatcher.class).asEagerSingleton();
         bind(FulltextAnalyzerResolver.class).asEagerSingleton();
+
+        bind(TimeValue.class).annotatedWith(TableStatsService.StatsUpdateInterval.class).toInstance(TimeValue.timeValueSeconds(60));
     }
 }

--- a/sql/src/test/java/io/crate/analyze/BaseAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/BaseAnalyzerTest.java
@@ -61,7 +61,7 @@ public abstract class BaseAnalyzerTest extends CrateUnitTest {
             .put("nodeOne", TreeMapBuilder.<String, List<Integer>>newMapBuilder().put("t1", Arrays.asList(1, 2)).map())
             .put("nodeTow", TreeMapBuilder.<String, List<Integer>>newMapBuilder().put("t1", Arrays.asList(3, 4)).map())
             .map());
-    static final TableIdent TEST_DOC_TABLE_IDENT = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "users");
+    public static final TableIdent TEST_DOC_TABLE_IDENT = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "users");
     public static final TableInfo userTableInfo = TestingTableInfo.builder(TEST_DOC_TABLE_IDENT, shardRouting)
             .add("id", DataTypes.LONG, null)
             .add("other_id", DataTypes.LONG, null)
@@ -83,8 +83,8 @@ public abstract class BaseAnalyzerTest extends CrateUnitTest {
             .addPrimaryKey("id")
             .clusteredBy("id")
             .build();
-    static final TableIdent TEST_DOC_TABLE_IDENT_MULTI_PK = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "users_multi_pk");
-    static final TableInfo userTableInfoMultiPk = TestingTableInfo.builder(TEST_DOC_TABLE_IDENT_MULTI_PK, shardRouting)
+    public static final TableIdent TEST_DOC_TABLE_IDENT_MULTI_PK = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "users_multi_pk");
+    public static final TableInfo userTableInfoMultiPk = TestingTableInfo.builder(TEST_DOC_TABLE_IDENT_MULTI_PK, shardRouting)
             .add("id", DataTypes.LONG, null)
             .add("name", DataTypes.STRING, null)
             .add("details", DataTypes.OBJECT, null)

--- a/sql/src/test/java/io/crate/planner/PlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/PlannerTest.java
@@ -125,6 +125,7 @@ public class PlannerTest extends CrateUnitTest {
 
         @Override
         protected void configure() {
+            bind(TableStatsService.class).toInstance(mock(TableStatsService.class));
             bind(ThreadPool.class).toInstance(threadPool);
             clusterService = mock(ClusterService.class);
             DiscoveryNode localNode = mock(DiscoveryNode.class);

--- a/sql/src/test/java/io/crate/planner/TableStatsServiceTest.java
+++ b/sql/src/test/java/io/crate/planner/TableStatsServiceTest.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner;
+
+import com.carrotsearch.randomizedtesting.annotations.Repeat;
+import com.google.common.collect.ImmutableSet;
+import io.crate.action.sql.SQLRequest;
+import io.crate.action.sql.SQLResponse;
+import io.crate.action.sql.TransportSQLAction;
+import io.crate.analyze.Analyzer;
+import io.crate.executor.transport.kill.TransportKillJobsNodeAction;
+import io.crate.metadata.TableIdent;
+import io.crate.operation.collect.StatsTables;
+import io.crate.test.integration.CrateUnitTest;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilter;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.common.inject.Provider;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.hamcrest.Matchers;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class TableStatsServiceTest extends CrateUnitTest  {
+
+    private ThreadPool threadPool;
+
+    @Before
+    public void init() throws Exception {
+        threadPool = new ThreadPool("dummy");
+    }
+
+    @After
+    public void clearThreadPool() throws Exception {
+        threadPool.shutdown();
+        threadPool.awaitTermination(30, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testNumDocs() throws Exception {
+        final AtomicInteger numRequests = new AtomicInteger(0);
+        final TransportSQLAction transportSQLAction = new TransportSQLAction(
+                mock(ClusterService.class),
+                ImmutableSettings.EMPTY,
+                threadPool,
+                mock(Analyzer.class),
+                mock(Planner.class),
+                mock(Provider.class),
+                mock(TransportService.class),
+                mock(StatsTables.class),
+                new ActionFilters(ImmutableSet.<ActionFilter>of()),
+                mock(TransportKillJobsNodeAction.class)
+        ) {
+            @Override
+            protected void doExecute(SQLRequest request, ActionListener<SQLResponse> listener) {
+                Object[] row;
+                if (numRequests.get() == 0) {
+                    row = new Object[] { 2L, "foo", "bar"};
+                } else {
+                    row = new Object[] { 4L, "foo", "bar"};
+                }
+                listener.onResponse(new SQLResponse(
+                        new String[] {"cast(sum(num_docs) as long)", "schema_name", "table_name"},
+                        new Object[][] { row },
+                        new DataType[] {DataTypes.LONG, DataTypes.STRING, DataTypes.STRING},
+                        1L,
+                        1L,
+                        false
+                ));
+                numRequests.incrementAndGet();
+            }
+        };
+
+        TableStatsService statsService = new TableStatsService(
+                ImmutableSettings.EMPTY, threadPool, TimeValue.timeValueMillis(100), new Provider<TransportSQLAction>() {
+            @Override
+            public TransportSQLAction get() {
+                return transportSQLAction;
+            }
+        });
+
+        assertThat(statsService.numDocs(new TableIdent("foo", "bar")), is(2L)); // first call triggers request
+        assertThat(statsService.numDocs(new TableIdent("foo", "bar")), is(2L)); // second call hits cache
+        int slept = 0;
+        while (numRequests.get() < 2 && slept < 1000) {
+            Thread.sleep(50);
+            slept += 50;
+        }
+        // periodic update happened
+        assertThat(numRequests.get(), Matchers.greaterThanOrEqualTo(2));
+        assertThat(statsService.numDocs(new TableIdent("foo", "bar")), is(4L));
+
+        assertThat(statsService.numDocs(new TableIdent("unknown", "table")), is(-1L));
+    }
+}


### PR DESCRIPTION
The smaller table should be broadcasted. This can significantly speed up query
execution if the size difference of the tables is very big.

In a simple test it reduced the time for a query from 125 sec to 0.8 sec