### PR TITLE
remove setting default assertion status in tests

### DIFF
--- a/app/src/test/java/io/crate/node/NodeSettingsTest.java
+++ b/app/src/test/java/io/crate/node/NodeSettingsTest.java
@@ -50,10 +50,6 @@ public class NodeSettingsTest {
     @Rule
     public TemporaryFolder tmp = new TemporaryFolder();
 
-    static {
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    }
-
     protected Node node;
     protected Client client;
     private boolean loggingConfigured = false;

--- a/blob/src/test/java/io/crate/integrationtests/RecoveryTests.java
+++ b/blob/src/test/java/io/crate/integrationtests/RecoveryTests.java
@@ -90,7 +90,6 @@ public class RecoveryTests extends ElasticsearchIntegrationTest {
 
     static {
         System.setProperty("tests.short_timeouts", "true");
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
 
         Logger logger;
         ConsoleAppender consoleAppender;

--- a/client/src/test/java/io/crate/client/CrateClientTest.java
+++ b/client/src/test/java/io/crate/client/CrateClientTest.java
@@ -47,10 +47,6 @@ import static org.hamcrest.Matchers.*;
 
 public class CrateClientTest extends ElasticsearchIntegrationTest {
 
-    static {
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    }
-
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 

--- a/core/src/test/java/io/crate/ClusterIdServiceTest.java
+++ b/core/src/test/java/io/crate/ClusterIdServiceTest.java
@@ -31,10 +31,6 @@ import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilde
 @ElasticsearchIntegrationTest.ClusterScope(scope = ElasticsearchIntegrationTest.Scope.TEST, numDataNodes = 0)
 public class ClusterIdServiceTest extends ElasticsearchIntegrationTest  {
 
-    static {
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    }
-
     @Test
     public void testClusterIdGeneration() throws Exception {
         Settings localSettings = settingsBuilder()

--- a/core/src/test/java/io/crate/DataTypeTest.java
+++ b/core/src/test/java/io/crate/DataTypeTest.java
@@ -37,10 +37,6 @@ import java.util.Map;
 
 public class DataTypeTest extends CrateUnitTest {
 
-    static {
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    }
-
     @Test
     public void testStreaming() throws Exception {
         BytesRef b1 = new BytesRef("hello");

--- a/core/src/test/java/io/crate/types/ArrayTypeTest.java
+++ b/core/src/test/java/io/crate/types/ArrayTypeTest.java
@@ -30,10 +30,6 @@ import static org.hamcrest.Matchers.instanceOf;
 
 public class ArrayTypeTest extends CrateUnitTest {
 
-    static {
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    }
-
     @Test
     public void testArrayTypeSerialization() throws Exception {
         // nested string array: [ ["x"], ["y"] ]

--- a/core/src/test/java/io/crate/types/DataTypesTest.java
+++ b/core/src/test/java/io/crate/types/DataTypesTest.java
@@ -36,10 +36,6 @@ import static org.hamcrest.Matchers.is;
 
 public class DataTypesTest extends CrateUnitTest {
 
-    static {
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    }
-
     @Test
     public void testConvertBooleanToString() {
         BytesRef value = DataTypes.STRING.value(true);

--- a/core/src/test/java/io/crate/types/GeoPointTypeTest.java
+++ b/core/src/test/java/io/crate/types/GeoPointTypeTest.java
@@ -33,10 +33,6 @@ import static org.hamcrest.Matchers.is;
 
 public class GeoPointTypeTest extends CrateUnitTest {
 
-    static {
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    }
-
     @Test
     public void testStreaming() throws Throwable {
         Double[] p1 = new Double[] { 41.2, -37.4 };

--- a/core/src/test/java/io/crate/types/GeoShapeTypeTest.java
+++ b/core/src/test/java/io/crate/types/GeoShapeTypeTest.java
@@ -32,10 +32,6 @@ import static org.hamcrest.Matchers.is;
 
 public class GeoShapeTypeTest extends CrateUnitTest {
 
-    static {
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    }
-
     private GeoShapeType type = GeoShapeType.INSTANCE;
 
     @Test

--- a/core/src/test/java/io/crate/types/IpTypeTest.java
+++ b/core/src/test/java/io/crate/types/IpTypeTest.java
@@ -30,10 +30,6 @@ import static org.hamcrest.Matchers.nullValue;
 
 public class IpTypeTest extends CrateUnitTest {
 
-    static {
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    }
-
     @Test
     public void testValidation() throws Exception {
         BytesRef[] validIps = {

--- a/core/src/test/java/io/crate/types/LongTypeTest.java
+++ b/core/src/test/java/io/crate/types/LongTypeTest.java
@@ -29,10 +29,6 @@ import static org.hamcrest.Matchers.is;
 
 public class LongTypeTest extends CrateUnitTest {
 
-    static {
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    }
-
     @Test
     public void testBytesRefToLongParsing() throws Exception {
         assertBytesRefParsing("12839", 12839L);

--- a/core/src/test/java/io/crate/types/TypeConversionTest.java
+++ b/core/src/test/java/io/crate/types/TypeConversionTest.java
@@ -33,10 +33,6 @@ import static org.hamcrest.core.Is.is;
 
 public class TypeConversionTest extends CrateUnitTest {
 
-    static {
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    }
-
     private static class Repeater<T> implements Iterable<T>, Iterator<T> {
 
         private final LongAdder repeated;

--- a/dns-discovery/src/test/java/org/elasticsearch/discovery/srv/SrvDiscoveryIntegrationTest.java
+++ b/dns-discovery/src/test/java/org/elasticsearch/discovery/srv/SrvDiscoveryIntegrationTest.java
@@ -36,10 +36,6 @@ import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilde
 @ElasticsearchIntegrationTest.ClusterScope(numClientNodes = 0, numDataNodes = 0)
 public class SrvDiscoveryIntegrationTest extends ElasticsearchIntegrationTest {
 
-    static {
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    }
-
     @Before
     public void prepare() throws Exception {
         Lookup.setDefaultCache(new MockedZoneCache("crate.internal."), DClass.IN);

--- a/sql/src/test/java/io/crate/analyze/CreateDropRepositoryAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateDropRepositoryAnalyzerTest.java
@@ -43,10 +43,6 @@ import static org.mockito.Mockito.when;
 
 public class CreateDropRepositoryAnalyzerTest extends BaseAnalyzerTest {
 
-    static {
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    }
-
     @Mock
     private RepositoriesMetaData repositoriesMetaData;
 

--- a/sql/src/test/java/io/crate/analyze/SnapshotRestoreAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SnapshotRestoreAnalyzerTest.java
@@ -51,10 +51,6 @@ import static org.mockito.Mockito.when;
 
 public class SnapshotRestoreAnalyzerTest extends BaseAnalyzerTest {
 
-    static {
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    }
-
     @Mock
     private RepositoriesMetaData repositoriesMetaData;
 

--- a/sql/src/test/java/io/crate/executor/transport/BaseTransportExecutorTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/BaseTransportExecutorTest.java
@@ -49,10 +49,6 @@ public class BaseTransportExecutorTest extends SQLTransportIntegrationTest {
 
     Setup setup = new Setup(sqlExecutor);
 
-    static {
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    }
-
     TransportExecutor executor;
     DocSchemaInfo docSchemaInfo;
 

--- a/sql/src/test/java/io/crate/executor/transport/TransportExecutorDDLTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/TransportExecutorDDLTest.java
@@ -61,30 +61,8 @@ import static org.hamcrest.Matchers.is;
 
 public class TransportExecutorDDLTest extends SQLTransportIntegrationTest {
 
-    static {
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    }
-
     private TransportExecutor executor;
 
-    private final static Map<String, Object> TEST_MAPPING = ImmutableMap.<String, Object>of(
-            "properties", ImmutableMap.of(
-                    "id", ImmutableMap.builder()
-                            .put("type", "integer")
-                            .put("store", false)
-                            .put("index", "not_analyzed")
-                            .put("doc_values", true).build(),
-                    "name", ImmutableMap.builder()
-                            .put("type", "string")
-                            .put("store", false)
-                            .put("index", "not_analyzed")
-                            .put("doc_values", true).build(),
-                    "names", ImmutableMap.builder()
-                            .put("type", "string")
-                            .put("store", false)
-                            .put("index", "not_analyzed")
-                            .put("doc_values", false).build()
-            ));
     private final static Map<String, Object> TEST_PARTITIONED_MAPPING = ImmutableMap.<String, Object>of(
             "_meta", ImmutableMap.of(
                     "partitioned_by", ImmutableList.of(Arrays.asList("name", "string"))

--- a/sql/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -50,10 +50,6 @@ import static org.hamcrest.core.Is.is;
 @ElasticsearchIntegrationTest.ClusterScope(randomDynamicTemplates = false)
 public class DDLIntegrationTest extends SQLTransportIntegrationTest {
 
-    static {
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    }
-
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 

--- a/sql/src/test/java/io/crate/integrationtests/EmptyStringRoutingIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/EmptyStringRoutingIntegrationTest.java
@@ -40,10 +40,6 @@ import static org.hamcrest.core.Is.is;
  */
 public class EmptyStringRoutingIntegrationTest extends SQLTransportIntegrationTest {
 
-    static {
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    }
-
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 

--- a/sql/src/test/java/io/crate/integrationtests/ObjectColumnTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ObjectColumnTest.java
@@ -34,10 +34,6 @@ import java.util.Map;
 
 public class ObjectColumnTest extends SQLTransportIntegrationTest {
 
-    static {
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    }
-
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 

--- a/sql/src/test/java/io/crate/integrationtests/RegexpIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/RegexpIntegrationTest.java
@@ -30,10 +30,6 @@ import static org.hamcrest.core.Is.is;
 
 public class RegexpIntegrationTest extends SQLTransportIntegrationTest {
 
-    static {
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    }
-
     private Setup setup = new Setup(sqlExecutor);
 
     @Rule

--- a/sql/src/test/java/io/crate/integrationtests/RepositoryIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/RepositoryIntegrationTest.java
@@ -38,10 +38,6 @@ import static org.hamcrest.Matchers.is;
 
 public class RepositoryIntegrationTest extends SQLTransportIntegrationTest {
 
-    static {
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    }
-
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 

--- a/sql/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
@@ -37,10 +37,6 @@ import static org.hamcrest.Matchers.is;
 
 public class SnapshotRestoreIntegrationTest extends SQLTransportIntegrationTest {
 
-    static {
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    }
-
     private static final String REPOSITORY_NAME = "my_repo";
     private static final String SNAPSHOT_NAME = "my_snapshot";
 

--- a/sql/src/test/java/io/crate/integrationtests/StaticInformationSchemaQueryTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/StaticInformationSchemaQueryTest.java
@@ -34,10 +34,6 @@ import org.junit.rules.ExpectedException;
 
 public class StaticInformationSchemaQueryTest extends ClassLifecycleIntegrationTest {
 
-    static {
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    }
-
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 

--- a/sql/src/test/java/io/crate/integrationtests/TableAliasIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TableAliasIntegrationTest.java
@@ -35,10 +35,6 @@ import static org.hamcrest.core.Is.is;
 @ElasticsearchIntegrationTest.ClusterScope(numDataNodes = 1, numClientNodes = 0)
 public class TableAliasIntegrationTest extends SQLTransportIntegrationTest {
 
-    static {
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    }
-
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 

--- a/sql/src/test/java/io/crate/integrationtests/UpdateIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/UpdateIntegrationTest.java
@@ -41,10 +41,6 @@ import static org.hamcrest.core.Is.is;
 
 public class UpdateIntegrationTest extends SQLTransportIntegrationTest {
 
-    static {
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    }
-
     private Setup setup = new Setup(sqlExecutor);
 
     @Rule

--- a/sql/src/test/java/io/crate/integrationtests/VersionHandlingIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/VersionHandlingIntegrationTest.java
@@ -34,10 +34,6 @@ import static org.hamcrest.core.Is.is;
 
 public class VersionHandlingIntegrationTest extends SQLTransportIntegrationTest {
 
-    static {
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    }
-
     private Setup setup = new Setup(sqlExecutor);
 
     @Rule

--- a/sql/src/test/java/io/crate/jobs/KeepAliveTimersTest.java
+++ b/sql/src/test/java/io/crate/jobs/KeepAliveTimersTest.java
@@ -40,10 +40,6 @@ import static org.mockito.Mockito.*;
 
 public class KeepAliveTimersTest extends CrateUnitTest {
 
-    static {
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    }
-
     private static final TimeValue TEST_DELAY = TimeValue.timeValueMillis(100);
 
     private ThreadPool threadPool;

--- a/sql/src/test/java/io/crate/metadata/PartitionReferenceResolverTest.java
+++ b/sql/src/test/java/io/crate/metadata/PartitionReferenceResolverTest.java
@@ -53,11 +53,26 @@ public class PartitionReferenceResolverTest extends CrateUnitTest {
                 fallbackRefResolver,
                 ImmutableList.<PartitionExpression>of()
         );
-        try {
+
+        if (assertionsEnabled()) {
+            try {
+                referenceResolver.getImplementation(refInfo);
+                fail("no assertion error thrown");
+            } catch (AssertionError e) {
+                assertThat(e.getMessage(), is("granularity < PARTITION should have been resolved already"));
+            }
+        } else {
             referenceResolver.getImplementation(refInfo);
-            fail();
-        } catch (AssertionError e) {
-            assertThat(e.getMessage(), is("granularity < PARTITION should have been resolved already"));
         }
+
+
     }
+
+    private static boolean assertionsEnabled() {
+        boolean assertsEnabled = false;
+        assert assertsEnabled = true; // Intentional side effect!!!
+        return assertsEnabled;
+    }
+
+
 }

--- a/sql/src/test/java/io/crate/metadata/RoutingTest.java
+++ b/sql/src/test/java/io/crate/metadata/RoutingTest.java
@@ -35,10 +35,6 @@ import static org.hamcrest.Matchers.is;
 
 public class RoutingTest extends CrateUnitTest {
 
-    static {
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    }
-
     @Test
     public void testStreamingWithLocations() throws Exception {
         Map<String, Map<String, List<Integer>>> locations = new TreeMap<>();

--- a/sql/src/test/java/io/crate/metadata/doc/DocTableInfoBuilderTest.java
+++ b/sql/src/test/java/io/crate/metadata/doc/DocTableInfoBuilderTest.java
@@ -46,10 +46,6 @@ import static org.mockito.Mockito.when;
 
 public class DocTableInfoBuilderTest extends CrateUnitTest {
 
-    static {
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    }
-
     private ExecutorService executorService;
 
     @Before

--- a/sql/src/test/java/io/crate/operation/projectors/FlatProjectorChainTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/FlatProjectorChainTest.java
@@ -40,10 +40,6 @@ import static org.mockito.Mockito.*;
 
 public class FlatProjectorChainTest extends CrateUnitTest {
 
-    static {
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    }
-
     @Test
     public void testFinalDownstreamPrepareIsCalled() throws Exception {
         RowReceiver finalDownstream = mock(RowReceiver.class);

--- a/sql/src/test/java/io/crate/planner/fetch/FetchRequiredVisitorTest.java
+++ b/sql/src/test/java/io/crate/planner/fetch/FetchRequiredVisitorTest.java
@@ -46,9 +46,6 @@ public class FetchRequiredVisitorTest extends CrateUnitTest {
     private final Function bothFun = TestingHelpers.createFunction("both", DataTypes.STRING, x, y);
     private final Function myOtherFun = TestingHelpers.createFunction("my_other_fun", DataTypes.STRING, x);
 
-    static {
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    }
 
     private FetchRequiredVisitor.Context context(List<Symbol> orderBySymbols) {
         if (!orderBySymbols.isEmpty()){

--- a/stresstest/src/test/java/io/crate/benchmark/BulkDeleteBenchmark.java
+++ b/stresstest/src/test/java/io/crate/benchmark/BulkDeleteBenchmark.java
@@ -56,10 +56,6 @@ import java.util.List;
 @BenchmarkMethodChart(filePrefix = "benchmark-bulk-delete")
 public class BulkDeleteBenchmark extends BenchmarkBase{
 
-    static {
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    }
-
     @Rule
     public TestRule benchmarkRun = RuleChain.outerRule(new BenchmarkRule()).around(super.ruleChain);
 

--- a/stresstest/src/test/java/io/crate/benchmark/BulkInsertBenchmark.java
+++ b/stresstest/src/test/java/io/crate/benchmark/BulkInsertBenchmark.java
@@ -46,10 +46,6 @@ import java.util.Collections;
 @BenchmarkMethodChart(filePrefix = "benchmark-bulk-insert")
 public class BulkInsertBenchmark extends BenchmarkBase {
 
-    static {
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    }
-
     @Rule
     public TestRule benchmarkRun = RuleChain.outerRule(new BenchmarkRule()).around(super.ruleChain);
 

--- a/stresstest/src/test/java/io/crate/benchmark/DeleteBenchmark.java
+++ b/stresstest/src/test/java/io/crate/benchmark/DeleteBenchmark.java
@@ -52,9 +52,6 @@ public class DeleteBenchmark extends BenchmarkBase {
 
     public static final int NUM_REQUESTS_PER_TEST = 100;
     public static final int BENCHMARK_ROUNDS = 24; // Don't exceed the number of deletable rows
-    static {
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    }
 
     @Rule
     public TestRule benchmarkRun = RuleChain.outerRule(new BenchmarkRule()).around(super.ruleChain);

--- a/stresstest/src/test/java/io/crate/benchmark/GroupByArbitraryBenchmark.java
+++ b/stresstest/src/test/java/io/crate/benchmark/GroupByArbitraryBenchmark.java
@@ -51,10 +51,6 @@ public class GroupByArbitraryBenchmark extends BenchmarkBase {
     public static SQLRequest arbitraryRequest = new SQLRequest(String.format("select continent, arbitrary(\"countryName\") from %s group by 1", INDEX_NAME));
 
 
-    static {
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    }
-
     @Rule
     public TestRule benchmarkRun = RuleChain.outerRule(new BenchmarkRule()).around(super.ruleChain);
 

--- a/stresstest/src/test/java/io/crate/benchmark/GroupByBenchmark.java
+++ b/stresstest/src/test/java/io/crate/benchmark/GroupByBenchmark.java
@@ -60,10 +60,6 @@ public class GroupByBenchmark extends BenchmarkBase {
     public static SQLRequest groupByRoutingColumnRequest = new SQLRequest(String.format("select sum(population), type from %s group by type order by 1", INDEX_NAME));
     public static SQLRequest groupByRoutingColumnRequestHighLimit = new SQLRequest(String.format("select sum(population), type from %s group by type order by 1 limit 100000", INDEX_NAME));
 
-    static {
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    }
-
     @Rule
     public TestRule benchmarkRun = RuleChain.outerRule(new BenchmarkRule()).around(super.ruleChain);
 

--- a/stresstest/src/test/java/io/crate/benchmark/InNumericBenchmark.java
+++ b/stresstest/src/test/java/io/crate/benchmark/InNumericBenchmark.java
@@ -51,10 +51,6 @@ public class InNumericBenchmark extends BenchmarkBase {
     public static final int NUMBER_OF_DOCUMENTS = 100_000;
     public static final String INDEX_NAME = "bench_in_numeric";
 
-    static {
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    }
-
     static AtomicInteger VALUE = new AtomicInteger(0);
     static Vector<Integer> VALUES = new Vector<>();
 

--- a/stresstest/src/test/java/io/crate/benchmark/InformationSchemaBenchmark.java
+++ b/stresstest/src/test/java/io/crate/benchmark/InformationSchemaBenchmark.java
@@ -22,10 +22,6 @@ public class InformationSchemaBenchmark extends BenchmarkBase {
 
     private boolean dataCreated = false;
 
-    static {
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    }
-
     @Rule
     public TestRule benchmarkRun = RuleChain.outerRule(new BenchmarkRule()).around(super.ruleChain);
 

--- a/stresstest/src/test/java/io/crate/benchmark/InsertBenchmark.java
+++ b/stresstest/src/test/java/io/crate/benchmark/InsertBenchmark.java
@@ -47,10 +47,6 @@ import java.io.IOException;
 @BenchmarkMethodChart(filePrefix = "benchmark-insert")
 public class InsertBenchmark extends BenchmarkBase {
 
-    static {
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    }
-
     @Rule
     public TestRule benchmarkRun = RuleChain.outerRule(new BenchmarkRule()).around(super.ruleChain);
 

--- a/stresstest/src/test/java/io/crate/benchmark/PartitionedTableBenchmark.java
+++ b/stresstest/src/test/java/io/crate/benchmark/PartitionedTableBenchmark.java
@@ -35,10 +35,6 @@ import org.junit.rules.TestRule;
 @BenchmarkMethodChart(filePrefix = "benchmark-partitionedtablebenchmark")
 public class PartitionedTableBenchmark extends BenchmarkBase {
 
-    static {
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    }
-
     private static boolean dataGenerated = false;
 
     private static final Integer NUMBER_OF_PARTITIONS = 500;

--- a/stresstest/src/test/java/io/crate/benchmark/SelectBenchmark.java
+++ b/stresstest/src/test/java/io/crate/benchmark/SelectBenchmark.java
@@ -59,10 +59,6 @@ public class SelectBenchmark extends BenchmarkBase {
 
     public static final SQLRequest SYS_SHARDS_REQUEST = new SQLRequest("select * from sys.shards order by schema_name, table_name");
 
-    static {
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    }
-
     @Rule
     public TestRule benchmarkRun = RuleChain.outerRule(new BenchmarkRule()).around(super.ruleChain);
 

--- a/stresstest/src/test/java/io/crate/benchmark/UpdateBenchmark.java
+++ b/stresstest/src/test/java/io/crate/benchmark/UpdateBenchmark.java
@@ -57,10 +57,6 @@ public class UpdateBenchmark extends BenchmarkBase {
     public String updateId = null;
     public String updateIdqueryPlannerEnabled = null;
 
-    static {
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    }
-
     @Rule
     public TestRule benchmarkRun = RuleChain.outerRule(new BenchmarkRule()).around(super.ruleChain);
 

--- a/stresstest/src/test/java/io/crate/benchmark/UpsertBenchmark.java
+++ b/stresstest/src/test/java/io/crate/benchmark/UpsertBenchmark.java
@@ -38,9 +38,6 @@ import org.junit.rules.TestRule;
 @BenchmarkMethodChart(filePrefix = "benchmark-upsert")
 public class UpsertBenchmark extends BenchmarkBase {
 
-    static {
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
-    }
     public static final String INDEX_NAME = "traffic_logs";
     public static final int BENCHMARK_ROUNDS = 120;
     public static final int BENCHMARK_ROUNDS_MANY_VALUES = 3;

--- a/testing/src/main/java/io/crate/test/integration/CrateUnitTest.java
+++ b/testing/src/main/java/io/crate/test/integration/CrateUnitTest.java
@@ -41,7 +41,6 @@ public abstract class CrateUnitTest extends AbstractRandomizedTest {
     static {
         // mute ES loggings
         Loggers.getLogger(ElasticsearchTestCase.class).setLevel("WARN");
-        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
     }
 
     @Rule


### PR DESCRIPTION
as it is not needed anymore to successfully run the tests.
this helps running tests without assertions