### PR TITLE
add benchmark for bulk inserts with generated column

### DIFF
--- a/stresstest/src/test/java/io/crate/benchmark/BulkInsertBenchmark.java
+++ b/stresstest/src/test/java/io/crate/benchmark/BulkInsertBenchmark.java
@@ -63,7 +63,7 @@ public class BulkInsertBenchmark extends BenchmarkBase {
         return new SQLRequest(BULK_INSERT_SQL_STMT, bulkObjects);
     }
 
-    private SQLBulkRequest getBulkArgsRequest() {
+    static SQLBulkRequest getBulkArgsRequest() {
         Object[][] bulkArgs = new Object[ROWS][];
         for (int i = 0; i < ROWS; i++) {
             bulkArgs[i] = getRandomObject();
@@ -71,7 +71,7 @@ public class BulkInsertBenchmark extends BenchmarkBase {
         return new SQLBulkRequest(SINGLE_INSERT_SQL_STMT, bulkArgs);
     }
 
-    private Object[] getRandomObject() {
+    private static Object[] getRandomObject() {
         return new Object[]{
                 RandomStringUtils.randomAlphabetic(10), // countryName
                 RandomStringUtils.randomAlphabetic(2),  // countryCode

--- a/stresstest/src/test/java/io/crate/benchmark/BulkInsertGeneratedColumnBenchmark.java
+++ b/stresstest/src/test/java/io/crate/benchmark/BulkInsertGeneratedColumnBenchmark.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.benchmark;
+
+
+import com.carrotsearch.junitbenchmarks.BenchmarkOptions;
+import com.carrotsearch.junitbenchmarks.annotation.AxisRange;
+import com.carrotsearch.junitbenchmarks.annotation.BenchmarkHistoryChart;
+import com.carrotsearch.junitbenchmarks.annotation.BenchmarkMethodChart;
+import com.carrotsearch.junitbenchmarks.annotation.LabelType;
+import io.crate.action.sql.SQLBulkResponse;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+
+@AxisRange(min = 0)
+@BenchmarkHistoryChart(filePrefix="benchmark-bulk-insert-t175-history", labelWith = LabelType.CUSTOM_KEY)
+@BenchmarkMethodChart(filePrefix = "benchmark-bulk-insert-t175")
+public class BulkInsertGeneratedColumnBenchmark extends BenchmarkBase {
+
+    public static final int BENCHMARK_ROUNDS = 10;
+
+    @Override
+    protected void createTable() {
+        execute("create table \"" + INDEX_NAME + "\" (" +
+                " \"areaInSqKm\" float," +
+                " capital string," +
+                " continent string," +
+                " \"continentName\" string," +
+                " \"countryCode\" string," +
+                " \"countryName\" string," +
+                " north float," +
+                " east float," +
+                " south float," +
+                " west float," +
+                " \"fipsCode\" string," +
+                " \"currencyCode\" string," +
+                " languages string," +
+                " \"isoAlpha3\" string," +
+                " \"isoNumeric\" string," +
+                " population integer," +
+                " population_generated integer GENERATED ALWAYS AS (population + 1)" +
+                ") clustered into 2 shards with (number_of_replicas=0)", new Object[0]);
+        client().admin().cluster().prepareHealth(INDEX_NAME).setWaitForGreenStatus().execute().actionGet();
+    }
+
+    @Test
+    @BenchmarkOptions(benchmarkRounds = BENCHMARK_ROUNDS, warmupRounds = 1)
+    public void testBulkInsertWithGeneratedColumn() throws Exception {
+        SQLBulkResponse response = execute(BulkInsertBenchmark.getBulkArgsRequest());
+        assertThat(response.results().length, is(BulkInsertBenchmark.ROWS));
+    }
+
+}


### PR DESCRIPTION
Bulk insert without generated col:  0.79  0.73  0.67
Bulk insert with generated col:       0.79  0.76  0.73

All done with 10.000 bulk inserts on same table (inserts with generated col just have 1 more col, the generated one ;-)