### PR TITLE
Disable Hadoop MiniCluster data replication

### DIFF
--- a/blackbox/hdfs/src/tests.py
+++ b/blackbox/hdfs/src/tests.py
@@ -60,7 +60,8 @@ class HadoopLayer(object):
     def setUp(self):
         cmd = ['bash',
                self.hadoop_bin, 'jar',
-               self.hadoop_mapreduce_client, 'minicluster', '-nnport', NN_PORT]
+               self.hadoop_mapreduce_client, 'minicluster',
+               '-nnport', NN_PORT, '-nomr', '-D', 'dfs.replication=0']
 
         JAVA_HOME = os.environ.get('JAVA_HOME', '/usr/lib/jvm/java-8-openjdk/')
         self.p = subprocess.Popen(


### PR DESCRIPTION
Also disable MR cluster startup - it's not necessary for HDFS test