### PR TITLE
fix bug in invalidation of cache in doc schema info

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed a bug which prevented complete deletion of tables in custom
+   schemas.
+
  - Improved the `KILL` behaviour for `COPY`, `UPDATE` and `DELETE` statements
 
  - Fixed a `ClassCastException` that occurred if the left side of a `IN`

--- a/sql/src/main/java/io/crate/metadata/doc/DocSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/doc/DocSchemaInfo.java
@@ -277,7 +277,6 @@ public class DocSchemaInfo implements SchemaInfo, ClusterStateListener {
     @Override
     public synchronized void clusterChanged(ClusterChangedEvent event) {
         if (event.metaDataChanged()) {
-            cache.invalidateAll(event.indicesDeleted());
 
             // search for aliases of deleted and created indices, they must be invalidated also
             for (String index : event.indicesDeleted()) {
@@ -309,7 +308,9 @@ public class DocSchemaInfo implements SchemaInfo, ClusterStateListener {
                 String indexName = getIndexName(tableName);
 
                 IndexMetaData newIndexMetaData = event.state().getMetaData().index(indexName);
-                if (newIndexMetaData != null && event.indexMetaDataChanged(newIndexMetaData)) {
+                if (newIndexMetaData == null) {
+                    cache.invalidate(tableName);
+                } else if (event.indexMetaDataChanged(newIndexMetaData)) {
                     cache.invalidate(tableName);
                     // invalidate aliases of changed indices
                     invalidateAliases(newIndexMetaData.getAliases());


### PR DESCRIPTION
 The invalidation logic didn't consider cases where the indexName didn't match the tableName. It has resulted in incorrect behavior of the tables deletion.