### PR TITLE
Use SettingApplier to validate create repository options

### DIFF
--- a/aws/src/main/java/io/crate/plugin/aws/S3RepositoryAnalysisModule.java
+++ b/aws/src/main/java/io/crate/plugin/aws/S3RepositoryAnalysisModule.java
@@ -22,34 +22,40 @@
 
 package io.crate.plugin.aws;
 
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableMap;
+import io.crate.analyze.SettingsApplier;
+import io.crate.analyze.SettingsAppliers;
 import io.crate.analyze.repositories.TypeSettings;
+import io.crate.metadata.settings.BoolSetting;
+import io.crate.metadata.settings.IntSetting;
+import io.crate.metadata.settings.StringSetting;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.inject.multibindings.MapBinder;
 import org.elasticsearch.common.settings.Settings;
+
+import java.util.Collections;
 
 public class S3RepositoryAnalysisModule extends AbstractModule {
 
     private MapBinder<String, TypeSettings> typeSettingsBinder;
 
     public static final String REPOSITORY_TYPE = "s3";
-    public static final TypeSettings S3_SETTINGS = new TypeSettings(ImmutableSet.<String>of(),
-            ImmutableSet.of(
-                    "access_key",
-                    "base_path",
-                    "bucket",
-                    "buffer_size",
-                    "canned_acl",
-                    "chunk_size",
-                    "compress",
-                    "concurrent_streams",
-                    "endpoint",
-                    "max_retries",
-                    "protocol",
-                    "region",
-                    "secret_key",
-                    "server_side_encryption"
-            ));
+    public static final TypeSettings S3_SETTINGS = new TypeSettings(Collections.<String, SettingsApplier>emptyMap(),
+            ImmutableMap.<String, SettingsApplier>builder()
+                    .put("access_key", new SettingsAppliers.StringSettingsApplier(new StringSetting("access_key", null, true)))
+                    .put("base_path", new SettingsAppliers.StringSettingsApplier(new StringSetting("base_path", null, true)))
+                    .put("bucket", new SettingsAppliers.StringSettingsApplier(new StringSetting("bucket", null, true)))
+                    .put("buffer_size", new SettingsAppliers.IntSettingsApplier(new IntSetting("buffer_size", null, true)))
+                    .put("canned_acl", new SettingsAppliers.StringSettingsApplier(new StringSetting("canned_acl", null, true)))
+                    .put("chunk_size", new SettingsAppliers.IntSettingsApplier(new IntSetting("chunk_size", null, true)))
+                    .put("compress", new SettingsAppliers.BooleanSettingsApplier(new BoolSetting("compress", true, true)))
+                    .put("concurrent_streams", new SettingsAppliers.IntSettingsApplier(new IntSetting("concurrent_streams", null, true)))
+                    .put("endpoint", new SettingsAppliers.StringSettingsApplier(new StringSetting("endpoint", null, true)))
+                    .put("max_retries", new SettingsAppliers.IntSettingsApplier(new IntSetting("max_retries", null, true)))
+                    .put("protocol", new SettingsAppliers.StringSettingsApplier(new StringSetting("protocol", null, true)))
+                    .put("region", new SettingsAppliers.StringSettingsApplier(new StringSetting("region", null, true)))
+                    .put("secret_key", new SettingsAppliers.StringSettingsApplier(new StringSetting("secret_key", null, true)))
+                    .put("server_side_encryption", new SettingsAppliers.BooleanSettingsApplier(new BoolSetting("server_side_encryption", false, true))).build());
 
     private final Settings settings;
 

--- a/aws/src/test/java/io/crate/plugin/aws/s3/S3RepositoryAnalyzerTest.java
+++ b/aws/src/test/java/io/crate/plugin/aws/s3/S3RepositoryAnalyzerTest.java
@@ -52,6 +52,7 @@ import org.mockito.Mock;
 
 import java.util.Map;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -125,7 +126,7 @@ public class S3RepositoryAnalyzerTest extends CrateUnitTest {
                                                              "concurrent_streams=4," +
                                                              "chunk_size=12," +
                                                              "compress=true," +
-                                                             "server_side_encryption='only for pussies'," +
+                                                             "server_side_encryption=false," +
                                                              "buffer_size=128," +
                                                              "max_retries=2," +
                                                              "canned_acl=false)");
@@ -148,7 +149,7 @@ public class S3RepositoryAnalyzerTest extends CrateUnitTest {
                    "protocol:arp," +
                    "region:us-north-42," +
                    "secret_key:0xCAFEE," +
-                   "server_side_encryption:only for pussies"));
+                   "server_side_encryption:false"));
     }
 
     @Test
@@ -156,13 +157,14 @@ public class S3RepositoryAnalyzerTest extends CrateUnitTest {
         CreateRepositoryAnalyzedStatement analysis = analyze("CREATE REPOSITORY foo TYPE s3");
         assertThat(analysis.repositoryName(), is("foo"));
         assertThat(analysis.repositoryType(), is("s3"));
-        assertThat(analysis.settings().getAsMap().isEmpty(), is(true));
+        // two settings are there because those have default values
+        assertThat(analysis.settings().getAsMap().keySet(), containsInAnyOrder("compress", "server_side_encryption"));
     }
 
     @Test
     public void testWrongSettings() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Invalid parameters specified: [wrong]");
