### PR TITLE
upsert action now uses the engine directly instead of using the index transport

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Improved bulk insert/update and copy-from performance when replicas
+   are configured.
+
  - Added support for set to array and array to set conversions
 
  - Improved the error message of insert into target/source column size

--- a/docs/sql/dml.txt
+++ b/docs/sql/dml.txt
@@ -354,8 +354,7 @@ increment a number like this::
 
     If the same documents are updated concurrently an VersionConflictException
     might occur. Crate contains a retry logic that tries to resolve the
-    conflict automatically. But if it fails more than 3 times the document
-    doesn't get updated and a zero row count is returned.
+    conflict automatically.
 
 Deleting Data
 =============

--- a/sql/src/main/java/io/crate/executor/transport/ShardUpsertRequest.java
+++ b/sql/src/main/java/io/crate/executor/transport/ShardUpsertRequest.java
@@ -22,7 +22,6 @@
 package io.crate.executor.transport;
 
 import com.google.common.base.Objects;
-import io.crate.Constants;
 import io.crate.Streamer;
 import io.crate.analyze.symbol.Reference;
 import io.crate.analyze.symbol.Symbol;
@@ -295,8 +294,8 @@ public class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, ShardUp
             this.source = source;
         }
 
-        public int retryOnConflict() {
-            return version == Versions.MATCH_ANY ? Constants.UPDATE_RETRY_ON_CONFLICT : 0;
+        public boolean retryOnConflict() {
+            return version == Versions.MATCH_ANY;
         }
 
         @Nullable

--- a/sql/src/main/java/io/crate/executor/transport/TransportShardUpsertAction.java
+++ b/sql/src/main/java/io/crate/executor/transport/TransportShardUpsertAction.java
@@ -251,8 +251,11 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
             return shardIndexOperation(request, item, version, indexShard);
         } catch (WriteFailureException w) {
             Throwable t = w.getCause();
-            if (t instanceof VersionConflictEngineException
-                && retryCount < item.retryOnConflict()) {
+            if (t instanceof VersionConflictEngineException && item.retryOnConflict()) {
+                if (logger.isTraceEnabled()) {
+                    logger.trace("[{}] VersionConflict, retrying operation for document id {}, retry count: {}",
+                            indexShard.shardId(), item.id(), retryCount);
+                }
                 return indexItem(tableInfo, request, item, indexShard, false, retryCount + 1);
             } else if (tryInsertFirst && item.updateAssignments() != null
                        && t instanceof DocumentAlreadyExistsException) {

--- a/sql/src/main/java/io/crate/executor/transport/task/UpsertByIdTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/UpsertByIdTask.java
@@ -31,6 +31,7 @@ import io.crate.executor.RowCountResult;
 import io.crate.executor.TaskResult;
 import io.crate.executor.transport.ShardUpsertRequest;
 import io.crate.jobs.*;
+import io.crate.metadata.PartitionName;
 import io.crate.metadata.settings.CrateSettings;
 import io.crate.planner.node.dml.UpsertByIdNode;
 import org.elasticsearch.ExceptionsHelper;
@@ -47,6 +48,7 @@ import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndexAlreadyExistsException;
+import org.elasticsearch.indices.IndexMissingException;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -134,13 +136,22 @@ public class UpsertByIdTask extends JobTask {
     }
 
     private void executeUpsertRequest(final UpsertByIdNode.Item item, final SettableFuture<TaskResult> futureResult) {
-        ShardId shardId = clusterService.operationRouting().indexShards(
-                clusterService.state(),
-                item.index(),
-                Constants.DEFAULT_MAPPING_TYPE,
-                item.id(),
-                item.routing()
-        ).shardId();
+        ShardId shardId;
+        try {
+            shardId = clusterService.operationRouting().indexShards(
+                    clusterService.state(),
+                    item.index(),
+                    Constants.DEFAULT_MAPPING_TYPE,
+                    item.id(),
+                    item.routing()
+            ).shardId();
+        } catch (IndexMissingException e) {
+            if (PartitionName.isPartition(item.index())) {
+                futureResult.set(TaskResult.ZERO);
+                return;
+            }
+            throw e;
+        }
 
         ShardUpsertRequest upsertRequest = new ShardUpsertRequest(
                 shardId, node.updateColumns(), node.insertColumns(), item.routing(), jobId());

--- a/sql/src/main/java/io/crate/jobs/BulkShardProcessorContext.java
+++ b/sql/src/main/java/io/crate/jobs/BulkShardProcessorContext.java
@@ -23,16 +23,20 @@ package io.crate.jobs;
 
 import io.crate.executor.transport.ShardRequest;
 import org.elasticsearch.action.bulk.BulkShardProcessor;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class BulkShardProcessorContext extends AbstractExecutionSubContext {
 
+    private static final ESLogger LOGGER = Loggers.getLogger(BulkShardProcessorContext.class);
+
     private final BulkShardProcessor<? extends ShardRequest> bulkShardProcessor;
 
     public BulkShardProcessorContext(int id, BulkShardProcessor<? extends ShardRequest> bulkShardProcessor) {
-        super(id);
+        super(id, LOGGER);
         this.bulkShardProcessor = bulkShardProcessor;
     }
 

--- a/sql/src/main/java/io/crate/jobs/CountContext.java
+++ b/sql/src/main/java/io/crate/jobs/CountContext.java
@@ -30,6 +30,8 @@ import io.crate.core.collections.Row1;
 import io.crate.operation.RowUpstream;
 import io.crate.operation.count.CountOperation;
 import io.crate.operation.projectors.RowReceiver;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -38,6 +40,8 @@ import java.util.List;
 import java.util.Map;
 
 public class CountContext extends AbstractExecutionSubContext implements RowUpstream {
+
+    private static final ESLogger LOGGER = Loggers.getLogger(CountContext.class);
 
     private final CountOperation countOperation;
     private final RowReceiver rowReceiver;
@@ -50,7 +54,7 @@ public class CountContext extends AbstractExecutionSubContext implements RowUpst
                         RowReceiver rowReceiver,
                         Map<String, List<Integer>> indexShardMap,
                         WhereClause whereClause) {
-        super(id);
+        super(id, LOGGER);
         this.countOperation = countOperation;
         this.rowReceiver = rowReceiver;
         rowReceiver.setUpstream(this);

--- a/sql/src/main/java/io/crate/jobs/ESJobContext.java
+++ b/sql/src/main/java/io/crate/jobs/ESJobContext.java
@@ -27,6 +27,8 @@ import io.crate.operation.projectors.FlatProjectorChain;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.support.TransportAction;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -34,6 +36,8 @@ import java.util.List;
 import java.util.concurrent.Future;
 
 public class ESJobContext extends AbstractExecutionSubContext {
+
+    private static final ESLogger LOGGER = Loggers.getLogger(ESJobContext.class);
 
     private final List<? extends ActionListener> listeners;
     private String operationName;
@@ -52,7 +56,7 @@ public class ESJobContext extends AbstractExecutionSubContext {
                         List<SettableFuture<TaskResult>> resultFutures,
                         TransportAction transportAction,
                         @Nullable FlatProjectorChain projectorChain) {
-        super(id);
+        super(id, LOGGER);
         this.operationName = operationName;
         this.requests = requests;
         this.listeners = listeners;

--- a/sql/src/main/java/io/crate/jobs/NestedLoopContext.java
+++ b/sql/src/main/java/io/crate/jobs/NestedLoopContext.java
@@ -27,6 +27,8 @@ import io.crate.operation.join.NestedLoopOperation;
 import io.crate.operation.projectors.FlatProjectorChain;
 import io.crate.operation.projectors.ListenableRowReceiver;
 import io.crate.planner.node.dql.join.NestedLoopPhase;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -34,6 +36,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class NestedLoopContext extends AbstractExecutionSubContext implements DownstreamExecutionSubContext, ExecutionState {
+
+    private final static ESLogger LOGGER = Loggers.getLogger(NestedLoopContext.class);
 
     private final AtomicInteger activeSubContexts = new AtomicInteger(0);
     private final NestedLoopPhase nestedLoopPhase;
@@ -54,7 +58,7 @@ public class NestedLoopContext extends AbstractExecutionSubContext implements Do
                              NestedLoopOperation nestedLoopOperation,
                              @Nullable PageDownstreamContext leftPageDownstreamContext,
                              @Nullable PageDownstreamContext rightPageDownstreamContext) {
-        super(phase.executionPhaseId());
+        super(phase.executionPhaseId(), LOGGER);
 
         nestedLoopPhase = phase;
         this.flatProjectorChain = flatProjectorChain;

--- a/sql/src/main/java/io/crate/jobs/ProjectorChainContext.java
+++ b/sql/src/main/java/io/crate/jobs/ProjectorChainContext.java
@@ -26,6 +26,8 @@ import com.google.common.util.concurrent.Futures;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.operation.projectors.*;
 import io.crate.planner.projection.Projection;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -33,6 +35,8 @@ import java.util.List;
 import java.util.UUID;
 
 public class ProjectorChainContext extends AbstractExecutionSubContext {
+
+    private final static ESLogger LOGGER = Loggers.getLogger(ProjectorChainContext.class);
 
     private final String name;
     private final RowReceiver rowReceiver;
@@ -45,7 +49,7 @@ public class ProjectorChainContext extends AbstractExecutionSubContext {
                                  List<Projection> projections,
                                  RowReceiver rowReceiver,
                                  RamAccountingContext ramAccountingContext) {
-        super(id);
+        super(id, LOGGER);
         this.name = name;
         ListenableRowReceiver listenableRowReceiver = RowReceivers.listenableRowReceiver(rowReceiver);
         Futures.addCallback(listenableRowReceiver.finishFuture(), new FutureCallback<Void>() {

--- a/sql/src/main/java/io/crate/jobs/UpsertByIdContext.java
+++ b/sql/src/main/java/io/crate/jobs/UpsertByIdContext.java
@@ -23,8 +23,8 @@ package io.crate.jobs;
 
 import com.google.common.util.concurrent.SettableFuture;
 import io.crate.executor.TaskResult;
-import io.crate.executor.transport.ShardUpsertRequest;
 import io.crate.executor.transport.ShardResponse;
+import io.crate.executor.transport.ShardUpsertRequest;
 import io.crate.metadata.PartitionName;
 import io.crate.planner.node.dml.UpsertByIdNode;
 import org.elasticsearch.ExceptionsHelper;
@@ -41,7 +41,7 @@ import javax.annotation.Nullable;
 
 public class UpsertByIdContext extends AbstractExecutionSubContext {
 
-    private static final ESLogger logger = Loggers.getLogger(ExecutionSubContext.class);
+    private final static ESLogger LOGGER = Loggers.getLogger(UpsertByIdContext.class);
 
     private final ShardUpsertRequest request;
     private final UpsertByIdNode.Item item;
@@ -53,7 +53,7 @@ public class UpsertByIdContext extends AbstractExecutionSubContext {
                              UpsertByIdNode.Item item,
                              SettableFuture<TaskResult> futureResult,
                              BulkRequestExecutor transportShardUpsertActionDelegate) {
-        super(id);
+        super(id, LOGGER);
         this.request = request;
         this.item = item;
         this.futureResult = futureResult;

--- a/sql/src/main/java/io/crate/operation/collect/JobCollectContext.java
+++ b/sql/src/main/java/io/crate/operation/collect/JobCollectContext.java
@@ -39,6 +39,8 @@ import io.crate.operation.projectors.RowReceivers;
 import io.crate.planner.node.dql.CollectPhase;
 import io.crate.planner.node.dql.RoutedCollectPhase;
 import org.elasticsearch.common.StopWatch;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import javax.annotation.Nonnull;
@@ -48,6 +50,8 @@ import java.util.Collection;
 import java.util.Locale;
 
 public class JobCollectContext extends AbstractExecutionSubContext implements ExecutionState {
+
+    private static final ESLogger LOGGER = Loggers.getLogger(JobCollectContext.class);
 
     private final CollectPhase collectPhase;
     private final MapSideDataCollectOperation collectOperation;
@@ -68,7 +72,7 @@ public class JobCollectContext extends AbstractExecutionSubContext implements Ex
                              RamAccountingContext queryPhaseRamAccountingContext,
                              final RowReceiver rowReceiver,
                              SharedShardContexts sharedShardContexts) {
-        super(collectPhase.executionPhaseId());
+        super(collectPhase.executionPhaseId(), LOGGER);
         this.collectPhase = collectPhase;
         this.collectOperation = collectOperation;
         this.queryPhaseRamAccountingContext = queryPhaseRamAccountingContext;
@@ -169,7 +173,7 @@ public class JobCollectContext extends AbstractExecutionSubContext implements Ex
         if (collectors.isEmpty()) {
             rowReceiver.finish();
         } else {
-            if (LOGGER.isTraceEnabled()) {
+            if (logger.isTraceEnabled()) {
                 measureCollectTime();
             }
             collectOperation.launchCollectors(collectors, threadPoolName);
@@ -183,7 +187,7 @@ public class JobCollectContext extends AbstractExecutionSubContext implements Ex
             @Override
             public void run() {
                 stopWatch.stop();
-                LOGGER.trace("Collectors finished: {}", stopWatch.shortSummary());
+                logger.trace("Collectors finished: {}", stopWatch.shortSummary());
             }
         }, MoreExecutors.directExecutor());
     }

--- a/sql/src/main/java/io/crate/operation/fetch/FetchContext.java
+++ b/sql/src/main/java/io/crate/operation/fetch/FetchContext.java
@@ -32,6 +32,8 @@ import io.crate.metadata.PartitionName;
 import io.crate.metadata.Routing;
 import io.crate.metadata.TableIdent;
 import io.crate.planner.node.fetch.FetchPhase;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.shard.ShardId;
@@ -42,6 +44,8 @@ import javax.annotation.Nullable;
 import java.util.*;
 
 public class FetchContext extends AbstractExecutionSubContext {
+
+    private static final ESLogger LOGGER = Loggers.getLogger(FetchContext.class);
 
     private final IntObjectOpenHashMap<Engine.Searcher> searchers = new IntObjectOpenHashMap<>();
     private final IntObjectOpenHashMap<SharedShardContext> shardContexts = new IntObjectOpenHashMap<>();
@@ -56,7 +60,7 @@ public class FetchContext extends AbstractExecutionSubContext {
                         String localNodeId,
                         SharedShardContexts sharedShardContexts,
                         Iterable<? extends Routing> routingIterable) {
-        super(phase.executionPhaseId());
+        super(phase.executionPhaseId(), LOGGER);
         this.phase = phase;
         this.localNodeId = localNodeId;
         this.sharedShardContexts = sharedShardContexts;

--- a/sql/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
@@ -23,7 +23,6 @@ package io.crate.integrationtests;
 
 import io.crate.action.sql.SQLActionException;
 import io.crate.action.sql.SQLBulkResponse;
-import io.crate.exceptions.ColumnUnknownException;
 import io.crate.testing.TestingHelpers;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.common.collect.MapBuilder;

--- a/sql/src/test/java/io/crate/jobs/AbstractExecutionSubContextTest.java
+++ b/sql/src/test/java/io/crate/jobs/AbstractExecutionSubContextTest.java
@@ -25,6 +25,8 @@ package io.crate.jobs;
 import com.carrotsearch.ant.tasks.junit4.dependencies.com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import io.crate.test.integration.CrateUnitTest;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -80,17 +82,19 @@ public class AbstractExecutionSubContextTest extends CrateUnitTest {
 
     public static class TestingExecutionSubContext extends AbstractExecutionSubContext {
 
+        private static final ESLogger LOGGER = Loggers.getLogger(TestingExecutionSubContext.class);
+
         final AtomicInteger numPrepare = new AtomicInteger();
         final AtomicInteger numStart = new AtomicInteger();
         final AtomicInteger numClose = new AtomicInteger();
         final AtomicInteger numKill = new AtomicInteger();
 
         public TestingExecutionSubContext(int id) {
-            super(id);
+            super(id, LOGGER);
         }
 
         public TestingExecutionSubContext() {
-            super(0);
+            this(0);
         }
 
         @Override

--- a/sql/src/test/java/io/crate/jobs/JobContextServiceTest.java
+++ b/sql/src/test/java/io/crate/jobs/JobContextServiceTest.java
@@ -30,6 +30,8 @@ import io.crate.operation.projectors.FlatProjectorChain;
 import io.crate.test.integration.CrateUnitTest;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.ImmutableSettings;
 import org.junit.After;
 import org.junit.Before;
@@ -238,12 +240,14 @@ public class JobContextServiceTest extends CrateUnitTest {
 
     protected static class DummySubContext extends AbstractExecutionSubContext {
 
+        private static final ESLogger LOGGER = Loggers.getLogger(DummySubContext.class);
+
         public DummySubContext() {
-            super(1);
+            this(1);
         }
 
         public DummySubContext(int id) {
-            super(id);
+            super(id, LOGGER);
         }
 
         @Override

--- a/sql/src/test/java/io/crate/jobs/JobExecutionContextTest.java
+++ b/sql/src/test/java/io/crate/jobs/JobExecutionContextTest.java
@@ -35,6 +35,8 @@ import io.crate.operation.projectors.RowReceiver;
 import io.crate.planner.node.dql.RoutedCollectPhase;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.types.IntegerType;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -195,9 +197,10 @@ public class JobExecutionContextTest extends CrateUnitTest {
 
     private static class SlowKillExecutionSubContext extends AbstractExecutionSubContext {
 
+        private static final ESLogger LOGGER = Loggers.getLogger(SlowKillExecutionSubContext.class);
 
         public SlowKillExecutionSubContext() {
-            super(1);
+            super(1, LOGGER);
         }
 
         @Override


### PR DESCRIPTION
This is a huge performance improvement when replicas are configured, because now 1 replica request is made instead 1 for each bulk item.
related benchmark results: https://gist.github.com/seut/183a8a69c6b6491ac873