### PR TITLE
remove ``partial`` from supported snapshot/restore parameters

### DIFF
--- a/docs/sql/reference/create_snapshot.txt
+++ b/docs/sql/reference/create_snapshot.txt
@@ -81,8 +81,5 @@ created:
                       whole snapshot was created or an error occurred.
                       This can take a serious amount of time.
 
-:partial: (Default ``false``) if a table has unavailable primary shards the snapshot creation will fail.
-          If set to ``true`` creation will continue and leave out the unavailable shards.
-
 :ignore_unavailable: (Default ``false``) if a given table does not exist the command will fail by default.
                      If set to ``true`` these tables are ignored and not included in the snapshot.

--- a/docs/sql/reference/restore_snapshot.txt
+++ b/docs/sql/reference/restore_snapshot.txt
@@ -55,10 +55,6 @@ WITH Clause
 The following configuration parameters can be used to modify how the snapshot is
 restored to the cluster:
 
-:partial: (Default ``false``) Per default a table does not have all shards in the snapshot
-          to restore from the restore command fails. If set to ``true`` the command
-          will ignore missing shards in the snapshot.
-
 :ignore_unavailable: (Default ``false``) Per default the restore command fails if a table
                      is given that does not exist in the snapshot. If set to ``true`` those
                      missing tables are ignored.

--- a/docs/sql/snapshot_restore.txt
+++ b/docs/sql/snapshot_restore.txt
@@ -50,7 +50,7 @@ of tables. The :ref:`ref-create-snapshot` statement is used to create
 a snapshots::
 
     cr> CREATE SNAPSHOT where_my_snapshots_go.snapshot1 ALL
-    ... WITH (wait_for_completion=true, partial=true, ignore_unavailable=true);
+    ... WITH (wait_for_completion=true, ignore_unavailable=true);
     CREATE OK (... sec)
 
 A snapshot is referenced by the name of the repository and the
@@ -66,7 +66,7 @@ included in the snapshot and the persistent settings will be excluded.
 ::
 
     cr> CREATE SNAPSHOT where_my_snapshots_go.snapshot2 TABLE quotes, doc.locations
-    ... WITH (wait_for_completion=true, partial=true, ignore_unavailable=true);
+    ... WITH (wait_for_completion=true, ignore_unavailable=true);
     CREATE OK (... sec)
 
 .. Hidden: create partitioned table
@@ -89,7 +89,7 @@ deleted but it should be possible to restore them if needed::
     cr> CREATE SNAPSHOT where_my_snapshots_go.snapshot3 TABLE
     ...    locations,
     ...    parted_table PARTITION (date='1970-01-01')
-    ... WITH (wait_for_completion=true, partial=true, ignore_unavailable=true);
+    ... WITH (wait_for_completion=true, ignore_unavailable=true);
     CREATE OK (... sec)
 
 When creating single partitions the partitioned table and its metadata

--- a/sql/src/main/java/io/crate/analyze/CreateSnapshotStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateSnapshotStatementAnalyzer.java
@@ -56,22 +56,6 @@ public class CreateSnapshotStatementAnalyzer extends AbstractRepositoryDDLAnalyz
     private static final ESLogger LOGGER = Loggers.getLogger(CreateSnapshotStatementAnalyzer.class);
     private final Schemas schemas;
 
-    public static final BoolSetting PARTIAL = new BoolSetting() {
-        @Override
-        public String name() {
-            return "partial";
-        }
-
-        @Override
-        public Boolean defaultValue() {
-            return Boolean.FALSE;
-        }
-
-        @Override
-        public boolean isRuntime() {
-            return false;
-        }
-    };
     public static final BoolSetting IGNORE_UNAVAILABLE = new BoolSetting() {
         @Override
         public String name() {
@@ -107,7 +91,6 @@ public class CreateSnapshotStatementAnalyzer extends AbstractRepositoryDDLAnalyz
 
 
     private static final ImmutableMap<String, SettingsApplier> SETTINGS = ImmutableMap.<String, SettingsApplier>builder()
-            .put(PARTIAL.name(), new SettingsAppliers.BooleanSettingsApplier(PARTIAL))
             .put(IGNORE_UNAVAILABLE.name(), new SettingsAppliers.BooleanSettingsApplier(IGNORE_UNAVAILABLE))
             .put(WAIT_FOR_COMPLETION.name(), new SettingsAppliers.BooleanSettingsApplier(WAIT_FOR_COMPLETION))
             .build();

--- a/sql/src/main/java/io/crate/executor/transport/SnapshotDDLDispatcher.java
+++ b/sql/src/main/java/io/crate/executor/transport/SnapshotDDLDispatcher.java
@@ -84,7 +84,6 @@ public class SnapshotDDLDispatcher {
         final SettableFuture<Long> resultFuture = SettableFuture.create();
 
         boolean waitForCompletion = statement.snapshotSettings().getAsBoolean(WAIT_FOR_COMPLETION.settingName(), WAIT_FOR_COMPLETION.defaultValue());
-        boolean partial = statement.snapshotSettings().getAsBoolean(PARTIAL.settingName(), PARTIAL.defaultValue());
         boolean ignoreUnavailable = statement.snapshotSettings().getAsBoolean(IGNORE_UNAVAILABLE.settingName(), IGNORE_UNAVAILABLE.defaultValue());
 
         // ignore_unavailable as set by statement
@@ -93,7 +92,6 @@ public class SnapshotDDLDispatcher {
 
         CreateSnapshotRequest request = new CreateSnapshotRequest(statement.snapshotId().getRepository(), statement.snapshotId().getSnapshot())
                 .includeGlobalState(statement.includeMetadata())
-                .partial(partial)
                 .waitForCompletion(waitForCompletion)
                 .indices(statement.indices())
                 .indicesOptions(indicesOptions)


### PR DESCRIPTION
using ``partial`` while restoring results in unusable repository (can't be modified anymore). this is a bug in ES