### PR TITLE
restrict within function to only accept geo_point and geo_shape as ar…

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - restrict WITHIN function to only accept geo_point (and compatible types)
+   as first argument
+
  - Added snapshot and restore functionality
 
  - Changed crate launch scripts to no longer support extending the

--- a/core/src/main/java/io/crate/geo/GeoJSONUtils.java
+++ b/core/src/main/java/io/crate/geo/GeoJSONUtils.java
@@ -198,8 +198,8 @@ public class GeoJSONUtils {
         double y;
         if (coordinate.getClass().isArray()) {
             Preconditions.checkArgument(Array.getLength(coordinate) == 2, invalidGeoJSON("invalid coordinate"));
-            x = Array.getDouble(coordinate, 0);
-            y = Array.getDouble(coordinate, 1);
+            x = ((Number)Array.get(coordinate, 0)).doubleValue();
+            y = ((Number)Array.get(coordinate, 1)).doubleValue();
         } else if (coordinate instanceof Collection) {
             Preconditions.checkArgument(((Collection) coordinate).size() == 2, invalidGeoJSON("invalid coordinate"));
             Iterator iter = ((Collection) coordinate).iterator();

--- a/core/src/test/java/io/crate/geo/GeoJSONUtilsTest.java
+++ b/core/src/test/java/io/crate/geo/GeoJSONUtilsTest.java
@@ -142,6 +142,17 @@ public class GeoJSONUtilsTest extends CrateUnitTest {
     }
 
     @Test
+    public void testMap2Shape() throws Exception {
+        Shape shape = GeoJSONUtils.map2Shape(ImmutableMap.<String, Object>of(
+                GeoJSONUtils.TYPE_FIELD, GeoJSONUtils.LINE_STRING,
+                GeoJSONUtils.COORDINATES_FIELD, new Double[][]{ {0.0, 0.1}, {1.0, 1.1} }
+                ));
+        assertThat(shape, instanceOf(JtsGeometry.class));
+        assertThat(((JtsGeometry)shape).getGeom(), instanceOf(LineString.class));
+
+    }
+
+    @Test
     public void testInvalidMap() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Cannot convert Map \"{}\" to shape");

--- a/docs/sql/scalar.txt
+++ b/docs/sql/scalar.txt
@@ -466,38 +466,6 @@ casting from strings to geo point and geo shapes::
 
 This function can always be used within the ``WHERE`` clause.
 
-.. _scalar_intersect:
-
-intersect(geo_shape, geo_shape) returns boolean
------------------------------------------------
-
-The ``intersect`` function returns true if both argument shapes
-share some points or area, they *overlap*. This also includes two shapes
-where one lies :ref:`within <scalar_within>` the other.
-If ``false`` is returned both shapes are *disjoint*.
-
-Example::
-
-    cr> select
-    ... intersect(
-    ...   {type='Polygon', coordinates=[[[13.4252, 52.7096],[13.9416, 52.0997],[12.7221, 52.1334],[13.4252, 52.7096]]]}
-    ...   'LINESTRING(13.9636 52.6763, 13.2275 51.9578, 12.9199 52.5830, 11.9970 52.6830'
-    ... ) as intersect
-    ... intersect(
-    ...   {type='Polygon', coordinates=[[[13.4252, 52.7096],[13.9416, 52.0997],[12.7221, 52.1334],[13.4252, 52.7096]]]},
-    ...   'LINESTRING (11.0742 49.453842594330744, 11.5686 48.1367)'
-    ... ) as disjoint
-    ... from sys.cluster;
-    +----------------------+
-    | intersect | disjoint |
-    +----------------------+
-    | TRUE      | FALSE    |
-    +----------------------+
-    SELECT 1 row in set (... sec)
-
-Due to a limitation on the :ref:`geo_shape_data_type` datatype
-this function cannot be used in the :ref:`sql_reference_order_by`.
-
 Mathematical Functions
 ======================
 

--- a/sql/src/main/java/io/crate/analyze/symbol/Literal.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/Literal.java
@@ -229,6 +229,10 @@ public class Literal<ReturnType>
         return new Literal<>(DataTypes.FLOAT, value);
     }
 
