### PR TITLE
[docs] Use SQL highlighting for create analyzer block

### DIFF
--- a/blackbox/docs/sql/ddl.txt
+++ b/blackbox/docs/sql/ddl.txt
@@ -649,7 +649,9 @@ This creates a custom analyzer called ``myanalyzer``. It uses the built-in
 :ref:`mapping-charfilter` char-filter.
 
 It is possible to further customize the built-in token filters, char-filters or
-tokenizers::
+tokenizers:
+
+.. code-block:: sql
 
     cr> create ANALYZER myanalyzer_customized (
     ...   TOKENIZER whitespace,


### PR DESCRIPTION
Fixes a sphinx warning:

> ddl.txt:654: WARNING: Could not lex literal_block as "psql".
> Highlighting skipped.