### PR TITLE
update groovy from 2.4.0 to 2.4.4

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Upgraded the included groovy dependency from 2.4.0 to 2.4.4 for security
+   fixes
+
  - Added a ``node_filters`` option to ``COPY FROM``
 
  - Add support for ``COPY FROM`` to ``EXPLAIN``

--- a/es/build.gradle
+++ b/es/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     compile 'net.java.dev.jna:jna:4.1.0'
     compile 'org.antlr:antlr-runtime:3.5'
     compile 'org.apache.commons:commons-lang3:3.3.2'
-    compile 'org.codehaus.groovy:groovy-all:2.4.0'
+    compile 'org.codehaus.groovy:groovy-all:2.4.4'
     compile 'org.joda:joda-convert:1.2'
     compile 'org.ow2.asm:asm-commons:4.1'
     compile 'org.ow2.asm:asm:4.1'


### PR DESCRIPTION
2.4.0 has known security issues. See
http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-3253

es/upstream already contains 2.4.4