### PR TITLE
Expose recovery information in sys.shards table

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Expose shard recovery information in sys.shards table
+
  - Expose relocating shards in sys.shards table
    Note that relocating shards are shown additionally to their already assigned
    source shards.

--- a/docs/sql/system.txt
+++ b/docs/sql/system.txt
@@ -688,6 +688,65 @@ _node
 |                      | table.                           |             |
 +----------------------+----------------------------------+-------------+
 
+recovery
+--------
+
+Recovery is the process of moving a table shard to a different node or loading it
+from disk, e.g. during node startup (local gateway recovery), replication,
+shard rebalancing or snapshot recovery.
+
++------------------------------------+----------------------------------------------------+-------------+
+| Column Name                        | Description                                        | Return Type |
++====================================+====================================================+=============+
+| ``recovery``                       | Represents recovery statistic of the particular    | ``Object``  |
+|                                    | shard.                                             |             |
++------------------------------------+----------------------------------------------------+-------------+
+| ``recovery['stage']``              | Recovery stage:                                    | ``String``  |
+|                                    |                                                    |             |
+|                                    | * init: Recovery has not started                   |             |
+|                                    | * index: Reading the Lucene index meta-data and    |             |
+|                                    |   copying bytes from source to destination         |             |
+|                                    | * start: Starting the engine,                      |             |
+|                                    |   opening the index for use                        |             |
+|                                    | * translog: Replaying transaction log              |             |
+|                                    | * finalize: Cleanup                                |             |
+|                                    | * done: Complete                                   |             |
++------------------------------------+----------------------------------------------------+-------------+
+| ``recovery['type']``               | Recovery type:                                     | ``String``  |
+|                                    |                                                    |             |
+|                                    | * gateway                                          |             |
+|                                    | * snapshot                                         |             |
+|                                    | * replica                                          |             |
+|                                    | * relocating                                       |             |
++------------------------------------+----------------------------------------------------+-------------+
+| ``recovery['size']``               | Shards recovery statistic in bytes.                | ``Object``  |
++------------------------------------+----------------------------------------------------+-------------+
+| ``recovery['size']['used']``       | Total number of bytes in the shard.                | ``Long``    |
++------------------------------------+----------------------------------------------------+-------------+
+| ``recovery['size']['reused']``     | Number of bytes reused from a local copy           | ``Long``    |
+|                                    | while recovering the shard.                        |             |
++------------------------------------+----------------------------------------------------+-------------+
+| ``recovery['size']['recovered']``  | Number of actual bytes recovered in the shard.     | ``Long``    |
+|                                    | Includes both existing and reused bytes.           |             |
++------------------------------------+----------------------------------------------------+-------------+
+| ``recovery['size']['percent']``    | Percentage of bytes already recovered.             | ``Float``   |
++------------------------------------+----------------------------------------------------+-------------+
+| ``recovery['files']``              | Shards recovery statistic in files.                | ``Object``  |
++------------------------------------+----------------------------------------------------+-------------+
+| ``recovery['files']['used']``      | Total number of files in the shard.                | ``Integer`` |
++------------------------------------+----------------------------------------------------+-------------+
+| ``recovery['files']['reused']``    | Total number of files reused from a local copy     | ``Integer`` |
+|                                    | while recovering the shard.                        |             |
++------------------------------------+----------------------------------------------------+-------------+
+| ``recovery['files']['recovered']`` | Number of actual files recovered in the shard.     | ``Integer`` |
+|                                    | Includes both existing and reused files.           |             |
++------------------------------------+----------------------------------------------------+-------------+
+| ``recovery['files']['percent']``   | Percentage of files already recovered.             | ``Float``   |
++------------------------------------+----------------------------------------------------+-------------+
+| ``recovery['total_time']``         | Returns elapsed time from the start of the shard   | ``Long``    |
+|                                    | recovery.                                          |             |
++------------------------------------+----------------------------------------------------+-------------+
+
 
 For example, you can query shards like this::
 

