### PR TITLE
remove ReferenceResolver and RowGranularity property from ImplementationSymbolVisitor

### DIFF
--- a/sql/src/main/java/io/crate/executor/transport/TransportExecutor.java
+++ b/sql/src/main/java/io/crate/executor/transport/TransportExecutor.java
@@ -26,6 +26,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import io.crate.action.job.ContextPreparer;
 import io.crate.action.sql.DDLStatementDispatcher;
 import io.crate.action.sql.ShowStatementDispatcher;
+import io.crate.analyze.EvaluatingNormalizer;
 import io.crate.executor.*;
 import io.crate.executor.task.DDLTask;
 import io.crate.executor.task.NoopTask;
@@ -106,15 +107,16 @@ public class TransportExecutor implements Executor, TaskExecutor {
         this.bulkRetryCoordinatorPool = bulkRetryCoordinatorPool;
         nodeVisitor = new NodeVisitor();
         planVisitor = new TaskCollectingVisitor();
-        ImplementationSymbolVisitor globalImplementationSymbolVisitor = new ImplementationSymbolVisitor(
-                referenceResolver, functions, RowGranularity.CLUSTER);
+        EvaluatingNormalizer normalizer = new EvaluatingNormalizer(functions, RowGranularity.CLUSTER, referenceResolver);
+        ImplementationSymbolVisitor globalImplementationSymbolVisitor = new ImplementationSymbolVisitor(functions);
         globalProjectionToProjectionVisitor = new ProjectionToProjectorVisitor(
                 clusterService,
                 threadPool,
                 settings,
                 transportActionProvider,
                 bulkRetryCoordinatorPool,
-                globalImplementationSymbolVisitor);
+                globalImplementationSymbolVisitor,
+                normalizer);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/executor/transport/TransportShardUpsertAction.java
+++ b/sql/src/main/java/io/crate/executor/transport/TransportShardUpsertAction.java
@@ -496,7 +496,7 @@ public class TransportShardUpsertAction
     static class SymbolToInputVisitor extends ImplementationSymbolVisitor {
 
         public SymbolToInputVisitor(Functions functions) {
-            super(null, functions, null);
+            super(functions);
         }
 
         @Override

--- a/sql/src/main/java/io/crate/operation/ImplementationSymbolVisitor.java
+++ b/sql/src/main/java/io/crate/operation/ImplementationSymbolVisitor.java
@@ -28,8 +28,6 @@ import io.crate.analyze.symbol.SymbolFormatter;
 import io.crate.core.collections.Row;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.Functions;
-import io.crate.metadata.NestedReferenceResolver;
-import io.crate.metadata.RowGranularity;
 import io.crate.operation.aggregation.AggregationFunction;
 import io.crate.operation.collect.CollectExpression;
 import io.crate.operation.collect.InputCollectExpression;
@@ -68,24 +66,8 @@ public class ImplementationSymbolVisitor extends
         }
     }
 
