### PR TITLE
fix: sidebar-toctree lists 2 documents as current

### DIFF
--- a/docs/sql/ddl.txt
+++ b/docs/sql/ddl.txt
@@ -729,10 +729,8 @@ This analyzer will use the char-filters and token-filters from
 Analyzer Reference
 ------------------
 
-.. toctree::
-  :maxdepth: 2
-
-  analyzer
+See the reference documentation of the :ref:`builtin-analyzer` to get detailed
+information on the available analyzers.
 
 
 .. _sql_ddl_system_columns:


### PR DESCRIPTION
Bug in Sphinx `toctree` directive leads to two current-marked pages in toctree if a page contains a 
`.. toctree::` of an other page.