### PR TITLE
fix conversion problem of FS stats

### DIFF
--- a/sigar/src/main/java/io/crate/monitor/SigarExtendedNodeInfo.java
+++ b/sigar/src/main/java/io/crate/monitor/SigarExtendedNodeInfo.java
@@ -113,7 +113,8 @@ public class SigarExtendedNodeInfo implements ExtendedNodeInfo {
 
                     FileSystemUsage fileSystemUsage = sigar.getFileSystemUsage(fileSystem.getDirName());
                     if (fileSystemUsage != null) {
-                        // total/free/available seem to be in megabytes?
+                        // total/free/available seem to be reported in kilobytes
+                        // so convert it into bytes
                         info.total(fileSystemUsage.getTotal() * 1024);
                         info.free(fileSystemUsage.getFree() * 1024);
                         info.used(fileSystemUsage.getUsed() * 1024);

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/fs/NodeFsDisksExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/fs/NodeFsDisksExpression.java
@@ -75,19 +75,19 @@ public class NodeFsDisksExpression extends SysObjectArrayReference {
             childImplementations.put(SIZE, new ChildExpression<Long>() {
                 @Override
                 public Long value() {
-                    return fsInfo.total() * 1024;
+                    return fsInfo.total();
                 }
             });
             childImplementations.put(USED, new ChildExpression<Long>() {
                 @Override
                 public Long value() {
-                    return fsInfo.used() * 1024;
+                    return fsInfo.used();
                 }
             });
             childImplementations.put(AVAILABLE, new ChildExpression<Long>() {
                 @Override
                 public Long value() {
-                    return fsInfo.available() * 1024;
+                    return fsInfo.available();
                 }
             });
             childImplementations.put(READS, new ChildExpression<Long>() {

--- a/sql/src/test/java/io/crate/operation/reference/sys/SysNodesExpressionsTest.java
+++ b/sql/src/test/java/io/crate/operation/reference/sys/SysNodesExpressionsTest.java
@@ -331,11 +331,11 @@ public class SysNodesExpressionsTest extends CrateUnitTest {
         assertThat(disks.length, is(2));
         Map<String, Object> disk0 = (Map<String, Object>) disks[0];
         assertThat((String) disk0.get("dev"), is(resolveCanonicalPath("/dev/sda1")));
-        assertThat((Long) disk0.get("size"), is(42L * 1024));
+        assertThat((Long) disk0.get("size"), is(42L));
 
         Map<String, Object> disk1 = (Map<String, Object>) disks[1];
         assertThat((String) disk1.get("dev"), is(resolveCanonicalPath("/dev/sda2")));
-        assertThat((Long) disk0.get("used"), is(42L * 1024));
+        assertThat((Long) disk0.get("used"), is(42L));
 
         Object[] data = (Object[]) v.get("data");
         assertThat(data.length, is(2));


### PR DESCRIPTION
file system stats were reported incorrectly in a magnitude of 1024 because the unit of the sigar probe values was assumed incorrectly

```sql
cr> select name, fs['disks']['available'] from sys.nodes order by 1;
+------+--------------------------+
| name | fs['disks']['available'] |
+------+--------------------------+
| st1  | [213105774690304]        |
| st2  | [234195314016256]        |
| st3  | [202687148720128]        |
| st4  | [201269327167488]        |
| st5  | [195099229159424]        |
| st6  | [235585394442240]        |
| st7  | [218244791140352]        |
| st8  | [217148660121600]        |
+------+--------------------------+
SELECT 8 rows in set (0.003 sec)
```

<img width="508" alt="screen shot 2016-04-28 at 10 01 42" src="https://cloud.githubusercontent.com/assets/281260/14879344/fff49b34-0d28-11e6-8683-6f3fc860ecaa.png">
