### PR TITLE
change ProjectionBuilder methods to static

### DIFF
--- a/sql/src/main/java/io/crate/planner/consumer/CrossJoinConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/CrossJoinConsumer.java
@@ -158,8 +158,6 @@ public class CrossJoinConsumer implements Consumer {
                     rightPlan.resultPhase(),
                     right.querySpec());
 
-            ProjectionBuilder projectionBuilder = new ProjectionBuilder(analysisMetaData.functions(), statement.querySpec());
-
             List<Projection> projections = new ArrayList<>();
             List<Field> inputs = concatFields(left, right);
             if (filterNeeded) {
@@ -167,11 +165,11 @@ public class CrossJoinConsumer implements Consumer {
                     throw new UnsupportedOperationException(
                             "JOIN condition in the WHERE clause is not supported if the statement contains user tables");
                 }
-                FilterProjection filterProjection = projectionBuilder.filterProjection(inputs, where.query());
+                FilterProjection filterProjection = ProjectionBuilder.filterProjection(inputs, where.query());
                 projections.add(filterProjection);
             }
 
-            TopNProjection topN = projectionBuilder.topNProjection(
+            TopNProjection topN = ProjectionBuilder.topNProjection(
                     inputs,
                     statement.querySpec().orderBy().orNull(),
                     statement.querySpec().offset(),

--- a/sql/src/main/java/io/crate/planner/consumer/DistributedGroupByConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/DistributedGroupByConsumer.java
@@ -142,7 +142,7 @@ public class DistributedGroupByConsumer implements Consumer {
                 if (havingClause.get().noMatch()) {
                     return new NoopPlannedAnalyzedRelation(table, plannerContext.jobId());
                 } else if (havingClause.get().hasQuery()) {
-                    reducerProjections.add(projectionBuilder.filterProjection(
+                    reducerProjections.add(ProjectionBuilder.filterProjection(
                             collectOutputs,
                             havingClause.get().query()
                     ));
@@ -151,7 +151,7 @@ public class DistributedGroupByConsumer implements Consumer {
 
             boolean isRootRelation = context.rootRelation() == table;
             if (isRootRelation) {
-                reducerProjections.add(projectionBuilder.topNProjection(
+                reducerProjections.add(ProjectionBuilder.topNProjection(
                         collectOutputs,
                         querySpec.orderBy().orNull(),
                         0,
@@ -174,7 +174,7 @@ public class DistributedGroupByConsumer implements Consumer {
             MergePhase localMergeNode = null;
             String localNodeId = plannerContext.clusterService().state().nodes().localNodeId();
             if(isRootRelation) {
-                TopNProjection topN = projectionBuilder.topNProjection(
+                TopNProjection topN = ProjectionBuilder.topNProjection(
                         querySpec.outputs(),
                         querySpec.orderBy().orNull(),
                         querySpec.offset(),

--- a/sql/src/main/java/io/crate/planner/consumer/GlobalAggregateConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/GlobalAggregateConsumer.java
@@ -139,14 +139,14 @@ public class GlobalAggregateConsumer implements Consumer {
             if (havingClause.get().noMatch()) {
                 return new NoopPlannedAnalyzedRelation(table, plannerContext.jobId());
             } else if (havingClause.get().hasQuery()){
-                projections.add(projectionBuilder.filterProjection(
+                projections.add(ProjectionBuilder.filterProjection(
                         splitPoints.aggregates(),
                         havingClause.get().query()
                 ));
             }
         }
 
-        TopNProjection topNProjection = projectionBuilder.topNProjection(
+        TopNProjection topNProjection = ProjectionBuilder.topNProjection(
                 splitPoints.aggregates(),
                 null, 0, 1,
                 table.querySpec().outputs()

--- a/sql/src/main/java/io/crate/planner/consumer/NonDistributedGroupByConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/NonDistributedGroupByConsumer.java
@@ -157,7 +157,7 @@ public class NonDistributedGroupByConsumer implements Consumer {
                 if (havingClause.get().noMatch()) {
                     return new NoopPlannedAnalyzedRelation(table, context.plannerContext().jobId());
                 } else if (havingClause.get().hasQuery()){
-                    projections.add(projectionBuilder.filterProjection(
+                    projections.add(ProjectionBuilder.filterProjection(
                             collectOutputs,
                             havingClause.get().query()
                     ));
@@ -175,7 +175,7 @@ public class NonDistributedGroupByConsumer implements Consumer {
             boolean outputsMatch = table.querySpec().outputs().size() == collectOutputs.size() &&
                                     collectOutputs.containsAll(table.querySpec().outputs());
             if (context.rootRelation() == table || !outputsMatch){
-                projections.add(projectionBuilder.topNProjection(
+                projections.add(ProjectionBuilder.topNProjection(
                         collectOutputs,
                         table.querySpec().orderBy().orNull(),
                         table.querySpec().offset(),

--- a/sql/src/main/java/io/crate/planner/consumer/QueryThenFetchConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/QueryThenFetchConsumer.java
@@ -100,7 +100,6 @@ public class QueryThenFetchConsumer implements Consumer {
                 return null;
             }
 
-            ProjectionBuilder projectionBuilder = new ProjectionBuilder(functions, querySpec);
             CollectAndMerge qaf = (CollectAndMerge) plannedSubQuery;
             CollectPhase collectPhase = qaf.collectPhase();
             if (collectPhase.nodePageSizeHint() == null) {
@@ -138,7 +137,7 @@ public class QueryThenFetchConsumer implements Consumer {
             MergePhase localMergePhase;
             assert qaf.localMerge() == null : "subRelation shouldn't plan localMerge";
 
-            TopNProjection topN = projectionBuilder.topNProjection(
+            TopNProjection topN = ProjectionBuilder.topNProjection(
                     collectPhase.toCollect(),
                     null, // orderBy = null because stuff is pre-sorted in collectPhase and sortedLocalMerge is used
                     querySpec.offset(),

--- a/sql/src/main/java/io/crate/planner/consumer/ReduceOnCollectorGroupByConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/ReduceOnCollectorGroupByConsumer.java
@@ -140,7 +140,7 @@ public class ReduceOnCollectorGroupByConsumer implements Consumer {
                 if (havingClause.get().noMatch()) {
                     return new NoopPlannedAnalyzedRelation(table, context.plannerContext().jobId());
                 } else if (havingClause.get().hasQuery()) {
-                    FilterProjection fp = projectionBuilder.filterProjection(
+                    FilterProjection fp = ProjectionBuilder.filterProjection(
                             collectOutputs,
                             havingClause.get().query()
                     );
@@ -155,7 +155,7 @@ public class ReduceOnCollectorGroupByConsumer implements Consumer {
             boolean collectorTopN = table.querySpec().limit().isPresent() || table.querySpec().offset() > 0 || !outputsMatch;
 
             if (collectorTopN) {
-                projections.add(projectionBuilder.topNProjection(
+                projections.add(ProjectionBuilder.topNProjection(
                         collectOutputs,
                         table.querySpec().orderBy().orNull(),
                         0, // no offset
@@ -178,7 +178,7 @@ public class ReduceOnCollectorGroupByConsumer implements Consumer {
                 // handler receives sorted results from collect nodes
                 // we can do the sorting with a sorting bucket merger
                 handlerProjections.add(
-                        projectionBuilder.topNProjection(
+                        ProjectionBuilder.topNProjection(
                                 table.querySpec().outputs(),
                                 null, // omit order by
                                 table.querySpec().offset(),
@@ -198,7 +198,7 @@ public class ReduceOnCollectorGroupByConsumer implements Consumer {
                 );
             } else {
                 handlerProjections.add(
-                        projectionBuilder.topNProjection(
+                        ProjectionBuilder.topNProjection(
                                 collectorTopN ? table.querySpec().outputs() : collectOutputs,
                                 table.querySpec().orderBy().orNull(),
                                 table.querySpec().offset(),

--- a/sql/src/main/java/io/crate/planner/projection/builder/ProjectionBuilder.java
+++ b/sql/src/main/java/io/crate/planner/projection/builder/ProjectionBuilder.java
@@ -117,16 +117,14 @@ public class ProjectionBuilder {
         return aggregations;
     }
 
-    public FilterProjection filterProjection(
-            Collection<? extends Symbol> inputs,
-            Symbol query) {
+    public static FilterProjection filterProjection(Collection<? extends Symbol> inputs, Symbol query) {
         InputCreatingVisitor.Context context = new InputCreatingVisitor.Context(inputs);
         query = inputVisitor.process(query, context);
         List<Symbol> outputs = inputVisitor.process(inputs, context);
         return new FilterProjection(query, outputs);
     }
 
-    public TopNProjection topNProjection(
+    public static TopNProjection topNProjection(
             Collection<? extends Symbol> inputs,
             @Nullable OrderBy orderBy,
             int offset,


### PR DESCRIPTION
in order to make it clear that they don't actually use/depend on the QuerySpec
that is passed into the ProjectionBuilder constructor.