### PR TITLE
Fixed an issue that caused delete queries to fail if they contain a f…

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed an issue that caused delete queries to fail if they contain
+   a expression on the left side of a comparison, e.g. 2 + 1 > x
+
  - Fix: ``path.conf`` setting was ignored when set as command line argument
 
  - Fixed error handling of concurrent update/insert and delete

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -831,7 +831,8 @@ public class ExpressionAnalyzer {
          * eq(2, name)  becomes  eq(name, 2)
          */
         private void swapIfNecessary() {
-            if (!(left.symbolType().isValueSymbol() && (right instanceof Reference || right instanceof Field))) {
+            if (!(right instanceof Reference || right instanceof Field)
+                    || left instanceof Reference || left instanceof Field) {
                 return;
             }
             ComparisonExpression.Type type = SWAP_OPERATOR_TABLE.get(comparisonExpressionType);

--- a/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -376,6 +376,17 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    public void testDeleteWhereFunctionLeftSide() throws Exception {
+        execute("create table test (x integer) with (number_of_replicas=0)");
+        execute("insert into test values (5)");
+        refresh();
+        execute("delete from test where 8 + 5 > x");
+        refresh();
+        execute("select * from test");
+        assertEquals(0, response.rowCount());
+    }
+
+    @Test
     public void testDeleteWhereIsNull() throws Exception {
         execute("create table test (id integer, name string) with (number_of_replicas=0)");
         execute("insert into test (id, name) values (1, 'foo')"); // name exists


### PR DESCRIPTION
…unction on the left side of a comparison, e.g. f() > x