### PR TITLE
fixed flaky testKeepAliveRunnableNotCalledWithManyResets

### DIFF
--- a/sql/src/test/java/io/crate/jobs/KeepAliveTimersTest.java
+++ b/sql/src/test/java/io/crate/jobs/KeepAliveTimersTest.java
@@ -99,13 +99,13 @@ public class KeepAliveTimersTest extends CrateUnitTest {
         final KeepAliveTimers.ResettableTimer timer = futureAndTimer.v2();
         SettableFuture<Void> future = futureAndTimer.v1();
 
-        timer.start();
         scheduledExecutorService.scheduleWithFixedDelay(new Runnable() {
             @Override
             public void run() {
                 timer.reset();
             }
         }, 0, 10, TimeUnit.MILLISECONDS);
+        timer.start();
         expectedException.expect(TimeoutException.class);
         future.get(200, TimeUnit.MILLISECONDS);
     }


### PR DESCRIPTION
timing issue where timer was started before the setup of the scheduled service finished. 
timer is now started after setup of the service finished.