### PR TITLE
improved validation of geo point data type

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Improved validation of geo point data type; now it is not possible any more
+   to insert invalid latitude or longitude in array literals.
+
  - Fix: ``path.conf`` setting was ignored when set as command line argument
 
  - Improved the error message of ON DUPLICATE KEY statements that attempt to

--- a/core/src/main/java/io/crate/types/GeoPointType.java
+++ b/core/src/main/java/io/crate/types/GeoPointType.java
@@ -66,6 +66,7 @@ public class GeoPointType extends DataType<Double[]> implements Streamer<Double[
         if (value instanceof Double[]) {
             Double[] doubles = (Double[]) value;
             checkLengthIs2(doubles.length);
+            validate(doubles);
             return doubles;
         }
         if (value instanceof BytesRef) {
@@ -77,13 +78,30 @@ public class GeoPointType extends DataType<Double[]> implements Streamer<Double[
         if (value instanceof List)  {
             List values = (List) value;
             checkLengthIs2(values.size());
-            return new Double[] { (Double) values.get(0), (Double) values.get(1) };
+            Double[] geoPoint = new Double[] { (Double) values.get(0), (Double) values.get(1) };
+            validate(geoPoint);
+            return geoPoint;
         }
-        Object[] values = (Object[])value;
+        Object[] values = (Object[]) value;
         checkLengthIs2(values.length);
-        return new Double[]{
+        Double[] geoPoint = new Double[] {
                 ((Number) values[0]).doubleValue(),
                 ((Number) values[1]).doubleValue()};
+        validate(geoPoint);
+        return geoPoint;
+    }
+
+    private void validate(Double[] doubles) {
+        if (!isValid(doubles)) {
+            throw new IllegalArgumentException(String.format(Locale.ENGLISH,
+                    "Failed to validate geo point [lon=%f, lat=%f], not a valid location.",
+                    doubles[0], doubles[1]));
+        }
+    }
+
+    private static boolean isValid(Double[] geoPoint) {
+        assert geoPoint.length == 2 : "Geo point array must contain 2 Double values.";
+        return (geoPoint[0] >= -180.0d && geoPoint[0] <= 180.0d) && (geoPoint[1] >= -90.0d && geoPoint[1] <= 90.0d);
     }
 
     private static void checkLengthIs2(int actualLength) {

--- a/core/src/test/java/io/crate/types/GeoPointTypeTest.java
+++ b/core/src/test/java/io/crate/types/GeoPointTypeTest.java
@@ -24,7 +24,9 @@ package io.crate.types;
 import io.crate.test.integration.CrateUnitTest;
 import org.elasticsearch.common.io.stream.BytesStreamInput;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.util.Arrays;
 
@@ -32,6 +34,9 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 public class GeoPointTypeTest extends CrateUnitTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void testStreaming() throws Throwable {
@@ -49,9 +54,14 @@ public class GeoPointTypeTest extends CrateUnitTest {
     @Test
     public void testWktToGeoPointValue() throws Exception {
         Double[] value = DataTypes.GEO_POINT.value("POINT(1 2)");
-
         assertThat(value[0], is(1.0d));
         assertThat(value[1], is(2.0d));
+    }
+
+    @Test
+    public void testInvalidWktToGeoPointValue() throws Exception {
+        expectedException.expectMessage("Cannot convert \"POINT(54.321 -123.456)\" to geo_point");
+        DataTypes.GEO_POINT.value("POINT(54.321 -123.456)");
     }
 
     @Test
@@ -73,5 +83,17 @@ public class GeoPointTypeTest extends CrateUnitTest {
         Double[] value = DataTypes.GEO_POINT.value(new Integer[] { 1, 2 });
         assertThat(value[0], is(1.0));
         assertThat(value[1], is(2.0));
+    }
+
+    @Test
+    public void testInvalidLatitude() throws Exception {
+        expectedException.expectMessage("Failed to validate geo point [lon=54.321000, lat=-123.456000], not a valid location.");
+        DataTypes.GEO_POINT.value(new Double[]{ 54.321, -123.456 });
+    }
+
+    @Test
+    public void testInvalidLongitude() throws Exception {
+        expectedException.expectMessage("Failed to validate geo point [lon=-187.654000, lat=123.456000], not a valid location.");
+        DataTypes.GEO_POINT.value(new Double[]{ -187.654, 123.456 });
     }
 }


### PR DESCRIPTION
now it is not possible any more to insert invalid latitude or longitude in array literals

```sql
insert into geotest (name, description, location) values ('Dornbirn', 'Dornbirn is a city in the Austrian state of Vorarlberg. It is the administrative centre for the district of Dornbirn, which also includes the town of Hohenems, and the market town Lustenau.', [9.7438,-147.4124])
```
will now raise: 
```
SQLActionException[Validation failed for location: [9.7438, -147.4124] cannot be cast to type geo_point]

io.crate.exceptions.ColumnValidationException: Validation failed for location: [9.7438, -147.4124] cannot be cast to type geo_point
	at io.crate.analyze.expressions.ValueNormalizer.normalizeInputForReference(ValueNormalizer.java:81)
	at io.crate.analyze.InsertFromValuesAnalyzer.addValues(InsertFromValuesAnalyzer.java:245)
	at io.crate.analyze.InsertFromValuesAnalyzer.analyzeValues(InsertFromValuesAnalyzer.java:197)
	at io.crate.analyze.InsertFromValuesAnalyzer.visitInsertFromValues(InsertFromValuesAnalyzer.java:120)
	at io.crate.analyze.InsertFromValuesAnalyzer.visitInsertFromValues(InsertFromValuesAnalyzer.java:53)
	at io.crate.sql.tree.InsertFromValues.accept(InsertFromValues.java:90)
...
```