### PR TITLE
fixed error handling of concurrent DML stmts on partitions

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed error handling of concurrent update/insert and delete
+   statements on partitioned tables.
+
  - Improved the error message of ON DUPLICATE KEY statements that attempt to
    update null objects using a subscript notation.
 

--- a/sql/src/main/java/io/crate/executor/transport/TransportShardUpsertAction.java
+++ b/sql/src/main/java/io/crate/executor/transport/TransportShardUpsertAction.java
@@ -77,6 +77,7 @@ import org.elasticsearch.index.mapper.internal.RoutingFieldMapper;
 import org.elasticsearch.index.mapper.internal.TTLFieldMapper;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.indices.IndexMissingException;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.search.fetch.source.FetchSourceContext;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -220,7 +221,8 @@ public class TransportShardUpsertAction
                         0);
                 shardUpsertResponse.add(location);
             } catch (Throwable t) {
-                if (!TransportActions.isShardNotAvailableException(t) && !request.continueOnError()) {
+                if ((!TransportActions.isShardNotAvailableException(t) && !request.continueOnError())
+                        || (t instanceof IndexMissingException && PartitionName.isPartition(request.index()))) {
                     throw t;
                 } else {
                     logger.debug("{} failed to execute upsert for [{}]/[{}]",

--- a/sql/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.integrationtests;
+
+import com.carrotsearch.randomizedtesting.annotations.TimeoutSuite;
+import io.crate.action.sql.SQLResponse;
+import io.crate.metadata.PartitionName;
+import io.crate.testing.SQLTransportExecutor;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+@TimeoutSuite(millis = 0)
+public class PartitionedTableConcurrentIntegrationTest extends SQLTransportIntegrationTest {
+
+    static Object[][] BULK_ARGS;
+
+    @BeforeClass
+    public static void setUpData() {
+        int numberOfDocs = 1000;
+        BULK_ARGS = new Object[numberOfDocs][];
+        for (int i = 0; i < numberOfDocs; i++) {
+            BULK_ARGS[i] = new Object[]{i % 2, randomAsciiOfLength(10)};
+        }
+    }
+
+    private void deletePartitionWhileInsertingData(final boolean useBulk) throws Exception {
+        execute("create table parted (id int, name string) " +
+                "partitioned by (id) " +
+                "with (number_of_replicas = 0)");
+        ensureYellow();
+
+        // partition to delete
+        final int idToDelete = 1;
+
+        final AtomicReference<Exception> exceptionRef = new AtomicReference<>();
+        final CountDownLatch insertLatch = new CountDownLatch(1);
+        final String insertStmt = "insert into parted (id, name) values (?, ?)";
+        Thread insertThread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    if (useBulk) {
+                        execute(insertStmt, BULK_ARGS);
+                    } else {
+                        for (Object[] args : BULK_ARGS) {
+                            execute(insertStmt, args);
+                        }
+                    }
+                } catch (Exception t) {
+                    exceptionRef.set(t);
+                } finally {
+                    insertLatch.countDown();
+                }
+            }
+        });
+
+        final CountDownLatch deleteLatch = new CountDownLatch(1);
+        final String partitionName = new PartitionName("parted",
+                Collections.singletonList(new BytesRef(String.valueOf(idToDelete)))
+        ).asIndexName();
+        final Object[] deleteArgs = new Object[]{idToDelete};
+        Thread deleteThread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                boolean deleted = false;
+                while (!deleted) {
+                    try {
+                        MetaData metaData = client().admin().cluster().prepareState().execute().actionGet()
+                                .getState().metaData();
+                        if (metaData.indices().get(partitionName) != null) {
+                            SQLResponse response = execute("delete from parted where id = ?", deleteArgs);
+                            if (response.rowCount() != 0) {
+                                deleted = true;
+                            }
+                        }
+                    } catch (Throwable t) {
+                        // ignore
+                    }
+                }
+                deleteLatch.countDown();
+            }
+        });
+
+        insertThread.start();
+        deleteThread.start();
+        deleteLatch.await(SQLTransportExecutor.REQUEST_TIMEOUT.getSeconds() + 1, TimeUnit.SECONDS);
+        insertLatch.await(SQLTransportExecutor.REQUEST_TIMEOUT.getSeconds() + 1, TimeUnit.SECONDS);
+
+        Exception exception = exceptionRef.get();
+        if (exception != null) {
+            throw exception;
+        }
+
+        insertThread.join();
+        deleteThread.join();
+    }
+
+    @Test
+    public void testDeletePartitionWhileInsertingData() throws Exception {
+        deletePartitionWhileInsertingData(false);
+    }
+
+    @Test
+    public void testDeletePartitionWhileBulkInsertingData() throws Exception {
+        deletePartitionWhileInsertingData(true);
+    }
+}

--- a/sql/src/test/java/io/crate/testing/SQLTransportExecutor.java
+++ b/sql/src/test/java/io/crate/testing/SQLTransportExecutor.java
@@ -45,10 +45,11 @@ public class SQLTransportExecutor {
 
     private static final String SQL_REQUEST_TIMEOUT = "CRATE_TESTS_SQL_REQUEST_TIMEOUT";
 
+    public static final TimeValue REQUEST_TIMEOUT = new TimeValue(Long.parseLong(
+            MoreObjects.firstNonNull(System.getenv(SQL_REQUEST_TIMEOUT), "5")), TimeUnit.SECONDS);
+
     private static final ESLogger LOGGER = Loggers.getLogger(SQLTransportExecutor.class);
     private final ClientProvider clientProvider;
-    private static final TimeValue REQUEST_TIMEOUT = new TimeValue(Long.parseLong(
-            MoreObjects.firstNonNull(System.getenv(SQL_REQUEST_TIMEOUT), "5")), TimeUnit.SECONDS);
 
     public static SQLTransportExecutor create(final TestCluster testCluster) {
         return new SQLTransportExecutor(new ClientProvider() {


### PR DESCRIPTION
 - inserting/updating a single document while partition is deleted resulted into an exception (0 row count expected)
 - inserting multiple documents (bulk) while partition is deleted resulted into threaded dispatched IndexRequest retries (running in cluster change listener threads) (expected is no operation is ongoing after upsert request finishes)