### PR TITLE
fix insert into a table with generated columns

### DIFF
--- a/sql/src/test/java/io/crate/analyze/InsertFromValuesAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/InsertFromValuesAnalyzerTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.analyze;
 
+import com.google.common.collect.ImmutableMap;
 import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.exceptions.ColumnUnknownException;
@@ -1013,5 +1014,31 @@ public class InsertFromValuesAnalyzerTest extends BaseAnalyzerTest {
         expectedException.expectMessage("Given value 1449999900000 for generated column does not match defined generated expression value 1447804800000");
         analyze("insert into generated_column (ts, day) values (?, ?)",
                 new Object[]{"2015-11-18T11:11:00", 1449999900000L});
+    }
+
+    @Test
+    public void testInsertMultipleValuesWithGeneratedColumn() throws Exception {
+        InsertFromValuesAnalyzedStatement analysis = (InsertFromValuesAnalyzedStatement) analyze(
+                "INSERT INTO generated_column (ts, user) values ('1970-01-01', {name='Johnny'}), ('1989-11-09T08:30:00', {name='Egon'})");
+        assertThat(analysis.columns(), hasSize(4));
+        assertThat(analysis.columns(), contains(isReference("ts"), isReference("user"), isReference("day"), isReference("name")));
+        assertThat(analysis.sourceMaps(), hasSize(2));
+        assertThat(analysis.sourceMaps(), contains(
+                Matchers.arrayContaining(0L, ImmutableMap.<String, Object>of("name", "Johnny"), 0L, new BytesRef("Johnnybar")),
+                Matchers.arrayContaining(626603400000L, ImmutableMap.<String, Object>of("name", "Egon"), 626572800000L, new BytesRef("Egonbar"))));
+    }
+
+    @Test
+    public void testInsertMultipleValuesTooManyValues() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("INSERT statement contains a VALUES clause with too many elements (3), expected (2)");
+        analyze("INSERT INTO users (id, name) values (1, 'Johnny'), (2, 'Egon', 1234)");
+    }
+
+    @Test
+    public void testInsertMultipleValuesWithGeneratedColumnAndTooFewValuesInSecondValues() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Invalid number of values: Got 2 columns specified but 1 values");
+        analyze("INSERT INTO generated_column (ts, user) values ('1970-01-01', {name='Johnny'}), ('1989-11-09T08:30:00')");
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
@@ -757,6 +757,25 @@ public class InsertIntoIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    public void testInsertMutipleRowsWithGeneratedColumn() throws Exception {
+        execute("CREATE TABLE computed (\n" +
+                "   dividend double,\n" +
+                "   divisor double,\n" +
+                "   quotient AS (dividend / divisor)\n" +
+                ")");
+        ensureYellow();
+        execute("INSERT INTO computed (dividend, divisor) VALUES (1.0, 1.0), (0.0, 10.0)");
+        assertThat(response.rowCount(), is(2L));
+        execute("refresh table computed");
+
+        execute("select * from computed order by quotient");
+        assertThat(TestingHelpers.printedTable(response.rows()), is(
+                "0.0| 10.0| 0.0\n" +
+                "1.0| 1.0| 1.0\n"));
+
+    }
+
+    @Test
     public void testInsertOnDuplicateWithGeneratedColumn() throws Exception {
         execute("create table test_generated_column (" +
                 " id integer primary key," +


### PR DESCRIPTION
when multiple VALUES clauses are used

it failed because the columns-size did not match anymore with the values size when generated columns were added