### PR TITLE
remove availableSpace from BlobStats

### DIFF
--- a/blob/src/main/java/io/crate/blob/stats/BlobStats.java
+++ b/blob/src/main/java/io/crate/blob/stats/BlobStats.java
@@ -24,16 +24,13 @@ package io.crate.blob.stats;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
-import org.elasticsearch.common.xcontent.ToXContent;
-import org.elasticsearch.common.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
-public class BlobStats implements Streamable, ToXContent {
+public class BlobStats implements Streamable {
 
     private long count;
     private long totalUsage;
-    private long availableSpace;
     private String location;
 
     public String location() {
@@ -52,14 +49,6 @@ public class BlobStats implements Streamable, ToXContent {
         this.count = count;
     }
 
-    public long availableSpace() {
-        return availableSpace;
-    }
-
-    public void availableSpace(long availableSpace) {
-        this.availableSpace = availableSpace;
-    }
-
     public long totalUsage() {
         return totalUsage;
     }
@@ -72,7 +61,6 @@ public class BlobStats implements Streamable, ToXContent {
     public void readFrom(StreamInput in) throws IOException {
         count = in.readVLong();
         totalUsage = in.readVLong();
-        availableSpace = in.readVLong();
         location = in.readString();
     }
 
@@ -80,20 +68,6 @@ public class BlobStats implements Streamable, ToXContent {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeVLong(count);
         out.writeVLong(totalUsage);
-        out.writeVLong(availableSpace);
         out.writeString(location);
-    }
-
-    @Override
-    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-
-        builder.startObject()
-            .field("count", count)
-            .field("size", totalUsage)
-            .field("available_space", availableSpace)
-            .field("location", location)
-        .endObject();
-
-        return builder;
     }
 }

--- a/blob/src/main/java/io/crate/blob/v2/BlobShard.java
+++ b/blob/src/main/java/io/crate/blob/v2/BlobShard.java
@@ -27,7 +27,6 @@ import io.crate.blob.BlobEnvironment;
 import io.crate.blob.stats.BlobStats;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.settings.IndexSettingsService;
 import org.elasticsearch.index.shard.AbstractIndexShardComponent;
 import org.elasticsearch.index.shard.IndexShard;
@@ -73,7 +72,6 @@ public class BlobShard extends AbstractIndexShardComponent {
         final BlobStats stats = new BlobStats();
 
         stats.location(blobContainer().getBaseDirectory().getAbsolutePath());
-        stats.availableSpace(blobContainer().getBaseDirectory().getFreeSpace());
         try {
             blobContainer().walkFiles(null, new BlobContainer.FileVisitor() {
                 @Override


### PR DESCRIPTION
Calling getFreeSpace causes access denied errors
("java.lang.RuntimePermission" "getFileSystemAttributes") due to the new
SecurityManager in ES

Since availableSpace was unused it can be removed completely.