### PR TITLE
updated ES upstream, fixed restore concrete indices

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fix: While restoring a snapshot with multiple indices inside,
+   selecting concrete indices can result in a wrong index being restored.
+
  - Fix: Insert by query into a table with nested primary keys or
    nested partitioned by columns defined did not work.
 


### PR DESCRIPTION
Elasticsearch PR's of this fix:
https://github.com/crate/elasticsearch/pull/68
https://github.com/elastic/elasticsearch/pull/17671

This will fix issue https://github.com/crate/crate/issues/3316