### PR TITLE
update java-testing to 0.4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,7 @@ before_install:
   - ulimit -u 65535
 
 script:
-  - ./gradlew -PtestForks=2 -s -x client:test test
-  - ./gradlew -s client:test
+  - ./gradlew -PtestForks=2 -s test
   - ./gradlew -s itest
 
 after_success:

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     compile 'org.apache.lucene:lucene-analyzers-common:4.10.4'
 
     compile files(depClasses)
-    testCompile 'io.crate:crate-testing:0.4.0'
+    testCompile 'io.crate:crate-testing:0.4.1'
     testCompile 'org.hamcrest:hamcrest-all:1.3'
 
 }

--- a/client/src/test/java/io/crate/client/CrateClientIntegrationTest.java
+++ b/client/src/test/java/io/crate/client/CrateClientIntegrationTest.java
@@ -66,10 +66,9 @@ public class CrateClientIntegrationTest extends Assert {
 
     @ClassRule
     public static final CrateTestCluster testCluster = CrateTestCluster.fromFile(tarBallPath)
-            .workingDir(System.getProperty("project_build_dir") + "/crate-testing").numberOfNodes(1).build();
+            .workingDir(Paths.get(System.getProperty("project_build_dir"), "crate-testing")).numberOfNodes(1).build();
 
     protected String serverAddress() {
-
         CrateTestServer server = testCluster.randomServer();
         return server.crateHost() + ':' + server.transportPort();
     }


### PR DESCRIPTION
solves the issue of running client tests in parallel