### PR TITLE
Remove creationTime from SQLRequest and calc duration server side

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,10 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Removed the `creationTime` property from `SQL(Bulk)Request` and changed the
+   `duration` property on `SQL(Bulk)Response` to return the server-side
+   duration instead of the full round-trip duration.
+
  - The default number of shards is calculated dynamically upon the table
    creation.
 

--- a/sql/src/main/java/io/crate/action/sql/SQLBaseRequest.java
+++ b/sql/src/main/java/io/crate/action/sql/SQLBaseRequest.java
@@ -43,7 +43,7 @@ import java.io.IOException;
  *
  *
  * this abstract base class provides the shared components
- * {@link #stmt()}, {@link #creationTime()} and {@link #includeTypesOnResponse()}
+ * {@link #stmt()} and {@link #includeTypesOnResponse()}
  * which both concrete classes use.
  *
  * (not using links for TransportSQLAction as they're not included for the client and would case an error under oraclejdk8)
@@ -58,16 +58,12 @@ public abstract class SQLBaseRequest extends ActionRequest<SQLBaseRequest> {
     public static final int HEADER_FLAG_ALLOW_QUOTED_SUBSCRIPT = 1;
 
     protected String stmt;
-    protected long creationTime;
     protected boolean includeTypesOnResponse = false;
 
-    public SQLBaseRequest() {
-        this.creationTime = System.currentTimeMillis();
-    }
+    public SQLBaseRequest() {}
 
     public SQLBaseRequest(String stmt) {
         this.stmt = stmt;
-        this.creationTime = System.currentTimeMillis();
     }
 
     /**
@@ -100,12 +96,6 @@ public abstract class SQLBaseRequest extends ActionRequest<SQLBaseRequest> {
         return includeTypesOnResponse;
     }
 
-    /**
-     * the system time in millis when the request was created.
-     */
-    public long creationTime() {
-        return creationTime;
-    }
 
     public void setDefaultSchema(String schemaName) {
         if (schemaName == null) {

--- a/sql/src/main/java/io/crate/action/sql/SQLBaseResponse.java
+++ b/sql/src/main/java/io/crate/action/sql/SQLBaseResponse.java
@@ -50,17 +50,16 @@ public abstract class SQLBaseResponse extends ActionResponse implements ToXConte
     protected String[] cols;
     protected DataType[] colTypes;
     protected boolean includeTypes;
-    protected long requestStartedTime;
-    protected Long duration;
+    private int duration;
 
     public SQLBaseResponse() {} // used for serialization
 
-    public SQLBaseResponse(String[] cols, DataType[] colTypes, boolean includeTypes, long requestStartedTime) {
+    public SQLBaseResponse(String[] cols, DataType[] colTypes, boolean includeTypes, int duration) {
         assert cols.length == colTypes.length : "cols and colTypes differ";
         this.cols = cols;
         this.colTypes = colTypes;
         this.includeTypes = includeTypes;
-        this.requestStartedTime = requestStartedTime;
+        this.duration = duration;
     }
 
     public String[] cols(){
@@ -83,14 +82,7 @@ public abstract class SQLBaseResponse extends ActionResponse implements ToXConte
         this.includeTypes = includeTypes;
     }
 
-    public long duration() {
-        if (duration == null) {
-            if (requestStartedTime > 0) {
-                duration = System.currentTimeMillis() - requestStartedTime;
-            } else {
-                duration = -1L;
-            }
-        }
+    public int duration() {
         return duration;
     }
 
@@ -124,8 +116,8 @@ public abstract class SQLBaseResponse extends ActionResponse implements ToXConte
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
         cols = in.readStringArray();
-        requestStartedTime = in.readVLong();
         includeTypes = in.readBoolean();
+        duration = in.readVInt();
         if (includeTypes) {
             int numColTypes = in.readVInt();
             colTypes = new DataType[numColTypes];
@@ -141,8 +133,8 @@ public abstract class SQLBaseResponse extends ActionResponse implements ToXConte
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeStringArray(cols);
-        out.writeVLong(requestStartedTime);
         out.writeBoolean(includeTypes);
+        out.writeVInt(duration);
         if (includeTypes) {
             out.writeVInt(colTypes.length);
             for (DataType colType : colTypes) {

--- a/sql/src/main/java/io/crate/action/sql/SQLBulkRequest.java
+++ b/sql/src/main/java/io/crate/action/sql/SQLBulkRequest.java
@@ -59,7 +59,6 @@ public class SQLBulkRequest extends SQLBaseRequest {
         super.readFrom(in);
 
         stmt = in.readString();
-        creationTime = in.readVLong();
         includeTypesOnResponse = in.readBoolean();
 
         int bulkArgsLength = in.readVInt();
@@ -82,7 +81,6 @@ public class SQLBulkRequest extends SQLBaseRequest {
         super.writeTo(out);
 
         out.writeString(stmt);
-        out.writeVLong(creationTime);
         out.writeBoolean(includeTypesOnResponse);
 
         out.writeVInt(bulkArgs.length);
@@ -99,7 +97,6 @@ public class SQLBulkRequest extends SQLBaseRequest {
     public String toString() {
         return MoreObjects.toStringHelper(this)
                 .add("stmt", stmt)
-                .add("bulkArgs", Arrays.asList(bulkArgs))
-                .add("creationTime", creationTime).toString();
+                .add("bulkArgs", Arrays.asList(bulkArgs)).toString();
     }
 }

--- a/sql/src/main/java/io/crate/action/sql/SQLBulkResponse.java
+++ b/sql/src/main/java/io/crate/action/sql/SQLBulkResponse.java
@@ -40,10 +40,10 @@ public class SQLBulkResponse extends SQLBaseResponse {
 
     public SQLBulkResponse(String[] outputNames,
                            Result[] results,
-                           long requestCreationTime,
+                           int duration,
                            DataType[] colTypes,
                            boolean includeTypes) {
-        super(outputNames, colTypes, includeTypes, requestCreationTime);
+        super(outputNames, colTypes, includeTypes, duration);
         this.results = results;
     }
 

--- a/sql/src/main/java/io/crate/action/sql/SQLRequest.java
+++ b/sql/src/main/java/io/crate/action/sql/SQLRequest.java
@@ -82,7 +82,6 @@ public class SQLRequest extends SQLBaseRequest {
         for (int i = 0; i < length; i++) {
             args[i] = in.readGenericValue();
         }
-        creationTime = in.readVLong();
         includeTypesOnResponse = in.readBoolean();
     }
 
@@ -95,7 +94,6 @@ public class SQLRequest extends SQLBaseRequest {
         for (int i = 0; i < args.length; i++) {
             out.writeGenericValue(args[i]);
         }
-        out.writeVLong(creationTime);
         out.writeBoolean(includeTypesOnResponse);
     }
 
@@ -103,7 +101,6 @@ public class SQLRequest extends SQLBaseRequest {
     public String toString() {
         return MoreObjects.toStringHelper(this)
                 .add("stmt", stmt)
-                .add("args", Arrays.asList(args))
-                .add("creationTime", creationTime).toString();
+                .add("args", Arrays.asList(args)).toString();
     }
 }

--- a/sql/src/main/java/io/crate/action/sql/SQLResponse.java
+++ b/sql/src/main/java/io/crate/action/sql/SQLResponse.java
@@ -44,9 +44,9 @@ public class SQLResponse extends SQLBaseResponse {
                        Object[][] rows,
                        DataType[] dataTypes,
                        long rowCount,
-                       long requestStartedTime,
+                       int duration,
                        boolean includeTypes) {
-        super(cols, dataTypes, includeTypes, requestStartedTime);
+        super(cols, dataTypes, includeTypes, duration);
         this.rows = rows;
         this.rowCount = rowCount;
     }
@@ -109,7 +109,6 @@ public class SQLResponse extends SQLBaseResponse {
                 rows[i][j] = in.readGenericValue();
             }
         }
-        requestStartedTime = in.readVLong();
         includeTypes = in.readBoolean();
         if (includeTypes) {
             int numColumnTypes = in.readInt();
@@ -136,7 +135,6 @@ public class SQLResponse extends SQLBaseResponse {
                 out.writeGenericValue(rows[i][j]);
             }
         }
-        out.writeVLong(requestStartedTime);
         out.writeBoolean(includeTypes);
         if (includeTypes) {
             out.writeInt(colTypes.length);

--- a/sql/src/main/java/io/crate/action/sql/TransportSQLAction.java
+++ b/sql/src/main/java/io/crate/action/sql/TransportSQLAction.java
@@ -82,13 +82,14 @@ public class TransportSQLAction extends TransportBaseSQLAction<SQLRequest, SQLRe
 
     @Override
     public SQLResponse emptyResponse(SQLRequest request,
+                                     int duration,
                                      String[] outputNames,
                                      @Nullable DataType[] types) {
         return new SQLResponse(outputNames,
                 TaskResult.EMPTY_OBJS,
                 types,
                 0L,
-                request.creationTime(),
+                duration,
                 request.includeTypesOnResponse());
     }
 
@@ -97,7 +98,8 @@ public class TransportSQLAction extends TransportBaseSQLAction<SQLRequest, SQLRe
                                                    DataType[] outputTypes,
                                                    List<TaskResult> result,
                                                    boolean expectsAffectedRows,
-                                                   SQLRequest request) {
+                                                   SQLRequest request,
+                                                   int duration) {
         assert result.size() == 1;
         TaskResult taskResult = result.get(0);
         Bucket rows = taskResult.rows();
@@ -122,7 +124,7 @@ public class TransportSQLAction extends TransportBaseSQLAction<SQLRequest, SQLRe
                 objs,
                 outputTypes,
                 rowCount,
-                request.creationTime(),
+                duration,
                 request.includeTypesOnResponse()
         );
     }

--- a/sql/src/main/java/io/crate/action/sql/TransportSQLBulkAction.java
+++ b/sql/src/main/java/io/crate/action/sql/TransportSQLBulkAction.java
@@ -73,13 +73,13 @@ public class TransportSQLBulkAction extends TransportBaseSQLAction<SQLBulkReques
     }
 
     @Override
-    protected SQLBulkResponse emptyResponse(SQLBulkRequest request, String[] outputNames, @Nullable DataType[] types) {
+    protected SQLBulkResponse emptyResponse(SQLBulkRequest request, int duration, String[] outputNames, @Nullable DataType[] types) {
         return new SQLBulkResponse(
-                outputNames,
-                SQLBulkResponse.EMPTY_RESULTS,
-                request.creationTime(),
-                types,
-                request.includeTypesOnResponse());
+            outputNames,
+            SQLBulkResponse.EMPTY_RESULTS,
+            duration,
+            types,
+            request.includeTypesOnResponse());
     }
 
     @Override
@@ -87,7 +87,8 @@ public class TransportSQLBulkAction extends TransportBaseSQLAction<SQLBulkReques
                                                        DataType[] dataTypes,
                                                        List<TaskResult> result,
                                                        boolean expectsAffectedRows,
-                                                       SQLBulkRequest request) {
+                                                       SQLBulkRequest request,
+                                                       int duration) {
         assert expectsAffectedRows : "bulk operations only works with statements that return rowcounts";
         SQLBulkResponse.Result[] results = new SQLBulkResponse.Result[result.size()];
         for (int i = 0, resultSize = result.size(); i < resultSize; i++) {
@@ -96,7 +97,7 @@ public class TransportSQLBulkAction extends TransportBaseSQLAction<SQLBulkReques
             results[i] = new SQLBulkResponse.Result(taskResult.errorMessage(), taskResult.rowCount());
         }
         return new SQLBulkResponse(
-                outputNames, results, request.creationTime(), dataTypes, request.includeTypesOnResponse());
+                outputNames, results, duration, dataTypes, request.includeTypesOnResponse());
     }
 
     private class TransportHandler implements TransportRequestHandler<SQLBulkRequest> {

--- a/sql/src/test/java/io/crate/action/sql/SQLRequestTest.java
+++ b/sql/src/test/java/io/crate/action/sql/SQLRequestTest.java
@@ -22,8 +22,8 @@
 package io.crate.action.sql;
 
 import io.crate.test.integration.CrateUnitTest;
-import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.junit.Test;
 
 import static org.hamcrest.core.Is.is;
@@ -39,7 +39,6 @@ public class SQLRequestTest extends CrateUnitTest {
                 "select * from users",
                 new Object[] { "arg1", "arg2" }
         );
-        request.creationTime = 0;
         request.includeTypesOnResponse(true);
 
 
@@ -47,7 +46,7 @@ public class SQLRequestTest extends CrateUnitTest {
         request.writeTo(out);
 
         byte[] expectedBytes = new byte[]
-                {0,19,115,101,108,101,99,116,32,42,32,102,114,111,109,32,117,115,101,114,115,2,0,4,97,114,103,49,0,4,97,114,103, 50, 0, 1};
+                {0,19,115,101,108,101,99,116,32,42,32,102,114,111,109,32,117,115,101,114,115,2,0,4,97,114,103,49,0,4,97,114,103, 50, 1};
         assertThat(out.bytes().toBytes(), is(expectedBytes));
     }
 
@@ -55,7 +54,7 @@ public class SQLRequestTest extends CrateUnitTest {
     @Test
     public void testSerializationReadFrom() throws Exception {
         byte[] buf = new byte[]
-                {0,19,115,101,108,101,99,116,32,42,32,102,114,111,109,32,117,115,101,114,115,2,0,4,97,114,103,49,0,4,97,114,103, 50, 0, 1};
+                {0,19,115,101,108,101,99,116,32,42,32,102,114,111,109,32,117,115,101,114,115,2,0,4,97,114,103,49,0,4,97,114,103, 50, 1};
         StreamInput in = StreamInput.wrap(buf);
         SQLRequest request = new SQLRequest();
         request.readFrom(in);

--- a/sql/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
@@ -78,7 +78,7 @@ public class CopyIntegrationTest extends SQLHttpIntegrationTest {
         String uriPath = Joiner.on("/").join(copyFilePath, "test_copy_from.json");
         execute("copy quotes from ?", new Object[]{uriPath});
         assertEquals(3L, response.rowCount());
-        assertThat(response.duration(), greaterThanOrEqualTo(0L));
+        assertThat(response.duration(), greaterThanOrEqualTo(0));
         refresh();
 
         execute("select * from quotes");
@@ -137,7 +137,7 @@ public class CopyIntegrationTest extends SQLHttpIntegrationTest {
         String uriPath = Joiner.on("/").join(copyFilePath, "test_copy_from.json");
         execute("copy quotes from ?", new Object[]{uriPath});
         assertEquals(6L, response.rowCount());
-        assertThat(response.duration(), greaterThanOrEqualTo(0L));
+        assertThat(response.duration(), greaterThanOrEqualTo(0));
         refresh();
 
         execute("select * from quotes");

--- a/sql/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -57,7 +57,7 @@ public class DDLIntegrationTest extends SQLTransportIntegrationTest {
     public void testCreateTable() throws Exception {
         execute("create table test (col1 integer primary key, col2 string) " +
                 "clustered into 5 shards with (number_of_replicas = 1)");
-        assertThat(response.duration(), greaterThanOrEqualTo(0L));
+        assertThat(response.duration(), greaterThanOrEqualTo(0));
         ensureYellow();
         assertTrue(client().admin().indices().exists(new IndicesExistsRequest("test"))
                 .actionGet().isExists());
@@ -95,7 +95,7 @@ public class DDLIntegrationTest extends SQLTransportIntegrationTest {
         execute("create table test (id int primary key, content string) " +
                 "clustered into 5 shards " +
                 "with (refresh_interval=0, number_of_replicas = 0)");
-        assertThat(response.duration(), greaterThanOrEqualTo(0L));
+        assertThat(response.duration(), greaterThanOrEqualTo(0));
         ensureYellow();
         assertTrue(client().admin().indices().exists(new IndicesExistsRequest("test"))
                 .actionGet().isExists());
@@ -545,7 +545,7 @@ public class DDLIntegrationTest extends SQLTransportIntegrationTest {
 
         execute("drop table test");
         assertThat(response.rowCount(), is(1L));
-        assertThat(response.duration(), greaterThanOrEqualTo(0L));
+        assertThat(response.duration(), greaterThanOrEqualTo(0));
         assertFalse(client().admin().indices().exists(new IndicesExistsRequest("test"))
                 .actionGet().isExists());
     }

--- a/sql/src/test/java/io/crate/integrationtests/DeleteIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/DeleteIntegrationTest.java
@@ -39,7 +39,7 @@ public class DeleteIntegrationTest extends SQLTransportIntegrationTest {
         refresh();
         execute("delete from test");
         assertEquals(1, response.rowCount());
-        assertThat(response.duration(), greaterThanOrEqualTo(0L));
+        assertThat(response.duration(), greaterThanOrEqualTo(0));
         refresh();
         execute("select \"_id\" from test");
         assertEquals(0, response.rowCount());
@@ -141,7 +141,7 @@ public class DeleteIntegrationTest extends SQLTransportIntegrationTest {
 
         execute("delete from test where pk_col='123'");
         assertEquals(1, response.rowCount());
-        assertThat(response.duration(), greaterThanOrEqualTo(0L));
+        assertThat(response.duration(), greaterThanOrEqualTo(0));
         refresh();
 
         execute("select * from test where pk_col='123'");
@@ -158,7 +158,7 @@ public class DeleteIntegrationTest extends SQLTransportIntegrationTest {
         refresh();
 
         execute("DELETE FROM test WHERE pk_col IN (?, ?, ?)", new Object[]{"1", "2", "4"});
-        assertThat(response.duration(), greaterThanOrEqualTo(0L));
+        assertThat(response.duration(), greaterThanOrEqualTo(0));
         refresh();
 
         execute("SELECT pk_col FROM test");
@@ -173,7 +173,7 @@ public class DeleteIntegrationTest extends SQLTransportIntegrationTest {
         execute("insert into test (pk_col, message) values ('1', 'foo'), ('2', 'bar'), ('3', 'baz')");
         refresh();
         execute("DELETE FROM test WHERE pk_col=? or pk_col=? or pk_col=?", new Object[]{"1", "2", "4"});
-        assertThat(response.duration(), greaterThanOrEqualTo(0L));
+        assertThat(response.duration(), greaterThanOrEqualTo(0));
         refresh();
         execute("SELECT pk_col FROM test");
         assertThat(response.rowCount(), is(1L));

--- a/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -101,20 +101,17 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
         assertEquals(3, response.rows()[0][1]);
         assertEquals("10", response.rows()[0][2]);
         assertEquals("id", response.rows()[0][3]);
-        assertThat(response.duration(), greaterThanOrEqualTo(0L));
+        assertThat(response.duration(), greaterThanOrEqualTo(0));
 
         execute("select * from information_schema.columns where table_name='quotes'");
         assertEquals(2L, response.rowCount());
-        assertThat(response.duration(), greaterThanOrEqualTo(0L));
 
 
         execute("select * from information_schema.table_constraints where schema_name='doc' and table_name='quotes'");
         assertEquals(1L, response.rowCount());
-        assertThat(response.duration(), greaterThanOrEqualTo(0L));
 
         execute("select * from information_schema.routines");
         assertEquals(118L, response.rowCount());
-        assertThat(response.duration(), greaterThanOrEqualTo(0L));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
@@ -58,7 +58,6 @@ public class InsertIntoIntegrationTest extends SQLTransportIntegrationTest {
         ensureGreen();
         execute("insert into test (\"firstName\", \"lastName\") values('Youri', 'Zoon')");
         assertEquals(1, response.rowCount());
-        assertThat(response.duration(), greaterThanOrEqualTo(0L));
         refresh();
 
         execute("select * from test where \"firstName\" = 'Youri'");

--- a/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -127,7 +127,7 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
         String uriPath = Joiner.on("/").join(copyFilePath, "test_copy_from.json");
         execute("copy quotes from ?", new Object[]{uriPath});
         assertEquals(3L, response.rowCount());
-        assertThat(response.duration(), greaterThanOrEqualTo(0L));
+        assertThat(response.duration(), greaterThanOrEqualTo(0));
         refresh();
         ensureYellow();
 

--- a/sql/src/test/java/io/crate/integrationtests/TransportSQLActionClassLifecycleTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TransportSQLActionClassLifecycleTest.java
@@ -276,7 +276,7 @@ public class TransportSQLActionClassLifecycleTest extends ClassLifecycleIntegrat
     public void testCountWithGroupByNullArgs() throws Exception {
         SQLResponse response = executor.exec("select count(*), race from characters group by race", new Object[]{null});
         assertEquals(3, response.rowCount());
-        assertThat(response.duration(), greaterThanOrEqualTo(0L));
+        assertThat(response.duration(), greaterThanOrEqualTo(0));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -83,7 +83,6 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
         execute("select \"_id\" as b, \"_version\" as a from test");
         assertArrayEquals(new String[]{"b", "a"}, response.cols());
         assertEquals(1, response.rowCount());
-        assertThat(response.duration(), greaterThanOrEqualTo(0L));
     }
 
     @Test
@@ -690,7 +689,6 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
         execute("select pk_col, message from test where pk_col='124'");
         assertEquals(1, response.rowCount());
         assertEquals("124", response.rows()[0][0]);
-        assertThat(response.duration(), greaterThanOrEqualTo(0L));
     }
 
     @Test
@@ -704,7 +702,6 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
 
         execute("SELECT * FROM test WHERE pk_col='1' OR pk_col='2'");
         assertEquals(2, response.rowCount());
-        assertThat(response.duration(), greaterThanOrEqualTo(0L));
 
         execute("SELECT * FROM test WHERE pk_col=? OR pk_col=?", new Object[]{"1", "2"});
         assertEquals(2, response.rowCount());
@@ -732,7 +729,6 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
         execute("SELECT pk_col, message FROM test WHERE pk_col='4' OR pk_col='3'");
         assertEquals(1, response.rowCount());
         assertThat(Arrays.asList(response.rows()[0]), hasItems(new Object[]{"3", "baz"}));
-        assertThat(response.duration(), greaterThanOrEqualTo(0L));
 
         execute("SELECT pk_col, message FROM test WHERE pk_col='4' OR pk_col='99'");
         assertEquals(0, response.rowCount());
@@ -749,7 +745,6 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
 
         execute("SELECT * FROM test WHERE pk_col IN (?,?,?)", new Object[]{"1", "2", "3"});
         assertEquals(3, response.rowCount());
-        assertThat(response.duration(), greaterThanOrEqualTo(0L));
     }
 
     @Test
@@ -759,7 +754,6 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
         refresh();
         execute("update test set message='new' WHERE pk_col='1' or pk_col='2' or pk_col='4'");
         assertThat(response.rowCount(), is(2L));
-        assertThat(response.duration(), greaterThanOrEqualTo(0L));
         refresh();
         execute("SELECT distinct message FROM test");
         assertThat(response.rowCount(), is(2L));

--- a/sql/src/test/java/io/crate/integrationtests/UpdateIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/UpdateIntegrationTest.java
@@ -38,7 +38,6 @@ import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$$;
 import static com.google.common.collect.Maps.newHashMap;
 import static io.crate.testing.TestingHelpers.mapToSortedString;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.core.Is.is;
 
 public class UpdateIntegrationTest extends SQLTransportIntegrationTest {
@@ -60,7 +59,6 @@ public class UpdateIntegrationTest extends SQLTransportIntegrationTest {
         execute("update test set message='b' where message = 'hello'");
 
         assertEquals(3, response.rowCount());
-        assertThat(response.duration(), greaterThanOrEqualTo(0L));
         refresh();
 
         execute("select message from test where message='b'");
@@ -505,7 +503,6 @@ public class UpdateIntegrationTest extends SQLTransportIntegrationTest {
 
         execute("update test set message='bar1' where pk_col='123'");
         assertEquals(1, response.rowCount());
-        assertThat(response.duration(), greaterThanOrEqualTo(0L));
         refresh();
 
         execute("select message from test where pk_col='123'");

--- a/sql/src/test/java/io/crate/module/sql/test/SQLResponseTest.java
+++ b/sql/src/test/java/io/crate/module/sql/test/SQLResponseTest.java
@@ -24,8 +24,8 @@ package io.crate.module.sql.test;
 import io.crate.action.sql.SQLResponse;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.types.*;
-import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -56,7 +56,7 @@ public class SQLResponseTest extends CrateUnitTest {
         r.rowCount(1L);
         //System.out.println(json(r));
         JSONAssert.assertEquals(
-                "{\"cols\":[\"col1\",\"col2\"],\"rows\":[[1,2]],\"rowcount\":1,\"duration\":-1}",
+                "{\"cols\":[\"col1\",\"col2\"],\"rows\":[[1,2]],\"rowcount\":1,\"duration\":0}",
                 json(r), true);
     }
 
@@ -70,7 +70,7 @@ public class SQLResponseTest extends CrateUnitTest {
         });
         //System.out.println(json(r));
         JSONAssert.assertEquals(
-                "{\"cols\":[\"some\",\"thing\"],\"rows\":[[\"one\",\"two\"],[\"three\",\"four\"]],\"rowcount\":-1, \"duration\":-1}",
+                "{\"cols\":[\"some\",\"thing\"],\"rows\":[[\"one\",\"two\"],[\"three\",\"four\"]],\"rowcount\":-1, \"duration\":0}",
                 json(r), true);
     }
 
@@ -84,12 +84,12 @@ public class SQLResponseTest extends CrateUnitTest {
         });
         // If no rowcount is set, -1 is returned
         JSONAssert.assertEquals(
-                "{\"cols\":[\"some\",\"thing\"],\"rows\":[[\"one\",\"two\"],[\"three\",\"four\"]],\"rowcount\":-1,\"duration\":-1}",
+                "{\"cols\":[\"some\",\"thing\"],\"rows\":[[\"one\",\"two\"],[\"three\",\"four\"]],\"rowcount\":-1,\"duration\":0}",
                 json(r), true);
 
         r.rowCount(2L);
         JSONAssert.assertEquals(
-                "{\"cols\":[\"some\",\"thing\"],\"rows\":[[\"one\",\"two\"],[\"three\",\"four\"]],\"rowcount\":2,\"duration\":-1}",
+                "{\"cols\":[\"some\",\"thing\"],\"rows\":[[\"one\",\"two\"],[\"three\",\"four\"]],\"rowcount\":2,\"duration\":0}",
                 json(r), true);
     }
 
@@ -104,7 +104,7 @@ public class SQLResponseTest extends CrateUnitTest {
         r.rowCount(1L);
         System.out.println(json(r));
         JSONAssert.assertEquals(
-                "{\"cols\":[\"col1\",\"col2\",\"col3\"],\"col_types\":[4,[100,9],[101,[100,10]]],\"rows\":[[1,[42],[[21]]]],\"rowcount\":1,\"duration\":-1}",
+                "{\"cols\":[\"col1\",\"col2\",\"col3\"],\"col_types\":[4,[100,9],[101,[100,10]]],\"rows\":[[1,[42],[[21]]]],\"rowcount\":1,\"duration\":0}",
                 json(r), true);
 
     }
@@ -192,7 +192,7 @@ public class SQLResponseTest extends CrateUnitTest {
         resp.writeTo(out);
 
         byte[] expectedBytes = new byte[]
-                { 0,0,2,2,4,99,111,108,49,4,99,111,108,50,0,0,0,2,0,9,114,111,119,49,95,99,111,108,49,0,9,114,111,119,49,95,99,111,108,50,0,9,114,111,119,50,95,99,111,108,49,0,9,114,111,119,50,95,99,111,108,50,0,1,0,0,0,2,4,4};
+                { 0,0,2,2,4,99,111,108,49,4,99,111,108,50,0,0,0,2,0,9,114,111,119,49,95,99,111,108,49,0,9,114,111,119,49,95,99,111,108,50,0,9,114,111,119,50,95,99,111,108,49,0,9,114,111,119,50,95,99,111,108,50,1,0,0,0,2,4,4};
         byte[] bytes = out.bytes().toBytes();
         assertThat(bytes, is(expectedBytes));
     }
@@ -200,7 +200,7 @@ public class SQLResponseTest extends CrateUnitTest {
     @Test
     public void testSerializationReadFrom() throws Exception {
         byte[] buf = new byte[]
-                { 0,0,2,2,4,99,111,108,49,4,99,111,108,50,0,0,0,2,0,9,114,111,119,49,95,99,111,108,49,0,9,114,111,119,49,95,99,111,108,50,0,9,114,111,119,50,95,99,111,108,49,0,9,114,111,119,50,95,99,111,108,50,0,1,0,0,0,2,4,4};
+                { 0,0,2,2,4,99,111,108,49,4,99,111,108,50,0,0,0,2,0,9,114,111,119,49,95,99,111,108,49,0,9,114,111,119,49,95,99,111,108,50,0,9,114,111,119,50,95,99,111,108,49,0,9,114,111,119,50,95,99,111,108,50,1,0,0,0,2,4,4};
         StreamInput in = StreamInput.wrap(buf);
         SQLResponse resp = new SQLResponse();
         resp.readFrom(in);
@@ -213,6 +213,6 @@ public class SQLResponseTest extends CrateUnitTest {
 
         assertThat(resp.columnTypes(), is(new DataType[] { DataTypes.STRING, DataTypes.STRING }));
         assertThat(resp.rowCount(), is(2L));
-        assertThat(resp.duration(), is(-1L));
+        assertThat(resp.duration(), is(0));
     }
 }

--- a/sql/src/test/java/io/crate/planner/TableStatsServiceTest.java
+++ b/sql/src/test/java/io/crate/planner/TableStatsServiceTest.java
@@ -98,7 +98,7 @@ public class TableStatsServiceTest extends CrateUnitTest  {
                         new Object[][] { row },
                         new DataType[] {DataTypes.LONG, DataTypes.STRING, DataTypes.STRING},
                         1L,
-                        1L,
+                        1,
                         false
                 ));
                 numRequests.incrementAndGet();


### PR DESCRIPTION
The duration in the SQLResponse was calculated lazy and was based on the
creationTime of the SQLRequest.
This caused an inconsistence between transport client and http clients.
For transport clients the duration measured the full round-trip. Http
clients measured the time it took to process the request on the server
side.

This commit changes the behaviour so that the duration is always the
time it took on the server to process a request.