### PR TITLE
Revert "Set CHANGES.txt git merge driver to union"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-/CHANGES.txt merge=union


### PR DESCRIPTION
This reverts commit ce5037b73c4d1d6dd6bcc752a9f968adf2a3947a.

Instead of removing the hassle with merge conflicts on the CHANGES.txt
file it lead to a couple of mistakes because it merged the CHANGES.txt
incorrectly without merge conflict.