### PR TITLE
don't include routing per item in ShardUpsertRequest

### DIFF
--- a/sql/src/main/java/io/crate/executor/transport/TransportShardUpsertAction.java
+++ b/sql/src/main/java/io/crate/executor/transport/TransportShardUpsertAction.java
@@ -358,7 +358,7 @@ public class TransportShardUpsertAction
         IndexRequest indexRequest = Requests.indexRequest(request.index())
                 .type(request.type())
                 .id(item.id())
-                .routing(item.routing())
+                .routing(request.routing())
                 .source(source)
                 .create(!request.overwriteDuplicates())
                 .operationThreaded(false);

--- a/sql/src/main/java/io/crate/executor/transport/task/UpsertByIdTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/UpsertByIdTask.java
@@ -146,9 +146,10 @@ public class UpsertByIdTask extends JobTask {
                 item.routing()
         ).shardId();
 
-        ShardUpsertRequest upsertRequest = new ShardUpsertRequest(shardId, node.updateColumns(), node.insertColumns(), jobId());
+        ShardUpsertRequest upsertRequest = new ShardUpsertRequest(
+                shardId, node.updateColumns(), node.insertColumns(), item.routing(), jobId());
         upsertRequest.continueOnError(false);
-        upsertRequest.add(0, item.id(), item.updateAssignments(), item.insertValues(), item.version(), item.routing());
+        upsertRequest.add(0, item.id(), item.updateAssignments(), item.insertValues(), item.version());
 
         UpsertByIdContext upsertByIdContext = new UpsertByIdContext(
                 node.executionPhaseId(), upsertRequest, item, futureResult, transportShardUpsertActionDelegate);

--- a/sql/src/main/java/org/elasticsearch/action/bulk/BulkShardProcessor.java
+++ b/sql/src/main/java/org/elasticsearch/action/bulk/BulkShardProcessor.java
@@ -258,7 +258,7 @@ public class BulkShardProcessor<Request extends BulkProcessorRequest> {
             executeLock.acquire();
             Request request = requestsByShard.get(shardId);
             if (request == null) {
-                request = requestBuilder.newRequest(shardId);
+                request = requestBuilder.newRequest(shardId, routing);
                 requestsByShard.put(shardId, request);
             }
             requestItemCounter.getAndIncrement();
@@ -269,7 +269,6 @@ public class BulkShardProcessor<Request extends BulkProcessorRequest> {
                     id,
                     assignments,
                     missingAssignments,
-                    routing,
                     version
             );
         } catch (InterruptedException e) {
@@ -530,7 +529,7 @@ public class BulkShardProcessor<Request extends BulkProcessorRequest> {
     }
 
     public interface BulkRequestBuilder<Request extends BulkProcessorRequest> {
-        Request newRequest(ShardId shardId);
+        Request newRequest(ShardId shardId, String routing);
 
         void addItem(Request existingRequest,
                      ShardId shardId,
@@ -538,7 +537,6 @@ public class BulkShardProcessor<Request extends BulkProcessorRequest> {
                      String id,
                      @Nullable Symbol[] assignments,
                      @Nullable Object[] missingAssignments,
-                     @Nullable String routing,
                      @Nullable Long version);
     }
 

--- a/sql/src/test/java/io/crate/executor/transport/ShardUpsertRequestTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/ShardUpsertRequestTest.java
@@ -60,16 +60,18 @@ public class ShardUpsertRequestTest extends CrateUnitTest {
         ShardUpsertRequest request = new ShardUpsertRequest(
                 shardId,
                 assignmentColumns,
-                missingAssignmentColumns, jobId);
+                missingAssignmentColumns,
+                "42",
+                jobId);
 
         request.add(123, "99",
                 null,
                 new Object[]{99, new BytesRef("Marvin")},
-                null, null);
+                null);
         request.add(5, "42",
                 new Symbol[]{Literal.newLiteral(42), Literal.newLiteral("Deep Thought") },
                 null,
-                2L, "42");
+                2L);
 
 
         BytesStreamOutput out = new BytesStreamOutput();
@@ -88,6 +90,7 @@ public class ShardUpsertRequestTest extends CrateUnitTest {
         assertThat(request2.itemIndices().size(), is(2));
         assertThat(request2.itemIndices().get(0), is(123));
         assertThat(request2.itemIndices().get(1), is(5));
+        assertThat(request2.routing(), is("42"));
 
         assertThat(request2.items().size(), is(2));
 
@@ -95,7 +98,6 @@ public class ShardUpsertRequestTest extends CrateUnitTest {
         assertThat(item1.id(), is("99"));
         assertNull(item1.updateAssignments());
         assertThat(item1.insertValues(), is(new Object[]{99, new BytesRef("Marvin")}));
-        assertNull(item1.routing());
         assertThat(item1.version(), is(Versions.MATCH_ANY));
         assertThat(item1.retryOnConflict(), is(Constants.UPDATE_RETRY_ON_CONFLICT));
 
@@ -103,7 +105,6 @@ public class ShardUpsertRequestTest extends CrateUnitTest {
         assertThat(item2.id(), is("42"));
         assertThat(item2.updateAssignments(), is(new Symbol[]{Literal.newLiteral(42), Literal.newLiteral("Deep Thought") }));
         assertNull(item2.insertValues());
-        assertThat(item2.routing(), is("42"));
         assertThat(item2.version(), is(2L));
         assertThat(item2.retryOnConflict(), is(0));
     }

--- a/sql/src/test/java/io/crate/executor/transport/TransportShardUpsertActionTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/TransportShardUpsertActionTest.java
@@ -103,8 +103,8 @@ public class TransportShardUpsertActionTest extends CrateUnitTest {
 
         ShardId shardId = new ShardId("characters", 0);
         final ShardUpsertRequest request = new ShardUpsertRequest(
-                new ShardId("characters", 0), null, new Reference[]{idRef}, UUID.randomUUID());
-        request.add(1, "1", null, new Object[]{1}, null, null);
+                new ShardId("characters", 0), null, new Reference[]{idRef}, null, UUID.randomUUID());
+        request.add(1, "1", null, new Object[]{1}, null);
 
         ShardUpsertResponse response = transportShardUpsertAction.processRequestItems(
                 shardId, request, new AtomicBoolean(false));


### PR DESCRIPTION
The requests are already shard specific which implies that the routing
value of an item must result in the same shardId. Therefore it can be
optimized to have the routing value only once on the request level
instead of item level.