### PR TITLE
cleanup jobs if coordinator node disconnects

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Made sure orphaned contexts are cleaned up eventually after a coordinator
+   node dies.
+
  - Improved retry logic of bulk inserts/updates in order to prevent stack
    overflows caused by recursive retry calls that could lead to hanging updates
    and imports using ``copy from``.

--- a/sql/src/main/java/io/crate/action/job/JobRequest.java
+++ b/sql/src/main/java/io/crate/action/job/JobRequest.java
@@ -34,13 +34,14 @@ import java.util.UUID;
 public class JobRequest extends TransportRequest {
 
     private UUID jobId;
+    private String coordinatorNodeId;
     private Collection<? extends NodeOperation> nodeOperations;
 
-    public JobRequest() {
-    }
+    public JobRequest() {}
 
-    public JobRequest(UUID jobId, Collection<? extends NodeOperation> nodeOperations) {
+    public JobRequest(UUID jobId, String coordinatorNodeId, Collection<? extends NodeOperation> nodeOperations) {
         this.jobId = jobId;
+        this.coordinatorNodeId = coordinatorNodeId;
         this.nodeOperations = nodeOperations;
     }
 
@@ -52,11 +53,16 @@ public class JobRequest extends TransportRequest {
         return nodeOperations;
     }
 
+    public String coordinatorNodeId() {
+        return coordinatorNodeId;
+    }
+
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
 
         jobId = new UUID(in.readLong(), in.readLong());
+        coordinatorNodeId = in.readString();
 
         int numNodeOperations = in.readVInt();
         ArrayList<NodeOperation> nodeOperations = new ArrayList<>(numNodeOperations);
@@ -72,6 +78,7 @@ public class JobRequest extends TransportRequest {
 
         out.writeLong(jobId.getMostSignificantBits());
         out.writeLong(jobId.getLeastSignificantBits());
+        out.writeString(coordinatorNodeId);
 
         out.writeVInt(nodeOperations.size());
         for (NodeOperation nodeOperation : nodeOperations) {

--- a/sql/src/main/java/io/crate/action/job/TransportJobAction.java
+++ b/sql/src/main/java/io/crate/action/job/TransportJobAction.java
@@ -80,7 +80,7 @@ public class TransportJobAction implements NodeAction<JobRequest, JobResponse> {
 
     @Override
     public void nodeOperation(final JobRequest request, final ActionListener<JobResponse> actionListener) {
-        JobExecutionContext.Builder contextBuilder = jobContextService.newBuilder(request.jobId());
+        JobExecutionContext.Builder contextBuilder = jobContextService.newBuilder(request.jobId(), request.coordinatorNodeId());
 
         SharedShardContexts sharedShardContexts = new SharedShardContexts(indicesService);
         List<ListenableFuture<Bucket>> directResponseFutures = contextPreparer.prepareOnRemote(

--- a/sql/src/main/java/io/crate/jobs/transport/NodeDisconnectJobMonitorService.java
+++ b/sql/src/main/java/io/crate/jobs/transport/NodeDisconnectJobMonitorService.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.jobs.transport;
+
+import com.google.common.collect.Collections2;
+import io.crate.jobs.JobContextService;
+import io.crate.jobs.JobExecutionContext;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.component.AbstractLifecycleComponent;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportConnectionListener;
+import org.elasticsearch.transport.TransportService;
+
+import java.util.Collection;
+
+/**
+ * service that listens to node-disconnected-events and kills jobContexts that were started by the nodes that got disconnected
+ */
+@Singleton
+public class NodeDisconnectJobMonitorService
+    extends AbstractLifecycleComponent<NodeDisconnectJobMonitorService>
+    implements TransportConnectionListener {
+
+    private final ThreadPool threadPool;
+    private final JobContextService jobContextService;
+    private final TransportService transportService;
+
+    private final static TimeValue DELAY = TimeValue.timeValueMinutes(1);
+
+    @Inject
+    public NodeDisconnectJobMonitorService(Settings settings,
+                                           ThreadPool threadPool,
+                                           JobContextService jobContextService,
+                                           TransportService transportService) {
+        super(settings);
+        this.threadPool = threadPool;
+        this.jobContextService = jobContextService;
+        this.transportService = transportService;
+    }
+
+
+    @Override
+    protected void doStart() {
+        transportService.addConnectionListener(this);
+    }
+
+    @Override
+    protected void doStop() {
+        transportService.removeConnectionListener(this);
+    }
+
+    @Override
+    protected void doClose() {
+    }
+
+    @Override
+    public void onNodeConnected(DiscoveryNode node) {
+    }
+
+    @Override
+    public void onNodeDisconnected(final DiscoveryNode node) {
+        final Collection<JobExecutionContext> contexts = jobContextService.getContextsByCoordinatorNode(node.id());
+        threadPool.schedule(DELAY, ThreadPool.Names.GENERIC, new Runnable() {
+            @Override
+            public void run() {
+                jobContextService.killJobs(Collections2.transform(contexts, JobExecutionContext.TO_ID));
+            }
+        });
+    }
+}

--- a/sql/src/main/java/io/crate/operation/collect/collectors/RemoteCollector.java
+++ b/sql/src/main/java/io/crate/operation/collect/collectors/RemoteCollector.java
@@ -133,7 +133,7 @@ public class RemoteCollector implements CrateCollector {
             }
             transportJobAction.execute(
                 remoteNode,
-                new JobRequest(jobId, Collections.singletonList(nodeOperation)),
+                new JobRequest(jobId, localNode, Collections.singletonList(nodeOperation)),
                 new ActionListener<JobResponse>() {
                     @Override
                     public void onResponse(JobResponse jobResponse) {
@@ -154,7 +154,7 @@ public class RemoteCollector implements CrateCollector {
     }
 
     private JobExecutionContext.Builder createPageDownstreamContext() {
-        JobExecutionContext.Builder builder = jobContextService.newBuilder(jobId);
+        JobExecutionContext.Builder builder = jobContextService.newBuilder(jobId, localNode);
 
         PassThroughPagingIterator<Void, Row> pagingIterator;
         if (rowReceiver.requirements().contains(Requirement.REPEAT)) {

--- a/sql/src/main/java/io/crate/plugin/SQLPlugin.java
+++ b/sql/src/main/java/io/crate/plugin/SQLPlugin.java
@@ -35,6 +35,7 @@ import io.crate.cluster.gracefulstop.DecommissioningService;
 import io.crate.executor.transport.TransportExecutorModule;
 import io.crate.jobs.JobContextService;
 import io.crate.jobs.JobModule;
+import io.crate.jobs.transport.NodeDisconnectJobMonitorService;
 import io.crate.lucene.CrateIndexModule;
 import io.crate.metadata.MetaDataModule;
 import io.crate.metadata.blob.MetaDataBlobModule;
@@ -112,6 +113,7 @@ public class SQLPlugin extends Plugin {
         return ImmutableList.<Class<? extends LifecycleComponent>>of(
             DecommissioningService.class,
             BulkRetryCoordinatorPool.class,
+            NodeDisconnectJobMonitorService.class,
             JobContextService.class);
     }
 

--- a/sql/src/test/java/io/crate/action/job/JobRequestTest.java
+++ b/sql/src/test/java/io/crate/action/job/JobRequestTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.action.job;
+
+import io.crate.operation.NodeOperation;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class JobRequestTest {
+
+    @Test
+    public void testJobRequestStreaming() throws Exception {
+        JobRequest r1 = new JobRequest(UUID.randomUUID(), "n1", Collections.<NodeOperation>emptyList());
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        r1.writeTo(out);
+
+        JobRequest r2 = new JobRequest();
+        r2.readFrom(StreamInput.wrap(out.bytes()));
+
+        assertThat(r1.coordinatorNodeId(), is(r2.coordinatorNodeId()));
+        assertThat(r1.jobId(), is(r2.jobId()));
+        assertThat(r1.nodeOperations().isEmpty(), is(true));
+    }
+}

--- a/sql/src/test/java/io/crate/executor/transport/task/elasticsearch/ESJobContextTaskTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/task/elasticsearch/ESJobContextTaskTest.java
@@ -35,10 +35,8 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.TransportAction;
-import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.threadpool.ThreadPool;
-import org.junit.After;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.cluster.NoopClusterService;
 import org.junit.Test;
 
 import java.util.UUID;
@@ -49,7 +47,7 @@ import static org.mockito.Mockito.mock;
 public class ESJobContextTaskTest extends CrateUnitTest {
 
     private final JobContextService jobContextService = new JobContextService(
-            Settings.EMPTY, mock(StatsTables.class));
+            Settings.EMPTY, new NoopClusterService(), mock(StatsTables.class));
 
     private JobTask createTask(UUID jobId) {
         EsJobContextTask task = new EsJobContextTask(jobId, 1, 1, jobContextService);

--- a/sql/src/test/java/io/crate/jobs/DummySubContext.java
+++ b/sql/src/test/java/io/crate/jobs/DummySubContext.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.jobs;
+
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
+
+public class DummySubContext extends AbstractExecutionSubContext {
+
+    private static final ESLogger LOGGER = Loggers.getLogger(DummySubContext.class);
+
+    public DummySubContext() {
+        this(1);
+    }
+
+    public DummySubContext(int id) {
+        super(id, LOGGER);
+    }
+
+    @Override
+    public String name() {
+        return "dummy " + id();
+    }
+}

--- a/sql/src/test/java/io/crate/jobs/JobExecutionContextTest.java
+++ b/sql/src/test/java/io/crate/jobs/JobExecutionContextTest.java
@@ -56,11 +56,12 @@ public class JobExecutionContextTest extends CrateUnitTest {
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
+    private String coordinatorNode = "dummyNode";
 
     @Test
     public void testAddTheSameContextTwiceThrowsAnError() throws Exception {
         JobExecutionContext.Builder builder =
-                new JobExecutionContext.Builder(UUID.randomUUID(), mock(StatsTables.class));
+                new JobExecutionContext.Builder(UUID.randomUUID(), coordinatorNode, mock(StatsTables.class));
         builder.addSubContext(new AbstractExecutionSubContextTest.TestingExecutionSubContext());
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("ExecutionSubContext for 0 already added");
@@ -70,7 +71,7 @@ public class JobExecutionContextTest extends CrateUnitTest {
     @Test
     public void testKillPropagatesToSubContexts() throws Exception {
         JobExecutionContext.Builder builder =
-                new JobExecutionContext.Builder(UUID.randomUUID(), mock(StatsTables.class));
+                new JobExecutionContext.Builder(UUID.randomUUID(), coordinatorNode, mock(StatsTables.class));
 
 
         AbstractExecutionSubContextTest.TestingExecutionSubContext ctx1 = new AbstractExecutionSubContextTest.TestingExecutionSubContext(1);
@@ -91,7 +92,7 @@ public class JobExecutionContextTest extends CrateUnitTest {
     public void testErrorMessageIsIncludedInStatsTableOnFailure() throws Exception {
         StatsTables statsTables = mock(StatsTables.class);
         JobExecutionContext.Builder builder =
-                new JobExecutionContext.Builder(UUID.randomUUID(), statsTables);
+                new JobExecutionContext.Builder(UUID.randomUUID(), coordinatorNode, statsTables);
 
         SubExecutionContextFuture future = new SubExecutionContextFuture();
         ExecutionSubContext executionSubContext = mock(ExecutionSubContext.class);
@@ -114,7 +115,7 @@ public class JobExecutionContextTest extends CrateUnitTest {
         when(collectPhase.maxRowGranularity()).thenReturn(RowGranularity.DOC);
 
         JobExecutionContext.Builder builder =
-                new JobExecutionContext.Builder(UUID.randomUUID(), mock(StatsTables.class));
+                new JobExecutionContext.Builder(UUID.randomUUID(), coordinatorNode, mock(StatsTables.class));
 
         JobCollectContext jobCollectContext = new JobCollectContext(
                 collectPhase,
@@ -155,7 +156,7 @@ public class JobExecutionContextTest extends CrateUnitTest {
         subContexts.setAccessible(true);
 
         JobExecutionContext.Builder builder =
-                new JobExecutionContext.Builder(UUID.randomUUID(), mock(StatsTables.class));
+                new JobExecutionContext.Builder(UUID.randomUUID(), coordinatorNode, mock(StatsTables.class));
         SlowKillExecutionSubContext slowKillExecutionSubContext = new SlowKillExecutionSubContext();
         builder.addSubContext(slowKillExecutionSubContext);
         final JobExecutionContext jobExecutionContext = builder.build();

--- a/sql/src/test/java/io/crate/jobs/transport/NodeDisconnectJobMonitorServiceTest.java
+++ b/sql/src/test/java/io/crate/jobs/transport/NodeDisconnectJobMonitorServiceTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.jobs.transport;
+
+import io.crate.exceptions.ContextMissingException;
+import io.crate.jobs.DummySubContext;
+import io.crate.jobs.JobContextService;
+import io.crate.jobs.JobExecutionContext;
+import io.crate.operation.collect.StatsTables;
+import io.crate.test.integration.CrateUnitTest;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.DummyTransportAddress;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.test.cluster.NoopClusterService;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.util.UUID;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class NodeDisconnectJobMonitorServiceTest extends CrateUnitTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testOnNodeDisconnectedKillsJobOriginatingFromThatNode() throws Exception {
+        JobContextService jobContextService = new JobContextService(
+            Settings.EMPTY, new NoopClusterService(), mock(StatsTables.class));
+
+        JobExecutionContext.Builder builder = jobContextService.newBuilder(UUID.randomUUID());
+        builder.addSubContext(new DummySubContext());
+        JobExecutionContext context = jobContextService.createContext(builder);
+
+        ThreadPool threadPool = mock(ThreadPool.class);
+        when(threadPool.schedule(any(TimeValue.class), anyString(), any(Runnable.class))).thenAnswer(new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                ((Runnable) invocation.getArguments()[2]).run();
+                return null;
+            }
+        });
+
+        NodeDisconnectJobMonitorService monitorService = new NodeDisconnectJobMonitorService(
+            Settings.EMPTY,
+            threadPool,
+            jobContextService,
+            mock(TransportService.class));
+
+        monitorService.onNodeDisconnected(new DiscoveryNode("noop_id", DummyTransportAddress.INSTANCE, Version.CURRENT));
+
+        expectedException.expect(ContextMissingException.class);
+        jobContextService.getContext(context.jobId());
+    }
+}

--- a/sql/src/test/java/io/crate/operation/collect/collectors/RemoteCollectorTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/collectors/RemoteCollectorTest.java
@@ -42,6 +42,7 @@ import io.crate.testing.CollectingRowReceiver;
 import io.crate.types.DataTypes;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.cluster.NoopClusterService;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -93,7 +94,7 @@ public class RemoteCollectorTest {
         transportKillJobsNodeAction = mock(TransportKillJobsNodeAction.class);
         rowReceiver = new CollectingRowReceiver();
 
-        JobContextService jobContextService = new JobContextService(Settings.EMPTY, mock(StatsTables.class));
+        JobContextService jobContextService = new JobContextService(Settings.EMPTY, new NoopClusterService(), mock(StatsTables.class));
         remoteCollector = new RemoteCollector(
             jobId,
             "localNode",


### PR DESCRIPTION
In order to prevent leaks of passive contexts (like FetchContext) which
don't "finish" by themselves