### PR TITLE
don't throw TableUnkownException internally

### DIFF
--- a/sql/src/main/java/io/crate/operation/collect/sources/ShardCollectSource.java
+++ b/sql/src/main/java/io/crate/operation/collect/sources/ShardCollectSource.java
@@ -31,7 +31,6 @@ import io.crate.analyze.EvaluatingNormalizer;
 import io.crate.analyze.OrderBy;
 import io.crate.core.collections.Buckets;
 import io.crate.core.collections.Row;
-import io.crate.exceptions.TableUnknownException;
 import io.crate.exceptions.UnhandledServerException;
 import io.crate.executor.transport.TransportActionProvider;
 import io.crate.metadata.Functions;
@@ -210,7 +209,7 @@ public class ShardCollectSource implements CollectSource {
                     if (PartitionName.isPartition(indexName)) {
                         break;
                     }
-                    throw new TableUnknownException(indexName, e);
+                    throw e;
                 } catch (Throwable t) {
                     throw new UnhandledServerException(t);
                 }
@@ -246,7 +245,7 @@ public class ShardCollectSource implements CollectSource {
                 if (PartitionName.isPartition(indexName)) {
                     continue;
                 }
-                throw new TableUnknownException(entry.getKey(), e);
+                throw e;
             }
 
             for (Integer shardId : entry.getValue()) {

--- a/sql/src/main/java/io/crate/operation/count/InternalCountOperation.java
+++ b/sql/src/main/java/io/crate/operation/count/InternalCountOperation.java
@@ -25,18 +25,15 @@ import com.google.common.base.Function;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.crate.analyze.WhereClause;
-import io.crate.exceptions.TableUnknownException;
 import io.crate.lucene.LuceneQueryBuilder;
 import io.crate.metadata.PartitionName;
 import io.crate.operation.ThreadPools;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
-import org.elasticsearch.common.lucene.Lucene;
+import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.engine.Engine;
-import org.elasticsearch.index.engine.EngineSearcher;
 import org.elasticsearch.index.shard.IndexShard;
-import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -100,7 +97,7 @@ public class InternalCountOperation implements CountOperation {
             if (PartitionName.isPartition(index)) {
                 return 0L;
             }
-            throw new TableUnknownException(index, e);
+            throw e;
         }
 
         IndexShard indexShard = indexService.shardSafe(shardId);

--- a/sql/src/main/java/io/crate/operation/fetch/FetchContext.java
+++ b/sql/src/main/java/io/crate/operation/fetch/FetchContext.java
@@ -26,7 +26,6 @@ import com.carrotsearch.hppc.cursors.IntObjectCursor;
 import io.crate.action.job.SharedShardContext;
 import io.crate.action.job.SharedShardContexts;
 import io.crate.analyze.symbol.Reference;
-import io.crate.exceptions.TableUnknownException;
 import io.crate.jobs.AbstractExecutionSubContext;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.Routing;
@@ -34,10 +33,10 @@ import io.crate.metadata.TableIdent;
 import io.crate.planner.node.fetch.FetchPhase;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.shard.ShardId;
-import org.elasticsearch.index.IndexNotFoundException;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -110,7 +109,7 @@ public class FetchContext extends AbstractExecutionSubContext {
                                 searchers.put(readerId, shardContext.searcher());
                             } catch (IndexNotFoundException e) {
                                 if (!PartitionName.isPartition(index)) {
-                                    throw new TableUnknownException(index, e);
+                                    throw e;
                                 }
                             }
                         }

--- a/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -24,13 +24,10 @@ package io.crate.integrationtests;
 import io.crate.action.sql.SQLActionException;
 import io.crate.core.collections.CollectionBucket;
 import io.crate.exceptions.Exceptions;
-import io.crate.exceptions.ResourceUnknownException;
-import io.crate.exceptions.TableUnknownException;
 import io.crate.operation.projectors.sorting.OrderingByPosition;
 import io.crate.testing.TestingHelpers;
-import org.elasticsearch.common.io.stream.NotSerializableExceptionWrapper;
+import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.hamcrest.Matchers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -43,7 +40,6 @@ import java.util.concurrent.TimeUnit;
 import static io.crate.testing.TestingHelpers.printRows;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static org.hamcrest.Matchers.arrayContaining;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(minNumDataNodes = 2)
@@ -542,14 +538,10 @@ public class JoinIntegrationTest extends SQLTransportIntegrationTest {
         PlanForNode plan = plan("select * from t1, t2 where t1.x = t2.x");
         execute("drop table t2");
 
-        expectedException.expect(Matchers.anyOf(instanceOf(TableUnknownException.class), instanceOf(ResourceUnknownException.class)));
+        expectedException.expect(IndexNotFoundException.class);
         try {
             execute(plan).get(1, TimeUnit.SECONDS);
         } catch (Throwable t) {
-            // TODO: figure out if it is safe to add NotSerializableExceptionWrapper to exceptions that are unwrapped in Exceptions.unwrap
-            if (t instanceof NotSerializableExceptionWrapper) {
-                t = t.getCause();
-            }
             throw Exceptions.unwrap(t);
         }
     }

--- a/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -29,16 +29,15 @@ import io.crate.TimestampFormat;
 import io.crate.action.sql.SQLActionException;
 import io.crate.action.sql.SQLBulkResponse;
 import io.crate.exceptions.Exceptions;
-import io.crate.exceptions.TableUnknownException;
 import io.crate.executor.TaskResult;
 import io.crate.testing.TestingHelpers;
 import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.collect.MapBuilder;
-import org.elasticsearch.common.io.stream.NotSerializableExceptionWrapper;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.hamcrest.Matchers;
@@ -88,11 +87,8 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
     }
 
     @Test
-    public void testTableUnknownExceptionIsRaisedIfDeletedAfterPlan() throws Throwable {
-        expectedException.expectMessage("Table 't' unknown");
-        // if the exception is streamed over the transport it is wrapped in a NotSerializableExceptionWrapper
-        // as long as the message is correct this is fine.
-        expectedException.expect(Matchers.anyOf(instanceOf(TableUnknownException.class), instanceOf(NotSerializableExceptionWrapper.class)));
+    public void testIndexNotFoundExceptionIsRaisedIfDeletedAfterPlan() throws Throwable {
+        expectedException.expect(IndexNotFoundException.class);
 
         execute("create table t (name string)");
         ensureYellow();


### PR DESCRIPTION
In general don't throw CrateException implementations
internally because they are not streamable and
will be wrapped otherwise