### PR TITLE
Add supportedOperations() to TableInfo

### DIFF
--- a/sql/src/main/java/io/crate/analyze/DeleteStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/DeleteStatementAnalyzer.java
@@ -28,6 +28,7 @@ import io.crate.analyze.symbol.Symbols;
 import io.crate.analyze.where.WhereClauseAnalyzer;
 import io.crate.exceptions.UnsupportedFeatureException;
 import io.crate.metadata.doc.DocSysColumns;
+import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.DefaultTraversalVisitor;
 import io.crate.sql.tree.Delete;
 import io.crate.sql.tree.Node;
@@ -102,9 +103,9 @@ public class DeleteStatementAnalyzer extends DefaultTraversalVisitor<AnalyzedSta
                 context.parameterContext(), analysisMetaData);
 
         AnalyzedRelation analyzedRelation = relationAnalyzer.process(node.getRelation(), relationAnalysisContext);
-        if (Relations.isReadOnly(analyzedRelation)) {
+        if (!Relations.supportsOperation(analyzedRelation, Operation.DELETE)) {
             throw new UnsupportedOperationException(String.format(Locale.ENGLISH,
-                    "relation \"%s\" is read-only and cannot be deleted", analyzedRelation));
+                    "relation \"%s\" doesn't support delete operations", analyzedRelation));
         }
         assert analyzedRelation instanceof DocTableRelation;
         DocTableRelation docTableRelation = (DocTableRelation) analyzedRelation;

--- a/sql/src/main/java/io/crate/analyze/UpdateStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/UpdateStatementAnalyzer.java
@@ -41,6 +41,7 @@ import io.crate.metadata.ReferenceInfo;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.doc.DocSysColumns;
 import io.crate.metadata.doc.DocTableInfo;
+import io.crate.metadata.table.Operation;
 import io.crate.metadata.table.TableInfo;
 import io.crate.sql.tree.Assignment;
 import io.crate.sql.tree.DefaultTraversalVisitor;
@@ -102,9 +103,9 @@ public class UpdateStatementAnalyzer extends DefaultTraversalVisitor<AnalyzedSta
         RelationAnalysisContext relationAnalysisContext = new RelationAnalysisContext(
                 analysis.parameterContext(), analysisMetaData);
         AnalyzedRelation analyzedRelation = relationAnalyzer.analyze(node.relation(), relationAnalysisContext);
-        if (Relations.isReadOnly(analyzedRelation)) {
+        if (!Relations.supportsOperation(analyzedRelation, Operation.UPDATE)) {
             throw new UnsupportedOperationException(String.format(Locale.ENGLISH,
-                    "relation \"%s\" is read-only and cannot be updated", analyzedRelation));
+                    "relation \"%s\" doesn't support update operations", analyzedRelation));
         }
         assert analyzedRelation instanceof DocTableRelation : "sourceRelation must be a DocTableRelation";
         DocTableRelation tableRelation = ((DocTableRelation) analyzedRelation);

--- a/sql/src/main/java/io/crate/metadata/blob/BlobTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/blob/BlobTableInfo.java
@@ -28,6 +28,7 @@ import io.crate.analyze.TableParameterInfo;
 import io.crate.analyze.WhereClause;
 import io.crate.analyze.symbol.DynamicReference;
 import io.crate.metadata.*;
+import io.crate.metadata.table.Operation;
 import io.crate.metadata.table.ShardedTable;
 import io.crate.metadata.table.TableInfo;
 import io.crate.types.DataType;
@@ -38,7 +39,6 @@ import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.routing.GroupShardsIterator;
 import org.elasticsearch.cluster.routing.ShardIterator;
 import org.elasticsearch.cluster.routing.ShardRouting;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.index.shard.ShardId;
 
@@ -195,5 +195,10 @@ public class BlobTableInfo implements TableInfo, ShardedTable {
 
     public ImmutableMap<String, Object> tableParameters() {
         return tableParameters;
+    }
+
+    @Override
+    public Set<Operation> supportedOperations() {
+        return Operation.READ_ONLY;
     }
 }

--- a/sql/src/main/java/io/crate/metadata/doc/DocTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/doc/DocTableInfo.java
@@ -33,6 +33,7 @@ import io.crate.exceptions.UnavailableShardsException;
 import io.crate.metadata.*;
 import io.crate.metadata.sys.TableColumn;
 import io.crate.metadata.table.ColumnPolicy;
+import io.crate.metadata.table.Operation;
 import io.crate.metadata.table.ShardedTable;
 import io.crate.metadata.table.TableInfo;
 import org.apache.lucene.util.BytesRef;
@@ -402,6 +403,11 @@ public class DocTableInfo implements TableInfo, ShardedTable {
 
     public ImmutableMap<String, Object> tableParameters() {
         return tableParameters;
+    }
+
+    @Override
+    public Set<Operation> supportedOperations() {
+        return Operation.ALL;
     }
 
     public String getAnalyzerForColumnIdent(ColumnIdent ident) {

--- a/sql/src/main/java/io/crate/metadata/table/Operation.java
+++ b/sql/src/main/java/io/crate/metadata/table/Operation.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.table;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+public enum Operation {
+    READ,
+    UPDATE,
+    INSERT,
+    DELETE;
+
+    public static final EnumSet<Operation> ALL = EnumSet.allOf(Operation.class);
+    public static final EnumSet<Operation> READ_ONLY = EnumSet.of(Operation.READ);
+}

--- a/sql/src/main/java/io/crate/metadata/table/StaticTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/table/StaticTableInfo.java
@@ -89,4 +89,9 @@ public abstract class StaticTableInfo implements TableInfo {
     public Iterator<ReferenceInfo> iterator() {
         return columnMap.values().iterator();
     }
+
+    @Override
+    public Set<Operation> supportedOperations() {
+        return Operation.READ_ONLY;
+    }
 }

--- a/sql/src/main/java/io/crate/metadata/table/TableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/table/TableInfo.java
@@ -28,6 +28,7 @@ import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public interface TableInfo extends Iterable<ReferenceInfo> {
 
@@ -53,4 +54,5 @@ public interface TableInfo extends Iterable<ReferenceInfo> {
 
     Map<String, Object> tableParameters();
 
+    Set<Operation> supportedOperations();
 }

--- a/sql/src/test/java/io/crate/integrationtests/TableAliasIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TableAliasIntegrationTest.java
@@ -202,7 +202,7 @@ public class TableAliasIntegrationTest extends SQLTransportIntegrationTest {
     public void testUpdateWithTableAlias() throws Exception {
         String tableAlias = tableAliasSetup();
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("relation \"DocTableRelation{table=doc.mytablealias}\" is read-only and cannot be updated");
+        expectedException.expectMessage("relation \"DocTableRelation{table=doc.mytablealias}\" doesn't support update operations");
 
         execute(String.format(Locale.ENGLISH, "update %s set id=?, content=?", tableAlias), new Object[]{1, "bla"});
     }
@@ -211,7 +211,7 @@ public class TableAliasIntegrationTest extends SQLTransportIntegrationTest {
     public void testDeleteWithTableAlias() throws Exception {
         String tableAlias = tableAliasSetup();
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("relation \"DocTableRelation{table=doc.mytablealias}\" is read-only and cannot be deleted");
+        expectedException.expectMessage("relation \"DocTableRelation{table=doc.mytablealias}\" doesn't support delete operations");
 
         execute(String.format(Locale.ENGLISH, "delete from %s where id=?", tableAlias), new Object[]{1});
     }


### PR DESCRIPTION
In order to have a more granular information about what kind of
operation is supported on a table.

This will be used to allow update operations on certain system tables.