--- a/sql/src/main/java/io/crate/metadata/AbstractReferenceResolver.java
+++ b/sql/src/main/java/io/crate/metadata/AbstractReferenceResolver.java
@@ -21,17 +21,20 @@
 
 package io.crate.metadata;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public abstract class AbstractReferenceResolver implements NestedReferenceResolver {
+
+    protected final Map<ReferenceIdent, ReferenceImplementation> implementations = new HashMap<>();
 
     @Override
     public ReferenceImplementation getImplementation(ReferenceInfo refInfo) {
         ReferenceIdent ident = refInfo.ident();
         if (ident.isColumn()) {
-            return implementations().get(ident);
+            return implementations.get(ident);
         }
-        ReferenceImplementation impl = implementations().get(ident.columnReferenceIdent());
+        ReferenceImplementation impl = implementations.get(ident.columnReferenceIdent());
         if (impl != null) {
             for (String part : ident.columnIdent().path()) {
                 impl = impl.getChildImplementation(part);
@@ -40,5 +43,4 @@ public abstract class AbstractReferenceResolver implements NestedReferenceResolv
         return impl;
     }
 
-    protected abstract Map<ReferenceIdent, ReferenceImplementation> implementations();
 }

--- a/sql/src/main/java/io/crate/metadata/GlobalReferenceResolver.java
+++ b/sql/src/main/java/io/crate/metadata/GlobalReferenceResolver.java
@@ -27,16 +27,9 @@ import java.util.Map;
 
 public class GlobalReferenceResolver extends AbstractReferenceResolver {
 
-    private final Map<ReferenceIdent, ReferenceImplementation> implementations;
-
     @Inject
-    public GlobalReferenceResolver(
-            Map<ReferenceIdent, ReferenceImplementation> implementations) {
-        this.implementations = implementations;
-    }
-
-    protected Map<ReferenceIdent, ReferenceImplementation> implementations() {
-        return implementations;
+    public GlobalReferenceResolver(Map<ReferenceIdent, ReferenceImplementation> implementations) {
+        this.implementations.putAll(implementations);
     }
 
 }

--- a/sql/src/main/java/io/crate/metadata/shard/RecoveryShardReferenceResolver.java
+++ b/sql/src/main/java/io/crate/metadata/shard/RecoveryShardReferenceResolver.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.shard;
+
+import io.crate.metadata.*;
+import io.crate.metadata.sys.SysShardsTableInfo;
+import io.crate.operation.reference.ReferenceResolver;
+import io.crate.operation.reference.sys.shard.ShardRecoveryExpression;
+import org.elasticsearch.index.shard.IndexShard;
+
+
+public class RecoveryShardReferenceResolver extends AbstractReferenceResolver {
+
+    /**
+     * <p>
+     *     The RecoveryShardReferenceResolver is necessary to be able to instantiate
+     *     the ShardRecoveryExpression at runtime.
+     *     This is required because the ShardRecoveryExpression needs to push the same recoveryState
+     *     to all of its childImplementations in order to receive the same state
+     *     when having multiple recovery objects in the select list of a query, e.g.
+     * </p>
+     * <code>
+     *     SELECT recovery['size'], recovery['files'] FROM sys.nodes;
+     * </code>
+     */
+
+    private final ReferenceResolver<ReferenceImplementation<?>> staticReferencesResolver;
+
+    public RecoveryShardReferenceResolver(ReferenceResolver<ReferenceImplementation<?>> shardResolver, IndexShard indexShard) {
+        staticReferencesResolver = shardResolver;
+        implementations.put(SysShardsTableInfo.ReferenceIdents.RECOVERY,
+                new ShardRecoveryExpression(indexShard));
+    }
+
+    @Override
+    public ReferenceImplementation getImplementation(ReferenceInfo refInfo) {
+        ReferenceImplementation impl = staticReferencesResolver.getImplementation(refInfo);
+        if (impl == null) {
+            impl = super.getImplementation(refInfo);
+        }
+        return impl;
+    }
+
+}

--- a/sql/src/main/java/io/crate/metadata/shard/ShardReferenceResolver.java
+++ b/sql/src/main/java/io/crate/metadata/shard/ShardReferenceResolver.java
@@ -37,7 +37,6 @@ import java.util.Map;
 
 public class ShardReferenceResolver extends AbstractReferenceResolver {
 
-    private final Map<ReferenceIdent, ReferenceImplementation> implementations;
     private static final ESLogger LOGGER = Loggers.getLogger(ShardReferenceResolver.class);
 
     @Inject
@@ -80,12 +79,6 @@ public class ShardReferenceResolver extends AbstractReferenceResolver {
                 LOGGER.error("Orphaned partition '{}' with missing table '{}' found", index, tableIdent.fqn());
             }
         }
-        this.implementations = builder.build();
+        this.implementations.putAll(builder.build());
     }
-
-    @Override
-    protected Map<ReferenceIdent, ReferenceImplementation> implementations() {
-        return implementations;
-    }
-
 }

--- a/sql/src/main/java/io/crate/metadata/shard/blob/BlobShardReferenceResolver.java
+++ b/sql/src/main/java/io/crate/metadata/shard/blob/BlobShardReferenceResolver.java
@@ -26,24 +26,14 @@ import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.ReferenceImplementation;
 import org.elasticsearch.common.inject.Inject;
 
-import java.util.HashMap;
 import java.util.Map;
 
 public class BlobShardReferenceResolver extends AbstractReferenceResolver {
 
-    private final Map<ReferenceIdent, ReferenceImplementation> implementations;
-
     @Inject
     public BlobShardReferenceResolver(final Map<ReferenceIdent, ReferenceImplementation> globalImplementations,
                                       final Map<ReferenceIdent, BlobShardReferenceImplementation> blobShardImplementations) {
-        Map<ReferenceIdent, ReferenceImplementation> implementations = new HashMap<>();
-        implementations.putAll(globalImplementations);
-        implementations.putAll(blobShardImplementations);
-        this.implementations = implementations;
-    }
-
-    @Override
-    protected Map<ReferenceIdent, ReferenceImplementation> implementations() {
-        return implementations;
+        this.implementations.putAll(globalImplementations);
+        this.implementations.putAll(blobShardImplementations);
     }
 }

--- a/sql/src/main/java/io/crate/metadata/sys/SysShardsTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysShardsTableInfo.java
@@ -25,10 +25,7 @@ import com.google.common.collect.ImmutableList;
 import io.crate.analyze.WhereClause;
 import io.crate.metadata.*;
 import io.crate.metadata.shard.unassigned.UnassignedShard;
-import io.crate.types.BooleanType;
-import io.crate.types.IntegerType;
-import io.crate.types.LongType;
-import io.crate.types.StringType;
+import io.crate.types.*;
 import org.elasticsearch.action.NoShardAvailableActionException;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.routing.GroupShardsIterator;
@@ -60,6 +57,33 @@ public class SysShardsTableInfo extends SysTableInfo {
         public static final ColumnIdent SIZE = new ColumnIdent("size");
         public static final ColumnIdent STATE = new ColumnIdent("state");
         public static final ColumnIdent ORPHAN_PARTITION = new ColumnIdent("orphan_partition");
+
+        public static final ColumnIdent RECOVERY = new ColumnIdent("recovery");
+        public static final ColumnIdent RECOVERY_STAGE = new ColumnIdent("recovery", ImmutableList.of("stage"));
+        public static final ColumnIdent RECOVERY_TYPE = new ColumnIdent("recovery", ImmutableList.of("type"));
+        public static final ColumnIdent RECOVERY_TOTAL_TIME =
+                new ColumnIdent("recovery", ImmutableList.of("total_time"));
+
+        public static final ColumnIdent RECOVERY_FILES = new ColumnIdent("recovery", ImmutableList.of("files"));
+        public static final ColumnIdent RECOVERY_FILES_USED =
+                new ColumnIdent("recovery", ImmutableList.of("files", "used"));
+        public static final ColumnIdent RECOVERY_FILES_REUSED =
+                new ColumnIdent("recovery", ImmutableList.of("files", "reused"));
+        public static final ColumnIdent RECOVERY_FILES_RECOVERED =
+                new ColumnIdent("recovery", ImmutableList.of("files", "recovered"));
+        public static final ColumnIdent RECOVERY_FILES_PERCENT =
+                new ColumnIdent("recovery", ImmutableList.of("files", "percent"));
+
+        public static final ColumnIdent RECOVERY_SIZE =
+                new ColumnIdent("recovery", ImmutableList.of("size"));
+        public static final ColumnIdent RECOVERY_SIZE_USED =
+                new ColumnIdent("recovery", ImmutableList.of("size", "used"));
+        public static final ColumnIdent RECOVERY_SIZE_REUSED =
+                new ColumnIdent("recovery", ImmutableList.of("size", "reused"));
+        public static final ColumnIdent RECOVERY_SIZE_RECOVERED =
+                new ColumnIdent("recovery", ImmutableList.of("size", "recovered"));
+        public static final ColumnIdent RECOVERY_SIZE_PERCENT =
+                new ColumnIdent("recovery", ImmutableList.of("size", "percent"));
     }
 
     public static class ReferenceIdents {
@@ -73,6 +97,7 @@ public class SysShardsTableInfo extends SysTableInfo {
         public static final ReferenceIdent SIZE = new ReferenceIdent(IDENT, Columns.SIZE);
         public static final ReferenceIdent STATE = new ReferenceIdent(IDENT, Columns.STATE);
         public static final ReferenceIdent ORPHAN_PARTITION = new ReferenceIdent(IDENT, Columns.ORPHAN_PARTITION);
+        public static final ReferenceIdent RECOVERY = new ReferenceIdent(IDENT, Columns.RECOVERY);
     }
 
     private static final ImmutableList<ColumnIdent> primaryKey = ImmutableList.of(
@@ -90,17 +115,34 @@ public class SysShardsTableInfo extends SysTableInfo {
         nodesTableColumn = sysNodesTableInfo.tableColumn();
 
         ColumnRegistrar registrar = new ColumnRegistrar(IDENT, RowGranularity.SHARD)
-            .register(Columns.SCHEMA_NAME, StringType.INSTANCE)
-            .register(Columns.TABLE_NAME, StringType.INSTANCE)
-            .register(Columns.ID, IntegerType.INSTANCE)
-            .register(Columns.PARTITION_IDENT, StringType.INSTANCE)
-            .register(Columns.NUM_DOCS, LongType.INSTANCE)
-            .register(Columns.PRIMARY, BooleanType.INSTANCE)
-            .register(Columns.RELOCATING_NODE, StringType.INSTANCE)
-            .register(Columns.SIZE, LongType.INSTANCE)
-            .register(Columns.STATE, StringType.INSTANCE)
-            .register(Columns.ORPHAN_PARTITION, BooleanType.INSTANCE)
-            .putInfoOnly(SysNodesTableInfo.SYS_COL_IDENT, SysNodesTableInfo.tableColumnInfo(IDENT));
+                .register(Columns.SCHEMA_NAME, StringType.INSTANCE)
+                .register(Columns.TABLE_NAME, StringType.INSTANCE)
+                .register(Columns.ID, IntegerType.INSTANCE)
+                .register(Columns.PARTITION_IDENT, StringType.INSTANCE)
+                .register(Columns.NUM_DOCS, LongType.INSTANCE)
+                .register(Columns.PRIMARY, BooleanType.INSTANCE)
+                .register(Columns.RELOCATING_NODE, StringType.INSTANCE)
+                .register(Columns.SIZE, LongType.INSTANCE)
+                .register(Columns.STATE, StringType.INSTANCE)
+                .register(Columns.ORPHAN_PARTITION, BooleanType.INSTANCE)
+
+                .register(Columns.RECOVERY, ObjectType.INSTANCE)
+                .register(Columns.RECOVERY_STAGE, StringType.INSTANCE)
+                .register(Columns.RECOVERY_TYPE, StringType.INSTANCE)
+                .register(Columns.RECOVERY_TOTAL_TIME, LongType.INSTANCE)
+
+                .register(Columns.RECOVERY_SIZE, ObjectType.INSTANCE)
+                .register(Columns.RECOVERY_SIZE_USED, LongType.INSTANCE)
+                .register(Columns.RECOVERY_SIZE_REUSED, LongType.INSTANCE)
+                .register(Columns.RECOVERY_SIZE_RECOVERED, LongType.INSTANCE)
+                .register(Columns.RECOVERY_SIZE_PERCENT, FloatType.INSTANCE)
+
+                .register(Columns.RECOVERY_FILES, ObjectType.INSTANCE)
+                .register(Columns.RECOVERY_FILES_USED, IntegerType.INSTANCE)
+                .register(Columns.RECOVERY_FILES_REUSED, IntegerType.INSTANCE)
+                .register(Columns.RECOVERY_FILES_RECOVERED, IntegerType.INSTANCE)
+                .register(Columns.RECOVERY_FILES_PERCENT, FloatType.INSTANCE)
+                .putInfoOnly(SysNodesTableInfo.SYS_COL_IDENT, SysNodesTableInfo.tableColumnInfo(IDENT));
         infos = registrar.infos();
         columns = registrar.columns();
     }

--- a/sql/src/main/java/io/crate/operation/reference/sys/shard/ShardRecoveryExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/shard/ShardRecoveryExpression.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.operation.reference.sys.shard;
+
+import io.crate.metadata.SimpleObjectExpression;
+import io.crate.operation.reference.NestedObjectExpression;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.lucene.BytesRefs;
+import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.indices.recovery.RecoveryState;
+
+public class ShardRecoveryExpression extends NestedObjectExpression {
+
+    private static final String TOTAL_TIME = "total_time";
+    private static final String STAGE = "stage";
+    private static final String TYPE = "type";
+    private static final String SIZE = "size";
+    private static final String FILES = "files";
+
+
+    public ShardRecoveryExpression(IndexShard indexShard) {
+        addChildImplementations(indexShard.recoveryState());
+    }
+
+    private void addChildImplementations(final RecoveryState recoveryState) {
+        childImplementations.put(TOTAL_TIME, new SimpleObjectExpression<Long>() {
+            @Override
+            public Long value() {
+                return recoveryState.getTimer().time();
+            }
+        });
+        childImplementations.put(STAGE, new SimpleObjectExpression<BytesRef>() {
+            @Override
+            public BytesRef value() {
+                return BytesRefs.toBytesRef(recoveryState.getStage().name());
+            }
+        });
+        childImplementations.put(TYPE, new SimpleObjectExpression<BytesRef>() {
+            @Override
+            public BytesRef value() {
+                return BytesRefs.toBytesRef(recoveryState.getType().name());
+            }
+        });
+        childImplementations.put(SIZE, new ShardRecoverySizeExpression(recoveryState));
+        childImplementations.put(FILES, new ShardRecoveryFilesExpression(recoveryState));
+    }
+
+}

--- a/sql/src/main/java/io/crate/operation/reference/sys/shard/ShardRecoveryFilesExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/shard/ShardRecoveryFilesExpression.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.operation.reference.sys.shard;
+
+import io.crate.metadata.SimpleObjectExpression;
+import io.crate.operation.reference.NestedObjectExpression;
+import org.elasticsearch.indices.recovery.RecoveryState;
+
+public class ShardRecoveryFilesExpression extends NestedObjectExpression  {
+
+    private static final String USED = "used";
+    private static final String REUSED = "reused";
+    private static final String RECOVERED = "recovered";
+    private static final String PERCENT = "percent";
+
+    public ShardRecoveryFilesExpression(RecoveryState recoveryState) {
+        addChildImplementations(recoveryState);
+    }
+
+    private void addChildImplementations(final RecoveryState recoveryState) {
+        childImplementations.put(USED, new SimpleObjectExpression<Integer>() {
+            @Override
+            public Integer value() {
+                return recoveryState.getIndex().totalFileCount();
+            }
+        });
+        childImplementations.put(REUSED, new SimpleObjectExpression<Integer>() {
+            @Override
+            public Integer value() {
+                return recoveryState.getIndex().reusedFileCount();
+            }
+        });
+        childImplementations.put(RECOVERED, new SimpleObjectExpression<Integer>() {
+            @Override
+            public Integer value() {
+                return recoveryState.getIndex().recoveredFileCount();
+            }
+        });
+        childImplementations.put(PERCENT, new SimpleObjectExpression<Float>() {
+            @Override
+            public Float value() {
+                return recoveryState.getIndex().recoveredFilesPercent();
+            }
+        });
+    }
+
+}

--- a/sql/src/main/java/io/crate/operation/reference/sys/shard/ShardRecoverySizeExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/shard/ShardRecoverySizeExpression.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.operation.reference.sys.shard;
+
+import io.crate.metadata.SimpleObjectExpression;
+import io.crate.operation.reference.NestedObjectExpression;
+import org.elasticsearch.indices.recovery.RecoveryState;
+
+public class ShardRecoverySizeExpression extends NestedObjectExpression {
+
+    private static final String USED = "used";
+    private static final String REUSED = "reused";
+    private static final String RECOVERED = "recovered";
+    private static final String PERCENT = "percent";
+
+    public ShardRecoverySizeExpression(RecoveryState recoveryState) {
+        addChildImplementations(recoveryState);
+    }
+
+    private void addChildImplementations(final RecoveryState recoveryState) {
+        childImplementations.put(USED, new SimpleObjectExpression<Long>() {
+            @Override
+            public Long value() {
+                return recoveryState.getIndex().totalBytes();
+            }
+        });
+        childImplementations.put(REUSED, new SimpleObjectExpression<Long>() {
+            @Override
+            public Long value() {
+                return recoveryState.getIndex().reusedBytes();
+            }
+        });
+        childImplementations.put(RECOVERED, new SimpleObjectExpression<Long>() {
+            @Override
+            public Long value() {
+                return recoveryState.getIndex().recoveredBytes();
+            }
+        });
+        childImplementations.put(PERCENT, new SimpleObjectExpression<Float>() {
+            @Override
+            public Float value() {
+                return recoveryState.getIndex().recoveredBytesPercent();
+            }
+        });
+    }
+}

--- a/sql/src/main/java/io/crate/operation/reference/sys/shard/unassigned/UnassignedShardsExpressionFactories.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/shard/unassigned/UnassignedShardsExpressionFactories.java
@@ -129,6 +129,22 @@ public class UnassignedShardsExpressionFactories {
                         };
                     }
                 })
