### PR TITLE
Move broadcast logic from KillTask into TransportAction

### DIFF
--- a/blob/src/main/java/io/crate/blob/v2/BlobIndices.java
+++ b/blob/src/main/java/io/crate/blob/v2/BlobIndices.java
@@ -22,6 +22,7 @@
 package io.crate.blob.v2;
 
 import com.google.common.base.Function;
+import com.google.common.base.Functions;
 import com.google.common.base.Predicate;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
@@ -119,9 +120,9 @@ public class BlobIndices extends AbstractComponent implements ClusterStateListen
      */
     public ListenableFuture<Void> alterBlobTable(String tableName, Settings indexSettings) {
         final SettableFuture<Void> result = SettableFuture.create();
+        ActionListener<UpdateSettingsResponse> listener = ActionListeners.wrap(result, Functions.<Void>constant(null));
         transportUpdateSettingsActionProvider.get().execute(
-                new UpdateSettingsRequest(indexSettings, fullIndexName(tableName)),
-                ActionListeners.<Void, UpdateSettingsResponse>futureSettingListener(result, null));
+            new UpdateSettingsRequest(indexSettings, fullIndexName(tableName)), listener);
         return result;
     }
 
@@ -149,8 +150,8 @@ public class BlobIndices extends AbstractComponent implements ClusterStateListen
 
     public ListenableFuture<Void> dropBlobTable(final String tableName) {
         final SettableFuture<Void> result = SettableFuture.create();
-        transportDeleteIndexActionProvider.get().execute(new DeleteIndexRequest(fullIndexName(tableName)),
-                ActionListeners.<Void, DeleteIndexResponse>futureSettingListener(result, null));
+        ActionListener<DeleteIndexResponse> listener = ActionListeners.wrap(result, Functions.<Void>constant(null));
+        transportDeleteIndexActionProvider.get().execute(new DeleteIndexRequest(fullIndexName(tableName)), listener);
         return result;
     }
 

--- a/sql/src/main/java/io/crate/action/sql/DDLStatementDispatcher.java
+++ b/sql/src/main/java/io/crate/action/sql/DDLStatementDispatcher.java
@@ -22,13 +22,15 @@
 package io.crate.action.sql;
 
 import com.google.common.base.Function;
+import com.google.common.base.Functions;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
+import io.crate.action.ActionListeners;
 import io.crate.analyze.*;
 import io.crate.blob.v2.BlobIndices;
 import io.crate.executor.transport.*;
-import io.crate.action.ActionListeners;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 import org.elasticsearch.action.admin.indices.refresh.RefreshResponse;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -110,9 +112,8 @@ public class DDLStatementDispatcher {
             request.indicesOptions(IndicesOptions.lenientExpandOpen());
 
             final SettableFuture<Long> future = SettableFuture.create();
-            transportActionProvider.transportRefreshAction().execute(
-                    request,
-                    ActionListeners.<Long, RefreshResponse>futureSettingListener(future, null));
+            ActionListener<RefreshResponse> listener = ActionListeners.wrap(future, Functions.<Long>constant(null));
+            transportActionProvider.transportRefreshAction().execute(request, listener);
             return future;
         }
 

