### PR TITLE
Remove localNode execution optimization from Transports

### DIFF
--- a/sql/src/main/java/io/crate/action/job/TransportJobAction.java
+++ b/sql/src/main/java/io/crate/action/job/TransportJobAction.java
@@ -64,12 +64,12 @@ public class TransportJobAction implements NodeAction<JobRequest, JobResponse> {
         this.contextPreparer = contextPreparer;
         transportService.registerRequestHandler(ACTION_NAME,
                 JobRequest.class,
-                ThreadPool.Names.GENERIC,
+                EXECUTOR,
                 new NodeActionRequestHandler<JobRequest, JobResponse>(this) { });
     }
 
     public void execute(String node, final JobRequest request, final ActionListener<JobResponse> listener) {
-        transports.executeLocalOrWithTransport(this, node, request, listener,
+        transports.sendRequest(ACTION_NAME, node, request, listener,
                 new DefaultTransportResponseHandler<JobResponse>(listener) {
                     @Override
                     public JobResponse newInstance() {
@@ -109,15 +109,5 @@ public class TransportJobAction implements NodeAction<JobRequest, JobResponse> {
                 }
             });
         }
-    }
-
-    @Override
-    public String actionName() {
-        return ACTION_NAME;
-    }
-
-    @Override
-    public String executorName() {
-        return EXECUTOR;
     }
 }

--- a/sql/src/main/java/io/crate/executor/transport/NodeAction.java
+++ b/sql/src/main/java/io/crate/executor/transport/NodeAction.java
@@ -27,8 +27,6 @@ import org.elasticsearch.transport.TransportResponse;
 
 public interface NodeAction<TRequest extends TransportRequest, TResponse extends TransportResponse> {
 
-    String actionName();
-    String executorName();
     void nodeOperation(TRequest request, ActionListener<TResponse> listener);
 
 }

