### PR TITLE
pgwire: Add support for the `NoData` msg

### DIFF
--- a/sql/src/main/java/io/crate/protocols/postgres/ConnectionContext.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/ConnectionContext.java
@@ -403,7 +403,7 @@ class ConnectionContext {
         try {
             Collection<Field> fields = session.describe((char) type, portalOrStatement);
             if (fields == null) {
-                // DML statement, no need for description
+                Messages.sendNoData(channel);
             } else {
                 Messages.sendRowDescription(channel, fields);
             }

--- a/sql/src/main/java/io/crate/protocols/postgres/Messages.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/Messages.java
@@ -315,16 +315,7 @@ class Messages {
      * | '1' | int32 len |
      */
     static void sendParseComplete(Channel channel) {
-        ChannelBuffer buffer = ChannelBuffers.buffer(5);
-        buffer.writeByte('1');
-        buffer.writeInt(4);
-
-        channel.write(buffer).addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) throws Exception {
-                LOGGER.trace("sentParseComplete");
-            }
-        });
+        sendShortMsg(channel, '1', "sentParseComplete");
     }
 
     /**
@@ -332,16 +323,7 @@ class Messages {
      * | '2' | int32 len |
      */
     static void sendBindComplete(Channel channel) {
-        ChannelBuffer buffer = ChannelBuffers.buffer(5);
-        buffer.writeByte('2');
-        buffer.writeInt(4);
-
-        channel.write(buffer).addListener(new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) throws Exception {
-                LOGGER.trace("sentBindComplete");
-            }
-        });
+        sendShortMsg(channel, '2', "sentBindComplete");
     }
 
     /**
@@ -349,8 +331,23 @@ class Messages {
      *  | 'I' | int32 len |
      */
     static void sendEmptyQueryResponse(Channel channel) {
+        sendShortMsg(channel, 'I', "sentEmptyQueryResponse");
+    }
+
+    /**
+     * NoData
+     *  | 'n' | int32 len |
+     */
+    static void sendNoData(Channel channel) {
+        sendShortMsg(channel, 'n', "sentNoData");
+    }
+
+    /**
+     * Send a message that just contains the msgType and the msg length
+     */
+    private static void sendShortMsg(Channel channel, char msgType, final String traceLogMsg) {
         ChannelBuffer buffer = ChannelBuffers.buffer(5);
-        buffer.writeByte('I');
+        buffer.writeByte(msgType);
         buffer.writeInt(4);
 
         ChannelFuture channelFuture = channel.write(buffer);
@@ -358,8 +355,7 @@ class Messages {
             channelFuture.addListener(new ChannelFutureListener() {
                 @Override
                 public void operationComplete(ChannelFuture future) throws Exception {
-                    LOGGER.trace("sentEmptyQueryResponse");
-
+                    LOGGER.trace(traceLogMsg);
                 }
             });
         }


### PR DESCRIPTION
See the following two paragraphs of the postgres protocol documentation:

> The Describe message (portal variant) specifies the name of an
> existing portal (or an empty string for the unnamed portal). The
> response is a RowDescription message describing the rows that will be
> returned by executing the portal; or a NoData message if the portal
> does not contain a query that will return rows; or ErrorResponse if
> there is no such portal.

> The Describe message (statement variant) specifies the name of an
> existing prepared statement (or an empty string for the unnamed prepared
> statement). The response is a ParameterDescription message describing
> the parameters needed by the statement, followed by a RowDescription
> message describing the rows that will be returned when the statement is
> eventually executed (or a NoData message if the statement will not
> return rows)