+        expectedException.expectMessage("setting 'wrong' not supported");
         analyze("CREATE REPOSITORY foo TYPE s3 WITH (wrong=true)");
 
     }

--- a/sql/src/main/java/io/crate/analyze/CopyStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CopyStatementAnalyzer.java
@@ -63,24 +63,11 @@ public class CopyStatementAnalyzer {
 
     private final AnalysisMetaData analysisMetaData;
 
-    private static final StringSetting COMPRESSION_SETTINGS = new StringSetting("compression", ImmutableSet.of(
-            "gzip"
-    )) {
-        @Override
-        public boolean isRuntime() {
-            return true;
-        }
-    };
+    private static final StringSetting COMPRESSION_SETTINGS =
+            new StringSetting("compression", ImmutableSet.of("gzip"), true);
 
-    private static final StringSetting OUTPUT_FORMAT_SETTINGS = new StringSetting("format", ImmutableSet.of(
-            "json_object",
-            "json_array"
-    )) {
-        @Override
-        public boolean isRuntime() {
-            return true;
-        }
-    };
+    private static final StringSetting OUTPUT_FORMAT_SETTINGS =
+            new StringSetting("format", ImmutableSet.of("json_object", "json_array"), true);
 
     private static final ImmutableMap<String, SettingsApplier> SETTINGS_APPLIERS =
             ImmutableMap.<String, SettingsApplier>builder()

--- a/sql/src/main/java/io/crate/analyze/CreateRepositoryAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateRepositoryAnalyzer.java
@@ -27,7 +27,6 @@ import io.crate.executor.transport.RepositoryService;
 import io.crate.sql.tree.CreateRepository;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
-import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 
 @Singleton
@@ -49,11 +48,8 @@ public class CreateRepositoryAnalyzer extends AbstractRepositoryDDLAnalyzer {
             throw new RepositoryAlreadyExistsException(repositoryName);
         }
 
-        Settings settings = ImmutableSettings.EMPTY;
-        if (node.properties().isPresent()) {
-            settings = GenericPropertiesConverter.genericPropertiesToSettings(node.properties().get(), context.parameterContext());
-        }
-        repositoryParamValidator.validate(node.type(), settings);
+        Settings settings = repositoryParamValidator.convertAndValidate(
+                node.type(), node.properties(), context.parameterContext());
         return new CreateRepositoryAnalyzedStatement(repositoryName, node.type(), settings);
     }
 }

