### PR TITLE
Remove systemSchema from SchemaInfo

### DIFF
--- a/sql/src/main/java/io/crate/metadata/blob/BlobSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/blob/BlobSchemaInfo.java
@@ -118,11 +118,6 @@ public class BlobSchemaInfo implements SchemaInfo, ClusterStateListener {
     }
 
     @Override
-    public boolean systemSchema() {
-        return true;
-    }
-
-    @Override
     public void invalidateTableCache(String tableName) {
         cache.invalidate(tableName);
     }

--- a/sql/src/main/java/io/crate/metadata/doc/DocSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/doc/DocSchemaInfo.java
@@ -265,11 +265,6 @@ public class DocSchemaInfo implements SchemaInfo, ClusterStateListener {
     }
 
     @Override
-    public boolean systemSchema() {
-        return false;
-    }
-
-    @Override
     public void invalidateTableCache(String tableName) {
         cache.invalidate(tableName);
     }

--- a/sql/src/main/java/io/crate/metadata/information/InformationSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/information/InformationSchemaInfo.java
@@ -62,11 +62,6 @@ public class InformationSchemaInfo implements SchemaInfo {
     }
 
     @Override
-    public boolean systemSchema() {
-        return true;
-    }
-
-    @Override
     public void invalidateTableCache(String tableName) {
     }
 

--- a/sql/src/main/java/io/crate/metadata/sys/SysSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysSchemaInfo.java
@@ -67,11 +67,6 @@ public class SysSchemaInfo implements SchemaInfo {
     }
 
     @Override
-    public boolean systemSchema() {
-        return true;
-    }
-
-    @Override
     public void invalidateTableCache(String tableName) {
 
     }

--- a/sql/src/main/java/io/crate/metadata/table/SchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/table/SchemaInfo.java
@@ -30,7 +30,5 @@ public interface SchemaInfo extends Iterable<TableInfo>, AutoCloseable {
 
     String name();
 
-    boolean systemSchema();
-
     void invalidateTableCache(String tableName);
 }

--- a/sql/src/test/java/io/crate/metadata/ReferenceInfosTest.java
+++ b/sql/src/test/java/io/crate/metadata/ReferenceInfosTest.java
@@ -87,7 +87,6 @@ public class ReferenceInfosTest {
         when(tableInfo.ident()).thenReturn(tableIdent);
         when(schemaInfo.getTableInfo(tableIdent.name())).thenReturn(tableInfo);
         when(schemaInfo.name()).thenReturn(tableIdent.schema());
-        when(schemaInfo.systemSchema()).thenReturn(true);
 
         Schemas schemas = getReferenceInfos(schemaInfo);
         schemas.getWritableTable(tableIdent);
@@ -106,7 +105,6 @@ public class ReferenceInfosTest {
         when(schemaInfo.name()).thenReturn(tableIdent.schema());
         when(tableInfo.isAlias()).thenReturn(true);
 
-        when(schemaInfo.systemSchema()).thenReturn(false);
 
         Schemas schemas = getReferenceInfos(schemaInfo);
         schemas.getWritableTable(tableIdent);


### PR DESCRIPTION
The systemSchema property was used to see if a schema contains writable
tables. But this check is now done based on `DocTableInfo`.

The only usage for systemSchema was in a test.