### PR TITLE
remove duplicate code in ExpressionAnalyzer

### DIFF
--- a/sql/src/main/java/io/crate/analyze/symbol/Literal.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/Literal.java
@@ -4,7 +4,10 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.FluentIterable;
 import io.crate.exceptions.ConversionException;
 import io.crate.operation.Input;
-import io.crate.types.*;
+import io.crate.types.ArrayType;
+import io.crate.types.CollectionType;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -31,19 +34,6 @@ public class Literal<ReturnType>
             return new Literal();
         }
     };
-
-    public static Literal implodeCollection(DataType itemType, Set<Literal> literals) {
-        Set<Object> set = new HashSet<>(literals.size(), 1.0F);
-        for (Literal literal : literals) {
-            assert literal.valueType() == itemType : typeMismatchMsg(itemType, literal);
-            set.add(literal.value());
-        }
-        return new Literal<>(new SetType(itemType), Collections.unmodifiableSet(set));
-    }
-
-    private static String typeMismatchMsg(DataType itemType, Literal literal) {
-        return String.format(Locale.ENGLISH, "Literal type: %s does not match item type: %s", literal.valueType(), itemType);
-    }
 
     public static Collection<Literal> explodeCollection(Literal collectionLiteral) {
         Preconditions.checkArgument(DataTypes.isCollectionType(collectionLiteral.valueType()));

--- a/sql/src/main/java/io/crate/exceptions/ConversionException.java
+++ b/sql/src/main/java/io/crate/exceptions/ConversionException.java
@@ -30,7 +30,7 @@ import java.util.Locale;
 
 public class ConversionException extends RuntimeException {
 
-    private static String ERROR_MESSAGE = "cannot cast %s to type %s";
+    private final static String ERROR_MESSAGE = "cannot cast %s to type %s";
 
     private String message;
 

--- a/sql/src/main/java/io/crate/operation/operator/EqOperator.java
+++ b/sql/src/main/java/io/crate/operation/operator/EqOperator.java
@@ -22,6 +22,7 @@
 package io.crate.operation.operator;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import io.crate.analyze.symbol.Function;
 import io.crate.core.collections.MapComparator;
 import io.crate.metadata.DynamicFunctionResolver;
@@ -44,6 +45,14 @@ public class EqOperator extends CmpOperator {
 
     public static void register(OperatorModule module) {
         module.registerDynamicOperatorFunction(NAME, dynamicResolver);
+    }
+
+    public static FunctionInfo createInfo(DataType targetType) {
+        return createInfo(ImmutableList.of(targetType, targetType));
+    }
+
+    private static FunctionInfo createInfo(List<DataType> dataTypes) {
+        return new FunctionInfo(new FunctionIdent(NAME, dataTypes), DataTypes.BOOLEAN);
     }
 
     @Override
@@ -127,7 +136,7 @@ public class EqOperator extends CmpOperator {
             DataType leftType = dataTypes.get(0);
             DataType rightType = dataTypes.get(1);
 
-            FunctionInfo info = new FunctionInfo(new FunctionIdent(NAME, dataTypes), DataTypes.BOOLEAN);
+            FunctionInfo info = createInfo(dataTypes);
             if (DataTypes.isCollectionType(leftType) && DataTypes.isCollectionType(rightType)) {
                 return new ArrayEqOperator(info);
             }

--- a/sql/src/main/java/io/crate/operation/operator/any/AnyEqOperator.java
+++ b/sql/src/main/java/io/crate/operation/operator/any/AnyEqOperator.java
@@ -21,15 +21,24 @@
 
 package io.crate.operation.operator.any;
 
+import com.google.common.collect.ImmutableList;
 import io.crate.analyze.symbol.Function;
+import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionInfo;
 import io.crate.operation.operator.OperatorModule;
 import io.crate.sql.tree.ComparisonExpression;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+import io.crate.types.SetType;
 
 public class AnyEqOperator extends AnyOperator {
 
     public static final String NAME = OPERATOR_PREFIX + ComparisonExpression.Type.EQUAL.getValue();
+
+    public static FunctionInfo createInfo(DataType targetType) {
+        return new FunctionInfo(new FunctionIdent(NAME, ImmutableList.of(targetType, new SetType(targetType))), DataTypes.BOOLEAN);
+    }
 
     static class AnyEqResolver extends AnyResolver {
 

--- a/sql/src/main/java/io/crate/operation/operator/any/AnyOperator.java
+++ b/sql/src/main/java/io/crate/operation/operator/any/AnyOperator.java
@@ -37,6 +37,8 @@ import io.crate.types.DataTypes;
 
 import java.util.*;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 public abstract class AnyOperator extends Operator<Object> {
 
     public static final String OPERATOR_PREFIX = "any_";
@@ -133,11 +135,10 @@ public abstract class AnyOperator extends Operator<Object> {
 
         @Override
         public FunctionImplementation<Function> getForTypes(List<DataType> dataTypes) throws IllegalArgumentException {
-            Preconditions.checkArgument(
-                    dataTypes.size() == 2 &&
-                            DataTypes.isCollectionType(dataTypes.get(1)) &&
-                            ((CollectionType)dataTypes.get(1)).innerType().equals(dataTypes.get(0))
-            );
+            checkArgument(dataTypes.size() == 2, "ANY operator requires exactly 2 arguments");
+            checkArgument(DataTypes.isCollectionType(dataTypes.get(1)), "The second argument to ANY must be an array or set");
+            checkArgument(((CollectionType) dataTypes.get(1)).innerType().equals(dataTypes.get(0)),
+                    "The inner type of the array/set passed to ANY must match its left expression");
             return newInstance(new FunctionInfo(new FunctionIdent(name(), dataTypes), BooleanType.INSTANCE));
         }
     }

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -28,6 +28,7 @@ import io.crate.analyze.relations.QueriedRelation;
 import io.crate.analyze.symbol.*;
 import io.crate.exceptions.AmbiguousColumnAliasException;
 import io.crate.exceptions.ColumnUnknownException;
+import io.crate.exceptions.ConversionException;
 import io.crate.exceptions.UnsupportedFeatureException;
 import io.crate.metadata.*;
 import io.crate.metadata.doc.DocSchemaInfo;
@@ -529,8 +530,10 @@ public class SelectStatementAnalyzerTest extends BaseAnalyzerTest {
         assertTrue(analysis.relation().querySpec().where().noMatch());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testWhereInSelectDifferentDataTypeValueUncompatibleDataTypes() throws Exception {
+        expectedException.expect(ConversionException.class);
+        expectedException.expectMessage("cannot cast 'foo' to type long");
         analyze("select 'found' from users where 1 in (1, 'foo', 2)");
     }
 

--- a/sql/src/test/java/io/crate/analyze/where/WhereClauseAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/where/WhereClauseAnalyzerTest.java
@@ -27,7 +27,6 @@ import io.crate.analyze.*;
 import io.crate.analyze.relations.DocTableRelation;
 import io.crate.analyze.repositories.RepositorySettingsModule;
 import io.crate.core.collections.TreeMapBuilder;
-import io.crate.exceptions.ConversionException;
 import io.crate.metadata.*;
 import io.crate.metadata.doc.DocSchemaInfo;
 import io.crate.metadata.sys.MetaDataSysModule;
@@ -655,8 +654,8 @@ public class WhereClauseAnalyzerTest extends CrateUnitTest {
 
     @Test
     public void testAnyInvalidArrayType() throws Exception {
-        expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("cannot cast ['foo', 'bar', 'baz'] to type boolean_array");
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("['foo', 'bar', 'baz'] cannot be cast to type boolean_array");
         analyzeSelectWhere("select * from users_multi_pk where awesome = any(['foo', 'bar', 'baz'])");
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/AnyIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/AnyIntegrationTest.java
@@ -119,4 +119,14 @@ public class AnyIntegrationTest extends SQLTransportIntegrationTest {
         execute("select * from t where s = ANY ([null])");
         assertThat(response.rowCount(), is(0L));
     }
+
+    @Test
+    public void testArrayReferenceOfDifferentTypeSoThatCastIsRequired() throws Exception {
+        execute("create table t (x array(short))");
+        ensureYellow();
+
+        execute("insert into t (x) values ([1, 2, 3, 4])");
+        execute("refresh table t");
+        execute("select * from t where 4 < ANY (x) ");
+    }
 }

--- a/sql/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
@@ -210,7 +210,7 @@ public class SQLTypeMappingTest extends SQLTransportIntegrationTest {
     @Test
     public void testInvalidWhereInWhereClause() throws Exception {
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("invalid IN LIST value 'a'. expected type 'byte'");
+        expectedException.expectMessage("cannot cast 'a' to type byte");
 
         setUpSimple();
         execute("update t1 set byte_field=0 where byte_field in ('a')");


### PR DESCRIPTION
 - re-use castIfNeededOrFail where possible. (Less code and makes the
   cast error messages more consistent)
 - Avoid to convert Expression into Symbol twice in visitInPredicate
 - Move FunctionInfo creation into Operator classes (They should know
   about their return type, not the ExpressionAnalyzer)