### PR TITLE
Wrap listener to manage statsTables call and transform exceptions

### DIFF
--- a/sql/src/main/java/io/crate/action/sql/TransportBaseSQLAction.java
+++ b/sql/src/main/java/io/crate/action/sql/TransportBaseSQLAction.java
@@ -198,14 +198,12 @@ public abstract class TransportBaseSQLAction<TRequest extends SQLBaseRequest, TR
         final UUID jobId = UUID.randomUUID();
         long startTime = System.nanoTime();
         statsTables.jobStarted(jobId, request.stmt());
-        statsTables.activeRequestsInc();
 
         ActionListener<TResponse> wrappedListener = new ActionListener<TResponse>() {
             @Override
             public void onResponse(TResponse tResponse) {
                 listener.onResponse(tResponse);
                 statsTables.jobFinished(jobId, null);
-                statsTables.activeRequestsDec();
             }
 
             @Override
@@ -213,7 +211,6 @@ public abstract class TransportBaseSQLAction<TRequest extends SQLBaseRequest, TR
                 SQLActionException e = buildSQLActionException(t);
                 listener.onFailure(e);
                 statsTables.jobFinished(jobId, e.getMessage());
-                statsTables.activeRequestsDec();
             }
         };
         doExecute(request, wrappedListener, 1, jobId, startTime);

--- a/sql/src/main/java/io/crate/exceptions/Exceptions.java
+++ b/sql/src/main/java/io/crate/exceptions/Exceptions.java
@@ -23,7 +23,6 @@ package io.crate.exceptions;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.util.concurrent.UncheckedExecutionException;
-import org.elasticsearch.common.io.stream.NotSerializableExceptionWrapper;
 import org.elasticsearch.common.util.concurrent.UncategorizedExecutionException;
 import org.elasticsearch.transport.RemoteTransportException;
 

--- a/sql/src/main/java/io/crate/operation/collect/StatsTables.java
+++ b/sql/src/main/java/io/crate/operation/collect/StatsTables.java
@@ -22,7 +22,6 @@
 package io.crate.operation.collect;
 
 import com.google.common.base.Supplier;
-import com.twitter.jsr166e.LongAdder;
 import io.crate.core.collections.BlockingEvictingQueue;
 import io.crate.core.collections.NoopQueue;
 import io.crate.metadata.settings.CrateSettings;
@@ -59,10 +58,10 @@ public class StatsTables {
     private final static BlockingQueue<OperationContextLog> NOOP_OPERATIONS_LOG = NoopQueue.instance();
     private final static BlockingQueue<JobContextLog> NOOP_JOBS_LOG = NoopQueue.instance();
 
-    protected final Map<UUID, JobContext> jobsTable = new ConcurrentHashMap<>();
-    protected final Map<Tuple<Integer, UUID>, OperationContext> operationsTable = new ConcurrentHashMap<>();
-    protected final AtomicReference<BlockingQueue<JobContextLog>> jobsLog = new AtomicReference<>(NOOP_JOBS_LOG);
-    protected final AtomicReference<BlockingQueue<OperationContextLog>> operationsLog = new AtomicReference<>(NOOP_OPERATIONS_LOG);
+    private final Map<UUID, JobContext> jobsTable = new ConcurrentHashMap<>();
+    private final Map<Tuple<Integer, UUID>, OperationContext> operationsTable = new ConcurrentHashMap<>();
+    final AtomicReference<BlockingQueue<JobContextLog>> jobsLog = new AtomicReference<>(NOOP_JOBS_LOG);
+    final AtomicReference<BlockingQueue<OperationContextLog>> operationsLog = new AtomicReference<>(NOOP_OPERATIONS_LOG);
 
     private final JobsLogIterableGetter jobsLogIterableGetter;
     private final JobsIterableGetter jobsIterableGetter;
@@ -70,23 +69,9 @@ public class StatsTables {
     private final OperationsLogIterableGetter operationsLogIterableGetter;
 
     protected final NodeSettingsService.Listener listener = new NodeSettingListener();
-    protected volatile int lastOperationsLogSize;
-    protected volatile int lastJobsLogSize;
-    protected volatile boolean lastIsEnabled;
-
-    private final LongAdder activeRequests = new LongAdder();
-
-    public void activeRequestsInc() {
-        activeRequests.increment();
-    }
-
-    public void activeRequestsDec() {
-        activeRequests.decrement();
-    }
-
-    public long activeRequests() {
-        return activeRequests.longValue();
-    }
+    volatile int lastOperationsLogSize;
+    volatile int lastJobsLogSize;
+    private volatile boolean lastIsEnabled;
 
     @Inject
     public StatsTables(Settings settings, NodeSettingsService nodeSettingsService) {


### PR DESCRIPTION
This moves the `statsTables` calls which should be made after a request
has been processed into a listener.
Same for the `buildSQLActionException`

These calls were at various places and it would have been easy to miss
doing that.

This commit also removes the KILL MESSAGE handling that was in a
`onFailure` block because `buildSQLActionException` already handles
InterruptedExceptions and sets the correct message.