### PR TITLE
avoid duplicate dynamic setting registration

### DIFF
--- a/sql/src/main/java/io/crate/analyze/SetStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/SetStatementAnalyzer.java
@@ -74,7 +74,7 @@ public class SetStatementAnalyzer {
     }
 
     private static void checkIfSettingIsRuntime(String name) {
-        checkIfSettingIsRuntime(CrateSettings.CRATE_SETTINGS, name);
+        checkIfSettingIsRuntime(CrateSettings.SETTINGS, name);
     }
 
     private static void checkIfSettingIsRuntime(List<Setting> settings, String name) {

--- a/sql/src/main/java/io/crate/metadata/settings/CrateSettings.java
+++ b/sql/src/main/java/io/crate/metadata/settings/CrateSettings.java
@@ -1823,7 +1823,13 @@ public class CrateSettings {
         }
     };
 
-    public static final ImmutableList<Setting> CRATE_SETTINGS = ImmutableList.<Setting>of(STATS, CLUSTER, DISCOVERY, INDICES, BULK, GATEWAY, UDC);
+    public static final List<Setting<?, ?>> CRATE_SETTINGS = ImmutableList.<Setting<?, ?>>of(
+            GRACEFUL_STOP,
+            STATS
+    );
+
+    public static final List<Setting> SETTINGS = ImmutableList.<Setting>of(
+            STATS, CLUSTER, DISCOVERY, INDICES, BULK, GATEWAY, UDC);
 
     public static final Map<String, SettingsApplier> SUPPORTED_SETTINGS = ImmutableMap.<String, SettingsApplier>builder()
             .put(CrateSettings.STATS.settingName(),

--- a/sql/src/main/java/io/crate/metadata/settings/Setting.java
+++ b/sql/src/main/java/io/crate/metadata/settings/Setting.java
@@ -72,4 +72,9 @@ public abstract class Setting<T, E> {
         return builder.build().reverse();
 
     }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "{" + settingName() + "}";
+    }
 }

--- a/sql/src/main/java/io/crate/operation/reference/sys/cluster/ClusterSettingsExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/cluster/ClusterSettingsExpression.java
@@ -97,7 +97,7 @@ public class ClusterSettingsExpression extends NestedObjectExpression {
 
         @Override
         public void onRefreshSettings(Settings settings) {
-            applySettings(CrateSettings.CRATE_SETTINGS,
+            applySettings(CrateSettings.SETTINGS,
                     Settings.builder()
                             .put(initialSettings)
                             .put(settings).build()
@@ -131,7 +131,7 @@ public class ClusterSettingsExpression extends NestedObjectExpression {
 
     @Inject
     public ClusterSettingsExpression(Settings settings, NodeSettingsService nodeSettingsService) {
-        applyDefaults(CrateSettings.CRATE_SETTINGS);
+        applyDefaults(CrateSettings.SETTINGS);
         ApplySettings applySettings = new ApplySettings(settings, values);
 
         nodeSettingsService.addListener(applySettings);


### PR DESCRIPTION
Duplicate registration now results in errors in the log. Before we
didn't realize that we registered them twice.