### PR TITLE
replaces usage of CancellationException with InterruptedException

### DIFF
--- a/sql/src/main/java/io/crate/executor/transport/TransportShardAction.java
+++ b/sql/src/main/java/io/crate/executor/transport/TransportShardAction.java
@@ -136,7 +136,7 @@ public abstract class TransportShardAction<R extends ShardRequest>
         }
     }
 
-    protected abstract ShardResponse processRequestItems(ShardId shardId, R request, AtomicBoolean killed);
+    protected abstract ShardResponse processRequestItems(ShardId shardId, R request, AtomicBoolean killed) throws InterruptedException;
 
     protected abstract void processRequestItemsOnReplica(ShardId shardId, R request);
 

--- a/sql/src/main/java/io/crate/executor/transport/TransportShardDeleteAction.java
+++ b/sql/src/main/java/io/crate/executor/transport/TransportShardDeleteAction.java
@@ -42,7 +42,6 @@ import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 @Singleton
@@ -70,7 +69,7 @@ public class TransportShardDeleteAction extends TransportShardAction<ShardDelete
     }
 
     @Override
-    protected ShardResponse processRequestItems(ShardId shardId, ShardDeleteRequest request, AtomicBoolean killed) {
+    protected ShardResponse processRequestItems(ShardId shardId, ShardDeleteRequest request, AtomicBoolean killed) throws InterruptedException {
         ShardResponse shardResponse = new ShardResponse();
         IndexService indexService = indicesService.indexServiceSafe(request.index());
         IndexShard indexShard = indexService.shardSafe(shardId.id());
@@ -82,7 +81,7 @@ public class TransportShardDeleteAction extends TransportShardAction<ShardDelete
                 // this way replica operation will be executed, but only items already processed here
                 // will be processed on the replica
                 request.skipFromLocation(location);
-                shardResponse.failure(new CancellationException(JobKilledException.MESSAGE));
+                shardResponse.failure(new InterruptedException(JobKilledException.MESSAGE));
                 break;
             }
             try {

--- a/sql/src/main/java/io/crate/executor/transport/task/UpsertByIdTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/UpsertByIdTask.java
@@ -57,7 +57,6 @@ import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.CancellationException;
 
 public class UpsertByIdTask extends JobTask {
 
@@ -253,7 +252,7 @@ public class UpsertByIdTask extends JobTask {
                 }
 
                 private void setAllToFailed(@Nullable Throwable throwable) {
-                    if (throwable instanceof CancellationException) {
+                    if (throwable instanceof InterruptedException) {
                         for (ListenableFuture<TaskResult> future : resultList) {
                             ((SettableFuture<TaskResult>) future).setException(throwable);
                         }

--- a/sql/src/main/java/io/crate/jobs/AbstractExecutionSubContext.java
+++ b/sql/src/main/java/io/crate/jobs/AbstractExecutionSubContext.java
@@ -27,7 +27,6 @@ import org.elasticsearch.common.logging.ESLogger;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.concurrent.CancellationException;
 
 public abstract class AbstractExecutionSubContext implements ExecutionSubContext {
 
@@ -108,7 +107,7 @@ public abstract class AbstractExecutionSubContext implements ExecutionSubContext
     final public void kill(@Nullable Throwable t) {
         if (future.firstClose()) {
             if (t == null) {
-                t = new CancellationException(JobKilledException.MESSAGE);
+                t = new InterruptedException(JobKilledException.MESSAGE);
             }
             logger.trace("killing id={} ctx={} cause={}", id, this, t);
             try {

--- a/sql/src/main/java/io/crate/operation/projectors/DMLProjector.java
+++ b/sql/src/main/java/io/crate/operation/projectors/DMLProjector.java
@@ -36,12 +36,11 @@ import org.elasticsearch.index.mapper.Uid;
 import org.elasticsearch.index.shard.ShardId;
 
 import java.util.UUID;
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public abstract class DMLProjector<Request extends ShardRequest> extends AbstractProjector {
+abstract class DMLProjector<Request extends ShardRequest> extends AbstractProjector {
 
-    public static final int DEFAULT_BULK_SIZE = 1024;
+    static final int DEFAULT_BULK_SIZE = 1024;
 
     private final ShardId shardId;
     private final CollectExpression<Row, ?> collectUidExpression;
@@ -53,9 +52,9 @@ public abstract class DMLProjector<Request extends ShardRequest> extends Abstrac
     protected final BulkRetryCoordinatorPool bulkRetryCoordinatorPool;
     protected final UUID jobId;
 
-    protected BulkShardProcessor<Request> bulkShardProcessor;
+    private BulkShardProcessor<Request> bulkShardProcessor;
 
-    public DMLProjector(ClusterService clusterService,
+    DMLProjector(ClusterService clusterService,
                         Settings settings,
                         ShardId shardId,
                         TransportActionProvider transportActionProvider,
@@ -102,7 +101,7 @@ public abstract class DMLProjector<Request extends ShardRequest> extends Abstrac
         failed.set(true);
         downstream.fail(throwable);
 
-        if (throwable instanceof CancellationException) {
+        if (throwable instanceof InterruptedException) {
             bulkShardProcessor.kill(throwable);
         } else {
             bulkShardProcessor.close();

--- a/sql/src/main/java/org/elasticsearch/action/admin/indices/create/TransportBulkCreateIndicesAction.java
+++ b/sql/src/main/java/org/elasticsearch/action/admin/indices/create/TransportBulkCreateIndicesAction.java
@@ -74,7 +74,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.*;
-import java.util.concurrent.CancellationException;
 
 import static org.elasticsearch.common.settings.Settings.settingsBuilder;
 
@@ -205,7 +204,7 @@ public class TransportBulkCreateIndicesAction
             }
         };
         if (timeStart <= lastKillAllEvent) {
-            responseListener.onFailure(new CancellationException(JobKilledException.MESSAGE));
+            responseListener.onFailure(new InterruptedException(JobKilledException.MESSAGE));
             return;
         }
         createIndices(request, stateUpdateListener);
@@ -514,7 +513,7 @@ public class TransportBulkCreateIndicesAction
         synchronized (pendingLock) {
             PendingOperation pendingOperation;
             while ( (pendingOperation = pendingOperations.poll()) != null) {
-                pendingOperation.responseListener.onFailure(new CancellationException(JobKilledException.MESSAGE));
+                pendingOperation.responseListener.onFailure(new InterruptedException(JobKilledException.MESSAGE));
             }
         }
     }
@@ -526,7 +525,7 @@ public class TransportBulkCreateIndicesAction
             while (it.hasNext()) {
                 PendingOperation pendingOperation = it.next();
                 if (pendingOperation.request.jobId().equals(jobId)) {
-                    pendingOperation.responseListener.onFailure(new CancellationException(JobKilledException.MESSAGE));
+                    pendingOperation.responseListener.onFailure(new InterruptedException(JobKilledException.MESSAGE));
                     it.remove();
                 }
             }

--- a/sql/src/main/java/org/elasticsearch/action/bulk/BulkShardProcessor.java
+++ b/sql/src/main/java/org/elasticsearch/action/bulk/BulkShardProcessor.java
@@ -32,6 +32,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.crate.Constants;
 import io.crate.exceptions.Exceptions;
+import io.crate.exceptions.JobKilledException;
 import io.crate.executor.transport.ShardRequest;
 import io.crate.executor.transport.ShardResponse;
 import io.crate.metadata.PartitionName;
@@ -368,7 +369,7 @@ public class BulkShardProcessor<Request extends ShardRequest> {
 
     public void kill(@Nullable Throwable throwable) {
         failure.compareAndSet(null, throwable);
-        result.cancel(true);
+        result.setException(new InterruptedException(JobKilledException.MESSAGE));
     }
 
     private void setFailure(Throwable e) {

--- a/sql/src/test/java/io/crate/jobs/BulkShardProcessorContextTest.java
+++ b/sql/src/test/java/io/crate/jobs/BulkShardProcessorContextTest.java
@@ -27,7 +27,6 @@ import org.elasticsearch.action.bulk.BulkShardProcessor;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.concurrent.CancellationException;
 
 import static org.mockito.Mockito.*;
 
@@ -50,7 +49,7 @@ public class BulkShardProcessorContextTest extends CrateUnitTest {
         verify(processor, times(1)).close();
 
         context.kill(null);
-        verify(processor, times(1)).kill(any(CancellationException.class));
+        verify(processor, times(1)).kill(any(InterruptedException.class));
     }
 
     @Test
@@ -60,14 +59,14 @@ public class BulkShardProcessorContextTest extends CrateUnitTest {
         context.kill(null);
         context.close();
         // BulkShardProcessor is killed and callback is closed once
-        verify(processor, times(1)).kill(any(CancellationException.class));
+        verify(processor, times(1)).kill(any(InterruptedException.class));
     }
 
     @Test
     public void testStartAfterKill() throws Exception {
         context.prepare();
         context.kill(null);
-        verify(processor, times(1)).kill(any(CancellationException.class));
+        verify(processor, times(1)).kill(any(InterruptedException.class));
         // close is never called on BulkShardProcessor so no requests are issued
         context.start();
         verify(processor, never()).close();

--- a/sql/src/test/java/io/crate/jobs/PageDownstreamContextTest.java
+++ b/sql/src/test/java/io/crate/jobs/PageDownstreamContextTest.java
@@ -38,7 +38,7 @@ import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import java.util.concurrent.CancellationException;
+import javax.annotation.Nonnull;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.hamcrest.Matchers.is;
@@ -91,12 +91,12 @@ public class PageDownstreamContextTest extends CrateUnitTest {
             }
 
             @Override
-            public void onFailure(Throwable t) {
+            public void onFailure(@Nonnull  Throwable t) {
                 assertTrue(throwable.compareAndSet(null, t));
             }
         });
         ctx.kill(null);
-        assertThat(throwable.get(), Matchers.instanceOf(CancellationException.class));
-        verify(downstream, times(1)).fail(any(CancellationException.class));
+        assertThat(throwable.get(), Matchers.instanceOf(InterruptedException.class));
+        verify(downstream, times(1)).fail(any(InterruptedException.class));
     }
 }

--- a/sql/src/test/java/io/crate/jobs/SubExecutionContextFutureTest.java
+++ b/sql/src/test/java/io/crate/jobs/SubExecutionContextFutureTest.java
@@ -29,7 +29,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.util.List;
-import java.util.concurrent.CancellationException;
 
 import static org.hamcrest.Matchers.isA;
 
@@ -40,14 +39,14 @@ public class SubExecutionContextFutureTest {
 
     @Test
     public void testCloseWithCancellationExceptionAsPartOfCombinedFuture() throws Exception {
-        expectedException.expectCause(isA(CancellationException.class));
+        expectedException.expectCause(isA(InterruptedException.class));
 
         SubExecutionContextFuture f1 = new SubExecutionContextFuture();
         SubExecutionContextFuture f2 = new SubExecutionContextFuture();
 
-        // close with Cancellation results in a cancel call on a internal future.
+        // close with InterruptedException results in a cancel call on a internal future.
         // cancel on one future causes the other futures to be canceled too
-        f1.close(new CancellationException());
+        f1.close(new InterruptedException());
 
         ListenableFuture<List<SubExecutionContextFuture.State>> asList = Futures.allAsList(f1, f2);
         asList.get();

--- a/sql/src/test/java/io/crate/jobs/UpsertByIdContextTest.java
+++ b/sql/src/test/java/io/crate/jobs/UpsertByIdContextTest.java
@@ -14,7 +14,6 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.TimeUnit;
 
 import static org.mockito.Mockito.*;
@@ -49,7 +48,7 @@ public class UpsertByIdContextTest extends CrateUnitTest {
         ShardResponse response = mock(ShardResponse.class);
         listener.getValue().onResponse(response);
 
-        expectedException.expectCause(CauseMatcher.cause(CancellationException.class));
+        expectedException.expectCause(CauseMatcher.cause(InterruptedException.class));
         context.future().get(500, TimeUnit.MILLISECONDS);
     }
 
@@ -57,7 +56,7 @@ public class UpsertByIdContextTest extends CrateUnitTest {
     public void testKillBeforeStart() throws Exception {
         context.prepare();
         context.kill(null);
-        expectedException.expectCause(CauseMatcher.cause(CancellationException.class));
+        expectedException.expectCause(CauseMatcher.cause(InterruptedException.class));
         context.future().get(500, TimeUnit.MILLISECONDS);
     }
 

--- a/sql/src/test/java/io/crate/operation/collect/JobCollectContextTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/JobCollectContextTest.java
@@ -36,8 +36,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import java.util.concurrent.CancellationException;
-
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -124,8 +122,8 @@ public class JobCollectContextTest extends RandomizedTest {
         jobCtx.start();
         jobCtx.kill(null);
 
-        verify(collectorMock1, times(1)).kill(any(CancellationException.class));
-        verify(collectorMock2, times(1)).kill(any(CancellationException.class));
+        verify(collectorMock1, times(1)).kill(any(InterruptedException.class));
+        verify(collectorMock2, times(1)).kill(any(InterruptedException.class));
         verify(mock1, times(1)).close();
         verify(ramAccountingContext, times(1)).close();
     }

--- a/sql/src/test/java/io/crate/operation/collect/LuceneDocCollectorTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/LuceneDocCollectorTest.java
@@ -41,7 +41,6 @@ import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 import java.util.ArrayList;
-import java.util.concurrent.CancellationException;
 
 import static io.crate.testing.TestingHelpers.printedTable;
 import static org.hamcrest.Matchers.*;
@@ -226,9 +225,10 @@ public class LuceneDocCollectorTest extends SQLTransportIntegrationTest {
         docCollector.doCollect();
         assertThat(projector.rows.size(), is(5));
 
-        docCollector.kill(new CancellationException());
+        docCollector.kill(new InterruptedException());
 
-        expectedException.expect(CancellationException.class);
+        expectedException.expect(RuntimeException.class);
+        expectedException.expectCause(isA(InterruptedException.class));
         projector.result();
     }
 

--- a/sql/src/test/java/io/crate/operation/join/NestedLoopOperationTest.java
+++ b/sql/src/test/java/io/crate/operation/join/NestedLoopOperationTest.java
@@ -47,7 +47,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -275,9 +274,9 @@ public class NestedLoopOperationTest extends CrateUnitTest {
         CollectingRowReceiver receiver = new CollectingRowReceiver();
         List<ListenableRowReceiver> listenableRowReceivers = getRandomLeftAndRightRowReceivers(receiver);
         ListenableRowReceiver receiver1 = listenableRowReceivers.get(0);
-        receiver1.kill(new CancellationException());
+        receiver1.kill(new InterruptedException());
 
-        expectedException.expectCause(isA(CancellationException.class));
+        expectedException.expectCause(isA(InterruptedException.class));
         listenableRowReceivers.get(1).finishFuture().get(1, TimeUnit.SECONDS);
     }
 
@@ -290,7 +289,7 @@ public class NestedLoopOperationTest extends CrateUnitTest {
         new RowSender(Collections.<Row>emptyList(), nl.leftRowReceiver(), MoreExecutors.directExecutor());
 
         nl.leftRowReceiver().setNextRow(new Row1(10)); // causes left to get paused
-        nl.rightRowReceiver().kill(new CancellationException());
+        nl.rightRowReceiver().kill(new InterruptedException());
 
         // a rowReceiver should not receive fail/or finish if paused but it can happen, e.g. if a node is stopped
         final CountDownLatch latch = new CountDownLatch(1);

--- a/sql/src/test/java/org/elasticsearch/action/bulk/BulkShardProcessorTest.java
+++ b/sql/src/test/java/org/elasticsearch/action/bulk/BulkShardProcessorTest.java
@@ -51,6 +51,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.isA;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -262,9 +263,10 @@ public class BulkShardProcessorTest extends CrateUnitTest {
                 UUID.randomUUID()
         );
         assertThat(bulkShardProcessor.add("foo", new ShardUpsertRequest.Item("1", null, new Object[]{"bar1"}, null), null), is(true));
-        bulkShardProcessor.kill(new CancellationException());
-        // A CancellationException is thrown
-        expectedException.expect(CancellationException.class);
+        bulkShardProcessor.kill(new InterruptedException());
+        // A InterruptedException is thrown
+        expectedException.expect(ExecutionException.class);
+        expectedException.expectCause(isA(InterruptedException.class));
         bulkShardProcessor.result().get();
         // it's not possible to add more
         assertThat(bulkShardProcessor.add("foo", new ShardUpsertRequest.Item("1", null, new Object[]{"bar1"}, null), null), is(false));


### PR DESCRIPTION
Since ES switched exception streaming from java serialize to own streaming format, a CancellationException would be read as an IllegalStateException (which it derives from).
This makes streaming a CancellationException unusable.