### PR TITLE
don't create OutputName instances but re-use path

### DIFF
--- a/sql/src/main/java/io/crate/analyze/MultiSourceSelect.java
+++ b/sql/src/main/java/io/crate/analyze/MultiSourceSelect.java
@@ -28,7 +28,6 @@ import io.crate.analyze.relations.QueriedRelation;
 import io.crate.analyze.relations.RelationSplitter;
 import io.crate.analyze.symbol.Field;
 import io.crate.analyze.symbol.Symbol;
-import io.crate.metadata.OutputName;
 import io.crate.metadata.Path;
 import io.crate.sql.tree.QualifiedName;
 
@@ -70,7 +69,7 @@ public class MultiSourceSelect implements QueriedRelation {
 
     public MultiSourceSelect(
             Map<QualifiedName, AnalyzedRelation> sources,
-            List<OutputName> outputNames,
+            List<? extends Path> outputNames,
             QuerySpec querySpec) {
         assert sources.size() > 1 : "MultiSourceSelect requires at least 2 relations";
         this.querySpec = querySpec;

--- a/sql/src/main/java/io/crate/metadata/Path.java
+++ b/sql/src/main/java/io/crate/metadata/Path.java
@@ -23,5 +23,5 @@ package io.crate.metadata;
 
 public interface Path {
 
-    public String outputName();
+    String outputName();
 }


### PR DESCRIPTION
Previously in the `select *` case there was a unnecessary conversion:

    `ColumnIdent ci -> String outputName -> new OutputName(outputName)`

Now the ColumnIdent is simply passed on as Path which removes the
OutputName allocation.