### PR TITLE
implement equals in FunctionFilter

### DIFF
--- a/sql/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
+++ b/sql/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
@@ -1105,16 +1105,21 @@ public class LuceneQueryBuilder {
             for (LuceneCollectorExpression expression : expressions) {
                 expression.startCollect(collectorContext);
             }
-            return new FunctionFilter(expressions, collectorContext, condition);
+            return new FunctionFilter(function, expressions, collectorContext, condition);
         }
 
         public static class FunctionFilter extends Filter {
 
+            private final Function function;
             private final List<LuceneCollectorExpression> expressions;
             private final CollectorContext collectorContext;
             private final Input<Boolean> condition;
 
-            public FunctionFilter(List<LuceneCollectorExpression> expressions, CollectorContext collectorContext, Input<Boolean> condition) {
+            public FunctionFilter(Function function,
+                                  List<LuceneCollectorExpression> expressions,
+                                  CollectorContext collectorContext,
+                                  Input<Boolean> condition) {
+                this.function = function;
                 this.expressions = expressions;
                 this.collectorContext = collectorContext;
                 this.condition = condition;
@@ -1147,6 +1152,15 @@ public class LuceneQueryBuilder {
                         ),
                         acceptDocs
                 );
+            }
+
+            @Override
+            public boolean equals(Object o) {
+                if (this == o) return true;
+                if (o == null || getClass() != o.getClass()) return false;
+                if (!super.equals(o)) return false;
+                FunctionFilter that = (FunctionFilter) o;
+                return Objects.equals(function, that.function);
             }
 
             @Override

--- a/sql/src/test/java/io/crate/integrationtests/ArithmeticIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ArithmeticIntegrationTest.java
@@ -33,6 +33,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 
+
 public class ArithmeticIntegrationTest extends SQLTransportIntegrationTest {
 
     @Rule


### PR DESCRIPTION
The default Filter/Query equals implementation only checks the
boost value for equality.

Therefore a query like `round(d) < 2` was equal to `ceil(d) < 3`. This
could cause incorrect results due to the QueryCache which used the first
FunctionFilter query it received for all subsequent queries.