### PR TITLE
Avoid creation of corrupt file on COPY TO

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Deprecated usage of COPY TO without specifying a DIRECTORY. This will prevent a user from defining an output path
+   that conflicts with multiple shards.
+
  - Fixed proper validation of the ``blocks.*`` table settings at all
    SQL operations.
 

--- a/blackbox/docs/sql/dml.txt
+++ b/blackbox/docs/sql/dml.txt
@@ -447,12 +447,6 @@ distributed way, meaning each node will export its own data.
 Replicated data is not exported. So every row of an exported table is
 stored only once.
 
-.. note::
-
- Data is written per shard. To prevent corrupted exports when more than one
- shard is allocated on a node, or data is exported to a shared storage system,
- use the ``DIRECTORY`` keyword (see :ref:`copy_to`).
-
 This example shows how to export a given table into files named after
 the table and shard id with gzip compression::
 

--- a/blackbox/docs/sql/reference/copy_to.txt
+++ b/blackbox/docs/sql/reference/copy_to.txt
@@ -15,40 +15,18 @@ Synopsis
     COPY table_ident [ PARTITION ( partition_column = value [ , ... ] ) ]
                      [ ( column [ , ...] ) ]
                      [ WHERE condition ]
-                     TO [DIRECTORY] output_uri
+                     TO DIRECTORY output_uri
                      [ WITH ( copy_parameter [= value] [, ... ] ) ]
 
 Description
 ===========
 
-The ``COPY TO`` command exports the contents of a table to one or more files.
-Each node of the cluster which contains a shard of the table will export the
+The ``COPY TO`` command exports the contents of a table to one or more
+files in the given directory, named to prevent filename conflicts. Each
+node of the cluster which contains a shard of the table will export the
 contents of its shards.
 
 The created files are JSON formatted and contain one table row per line.
-
-If the ``DIRECTORY`` keyword is given, the URI is treated as a directory path.
-This will generate one or more files in the given directory, named to prevent
-filename conflicts.
-
-
-
-Implications of shard level export
-==================================
-
-Exporting the data on a shard level is the fastest possible way to export data
-in Crate.
-
-There are quirks users should be aware of when using ``COPY TO``:
-
-Since data is exported and written per shard there might be concurrent writes
-to the same file if a single node contains more than one shard. This could
-cause corruption in the file being written. The same holds true when data is
-written to a shared file system such as `Amazon S3`_ or `NFS`_.
-
-To prevent this from happening writing a separate file per shard is required.
-To do this the ``DIRECTORY`` keyword can be used. An example is given in
-:ref:`exporting_data`.
 
 
 .. note::
@@ -87,7 +65,7 @@ The resulting string should be a valid URI of one of the supporting schemes:
  * ``file://``
  * ``s3://[<accesskey>:<secretkey>@]<bucketname>/<path>``
 
-If no scheme is given (e.g.: '/path/to/file') the default uri-scheme ``file://``
+If no scheme is given (e.g.: '/path/to/dir') the default uri-scheme ``file://``
 will be used.
 
 .. note::