+                .put(SysShardsTableInfo.Columns.RECOVERY, new RowCollectExpressionFactory() {
+                    @Override
+                    public RowContextCollectorExpression create() {
+                        return new RowContextCollectorExpression() {
+                            @Override
+                            public Object value() {
+                                return null;
+                            }
+
+                            @Override
+                            public ReferenceImplementation getChildImplementation(String name) {
+                                return this;
+                            }
+                        };
+                    }
+                })
                 .put(SysNodesTableInfo.SYS_COL_IDENT, new RowCollectExpressionFactory() {
                     @Override
                     public RowContextCollectorExpression create() {

--- a/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -435,7 +435,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultColumns() throws Exception {
         execute("select * from information_schema.columns order by schema_name, table_name");
-        assertEquals(316L, response.rowCount());
+        assertEquals(330L, response.rowCount());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/RegexpIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/RegexpIntegrationTest.java
@@ -227,27 +227,24 @@ public class RegexpIntegrationTest extends SQLTransportIntegrationTest {
      */
     @Test
     public void testRegexpMatchQueryOperatorOnSysShards() throws Exception {
-
         this.setup.setUpLocations();
         ensureGreen();
         refresh();
 
-        execute("select * from sys.shards where table_name ~ '(?i)LOCATIONS'");
+        execute("select * from sys.shards where table_name ~ '(?i)LOCATIONS' order by table_name");
         assertThat(response.rowCount(), is(2L));
-        assertThat((String) response.rows()[0][9], is("locations"));
-
+        assertThat((String) response.rows()[0][10], is("locations"));
     }
 
     @Test
     public void testRegexpMatchQueryOperatorWithCaseInsensitivityOnSysShards() throws Exception {
-
         this.setup.setUpLocations();
         ensureGreen();
         refresh();
 
-        execute("select * from sys.shards where table_name ~* 'LOCATIONS'");
+        execute("select * from sys.shards where table_name ~* 'LOCATIONS' order by table_name");
         assertThat(response.rowCount(), is(2L));
-        assertThat((String) response.rows()[0][9], is("locations"));
+        assertThat((String) response.rows()[0][10], is("locations"));
     }
 
 }

--- a/sql/src/test/java/io/crate/integrationtests/ShardStatsTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ShardStatsTest.java
@@ -60,11 +60,14 @@ public class ShardStatsTest extends SQLTransportIntegrationTest {
             "with (number_of_replicas=2)");
         client().admin().cluster().prepareHealth("locations").setWaitForYellowStatus().execute().actionGet();
 
-        execute("select * from sys.shards where table_name = 'locations' order by state, \"primary\"");
+        execute("select state, \"primary\", recovery from sys.shards where table_name = 'locations' order by state, \"primary\"");
         assertEquals(6L, response.rowCount());
-        assertEquals(10, response.cols().length);
-        assertEquals("UNASSIGNED", response.rows()[5][8]);
-        assertEquals(false, response.rows()[5][4]);
+        for (int i = 4; i < response.rowCount(); i++) {
+            Object[] row = response.rows()[i];
+            assertEquals("UNASSIGNED", row[0]);
+            assertEquals(false, row[1]);
+            assertEquals(null, row[2]);
+        }
     }
 
     @Test
@@ -105,19 +108,21 @@ public class ShardStatsTest extends SQLTransportIntegrationTest {
         blobIndices.createBlobTable("blobs", indexSettings).get();
         ensureGreen();
 
-        execute("select * from sys.shards where table_name = 'blobs'");
+        execute("select schema_name, table_name from sys.shards where table_name = 'blobs'");
         assertThat(response.rowCount(), is(2L));
         for (int i = 0; i<response.rowCount(); i++) {
-            assertThat((String)response.rows()[0][9], is("blobs"));
+            assertThat((String)response.rows()[i][0], is("blob"));
+            assertThat((String)response.rows()[i][1], is("blobs"));
         }
 
         execute("create blob table sbolb clustered into 4 shards with (number_of_replicas=3)");
         ensureYellow();
 
-        execute("select * from sys.shards where table_name = 'sbolb'");
+        execute("select schema_name, table_name from sys.shards where table_name = 'sbolb'");
         assertThat(response.rowCount(), is(16L));
         for (int i = 0; i < response.rowCount(); i++) {
-            assertThat((String)response.rows()[i][9], is("sbolb"));
+            assertThat((String)response.rows()[i][0], is("blob"));
+            assertThat((String)response.rows()[i][1], is("sbolb"));
         }
         execute("select count(*) from sys.shards " +
                 "where schema_name='blob' and table_name != 'blobs' " +


### PR DESCRIPTION
Example:
```sql
cr> SELECT schema_name, table_name, recovery['type'], recovery['stage'], avg(recovery['size']['percent']) FROM sys.shards WHERE recovery IS NOT NULL GROUP BY 1, 2, 3, 4;
+-------------+------------+------------------+-------------------+----------------------------------+
| schema_name | table_name | recovery['type'] | recovery['stage'] | avg(recovery['size']['percent']) |
+-------------+------------+------------------+-------------------+----------------------------------+
| doc         | github     | REPLICA          | INDEX             |               41.561377462744716 |
| doc         | github     | GATEWAY          | DONE              |              100.0               |
| doc         | github     | RELOCATION       | DONE              |              100.0               |
| doc         | github     | REPLICA          | DONE              |              100.0               |
+-------------+------------+------------------+-------------------+----------------------------------+
SELECT 4 rows in set (0.002 sec)
```