### PR TITLE
Deprecate ``rows()`` in SQLResponse and add ``bucket()``

### DIFF
--- a/blackbox/docs/sql/rest.txt
+++ b/blackbox/docs/sql/rest.txt
@@ -21,6 +21,7 @@ A simple `SELECT` statement can be submitted like this::
     ... }'
     {
       "cols" : [ "name", "position" ],
+      "col_types" : [ 4, 9 ],
       "duration" : ...,
       "rows" : [ [ "North West Ripple", 1 ], [ "Arkintoofle Minor", 3 ] ],
       "rowcount" : 2
@@ -50,6 +51,7 @@ expected under the ``args`` key::
     ... EOF
     {
       "cols" : [ "date", "position" ],
+      "col_types" : [ 11, 9 ],
       "duration" : ...,
       "rows" : [ [ 308534400000, 1 ], [ 308534400000, 2 ] ],
       "rowcount" : 2
@@ -76,6 +78,7 @@ The same query using question marks as placeholders looks like this::
     ... EOF
     {
       "cols" : [ "date", "position" ],
+      "col_types" : [ 11, 9 ],
       "duration" : ...,
       "rows" : [ [ 308534400000, 1 ], [ 308534400000, 2 ] ],
       "rowcount" : 2
@@ -98,6 +101,7 @@ It is possible to set a default schema while querying the Crate cluster via
     ... }'
     {
       "cols" : [ "name", "position" ],
+      "col_types" : [ 4, 9 ],
       "duration" : ...,
       "rows" : [ [ "North West Ripple", 1 ], [ "Arkintoofle Minor", 3 ] ],
       "rowcount" : 2
@@ -109,27 +113,9 @@ will be used instead.
 Column Types
 ============
 
-Crate can respond a list ``col_types`` with the data type id of every
+The response contains a list ``col_types`` with the data type id of every
 responded column. This way one can know what exact data type a column
 is holding.
-
-In order to get the list of column data types, a ``types`` query
-parameter must be passed to the request::
-
-    sh$ curl -sSXPOST '127.0.0.1:4200/_sql?types&pretty' -d@- <<- EOF
-    ... {"stmt":
-    ...     "select date, position from locations
-    ...      where date <= \$1 and position < \$2 order by position",
-    ...  "args": ["1979-10-12", 3]
-    ... }
-    ... EOF
-    {
-      "cols" : [ "date", "position" ],
-      "col_types" : [ 11, 9 ],
-      "duration" : ...,
-      "rows" : [ [ 308534400000, 1 ], [ 308534400000, 2 ] ],
-      "rowcount" : 2
-    }
 
 Collection data types like ``Set`` or ``Array`` are displayed as
 a list where the first value is the collection type and the second is

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -18,6 +18,8 @@ def coreIncludes = ['io/crate/Streamer*',
                     "io/crate/TimestampFormat*",
                     "io/crate/core/collections/MapComparator*",
                     "io/crate/core/collections/ForEach*",
+                    "io/crate/core/collections/Bucket*",
+                    "io/crate/core/collections/Row*",
                     "io/crate/core/StringUtils*",
                     "io/crate/geo/GeoJSONUtils*",
                     "io/crate/types/**"]
@@ -27,6 +29,8 @@ def sqlIncludes = [
     "io/crate/action/sql/Fetch*",
     "io/crate/action/sql/fetch/Fetch*",
     "io/crate/action/sql/fetch/SQLFetchAction*",
+    "io/crate/executor/BytesRefUtils.class",
+    "io/crate/executor/transport/StreamBucket*"
 ]
 
 task depClasses(type: Copy, dependsOn: [':core:compileJava', ':sql:compileJava']) {

--- a/client/src/test/java/io/crate/client/CrateClientUsageTest.java
+++ b/client/src/test/java/io/crate/client/CrateClientUsageTest.java
@@ -27,6 +27,7 @@ import io.crate.action.sql.SQLBulkResponse;
 import io.crate.action.sql.SQLRequest;
 import io.crate.action.sql.SQLResponse;
 import io.crate.types.DataType;
+import io.crate.types.DataTypes;
 import io.crate.types.IntegerType;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
@@ -68,7 +69,7 @@ public class CrateClientUsageTest extends CrateClientIntegrationTest {
         assertEquals("id", r.cols()[0]);
         assertEquals(1, r.rows()[0][0]);
 
-        assertThat(r.columnTypes(), is(new DataType[0]));
+        assertThat(r.columnTypes(), is(new DataType[] {DataTypes.INTEGER }));
     }
 
     @Test
@@ -112,7 +113,7 @@ public class CrateClientUsageTest extends CrateClientIntegrationTest {
                     assertEquals("id", r.cols()[0]);
                     assertEquals(1, r.rows()[0][0]);
 
-                    assertThat(r.columnTypes(), is(new DataType[0]));
+                    assertThat(r.columnTypes(), is(new DataType[] { DataTypes.INTEGER }));
                 } catch (AssertionError e) {
                     assertionError.set(e);
                 } finally {

--- a/sql/src/main/java/io/crate/action/sql/SQLBaseRequest.java
+++ b/sql/src/main/java/io/crate/action/sql/SQLBaseRequest.java
@@ -58,7 +58,6 @@ public abstract class SQLBaseRequest extends ActionRequest<SQLBaseRequest> {
     public static final int HEADER_FLAG_ALLOW_QUOTED_SUBSCRIPT = 1;
 
     private String stmt;
-    private boolean includeTypesOnResponse = false;
 
     public SQLBaseRequest() {}
 
@@ -79,21 +78,20 @@ public abstract class SQLBaseRequest extends ActionRequest<SQLBaseRequest> {
     }
 
     /**
-     * set to true if the column types should be included in the {@link io.crate.action.sql.SQLResponse}
-     * or {@link SQLBulkResponse}
-     *
-     * if set to false (the default) the types won't be included in the response.
+     * @deprecated types are now always included, setting this has no effect.
      */
+    @Deprecated
     public void includeTypesOnResponse(boolean includeTypesOnResponse) {
-        this.includeTypesOnResponse = includeTypesOnResponse;
     }
 
     /**
      * See also {@link #includeTypesOnResponse(boolean)}
-     * @return true or false indicating if the column dataTypes will be included in the requests response.
+     * @deprecated types are now always included
+     * @return true
      */
+    @Deprecated
     public boolean includeTypesOnResponse() {
-        return includeTypesOnResponse;
+        return true;
     }
 
 
@@ -139,13 +137,11 @@ public abstract class SQLBaseRequest extends ActionRequest<SQLBaseRequest> {
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
         stmt = in.readString();
-        includeTypesOnResponse = in.readBoolean();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeString(stmt);
-        out.writeBoolean(includeTypesOnResponse);
     }
 }

--- a/sql/src/main/java/io/crate/action/sql/SQLBaseResponse.java
+++ b/sql/src/main/java/io/crate/action/sql/SQLBaseResponse.java
@@ -48,7 +48,7 @@ public abstract class SQLBaseResponse extends ActionResponse implements ToXConte
     }
 
     private String[] cols;
-    private DataType[] colTypes;
+    protected DataType[] colTypes;
     private boolean includeTypes;
     private float duration;
 
@@ -72,14 +72,6 @@ public abstract class SQLBaseResponse extends ActionResponse implements ToXConte
 
     public DataType[] columnTypes() {
         return colTypes;
-    }
-
-    public void colTypes(DataType[] dataTypes) {
-        this.colTypes = dataTypes;
-    }
-
-    public void includeTypes(boolean includeTypes) {
-        this.includeTypes = includeTypes;
     }
 
     public float duration() {

--- a/sql/src/main/java/io/crate/executor/transport/AlterTableOperation.java
+++ b/sql/src/main/java/io/crate/executor/transport/AlterTableOperation.java
@@ -87,7 +87,7 @@ public class AlterTableOperation {
             transportActionProvider.transportSQLAction().execute(new SQLRequest(stmt), new ActionListener<SQLResponse>() {
                 @Override
                 public void onResponse(SQLResponse sqlResponse) {
-                    Long count = (Long) sqlResponse.rows()[0][0];
+                    Long count = (Long) sqlResponse.bucket().iterator().next().get(0);
                     if (count == 0L) {
                         addColumnToTable(analysis, result);
                     } else {

--- a/sql/src/main/java/io/crate/planner/TableStatsService.java
+++ b/sql/src/main/java/io/crate/planner/TableStatsService.java
@@ -23,12 +23,14 @@
 package io.crate.planner;
 
 
-import com.carrotsearch.hppc.ObjectLongMap;
 import com.carrotsearch.hppc.ObjectLongHashMap;
+import com.carrotsearch.hppc.ObjectLongMap;
 import io.crate.action.sql.SQLRequest;
 import io.crate.action.sql.SQLResponse;
 import io.crate.action.sql.TransportSQLAction;
+import io.crate.core.collections.Row;
 import io.crate.metadata.TableIdent;
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.BindingAnnotation;
@@ -92,8 +94,9 @@ public class TableStatsService extends AbstractComponent implements Runnable {
 
     private static ObjectLongMap<TableIdent> statsFromResponse(SQLResponse sqlResponse) {
         ObjectLongMap<TableIdent> newStats = new ObjectLongHashMap<>((int) sqlResponse.rowCount());
-        for (Object[] row : sqlResponse.rows()) {
-            newStats.put(new TableIdent((String) row[1], (String) row[2]), (long) row[0]);
+        for (Row row : sqlResponse.bucket()) {
+            newStats.put(new TableIdent(((BytesRef) row.get(1)).utf8ToString(), ((BytesRef) row.get(2)).utf8ToString()),
+                (long) row.get(0));
         }
         return newStats;
     }

--- a/sql/src/test/java/io/crate/action/sql/SQLRequestTest.java
+++ b/sql/src/test/java/io/crate/action/sql/SQLRequestTest.java
@@ -40,13 +40,12 @@ public class SQLRequestTest extends CrateUnitTest {
                 new Object[] { "arg1", "arg2" }
         );
         request.fetchProperties(new FetchProperties(20, true));
-        request.includeTypesOnResponse(true);
 
         BytesStreamOutput out = new BytesStreamOutput();
         request.writeTo(out);
 
         byte[] expectedBytes = new byte[]
-            {0, 19, 115, 101, 108, 101, 99, 116, 32, 42, 32, 102, 114, 111, 109, 32, 117, 115, 101, 114, 115, 1, 20, 0, 0, 0, 6, -4, 35, -84, 0, 1, 2, 0, 4, 97, 114, 103, 49, 0, 4, 97, 114, 103, 50};
+            {0, 19, 115, 101, 108, 101, 99, 116, 32, 42, 32, 102, 114, 111, 109, 32, 117, 115, 101, 114, 115, 20, 0, 0, 0, 6, -4, 35, -84, 0, 1, 2, 0, 4, 97, 114, 103, 49, 0, 4, 97, 114, 103, 50};
         assertThat(out.bytes().toBytes(), is(expectedBytes));
     }
 
@@ -54,13 +53,12 @@ public class SQLRequestTest extends CrateUnitTest {
     @Test
     public void testSerializationReadFrom() throws Exception {
         byte[] buf = new byte[]
-            {0, 19, 115, 101, 108, 101, 99, 116, 32, 42, 32, 102, 114, 111, 109, 32, 117, 115, 101, 114, 115, 1, 20, 0, 0, 0, 6, -4, 35, -84, 0, 1, 2, 0, 4, 97, 114, 103, 49, 0, 4, 97, 114, 103, 50};
+            {0, 19, 115, 101, 108, 101, 99, 116, 32, 42, 32, 102, 114, 111, 109, 32, 117, 115, 101, 114, 115, 20, 0, 0, 0, 6, -4, 35, -84, 0, 1, 2, 0, 4, 97, 114, 103, 49, 0, 4, 97, 114, 103, 50};
         StreamInput in = StreamInput.wrap(buf);
         SQLRequest request = new SQLRequest();
         request.readFrom(in);
 
         assertThat(request.args(), is(new Object[] { "arg1", "arg2" }));
-        assertThat(request.includeTypesOnResponse(), is(true));
         assertThat(request.stmt(), is("select * from users"));
         FetchProperties fetchProperties = request.fetchProperties();
         assertThat(fetchProperties.fetchSize(), is(20));

--- a/sql/src/test/java/io/crate/integrationtests/RestSqlActionTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/RestSqlActionTest.java
@@ -50,7 +50,8 @@ public class RestSqlActionTest extends SQLTransportIntegrationTest {
                 "seventeen million.\", \"1\", \"Galaxy\", \"North West Ripple\", 1, " +
                 "null ] ],\n" +
                 " \"rowcount\": 1," +
-                " \"duration\": " + responseDuration +
+                " \"duration\": " + responseDuration + ", " +
+                " \"col_types\": [11, 4, 4, 4, 4, 9, 12]," +
                 "}"
                 , json, true
         );
@@ -92,7 +93,8 @@ public class RestSqlActionTest extends SQLTransportIntegrationTest {
                 " West ripple of the Galaxy is said to be easier by a factor of about " +
                 "seventeen million.\", \"1\", \"Galaxy\", \"North West Ripple\", 1, null ] ],\n" +
                 " \"rowcount\": 1," +
-                " \"duration\": " + responseDuration +
+                " \"duration\": " + responseDuration + "," +
+                " \"col_types\": [11, 4, 4, 4, 4, 9, 12], " +
                 "}"
                 , json, true);
     }
@@ -110,7 +112,8 @@ public class RestSqlActionTest extends SQLTransportIntegrationTest {
                 "  \"cols\" : [ ],\n" +
                 "  \"rows\" : [ ],\n" +
                 "  \"rowcount\" : 1,\n" +
-                "  \"duration\" : \n" + responseDuration +
+                "  \"duration\" : \n" + responseDuration + ", " +
+                "  \"col_types\": []," +
                 "}", json, true);
     }
 
@@ -201,7 +204,8 @@ public class RestSqlActionTest extends SQLTransportIntegrationTest {
                 "  \"cols\" : [ \"name\" ],\n" +
                 "  \"duration\" : " + responseDuration + ",\n" +
                 "  \"rows\" : [ ],\n" +
-                "  \"rowcount\" : 0\n" +
+                "  \"rowcount\" : 0,\n" +
+                "  \"col_types\": [4]\n "+
                 "}", json, true);
     }
 
@@ -215,6 +219,7 @@ public class RestSqlActionTest extends SQLTransportIntegrationTest {
                 "{\n" +
                 "  \"cols\" : [ \"name\" ],\n" +
                 "  \"duration\" : " + responseDuration + ",\n" +
+                "  \"col_types\" : [ 4 ],\n" +
                 "  \"rows\" : [ ],\n" +
                 "  \"rowcount\" : 0\n" +
                 "}", json, true);

--- a/sql/src/test/java/io/crate/module/sql/test/SQLResponseTest.java
+++ b/sql/src/test/java/io/crate/module/sql/test/SQLResponseTest.java
@@ -22,8 +22,11 @@
 package io.crate.module.sql.test;
 
 import io.crate.action.sql.SQLResponse;
+import io.crate.core.collections.Buckets;
+import io.crate.core.collections.CollectionBucket;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.types.*;
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.xcontent.ToXContent;
@@ -34,6 +37,8 @@ import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.UUID;
 
@@ -51,58 +56,68 @@ public class SQLResponseTest extends CrateUnitTest {
 
     @Test
     public void testXContentInt() throws Exception {
-        SQLResponse r = new SQLResponse();
-        r.cols(new String[]{"col1", "col2"});
-        r.rows(new Object[][]{new Object[]{1, 2}});
-        r.rowCount(1L);
-        //System.out.println(json(r));
+        SQLResponse r = new SQLResponse(
+            new String[]{"col1", "col2"},
+            new CollectionBucket(Arrays.<Object[]>asList(new Object[] {1, 2})),
+            new DataType[] { DataTypes.INTEGER, DataTypes.INTEGER },
+            1L,
+            0.0f,
+            UUID.randomUUID()
+        );
         JSONAssert.assertEquals(
-                "{\"cols\":[\"col1\",\"col2\"],\"rows\":[[1,2]],\"rowcount\":1,\"duration\":0}",
+                "{\"cols\":[\"col1\",\"col2\"],\"rows\":[[1,2]],\"rowcount\":1,\"duration\":0, \"col_types\": [9, 9]}}",
                 json(r), true);
     }
 
     @Test
     public void testXContentString() throws Exception {
-        SQLResponse r = new SQLResponse();
-        r.cols(new String[]{"some", "thing"});
-        r.rows(new Object[][]{
+        SQLResponse r = new SQLResponse(
+            new String[]{"some", "thing"},
+            new CollectionBucket(Arrays.asList(
                 new Object[]{"one", "two"},
-                new Object[]{"three", "four"},
-        });
-        //System.out.println(json(r));
+                new Object[]{"three", "four"}
+            )),
+            new DataType[] { DataTypes.STRING, DataTypes.STRING },
+            2L,
+            0.0f,
+            UUID.randomUUID()
+        );
         JSONAssert.assertEquals(
-                "{\"cols\":[\"some\",\"thing\"],\"rows\":[[\"one\",\"two\"],[\"three\",\"four\"]],\"rowcount\":-1, \"duration\":0}",
+                "{\"cols\":[\"some\",\"thing\"],\"rows\":[[\"one\",\"two\"],[\"three\",\"four\"]],\"rowcount\": 2, \"duration\":0, \"col_types\": [4, 4]}",
                 json(r), true);
     }
 
     @Test
     public void testXContentRowCount() throws Exception {
-        SQLResponse r = new SQLResponse();
-        r.cols(new String[]{"some", "thing"});
-        r.rows(new Object[][]{
+        SQLResponse r = new SQLResponse(
+            new String[]{"some", "thing"},
+            new CollectionBucket(Arrays.asList(
                 new Object[]{"one", "two"},
-                new Object[]{"three", "four"},
-        });
-        // If no rowcount is set, -1 is returned
+                new Object[]{"three", "four"}
+            )),
+            new DataType[] { DataTypes.STRING, DataTypes.STRING },
+            2L,
+            0.0f,
+            UUID.randomUUID()
+        );
         JSONAssert.assertEquals(
-                "{\"cols\":[\"some\",\"thing\"],\"rows\":[[\"one\",\"two\"],[\"three\",\"four\"]],\"rowcount\":-1,\"duration\":0}",
-                json(r), true);
-
-        r.rowCount(2L);
-        JSONAssert.assertEquals(
-                "{\"cols\":[\"some\",\"thing\"],\"rows\":[[\"one\",\"two\"],[\"three\",\"four\"]],\"rowcount\":2,\"duration\":0}",
+                "{\"cols\":[\"some\",\"thing\"],\"rows\":[[\"one\",\"two\"],[\"three\",\"four\"]],\"rowcount\":2,\"duration\":0, \"col_types\": [4, 4]}",
                 json(r), true);
     }
 
     @Test
     public void testXContentColumnTypes() throws Exception {
-        SQLResponse r = new SQLResponse();
-        r.cols(new String[]{"col1", "col2", "col3"});
-        r.colTypes(new DataType[]{StringType.INSTANCE, new ArrayType(IntegerType.INSTANCE),
-                new SetType(new ArrayType(LongType.INSTANCE))});
-        r.includeTypes(true);
-        r.rows(new Object[][]{new Object[]{1, new Integer[]{42}, new HashSet<Long[]>(){{add(new Long[]{21L});}}}});
-        r.rowCount(1L);
+        SQLResponse r = new SQLResponse(
+            new String[]{"col1", "col2", "col3"},
+            new CollectionBucket(Collections.singletonList(
+                new Object[]{1, new Integer[]{42}, new HashSet<Long[]>(){{add(new Long[]{21L});}}}
+            )),
+            new DataType[]{StringType.INSTANCE, new ArrayType(IntegerType.INSTANCE),
+                new SetType(new ArrayType(LongType.INSTANCE))},
+            1L,
+            0.0f,
+            UUID.randomUUID()
+        );
         System.out.println(json(r));
         JSONAssert.assertEquals(
                 "{\"cols\":[\"col1\",\"col2\",\"col3\"],\"col_types\":[4,[100,9],[101,[100,10]]],\"rows\":[[1,[42],[[21]]]],\"rowcount\":1,\"duration\":0}",
@@ -118,11 +133,10 @@ public class SQLResponseTest extends CrateUnitTest {
 
         r1 = new SQLResponse(
             new String[] {},
-            new Object[][]{new String[]{}},
+            new CollectionBucket(Collections.<Object[]>singletonList(new String[0])),
             new DataType[] {},
             0L,
             10.f,
-            false,
             new UUID(20L, 24L));
 
         r1.writeTo(o);
@@ -133,18 +147,19 @@ public class SQLResponseTest extends CrateUnitTest {
 
         assertArrayEquals(r1.cols(), r2.cols());
         assertArrayEquals(r1.columnTypes(), r2.columnTypes());
-        assertArrayEquals(r1.rows(), r2.rows());
+        assertThat(Buckets.materialize(r2.bucket()), is(Buckets.materialize(r1.bucket())));
         assertEquals(r1.rowCount(), r2.rowCount());
         assertThat(r1.duration(), is(r2.duration()));
 
         o.reset();
         r1 = new SQLResponse(
             new String[] {"a", "b"},
-            new Object[][]{new String[]{"va", "vb"}},
+            new CollectionBucket(Arrays.<Object[]>asList(
+                new Object[]{new BytesRef("va"), new BytesRef("vb")}
+            )),
             new DataType[] {DataTypes.STRING, DataTypes.STRING},
             2L,
             10.f,
-            true,
             new UUID(20L, 24L));
 
         r1.writeTo(o);
@@ -169,14 +184,13 @@ public class SQLResponseTest extends CrateUnitTest {
     public void testSerializationWriteTo() throws Exception {
         SQLResponse resp = new SQLResponse(
             new String[] {"col1", "col2"},
-            new Object[][] {
-                    new Object[] {"row1_col1", "row1_col2"},
-                    new Object[] {"row2_col1", "row2_col2"}
-            },
+            new CollectionBucket(Arrays.asList(
+                    new Object[] {new BytesRef("row1_col1"), new BytesRef("row1_col2")},
+                    new Object[] {new BytesRef("row2_col1"), new BytesRef("row2_col2")}
+            )),
             new DataType[] { DataTypes.STRING, DataTypes.STRING },
             2L,
             0,
-            true,
             new UUID(20L, 24L)
         );
 
@@ -184,7 +198,7 @@ public class SQLResponseTest extends CrateUnitTest {
         resp.writeTo(out);
 
         byte[] expectedBytes = new byte[]
-            {0, 2, 4, 99, 111, 108, 49, 4, 99, 111, 108, 50, 1, 0, 0, 0, 0, 2, 4, 4, 0, 0, 0, 0, 0, 0, 0, 20, 0, 0, 0, 0, 0, 0, 0, 24, 0, 2, 0, 0, 0, 2, 0, 9, 114, 111, 119, 49, 95, 99, 111, 108, 49, 0, 9, 114, 111, 119, 49, 95, 99, 111, 108, 50, 0, 9, 114, 111, 119, 50, 95, 99, 111, 108, 49, 0, 9, 114, 111, 119, 50, 95, 99, 111, 108, 50};
+            {0, 2, 4, 99, 111, 108, 49, 4, 99, 111, 108, 50, 1, 0, 0, 0, 0, 2, 4, 4, 0, 0, 0, 0, 0, 0, 0, 20, 0, 0, 0, 0, 0, 0, 0, 24, 0, 2, 2, 40, 10, 114, 111, 119, 49, 95, 99, 111, 108, 49, 10, 114, 111, 119, 49, 95, 99, 111, 108, 50, 10, 114, 111, 119, 50, 95, 99, 111, 108, 49, 10, 114, 111, 119, 50, 95, 99, 111, 108, 50};
         byte[] bytes = out.bytes().toBytes();
         assertThat(bytes, is(expectedBytes));
     }
@@ -192,7 +206,7 @@ public class SQLResponseTest extends CrateUnitTest {
     @Test
     public void testSerializationReadFrom() throws Exception {
         byte[] buf = new byte[]
-            {0, 2, 4, 99, 111, 108, 49, 4, 99, 111, 108, 50, 1, 0, 0, 0, 0, 2, 4, 4, 0, 0, 0, 0, 0, 0, 0, 20, 0, 0, 0, 0, 0, 0, 0, 24, 0, 2, 0, 0, 0, 2, 0, 9, 114, 111, 119, 49, 95, 99, 111, 108, 49, 0, 9, 114, 111, 119, 49, 95, 99, 111, 108, 50, 0, 9, 114, 111, 119, 50, 95, 99, 111, 108, 49, 0, 9, 114, 111, 119, 50, 95, 99, 111, 108, 50};
+            {0, 2, 4, 99, 111, 108, 49, 4, 99, 111, 108, 50, 1, 0, 0, 0, 0, 2, 4, 4, 0, 0, 0, 0, 0, 0, 0, 20, 0, 0, 0, 0, 0, 0, 0, 24, 0, 2, 2, 40, 10, 114, 111, 119, 49, 95, 99, 111, 108, 49, 10, 114, 111, 119, 49, 95, 99, 111, 108, 50, 10, 114, 111, 119, 50, 95, 99, 111, 108, 49, 10, 114, 111, 119, 50, 95, 99, 111, 108, 50};
         StreamInput in = StreamInput.wrap(buf);
         SQLResponse resp = new SQLResponse();
         resp.readFrom(in);

--- a/sql/src/test/java/io/crate/planner/TableStatsServiceTest.java
+++ b/sql/src/test/java/io/crate/planner/TableStatsServiceTest.java
@@ -27,12 +27,14 @@ import io.crate.action.sql.SQLRequest;
 import io.crate.action.sql.SQLResponse;
 import io.crate.action.sql.TransportSQLAction;
 import io.crate.analyze.Analyzer;
+import io.crate.core.collections.CollectionBucket;
 import io.crate.executor.transport.kill.TransportKillJobsNodeAction;
 import io.crate.metadata.TableIdent;
 import io.crate.operation.collect.StatsTables;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilter;
 import org.elasticsearch.action.support.ActionFilters;
@@ -49,6 +51,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Answers;
 
+import java.util.Collections;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -91,17 +94,16 @@ public class TableStatsServiceTest extends CrateUnitTest  {
             protected void doExecute(SQLRequest request, ActionListener<SQLResponse> listener) {
                 Object[] row;
                 if (numRequests.get() == 0) {
-                    row = new Object[] { 2L, "foo", "bar"};
+                    row = new Object[] { 2L, new BytesRef("foo"), new BytesRef("bar")};
                 } else {
-                    row = new Object[] { 4L, "foo", "bar"};
+                    row = new Object[] { 4L, new BytesRef("foo"), new BytesRef("bar")};
                 }
                 listener.onResponse(new SQLResponse(
                     new String[] {"cast(sum(num_docs) as long)", "schema_name", "table_name"},
-                    new Object[][] { row },
+                    new CollectionBucket(Collections.singletonList(row)),
                     new DataType[] {DataTypes.LONG, DataTypes.STRING, DataTypes.STRING},
                     1L,
                     1,
-                    false,
                     UUID.randomUUID()
                 ));
                 numRequests.incrementAndGet();


### PR DESCRIPTION
This is a breaking change that requires clients to at least upgrade to a
newer version, but ``rows()`` is kept for now to not require
any code changes.

The ``rowCount`` and ``includeTypes`` setters on the ``SQLResponse`` are
removed without deprecation as those are very unlikely to have had any
use.