### PR TITLE
Fetch: Clear buckets to avoid memory usage growth

### DIFF
--- a/sql/src/main/java/io/crate/operation/projectors/fetch/FetchProjector.java
+++ b/sql/src/main/java/io/crate/operation/projectors/fetch/FetchProjector.java
@@ -264,6 +264,7 @@ public class FetchProjector extends AbstractProjector {
             }
             downstream.setNextRow(outputRow);
         }
+        context.clearBuckets();
         if (!isLast) {
             if (nextStage(Stage.EMIT, Stage.COLLECT)) {
                 return;

--- a/sql/src/main/java/io/crate/operation/projectors/fetch/FetchProjectorContext.java
+++ b/sql/src/main/java/io/crate/operation/projectors/fetch/FetchProjectorContext.java
@@ -26,6 +26,7 @@ import com.carrotsearch.hppc.IntObjectHashMap;
 import com.carrotsearch.hppc.IntObjectMap;
 import com.carrotsearch.hppc.IntSet;
 import com.carrotsearch.hppc.cursors.IntCursor;
+import com.carrotsearch.hppc.cursors.ObjectCursor;
 import io.crate.Streamer;
 import io.crate.analyze.symbol.Symbols;
 import io.crate.metadata.PartitionName;
@@ -129,4 +130,9 @@ public class FetchProjectorContext {
         return nodeIdToReaderIdToStreamers;
     }
 
+    void clearBuckets() {
+        for (ObjectCursor<ReaderBucket> bucketCursor : readerBuckets.values()) {
+            bucketCursor.value.docs.clear();
+        }
+    }
 }

--- a/sql/src/main/java/io/crate/operation/projectors/fetch/ReaderBucket.java
+++ b/sql/src/main/java/io/crate/operation/projectors/fetch/ReaderBucket.java
@@ -29,6 +29,7 @@ import io.crate.core.collections.Row;
 
 import javax.annotation.Nullable;
 import java.util.Iterator;
+import java.util.Locale;
 
 class ReaderBucket {
 
@@ -50,9 +51,10 @@ class ReaderBucket {
     }
 
     void fetched(Bucket bucket) {
-        assert bucket.size() == docs.size();
-        Iterator<Row> rowIterator = bucket.iterator();
+        assert bucket.size() == docs.size()
+            : String.format(Locale.ENGLISH, "requested %d docs but got %d", docs.size(), bucket.size());
 
+        Iterator<Row> rowIterator = bucket.iterator();
         for (IntCursor intCursor : docs.keys()) {
             docs.indexReplace(intCursor.index, rowIterator.next().materialize());
         }


### PR DESCRIPTION
docIds and values were kept in memory until the FetchProjector finished.
This also caused subsequent fetch requests to re-fetch all previously
fetched rows again.

In a simple test to stream 1mio rows with only 128m of HEAP this change
improved the performance from 25 minutes to 17 seconds.