### PR TITLE
integrate QuerySplitter into ManyTableConsumer

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Added support for 2+ table joins
+
  - Fix: All insert from subquery statements are now executed without ``limit``
 
  - Updated crate-admin to 0.17.0 which includes following changes:
@@ -15,6 +17,7 @@ Unreleased
      - Updated calculation of underreplicated shards/records to work with the
        change in Crate server where shards in sys.shards table have a more fine
        granular state now and relocating shards are listed, too.
+
 
  - Added ``show schemas``, ``show tables``, and ``show columns``
    commands.

--- a/docs/sql/joins.txt
+++ b/docs/sql/joins.txt
@@ -108,18 +108,17 @@ each shard of the used tables.
 Limitations
 ...........
 
- - Joining more than 2 tables is currently not possible
+ - Joining more than 2 tables can result in execution plans which perform
+   poorly as there is no query optimizer in place yet.
 
+ - The ORDER BY clause must not contain expressions which involve multiple
+   relations. ``ORDER BY t1.x + t2.x`` won't work, but ``ORDER BY t1.x, t2.x``
+   is allowed.
 
 Roadmap
 -------
 
-*Date: Nov 20th, 2015*
-
-Currently working on
-....................
-
-* Support for joining more than 2 tables.
+*Date: Dec 15th, 2015*
 
 Upcoming
 ........

