### PR TITLE
Add a ResultReceiver that's used to receive rows from the TransportExecutor

### DIFF
--- a/sql/src/main/java/io/crate/executor/Executor.java
+++ b/sql/src/main/java/io/crate/executor/Executor.java
@@ -22,14 +22,14 @@
 package io.crate.executor;
 
 import com.google.common.util.concurrent.ListenableFuture;
-import io.crate.operation.projectors.RowReceiver;
+import io.crate.action.sql.ResultReceiver;
 import io.crate.planner.Plan;
 
 import java.util.List;
 
 public interface Executor {
 
-    void execute(Plan plan, RowReceiver resultReceiver);
+    void execute(Plan plan, ResultReceiver resultReceiver);
 
     List<? extends ListenableFuture<TaskResult>> executeBulk(Plan plan);
 }

--- a/sql/src/main/java/io/crate/executor/Task.java
+++ b/sql/src/main/java/io/crate/executor/Task.java
@@ -22,7 +22,7 @@
 package io.crate.executor;
 
 import com.google.common.util.concurrent.ListenableFuture;
-import io.crate.operation.projectors.RowReceiver;
+import io.crate.action.sql.ResultReceiver;
 
 import java.util.List;
 
@@ -31,7 +31,7 @@ import java.util.List;
  * {@linkplain io.crate.executor.Job} and returns a result asynchronously
  * as a list of futures.
  * <p>
