### PR TITLE
[testing] removed deprecated test helper methods and usage of deprecated ES test helpers

### DIFF
--- a/sql/src/main/java/io/crate/metadata/Functions.java
+++ b/sql/src/main/java/io/crate/metadata/Functions.java
@@ -22,7 +22,6 @@
 package io.crate.metadata;
 
 import com.google.common.base.Joiner;
-import io.crate.analyze.symbol.Function;
 import io.crate.metadata.tablefunctions.TableFunctionImplementation;
 import org.elasticsearch.common.inject.Inject;
 

--- a/sql/src/main/java/io/crate/operation/scalar/SubstrFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/SubstrFunction.java
@@ -23,8 +23,6 @@ package io.crate.operation.scalar;
 
 import com.google.common.base.Preconditions;
 import io.crate.analyze.symbol.Function;
-import io.crate.analyze.symbol.Literal;
-import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.*;
 import io.crate.operation.Input;
 import io.crate.types.DataType;
@@ -139,43 +137,6 @@ public class SubstrFunction extends Scalar<BytesRef, Object> implements DynamicF
         // Check if we didn't go over the limit on the last character.
         if (pos > limit) throw new IllegalArgumentException();
         return new BytesRef(bytes, posBegin, pos - posBegin);
-    }
-
-    @Override
-    public Symbol normalizeSymbol(Function symbol) {
-        final int size = symbol.arguments().size();
-        assert (size >= 2 && size <= 3);
-
-        final Symbol input = symbol.arguments().get(0);
-        final Symbol beginIdx = symbol.arguments().get(1);
-
-        if (anyNonLiterals(input, beginIdx, symbol.arguments())) {
-            return symbol;
-        }
-
-        final Object inputValue = ((Input) input).value();
-        final Object beginIdxValue = ((Input) beginIdx).value();
-        if (inputValue == null || beginIdxValue == null) {
-            return Literal.NULL;
-        }
-        if (size == 3) {
-            if (((Input)symbol.arguments().get(2)).value() == null) {
-                return Literal.NULL;
-            }
-            return Literal.newLiteral(
-                    evaluate(BytesRefs.toBytesRef(inputValue),
-                    ((Number) ((Input) beginIdx).value()).intValue(),
-                    ((Number) ((Input) symbol.arguments().get(2)).value()).intValue()));
-        }
-        return Literal.newLiteral(evaluate(
-                BytesRefs.toBytesRef(inputValue),
-                ((Number) ((Input) beginIdx).value()).intValue()));
-    }
-
-    private static boolean anyNonLiterals(Symbol input, Symbol beginIdx, List<Symbol> arguments) {
-        return !input.symbolType().isValueSymbol() ||
-                !beginIdx.symbolType().isValueSymbol() ||
-                (arguments.size() == 3 && !arguments.get(2).symbolType().isValueSymbol());
     }
 
     @Override

--- a/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -228,8 +228,9 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
                 .getState().metaData();
         assertNotNull(metaData.indices().get(partitionName).getAliases().get("parted"));
         assertThat(
-                client().prepareCount(partitionName).setTypes(Constants.DEFAULT_MAPPING_TYPE)
-                        .setQuery(new MatchAllQueryBuilder()).execute().actionGet().getCount(),
+                client().prepareSearch(partitionName).setTypes(Constants.DEFAULT_MAPPING_TYPE)
+                    .setSize(0).setQuery(new MatchAllQueryBuilder())
+                    .execute().actionGet().getHits().totalHits(),
                 is(1L)
         );
 
@@ -248,8 +249,9 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
         assertNotNull(client().admin().cluster().prepareState().execute().actionGet()
                 .getState().metaData().indices().get(partitionName).getAliases().get("parted"));
         assertThat(
-                client().prepareCount(partitionName).setTypes(Constants.DEFAULT_MAPPING_TYPE)
-                        .setQuery(new MatchAllQueryBuilder()).execute().actionGet().getCount(),
+                client().prepareSearch(partitionName).setTypes(Constants.DEFAULT_MAPPING_TYPE)
+                    .setSize(0).setQuery(new MatchAllQueryBuilder())
+                    .execute().actionGet().getHits().totalHits(),
                 is(1L)
         );
 
@@ -258,8 +260,9 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
         assertNotNull(client().admin().cluster().prepareState().execute().actionGet()
                 .getState().metaData().indices().get(partitionName).getAliases().get("parted"));
         assertThat(
-                client().prepareCount(partitionName).setTypes(Constants.DEFAULT_MAPPING_TYPE)
-                        .setQuery(new MatchAllQueryBuilder()).execute().actionGet().getCount(),
+                client().prepareSearch(partitionName).setTypes(Constants.DEFAULT_MAPPING_TYPE)
+                    .setSize(0).setQuery(new MatchAllQueryBuilder())
+                    .execute().actionGet().getHits().totalHits(),
                 is(1L)
         );
 
@@ -270,8 +273,9 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
         assertNotNull(client().admin().cluster().prepareState().execute().actionGet()
                 .getState().metaData().indices().get(partitionName).getAliases().get("parted"));
         assertThat(
-                client().prepareCount(partitionName).setTypes(Constants.DEFAULT_MAPPING_TYPE)
-                        .setQuery(new MatchAllQueryBuilder()).execute().actionGet().getCount(),
+                client().prepareSearch(partitionName).setTypes(Constants.DEFAULT_MAPPING_TYPE)
+                    .setSize(0).setQuery(new MatchAllQueryBuilder())
+                    .execute().actionGet().getHits().totalHits(),
                 is(1L)
         );
     }
@@ -327,8 +331,9 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
         assertNotNull(client().admin().cluster().prepareState().execute().actionGet()
                 .getState().metaData().indices().get(partitionName).getAliases().get("parted"));
         assertThat(
-                client().prepareCount(partitionName).setTypes(Constants.DEFAULT_MAPPING_TYPE)
-                        .setQuery(new MatchAllQueryBuilder()).execute().actionGet().getCount(),
+                client().prepareSearch(partitionName).setTypes(Constants.DEFAULT_MAPPING_TYPE)
+                    .setSize(0).setQuery(new MatchAllQueryBuilder())
+                    .execute().actionGet().getHits().totalHits(),
                 is(1L)
         );
         execute("select * from parted");

