### PR TITLE
Transports: Use `listener.onFailure` instead of raising exceptions

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed an issue that could lead to stuck queries if a node dropped out of the
+   cluster.
+
  - NOTE: Upgrading to this Crate version is only supported from >= 0.52
 
  - Upgraded Elasticsearch to 2.2.2

--- a/sql/src/main/java/io/crate/executor/transport/Transports.java
+++ b/sql/src/main/java/io/crate/executor/transport/Transports.java
@@ -64,7 +64,9 @@ public class Transports {
             TransportResponseHandler<TResponse> transportResponseHandler) {
         DiscoveryNode discoveryNode = clusterService.state().nodes().get(node);
         if (discoveryNode == null) {
-            throw new IllegalArgumentException(String.format(Locale.ENGLISH, "node \"%s\" not found in cluster state!", node));
+            listener.onFailure(new IllegalArgumentException(
+                String.format(Locale.ENGLISH, "node \"%s\" not found in cluster state!", node)));
+            return;
         }
         executeLocalOrWithTransport(nodeAction, discoveryNode, request, listener, transportResponseHandler);
     }

--- a/sql/src/test/java/io/crate/executor/transport/TransportsTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/TransportsTest.java
@@ -31,6 +31,7 @@ import org.elasticsearch.test.cluster.NoopClusterService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.transport.TransportResponse;
+import org.elasticsearch.transport.TransportResponseHandler;
 import org.elasticsearch.transport.TransportService;
 import org.junit.After;
 import org.junit.Before;
@@ -41,8 +42,8 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.core.Is.is;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
 
 public class TransportsTest extends CrateUnitTest {
 
@@ -105,5 +106,16 @@ public class TransportsTest extends CrateUnitTest {
 
         Boolean result = failCalled.get(100, TimeUnit.MILLISECONDS);
         assertThat(result, is(true));
+    }
+
+
+    @Test
+    public void testOnFailureOnListenerIsCalledIfNodeIsNotInClusterState() throws Exception {
+        Transports transports = new Transports(new NoopClusterService(), mock(TransportService.class), mock(ThreadPool.class));
+        ActionListener actionListener = mock(ActionListener.class);
+        transports.executeLocalOrWithTransport(mock(NodeAction.class),
+            "invalid", mock(TransportRequest.class), actionListener, mock(TransportResponseHandler.class));
+
+        verify(actionListener, times(1)).onFailure(any(Throwable.class));
     }
 }


### PR DESCRIPTION
Consumers of the executeLocalOrWithTransport method don't expect it to
throw exceptions and don't handle them.

This could lead to stuck queries as the exception could be swallowed.