### PR TITLE
Make object equality more lenient

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Made equality operator for ``object`` types work correctly for different
+   inner numeric values.
+
  - Fix: Querying system tables could fail if connected to a client
    node and cluster contains another client node.
 

--- a/core/src/main/java/io/crate/core/collections/MapComparator.java
+++ b/core/src/main/java/io/crate/core/collections/MapComparator.java
@@ -22,6 +22,8 @@
 package io.crate.core.collections;
 
 import com.google.common.base.Preconditions;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
 
 import java.util.Comparator;
 import java.util.Map;
@@ -39,11 +41,22 @@ public class MapComparator implements Comparator<Map> {
     public static <K, V> int compareMaps(Map<K, V> m1, Map<K, V> m2) {
         Preconditions.checkNotNull(m1, "map is null");
         Preconditions.checkNotNull(m2, "map is null");
-        int sizeCompare = Integer.valueOf(m1.size()).compareTo(m2.size());
+        int sizeCompare = Integer.compare(m1.size(), m2.size());
         if (sizeCompare != 0)
             return sizeCompare;
+
         for (Map.Entry<K, V> entry : m1.entrySet()) {
-            if (!entry.getValue().equals(m2.get(entry.getKey()))) {
+            V thisValue = entry.getValue();
+            V otherValue = m2.get(entry.getKey());
+            if (!thisValue.equals(otherValue)) {
+                if (!thisValue.getClass().equals(otherValue.getClass())) {
+                    DataType leftType = DataTypes.guessType(thisValue);
+                    int cmp = leftType.compareValueTo(thisValue, leftType.value(otherValue));
+                    if (cmp == 0) {
+                        continue;
+                    }
+                    return cmp;
+                }
                 return 1;
             }
         }

--- a/sql/src/test/java/io/crate/integrationtests/LuceneQueryBuilderIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/LuceneQueryBuilderIntegrationTest.java
@@ -135,4 +135,15 @@ public class LuceneQueryBuilderIntegrationTest extends SQLTransportIntegrationTe
         assertThat(response.rowCount(), is(1L));
 
     }
+
+    @Test
+    public void testObjectEq() throws Exception {
+        execute("create table t (o object as (x int, y long))");
+        ensureYellow();
+
+        execute("insert into t (o) values ({x=10, y=20})");
+        execute("refresh table t");
+
+        assertThat(execute("select * from t where o = {x=10, y=20}").rowCount(), is(1L));
+    }
 }


### PR DESCRIPTION
The EQ operator implementation for objects was too strict. Comparing
{x=4} with {x=4} would return false if one 4 was of type Long and the
other of type Integer.

This could happen in the following example because the SQL Parser only
generates Longs and never Integers:

    create table t (o object as (x int, y long));
    insert into t (o) values ({x=10, y=20});
    select * from t where o = {x=10, y=20};