### PR TITLE
Set CHANGES.txt git merge driver to union

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/CHANGES.txt merge=union


### PR DESCRIPTION
union behaviour:

> Run 3-way file level merge for text files, but take lines from both
> versions, instead of leaving conflict markers. This tends to leave the
> added lines in the resulting file in random order and the user should
> verify the result. Do not use this if you do not understand the
> implications.