- * create a task, call {@linkplain #execute(RowReceiver)} or {@linkplain #executeBulk()}
+ * create a task, call {@linkplain #execute(ResultReceiver)} or {@linkplain #executeBulk()}
  * and wait for the futures returned to fetch the result or raise an exception.
  *
  * @see io.crate.executor.Job
@@ -41,7 +41,7 @@ public interface Task {
     /**
      * execute the task
      */
-    void execute(RowReceiver resultReceiver);
+    void execute(ResultReceiver resultReceiver);
 
     /**
      * execute the bulk operation

--- a/sql/src/main/java/io/crate/executor/task/DDLTask.java
+++ b/sql/src/main/java/io/crate/executor/task/DDLTask.java
@@ -25,13 +25,13 @@ import com.google.common.base.Function;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.crate.action.sql.DDLStatementDispatcher;
+import io.crate.action.sql.ResultReceiver;
 import io.crate.analyze.AnalyzedStatement;
 import io.crate.core.collections.Row;
 import io.crate.core.collections.Row1;
 import io.crate.executor.JobTask;
 import io.crate.executor.TaskResult;
 import io.crate.executor.transport.OneRowActionListener;
-import io.crate.operation.projectors.RowReceiver;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -49,7 +49,7 @@ public class DDLTask extends JobTask {
     }
 
     @Override
-    public void execute(final RowReceiver resultReceiver) {
+    public void execute(final ResultReceiver resultReceiver) {
         ListenableFuture<Long> future = ddlStatementDispatcher.dispatch(analyzedStatement, jobId());
         Futures.addCallback(future, new OneRowActionListener<>(resultReceiver, new Function<Long, Row>() {
             @Nullable

--- a/sql/src/main/java/io/crate/executor/task/ExplainTask.java
+++ b/sql/src/main/java/io/crate/executor/task/ExplainTask.java
@@ -23,10 +23,10 @@
 package io.crate.executor.task;
 
 import com.google.common.util.concurrent.ListenableFuture;
+import io.crate.action.sql.ResultReceiver;
 import io.crate.core.collections.Row1;
 import io.crate.executor.Task;
 import io.crate.executor.TaskResult;
-import io.crate.operation.projectors.RowReceiver;
 import io.crate.planner.PlanPrinter;
 import io.crate.planner.node.management.ExplainPlan;
 
@@ -42,7 +42,7 @@ public class ExplainTask implements Task {
     }
 
     @Override
-    public void execute(RowReceiver resultReceiver) {
+    public void execute(ResultReceiver resultReceiver) {
         try {
             Map<String, Object> map = PlanPrinter.objectMap(explainPlan.subPlan());
             resultReceiver.setNextRow(new Row1(map));

--- a/sql/src/main/java/io/crate/executor/task/NoopTask.java
+++ b/sql/src/main/java/io/crate/executor/task/NoopTask.java
@@ -24,9 +24,9 @@ package io.crate.executor.task;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import io.crate.action.sql.ResultReceiver;
 import io.crate.executor.Task;
 import io.crate.executor.TaskResult;
-import io.crate.operation.projectors.RowReceiver;
 
 import java.util.List;
 
@@ -43,7 +43,7 @@ public class NoopTask implements Task {
     }
 
     @Override
-    public void execute(RowReceiver resultReceiver) {
+    public void execute(ResultReceiver resultReceiver) {
         resultReceiver.finish();
     }
 

--- a/sql/src/main/java/io/crate/executor/transport/TransportExecutor.java
+++ b/sql/src/main/java/io/crate/executor/transport/TransportExecutor.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.crate.action.job.ContextPreparer;
 import io.crate.action.sql.DDLStatementDispatcher;
+import io.crate.action.sql.ResultReceiver;
 import io.crate.action.sql.ShowStatementDispatcher;
 import io.crate.analyze.EvaluatingNormalizer;
 import io.crate.executor.Executor;
@@ -47,7 +48,6 @@ import io.crate.operation.ImplementationSymbolVisitor;
 import io.crate.operation.NodeOperation;
 import io.crate.operation.NodeOperationTree;
 import io.crate.operation.projectors.ProjectionToProjectorVisitor;
-import io.crate.operation.projectors.RowReceiver;
 import io.crate.planner.NoopPlan;
 import io.crate.planner.Plan;
 import io.crate.planner.PlanVisitor;
@@ -142,7 +142,7 @@ public class TransportExecutor implements Executor {
     }
 
     @Override
-    public void execute(Plan plan, RowReceiver resultReceiver) {
+    public void execute(Plan plan, ResultReceiver resultReceiver) {
         plan2TaskVisitor.process(plan, null).execute(resultReceiver);
     }
 

--- a/sql/src/main/java/io/crate/executor/transport/executionphases/ExecutionPhasesTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/executionphases/ExecutionPhasesTask.java
@@ -31,6 +31,7 @@ import io.crate.action.job.ContextPreparer;
 import io.crate.action.job.JobRequest;
 import io.crate.action.job.SharedShardContexts;
 import io.crate.action.job.TransportJobAction;
+import io.crate.action.sql.ResultReceiver;
 import io.crate.core.collections.Bucket;
 import io.crate.executor.JobTask;
 import io.crate.executor.TaskResult;
@@ -95,7 +96,7 @@ public class ExecutionPhasesTask extends JobTask {
     }
 
     @Override
-    public void execute(RowReceiver resultReceiver) {
+    public void execute(ResultReceiver resultReceiver) {
         assert nodeOperationTrees.size() == 1 : "must only have 1 NodeOperationTree for non-bulk operations";
         NodeOperationTree nodeOperationTree = nodeOperationTrees.get(0);
         Map<String, Collection<NodeOperation>> operationByServer = NodeOperationGrouper.groupByServer(nodeOperationTree.nodeOperations());

--- a/sql/src/main/java/io/crate/executor/transport/executionphases/InterceptingRowReceiver.java
+++ b/sql/src/main/java/io/crate/executor/transport/executionphases/InterceptingRowReceiver.java
@@ -24,35 +24,41 @@ package io.crate.executor.transport.executionphases;
 
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
+import io.crate.action.sql.ResultReceiver;
+import io.crate.core.collections.Row;
 import io.crate.exceptions.Exceptions;
 import io.crate.executor.transport.kill.KillJobsRequest;
 import io.crate.executor.transport.kill.KillResponse;
 import io.crate.executor.transport.kill.TransportKillJobsNodeAction;
-import io.crate.operation.projectors.ForwardingRowReceiver;
+import io.crate.operation.RowUpstream;
+import io.crate.operation.projectors.Requirement;
+import io.crate.operation.projectors.Requirements;
 import io.crate.operation.projectors.RowReceiver;
 import org.elasticsearch.action.ActionListener;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Collections;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-class InterceptingRowReceiver extends ForwardingRowReceiver implements FutureCallback<Void> {
+class InterceptingRowReceiver implements RowReceiver, FutureCallback<Void> {
 
     private final AtomicInteger upstreams = new AtomicInteger(2);
     private final UUID jobId;
+    private final ResultReceiver resultReceiver;
     private final TransportKillJobsNodeAction transportKillJobsNodeAction;
     private final AtomicBoolean rowReceiverDone = new AtomicBoolean(false);
     private Throwable failure;
 
     InterceptingRowReceiver(UUID jobId,
-                            RowReceiver rowReceiver,
+                            ResultReceiver resultReceiver,
                             InitializationTracker jobsInitialized,
                             TransportKillJobsNodeAction transportKillJobsNodeAction) {
-        super(rowReceiver);
         this.jobId = jobId;
+        this.resultReceiver = resultReceiver;
         this.transportKillJobsNodeAction = transportKillJobsNodeAction;
         Futures.addCallback(jobsInitialized.future, this);
     }
@@ -67,6 +73,24 @@ class InterceptingRowReceiver extends ForwardingRowReceiver implements FutureCal
     @Override
     public void kill(Throwable throwable) {
         fail(throwable);
+    }
+
+    @Override
+    public void prepare() {
+    }
+
+    @Override
+    public void setUpstream(RowUpstream rowUpstream) {
+    }
+
+    @Override
+    public Set<Requirement> requirements() {
+        return Requirements.NO_REQUIREMENTS;
+    }
+
+    @Override
+    public boolean setNextRow(Row row) {
+        return resultReceiver.setNextRow(row);
     }
 
     @Override
@@ -92,18 +116,18 @@ class InterceptingRowReceiver extends ForwardingRowReceiver implements FutureCal
             return;
         }
         if (failure == null) {
-            super.finish();
+            resultReceiver.finish();
         } else {
             transportKillJobsNodeAction.executeKillOnAllNodes(
                 new KillJobsRequest(Collections.singletonList(jobId)), new ActionListener<KillResponse>() {
                     @Override
                     public void onResponse(KillResponse killResponse) {
-                        InterceptingRowReceiver.super.fail(failure);
+                        resultReceiver.fail(failure);
                     }
 
                     @Override
                     public void onFailure(Throwable e) {
-                        InterceptingRowReceiver.super.fail(failure);
+                        resultReceiver.fail(failure);
                     }
                 });
         }

--- a/sql/src/main/java/io/crate/executor/transport/task/DropTableTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/DropTableTask.java
@@ -23,11 +23,11 @@ package io.crate.executor.transport.task;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
+import io.crate.action.sql.ResultReceiver;
 import io.crate.executor.JobTask;
 import io.crate.executor.TaskResult;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.doc.DocTableInfo;
-import io.crate.operation.projectors.RowReceiver;
 import io.crate.planner.node.ddl.DropTablePlan;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
@@ -69,8 +69,8 @@ public class DropTableTask extends JobTask {
     }
 
     @Override
-    public void execute(RowReceiver rowReceiver) {
-        JobTask.resultToRowReceiver(result, rowReceiver);
+    public void execute(ResultReceiver resultReceiver) {
+        JobTask.resultToResultReceiver(result, resultReceiver);
         if (tableInfo.isPartitioned()) {
             String templateName = PartitionName.templateName(tableInfo.ident().schema(), tableInfo.ident().name());
             deleteTemplateAction.execute(new DeleteIndexTemplateRequest(templateName), new ActionListener<DeleteIndexTemplateResponse>() {

--- a/sql/src/main/java/io/crate/executor/transport/task/GenericShowTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/GenericShowTask.java
@@ -22,12 +22,12 @@
 package io.crate.executor.transport.task;
 
 import com.google.common.util.concurrent.ListenableFuture;
+import io.crate.action.sql.ResultReceiver;
 import io.crate.action.sql.ShowStatementDispatcher;
 import io.crate.analyze.AbstractShowAnalyzedStatement;
 import io.crate.core.collections.Row1;
 import io.crate.executor.Task;
 import io.crate.executor.TaskResult;
-import io.crate.operation.projectors.RowReceiver;
 
 import java.util.List;
 import java.util.UUID;
@@ -45,7 +45,7 @@ public class GenericShowTask implements Task {
     }
 
     @Override
-    public void execute(RowReceiver resultReceiver) {
+    public void execute(ResultReceiver resultReceiver) {
         try {
             resultReceiver.setNextRow(new Row1(showStatementDispatcher.process(statement, jobId)));
             resultReceiver.finish();

--- a/sql/src/main/java/io/crate/executor/transport/task/KillJobTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/KillJobTask.java
@@ -23,6 +23,7 @@ package io.crate.executor.transport.task;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
+import io.crate.action.sql.ResultReceiver;
 import io.crate.executor.JobTask;
 import io.crate.executor.TaskResult;
 import io.crate.executor.transport.OneRowActionListener;
@@ -47,7 +48,7 @@ public class KillJobTask extends JobTask {
     }
 
     @Override
-    public void execute(RowReceiver resultReceiver) {
+    public void execute(ResultReceiver resultReceiver) {
         KillJobsRequest request = new KillJobsRequest(ImmutableList.of(jobToKill));
         nodeAction.executeKillOnAllNodes(request,
             new OneRowActionListener<>(resultReceiver, KillTask.KILL_RESPONSE_TO_ROW_FUNCTION));

--- a/sql/src/main/java/io/crate/executor/transport/task/KillTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/KillTask.java
@@ -23,6 +23,7 @@ package io.crate.executor.transport.task;
 
 import com.google.common.base.Function;
 import com.google.common.util.concurrent.ListenableFuture;
+import io.crate.action.sql.ResultReceiver;
 import io.crate.core.collections.Row;
 import io.crate.core.collections.Row1;
 import io.crate.executor.JobTask;
@@ -31,7 +32,6 @@ import io.crate.executor.transport.OneRowActionListener;
 import io.crate.executor.transport.kill.KillAllRequest;
 import io.crate.executor.transport.kill.KillResponse;
 import io.crate.executor.transport.kill.TransportKillAllNodeAction;
-import io.crate.operation.projectors.RowReceiver;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -54,7 +54,7 @@ public class KillTask extends JobTask {
     }
 
     @Override
-    public void execute(RowReceiver resultReceiver) {
+    public void execute(ResultReceiver resultReceiver) {
         nodeAction.broadcast(new KillAllRequest(),
             new OneRowActionListener<>(resultReceiver, KILL_RESPONSE_TO_ROW_FUNCTION));
     }

--- a/sql/src/main/java/io/crate/executor/transport/task/UpsertByIdTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/UpsertByIdTask.java
@@ -26,6 +26,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.crate.Constants;
+import io.crate.action.sql.ResultReceiver;
 import io.crate.executor.JobTask;
 import io.crate.executor.RowCountResult;
 import io.crate.executor.TaskResult;
@@ -106,8 +107,8 @@ public class UpsertByIdTask extends JobTask {
     }
 
     @Override
-    public void execute(RowReceiver rowReceiver) {
-        JobTask.resultToRowReceiver(executeBulk().get(0), rowReceiver);
+    public void execute(ResultReceiver resultReceiver) {
+        JobTask.resultToResultReceiver(executeBulk().get(0), resultReceiver);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/ESClusterUpdateSettingsTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/ESClusterUpdateSettingsTask.java
@@ -24,12 +24,12 @@ package io.crate.executor.transport.task.elasticsearch;
 import com.google.common.base.Function;
 import com.google.common.base.Functions;
 import com.google.common.util.concurrent.ListenableFuture;
+import io.crate.action.sql.ResultReceiver;
 import io.crate.core.collections.Row;
 import io.crate.core.collections.Row1;
 import io.crate.executor.JobTask;
 import io.crate.executor.TaskResult;
 import io.crate.executor.transport.OneRowActionListener;
-import io.crate.operation.projectors.RowReceiver;
 import io.crate.planner.node.ddl.ESClusterUpdateSettingsPlan;
 import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsResponse;
@@ -60,8 +60,8 @@ public class ESClusterUpdateSettingsTask extends JobTask {
     }
 
     @Override
-    public void execute(final RowReceiver rowReceiver) {
-        OneRowActionListener<ClusterUpdateSettingsResponse> actionListener = new OneRowActionListener<>(rowReceiver, TO_ONE_ROW);
+    public void execute(ResultReceiver resultReceiver) {
+        OneRowActionListener<ClusterUpdateSettingsResponse> actionListener = new OneRowActionListener<>(resultReceiver, TO_ONE_ROW);
         transport.execute(request, actionListener);
     }
 

--- a/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/ESDeletePartitionTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/ESDeletePartitionTask.java
@@ -24,12 +24,12 @@ package io.crate.executor.transport.task.elasticsearch;
 import com.google.common.base.Function;
 import com.google.common.base.Functions;
 import com.google.common.util.concurrent.ListenableFuture;
+import io.crate.action.sql.ResultReceiver;
 import io.crate.core.collections.Row;
 import io.crate.core.collections.Row1;
 import io.crate.executor.JobTask;
 import io.crate.executor.TaskResult;
 import io.crate.executor.transport.OneRowActionListener;
-import io.crate.operation.projectors.RowReceiver;
 import io.crate.planner.node.ddl.ESDeletePartition;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexResponse;
@@ -46,8 +46,8 @@ public class ESDeletePartitionTask extends JobTask {
     private final DeleteIndexRequest request;
 
     @Override
-    public void execute(final RowReceiver rowReceiver) {
-        OneRowActionListener<DeleteIndexResponse> actionListener = new OneRowActionListener<>(rowReceiver, TO_UNKNOWN_COUNT_ROW);
+    public void execute(ResultReceiver resultReceiver) {
+        OneRowActionListener<DeleteIndexResponse> actionListener = new OneRowActionListener<>(resultReceiver, TO_UNKNOWN_COUNT_ROW);
         transport.execute(request, actionListener);
     }
 

--- a/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/EsJobContextTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/EsJobContextTask.java
@@ -23,13 +23,13 @@ package io.crate.executor.transport.task.elasticsearch;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
+import io.crate.action.sql.ResultReceiver;
 import io.crate.executor.JobTask;
 import io.crate.executor.TaskResult;
 import io.crate.jobs.ESJobContext;
 import io.crate.jobs.JobContextService;
 import io.crate.jobs.JobExecutionContext;
 import io.crate.operation.projectors.FlatProjectorChain;
-import io.crate.operation.projectors.RowReceiver;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.support.TransportAction;
@@ -68,7 +68,7 @@ class EsJobContextTask extends JobTask {
     }
 
     @Override
-    public void execute(RowReceiver rowReceiver) {
+    public void execute(ResultReceiver resultReceiver) {
         assert builder != null : "Context must be created first";
         SettableFuture<TaskResult> result = results.get(0);
         try {
@@ -77,7 +77,7 @@ class EsJobContextTask extends JobTask {
         } catch (Throwable throwable) {
             result.setException(throwable);
         }
-        JobTask.resultToRowReceiver(result, rowReceiver);
+        JobTask.resultToResultReceiver(result, resultReceiver);
     }
 
     @Override


### PR DESCRIPTION
This adds a new interface `ResultReceiver` which is a subset of the
`RowReceiver`.

It is used to retrieve the rows from the `TransportExecutor` so it is
mainly for "clients" that want to receive the final result.

Currently the only real client is the `TransportSQLAction`.