### PR TITLE
move s3 repository settings to aws module

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,5 @@
 import org.apache.tools.ant.filters.ReplaceTokens
 
-
 buildscript {
     repositories {
         jcenter()
@@ -64,7 +63,6 @@ dependencies {
     compileNotTransitive project(':udc')
     compileNotTransitive project(':client')
     compileNotTransitive project(':dns-discovery')
-    compileNotTransitive project(':aws')
 }
 
 task release(dependsOn: 'distTar') << {
@@ -92,7 +90,6 @@ fatJar {
 
 
 task writeBuildInfo (dependsOn: [':core:getVersion']) << {
-    def stdout = new ByteArrayOutputStream()
     def hash = "git rev-parse HEAD".execute().in.text.trim()
 
     def file = new File(project.projectDir.path + "/src/main/resources/crate-build.properties");
@@ -145,7 +142,13 @@ task buildJavadocJar (dependsOn: [':core:getVersion', myJavadocs] ) << {
 
 task sourceJar (type : Jar) {
     classifier = 'sources'
-    from sourceSets.main.allSource + project(':core').sourceSets.main.allJava + project(':sql').sourceSets.main.allJava + project(':sql-parser').sourceSets.main.allJava + project(':blob').sourceSets.main.allJava + project(':udc').sourceSets.main.allJava + project(':client').sourceSets.main.allJava
+    from (sourceSets.main.allSource +
+            project(':core').sourceSets.main.allJava +
+            project(':sql').sourceSets.main.allJava +
+            project(':sql-parser').sourceSets.main.allJava +
+            project(':blob').sourceSets.main.allJava +
+            project(':udc').sourceSets.main.allJava +
+            project(':client').sourceSets.main.allJava)
     manifest {
         attributes("Implementation-Title": "Crate.IO")
     }
@@ -173,7 +176,7 @@ install {
         mavenInstaller {
             pom.whenConfigured {
                 pom -> pom.dependencies.clear()
-                project.parent.subprojects.findAll{ it.name != 'app'}.each {
+                project.parent.subprojects.findAll{ it.name != 'app' && it.name != 'aws' }.each {
                     if (it.hasProperty('install')) {
                         pom.dependencies.addAll(it.install.repositories.mavenInstaller.pom.getEffectivePom().dependencies.findAll { it.groupId != 'io.crate'})
                     }
@@ -218,7 +221,7 @@ uploadArchives {
             }
             pom.whenConfigured {
                 pom -> pom.dependencies.clear()
-                project.parent.subprojects.findAll{ it.name != 'app'}.each {
+                project.parent.subprojects.findAll{ it.name != 'app' && it.name != 'aws' }.each {
                     if (it.hasProperty('install')) {
                         pom.dependencies.addAll(it.install.repositories.mavenInstaller.pom.getEffectivePom().dependencies.findAll { it.groupId != 'io.crate'})
                     }
@@ -398,11 +401,27 @@ task downloadPlugins << {
         from dest
         into 'plugins/hdfs'
     }
+
+    // copy aws jar
+    copy {
+        from(project(':aws').tasks.jar.archivePath)
+        into 'plugins/aws'
+    }
+    // copy aws deps
+    def awsLib = new File(project.projectDir, 'plugins/aws/lib')
+    awsLib.mkdirs()
+    copy {
+        from(project(':aws').configurations.awsDeps)
+        into awsLib
+    }
+
 }
 downloadPlugins.outputs.dir files(
     "$projectDir/plugins/crate-admin",
-    "$projectDir/plugins/hdfs"
+    "$projectDir/plugins/hdfs",
+    "$projectDir/plugins/aws"
 )
+downloadPlugins.dependsOn(':aws:jar')
 
 task downloadCrash << {
     def dest = download(

--- a/aws/.gitignore
+++ b/aws/.gitignore
@@ -1,1 +1,1 @@
-/src/
+/src/*/java/org/elasticsearch

--- a/aws/build.gradle
+++ b/aws/build.gradle
@@ -8,6 +8,8 @@ dependencies {
     compile project(':core')
     compile 'com.amazonaws:aws-java-sdk-ec2:1.10.12'
     compile 'com.amazonaws:aws-java-sdk-s3:1.10.12'
+    compile project(':sql')
+
     testCompile project(':testing')
 }
 
@@ -15,6 +17,9 @@ sourceSets {
     main {
         java {
             srcDir 'src/main/java'
+        }
+        resources {
+            include '**/*.Plugin'
         }
     }
     test {
@@ -32,11 +37,6 @@ task copyUpstreamSource << {
         copy {
             from 'upstream/src/main/java'
             into 'src/main/java'
-
-            // make it a crate plugin
-            filter { line ->
-                line.replaceAll("org\\.elasticsearch\\.plugins\\.AbstractPlugin", "io.crate.plugin.AbstractPlugin")
-            }
         }
     }
     if (!file('src/test/java').exists()) {

--- a/aws/build.gradle
+++ b/aws/build.gradle
@@ -2,16 +2,29 @@ apply plugin: 'java'
 
 archivesBaseName = 'crate-aws'
 group = 'io.crate'
+description = 'Crate.IO AWS Plugin'
+
+configurations {
+    all*.exclude group: 'org.elasticsearch'
+    awsDeps
+    compile.extendsFrom awsDeps
+}
 
 dependencies {
     compile project(':es')
     compile project(':core')
-    compile 'com.amazonaws:aws-java-sdk-ec2:1.10.12'
-    compile 'com.amazonaws:aws-java-sdk-s3:1.10.12'
     compile project(':sql')
+
+    awsDeps 'com.amazonaws:aws-java-sdk-ec2:1.10.12'
+    awsDeps 'com.amazonaws:aws-java-sdk-s3:1.10.12'
 
     testCompile project(':testing')
 }
+
+test {
+    testLogging.exceptionFormat = 'full'
+}
+
 
 sourceSets {
     main {
@@ -55,3 +68,19 @@ task deleteUpstreamSource(type: Delete) {
 compileJava {
     dependsOn copyUpstreamSource
 }
+
+// get version and set it on the project, so it gets appended to the jar name
+task getVersion(dependsOn: [':core:getVersion']) {
+    doFirst {
+        project.version = project(':core').getVersion.version
+    }
+}
+
+jar {
+    doLast {
+        manifest {
+            attributes("Implementation-Title": "Crate.IO AWS Plugin", "Implementation-Version": project.version)
+        }
+    }
+}
+jar.dependsOn(getVersion)

--- a/aws/src/main/java/io/crate/plugin/aws/CrateAwsPlugin.java
+++ b/aws/src/main/java/io/crate/plugin/aws/CrateAwsPlugin.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.plugin.aws;
+
+import com.google.common.collect.Lists;
+import io.crate.plugin.AbstractPlugin;
+import org.elasticsearch.common.component.LifecycleComponent;
+import org.elasticsearch.common.inject.Module;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugin.cloud.aws.CloudAwsPlugin;
+import org.elasticsearch.repositories.RepositoriesModule;
+
+import java.util.Collection;
+import java.util.List;
+
+public class CrateAwsPlugin extends AbstractPlugin {
+
+    private final CloudAwsPlugin esAwsPlugin;
+
+    public CrateAwsPlugin(Settings settings) {
+        this.esAwsPlugin = new CloudAwsPlugin(settings);
+    }
+
+    @Override
+    public String name() {
+        return "crate-aws";
+    }
+
+    @Override
+    public String description() {
+        return "crate on aws";
+    }
+
+    @Override
+    public Collection<Module> modules(Settings settings) {
+        List<Module> modules = Lists.newArrayList(super.modules(settings));
+        modules.add(new S3RepositoryAnalysisModule(settings));
+        modules.addAll(esAwsPlugin.modules(settings));
+        return modules;
+    }
+
+    @Override
+    public Collection<Class<? extends LifecycleComponent>> services() {
+        return esAwsPlugin.services();
+    }
+
+    public void onModule(RepositoriesModule repositoriesModule) {
+        esAwsPlugin.onModule(repositoriesModule);
+    }
+}

--- a/aws/src/main/java/io/crate/plugin/aws/S3RepositoryAnalysisModule.java
+++ b/aws/src/main/java/io/crate/plugin/aws/S3RepositoryAnalysisModule.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.plugin.aws;
+
+import com.google.common.collect.ImmutableSet;
+import io.crate.analyze.repositories.TypeSettings;
+import org.elasticsearch.common.inject.AbstractModule;
+import org.elasticsearch.common.inject.multibindings.MapBinder;
+import org.elasticsearch.common.settings.Settings;
+
+public class S3RepositoryAnalysisModule extends AbstractModule {
+
+    private MapBinder<String, TypeSettings> typeSettingsBinder;
+
+    public static final String REPOSITORY_TYPE = "s3";
+    public static final TypeSettings S3_SETTINGS = new TypeSettings(ImmutableSet.<String>of(),
+            ImmutableSet.of(
+                    "access_key",
+                    "base_path",
+                    "bucket",
+                    "buffer_size",
+                    "canned_acl",
+                    "chunk_size",
+                    "compress",
+                    "concurrent_streams",
+                    "endpoint",
+                    "max_retries",
+                    "protocol",
+                    "region",
+                    "secret_key",
+                    "server_side_encryption"
+            ));
+
+    private final Settings settings;
+
+    public S3RepositoryAnalysisModule(Settings settings) {
+        this.settings = settings;
+    }
+
+    @Override
+    protected void configure() {
+        typeSettingsBinder = MapBinder.newMapBinder(binder(), String.class, TypeSettings.class);
+        if (settings.getAsBoolean("cloud.enabled", true)) {
+            typeSettingsBinder.addBinding(REPOSITORY_TYPE).toInstance(S3_SETTINGS);
+        }
+    }
+}

--- a/aws/src/main/resources/META-INF/services/io.crate.Plugin
+++ b/aws/src/main/resources/META-INF/services/io.crate.Plugin
@@ -1,1 +1,1 @@
-org.elasticsearch.plugin.cloud.aws.CloudAwsPlugin
+io.crate.plugin.aws.CrateAwsPlugin

--- a/aws/src/test/java/io/crate/plugin/aws/s3/S3RepositoryAnalyzerTest.java
+++ b/aws/src/test/java/io/crate/plugin/aws/s3/S3RepositoryAnalyzerTest.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.plugin.aws.s3;
+
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableSortedMap;
+import io.crate.action.sql.SQLBulkRequest;
+import io.crate.action.sql.SQLRequest;
+import io.crate.analyze.Analyzer;
+import io.crate.analyze.CreateRepositoryAnalyzedStatement;
+import io.crate.analyze.ParameterContext;
+import io.crate.analyze.repositories.RepositorySettingsModule;
+import io.crate.executor.transport.TransportActionProvider;
+import io.crate.metadata.MetaDataModule;
+import io.crate.metadata.Schemas;
+import io.crate.plugin.aws.S3RepositoryAnalysisModule;
+import io.crate.sql.parser.SqlParser;
+import io.crate.test.integration.CrateUnitTest;
+import org.elasticsearch.action.admin.indices.template.put.TransportPutIndexTemplateAction;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.cluster.metadata.RepositoriesMetaData;
+import org.elasticsearch.common.inject.*;
+import org.elasticsearch.common.settings.ImmutableSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import java.util.Map;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class S3RepositoryAnalyzerTest extends CrateUnitTest {
+
+    @Mock
+    private RepositoriesMetaData repositoriesMetaData;
+
+    @Mock
+    private ThreadPool threadPool;
+
+
+    private Analyzer analyzer;
+
+    private class MyMockedClusterServiceModule extends AbstractModule {
+
+        @Override
+        protected void configure() {
+            ClusterService clusterService = mock(ClusterService.class);
+            ClusterState state = mock(ClusterState.class);
+            MetaData metaData = mock(MetaData.class);
+            when(metaData.settings()).thenReturn(ImmutableSettings.EMPTY);
+            when(state.metaData()).thenReturn(metaData);
+            when(clusterService.state()).thenReturn(state);
+            bind(ClusterService.class).toInstance(clusterService);
+            bind(Settings.class).toInstance(ImmutableSettings.EMPTY);
+
+            bind(TransportActionProvider.class).toInstance(mock(TransportActionProvider.class));
+
+            bind(TransportPutIndexTemplateAction.class).toInstance(mock(TransportPutIndexTemplateAction.class));
+
+            when(metaData.custom(RepositoriesMetaData.TYPE)).thenReturn(repositoriesMetaData);
+        }
+    }
+
+    @Before
+    public void prepareModules() throws Exception {
+        ModulesBuilder builder = new ModulesBuilder();
+        builder.add(new Module() {
+            @Override
+            public void configure(Binder binder) {
+                binder.bind(ThreadPool.class).toInstance(threadPool);
+            }
+        });
+        builder.add(
+                new RepositorySettingsModule(),
+                new S3RepositoryAnalysisModule(ImmutableSettings.EMPTY),
+                new MyMockedClusterServiceModule(),
+                new MetaDataModule()
+        );
+        Injector injector = builder.createInjector();
+        analyzer = injector.getInstance(Analyzer.class);
+    }
+
+    private CreateRepositoryAnalyzedStatement analyze(String statement) {
+        return (CreateRepositoryAnalyzedStatement)analyzer.analyze(SqlParser.createStatement(statement),
+                new ParameterContext(SQLRequest.EMPTY_ARGS, SQLBulkRequest.EMPTY_BULK_ARGS, Schemas.DEFAULT_SCHEMA_NAME)).analyzedStatement();
+    }
+
+    @Test
+    public void testCreateS3RepositoryWithAllSettings() throws Exception {
+        CreateRepositoryAnalyzedStatement analysis = analyze("CREATE REPOSITORY foo TYPE s3 WITH (" +
+                                                             "bucket='abc'," +
+                                                             "region='us-north-42'," +
+                                                             "endpoint='www.example.com'," +
+                                                             "protocol='arp'," +
+                                                             "base_path='/holz/'," +
+                                                             "access_key='0xAFFE'," +
+                                                             "secret_key='0xCAFEE'," +
+                                                             "concurrent_streams=4," +
+                                                             "chunk_size=12," +
+                                                             "compress=true," +
+                                                             "server_side_encryption='only for pussies'," +
+                                                             "buffer_size=128," +
+                                                             "max_retries=2," +
+                                                             "canned_acl=false)");
+        assertThat(analysis.repositoryType(), is("s3"));
+        assertThat(analysis.repositoryName(), is("foo"));
+        Map<String, String> sortedSettingsMap = ImmutableSortedMap.copyOf(analysis.settings().getAsMap());
+        assertThat(
+                Joiner.on(",").withKeyValueSeparator(":")
+                        .join(sortedSettingsMap),
+                is("access_key:0xAFFE," +
+                   "base_path:/holz/," +
+                   "bucket:abc," +
+                   "buffer_size:128," +
+                   "canned_acl:false," +
+                   "chunk_size:12," +
+                   "compress:true," +
+                   "concurrent_streams:4," +
+                   "endpoint:www.example.com," +
+                   "max_retries:2," +
+                   "protocol:arp," +
+                   "region:us-north-42," +
+                   "secret_key:0xCAFEE," +
+                   "server_side_encryption:only for pussies"));
+    }
+
+    @Test
+    public void testWithoutSettings() throws Exception {
+        CreateRepositoryAnalyzedStatement analysis = analyze("CREATE REPOSITORY foo TYPE s3");
+        assertThat(analysis.repositoryName(), is("foo"));
+        assertThat(analysis.repositoryType(), is("s3"));
+        assertThat(analysis.settings().getAsMap().isEmpty(), is(true));
+    }
+
+    @Test
+    public void testWrongSettings() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Invalid parameters specified: [wrong]");
+        analyze("CREATE REPOSITORY foo TYPE s3 WITH (wrong=true)");
+
+    }
+}
+


### PR DESCRIPTION
by binding supported repository types and their settings with a map binder

also fix PluginLoader to not double-load any modules and also consider the classpath
if plugin urls are given