### PR TITLE
remove printStackDump from assertNoJobExecutionContextAreLeftOpen

### DIFF
--- a/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
@@ -176,14 +176,17 @@ public abstract class SQLTransportIntegrationTest extends ElasticsearchIntegrati
 
                     // prevent other tests from failing:
                     for (JobExecutionContext jobExecutionContext : contexts.values()) {
-                        jobExecutionContext.kill();
+                        try {
+                            jobExecutionContext.kill();
+                        } catch (Throwable t) {
+                            LOGGER.error("Error killing {} in assertNoJobExecutionContextAreLeftOpen", t, jobExecutionContext);
+                        }
                     }
                     contexts.clear();
                 } catch (IllegalAccessException ex) {
                     throw Throwables.propagate(e);
                 }
             }
-            printStackDump(LOGGER);
             throw new AssertionError(errorMessageBuilder.toString(), e);
         }
     }


### PR DESCRIPTION
It turned out that if a context isn't cleaned up it is almost always
because some callback isn't fired, never because of a hanging thread.

The stack dump is therefore mostly useless and just adds noise to the
logs.