### PR TITLE
re-add docs symlink

### DIFF
--- a/docs
+++ b/docs
@@ -1,0 +1,1 @@
+blackbox/docs


### PR DESCRIPTION
Got removed in 80483a5a105ad19dc8a0e389275f40eb4ee8da67 for no apparent
reason.
This broke our rtd build.