### PR TITLE
introduce static method Routing.forTableOnNode

### DIFF
--- a/sql/src/main/java/io/crate/metadata/Routing.java
+++ b/sql/src/main/java/io/crate/metadata/Routing.java
@@ -208,6 +208,17 @@ public class Routing implements Streamable {
         return true;
     }
 
+    /**
+     * Return a routing for the given table on the given node id.
+     */
+    public static Routing forTableOnNode(TableIdent tableIdent, String nodeId) {
+        Map<String, Map<String, List<Integer>>> locations = new TreeMap<>();
+        Map<String, List<Integer>> tableLocation = new TreeMap<>();
+        tableLocation.put(tableIdent.fqn(), null);
+        locations.put(nodeId, tableLocation);
+        return new Routing(locations);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/sql/src/main/java/io/crate/metadata/information/InformationTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/information/InformationTableInfo.java
@@ -146,11 +146,7 @@ public class InformationTableInfo extends AbstractTableInfo {
 
     @Override
     public Routing getRouting(WhereClause whereClause, @Nullable String preference) {
-        Map<String, Map<String, List<Integer>>> locations = new TreeMap<>();
-        Map<String, List<Integer>> tableLocation = new TreeMap<>();
-        tableLocation.put(ident.fqn(), null);
-        locations.put(clusterService.localNode().id(), tableLocation);
-        return new Routing(locations);
+        return Routing.forTableOnNode(ident, clusterService.localNode().id());
     }
 
     @Override

--- a/sql/src/main/java/io/crate/metadata/sys/SysChecksTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysChecksTableInfo.java
@@ -23,7 +23,6 @@ package io.crate.metadata.sys;
 
 import com.google.common.collect.ImmutableList;
 import io.crate.analyze.WhereClause;
-import io.crate.core.collections.TreeMapBuilder;
 import io.crate.metadata.*;
 import io.crate.types.DataTypes;
 import org.elasticsearch.cluster.ClusterService;
@@ -87,11 +86,7 @@ public class SysChecksTableInfo extends SysTableInfo {
 
     @Override
     public Routing getRouting(WhereClause whereClause, @Nullable String preference) {
-        return new Routing(
-                TreeMapBuilder.<String, Map<String, List<Integer>>>newMapBuilder().put(
-                        clusterService.localNode().id(),
-                        TreeMapBuilder.<String, List<Integer>>newMapBuilder().put(IDENT.fqn(), null).map()).map()
-        );
+        return Routing.forTableOnNode(IDENT, clusterService.localNode().id());
     }
 
     @Override

--- a/sql/src/main/java/io/crate/metadata/sys/SysClusterTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysClusterTableInfo.java
@@ -23,7 +23,6 @@ package io.crate.metadata.sys;
 
 import com.google.common.collect.ImmutableList;
 import io.crate.analyze.WhereClause;
-import io.crate.core.collections.TreeMapBuilder;
 import io.crate.metadata.*;
 import io.crate.metadata.settings.CrateSettings;
 import io.crate.operation.reference.sys.cluster.ClusterSettingsExpression;
@@ -377,12 +376,7 @@ public class SysClusterTableInfo extends SysTableInfo {
 
     @Override
     public Routing getRouting(WhereClause whereClause, @Nullable String preference) {
-        return new Routing(
-                TreeMapBuilder.<String, Map<String, List<Integer>>>newMapBuilder().put(
-                        clusterService.localNode().id(),
-                        TreeMapBuilder.<String, List<Integer>>newMapBuilder().put(IDENT.fqn(), null).map()
-                ).map()
-        );
+        return Routing.forTableOnNode(IDENT, clusterService.localNode().id());
     }
 
     @Override

--- a/sql/src/main/java/io/crate/metadata/sys/SysRepositoriesTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysRepositoriesTableInfo.java
@@ -79,11 +79,7 @@ public class SysRepositoriesTableInfo extends SysTableInfo {
 
     @Override
     public Routing getRouting(WhereClause whereClause, @Nullable String preference) {
-        Map<String, Map<String, List<Integer>>> locations = new TreeMap<>();
-        Map<String, List<Integer>> tableLocation = new TreeMap<>();
-        tableLocation.put(IDENT.fqn(), null);
-        locations.put(clusterService.localNode().id(), tableLocation);
-        return new Routing(locations);
+        return Routing.forTableOnNode(IDENT, clusterService.localNode().id());
     }
 
     @Override


### PR DESCRIPTION
that returns a simple routing for a table on the given node (without shards)

mostly used for sys tables