### PR TITLE
Make sure PageDownstream doesn't call upstream listener twice

### DIFF
--- a/sql/src/test/java/io/crate/operation/merge/IteratorPageDownstreamTest.java
+++ b/sql/src/test/java/io/crate/operation/merge/IteratorPageDownstreamTest.java
@@ -276,5 +276,7 @@ public class IteratorPageDownstreamTest extends CrateUnitTest {
 
         rowReceiver.resumeUpstream(false);
         assertThat(rowReceiver.rows.size(), is(4));
+        verify(pageConsumeListener, times(1)).needMore();
+        verify(pageConsumeListener, times(0)).finish();
     }
 }


### PR DESCRIPTION
Additional improvement to 23388ddcd075c92f3d7297020151575bb37c49e4

After the upstream was finished resume/repeat would cause additional
needMore/finish calls on the upstream