### PR TITLE
Fix resultIsDistributed implementation of NestedLoop

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,8 +13,8 @@ Unreleased
  - Improved the error message of insert into target/source column size
    miss-match
 
- - Fixed an issue that could cause INSERT INTO with an INNER JOIN in the
-   sub-query to fail.
+ - Fixed planner issues that could cause INSERT INTO with a JOIN in the
+   sub-query to fail or get stuck.
 
  - Removed the ``jobs.keep_alive_timeout`` setting and all related logic.
    This means it is no longer possible to enable automatic job termination.

--- a/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
@@ -265,7 +265,7 @@ public class NestedLoopConsumer implements Consumer {
                 );
                 localMergePhase.addProjection(finalTopN);
             }
-            return new NestedLoop(nl, leftPlan, rightPlan, localMergePhase);
+            return new NestedLoop(nl, leftPlan, rightPlan, localMergePhase, handlerNodes);
         }
 
         private void addOutputsAndSymbolMap(Iterable<? extends Symbol> outputs,

--- a/sql/src/main/java/io/crate/planner/node/dql/join/NestedLoop.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/join/NestedLoop.java
@@ -28,6 +28,8 @@ import io.crate.planner.node.dql.MergePhase;
 import io.crate.planner.projection.Projection;
 
 import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -64,6 +66,7 @@ public class NestedLoop extends PlanAndPlannedAnalyzedRelation {
 
     @Nullable
     private final MergePhase localMerge;
+    private final boolean resultIsDistributed;
 
     /**
      * create a new NestedLoop
@@ -94,12 +97,14 @@ public class NestedLoop extends PlanAndPlannedAnalyzedRelation {
     public NestedLoop(NestedLoopPhase nestedLoopPhase,
                       PlannedAnalyzedRelation left,
                       PlannedAnalyzedRelation right,
-                      @Nullable MergePhase localMerge) {
+                      @Nullable MergePhase localMerge,
+                      Collection<String> handlerNodes) {
         this.jobId = nestedLoopPhase.jobId();
         this.left = left;
         this.right = right;
         this.nestedLoopPhase = nestedLoopPhase;
         this.localMerge = localMerge;
+        this.resultIsDistributed = localMerge == null && !nestedLoopPhase.executionNodes().equals(handlerNodes);
     }
 
     public PlannedAnalyzedRelation left() {
@@ -125,7 +130,7 @@ public class NestedLoop extends PlanAndPlannedAnalyzedRelation {
 
     @Override
     public boolean resultIsDistributed() {
-        return resultPhase().executionNodes().size() > 1;
+        return resultIsDistributed;
     }
 
     @Override


### PR DESCRIPTION
Tests failed with Seed A3C65CC9BA044507

If the NestedLoop was executed on a single node that is not the handler,
insert from subquery would use the NestedLoopPhase as handlerPhase
because `resultIsDistributed` was false.