### PR TITLE
fixed JVM syscheck that leads to invalid java version

### DIFF
--- a/sql/src/main/java/io/crate/operation/reference/sys/check/checks/JvmVersionSysCheck.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/check/checks/JvmVersionSysCheck.java
@@ -52,11 +52,13 @@ public class JvmVersionSysCheck extends AbstractSysCheck {
         try {
             final StringTokenizer st = new StringTokenizer(javaVersion, "_");
             String javaSpecVersion = st.nextToken();
-            javaUpdate = Integer.parseInt(st.nextToken());
 
-            final StringTokenizer st2 = new StringTokenizer(javaSpecVersion, ".");
-            st2.nextToken();
-            javaMajorVersion = Integer.parseInt(st2.nextToken());
+            final StringTokenizer st2 = new StringTokenizer(st.nextToken(), "-");
+            javaUpdate = Integer.parseInt(st2.nextToken());
+
+            final StringTokenizer st3 = new StringTokenizer(javaSpecVersion, ".");
+            st3.nextToken();
+            javaMajorVersion = Integer.parseInt(st3.nextToken());
         } catch (Exception ex) {
             return false;
         }

--- a/sql/src/test/java/io/crate/operation/reference/sys/check/checks/SysChecksTest.java
+++ b/sql/src/test/java/io/crate/operation/reference/sys/check/checks/SysChecksTest.java
@@ -224,6 +224,7 @@ public class SysChecksTest extends CrateUnitTest {
         assertThat(jvmVersionSysCheck.validateJavaVersion("1.7.0_10"), is(false));
         assertThat(jvmVersionSysCheck.validateJavaVersion("1.8.0_11"), is(false));
         assertThat(jvmVersionSysCheck.validateJavaVersion("1.8.0_54"), is(true));
+        assertThat(jvmVersionSysCheck.validateJavaVersion("1.8.0_72-internal"), is(true));
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
` - Implemented cluster check for installed java version`
Unreleased feature - no changelog update necessary.