### PR TITLE
restrict table creating with pk in array columns and its children

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Restrict creation of tables having the primary key constraint within
+   an array column type or its children.
+
  - Renamed all scalar function names to lowercase (CamelCase names
    were transformed to lowercase using `_` as word boundary)
 

--- a/sql/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
@@ -199,6 +199,10 @@ public class AnalyzedColumnDefinition {
             throw new UnsupportedOperationException(
                     String.format(Locale.ENGLISH, "Cannot use columns of type \"%s\" as primary key", dataType));
         }
+        if (isArrayOrInArray()) {
+            throw new UnsupportedOperationException(
+                    String.format(Locale.ENGLISH, "Cannot use column \"%s\" as primary key within an array object", name));
+        }
     }
 
     public String name() {

--- a/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -920,4 +920,17 @@ public class CreateAlterTableStatementAnalyzerTest extends BaseAnalyzerTest {
         }
     }
 
+    @Test
+    public void testCreateTableWithPrimaryKeyConstraintInArrayItem() throws Exception {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("Cannot use column \"id\" as primary key within an array object");
+        analyze("create table test (arr array(object as (id long primary key)))");
+    }
+
+    @Test
+    public void testCreateTableWithDeepNestedPrimaryKeyConstraintInArrayItem() throws Exception {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("Cannot use column \"name\" as primary key within an array object");
+        analyze("create table test (arr array(object as (user object as (name string primary key), id long)))");
+    }
 }


### PR DESCRIPTION
E.g. tables with the ```(arr array(obj AS (id long PRIMARY KEY)))```  column definition cannot be created.