--- a/sql/src/main/java/io/crate/executor/transport/distributed/TransportDistributedResultAction.java
+++ b/sql/src/main/java/io/crate/executor/transport/distributed/TransportDistributedResultAction.java
@@ -76,23 +76,13 @@ public class TransportDistributedResultAction extends AbstractComponent implemen
     }
 
     public void pushResult(String node, DistributedResultRequest request, ActionListener<DistributedResultResponse> listener) {
-        transports.executeLocalOrWithTransport(this, node, request, listener,
+        transports.sendRequest(DISTRIBUTED_RESULT_ACTION, node, request, listener,
                 new DefaultTransportResponseHandler<DistributedResultResponse>(listener, EXECUTOR_NAME) {
                     @Override
                     public DistributedResultResponse newInstance() {
                         return new DistributedResultResponse();
                     }
                 });
-    }
-
-    @Override
-    public String actionName() {
-        return DISTRIBUTED_RESULT_ACTION;
-    }
-
-    @Override
-    public String executorName() {
-        return EXECUTOR_NAME;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/executor/transport/kill/TransportKillAllNodeAction.java
+++ b/sql/src/main/java/io/crate/executor/transport/kill/TransportKillAllNodeAction.java
@@ -54,23 +54,13 @@ public class TransportKillAllNodeAction implements NodeAction<KillAllRequest, Ki
     }
 
     public void execute(String targetNode, KillAllRequest request, ActionListener<KillResponse> listener) {
-        transports.executeLocalOrWithTransport(this, targetNode, request, listener,
+        transports.sendRequest(TRANSPORT_ACTION, targetNode, request, listener,
                 new DefaultTransportResponseHandler<KillResponse>(listener) {
             @Override
             public KillResponse newInstance() {
                 return new KillResponse(0);
             }
         });
-    }
-
-    @Override
-    public String actionName() {
-        return TRANSPORT_ACTION;
-    }
-
-    @Override
-    public String executorName() {
-        return ThreadPool.Names.MANAGEMENT;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/executor/transport/kill/TransportKillJobsNodeAction.java
+++ b/sql/src/main/java/io/crate/executor/transport/kill/TransportKillJobsNodeAction.java
@@ -108,19 +108,9 @@ public class TransportKillJobsNodeAction extends AbstractComponent implements No
 
         logger.trace("Sending {} to {}", request, nodes);
         for (DiscoveryNode node : nodes) {
-            transports.executeLocalOrWithTransport(
-                    this, node.id(), request, killResponseActionListener, transportResponseHandler);
+            transports.sendRequest(
+                    TRANSPORT_ACTION, node.id(), request, killResponseActionListener, transportResponseHandler);
         }
-    }
-
-    @Override
-    public String actionName() {
-        return TRANSPORT_ACTION;
-    }
-
-    @Override
-    public String executorName() {
-        return ThreadPool.Names.MANAGEMENT;
     }
 
     @Override

--- a/sql/src/test/java/io/crate/executor/transport/TransportsTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/TransportsTest.java
@@ -21,99 +21,24 @@
 
 package io.crate.executor.transport;
 
-import com.google.common.util.concurrent.SettableFuture;
 import io.crate.test.integration.CrateUnitTest;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.common.logging.ESLogger;
-import org.elasticsearch.common.logging.Loggers;
-import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.test.cluster.NoopClusterService;
-import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportRequest;
-import org.elasticsearch.transport.TransportResponse;
 import org.elasticsearch.transport.TransportResponseHandler;
 import org.elasticsearch.transport.TransportService;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
-import javax.annotation.Nonnull;
-import java.util.concurrent.Executor;
-import java.util.concurrent.TimeUnit;
-
-import static org.hamcrest.core.Is.is;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 public class TransportsTest extends CrateUnitTest {
 
-
-    private ESLogger logger;
-    private String logLevel;
-
-    @Override
-    @Before
-    public void setUp() throws Exception {
-        super.setUp();
-        // mute WARN logging for this test
-        logger = Loggers.getLogger(Transports.class);
-        logLevel = logger.getLevel();
-        logger.setLevel("ERROR");
-    }
-
-    @Override
-    @After
-    public void tearDown() throws Exception {
-        super.tearDown();
-        logger.setLevel(logLevel);
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void testEsRejectedExecutionExceptionCallsFailOnListener() throws Exception {
-        ThreadPool threadPool = mock(ThreadPool.class);
-        final String executorName = "dummy";
-        when(threadPool.executor(executorName)).thenReturn(new Executor() {
-            @Override
-            public void execute(@Nonnull Runnable command) {
-                throw new EsRejectedExecutionException();
-            }
-        });
-        Transports transports = new Transports(new NoopClusterService(), mock(TransportService.class), threadPool);
-
-        final SettableFuture<Boolean> failCalled = SettableFuture.create();
-        ActionListener listener = new ActionListener() {
-            @Override
-            public void onResponse(Object o) {
-                failCalled.set(false);
-            }
-
-            @Override
-            public void onFailure(Throwable e) {
-                failCalled.set(true);
-
-            }
-        };
-        NodeAction nodeAction = mock(NodeAction.class);
-        when(nodeAction.executorName()).thenReturn(executorName);
-        transports.executeLocalOrWithTransport(nodeAction, "noop_id", mock(TransportRequest.class), listener,
-                new DefaultTransportResponseHandler(listener) {
-            @Override
-            public TransportResponse newInstance() {
-                return mock(TransportResponse.class);
-            }
-        });
-
-        Boolean result = failCalled.get(100, TimeUnit.MILLISECONDS);
-        assertThat(result, is(true));
-    }
-
-
     @Test
     public void testOnFailureOnListenerIsCalledIfNodeIsNotInClusterState() throws Exception {
-        Transports transports = new Transports(new NoopClusterService(), mock(TransportService.class), mock(ThreadPool.class));
+        Transports transports = new Transports(new NoopClusterService(), mock(TransportService.class));
         ActionListener actionListener = mock(ActionListener.class);
-        transports.executeLocalOrWithTransport(mock(NodeAction.class),
+        transports.sendRequest("actionName",
             "invalid", mock(TransportRequest.class), actionListener, mock(TransportResponseHandler.class));
 
         verify(actionListener, times(1)).onFailure(any(Throwable.class));

--- a/sql/src/test/java/io/crate/executor/transport/kill/TransportKillJobsNodeActionTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/kill/TransportKillJobsNodeActionTest.java
@@ -27,10 +27,7 @@ import io.crate.jobs.JobContextService;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.cluster.NoopClusterService;
-import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.util.List;
@@ -42,19 +39,6 @@ import static org.mockito.Mockito.*;
 
 public class TransportKillJobsNodeActionTest {
 
-    private ThreadPool threadPool;
-
-    @Before
-    public void setUp() throws Exception {
-        threadPool = new ThreadPool("dummy");
-    }
-
-    @After
-    public void tearDown() throws Exception {
-        threadPool.shutdown();
-        threadPool.awaitTermination(100, TimeUnit.MILLISECONDS);
-    }
-
     @Test
     public void testKillIsCalledOnJobContextService() throws Exception {
         TransportService transportService = mock(TransportService.class);
@@ -65,13 +49,14 @@ public class TransportKillJobsNodeActionTest {
                 Settings.EMPTY,
                 jobContextService,
                 new NoopClusterService(),
-                new Transports(noopClusterService, transportService, threadPool),
+                new Transports(noopClusterService, transportService),
                 transportService
         );
 
         final CountDownLatch latch = new CountDownLatch(1);
         List<UUID> toKill = ImmutableList.of(UUID.randomUUID(), UUID.randomUUID());
-        transportKillJobsNodeAction.executeKillOnAllNodes(new KillJobsRequest(toKill), new ActionListener<KillResponse>() {
+
+        transportKillJobsNodeAction.nodeOperation(new KillJobsRequest(toKill), new ActionListener<KillResponse>() {
             @Override
             public void onResponse(KillResponse killAllResponse) {
                 latch.countDown();
@@ -83,8 +68,7 @@ public class TransportKillJobsNodeActionTest {
             }
         });
 
-        latch.await();
+        latch.await(1, TimeUnit.SECONDS);
         verify(jobContextService, times(1)).killJobs(toKill);
     }
-
 }


### PR DESCRIPTION
The optimization became part of `TransportService.sendRequest` with the
ES 2.X upgrade.

Didn't remove the Transports class completely because of the nodeName ->
DiscoveryNode resolve logic.