--- a/sql/src/test/java/io/crate/operation/scalar/AbstractScalarFunctionsTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/AbstractScalarFunctionsTest.java
@@ -46,12 +46,14 @@ import org.junit.Before;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import static org.hamcrest.core.Is.is;
 
 public abstract class AbstractScalarFunctionsTest extends CrateUnitTest {
     protected SqlExpressions sqlExpressions;
     protected Functions functions;
+    protected Map<QualifiedName, AnalyzedRelation> tableSources;
 
 
     /**
@@ -173,9 +175,15 @@ public abstract class AbstractScalarFunctionsTest extends CrateUnitTest {
                 .add("tags", new ArrayType(DataTypes.STRING))
                 .add("age", DataTypes.INTEGER)
                 .add("shape", DataTypes.GEO_SHAPE)
+                .add("timestamp", DataTypes.TIMESTAMP)
+                .add("timezone", DataTypes.STRING)
+                .add("time_format", DataTypes.STRING)
+                .add("long_array", new ArrayType(DataTypes.LONG))
+                .add("regex_pattern", DataTypes.STRING)
                 .build();
         TableRelation tableRelation = new TableRelation(tableInfo);
-        sqlExpressions = new SqlExpressions(ImmutableMap.<QualifiedName, AnalyzedRelation>of(new QualifiedName("users"), tableRelation));
+        tableSources = ImmutableMap.<QualifiedName, AnalyzedRelation>of(new QualifiedName("users"), tableRelation);
+        sqlExpressions = new SqlExpressions(tableSources);
         functions = sqlExpressions.getInstance(Functions.class);
     }
 }

--- a/sql/src/test/java/io/crate/operation/scalar/DateFormatFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/DateFormatFunctionTest.java
@@ -21,260 +21,94 @@
 
 package io.crate.operation.scalar;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
-import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
-import io.crate.metadata.FunctionImplementation;
-import io.crate.metadata.Scalar;
-import io.crate.operation.Input;
 import io.crate.types.DataTypes;
 import org.apache.lucene.util.BytesRef;
 import org.junit.Test;
 
-import java.util.Arrays;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import static io.crate.testing.TestingHelpers.*;
-import static org.hamcrest.Matchers.*;
+import static io.crate.testing.TestingHelpers.isLiteral;
 
 public class DateFormatFunctionTest extends AbstractScalarFunctionsTest {
 
-    Iterable<Literal> timestampEquivalents(String ts) {
-        Literal tsLiteral = Literal.newLiteral(DataTypes.TIMESTAMP, DataTypes.TIMESTAMP.value(ts));
-        return ImmutableList.of(
-                tsLiteral,
-                Literal.convert(tsLiteral, DataTypes.LONG),
-                Literal.newLiteral(ts)
-        );
-    }
-
-    public Symbol normalizeForArgs(List<Symbol> args) {
-        Function function = createFunction(DateFormatFunction.NAME, DataTypes.STRING, args);
-        FunctionImplementation impl = functions.get(function.info().ident());
-        if (randomBoolean()) {
-            impl = ((Scalar)impl).compile(function.arguments());
-        }
-
-        return impl.normalizeSymbol(function);
-    }
-    
-    public Object evaluateForArgs(List<Symbol> args) {
-        Function function = createFunction(DateFormatFunction.NAME, DataTypes.STRING, args);
-        Scalar impl = (Scalar)functions.get(function.info().ident());
-        if (randomBoolean()) {
-            impl = impl.compile(function.arguments());
-        }
-        Input[] inputs = new Input[args.size()];
-        for (int i = 0; i < args.size(); i++) {
-            inputs[i] = (Input)args.get(i);
-        }
-        return impl.evaluate(inputs);
-    }
-
     @Test
     public void testNormalizeDefault() throws Exception {
-        for (Literal tsLiteral : timestampEquivalents("1970-01-01T00:00:00")) {
-            List<Symbol> args = Lists.<Symbol>newArrayList(
-                    tsLiteral
-            );
-            assertThat(
-                    normalizeForArgs(args),
-                    isLiteral(new BytesRef("1970-01-01T00:00:00.000000Z")));
-        }
+        assertNormalize("date_format('1970-01-01T00:00:00')", isLiteral("1970-01-01T00:00:00.000000Z"));
     }
 
     @Test
     public void testNormalizeDefaultTimezone() throws Exception {
-        for (Literal tsLiteral : timestampEquivalents("1970-02-01")) {
-            List<Symbol> args = Lists.<Symbol>newArrayList(
-                    Literal.newLiteral("%d.%m.%Y"),
-                    tsLiteral
-            );
-            assertThat(
-                    normalizeForArgs(args),
-                    isLiteral(new BytesRef("01.02.1970")));
-        }
+        assertNormalize("date_format('%d.%m.%Y', '1970-02-01')", isLiteral("01.02.1970"));
     }
 
     @Test
     public void testNormalizeWithTimezone() throws Exception {
-        for (Literal tsLiteral : timestampEquivalents("1970-01-01T00:00:00")) {
-            List<Symbol> args = Lists.<Symbol>newArrayList(
-                    Literal.newLiteral("%d.%m.%Y %T"),
-                    Literal.newLiteral("Europe/Rome"),
-                    tsLiteral
-            );
-            assertThat(
-                    normalizeForArgs(args),
-                    isLiteral(new BytesRef("01.01.1970 01:00:00")));
-        }
+        assertNormalize("date_format('%d.%m.%Y %T', 'Europe/Rome', '1970-01-01T00:00:00')", isLiteral("01.01.1970 01:00:00"));
     }
 
     @Test
-    public void testNormalizeReferenceWithTimezone() throws Exception {
-        for (Literal tsLiteral : timestampEquivalents("1970-01-01T00:00:00")) {
-            List<Symbol> args = Lists.newArrayList(
-                    Literal.newLiteral("%d.%m.%Y %H:%i:%S"),
-                    createReference("timezone", DataTypes.STRING),
-                    tsLiteral
-            );
-            Function function = createFunction(DateFormatFunction.NAME, DataTypes.STRING, args);
-
-            FunctionImplementation dateFormat = functions.get(function.info().ident());
-            if (randomBoolean()) {
-                dateFormat = ((Scalar)dateFormat).compile(args);
-            }
-            Symbol normalized = dateFormat.normalizeSymbol(function);
-
-            assertSame(function, normalized);
-        }
-    }
-
-    @Test
-    public void testNormalizeWithNullLiteral() throws Exception {
-        Literal timestampNull = Literal.newLiteral(DataTypes.TIMESTAMP, null);
-        List<List<Symbol>> argLists = Arrays.asList(
-                Arrays.<Symbol>asList(
-                        Literal.newLiteral("%d.%m.%Y %H:%i:%S"),
-                        Literal.newLiteral(DataTypes.STRING, null),
-                        timestampNull
-                ),
-                Arrays.<Symbol>asList(
-                        Literal.newLiteral(DataTypes.STRING, null),
-                        Literal.newLiteral("Europe/Berlin"),
-                        Literal.newLiteral(DataTypes.TIMESTAMP, 0L)
-                ),
-                Arrays.<Symbol>asList(timestampNull),
-                Arrays.<Symbol>asList(Literal.newLiteral(DataTypes.STRING, null), timestampNull)
-        );
-        for (List<Symbol> argList : argLists) {
-            assertThat(normalizeForArgs(argList), isLiteral(null));
-        }
+    public void testEvaluateWithNullValues() throws Exception {
+        assertEvaluate("date_format('%d.%m.%Y %H:%i:%S', timestamp)", null, Literal.newLiteral(DataTypes.TIMESTAMP, null));
+        assertEvaluate("date_format(name, 'Europe/Berlin', 0)", null, Literal.newLiteral(DataTypes.STRING, null));
     }
 
     @Test
     public void testEvaluateDefault() throws Exception {
-        for (Literal tsLiteral : timestampEquivalents("2015-06-10T09:03:00.004+02")) {
-
-            List<Symbol> args = Arrays.<Symbol>asList(
-                    tsLiteral
-            );
-            Object value = evaluateForArgs(args);
-            assertThat(value, instanceOf(BytesRef.class));
-            assertThat(((BytesRef)value).utf8ToString(), is("2015-06-10T07:03:00.004000Z"));
-        }
+        assertEvaluate("date_format(timestamp)", new BytesRef("2015-06-10T07:03:00.004000Z"),
+            Literal.newLiteral(DataTypes.TIMESTAMP, DataTypes.TIMESTAMP.value("2015-06-10T09:03:00.004+02")));
     }
 
     @Test
     public void testEvaluateDefaultTimezone() throws Exception {
-        for (Literal tsLiteral : timestampEquivalents("2055-01-01")) {
-
-            List<Symbol> args = Arrays.<Symbol>asList(
-                    Literal.newLiteral(
-                        "%a %b %c %D %d %e %f %H %h %I %i %j %k %l %M %m %p %r " +
-                        "%S %s %T %U %u %V %v %W %w %X %x %Y %y"),
-                    tsLiteral
-            );
-            Object value = evaluateForArgs(args);
-            assertThat(value, instanceOf(BytesRef.class));
-            assertThat(((BytesRef)value).utf8ToString(), is(
-                    "Fri Jan 1 1st 01 1 000000 00 12 12 00 001 0 12 January 01 AM 12:00:00 AM " +
-                    "00 00 00:00:00 00 00 52 53 Friday 5 2054 2054 2055 55"));
-        }
+        assertEvaluate("date_format(time_format, timestamp)",
+            new BytesRef("Fri Jan 1 1st 01 1 000000 00 12 12 00 001 0 12 January 01 AM 12:00:00 AM " +
+                         "00 00 00:00:00 00 00 52 53 Friday 5 2054 2054 2055 55"),
+            Literal.newLiteral("%a %b %c %D %d %e %f %H %h %I %i %j %k %l %M %m %p %r " +
+                               "%S %s %T %U %u %V %v %W %w %X %x %Y %y"),
+            Literal.newLiteral(DataTypes.TIMESTAMP, DataTypes.TIMESTAMP.value("2055-01-01")));
     }
 
     @Test
     public void testEvaluateWithTimezone() throws Exception {
-        for (Literal tsLiteral : timestampEquivalents("1871-01-01T09:00:00.000Z")) {
-
-            List<Symbol> args = Arrays.<Symbol>asList(
-                    Literal.newLiteral(
-                            "%a %b %c %D %d %e %f %H %h %I %i %j %k %l %M %m %p %r " +
-                            "%S %s %T %U %u %V %v %W %w %X %x %Y %y"),
-                    Literal.newLiteral("EST"),
-                    tsLiteral
-            );
-            Object value = evaluateForArgs(args);
-            assertThat(value, instanceOf(BytesRef.class));
-            assertThat(((BytesRef)value).utf8ToString(), is(
-                    "Sun Jan 1 1st 01 1 000000 04 04 04 00 001 4 4 January 01 AM 04:00:00 AM " +
-                    "00 00 04:00:00 01 00 01 52 Sunday 0 1871 1870 1871 71"));
-        }
+        assertEvaluate("date_format(time_format, timezone, timestamp)",
+            new BytesRef("Sun Jan 1 1st 01 1 000000 04 04 04 00 001 4 4 January 01 AM 04:00:00 AM " +
+                         "00 00 04:00:00 01 00 01 52 Sunday 0 1871 1870 1871 71"),
+            Literal.newLiteral("%a %b %c %D %d %e %f %H %h %I %i %j %k %l %M %m %p %r " +
+                               "%S %s %T %U %u %V %v %W %w %X %x %Y %y"),
+            Literal.newLiteral("EST"),
+            Literal.newLiteral(DataTypes.TIMESTAMP, DataTypes.TIMESTAMP.value("1871-01-01T09:00:00.000Z")));
     }
 
     @Test
-    public void testEvaluateWithNullInputs() throws Exception {
-        Literal timestampNull = Literal.newLiteral(DataTypes.TIMESTAMP, null);
-        List<List<Symbol>> argLists = Arrays.asList(
-                Arrays.<Symbol>asList(
-                        Literal.newLiteral("%d.%m.%Y %H:%i:%S"),
-                        Literal.newLiteral(DataTypes.STRING, null),
-                        timestampNull
-                ),
-                Arrays.<Symbol>asList(
-                        Literal.newLiteral(DataTypes.STRING, null),
-                        Literal.newLiteral("Europe/Berlin"),
-                        Literal.newLiteral(DataTypes.TIMESTAMP, 0L)
-                ),
-                Arrays.<Symbol>asList(timestampNull),
-                Arrays.<Symbol>asList(Literal.newLiteral(DataTypes.STRING, null), timestampNull)
-        );
-        for (List<Symbol> argList : argLists) {
-            Object value = evaluateForArgs(argList);
-            assertThat(value, is(nullValue()));
-        }
+    public void testNullInputs() throws Exception {
+        assertEvaluate("date_format(time_format, timezone, timestamp)",
+            null,
+            Literal.newLiteral("%d.%m.%Y %H:%i:%S"),
+            Literal.newLiteral(DataTypes.STRING, null),
+            Literal.newLiteral(DataTypes.TIMESTAMP, null));
+        assertEvaluate("date_format(time_format, timezone, timestamp)",
+            null,
+            Literal.newLiteral(DataTypes.STRING, null),
+            Literal.newLiteral("Europe/Berlin"),
+            Literal.newLiteral(DataTypes.TIMESTAMP, 0L));
     }
 
     @Test
-    public void testNormalizeInvalidTimeZone() throws Exception {
+    public void testInvalidTimeZone() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("invalid time zone value 'wrong timezone'");
-        List<Symbol> args = Arrays.<Symbol>asList(
-                Literal.newLiteral("%d.%m.%Y"),
-                Literal.newLiteral("wrong timezone"),
-                Literal.newLiteral(0L)
-        );
-        normalizeForArgs(args);
+        sqlExpressions.normalize(sqlExpressions.asSymbol("date_format('%d.%m.%Y', 'wrong timezone', 0)"));
     }
 
     @Test
-    public void testEvaluateInvalidTimeZone() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("invalid time zone value 'wrong timezone'");
-        List<Symbol> args = Arrays.<Symbol>asList(
-                Literal.newLiteral("%d.%m.%Y"),
-                Literal.newLiteral("wrong timezone"),
-                Literal.newLiteral(0L)
-        );
-        evaluateForArgs(args);
-    }
-
-    @Test
-    public void testNormalizeInvalidTimestamp() throws Exception {
+    public void testInvalidTimestamp() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Invalid format: \"NO TIMESTAMP\"");
-        List<Symbol> args = Arrays.<Symbol>asList(
-                Literal.newLiteral("%d.%m.%Y"),
-                Literal.newLiteral("NO TIMESTAMP")
-        );
-        normalizeForArgs(args);
-
-    }
-
-    @Test
-    public void testEvaluateInvalidTimestamp() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Invalid format: \"NO TIMESTAMP\"");
-        List<Symbol> args = Arrays.<Symbol>asList(
-                Literal.newLiteral("%d.%m.%Y"),
-                Literal.newLiteral("NO TIMESTAMP")
-        );
-        evaluateForArgs(args);
+        sqlExpressions.normalize(sqlExpressions.asSymbol("date_format('%d.%m.%Y', 'NO TIMESTAMP')"));
     }
 
     @Test
@@ -337,38 +171,28 @@ public class DateFormatFunctionTest extends AbstractScalarFunctionsTest {
                 .build();
         for (Map.Entry<String, Map<String, String>> entry : dateToInputOutputMap.entrySet()) {
             for (Map.Entry<String, String> ioEntry : entry.getValue().entrySet()) {
-                List<Symbol> args = Arrays.<Symbol>asList(
-                        Literal.newLiteral(ioEntry.getKey()),
-                        Literal.newLiteral(entry.getKey())
-                );
-                Object result = evaluateForArgs(args);
-                assertThat(result, instanceOf(BytesRef.class));
+                Symbol result = sqlExpressions.normalize(sqlExpressions.asSymbol(String.format(Locale.ENGLISH,
+                    "date_format('%s', '%s')", ioEntry.getKey(), entry.getKey())));
                 assertThat(String.format(Locale.ENGLISH, "Format String '%s' returned wrong result for date '%s'", ioEntry.getKey(), entry.getKey()),
-                        ((BytesRef)result).utf8ToString(),
-                        is(ioEntry.getValue()));
+                        result,
+                        isLiteral(ioEntry.getValue()));
             }
         }
     }
 
     @Test
     public void testEvaluateUTF8Support() throws Exception {
-        List<Symbol> args = Arrays.<Symbol>asList(
-                Literal.newLiteral("%Y®%m\uD834\uDD1E%d € %H:%i:%S"),
-                Literal.newLiteral("2000-01-01")
-        );
-        Object result = evaluateForArgs(args);
-        assertThat(result, instanceOf(BytesRef.class));
-        assertThat(((BytesRef)result).utf8ToString(), is("2000®01\uD834\uDD1E01 € 00:00:00"));
+        assertEvaluate("date_format(time_format, timestamp)",
+            "2000®01\uD834\uDD1E01 € 00:00:00",
+            Literal.newLiteral("%Y®%m\uD834\uDD1E%d € %H:%i:%S"),
+            Literal.newLiteral(DataTypes.TIMESTAMP, DataTypes.TIMESTAMP.value("2000-01-01")));
     }
 
     @Test
     public void testInvalidFormats() throws Exception {
-        List<Symbol> args = Arrays.<Symbol>asList(
-                Literal.newLiteral("%t%%%Z"),
-                Literal.newLiteral("2000-01-01")
-        );
-        Object result = evaluateForArgs(args);
-        assertThat(result, instanceOf(BytesRef.class));
-        assertThat(((BytesRef)result).utf8ToString(), is("t%Z"));
+        assertEvaluate("date_format(time_format, timestamp)",
+            "t%Z",
+            Literal.newLiteral("%t%%%Z"),
+            Literal.newLiteral(DataTypes.TIMESTAMP, DataTypes.TIMESTAMP.value("2000-01-01")));
     }
 }

--- a/sql/src/test/java/io/crate/operation/scalar/SubstrFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/SubstrFunctionTest.java
@@ -21,113 +21,27 @@
 
 package io.crate.operation.scalar;
 
-import com.google.common.collect.ImmutableList;
-import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Literal;
-import io.crate.analyze.symbol.Symbol;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.Scalar;
-import io.crate.operation.Input;
 import io.crate.testing.TestingHelpers;
-import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.apache.lucene.util.BytesRef;
 import org.junit.Test;
 
-import java.util.Arrays;
-import java.util.List;
-
-import static io.crate.testing.TestingHelpers.*;
+import static io.crate.testing.TestingHelpers.isLiteral;
 import static org.hamcrest.core.Is.is;
 
 public class SubstrFunctionTest extends AbstractScalarFunctionsTest {
 
-    private final SubstrFunction funcA = new SubstrFunction(
-            new FunctionInfo(new FunctionIdent(SubstrFunction.NAME, ImmutableList.<DataType>of(DataTypes.STRING, DataTypes.LONG)),
-                    DataTypes.STRING));
-
-    private final SubstrFunction funcB = new SubstrFunction(
-            new FunctionInfo(new FunctionIdent(SubstrFunction.NAME, ImmutableList.<DataType>of(DataTypes.STRING, DataTypes.LONG, DataTypes.LONG)),
-                    DataTypes.STRING));
-
-
-    private Function substr(String str, long startIndex) {
-        return new Function(funcA.info(),
-                Arrays.<Symbol>asList(Literal.newLiteral(str), Literal.newLiteral(startIndex)));
-    }
-
-    private Function substr(String str, long startIndex, long count) {
-        return new Function(funcB.info(),
-                Arrays.<Symbol>asList(Literal.newLiteral(str), Literal.newLiteral(startIndex), Literal.newLiteral(count)));
-    }
-
-    private Function substr(String str, Literal from) {
-        return new Function(funcA.info(),
-                Arrays.<Symbol>asList(Literal.newLiteral(str), from));
-    }
-
-    private Function substr(String str, Literal from, Literal count) {
-        return new Function(funcB.info(),
-                Arrays.<Symbol>asList(Literal.newLiteral(str), from, count));
-    }
-
     @Test
-    @SuppressWarnings("unchecked")
     public void testNormalizeSymbol() throws Exception {
-
-        Function function = substr("cratedata", 0L);
-        Symbol result = funcA.normalizeSymbol(function);
-        assertThat(result, isLiteral("cratedata"));
-
-        function = substr("cratedata", 6L);
-        result = funcA.normalizeSymbol(function);
-        assertThat(result, isLiteral("data"));
-
-        function = substr("cratedata", 10L);
-        result = funcA.normalizeSymbol(function);
-        assertThat(result, isLiteral(""));
-
-        function = substr("cratedata", 1L, 1L);
-        result = funcB.normalizeSymbol(function);
-        assertThat(result, isLiteral("c"));
-
-        function = substr("cratedata", 3L, 2L);
-        result = funcB.normalizeSymbol(function);
-        assertThat(result, isLiteral("at"));
-
-        function = substr("cratedata", 6L, 10L);
-        result = funcB.normalizeSymbol(function);
-        assertThat(result, isLiteral("data"));
-
-        function = substr("cratedata", 6L, 0L);
-        result = funcB.normalizeSymbol(function);
-        assertThat(result, isLiteral(""));
-
-        function = substr("cratedata", 10L, -1L);
-        result = funcB.normalizeSymbol(function);
-        assertThat(result, isLiteral(""));
-    }
-
-    @Test
-    public void testNullLiteralFrom() throws Exception {
-        Function function = substr("cratedata", Literal.NULL);
-        Symbol result = funcA.normalizeSymbol(function);
-        assertThat(result, isLiteral(null, DataTypes.UNDEFINED));
-    }
-
-    @Test
-    public void testNullLiteralCount() throws Exception {
-        Function function = substr("cratedata", Literal.newLiteral(1), Literal.NULL);
-        Symbol result = funcB.normalizeSymbol(function);
-        assertThat(result, isLiteral(null, DataTypes.UNDEFINED));
-    }
-
-    @Test
-    public void testNullLiteralFromCount() throws Exception {
-        Function function = substr("cratedata", Literal.NULL, Literal.NULL);
-        Symbol result = funcB.normalizeSymbol(function);
-        assertThat(result, isLiteral(null, DataTypes.UNDEFINED));
+        assertNormalize("substr('cratedata', 0)", isLiteral("cratedata"));
+        assertNormalize("substr('cratedata', 6)", isLiteral("data"));
+        assertNormalize("substr('cratedata', 10)", isLiteral(""));
+        assertNormalize("substr('cratedata', 1, 1)", isLiteral("c"));
+        assertNormalize("substr('cratedata', 3, 2)", isLiteral("at"));
+        assertNormalize("substr('cratedata', 6, 10)", isLiteral("data"));
+        assertNormalize("substr('cratedata', 6, 0)", isLiteral(""));
+        assertNormalize("substr('cratedata', 10, -1)", isLiteral(""));
     }
 
     @Test
@@ -138,158 +52,37 @@ public class SubstrFunctionTest extends AbstractScalarFunctionsTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void testEvaluate() throws Exception {
-        final Literal<Long> startPos = Literal.newLiteral(6L);
-
-        List<Symbol> args = Arrays.<Symbol>asList(
-                createReference("tag", DataTypes.STRING),
-                startPos
-        );
-        Function function = createFunction(SubstrFunction.NAME, DataTypes.STRING, args);
-        Scalar<BytesRef, Object> format = (Scalar<BytesRef, Object>) functions.get(function.info().ident());
-
-        Input<Object> arg1 = new Input<Object>() {
-            @Override
-            public Object value() {
-                return new BytesRef("cratedata");
-            }
-        };
-        Input<Object> arg2 = new Input<Object>() {
-            @Override
-            public Object value() {
-                return startPos.value();
-            }
-        };
-
-        BytesRef result = format.evaluate(arg1, arg2);
-        assertThat(result.utf8ToString(), is("data"));
-
-        final Literal<Long> count = Literal.newLiteral(2L);
-
-        args = Arrays.<Symbol>asList(
-                createReference("tag", DataTypes.STRING),
-                startPos,
-                count
-        );
-        function = createFunction(SubstrFunction.NAME, DataTypes.STRING, args);
-        format = (Scalar<BytesRef, Object>) functions.get(function.info().ident());
-
-        Input<Object> arg3 = new Input<Object>() {
-            @Override
-            public Object value() {
-                return count.value();
-            }
-        };
-
-        result = format.evaluate(arg1, arg2, arg3);
-        assertThat(result.utf8ToString(), is("da"));
-
+        assertEvaluate("substr('cratedata', 6, 2)", "da");
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void testEvaluateWithArgsAsNonLiterals() throws Exception {
-        List<Symbol> args = Arrays.<Symbol>asList(
-                createReference("tag", DataTypes.STRING),
-                createReference("start", DataTypes.LONG),
-                createReference("end", DataTypes.LONG)
-        );
-        Function function = createFunction(SubstrFunction.NAME, DataTypes.STRING, args);
-        Scalar<BytesRef, Object> format = (Scalar<BytesRef, Object>) functions.get(function.info().ident());
-
-        Input<Object> arg1 = new Input<Object>() {
-            @Override
-            public Object value() {
-                return new BytesRef("cratedata");
-            }
-        };
-        Input<Object> arg2 = new Input<Object>() {
-            @Override
-            public Object value() {
-                return 1L;
-            }
-        };
-        Input<Object> arg3 = new Input<Object>() {
-            @Override
-            public Object value() {
-                return 5L;
-            }
-        };
-
-        BytesRef result = format.evaluate(arg1, arg2, arg3);
-        assertThat(result.utf8ToString(), is("crate"));
+        assertEvaluate("substr('cratedata', id, id)", "crate", Literal.newLiteral(1L), Literal.newLiteral(5L));
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void testEvaluateWithArgsAsNonLiteralsIntShort() throws Exception {
-        List<Symbol> args = Arrays.<Symbol>asList(
-                createReference("tag", DataTypes.STRING),
-                createReference("start", DataTypes.INTEGER),
-                createReference("end", DataTypes.SHORT)
-        );
-        Function function = createFunction(SubstrFunction.NAME, DataTypes.STRING, args);
-        Scalar<BytesRef, Object> format = (Scalar<BytesRef, Object>) functions.get(function.info().ident());
-
-        BytesRef resultBytesRef = format.evaluate(generateInputs(new BytesRef("cratedata"), 1, 5));
-        assertThat(resultBytesRef.utf8ToString(), is("crate"));
-
-        BytesRef resultString = format.evaluate(generateInputs("cratedata", 1, 5));
-        assertThat(resultString.utf8ToString(), is("crate"));
-    }
-
-    private Input[] generateInputs(Object i1, int offset, int lenght) {
-        return new Input[] {new ObjectInput(i1), new ObjectInput(offset), new ObjectInput(lenght)};
-    }
-
-    private static class ObjectInput implements Input<Object> {
-        final Object value;
-        public ObjectInput(Object value) {
-            this.value = value;
-        }
-
-        @Override
-        public Object value() {
-            return value;
-        }
+        assertEvaluate("substr(name, id, id)", "crate",
+            Literal.newLiteral("cratedata"),
+            Literal.newLiteral(DataTypes.SHORT, (short) 1),
+            Literal.newLiteral(DataTypes.SHORT, (short) 5));
     }
 
     @Test
-    public void testEvaluateWithNullInput() throws Exception {
-        List<Symbol> args = Arrays.<Symbol>asList(
-                createReference("tag", DataTypes.STRING),
-                createReference("start", DataTypes.INTEGER),
-                createReference("end", DataTypes.SHORT)
-        );
-        Function function = createFunction(SubstrFunction.NAME, DataTypes.STRING, args);
-        Scalar<BytesRef, Object> format = (Scalar<BytesRef, Object>) functions.get(function.info().ident());
-
-        assertNull(format.evaluate(
-                (Input) Literal.newLiteral(DataTypes.STRING, null),
-                (Input) Literal.newLiteral(1)));
-
-        assertNull(format.evaluate(
-                (Input) Literal.newLiteral("crate"),
-                (Input) Literal.newLiteral(DataTypes.INTEGER, null)));
-
-        assertNull(format.evaluate(
-                (Input) Literal.newLiteral("crate"),
-                (Input) Literal.newLiteral(1),
-                (Input) Literal.newLiteral(DataTypes.INTEGER, null)));
+    public void testNullInputs() throws Exception {
+        assertEvaluate("substr(name, id, id)", null,
+            Literal.newLiteral(DataTypes.STRING, null),
+            Literal.newLiteral(1),
+            Literal.newLiteral(1));
+        assertEvaluate("substr(name, id, id)", null,
+            Literal.newLiteral("crate"),
+            Literal.newLiteral(DataTypes.INTEGER, null),
+            Literal.newLiteral(1));
+        assertEvaluate("substr(name, id, id)", null,
+            Literal.newLiteral("crate"),
+            Literal.newLiteral(1),
+            Literal.newLiteral(DataTypes.SHORT, null));
     }
-
-    @Test
-    public void testNormalizeWithNullLiteral() throws Exception {
-        Function function = createFunction(SubstrFunction.NAME, DataTypes.STRING,
-                Arrays.<Symbol>asList(
-                        Literal.newLiteral(DataTypes.STRING, null),
-                        Literal.newLiteral(1)
-                ));
-        Scalar<BytesRef, Object> func = (Scalar<BytesRef, Object>) functions.get(function.info().ident());
-        Symbol symbol = func.normalizeSymbol(function);
-        assertNull(((Literal) symbol).value());
-    }
-
 }
 

--- a/sql/src/test/java/io/crate/operation/scalar/cast/ToStringArrayFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/cast/ToStringArrayFunctionTest.java
@@ -21,78 +21,39 @@
 
 package io.crate.operation.scalar.cast;
 
-import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Literal;
-import io.crate.analyze.symbol.Symbol;
-import io.crate.operation.Input;
 import io.crate.operation.scalar.AbstractScalarFunctionsTest;
 import io.crate.types.ArrayType;
 import io.crate.types.DataTypes;
-import org.apache.lucene.util.BytesRef;
 import org.junit.Test;
 
-import java.util.Collections;
-import java.util.List;
-
-import static io.crate.testing.TestingHelpers.*;
-import static org.hamcrest.core.Is.is;
+import static io.crate.testing.TestingHelpers.isLiteral;
 
 public class ToStringArrayFunctionTest extends AbstractScalarFunctionsTest {
 
-    public static final String FUNCTION_NAME = CastFunctionResolver.FunctionNames.TO_STRING_ARRAY;
-
     @Test
     public void testNormalize() throws Exception {
-        List<Symbol> arguments = Collections.<Symbol>singletonList(
-                Literal.newLiteral(new Integer[]{1, 2, 3}, new ArrayType(DataTypes.INTEGER))
-        );
-        BytesRef[] expected = new BytesRef[]{ new BytesRef("1"), new BytesRef("2"), new BytesRef("3") };
-        Function function = createFunction(FUNCTION_NAME, new ArrayType(DataTypes.STRING), arguments);
-        ToArrayFunction arrayFunction = (ToArrayFunction) functions.get(function.info().ident());
-
-        Symbol result = arrayFunction.normalizeSymbol(function);
-        assertThat(result, isLiteral(expected, new ArrayType(DataTypes.STRING)));
-
-        arguments = Collections.<Symbol>singletonList(
-                Literal.newLiteral(new Float[]{ 1.0f, 2.0f, 3.0f }, new ArrayType(DataTypes.FLOAT)
-        ));
-        expected = new BytesRef[]{ new BytesRef("1.0"), new BytesRef("2.0"), new BytesRef("3.0") };
-        function = createFunction(FUNCTION_NAME, new ArrayType(DataTypes.STRING), arguments);
-        arrayFunction = (ToArrayFunction) functions.get(function.info().ident());
-
-        result = arrayFunction.normalizeSymbol(function);
-        assertThat(result, isLiteral(expected, new ArrayType(DataTypes.STRING)));
+        assertNormalize("\"toStringArray\"([1, 2, 3])", isLiteral(new ArrayType(DataTypes.STRING).value(new Object[]{"1", "2", "3"})));
     }
 
     @Test
     public void testEvaluate() throws Exception {
-        Object[] expected = new BytesRef[]{ new BytesRef("1"), new BytesRef("2"), new BytesRef("3") };
-        ToArrayFunction arrayFunction = getFunction(FUNCTION_NAME, new ArrayType(DataTypes.INTEGER));
-
-        Input[] args = new Input[1];
-        args[0] = new Input<Object>() {
-            @Override
-            public Object value() {
-                return new Integer[]{ 1, 2, 3 };
-            }
-        };
-
-        Object[] result = arrayFunction.evaluate(args);
-        assertThat(result, is(expected));
+        assertEvaluate("\"toStringArray\"(long_array)", new ArrayType(DataTypes.STRING).value(new Object[]{"1", "2", "3"}),
+            Literal.newLiteral(new Long[]{1L, 2L, 3L}, new ArrayType(DataTypes.LONG)));
     }
 
     @Test
     public void testInvalidArgumentType() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expect(UnsupportedOperationException.class);
         expectedException.expectMessage("type 'string' not supported for conversion to 'string_array'");
-        getFunction(FUNCTION_NAME, DataTypes.STRING);
+        sqlExpressions.normalize(sqlExpressions.asSymbol("\"toStringArray\"('bla')"));
     }
 
     @Test
     public void testInvalidArgumentInnerType() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expect(UnsupportedOperationException.class);
         expectedException.expectMessage("type 'object_array' not supported for conversion to 'string_array'");
-        getFunction(FUNCTION_NAME, new ArrayType(DataTypes.OBJECT));
+        sqlExpressions.normalize(sqlExpressions.asSymbol("\"toStringArray\"([{a = 1}])"));
     }
 
 }

--- a/sql/src/test/java/io/crate/operation/scalar/string/LowerFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/string/LowerFunctionTest.java
@@ -21,81 +21,22 @@
 
 package io.crate.operation.scalar.string;
 
-import com.google.common.collect.Lists;
-import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Literal;
-import io.crate.analyze.symbol.Symbol;
-import io.crate.metadata.FunctionImplementation;
-import io.crate.metadata.Scalar;
-import io.crate.operation.Input;
 import io.crate.operation.scalar.AbstractScalarFunctionsTest;
 import io.crate.types.DataTypes;
-import org.apache.lucene.util.BytesRef;
 import org.junit.Test;
 
-import java.util.Arrays;
-import java.util.List;
-
-import static io.crate.testing.TestingHelpers.createFunction;
 import static io.crate.testing.TestingHelpers.isLiteral;
-import static org.hamcrest.Matchers.*;
 
 public class LowerFunctionTest extends AbstractScalarFunctionsTest {
 
-    public Symbol normalizeForArgs(List<Symbol> args) {
-        Function function = createFunction(LowerFunction.NAME, DataTypes.STRING, args);
-        FunctionImplementation impl = functions.get(function.info().ident());
-        impl = ((Scalar) impl).compile(function.arguments());
-
-        return impl.normalizeSymbol(function);
-    }
-
-    public Object evaluateForArgs(List<Symbol> args) {
-        Function function = createFunction(LowerFunction.NAME, DataTypes.STRING, args);
-        Scalar impl = (Scalar) functions.get(function.info().ident());
-        impl = impl.compile(function.arguments());
-
-        Input[] inputs = new Input[args.size()];
-        for (int i = 0; i < args.size(); i++) {
-            inputs[i] = (Input) args.get(i);
-        }
-
-        return impl.evaluate(inputs);
-    }
-
     @Test
-    public void testNormalizeDefault() throws Exception {
-        List<Symbol> args = Lists.<Symbol>newArrayList(
-                Literal.newLiteral("ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÜΑΒΓ")
-        );
-        assertThat(
-                normalizeForArgs(args),
-                isLiteral("abcdefghijklmnopqrstuvwxyzäöüαβγ"));
+    public void testNormalize() throws Exception {
+        assertNormalize("lower('ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÜΑΒΓ')", isLiteral("abcdefghijklmnopqrstuvwxyzäöüαβγ"));
     }
 
     @Test
     public void testEvaluateNull() throws Exception {
-        Literal stringNull = Literal.newLiteral(DataTypes.STRING, null);
-        List<List<Symbol>> argLists = Arrays.asList(
-                Arrays.<Symbol>asList(stringNull)
-        );
-
-        for (List<Symbol> argList : argLists) {
-            Object value = evaluateForArgs(argList);
-            assertThat(value, is(nullValue()));
-        }
-    }
-
-    public void testNormalizeSymbol() throws Exception {
-        Function function = (Function) sqlExpressions.asSymbol("lower('SomeString')");
-        LowerFunction lowerFunction = (LowerFunction) functions.get(function.info().ident());
-        Symbol result = lowerFunction.normalizeSymbol(function);
-        assertThat(result, isLiteral(new BytesRef("somestring")));
-
-        function = (Function) sqlExpressions.asSymbol("lower(name)");
-        lowerFunction = (LowerFunction) functions.get(function.info().ident());
-        result = lowerFunction.normalizeSymbol(function);
-        assertThat(result, instanceOf(Function.class));
-        assertThat((Function)result, is(function));
+        assertEvaluate("lower(name)", null, Literal.newLiteral(DataTypes.STRING, null));
     }
 }

--- a/sql/src/test/java/io/crate/operation/scalar/string/UpperFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/string/UpperFunctionTest.java
@@ -21,81 +21,22 @@
 
 package io.crate.operation.scalar.string;
 
-import com.google.common.collect.Lists;
-import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Literal;
-import io.crate.analyze.symbol.Symbol;
-import io.crate.metadata.FunctionImplementation;
-import io.crate.metadata.Scalar;
-import io.crate.operation.Input;
 import io.crate.operation.scalar.AbstractScalarFunctionsTest;
 import io.crate.types.DataTypes;
-import org.apache.lucene.util.BytesRef;
 import org.junit.Test;
 
-import java.util.Arrays;
-import java.util.List;
-
-import static io.crate.testing.TestingHelpers.createFunction;
 import static io.crate.testing.TestingHelpers.isLiteral;
-import static org.hamcrest.Matchers.*;
 
 public class UpperFunctionTest extends AbstractScalarFunctionsTest {
 
-    public Symbol normalizeForArgs(List<Symbol> args) {
-        Function function = createFunction(UpperFunction.NAME, DataTypes.STRING, args);
-        FunctionImplementation impl = functions.get(function.info().ident());
-        impl = ((Scalar) impl).compile(function.arguments());
-
-        return impl.normalizeSymbol(function);
-    }
-
-    public Object evaluateForArgs(List<Symbol> args) {
-        Function function = createFunction(UpperFunction.NAME, DataTypes.STRING, args);
-        Scalar impl = (Scalar) functions.get(function.info().ident());
-        impl = impl.compile(function.arguments());
-
-        Input[] inputs = new Input[args.size()];
-        for (int i = 0; i < args.size(); i++) {
-            inputs[i] = (Input) args.get(i);
-        }
-
-        return impl.evaluate(inputs);
-    }
-
     @Test
-    public void testNormalizeDefault() throws Exception {
-        List<Symbol> args = Lists.<Symbol>newArrayList(
-                Literal.newLiteral("abcdefghijklmnopqrstuvwxyzäöüαβγ")
-        );
-        assertThat(
-                normalizeForArgs(args),
-                isLiteral("ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÜΑΒΓ"));
+    public void testNormalize() throws Exception {
+        assertNormalize("upper('abcdefghijklmnopqrstuvwxyzäöüαβγ')", isLiteral("ABCDEFGHIJKLMNOPQRSTUVWXYZÄÖÜΑΒΓ"));
     }
 
     @Test
     public void testEvaluateNull() throws Exception {
-        Literal stringNull = Literal.newLiteral(DataTypes.STRING, null);
-        List<List<Symbol>> argLists = Arrays.asList(
-                Arrays.<Symbol>asList(stringNull)
-        );
-
-        for (List<Symbol> argList : argLists) {
-            Object value = evaluateForArgs(argList);
-            assertThat(value, is(nullValue()));
-        }
-    }
-
-    public void testNormalizeSymbol() throws Exception {
-        Function function = (Function) sqlExpressions.asSymbol("upper('SomeString')");
-        UpperFunction upperFunction = (UpperFunction) functions.get(function.info().ident());
-        Symbol result = upperFunction.normalizeSymbol(function);
-        assertThat(result, isLiteral(new BytesRef("SOMESTRING")));
-
-        function = (Function) sqlExpressions.asSymbol("upper(name)");
-        upperFunction = (UpperFunction) functions.get(function.info().ident());
-        result = upperFunction.normalizeSymbol(function);
-        assertThat(result, instanceOf(Function.class));
-        assertThat((Function)result, is(function));
+        assertEvaluate("upper(name)", null, Literal.newLiteral(DataTypes.STRING, null));
     }
 }

--- a/sql/src/test/java/io/crate/operation/scalar/timestamp/CurrentTimestampFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/timestamp/CurrentTimestampFunctionTest.java
@@ -1,30 +1,23 @@
 package io.crate.operation.scalar.timestamp;
 
-import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Literal;
-import io.crate.analyze.symbol.Reference;
-import io.crate.analyze.symbol.Symbol;
-import io.crate.test.integration.CrateUnitTest;
-import io.crate.testing.TestingHelpers;
-import io.crate.types.DataTypes;
+import io.crate.operation.scalar.AbstractScalarFunctionsTest;
 import org.joda.time.DateTimeUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.text.SimpleDateFormat;
-import java.util.Arrays;
 import java.util.Date;
 
-import static io.crate.testing.TestingHelpers.createFunction;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
-public class CurrentTimestampFunctionTest extends CrateUnitTest {
+public class CurrentTimestampFunctionTest extends AbstractScalarFunctionsTest {
 
     private CurrentTimestampFunction timestampFunction;
-    public static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS";
-    public static final long EXPECTED_TIMESTAMP = 1422294644581L;
+    private static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS";
+    private static final long EXPECTED_TIMESTAMP = 1422294644581L;
 
     @Before
     public void prepare() {
@@ -91,16 +84,6 @@ public class CurrentTimestampFunctionTest extends CrateUnitTest {
 
     @Test
     public void integerIsNormalizedToLiteral() {
-        Function function = createFunction("CURRENT_TIMESTAMP", DataTypes.TIMESTAMP, Arrays.<Symbol>asList(Literal.newLiteral(1)));
-        assertThat(timestampFunction.normalizeSymbol(function), instanceOf(Literal.class));
-    }
-
-    @Test
-    public void normalizeReferenceRaisesException() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Invalid argument to CURRENT_TIMESTAMP");
-        Reference ref = TestingHelpers.createReference("Some_Column", DataTypes.INTEGER);
-        Function function = createFunction("CURRENT_TIMESTAMP", DataTypes.TIMESTAMP, Arrays.<Symbol>asList(ref));
-        timestampFunction.normalizeSymbol(function);
+        assertNormalize("CURRENT_TIMESTAMP(1)", instanceOf(Literal.class));
     }
 }

--- a/sql/src/test/java/io/crate/planner/projection/FilterProjectionTest.java
+++ b/sql/src/test/java/io/crate/planner/projection/FilterProjectionTest.java
@@ -23,25 +23,25 @@ package io.crate.planner.projection;
 
 import com.google.common.collect.ImmutableList;
 import io.crate.analyze.symbol.InputColumn;
-import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.RowGranularity;
-import io.crate.operation.operator.AndOperator;
 import io.crate.test.integration.CrateUnitTest;
-import io.crate.testing.TestingHelpers;
-import io.crate.types.DataTypes;
-import org.elasticsearch.common.io.stream.StreamInput;
+import io.crate.testing.SqlExpressions;
+import io.crate.testing.T3;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.junit.Test;
 
 public class FilterProjectionTest extends CrateUnitTest {
 
     @Test
     public void testStreaming() throws Exception {
+        SqlExpressions sqlExpressions = new SqlExpressions(T3.SOURCES, T3.TR_1);
+
         FilterProjection p = new FilterProjection();
         p.outputs(ImmutableList.<Symbol>of(new InputColumn(1)));
         p.requiredGranularity(RowGranularity.SHARD);
-        p.query(TestingHelpers.createFunction(AndOperator.NAME, DataTypes.BOOLEAN, Literal.newLiteral(true), Literal.newLiteral(false)));
+        p.query(sqlExpressions.normalize(sqlExpressions.asSymbol("a = 'foo'")));
 
         BytesStreamOutput out = new BytesStreamOutput();
         Projection.toStream(p, out);

--- a/sql/src/test/java/io/crate/testing/SqlExpressions.java
+++ b/sql/src/test/java/io/crate/testing/SqlExpressions.java
@@ -53,10 +53,22 @@ public class SqlExpressions {
     private final AnalysisMetaData analysisMetaData;
 
     public SqlExpressions(Map<QualifiedName, AnalyzedRelation> sources) {
-        this(sources, null);
+        this(sources, null, null);
     }
 
-    public SqlExpressions(Map<QualifiedName, AnalyzedRelation> sources, @Nullable FieldResolver fieldResolver) {
+
+    public SqlExpressions(Map<QualifiedName, AnalyzedRelation> sources, Object[] parameters) {
+        this(sources, null, parameters);
+    }
+
+    public SqlExpressions(Map<QualifiedName, AnalyzedRelation> sources,
+                          @Nullable FieldResolver fieldResolver) {
+        this(sources, fieldResolver, null);
+    }
+
+    public SqlExpressions(Map<QualifiedName, AnalyzedRelation> sources,
+                          @Nullable FieldResolver fieldResolver,
+                          @Nullable Object[] parameters) {
         ModulesBuilder modulesBuilder = new ModulesBuilder()
                 .add(new OperatorModule())
                 .add(new ScalarFunctionModule())
@@ -73,7 +85,7 @@ public class SqlExpressions {
         analysisMetaData = new AnalysisMetaData(injector.getInstance(Functions.class), schemas, referenceResolver);
         expressionAnalyzer =  new ExpressionAnalyzer(
                 analysisMetaData,
-                new ParameterContext(new Object[0], new Object[0][], null),
+                new ParameterContext(parameters == null ? new Object[0] : parameters, new Object[0][], null),
                 new FullQualifedNameFieldProvider(sources),
                 fieldResolver);
         expressionAnalysisCtx = new ExpressionAnalysisContext();

--- a/sql/src/test/java/io/crate/testing/TestingHelpers.java
+++ b/sql/src/test/java/io/crate/testing/TestingHelpers.java
@@ -144,39 +144,6 @@ public class TestingHelpers {
                 .add(new OperatorModule()).createInjector().getInstance(Functions.class);
     }
 
-    /**
-     * @deprecated use {@link SqlExpressions} instead
-     */
-    @Deprecated
-    public static Function createFunction(String functionName, DataType returnType, Symbol... arguments) {
-        return createFunction(functionName, returnType, Arrays.asList(arguments), true, false);
-    }
-
-    /**
-     * @deprecated use {@link SqlExpressions} instead
-     */
-    @Deprecated
-    public static Function createFunction(String functionName, DataType returnType, List<Symbol> arguments) {
-        return createFunction(functionName, returnType, arguments, true, false);
-    }
-
-    /**
-     * @deprecated use {@link SqlExpressions} instead
-     */
-    @Deprecated
-    public static Function createFunction(String functionName,
-                                          DataType returnType,
-                                          List<Symbol> arguments,
-                                          boolean deterministic,
-                                          boolean comparisonReplacementPossible) {
-        List<DataType> dataTypes = Symbols.extractTypes(arguments);
-        return new Function(
-                new FunctionInfo(new FunctionIdent(functionName, dataTypes), returnType, FunctionInfo.Type.SCALAR,
-                        deterministic, comparisonReplacementPossible),
-                arguments
-        );
-    }
-
     public static Reference createReference(String columnName, DataType dataType) {
         return createReference("dummyTable", new ColumnIdent(columnName), dataType);
     }

--- a/sql/src/test/java/io/crate/testing/TestingHelpers.java
+++ b/sql/src/test/java/io/crate/testing/TestingHelpers.java
@@ -25,7 +25,6 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Ordering;
-import io.crate.analyze.WhereClause;
 import io.crate.analyze.symbol.*;
 import io.crate.analyze.where.DocKeys;
 import io.crate.core.collections.Bucket;
@@ -489,17 +488,6 @@ public class TestingHelpers {
             column[i] = rows[i][index];
         }
         return column;
-    }
-
-    /**
-     * @deprecated use {@link SqlExpressions} instead
-     */
-    @Deprecated
-    public static WhereClause whereClause(String opname, Symbol left, Symbol right) {
-        return new WhereClause(new Function(new FunctionInfo(
-                new FunctionIdent(opname, Arrays.asList(left.valueType(), right.valueType())), DataTypes.BOOLEAN),
-                Arrays.asList(left, right)
-        ));
     }
 
     public static ThreadPool newMockedThreadPool() {


### PR DESCRIPTION
removed following deprecated TestHelpers methods:
* createFunction() (all variants)
* whereClause()

also removed usage of deprecated ES client().prepareCount() test helper method