### PR TITLE
Don't allow nulling primary key values

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed a validation issue that allowed setting a primary key column value to
+   null
+
  - Upgraded Elasticsearch to 2.3.3
 
  - Updated crate-admin to 0.18.0 which contains following changes:

--- a/sql/src/main/java/io/crate/analyze/InsertFromSubQueryAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/InsertFromSubQueryAnalyzer.java
@@ -216,7 +216,7 @@ public class InsertFromSubQueryAnalyzer {
                     columnName);
 
             UpdateStatementAnalyzer.ensureUpdateIsAllowed(
-                    tableRelation.tableInfo(), columnName.ident().columnIdent(), assignmentExpression);
+                    tableRelation.tableInfo(), columnName.ident().columnIdent());
             updateAssignments.put(columnName, assignmentExpression);
         }
 

--- a/sql/src/main/java/io/crate/analyze/InsertFromValuesAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/InsertFromValuesAnalyzer.java
@@ -304,7 +304,7 @@ public class InsertFromValuesAnalyzer extends AbstractInsertAnalyzer {
                 onDupKeyAssignments[i] = assignmentExpression;
 
                 UpdateStatementAnalyzer.ensureUpdateIsAllowed(
-                        tableRelation.tableInfo(), columnName.ident().columnIdent(), onDupKeyAssignments[i]);
+                        tableRelation.tableInfo(), columnName.ident().columnIdent());
                 if (valuesResolver.assignmentColumns.size() == i) {
                     valuesResolver.assignmentColumns.add(columnName.ident().columnIdent().fqn());
                 }

--- a/sql/src/main/java/io/crate/analyze/UpdateStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/UpdateStatementAnalyzer.java
@@ -27,12 +27,10 @@ import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.expressions.ValueNormalizer;
 import io.crate.analyze.relations.*;
-import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Reference;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.Symbols;
 import io.crate.analyze.where.WhereClauseAnalyzer;
-import io.crate.core.collections.StringObjectMaps;
 import io.crate.exceptions.ColumnValidationException;
 import io.crate.exceptions.UnsupportedFeatureException;
 import io.crate.metadata.ColumnIdent;
@@ -56,7 +54,6 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 
 
 @Singleton
@@ -180,7 +177,7 @@ public class UpdateStatementAnalyzer extends DefaultTraversalVisitor<AnalyzedSta
                 expressionAnalyzer.convert(node.expression(), expressionAnalysisContext));
         try {
             value = valueNormalizer.normalizeInputForReference(value, reference);
-            ensureUpdateIsAllowed(tableRelation.tableInfo(), ident, value);
+            ensureUpdateIsAllowed(tableRelation.tableInfo(), ident);
         } catch (IllegalArgumentException | UnsupportedOperationException e) {
             throw new ColumnValidationException(ident.sqlFqn(), e);
         }
@@ -188,24 +185,24 @@ public class UpdateStatementAnalyzer extends DefaultTraversalVisitor<AnalyzedSta
         nestedAnalyzedStatement.addAssignment(reference, value);
     }
 
-    public static void ensureUpdateIsAllowed(DocTableInfo tableInfo, ColumnIdent column, Symbol value) {
+    public static void ensureUpdateIsAllowed(DocTableInfo tableInfo, ColumnIdent column) {
         if (tableInfo.clusteredBy() != null) {
-            ensureNotUpdated(column, value, tableInfo.clusteredBy(),
+            ensureNotUpdated(column, tableInfo.clusteredBy(),
                     "Updating a clustered-by column is not supported");
         }
         for (ColumnIdent pkIdent : tableInfo.primaryKey()) {
-            ensureNotUpdated(column, value, pkIdent, "Updating a primary key is not supported");
+            ensureNotUpdated(column, pkIdent, "Updating a primary key is not supported");
         }
 
         List<GeneratedReferenceInfo> generatedReferenceInfos = tableInfo.generatedColumns();
 
         for (ColumnIdent partitionIdent : tableInfo.partitionedBy()) {
-            ensureNotUpdated(column, value, partitionIdent, "Updating a partitioned-by column is not supported");
+            ensureNotUpdated(column, partitionIdent, "Updating a partitioned-by column is not supported");
             int idx = generatedReferenceInfos.indexOf(tableInfo.getReferenceInfo(partitionIdent));
             if (idx >= 0) {
                 GeneratedReferenceInfo generatedReferenceInfo = generatedReferenceInfos.get(idx);
                 for (ReferenceInfo referenceInfo : generatedReferenceInfo.referencedReferenceInfos()) {
-                    ensureNotUpdated(column, value, referenceInfo.ident().columnIdent(),
+                    ensureNotUpdated(column, referenceInfo.ident().columnIdent(),
                             "Updating a column which is referenced in a partitioned by generated column expression is not supported");
                 }
             }
@@ -213,18 +210,9 @@ public class UpdateStatementAnalyzer extends DefaultTraversalVisitor<AnalyzedSta
     }
 
     private static void ensureNotUpdated(ColumnIdent columnUpdated,
-                                         Symbol newValue,
                                          ColumnIdent protectedColumnIdent,
                                          String errorMessage) {
-        if (columnUpdated.equals(protectedColumnIdent)) {
-            throw new UnsupportedOperationException(errorMessage);
-        }
-        if (protectedColumnIdent.isChildOf(columnUpdated)) {
-            if (newValue.valueType().equals(DataTypes.OBJECT)
-                    && newValue.symbolType().isValueSymbol()
-                    && StringObjectMaps.fromMapByPath((Map) ((Literal) newValue).value(), protectedColumnIdent.path()) == null) {
-                return;
-            }
+        if (columnUpdated.equals(protectedColumnIdent) || protectedColumnIdent.isChildOf(columnUpdated)) {
             throw new UnsupportedOperationException(errorMessage);
         }
     }


### PR DESCRIPTION
A primary key column could be changed to a null value if it's part of an
object and the whole object got replaced:

    create table t (o object as (x int primary key, y int));
    insert into t (o) values ({x=10, y=20});
    update t set o = {y = 12};
    select o from t;
    +-----------+
    | o         |
    +-----------+
    | {"y": 12} |
    +-----------+

This commit will prohibit that.

Note that this will also prohibit the following valid case where the
primary key columns value would be left unchanged:

    update t set o = {x=10, y = 12};

This should be okay because on top level the same kind of statement
would also fail (`update t set pk_col = <current_value>`).