### PR TITLE
bind ContextPreparer and LuceneQueryBuilder as asEagerSingleton

### DIFF
--- a/sql/src/main/java/io/crate/executor/transport/TransportExecutorModule.java
+++ b/sql/src/main/java/io/crate/executor/transport/TransportExecutorModule.java
@@ -21,10 +21,12 @@
 
 package io.crate.executor.transport;
 
+import io.crate.action.job.ContextPreparer;
 import io.crate.action.job.TransportJobAction;
 import io.crate.executor.Executor;
 import io.crate.executor.transport.distributed.TransportDistributedResultAction;
 import io.crate.executor.transport.kill.TransportKillAllNodeAction;
+import io.crate.lucene.LuceneQueryBuilder;
 import org.elasticsearch.common.inject.AbstractModule;
 
 public class TransportExecutorModule extends AbstractModule {
@@ -33,6 +35,8 @@ public class TransportExecutorModule extends AbstractModule {
     protected void configure() {
         bind(TransportActionProvider.class).asEagerSingleton();
         bind(Executor.class).to(TransportExecutor.class).asEagerSingleton();
+        bind(ContextPreparer.class).asEagerSingleton();
+        bind(LuceneQueryBuilder.class).asEagerSingleton();
 
         bind(TransportJobAction.class).asEagerSingleton();
         bind(TransportDistributedResultAction.class).asEagerSingleton();


### PR DESCRIPTION
There was some kind of race condition which could cause the
LuceneQueryBuilder to be bound in the shardInjector instead of the
nodeInjector.

Which would then cause guice injection errors once the
LuceneQueryBuilder was accessed on a node level.