### PR TITLE
Round cpuPerc values before casting to short

### DIFF
--- a/sigar/src/main/java/io/crate/monitor/SigarExtendedNodeInfo.java
+++ b/sigar/src/main/java/io/crate/monitor/SigarExtendedNodeInfo.java
@@ -142,10 +142,10 @@ public class SigarExtendedNodeInfo implements ExtendedNodeInfo {
         try {
             CpuPerc cpuPerc = sigar.getCpuPerc();
             cpu = new ExtendedOsStats.Cpu(
-                    (short) (cpuPerc.getSys() * 100),
-                    (short) (cpuPerc.getUser() * 100),
-                    (short) (cpuPerc.getIdle() * 100),
-                    (short) (cpuPerc.getStolen() * 100)
+                    (short) Math.round(cpuPerc.getSys() * 100),
+                    (short) Math.round(cpuPerc.getUser() * 100),
+                    (short) Math.round(cpuPerc.getIdle() * 100),
+                    (short) Math.round(cpuPerc.getStolen() * 100)
             );
         } catch (SigarException e) {
             // ignore
@@ -182,7 +182,7 @@ public class SigarExtendedNodeInfo implements ExtendedNodeInfo {
         try {
             ProcCpu cpu = sigar.getProcCpu(sigar.getPid());
             return new ExtendedProcessCpuStats(
-                    (short) (cpu.getPercent() * 100),
+                    (short) Math.round(cpu.getPercent() * 100),
                     cpu.getSys(),
                     cpu.getUser(),
                     cpu.getTotal()


### PR DESCRIPTION
To keep the behaviour we had before, see:

https://github.com/crate/elasticsearch/commit/029f6c67d8ddf6ef2700014938f3a0b40b92e9d5