-    protected final NestedReferenceResolver referenceResolver;
-    protected final RowGranularity rowGranularity;
-
-
-    public ImplementationSymbolVisitor(NestedReferenceResolver referenceResolver,
-                                       Functions functions,
-                                       RowGranularity rowGranularity) {
+    public ImplementationSymbolVisitor(Functions functions) {
         super(functions);
-        this.referenceResolver = referenceResolver;
-        this.rowGranularity = rowGranularity;
-    }
-
-    public NestedReferenceResolver referenceResolver() {
-        return referenceResolver;
-    }
-
-    public RowGranularity rowGranularity() {
-        return rowGranularity;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/operation/PageDownstreamFactory.java
+++ b/sql/src/main/java/io/crate/operation/PageDownstreamFactory.java
@@ -22,6 +22,7 @@
 package io.crate.operation;
 
 import com.google.common.base.Optional;
+import io.crate.analyze.EvaluatingNormalizer;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.core.collections.Row;
 import io.crate.executor.transport.TransportActionProvider;
@@ -61,18 +62,16 @@ public class PageDownstreamFactory {
                                  BulkRetryCoordinatorPool bulkRetryCoordinatorPool,
                                  NestedReferenceResolver referenceResolver,
                                  Functions functions) {
-        ImplementationSymbolVisitor implementationSymbolVisitor = new ImplementationSymbolVisitor(
-                referenceResolver,
-                functions,
-                RowGranularity.DOC
-        );
+        ImplementationSymbolVisitor implementationSymbolVisitor = new ImplementationSymbolVisitor(functions);
+        EvaluatingNormalizer normalizer = new EvaluatingNormalizer(functions, RowGranularity.DOC, referenceResolver);
         this.projectionToProjectorVisitor = new ProjectionToProjectorVisitor(
                 clusterService,
                 threadPool,
                 settings,
                 transportActionProvider,
                 bulkRetryCoordinatorPool,
-                implementationSymbolVisitor
+                implementationSymbolVisitor,
+                normalizer
         );
     }
 

--- a/sql/src/main/java/io/crate/operation/collect/ShardCollectService.java
+++ b/sql/src/main/java/io/crate/operation/collect/ShardCollectService.java
@@ -107,11 +107,7 @@ public class ShardCollectService {
         NestedReferenceResolver shardResolver = isBlobShard ? blobShardReferenceResolver : referenceResolver;
         docInputSymbolVisitor = crateDocIndexService.docInputSymbolVisitor();
 
-        this.shardImplementationSymbolVisitor = new ImplementationSymbolVisitor(
-                shardResolver,
-                functions,
-                RowGranularity.SHARD
-        );
+        this.shardImplementationSymbolVisitor = new ImplementationSymbolVisitor(functions);
         this.shardNormalizer = new EvaluatingNormalizer(
                 functions,
                 RowGranularity.SHARD,

--- a/sql/src/main/java/io/crate/operation/collect/sources/CollectSourceResolver.java
+++ b/sql/src/main/java/io/crate/operation/collect/sources/CollectSourceResolver.java
@@ -23,6 +23,7 @@ package io.crate.operation.collect.sources;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import io.crate.analyze.EvaluatingNormalizer;
 import io.crate.executor.transport.TransportActionProvider;
 import io.crate.metadata.Functions;
 import io.crate.metadata.NestedReferenceResolver;
@@ -77,18 +78,16 @@ public class CollectSourceResolver {
                                  SingleRowSource singleRowSource,
                                  SystemCollectSource systemCollectSource) {
 
-        ImplementationSymbolVisitor nodeImplementationSymbolVisitor = new ImplementationSymbolVisitor(
-                clusterReferenceResolver,
-                functions,
-                RowGranularity.NODE
-        );
+        ImplementationSymbolVisitor nodeImplementationSymbolVisitor = new ImplementationSymbolVisitor(functions);
+        EvaluatingNormalizer normalizer = new EvaluatingNormalizer(functions, RowGranularity.NODE, clusterReferenceResolver);
         ProjectorFactory projectorFactory = new ProjectionToProjectorVisitor(
                 clusterService,
                 threadPool,
                 settings,
                 transportActionProvider,
                 bulkRetryCoordinatorPool,
-                nodeImplementationSymbolVisitor
+                nodeImplementationSymbolVisitor,
+                normalizer
         );
         this.shardCollectSource = shardCollectSource;
         this.fileCollectSource = new ProjectorSetupCollectSource(fileCollectSource, projectorFactory);

--- a/sql/src/main/java/io/crate/operation/collect/sources/ShardCollectSource.java
+++ b/sql/src/main/java/io/crate/operation/collect/sources/ShardCollectSource.java
@@ -112,11 +112,7 @@ public class ShardCollectSource implements CollectSource {
     @Override
     public Collection<CrateCollector> getCollectors(CollectPhase collectPhase, RowReceiver downstream, JobCollectContext jobCollectContext) {
         NodeSysReferenceResolver referenceResolver = new NodeSysReferenceResolver(nodeSysExpression);
-        ImplementationSymbolVisitor implementationSymbolVisitor = new ImplementationSymbolVisitor(
-                referenceResolver,
-                functions,
-                RowGranularity.NODE
-        );
+        ImplementationSymbolVisitor implementationSymbolVisitor = new ImplementationSymbolVisitor(functions);
         EvaluatingNormalizer nodeNormalizer = new EvaluatingNormalizer(functions,
                 RowGranularity.NODE,
                 referenceResolver);
@@ -128,7 +124,8 @@ public class ShardCollectSource implements CollectSource {
                 settings,
                 transportActionProvider,
                 bulkRetryCoordinatorPool,
-                implementationSymbolVisitor
+                implementationSymbolVisitor,
+                nodeNormalizer
         );
 
         String localNodeId = clusterService.localNode().id();

--- a/sql/src/main/java/io/crate/operation/collect/sources/SingleRowSource.java
+++ b/sql/src/main/java/io/crate/operation/collect/sources/SingleRowSource.java
@@ -23,14 +23,11 @@ package io.crate.operation.collect.sources;
 
 import com.google.common.collect.ImmutableList;
 import io.crate.metadata.Functions;
-import io.crate.metadata.RowGranularity;
 import io.crate.operation.ImplementationSymbolVisitor;
 import io.crate.operation.collect.CrateCollector;
 import io.crate.operation.collect.JobCollectContext;
 import io.crate.operation.collect.RowsCollector;
 import io.crate.operation.projectors.RowReceiver;
-import io.crate.operation.reference.sys.node.NodeSysExpression;
-import io.crate.operation.reference.sys.node.NodeSysReferenceResolver;
 import io.crate.planner.node.dql.CollectPhase;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
@@ -41,21 +38,15 @@ import java.util.Collection;
 public class SingleRowSource implements CollectSource {
 
     private final Functions functions;
-    private final NodeSysExpression nodeSysExpression;
 
     @Inject
-    public SingleRowSource(Functions functions, NodeSysExpression nodeSysExpression) {
+    public SingleRowSource(Functions functions) {
         this.functions = functions;
-        this.nodeSysExpression = nodeSysExpression;
     }
 
     @Override
     public Collection<CrateCollector> getCollectors(CollectPhase collectPhase, RowReceiver downstream, JobCollectContext jobCollectContext) {
-        ImplementationSymbolVisitor nodeImplementationSymbolVisitor = new ImplementationSymbolVisitor(
-                new NodeSysReferenceResolver(nodeSysExpression),
-                functions,
-                RowGranularity.NODE
-        );
+        ImplementationSymbolVisitor nodeImplementationSymbolVisitor = new ImplementationSymbolVisitor(functions);
         if (collectPhase.whereClause().noMatch()){
             return ImmutableList.<CrateCollector>of(RowsCollector.empty(downstream));
         }

--- a/sql/src/main/java/io/crate/operation/projectors/ProjectionToProjectorVisitor.java
+++ b/sql/src/main/java/io/crate/operation/projectors/ProjectionToProjectorVisitor.java
@@ -85,20 +85,6 @@ public class ProjectionToProjectorVisitor
         this(clusterService, threadPool, settings, transportActionProvider, bulkRetryCoordinatorPool, symbolVisitor, normalizer, null);
     }
 
-    public ProjectionToProjectorVisitor(ClusterService clusterService,
-                                        ThreadPool threadPool,
-                                        Settings settings,
-                                        TransportActionProvider transportActionProvider,
-                                        BulkRetryCoordinatorPool bulkRetryCoordinatorPool,
-                                        ImplementationSymbolVisitor symbolVisitor) {
-        this(clusterService, threadPool, settings, transportActionProvider, bulkRetryCoordinatorPool, symbolVisitor,
-                new EvaluatingNormalizer(
-                        symbolVisitor.functions(),
-                        symbolVisitor.rowGranularity(),
-                        symbolVisitor.referenceResolver())
-        );
-    }
-
     @Override
     public Projector visitTopNProjection(TopNProjection projection, Context context) {
         Projector projector;

--- a/sql/src/test/java/io/crate/operation/ImplementationSymbolVisitorTest.java
+++ b/sql/src/test/java/io/crate/operation/ImplementationSymbolVisitorTest.java
@@ -103,11 +103,7 @@ public class ImplementationSymbolVisitorTest extends CrateUnitTest {
                 new TestScalarFunctionModule()
         ).createInjector();
 
-        visitor = new ImplementationSymbolVisitor(
-                null,
-                injector.getInstance(Functions.class),
-                RowGranularity.DOC
-        );
+        visitor = new ImplementationSymbolVisitor(injector.getInstance(Functions.class));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/projectors/ShardProjectorChainTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/ShardProjectorChainTest.java
@@ -22,6 +22,7 @@
 package io.crate.operation.projectors;
 
 import com.google.common.collect.ImmutableList;
+import io.crate.analyze.EvaluatingNormalizer;
 import io.crate.analyze.symbol.Aggregation;
 import io.crate.analyze.symbol.InputColumn;
 import io.crate.analyze.symbol.Literal;
@@ -99,10 +100,8 @@ public class ShardProjectorChainTest extends CrateUnitTest {
                 new MetaDataModule());
         Injector injector = builder.createInjector();
 
-        ImplementationSymbolVisitor implementationSymbolVisitor = new ImplementationSymbolVisitor(
-                injector.getInstance(NestedReferenceResolver.class),
-                injector.getInstance(Functions.class),
-                RowGranularity.CLUSTER);
+        Functions functions = injector.getInstance(Functions.class);
+        ImplementationSymbolVisitor implementationSymbolVisitor = new ImplementationSymbolVisitor(functions);
         projectionToProjectorVisitor = new ProjectionToProjectorVisitor(
                 new NoopClusterService(),
                 threadPool,
@@ -110,6 +109,7 @@ public class ShardProjectorChainTest extends CrateUnitTest {
                 mock(TransportActionProvider.class),
                 mock(BulkRetryCoordinatorPool.class),
                 implementationSymbolVisitor,
+                new EvaluatingNormalizer(functions, RowGranularity.DOC, injector.getInstance(NestedReferenceResolver.class)),
                 null
         );
     }


### PR DESCRIPTION
the ImplementationSymbolVisitor doesn't use the ReferenceResolver and
RowGranularity property itself but just exposed it for others. That is kinda
senseless and just made things more complicated.