### PR TITLE
support orderBy on collectPhase

### DIFF
--- a/core/src/main/java/io/crate/core/collections/Row.java
+++ b/core/src/main/java/io/crate/core/collections/Row.java
@@ -21,7 +21,19 @@
 
 package io.crate.core.collections;
 
+import com.google.common.base.Function;
+
 public interface Row {
+
+    Function<Row, Object[]> MATERIALIZE = new Function<Row, Object[]>() {
+        @Override
+        public Object[] apply(Row input) {
+            if (input == null) {
+                return null;
+            }
+            return input.materialize();
+        }
+    };
 
     int size();
 

--- a/sql/src/main/java/io/crate/operation/projectors/sorting/OrderingByPosition.java
+++ b/sql/src/main/java/io/crate/operation/projectors/sorting/OrderingByPosition.java
@@ -22,7 +22,10 @@
 package io.crate.operation.projectors.sorting;
 
 import com.google.common.collect.Ordering;
+import io.crate.analyze.OrderBy;
 import io.crate.core.collections.Row;
+import io.crate.planner.consumer.OrderByPositionVisitor;
+import io.crate.planner.node.dql.CollectPhase;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -30,6 +33,16 @@ import java.util.Comparator;
 import java.util.List;
 
 public abstract class OrderingByPosition<T> extends Ordering<T> {
+
+    public static Ordering<Object[]> arrayOrdering(CollectPhase collectPhase) {
+        OrderBy orderBy = collectPhase.orderBy();
+        assert orderBy != null : "collectPhase must have an orderBy clause to generate an ordering";
+        return arrayOrdering(
+                OrderByPositionVisitor.orderByPositions(orderBy.orderBySymbols(), collectPhase.toCollect()),
+                orderBy.reverseFlags(),
+                orderBy.nullsFirst()
+        );
+    }
 
     public static Ordering<Row> rowOrdering(int[] positions, boolean[] reverseFlags, Boolean[] nullsFirst) {
         List<Comparator<Row>> comparators = new ArrayList<>(positions.length);

--- a/sql/src/test/java/io/crate/planner/PlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/PlannerTest.java
@@ -495,18 +495,18 @@ public class PlannerTest extends CrateUnitTest {
 
     @Test
     public void testShardSelectWithOrderBy() throws Exception {
-        CollectAndMerge planNode = (CollectAndMerge) plan("select id from sys.shards order by id limit 10");
+        CollectAndMerge planNode = plan("select id from sys.shards order by id limit 10");
         CollectPhase collectPhase = planNode.collectPhase();
 
         assertEquals(DataTypes.INTEGER, collectPhase.outputTypes().get(0));
         assertThat(collectPhase.maxRowGranularity(), is(RowGranularity.SHARD));
 
-        assertThat(collectPhase.orderBy(), nullValue());
-        assertThat(collectPhase.nodePageSizeHint(), nullValue());
+        assertThat(collectPhase.orderBy(), notNullValue());
 
         List<Projection> projections = collectPhase.projections();
         assertThat(projections.size(), is(1));
         assertThat(projections.get(0), instanceOf(TopNProjection.class));
+        assertThat(((TopNProjection) projections.get(0)).isOrdered(), is(false));
 
         MergePhase mergeNode = planNode.localMerge();
 


### PR DESCRIPTION
Previously the `collectPhase.orderBy()` property wasn't supported in the
execution-phase of sys tables. Therefore the Planner had to add a
TopNProjection instead.

This commit adds support for the `orderBy` property so that the planner no
longer has to differentiate between sys and doc tables.

Unfortunately, as there is no hard-limit on the collectPhase it will now
always order ALL rows und not just LIMIT rows.