+    public static Literal<Double[]> newGeoPoint(Object point) {
+        return new Literal<>(DataTypes.GEO_POINT, DataTypes.GEO_POINT.value(point));
+    }
+
     public static Literal<Map<String, Object>> newGeoShape(String value) {
         return new Literal<>(DataTypes.GEO_SHAPE, DataTypes.GEO_SHAPE.value(value));
     }

--- a/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/ESQueryBuilder.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/ESQueryBuilder.java
@@ -338,7 +338,7 @@ public class ESQueryBuilder {
                 Symbol leftSymbol = withinFunction.arguments().get(0);
                 Symbol rightSymbol = withinFunction.arguments().get(1);
 
-                if (!(leftSymbol instanceof Reference)) {
+                if (!(leftSymbol instanceof Reference && rightSymbol instanceof Input)) {
                     throw new IllegalArgumentException("Second argument to the within function must be a literal");
                 }
                 writeFilterToContext(context, (Reference) leftSymbol, (Input) rightSymbol);

--- a/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -44,7 +44,6 @@ import static org.hamcrest.Matchers.*;
 @ElasticsearchIntegrationTest.ClusterScope(numDataNodes = 2)
 public class InformationSchemaTest extends SQLTransportIntegrationTest {
 
-    final static Joiner dotJoiner = Joiner.on('.');
     final static Joiner commaJoiner = Joiner.on(", ");
 
     @Rule
@@ -735,42 +734,6 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
 
         assertEquals("title", response.rows()[3][0]);
         assertEquals(ordinal_position, response.rows()[3][1]);
-    }
-
-    @Test
-    public void testUnknownTypes() throws Exception {
-        new Setup(sqlExecutor).setUpObjectMappingWithUnknownTypes();
-        execute("select * from information_schema.columns where table_name='ut' order by column_name");
-        assertEquals(4, response.rowCount());
-
-        assertEquals("location", response.rows()[0][2]);
-        short ordinal_position = 1;
-        assertEquals(ordinal_position, response.rows()[0][3]);
-        assertEquals("geo_shape", response.rows()[0][4]);
-
-        assertEquals("name", response.rows()[1][2]);
-        ordinal_position = 2;
-        assertEquals(ordinal_position, response.rows()[1][3]);
-        assertEquals("string", response.rows()[1][4]);
-
-        assertEquals("o", response.rows()[2][2]);
-        ordinal_position = 3;
-        assertEquals(ordinal_position, response.rows()[2][3]);
-        assertEquals("object", response.rows()[2][4]);
-
-        assertEquals("population", response.rows()[3][2]);
-        ordinal_position = 4;
-        assertEquals(ordinal_position, response.rows()[3][3]);
-        assertEquals("long", response.rows()[3][4]);
-
-        // TODO: enable when information_schema.indices is implemented
-        //execute("select * from information_schema.indices where table_name='ut' order by index_name");
-        //assertEquals(2, response.rowCount());
-        //assertEquals("name", response.rows()[0][1]);
-        //assertEquals("population", response.rows()[1][1]);
-
-        execute("select sum(number_of_shards) from information_schema.tables");
-        assertEquals(1, response.rowCount());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/LuceneQueryBuilderIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/LuceneQueryBuilderIntegrationTest.java
@@ -120,4 +120,19 @@ public class LuceneQueryBuilderIntegrationTest extends SQLTransportIntegrationTe
         execute(sb.toString());
         assertThat(response.rowCount(), is(2L));
     }
+
+    @Test
+    public void testWithinGenericFunction() throws Exception {
+        execute("create table shaped (id int, point geo_point, shape geo_shape) with (number_of_replicas=0)");
+        ensureYellow();
+        execute("insert into shaped (id, point, shape) VALUES (?, ?, ?)", $$(
+                $(1, "POINT (15 15)", "polygon (( 10 10, 10 20, 20 20, 20 15, 10 10))"),
+                $(1, "POINT (-10 -10)", "polygon (( 10 10, 10 20, 20 20, 20 15, 10 10))")
+        ));
+        execute("refresh table shaped");
+
+        execute("select * from shaped where within(point, shape) order by id");
+        assertThat(response.rowCount(), is(1L));
+
+    }
 }

--- a/sql/src/test/java/io/crate/integrationtests/Setup.java
+++ b/sql/src/test/java/io/crate/integrationtests/Setup.java
@@ -21,10 +21,8 @@
 
 package io.crate.integrationtests;
 
-import io.crate.Constants;
 import io.crate.action.sql.SQLResponse;
 import io.crate.testing.SQLTransportExecutor;
-import org.elasticsearch.common.settings.ImmutableSettings;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -225,38 +223,6 @@ public class Setup {
                 }
         );
         transportExecutor.refresh("ot");