--- a/sql/src/main/java/io/crate/analyze/CopyStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CopyStatementAnalyzer.java
@@ -133,6 +133,10 @@ public class CopyStatementAnalyzer {
     public CopyToAnalyzedStatement convertCopyTo(CopyTo node, Analysis analysis) {
         analysis.expectsAffectedRows(true);
 
+        if (!node.directoryUri()) {
+            throw new UnsupportedOperationException("Using COPY TO without specifying a DIRECTORY is deprecated");
+        }
+
         TableInfo tableInfo = analysisMetaData.schemas().getTableInfo(
                 TableIdent.of(node.table(), analysis.parameterContext().defaultSchema()));
         if (!(tableInfo instanceof DocTableInfo)) {
@@ -197,7 +201,7 @@ public class CopyStatementAnalyzer {
         }
 
         QueriedDocTable subRelation = new QueriedDocTable(tableRelation, querySpec);
-        return new CopyToAnalyzedStatement(subRelation, settings, uri, node.directoryUri(), compressionType, outputFormat, outputNames, columnsDefined, overwrites);
+        return new CopyToAnalyzedStatement(subRelation, settings, uri, compressionType, outputFormat, outputNames, columnsDefined, overwrites);
     }
 
     private static <E extends Enum<E>> E settingAsEnum(Class<E> settingsEnum, String settingValue) {

--- a/sql/src/main/java/io/crate/analyze/CopyToAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/CopyToAnalyzedStatement.java
@@ -51,7 +51,6 @@ public class CopyToAnalyzedStatement extends AbstractCopyAnalyzedStatement imple
     private final WriterProjection.OutputFormat outputFormat;
     @Nullable
     private final List<String> outputNames;
-    private final boolean isDirectoryUri;
 
     /*
      * add values that should be added or overwritten
@@ -62,7 +61,6 @@ public class CopyToAnalyzedStatement extends AbstractCopyAnalyzedStatement imple
     public CopyToAnalyzedStatement(QueriedDocTable subQueryRelation,
                                    Settings settings,
                                    Symbol uri,
-                                   boolean isDirectoryUri,
                                    @Nullable WriterProjection.CompressionType compressionType,
                                    @Nullable WriterProjection.OutputFormat outputFormat,
                                    @Nullable List<String> outputNames,
@@ -74,7 +72,6 @@ public class CopyToAnalyzedStatement extends AbstractCopyAnalyzedStatement imple
         this.compressionType = compressionType;
         this.outputNames = outputNames;
         this.outputFormat = outputFormat;
-        this.isDirectoryUri = isDirectoryUri;
         this.overwrites = MoreObjects.firstNonNull(overwrites, ImmutableMap.<ColumnIdent, Symbol>of());
     }
 
@@ -94,10 +91,6 @@ public class CopyToAnalyzedStatement extends AbstractCopyAnalyzedStatement imple
 
     @Nullable
     public List<String> outputNames() { return outputNames; }
-
-    public boolean isDirectoryUri() {
-        return isDirectoryUri;
-    }
 
     public Map<ColumnIdent, Symbol> overwrites() {
         return this.overwrites;

--- a/sql/src/main/java/io/crate/operation/projectors/ProjectionToProjectorVisitor.java
+++ b/sql/src/main/java/io/crate/operation/projectors/ProjectionToProjectorVisitor.java
@@ -199,21 +199,21 @@ public class ProjectionToProjectorVisitor
         projection = projection.normalize(normalizer);
         String uri = ValueSymbolVisitor.STRING.process(projection.uri());
         assert uri != null : "URI must not be null";
-        if (projection.isDirectoryUri()) {
-            StringBuilder sb = new StringBuilder(uri);
-            Symbol resolvedFileName = normalizer.normalize(WriterProjection.DIRECTORY_TO_FILENAME);
-            assert resolvedFileName instanceof Literal;
-            assert resolvedFileName.valueType() == StringType.INSTANCE;
-            String fileName = ValueSymbolVisitor.STRING.process(resolvedFileName);
-            if (!uri.endsWith("/")) {
-                sb.append("/");
-            }
-            sb.append(fileName);
-            if (projection.compressionType() == WriterProjection.CompressionType.GZIP) {
-                sb.append(".gz");
-            }
-            uri = sb.toString();
+
+        StringBuilder sb = new StringBuilder(uri);
+        Symbol resolvedFileName = normalizer.normalize(WriterProjection.DIRECTORY_TO_FILENAME);
+        assert resolvedFileName instanceof Literal;
+        assert resolvedFileName.valueType() == StringType.INSTANCE;
+        String fileName = ValueSymbolVisitor.STRING.process(resolvedFileName);
+        if (!uri.endsWith("/")) {
+            sb.append("/");
         }
+        sb.append(fileName);
+        if (projection.compressionType() == WriterProjection.CompressionType.GZIP) {
+            sb.append(".gz");
+        }
+        uri = sb.toString();
+
         return new WriterProjector(
                 ((ThreadPoolExecutor) threadPool.generic()),
                 uri,

--- a/sql/src/main/java/io/crate/planner/projection/WriterProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/WriterProjection.java
@@ -87,14 +87,12 @@ public class WriterProjection extends Projection {
 
     public WriterProjection(List<Symbol> inputs,
                             Symbol uri,
-                            boolean isDirectoryUri,
                             @Nullable CompressionType compressionType,
                             Map<ColumnIdent, Symbol> overwrites,
                             @Nullable List<String> outputNames,
                             OutputFormat outputFormat) {
         this.inputs = inputs;
         this.uri = uri;
-        this.isDirectoryUri = isDirectoryUri;
         this.overwrites = overwrites;
         this.outputNames = outputNames;
         this.outputFormat = outputFormat;
@@ -115,10 +113,6 @@ public class WriterProjection extends Projection {
 
     public Symbol uri() {
         return uri;
-    }
-
-    public boolean isDirectoryUri() {
-        return isDirectoryUri;
     }
 
     @Override
@@ -154,7 +148,6 @@ public class WriterProjection extends Projection {
 
     @Override
     public void readFrom(StreamInput in) throws IOException {
-        isDirectoryUri = in.readBoolean();
         uri = Symbol.fromStream(in);
         int size = in.readVInt();
         if (size > 0) {
@@ -176,7 +169,6 @@ public class WriterProjection extends Projection {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeBoolean(isDirectoryUri);
         Symbol.toStream(uri, out);
         if (outputNames != null) {
             out.writeVInt(outputNames.size());
@@ -204,7 +196,6 @@ public class WriterProjection extends Projection {
 
         WriterProjection that = (WriterProjection) o;
 
-        if (isDirectoryUri != that.isDirectoryUri) return false;
         if (outputNames != null ? !outputNames.equals(that.outputNames) : that.outputNames != null)
             return false;
         if (!uri.equals(that.uri)) return false;
@@ -219,7 +210,6 @@ public class WriterProjection extends Projection {
     public int hashCode() {
         int result = super.hashCode();
         result = 31 * result + uri.hashCode();
-        result = 31 * result + (isDirectoryUri ? 1 : 0);
         result = 31 * result + (outputNames != null ? outputNames.hashCode() : 0);
         result = 31 * result + overwrites.hashCode();
         result = 31 * result + (compressionType != null ? compressionType.hashCode() : 0);
@@ -232,7 +222,6 @@ public class WriterProjection extends Projection {
         return "WriterProjection{" +
                 "uri=" + uri +
                 ", outputNames=" + outputNames +
-                ", isDirectory=" + isDirectoryUri +
                 ", compressionType=" + compressionType +
                 ", outputFormat=" + outputFormat +
                 '}';

--- a/sql/src/main/java/io/crate/planner/projection/builder/ProjectionBuilder.java
+++ b/sql/src/main/java/io/crate/planner/projection/builder/ProjectionBuilder.java
@@ -152,7 +152,6 @@ public class ProjectionBuilder {
 
     public static WriterProjection writerProjection(Collection<? extends Symbol> inputs,
                                                     Symbol uri,
-                                                    boolean isDirectoryUri,
                                                     @Nullable WriterProjection.CompressionType compressionType,
                                                     Map<ColumnIdent, Symbol> overwrites,
                                                     @Nullable List<String> outputNames,
@@ -160,6 +159,6 @@ public class ProjectionBuilder {
         InputCreatingVisitor.Context context = new InputCreatingVisitor.Context(inputs);
 
         return new WriterProjection(
-                inputVisitor.process(inputs, context), uri, isDirectoryUri, compressionType, overwrites, outputNames, outputFormat);
+                inputVisitor.process(inputs, context), uri, compressionType, overwrites, outputNames, outputFormat);
     }
 }

--- a/sql/src/main/java/io/crate/planner/statement/CopyStatementPlanner.java
+++ b/sql/src/main/java/io/crate/planner/statement/CopyStatementPlanner.java
@@ -93,7 +93,7 @@ public class CopyStatementPlanner {
 
             if (table.isPartitioned()) {
                 partitionedByNames = Lists.newArrayList(
-                        Lists.transform(table.partitionedBy(), ColumnIdent.GET_FQN_NAME_FUNCTION));
+                    Lists.transform(table.partitionedBy(), ColumnIdent.GET_FQN_NAME_FUNCTION));
             } else {
                 partitionedByNames = Collections.emptyList();
             }
@@ -108,19 +108,19 @@ public class CopyStatementPlanner {
         }
 
         SourceIndexWriterProjection sourceIndexWriterProjection = new SourceIndexWriterProjection(
-                table.ident(),
-                partitionIdent,
-                new Reference(table.getReferenceInfo(DocSysColumns.RAW)),
-                table.primaryKey(),
-                table.partitionedBy(),
-                partitionValues,
-                table.clusteredBy(),
-                clusteredByPrimaryKeyIdx,
-                analysis.settings(),
-                null,
-                partitionedByNames.size() >
-                0 ? partitionedByNames.toArray(new String[partitionedByNames.size()]) : null,
-                table.isPartitioned() // autoCreateIndices
+            table.ident(),
+            partitionIdent,
+            new Reference(table.getReferenceInfo(DocSysColumns.RAW)),
+            table.primaryKey(),
+            table.partitionedBy(),
+            partitionValues,
+            table.clusteredBy(),
+            clusteredByPrimaryKeyIdx,
+            analysis.settings(),
+            null,
+            partitionedByNames.size() >
+            0 ? partitionedByNames.toArray(new String[partitionedByNames.size()]) : null,
+            table.isPartitioned() // autoCreateIndices
         );
         List<Projection> projections = Collections.<Projection>singletonList(sourceIndexWriterProjection);
         partitionedByNames.removeAll(Lists.transform(table.primaryKey(), ColumnIdent.GET_FQN_NAME_FUNCTION));
@@ -149,7 +149,7 @@ public class CopyStatementPlanner {
         // add clusteredBy column (if not part of primaryKey)
         if (clusteredByPrimaryKeyIdx == -1) {
             toCollect.add(
-                    new Reference(table.getReferenceInfo(table.clusteredBy())));
+                new Reference(table.getReferenceInfo(table.clusteredBy())));
         }
         // add _raw or _doc
         if (table.isPartitioned() && analysis.partitionIdent() == null) {
@@ -168,43 +168,42 @@ public class CopyStatementPlanner {
 
         DiscoveryNodes allNodes = clusterService.state().nodes();
         FileUriCollectPhase collectPhase = new FileUriCollectPhase(
-                context.jobId(),
-                context.nextExecutionPhaseId(),
-                "copyFrom",
-                getExecutionNodes(allNodes, analysis.settings().getAsInt("num_readers", allNodes.getSize()), analysis.nodePredicate()),
-                analysis.uri(),
-                toCollect,
-                projections,
-                analysis.settings().get("compression", null),
-                analysis.settings().getAsBoolean("shared", null)
+            context.jobId(),
+            context.nextExecutionPhaseId(),
+            "copyFrom",
+            getExecutionNodes(allNodes, analysis.settings().getAsInt("num_readers", allNodes.getSize()), analysis.nodePredicate()),
+            analysis.uri(),
+            toCollect,
+            projections,
+            analysis.settings().get("compression", null),
+            analysis.settings().getAsBoolean("shared", null)
         );
 
         return new CollectAndMerge(collectPhase, MergePhase.localMerge(
-                context.jobId(),
-                context.nextExecutionPhaseId(),
-                ImmutableList.<Projection>of(MergeCountProjection.INSTANCE),
-                collectPhase.executionNodes().size(),
-                collectPhase.outputTypes()));
+            context.jobId(),
+            context.nextExecutionPhaseId(),
+            ImmutableList.<Projection>of(MergeCountProjection.INSTANCE),
+            collectPhase.executionNodes().size(),
+            collectPhase.outputTypes()));
     }
 
     public Plan planCopyTo(CopyToAnalyzedStatement statement, Planner.Context context) {
         WriterProjection.OutputFormat outputFormat = statement.outputFormat();
         if (outputFormat == null) {
             outputFormat = statement.columnsDefined() ?
-                    WriterProjection.OutputFormat.JSON_ARRAY : WriterProjection.OutputFormat.JSON_OBJECT;
+                WriterProjection.OutputFormat.JSON_ARRAY : WriterProjection.OutputFormat.JSON_OBJECT;
         }
 
         WriterProjection projection = ProjectionBuilder.writerProjection(
-                statement.subQueryRelation().querySpec().outputs(),
-                statement.uri(),
-                statement.isDirectoryUri(),
-                statement.compressionType(),
-                statement.overwrites(),
-                statement.outputNames(),
-                outputFormat);
+            statement.subQueryRelation().querySpec().outputs(),
+            statement.uri(),
+            statement.compressionType(),
+            statement.overwrites(),
+            statement.outputNames(),
+            outputFormat);
 
         PlannedAnalyzedRelation plannedSubQuery = context.planSubRelation(statement.subQueryRelation(),
-                new ConsumerContext(statement, context));
+            new ConsumerContext(statement, context));
         if (plannedSubQuery == null) {
             return null;
         }
@@ -212,11 +211,11 @@ public class CopyStatementPlanner {
         plannedSubQuery.addProjection(projection);
 
         MergePhase mergePhase = MergePhase.localMerge(
-                context.jobId(),
-                context.nextExecutionPhaseId(),
-                ImmutableList.<Projection>of(MergeCountProjection.INSTANCE),
-                plannedSubQuery.resultPhase().executionNodes().size(),
-                Symbols.extractTypes(projection.outputs()));
+            context.jobId(),
+            context.nextExecutionPhaseId(),
+            ImmutableList.<Projection>of(MergeCountProjection.INSTANCE),
+            plannedSubQuery.resultPhase().executionNodes().size(),
+            Symbols.extractTypes(projection.outputs()));
 
         return new CopyTo(context.jobId(), plannedSubQuery.plan(), mergePhase);
     }

--- a/sql/src/test/java/io/crate/integrationtests/ReadOnlyNodeIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ReadOnlyNodeIntegrationTest.java
@@ -152,8 +152,8 @@ public class ReadOnlyNodeIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testAllowedCopyTo() throws Exception {
-        String uri = Paths.get(folder.getRoot().toURI()).resolve("test.json").toUri().toString();
-        SQLResponse response = execute("copy write_test to ?", new Object[] { uri });
+        String uri = folder.getRoot().toURI().toString();
+        SQLResponse response = execute("copy write_test to directory ?", new Object[] { uri });
         assertThat(response.rowCount(), greaterThanOrEqualTo(0L));
     }
 

--- a/sql/src/test/java/io/crate/planner/PlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/PlannerTest.java
@@ -764,7 +764,7 @@ public class PlannerTest extends AbstractPlannerTest {
 
     @Test
     public void testCopyToWithColumnsReferenceRewrite() throws Exception {
-        CopyTo plan = plan("copy users (name) to '/file.ext'");
+        CopyTo plan = plan("copy users (name) to directory '/tmp'");
         CollectAndMerge innerPlan = (CollectAndMerge) plan.innerPlan();
         RoutedCollectPhase node = ((RoutedCollectPhase) innerPlan.collectPhase());
         Reference nameRef = (Reference)node.toCollect().get(0);
@@ -776,7 +776,7 @@ public class PlannerTest extends AbstractPlannerTest {
     @Test
     public void testCopyToWithPartitionedGeneratedColumn() throws Exception {
         // test that generated partition column is NOT exported
-        CopyTo plan = plan("copy parted_generated to '/file.ext'");
+        CopyTo plan = plan("copy parted_generated to directory '/tmp'");
         CollectAndMerge innerPlan = (CollectAndMerge) plan.innerPlan();
         RoutedCollectPhase node = ((RoutedCollectPhase) innerPlan.collectPhase());
         WriterProjection projection = (WriterProjection) node.projections().get(0);

--- a/sql/src/test/java/io/crate/planner/projection/WriterProjectionTest.java
+++ b/sql/src/test/java/io/crate/planner/projection/WriterProjectionTest.java
@@ -26,17 +26,11 @@ import io.crate.analyze.symbol.InputColumn;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.RowGranularity;
-import io.crate.operation.operator.AndOperator;
 import io.crate.test.integration.CrateUnitTest;
-import io.crate.testing.TestingHelpers;
-import io.crate.types.DataTypes;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.junit.Test;
-
-import java.util.HashMap;
 
 public class WriterProjectionTest extends CrateUnitTest {
 
@@ -45,8 +39,7 @@ public class WriterProjectionTest extends CrateUnitTest {
         WriterProjection p = new WriterProjection(
                 ImmutableList.<Symbol>of(new InputColumn(1)),
                 Literal.newLiteral("/foo.json"),
-                false,
-                WriterProjection.CompressionType.GZIP,
+            WriterProjection.CompressionType.GZIP,
                 MapBuilder.<ColumnIdent, Symbol>newMapBuilder().put(
                         new ColumnIdent("partitionColumn"), Literal.newLiteral(1)).map(),
                 ImmutableList.of("foo"),


### PR DESCRIPTION
Deprecate usage of `COPY TO` without specifying a `DIRECTORY`. This will prevent a user from defining an output path that conflicts with multiple shards.