### PR TITLE
Make CrateClient documentation executable

### DIFF
--- a/blackbox/build.gradle
+++ b/blackbox/build.gradle
@@ -1,6 +1,8 @@
 def crateDist = file("$projectDir/tmp/crate/")
+def crateClient = file("$projectDir/tmp/crateClient/")
 
 evaluationDependsOn(':app')
+evaluationDependsOn(':client')
 evaluationDependsOn(':es-repository-hdfs')
 
 task bootstrap (type:Exec) {
@@ -10,7 +12,7 @@ task bootstrap (type:Exec) {
     commandLine 'python', "$projectDir/bootstrap.py"
 }
 
-task unpackDistTar (dependsOn: project(':app').distTar) << {
+task unpackDistTar (dependsOn: [project(':app').distTar, project(':client').jar]) << {
     copy {
         includeEmptyDirs = false
         from(tarTree(project(':app').distTar.archivePath)) {
@@ -21,10 +23,14 @@ task unpackDistTar (dependsOn: project(':app').distTar) << {
         }
         into crateDist
     }
+    copy {
+        from(project(':client').jar)
+        into crateClient
+    }
 }
 
 task buildout (type:Exec, dependsOn: bootstrap) {
-    commandLine "$projectDir/bin/buildout", 'install', 'test', 'sphinx'
+    commandLine "$projectDir/bin/buildout", 'install', 'test', 'sphinx', 'java_repl'
 }
 
 task buildoutHadoop(type:Exec, dependsOn: buildout) {

--- a/blackbox/buildout.cfg
+++ b/blackbox/buildout.cfg
@@ -6,6 +6,7 @@ parts = sphinx
         sphinx-cmd
         test
         hdfs-test
+        java_repl
 
 [test]
 recipe = zc.recipe.egg:script
@@ -65,3 +66,9 @@ input = inline:
     ${buildout:bin-directory}/sphinx-build -c docs/ -b text -E docs/clients ${buildout:directory}/docs/clients/out/text
     RESULT+=$?
     exit $RESULT
+
+[java_repl]
+recipe = hexagonit.recipe.download
+url = http://albertlatacz.published.s3.amazonaws.com/javarepl/javarepl.jar
+strip-top-level-dir = true
+download-only = true

--- a/blackbox/docs/clients/client.txt
+++ b/blackbox/docs/clients/client.txt
@@ -15,14 +15,11 @@ Since Crate is a clustered database it is recommended to specify all the hosts
 of the cluster. This way if a server is unavailable the host is skipped and the
 request is automatically routed to the next server::
 
+    jv> import io.crate.client.CrateClient;
+    jv> import io.crate.action.sql.*;
+    jv> import org.elasticsearch.action.*;
 
-    import io.crate.client.CrateClient;
-
-    CrateClient client = new CrateClient(
-        "host1.example.com:4300",
-        "host2.example.com:4300"
-    );
-
+    jv> CrateClient client = new CrateClient("localhost:4300");
 
 Executing Queries
 =================
@@ -32,7 +29,7 @@ different arguments to execute SQL statements.
 
 The simplest variant only takes a ``String``::
 
-    ActionFuture<SQLResponse> respFuture = client.sql("SELECT * FROM sys.nodes");
+    jv> ActionFuture<SQLResponse> respFuture = client.sql("SELECT * FROM sys.nodes");
 
 Calling the ``sql`` method won't block but instead execute asynchronous and
 return a ``Future``.
@@ -40,7 +37,7 @@ return a ``Future``.
 In order to get the actual result ``actionGet`` or ``get`` has to be called on
 the future::
 
-    SQLResponse response = respFuture.actionGet();
+    jv> SQLResponse response = respFuture.actionGet();
 
 ``actionGet`` will block until the result is available.
 
@@ -48,16 +45,16 @@ To avoid blocking there is another ``sql`` variant which takes an
 ``ActionListener`` as additional argument. This ``ActionListener`` acts as a
 callback which will be called once the result is ready::
 
-    client.sql("select name from sys.cluster", new ActionListener<SQLResponse>() {
-        @Override
-        public void onResponse(SQLResponse sqlResponse) {
-            System.out.println(sqlResponse);
-        }
-
-        @Override
-        public void onFailure(Throwable e) {
-        }
-    });
+    jv> client.sql("select name from sys.cluster", new ActionListener<SQLResponse>() {
+    ...    @Override
+    ...    public void onResponse(SQLResponse sqlResponse) {
+    ...        System.out.println(sqlResponse);
+    ...    }
+    ...
+    ...    @Override
+    ...    public void onFailure(Throwable e) {
+    ...    }
+    ... });
 
 
 SQLRequest Class
@@ -95,9 +92,9 @@ from improved performance.
 
 Here is an example that shows how to use it::
 
-    SQLRequest request = new SQLRequest(
-        "select * from sys.nodes where name = ?", new Object[] { "node1" });
-    client.sql(request).actionGet();
+    jv> SQLRequest request = new SQLRequest(
+    ...     "select * from sys.nodes where name = ?", new Object[] { "node1" });
+    jv> client.sql(request).actionGet();
 
 
 Default Schema
@@ -107,8 +104,8 @@ In case the schema name isn't set explicitly in the statement Crate will
 default to ``doc``. In order to overwrite that default it is possible to set
 the default schema name on the ``SQLRequest``::
 
-    SQLRequest request = new SQLRequest("select * from t");
-    request.setDefaultSchema("custom_schema");
+    jv> SQLRequest request = new SQLRequest("select * from t");
+    jv> request.setDefaultSchema("custom_schema");
 
 This will then return the results from ``custom_schema.t`` instead of
 ``doc.t``.
@@ -119,8 +116,8 @@ Request Column Data Types
 By default the ``SQLResponse`` won't contain the data types of the result
 columns. To retrieve them a flag can be set on the ``SQLRequest``::
 
-    SQLRequest request = new SQLRequest("SELECT name FROM sys.nodes");
-    request.includeTypesOnResponse(true);
+    jv> SQLRequest request = new SQLRequest("SELECT name FROM sys.nodes");
+    jv> request.includeTypesOnResponse(true);
 
 
 SQLResponse Class
@@ -201,15 +198,17 @@ one record and needs to match the specified parameters of a statement.
 The following example describes how to issue an insert bulk operation and
 insert three records at once::
 
-    String stmt = "INSERT INTO foo (id, name) VALUES (?, ?)";
-    Object[][] bulkArgs = new Object[][] {
-        {1, "I am Batman!"},
-        {2, "Deadpool"},
-        {3, "Nancy Callahan"}
-    };
+    jv> client.sql("create table foo (id int primary key, name string)").actionGet();
 
-    SQLBulkRequest request = new SQLBulkRequest(stmt, bulkArgs);
-    client.bulkSql(request).actionGet();
+    jv> String stmt = "INSERT INTO foo (id, name) VALUES (?, ?)";
+    jv> Object[][] bulkArgs = new Object[][] {
+    ...     {1, "I am Batman!"},
+    ...     {2, "Deadpool"},
+    ...     {3, "Nancy Callahan"}
+    ... };
+
+    jv> SQLBulkRequest request = new SQLBulkRequest(stmt, bulkArgs);
+    jv> client.bulkSql(request).actionGet();
 
 .. note::
 

--- a/blackbox/docs/src/crate/java_repl.py
+++ b/blackbox/docs/src/crate/java_repl.py
@@ -1,0 +1,52 @@
+import subprocess
+import json
+import os
+import time
+import socket
+try:
+    from urllib.request import urlopen
+    from urllib.parse import urlencode
+except ImportError:
+    from urllib import urlopen, urlencode
+
+
+def is_up(host, port):
+    """test if a host is up"""
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    ex = s.connect_ex((host, int(port)))
+    if ex == 0:
+        s.close()
+        return True
+    return False
+
+
+class JavaRepl(object):
+    def __init__(self, java_repl_jar, jars, port):
+        self.port = port = str(port)
+        jars = [os.path.abspath(p) for p in [java_repl_jar] + jars]
+        cp = ':'.join(jars)
+        self.cmd = [
+            'java', '-cp', cp, 'javarepl.Repl', '--port=' + port]
+        self.url = 'http://localhost:' + port + '/execute'
+
+    def setUp(self):
+        self.process = subprocess.Popen(
+            self.cmd,
+            stderr=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stdin=subprocess.PIPE)
+        slept = 0
+        while not is_up('localhost', self.port) and slept < 10:
+            time.sleep(0.1)
+            slept += 0.1
+
+    def tearDown(self, *args, **kwargs):
+        self.process.kill()
+
+    def execute(self, expression):
+        data = urlencode({'expression': expression}).encode('utf-8')
+        r = urlopen(self.url, data=data)
+        r = json.loads(r.read().decode('utf-8'))
+        for log in r['logs']:
+            if log['type'] == 'ERROR' and not log['message'].startswith('log4j'):
+                return log['message']

--- a/blackbox/docs/src/crate/java_repl.py
+++ b/blackbox/docs/src/crate/java_repl.py
@@ -21,6 +21,10 @@ def is_up(host, port):
 
 
 class JavaRepl(object):
+
+    __bases__ = ()
+    __name__ = 'javarepl'
+
     def __init__(self, java_repl_jar, jars, port):
         self.port = port = str(port)
         jars = [os.path.abspath(p) for p in [java_repl_jar] + jars]
@@ -41,7 +45,11 @@ class JavaRepl(object):
             slept += 0.1
 
     def tearDown(self, *args, **kwargs):
+        self.process.stdin.close()
+        self.process.stdout.close()
+        self.process.stderr.close()
         self.process.kill()
+        self.process.wait()
 
     def execute(self, expression):
         data = urlencode({'expression': expression}).encode('utf-8')


### PR DESCRIPTION
This adds a new ``jv>`` marker to the doctest setup. This marker can be
used in the documentation to write Java code that will be executed.

Only errors return an output. Everything else is silently executed.
This is because https://github.com/albertlatacz/java-repl is used to enable this
functionality and its output doesn't indicate if something was just an
assignment.

It'd look like this:

    {
        'expression': 'SQLRequest request = new SQLRequest("select * from sys.nodes where name = ?", new Object[] { "node1" });',
        'logs': [
            {
                'message': 'io.crate.action.sql.SQLRequest request = SQLRequest{stmt=select * from sys.nodes where name = ?, args=[node1]}',
                'type': 'SUCCESS'
            }
        ]
    }