### PR TITLE
Replace ActionListeners.wrap with a ActionListener & Future

### DIFF
--- a/blob/src/main/java/io/crate/blob/v2/BlobIndices.java
+++ b/blob/src/main/java/io/crate/blob/v2/BlobIndices.java
@@ -26,7 +26,7 @@ import com.google.common.base.Functions;
 import com.google.common.base.Predicate;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
-import io.crate.action.ActionListeners;
+import io.crate.action.FutureActionListener;
 import io.crate.blob.BlobEnvironment;
 import io.crate.blob.BlobShardFuture;
 import org.apache.lucene.util.IOUtils;
@@ -119,11 +119,12 @@ public class BlobIndices extends AbstractComponent implements ClusterStateListen
      * @param indexSettings updated index settings
      */
     public ListenableFuture<Void> alterBlobTable(String tableName, Settings indexSettings) {
-        final SettableFuture<Void> result = SettableFuture.create();
-        ActionListener<UpdateSettingsResponse> listener = ActionListeners.wrap(result, Functions.<Void>constant(null));
+        FutureActionListener<UpdateSettingsResponse, Void> listener =
+            new FutureActionListener<>(Functions.<Void>constant(null));
+
         transportUpdateSettingsActionProvider.get().execute(
             new UpdateSettingsRequest(indexSettings, fullIndexName(tableName)), listener);
-        return result;
+        return listener;
     }
 
     public ListenableFuture<Void> createBlobTable(String tableName,
@@ -149,10 +150,9 @@ public class BlobIndices extends AbstractComponent implements ClusterStateListen
     }
 
     public ListenableFuture<Void> dropBlobTable(final String tableName) {
-        final SettableFuture<Void> result = SettableFuture.create();
-        ActionListener<DeleteIndexResponse> listener = ActionListeners.wrap(result, Functions.<Void>constant(null));
+        FutureActionListener<DeleteIndexResponse, Void> listener = new FutureActionListener<>(Functions.<Void>constant(null));
         transportDeleteIndexActionProvider.get().execute(new DeleteIndexRequest(fullIndexName(tableName)), listener);
-        return result;
+        return listener;
     }
 
     public BlobShard blobShard(String index, int shardId) {

--- a/core/src/main/java/io/crate/action/ActionListeners.java
+++ b/core/src/main/java/io/crate/action/ActionListeners.java
@@ -22,8 +22,6 @@
 
 package io.crate.action;
 
-import com.google.common.base.Function;
-import com.google.common.util.concurrent.SettableFuture;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
@@ -57,32 +55,4 @@ public class ActionListeners {
             }
         };
     }
-
-    public static <Response, Result> ActionListener<Response> wrap(
-        final SettableFuture<? super Result> future,
-        final Function<? super Response, ? extends Result> transformFunction) {
-
-        return new SettableActionListener<>(future, transformFunction);
-    }
-
-    private static class SettableActionListener<Response, Result> implements ActionListener<Response> {
-        private final SettableFuture<? super Result> future;
-        private final Function<? super Response, ? extends Result> transformFunction;
-
-        SettableActionListener(SettableFuture<? super Result> future, Function<? super Response, ? extends Result> transformFunction) {
-            this.future = future;
-            this.transformFunction = transformFunction;
-        }
-
-        @Override
-        public void onResponse(Response response) {
-            future.set(transformFunction.apply(response));
-        }
-
-        @Override
-        public void onFailure(Throwable e) {
-            future.setException(e);
-        }
-    }
-
 }

--- a/core/src/main/java/io/crate/action/FutureActionListener.java
+++ b/core/src/main/java/io/crate/action/FutureActionListener.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.action;
+
+import com.google.common.base.Function;
+import com.google.common.util.concurrent.AbstractFuture;
+import org.elasticsearch.action.ActionListener;
+
+public class FutureActionListener<Response, Result> extends AbstractFuture<Result> implements ActionListener<Response> {
+
+    private final Function<? super Response, ? extends Result> transformFunction;
+
+    public FutureActionListener(Function<? super Response, ? extends Result> transformFunction) {
+        this.transformFunction = transformFunction;
+    }
+
+    @Override
+    public void onResponse(Response response) {
+        set(transformFunction.apply(response));
+    }
+
+    @Override
+    public void onFailure(Throwable e) {
+        setException(e);
+    }
+}

--- a/sql/src/main/java/io/crate/action/sql/DDLStatementDispatcher.java
+++ b/sql/src/main/java/io/crate/action/sql/DDLStatementDispatcher.java
@@ -25,12 +25,10 @@ import com.google.common.base.Function;
 import com.google.common.base.Functions;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.SettableFuture;
-import io.crate.action.ActionListeners;
+import io.crate.action.FutureActionListener;
 import io.crate.analyze.*;
 import io.crate.blob.v2.BlobIndices;
 import io.crate.executor.transport.*;
-import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 import org.elasticsearch.action.admin.indices.refresh.RefreshResponse;
 import org.elasticsearch.action.support.IndicesOptions;
@@ -111,10 +109,9 @@ public class DDLStatementDispatcher {
                     new String[analysis.indexNames().size()]));
             request.indicesOptions(IndicesOptions.lenientExpandOpen());
 
-            final SettableFuture<Long> future = SettableFuture.create();
-            ActionListener<RefreshResponse> listener = ActionListeners.wrap(future, Functions.<Long>constant(null));
+            FutureActionListener<RefreshResponse, Long> listener = new FutureActionListener<>(Functions.<Long>constant(null));
             transportActionProvider.transportRefreshAction().execute(request, listener);
-            return future;
+            return listener;
         }
 
 


### PR DESCRIPTION
This adds a ``FutureActionListener`` that is both a ``ListenableFuture``
and a `ActionListener``.

This can be used instead of having to create a ``SettableFuture`` and an
anonymous ``ActionListener`` to transfer the result.