### PR TITLE
change thread pools for queries on system tables

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Improved reliability of queries on system tables even if cluster is
+   overloaded and/or doc table queries are stuck.
+
  - Fewer retries are done when a shard is not fully recovered and
    queried in order to safe threads.
 

--- a/sql/src/main/java/io/crate/action/job/ContextPreparer.java
+++ b/sql/src/main/java/io/crate/action/job/ContextPreparer.java
@@ -404,6 +404,7 @@ public class ContextPreparer {
             return new JobCollectContext(
                     phase,
                     collectOperation,
+                    clusterService.state().nodes().localNodeId(),
                     ramAccountingContext,
                     rowReceiver,
                     context.sharedShardContexts

--- a/sql/src/main/java/io/crate/action/job/TransportJobAction.java
+++ b/sql/src/main/java/io/crate/action/job/TransportJobAction.java
@@ -54,7 +54,7 @@ public class TransportJobAction implements NodeAction<JobRequest, JobResponse> {
     private static final ESLogger LOGGER = Loggers.getLogger(TransportJobAction.class);
 
     public static final String ACTION_NAME = "crate/sql/job";
-    private static final String EXECUTOR = ThreadPool.Names.SAME;
+    private static final String EXECUTOR = ThreadPool.Names.PERCOLATE;
 
     private final IndicesService indicesService;
     private final Transports transports;

--- a/sql/src/main/java/io/crate/operation/ThreadPools.java
+++ b/sql/src/main/java/io/crate/operation/ThreadPools.java
@@ -44,9 +44,8 @@ public class ThreadPools {
      * @throws RejectedExecutionException in case all threads are busy and overloaded.
      */
     public static void runWithAvailableThreads(ThreadPoolExecutor executor,
-                                               int poolSize,
                                                Collection<Runnable> runnableCollection) throws RejectedExecutionException {
-        int availableThreads = Math.max(poolSize - executor.getActiveCount(), 2);
+        int availableThreads = Math.max(executor.getMaximumPoolSize() - executor.getActiveCount(), 2);
         if (availableThreads < runnableCollection.size()) {
             Iterable<List<Runnable>> partition = Iterables.partition(runnableCollection,
                     runnableCollection.size() / availableThreads);

--- a/sql/src/test/java/io/crate/operation/collect/HandlerSideLevelCollectTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/HandlerSideLevelCollectTest.java
@@ -51,7 +51,6 @@ import org.junit.Test;
 
 import java.util.*;
 
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.mock;
 
@@ -100,11 +99,11 @@ public class HandlerSideLevelCollectTest extends SQLTransportIntegrationTest {
         assertThat(((BytesRef) result.iterator().next().get(0)).utf8ToString(), Matchers.startsWith("SUITE-"));
     }
 
-    private Bucket collect(CollectPhase collectNode) throws Exception {
+    private Bucket collect(CollectPhase collectPhase) throws Exception {
         CollectingRowReceiver collectingProjector = new CollectingRowReceiver();
         collectingProjector.prepare(mock(ExecutionState.class));
-        Collection<CrateCollector> collectors = operation.createCollectors(collectNode, collectingProjector, mock(JobCollectContext.class));
-        operation.launchCollectors(collectors);
+        Collection<CrateCollector> collectors = operation.createCollectors(collectPhase, collectingProjector, mock(JobCollectContext.class));
+        operation.launchCollectors(collectors, JobCollectContext.threadPoolName(collectPhase, clusterService().localNode().id()));
         return collectingProjector.result();
     }
 

--- a/sql/src/test/java/io/crate/testing/LuceneDocCollectorProvider.java
+++ b/sql/src/test/java/io/crate/testing/LuceneDocCollectorProvider.java
@@ -81,7 +81,9 @@ public class LuceneDocCollectorProvider implements AutoCloseable {
 
         SharedShardContexts sharedShardContexts = new SharedShardContexts(indicesService);
         JobExecutionContext.Builder builder = jobContextService.newBuilder(collectPhase.jobId());
-        JobCollectContext jobCollectContext = new JobCollectContext(collectPhase, collectOperation, RAM_ACCOUNTING_CONTEXT, downstream, sharedShardContexts);
+        JobCollectContext jobCollectContext = new JobCollectContext(
+                collectPhase, collectOperation,  cluster.clusterService().state().nodes().localNodeId(),
+                RAM_ACCOUNTING_CONTEXT, downstream, sharedShardContexts);
         collectContexts.add(jobCollectContext);
         builder.addSubContext(jobCollectContext);
         jobContextService.createContext(builder);


### PR DESCRIPTION
by using not the same thread pool to system and doc
tables, information retrieval from system tables
is possible even if thread pools used by doc
table queries are full
(known as cluster is stuck, no query respond)