### PR TITLE
increased wait time in testKeepAliveRunnableWithoutResetIsCalled

### DIFF
--- a/sql/src/test/java/io/crate/jobs/KeepAliveTimersTest.java
+++ b/sql/src/test/java/io/crate/jobs/KeepAliveTimersTest.java
@@ -80,7 +80,7 @@ public class KeepAliveTimersTest extends CrateUnitTest {
         KeepAliveTimers.ResettableTimer timer = futureAndTimer.v2();
         SettableFuture<Void> future = futureAndTimer.v1();
         timer.start();
-        future.get(100, TimeUnit.MILLISECONDS);
+        future.get(1000, TimeUnit.MILLISECONDS);
     }
 
     @Test


### PR DESCRIPTION
to decrease likelyhood of a race condition

was not able to reproduce the flaky timeout though