### PR TITLE
Don't change isDistributed flag based on number of executionNodes

### DIFF
--- a/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
@@ -174,7 +174,6 @@ public class NestedLoopConsumer implements Consumer {
             }
             Set<String> handlerNodes = ImmutableSet.of(clusterService.localNode().id());
             Collection<String> nlExecutionNodes = handlerNodes;
-            isDistributed = isDistributed && leftPlan.resultPhase().executionNodes().size() > 1;
 
             MergePhase leftMerge = null;
             MergePhase rightMerge = null;


### PR DESCRIPTION
Changing the flag can result in an invalid plan.
testFilteredJoinWithPartitionsAndSelectFromOnlyOneTable failed with seed
1C4DC12F5B2717EC