### PR TITLE
remove Powermock dependency in favour of an ES patch

### DIFF
--- a/sql/build.gradle
+++ b/sql/build.gradle
@@ -20,11 +20,6 @@ dependencies {
     compile 'org.apache.commons:commons-math3:3.4.1'
     testCompile project(':testing')
     testCompile 'org.skyscreamer:jsonassert:1.2.0'
-    testCompile 'org.powermock:powermock-module-junit4:1.6.1'
-    testCompile ('org.powermock:powermock-api-mockito:1.6.1') {
-        // includes hamcrest stuff
-        exclude group: 'org.mockito', module: 'mockito-all'
-    }
     testCompile 'org.hamcrest:hamcrest-all:1.3'
     benchmarksCompile 'com.carrotsearch:junit-benchmarks:0.7.2'
     benchmarksCompile 'com.h2database:h2:1.3.173'
@@ -40,10 +35,6 @@ buildscript {
 test {
     testLogging.exceptionFormat = 'full'
     outputs.dir("$projectDir/data")
-
-    // fix powermock issue - causing VerifyErrors being thrown
-    // see: https://issues.jboss.org/browse/JASSIST-228
-    jvmArgs '-XX:-UseSplitVerifier'
 
     jacoco.excludes = ["*Test*"]
 

--- a/sql/src/test/java/io/crate/operation/collect/JobCollectContextTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/JobCollectContextTest.java
@@ -31,28 +31,20 @@ import io.crate.metadata.RowGranularity;
 import io.crate.operation.projectors.RowReceiver;
 import io.crate.planner.node.dql.RoutedCollectPhase;
 import io.crate.testing.CollectingRowReceiver;
-import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.concurrent.CancellationException;
 
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
-import static org.powermock.api.mockito.PowerMockito.mock;
 
-/**
- * This class requires PowerMock in order to mock the final {@link SearchContext#close} method.
- */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(CrateSearchContext.class)
 public class JobCollectContextTest extends RandomizedTest {
 
     private JobCollectContext jobCollectContext;

--- a/sql/src/test/java/io/crate/testing/TestingHelpers.java
+++ b/sql/src/test/java/io/crate/testing/TestingHelpers.java
@@ -38,10 +38,6 @@ import io.crate.operation.aggregation.impl.AggregationImplModule;
 import io.crate.operation.operator.OperatorModule;
 import io.crate.operation.predicate.PredicateModule;
 import io.crate.operation.scalar.ScalarFunctionModule;
-import io.crate.operation.aggregation.impl.AggregationImplModule;
-import io.crate.operation.operator.OperatorModule;
-import io.crate.operation.predicate.PredicateModule;
-import io.crate.operation.scalar.ScalarFunctionModule;
 import io.crate.operation.tablefunctions.TableFunctionModule;
 import io.crate.sql.Identifiers;
 import io.crate.types.DataType;
@@ -51,9 +47,9 @@ import org.elasticsearch.common.inject.ModulesBuilder;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.hamcrest.*;
+import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import org.powermock.api.mockito.PowerMockito;
 
 import javax.annotation.Nullable;
 import java.io.ByteArrayOutputStream;
@@ -540,7 +536,7 @@ public class TestingHelpers {
     }
 
     public static ThreadPool newMockedThreadPool() {
-        ThreadPool threadPool = PowerMockito.mock(ThreadPool.class);
+        ThreadPool threadPool = Mockito.mock(ThreadPool.class);
         final ExecutorService executorService = Executors.newSingleThreadExecutor();
 
         doAnswer(new Answer() {


### PR DESCRIPTION
Powermock caused lot of problems and it's not worth
solving them comparing to a small patch in ES.
Required ES patch:
https://github.com/crate/elasticsearch/commit/b76dd1fd513168f3df9f86409ff171c2adeb9a50