### PR TITLE
fix YAML contentType handling in TransportShardUpsertAction

### DIFF
--- a/sql/src/main/java/io/crate/executor/transport/ShardUpsertRequest.java
+++ b/sql/src/main/java/io/crate/executor/transport/ShardUpsertRequest.java
@@ -205,8 +205,7 @@ public class ShardUpsertRequest extends ShardReplicationOperationRequest<ShardUp
     }
 
     public ShardUpsertRequest(ShardId shardId,
-                              @Nullable
-                                         String[] updateColumns,
+                              @Nullable String[] updateColumns,
                               @Nullable Reference[] insertColumns,
                               UUID jobId) {
         this.jobId = jobId;


### PR DESCRIPTION
Since eabe917773b31cf624b187a6f4689f27e08484fa
`testCopyFromPartitionedTableCustomSchema` would fail when
`Requests.INDEX_CONTENT_TYPE` got set to YAML.

This fixes the issue and also avoids creating an unnecessary
XContentBuilder (which by default allocates 16kb) if the request
contains a rawSource