### PR TITLE
handle pause correctly in NestedLoopOperation

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed a race condition which could cause a join on more than 2 tables to
+   produce an incorrect result.
+
  - Fix: Comparing generated partition columns using a <= or >=
    operator resulted in a NPE exception
 

--- a/core/src/main/java/io/crate/core/collections/RowN.java
+++ b/core/src/main/java/io/crate/core/collections/RowN.java
@@ -21,6 +21,8 @@
 
 package io.crate.core.collections;
 
+import java.util.Arrays;
+
 public class RowN implements Row {
 
     private final int size;
@@ -56,5 +58,10 @@ public class RowN implements Row {
         Object[] result = new Object[size];
         System.arraycopy(cells, 0, result, 0, size);
         return result;
+    }
+
+    @Override
+    public String toString() {
+        return "RowN{" + Arrays.toString(cells) + '}';
     }
 }

--- a/sql/src/benchmarks/java/io/crate/operation/join/NestedLoopOperationBenchmark.java
+++ b/sql/src/benchmarks/java/io/crate/operation/join/NestedLoopOperationBenchmark.java
@@ -171,7 +171,7 @@ public class NestedLoopOperationBenchmark {
         Iterable<Row> right = new RowIter(rightSize);
 
         RowCountRowReceiver receiver = new RowCountRowReceiver();
-        NestedLoopOperation operation = new NestedLoopOperation(receiver);
+        NestedLoopOperation operation = new NestedLoopOperation(0, receiver);
         ListenableRowReceiver leftSide = operation.leftRowReceiver();
         ListenableRowReceiver rightSide = operation.rightRowReceiver();
 

--- a/sql/src/main/java/io/crate/action/job/ContextPreparer.java
+++ b/sql/src/main/java/io/crate/action/job/ContextPreparer.java
@@ -463,7 +463,7 @@ public class ContextPreparer {
                 flatProjectorChain = FlatProjectorChain.withReceivers(Collections.singletonList(downstreamRowReceiver));
             }
 
-            NestedLoopOperation nestedLoopOperation = new NestedLoopOperation(flatProjectorChain.firstProjector());
+            NestedLoopOperation nestedLoopOperation = new NestedLoopOperation(phase.executionPhaseId(), flatProjectorChain.firstProjector());
             return new NestedLoopContext(
                     phase,
                     flatProjectorChain,

--- a/sql/src/main/java/io/crate/operation/join/NestedLoopOperation.java
+++ b/sql/src/main/java/io/crate/operation/join/NestedLoopOperation.java
@@ -45,8 +45,10 @@ public class NestedLoopOperation implements RowUpstream {
     private final LeftRowReceiver left;
     private final RightRowReceiver right;
 
-    private RowReceiver downstream;
+    private final int phaseId;
+    private final RowReceiver downstream;
     private volatile boolean downstreamWantsMore = true;
+    private volatile boolean paused;
 
     /**
      * state of the left and right side.
@@ -70,7 +72,8 @@ public class NestedLoopOperation implements RowUpstream {
 
     private final AtomicBoolean leadAcquired = new AtomicBoolean(false);
 
-    public NestedLoopOperation(RowReceiver rowReceiver) {
+    public NestedLoopOperation(int phaseId, RowReceiver rowReceiver) {
+        this.phaseId = phaseId;
         this.downstream = rowReceiver;
         downstream.setUpstream(this);
         left = new LeftRowReceiver();
@@ -87,11 +90,13 @@ public class NestedLoopOperation implements RowUpstream {
 
     @Override
     public void pause() {
+        paused = true;
         right.upstream.pause();
     }
 
     @Override
     public void resume(boolean async) {
+        paused = false;
         right.upstream.resume(async);
     }
 
@@ -194,7 +199,7 @@ public class NestedLoopOperation implements RowUpstream {
         public boolean setNextRow(Row row) {
             assert !done : "shouldn't receive a row if finished";
             State rightState = right.state.get();
-            LOGGER.trace("LEFT downstream received a row {}, rightState: {}", row, rightState);
+            LOGGER.trace("[{}] LEFT downstream received a row {}, rightState: {}", phaseId, row, rightState);
             switch (rightState) {
                 case LEAD_ELECTION:
                     if (leadAcquired.compareAndSet(false, true)) {
@@ -226,7 +231,7 @@ public class NestedLoopOperation implements RowUpstream {
                         state.set(State.PAUSED);
                         return right.resume(rightState);
                     }
-                    LOGGER.trace("LEFT: done, returning false");
+                    LOGGER.trace("[{}] LEFT: done, returning false", phaseId);
                     done = true;
                     return false;
                 default:
@@ -236,7 +241,7 @@ public class NestedLoopOperation implements RowUpstream {
 
         @Override
         public void finish() {
-            LOGGER.trace("LEFT downstream finished");
+            LOGGER.trace("[{}] LEFT upstream called finish", phaseId);
             finish(right.state, right.upstream);
         }
 
@@ -275,14 +280,14 @@ public class NestedLoopOperation implements RowUpstream {
             }
 
             State leftState = left.state.get();
-            LOGGER.trace("RIGHT: left state: {}", leftState);
+            LOGGER.trace("[{}] RIGHT: left state: {}", phaseId, leftState);
             switch (leftState) {
                 case LEAD_ELECTION:
                     if (leadAcquired.compareAndSet(false, true)) {
                         lastRow = rightRow;
                         upstream.pause();
                         state.set(State.PAUSED);
-                        LOGGER.trace("RIGHT: pausing, left doesn't has any rows yet. Left state: {}", leftState);
+                        LOGGER.trace("[{}] RIGHT: pausing, left doesn't has any rows yet. Left state: {}", phaseId, leftState);
                         return true;
                     } else {
                         return handlePauseOrFinished(rightRow, waitForStateChange(left.state));
@@ -313,7 +318,7 @@ public class NestedLoopOperation implements RowUpstream {
             boolean wantsMore = downstream.setNextRow(combinedRow);
             assert downstreamWantsMore : "shouldn't emit rows if downstream doesn't need anymore";
             if (!wantsMore) {
-                LOGGER.trace("downstream doesn't need any more rows");
+                LOGGER.trace("[{}] downstream doesn't need any more rows", phaseId);
             }
             downstreamWantsMore = wantsMore;
             return wantsMore;
@@ -321,7 +326,7 @@ public class NestedLoopOperation implements RowUpstream {
 
         @Override
         public void finish() {
-            LOGGER.trace("RIGHT downstream finished");
+            LOGGER.trace("[{}] RIGHT upstream called finish", phaseId);
 
             leftIsSuspended = false;
             finish(left.state, left.upstream);
@@ -341,24 +346,27 @@ public class NestedLoopOperation implements RowUpstream {
         boolean resume(State rightState) {
             if (lastRow != null) {
                 boolean wantMore = emitRow(lastRow);
+                lastRow = null;
+                if (paused) {
+                    return wantMore;
+                }
                 if (!wantMore) {
-                    LOGGER.trace("LEFT - right resume - downstream doesn't need any more rows, return false");
+                    LOGGER.trace("[{}] LEFT - right resume - downstream doesn't need any more rows, return false", phaseId);
                     upstream.resume(false);
                     return false;
                 }
-                lastRow = null;
             }
 
             if (rightState == State.FINISHED) {
                 if (receivedRows) {
-                    LOGGER.trace("repeat right");
+                    LOGGER.trace("[{}] repeat right", phaseId);
                     upstream.repeat();
                 } else {
-                    LOGGER.trace("LEFT - resume right - right finished and no rows: return false");
+                    LOGGER.trace("[{}] LEFT - resume right - right finished and no rows: return false", phaseId);
                     return false;
                 }
             } else {
-                LOGGER.trace("resume right on {}", upstream);
+                LOGGER.trace("[{}] resume right on {}", phaseId, upstream);
                 upstream.resume(false);
             }
             return true;

--- a/sql/src/test/java/io/crate/testing/RowSender.java
+++ b/sql/src/test/java/io/crate/testing/RowSender.java
@@ -80,7 +80,7 @@ public class RowSender implements Runnable, RowUpstream {
 
     @Override
     public void pause() {
-        topRowUpstream.pause();;
+        topRowUpstream.pause();
     }
 
     @Override


### PR DESCRIPTION
This fixes a race condition that could cause joins with more than 2
tables to produce a wrong result.