### PR TITLE
change locations of Routing to be non-nullable

### DIFF
--- a/sql/src/main/java/io/crate/action/job/ContextPreparer.java
+++ b/sql/src/main/java/io/crate/action/job/ContextPreparer.java
@@ -318,9 +318,6 @@ public class ContextPreparer {
         @Override
         public ExecutionSubContext visitCountPhase(final CountPhase phase, final PreparerContext context) {
             Map<String, Map<String, List<Integer>>> locations = phase.routing().locations();
-            if (locations == null) {
-                throw new IllegalArgumentException("locations are empty. Can't start count operation");
-            }
             String localNodeId = clusterService.localNode().id();
             final Map<String, List<Integer>> indexShardMap = locations.get(localNodeId);
             if (indexShardMap == null) {

--- a/sql/src/main/java/io/crate/metadata/doc/DocTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/doc/DocTableInfo.java
@@ -206,7 +206,7 @@ public class DocTableInfo extends AbstractDynamicTableInfo implements ShardedTab
         try {
             shardIterators = getShardIterators(whereClause, preference, state);
         } catch (IndexMissingException e) {
-            return new Routing();
+            return new Routing(locations);
         }
 
         fillLocationsFromShardIterators(locations, shardIterators, missingShards);

--- a/sql/src/main/java/io/crate/operation/collect/sources/CollectSourceResolver.java
+++ b/sql/src/main/java/io/crate/operation/collect/sources/CollectSourceResolver.java
@@ -109,9 +109,6 @@ public class CollectSourceResolver {
     public CollectSource getService(CollectPhase collectPhase, String localNodeId) {
 
         Map<String, Map<String, List<Integer>>> locations = collectPhase.routing().locations();
-        if (locations == null) {
-            throw new IllegalArgumentException("routing of collectPhase must contain locations");
-        }
         if (collectPhase.routing().containsShards(localNodeId)) {
             return shardCollectSource;
         }

--- a/sql/src/main/java/io/crate/operation/collect/sources/ShardCollectSource.java
+++ b/sql/src/main/java/io/crate/operation/collect/sources/ShardCollectSource.java
@@ -161,9 +161,6 @@ public class ShardCollectSource implements CollectSource {
                 jobCollectContext.queryPhaseRamAccountingContext());
 
         Map<String, Map<String, List<Integer>>> locations = normalizedPhase.routing().locations();
-        if (locations == null) {
-            throw new IllegalStateException("locations must not be null");
-        }
         final List<CrateCollector> shardCollectors = new ArrayList<>(maxNumShards);
 
         if (normalizedPhase.maxRowGranularity() == RowGranularity.SHARD) {
@@ -186,8 +183,6 @@ public class ShardCollectSource implements CollectSource {
                                                              String localNodeId) {
 
         Map<String, Map<String, List<Integer>>> locations = collectPhase.routing().locations();
-        assert locations != null : "routing must not be null";
-
         SharedShardContexts sharedShardContexts = jobCollectContext.sharedShardContexts();
         Map<String, List<Integer>> indexShards = locations.get(localNodeId);
         List<OrderedDocCollector> orderedDocCollectors = new ArrayList<>();
@@ -276,7 +271,6 @@ public class ShardCollectSource implements CollectSource {
                                               String localNodeId,
                                               ShardProjectorChain projectorChain) {
         Map<String, Map<String, List<Integer>>> locations = collectPhase.routing().locations();
-        assert locations != null : "locations must not be null";
         List<UnassignedShard> unassignedShards = new ArrayList<>();
         List<Object[]> rows = new ArrayList<>();
         Map<String, List<Integer>> indexShardsMap = locations.get(localNodeId);

--- a/sql/src/main/java/io/crate/operation/collect/sources/SystemCollectSource.java
+++ b/sql/src/main/java/io/crate/operation/collect/sources/SystemCollectSource.java
@@ -150,7 +150,6 @@ public class SystemCollectSource implements CollectSource {
     @Override
     public Collection<CrateCollector> getCollectors(CollectPhase collectPhase, RowReceiver downstream, JobCollectContext jobCollectContext) {
         Map<String, Map<String, List<Integer>>> locations = collectPhase.routing().locations();
-        assert locations != null : "routing must contain locations";
         String table = Iterables.getOnlyElement(locations.get(discoveryService.localNode().id()).keySet());
         Supplier<Iterable<?>> iterableGetter = iterableGetters.get(table);
         assert iterableGetter != null : "iterableGetter for " + table + " must exist";

--- a/sql/src/main/java/io/crate/operation/fetch/FetchContext.java
+++ b/sql/src/main/java/io/crate/operation/fetch/FetchContext.java
@@ -79,9 +79,6 @@ public class FetchContext extends AbstractExecutionSubContext {
 
         for (Routing routing : routingIterable) {
             Map<String, Map<String, List<Integer>>> locations = routing.locations();
-            if (locations == null) {
-                continue;
-            }
             Map<String, List<Integer>> indexShards = locations.get(localNodeId);
             for (Map.Entry<String, List<Integer>> indexShardsEntry : indexShards.entrySet()) {
                 String index = indexShardsEntry.getKey();

--- a/sql/src/main/java/io/crate/planner/node/dql/CollectPhase.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/CollectPhase.java
@@ -235,8 +235,7 @@ public class CollectPhase extends AbstractDQLPlanPhase implements UpstreamPhase 
         maxRowGranularity = RowGranularity.fromStream(in);
 
         if (in.readBoolean()) {
-            routing = new Routing();
-            routing.readFrom(in);
+            routing = Routing.fromStream(in);
         }
 
         whereClause = new WhereClause(in);

--- a/sql/src/main/java/io/crate/planner/node/dql/CountPhase.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/CountPhase.java
@@ -113,8 +113,7 @@ public class CountPhase implements UpstreamPhase {
     public void readFrom(StreamInput in) throws IOException {
         jobId = new UUID(in.readLong(), in.readLong());
         executionPhaseId = in.readVInt();
-        routing = new Routing();
-        routing.readFrom(in);
+        routing = Routing.fromStream(in);
         whereClause = new WhereClause(in);
         distributionInfo = DistributionInfo.fromStream(in);
     }

--- a/sql/src/test/java/io/crate/analyze/BaseAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/BaseAnalyzerTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.analyze;
 
+import com.google.common.collect.ImmutableMap;
 import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
@@ -121,7 +122,7 @@ public abstract class BaseAnalyzerTest extends CrateUnitTest {
             .build();
     static final TableIdent TEST_PARTITIONED_TABLE_IDENT = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "parted");
     static final TableInfo TEST_PARTITIONED_TABLE_INFO = new TestingTableInfo.Builder(
-            TEST_PARTITIONED_TABLE_IDENT, new Routing())
+            TEST_PARTITIONED_TABLE_IDENT, new Routing(ImmutableMap.<String, Map<String, List<Integer>>>of()))
             .add("id", DataTypes.INTEGER, null)
             .add("name", DataTypes.STRING, null)
             .add("date", DataTypes.TIMESTAMP, null, true)
@@ -134,7 +135,7 @@ public abstract class BaseAnalyzerTest extends CrateUnitTest {
             .build();
     static final TableIdent TEST_MULTIPLE_PARTITIONED_TABLE_IDENT = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "multi_parted");
     static final TableInfo TEST_MULTIPLE_PARTITIONED_TABLE_INFO = new TestingTableInfo.Builder(
-            TEST_MULTIPLE_PARTITIONED_TABLE_IDENT, new Routing())
+            TEST_MULTIPLE_PARTITIONED_TABLE_IDENT, new Routing(ImmutableMap.<String, Map<String,List<Integer>>>of()))
             .add("id", DataTypes.INTEGER, null)
             .add("date", DataTypes.TIMESTAMP, null, true)
             .add("num", DataTypes.LONG, null)
@@ -148,7 +149,7 @@ public abstract class BaseAnalyzerTest extends CrateUnitTest {
             .build();
     static final TableIdent TEST_NESTED_PARTITIONED_TABLE_IDENT = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "nested_parted");
     static final TableInfo TEST_NESTED_PARTITIONED_TABLE_INFO = new TestingTableInfo.Builder(
-            TEST_NESTED_PARTITIONED_TABLE_IDENT, new Routing())
+            TEST_NESTED_PARTITIONED_TABLE_IDENT, new Routing(ImmutableMap.<String, Map<String,List<Integer>>>of()))
             .add("id", DataTypes.INTEGER, null)
             .add("date", DataTypes.TIMESTAMP, null, true)
             .add("obj", DataTypes.OBJECT, null, ColumnPolicy.DYNAMIC)
@@ -161,7 +162,7 @@ public abstract class BaseAnalyzerTest extends CrateUnitTest {
             .build();
     static final TableIdent TEST_DOC_TRANSACTIONS_TABLE_IDENT = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "transactions");
     static final TableInfo TEST_DOC_TRANSACTIONS_TABLE_INFO = new TestingTableInfo.Builder(
-            TEST_DOC_TRANSACTIONS_TABLE_IDENT, new Routing())
+            TEST_DOC_TRANSACTIONS_TABLE_IDENT, new Routing(ImmutableMap.<String, Map<String,List<Integer>>>of()))
             .add("id", DataTypes.LONG, null)
             .add("sender", DataTypes.STRING, null)
             .add("recipient", DataTypes.STRING, null)
@@ -170,7 +171,7 @@ public abstract class BaseAnalyzerTest extends CrateUnitTest {
             .build();
     static final TableIdent DEEPLY_NESTED_TABLE_IDENT = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "deeply_nested");
     static final TableInfo DEEPLY_NESTED_TABLE_INFO = new TestingTableInfo.Builder(
-            DEEPLY_NESTED_TABLE_IDENT, new Routing())
+            DEEPLY_NESTED_TABLE_IDENT, new Routing(ImmutableMap.<String, Map<String,List<Integer>>>of()))
             .add("details", DataTypes.OBJECT, null, ColumnPolicy.DYNAMIC)
             .add("details", DataTypes.BOOLEAN, Arrays.asList("awesome"))
             .add("details", DataTypes.OBJECT, Arrays.asList("stuff"), ColumnPolicy.DYNAMIC)
@@ -186,7 +187,7 @@ public abstract class BaseAnalyzerTest extends CrateUnitTest {
 
     public static final TableIdent IGNORED_NESTED_TABLE_IDENT = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "ignored_nested");
     public static final TableInfo IGNORED_NESTED_TABLE_INFO = new TestingTableInfo.Builder(
-                IGNORED_NESTED_TABLE_IDENT, new Routing())
+                IGNORED_NESTED_TABLE_IDENT, new Routing(ImmutableMap.<String, Map<String,List<Integer>>>of()))
                 .add("details", DataTypes.OBJECT, null, ColumnPolicy.IGNORED)
                 .build();
 

--- a/sql/src/test/java/io/crate/analyze/ExpressionAnalyzerNormalizeTest.java
+++ b/sql/src/test/java/io/crate/analyze/ExpressionAnalyzerNormalizeTest.java
@@ -55,6 +55,7 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -70,7 +71,8 @@ public class ExpressionAnalyzerNormalizeTest extends CrateUnitTest {
     private static final TableIdent TEST_TABLE_IDENT = new TableIdent(null, "test1");
     private static final FunctionInfo TEST_FUNCTION_INFO = new FunctionInfo(
             new FunctionIdent("abs", ImmutableList.<DataType>of(DataTypes.DOUBLE)), DataTypes.DOUBLE);
-    private static final TableInfo userTableInfo = TestingTableInfo.builder(TEST_TABLE_IDENT, new Routing())
+    private static final TableInfo userTableInfo = TestingTableInfo.builder(TEST_TABLE_IDENT,
+            new Routing(ImmutableMap.<String, Map<String,List<Integer>>>of()))
             .add("id", DataTypes.LONG, null)
             .add("name", DataTypes.STRING, null)
             .add("d", DataTypes.DOUBLE, null)

--- a/sql/src/test/java/io/crate/analyze/InsertFromValuesAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/InsertFromValuesAnalyzerTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.analyze;
 
+import com.google.common.collect.ImmutableMap;
 import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.exceptions.ColumnUnknownException;
@@ -55,13 +56,13 @@ public class InsertFromValuesAnalyzerTest extends BaseAnalyzerTest {
 
     private static final TableIdent TEST_ALIAS_TABLE_IDENT = new TableIdent(null, "alias");
     private static final TableInfo TEST_ALIAS_TABLE_INFO = new TestingTableInfo.Builder(
-            TEST_ALIAS_TABLE_IDENT, new Routing())
+            TEST_ALIAS_TABLE_IDENT, new Routing(ImmutableMap.<String, Map<String,List<Integer>>>of()))
             .add("bla", DataTypes.STRING, null)
             .isAlias(true).build();
 
     private static final TableIdent NESTED_CLUSTERED_TABLE_IDENT = new TableIdent(null, "nested_clustered");
     private static final TableInfo NESTED_CLUSTERED_TABLE_INFO = new TestingTableInfo.Builder(
-            NESTED_CLUSTERED_TABLE_IDENT, new Routing())
+            NESTED_CLUSTERED_TABLE_IDENT, new Routing(ImmutableMap.<String, Map<String,List<Integer>>>of()))
             .add("o", DataTypes.OBJECT, null)
             .add("o", DataTypes.STRING, Arrays.asList("c"))
             .clusteredBy("o.c")

--- a/sql/src/test/java/io/crate/analyze/PartitionPropertiesAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/PartitionPropertiesAnalyzerTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.analyze;
 
+import com.google.common.collect.ImmutableMap;
 import io.crate.metadata.MetaDataModule;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.Routing;
@@ -38,6 +39,7 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import static org.hamcrest.Matchers.is;
 
@@ -53,7 +55,8 @@ public class PartitionPropertiesAnalyzerTest extends BaseAnalyzerTest {
 
     @Test
     public void testPartitionNameFromAssignmentWithBytesRef() throws Exception {
-        DocTableInfo tableInfo = TestingTableInfo.builder(new TableIdent("doc", "users"), new Routing(null))
+        DocTableInfo tableInfo = TestingTableInfo.builder(new TableIdent("doc", "users"),
+                new Routing(ImmutableMap.<String, Map<String,List<Integer>>>of()))
                 .add("name", DataTypes.STRING, null, true)
                 .addPrimaryKey("name").build();
 

--- a/sql/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.analyze;
 
+import com.google.common.collect.ImmutableMap;
 import io.crate.analyze.relations.DocTableRelation;
 import io.crate.analyze.symbol.*;
 import io.crate.exceptions.ColumnValidationException;
@@ -69,7 +70,7 @@ public class UpdateAnalyzerTest extends BaseAnalyzerTest {
 
     private final static TableIdent TEST_ALIAS_TABLE_IDENT = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "alias");
     private final static TableInfo TEST_ALIAS_TABLE_INFO = new TestingTableInfo.Builder(
-            TEST_ALIAS_TABLE_IDENT, new Routing())
+            TEST_ALIAS_TABLE_IDENT, new Routing(ImmutableMap.<String, Map<String,List<Integer>>>of()))
             .add("bla", DataTypes.STRING, null)
             .isAlias(true).build();
 

--- a/sql/src/test/java/io/crate/metadata/RoutingTest.java
+++ b/sql/src/test/java/io/crate/metadata/RoutingTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.metadata;
 
+import com.google.common.collect.ImmutableMap;
 import io.crate.test.integration.CrateUnitTest;
 import org.elasticsearch.common.io.stream.BytesStreamInput;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
@@ -47,7 +48,7 @@ public class RoutingTest extends CrateUnitTest {
         routing1.writeTo(out);
 
         BytesStreamInput in = new BytesStreamInput(out.bytes());
-        Routing routing2 = new Routing();
+        Routing routing2 = new Routing(ImmutableMap.<String, Map<String,List<Integer>>>of());
         routing2.readFrom(in);
 
         assertThat(routing1.locations(), is(routing2.locations()));
@@ -56,13 +57,11 @@ public class RoutingTest extends CrateUnitTest {
     @Test
     public void testStreamingWithoutLocations() throws Exception {
         BytesStreamOutput out = new BytesStreamOutput();
-        Routing routing1 = new Routing(null);
+        Routing routing1 = new Routing(ImmutableMap.<String, Map<String,List<Integer>>>of());
         routing1.writeTo(out);
 
         BytesStreamInput in = new BytesStreamInput(out.bytes());
-        Routing routing2 = new Routing();
-        routing2.readFrom(in);
-
+        Routing routing2 = Routing.fromStream(in);
         assertThat(routing1.locations(), is(routing2.locations()));
     }
 }

--- a/sql/src/test/java/io/crate/operation/collect/sources/SystemCollectSourceTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/sources/SystemCollectSourceTest.java
@@ -23,6 +23,7 @@
 package io.crate.operation.collect.sources;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.WhereClause;
 import io.crate.analyze.symbol.Reference;
@@ -46,6 +47,8 @@ import org.junit.Test;
 import org.mockito.Answers;
 
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import static org.hamcrest.Matchers.is;
@@ -72,7 +75,7 @@ public class SystemCollectSourceTest {
                 UUID.randomUUID(),
                 1,
                 "collect",
-                new Routing(null),
+                new Routing(ImmutableMap.<String, Map<String,List<Integer>>>of()),
                 RowGranularity.SHARD,
                 Collections.<Symbol>singletonList(shardId),
                 ImmutableList.<Projection>of(),

--- a/sql/src/test/java/io/crate/planner/PlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/PlannerTest.java
@@ -3,6 +3,7 @@ package io.crate.planner;
 import com.carrotsearch.hppc.IntSet;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import io.crate.Constants;
 import io.crate.analyze.Analyzer;
@@ -200,7 +201,7 @@ public class PlannerTest extends CrateUnitTest {
                     .build();
             TableIdent multiplePartitionedTableIdent= new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "multi_parted");
             TableInfo multiplePartitionedTableInfo = new TestingTableInfo.Builder(
-                    multiplePartitionedTableIdent, new Routing())
+                    multiplePartitionedTableIdent, new Routing(ImmutableMap.<String, Map<String,List<Integer>>>of()))
                     .add("id", DataTypes.INTEGER, null)
                     .add("date", DataTypes.TIMESTAMP, null, true)
                     .add("num", DataTypes.LONG, null)

--- a/sql/src/test/java/io/crate/planner/consumer/CrossJoinConsumerTest.java
+++ b/sql/src/test/java/io/crate/planner/consumer/CrossJoinConsumerTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.planner.consumer;
 
+import com.google.common.collect.ImmutableMap;
 import io.crate.Constants;
 import io.crate.analyze.*;
 import io.crate.analyze.relations.PlannedAnalyzedRelation;
@@ -70,6 +71,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import static io.crate.testing.TestingHelpers.*;
@@ -109,7 +111,8 @@ public class CrossJoinConsumerTest extends CrateUnitTest {
         consumer = new CrossJoinConsumer(clusterService, mock(AnalysisMetaData.class), statsService);
     }
 
-    private static final TableInfo EMPTY_ROUTING_TABLE = TestingTableInfo.builder(new TableIdent(DocSchemaInfo.NAME, "empty"), new Routing())
+    private static final TableInfo EMPTY_ROUTING_TABLE = TestingTableInfo.builder(new TableIdent(DocSchemaInfo.NAME, "empty"),
+            new Routing(ImmutableMap.<String, Map<String, List<Integer>>>of()))
             .add("nope", DataTypes.BOOLEAN)
             .build();
 

--- a/sql/src/test/java/io/crate/planner/node/CollectNodeTest.java
+++ b/sql/src/test/java/io/crate/planner/node/CollectNodeTest.java
@@ -22,6 +22,7 @@
 package io.crate.planner.node;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.crate.analyze.WhereClause;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.Value;
@@ -36,6 +37,8 @@ import org.elasticsearch.common.io.stream.BytesStreamInput;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.junit.Test;
 
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -51,7 +54,7 @@ public class CollectNodeTest extends CrateUnitTest {
                 jobId,
                 0,
                 "cn",
-                new Routing(),
+                new Routing(ImmutableMap.<String, Map<String,List<Integer>>>of()),
                 RowGranularity.DOC,
                 toCollect,
                 ImmutableList.<Projection>of(),


### PR DESCRIPTION
With the exception of one error case and a couple of tests the locations
were never null anyway. Cleaner to make it non-null and safe a couple of
null checks and possible NPEs.