### PR TITLE
Merge pendingOperations in TransportBulkCreateIndicesAction

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Improved performance of queries like `COPY FROM` which can create a lot of
+   partitions
+
  - Fixed an issue that prevented altering a partitioned table by adding a new
    column if the table already contains an array column.
 


### PR DESCRIPTION
After sending a `BulkCreateIndicesRequest` the `BulkShardProcessor`
doesn't suspend and wait for a response but instead continues gathering
data and send more `BulkCreateIndicesRequest`s.

Depending on the input data this could be quite a lot of *small*
requests with only a couple of indices each.

With this commit any pending operations with the same jobId will be
merged together so that there are less cluster-state updates.

This can greatly improve performance (E.g. in a test scenario creating
500 partitions went from minutes to a couple of seconds)