### PR TITLE
Fix: queries could be slower if they contain an expression on

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fix: queries could be slower if they contain an expression on
+   the left side of a comparison, ( e.g: 2 + 1 > x ) instead of the right side
+
  - Updated crate/elasticsearch to fix an issue where the `minAvailability`
    setting was not read from config file
 

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -764,12 +764,13 @@ public class ExpressionAnalyzer {
         }
 
         /**
-         * swaps the comparison so that references are on the left side.
+         * swaps the comparison so that references and fields are on the left side.
          * e.g.:
          * eq(2, name)  becomes  eq(name, 2)
          */
         private void swapIfNecessary() {
-            if (!(left.symbolType().isValueSymbol() && (right instanceof Reference || right instanceof Field))) {
+            if (!(right instanceof Reference || right instanceof Field)
+                    || left instanceof Reference || left instanceof Field) {
                 return;
             }
             ComparisonExpression.Type type = SWAP_OPERATOR_TABLE.get(comparisonExpressionType);

--- a/sql/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -39,6 +39,8 @@ import io.crate.metadata.table.TableInfo;
 import io.crate.sql.parser.SqlParser;
 import io.crate.sql.tree.QualifiedName;
 import io.crate.test.integration.CrateUnitTest;
+import io.crate.testing.SqlExpressions;
+import io.crate.testing.T3;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.junit.Before;
@@ -47,6 +49,7 @@ import org.junit.Test;
 import java.util.*;
 
 import static io.crate.testing.TestingHelpers.getFunctions;
+import static io.crate.testing.TestingHelpers.isField;
 import static org.hamcrest.Matchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -158,6 +161,15 @@ public class ExpressionAnalyzerTest extends CrateUnitTest {
         Field t1Id = ((Field) ((Function) ((Function) andFunction.arguments().get(0)).arguments().get(0)).arguments().get(0));
         Field t2Id = ((Field) ((Function) ((Function) andFunction.arguments().get(1)).arguments().get(0)).arguments().get(0));
         assertTrue(t1Id.relation() != t2Id.relation());
+    }
+
+    @Test
+    public void testSwapFunctionLeftSide() throws Exception {
+        SqlExpressions expressions = new SqlExpressions(T3.SOURCES);
+        Function cmp = (Function)expressions.normalize(expressions.asSymbol("8 + 5 > t1.x"));
+        // the comparison was swapped so the field is on the left side
+        assertThat(cmp.info().ident().name(), is("op_<"));
+        assertThat(cmp.arguments().get(0), isField("x"));
     }
 
     @Test


### PR DESCRIPTION
the left side of a comparison, ( e.g: 2 + 1 > x ) instead of the right side