### PR TITLE
Extend ByteSizeSetting to have common used attributes

### DIFF
--- a/sql/src/main/java/io/crate/metadata/settings/ByteSizeSetting.java
+++ b/sql/src/main/java/io/crate/metadata/settings/ByteSizeSetting.java
@@ -26,7 +26,30 @@ import io.crate.types.DataTypes;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 
-public abstract class ByteSizeSetting extends Setting<ByteSizeValue, String> {
+import javax.annotation.Nullable;
+
+public class ByteSizeSetting extends Setting<ByteSizeValue, String> {
+
+    private final String name;
+    private final ByteSizeValue defaultValue;
+    private final boolean isRuntime;
+    private final Setting<?, ?> parent;
+
+    public ByteSizeSetting(String name, ByteSizeValue defaultValue, boolean isRuntime) {
+        this(name, defaultValue, isRuntime, null);
+    }
+
+    public ByteSizeSetting(String name, ByteSizeValue defaultValue, boolean isRuntime, @Nullable  Setting<?, ?> parent) {
+        this.name = name;
+        this.defaultValue = defaultValue;
+        this.isRuntime = isRuntime;
+        this.parent = parent;
+    }
+
+    @Override
+    public Setting parent() {
+        return parent;
+    }
 
     public long maxValue() {
         return Long.MAX_VALUE;
@@ -42,8 +65,23 @@ public abstract class ByteSizeSetting extends Setting<ByteSizeValue, String> {
     }
 
     @Override
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public ByteSizeValue defaultValue() {
+        return defaultValue;
+    }
+
+    @Override
     public String extract(Settings settings) {
         return extractByteSizeValue(settings).toString();
+    }
+
+    @Override
+    public boolean isRuntime() {
+        return isRuntime;
     }
 
     public Long extractBytes(Settings settings) {

--- a/sql/src/main/java/io/crate/metadata/settings/CrateSettings.java
+++ b/sql/src/main/java/io/crate/metadata/settings/CrateSettings.java
@@ -856,23 +856,9 @@ public class CrateSettings {
         }
     };
 
-    public static final ByteSizeSetting INDICES_RECOVERY_FILE_CHUNK_SIZE = new ByteSizeSetting() {
-        @Override
-        public String name() { return "file_chunk_size"; }
+    public static final ByteSizeSetting INDICES_RECOVERY_FILE_CHUNK_SIZE = new ByteSizeSetting(
+            "file_chunk_size", new ByteSizeValue(512, ByteSizeUnit.KB), true, INDICES_RECOVERY);
 
-        @Override
-        public ByteSizeValue defaultValue() { return new ByteSizeValue(512, ByteSizeUnit.KB); }
-
-        @Override
-        public Setting parent() {
-            return INDICES_RECOVERY;
-        }
-
-        @Override
-        public boolean isRuntime() {
-            return true;
-        }
-    };
 
     public static final IntSetting INDICES_RECOVERY_TRANSLOG_OPS = new IntSetting("translog_ops", 1000, true) {
         @Override
@@ -881,23 +867,9 @@ public class CrateSettings {
         }
     };
 
-    public static final ByteSizeSetting INDICES_RECOVERY_TRANSLOG_SIZE = new ByteSizeSetting() {
-        @Override
-        public String name() { return "translog_size"; }
+    public static final ByteSizeSetting INDICES_RECOVERY_TRANSLOG_SIZE = new ByteSizeSetting(
+            "translog_size", new ByteSizeValue(512, ByteSizeUnit.KB), true, INDICES_RECOVERY);
 
-        @Override
-        public ByteSizeValue defaultValue() { return new ByteSizeValue(512, ByteSizeUnit.KB); }
-
-        @Override
-        public Setting parent() {
-            return INDICES_RECOVERY;
-        }
-
-        @Override
-        public boolean isRuntime() {
-            return true;
-        }
-    };
 
     public static final BoolSetting INDICES_RECOVERY_COMPRESS = new BoolSetting("compress", true, true) {
 
@@ -907,23 +879,8 @@ public class CrateSettings {
         }
     };
 
-    public static final ByteSizeSetting INDICES_RECOVERY_MAX_BYTES_PER_SEC = new ByteSizeSetting() {
-        @Override
-        public String name() { return "max_bytes_per_sec"; }
-
-        @Override
-        public ByteSizeValue defaultValue() { return new ByteSizeValue(40, ByteSizeUnit.MB); }
-
-        @Override
-        public Setting parent() {
-            return INDICES_RECOVERY;
-        }
-
-        @Override
-        public boolean isRuntime() {
-            return true;
-        }
-    };
+    public static final ByteSizeSetting INDICES_RECOVERY_MAX_BYTES_PER_SEC = new ByteSizeSetting(
+            "max_bytes_per_sec", new ByteSizeValue(40, ByteSizeUnit.MB), true, INDICES_RECOVERY);
 
     public static final TimeSetting INDICES_RECOVERY_RETRY_DELAY_STATE_SYNC = new TimeSetting() {
         @Override
@@ -1076,23 +1033,8 @@ public class CrateSettings {
         }
     };
 
-    public static final ByteSizeSetting INDICES_STORE_THROTTLE_MAX_BYTES_PER_SEC = new ByteSizeSetting() {
-        @Override
-        public String name() { return "max_bytes_per_sec"; }
-
-        @Override
-        public ByteSizeValue defaultValue() { return new ByteSizeValue(20, ByteSizeUnit.MB); }
-
-        @Override
-        public Setting parent() {
-            return INDICES_STORE_THROTTLE;
-        }
-
-        @Override
-        public boolean isRuntime() {
-            return true;
-        }
-    };
+    public static final ByteSizeSetting INDICES_STORE_THROTTLE_MAX_BYTES_PER_SEC = new ByteSizeSetting(
+            "max_bytes_per_sec", new ByteSizeValue(20, ByteSizeUnit.MB), true, INDICES_STORE_THROTTLE);
 
     public static final NestedSetting INDICES_FIELDDATA = new NestedSetting() {
         @Override

--- a/sql/src/main/java/io/crate/metadata/settings/CrateTableSettings.java
+++ b/sql/src/main/java/io/crate/metadata/settings/CrateTableSettings.java
@@ -91,22 +91,8 @@ public class CrateTableSettings {
     };
 
 
-    public static final ByteSizeSetting FLUSH_THRESHOLD_SIZE = new ByteSizeSetting() {
-        @Override
-        public String name() {
-            return TableParameterInfo.FLUSH_THRESHOLD_SIZE;
-        }
-
-        @Override
-        public ByteSizeValue defaultValue() {
-            return new ByteSizeValue(200, ByteSizeUnit.MB);
-        }
-
-        @Override
-        public boolean isRuntime() {
-            return true;
-        }
-    };
+    public static final ByteSizeSetting FLUSH_THRESHOLD_SIZE = new ByteSizeSetting(
+            TableParameterInfo.FLUSH_THRESHOLD_SIZE, new ByteSizeValue(200, ByteSizeUnit.MB), true);
 
     public static final IntSetting FLUSH_THRESHOLD_OPS = new IntSetting(TableParameterInfo.FLUSH_THRESHOLD_OPS, Integer.MAX_VALUE, true);
 


### PR DESCRIPTION
Avoids having to subclass ByteSizeSetting all the time.