### PR TITLE
Fix bug which could cause match predicate in WHERE clause for partitioned tables to fail. 

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,10 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fix bug which could cause the MATCH predicate in WHERE clause for
+   partitioned tables to fail. This happens in cases when a column ident of the
+   MATCH predicate is not a primary key column.
+
  - Fix: While restoring a snapshot with multiple indices inside,
    selecting concrete indices can result in a wrong index being restored.
 

--- a/sql/src/main/java/io/crate/analyze/where/EqualityExtractor.java
+++ b/sql/src/main/java/io/crate/analyze/where/EqualityExtractor.java
@@ -89,12 +89,14 @@ public class EqualityExtractor {
                 if (anyNull){
                     return null;
                 }
-                List<Symbol> row = new ArrayList<>(proxies.size());
-                for (EqProxy proxy : proxies) {
-                    proxy.reset();
-                    row.add(proxy.origin.arguments().get(1));
+                if (!proxies.isEmpty()) {
+                    List<Symbol> row = new ArrayList<>(proxies.size());
+                    for (EqProxy proxy : proxies) {
+                        proxy.reset();
+                        row.add(proxy.origin.arguments().get(1));
+                    }
+                    result.add(row);
                 }
-                result.add(row);
             } else {
                 for (EqProxy proxy : proxies) {
                     proxy.reset();

--- a/sql/src/test/java/io/crate/analyze/where/WhereClauseAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/where/WhereClauseAnalyzerTest.java
@@ -288,7 +288,13 @@ public class WhereClauseAnalyzerTest extends CrateUnitTest {
         assertThat(whereClause.docKeys().get(), contains(isDocKey(1, 1395874800000L)));
         // not partitions if docKeys are there
         assertThat(whereClause.partitions(), empty());
+    }
 
+    @Test
+    public void testSelectFromPartitionedTableWithoutPKInWhereClause() throws Exception {
+        WhereClause whereClause = analyzeSelectWhere("select id from parted where match(name, 'name')");
+        assertThat(whereClause.docKeys().isPresent(), is(false));
+        assertThat(whereClause.partitions(), empty());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -1938,4 +1938,31 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
         execute("select _raw from t");
         assertThat(((String) response.rows()[0][0]), is("{\"v\":\"Marvin\"}"));
     }
+
+    @Test
+    public void testMatchPredicateOnPartitionedTableWithPKColumn() throws Throwable {
+        execute("create table foo (id integer primary key, name string INDEX using fulltext) partitioned by (id)");
+        ensureYellow();
+        execute("insert into foo (id, name) values (?, ?)", new Object[]{1, "Marvin Other Name"});
+        execute("insert into foo (id, name) values (?, ?)", new Object[]{2, "Ford Yet Another Name"});
+        execute("refresh table foo");
+
+        execute("select id from foo where match(name, 'Ford')");
+        assertThat(response.rowCount(), is(1L));
+        assertThat((int)response.rows()[0][0], is(2));
+    }
+
+    @Test
+    public void testMatchPredicateOnPartitionedTableWithoutPKColumn() throws Throwable {
+        execute("create table foo (id integer, name string INDEX using fulltext) partitioned by (id)");
+        ensureYellow();
+        execute("insert into foo (id, name) values (?, ?)", new Object[]{1, "Marvin Other Name"});
+        execute("insert into foo (id, name) values (?, ?)", new Object[]{2, "Ford Yet Another Name"});
+        execute("refresh table foo");
+
+        execute("select id from foo where match(name, 'Marvin')");
+        assertThat(response.rowCount(), is(1L));
+        assertThat((int)response.rows()[0][0], is(1));
+    }
+
 }


### PR DESCRIPTION
Fix bug which could cause the MATCH predicate in WHERE clause for partitioned tables to fail. This happens in cases when a column ident of the MATCH predicate is not a primary key column.
It causes the initialization of the new DocKeys object with wrong indexes for "partition by" columns when the MATCH predicate in the WHERE clause did not contain a primary key and it led to the execution of the wrong plan.