### PR TITLE
testing: set minNumDataNodes to 2 in TransportSQLActionTest and SysCheckerIT

### DIFF
--- a/sql/src/test/java/io/crate/integrationtests/SysCheckerIntegrtionTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysCheckerIntegrtionTest.java
@@ -24,12 +24,14 @@ package io.crate.integrationtests;
 import io.crate.action.sql.SQLResponse;
 import io.crate.operation.reference.sys.check.checks.SysCheck.Severity;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.After;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
+@ESIntegTestCase.ClusterScope(minNumDataNodes = 2)
 public class SysCheckerIntegrtionTest extends SQLTransportIntegrationTest {
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -41,6 +41,7 @@ import org.elasticsearch.common.io.stream.NotSerializableExceptionWrapper;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.test.ESIntegTestCase;
 import org.hamcrest.Matchers;
 import org.junit.Rule;
 import org.junit.Test;
@@ -56,6 +57,7 @@ import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.Is.is;
 
+@ESIntegTestCase.ClusterScope(minNumDataNodes = 2)
 public class TransportSQLActionTest extends SQLTransportIntegrationTest {
 
     private Setup setup = new Setup(sqlExecutor);


### PR DESCRIPTION
the default changed from 2 to 1 in the test base classes. This caused
`testMinimumMasterNodesCheckSetNotCorrectNumberOfMasterNodes` and
`testTwoSubStrOnSameColumn` to become flaky since they depend on at
least 2 nodes to pass.