### PR TITLE
don’t try to load default settings for the client from elasticsearch …

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - removed wrong behaving CrateClient feature which allowed to load
+   client settings from a configuration file.
+
  - Implemented the EXPLAIN command for SELECT statements.
 
  - BREAKING CHANGE: Tables are not refreshed automatically anymore

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,7 +33,6 @@ evaluationDependsOn(':sql')
 evaluationDependsOn(':sql-parser')
 evaluationDependsOn(':blob')
 evaluationDependsOn(':udc')
-evaluationDependsOn(':client')
 evaluationDependsOn(':dns-discovery')
 evaluationDependsOn(':aws')
 
@@ -44,7 +43,6 @@ dependencies {
     compile project(':admin-ui')
     compile project(':blob')
     compile project(':udc')
-    compile project(':client')
     compile project(':dns-discovery')
     compile project(':aws')
 
@@ -61,7 +59,6 @@ dependencies {
     compileNotTransitive project(':admin-ui')
     compileNotTransitive project(':blob')
     compileNotTransitive project(':udc')
-    compileNotTransitive project(':client')
     compileNotTransitive project(':dns-discovery')
 }
 
@@ -123,7 +120,12 @@ task dist {
 
 task myJavadocs(type: Javadoc, dependsOn: processResources) {
     classpath = configurations.compile
-    source = sourceSets.main.allJava + project(':core').sourceSets.main.allJava + project(':sql').sourceSets.main.allJava + project(':sql-parser').sourceSets.main.allJava + project(':blob').sourceSets.main.allJava + project(':udc').sourceSets.main.allJava + project(':client').sourceSets.main.allJava
+    source = sourceSets.main.allJava +
+            project(':core').sourceSets.main.allJava +
+            project(':sql').sourceSets.main.allJava +
+            project(':sql-parser').sourceSets.main.allJava +
+            project(':blob').sourceSets.main.allJava +
+            project(':udc').sourceSets.main.allJava
 }
 
 task javadocJar (type: Jar, dependsOn: [myJavadocs]) {
@@ -147,8 +149,7 @@ task sourceJar (type : Jar) {
             project(':sql').sourceSets.main.allJava +
             project(':sql-parser').sourceSets.main.allJava +
             project(':blob').sourceSets.main.allJava +
-            project(':udc').sourceSets.main.allJava +
-            project(':client').sourceSets.main.allJava)
+            project(':udc').sourceSets.main.allJava)
     manifest {
         attributes("Implementation-Title": "Crate.IO")
     }

--- a/build.gradle
+++ b/build.gradle
@@ -206,7 +206,7 @@ subprojects {
 
 
 
-def jvmTestFlags = ['-ea']
+def jvmTestFlags = ['-ea', "-Dproject_build_dir=$project.buildDir", '-Dproject_root=$PROJECT_DIR$']
 
 idea {
     workspace {

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -5,17 +5,41 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '1.2.3'
 }
 
+repositories {
+    jcenter()
+}
+
 archivesBaseName = "crate-client"
 
-evaluationDependsOn(':core')
-evaluationDependsOn(':sql')
+evaluationDependsOn(':app')
 
 configurations {
     all*.exclude group: 'org.elasticsearch'
 }
 
+def coreIncludes = ['io/crate/Streamer*',
+                    "io/crate/TimestampFormat*",
+                    "io/crate/core/collections/MapComparator*",
+                    "io/crate/core/collections/ForEach*",
+                    "io/crate/core/StringUtils*",
+                    "io/crate/geo/GeoJSONUtils*",
+                    "io/crate/types/**"]
+
+def sqlIncludes = ["io/crate/action/sql/SQL*"]
+
+task depClasses(type: Copy, dependsOn: [':core:compileJava', ':sql:compileJava']) {
+    duplicatesStrategy 'fail'
+    from(project(':core').sourceSets.main.output) {
+        include coreIncludes
+    }
+    from(project(':sql').sourceSets.main.output) {
+        include sqlIncludes
+    }
+    into file('build/deps/')
+}
+
 dependencies {
-    compile (project(':es')) {
+    compile(project(':es')) {
         exclude group: 'org.apache.lucene'
         exclude group: 'org.codehaus.groovy'
         exclude group: 'com.github.spullara.mustache.java'
@@ -25,26 +49,26 @@ dependencies {
         exclude group: 'commons-cli'
         exclude group: 'org.slf4j'
     }
-    // needed by ES Version class - keep up to date with es dependencies
+    // required by ES and Lucene Version classes - keep up to date with es dependencies
+    // The version module is required by the DiscoveryNode module
     compile 'org.apache.lucene:lucene-core:4.10.4'
     compile 'org.apache.lucene:lucene-analyzers-common:4.10.4'
 
-    compile 'com.google.code.findbugs:annotations:3.0.0'
-    compile files(project(':core').sourceSets.shared.output.classesDir)
-    compile files(project(':sql').sourceSets.shared.output.classesDir)
+    compile files(depClasses)
+    testCompile 'io.crate:crate-testing:0.3.1'
+    testCompile 'org.hamcrest:hamcrest-all:1.3'
 
-    testCompile project(':testing')
-    testCompile project(':core')
-    testCompile project(':sql')
 }
 
-processResources.dependsOn([':core:compileSharedJava', ':sql:compileSharedJava'])
-compileJava.dependsOn([':core:compileSharedJava', ':sql:compileSharedJava'])
-
+compileTestJava {
+    dependsOn ':app:distTar'
+}
 
 test {
+    systemProperty 'project_root', rootProject.projectDir
+    systemProperty 'project_build_dir', rootProject.buildDir
+    dependsOn ':app:distTar'
     testLogging.exceptionFormat = 'full'
-
     jacoco {
         excludes = [ "*Test*" ]
     }
@@ -54,25 +78,25 @@ shadowJar {
 
     baseName 'crate-client'
     classifier ''
-    duplicatesStrategy 'exclude'
+    duplicatesStrategy 'fail'
 
     exclude 'org/hyperic/**' // exclude sigar stuff
     exclude 'META-INF/**'
 
     // remember to update mapping in CrateClientClassLoader when changing this
-    relocate 'org.elasticsearch',     'io.crate.shade.org.elasticsearch'
-    relocate 'org.apache.lucene',     'io.crate.shade.org.apache.lucene'
-    relocate 'org.joda',              'io.crate.shade.org.joda'
+    relocate 'org.elasticsearch', 'io.crate.shade.org.elasticsearch'
+    relocate 'org.apache.lucene', 'io.crate.shade.org.apache.lucene'
+    relocate 'org.joda', 'io.crate.shade.org.joda'
     relocate 'org.tartarus.snowball', 'io.crate.shade.org.tartarus.snowball'
     relocate 'com.carrotsearch.hppc', 'io.crate.shade.com.carrotsearch.hppc'
     relocate 'com.fasterxml.jackson', 'io.crate.shade.com.fasterxml.jackson'
-    relocate 'com.google',            'io.crate.shade.com.google'
-    relocate 'com.ning.compress',     'io.crate.shade.com.ning.compress'
-    relocate 'org.jboss.netty',       'io.crate.shade.org.jboss.netty'
-    relocate 'org.apache.commons',    'io.crate.shade.org.apache.commons'
-    relocate 'jsr166e',               'io.crate.shade.jsr166e'
-    relocate 'com.spatial4j',         'io.crate.shade.com.spatial4j'
-    relocate 'com.vividsolutions',    'io.crate.shade.com.vividsolutions'
+    relocate 'com.google', 'io.crate.shade.com.google'
+    relocate 'com.ning.compress', 'io.crate.shade.com.ning.compress'
+    relocate 'org.jboss.netty', 'io.crate.shade.org.jboss.netty'
+    relocate 'org.apache.commons', 'io.crate.shade.org.apache.commons'
+    relocate 'jsr166e', 'io.crate.shade.jsr166e'
+    relocate 'com.spatial4j', 'io.crate.shade.com.spatial4j'
+    relocate 'com.vividsolutions', 'io.crate.shade.com.vividsolutions'
 
     doLast {
         manifest {
@@ -82,7 +106,8 @@ shadowJar {
     }
 }
 
-task buildJar(dependsOn: [':core:getVersion', ':core:compileSharedJava', ':sql:compileSharedJava', 'classes']) {
+
+task buildJar(dependsOn: [':core:getVersion', 'classes']) {
     doLast {
         ext.version = project(':core').getVersion.version
         project.version = ext.version
@@ -91,9 +116,17 @@ task buildJar(dependsOn: [':core:getVersion', ':core:compileSharedJava', ':sql:c
 }
 tasks.buildJar.mustRunAfter jar // otherwise jar task would override shadowJar artifact
 
+task sourceJar (type : Jar) {
+    classifier = 'sources'
+    from sourceSets.main.java
+    manifest {
+        attributes("Implementation-Title": "Crate.IO Java Client")
+    }
+}
+
 task myJavadocs(type: Javadoc, dependsOn: processResources) {
     classpath = configurations.compile
-    source = sourceSets.main.allJava + project(':core').sourceSets.shared.allJava + project(':sql').sourceSets.shared.allJava
+    source = sourceSets.main.java //compileJava.source
 }
 task javadocJar (type: Jar, dependsOn: [myJavadocs]) {
     classifier = 'javadoc'
@@ -109,13 +142,6 @@ task buildJavadocJar (dependsOn: [':core:getVersion', myJavadocs] ) << {
     tasks.javadocJar.execute()
 }
 
-task sourceJar (type : Jar) {
-    classifier = 'sources'
-    from sourceSets.main.allSource + project(':core').sourceSets.shared.allSource + project(':sql').sourceSets.shared.allSource
-    manifest {
-        attributes("Implementation-Title": "Crate.IO Java Client")
-    }
-}
 
 task buildSourceJar (dependsOn: [':core:getVersion'] ) << {
     ext.version = project(':core').getVersion.version
@@ -148,7 +174,7 @@ install {
 project.ext.bintrayUsername = project.hasProperty('bintrayUsername') ? bintrayUsername : ""
 project.ext.bintrayPassword = project.hasProperty('bintrayPassword') ? bintrayPassword : ""
 
-uploadArchives.dependsOn([':core:compileSharedJava', ':sql:compileSharedJava', buildJavadocJar, buildSourceJar, buildJar, signJars])
+uploadArchives.dependsOn([install, signJars])
 uploadArchives {
     repositories{
         mavenDeployer {

--- a/client/src/main/java/io/crate/client/CrateClient.java
+++ b/client/src/main/java/io/crate/client/CrateClient.java
@@ -67,7 +67,7 @@ public class CrateClient {
     private static final ESLogger logger = Loggers.getLogger(CrateClient.class);
 
 
-    public CrateClient(Settings pSettings, boolean loadConfigSettings, String ... servers) throws
+    public CrateClient(Settings pSettings, String ... servers) throws
             ElasticsearchException {
 
         Settings settings = settingsBuilder()
@@ -84,13 +84,11 @@ public class CrateClient {
                 .put("threadpool.get.size", 1)
                 .put("threadpool.percolate.size", 1)
                 .build();
-        Tuple<Settings, Environment> tuple = InternalSettingsPreparer.prepareSettings(
-            settings, loadConfigSettings);
+        Tuple<Settings, Environment> tuple = InternalSettingsPreparer.prepareSettings(settings, false);
 
         // override classloader
         CrateClientClassLoader clientClassLoader = new CrateClientClassLoader(tuple.v1().getClassLoader());
         this.settings = ImmutableSettings.builder().put(tuple.v1()).classLoader(clientClassLoader).build();
-        Version version = Version.CURRENT;
 
         CompressorFactory.configure(this.settings);
 
@@ -98,7 +96,7 @@ public class CrateClient {
 
         ModulesBuilder modules = new ModulesBuilder();
         modules.add(new CrateClientModule());
-        modules.add(new Version.Module(version));
+        modules.add(new Version.Module(Version.CURRENT));
         modules.add(new ThreadPoolModule(threadPool));
 
         modules.add(new SettingsModule(this.settings));
@@ -120,11 +118,11 @@ public class CrateClient {
     }
 
     public CrateClient() {
-        this(ImmutableSettings.Builder.EMPTY_SETTINGS, true);
+        this(ImmutableSettings.Builder.EMPTY_SETTINGS);
     }
 
     public CrateClient(String... servers) {
-        this(ImmutableSettings.EMPTY, true, servers);
+        this(ImmutableSettings.EMPTY, servers);
     }
 
     @Nullable

--- a/client/src/test/java/io/crate/client/CrateClientCreationTest.java
+++ b/client/src/test/java/io/crate/client/CrateClientCreationTest.java
@@ -22,53 +22,22 @@
 
 package io.crate.client;
 
-import io.crate.plugin.CrateCorePlugin;
 import org.elasticsearch.client.transport.TransportClientNodesService;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.transport.InetSocketTransportAddress;
-import org.elasticsearch.test.ElasticsearchIntegrationTest;
-import org.elasticsearch.transport.TransportService;
 import org.hamcrest.Matchers;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.lang.reflect.Field;
-import java.net.InetSocketAddress;
 import java.util.List;
-import java.util.Locale;
 
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
 
-public class CrateClientCreationTest extends ElasticsearchIntegrationTest {
-
-    private int port;
-    private String serverAddress;
-
-    private static final String TEST_SETTINGS_PATH = CrateClientCreationTest.class.getResource("crate.yml").getPath();
-
-    @Override
-    protected Settings nodeSettings(int nodeOrdinal) {
-        return ImmutableSettings.settingsBuilder()
-                .put(super.nodeSettings(nodeOrdinal))
-                .put("node.mode", "network")
-                .put("plugin.types", CrateCorePlugin.class.getName())
-                .build();
-    }
-
-    @Before
-    public void prepare() {
-        System.setProperty("es.config", TEST_SETTINGS_PATH);
-        InetSocketAddress address = ((InetSocketTransportAddress) internalCluster()
-                .getInstance(TransportService.class)
-                .boundAddress().boundAddress()).address();
-        port = address.getPort();
-        serverAddress = String.format(Locale.ENGLISH, "localhost:%s", port);
-    }
+public class CrateClientCreationTest extends CrateClientIntegrationTest {
 
     @After
     public void cleanUp() throws Exception {
@@ -87,7 +56,7 @@ public class CrateClientCreationTest extends ElasticsearchIntegrationTest {
 
     @Test
     public void testWithNode() throws Exception {
-        CrateClient localClient = new CrateClient(ImmutableSettings.EMPTY, false, serverAddress);
+        CrateClient localClient = new CrateClient(ImmutableSettings.EMPTY, serverAddress());
         try {
             assertThat(extractDiscoveryNodes(localClient), hasSize(1));
         } finally {
@@ -107,7 +76,7 @@ public class CrateClientCreationTest extends ElasticsearchIntegrationTest {
 
     @Test
     public void testCreateWithServer() throws Exception {
-        CrateClient localClient = new CrateClient(ImmutableSettings.EMPTY, false, serverAddress);
+        CrateClient localClient = new CrateClient(ImmutableSettings.EMPTY, serverAddress());
         try {
             assertThat(extractDiscoveryNodes(localClient), hasSize(1));
         } finally {
@@ -138,7 +107,7 @@ public class CrateClientCreationTest extends ElasticsearchIntegrationTest {
         CrateClient localClient = new CrateClient(ImmutableSettings.builder()
                 .put("fancy.setting", "check") // will not be overridden
                 .put("node.name", "fancy-node-name") // will be overridden
-                .build(), false);
+                .build());
 
         try {
             Settings settings = localClient.settings();
@@ -147,23 +116,5 @@ public class CrateClientCreationTest extends ElasticsearchIntegrationTest {
         } finally {
             localClient.close();
         }
-    }
-
-    @Test
-    public void testLoadFromConfig() throws Exception {
-        CrateClient configClient = new CrateClient(ImmutableSettings.EMPTY, true);
-        CrateClient noConfigClient = new CrateClient(ImmutableSettings.EMPTY, false);
-        try {
-            Settings configSettings = configClient.settings();
-            Settings noConfigSettings = noConfigClient.settings();
-
-            assertThat(configSettings.getAsBoolean("loaded.from.file", false), is(true));
-            assertThat(noConfigSettings.getAsMap().containsKey("loaded.from.file"), is(false));
-        } finally {
-            configClient.close();
-            noConfigClient.close();
-        }
-
-
     }
 }

--- a/client/src/test/java/io/crate/client/CrateClientIntegrationTest.java
+++ b/client/src/test/java/io/crate/client/CrateClientIntegrationTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.client;
+
+import com.google.common.base.Throwables;
+import io.crate.action.sql.SQLResponse;
+import io.crate.testing.CrateTestCluster;
+import io.crate.testing.CrateTestServer;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+
+public class CrateClientIntegrationTest extends Assert {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private static String tarBallPath;
+
+    static {
+
+        final PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:crate-*.tar.gz");
+        FileVisitor<Path> matcherVisitor = new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attribs) {
+                if (matcher.matches(file.getFileName())) {
+                    tarBallPath = file.toAbsolutePath().toString();
+                    return FileVisitResult.TERMINATE;
+                }
+                return FileVisitResult.CONTINUE;
+            }
+        };
+        try {
+            Files.walkFileTree(Paths.get(System.getProperty("project_root") + "/app/build/distributions/"), matcherVisitor);
+        } catch (IOException e) {
+            Throwables.propagate(e);
+        }
+        assert tarBallPath != null;
+    }
+
+
+    @ClassRule
+    public static final CrateTestCluster testCluster = CrateTestCluster.fromFile(tarBallPath)
+            .workingDir(System.getProperty("project_build_dir") + "/crate-testing").numberOfNodes(1).build();
+
+    protected String serverAddress() {
+
+        CrateTestServer server = testCluster.randomServer();
+        return server.crateHost() + ':' + server.transportPort();
+    }
+
+    private void waitForZeroCount(CrateClient client, String stmt){
+        for (int i = 1; i < 10; i++) {
+            SQLResponse r = client.sql("select count(*) from sys.shards where primary=true and state<>'STARTED'").actionGet();
+            if (((Long) r.rows()[0][0]) == 0L) {
+                return;
+            }
+            try {
+                Thread.sleep(i*100);
+            } catch (InterruptedException e) {
+                Throwables.propagate(e);
+            }
+        }
+        throw new RuntimeException("waiting for zero result timed out");
+    }
+
+    protected void ensureYellow(CrateClient client){
+        waitForZeroCount(client, "select count(*) from sys.shards where primary=true and state <> 'STARTED'");
+    }
+
+    protected void ensureGreen(CrateClient client){
+        waitForZeroCount(client, "select count(*) from sys.shards state <> 'STARTED'");
+    }
+
+
+}

--- a/client/src/test/resources/io/crate/client/crate.yml
+++ b/client/src/test/resources/io/crate/client/crate.yml
@@ -1,3 +1,0 @@
-loaded:
-  from:
-    file: true

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -8,7 +8,6 @@ archivesBaseName = 'crate-core'
 configurations {
     all*.exclude group: 'org.elasticsearch'
     all*.exclude group: 'org.apache.commons', module: 'commons-math3'
-    sharedCompile.extendsFrom compile
 }
 
 dependencies {
@@ -67,18 +66,6 @@ sourceSets {
     test {
         resources {
             srcDir 'src/test/java'
-        }
-    }
-    shared {
-        java {
-            srcDir "src/main/java/"
-            include "io/crate/Streamer*"
-            include "io/crate/TimestampFormat*"
-            include "io/crate/core/collections/MapComparator*"
-            include "io/crate/core/collections/ForEach*"
-            include "io/crate/core/StringUtils*"
-            include "io/crate/geo/GeoJSONUtils*"
-            include "io/crate/types/**"
         }
     }
 }

--- a/sql/build.gradle
+++ b/sql/build.gradle
@@ -8,7 +8,6 @@ archivesBaseName = 'crate-sql'
 // we do not want to have elasticsearch here, since we provide it in :es
 configurations {
     all*.exclude group: 'org.elasticsearch'
-    sharedCompile.extendsFrom compile
     benchmarksCompile.extendsFrom testCompile
     benchmarksRuntime.extendsFrom testRuntime, benchmarksCompile
 }
@@ -75,12 +74,6 @@ sourceSets {
             srcDir 'src/benchmarks/java'
             compileClasspath += main.output + test.output + configurations.benchmarksCompile
             runtimeClasspath += main.output + test.output + configurations.benchmarksRuntime
-        }
-    }
-    shared {
-        java {
-            srcDir "src/main/java/"
-            include "io/crate/action/sql/SQL*"
         }
     }
 }


### PR DESCRIPTION
…config

files and removed loadConfigSettings parameter from client constructor

client tests now use crate-testing, so the client tests run agains a seperate
jvm which reflects the real world scenario