### PR TITLE
use default value for the disk low watermark setting.

### DIFF
--- a/sql/src/main/java/io/crate/metadata/settings/CrateSettings.java
+++ b/sql/src/main/java/io/crate/metadata/settings/CrateSettings.java
@@ -628,7 +628,7 @@ public class CrateSettings {
     };
 
     public static final StringSetting ROUTING_ALLOCATION_DISK_WATERMARK_LOW =
-            new StringSetting("low", null, true, "", ROUTING_ALLOCATION_DISK_WATERMARK);
+            new StringSetting("low", null, true, "85%", ROUTING_ALLOCATION_DISK_WATERMARK);
 
     public static final StringSetting ROUTING_ALLOCATION_DISK_WATERMARK_HIGH =
             new StringSetting("high", null, true, "90%", ROUTING_ALLOCATION_DISK_WATERMARK);


### PR DESCRIPTION
Accordingly to the Crate documentation the
`cluster.routing.allocation.disk.watermark.low`
setting defaults to `85%`.