### PR TITLE
fixed settings overrides

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - In certain cases settings provided via ``-Des.`` system properties could
+   be overridden by the ``crate.yml`` provided in ``$CRATE_HOME/config``
+
  - Fixed an issue that prevented generated columns to work correctly
    with arrays.
 

--- a/app/src/main/java/io/crate/node/NodeSettings.java
+++ b/app/src/main/java/io/crate/node/NodeSettings.java
@@ -36,20 +36,6 @@ public class NodeSettings {
      */
     public static void applyDefaultSettings(ImmutableSettings.Builder settingsBuilder) {
 
-        // read also from crate.yml by default if no other config path has been set
-        // if there is also a elasticsearch.yml file this file will be read first and the settings in crate.yml
-        // will overwrite them.
-        Environment environment = new Environment(settingsBuilder.build());
-        if (System.getProperty("es.config") == null && System.getProperty("elasticsearch.config") == null) {
-            // no explicit config path set
-            try {
-                URL crateConfigUrl = environment.resolveConfig("crate.yml");
-                settingsBuilder.loadFromUrl(crateConfigUrl);
-            } catch (FailedToResolveConfigException e) {
-                // ignore
-            }
-        }
-
         if (settingsBuilder.get("http.port") == null) {
             settingsBuilder.put("http.port", Constants.HTTP_PORT_RANGE);
         }

--- a/app/src/main/java/org/elasticsearch/node/internal/InternalSettingsPreparer.java
+++ b/app/src/main/java/org/elasticsearch/node/internal/InternalSettingsPreparer.java
@@ -107,6 +107,7 @@ public class InternalSettingsPreparer {
             }
             if (loadFromEnv) {
                 try {
+                    // read only from crate.yml
                     settingsBuilder.loadFromUrl(environment.resolveConfig("crate.yml"));
                 } catch (FailedToResolveConfigException e) {
                     // ignore

--- a/app/src/test/resources/crate/config/crate.yml
+++ b/app/src/test/resources/crate/config/crate.yml
@@ -1,0 +1,8 @@
+# This is a crate.yml configuration file for testing
+# that system properties are overriding settings from
+# this file correctly!
+
+path:
+  work: /tmp
+  data: /tmp/crate/data
+  logs: /tmp/crate/logs

--- a/app/src/test/resources/crate/config/custom.yml
+++ b/app/src/test/resources/crate/config/custom.yml
@@ -1,0 +1,3 @@
+# Custom named configuration file
+
+cluster.name: custom

--- a/app/src/test/resources/crate/config/logging.yml
+++ b/app/src/test/resources/crate/config/logging.yml
@@ -1,0 +1,10 @@
+rootLogger: INFO, console
+logger:
+  env: DEBUG
+appender:
+  console:
+    type: console
+    layout:
+      type: consolePattern
+      conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
+


### PR DESCRIPTION
In certain cases settings provided via ``-Des.`` system properties could be overridden by the ``crate.yml`` provided in ``$CRATE_HOME/config``.