### PR TITLE
ensureStringTypesAreStrings micro-optimization

### DIFF
--- a/sql/src/test/java/io/crate/executor/BytesRefUtilsTest.java
+++ b/sql/src/test/java/io/crate/executor/BytesRefUtilsTest.java
@@ -63,4 +63,16 @@ public class BytesRefUtilsTest extends CrateUnitTest {
         BytesRefUtils.ensureStringTypesAreStrings(dataTypes, rows);
         assertThat(commaJoiner.join((String[])rows[0][0]), is("foo, bar"));
     }
+
+    @Test
+    public void testConvertSetWithNullValues() throws Exception {
+        DataType[] dataTypes = new DataType[] { new SetType(DataTypes.STRING) };
+        Object[][] rows = new Object[1][1];
+        Set<BytesRef> refs = new HashSet<>(
+                Arrays.asList(new BytesRef("foo"), null));
+        rows[0][0] = refs;
+        BytesRefUtils.ensureStringTypesAreStrings(dataTypes, rows);
+
+        assertThat((String[]) rows[0][0], Matchers.arrayContainingInAnyOrder("foo", null));
+    }
 }


### PR DESCRIPTION
split up the function so that it can be inlined.

Before:

    io.crate.executor.BytesRefUtils::
        ensureStringTypesAreStrings (456 bytes)   hot method too big

Now:

    io.crate.executor.BytesRefUtils::
        ensureStringTypesAreStrings (160 bytes)   inline (hot)