### PR TITLE
optimize queries containing references used

### DIFF
--- a/sql/src/main/java/io/crate/analyze/GeneratedColumnComparisonReplacer.java
+++ b/sql/src/main/java/io/crate/analyze/GeneratedColumnComparisonReplacer.java
@@ -148,7 +148,7 @@ public class GeneratedColumnComparisonReplacer {
         private Map<ReferenceInfo, GeneratedReferenceInfo> extractGeneratedReferences(DocTableInfo tableInfo) {
             ImmutableMap.Builder<ReferenceInfo, GeneratedReferenceInfo> builder = ImmutableMap.builder();
             for (GeneratedReferenceInfo referenceInfo : tableInfo.generatedColumns()) {
-                if (referenceInfo.referencedReferenceInfos().size() == 1) {
+                if (referenceInfo.referencedReferenceInfos().size() == 1 && tableInfo.partitionedByColumns().contains(referenceInfo)) {
                     builder.put(referenceInfo.referencedReferenceInfos().get(0), referenceInfo);
                 }
             }


### PR DESCRIPTION
in generated columns only if table is partitioned
by the generated column