### PR TITLE
Catching Throwable to include regex exceptions

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed an issue that caused queries to get stuck if an invalid regex is used. 
+
  - Fixed an issue that caused INSERT-FROM-QUERY statements to fail if the
    target table contained a generated column as primary key
 

--- a/sql/src/main/java/io/crate/operation/collect/collectors/CrateDocCollector.java
+++ b/sql/src/main/java/io/crate/operation/collect/collectors/CrateDocCollector.java
@@ -144,11 +144,10 @@ public class CrateDocCollector implements CrateCollector {
         try {
             weight = searchContext.engineSearcher().searcher().createNormalizedWeight(searchContext.query());
             leavesIt = contextIndexSearcher.getTopReaderContext().leaves().iterator();
-        } catch (IOException e) {
+        } catch (Throwable e) {
             fail(e);
             return;
         }
-
         // these won't change anymore, so safe the state once in case there is a pause or resume
         state.collector = collector;
         state.weight = weight;


### PR DESCRIPTION
The method was not catching RegexSyntaxException, changed catch part to catch all Throwable(s).