### PR TITLE
Fix: exporting a table with a generated partitioned

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fix: exporting a table with a generated partitioned column using `copy to`
+   caused an Exception
+
  - Implemented the EXPLAIN command for SELECT statements.
 
  - Added `routing_state` column to `sys.shards` table in order to fix the

--- a/sql/src/main/java/io/crate/analyze/CopyStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CopyStatementAnalyzer.java
@@ -164,12 +164,16 @@ public class CopyStatementAnalyzer {
             Reference sourceRef;
             if (tableRelation.tableInfo().isPartitioned() && partitions.isEmpty()) {
                 // table is partitioned, insert partitioned columns into the output
-                sourceRef = new Reference(tableRelation.tableInfo().getReferenceInfo(DocSysColumns.DOC));
                 overwrites = new HashMap<>();
                 for (ReferenceInfo referenceInfo : tableRelation.tableInfo().partitionedByColumns()) {
                     if (!(referenceInfo instanceof GeneratedReferenceInfo)) {
                         overwrites.put(referenceInfo.ident().columnIdent(), new Reference(referenceInfo));
                     }
+                }
+                if (overwrites.size() > 0) {
+                    sourceRef = new Reference(tableRelation.tableInfo().getReferenceInfo(DocSysColumns.DOC));
+                } else {
+                    sourceRef = new Reference(tableRelation.tableInfo().getReferenceInfo(DocSysColumns.RAW));
                 }
             } else {
                 sourceRef = new Reference(tableRelation.tableInfo().getReferenceInfo(DocSysColumns.RAW));
@@ -223,12 +227,13 @@ public class CopyStatementAnalyzer {
         } else if (whereClause.noMatch()) {
             return whereClause;
         } else {
-            if (!whereClause.partitions().isEmpty() && !partitions.isEmpty() && !whereClause.partitions().equals(partitions)) {
+            if (!whereClause.partitions().isEmpty() && !partitions.isEmpty() &&
+                !whereClause.partitions().equals(partitions)) {
                 throw new IllegalArgumentException("Given partition ident does not match partition evaluated from where clause");
             }
 
             return new WhereClause(whereClause.query(), whereClause.docKeys().orNull(),
-                            partitions.isEmpty() ? whereClause.partitions() : partitions);
+                    partitions.isEmpty() ? whereClause.partitions() : partitions);
         }
     }
 
@@ -263,7 +268,7 @@ public class CopyStatementAnalyzer {
         if (table.isPartitioned() && partition != null) {
             for (PartitionName partitionName : table.partitions()) {
                 if (partitionName.tableIdent().equals(table.ident())
-                        && partitionName.equals(partition)) {
+                    && partitionName.equals(partition)) {
                     return true;
                 }
             }

--- a/sql/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
@@ -397,7 +397,7 @@ public class CopyIntegrationTest extends SQLTransportIntegrationTest {
         execute("refresh table singleshard");
 
         String uri = Paths.get(folder.getRoot().toURI()).resolve("testsingleshard.json").toUri().toString();
-        SQLResponse response = execute("copy singleshard (name, test['foo']) to ? with (format='json_object')", new Object[] { uri });
+        SQLResponse response = execute("copy singleshard (name, test['foo']) to ? with (format='json_object')", new Object[]{uri});
         assertThat(response.rowCount(), is(1L));
         List<String> lines = Files.readAllLines(
                 Paths.get(folder.getRoot().toURI().resolve("testsingleshard.json")), UTF8);
@@ -442,6 +442,21 @@ public class CopyIntegrationTest extends SQLTransportIntegrationTest {
         assertThat(response.rowCount(), is(1L));
 
         assertThat(TestingHelpers.printedTable(response.rows()), is("2| Trillian\n"));
+    }
+
+    @Test
+    public void testCopyToWithGeneratedColumn() throws Exception {
+        execute("CREATE TABLE foo (\n" +
+                "day TIMESTAMP GENERATED ALWAYS AS date_trunc('day', timestamp),\n" +
+                "timestamp TIMESTAMP\n" +
+                ")\n" +
+                "PARTITIONED BY (day)");
+        ensureYellow();
+        execute("insert into foo ( timestamp) values (1454454000377)");
+        refresh();
+        String uriTemplate = Paths.get(folder.getRoot().toURI()).toUri().toString();
+        SQLResponse response = execute("copy foo to DIRECTORY ?", new Object[]{uriTemplate});
+        assertThat(response.rowCount(), is(1L));
     }
 
     @Test


### PR DESCRIPTION
column using `copy to` caused an Exception