### PR TITLE
fixed bug in altering partitioned tables

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed an issue that prevented altering a partitioned table by adding a new
+   column if the table already contains an array column.
+
 2016/05/12 0.54.9
 =================
 

--- a/sql/src/main/java/org/elasticsearch/index/mapper/core/ArrayMapper.java
+++ b/sql/src/main/java/org/elasticsearch/index/mapper/core/ArrayMapper.java
@@ -262,7 +262,11 @@ public class ArrayMapper implements ArrayValueMapperParser, Mapper {
 
     @Override
     public void merge(Mapper mergeWith, MergeContext mergeContext) throws MergeMappingException {
-        innerMapper.merge(mergeWith, mergeContext);
+        if (mergeWith instanceof ArrayMapper) {
+            innerMapper.merge(((ArrayMapper) mergeWith).innerMapper, mergeContext);
+        } else {
+            innerMapper.merge(mergeWith, mergeContext);
+        }
     }
 
     @Override


### PR DESCRIPTION
The issue was caused by using ObjectMapper for Array column types.

The following sequence of SQL statements would result in an exception:

```sql
create table foo (id int, tag array(string)) partitioned by(id)
insert into foo (id) values (1)
alter table foo add column name string
```