### PR TITLE
internal paging: Use ShardId instead of int as key for exhausted iteraters

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,11 @@ Changes for Crate
 
 Unreleased
 ==========
+
+ - Fixed an issue that could cause queries with ORDER BY on partitioned tables
+   to get stuck if multiple shards were on the same node and a single shard
+   couldn't produce the whole result
+
  - Implemented cluster check for installed java version 
 
  - removed wrong behaving CrateClient feature which allowed to load

--- a/sql/src/benchmarks/java/io/crate/operation/merge/SortedPagingIteratorBenchmark.java
+++ b/sql/src/benchmarks/java/io/crate/operation/merge/SortedPagingIteratorBenchmark.java
@@ -30,8 +30,6 @@ import com.google.common.collect.Ordering;
 import io.crate.core.collections.ArrayBucket;
 import io.crate.core.collections.Bucket;
 import io.crate.core.collections.Row;
-import io.crate.operation.merge.NumberedIterable;
-import io.crate.operation.merge.SortedPagingIterator;
 import io.crate.operation.projectors.sorting.OrderingByPosition;
 import org.junit.Before;
 import org.junit.Rule;
@@ -65,14 +63,14 @@ public class SortedPagingIteratorBenchmark {
     }
 
     @SafeVarargs
-    private final Iterable<? extends NumberedIterable<Row>> numbered(Iterable<Row>... buckets) {
+    private final Iterable<? extends KeyIterable<Integer, Row>> numbered(Iterable<Row>... buckets) {
 
-        return Iterables.transform(Arrays.asList(buckets), new Function<Iterable<Row>, NumberedIterable<Row>>() {
+        return Iterables.transform(Arrays.asList(buckets), new Function<Iterable<Row>, KeyIterable<Integer, Row>>() {
             private int i = 0;
             @Nullable
             @Override
-            public NumberedIterable<Row> apply(Iterable<Row> input) {
-                return new NumberedIterable<>(i++, input);
+            public KeyIterable<Integer, Row> apply(Iterable<Row> input) {
+                return new KeyIterable<>(i++, input);
             }
         });
     }
@@ -80,7 +78,7 @@ public class SortedPagingIteratorBenchmark {
     @BenchmarkOptions(benchmarkRounds = 10, warmupRounds = 1)
     @Test
     public void testIterateWithRepeat() throws Exception {
-        SortedPagingIterator<Row> iterator = new SortedPagingIterator<>(ORDERING, true);
+        SortedPagingIterator<Integer, Row> iterator = new SortedPagingIterator<>(ORDERING, true);
         iterator.merge(numbered(bucket1, bucket2));
         int size1 = 0;
         while (iterator.hasNext()) {

--- a/sql/src/main/java/io/crate/operation/PageDownstreamFactory.java
+++ b/sql/src/main/java/io/crate/operation/PageDownstreamFactory.java
@@ -96,7 +96,7 @@ public class PageDownstreamFactory {
             rowReceiver = projectorChain.firstProjector();
         }
 
-        PagingIterator<Row> pagingIterator;
+        PagingIterator<Void, Row> pagingIterator;
         if (mergeNode.sortedInputOutput() && mergeNode.numUpstreams() > 1) {
             pagingIterator = new SortedPagingIterator<>(
                     OrderingByPosition.rowOrdering(
@@ -108,7 +108,7 @@ public class PageDownstreamFactory {
             );
         } else {
             pagingIterator = requiresRepeatSupport ?
-                    PassThroughPagingIterator.<Row>repeatable() : PassThroughPagingIterator.<Row>oneShot();
+                    PassThroughPagingIterator.<Void, Row>repeatable() : PassThroughPagingIterator.<Void, Row>oneShot();
         }
         PageDownstream pageDownstream = new IteratorPageDownstream(rowReceiver, pagingIterator, executorOptional);
         return new Tuple<>(pageDownstream, projectorChain);

--- a/sql/src/main/java/io/crate/operation/collect/collectors/MultiShardScoreDocCollector.java
+++ b/sql/src/main/java/io/crate/operation/collect/collectors/MultiShardScoreDocCollector.java
@@ -22,7 +22,7 @@
 
 package io.crate.operation.collect.collectors;
 
-import com.carrotsearch.hppc.IntObjectOpenHashMap;
+import com.carrotsearch.hppc.ObjectObjectOpenHashMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Ordering;
 import com.google.common.util.concurrent.*;
@@ -30,7 +30,7 @@ import io.crate.core.collections.Row;
 import io.crate.jobs.ExecutionState;
 import io.crate.jobs.KeepAliveListener;
 import io.crate.operation.collect.CrateCollector;
-import io.crate.operation.merge.NumberedIterable;
+import io.crate.operation.merge.KeyIterable;
 import io.crate.operation.merge.PagingIterator;
 import io.crate.operation.merge.PassThroughPagingIterator;
 import io.crate.operation.merge.SortedPagingIterator;
@@ -41,6 +41,7 @@ import io.crate.operation.projectors.RowReceiver;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
+import org.elasticsearch.index.shard.ShardId;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -54,13 +55,13 @@ public class MultiShardScoreDocCollector implements CrateCollector, ExecutionSta
 
     private static final int KEEP_ALIVE_AFTER_ROWS = 1_000_000;
     private final List<OrderedDocCollector> orderedDocCollectors;
-    private final IntObjectOpenHashMap<OrderedDocCollector> orderedCollectorsMap;
+    private final ObjectObjectOpenHashMap<ShardId, OrderedDocCollector> orderedCollectorsMap;
     private final RowReceiver rowReceiver;
-    private final PagingIterator<Row> pagingIterator;
+    private final PagingIterator<ShardId, Row> pagingIterator;
     private final TopRowUpstream topRowUpstream;
     private final ListeningExecutorService executor;
     private final ListeningExecutorService directExecutor;
-    private final FutureCallback<List<NumberedIterable<Row>>> futureCallback;
+    private final FutureCallback<List<KeyIterable<ShardId, Row>>> futureCallback;
     private final KeepAliveListener keepAliveListener;
     private final FlatProjectorChain flatProjectorChain;
     private final boolean singleShard;
@@ -97,14 +98,16 @@ public class MultiShardScoreDocCollector implements CrateCollector, ExecutionSta
 
         boolean needsRepeat = rowReceiver.requirements().contains(Requirement.REPEAT);
         if (singleShard) {
-            pagingIterator = needsRepeat ? PassThroughPagingIterator.<Row>repeatable() : PassThroughPagingIterator.<Row>oneShot();
+            pagingIterator = needsRepeat ?
+                    PassThroughPagingIterator.<ShardId, Row>repeatable() :
+                    PassThroughPagingIterator.<ShardId, Row>oneShot();
             orderedCollectorsMap = null;
             futureCallback = null;
         } else {
             pagingIterator = new SortedPagingIterator<>(rowOrdering, needsRepeat);
-            futureCallback = new FutureCallback<List<NumberedIterable<Row>>>() {
+            futureCallback = new FutureCallback<List<KeyIterable<ShardId, Row>>>() {
                 @Override
-                public void onSuccess(@Nullable List<NumberedIterable<Row>> result) {
+                public void onSuccess(@Nullable List<KeyIterable<ShardId, Row>> result) {
                     assert result != null : "result must not be null";
 
                     pagingIterator.merge(result);
@@ -117,7 +120,7 @@ public class MultiShardScoreDocCollector implements CrateCollector, ExecutionSta
                 }
             };
 
-            this.orderedCollectorsMap = new IntObjectOpenHashMap<>(orderedDocCollectors.size());
+            this.orderedCollectorsMap = new ObjectObjectOpenHashMap<>(orderedDocCollectors.size());
             for (OrderedDocCollector orderedDocCollector : orderedDocCollectors) {
                 this.orderedCollectorsMap.put(orderedDocCollector.shardId(), orderedDocCollector);
             }
@@ -135,7 +138,7 @@ public class MultiShardScoreDocCollector implements CrateCollector, ExecutionSta
     }
 
     private void runThreaded() {
-        List<ListenableFuture<NumberedIterable<Row>>> futures = new ArrayList<>(orderedDocCollectors.size());
+        List<ListenableFuture<KeyIterable<ShardId, Row>>> futures = new ArrayList<>(orderedDocCollectors.size());
         for (OrderedDocCollector orderedDocCollector : orderedDocCollectors.subList(1, this.orderedDocCollectors.size())) {
             try {
                 futures.add(executor.submit(orderedDocCollector));
@@ -150,7 +153,7 @@ public class MultiShardScoreDocCollector implements CrateCollector, ExecutionSta
     }
 
     private void runWithoutThreads(OrderedDocCollector orderedDocCollector) {
-        NumberedIterable<Row> rows;
+        KeyIterable<ShardId, Row> rows;
         try {
             rows = orderedDocCollector.call();
         } catch (Exception e) {
@@ -180,7 +183,7 @@ public class MultiShardScoreDocCollector implements CrateCollector, ExecutionSta
                         if (singleShard) {
                             runWithoutThreads(orderedDocCollectors.get(0));
                         } else {
-                            int shardId = pagingIterator.exhaustedIterable();
+                            ShardId shardId = pagingIterator.exhaustedIterable();
                             LOGGER.trace("Iterator {} exhausted. Retrieving more data", shardId);
                             runWithoutThreads(orderedCollectorsMap.get(shardId));
                         }

--- a/sql/src/main/java/io/crate/operation/merge/IteratorPageDownstream.java
+++ b/sql/src/main/java/io/crate/operation/merge/IteratorPageDownstream.java
@@ -54,7 +54,7 @@ public class IteratorPageDownstream implements PageDownstream {
     private final RowReceiver rowReceiver;
     private final Executor executor;
     private final AtomicBoolean finished = new AtomicBoolean(false);
-    private final PagingIterator<Row> pagingIterator;
+    private final PagingIterator<Void, Row> pagingIterator;
     private final TopRowUpstream topRowUpstream;
 
     private volatile PageConsumeListener pausedListener;
@@ -62,7 +62,7 @@ public class IteratorPageDownstream implements PageDownstream {
     private boolean downstreamWantsMore = true;
 
     public IteratorPageDownstream(final RowReceiver rowReceiver,
-                                  final PagingIterator<Row> pagingIterator,
+                                  final PagingIterator<Void, Row> pagingIterator,
                                   Optional<Executor> executor) {
         this.pagingIterator = pagingIterator;
         this.executor = executor.or(MoreExecutors.directExecutor());
@@ -163,16 +163,13 @@ public class IteratorPageDownstream implements PageDownstream {
         }
     }
 
-    private Iterable<? extends NumberedIterable<Row>> numberedBuckets(List<Bucket> buckets) {
-        return Iterables.transform(buckets, new Function<Bucket, NumberedIterable<Row>>() {
-
-            int number = -1;
+    private Iterable<? extends KeyIterable<Void, Row>> numberedBuckets(List<Bucket> buckets) {
+        return Iterables.transform(buckets, new Function<Bucket, KeyIterable<Void, Row>>() {
 
             @Nullable
             @Override
-            public NumberedIterable<Row> apply(Bucket input) {
-                number++;
-                return new NumberedIterable<>(number, input);
+            public KeyIterable<Void, Row> apply(Bucket input) {
+                return new KeyIterable<>(null, input);
             }
         });
     }

--- a/sql/src/main/java/io/crate/operation/merge/KeyIterable.java
+++ b/sql/src/main/java/io/crate/operation/merge/KeyIterable.java
@@ -24,22 +24,22 @@ package io.crate.operation.merge;
 
 import java.util.Iterator;
 
-public class NumberedIterable<T> implements Iterable<T> {
+public class KeyIterable<TKey, TRow> implements Iterable<TRow> {
 
-    private final int number;
-    private final Iterable<T> iterable;
+    private final TKey key;
+    private final Iterable<TRow> iterable;
 
-    public NumberedIterable(int number, Iterable<T> iterable) {
-        this.number = number;
+    public KeyIterable(TKey key, Iterable<TRow> iterable) {
+        this.key = key;
         this.iterable = iterable;
     }
 
     @Override
-    public Iterator<T> iterator() {
+    public Iterator<TRow> iterator() {
         return iterable.iterator();
     }
 
-    public int number() {
-        return number;
+    public TKey key() {
+        return key;
     }
 }

--- a/sql/src/main/java/io/crate/operation/merge/PagingIterator.java
+++ b/sql/src/main/java/io/crate/operation/merge/PagingIterator.java
@@ -23,12 +23,12 @@ package io.crate.operation.merge;
 
 import java.util.Iterator;
 
-public interface PagingIterator<T> extends Iterator<T> {
+public interface PagingIterator<TKey, TRow> extends Iterator<TRow> {
 
     /**
      * Add additional iterables to the PagingIterator. (E.g. due to a new Page that has arrived)
      */
-    void merge(Iterable<? extends NumberedIterable<T>> iterables);
+    void merge(Iterable<? extends KeyIterable<TKey, TRow>> iterables);
 
     /**
      * This is called if the last page has been received and merge has been called for the last time.
@@ -37,11 +37,11 @@ public interface PagingIterator<T> extends Iterator<T> {
      */
     void finish();
 
-    int exhaustedIterable();
+    TKey exhaustedIterable();
 
     /**
      * create an iterable to repeat the previous iteration
      * @return an iterable that will iterate through the already emitted items and emit them again in the same order as before
      */
-    Iterable<T> repeat();
+    Iterable<TRow> repeat();
 }

--- a/sql/src/main/java/io/crate/operation/merge/PassThroughPagingIterator.java
+++ b/sql/src/main/java/io/crate/operation/merge/PassThroughPagingIterator.java
@@ -29,12 +29,12 @@ import com.google.common.collect.Iterators;
 import java.util.Collections;
 import java.util.Iterator;
 
-public class PassThroughPagingIterator<T> extends ForwardingIterator<T> implements PagingIterator<T> {
+public class PassThroughPagingIterator<TKey, TRow> extends ForwardingIterator<TRow> implements PagingIterator<TKey, TRow> {
 
-    private Iterator<T> iterator = Collections.emptyIterator();
-    private final ImmutableList.Builder<NumberedIterable<T>> iterables = ImmutableList.builder();
+    private Iterator<TRow> iterator = Collections.emptyIterator();
+    private final ImmutableList.Builder<KeyIterable<TKey, TRow>> iterables = ImmutableList.builder();
     private final boolean repeatable;
-    private Iterable<T> storedForRepeat = null;
+    private Iterable<TRow> storedForRepeat = null;
 
     private PassThroughPagingIterator(boolean repeatable) {
         this.repeatable = repeatable;
@@ -43,7 +43,7 @@ public class PassThroughPagingIterator<T> extends ForwardingIterator<T> implemen
     /**
      * Create an iterator that is able to repeat over what has previously been iterated
      */
-    public static <T> PassThroughPagingIterator<T> repeatable() {
+    public static <TKey, TRow> PassThroughPagingIterator<TKey, TRow> repeatable() {
         return new PassThroughPagingIterator<>(true);
     }
 
@@ -51,18 +51,18 @@ public class PassThroughPagingIterator<T> extends ForwardingIterator<T> implemen
      * Create an iterator that is not able to repeat.
      * Calling {@link #repeat()} with instances created by this method is discouraged.
      */
-    public static <T> PassThroughPagingIterator<T> oneShot() {
+    public static <TKey, TRow> PassThroughPagingIterator<TKey, TRow> oneShot() {
         return new PassThroughPagingIterator<>(false);
     }
 
     @Override
-    protected Iterator<T> delegate() {
+    protected Iterator<TRow> delegate() {
         return iterator;
     }
 
     @Override
-    public void merge(Iterable<? extends NumberedIterable<T>> iterables) {
-        Iterable<T> concat = Iterables.concat(iterables);
+    public void merge(Iterable<? extends KeyIterable<TKey, TRow>> iterables) {
+        Iterable<TRow> concat = Iterables.concat(iterables);
 
         if (repeatable) {
             this.iterables.addAll(iterables);
@@ -80,13 +80,13 @@ public class PassThroughPagingIterator<T> extends ForwardingIterator<T> implemen
     }
 
     @Override
-    public int exhaustedIterable() {
-        return -1;
+    public TKey exhaustedIterable() {
+        return null;
     }
 
     @Override
-    public Iterable<T> repeat() {
-        Iterable<T> repeatMe = storedForRepeat;
+    public Iterable<TRow> repeat() {
+        Iterable<TRow> repeatMe = storedForRepeat;
         if (repeatMe == null) {
             repeatMe = Iterables.concat(this.iterables.build());
             this.storedForRepeat = repeatMe;

--- a/sql/src/main/java/io/crate/operation/merge/SortedMergeIterator.java
+++ b/sql/src/main/java/io/crate/operation/merge/SortedMergeIterator.java
@@ -31,9 +31,9 @@ import java.util.Iterator;
  *
  * And it also has a merge function with which additional backing iterables can be added to enable paging.
  */
-public interface SortedMergeIterator<T> extends Iterator<T> {
-    void merge(Iterable<? extends NumberedIterable<T>> iterables);
+public interface SortedMergeIterator<TKey, TRow> extends Iterator<TRow> {
+    void merge(Iterable<? extends KeyIterable<TKey, TRow>> iterables);
     boolean isLeastExhausted();
-    int exhaustedIterable();
-    Iterable<T> repeat();
+    TKey exhaustedIterable();
+    Iterable<TRow> repeat();
 }

--- a/sql/src/main/java/io/crate/operation/merge/SortedPagingIterator.java
+++ b/sql/src/main/java/io/crate/operation/merge/SortedPagingIterator.java
@@ -31,9 +31,9 @@ import java.util.Collections;
  * {@link #hasNext()} might call next() on a backing iterator. So if one or more of the backing iterators contains shared
  * objects these should be consumed after a next() call and before the next hasNext() or next() call or they'll change.
  */
-public class SortedPagingIterator<T> implements PagingIterator<T> {
+public class SortedPagingIterator<TKey, TRow> implements PagingIterator<TKey, TRow> {
 
-    private final SortedMergeIterator<T> mergingIterator;
+    private final SortedMergeIterator<TKey, TRow> mergingIterator;
     private boolean ignoreLeastExhausted = false;
 
     /**
@@ -41,17 +41,17 @@ public class SortedPagingIterator<T> implements PagingIterator<T> {
      * @param needsRepeat if true additional internal state is kept in order to be able to repeat this iterator.
      *                    If this is false a call to {@link #repeat()} might result in an excaption, at best the behaviour is undefined.
      */
-    public SortedPagingIterator(Ordering<T> ordering, boolean needsRepeat) {
+    public SortedPagingIterator(Ordering<TRow> ordering, boolean needsRepeat) {
         if (needsRepeat) {
-            mergingIterator = new RecordingSortedMergeIterator<>(Collections.<NumberedIterable<T>>emptyList(), ordering);
+            mergingIterator = new RecordingSortedMergeIterator<>(Collections.<KeyIterable<TKey, TRow>>emptyList(), ordering);
         } else {
             // does not support repeat !!!
-            mergingIterator = new PlainSortedMergeIterator<>(Collections.<NumberedIterable<T>>emptyList(), ordering);
+            mergingIterator = new PlainSortedMergeIterator<>(Collections.<KeyIterable<TKey, TRow>>emptyList(), ordering);
         }
     }
 
     @Override
-    public void merge(Iterable<? extends NumberedIterable<T>> iterables) {
+    public void merge(Iterable<? extends KeyIterable<TKey, TRow>> iterables) {
         mergingIterator.merge(iterables);
     }
 
@@ -61,12 +61,12 @@ public class SortedPagingIterator<T> implements PagingIterator<T> {
     }
 
     @Override
-    public int exhaustedIterable() {
+    public TKey exhaustedIterable() {
         return mergingIterator.exhaustedIterable();
     }
 
     @Override
-    public Iterable<T> repeat() {
+    public Iterable<TRow> repeat() {
         return mergingIterator.repeat();
     }
 
@@ -76,7 +76,7 @@ public class SortedPagingIterator<T> implements PagingIterator<T> {
     }
 
     @Override
-    public T next() {
+    public TRow next() {
         return mergingIterator.next();
     }
 

--- a/sql/src/test/java/io/crate/operation/collect/collectors/MultiShardScoreDocCollectorTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/collectors/MultiShardScoreDocCollectorTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.operation.collect.collectors;
+
+import com.google.common.collect.Ordering;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import io.crate.core.collections.Bucket;
+import io.crate.core.collections.Row;
+import io.crate.core.collections.Row1;
+import io.crate.jobs.KeepAliveListener;
+import io.crate.operation.merge.KeyIterable;
+import io.crate.operation.projectors.FlatProjectorChain;
+import io.crate.operation.projectors.sorting.OrderingByPosition;
+import io.crate.testing.CollectingRowReceiver;
+import io.crate.testing.TestingHelpers;
+import org.elasticsearch.index.shard.ShardId;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MultiShardScoreDocCollectorTest {
+
+
+    @Test
+    public void testSingleCollectorGetsExhausted() throws Exception {
+        ListeningExecutorService executor = MoreExecutors.newDirectExecutorService();
+        Ordering<Row> rowOrdering =
+                OrderingByPosition.rowOrdering(new int[]{0}, new boolean[]{false}, new Boolean[]{null});
+
+        List<OrderedDocCollector> collectors = new ArrayList<>();
+        collectors.add(mockedCollector(new ShardId("p1", 0), 0, Arrays.<Row>asList(new Row1(1), new Row1(1))));
+        collectors.add(mockedCollector(new ShardId("p2", 0), 2, Arrays.<Row>asList(new Row1(2), new Row1(2), new Row1(2))));
+        collectors.add(mockedCollector(new ShardId("p1", 1), 10, Arrays.<Row>asList(new Row1(3), new Row1(3))));
+
+        CollectingRowReceiver rowReceiver = CollectingRowReceiver.withLimit(6);
+        FlatProjectorChain projectorChain = FlatProjectorChain.withReceivers(Collections.singletonList(rowReceiver));
+
+        MultiShardScoreDocCollector docCollector = new MultiShardScoreDocCollector(
+                collectors,
+                mock(KeepAliveListener.class),
+                rowOrdering,
+                projectorChain,
+                executor
+        );
+        docCollector.doCollect();
+        Bucket result = rowReceiver.result();
+
+        assertThat(TestingHelpers.printedTable(result), is("1\n1\n2\n2\n2\n2\n"));
+    }
+
+    private OrderedDocCollector mockedCollector(final ShardId shardId, final int numRepeats, final Iterable<Row> iterable) throws Exception {
+        final OrderedDocCollector collector = mock(OrderedDocCollector.class);
+        when(collector.shardId()).thenReturn(shardId);
+        when(collector.call()).then(new Answer<Object>() {
+            int repeat = 0;
+
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                if (collector.exhausted) {
+                    return new KeyIterable<>(shardId, Collections.emptyList());
+                }
+                if (repeat++ == numRepeats) {
+                    collector.exhausted = true;
+                }
+                return new KeyIterable<>(shardId, iterable);
+            }
+        });
+        return collector;
+    }
+}

--- a/sql/src/test/java/io/crate/operation/join/NestedLoopOperationTest.java
+++ b/sql/src/test/java/io/crate/operation/join/NestedLoopOperationTest.java
@@ -69,7 +69,7 @@ public class NestedLoopOperationTest extends CrateUnitTest {
     private PageDownstream pageDownstream(RowReceiver rowReceiver) {
         return new IteratorPageDownstream(
                     rowReceiver,
-                    PassThroughPagingIterator.<Row>repeatable(),
+                    PassThroughPagingIterator.<Void, Row>repeatable(),
                     Optional.<Executor>absent()
         );
     }

--- a/sql/src/test/java/io/crate/operation/merge/IteratorPageDownstreamTest.java
+++ b/sql/src/test/java/io/crate/operation/merge/IteratorPageDownstreamTest.java
@@ -24,12 +24,7 @@ package io.crate.operation.merge;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.SettableFuture;
-import io.crate.core.collections.ArrayBucket;
-import io.crate.core.collections.Bucket;
-import io.crate.core.collections.BucketPage;
-import io.crate.core.collections.Row;
-import io.crate.core.collections.Row1;
-import io.crate.core.collections.SingleRowBucket;
+import io.crate.core.collections.*;
 import io.crate.operation.PageConsumeListener;
 import io.crate.operation.projectors.RowReceiver;
 import io.crate.test.integration.CrateUnitTest;
@@ -47,9 +42,7 @@ import javax.annotation.Nonnull;
 import java.util.concurrent.Executor;
 
 import static org.hamcrest.core.Is.is;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 public class IteratorPageDownstreamTest extends CrateUnitTest {
 
@@ -66,7 +59,7 @@ public class IteratorPageDownstreamTest extends CrateUnitTest {
     };
 
     @Mock
-    PagingIterator<Row> mockedPagingIterator;
+    PagingIterator<Void, Row> mockedPagingIterator;
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
@@ -79,11 +72,11 @@ public class IteratorPageDownstreamTest extends CrateUnitTest {
         SettableFuture<Bucket> b1 = SettableFuture.create();
         SettableFuture<Bucket> b2 = SettableFuture.create();
         downstream.nextPage(new BucketPage(ImmutableList.of(b1, b2)), PAGE_CONSUME_LISTENER);
-        verify(mockedPagingIterator, times(0)).merge(Mockito.<Iterable<? extends NumberedIterable<Row>>>any());
+        verify(mockedPagingIterator, times(0)).merge(Mockito.<Iterable<? extends KeyIterable<Void, Row>>>any());
         b1.set(Bucket.EMPTY);
-        verify(mockedPagingIterator, times(0)).merge(Mockito.<Iterable<? extends NumberedIterable<Row>>>any());
+        verify(mockedPagingIterator, times(0)).merge(Mockito.<Iterable<? extends KeyIterable<Void, Row>>>any());
         b2.set(Bucket.EMPTY);
-        verify(mockedPagingIterator, times(1)).merge(Mockito.<Iterable<? extends NumberedIterable<Row>>>any());
+        verify(mockedPagingIterator, times(1)).merge(Mockito.<Iterable<? extends KeyIterable<Void, Row>>>any());
     }
 
     @Test
@@ -99,7 +92,7 @@ public class IteratorPageDownstreamTest extends CrateUnitTest {
 
         CollectingRowReceiver rowReceiver = new FailingRowReceiver();
         IteratorPageDownstream downstream = new IteratorPageDownstream(
-                rowReceiver, PassThroughPagingIterator.<Row>oneShot(), Optional.<Executor>absent());
+                rowReceiver, PassThroughPagingIterator.<Void, Row>oneShot(), Optional.<Executor>absent());
 
         SettableFuture<Bucket> b1 = SettableFuture.create();
         downstream.nextPage(new BucketPage(ImmutableList.of(b1)), PAGE_CONSUME_LISTENER);
@@ -139,7 +132,7 @@ public class IteratorPageDownstreamTest extends CrateUnitTest {
         CollectingRowReceiver rowReceiver = CollectingRowReceiver.withLimit(1);
         IteratorPageDownstream downstream = new IteratorPageDownstream(
                 rowReceiver,
-                PassThroughPagingIterator.<Row>oneShot(),
+                PassThroughPagingIterator.<Void, Row>oneShot(),
                 Optional.<Executor>absent()
         );
 
@@ -164,7 +157,7 @@ public class IteratorPageDownstreamTest extends CrateUnitTest {
 
          IteratorPageDownstream pageDownstream = new IteratorPageDownstream(
                  rowReceiver,
-                 PassThroughPagingIterator.<Row>oneShot(),
+                 PassThroughPagingIterator.<Void, Row>oneShot(),
                  Optional.<Executor>of(new Executor() {
                      @Override
                      public void execute(@Nonnull Runnable command) {
@@ -193,7 +186,7 @@ public class IteratorPageDownstreamTest extends CrateUnitTest {
         CollectingRowReceiver rowReceiver = new CollectingRowReceiver();
         IteratorPageDownstream pageDownstream = new IteratorPageDownstream(
                 rowReceiver,
-                PassThroughPagingIterator.<Row>repeatable(),
+                PassThroughPagingIterator.<Void, Row>repeatable(),
                 Optional.<Executor>absent());
 
         SettableFuture<Bucket> b1 = SettableFuture.create();
@@ -229,7 +222,7 @@ public class IteratorPageDownstreamTest extends CrateUnitTest {
         CollectingRowReceiver rowReceiver = CollectingRowReceiver.withPauseAfter(2);
         IteratorPageDownstream pageDownstream = new IteratorPageDownstream(
                 rowReceiver,
-                PassThroughPagingIterator.<Row>repeatable(),
+                PassThroughPagingIterator.<Void, Row>repeatable(),
                 Optional.<Executor>absent());
 
         SettableFuture<Bucket> b1 = SettableFuture.create();

--- a/sql/src/test/java/io/crate/operation/merge/PassThroughPagingIteratorTest.java
+++ b/sql/src/test/java/io/crate/operation/merge/PassThroughPagingIteratorTest.java
@@ -33,22 +33,22 @@ import static org.hamcrest.core.Is.is;
 
 public class PassThroughPagingIteratorTest extends CrateUnitTest {
 
-    private static <T> PassThroughPagingIterator<T> iter() {
-        return randomBoolean() ? PassThroughPagingIterator.<T>repeatable() : PassThroughPagingIterator.<T>oneShot();
+    private static <T> PassThroughPagingIterator<Integer, T> iter() {
+        return randomBoolean() ? PassThroughPagingIterator.<Integer, T>repeatable() : PassThroughPagingIterator.<Integer, T>oneShot();
     }
 
     @Test
     public void testHasNextCallWithoutMerge() throws Exception {
-        PassThroughPagingIterator<Object> iterator = iter();
+        PassThroughPagingIterator<Integer, Object> iterator = iter();
         assertThat(iterator.hasNext(), is(false));
     }
 
     @Test
     public void testInputIsPassedThrough() throws Exception {
-        PassThroughPagingIterator<String> iterator = iter();
+        PassThroughPagingIterator<Integer, String> iterator = iter();
         iterator.merge(Arrays.asList(
-                new NumberedIterable<>(0, Arrays.asList("a", "b", "c")),
-                new NumberedIterable<>(1, Arrays.asList("d", "e"))));
+                new KeyIterable<>(0, Arrays.asList("a", "b", "c")),
+                new KeyIterable<>(1, Arrays.asList("d", "e"))));
 
         iterator.finish();
         String[] objects = Iterators.toArray(iterator, String.class);
@@ -57,12 +57,12 @@ public class PassThroughPagingIteratorTest extends CrateUnitTest {
 
     @Test
     public void testInputIsPassedThroughWithSecondMergeCall() throws Exception {
-        PassThroughPagingIterator<String> iterator = iter();
+        PassThroughPagingIterator<Integer, String> iterator = iter();
         iterator.merge(Arrays.asList(
-                        new NumberedIterable<>(0, Arrays.asList("a", "b", "c")),
-                        new NumberedIterable<>(1, Arrays.asList("d", "e"))));
+                        new KeyIterable<>(0, Arrays.asList("a", "b", "c")),
+                        new KeyIterable<>(1, Arrays.asList("d", "e"))));
         iterator.merge(Collections.singletonList(
-                new NumberedIterable<>(1, Arrays.asList("f", "g"))));
+                new KeyIterable<>(1, Arrays.asList("f", "g"))));
         iterator.finish();
         String[] objects = Iterators.toArray(iterator, String.class);
         assertThat(objects, Matchers.arrayContaining("a", "b", "c", "d", "e", "f", "g"));

--- a/sql/src/test/java/io/crate/operation/merge/SortedPagingIteratorTest.java
+++ b/sql/src/test/java/io/crate/operation/merge/SortedPagingIteratorTest.java
@@ -47,7 +47,7 @@ public class SortedPagingIteratorTest extends CrateUnitTest {
 
     @Test
     public void testTwoBucketsAndTwoPagesAreSortedCorrectly() throws Exception {
-        SortedPagingIterator<Row> pagingIterator = new SortedPagingIterator<>(ORDERING, randomBoolean());
+        SortedPagingIterator<Void, Row> pagingIterator = new SortedPagingIterator<>(ORDERING, randomBoolean());
 
         pagingIterator.merge(numberedBuckets(Arrays.<Bucket>asList(
                 new ArrayBucket(new Object[][] {
@@ -102,7 +102,7 @@ public class SortedPagingIteratorTest extends CrateUnitTest {
 
     @Test
     public void testReplayReplaysCorrectly() throws Exception {
-        SortedPagingIterator<Row> pagingIterator = new SortedPagingIterator<>(ORDERING, true);
+        SortedPagingIterator<Void, Row> pagingIterator = new SortedPagingIterator<>(ORDERING, true);
         pagingIterator.merge(numberedBuckets(Arrays.<Bucket>asList(
                 new ArrayBucket(new Object[][]{
                         new Object[]{"a"},
@@ -139,16 +139,13 @@ public class SortedPagingIteratorTest extends CrateUnitTest {
         assertThat(rows, is(replayedRows));
     }
 
-    private Iterable<? extends NumberedIterable<Row>> numberedBuckets(List<Bucket> buckets) {
-        return Iterables.transform(buckets, new Function<Bucket, NumberedIterable<Row>>() {
-
-            int number = -1;
+    private Iterable<? extends KeyIterable<Void, Row>> numberedBuckets(List<Bucket> buckets) {
+        return Iterables.transform(buckets, new Function<Bucket, KeyIterable<Void, Row>>() {
 
             @Nullable
             @Override
-            public NumberedIterable<Row> apply(Bucket input) {
-                number++;
-                return new NumberedIterable<>(number, input);
+            public KeyIterable<Void, Row> apply(Bucket input) {
+                return new KeyIterable<>(null, input);
             }
         });
     }

--- a/sql/src/test/java/io/crate/planner/PlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/PlannerTest.java
@@ -2055,7 +2055,8 @@ public class PlannerTest extends CrateUnitTest {
     @Test
     public void testShardQueueSizeCalculation() throws Exception {
         CollectAndMerge plan = plan("select name from users order by name limit 100");
-        int shardQueueSize = ((RoutedCollectPhase) plan.collectPhase()).shardQueueSize(plan.collectPhase().executionNodes().iterator().next());
+        int shardQueueSize = ((RoutedCollectPhase) plan.collectPhase()).shardQueueSize(
+                plan.collectPhase().executionNodes().iterator().next());
         assertThat(shardQueueSize, is(75));
     }
 


### PR DESCRIPTION
The internal paging logic was broken for queries on partitioned tables.

There is a PagingIterator which is backed by multiple iterators and
keeps track which of them got exhausted.

The problem was that only the integer part of the ShardId was used to
track which backing iterator is exhausted.

If a partitioned table is queried this id isn't unique since there are
multiple indices which all can have the same shardids.

For example in the following case:

    2 Collectors for ShardId(index1, 0) and ShardId(index2, 0)

    ShardId(index1, 0) becoming exhausted.

    getCollector for 0
    -> returns Collector for ShardId(index2, 0) instead of index1

This would cause an endless-recursion until a StackOverflow got raised.