### PR TITLE
renames all scalar function names to lowercase

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Renamed all scalar function names to lowercase (CamelCase names
+   were transformed to lowercase using `_` as word boundary)
+
  - Fixed an issue that prevented generated columns to work correctly
    with arrays.
 

--- a/sql/src/main/java/io/crate/operation/scalar/cast/CastFunctionResolver.java
+++ b/sql/src/main/java/io/crate/operation/scalar/cast/CastFunctionResolver.java
@@ -39,28 +39,28 @@ public class CastFunctionResolver {
     public static final String TRY_CAST_PREFIX = "try_";
 
     public static class FunctionNames {
-        public static final String TO_STRING = "toString";
-        public static final String TO_INTEGER = "toInt";
-        public static final String TO_LONG = "toLong";
-        public static final String TO_TIMESTAMP = "toTimestamp";
-        public static final String TO_DOUBLE = "toDouble";
-        public static final String TO_BOOLEAN = "toBoolean";
-        public static final String TO_FLOAT = "toFloat";
-        public static final String TO_BYTE = "toByte";
-        public static final String TO_SHORT = "toShort";
-        public static final String TO_IP = "toIp";
+        public static final String TO_STRING = "to_string";
+        public static final String TO_INTEGER = "to_int";
+        public static final String TO_LONG = "to_long";
+        public static final String TO_TIMESTAMP = "to_timestamp";
+        public static final String TO_DOUBLE = "to_double";
+        public static final String TO_BOOLEAN = "to_boolean";
+        public static final String TO_FLOAT = "to_float";
+        public static final String TO_BYTE = "to_byte";
+        public static final String TO_SHORT = "to_short";
+        public static final String TO_IP = "to_ip";
 
-        public static final String TO_STRING_ARRAY = "toStringArray";
-        public static final String TO_LONG_ARRAY = "toLongArray";
-        public static final String TO_INTEGER_ARRAY = "toIntArray";
-        public static final String TO_DOUBLE_ARRAY = "toDoubleArray";
-        public static final String TO_BOOLEAN_ARRAY = "toBooleanArray";
-        public static final String TO_BYTE_ARRAY = "toByteArray";
-        public static final String TO_FLOAT_ARRAY = "toFloatArray";
-        public static final String TO_SHORT_ARRAY = "toShortArray";
-        public static final String TO_IP_ARRAY = "toIpArray";
-        public static final String TO_GEO_POINT = "toGeoPoint";
-        public static final String TO_GEO_SHAPE = "toGeoShape";
+        public static final String TO_STRING_ARRAY = "to_string_array";
+        public static final String TO_LONG_ARRAY = "to_long_array";
+        public static final String TO_INTEGER_ARRAY = "to_int_array";
+        public static final String TO_DOUBLE_ARRAY = "to_double_array";
+        public static final String TO_BOOLEAN_ARRAY = "to_boolean_array";
+        public static final String TO_BYTE_ARRAY = "to_byte_array";
+        public static final String TO_FLOAT_ARRAY = "to_float_array";
+        public static final String TO_SHORT_ARRAY = "to_short_array";
+        public static final String TO_IP_ARRAY = "to_ip_array";
+        public static final String TO_GEO_POINT = "to_geo_point";
+        public static final String TO_GEO_SHAPE = "to_geo_shape";
     }
 
     static final ImmutableMap<DataType, String> PRIMITIVE_FUNCTION_MAP = new ImmutableMap.Builder<DataType, String>()

--- a/sql/src/main/java/io/crate/operation/scalar/timestamp/CurrentTimestampFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/timestamp/CurrentTimestampFunction.java
@@ -41,7 +41,7 @@ import java.util.Locale;
 
 public class CurrentTimestampFunction extends Scalar<Long, Integer> implements FunctionFormatSpec {
 
-    public static final String NAME = "CURRENT_TIMESTAMP";
+    public static final String NAME = "current_timestamp";
     public static final int DEFAULT_PRECISION = 3;
 
     public static final FunctionInfo INFO = new FunctionInfo(
@@ -105,7 +105,7 @@ public class CurrentTimestampFunction extends Scalar<Long, Integer> implements F
 
     @Override
     public String beforeArgs(Function function) {
-        return "CURRENT_TIMESTAMP" + (function.arguments().isEmpty() ? "" : "(");
+        return "current_timestamp" + (function.arguments().isEmpty() ? "" : "(");
     }
 
     @Override

--- a/sql/src/test/java/io/crate/analyze/InsertFromValuesAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/InsertFromValuesAnalyzerTest.java
@@ -945,7 +945,7 @@ public class InsertFromValuesAnalyzerTest extends BaseAnalyzerTest {
                 "on duplicate key update name = awesome");
         assertThat(statement.onDuplicateKeyAssignments().size(), is(1));
         Symbol symbol = statement.onDuplicateKeyAssignments().get(0)[0];
-        assertThat(symbol, isFunction("toString"));
+        assertThat(symbol, isFunction("to_string"));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -1683,7 +1683,7 @@ public class SelectStatementAnalyzerTest extends BaseAnalyzerTest {
         assertThat(symbol, isFunction("extract_DAY_OF_MONTH"));
 
         Symbol argument = ((Function) symbol).arguments().get(0);
-        assertThat(argument, isFunction("toTimestamp"));
+        assertThat(argument, isFunction("to_timestamp"));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/scalar/cast/ToStringArrayFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/cast/ToStringArrayFunctionTest.java
@@ -33,12 +33,12 @@ public class ToStringArrayFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testNormalize() throws Exception {
-        assertNormalize("\"toStringArray\"([1, 2, 3])", isLiteral(new ArrayType(DataTypes.STRING).value(new Object[]{"1", "2", "3"})));
+        assertNormalize("to_string_array([1, 2, 3])", isLiteral(new ArrayType(DataTypes.STRING).value(new Object[]{"1", "2", "3"})));
     }
 
     @Test
     public void testEvaluate() throws Exception {
-        assertEvaluate("\"toStringArray\"(long_array)", new ArrayType(DataTypes.STRING).value(new Object[]{"1", "2", "3"}),
+        assertEvaluate("to_string_array(long_array)", new ArrayType(DataTypes.STRING).value(new Object[]{"1", "2", "3"}),
             Literal.newLiteral(new Long[]{1L, 2L, 3L}, new ArrayType(DataTypes.LONG)));
     }
 
@@ -46,14 +46,14 @@ public class ToStringArrayFunctionTest extends AbstractScalarFunctionsTest {
     public void testInvalidArgumentType() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
         expectedException.expectMessage("type 'string' not supported for conversion to 'string_array'");
-        sqlExpressions.normalize(sqlExpressions.asSymbol("\"toStringArray\"('bla')"));
+        sqlExpressions.normalize(sqlExpressions.asSymbol("to_string_array('bla')"));
     }
 
     @Test
     public void testInvalidArgumentInnerType() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
         expectedException.expectMessage("type 'object_array' not supported for conversion to 'string_array'");
-        sqlExpressions.normalize(sqlExpressions.asSymbol("\"toStringArray\"([{a = 1}])"));
+        sqlExpressions.normalize(sqlExpressions.asSymbol("to_string_array([{a = 1}])"));
     }
 
 }

--- a/sql/src/test/java/io/crate/operation/scalar/timestamp/CurrentTimestampFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/timestamp/CurrentTimestampFunctionTest.java
@@ -78,12 +78,12 @@ public class CurrentTimestampFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void precisionOfNullLRaisesException() {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("NULL precision not supported for CURRENT_TIMESTAMP");
+        expectedException.expectMessage("NULL precision not supported for current_timestamp");
         timestampFunction.evaluate(Literal.newLiteral((Integer) null));
     }
 
     @Test
     public void integerIsNormalizedToLiteral() {
-        assertNormalize("CURRENT_TIMESTAMP(1)", instanceOf(Literal.class));
+        assertNormalize("current_timestamp(1)", instanceOf(Literal.class));
     }
 }

--- a/sql/src/test/java/io/crate/planner/PlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/PlannerTest.java
@@ -37,10 +37,8 @@ import java.lang.reflect.Field;
 import java.util.*;
 
 import static io.crate.testing.TestingHelpers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.*;
 
 @SuppressWarnings("ConstantConditions")
 public class PlannerTest extends AbstractPlannerTest {
@@ -1198,7 +1196,7 @@ public class PlannerTest extends AbstractPlannerTest {
         TopNProjection collectTopN = (TopNProjection)collectPhase.projections().get(1);
         assertThat(collectTopN.limit(), is(TopN.NO_LIMIT));
         assertThat(collectTopN.offset(), is(TopN.NO_OFFSET));
-        assertThat(collectTopN.outputs(), contains(isInputColumn(0), isFunction("toString")));
+        assertThat(collectTopN.outputs(), contains(isInputColumn(0), isFunction("to_string")));
 
         MergePhase mergePhase = nonDistributedGroupBy.localMerge();
         assertThat(mergePhase.projections(), hasSize(2));
@@ -1252,7 +1250,7 @@ public class PlannerTest extends AbstractPlannerTest {
         RoutedCollectPhase collectPhase = ((RoutedCollectPhase) queryAndFetch.collectPhase());
         List<Symbol> toCollect = collectPhase.toCollect();
         assertThat(toCollect.size(), is(2));
-        assertThat(toCollect.get(0), isFunction("toLong"));
+        assertThat(toCollect.get(0), isFunction("to_long"));
         assertThat(((Function) toCollect.get(0)).arguments().get(0), isReference("_doc['id']"));
         assertThat((Reference) toCollect.get(1), equalTo(new Reference(new ReferenceInfo(
                 new ReferenceIdent(new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "parted"), "date"), RowGranularity.PARTITION, DataTypes.TIMESTAMP))));


### PR DESCRIPTION
CamelCase names are transformed to lowercase using `_` as word boundary (affects mostly internal functions)