--- a/sql/src/main/java/io/crate/analyze/SettingsAppliers.java
+++ b/sql/src/main/java/io/crate/analyze/SettingsAppliers.java
@@ -85,7 +85,7 @@ public class SettingsAppliers {
         protected final Setting setting;
 
         public NumberSettingsApplier(Setting setting) {
-            super(setting.settingName(),
+            super(setting.settingName(), setting.defaultValue() == null ? ImmutableSettings.EMPTY :
                     ImmutableSettings.builder().put(setting.settingName(), setting.defaultValue()).build());
             this.setting = setting;
         }
@@ -241,7 +241,7 @@ public class SettingsAppliers {
         private final ByteSizeSetting setting;
 
         public ByteSizeSettingsApplier(ByteSizeSetting setting) {
-            super(setting.settingName(),
+            super(setting.settingName(), setting.defaultValue() == null ? ImmutableSettings.EMPTY :
                     ImmutableSettings.builder().put(setting.settingName(), setting.defaultValue()).build());
             this.setting = setting;
         }
@@ -298,7 +298,7 @@ public class SettingsAppliers {
         private final StringSetting setting;
 
         public StringSettingsApplier(StringSetting setting) {
-            super(setting.settingName(),
+            super(setting.settingName(), setting.defaultValue() == null ? ImmutableSettings.EMPTY :
                     ImmutableSettings.builder().put(setting.settingName(), setting.defaultValue()).build());
             this.setting = setting;
         }

--- a/sql/src/main/java/io/crate/analyze/repositories/RepositoryParamValidator.java
+++ b/sql/src/main/java/io/crate/analyze/repositories/RepositoryParamValidator.java
@@ -23,12 +23,15 @@
 package io.crate.analyze.repositories;
 
 import com.google.common.base.Joiner;
+import com.google.common.base.Optional;
 import com.google.common.collect.Sets;
+import io.crate.analyze.GenericPropertiesConverter;
+import io.crate.analyze.ParameterContext;
+import io.crate.sql.tree.GenericProperties;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.settings.Settings;
 
-import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -42,42 +45,29 @@ public class RepositoryParamValidator {
         typeSettings = repositoryTypeSettings;
     }
 
-    /**
-     * validates the type and settings
-     * @throws IllegalArgumentException if the type is invalid, required settings are missing or invalid settings are provided
-     */
-    public void validate(String type, Settings settings) throws IllegalArgumentException {
+    public Settings convertAndValidate(String type, Optional<GenericProperties> genericProperties, ParameterContext parameterContext) {
         TypeSettings typeSettings = this.typeSettings.get(type);
         if (typeSettings == null) {
             throw new IllegalArgumentException(String.format(Locale.ENGLISH, "Invalid repository type \"%s\"", type));
         }
+
+        genericProperties = typeSettings.preProcess(genericProperties);
+        Settings settings = GenericPropertiesConverter.settingsFromProperties(
+                genericProperties, parameterContext, typeSettings.all()).build();
+
         Set<String> names = settings.getAsMap().keySet();
-        Sets.SetView<String> missingRequiredSettings = Sets.difference(typeSettings.required(), names);
+        Sets.SetView<String> missingRequiredSettings = Sets.difference(typeSettings.required().keySet(), names);
         if (!missingRequiredSettings.isEmpty()) {
             throw new IllegalArgumentException(String.format(Locale.ENGLISH,
                     "The following required parameters are missing to create a repository of type \"%s\": [%s]",
                     type, Joiner.on(", ").join(missingRequiredSettings)));
         }
 
-        Set<String> invalidSettings = removeDynamicHdfsConfSettings(type, Sets.difference(names, typeSettings.all()));
+        Set<String> invalidSettings = Sets.difference(names, typeSettings.all().keySet());
         if (!invalidSettings.isEmpty()) {
             throw new IllegalArgumentException(String.format(Locale.ENGLISH, "Invalid parameters specified: [%s]",
                     Joiner.on(", ").join(invalidSettings)));
         }
-    }
-
-    private Set<String> removeDynamicHdfsConfSettings(String type, Sets.SetView<String> invalidSettings) {
-        // hdfs supports dynamic params conf.<key>
-        // don't want to fail just because of those
-        if (!invalidSettings.isEmpty() && type.equalsIgnoreCase("hdfs")) {
-            Set<String> newSet = new HashSet<>(invalidSettings.size());
-            for (String s : invalidSettings.immutableCopy()) {
-                if (!s.startsWith("conf.")) {
-                    newSet.add(s);
-                }
-            }
-            return newSet;
-        }
-        return invalidSettings;
+        return settings;
     }
 }

--- a/sql/src/main/java/io/crate/analyze/repositories/RepositorySettingsModule.java
+++ b/sql/src/main/java/io/crate/analyze/repositories/RepositorySettingsModule.java
@@ -22,9 +22,22 @@
 
 package io.crate.analyze.repositories;
 
-import com.google.common.collect.ImmutableSet;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
+import io.crate.analyze.SettingsApplier;
+import io.crate.analyze.SettingsAppliers;
+import io.crate.metadata.settings.BoolSetting;
+import io.crate.metadata.settings.ByteSizeSetting;
+import io.crate.metadata.settings.IntSetting;
+import io.crate.metadata.settings.StringSetting;
+import io.crate.sql.tree.Expression;
+import io.crate.sql.tree.GenericProperties;
+import io.crate.sql.tree.GenericProperty;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.inject.multibindings.MapBinder;
+
+import java.util.Collections;
+import java.util.Map;
 
 public class RepositorySettingsModule extends AbstractModule {
 
@@ -32,11 +45,46 @@ public class RepositorySettingsModule extends AbstractModule {
     private static final String URL = "url";
     private static final String HDFS = "hdfs";
 
-    static final TypeSettings FS_SETTINGS = new TypeSettings(ImmutableSet.of("location"),  ImmutableSet.of("compress", "chunk_size"));
-    static final TypeSettings URL_SETTINGS = new TypeSettings(ImmutableSet.of("url"), ImmutableSet.<String>of());
+    static final TypeSettings FS_SETTINGS = new TypeSettings(
+            ImmutableMap.<String, SettingsApplier>of("location", new SettingsAppliers.StringSettingsApplier(new StringSetting("location", true))),
+            ImmutableMap.<String, SettingsApplier>of(
+                    "compress", new SettingsAppliers.BooleanSettingsApplier(new BoolSetting("compress", true, true)),
+                    "chunk_size", new SettingsAppliers.ByteSizeSettingsApplier(new ByteSizeSetting("chunk_size", null, true))
+            ));
+
+    static final TypeSettings URL_SETTINGS = new TypeSettings(
+            ImmutableMap.<String, SettingsApplier>of("url", new SettingsAppliers.StringSettingsApplier(new StringSetting("url", true))),
+            Collections.<String, SettingsApplier>emptyMap());
+
+
     static final TypeSettings HDFS_SETTINGS = new TypeSettings(
-            ImmutableSet.<String>of(),
-            ImmutableSet.of("uri", "user", "path", "load_defaults", "conf_location", "concurrent_streams", "compress", "chunk_size"));
+            Collections.<String, SettingsApplier>emptyMap(),
+            ImmutableMap.<String, SettingsApplier>builder()
+                    .put("uri", new SettingsAppliers.StringSettingsApplier(new StringSetting("uri", true)))
+                    .put("user", new SettingsAppliers.StringSettingsApplier(new StringSetting("user", true)))
+                    .put("path", new SettingsAppliers.StringSettingsApplier(new StringSetting("path", true)))
+                    .put("load_defaults", new SettingsAppliers.BooleanSettingsApplier(new BoolSetting("load_defaults", true, true)))
+                    .put("conf_location", new SettingsAppliers.StringSettingsApplier(new StringSetting("conf_location", true)))
+                    .put("concurrent_streams", new SettingsAppliers.IntSettingsApplier(new IntSetting("concurrent_streams", 5, true)))
+                    .put("compress", new SettingsAppliers.BooleanSettingsApplier(new BoolSetting("compress", true, true)))
+                    .put("chunk_size", new SettingsAppliers.ByteSizeSettingsApplier(new ByteSizeSetting("chunk_size", null, true)))
+            .build()) {
+        @Override
+        public Optional<GenericProperties> preProcess(Optional<GenericProperties> genericProperties) {
+            if (!genericProperties.isPresent()) {
+                return genericProperties;
+            }
+            GenericProperties newProperties = new GenericProperties();
+            GenericProperties properties = genericProperties.get();
+            for (Map.Entry<String, Expression> entry : properties.properties().entrySet()) {
+                String key = entry.getKey();
+                if (!key.startsWith("conf.")) {
+                    newProperties.add(new GenericProperty(key, entry.getValue()));
+                }
+            }
+            return Optional.of(newProperties);
+        }
+    };
 
     private MapBinder<String, TypeSettings> typeSettingsBinder;
 

--- a/sql/src/main/java/io/crate/metadata/settings/CrateSettings.java
+++ b/sql/src/main/java/io/crate/metadata/settings/CrateSettings.java
@@ -133,19 +133,13 @@ public class CrateSettings {
     };
 
     public static final StringSetting GRACEFUL_STOP_MIN_AVAILABILITY = new StringSetting("min_availability",
-            Sets.newHashSet("full", "primaries", "none")
-    ) {
+            Sets.newHashSet("full", "primaries", "none"), true) {
         @Override
         public String defaultValue() { return "primaries"; }
 
         @Override
         public Setting parent() {
             return GRACEFUL_STOP;
-        }
-
-        @Override
-        public boolean isRuntime() {
-            return true;
         }
     };
 
@@ -329,40 +323,21 @@ public class CrateSettings {
         }
     };
 
-    public static final StringSetting ROUTING_ALLOCATION_ENABLE = new StringSetting("enable",
-            Sets.newHashSet("none", "primaries", "all", "new_primaries")
-    ) {
+    public static final StringSetting ROUTING_ALLOCATION_ENABLE = new StringSetting(
+            "enable",
+            Sets.newHashSet("none", "primaries", "all", "new_primaries"),
+            true,
+            "all",
+            ROUTING_ALLOCATION
+    );
 
-        @Override
-        public String defaultValue() { return "all"; }
-
-        @Override
-        public Setting parent() {
-            return ROUTING_ALLOCATION;
-        }
-
-        @Override
-        public boolean isRuntime() {
-            return true;
-        }
-    };
-
-    public static final StringSetting ROUTING_ALLOCATION_ALLOW_REBALANCE = new StringSetting("allow_rebalance",
-            Sets.newHashSet("always", "indices_primary_active", "indices_all_active")
-    ) {
-        @Override
-        public String defaultValue() { return "indices_all_active"; }
-
-        @Override
-        public Setting parent() {
-            return ROUTING_ALLOCATION;
-        }
-
-        @Override
-        public boolean isRuntime() {
-            return true;
-        }
-    };
+    public static final StringSetting ROUTING_ALLOCATION_ALLOW_REBALANCE = new StringSetting(
+            "allow_rebalance",
+            Sets.newHashSet("always", "indices_primary_active", "indices_all_active"),
+            true,
+            "indices_all_active",
+            ROUTING_ALLOCATION
+    );
 
     public static final IntSetting ROUTING_ALLOCATION_CLUSTER_CONCURRENT_REBALANCE =
             new IntSetting("cluster_concurrent_rebalance", 2, true) {
@@ -414,54 +389,18 @@ public class CrateSettings {
         }
     };
 
-    public static final StringSetting ROUTING_ALLOCATION_INCLUDE_IP = new StringSetting("_ip") {
+    public static final StringSetting ROUTING_ALLOCATION_INCLUDE_IP =
+            new StringSetting("_ip", null, true, "", ROUTING_ALLOCATION_INCLUDE);
 
-        @Override
-        public Setting parent() {
-            return ROUTING_ALLOCATION_INCLUDE;
-        }
+    public static final StringSetting ROUTING_ALLOCATION_INCLUDE_ID =
+            new StringSetting("_id", null, true, "", ROUTING_ALLOCATION_INCLUDE);
 
-        @Override
-        public boolean isRuntime() {
-            return true;
-        }
-    };
 
-    public static final StringSetting ROUTING_ALLOCATION_INCLUDE_ID = new StringSetting("_id") {
-        @Override
-        public Setting parent() {
-            return ROUTING_ALLOCATION_INCLUDE;
-        }
+    public static final StringSetting ROUTING_ALLOCATION_INCLUDE_HOST =
+            new StringSetting("_host", null, true, "", ROUTING_ALLOCATION_INCLUDE);
 
-        @Override
-        public boolean isRuntime() {
-            return true;
-        }
-    };
-
-    public static final StringSetting ROUTING_ALLOCATION_INCLUDE_HOST = new StringSetting("_host") {
-        @Override
-        public Setting parent() {
-            return ROUTING_ALLOCATION_INCLUDE;
-        }
-
-        @Override
-        public boolean isRuntime() {
-            return true;
-        }
-    };
-
-    public static final StringSetting ROUTING_ALLOCATION_INCLUDE_NAME = new StringSetting("_name") {
-        @Override
-        public Setting parent() {
-            return ROUTING_ALLOCATION_INCLUDE;
-        }
-
-        @Override
-        public boolean isRuntime() {
-            return true;
-        }
-    };
+    public static final StringSetting ROUTING_ALLOCATION_INCLUDE_NAME =
+            new StringSetting("_name", null, true, "", ROUTING_ALLOCATION_INCLUDE);
 
     public static final NestedSetting ROUTING_ALLOCATION_EXCLUDE = new NestedSetting() {
         @Override
@@ -488,56 +427,18 @@ public class CrateSettings {
         }
     };
 
-    public static final StringSetting ROUTING_ALLOCATION_EXCLUDE_IP = new StringSetting("_ip") {
-        @Override
-        public Setting parent() {
-            return ROUTING_ALLOCATION_EXCLUDE;
-        }
+    public static final StringSetting ROUTING_ALLOCATION_EXCLUDE_IP =
+            new StringSetting("_ip", null, true, "", ROUTING_ALLOCATION_EXCLUDE);
 
-        @Override
-        public boolean isRuntime() {
-            return true;
-        }
-    };
+    public static final StringSetting ROUTING_ALLOCATION_EXCLUDE_ID =
+            new StringSetting("_id", null, true, "", ROUTING_ALLOCATION_EXCLUDE);
 
-    public static final StringSetting ROUTING_ALLOCATION_EXCLUDE_ID = new StringSetting("_id") {
-
-        @Override
-        public Setting parent() {
-            return ROUTING_ALLOCATION_EXCLUDE;
-        }
-
-        @Override
-        public boolean isRuntime() {
-            return true;
-        }
-    };
-
-    public static final StringSetting ROUTING_ALLOCATION_EXCLUDE_HOST = new StringSetting("_host") {
-
-        @Override
-        public Setting parent() {
-            return ROUTING_ALLOCATION_EXCLUDE;
-        }
-
-        @Override
-        public boolean isRuntime() {
-            return true;
-        }
-    };
+    public static final StringSetting ROUTING_ALLOCATION_EXCLUDE_HOST =
+            new StringSetting("_host", null, true, "", ROUTING_ALLOCATION_EXCLUDE);
 
 
-    public static final StringSetting ROUTING_ALLOCATION_EXCLUDE_NAME = new StringSetting("_name") {
-        @Override
-        public Setting parent() {
-            return ROUTING_ALLOCATION_EXCLUDE;
-        }
-
-        @Override
-        public boolean isRuntime() {
-            return true;
-        }
-    };
+    public static final StringSetting ROUTING_ALLOCATION_EXCLUDE_NAME =
+            new StringSetting("_name", null, true, "", ROUTING_ALLOCATION_EXCLUDE);
 
     public static final NestedSetting ROUTING_ALLOCATION_REQUIRE = new NestedSetting() {
         @Override
@@ -564,57 +465,17 @@ public class CrateSettings {
         }
     };
 
-    public static final StringSetting ROUTING_ALLOCATION_REQUIRE_IP = new StringSetting("_ip") {
+    public static final StringSetting ROUTING_ALLOCATION_REQUIRE_IP =
+            new StringSetting("_ip", null, true, "", ROUTING_ALLOCATION_REQUIRE);
 
-        @Override
-        public Setting parent() {
-            return ROUTING_ALLOCATION_REQUIRE;
-        }
+    public static final StringSetting ROUTING_ALLOCATION_REQUIRE_ID =
+            new StringSetting("_id", null, true, "", ROUTING_ALLOCATION_REQUIRE);
 
-        @Override
-        public boolean isRuntime() {
-            return true;
-        }
-    };
+    public static final StringSetting ROUTING_ALLOCATION_REQUIRE_HOST =
+        new StringSetting("_host", null, true, "", ROUTING_ALLOCATION_REQUIRE);
 
-    public static final StringSetting ROUTING_ALLOCATION_REQUIRE_ID = new StringSetting("_id") {
-
-        @Override
-        public Setting parent() {
-            return ROUTING_ALLOCATION_REQUIRE;
-        }
-
-        @Override
-        public boolean isRuntime() {
-            return true;
-        }
-    };
-
-    public static final StringSetting ROUTING_ALLOCATION_REQUIRE_HOST = new StringSetting("_host") {
-
-        @Override
-        public Setting parent() {
-            return ROUTING_ALLOCATION_REQUIRE;
-        }
-
-        @Override
-        public boolean isRuntime() {
-            return true;
-        }
-    };
-
-    public static final StringSetting ROUTING_ALLOCATION_REQUIRE_NAME = new StringSetting("_name") {
-
-        @Override
-        public Setting parent() {
-            return ROUTING_ALLOCATION_REQUIRE;
-        }
-
-        @Override
-        public boolean isRuntime() {
-            return true;
-        }
-    };
+    public static final StringSetting ROUTING_ALLOCATION_REQUIRE_NAME =
+            new StringSetting("_name", null, true, "", ROUTING_ALLOCATION_REQUIRE);
 
     public static final NestedSetting ROUTING_ALLOCATION_BALANCE = new NestedSetting() {
         @Override
@@ -768,37 +629,11 @@ public class CrateSettings {
         }
     };
 
-    public static final StringSetting ROUTING_ALLOCATION_DISK_WATERMARK_LOW = new StringSetting("low") {
+    public static final StringSetting ROUTING_ALLOCATION_DISK_WATERMARK_LOW =
+            new StringSetting("low", null, true, "", ROUTING_ALLOCATION_DISK_WATERMARK);
 
-        @Override
-        public String defaultValue() { return "85%"; }
-
-        @Override
-        public Setting parent() {
-            return ROUTING_ALLOCATION_DISK_WATERMARK;
-        }
-
-        @Override
-        public boolean isRuntime() {
-            return true;
-        }
-    };
-
-    public static final StringSetting ROUTING_ALLOCATION_DISK_WATERMARK_HIGH = new StringSetting("high") {
-
-        @Override
-        public String defaultValue() { return "90%"; }
-
-        @Override
-        public Setting parent() {
-            return ROUTING_ALLOCATION_DISK_WATERMARK;
-        }
-
-        @Override
-        public boolean isRuntime() {
-            return true;
-        }
-    };
+    public static final StringSetting ROUTING_ALLOCATION_DISK_WATERMARK_HIGH =
+            new StringSetting("high", null, true, "90%", ROUTING_ALLOCATION_DISK_WATERMARK);
 
     public static final NestedSetting INDICES = new NestedSetting() {
         @Override
@@ -1015,23 +850,8 @@ public class CrateSettings {
         }
     };
 
-    public static final StringSetting INDICES_STORE_THROTTLE_TYPE = new StringSetting("type",
-            Sets.newHashSet("all", "merge", "none")
-    ) {
-
-        @Override
-        public String defaultValue() { return "merge"; }
-
-        @Override
-        public Setting parent() {
-            return INDICES_STORE_THROTTLE;
-        }
-
-        @Override
-        public boolean isRuntime() {
-            return true;
-        }
-    };
+    public static final StringSetting INDICES_STORE_THROTTLE_TYPE = new StringSetting(
+            "type", Sets.newHashSet("all", "merge", "none"), true, "merge", INDICES_STORE_THROTTLE);
 
     public static final ByteSizeSetting INDICES_STORE_THROTTLE_MAX_BYTES_PER_SEC = new ByteSizeSetting(
             "max_bytes_per_sec", new ByteSizeValue(20, ByteSizeUnit.MB), true, INDICES_STORE_THROTTLE);
@@ -1079,21 +899,8 @@ public class CrateSettings {
         }
     };
 
-    public static final StringSetting INDICES_FIELDDATA_BREAKER_LIMIT = new StringSetting("limit") {
-
-        @Override
-        public String defaultValue() { return "60%"; }
-
-        @Override
-        public Setting parent() {
-            return INDICES_FIELDDATA_BREAKER;
-        }
-
-        @Override
-        public boolean isRuntime() {
-            return true;
-        }
-    };
+    public static final StringSetting INDICES_FIELDDATA_BREAKER_LIMIT = new StringSetting(
+            "limit", null, true, "60%", INDICES_FIELDDATA_BREAKER);
 
     public static final DoubleSetting INDICES_FIELDDATA_BREAKER_OVERHEAD = new DoubleSetting() {
         @Override
@@ -1159,21 +966,8 @@ public class CrateSettings {
         }
     };
 
-    public static final StringSetting INDICES_BREAKER_QUERY_LIMIT = new StringSetting("limit") {
-
-        @Override
-        public String defaultValue() { return CrateCircuitBreakerService.DEFAULT_QUERY_CIRCUIT_BREAKER_LIMIT; }
-
-        @Override
-        public Setting parent() {
-            return INDICES_BREAKER_QUERY;
-        }
-
-        @Override
-        public boolean isRuntime() {
-            return true;
-        }
-    };
+    public static final StringSetting INDICES_BREAKER_QUERY_LIMIT = new StringSetting(
+            "limit", null, true, CrateCircuitBreakerService.DEFAULT_QUERY_CIRCUIT_BREAKER_LIMIT, INDICES_BREAKER_QUERY);
 
     public static final DoubleSetting INDICES_BREAKER_QUERY_OVERHEAD = new DoubleSetting() {
         @Override
@@ -1216,21 +1010,8 @@ public class CrateSettings {
         }
     };
 
-    public static final StringSetting INDICES_BREAKER_REQUEST_LIMIT = new StringSetting("limit") {
-
-        @Override
-        public String defaultValue() { return "40%"; }
-
-        @Override
-        public Setting parent() {
-            return INDICES_BREAKER_REQUEST;
-        }
-
-        @Override
-        public boolean isRuntime() {
-            return true;
-        }
-    };
+    public static final StringSetting INDICES_BREAKER_REQUEST_LIMIT = new StringSetting(
+            "limit", null, true, "40%", INDICES_BREAKER_REQUEST);
 
     public static final DoubleSetting INDICES_BREAKER_REQUEST_OVERHEAD = new DoubleSetting() {
         @Override
@@ -1499,23 +1280,7 @@ public class CrateSettings {
         }
     };
 
-    public static final StringSetting UDC_URL = new StringSetting("url") {
-
-        @Override
-        public String defaultValue() {
-            return "https://udc.crate.io";
-        }
-
-        @Override
-        public Setting parent() {
-            return UDC;
-        }
-
-        @Override
-        public boolean isRuntime() {
-            return false;
-        }
-    };
+    public static final StringSetting UDC_URL = new StringSetting("url", null, true, "https://udc.crate.io", UDC);
 
     public static final ImmutableList<Setting> CRATE_SETTINGS = ImmutableList.<Setting>of(STATS, CLUSTER, DISCOVERY, INDICES, BULK, GATEWAY, UDC);
 

--- a/sql/src/main/java/io/crate/metadata/settings/CrateTableSettings.java
+++ b/sql/src/main/java/io/crate/metadata/settings/CrateTableSettings.java
@@ -59,36 +59,20 @@ public class CrateTableSettings {
 
     public static final IntSetting TOTAL_SHARDS_PER_NODE = new IntSetting(TableParameterInfo.TOTAL_SHARDS_PER_NODE, -1, true);
 
-    public static final StringSetting ROUTING_ALLOCATION_ENABLE = new StringSetting(TableParameterInfo.ROUTING_ALLOCATION_ENABLE,
-            ImmutableSet.of(
-                    "primaries",
+    public static final StringSetting ROUTING_ALLOCATION_ENABLE = new StringSetting(
+            TableParameterInfo.ROUTING_ALLOCATION_ENABLE,
+            ImmutableSet.of( "primaries",
                     "new_primaries",
                     "none",
                     "all"
-            )) {
+            ),
+            true,
+            "all",
+            null
+    );
 
-        @Override
-        public String defaultValue() {
-            return "all";
-        }
-        @Override
-        public boolean isRuntime() {
-            return true;
-        }
-    };
-
-    public static final StringSetting RECOVERY_INITIAL_SHARDS = new StringSetting(TableParameterInfo.RECOVERY_INITIAL_SHARDS) {
-
-        @Override
-        public String defaultValue() {
-            return "quorum";
-        }
-
-        @Override
-        public boolean isRuntime() {
-            return true;
-        }
-    };
+    public static final StringSetting RECOVERY_INITIAL_SHARDS = new StringSetting(
+            TableParameterInfo.RECOVERY_INITIAL_SHARDS, null, true, "quorum", null);
 
 
     public static final ByteSizeSetting FLUSH_THRESHOLD_SIZE = new ByteSizeSetting(

--- a/sql/src/main/java/io/crate/metadata/settings/Setting.java
+++ b/sql/src/main/java/io/crate/metadata/settings/Setting.java
@@ -60,7 +60,7 @@ public abstract class Setting<T, E> {
      * Return a list of setting names up to the uppers parent which will be used
      * e.g. to compute the full-qualified setting name
      */
-    public List<String> chain() {
+    private List<String> chain() {
         Setting parentSetting = parent();
         if (parentSetting == null) { return ImmutableList.of(name()); }
         ImmutableList.Builder<String> builder = ImmutableList.builder();

--- a/sql/src/main/java/io/crate/metadata/settings/StringSetting.java
+++ b/sql/src/main/java/io/crate/metadata/settings/StringSetting.java
@@ -24,25 +24,52 @@ package io.crate.metadata.settings;
 import com.google.common.base.Joiner;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.settings.Settings;
 
+import javax.annotation.Nullable;
 import java.util.Locale;
 import java.util.Set;
 
-public abstract class StringSetting extends Setting<String, String> {
+public class StringSetting extends Setting<String, String> {
 
     private final String name;
     protected final Set<String> allowedValues;
+    private final boolean isRuntime;
 
-    protected StringSetting(String name, Set<String> allowedValues) {
+    @Nullable
+    private final String defaultValue;
+    @Nullable
+    private final Setting<?, ?> parent;
+
+    public StringSetting(String name,
+                         @Nullable Set<String> allowedValues,
+                         boolean isRuntime,
+                         @Nullable String defaultValue,
+                         @Nullable  Setting<?, ?> parent) {
+
         this.name = name;
         this.allowedValues = allowedValues;
+        this.isRuntime = isRuntime;
+        this.defaultValue = defaultValue;
+        this.parent = parent;
     }
 
-    protected StringSetting(String name) {
-        this.name = name;
-        this.allowedValues = null;
+    public StringSetting(String name, @javax.annotation.Nullable Set<String> allowedValues, boolean isRuntime) {
+        this(name, allowedValues, isRuntime, null, null);
+    }
+
+    public StringSetting(String name, boolean isRuntime) {
+        this(name, null, isRuntime, null, null);
+    }
+
+    @Override
+    public Setting parent() {
+        return parent;
+    }
+
+    @Override
+    public boolean isRuntime() {
+        return isRuntime;
     }
 
     @Override
@@ -52,7 +79,7 @@ public abstract class StringSetting extends Setting<String, String> {
 
     @Override
     public String defaultValue() {
-        return "";
+        return defaultValue;
     }
 
     @Override

--- a/sql/src/test/java/io/crate/analyze/RepositoryParamValidatorTest.java
+++ b/sql/src/test/java/io/crate/analyze/RepositoryParamValidatorTest.java
@@ -22,13 +22,14 @@
 
 package io.crate.analyze;
 
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
+import com.google.common.base.Optional;
 import io.crate.analyze.repositories.RepositoryParamValidator;
-import io.crate.analyze.repositories.TypeSettings;
+import io.crate.analyze.repositories.RepositorySettingsModule;
+import io.crate.sql.tree.GenericProperties;
+import io.crate.sql.tree.GenericProperty;
+import io.crate.sql.tree.StringLiteral;
 import io.crate.test.integration.CrateUnitTest;
-import org.elasticsearch.common.settings.ImmutableSettings;
-import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.inject.ModulesBuilder;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -38,18 +39,15 @@ public class RepositoryParamValidatorTest extends CrateUnitTest {
 
     @Before
     public void initValidator() throws Exception {
-        validator = new RepositoryParamValidator(
-                ImmutableMap.of(
-                        "fs", new TypeSettings(ImmutableSet.of("location"), ImmutableSet.<String>of()),
-                        "hdfs", new TypeSettings(ImmutableSet.<String>of(), ImmutableSet.of("path"))
-                        ));
+        validator = new ModulesBuilder()
+                .add(new RepositorySettingsModule()).createInjector().getInstance(RepositoryParamValidator.class);
     }
 
     @Test
     public void testValidate() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Invalid repository type \"invalid_type\"");
-        validator.validate("invalid_type", ImmutableSettings.EMPTY);
+        validator.convertAndValidate("invalid_type", Optional.of(new GenericProperties()), ParameterContext.EMPTY);
     }
 
     @Test
@@ -57,24 +55,24 @@ public class RepositoryParamValidatorTest extends CrateUnitTest {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage(
                 "The following required parameters are missing to create a repository of type \"fs\": [location]");
-        validator.validate("fs", ImmutableSettings.EMPTY);
+        validator.convertAndValidate("fs", Optional.of(new GenericProperties()), ParameterContext.EMPTY);
     }
 
     @Test
     public void testInvalidSetting() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Invalid parameters specified: [yay]");
-        Settings settings = ImmutableSettings.builder()
-                .put("location", "foo")
-                .put("yay", "invalid").build();
-        validator.validate("fs", settings);
+        expectedException.expectMessage("setting 'yay' not supported");
+        GenericProperties genericProperties = new GenericProperties();
+        genericProperties.add(new GenericProperty("location", new StringLiteral("foo")));
+        genericProperties.add(new GenericProperty("yay", new StringLiteral("invalid")));
+        validator.convertAndValidate("fs", Optional.of(genericProperties), ParameterContext.EMPTY);
     }
 
     @Test
     public void testHdfsDynamicConfParam() throws Exception {
-        Settings settings = ImmutableSettings.builder()
-                .put("path", "/data")
-                .put("conf.foobar", "bar").build();
-        validator.validate("hdfs", settings);
+        GenericProperties genericProperties = new GenericProperties();
+        genericProperties.add(new GenericProperty("path", new StringLiteral("/data")));
+        genericProperties.add(new GenericProperty("conf.foobar", new StringLiteral("bar")));
+        validator.convertAndValidate("hdfs", Optional.of(genericProperties), ParameterContext.EMPTY);
     }
 }

--- a/sql/src/test/java/io/crate/metadata/settings/CrateSettingsTest.java
+++ b/sql/src/test/java/io/crate/metadata/settings/CrateSettingsTest.java
@@ -29,17 +29,8 @@ public class CrateSettingsTest extends CrateUnitTest {
 
     @Test
     public void testStringSettingsValidation() throws Exception {
-        StringSetting stringSetting = new StringSetting("foo_bar_setting",
-                Sets.newHashSet("foo", "bar", "foobar")
-        ) {
-            @Override
-            public String defaultValue() { return "foo"; }
-
-            @Override
-            public boolean isRuntime() {
-                return false;
-            }
-        };
+        StringSetting stringSetting =
+                new StringSetting("foo_bar_setting", Sets.newHashSet("foo", "bar", "foobar"), false, "foo", null);
 
         String validation = stringSetting.validate("foo");
         assertEquals(validation, null);
@@ -49,18 +40,7 @@ public class CrateSettingsTest extends CrateUnitTest {
 
     @Test
     public void testStringSettingsEmptyValidation() throws Exception {
-        StringSetting stringSetting = new StringSetting("foo_bar_setting",
-                Sets.newHashSet("")
-        ) {
-            @Override
-            public String defaultValue() { return "foo"; }
-
-            @Override
-            public boolean isRuntime() {
-                return false;
-            }
-
-        };
+        StringSetting stringSetting = new StringSetting("foo_bar_setting", Sets.newHashSet(""), false, "foo", null);
 
         String validation = stringSetting.validate("foo");
         assertEquals(validation, "'foo' is not an allowed value. Allowed values are: ");


### PR DESCRIPTION
This change is mostly for the ES 2.X upgrade.
In ES 2.X byte or time settings will require a unit ('b', 'm', etc..).

By using the SettingApplier those units can be included.