### PR TITLE
Fix: Don't set distributionInfo to broadcast if SAME_NODE is applicable

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed an issue that could cause INSERT INTO with an INNER JOIN in the
+   sub-query to fail.
+
  - Removed the ``jobs.keep_alive_timeout`` setting and all related logic.
    This means it is no longer possible to enable automatic job termination.
 

--- a/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
@@ -251,7 +251,7 @@ public class NestedLoopConsumer implements Consumer {
                     rightMerge,
                     nlExecutionNodes
             );
-            if (isDistributed) {
+            if (isDistributed && !(nlExecutionNodes.size() == 1 && nlExecutionNodes.equals(rightPlan.resultPhase().executionNodes()))) {
                 nl.distributionInfo(DistributionInfo.DEFAULT_BROADCAST);
             }
             MergePhase localMergePhase = null;

--- a/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
@@ -251,7 +251,7 @@ public class NestedLoopConsumer implements Consumer {
                     rightMerge,
                     nlExecutionNodes
             );
-            if (isDistributed && !(nlExecutionNodes.size() == 1 && nlExecutionNodes.equals(rightPlan.resultPhase().executionNodes()))) {
+            if (isDistributed && !nlExecutionNodes.equals(localExecutionNodes))  {
                 nl.distributionInfo(DistributionInfo.DEFAULT_BROADCAST);
             }
             MergePhase localMergePhase = null;

--- a/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -72,7 +72,6 @@ public class JoinIntegrationTest extends SQLTransportIntegrationTest {
     @Test
     public void testInsertFromCrossJoin() throws Exception {
         createColorsAndSizes();
-
         execute("create table target (color string, size string)");
         ensureYellow();
 
@@ -85,6 +84,24 @@ public class JoinIntegrationTest extends SQLTransportIntegrationTest {
                 "green| large\n" +
                 "red| large\n" +
                 "blue| small\n"));
+    }
+
+    @Test
+    public void testInsertFromInnerJoin() throws Exception {
+        execute("create table t1 (x int)");
+        execute("create table t2 (y int)");
+        execute("create table target (x int, y int)");
+        ensureYellow();
+
+        execute("insert into t1 (x) values (1), (2)");
+        execute("insert into t2 (y) values (2), (3)");
+        execute("refresh table t1, t2");
+
+        execute("insert into target (x, y) (select t1.x, t2.y from t1 inner join t2 on t1.x = t2.y)");
+        execute("refresh table target");
+
+        execute("select x, y from target order by x, y");
+        assertThat(printedTable(response.rows()), is("2| 2\n"));
     }
 
     @Test


### PR DESCRIPTION
If all CollectPhases and the NestedLoopPhase ran on the same node there
was a failure in the ContextPreparer.

It expected another downstream for the NestedLoopPhase due to the
distributionInfo being set to BROADCAST.