### PR TITLE
Ignore InternalSettingsPreparer in JarHell check

### DIFF
--- a/core/src/main/java/org/elasticsearch/bootstrap/JarHell.java
+++ b/core/src/main/java/org/elasticsearch/bootstrap/JarHell.java
@@ -274,6 +274,8 @@ public class JarHell {
                 if (clazz.startsWith("org.apache.log4j")) {
                     return; // go figure, jar hell for what should be System.out.println...
                 }
+                if (clazz.equals("org.elasticsearch.node.internal.InternalSettingsPreparer"))
+                    return; // duplicate class in Crate which includes crate specific settings
                 if (clazz.equals("org.joda.time.base.BaseDateTime")) {
                     return; // apparently this is intentional... clean this up
                 }


### PR DESCRIPTION
Class overloading is done on purpose.

This is just a quick fix because the InternalSettingsPreparer is removed
in the es21 branch anyway.