### PR TITLE
remove lovely.testlayers

### DIFF
--- a/blackbox/buildout.cfg
+++ b/blackbox/buildout.cfg
@@ -14,7 +14,6 @@ entry-points=test=zope.testrunner:run
 eggs = zope.testrunner
        crate [test]
        crash
-       lovely.testlayers
        zc.customdoctests
 initialization=
  sys.path.append('${buildout:directory}/docs/src')

--- a/blackbox/docs/src/crate/process_test.py
+++ b/blackbox/docs/src/crate/process_test.py
@@ -7,7 +7,19 @@ from crate.testing.layer import CrateLayer
 from crate.client.http import Client
 from .paths import crate_path
 from .ports import GLOBAL_PORT_POOL
-from lovely.testlayers.layer import CascadedLayer
+
+
+class CascadedLayer(object):
+
+    def __init__(self, name, *bases):
+        self.__name__ = name
+        self.__bases__ = tuple(bases)
+
+    def setUp(self):
+        pass
+
+    def teardown(self):
+        pass
 
 
 class GracefulStopCrateLayer(CrateLayer):

--- a/blackbox/versions.cfg
+++ b/blackbox/versions.cfg
@@ -10,7 +10,6 @@ collective.recipe.template = 1.12
 crate = 0.14.1
 crate-docs-theme = 0.5.3
 docutils = 0.12
-lovely.testlayers = 0.6.0
 mock = 1.0.1
 pytz = 2015.4
 snowballstemmer = 1.2.0


### PR DESCRIPTION
In order to get rid of the SyntaxErrors during buildout under python3.

Only the CascadedLayer was still in use - and it has only 10 lines of
code.