### PR TITLE
remove timestamp type guessing

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Removed timestamp type guessing within objects and within the PARTITION
+   clause of the RESTORE SNAPSHOT statement.
+
  - Made equality operator for ``object`` types work correctly for different
    inner numeric values.
 

--- a/core/src/test/java/io/crate/DataTypeTest.java
+++ b/core/src/test/java/io/crate/DataTypeTest.java
@@ -80,8 +80,8 @@ public class DataTypeTest extends CrateUnitTest {
     @Test
     public void testForValueWithTimestampArrayAsString() {
         String[] strings = {"2013-09-10T21:51:43", "2013-11-10T21:51:43"};
-        DataType dataType = DataTypes.guessType(strings, false);
-        assertEquals(dataType, new ArrayType(DataTypes.TIMESTAMP));
+        DataType dataType = DataTypes.guessType(strings);
+        assertEquals(dataType, new ArrayType(DataTypes.STRING));
     }
 
     @Test

--- a/sql/src/main/java/io/crate/analyze/ParameterContext.java
+++ b/sql/src/main/java/io/crate/analyze/ParameterContext.java
@@ -81,7 +81,7 @@ public class ParameterContext {
     }
 
     private static DataType guessTypeSafe(Object value) throws IllegalArgumentException {
-        DataType guessedType = DataTypes.guessType(value, true);
+        DataType guessedType = DataTypes.guessType(value);
         if (guessedType == null) {
             throw new IllegalArgumentException(String.format(Locale.ENGLISH,
                     "Got an argument \"%s\" that couldn't be recognized", value));

--- a/sql/src/main/java/io/crate/analyze/PartitionPropertiesAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/PartitionPropertiesAnalyzer.java
@@ -30,7 +30,6 @@ import io.crate.metadata.ReferenceInfo;
 import io.crate.metadata.TableIdent;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.sql.tree.Assignment;
-import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.apache.lucene.util.BytesRef;
 
@@ -93,10 +92,8 @@ public class PartitionPropertiesAnalyzer {
         BytesRef[] values = new BytesRef[properties.size()];
 
         int idx = 0;
-        for (Map.Entry<ColumnIdent, Object> entry : properties.entrySet()) {
-            DataType guessedType = DataTypes.guessType(entry.getValue(), false);
-            Object value = guessedType.value(entry.getValue());
-            values[idx++] = DataTypes.STRING.value(value);
+        for (Object o : properties.values()) {
+            values[idx++] = DataTypes.STRING.value(o);
         }
         return new PartitionName(tableIdent, Arrays.asList(values));
     }

--- a/sql/src/main/java/io/crate/analyze/expressions/ValueNormalizer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ValueNormalizer.java
@@ -147,7 +147,7 @@ public class ValueNormalizer {
                 if (dynamicReference == null) {
                     throw new ColumnUnknownException(nestedIdent.sqlFqn());
                 }
-                DataType type = DataTypes.guessType(entry.getValue(), false);
+                DataType type = DataTypes.guessType(entry.getValue());
                 if (type == null) {
                     throw new ColumnValidationException(info.ident().columnIdent().sqlFqn(), "Invalid value");
                 }

--- a/sql/src/test/java/io/crate/analyze/ValueNormalizerTest.java
+++ b/sql/src/test/java/io/crate/analyze/ValueNormalizerTest.java
@@ -193,7 +193,7 @@ public class ValueNormalizerTest extends CrateUnitTest {
         map.put("false", true);
         Literal<Map<String, Object>> normalized = (Literal)valueNormalizer.normalizeInputForReference(
                 Literal.newLiteral(map), new Reference(objInfo));
-        assertThat((Long) normalized.value().get("time"), is(1392508801000l));
+        assertThat((String) normalized.value().get("time"), is("2014-02-16T00:00:01"));
         assertThat((Boolean)normalized.value().get("false"), is(true));
     }
 
@@ -297,7 +297,7 @@ public class ValueNormalizerTest extends CrateUnitTest {
         Literal<Map<String, Object>> literal = (Literal)valueNormalizer.normalizeInputForReference(
                 Literal.newLiteral(map),
                 new Reference(objInfo));
-        assertThat((Long) literal.value().get("time"), is(0l));
+        assertThat((String) literal.value().get("time"), is("1970-01-01T00:00:00"));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
@@ -311,7 +311,7 @@ public class SQLTypeMappingTest extends SQLTransportIntegrationTest {
         SQLResponse response = execute("select id, new_col from t1 where id=0");
         @SuppressWarnings("unchecked")
         Map<String, Object> mapped = (Map<String, Object>)response.rows()[0][1];
-        assertEquals(0, mapped.get("a_date"));
+        assertEquals("1970-01-01", mapped.get("a_date"));
         assertEquals(127, mapped.get("an_int"));
         assertEquals(0x7fffffffffffffffL, mapped.get("a_long"));
         assertEquals(true, mapped.get("a_boolean"));
@@ -333,7 +333,7 @@ public class SQLTypeMappingTest extends SQLTransportIntegrationTest {
         Map<String, Object> selectedObject = (Map<String, Object>)response.rows()[0][0];
 
         assertThat((String)selectedObject.get("new_col"), is("a string"));
-        assertEquals(0, selectedObject.get("another_new_col"));
+        assertEquals("1970-01-01T00:00:00", selectedObject.get("another_new_col"));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
@@ -301,7 +301,7 @@ public class SnapshotRestoreIntegrationTest extends SQLTransportIntegrationTest 
 
         execute("drop table my_parted_table");
         waitNoPendingTasksOnAll();
-        execute("RESTORE SNAPSHOT " + snapshotName() + " TABLE my_parted_table PARTITION (date='1970-01-01') with (" +
+        execute("RESTORE SNAPSHOT " + snapshotName() + " TABLE my_parted_table PARTITION (date=0) with (" +
                 "ignore_unavailable=false, " +
                 "wait_for_completion=true)");
 


### PR DESCRIPTION
Type recognition for timestamps was removed in
https://github.com/crate/crate/pull/3061 because of the issue reported
here https://github.com/crate/crate/issues/3042

But it was only removed for top level columns and the issue is still
present for object columns.

This commit fixes that and removes it completely.