### PR TITLE
let graceful test layers bind to localhost instead of any

### DIFF
--- a/blackbox/docs/src/crate/process_test.py
+++ b/blackbox/docs/src/crate/process_test.py
@@ -86,7 +86,6 @@ class GracefulStopTest(unittest.TestCase):
             layer = GracefulStopCrateLayer(
                 self.node_name(i),
                 crate_path(),
-                host='0.0.0.0',
                 port=GLOBAL_PORT_POOL.get(),
                 transport_port=GLOBAL_PORT_POOL.get(),
                 multicast=True,


### PR DESCRIPTION
otherwise they could bind to virtual ifaces (e.g. vpn one's) and fail