### PR TITLE
correctly resolve crate.yml and logging.yml configuration files

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fix: ``path.conf`` setting was ignored when set as command line argument
+
  - Improved the error message of ON DUPLICATE KEY statements that attempt to
    update null objects using a subscript notation.
 

--- a/app/src/main/dist/bin/crate
+++ b/app/src/main/dist/bin/crate
@@ -70,10 +70,6 @@ CRATE_HOME=`dirname "$SCRIPT"`/..
 # make CRATE_HOME absolute
 CRATE_HOME=`cd "$CRATE_HOME"; pwd`
 
-# define crate config file
-CRATE_CONFIG=$CRATE_HOME/config/crate.yml
-
-
 # If an include wasn't specified in the environment, then search for one...
 if [ "x$CRATE_INCLUDE" = "x" ]; then
     # Locations (in order) to use when searching for an include file.
@@ -123,12 +119,12 @@ launch_service()
     fi
 
     if [ "x$daemonized" = "x" ]; then
-        exec "$JAVA" $JAVA_OPTS $CRATE_JAVA_OPTS $es_parms -Des.path.home="$CRATE_HOME" -Des.config="$CRATE_CONFIG" -cp "$CRATE_CLASSPATH" $props \
+        exec "$JAVA" $JAVA_OPTS $CRATE_JAVA_OPTS $es_parms -Des.path.home="$CRATE_HOME" -cp "$CRATE_CLASSPATH" $props \
                 io.crate.bootstrap.CrateF
         execval=$?
     else
         # Startup Crate, background it, and write the pid.
-        exec "$JAVA" $JAVA_OPTS $CRATE_JAVA_OPTS $es_parms -Des.path.home="$CRATE_HOME" -Des.config="$CRATE_CONFIG" -cp "$CRATE_CLASSPATH" $props \
+        exec "$JAVA" $JAVA_OPTS $CRATE_JAVA_OPTS $es_parms -Des.path.home="$CRATE_HOME" -cp "$CRATE_CLASSPATH" $props \
                     io.crate.bootstrap.Crate <&- &
         execval=$?
         [ ! -z "$pidpath" ] && printf '%d' $! > "$pidpath"

--- a/app/src/main/java/org/elasticsearch/node/internal/InternalSettingsPreparer.java
+++ b/app/src/main/java/org/elasticsearch/node/internal/InternalSettingsPreparer.java
@@ -45,8 +45,6 @@ import static org.elasticsearch.common.settings.ImmutableSettings.settingsBuilde
  */
 public class InternalSettingsPreparer {
 
-    static final List<String> ALLOWED_SUFFIXES = ImmutableList.of(".yml", ".yaml", ".json", ".properties");
-
     public static final String SECRET_PROMPT_VALUE = "${prompt.secret}";
     public static final String TEXT_PROMPT_VALUE = "${prompt.text}";
     public static final String IGNORE_SYSTEM_PROPERTIES_SETTING = "config.ignore_system_properties";
@@ -108,12 +106,10 @@ public class InternalSettingsPreparer {
                 }
             }
             if (loadFromEnv) {
-                for (String allowedSuffix : ALLOWED_SUFFIXES) {
-                    try {
-                        settingsBuilder.loadFromUrl(environment.resolveConfig("elasticsearch" + allowedSuffix));
-                    } catch (FailedToResolveConfigException e) {
-                        // ignore
-                    }
+                try {
+                    settingsBuilder.loadFromUrl(environment.resolveConfig("crate.yml"));
+                } catch (FailedToResolveConfigException e) {
+                    // ignore
                 }
             }
         }


### PR DESCRIPTION
when ``path.conf`` setting is set as command line argument, e.g.

```
/path1/bin/crate -Des.path.conf=/path2/config
```

now correctly resolves the config file ``/path2/config/crate.yml``