### PR TITLE
make Job class immutable and avoid side effects in TransportExecutor

### DIFF
--- a/sql/src/main/java/io/crate/executor/Job.java
+++ b/sql/src/main/java/io/crate/executor/Job.java
@@ -21,29 +21,24 @@
 
 package io.crate.executor;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 
 public class Job {
 
     private final UUID id;
-    private List<Task> tasks = new ArrayList<>();
+    private final List<? extends Task> tasks;
 
-    public Job(UUID id) {
+    public Job(UUID id, List<? extends Task> tasks) {
         this.id = id;
+        this.tasks = tasks;
     }
 
     public UUID id() {
         return id;
     }
 
-    public void addTasks(Collection<? extends Task> tasks) {
-        this.tasks.addAll(tasks);
-    }
-
-    public List<Task> tasks() {
+    public List<? extends Task> tasks() {
         return tasks;
     }
 }


### PR DESCRIPTION
Before the TaskCollectingVisitor could've called addTasks itself. Now
the process functions of the visitor can no longer add tasks directly
but have to return them.