### PR TITLE
testing: make sure plan is executed on "planner-node"

### DIFF
--- a/sql/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
@@ -26,7 +26,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 import io.crate.action.sql.SQLResponse;
 import io.crate.executor.TaskResult;
 import io.crate.metadata.PartitionName;
-import io.crate.planner.Plan;
 import io.crate.testing.SQLTransportExecutor;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteRequestBuilder;
@@ -175,7 +174,7 @@ public class PartitionedTableConcurrentIntegrationTest extends SQLTransportInteg
         execute("insert into t (name, p) values ('Arthur', 'a'), ('Trillian', 't')");
         ensureYellow();
 
-        Plan plan = plan(stmt);
+        PlanForNode plan = plan(stmt);
         execute("delete from t");
         ListenableFuture<List<TaskResult>> future = execute(plan);
         return future.get(500, TimeUnit.MILLISECONDS).get(0);
@@ -207,7 +206,7 @@ public class PartitionedTableConcurrentIntegrationTest extends SQLTransportInteg
         execute("insert into t (name, p) values ('Arthur', 'a'), ('Trillian', 't')");
         execute("refresh table t");
 
-        Plan plan = plan("refresh table t"); // create a plan in which the partitions exist
+        PlanForNode plan = plan("refresh table t"); // create a plan in which the partitions exist
         execute("delete from t");
 
         ListenableFuture<List<TaskResult>> future = execute(plan); // execute now that the partitions are gone

--- a/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
@@ -267,17 +267,31 @@ public abstract class SQLTransportIntegrationTest extends ElasticsearchIntegrati
         return response;
     }
 
-    public Plan plan(String stmt) {
-        Analyzer analyzer = internalCluster().getInstance(Analyzer.class);
-        Planner planner = internalCluster().getInstance(Planner.class);
+    public static class PlanForNode {
+        private final Plan plan;
+        private final String nodeName;
 
-        ParameterContext parameterContext = new ParameterContext(new Object[0], new Object[0][], null);
-        return planner.plan(analyzer.analyze(SqlParser.createStatement(stmt), parameterContext), UUID.randomUUID());
+        private PlanForNode(Plan plan, String nodeName) {
+            this.plan = plan;
+            this.nodeName = nodeName;
+        }
     }
 
-    public ListenableFuture<List<TaskResult>> execute(Plan plan) {
-        TransportExecutor transportExecutor = internalCluster().getInstance(TransportExecutor.class);
-        Job job = transportExecutor.newJob(plan);
+    public PlanForNode plan(String stmt) {
+        String[] nodeNames = internalCluster().getNodeNames();
+        String nodeName = nodeNames[randomIntBetween(1, nodeNames.length) - 1];
+
+        Analyzer analyzer = internalCluster().getInstance(Analyzer.class, nodeName);
+        Planner planner = internalCluster().getInstance(Planner.class, nodeName);
+
+        ParameterContext parameterContext = new ParameterContext(new Object[0], new Object[0][], null);
+        Plan plan = planner.plan(analyzer.analyze(SqlParser.createStatement(stmt), parameterContext), UUID.randomUUID());
+        return new PlanForNode(plan, nodeName);
+    }
+
+    public ListenableFuture<List<TaskResult>> execute(PlanForNode planForNode) {
+        TransportExecutor transportExecutor = internalCluster().getInstance(TransportExecutor.class, planForNode.nodeName);
+        Job job = transportExecutor.newJob(planForNode.plan);
         List<? extends ListenableFuture<TaskResult>> futures = transportExecutor.execute(job);
         return Futures.allAsList(futures);
     }

--- a/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -31,7 +31,6 @@ import io.crate.action.sql.SQLBulkResponse;
 import io.crate.exceptions.Exceptions;
 import io.crate.exceptions.TableUnknownException;
 import io.crate.executor.TaskResult;
-import io.crate.planner.Plan;
 import io.crate.testing.TestingHelpers;
 import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsRequest;
 import org.elasticsearch.common.collect.MapBuilder;
@@ -88,7 +87,7 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
         execute("create table t (name string)");
         ensureYellow();
 
-        Plan plan = plan("select * from t");
+        PlanForNode plan = plan("select * from t");
         execute("drop table t");
         ListenableFuture<List<TaskResult>> future = execute(plan);
         try {


### PR DESCRIPTION
A plan has to be executed on the node that generated the plan. Otherwise
parts of the plan that involve the handler/coordinator node could be
invalid.