### PR TITLE
Fixing broken links refs to moved docs

### DIFF
--- a/docs/best_practice/crate_ami.txt
+++ b/docs/best_practice/crate_ami.txt
@@ -103,7 +103,7 @@ Adapt Crate Configuration
 The Crate configuration file ``/etc/crate/crate.yml`` can be adapted on startup
 by using the *User-Data* script (see :ref:`cloud_init`). The following example
 shows how to set the ``minimum_master_nodes`` and gateway configuration setting
-which are essential for a multi node setup (:ref:`multi_node_setup`). This
+which are essential for a `multi node setup`_. This
 configuration is used when a cluster with 3 or more nodes is set up.
 
 .. code-block:: bash
@@ -181,4 +181,5 @@ directory of Crate is set to ``/var/lib/crate``. The data paths are set in
 .. _AWS CLI: https://aws.amazon.com/cli/
 .. _Cloud-Init: http://cloudinit.readthedocs.org/en/latest/
 .. _Amazon Linux: https://aws.amazon.com/amazon-linux-ami/
+.. _multi node setup: https://crate.io/docs/scale/multi_node_setup/
 .. _IAM roles: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html

--- a/docs/best_practice/index.txt
+++ b/docs/best_practice/index.txt
@@ -11,10 +11,8 @@ This is a collection of best practice examples how to use Crate in the wild.
 
    data_import
    cluster_upgrade
-   multi_node_setup
    migrating_from_mysql
    migrating_from_mongodb
-   multi_zone_setup
    ec2_setup
    s3_setup
    crate_ami

--- a/docs/storage_consistency.txt
+++ b/docs/storage_consistency.txt
@@ -33,9 +33,9 @@ primary shard.
 
 With read operations, there is no difference between executing
 the operation on the primary shard or on any of the replicas. Crate
-randomly assigns a shard when routing an operation. However it is
-possible to configure this behavior if required - for example in a
-:ref:`multi_zone_setup`.
+randomly assigns a shard when routing an operation. It is possible
+to configure this behavior if required, see our best practice guide
+on `multi zone setups`_ for more details.
 
 Write operations are handled differently than reads. Such operations
 are synchronous over all active replicas with the following flow:
@@ -57,7 +57,7 @@ are synchronous over all active replicas with the following flow:
    returned to the caller.
 
 Should any replica shard fail to write the data or times out in step
-5, it's immediatly considered as unavailable.
+5, it's immediately considered as unavailable.
 
 
 Atomic on Document Level
@@ -93,7 +93,7 @@ The translog is also directly transferred when a newly allocated
 replica initializes itself from the primary shard. There is no need
 to flush segments to disc just for replica-recovery purposes.
 
-Adressing of Documents
+Addressing of Documents
 ======================
 
 Every document has an internal identifier (see
@@ -116,7 +116,7 @@ accesses documents:
       a single shard gets accessed and only a simple index lookup on
       the ``_id`` field has to be done.
 
-:search: Query by matching against fields of documents accross all
+:search: Query by matching against fields of documents across all
          candidate shards of the table.
 
 Consistency
@@ -209,3 +209,5 @@ schema of a table:
 .. _Lucene: http://lucene.apache.org/core/
 
 .. _WAL: http://en.wikipedia.org/wiki/Write-ahead_logging
+
+.. _multi zone setups: https://crate.io/docs/scale/multi_zone_setup


### PR DESCRIPTION
@chaudum ref - https://trello.com/c/Mei5Vky9/68-reference-resolve-remove-broken-links-in-server-documentation I'm not getting the errors anymore when I build locally.

Also fixed some typos.