### PR TITLE
load crate.yml explicitly and do not allow any other extension than yml

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Load ``crate.yml`` explicitly and do not allow any other extension than
+   ``yml`` for the configuration file.
+
  - Restrict creation of tables having the primary key constraint within
    an array column type or its children.
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -396,7 +396,7 @@ test {
 
 sourceSets {
     test {
-        output.resourcesDir = null
+        output.resourcesDir = 'build/resources'
     }
 }
 

--- a/app/src/main/java/org/elasticsearch/bootstrap/BootstrapProxy.java
+++ b/app/src/main/java/org/elasticsearch/bootstrap/BootstrapProxy.java
@@ -365,7 +365,7 @@ public class BootstrapProxy {
     private static void checkUnsetAndMaybeExit(String confFileSetting, String settingName) {
         if (confFileSetting != null && confFileSetting.isEmpty() == false) {
             ESLogger logger = Loggers.getLogger(Bootstrap.class);
-            logger.info("{} is no longer supported. elasticsearch.yml must be placed in the config directory and cannot be renamed.", settingName);
+            logger.info("{} is no longer supported. crate.yml must be placed in the config directory and cannot be renamed.", settingName);
             System.exit(1);
         }
     }

--- a/app/src/test/resources/crate/config/crate.yml
+++ b/app/src/test/resources/crate/config/crate.yml
@@ -1,0 +1,8 @@
+# This is a crate.yml configuration file for testing
+# that system properties are overriding settings from
+# this file correctly!
+
+path:
+  work: /tmp
+  data: /tmp/crate/data
+  logs: /tmp/crate/logs

--- a/app/src/test/resources/crate/config/logging.yml
+++ b/app/src/test/resources/crate/config/logging.yml
@@ -1,0 +1,10 @@
+rootLogger: INFO, console
+logger:
+  env: DEBUG
+appender:
+  console:
+    type: console
+    layout:
+      type: consolePattern
+      conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
+


### PR DESCRIPTION
this is a combination of commits https://github.com/crate/crate/commit/e11f532bb5c367174cf33b4a76ee7158c7857f97 and https://github.com/crate/crate/commit/1f9e67a3e16101b6ef10e5ab7992bfa3eca1ea90 that have been applied to 0.54 and adopted to the recent ES 2.2 upgrade