### PR TITLE
Add shard wormhole to handle shard relocation without retry

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed a race condition that could lead to relative write operations (`x = x
+   + 1`) to be executed twice.
+
  - Load ``crate.yml`` explicitly and do not allow any other extension than
    ``yml`` for the configuration file.
 

--- a/sql/src/main/java/io/crate/action/sql/TransportBaseSQLAction.java
+++ b/sql/src/main/java/io/crate/action/sql/TransportBaseSQLAction.java
@@ -39,10 +39,13 @@ import io.crate.executor.transport.kill.KillJobsRequest;
 import io.crate.executor.transport.kill.KillResponse;
 import io.crate.executor.transport.kill.TransportKillJobsNodeAction;
 import io.crate.metadata.PartitionName;
+import io.crate.operation.collect.JobCollectContext;
 import io.crate.operation.collect.StatsTables;
+import io.crate.operation.projectors.ShardProjectorChain;
 import io.crate.planner.Plan;
 import io.crate.planner.PlanPrinter;
 import io.crate.planner.Planner;
+import io.crate.planner.node.dql.RoutedCollectPhase;
 import io.crate.sql.parser.ParsingException;
 import io.crate.sql.parser.SqlParser;
 import io.crate.sql.tree.Statement;
@@ -73,10 +76,7 @@ import org.elasticsearch.transport.NodeDisconnectedException;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
-import java.util.Locale;
-import java.util.UUID;
+import java.util.*;
 
 public abstract class TransportBaseSQLAction<TRequest extends SQLBaseRequest, TResponse extends SQLBaseResponse>
         extends TransportAction<TRequest, TResponse> {
@@ -278,6 +278,19 @@ public abstract class TransportBaseSQLAction<TRequest extends SQLBaseRequest, TR
                     }
 
                     private void killAndRetry(@Nonnull final Throwable t) {
+                        /**
+                         * retry should only be done for select operations or absolute write operations
+                         *
+                         * relative write operations (x = x + 1) must not be retried
+                         *  - if one shard was successful that operation would be executed twice.
+                         *
+                         * This is currently ensured by the fact that
+                         * {@link io.crate.operation.collect.sources.ShardCollectSource#getDocCollectors(JobCollectContext, RoutedCollectPhase, ShardProjectorChain, Map)}
+                         * doesn't raise shard errors but instead uses a remoteCollector as fallback
+                         *
+                         * ORDERED collect operations would raise shard failures, but currently there is no case where
+                         * ordered + relative write operations happen
+                         */
                         transportKillJobsNodeAction.executeKillOnAllNodes(
                                 new KillJobsRequest(Collections.singletonList(plan.jobId())), new ActionListener<KillResponse>() {
                                     @Override

--- a/sql/src/main/java/io/crate/metadata/Routing.java
+++ b/sql/src/main/java/io/crate/metadata/Routing.java
@@ -195,11 +195,11 @@ public class Routing implements Streamable {
         if (locations.isEmpty()) {
             return true;
         }
-        if (!(locations instanceof TreeMap)) {
+        if (!(locations instanceof TreeMap) && locations.size() > 1) {
             return false;
         }
         for (Map<String, List<Integer>> innerMap : locations.values()) {
-            if (!innerMap.isEmpty() &&  !(innerMap instanceof TreeMap)) {
+            if (innerMap.size() > 1 &&  !(innerMap instanceof TreeMap)) {
                 return false;
             }
         }

--- a/sql/src/main/java/io/crate/operation/NodeOperation.java
+++ b/sql/src/main/java/io/crate/operation/NodeOperation.java
@@ -50,10 +50,10 @@ public class NodeOperation implements Streamable {
     private int downstreamExecutionPhaseId = NO_DOWNSTREAM;
     private byte downstreamExecutionPhaseInputId;
 
-    private NodeOperation(ExecutionPhase executionPhase,
-                          Collection<String> downstreamNodes,
-                          int downstreamExecutionPhaseId,
-                          byte downstreamExecutionPhaseInputId) {
+    public NodeOperation(ExecutionPhase executionPhase,
+                         Collection<String> downstreamNodes,
+                         int downstreamExecutionPhaseId,
+                         byte downstreamExecutionPhaseInputId) {
         this.executionPhase = executionPhase;
         this.downstreamNodes = downstreamNodes;
         this.downstreamExecutionPhaseId = downstreamExecutionPhaseId;

--- a/sql/src/main/java/io/crate/operation/collect/RemoteCollectorFactory.java
+++ b/sql/src/main/java/io/crate/operation/collect/RemoteCollectorFactory.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.operation.collect;
+
+import io.crate.analyze.EvaluatingNormalizer;
+import io.crate.breaker.RamAccountingContext;
+import io.crate.core.collections.TreeMapBuilder;
+import io.crate.executor.transport.TransportActionProvider;
+import io.crate.jobs.JobContextService;
+import io.crate.metadata.Functions;
+import io.crate.metadata.NestedReferenceResolver;
+import io.crate.metadata.Routing;
+import io.crate.metadata.RowGranularity;
+import io.crate.operation.ImplementationSymbolVisitor;
+import io.crate.operation.collect.collectors.RemoteCollector;
+import io.crate.operation.projectors.ProjectionToProjectorVisitor;
+import io.crate.operation.projectors.ProjectorFactory;
+import io.crate.operation.projectors.ShardProjectorChain;
+import io.crate.planner.distribution.DistributionInfo;
+import io.crate.planner.node.dql.RoutedCollectPhase;
+import io.crate.planner.projection.Projection;
+import org.elasticsearch.action.bulk.BulkRetryCoordinatorPool;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Used to create RemoteCollectors
+ * Those RemoteCollectors act as proxy collectors to collect data from a shard located on another node.
+ */
+@Singleton
+public class RemoteCollectorFactory {
+
+    private static final int SENDER_PHASE_ID = 0;
+    private final ClusterService clusterService;
+    private final Functions functions;
+    private final ThreadPool threadPool;
+    private final JobContextService jobContextService;
+    private final Settings settings;
+    private final TransportActionProvider transportActionProvider;
+    private final BulkRetryCoordinatorPool bulkRetryCoordinatorPool;
+    private final IndexNameExpressionResolver indexNameExpressionResolver;
+    private final EvaluatingNormalizer normalizer;
+    private final ImplementationSymbolVisitor implementationVisitor;
+
+    @Inject
+    public RemoteCollectorFactory(ClusterService clusterService,
+                                  Functions functions,
+                                  ThreadPool threadPool,
+                                  JobContextService jobContextService,
+                                  Settings settings,
+                                  TransportActionProvider transportActionProvider,
+                                  BulkRetryCoordinatorPool bulkRetryCoordinatorPool,
+                                  IndexNameExpressionResolver indexNameExpressionResolver,
+                                  NestedReferenceResolver referenceResolver) {
+        this.clusterService = clusterService;
+        this.functions = functions;
+        this.threadPool = threadPool;
+        this.jobContextService = jobContextService;
+        this.settings = settings;
+        this.transportActionProvider = transportActionProvider;
+        this.bulkRetryCoordinatorPool = bulkRetryCoordinatorPool;
+        this.indexNameExpressionResolver = indexNameExpressionResolver;
+
+        normalizer = new EvaluatingNormalizer(functions, RowGranularity.NODE, referenceResolver);
+        implementationVisitor = new ImplementationSymbolVisitor(functions);
+    }
+
+    /**
+     * create a RemoteCollector
+     * The RemoteCollector will collect data from another node using a wormhole as if it was collecting on this node.
+     *
+     * This should only be used if a shard is not available on the current node due to a relocation
+     */
+    public CrateCollector createCollector(String index,
+                                          Integer shardId,
+                                          RoutedCollectPhase collectPhase,
+                                          ShardProjectorChain projectorChain,
+                                          RamAccountingContext ramAccountingContext) {
+        UUID childJobId = UUID.randomUUID(); // new job because subContexts can't be merged into an existing job
+
+        IndexShardRoutingTable shardRoutings = clusterService.state().routingTable().shardRoutingTable(index, shardId);
+        // for update operations primaryShards must be used
+        // (for others that wouldn't be the case, but at this point it is not easily visible which is the case)
+        ShardRouting shardRouting = shardRoutings.primaryShard();
+
+        String remoteNodeId = shardRouting.currentNodeId();
+        assert remoteNodeId != null : "primaryShard not assigned :(";
+        String localNodeId = clusterService.localNode().id();
+        RoutedCollectPhase newCollectPhase = createNewCollectPhase(childJobId, collectPhase, index, shardId, remoteNodeId);
+
+        ProjectorFactory projectorFactory = new ProjectionToProjectorVisitor(
+            clusterService,
+            functions,
+            indexNameExpressionResolver,
+            threadPool,
+            settings,
+            transportActionProvider,
+            bulkRetryCoordinatorPool,
+            implementationVisitor,
+            normalizer,
+            new ShardId(index, shardId));
+
+        return new RemoteCollector(
+            childJobId,
+            localNodeId,
+            remoteNodeId,
+            transportActionProvider.transportJobInitAction(),
+            transportActionProvider.transportKillJobsNodeAction(),
+            jobContextService,
+            ramAccountingContext,
+            projectorChain.newShardDownstreamProjector(projectorFactory),
+            newCollectPhase);
+    }
+
+    private RoutedCollectPhase createNewCollectPhase(
+        UUID childJobId, RoutedCollectPhase collectPhase, String index, Integer shardId, String nodeId) {
+
+        Routing routing = new Routing(TreeMapBuilder.<String, Map<String, List<Integer>>>newMapBuilder().put(nodeId,
+            TreeMapBuilder.<String, List<Integer>>newMapBuilder().put(index, Collections.singletonList(shardId)).map()).map());
+        return new RoutedCollectPhase(
+            childJobId,
+            SENDER_PHASE_ID,
+            collectPhase.name(),
+            routing,
+            collectPhase.maxRowGranularity(),
+            collectPhase.toCollect(),
+
+             // the projector chain is already here on this node, don't need to run projections on the other node
+            Collections.<Projection>emptyList(),
+            collectPhase.whereClause(),
+            DistributionInfo.DEFAULT_BROADCAST
+        );
+    }
+}

--- a/sql/src/main/java/io/crate/operation/collect/collectors/RemoteCollector.java
+++ b/sql/src/main/java/io/crate/operation/collect/collectors/RemoteCollector.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.operation.collect.collectors;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Optional;
+import io.crate.action.job.JobRequest;
+import io.crate.action.job.JobResponse;
+import io.crate.action.job.TransportJobAction;
+import io.crate.breaker.RamAccountingContext;
+import io.crate.core.collections.Row;
+import io.crate.executor.transport.kill.KillJobsRequest;
+import io.crate.executor.transport.kill.KillResponse;
+import io.crate.executor.transport.kill.TransportKillJobsNodeAction;
+import io.crate.jobs.JobContextService;
+import io.crate.jobs.JobExecutionContext;
+import io.crate.jobs.PageDownstreamContext;
+import io.crate.operation.NodeOperation;
+import io.crate.operation.collect.CrateCollector;
+import io.crate.operation.merge.IteratorPageDownstream;
+import io.crate.operation.merge.PassThroughPagingIterator;
+import io.crate.operation.projectors.Requirement;
+import io.crate.operation.projectors.RowReceiver;
+import io.crate.planner.node.dql.RoutedCollectPhase;
+import io.crate.types.DataTypes;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
+
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.UUID;
+import java.util.concurrent.Executor;
+
+public class RemoteCollector implements CrateCollector {
+
+    private final static ESLogger LOGGER = Loggers.getLogger(RemoteCollector.class);
+    private final static int RECEIVER_PHASE_ID = 1;
+
+    private final UUID jobId;
+    private final String localNode;
+    private final String remoteNode;
+    private final TransportJobAction transportJobAction;
+    private final TransportKillJobsNodeAction transportKillJobsNodeAction;
+    private final JobContextService jobContextService;
+    private final RamAccountingContext ramAccountingContext;
+    private final RowReceiver rowReceiver;
+    private final RoutedCollectPhase collectPhase;
+
+    private final Object killLock = new Object();
+    private JobExecutionContext context = null;
+    private boolean collectorKilled = false;
+
+    public RemoteCollector(UUID jobId,
+                           String localNode,
+                           String remoteNode,
+                           TransportJobAction transportJobAction,
+                           TransportKillJobsNodeAction transportKillJobsNodeAction,
+                           JobContextService jobContextService,
+                           RamAccountingContext ramAccountingContext,
+                           RowReceiver rowReceiver,
+                           RoutedCollectPhase collectPhase) {
+        this.jobId = jobId;
+        this.localNode = localNode;
+        this.remoteNode = remoteNode;
+
+        this.transportJobAction = transportJobAction;
+        this.transportKillJobsNodeAction = transportKillJobsNodeAction;
+        this.jobContextService = jobContextService;
+        this.ramAccountingContext = ramAccountingContext;
+        this.rowReceiver = rowReceiver;
+        this.collectPhase = collectPhase;
+    }
+
+    @Override
+    public void doCollect() {
+        if (!createLocalContext()) return;
+        createRemoteContext();
+    }
+
+    @VisibleForTesting
+    boolean createLocalContext() {
+        JobExecutionContext.Builder builder = createPageDownstreamContext();
+        try {
+            synchronized (killLock) {
+                if (collectorKilled) {
+                    rowReceiver.fail(new InterruptedException());
+                    return false;
+                }
+                context = jobContextService.createContext(builder);
+                context.start();
+                return true;
+            }
+        } catch (Throwable t) {
+            if (context == null) {
+                rowReceiver.fail(t);
+            } else {
+                context.kill();
+            }
+            return false;
+        }
+    }
+
+    @VisibleForTesting
+    void createRemoteContext() {
+        NodeOperation nodeOperation = new NodeOperation(
+            collectPhase, Collections.singletonList(localNode), RECEIVER_PHASE_ID, (byte) 0);
+
+        synchronized (killLock) {
+            if (collectorKilled) {
+                context.kill();
+                return;
+            }
+            transportJobAction.execute(
+                remoteNode,
+                new JobRequest(jobId, Collections.singletonList(nodeOperation)),
+                new ActionListener<JobResponse>() {
+                    @Override
+                    public void onResponse(JobResponse jobResponse) {
+                        LOGGER.trace("RemoteCollector jobAction=onResponse");
+                        if (collectorKilled) {
+                            killRemoteContext();
+                        }
+                    }
+
+                    @Override
+                    public void onFailure(Throwable e) {
+                        LOGGER.error("RemoteCollector jobAction=onFailure", e);
+                        context.kill();
+                    }
+                }
+            );
+        }
+    }
+
+    private JobExecutionContext.Builder createPageDownstreamContext() {
+        JobExecutionContext.Builder builder = jobContextService.newBuilder(jobId);
+
+        PassThroughPagingIterator<Void, Row> pagingIterator;
+        if (rowReceiver.requirements().contains(Requirement.REPEAT)) {
+            pagingIterator = PassThroughPagingIterator.repeatable();
+        } else {
+            pagingIterator = PassThroughPagingIterator.oneShot();
+        }
+        builder.addSubContext(new PageDownstreamContext(
+            LOGGER,
+            localNode,
+            RECEIVER_PHASE_ID,
+            "remoteCollectReceiver",
+            new IteratorPageDownstream(rowReceiver, pagingIterator, Optional.<Executor>absent()),
+            DataTypes.getStreamer(collectPhase.outputTypes()),
+            ramAccountingContext,
+            1,
+            null
+        ));
+        return builder;
+    }
+
+    private void killRemoteContext() {
+        transportKillJobsNodeAction.executeKillOnAllNodes(new KillJobsRequest(Collections.singletonList(jobId)),
+            new ActionListener<KillResponse>() {
+
+                @Override
+                public void onResponse(KillResponse killResponse) {
+                    context.kill();
+                }
+
+                @Override
+                public void onFailure(Throwable e) {
+                    context.kill();
+                }
+            });
+    }
+
+    @Override
+    public void kill(@Nullable Throwable throwable) {
+        synchronized (killLock) {
+            collectorKilled = true;
+            /**
+             * due to the lock there are 3 kill windows:
+             *
+             *  1. localContext not even created - doCollect aborts
+             *  2. localContext created, no requests sent - doCollect aborts
+             *  3. localContext created, requests sent - clean-up happens once response from remote is received
+             */
+        }
+    }
+}

--- a/sql/src/test/java/io/crate/integrationtests/RemoteCollectorIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/RemoteCollectorIntegrationTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.integrationtests;
+
+import com.carrotsearch.hppc.cursors.ObjectCursor;
+import io.crate.testing.TestingHelpers;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
+import org.elasticsearch.cluster.routing.allocation.command.MoveAllocationCommand;
+import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.is;
+
+@ESIntegTestCase.ClusterScope(numDataNodes = 2)
+public class RemoteCollectorIntegrationTest extends SQLTransportIntegrationTest {
+
+    @Test
+    public void testUpdateWithExpressionAndRelocatedShard() throws Exception {
+        execute("create table t (id int primary key, x int) " +
+                "clustered into 2 shards " +
+                "with (number_of_replicas = 0)");
+        ensureGreen();
+
+        execute("insert into t (id, x) values (1, 10)");
+        execute("insert into t (id, x) values (2, 20)");
+        execute("refresh table t");
+
+        PlanForNode plan = plan("update t set x = x * 2");
+
+        ClusterService clusterService = internalCluster().getInstance(ClusterService.class);
+        IndexShardRoutingTable t = clusterService.state().routingTable().shardRoutingTable("t", 0);
+
+        String sourceNodeId = t.primaryShard().currentNodeId();
+        assert sourceNodeId != null;
+        String targetNodeId = null;
+
+        for (ObjectCursor<String> cursor : clusterService.state().nodes().dataNodes().keys()) {
+            if (!sourceNodeId.equals(cursor.value)) {
+                targetNodeId = cursor.value;
+            }
+        }
+        assert targetNodeId != null;
+
+        client().admin().cluster().prepareReroute()
+            .add(new MoveAllocationCommand(new ShardId("t", 0), sourceNodeId, targetNodeId))
+            .execute().actionGet();
+
+        client().admin().cluster().prepareHealth("t")
+            .setWaitForEvents(Priority.LANGUID)
+            .setWaitForRelocatingShards(0)
+            .setTimeout(TimeValue.timeValueSeconds(5)).execute().actionGet();
+
+        execute(plan).get(1, TimeUnit.SECONDS);
+
+        execute("refresh table t");
+        assertThat(TestingHelpers.printedTable(execute("select * from t order by id").rows()),
+            is("1| 20\n" +
+               "2| 40\n")
+        );
+    }
+}

--- a/sql/src/test/java/io/crate/operation/collect/collectors/RemoteCollectorTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/collectors/RemoteCollectorTest.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.operation.collect.collectors;
+
+import com.google.common.collect.ImmutableMap;
+import io.crate.action.job.JobRequest;
+import io.crate.action.job.JobResponse;
+import io.crate.action.job.TransportJobAction;
+import io.crate.analyze.WhereClause;
+import io.crate.analyze.symbol.Symbol;
+import io.crate.breaker.RamAccountingContext;
+import io.crate.executor.transport.kill.KillJobsRequest;
+import io.crate.executor.transport.kill.TransportKillJobsNodeAction;
+import io.crate.jobs.JobContextService;
+import io.crate.metadata.Routing;
+import io.crate.metadata.RowGranularity;
+import io.crate.operation.collect.StatsTables;
+import io.crate.planner.distribution.DistributionInfo;
+import io.crate.planner.node.dql.RoutedCollectPhase;
+import io.crate.planner.projection.Projection;
+import io.crate.testing.CollectingRowReceiver;
+import io.crate.types.DataTypes;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.settings.Settings;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static io.crate.testing.TestingHelpers.createReference;
+import static org.hamcrest.Matchers.isA;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+
+public class RemoteCollectorTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private TransportJobAction transportJobAction;
+    private TransportKillJobsNodeAction transportKillJobsNodeAction;
+    private CollectingRowReceiver rowReceiver;
+    private RemoteCollector remoteCollector;
+
+    @Captor
+    public ArgumentCaptor<ActionListener<JobResponse>> listenerCaptor;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        UUID jobId = UUID.randomUUID();
+        RoutedCollectPhase collectPhase = new RoutedCollectPhase(
+            jobId,
+            0,
+            "remoteCollect",
+            new Routing(ImmutableMap.<String, Map<String, List<Integer>>>of("remoteNode", ImmutableMap.of("dummyTable", Collections.singletonList(1)))),
+            RowGranularity.DOC,
+            Collections.<Symbol>singletonList(createReference("name", DataTypes.STRING)),
+            Collections.<Projection>emptyList(),
+            WhereClause.MATCH_ALL,
+            DistributionInfo.DEFAULT_BROADCAST
+        );
+        transportJobAction = mock(TransportJobAction.class);
+        transportKillJobsNodeAction = mock(TransportKillJobsNodeAction.class);
+        rowReceiver = new CollectingRowReceiver();
+
+        JobContextService jobContextService = new JobContextService(Settings.EMPTY, mock(StatsTables.class));
+        remoteCollector = new RemoteCollector(
+            jobId,
+            "localNode",
+            "remoteNode",
+            transportJobAction,
+            transportKillJobsNodeAction,
+            jobContextService,
+            mock(RamAccountingContext.class),
+            rowReceiver,
+            collectPhase
+        );
+    }
+
+    @Test
+    public void testKillBeforeContextCreation() throws Exception {
+        remoteCollector.kill(new InterruptedException("KILLED"));
+        remoteCollector.doCollect();
+
+        verify(transportJobAction, times(0)).execute(eq("remoteNode"), any(JobRequest.class), any(ActionListener.class));
+
+        expectedException.expectCause(isA(InterruptedException.class));
+        rowReceiver.result();
+    }
+
+
+    @Test
+    public void testRemoteContextIsNotCreatedIfKillHappensBeforeCreateRemoteContext() throws Exception {
+        remoteCollector.createLocalContext();
+        remoteCollector.kill(new InterruptedException());
+        remoteCollector.createRemoteContext();
+
+        verify(transportJobAction, times(0)).execute(eq("remoteNode"), any(JobRequest.class), any(ActionListener.class));
+        expectedException.expectCause(isA(InterruptedException.class));
+        rowReceiver.result();
+    }
+
+    @Test
+    public void testKillRequestsAreMadeIfCollectorIsKilledAfterRemoteContextCreation() throws Exception {
+        remoteCollector.doCollect();
+        verify(transportJobAction, times(1)).execute(eq("remoteNode"), any(JobRequest.class), listenerCaptor.capture());
+
+        remoteCollector.kill(new InterruptedException());
+
+        ActionListener<JobResponse> listener = listenerCaptor.getValue();
+        listener.onResponse(new JobResponse());
+
+        verify(transportKillJobsNodeAction, times(1)).executeKillOnAllNodes(any(KillJobsRequest.class), any(ActionListener.class));
+    }
+}


### PR DESCRIPTION
The retry logic is dangerous when executing queries with "relative write
operations" (something like `x = x + 1`).
It could repeat a operation that was already successful.
(E.g. x = x + 1 on shard 1 worked, but shard 2 failed)

This commit adds a shard-wormhole which will prevent shard failures due
to relocations by proxying to another node.

This wormhole will only be used if the shard failure happens during the
creation of a `CrateDocCollector`.

Other places (FetchContext creation, sorted collector creation, ...)
will still fail and require the retry logic. But in those cases there
are no relative write operations so it is safe to retry.

![wormhole](https://media.giphy.com/media/9ALcdYJwOsuBi/giphy.gif)