### PR TITLE
use Long.valueOf instead of new Long in TimestampType conversion

### DIFF
--- a/core/src/main/java/io/crate/types/TimestampType.java
+++ b/core/src/main/java/io/crate/types/TimestampType.java
@@ -69,7 +69,7 @@ public class TimestampType extends LongType implements Streamer<Long>, DataTypeF
 
     private Long valueFromString(String s) {
         try {
-            return new Long(s);
+            return Long.valueOf(s);
         } catch (NumberFormatException e) {
             return TimestampFormat.parseTimestampString(s);
         }


### PR DESCRIPTION
In order to make use of the internal long value cache.