### PR TITLE
fixes 2 alter partitioned table bugs

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,12 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fix: Changing the column policy on a partitioned table throws an
+   exception if more than 1 partition exists.
+
+ - Fix: Altering a setting on an empty partitioned table is changing
+   the setting on all exising tables.
+
  - Fix: Throw proper error if a column is used twice in primary key constraint.
 
  - Fix: Improved error handling to make sure JOIN queries don't get stuck on

--- a/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -1965,4 +1965,20 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
         assertThat((int)response.rows()[0][0], is(1));
     }
 
+    @Test
+    public void testAlterSettingsEmptyPartitionedTableDoNotAffectAllTables() throws Exception {
+        execute("create table tweets (id string primary key)" +
+                " with (number_of_replicas='0')");
+        execute("create table device_event (id long, reseller_id long, date_partition string, value float," +
+                " primary key (id, reseller_id, date_partition))" +
+                " partitioned by (date_partition)" +
+                " with (number_of_replicas='0')");
+        ensureYellow();
+
+        execute("alter table device_event SET (number_of_replicas='3')");
+
+        execute("select table_name, number_of_replicas from information_schema.tables where schema_name = 'doc' order by table_name");
+        assertThat((String) response.rows()[0][1], is("3"));
+        assertThat((String) response.rows()[1][1], is("0"));
+    }
 }


### PR DESCRIPTION
 - alter empty partitioned table settings changes
   setting on all tables
 - changing the column policy on a partitioned table
   throws an exception if more than 1 partition exists.