### PR TITLE
testing: Include nodeName in assertNoJobExecutionContextAreLeftOpen

### DIFF
--- a/sql/src/main/java/io/crate/operation/collect/JobCollectContext.java
+++ b/sql/src/main/java/io/crate/operation/collect/JobCollectContext.java
@@ -154,7 +154,8 @@ public class JobCollectContext extends AbstractExecutionSubContext {
     @Override
     public String toString() {
         return "JobCollectContext{" +
-               "sharedContexts=" + sharedShardContexts +
+               "id=" + id +
+               ", sharedContexts=" + sharedShardContexts +
                ", rowReceiver=" + rowReceiver +
                ", searchContexts=" + Arrays.toString(searchContexts.keys) +
                ", closed=" + future.closed() +

--- a/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
@@ -167,10 +167,15 @@ public abstract class SQLTransportIntegrationTest extends ElasticsearchIntegrati
             }, 10L, TimeUnit.SECONDS);
         } catch (AssertionError e) {
             StringBuilder errorMessageBuilder = new StringBuilder();
-            for (JobContextService jobContextService : internalCluster().getInstances(JobContextService.class)) {
+            String[] nodeNames = internalCluster().getNodeNames();
+            for (String nodeName : nodeNames) {
+                JobContextService jobContextService = internalCluster().getInstance(JobContextService.class, nodeName);
                 try {
                     //noinspection unchecked
                     Map<UUID, JobExecutionContext> contexts = (Map<UUID, JobExecutionContext>) activeContexts.get(jobContextService);
+                    errorMessageBuilder.append("## node: ");
+                    errorMessageBuilder.append(nodeName);
+                    errorMessageBuilder.append("\n");
                     errorMessageBuilder.append(contexts.toString());
                     errorMessageBuilder.append("\n");
 


### PR DESCRIPTION
This way it is possible to see on which node a context has been left
open.