--- a/sql/src/main/java/io/crate/executor/MultiActionListener.java
+++ b/sql/src/main/java/io/crate/executor/MultiActionListener.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.executor;
+
+import com.google.common.base.Function;
+import org.elasticsearch.action.ActionListener;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class MultiActionListener<SingleResponse, FinalResponse> implements ActionListener<SingleResponse> {
+
+    private final AtomicInteger counter;
+    private final AtomicReference<Throwable> lastThrowable = new AtomicReference<>(null);
+    private final Function<List<SingleResponse>, FinalResponse> mergeFunction;
+    private final ActionListener<? super FinalResponse> actionListener;
+    private final ArrayList<SingleResponse> results;
+
+    public MultiActionListener(int numResponses,
+                               Function<List<SingleResponse>, FinalResponse> mergeFunction,
+                               ActionListener<? super FinalResponse> actionListener) {
+        this.mergeFunction = mergeFunction;
+        this.actionListener = actionListener;
+        results = new ArrayList<>(numResponses);
+        counter = new AtomicInteger(numResponses);
+    }
+
+    @Override
+    public void onResponse(SingleResponse response) {
+        results.add(response);
+        countdown();
+    }
+
+    @Override
+    public void onFailure(Throwable e) {
+        lastThrowable.set(e);
+        countdown();
+    }
+
+    private void countdown() {
+        if (counter.decrementAndGet() == 0) {
+            Throwable t = lastThrowable.get();
+            if (t == null) {
+                actionListener.onResponse(mergeFunction.apply(results));
+            } else {
+                actionListener.onFailure(t);
+            }
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/executor/transport/SnapshotRestoreDDLDispatcher.java
+++ b/sql/src/main/java/io/crate/executor/transport/SnapshotRestoreDDLDispatcher.java
@@ -22,13 +22,14 @@
 
 package io.crate.executor.transport;
 
+import com.google.common.base.Functions;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
+import io.crate.action.ActionListeners;
 import io.crate.analyze.CreateSnapshotAnalyzedStatement;
 import io.crate.analyze.DropSnapshotAnalyzedStatement;
 import io.crate.analyze.RestoreSnapshotAnalyzedStatement;
 import io.crate.exceptions.CreateSnapshotException;
-import io.crate.action.ActionListeners;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotRequest;
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
@@ -148,8 +149,8 @@ public class SnapshotRestoreDDLDispatcher {
                 .waitForCompletion(waitForCompletion)
                 .includeGlobalState(false)
                 .includeAliases(true);
-        transportActionProvider.transportRestoreSnapshotAction().execute(request,
-                ActionListeners.<Long, RestoreSnapshotResponse>futureSettingListener(resultFuture, 1L));
+        ActionListener<RestoreSnapshotResponse> listener = ActionListeners.wrap(resultFuture, Functions.constant(1L));
+        transportActionProvider.transportRestoreSnapshotAction().execute(request, listener);
         return resultFuture;
     }
 }

--- a/sql/src/main/java/io/crate/executor/transport/TransportExecutor.java
+++ b/sql/src/main/java/io/crate/executor/transport/TransportExecutor.java
@@ -235,9 +235,7 @@ public class TransportExecutor implements Executor {
                     new KillJobTask(transportActionProvider.transportKillJobsNodeAction(),
                             jobId,
                             killPlan.jobToKill().get()) :
-                    new KillTask(clusterService,
-                            transportActionProvider.transportKillAllNodeAction(),
-                            jobId);
+                    new KillTask(transportActionProvider.transportKillAllNodeAction(), jobId);
             return ImmutableList.of(task);
         }
 

--- a/sql/src/main/java/io/crate/executor/transport/Transports.java
+++ b/sql/src/main/java/io/crate/executor/transport/Transports.java
@@ -49,8 +49,8 @@ public class Transports {
     public <TRequest extends TransportRequest, TResponse extends TransportResponse> void sendRequest(
             String actionName,
             String node,
-            final TRequest request,
-            final ActionListener<TResponse> listener,
+            TRequest request,
+            ActionListener<TResponse> listener,
             TransportResponseHandler<TResponse> transportResponseHandler) {
         DiscoveryNode discoveryNode = clusterService.state().nodes().get(node);
         if (discoveryNode == null) {

--- a/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/ESClusterUpdateSettingsTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/ESClusterUpdateSettingsTask.java
@@ -21,12 +21,13 @@
 
 package io.crate.executor.transport.task.elasticsearch;
 
+import com.google.common.base.Functions;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
+import io.crate.action.ActionListeners;
 import io.crate.executor.JobTask;
 import io.crate.executor.TaskResult;
 import io.crate.planner.node.ddl.ESClusterUpdateSettingsNode;
-import io.crate.action.ActionListeners;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsResponse;
@@ -62,7 +63,7 @@ public class ESClusterUpdateSettingsTask extends JobTask {
         if (node.transientSettingsToRemove() != null) {
             request.transientSettingsToRemove(node.transientSettingsToRemove());
         }
-        listener = ActionListeners.futureSettingListener(result, TaskResult.ONE_ROW);
+        listener = ActionListeners.wrap(result, Functions.constant(TaskResult.ONE_ROW));
     }
 
     @Override

--- a/sql/src/test/java/io/crate/executor/transport/kill/KillResponseTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/kill/KillResponseTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.executor.transport.kill;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class KillResponseTest {
+
+    @Test
+    public void testMergeFunctionMergesRowCount() throws Exception {
+        KillResponse response = KillResponse.MERGE_FUNCTION.apply(
+            Arrays.asList(new KillResponse(10), new KillResponse(20)));
+        assertThat(response, Matchers.notNullValue());
+        assertThat(response.numKilled(), is(30L));
+    }
+}

--- a/sql/src/test/java/io/crate/executor/transport/kill/TransportKillAllNodeActionTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/kill/TransportKillAllNodeActionTest.java
@@ -21,16 +21,19 @@
 
 package io.crate.executor.transport.kill;
 
-import io.crate.executor.transport.Transports;
 import io.crate.jobs.JobContextService;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.test.cluster.NoopClusterService;
 import org.elasticsearch.transport.TransportService;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.*;
 
 public class TransportKillAllNodeActionTest {
@@ -42,9 +45,9 @@ public class TransportKillAllNodeActionTest {
         NoopClusterService noopClusterService = new NoopClusterService();
 
         TransportKillAllNodeAction transportKillAllNodeAction = new TransportKillAllNodeAction(
-                jobContextService,
-                new Transports(noopClusterService, transportService),
-                transportService
+            jobContextService,
+            noopClusterService,
+            transportService
         );
 
         final CountDownLatch latch = new CountDownLatch(1);
@@ -63,4 +66,5 @@ public class TransportKillAllNodeActionTest {
         latch.await(1, TimeUnit.SECONDS);
         verify(jobContextService, times(1)).killAll();
     }
+
 }

--- a/sql/src/test/java/io/crate/executor/transport/kill/TransportKillJobsNodeActionTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/kill/TransportKillJobsNodeActionTest.java
@@ -22,7 +22,6 @@
 package io.crate.executor.transport.kill;
 
 import com.google.common.collect.ImmutableList;
-import io.crate.executor.transport.Transports;
 import io.crate.jobs.JobContextService;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.settings.Settings;
@@ -43,13 +42,11 @@ public class TransportKillJobsNodeActionTest {
     public void testKillIsCalledOnJobContextService() throws Exception {
         TransportService transportService = mock(TransportService.class);
         JobContextService jobContextService = mock(JobContextService.class);
-        NoopClusterService noopClusterService = new NoopClusterService();
 
         TransportKillJobsNodeAction transportKillJobsNodeAction = new TransportKillJobsNodeAction(
                 Settings.EMPTY,
                 jobContextService,
                 new NoopClusterService(),
-                new Transports(noopClusterService, transportService),
                 transportService
         );
 

--- a/sql/src/test/java/io/crate/executor/transport/task/KillTaskTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/task/KillTaskTest.java
@@ -21,24 +21,17 @@
 
 package io.crate.executor.transport.task;
 
-import io.crate.core.collections.Bucket;
-import io.crate.core.collections.Row;
-import io.crate.executor.transport.kill.*;
+import io.crate.executor.transport.kill.KillAllRequest;
+import io.crate.executor.transport.kill.KillResponse;
+import io.crate.executor.transport.kill.TransportKillAllNodeAction;
 import io.crate.test.integration.CrateUnitTest;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.cluster.ClusterService;
-import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.cluster.node.DiscoveryNodes;
-import org.elasticsearch.common.transport.DummyTransportAddress;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 
 import java.util.UUID;
 
-import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.*;
 
 public class KillTaskTest extends CrateUnitTest {
@@ -51,85 +44,12 @@ public class KillTaskTest extends CrateUnitTest {
 
     @SuppressWarnings("unchecked")
     @Test
-    public void testExecuteIsCalledOnTransportForEachNode() throws Exception {
-        TransportKillAllNodeAction killNodeAction = startKillTaskAndGetTransportKillAllNodeAction();
+    public void testKillTaskCallsBroadcastOnTransportKillAllNodeAction() throws Exception {
+        TransportKillAllNodeAction killAllNodeAction = mock(TransportKillAllNodeAction.class);
+        KillTask task =  new KillTask(killAllNodeAction, UUID.randomUUID());
 
-        verify(killNodeAction, times(1)).execute(eq("n1"), any(KillAllRequest.class), any(ActionListener.class));
-        verify(killNodeAction, times(1)).execute(eq("n2"), any(KillAllRequest.class), any(ActionListener.class));
-        verify(killNodeAction, times(1)).execute(eq("n3"), any(KillAllRequest.class), any(ActionListener.class));
+        task.start();
+        verify(killAllNodeAction, times(1)).broadcast(any(KillAllRequest.class), any(ActionListener.class));
+        verify(killAllNodeAction, times(0)).nodeOperation(any(KillAllRequest.class), any(ActionListener.class));
     }
-
-    @Test
-    public void testRowCountIsAccumulated() throws Exception {
-        TransportKillAllNodeAction killNodeAction = startKillTaskAndGetTransportKillAllNodeAction();
-        verify(killNodeAction, times(3)).execute(anyString(), any(KillAllRequest.class), responseListener.capture());
-
-        for (ActionListener<KillResponse> killAllResponseActionListener : responseListener.getAllValues()) {
-            killAllResponseActionListener.onResponse(new KillResponse(3));
-        }
-
-        Bucket rows = killTask.result().get(0).get().rows();
-        assertThat(rows.size(), is(1));
-        Row next = rows.iterator().next();
-        assertThat((Long) next.get(0), is(9L));
-    }
-
-    private TransportKillAllNodeAction startKillTaskAndGetTransportKillAllNodeAction() {
-        ClusterService clusterService = mock(ClusterService.class);
-        TransportKillAllNodeAction killNodeAction = mock(TransportKillAllNodeAction.class);
-        DiscoveryNodes nodes = DiscoveryNodes.builder()
-                .put(new DiscoveryNode("n1", DummyTransportAddress.INSTANCE, Version.CURRENT))
-                .put(new DiscoveryNode("n2", DummyTransportAddress.INSTANCE, Version.CURRENT))
-                .put(new DiscoveryNode("n3", DummyTransportAddress.INSTANCE, Version.CURRENT)).build();
-
-        ClusterState state = mock(ClusterState.class);
-        when(clusterService.state()).thenReturn(state);
-        when(state.nodes()).thenReturn(nodes);
-
-        killTask = new KillTask(clusterService, killNodeAction, UUID.randomUUID());
-        killTask.start();
-        return killNodeAction;
-    }
-
-    @SuppressWarnings("unchecked")
-    @Test
-    public void testExecuteKillJobsIsCalledOnTransportForEachNode() throws Exception {
-        TransportKillJobsNodeAction killNodeAction = startKillTaskAndGetTransportKillJobsNodeAction();
-        verify(killNodeAction, times(1)).executeKillOnAllNodes(any(KillJobsRequest.class), any(ActionListener.class));
-    }
-
-    @Test
-    public void testKillJobsRowCountIsAccumulated() throws Exception {
-        TransportKillJobsNodeAction killJobsNodeAction = startKillTaskAndGetTransportKillJobsNodeAction();
-        verify(killJobsNodeAction, times(1)).executeKillOnAllNodes(any(KillJobsRequest.class), responseListener.capture());
-
-        for (ActionListener<KillResponse> killAllResponseActionListener : responseListener.getAllValues()) {
-            killAllResponseActionListener.onResponse(new KillResponse(3));
-        }
-
-        Bucket rows = killJobsTask.result().get(0).get().rows();
-        assertThat(rows.size(), is(1));
-        Row next = rows.iterator().next();
-        assertThat((Long) next.get(0), is(3L));
-    }
-
-    private TransportKillJobsNodeAction startKillTaskAndGetTransportKillJobsNodeAction() {
-        ClusterService clusterService = mock(ClusterService.class);
-        TransportKillJobsNodeAction killNodeAction = mock(TransportKillJobsNodeAction.class);
-        DiscoveryNodes nodes = DiscoveryNodes.builder()
-                .put(new DiscoveryNode("n1", DummyTransportAddress.INSTANCE, Version.CURRENT))
-                .put(new DiscoveryNode("n2", DummyTransportAddress.INSTANCE, Version.CURRENT))
-                .put(new DiscoveryNode("n3", DummyTransportAddress.INSTANCE, Version.CURRENT)).build();
-
-        ClusterState state = mock(ClusterState.class);
-        when(clusterService.state()).thenReturn(state);
-        when(state.nodes()).thenReturn(nodes);
-
-        killJobsTask = new KillJobTask(killNodeAction,
-                UUID.randomUUID(),
-                UUID.randomUUID());
-        killJobsTask.start();
-        return killNodeAction;
-    }
-
 }


### PR DESCRIPTION
By moving the logic from `KillTask` to the `TransportAction` the
`TransportKillAllNodeAction` follows the pattern of
`TransportKillJobsNodeAction`.

In addition this commit also extracts some shared logic between those
two TransportActions into re-usable components like the
`MultiActionListener`