### PR TITLE
Don't run keepAliveTimers every 1ms if keepAliveTime is 0

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Avoid running KeepAliveTimers every ms if ``jobs.keep_alive_timeout`` is set
+   to zero
+
 2016/03/11 0.54.7
 =================
 

--- a/sql/src/test/java/io/crate/executor/transport/distributed/DistributingDownstreamTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/distributed/DistributingDownstreamTest.java
@@ -80,15 +80,7 @@ public class DistributingDownstreamTest extends CrateUnitTest {
                 return System.currentTimeMillis();
             }
         }).when(threadPool).estimatedTimeInMillis();
-        when(threadPool.scheduleWithFixedDelay(any(Runnable.class), any(TimeValue.class))).thenAnswer(new Answer<ScheduledFuture<?>>() {
-            @Override
-            public ScheduledFuture<?> answer(InvocationOnMock invocation) throws Throwable {
-
-                Runnable runnable = (Runnable)invocation.getArguments()[0];
-                TimeValue interval = (TimeValue)invocation.getArguments()[1];
-                return scheduledExecutorService.scheduleWithFixedDelay(runnable, interval.millis(), interval.millis(), TimeUnit.MILLISECONDS);
-            }
-        });
+        when(threadPool.scheduler()).thenReturn(scheduledExecutorService);
     }
 
     @Override

--- a/sql/src/test/java/io/crate/jobs/KeepAliveTimersTest.java
+++ b/sql/src/test/java/io/crate/jobs/KeepAliveTimersTest.java
@@ -35,9 +35,13 @@ import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import java.util.concurrent.*;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class KeepAliveTimersTest extends CrateUnitTest {
 
@@ -60,14 +64,7 @@ public class KeepAliveTimersTest extends CrateUnitTest {
                 return System.currentTimeMillis();
             }
         });
-        when(threadPool.scheduleWithFixedDelay(any(Runnable.class), any(TimeValue.class))).thenAnswer(new Answer<ScheduledFuture<?>>() {
-            @Override
-            public ScheduledFuture<?> answer(InvocationOnMock invocation) throws Throwable {
-                Runnable runnable = (Runnable)invocation.getArguments()[0];
-                TimeValue interval = (TimeValue)invocation.getArguments()[1];
-                return scheduledExecutorService.scheduleWithFixedDelay(runnable, interval.getMillis(), interval.getMillis(), TimeUnit.MILLISECONDS);
-            }
-        });
+        when(threadPool.scheduler()).thenReturn(scheduledExecutorService);
         transportKeepAliveAction = mock(TransportKeepAliveAction.class);
         keepAliveTimers = new KeepAliveTimers(threadPool, TEST_DELAY, transportKeepAliveAction);
     }


### PR DESCRIPTION
The fallback value was crazy low. This caused lots of keep alive
requests.

And worse, if those keep alive requests failed for some reason it didn't
stop sending keepAlive requests but instead filled up the logs with
warnings. Because ``ThreadPool#scheduleWithFixedDelay`` wraps all
Runnables into a LoggingRunnable that catches all exceptions.

This was missed in 12ee7130185c62bd461e1b6a05b7fcf0dba92870 when the
JobContextReaper got disabled by default.