### PR TITLE
fix bug preventing setting the wildcard setting via SET statement

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fix bug preventing setting the wildcard runtime settings via SET statement.
+
  - Fix: Improved error handling to make sure JOIN queries don't get stuck on
    shard failures.
 

--- a/sql/src/main/java/io/crate/analyze/SetStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/SetStatementAnalyzer.java
@@ -44,7 +44,7 @@ public class SetStatementAnalyzer {
             String settingsName = ExpressionToStringVisitor.convert(assignment.columnName(),
                     parameterContext.parameters());
 
-            SettingsApplier settingsApplier = CrateSettings.getSetting(settingsName);
+            SettingsApplier settingsApplier = CrateSettings.getSettingsApplier(settingsName);
             for (String setting : ExpressionToSettingNameListVisitor.convert(assignment)) {
                 checkIfSettingIsRuntime(setting);
             }

--- a/sql/src/main/java/io/crate/analyze/SettingsAppliers.java
+++ b/sql/src/main/java/io/crate/analyze/SettingsAppliers.java
@@ -136,7 +136,7 @@ public class SettingsAppliers {
                             setting.getValue());
                 }
             } else {
-                SettingsApplier settingsApplier = CrateSettings.getSetting(key);
+                SettingsApplier settingsApplier = CrateSettings.getSettingsApplier(key);
                 settingsApplier.applyValue(settingsBuilder, value);
             }
         }

--- a/sql/src/test/java/io/crate/analyze/SetAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SetAnalyzerTest.java
@@ -268,4 +268,11 @@ public class SetAnalyzerTest extends BaseAnalyzerTest {
         analyze("RESET GLOBAL gateway");
     }
 
+    @Test
+    public void testSetWildcardRuntimeSetting() {
+        SetAnalyzedStatement analysis = analyze("SET GLOBAL TRANSIENT \"cluster.routing.allocation.include.zone\" = 'zone'");
+        assertThat(analysis.isPersistent(), is(false));
+        assertThat(analysis.settings().get("cluster.routing.allocation.include.zone"), is("zone"));
+    }
+
 }


### PR DESCRIPTION
The setting like cluster.routing.allocation.include.* was not possible to via **SET** statement.