### PR TITLE
AbstractImplementationSymbolVisitor: change extractImplementations overloads

### DIFF
--- a/sql/src/main/java/io/crate/operation/AbstractImplementationSymbolVisitor.java
+++ b/sql/src/main/java/io/crate/operation/AbstractImplementationSymbolVisitor.java
@@ -23,7 +23,6 @@ package io.crate.operation;
 
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.Functions;
-import io.crate.planner.node.dql.CollectPhase;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -48,21 +47,9 @@ public abstract class AbstractImplementationSymbolVisitor<C extends AbstractImpl
 
     protected abstract C newContext();
 
-    public C extractImplementations(CollectPhase node) {
+    public C extractImplementations(Symbol symbol) {
         C context = newContext();
-        if (node.toCollect() != null) {
-            for (Symbol symbol : node.toCollect()) {
-                context.add(process(symbol, context));
-            }
-        }
-        return context;
-    }
-
-    public C extractImplementations(Symbol... symbols) {
-        C context = newContext();
-        for (Symbol symbol : symbols) {
-            context.add(process(symbol, context));
-        }
+        context.add(process(symbol, context));
         return context;
     }
 

--- a/sql/src/main/java/io/crate/operation/collect/CollectInputSymbolVisitor.java
+++ b/sql/src/main/java/io/crate/operation/collect/CollectInputSymbolVisitor.java
@@ -70,7 +70,6 @@ public class CollectInputSymbolVisitor<E extends Input<?>>
         this.referenceResolver = referenceResolver;
     }
 
-    @Override
     public Context extractImplementations(CollectPhase node) {
         Context context = newContext();
         context.orderBy(node.orderBy());

--- a/sql/src/main/java/io/crate/operation/collect/ShardCollectService.java
+++ b/sql/src/main/java/io/crate/operation/collect/ShardCollectService.java
@@ -134,7 +134,7 @@ public class ShardCollectService {
         assert !collectPhase.whereClause().hasQuery()
                 : "whereClause shouldn't have a query after normalize. Should be NO_MATCH or MATCH_ALL";
         return RowsCollector.single(
-                shardImplementationSymbolVisitor.extractImplementations(collectPhase).topLevelInputs(),
+                shardImplementationSymbolVisitor.extractImplementations(collectPhase.toCollect()).topLevelInputs(),
                 rowReceiver
         );
     }

--- a/sql/src/main/java/io/crate/operation/collect/sources/FileCollectSource.java
+++ b/sql/src/main/java/io/crate/operation/collect/sources/FileCollectSource.java
@@ -61,7 +61,7 @@ public class FileCollectSource implements CollectSource {
             return ImmutableList.<CrateCollector>of(RowsCollector.empty(downstream));
         }
 
-        FileCollectInputSymbolVisitor.Context context = fileInputSymbolVisitor.extractImplementations(collectPhase);
+        FileCollectInputSymbolVisitor.Context context = fileInputSymbolVisitor.extractImplementations(collectPhase.toCollect());
         FileUriCollectPhase fileUriCollectPhase = (FileUriCollectPhase) collectPhase;
 
         // FileUriCollectPhase is only used in copy plans which never require ordering

--- a/sql/src/main/java/io/crate/operation/collect/sources/SingleRowSource.java
+++ b/sql/src/main/java/io/crate/operation/collect/sources/SingleRowSource.java
@@ -50,7 +50,7 @@ public class SingleRowSource implements CollectSource {
         if (collectPhase.whereClause().noMatch()){
             return ImmutableList.<CrateCollector>of(RowsCollector.empty(downstream));
         }
-        ImplementationSymbolVisitor.Context ctx = nodeImplementationSymbolVisitor.extractImplementations(collectPhase);
+        ImplementationSymbolVisitor.Context ctx = nodeImplementationSymbolVisitor.extractImplementations(collectPhase.toCollect());
         return ImmutableList.<CrateCollector>of(RowsCollector.single(ctx.topLevelInputs(), downstream));
     }
 }


### PR DESCRIPTION
The varargs overload was only ever called with one argument resulting in an
unnecessary array allocation.

Removed the collectPhase overload because it doesn't really reduce any
boilerplate but just made it unclear which symbols of the phase are being
extracted.