### PR TITLE
pgwire: Handle formatCodes according to spec

### DIFF
--- a/sql/src/main/java/io/crate/action/sql/SQLOperations.java
+++ b/sql/src/main/java/io/crate/action/sql/SQLOperations.java
@@ -37,6 +37,7 @@ import io.crate.executor.Executor;
 import io.crate.executor.TaskResult;
 import io.crate.planner.Plan;
 import io.crate.planner.Planner;
+import io.crate.protocols.postgres.FormatCodes;
 import io.crate.sql.parser.SqlParser;
 import io.crate.sql.tree.Statement;
 import io.crate.types.DataType;
@@ -133,6 +134,9 @@ public class SQLOperations {
         private List<List<Object>> bulkParams = new ArrayList<>();
         private List<ResultReceiver> resultReceivers = new ArrayList<>();
 
+        @Nullable
+        private FormatCodes.FormatCode[] resultFormatCodes;
+
         private Session(Executor executor, String defaultSchema) {
             this.executor = executor;
             this.defaultSchema = defaultSchema;
@@ -190,10 +194,11 @@ public class SQLOperations {
             }
         }
 
-        public void bind(String portalName, String statementName, List<Object> params) {
+        public void bind(String portalName, String statementName, List<Object> params, @Nullable FormatCodes.FormatCode[] resultFormatCodes) {
             LOGGER.debug("method=bind portalName={} statementName={} params={}", portalName, statementName, params);
             checkError();
             bulkParams.add(params);
+            this.resultFormatCodes = resultFormatCodes;
         }
 
         public List<Field> describe(char type, String portalOrStatement) {
@@ -289,6 +294,7 @@ public class SQLOperations {
             maxRows = 0;
             resultReceivers.clear();
             statement = null;
+            resultFormatCodes = null;
         }
 
         public List<? extends DataType> outputTypes() {
@@ -301,6 +307,11 @@ public class SQLOperations {
 
         public DataType getParamType(int idx) {
             return paramTypes.get(idx);
+        }
+
+        @Nullable
+        public FormatCodes.FormatCode[] resultFormatCodes() {
+            return resultFormatCodes;
         }
     }
 

--- a/sql/src/main/java/io/crate/protocols/postgres/FormatCodes.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/FormatCodes.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.protocols.postgres;
+
+import org.jboss.netty.buffer.ChannelBuffer;
+
+import javax.annotation.Nullable;
+
+public class FormatCodes {
+
+    public enum FormatCode {
+        TEXT, // 0
+        BINARY // 1
+    }
+
+    private static final FormatCode[] EMPTY_FORMAT_CODES = new FormatCode[0];
+
+    /**
+     * Read format codes from a ChannelBuffer.
+     *
+     * Buffer must contain:
+     * <pre>
+     * int16 num formatCodes
+     *      foreach:
+     *      int16 formatCode
+     * </pre>
+     */
+    static FormatCode[] fromBuffer(ChannelBuffer buffer) {
+        short numFormatCodes = buffer.readShort();
+        if (numFormatCodes == 0) {
+            return EMPTY_FORMAT_CODES;
+        }
+        FormatCode[] formatCodes = new FormatCode[numFormatCodes];
+        for (int i = 0; i < numFormatCodes; i++) {
+            formatCodes[i] = FormatCode.values()[buffer.readShort()];
+        }
+        return formatCodes;
+    }
+
+    /**
+     * Get the formatCode for a column idx
+     *
+     * According to spec:
+     * length of formatCodes:
+     *      0 = uses default (TEXT)
+     *      1 = all params uses this format
+     *      n = one for each param
+     */
+    static FormatCode getFormatCode(@Nullable FormatCode[] formatCodes, int idx) {
+        if (formatCodes == null || formatCodes.length == 0) {
+            return FormatCode.TEXT;
+        }
+        return formatCodes.length == 1 ? formatCodes[0] : formatCodes[idx];
+    }
+}

--- a/sql/src/main/java/io/crate/protocols/postgres/ResultSetReceiver.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/ResultSetReceiver.java
@@ -31,6 +31,7 @@ import io.crate.types.DataType;
 import org.jboss.netty.channel.Channel;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.List;
 
 class ResultSetReceiver implements ResultReceiver {
@@ -38,19 +39,22 @@ class ResultSetReceiver implements ResultReceiver {
     private final String query;
     private final Channel channel;
     private final List<? extends DataType> columnTypes;
+    @Nullable
+    private final FormatCodes.FormatCode[] formatCodes;
 
     private CompletionListener listener = CompletionListener.NO_OP;
     private long rowCount = 0;
 
-    ResultSetReceiver(String query, Channel channel, List<? extends DataType> columnTypes) {
+    ResultSetReceiver(String query, Channel channel, List<? extends DataType> columnTypes, @Nullable FormatCodes.FormatCode[] formatCodes) {
         this.query = query;
         this.channel = channel;
         this.columnTypes = columnTypes;
+        this.formatCodes = formatCodes;
     }
 
     @Override
     public boolean setNextRow(Row row) {
-        Messages.sendDataRow(channel, row, columnTypes);
+        Messages.sendDataRow(channel, row, columnTypes, formatCodes);
         rowCount++;
         return true;
     }

--- a/sql/src/main/java/io/crate/protocols/postgres/types/BigIntType.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/BigIntType.java
@@ -33,17 +33,21 @@ class BigIntType extends PGType {
 
     private static final int TYPE_LEN = 8;
     private static final int TYPE_MOD = -1;
-    private static final short DEFAULT_FORMAT_CODE = FormatCode.BINARY;
 
     BigIntType() {
-        super(OID, TYPE_LEN, TYPE_MOD, DEFAULT_FORMAT_CODE);
+        super(OID, TYPE_LEN, TYPE_MOD);
     }
 
     @Override
-    public int writeValue(ChannelBuffer buffer, @Nonnull Object value) {
+    public int writeAsBytes(ChannelBuffer buffer, @Nonnull Object value) {
         buffer.writeInt(TYPE_LEN);
         buffer.writeLong(((long) value));
         return INT32_BYTE_SIZE + TYPE_LEN;
+    }
+
+    @Override
+    protected byte[] asUTF8StringBytes(@Nonnull Object value) {
+        return Long.toString(((long) value)).getBytes(StandardCharsets.UTF_8);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/protocols/postgres/types/DoubleType.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/DoubleType.java
@@ -33,17 +33,21 @@ class DoubleType extends PGType {
 
     private static final int TYPE_LEN = 8;
     private static final int TYPE_MOD = -1;
-    private static final short DEFAULT_FORMAT_CODE = FormatCode.BINARY;
 
     DoubleType() {
-        super(OID, TYPE_LEN, TYPE_MOD, DEFAULT_FORMAT_CODE);
+        super(OID, TYPE_LEN, TYPE_MOD);
     }
 
     @Override
-    public int writeValue(ChannelBuffer buffer, @Nonnull Object value) {
+    public int writeAsBytes(ChannelBuffer buffer, @Nonnull Object value) {
         buffer.writeInt(8);
         buffer.writeDouble(((double) value));
         return 12;
+    }
+
+    @Override
+    protected byte[] asUTF8StringBytes(@Nonnull Object value) {
+        return Double.toString(((double) value)).getBytes(StandardCharsets.UTF_8);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/protocols/postgres/types/IntegerType.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/IntegerType.java
@@ -33,17 +33,21 @@ class IntegerType extends PGType {
 
     private static final int TYPE_LEN = 4;
     private static final int TYPE_MOD = -1;
-    private static final short DEFAULT_FORMAT_CODE = FormatCode.BINARY;
 
     IntegerType() {
-        super(OID, TYPE_LEN, TYPE_MOD, DEFAULT_FORMAT_CODE);
+        super(OID, TYPE_LEN, TYPE_MOD);
     }
 
     @Override
-    public int writeValue(ChannelBuffer buffer, @Nonnull Object value) {
+    public int writeAsBytes(ChannelBuffer buffer, @Nonnull Object value) {
         buffer.writeInt(INT32_BYTE_SIZE);
         buffer.writeInt(((int) value));
         return 8;
+    }
+
+    @Override
+    protected byte[] asUTF8StringBytes(@Nonnull Object value) {
+        return Integer.toString(((int) value)).getBytes(StandardCharsets.UTF_8);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/protocols/postgres/types/RealType.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/RealType.java
@@ -33,17 +33,21 @@ class RealType extends PGType {
 
     private static final int TYPE_LEN = 4;
     private static final int TYPE_MOD = -1;
-    private static final short DEFAULT_FORMAT_CODE = FormatCode.BINARY;
 
     RealType() {
-        super(OID, TYPE_LEN, TYPE_MOD, DEFAULT_FORMAT_CODE);
+        super(OID, TYPE_LEN, TYPE_MOD);
     }
 
     @Override
-    public int writeValue(ChannelBuffer buffer, @Nonnull Object value) {
+    public int writeAsBytes(ChannelBuffer buffer, @Nonnull Object value) {
         buffer.writeInt(4);
         buffer.writeFloat(((float) value));
         return 8;
+    }
+
+    @Override
+    protected byte[] asUTF8StringBytes(@Nonnull Object value) {
+        return Float.toString(((float) value)).getBytes(StandardCharsets.UTF_8);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/protocols/postgres/types/SmallIntType.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/SmallIntType.java
@@ -33,17 +33,21 @@ class SmallIntType extends PGType {
 
     private static final int TYPE_LEN = 2;
     private static final int TYPE_MOD = -1;
-    private static final short DEFAULT_FORMAT_CODE = FormatCode.BINARY;
 
     SmallIntType() {
-        super(OID, TYPE_LEN, TYPE_MOD, DEFAULT_FORMAT_CODE);
+        super(OID, TYPE_LEN, TYPE_MOD);
     }
 
     @Override
-    public int writeValue(ChannelBuffer buffer, @Nonnull Object value) {
+    public int writeAsBytes(ChannelBuffer buffer, @Nonnull Object value) {
         buffer.writeInt(2);
         buffer.writeShort((short) value);
         return INT32_BYTE_SIZE + TYPE_LEN;
+    }
+
+    @Override
+    protected byte[] asUTF8StringBytes(@Nonnull Object value) {
+        return Short.toString(((short) value)).getBytes(StandardCharsets.UTF_8);
     }
 
     @Override

--- a/sql/src/test/java/io/crate/integrationtests/PostgresITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PostgresITest.java
@@ -84,14 +84,16 @@ public class PostgresITest extends SQLTransportIntegrationTest {
             conn.setAutoCommit(true);
 
             Statement stmt = conn.createStatement();
-            stmt.executeUpdate("create table t (x string) with (number_of_replicas = 0)");
+            stmt.executeUpdate("create table t (x string, b boolean) with (number_of_replicas = 0)");
             ensureYellow();
 
-            PreparedStatement preparedStatement = conn.prepareStatement("insert into t (x) values (?)");
+            PreparedStatement preparedStatement = conn.prepareStatement("insert into t (x, b) values (?, ?)");
             preparedStatement.setString(1, "Arthur");
+            preparedStatement.setBoolean(2, true);
             preparedStatement.addBatch();
 
             preparedStatement.setString(1, "Trillian");
+            preparedStatement.setBoolean(2, false);
             preparedStatement.addBatch();
 
             int[] results = preparedStatement.executeBatch();

--- a/sql/src/test/java/io/crate/protocols/postgres/types/BasePGTypeTest.java
+++ b/sql/src/test/java/io/crate/protocols/postgres/types/BasePGTypeTest.java
@@ -22,6 +22,7 @@
 
 package io.crate.protocols.postgres.types;
 
+import io.crate.protocols.postgres.FormatCodes;
 import io.crate.test.integration.CrateUnitTest;
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.buffer.ChannelBuffers;
@@ -42,7 +43,7 @@ public abstract class BasePGTypeTest<T> extends CrateUnitTest {
 
     void assertBytesWritten(Object value, byte[] expectedBytes, int expectedLength) {
         ChannelBuffer writeBuffer = ChannelBuffers.dynamicBuffer();
-        int bytesWritten = pgType.writeValue(writeBuffer, value);
+        int bytesWritten = pgType.writeAsBytes(writeBuffer, value);
         assertThat(bytesWritten, is(expectedLength));
 
         byte[] bytes = new byte[expectedLength];
@@ -55,7 +56,7 @@ public abstract class BasePGTypeTest<T> extends CrateUnitTest {
     }
 
     void assertBytesReadBinary(byte[] value, T expectedValue, int pos) {
-        assertBytesRead(value, expectedValue, pos, PGType.FormatCode.BINARY);
+        assertBytesRead(value, expectedValue, pos, FormatCodes.FormatCode.BINARY);
     }
 
     void assertBytesReadText(byte[] value, T expectedValue) {
@@ -63,14 +64,14 @@ public abstract class BasePGTypeTest<T> extends CrateUnitTest {
     }
 
     void assertBytesReadText(byte[] value, T expectedValue, int pos) {
-        assertBytesRead(value, expectedValue, pos, PGType.FormatCode.TEXT);
+        assertBytesRead(value, expectedValue, pos, FormatCodes.FormatCode.TEXT);
     }
 
     @SuppressWarnings("unchecked")
-    private void assertBytesRead(byte[] value, T expectedValue, int pos, short formatCode) {
+    private void assertBytesRead(byte[] value, T expectedValue, int pos, FormatCodes.FormatCode formatCode) {
         ChannelBuffer buffer = ChannelBuffers.wrappedBuffer(value);
         T readValue;
-        if (formatCode == PGType.FormatCode.BINARY) {
+        if (formatCode == FormatCodes.FormatCode.BINARY) {
             readValue = (T) pgType.readBinaryValue(buffer, pos);
         } else {
             readValue = (T) pgType.readTextValue(buffer, pos);

--- a/sql/src/test/java/io/crate/protocols/postgres/types/BooleanTypeTest.java
+++ b/sql/src/test/java/io/crate/protocols/postgres/types/BooleanTypeTest.java
@@ -32,8 +32,8 @@ public class BooleanTypeTest extends BasePGTypeTest<Boolean> {
 
     @Test
     public void testWriteValue() throws Exception {
-        assertBytesWritten(true, new byte[]{ 0, 0, 0, 1, 't' });
-        assertBytesWritten(false, new byte[]{ 0, 0, 0, 1, 'f' });
+        assertBytesWritten(true, new byte[]{ 0, 0, 0, 1, 1 });
+        assertBytesWritten(false, new byte[]{ 0, 0, 0, 1, 0 });
     }
 
     @Test

--- a/sql/src/test/java/io/crate/protocols/postgres/types/JsonTypeTest.java
+++ b/sql/src/test/java/io/crate/protocols/postgres/types/JsonTypeTest.java
@@ -52,6 +52,5 @@ public class JsonTypeTest extends BasePGTypeTest<Map<String, Object>> {
             123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 44, 34, 120, 34, 58, 49, 48, 125
         };
         assertBytesReadBinary(bytes, map, 20);
-        assertBytesReadBinary(bytes, map, 20);
     }
 }


### PR DESCRIPTION
The simple query protocol expects the values to be serialized as text.

So this this changes the default formatCode to Text and uses the
formatCodes from the Bind message for streaming so that the client can
dictate the format code which should be used.

(Before the result formatCodes of the Bind message were ignored)


![screenshot](https://cloud.githubusercontent.com/assets/38700/16446578/97c9a43c-3de8-11e6-9ecb-38c56d5903ab.png)
