### PR TITLE
fix NPE on invalid blob digest

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed a NPE that occurred if a invalid formatted digest was used to request
+   a blob.
+
  - The ``COPY FROM`` statement now also accepts an array of strings as URI.
 
  - Added support for schemes supported by the used JVM's `URL` implementation

--- a/blob/src/main/java/io/crate/http/netty/HttpBlobHandler.java
+++ b/blob/src/main/java/io/crate/http/netty/HttpBlobHandler.java
@@ -120,8 +120,8 @@ public class HttpBlobHandler extends SimpleChannelUpstreamHandler implements
 
             Matcher matcher = blobsMatcher.reset(uri);
             if (!matcher.matches()) {
-                reset();
                 simpleResponse(HttpResponseStatus.NOT_FOUND);
+                reset();
                 return;
             }
 

--- a/blob/src/test/java/io/crate/integrationtests/BlobHttpIntegrationTest.java
+++ b/blob/src/test/java/io/crate/integrationtests/BlobHttpIntegrationTest.java
@@ -29,7 +29,6 @@ import io.crate.plugin.CrateCorePlugin;
 import io.crate.rest.CrateRestFilter;
 import io.crate.test.utils.Blobs;
 import org.apache.http.Header;
-import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.methods.*;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.entity.StringEntity;

--- a/blob/src/test/java/io/crate/integrationtests/BlobIntegrationTest.java
+++ b/blob/src/test/java/io/crate/integrationtests/BlobIntegrationTest.java
@@ -7,7 +7,6 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.util.EntityUtils;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
@@ -19,7 +18,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.net.Socket;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -274,6 +272,12 @@ public class BlobIntegrationTest extends BlobHttpIntegrationTest {
         res = put(blobUri("da39a3ee5e6b4b0d3255bfef95601890afd80709"), "");
         assertEquals(res.getStatusLine().getStatusCode(), 409);
         assertEquals(res.getStatusLine().getReasonPhrase(), "Conflict");
+    }
+
+    @Test
+    public void testGetInvalidDigest() throws Exception {
+        CloseableHttpResponse resp = get(blobUri("invlaid"));
+        assertThat(resp.getStatusLine().getStatusCode(), is(404));
     }
 
     @Test


### PR DESCRIPTION
simpleResponse uses the currentMessage to determine if the connection
should be kept alive. `reset()` sets the currentMessage to null which
resulted in a NPE.