### PR TITLE
Fix sameNode/broadcast distributionInfo missmatch

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed an issue that could cause INSERT INTO with an INNER JOIN in the
+   sub-query to fail.
+
  - Removed the ``jobs.keep_alive_timeout`` setting and all related logic.
    This means it is no longer possible to enable automatic job termination.
 

--- a/sql/src/main/java/io/crate/action/job/ContextPreparer.java
+++ b/sql/src/main/java/io/crate/action/job/ContextPreparer.java
@@ -21,14 +21,16 @@
 
 package io.crate.action.job;
 
-import com.carrotsearch.hppc.IntObjectOpenHashMap;
-import com.carrotsearch.hppc.cursors.IntObjectCursor;
+import com.carrotsearch.hppc.IntArrayList;
+import com.carrotsearch.hppc.IntCollection;
+import com.carrotsearch.hppc.IntOpenHashSet;
+import com.carrotsearch.hppc.LongObjectOpenHashMap;
+import com.carrotsearch.hppc.cursors.IntCursor;
 import com.google.common.base.Function;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicates;
-import com.google.common.collect.FluentIterable;
-import com.google.common.collect.Lists;
+import com.google.common.collect.*;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.crate.Streamer;
 import io.crate.breaker.CrateCircuitBreakerService;
@@ -55,17 +57,21 @@ import io.crate.planner.node.ExecutionPhase;
 import io.crate.planner.node.ExecutionPhaseVisitor;
 import io.crate.planner.node.ExecutionPhases;
 import io.crate.planner.node.StreamerVisitor;
-import io.crate.planner.node.dql.*;
+import io.crate.planner.node.dql.CollectPhase;
+import io.crate.planner.node.dql.CountPhase;
+import io.crate.planner.node.dql.MergePhase;
+import io.crate.planner.node.dql.RoutedCollectPhase;
 import io.crate.planner.node.dql.join.NestedLoopPhase;
 import io.crate.planner.node.fetch.FetchPhase;
 import io.crate.types.DataTypes;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.logging.ESLogger;
-import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import javax.annotation.Nullable;
@@ -73,9 +79,7 @@ import java.util.*;
 import java.util.concurrent.Executor;
 
 @Singleton
