### PR TITLE
Always use SingleUpstreamRowDownstream if there is only 1 shard

### DIFF
--- a/sql/src/main/java/io/crate/operation/projectors/ShardProjectorChain.java
+++ b/sql/src/main/java/io/crate/operation/projectors/ShardProjectorChain.java
@@ -153,11 +153,7 @@ public class ShardProjectorChain {
     private RowDownstream getRowDownstream(int maxNumShards) {
         if (maxNumShards == 1) {
             LOGGER.debug("Getting RowDownstream for 1 upstream, repeat support: " + firstNodeProjector.requirements());
-            if (firstNodeProjector.requirements().contains(Requirement.REPEAT)) {
-                return RowMergers.passThroughRowMerger(firstNodeProjector);
-            } else {
-                return new SingleUpstreamRowDownstream(firstNodeProjector);
-            }
+            return new SingleUpstreamRowDownstream(firstNodeProjector);
         } else {
             LOGGER.debug("Getting RowDownstream for multiple upstreams; unsorted; repeat support: "
                     + firstNodeProjector.requirements());


### PR DESCRIPTION
`passThroughRowMerger` was used because at some point the
CrateDocCollector couldn't handle repeat calls and a RowMerger had to
buffer the rows.

But at some point repeat support was added on the `CrateDocCollector`.
So it is fine to use `SingleUpstreamRowDownstream` for single shards, it
will delegate repeat calls (the same way that `passThroughRowMerger`
does)