### PR TITLE
remove unused methods from ArrayComparison

### DIFF
--- a/sql-parser/src/main/java/io/crate/sql/tree/ArrayComparison.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/ArrayComparison.java
@@ -23,15 +23,10 @@ package io.crate.sql.tree;
 
 public interface ArrayComparison {
 
-    public enum Quantifier {
+    enum Quantifier {
         ANY,
         ALL
     }
 
-    public Quantifier quantifier();
-
-    public Expression left();
-
-    public Expression right();
-
+    Quantifier quantifier();
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/ArrayComparisonExpression.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/ArrayComparisonExpression.java
@@ -21,29 +21,34 @@
 
 package io.crate.sql.tree;
 
+/**
+ * <pre>
+ *      expression cmpOp quantifier ( arrayExpression )
+ * </pre>
+ *
+ * E.g.
+ * <pre>
+ *      x = ANY ([1, 2, 3])
+ * </pre>
+ *
+ * Use {@link #getLeft()} to access expression.
+ * Use {@link #getRight()} to access arrayExpression
+ */
 public class ArrayComparisonExpression extends ComparisonExpression implements ArrayComparison {
 
     private final Quantifier quantifier;
 
-    public ArrayComparisonExpression(Type type, Quantifier quantifier,
-                                     Expression left, Expression right) {
-        super(type, left, right);
+    public ArrayComparisonExpression(Type type,
+                                     Quantifier quantifier,
+                                     Expression expression,
+                                     Expression arrayExpression) {
+        super(type, expression, arrayExpression);
         this.quantifier = quantifier;
     }
 
     @Override
     public Quantifier quantifier() {
         return quantifier;
-    }
-
-    @Override
-    public Expression left() {
-        return getLeft();
-    }
-
-    @Override
-    public Expression right() {
-        return getRight();
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/ArrayLikePredicate.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/ArrayLikePredicate.java
@@ -39,33 +39,23 @@ public class ArrayLikePredicate extends LikePredicate implements ArrayComparison
     /**
      *
      * @param quantifier quantifier of comparison operation
-     * @param value array/set expression to apply the like operation on
+     * @param arrayExpression array/set expression to apply the like operation on
      * @param pattern the like pattern used
      * @param escape the escape value
      * @param inverse if true, inverse the operation for every single comparison
      */
     public ArrayLikePredicate(Quantifier quantifier,
-                              Expression value,
+                              Expression arrayExpression,
                               Expression pattern,
                               Expression escape,
                               boolean inverse) {
-        super(pattern, value, escape);
+        super(pattern, arrayExpression, escape);
         this.quantifier = quantifier;
         this.inverse = inverse;
     }
 
     public Quantifier quantifier() {
         return quantifier;
-    }
-
-    @Override
-    public Expression left() {
-        return getPattern();
-    }
-
-    @Override
-    public Expression right() {
-        return getValue();
     }
 
     public boolean inverse() {

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -517,13 +517,13 @@ public class ExpressionAnalyzer {
                 throw new UnsupportedFeatureException("ALL is not supported");
             }
 
-            Symbol rightSymbol = process(node.getRight(), context);
+            Symbol arraySymbol = process(node.getRight(), context);
             Symbol leftSymbol = process(node.getLeft(), context);
-            DataType rightType = rightSymbol.valueType();
+            DataType rightType = arraySymbol.valueType();
 
             if (!DataTypes.isCollectionType(rightType)) {
                 throw new IllegalArgumentException(
-                        SymbolFormatter.format("invalid array expression: '%s'", rightSymbol));
+                        SymbolFormatter.format("invalid array expression: '%s'", arraySymbol));
             }
             DataType rightInnerType = ((CollectionType) rightType).innerType();
             if (rightInnerType.equals(DataTypes.OBJECT)) {
@@ -533,8 +533,8 @@ public class ExpressionAnalyzer {
             // always try to convert literal to reference type
             if (!rightInnerType.equals(leftSymbol.valueType())) {
                 if (rightInnerType.isConvertableTo(leftSymbol.valueType())) {
-                    if (rightSymbol.symbolType().isValueSymbol()) {
-                        rightSymbol = Literal.convert(rightSymbol, new ArrayType(leftSymbol.valueType()));
+                    if (arraySymbol.symbolType().isValueSymbol()) {
+                        arraySymbol = Literal.convert(arraySymbol, new ArrayType(leftSymbol.valueType()));
                     } else {
                         leftSymbol = normalizeInputForType(leftSymbol, rightInnerType);
                     }
@@ -548,9 +548,9 @@ public class ExpressionAnalyzer {
             ComparisonExpression.Type operationType = node.getType();
             String operatorName;
             operatorName = AnyOperator.OPERATOR_PREFIX + operationType.getValue();
-            FunctionIdent functionIdent = new FunctionIdent(operatorName, Arrays.asList(leftSymbol.valueType(), rightSymbol.valueType()));
+            FunctionIdent functionIdent = new FunctionIdent(operatorName, Arrays.asList(leftSymbol.valueType(), arraySymbol.valueType()));
             FunctionInfo functionInfo = getFunctionInfo(functionIdent);
-            return context.allocateFunction(functionInfo, Arrays.asList(leftSymbol, rightSymbol));
+            return context.allocateFunction(functionInfo, Arrays.asList(leftSymbol, arraySymbol));
         }
 
         @Override


### PR DESCRIPTION
left/right aren't used. The getLeft/getRight methods from the
ComparisonExpression class are used instead.