### PR TITLE
fixed template ordering while adding column to partitioned table

### DIFF
--- a/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -1623,6 +1623,8 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
                 .mapAndClose()
                 .get(Constants.DEFAULT_MAPPING_TYPE);
         assertNotNull(((Map) mapping.get("properties")).get("name"));
+        // template order must not be touched
+        assertThat(metaData.order(), is(100));
     }
 
     @Test


### PR DESCRIPTION
template order value was lost after template was updated (replaced) caused by a newly added column.