-public class ContextPreparer {
-
-    private static final ESLogger LOGGER = Loggers.getLogger(ContextPreparer.class);
+public class ContextPreparer extends AbstractComponent {
 
     private final MapSideDataCollectOperation collectOperation;
     private ClusterService clusterService;
@@ -87,13 +91,15 @@ public class ContextPreparer {
     private final InnerPreparer innerPreparer;
 
     @Inject
-    public ContextPreparer(MapSideDataCollectOperation collectOperation,
+    public ContextPreparer(Settings settings,
+                           MapSideDataCollectOperation collectOperation,
                            ClusterService clusterService,
                            CrateCircuitBreakerService breakerService,
                            CountOperation countOperation,
                            ThreadPool threadPool,
                            PageDownstreamFactory pageDownstreamFactory,
                            RowDownstreamFactory rowDownstreamFactory) {
+        super(settings);
         this.collectOperation = collectOperation;
         this.clusterService = clusterService;
         this.countOperation = countOperation;
@@ -108,24 +114,14 @@ public class ContextPreparer {
                                                           Iterable<? extends NodeOperation> nodeOperations,
                                                           JobExecutionContext.Builder contextBuilder,
                                                           SharedShardContexts sharedShardContexts) {
-        PreparerContext preparerContext = new PreparerContext(jobId, rowDownstreamFactory, nodeOperations,
-                sharedShardContexts);
-        List<ListenableFuture<Bucket>> directResponseFutures = new ArrayList<>();
-        processDownstreamExecutionPhaseIds(nodeOperations, preparerContext);
+        PreparerContext preparerContext = initContext(jobId, nodeOperations, contextBuilder, sharedShardContexts);
+        logger.trace("prepareOnRemote: nodeOperations={}, targetSourceMap={}", nodeOperations, preparerContext.opCtx.targetToSourceMap);
 
-        List<NodeOperation> reversedNodeOperations = Lists.reverse(Lists.newArrayList(nodeOperations));
-        for (NodeOperation nodeOperation : reversedNodeOperations) {
-            if (ExecutionPhases.hasDirectResponseDownstream(nodeOperation.downstreamNodes())) {
-                Streamer<?>[] streamers = StreamerVisitor.streamerFromOutputs(nodeOperation.executionPhase());
-                SingleBucketBuilder bucketBuilder = new SingleBucketBuilder(streamers);
-                directResponseFutures.add(bucketBuilder.result());
-                preparerContext.registerRowReceiverForUpstreamPhase(nodeOperation.executionPhase(), bucketBuilder);
-            }
-            processExecutionPhase(nodeOperation.executionPhase(), preparerContext, contextBuilder);
+        for (IntCursor cursor : preparerContext.opCtx.findLeafs()) {
+            contextBuilder.addAllSubContexts(prepareSourceOperations(cursor.value, preparerContext));
         }
-        postPrepare(contextBuilder, preparerContext);
-
-        return directResponseFutures;
+        assert preparerContext.opCtx.allContextsBuilt() : "some nodeOperations haven't been processed";
+        return preparerContext.directResponseFutures;
     }
 
     public List<ExecutionSubContext> prepareOnHandler(UUID jobId,
@@ -133,182 +129,279 @@ public class ContextPreparer {
                                                       JobExecutionContext.Builder contextBuilder,
                                                       List<Tuple<ExecutionPhase, RowReceiver>> handlerPhases,
                                                       @Nullable SharedShardContexts sharedShardContexts) {
-        ContextPreparer.PreparerContext preparerContext = new PreparerContext(jobId, rowDownstreamFactory,
-                nodeOperations, sharedShardContexts);
-        processDownstreamExecutionPhaseIds(nodeOperations, preparerContext);
+        PreparerContext preparerContext = initContext(jobId, nodeOperations, contextBuilder, sharedShardContexts);
+        logger.trace("prepareOnHandler: nodeOperations={}, handlerPhases={}, targetSourceMap={}",
+                nodeOperations, handlerPhases, preparerContext.opCtx.targetToSourceMap);
 
-
-        // register handler phase row receiver
-        // and build handler context, must be done first because it's downstream is already known
-        // and it is needed as a row receiver by others
         List<ExecutionSubContext> handlerContexts = new ArrayList<>(handlerPhases.size());
+        IntOpenHashSet leafs = new IntOpenHashSet();
         for (Tuple<ExecutionPhase, RowReceiver> handlerPhase : handlerPhases) {
-            ExecutionPhase handlerExecutionPhase = handlerPhase.v1();
-            preparerContext.registerRowReceiverForUpstreamPhase(handlerExecutionPhase, handlerPhase.v2());
-            ExecutionSubContext finalLocalMergeContext = innerPreparer.process(handlerExecutionPhase, preparerContext);
-            if (finalLocalMergeContext != null) {
-                contextBuilder.addSubContext(finalLocalMergeContext);
-                handlerContexts.add(finalLocalMergeContext);
+            ExecutionPhase phase = handlerPhase.v1();
+            preparerContext.registerRowReceiver(phase.executionPhaseId(), handlerPhase.v2());
+            ExecutionSubContext subContext = createContext(phase, preparerContext);
+            if (subContext != null) {
+                contextBuilder.addSubContext(subContext);
+                handlerContexts.add(subContext);
             }
+            leafs.add(phase.executionPhaseId());
         }
-        List<NodeOperation> reversedNodeOperations = Lists.reverse(Lists.newArrayList(nodeOperations));
-        for (NodeOperation nodeOperation : reversedNodeOperations) {
-            processExecutionPhase(nodeOperation.executionPhase(), preparerContext, contextBuilder);
+        leafs.addAll(preparerContext.opCtx.findLeafs());
+        for (IntCursor cursor : leafs) {
+            contextBuilder.addAllSubContexts(prepareSourceOperations(cursor.value, preparerContext));
         }
-        postPrepare(contextBuilder, preparerContext);
+        assert preparerContext.opCtx.allContextsBuilt() : "some nodeOperations haven't been processed";
         return handlerContexts;
     }
 
+    private ExecutionSubContext createContext(ExecutionPhase phase, PreparerContext preparerContext) {
+        try {
+            return innerPreparer.process(phase, preparerContext);
+        } catch (Throwable t) {
+            throw new IllegalArgumentException(String.format(Locale.ENGLISH,
+                    "Couldn't create executionContexts from\n" +
+                    "NodeOperations: %s\n" +
+                    "target-sources: %s", preparerContext.opCtx.nodeOperationMap, preparerContext.opCtx.targetToSourceMap), t);
+        }
+    }
+
+    private PreparerContext initContext(UUID jobId,
+                                        Iterable<? extends NodeOperation> nodeOperations,
+                                        JobExecutionContext.Builder contextBuilder,
+                                        @Nullable SharedShardContexts sharedShardContexts) {
+        ContextPreparer.PreparerContext preparerContext = new PreparerContext(
+                jobId, logger, rowDownstreamFactory, nodeOperations, sharedShardContexts);
+
+        for (NodeOperation nodeOperation : nodeOperations) {
+            // context for nodeOperations without dependencies can be built immediately (e.g. FetchPhase)
+            if (nodeOperation.downstreamExecutionPhaseId() == NodeOperation.NO_DOWNSTREAM) {
+                contextBuilder.addSubContext(createContext(nodeOperation.executionPhase(), preparerContext));
+                preparerContext.opCtx.builtContexts.set(nodeOperation.executionPhase().executionPhaseId());
+            }
+            if (ExecutionPhases.hasDirectResponseDownstream(nodeOperation.downstreamNodes())) {
+                Streamer<?>[] streamers = StreamerVisitor.streamerFromOutputs(nodeOperation.executionPhase());
+                SingleBucketBuilder bucketBuilder = new SingleBucketBuilder(streamers);
+                preparerContext.directResponseFutures.add(bucketBuilder.result());
+                preparerContext.registerRowReceiver(nodeOperation.downstreamExecutionPhaseId(), bucketBuilder);
+            }
+        }
+        return preparerContext;
+    }
 
     /**
-     * Build all contexts which could not build in first iteration due to missing downstreams
+     * recursively build all contexts that depend on startPhaseId (excl. startPhaseId)
+     *
+     * {@link PreparerContext#opCtx#targetToSourceMap} will be used to traverse the nodeOperations
      */
-    private void postPrepare(JobExecutionContext.Builder contextBuilder,
-                             PreparerContext preparerContext) {
+    private Collection<ExecutionSubContext> prepareSourceOperations(int startPhaseId, PreparerContext preparerContext) {
+        Collection<Integer> sourcePhaseIds = preparerContext.opCtx.targetToSourceMap.get(startPhaseId);
+        if (sourcePhaseIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<ExecutionSubContext> subContexts = new ArrayList<>();
+        for (Integer sourcePhaseId : sourcePhaseIds) {
+            NodeOperation nodeOperation = preparerContext.opCtx.nodeOperationMap.get(sourcePhaseId);
 
+            ExecutionSubContext subContext = createContext(nodeOperation.executionPhase(), preparerContext);
+            preparerContext.opCtx.builtContexts.set(nodeOperation.executionPhase().executionPhaseId());
+            assert subContext != null : "subContext must not be null";
+            subContexts.add(subContext);
+        }
+        for (Integer sourcePhaseId : sourcePhaseIds) {
+            subContexts.addAll(prepareSourceOperations(sourcePhaseId, preparerContext));
+        }
+        return subContexts;
+    }
+
+    static class NodeOperationCtx {
 
         /**
-         * infinite loop protection
-         * if a phase has its upstream on the same node it might need to be processes 2 times
-         * (the first time it might be skipped if the upstream hasn't been processed yet)
+         * a map from target phase to source phase
+         * <p/>
+         * For example with NodeOperations as the following:
+         * <p/>
+         * NodeOp {0, target=1}
+         * NodeOp {1, target=2}
+         * (handlerMergePhase (2))
+         * <p/>
+         * This map contains
+         * <p/>
+         * 1 -> 0
+         * 2 -> 1
+         * <p/>
+         * This map is used in {@link #prepareSourceOperations(int, PreparerContext)} to process to NodeOperations in the
+         * correct order (last ones in the data flow first - this is done so that the RowReceivers are always registered)
+         * <p/>
+         * (In the example above, NodeOp 0 might depend on the context/RowReceiver of NodeOp 1 being built first.)
          */
-        int reProcessLimit = preparerContext.executionPhasesToProcess.size() * 2;
-        for (int i = 0; i < reProcessLimit && !preparerContext.executionPhasesToProcess.isEmpty(); i++) {
-            List<ExecutionPhase> executionPhasesToProcess = Lists.newArrayList(preparerContext.executionPhasesToProcess);
-            preparerContext.executionPhasesToProcess.clear();
-            for (ExecutionPhase executionPhase : executionPhasesToProcess) {
-                processExecutionPhase(executionPhase, preparerContext, contextBuilder);
+        private final Multimap<Integer, Integer> targetToSourceMap;
+        private final ImmutableMap<Integer, ? extends NodeOperation> nodeOperationMap;
+        private final BitSet builtContexts;
+
+        public NodeOperationCtx(Iterable<? extends NodeOperation> nodeOperations) {
+            targetToSourceMap = createTargetToSourceMap(nodeOperations);
+            nodeOperationMap = Maps.uniqueIndex(nodeOperations, new Function<NodeOperation, Integer>() {
+                @Nullable
+                @Override
+                public Integer apply(@Nullable NodeOperation input) {
+                    return input == null ? null : input.executionPhase().executionPhaseId();
+                }
+            });
+            builtContexts = new BitSet(nodeOperationMap.size());
+        }
+
+        static Multimap<Integer, Integer> createTargetToSourceMap(Iterable<? extends NodeOperation> nodeOperations) {
+            HashMultimap<Integer, Integer> targetToSource = HashMultimap.create();
+            for (NodeOperation nodeOperation : nodeOperations) {
+                if (nodeOperation.downstreamExecutionPhaseId() == NodeOperation.NO_DOWNSTREAM) {
+                    continue;
+                }
+                targetToSource.put(nodeOperation.downstreamExecutionPhaseId(), nodeOperation.executionPhase().executionPhaseId());
             }
+            return targetToSource;
         }
-        if (!preparerContext.executionPhasesToProcess.isEmpty()) {
-            throw new IllegalStateException("Aborted context preparation as an infinite loop was detected");
-        }
-    }
 
-    private void processExecutionPhase(ExecutionPhase executionPhase,
-                                       PreparerContext preparerContext,
-                                       JobExecutionContext.Builder contextBuilder) {
-        ExecutionSubContext subContext = innerPreparer.process(executionPhase, preparerContext);
-        if (subContext != null) {
-            contextBuilder.addSubContext(subContext);
-        }
-    }
-
-    private void processDownstreamExecutionPhaseIds(Iterable<? extends NodeOperation> nodeOperations,
-                                                    PreparerContext context) {
-        for (NodeOperation nodeOperation : nodeOperations) {
-            boolean val = false;
-            ExecutionPhase phase = nodeOperation.executionPhase();
-            if (phase instanceof UpstreamPhase) {
-                val = isSameNodeUpstreamDistributionType((UpstreamPhase) phase);
+        /**
+         * find all phases that don't have any downstreams.
+         *
+         * This is usually only one phase (the handlerPhase, but there might be more in case of bulk operations)
+         */
+        private static IntCollection findLeafs(Multimap<Integer, Integer> targetToSourceMap) {
+            IntArrayList leafs = new IntArrayList();
+            for (Integer targetPhaseId : targetToSourceMap.keySet()) {
+                if (!targetToSourceMap.containsValue(targetPhaseId)) {
+                    leafs.add(targetPhaseId);
+                }
             }
-            context.setPhaseHasSameNodeUpstream(
-                    nodeOperation.downstreamExecutionPhaseId(),
-                    nodeOperation.downstreamExecutionPhaseInputId(),
-                    val);
-            context.setNodeOperation(nodeOperation.executionPhase().executionPhaseId(), nodeOperation);
+            return leafs;
         }
-    }
 
-    private boolean isSameNodeUpstreamDistributionType(UpstreamPhase phase) {
-        return phase.distributionInfo().distributionType() == DistributionType.SAME_NODE;
+        public boolean upstreamsAreOnSameNode(int phaseId) {
+            Collection<Integer> sourcePhases = targetToSourceMap.get(phaseId);
+            if (sourcePhases.isEmpty()) {
+                return false;
+            }
+            boolean sameNode = true;
+            for (Integer sourcePhase : sourcePhases) {
+                NodeOperation nodeOperation = nodeOperationMap.get(sourcePhase);
+                if (nodeOperation == null) {
+                    return false;
+                }
+                ExecutionPhase executionPhase = nodeOperation.executionPhase();
+                sameNode = sameNode & executionPhase instanceof UpstreamPhase &&
+                           (((UpstreamPhase) executionPhase).distributionInfo().distributionType() == DistributionType.SAME_NODE);
+            }
+            return sameNode;
+        }
+
+        public Iterable<? extends IntCursor> findLeafs() {
+            return findLeafs(targetToSourceMap);
+        }
+
+        public boolean allContextsBuilt() {
+            return builtContexts.cardinality() == nodeOperationMap.size();
+        }
     }
 
     private static class PreparerContext {
 
         private final UUID jobId;
         private final RowDownstreamFactory rowDownstreamFactory;
-        private final Map<Tuple<Integer, Byte>, Boolean> phaseHasSameNodeUpstream = new HashMap<>();
-        private final IntObjectOpenHashMap<NodeOperation> phaseIdToNodeOperations = new IntObjectOpenHashMap<>();
-        private final IntObjectOpenHashMap<RowReceiver> phaseIdToRowReceivers = new IntObjectOpenHashMap<>();
-        private final List<ExecutionPhase> executionPhasesToProcess = new ArrayList<>();
-        private final Iterable<? extends NodeOperation> nodeOperations;
+
+        /**
+         * from toKey(phaseId, inputId) to RowReceiver.
+         */
+        private final LongObjectOpenHashMap<RowReceiver> phaseIdToRowReceivers = new LongObjectOpenHashMap<>();
 
         @Nullable
         private final SharedShardContexts sharedShardContexts;
 
+        private final List<ListenableFuture<Bucket>> directResponseFutures = new ArrayList<>();
+        private final NodeOperationCtx opCtx;
+        private final ESLogger logger;
+
         public PreparerContext(UUID jobId,
+                               ESLogger logger,
                                RowDownstreamFactory rowDownstreamFactory,
                                Iterable<? extends NodeOperation> nodeOperations,
                                @Nullable SharedShardContexts sharedShardContexts) {
+            this.logger = logger;
+            this.opCtx = new NodeOperationCtx(nodeOperations);
             this.jobId = jobId;
             this.rowDownstreamFactory = rowDownstreamFactory;
-            this.nodeOperations = nodeOperations;
             this.sharedShardContexts = sharedShardContexts;
         }
 
-        public boolean getPhaseHasSameNodeUpstream(int executionPhaseId, byte inputId) {
-            Tuple<Integer, Byte> key = new Tuple<>(executionPhaseId, inputId);
-            Boolean res = phaseHasSameNodeUpstream.get(key);
-            if (res == null) {
-                return false;
-            }
-            return res;
-        }
-
-        public void setPhaseHasSameNodeUpstream(int executionPhaseId, byte inputId, boolean val) {
-            Tuple<Integer, Byte> key = new Tuple<>(executionPhaseId, inputId);
-            phaseHasSameNodeUpstream.put(key, val);
-        }
-
-        public NodeOperation getNodeOperation(int executionPhaseId) {
-            NodeOperation nodeOperation = phaseIdToNodeOperations.get(executionPhaseId);
+        /**
+         * Retrieve the rowReceiver of the downstream of phase
+         */
+        RowReceiver getRowReceiver(UpstreamPhase phase, int pageSize) {
+            NodeOperation nodeOperation = opCtx.nodeOperationMap.get(phase.executionPhaseId());
             if (nodeOperation == null) {
-                throw new IllegalStateException(String.format(Locale.ENGLISH,
-                        "NodeOperation with phaseId %d not found, must be registered first", executionPhaseId));
+                return handlerPhaseRowReceiver(phase.executionPhaseId());
             }
-            return nodeOperation;
-        }
 
-        public void setNodeOperation(int executionPhaseId, NodeOperation nodeOperation) {
-            phaseIdToNodeOperations.put(executionPhaseId, nodeOperation);
-        }
-
-        /**
-         * Register a {@link RowReceiver} for an {@link UpstreamPhase}
-         */
-        public void registerRowReceiverForUpstreamPhase(ExecutionPhase executionPhase, RowReceiver rowReceiver) {
-            assert executionPhase instanceof UpstreamPhase : "Given ExecutionPhase is not a UpstreamPhase";
-            phaseIdToRowReceivers.put(executionPhase.executionPhaseId(), rowReceiver);
-        }
-
-        /**
-         * Register a {@link RowReceiver} of a downstream {@link ExecutionPhase}
-         */
-        public void registerRowReceiver(int downstreamExecutionPhaseId,
-                                        byte downstreamExecutionPhaseInputId,
-                                        RowReceiver rowReceiver) {
-            for (IntObjectCursor<NodeOperation> cursor : phaseIdToNodeOperations) {
-                NodeOperation nodeOperation = cursor.value;
-                if (nodeOperation.downstreamExecutionPhaseId() == downstreamExecutionPhaseId
-                        && nodeOperation.downstreamExecutionPhaseInputId() == downstreamExecutionPhaseInputId) {
-                    registerRowReceiverForUpstreamPhase(nodeOperation.executionPhase(), rowReceiver);
-                }
-            }
-        }
-
-        @Nullable
-        public RowReceiver getRowReceiver(UpstreamPhase upstreamPhase, int pageSize) {
-            if (upstreamPhase.distributionInfo().distributionType() == DistributionType.SAME_NODE) {
-                LOGGER.trace("Phase uses SAME_NODE downstream: {}", upstreamPhase);
-                return phaseIdToRowReceivers.get(upstreamPhase.executionPhaseId());
-            }
-            NodeOperation nodeOperation = getNodeOperation(upstreamPhase.executionPhaseId());
+            RowReceiver targetRowReceiver = phaseIdToRowReceivers.get(
+                    toKey(nodeOperation.downstreamExecutionPhaseId(), nodeOperation.downstreamExecutionPhaseInputId()));
             if (ExecutionPhases.hasDirectResponseDownstream(nodeOperation.downstreamNodes())) {
-                LOGGER.trace("Phase uses DIRECT_RESPONSE downstream: {}", upstreamPhase);
-                return phaseIdToRowReceivers.get(upstreamPhase.executionPhaseId());
+                traceGetRowReceiver(phase, "DIRECT_RESPONSE", nodeOperation, targetRowReceiver);
+                return safeReceiver(targetRowReceiver, nodeOperation);
             }
-            LOGGER.trace("Phase uses DISTRIBUTED downstream: {}", upstreamPhase);
-            return rowDownstreamFactory.createDownstream(
-                    nodeOperation,
-                    upstreamPhase.distributionInfo(),
-                    jobId,
-                    pageSize);
-
+            switch (phase.distributionInfo().distributionType()) {
+                case SAME_NODE:
+                    traceGetRowReceiver(phase, "SAME_NODE", nodeOperation, targetRowReceiver);
+                    return safeReceiver(targetRowReceiver, nodeOperation);
+                case BROADCAST:
+                case MODULO:
+                    RowReceiver downstream = rowDownstreamFactory.createDownstream(
+                            nodeOperation, phase.distributionInfo(), jobId, pageSize);
+                    traceGetRowReceiver(
+                            phase, phase.distributionInfo().distributionType().toString(), nodeOperation, downstream);
+                    return downstream;
+                default:
+                    throw new AssertionError("unhandled distributionType: " + phase.distributionInfo().distributionType());
+            }
         }
 
-        public Iterable<? extends NodeOperation> nodeOperations() {
-            return nodeOperations;
+        private void traceGetRowReceiver(UpstreamPhase phase,
+                                         String distributionTypeName,
+                                         NodeOperation nodeOperation,
+                                         RowReceiver targetRowReceiver) {
+            logger.trace("action=getRowReceiver, distributionType={}, phase={}, targetRowReceiver={}, target={}/{},",
+                    distributionTypeName,
+                    phase.executionPhaseId(),
+                    targetRowReceiver,
+                    nodeOperation.downstreamExecutionPhaseId(),
+                    nodeOperation.downstreamExecutionPhaseInputId()
+            );
+        }
+
+        private RowReceiver safeReceiver(RowReceiver targetRowReceiver, NodeOperation nodeOperation) {
+            if (targetRowReceiver == null) {
+                String msg =  String.format(Locale.ENGLISH,
+                        "targetRowReceiver %d/%d must be on the same node as phase %d, but it is null",
+                        nodeOperation.downstreamExecutionPhaseId(),
+                        nodeOperation.downstreamExecutionPhaseInputId(),
+                        nodeOperation.executionPhase().executionPhaseId());
+                throw new IllegalStateException(msg);
+            }
+            return targetRowReceiver;
+        }
+
+        /**
+         * The rowReceiver for handlerPhases got passed into {@link #prepareOnHandler(UUID, Iterable, JobExecutionContext.Builder, List, SharedShardContexts)}
+         * and is registered there.
+         *
+         * Retrieve it
+         */
+        private RowReceiver handlerPhaseRowReceiver(int phaseId) {
+            RowReceiver rowReceiver = phaseIdToRowReceivers.get(toKey(phaseId, (byte) 0));
+            logger.trace("Using rowReceiver {} for phase {}, this is a leaf/handlerPhase", rowReceiver, phaseId);
+            assert rowReceiver != null : "No rowReceiver for handlerPhase " + phaseId;
+            return rowReceiver;
+        }
+
+        public void registerRowReceiver(int phaseId, RowReceiver rowReceiver) {
+            phaseIdToRowReceivers.put(toKey(phaseId, (byte) 0), rowReceiver);
         }
     }
 
@@ -324,11 +417,6 @@ public class ContextPreparer {
             }
 
             RowReceiver rowReceiver = context.getRowReceiver(phase, 0);
-            if (rowReceiver == null) {
-                context.executionPhasesToProcess.add(phase);
-                return null;
-            }
-
             return new CountContext(
                     phase.executionPhaseId(),
                     countOperation,
@@ -342,14 +430,10 @@ public class ContextPreparer {
         public ExecutionSubContext visitMergePhase(final MergePhase phase, final PreparerContext context) {
             RamAccountingContext ramAccountingContext = RamAccountingContext.forExecutionPhase(circuitBreaker, phase);
 
-            boolean upstreamOnSameNode = context.getPhaseHasSameNodeUpstream(phase.executionPhaseId(), (byte) 0);
+            boolean upstreamOnSameNode = context.opCtx.upstreamsAreOnSameNode(phase.executionPhaseId());
 
             int pageSize = Paging.getWeightedPageSize(Paging.PAGE_SIZE, 1.0d / phase.executionNodes().size());
             RowReceiver rowReceiver = context.getRowReceiver(phase, pageSize);
-            if (rowReceiver == null) {
-                context.executionPhasesToProcess.add(phase);
-                return null;
-            }
 
             if (upstreamOnSameNode) {
                 if (!phase.projections().isEmpty()) {
@@ -361,11 +445,11 @@ public class ContextPreparer {
                             phase.projections(),
                             rowReceiver,
                             ramAccountingContext);
-                    context.registerRowReceiver(phase.executionPhaseId(), (byte) 0, projectorChainContext.rowReceiver());
+                    context.registerRowReceiver(phase.executionPhaseId(), projectorChainContext.rowReceiver());
                     return projectorChainContext;
                 }
 
-                context.registerRowReceiver(phase.executionPhaseId(), (byte) 0, rowReceiver);
+                context.registerRowReceiver(phase.executionPhaseId(), rowReceiver);
                 return null;
             }
 
@@ -389,15 +473,12 @@ public class ContextPreparer {
                     pageDownstreamProjectorChain.v2());
         }
 
+
         @Override
         public ExecutionSubContext visitRoutedCollectPhase(final RoutedCollectPhase phase, final PreparerContext context) {
             RamAccountingContext ramAccountingContext = RamAccountingContext.forExecutionPhase(circuitBreaker, phase);
             RowReceiver rowReceiver = context.getRowReceiver(phase,
                     MoreObjects.firstNonNull(phase.nodePageSizeHint(), Paging.PAGE_SIZE));
-            if (rowReceiver == null) {
-                context.executionPhasesToProcess.add(phase);
-                return null;
-            }
             return new JobCollectContext(
                     phase,
                     collectOperation,
@@ -412,10 +493,6 @@ public class ContextPreparer {
         public ExecutionSubContext visitCollectPhase(CollectPhase phase, PreparerContext context) {
             RamAccountingContext ramAccountingContext = RamAccountingContext.forExecutionPhase(circuitBreaker, phase);
             RowReceiver rowReceiver = context.getRowReceiver(phase, Paging.PAGE_SIZE);
-            if (rowReceiver == null) {
-                context.executionPhasesToProcess.add(phase);
-                return null;
-            }
             return new JobCollectContext(
                     phase,
                     collectOperation,
@@ -428,7 +505,7 @@ public class ContextPreparer {
 
         @Override
         public ExecutionSubContext visitFetchPhase(final FetchPhase phase, final PreparerContext context) {
-            final FluentIterable<Routing> routings = FluentIterable.from(context.nodeOperations())
+            final FluentIterable<Routing> routings = FluentIterable.from(context.opCtx.nodeOperationMap.values())
                     .transform(new Function<NodeOperation, ExecutionPhase>() {
                 @Nullable
                 @Override
@@ -461,10 +538,6 @@ public class ContextPreparer {
         public ExecutionSubContext visitNestedLoopPhase(NestedLoopPhase phase, PreparerContext context) {
             RamAccountingContext ramAccountingContext = RamAccountingContext.forExecutionPhase(circuitBreaker, phase);
             RowReceiver downstreamRowReceiver = context.getRowReceiver(phase, Paging.PAGE_SIZE);
-            if (downstreamRowReceiver == null) {
-                context.executionPhasesToProcess.add(phase);
-                return null;
-            }
 
             FlatProjectorChain flatProjectorChain;
             if (!phase.projections().isEmpty()) {
@@ -509,13 +582,10 @@ public class ContextPreparer {
                                                                          @Nullable MergePhase mergePhase,
                                                                          RowReceiver rowReceiver,
                                                                          RamAccountingContext ramAccountingContext) {
-            boolean upstreamOnSameNode = ctx.getPhaseHasSameNodeUpstream(nlPhaseId, inputId);
-            if (upstreamOnSameNode) {
-                assert mergePhase == null : "if upstream is on same node the phase must be null";
-                ctx.registerRowReceiver(nlPhaseId, inputId, rowReceiver);
+            if (mergePhase == null) {
+                ctx.phaseIdToRowReceivers.put(toKey(nlPhaseId, inputId), rowReceiver);
                 return null;
             }
-            assert mergePhase != null : "if upstream isn't on the same node, there must be a mergePhase";
             Tuple<PageDownstream, FlatProjectorChain> pageDownstreamWithChain = pageDownstreamFactory.createMergeNodePageDownstream(
                     mergePhase,
                     rowReceiver,
@@ -533,5 +603,10 @@ public class ContextPreparer {
                     pageDownstreamWithChain.v2()
             );
         }
+    }
+
+    private static long toKey(int phaseId, byte inputId) {
+        long l = (long) phaseId;
+        return (l << 32) | (inputId & 0xffffffffL);
     }
 }

--- a/sql/src/main/java/io/crate/action/job/SharedShardContexts.java
+++ b/sql/src/main/java/io/crate/action/job/SharedShardContexts.java
@@ -60,4 +60,11 @@ public class SharedShardContexts {
         }
         return sharedShardContext;
     }
+
+    @Override
+    public String toString() {
+        return "SharedShardContexts{" +
+               "allocatedShards=" + allocatedShards.keySet() +
+               '}';
+    }
 }

--- a/sql/src/main/java/io/crate/executor/transport/ExecutionPhasesTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/ExecutionPhasesTask.java
@@ -160,7 +160,7 @@ public class ExecutionPhasesTask extends JobTask {
         if (hasDirectResponse) {
             for (ExecutionSubContext executionSubContext : localContextAndStartOperation) {
                 assert executionSubContext != null && executionSubContext instanceof DownstreamExecutionSubContext
-                        : "Need DownstreamExecutionSubContext for DIRECT_RESPONSE remote jobs";
+                        : "Need DownstreamExecutionSubContext for DIRECT_RESPONSE remote jobs. Got " + executionSubContext;
                 pageDownstreamContexts.add(((DownstreamExecutionSubContext) executionSubContext).pageDownstreamContext((byte) 0));
             }
         }

--- a/sql/src/main/java/io/crate/executor/transport/TransportExecutor.java
+++ b/sql/src/main/java/io/crate/executor/transport/TransportExecutor.java
@@ -48,7 +48,10 @@ import io.crate.planner.IterablePlan;
 import io.crate.planner.NoopPlan;
 import io.crate.planner.Plan;
 import io.crate.planner.PlanVisitor;
+import io.crate.planner.distribution.DistributionType;
+import io.crate.planner.distribution.UpstreamPhase;
 import io.crate.planner.node.ExecutionPhase;
+import io.crate.planner.node.ExecutionPhases;
 import io.crate.planner.node.PlanNode;
 import io.crate.planner.node.PlanNodeVisitor;
 import io.crate.planner.node.ddl.*;
@@ -61,6 +64,8 @@ import io.crate.planner.node.management.KillPlan;
 import org.elasticsearch.action.bulk.BulkRetryCoordinatorPool;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -69,6 +74,8 @@ import javax.annotation.Nullable;
 import java.util.*;
 
 public class TransportExecutor implements Executor {
+
+    private static final ESLogger LOGGER = Loggers.getLogger(TransportExecutor.class);
 
     private final Functions functions;
     private final TaskCollectingVisitor planVisitor;
@@ -200,6 +207,7 @@ public class TransportExecutor implements Executor {
         private ExecutionPhasesTask executionPhasesTask(Plan plan, UUID jobId, ExecutionPhasesTask.OperationType operationType) {
             List<NodeOperationTree> nodeOperationTrees = BULK_NODE_OPERATION_VISITOR.createNodeOperationTrees(
                     plan, clusterService.localNode().id());
+            LOGGER.debug("Created NodeOperationTrees from Plan: {}", nodeOperationTrees);
             return new ExecutionPhasesTask(
                     jobId,
                     clusterService,
@@ -460,11 +468,23 @@ public class TransportExecutor implements Executor {
                     previousPhase = currentBranch.phases.lastElement();
                 }
                 if (setDownstreamNodes) {
+                    assert saneConfiguration(executionPhase, previousPhase.executionNodes()) : String.format(Locale.ENGLISH,
+                            "NodeOperation with %s and %s as downstreams cannot work",
+                            ExecutionPhases.debugPrint(executionPhase), previousPhase.executionNodes());
+
                     nodeOperations.add(NodeOperation.withDownstream(executionPhase, previousPhase, currentBranch.inputId, localNodeId));
                 } else {
                     nodeOperations.add(NodeOperation.withoutDownstream(executionPhase));
                 }
                 currentBranch.phases.add(executionPhase);
+            }
+
+            private boolean saneConfiguration(ExecutionPhase executionPhase, Collection<String> downstreamNodes) {
+                if (executionPhase instanceof UpstreamPhase && ((UpstreamPhase) executionPhase).distributionInfo().distributionType() ==
+                                                               DistributionType.SAME_NODE) {
+                    return downstreamNodes.isEmpty() || downstreamNodes.equals(executionPhase.executionNodes());
+                }
+                return true;
             }
 
             public void branch(byte inputId) {

--- a/sql/src/main/java/io/crate/jobs/JobExecutionContext.java
+++ b/sql/src/main/java/io/crate/jobs/JobExecutionContext.java
@@ -67,6 +67,12 @@ public class JobExecutionContext {
             this.statsTables = statsTables;
         }
 
+        public void addAllSubContexts(Iterable<? extends ExecutionSubContext> subContexts) {
+            for (ExecutionSubContext subContext : subContexts) {
+                addSubContext(subContext);
+            }
+        }
+
         public void addSubContext(ExecutionSubContext subContext) {
             ExecutionSubContext existingSubContext = subContexts.put(subContext.id(), subContext);
             if (existingSubContext != null) {

--- a/sql/src/main/java/io/crate/jobs/NestedLoopContext.java
+++ b/sql/src/main/java/io/crate/jobs/NestedLoopContext.java
@@ -153,6 +153,17 @@ public class NestedLoopContext extends AbstractExecutionSubContext implements Do
         return rightPageDownstreamContext;
     }
 
+    @Override
+    public String toString() {
+        return "NestedLoopContext{" +
+               "id=" + id() +
+               ", activeSubContexts=" + activeSubContexts +
+               ", leftCtx=" + leftPageDownstreamContext +
+               ", rightCtx=" + rightPageDownstreamContext +
+               ", closed=" + future.closed() +
+               '}';
+    }
+
     private class RemoveContextCallback implements FutureCallback<Object> {
 
         public RemoveContextCallback() {

--- a/sql/src/main/java/io/crate/jobs/PageDownstreamContext.java
+++ b/sql/src/main/java/io/crate/jobs/PageDownstreamContext.java
@@ -198,6 +198,17 @@ public class PageDownstreamContext extends AbstractExecutionSubContext implement
         return name;
     }
 
+    @Override
+    public String toString() {
+        return "PageDownstreamContext{" +
+               "id=" + id() +
+               ", numBuckets=" + numBuckets +
+               ", allFuturesSet=" + allFuturesSet +
+               ", exhausted=" + exhausted +
+               ", closed=" + future.closed() +
+               '}';
+    }
+
     @Nullable
     @Override
     public PageDownstreamContext pageDownstreamContext(byte inputId) {

--- a/sql/src/main/java/io/crate/operation/NodeOperation.java
+++ b/sql/src/main/java/io/crate/operation/NodeOperation.java
@@ -23,6 +23,7 @@ package io.crate.operation;
 
 import com.google.common.collect.ImmutableList;
 import io.crate.planner.distribution.DistributionInfo;
+import io.crate.planner.distribution.DistributionType;
 import io.crate.planner.distribution.UpstreamPhase;
 import io.crate.planner.node.ExecutionPhase;
 import io.crate.planner.node.ExecutionPhases;
@@ -36,14 +37,17 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Locale;
 
 public class NodeOperation implements Streamable {
 
     private static final ESLogger LOGGER = Loggers.getLogger(NodeOperation.class);
 
+    public static final int NO_DOWNSTREAM = Integer.MAX_VALUE;
+
     private ExecutionPhase executionPhase;
     private Collection<String> downstreamNodes;
-    private int downstreamExecutionPhaseId;
+    private int downstreamExecutionPhaseId = NO_DOWNSTREAM;
     private byte downstreamExecutionPhaseInputId;
 
     private NodeOperation(ExecutionPhase executionPhase,
@@ -89,9 +93,10 @@ public class NodeOperation implements Streamable {
                     inputId);
         } else {
             if (executionPhase instanceof UpstreamPhase) {
+                UpstreamPhase upstreamPhase = (UpstreamPhase) executionPhase;
                 if (executionPhase.executionNodes().size() == 1
                         && executionPhase.executionNodes().equals(downstreamExecutionPhase.executionNodes())) {
-                    ((UpstreamPhase) executionPhase).distributionInfo(DistributionInfo.DEFAULT_SAME_NODE);
+                    upstreamPhase.distributionInfo(DistributionInfo.DEFAULT_SAME_NODE);
                     LOGGER.trace("Phase uses SAME_NODE downstream, reason: ON DOWNSTRREAM NODE, executionNodes: {}, phase: {}", executionPhase.executionNodes(), executionPhase);
                 }
             }
@@ -143,7 +148,7 @@ public class NodeOperation implements Streamable {
 
     @Override
     public String toString() {
-        return "NodeOp{ " + executionPhase.executionPhaseId() + " " + executionPhase.name() +
+        return "NodeOp{ " + ExecutionPhases.debugPrint(executionPhase) +
                 ", downstreamNodes=" + downstreamNodes +
                 ", downstreamPhase=" + downstreamExecutionPhaseId +
                 ", downstreamInputId=" + downstreamExecutionPhaseInputId +

--- a/sql/src/main/java/io/crate/operation/NodeOperationTree.java
+++ b/sql/src/main/java/io/crate/operation/NodeOperationTree.java
@@ -68,4 +68,12 @@ public class NodeOperationTree {
     public ExecutionPhase leaf() {
         return leaf;
     }
+
+    @Override
+    public String toString() {
+        return "NodeOperationTree{" +
+               "nodeOperations=" + nodeOperations +
+               ", leaf=" + leaf +
+               '}';
+    }
 }

--- a/sql/src/main/java/io/crate/operation/collect/JobCollectContext.java
+++ b/sql/src/main/java/io/crate/operation/collect/JobCollectContext.java
@@ -43,6 +43,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Locale;
 
@@ -150,9 +151,11 @@ public class JobCollectContext extends AbstractExecutionSubContext implements Ex
     @Override
     public String toString() {
         return "JobCollectContext{" +
-                "searchContexts=" + searchContexts +
-                ", closed=" + future.closed() +
-                '}';
+               "sharedContexts=" + sharedShardContexts +
+               ", rowReceiver=" + rowReceiver +
+               ", searchContexts=" + Arrays.toString(searchContexts.keys) +
+               ", closed=" + future.closed() +
+               '}';
     }
 
     @Override

--- a/sql/src/main/java/io/crate/operation/projectors/InternalRowDownstreamFactory.java
+++ b/sql/src/main/java/io/crate/operation/projectors/InternalRowDownstreamFactory.java
@@ -54,7 +54,8 @@ public class InternalRowDownstreamFactory implements RowDownstreamFactory {
                                         UUID jobId,
                                         int pageSize) {
         Streamer<?>[] streamers = StreamerVisitor.streamerFromOutputs(nodeOperation.executionPhase());
-        assert !ExecutionPhases.hasDirectResponseDownstream(nodeOperation.downstreamNodes());
+        assert !ExecutionPhases.hasDirectResponseDownstream(nodeOperation.downstreamNodes())
+                : "trying to build a DistributingDownstream but nodeOperation has a directResponse downstream";
         assert nodeOperation.downstreamNodes().size() > 0 : "must have at least one downstream";
 
         // TODO: set bucketIdx properly

--- a/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
@@ -172,8 +172,9 @@ public class NestedLoopConsumer implements Consumer {
                     right = tmpRelation;
                 }
             }
-            Set<String> localExecutionNodes = ImmutableSet.of(clusterService.localNode().id());
-            Collection<String> nlExecutionNodes = localExecutionNodes;
+            Set<String> handlerNodes = ImmutableSet.of(clusterService.localNode().id());
+            Collection<String> nlExecutionNodes = handlerNodes;
+            isDistributed = isDistributed && leftPlan.resultPhase().executionNodes().size() > 1;
 
             MergePhase leftMerge = null;
             MergePhase rightMerge = null;
@@ -251,13 +252,10 @@ public class NestedLoopConsumer implements Consumer {
                     rightMerge,
                     nlExecutionNodes
             );
-            if (isDistributed) {
-                nl.distributionInfo(DistributionInfo.DEFAULT_BROADCAST);
-            }
             MergePhase localMergePhase = null;
             // TODO: build local merge phases somewhere else for any subplan
             if (isDistributed && context.isRoot()) {
-                localMergePhase = mergePhase(context, localExecutionNodes, nl, orderByBeforeSplit, postNLOutputs, true);
+                localMergePhase = mergePhase(context, handlerNodes, nl, orderByBeforeSplit, postNLOutputs, true);
                 assert localMergePhase != null : "local merge phase must not be null";
                 TopNProjection finalTopN = ProjectionBuilder.topNProjection(
                         postNLOutputs,

--- a/sql/src/main/java/io/crate/planner/node/ExecutionPhases.java
+++ b/sql/src/main/java/io/crate/planner/node/ExecutionPhases.java
@@ -21,6 +21,7 @@
 
 package io.crate.planner.node;
 
+import io.crate.planner.distribution.UpstreamPhase;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -48,5 +49,22 @@ public class ExecutionPhases {
             }
         }
         return false;
+    }
+
+    public static String debugPrint(ExecutionPhase phase) {
+        StringBuilder sb = new StringBuilder("phase{id=");
+        sb.append(phase.executionPhaseId());
+        sb.append("/");
+        sb.append(phase.name());
+        sb.append(", ");
+        sb.append("nodes=");
+        sb.append(phase.executionNodes());
+        if (phase instanceof UpstreamPhase) {
+            UpstreamPhase uPhase = (UpstreamPhase) phase;
+            sb.append(", dist=");
+            sb.append(uPhase.distributionInfo().distributionType());
+        }
+        sb.append("}");
+        return sb.toString();
     }
 }

--- a/sql/src/main/java/io/crate/planner/node/dql/join/NestedLoopPhase.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/join/NestedLoopPhase.java
@@ -53,7 +53,7 @@ public class NestedLoopPhase extends AbstractProjectionsPhase implements Upstrea
     private Collection<String> executionNodes;
     private MergePhase leftMergePhase;
     private MergePhase rightMergePhase;
-    private DistributionInfo distributionInfo = DistributionInfo.DEFAULT_SAME_NODE;
+    private DistributionInfo distributionInfo = DistributionInfo.DEFAULT_BROADCAST;
 
     public NestedLoopPhase() {}
 

--- a/sql/src/test/groovy/io/crate/action/job/NodeOperationCtxTest.groovy
+++ b/sql/src/test/groovy/io/crate/action/job/NodeOperationCtxTest.groovy
@@ -1,0 +1,93 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.action.job
+
+import com.carrotsearch.hppc.IntArrayList
+import io.crate.operation.NodeOperation
+import io.crate.planner.distribution.DistributionInfo
+import io.crate.test.integration.CrateUnitTest
+import io.crate.testing.StubPhases
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.ExpectedException
+
+class NodeOperationCtxTest extends CrateUnitTest {
+
+    @Test
+    void testFindLeafs() {
+        def p1 = StubPhases.newPhase(0, "n1", "n2")
+        def p2 = StubPhases.newPhase(1, "n1", "n2")
+        def p3 = StubPhases.newPhase(2, "n2")
+
+        def opCtx = new ContextPreparer.NodeOperationCtx([
+                NodeOperation.withDownstream(p1, p2, (byte)0, "n2"),
+                NodeOperation.withDownstream(p2, p3, (byte)0, "n2")])
+
+        def expected = new IntArrayList()
+        expected.add(2)
+
+        assert opCtx.findLeafs() == expected
+    }
+
+    @Test
+    void testFindLeafWithNodeOperationsThatHaveNoLeaf() {
+        def p1 = StubPhases.newPhase(0, "n1");
+        def opCtx = new ContextPreparer.NodeOperationCtx([
+                NodeOperation.withDownstream(p1, p1, (byte)0, "n1")])
+
+        opCtx.findLeafs().size() == 0;
+    }
+
+    @Test
+    public void testIsUpstreamOnSameNodeWithSameNodeOptimization() throws Exception {
+        def p1 = StubPhases.newUpstreamPhase(0, DistributionInfo.DEFAULT_BROADCAST, "n1")
+        def p2 = StubPhases.newPhase(1, "n1")
+        def opCtx = new ContextPreparer.NodeOperationCtx([NodeOperation.withDownstream(p1, p2, (byte)0, "n2")])
+
+        // withDownstream set DistributionInfo to SAME_NODE because both phases are on n1
+        assert opCtx.upstreamsAreOnSameNode(1)
+    }
+
+    @Test
+    public void testIsUpstreamOnSameNodeWithUpstreamOnOtherNode() throws Exception {
+        def p1 = StubPhases.newUpstreamPhase(0, DistributionInfo.DEFAULT_BROADCAST, "n2")
+        def p2 = StubPhases.newPhase(1, "n1")
+        def opCtx = new ContextPreparer.NodeOperationCtx([NodeOperation.withDownstream(p1, p2, (byte)0, "n1")])
+
+        assert opCtx.upstreamsAreOnSameNode(1) == false
+    }
+
+    @Test
+    public void testIsUpstreamOnSameNodeWithTwoUpstreamsThatAreOnTheSameNode() throws Exception {
+        def p1 = StubPhases.newUpstreamPhase(0, DistributionInfo.DEFAULT_SAME_NODE, "n2")
+        def p2 = StubPhases.newUpstreamPhase(2, DistributionInfo.DEFAULT_SAME_NODE, "n2")
+        def p3 = StubPhases.newPhase(3, "n2")
+
+        def opCtx = new ContextPreparer.NodeOperationCtx([
+                NodeOperation.withDownstream(p1, p3, (byte)0, "n1"),
+                NodeOperation.withDownstream(p2, p3, (byte)0, "n1")])
+
+
+        assert opCtx.upstreamsAreOnSameNode(3)
+    }
+}

--- a/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -72,7 +72,6 @@ public class JoinIntegrationTest extends SQLTransportIntegrationTest {
     @Test
     public void testInsertFromCrossJoin() throws Exception {
         createColorsAndSizes();
-
         execute("create table target (color string, size string)");
         ensureYellow();
 
@@ -85,6 +84,24 @@ public class JoinIntegrationTest extends SQLTransportIntegrationTest {
                 "green| large\n" +
                 "red| large\n" +
                 "blue| small\n"));
+    }
+
+    @Test
+    public void testInsertFromInnerJoin() throws Exception {
+        execute("create table t1 (x int)");
+        execute("create table t2 (y int)");
+        execute("create table target (x int, y int)");
+        ensureYellow();
+
+        execute("insert into t1 (x) values (1), (2)");
+        execute("insert into t2 (y) values (2), (3)");
+        execute("refresh table t1, t2");
+
+        execute("insert into target (x, y) (select t1.x, t2.y from t1 inner join t2 on t1.x = t2.y)");
+        execute("refresh table target");
+
+        execute("select x, y from target order by x, y");
+        assertThat(printedTable(response.rows()), is("2| 2\n"));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/collect/DocLevelCollectTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/DocLevelCollectTest.java
@@ -177,7 +177,7 @@ public class DocLevelCollectTest extends SQLTransportIntegrationTest {
     private RoutedCollectPhase getCollectNode(List<Symbol> toCollect, Routing routing, WhereClause whereClause) {
         return new RoutedCollectPhase(
                 UUID.randomUUID(),
-                0,
+                1,
                 "docCollect",
                 routing,
                 RowGranularity.DOC,

--- a/sql/src/test/java/io/crate/testing/StubPhases.java
+++ b/sql/src/test/java/io/crate/testing/StubPhases.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.testing;
+
+import io.crate.planner.distribution.DistributionInfo;
+import io.crate.planner.distribution.UpstreamPhase;
+import io.crate.planner.node.ExecutionPhase;
+import io.crate.planner.node.ExecutionPhaseVisitor;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+public class StubPhases {
+
+    public static UpstreamPhase newUpstreamPhase(int phaseId, DistributionInfo distributionInfo, String ... executionNodes) {
+        return new UpstreamStubPhase(phaseId, ExecutionPhase.Type.COLLECT, distributionInfo, executionNodes);
+    }
+
+    public static ExecutionPhase newPhase(int phaseId, String ... executionNodes) {
+        return new StubPhase(phaseId, ExecutionPhase.Type.COLLECT, executionNodes);
+    }
+
+    static class StubPhase implements ExecutionPhase {
+
+        private final int phaseId;
+        private final Type type;
+        private final List<String> executionNodes;
+
+        public StubPhase(int phaseId, Type type, String ... executionNodes) {
+            this.phaseId = phaseId;
+            this.type = type;
+            this.executionNodes = Arrays.asList(executionNodes);
+        }
+
+        @Override
+        public Type type() {
+            return type;
+        }
+
+        @Override
+        public String name() {
+            return "stub";
+        }
+
+        @Override
+        public int executionPhaseId() {
+            return phaseId;
+        }
+
+        @Override
+        public Collection<String> executionNodes() {
+            return executionNodes;
+        }
+
+        @Override
+        public <C, R> R accept(ExecutionPhaseVisitor<C, R> visitor, C context) {
+            return null;
+        }
+
+        @Override
+        public void readFrom(StreamInput in) throws IOException {
+
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+
+        }
+    }
+
+    static class UpstreamStubPhase extends StubPhase implements UpstreamPhase {
+
+        private DistributionInfo distributionInfo;
+
+        public UpstreamStubPhase(int phaseId, Type type, DistributionInfo distributionInfo, String... executionNodes) {
+            super(phaseId, type, executionNodes);
+            this.distributionInfo = distributionInfo;
+        }
+
+        @Override
+        public DistributionInfo distributionInfo() {
+            return distributionInfo;
+        }
+
+        @Override
+        public void distributionInfo(DistributionInfo distributionInfo) {
+            this.distributionInfo = distributionInfo;
+        }
+    }
+}


### PR DESCRIPTION
If all CollectPhases and the NestedLoopPhase ran on the same node a
incorrect execution plan was generated.

The NestedLoopConsumer planned the NestedLoopPhase as being distributed
but the ContextPreparer assumed that it runs in SAME_NODE mode.

This also includes a refactoring for the ContextPreparer because it
couldn't handle a NestedLoopPhase being the "leafPhase" in some cases.

The ContextPreparer is now smart and knowns in which order the contexts
have to be built instead of trying and re-process if some dependency has
been missing.