### PR TITLE
Run aggregation projector on shard level

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Improved the speed of global aggregation queries which involve more than 1
+   shard per node.
+
  - The log level of loggers can now be set at runtime via the ``SET`` statement.
 
  - Fix: Changing the column policy on a partitioned table throws an

--- a/sql/src/main/java/io/crate/planner/projection/AggregationProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/AggregationProjection.java
@@ -24,6 +24,7 @@ package io.crate.planner.projection;
 import com.google.common.collect.ImmutableList;
 import io.crate.analyze.symbol.Aggregation;
 import io.crate.analyze.symbol.Symbol;
+import io.crate.metadata.RowGranularity;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -51,6 +52,11 @@ public class AggregationProjection extends Projection {
     public AggregationProjection(List<Aggregation> aggregations) {
         assert aggregations != null;
         this.aggregations = aggregations;
+    }
+
+    @Override
+    public RowGranularity requiredGranularity() {
+        return RowGranularity.SHARD;
     }
 
     public List<Aggregation> aggregations() {

--- a/sql/src/test/java/io/crate/planner/PlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/PlannerTest.java
@@ -240,6 +240,7 @@ public class PlannerTest extends AbstractPlannerTest {
         assertThat(collectPhase.maxRowGranularity(), is(RowGranularity.DOC));
         assertThat(collectPhase.projections().size(), is(1));
         assertThat(collectPhase.projections().get(0), instanceOf(AggregationProjection.class));
+        assertThat(collectPhase.projections().get(0).requiredGranularity(), is(RowGranularity.SHARD));
 
         MergePhase mergeNode = globalAggregate.localMerge();
 


### PR DESCRIPTION
This reduces a lot of blocking between the search threads and can speed
up queries a lot if there are multiple shards on the same node.

In a simple test with 5 shards on 1 node a sum aggregation query
improved from 1.2 to 0.7sec

before:
![aggregation_blocked](https://cloud.githubusercontent.com/assets/38700/14609935/1e298a32-058c-11e6-957e-97c694c4dbef.png)

after:
![aggregation](https://cloud.githubusercontent.com/assets/38700/14609920/16ded336-058c-11e6-98ff-9dfbad13d710.png)