-    }
-
-    public void setUpObjectMappingWithUnknownTypes() throws Exception {
-        transportExecutor.prepareCreate("ut")
-                .setSettings(ImmutableSettings.builder().put("number_of_replicas", 0).put("number_of_shards", 2).build())
-                .addMapping(Constants.DEFAULT_MAPPING_TYPE, new HashMap<String, Object>(){{
-                    put("properties", new HashMap<String, Object>(){{
-                        put("name", new HashMap<String, Object>(){{
-                            put("type", "string");
-                            put("store", "false");
-                            put("index", "not_analyzed");
-                        }});
-                        put("location", new HashMap<String, Object>(){{
-                            put("type", "geo_shape");
-                        }});
-                        put("o", new HashMap<String, Object>(){{
-                            put("type", "object");
-                        }});
-                        put("population", new HashMap<String, Object>(){{
-                            put("type", "long");
-                            put("store", "false");
-                            put("index", "not_analyzed");
-                        }});
-                    }});
-                }}).execute().actionGet();
-        transportExecutor.client().prepareIndex("ut", Constants.DEFAULT_MAPPING_TYPE, "id1")
-                .setSource("{\"name\":\"Berlin\",\"location\":{\"type\": \"point\", \"coordinates\": [52.5081, 13.4416]}, \"population\":3500000}")
-                .execute().actionGet();
-        transportExecutor.client().prepareIndex("ut", Constants.DEFAULT_MAPPING_TYPE, "id2")
-                .setSource("{\"name\":\"Dornbirn\",\"location\":{\"type\": \"point\", \"coordinates\": [47.3904,9.7562]}, \"population\":46080}")
-                .execute().actionGet();
-        transportExecutor.refresh("ut");
     }
 
     public void setUpArrayTables() {

--- a/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -23,6 +23,7 @@ package io.crate.integrationtests;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.crate.TimestampFormat;
 import io.crate.action.sql.SQLActionException;
@@ -1645,6 +1646,20 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
 
         execute("select * from t where within(p, 'POLYGON (( 5 5, 30 5, 30 30, 5 30, 5 5 ))')");
         assertThat(response.rowCount(), is(1L));
+        execute("select * from t where within(p, ?)", $(ImmutableMap.of(
+                "type", "Polygon",
+                "coordinates", new double[][][] {
+                        {
+                                {5.0, 5.0},
+                                {30.0, 5.0},
+                                {30.0, 30.0},
+                                {5.0, 30.0},
+                                {5.0, 5.0}
+                        }
+                }
+        )));
+        assertThat(response.rowCount(), is(1L));
+
         execute("select * from t where within(p, 'POLYGON (( 5 5, 30 5, 30 30, 5 35, 5 5 ))') = false");
         assertThat(response.rowCount(), is(0L));
     }


### PR DESCRIPTION
…guments

and change implementation if operating on shape references, as these need to be fetched from source
and can thus only be executed with a generic function query