### PR TITLE
[testing] bind http transport to 127.0.0.1 in http integration tests

### DIFF
--- a/sql/src/test/java/io/crate/integrationtests/SQLHttpIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SQLHttpIntegrationTest.java
@@ -44,7 +44,9 @@ public abstract class SQLHttpIntegrationTest extends SQLTransportIntegrationTest
     protected Settings nodeSettings(int nodeOrdinal) {
         return ImmutableSettings.settingsBuilder()
                 .put(super.nodeSettings(nodeOrdinal))
-                .put("http.enabled", true).build();
+                .put("http.host", "127.0.0.1")
+                .put("http.enabled", true)
+                .build();
     }
 
     @Before


### PR DESCRIPTION
so it will work no matter what interfaces are up and configured