### PR TITLE
Fix FetchProjector pause support if isLast=true

### DIFF
--- a/sql/src/main/java/io/crate/operation/projectors/fetch/FetchProjector.java
+++ b/sql/src/main/java/io/crate/operation/projectors/fetch/FetchProjector.java
@@ -207,9 +207,6 @@ public class FetchProjector extends AbstractProjector {
                                 @Override
                                 protected void doRun() throws Exception {
                                     sendToDownstream(isLast, 0);
-                                    if (isLast) {
-                                        finishDownstream();
-                                    }
                                 }
                             });
                         }
@@ -226,9 +223,6 @@ public class FetchProjector extends AbstractProjector {
         }
         if (!anyRequestSent) {
             sendToDownstream(isLast, 0);
-            if (isLast) {
-                finishDownstream();
-            }
         }
     }
 
@@ -297,6 +291,8 @@ public class FetchProjector extends AbstractProjector {
             inputValues.clear();
             currentRowCount = 0;
             resume();
+        } else {
+            finishDownstream();
         }
     }
 

--- a/sql/src/test/java/io/crate/operation/projectors/FetchProjectorTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/FetchProjectorTest.java
@@ -95,7 +95,7 @@ public class FetchProjectorTest extends CrateUnitTest {
     @Test
     public void testPauseSupport() throws Exception {
         final CollectingRowReceiver rowReceiver = CollectingRowReceiver.withPauseAfter(2);
-        int fetchSize = 4;
+        int fetchSize = random().nextInt(20);
         FetchProjector fetchProjector = prepareFetchProjector(fetchSize, rowReceiver, fetchOperation);
         final RowSender rowSender = new RowSender(RowSender.rowRange(0, 10), fetchProjector, MoreExecutors.directExecutor());
         rowSender.run();
@@ -103,10 +103,10 @@ public class FetchProjectorTest extends CrateUnitTest {
         assertBusy(new Runnable() {
             @Override
             public void run() {
-                assertThat(rowSender.numPauses(), is(1));
                 assertThat(rowReceiver.rows.size(), is(2));
             }
         });
+        assertThat(rowReceiver.getNumFailOrFinishCalls(), is(0));
         rowReceiver.resumeUpstream(false);
         assertThat(TestingHelpers.printedTable(rowReceiver.result()),
             is("0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n"));

--- a/sql/src/test/java/io/crate/testing/CollectingRowReceiver.java
+++ b/sql/src/test/java/io/crate/testing/CollectingRowReceiver.java
@@ -155,7 +155,7 @@ public class CollectingRowReceiver implements RowReceiver, ResultReceiver {
         private final int limit;
         private int numRows = 0;
 
-        public LimitingReceiver(int limit) {
+        LimitingReceiver(int limit) {
             this.limit = limit;
         }
 
@@ -176,7 +176,7 @@ public class CollectingRowReceiver implements RowReceiver, ResultReceiver {
         private final int pauseAfter;
         private int numRows = 0;
 
-        public PausingReceiver(int pauseAfter) {
+        PausingReceiver(int pauseAfter) {
             this.pauseAfter = pauseAfter;
         }
 


### PR DESCRIPTION
If `isLast` was true and a downstream returned `pause` `finish` was called on it.