### PR TITLE
Be more lenient on GeoPoint conversion

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,10 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Conversion from (double) arrays to geo_point is now more lenient and allows
+   integer values inside the array. This was done since some encoders tend to
+   convert float/double values to integers.
+
  - Added support for the ``unnest`` table function
 
  - Implemented cluster check for installed java version 

--- a/core/src/main/java/io/crate/types/GeoPointType.java
+++ b/core/src/main/java/io/crate/types/GeoPointType.java
@@ -32,7 +32,6 @@ import org.elasticsearch.common.lucene.BytesRefs;
 
 import java.io.IOException;
 import java.text.ParseException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
@@ -64,6 +63,11 @@ public class GeoPointType extends DataType<Double[]> implements Streamer<Double[
         if (value == null) {
             return null;
         }
+        if (value instanceof Double[]) {
+            Double[] doubles = (Double[]) value;
+            checkLengthIs2(doubles.length);
+            return doubles;
+        }
         if (value instanceof BytesRef) {
             return pointFromString(BytesRefs.toString(value));
         }
@@ -72,14 +76,19 @@ public class GeoPointType extends DataType<Double[]> implements Streamer<Double[
         }
         if (value instanceof List)  {
             List values = (List) value;
-            Preconditions.checkArgument(values.size() == 2,
-                    "The value of a GeoPoint must be a double array with 2 items, not %s", values.size());
+            checkLengthIs2(values.size());
             return new Double[] { (Double) values.get(0), (Double) values.get(1) };
         }
         Object[] values = (Object[])value;
-        Preconditions.checkArgument(values.length == 2,
-                "The value of a GeoPoint must be a double array with 2 items, not %s", values.length);
-        return Arrays.copyOf(values, 2, Double[].class);
+        checkLengthIs2(values.length);
+        return new Double[]{
+                ((Number) values[0]).doubleValue(),
+                ((Number) values[1]).doubleValue()};
+    }
+
+    private static void checkLengthIs2(int actualLength) {
+        Preconditions.checkArgument(actualLength == 2,
+                "The value of a GeoPoint must be a double array with 2 items, not %s", actualLength);
     }
 
     private static Double[] pointFromString(String value) {

--- a/core/src/test/java/io/crate/types/GeoPointTypeTest.java
+++ b/core/src/test/java/io/crate/types/GeoPointTypeTest.java
@@ -60,4 +60,18 @@ public class GeoPointTypeTest extends CrateUnitTest {
         assertThat(value[0], is(10.0d));
         assertThat(value[1], is(20.2d));
     }
+
+    @Test
+    public void testConversionFromObjectArrayOfIntegers() throws Exception {
+        Double[] value = DataTypes.GEO_POINT.value(new Object[] { 1, 2 });
+        assertThat(value[0], is(1.0));
+        assertThat(value[1], is(2.0));
+    }
+
+    @Test
+    public void testConversionFromIntegerArray() throws Exception {
+        Double[] value = DataTypes.GEO_POINT.value(new Integer[] { 1, 2 });
+        assertThat(value[0], is(1.0));
+        assertThat(value[1], is(2.0));
+    }
 }


### PR DESCRIPTION
Fixes the issue raised here: https://github.com/crate/crate/issues/3131

Seems like encoders in certain languages convert double / float values
to integer if there is no precision loss (2.0 -> 2)