--- a/sql/src/main/java/io/crate/analyze/TwoTableJoin.java
+++ b/sql/src/main/java/io/crate/analyze/TwoTableJoin.java
@@ -33,6 +33,7 @@ import io.crate.sql.tree.QualifiedName;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class TwoTableJoin implements QueriedRelation {
@@ -57,7 +58,7 @@ public class TwoTableJoin implements QueriedRelation {
         this.left = left;
         this.rightName = rightName;
         this.right = right;
-        this.name = new QualifiedName("join(" + leftName.toString() + ", " + rightName.toString() + ")");
+        this.name = QualifiedName.of("join", leftName.toString(), rightName.toString());
         this.remainingOrderBy = remainingOrderBy;
         fields = new ArrayList<>(querySpec.outputs().size());
         for (int i = 0; i < querySpec.outputs().size(); i++) {

--- a/sql/src/main/java/io/crate/analyze/relations/QuerySplitter.java
+++ b/sql/src/main/java/io/crate/analyze/relations/QuerySplitter.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.analyze.relations;
+
+
+import io.crate.analyze.symbol.Function;
+import io.crate.analyze.symbol.Symbol;
+import io.crate.analyze.symbol.SymbolVisitor;
+import io.crate.operation.operator.AndOperator;
+import io.crate.planner.consumer.ManyTableConsumer;
+import io.crate.sql.tree.QualifiedName;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class QuerySplitter {
+
+    private static final SplitVisitor SPLIT_VISITOR = new SplitVisitor();
+
+    /**
+     * <p>
+     * splits a (function) symbol into multiple symbols where each symbol has 2 or more relations.
+     * </p>
+     *
+     * E.g.
+     * <pre>
+     *     t1.x = t2.x and t2.x = t3.x
+     * </pre>
+     * Will be split into:
+     *
+     * <pre>
+     *     t1.x = t2.x  ->  t1, t2
+     *     t2.x = t3.x  ->  t2, t3
+     * </pre>
+     */
+    public static Map<Set<QualifiedName>, Symbol> split(Symbol symbol) {
+        Map<Set<QualifiedName>, Symbol> splits = new HashMap<>();
+        SPLIT_VISITOR.process(symbol, splits);
+        return splits;
+    }
+
+    private static class SplitVisitor extends SymbolVisitor<Map<Set<QualifiedName>, Symbol>, Void> {
+
+        @Override
+        public Void visitFunction(Function function, Map<Set<QualifiedName>, Symbol> splits) {
+            if (!function.info().equals(AndOperator.INFO)) {
+                HashSet<QualifiedName> qualifiedNames = new HashSet<>();
+                ManyTableConsumer.QualifiedNameCounter.INSTANCE.process(function, qualifiedNames);
+                splits.put(qualifiedNames, function);
+                return null;
+            }
+
+            for (Symbol arg : function.arguments()) {
+                process(arg, splits);
+            }
+            return null;
+        }
+    }
+}

--- a/sql/src/test/java/io/crate/analyze/relations/QuerySplitterTest.java
+++ b/sql/src/test/java/io/crate/analyze/relations/QuerySplitterTest.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.analyze.relations;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
+import io.crate.analyze.symbol.Field;
+import io.crate.analyze.symbol.RelationColumn;
+import io.crate.analyze.symbol.Symbol;
+import io.crate.metadata.ReplacingSymbolVisitor;
+import io.crate.sql.tree.QualifiedName;
+import io.crate.testing.SqlExpressions;
+import io.crate.testing.T3;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+
+public class QuerySplitterTest {
+
+    private SqlExpressions expressions;
+    QualifiedName tr1 = new QualifiedName("tr1");
+    QualifiedName tr2 = new QualifiedName("tr2");
+    QualifiedName tr3 = new QualifiedName("tr3");
+
+    Map<AnalyzedRelation, QualifiedName> relationToName = ImmutableMap.<AnalyzedRelation, QualifiedName>of(
+            T3.TR_1, tr1,
+            T3.TR_2, tr2,
+            T3.TR_3, tr3);
+
+    @Before
+    public void setUp() throws Exception {
+        expressions = new SqlExpressions(T3.SOURCES);
+    }
+
+    private Symbol asSymbol(String expression) {
+        return ToRelationColumn.INSTANCE.process(expressions.asSymbol(expression), relationToName);
+    }
+
+    @Test
+    public void testSplitQueryWith3Relations() throws Exception {
+        Symbol symbol = asSymbol("t1.a = t2.b and t2.b = t3.c");
+        Map<Set<QualifiedName>, Symbol> split = QuerySplitter.split(symbol);
+        assertThat(split.size(), is(2));
+
+
+        Symbol t1t2 = asSymbol("t1.a = t2.b");
+        Symbol t2t3 = asSymbol("t2.b = t3.c");
+
+        Set<QualifiedName> tr1AndTr2 = Sets.newHashSet(tr1, tr2);
+        assertThat(split.containsKey(tr1AndTr2), is(true));
+        assertThat(split.get(tr1AndTr2), is(t1t2));
+
+        Set<QualifiedName> tr2AndTr3 = Sets.newHashSet(tr2, tr3);
+        assertThat(split.containsKey(tr2AndTr3), is(true));
+        assertThat(split.get(tr2AndTr3), is(t2t3));
+    }
+
+    @Test
+    public void testSplitQueryWith2TableJoinAnd3TableJoin() throws Exception {
+        Symbol symbol = asSymbol("t1.a = t2.b and t2.b = t3.c || t1.a");
+        Map<Set<QualifiedName>, Symbol> split = QuerySplitter.split(symbol);
+        assertThat(split.size(), is(2));
+
+        Symbol t1t2 = asSymbol("t1.a = t2.b");
+        Symbol t1t2t3 = asSymbol("t2.b = t3.c || t1.a");
+
+        Set<QualifiedName> tr1AndTr2 = Sets.newHashSet(tr1, tr2);
+        assertThat(split.containsKey(tr1AndTr2), is(true));
+        assertThat(split.get(tr1AndTr2), is(t1t2));
+
+        Set<QualifiedName> tr1AndTr2AndTr3 = Sets.newHashSet(tr1, tr2, tr3);
+        assertThat(split.containsKey(tr1AndTr2AndTr3), is(true));
+        assertThat(split.get(tr1AndTr2AndTr3), is(t1t2t3));
+    }
+
+    private static class ToRelationColumn extends ReplacingSymbolVisitor<Map<AnalyzedRelation, QualifiedName>> {
+
+        private final static ToRelationColumn INSTANCE = new ToRelationColumn(true);
+
+        public ToRelationColumn(boolean inPlace) {
+            super(inPlace);
+        }
+
+        @Override
+        public Symbol visitField(Field field, Map<AnalyzedRelation, QualifiedName> ctx) {
+            return new RelationColumn(ctx.get(field.relation()), field.index(), field.valueType());
+        }
+    }
+}

--- a/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -21,7 +21,6 @@
 
 package io.crate.integrationtests;
 
-import io.crate.action.sql.SQLActionException;
 import io.crate.core.collections.CollectionBucket;
 import io.crate.operation.projectors.sorting.OrderingByPosition;
 import io.crate.testing.TestingHelpers;
@@ -430,9 +429,6 @@ public class JoinIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test
     public void test3TableJoinWithJoinFilters() throws Exception {
-        expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("Joining more than 2 tables with a join condition is not possible");
-
         execute("create table users (id int primary key, name string) with (number_of_replicas = 0)");
         execute("create table events (id int primary key, name string) with (number_of_replicas = 0)");
         execute("create table logs (user_id int, event_id int) with (number_of_replicas = 0)");

--- a/sql/src/test/java/io/crate/planner/consumer/ManyTableConsumerTest.java
+++ b/sql/src/test/java/io/crate/planner/consumer/ManyTableConsumerTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.consumer;
+
+import io.crate.analyze.*;
+import io.crate.operation.aggregation.impl.AggregationImplModule;
+import io.crate.operation.operator.OperatorModule;
+import io.crate.operation.predicate.PredicateModule;
+import io.crate.operation.scalar.ScalarFunctionModule;
+import io.crate.sql.parser.SqlParser;
+import io.crate.testing.MockedClusterServiceModule;
+import io.crate.testing.T3;
+import org.elasticsearch.common.inject.AbstractModule;
+import org.elasticsearch.common.inject.Injector;
+import org.elasticsearch.common.inject.ModulesBuilder;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+
+import static io.crate.testing.TestingHelpers.isSQL;
+import static io.crate.testing.TestingHelpers.newMockedThreadPool;
+import static org.junit.Assert.assertThat;
+
+public class ManyTableConsumerTest {
+
+    private Analyzer analyzer;
+
+    @Before
+    public void setUp() throws Exception {
+        Injector injector = new ModulesBuilder()
+                .add(new MockedClusterServiceModule())
+                .add(T3.META_DATA_MODULE)
+                .add(new AbstractModule() {
+                    @Override
+                    protected void configure() {
+                        bind(ThreadPool.class).toInstance(newMockedThreadPool());
+                    }
+                })
+                .add(new AggregationImplModule())
+                .add(new ScalarFunctionModule())
+                .add(new PredicateModule())
+                .add(new OperatorModule())
+                .createInjector();
+        analyzer = injector.getInstance(Analyzer.class);
+    }
+
+    private MultiSourceSelect analyze(String statement) {
+        Analysis analysis = analyzer.analyze(SqlParser.createStatement(statement), ParameterContext.EMPTY);
+        MultiSourceSelect mss = (MultiSourceSelect) ((SelectAnalyzedStatement) analysis.analyzedStatement()).relation();
+        ManyTableConsumer.replaceFieldsWithRelationColumns(mss);
+        return mss;
+    }
+
+    @Test
+    public void testQuerySplitting() throws Exception {
+        MultiSourceSelect mss = analyze("select * from t1 " +
+                                        "join t2 on t1.a = t2.b " +
+                                        "join t3 on t2.b = t3.c " +
+                                        "order by t1.a, t2.b, t3.c");
+        TwoTableJoin root = ManyTableConsumer.buildTwoTableJoinTree(mss);
+        TwoTableJoin t1AndT2 = ((TwoTableJoin) root.left().relation());
+
+        assertThat(t1AndT2.querySpec().where().query(), isSQL("(RELCOL(doc.t1, 0) = RELCOL(doc.t2, 0))"));
+        assertThat(root.querySpec().where().query(), isSQL("(RELCOL(join.doc.t1.doc.t2, 2) = RELCOL(doc.t3, 0))"));
+    }
+
+    @Test
+    public void testQuerySplittingWithBadRelationOrder() throws Exception {
+        MultiSourceSelect mss = analyze("select * from t1 " +
+                                        "join t2 on t1.a = t2.b " +
+                                        "join t3 on t2.b = t3.c " +
+                                        "order by t3.c, t1.a, t2.b");
+        TwoTableJoin root = ManyTableConsumer.buildTwoTableJoinTree(mss);
+        TwoTableJoin t3AndT1 = ((TwoTableJoin) root.left().relation());
+
+        assertThat(t3AndT1.querySpec().where().query(), isSQL("null"));
+
+        assertThat(root.querySpec().where().query(), Matchers.anyOf(
+                // order of the AND clauses is not deterministic, but both are okay as they're semantically the same
+                isSQL("((RELCOL(doc.t2, 0) = RELCOL(join.doc.t3.doc.t1, 0)) " +
+                      "AND (RELCOL(join.doc.t3.doc.t1, 2) = RELCOL(doc.t2, 0)))"),
+                isSQL("((RELCOL(join.doc.t3.doc.t1, 2) = RELCOL(doc.t2, 0)) " +
+                      "AND (RELCOL(doc.t2, 0) = RELCOL(join.doc.t3.doc.t1, 0)))")));
+    }
+}

--- a/sql/src/test/java/io/crate/testing/T3.java
+++ b/sql/src/test/java/io/crate/testing/T3.java
@@ -23,6 +23,7 @@
 package io.crate.testing;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.DocTableRelation;
 import io.crate.analyze.relations.TableRelation;
@@ -33,7 +34,10 @@ import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.SchemaInfo;
 import io.crate.metadata.table.TableInfo;
 import io.crate.metadata.table.TestingTableInfo;
+import io.crate.sql.tree.QualifiedName;
 import io.crate.types.DataTypes;
+
+import java.util.Map;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -65,10 +69,20 @@ public class T3 {
             SchemaInfo schemaInfo = mock(SchemaInfo.class);
             when(schemaInfo.getTableInfo(T1_INFO.ident().name())).thenReturn(T1_INFO);
             when(schemaInfo.getTableInfo(T2_INFO.ident().name())).thenReturn(T2_INFO);
+            when(schemaInfo.getTableInfo(T3_INFO.ident().name())).thenReturn(T3_INFO);
             when(schemaInfo.name()).thenReturn(Schemas.DEFAULT_SCHEMA_NAME);
             schemaBinder.addBinding(Schemas.DEFAULT_SCHEMA_NAME).toInstance(schemaInfo);
         }
     };
 
+    public static final QualifiedName T1 = new QualifiedName("t1");
+    public static final QualifiedName T2 = new QualifiedName("t2");
+    public static final QualifiedName T3 = new QualifiedName("t3");
+
     public static final ImmutableList<AnalyzedRelation> RELATIONS = ImmutableList.<AnalyzedRelation>of(TR_1, TR_2, TR_3);
+    public static final Map<QualifiedName, AnalyzedRelation> SOURCES = ImmutableMap.<QualifiedName, AnalyzedRelation>of(
+            T1, TR_1,
+            T2, TR_2,
+            T3, TR_3
+    );
 }


### PR DESCRIPTION
The integration is rather dumb as there is no optimization of which
tables to join first yet.

That means in a query like

    where t1.x = t2.x and t2.x = t3.x
    order by t1.x, t3.x, t2.x

The tables will be joined as follows:

          join (with filter t1.x = t2.x and t2.x = t3.x)
          /   \
       join   t2
        / \
       t1  t3

This is due to the fact that currently the ORDER BY clause determines
which relations to join with each other first.

This can lead to badly performing execution plans since the filter might
be applied on the top join node and not further down in the tree.