### PR TITLE
removes obsolete getField() from AnalyzedRelation interface

### DIFF
--- a/sql/src/main/java/io/crate/analyze/AbstractShowAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/AbstractShowAnalyzedStatement.java
@@ -26,7 +26,6 @@ import io.crate.analyze.symbol.Field;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.metadata.Path;
 import io.crate.metadata.table.Operation;
-import org.elasticsearch.common.Nullable;
 
 import java.util.Collections;
 import java.util.List;
@@ -36,12 +35,6 @@ public abstract class AbstractShowAnalyzedStatement implements AnalyzedStatement
     @Override
     public <C, R> R accept(AnalyzedStatementVisitor<C, R> analyzedStatementVisitor, C context) {
         return analyzedStatementVisitor.visitShowAnalyzedStatement(this, context);
-    }
-
-    @Nullable
-    @Override
-    public Field getField(Path path) {
-        throw new UnsupportedOperationException("getField() is not supported on ShowCreateTableAnalyzedStatement");
     }
 
     @Override

--- a/sql/src/main/java/io/crate/analyze/CopyToAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/CopyToAnalyzedStatement.java
@@ -103,12 +103,6 @@ public class CopyToAnalyzedStatement extends AbstractCopyAnalyzedStatement imple
 
     @Nullable
     @Override
-    public Field getField(Path path) {
-        throw new UnsupportedOperationException("getField not implemented on CopyToAnalyzedStatement");
-    }
-
-    @Nullable
-    @Override
     public Field getField(Path path, Operation operation) throws UnsupportedOperationException, ColumnUnknownException {
         throw new UnsupportedOperationException("getField not implemented on CopyToAnalyzedStatement");
     }

--- a/sql/src/main/java/io/crate/analyze/ExplainAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/ExplainAnalyzedStatement.java
@@ -31,7 +31,6 @@ import io.crate.metadata.Path;
 import io.crate.metadata.table.Operation;
 import io.crate.types.DataTypes;
 
-import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 
@@ -57,12 +56,6 @@ public class ExplainAnalyzedStatement implements AnalyzedStatement, AnalyzedRela
     @Override
     public <C, R> R accept(AnalyzedRelationVisitor<C, R> visitor, C context) {
         return visitor.visitExplain(this, context);
-    }
-
-    @Nullable
-    @Override
-    public Field getField(Path path) {
-        throw new UnsupportedOperationException("getField is not supported");
     }
 
     @Override

--- a/sql/src/main/java/io/crate/analyze/InsertFromSubQueryAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/InsertFromSubQueryAnalyzedStatement.java
@@ -178,12 +178,6 @@ public class InsertFromSubQueryAnalyzedStatement implements AnalyzedRelation, An
 
     @Nullable
     @Override
-    public Field getField(Path path) {
-        return null;
-    }
-
-    @Nullable
-    @Override
     public Field getField(Path path, Operation operation) throws UnsupportedOperationException, ColumnUnknownException {
         return null;
     }

--- a/sql/src/main/java/io/crate/analyze/MultiSourceSelect.java
+++ b/sql/src/main/java/io/crate/analyze/MultiSourceSelect.java
@@ -105,11 +105,6 @@ public class MultiSourceSelect implements QueriedRelation {
     }
 
     @Override
-    public Field getField(Path path) {
-        throw new UnsupportedOperationException("getField on SelectAnalyzedStatement is not implemented");
-    }
-
-    @Override
     public Field getField(Path path, Operation operation) throws UnsupportedOperationException {
         throw new UnsupportedOperationException("getField on SelectAnalyzedStatement is not implemented");
     }

--- a/sql/src/main/java/io/crate/analyze/QueriedTableRelation.java
+++ b/sql/src/main/java/io/crate/analyze/QueriedTableRelation.java
@@ -73,11 +73,6 @@ public abstract class QueriedTableRelation<TR extends AbstractTableRelation> imp
     }
 
     @Override
-    public Field getField(Path path) {
-        throw new UnsupportedOperationException("getField on SelectAnalyzedStatement is not implemented");
-    }
-
-    @Override
     public Field getField(Path path, Operation operation) throws UnsupportedOperationException {
         throw new UnsupportedOperationException("getField on SelectAnalyzedStatement is not implemented");
     }

--- a/sql/src/main/java/io/crate/analyze/TwoTableJoin.java
+++ b/sql/src/main/java/io/crate/analyze/TwoTableJoin.java
@@ -32,9 +32,7 @@ import io.crate.metadata.Path;
 import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.QualifiedName;
 
-import javax.annotation.Nullable;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 public class TwoTableJoin implements QueriedRelation {
@@ -87,12 +85,6 @@ public class TwoTableJoin implements QueriedRelation {
     @Override
     public <C, R> R accept(AnalyzedRelationVisitor<C, R> visitor, C context) {
         return visitor.visitTwoTableJoin(this, context);
-    }
-
-    @Nullable
-    @Override
-    public Field getField(Path path) {
-        throw new UnsupportedOperationException("getField is not supported");
     }
 
     @Override

--- a/sql/src/main/java/io/crate/analyze/UpdateAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/UpdateAnalyzedStatement.java
@@ -31,7 +31,6 @@ import io.crate.exceptions.ColumnUnknownException;
 import io.crate.metadata.Path;
 import io.crate.metadata.table.Operation;
 
-import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -89,12 +88,6 @@ public class UpdateAnalyzedStatement implements AnalyzedRelation, AnalyzedStatem
     @Override
     public <C, R> R accept(AnalyzedRelationVisitor<C, R> visitor, C context) {
         return visitor.visitUpdateAnalyzedStatement(this, context);
-    }
-
-    @Nullable
-    @Override
-    public Field getField(Path path) {
-        throw new UnsupportedOperationException("getField on UpdateAnalyzedStatement is not implemented");
     }
 
     @Override

--- a/sql/src/main/java/io/crate/analyze/relations/AbstractTableRelation.java
+++ b/sql/src/main/java/io/crate/analyze/relations/AbstractTableRelation.java
@@ -65,7 +65,6 @@ public abstract class AbstractTableRelation<T extends TableInfo> implements Anal
     }
 
     @Nullable
-    @Override
     public Field getField(Path path) {
         ColumnIdent ci = toColumnIdent(path);
         ReferenceInfo referenceInfo = tableInfo.getReferenceInfo(ci);

--- a/sql/src/main/java/io/crate/analyze/relations/AnalyzedRelation.java
+++ b/sql/src/main/java/io/crate/analyze/relations/AnalyzedRelation.java
@@ -26,15 +26,11 @@ import io.crate.exceptions.ColumnUnknownException;
 import io.crate.metadata.Path;
 import io.crate.metadata.table.Operation;
 
-import javax.annotation.Nullable;
 import java.util.List;
 
 public interface AnalyzedRelation {
 
     <C, R> R accept(AnalyzedRelationVisitor<C, R> visitor, C context);
-
-    @Nullable
-    Field getField(Path path);
 
     Field getField(Path path, Operation operation) throws UnsupportedOperationException, ColumnUnknownException;
 

--- a/sql/src/main/java/io/crate/planner/PlanAndPlannedAnalyzedRelation.java
+++ b/sql/src/main/java/io/crate/planner/PlanAndPlannedAnalyzedRelation.java
@@ -28,7 +28,6 @@ import io.crate.exceptions.ColumnUnknownException;
 import io.crate.metadata.Path;
 import io.crate.metadata.table.Operation;
 
-import javax.annotation.Nullable;
 import java.util.List;
 
 public abstract class PlanAndPlannedAnalyzedRelation implements PlannedAnalyzedRelation, Plan {
@@ -41,12 +40,6 @@ public abstract class PlanAndPlannedAnalyzedRelation implements PlannedAnalyzedR
     @Override
     public <C, R> R accept(AnalyzedRelationVisitor<C, R> visitor, C context) {
         return visitor.visitPlanedAnalyzedRelation(this, context);
-    }
-
-    @Nullable
-    @Override
-    public Field getField(Path path) {
-        throw new UnsupportedOperationException("getField is not supported");
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/node/NoopPlannedAnalyzedRelation.java
+++ b/sql/src/main/java/io/crate/planner/node/NoopPlannedAnalyzedRelation.java
@@ -33,7 +33,6 @@ import io.crate.planner.Plan;
 import io.crate.planner.distribution.UpstreamPhase;
 import io.crate.planner.projection.Projection;
 
-import javax.annotation.Nullable;
 import java.util.List;
 import java.util.UUID;
 
@@ -55,12 +54,6 @@ public class NoopPlannedAnalyzedRelation implements PlannedAnalyzedRelation {
     @Override
     public <C, R> R accept(AnalyzedRelationVisitor<C, R> visitor, C context) {
         return visitor.visitPlanedAnalyzedRelation(this, context);
-    }
-
-    @Nullable
-    @Override
-    public Field getField(Path path) {
-        return relation.getField(path);
     }
 
     @Override

--- a/sql/src/test/java/io/crate/analyze/CompoundLiteralTest.java
+++ b/sql/src/test/java/io/crate/analyze/CompoundLiteralTest.java
@@ -56,7 +56,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -120,12 +119,6 @@ public class CompoundLiteralTest extends CrateUnitTest {
 
         @Override
         public <C, R> R accept(AnalyzedRelationVisitor<C, R> visitor, C context) {
-            return null;
-        }
-
-        @Nullable
-        @Override
-        public Field getField(Path path) {
             return null;
         }
 

--- a/sql/src/test/java/io/crate/analyze/ReferenceToTrueVisitorTest.java
+++ b/sql/src/test/java/io/crate/analyze/ReferenceToTrueVisitorTest.java
@@ -68,13 +68,8 @@ public class ReferenceToTrueVisitorTest extends CrateUnitTest {
         }
 
         @Override
-        public Field getField(Path path) {
-            return new Field(this, path, DataTypes.STRING);
-        }
-
-        @Override
         public Field getField(Path path, Operation operation) throws UnsupportedOperationException {
-            return getField(path);
+            return new Field(this, path, DataTypes.STRING);
         }
 
         @Override

--- a/sql/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -214,17 +214,12 @@ public class ExpressionAnalyzerTest extends CrateUnitTest {
         }
 
         @Override
-        public Field getField(Path path) {
+        public Field getField(Path path, Operation operation) throws UnsupportedOperationException {
             ColumnIdent columnIdent = (ColumnIdent) path;
             if (supportedReference.contains(columnIdent)) {
                 return new Field(this, columnIdent, DataTypes.STRING);
             }
             return null;
-        }
-
-        @Override
-        public Field getField(Path path, Operation operation) throws UnsupportedOperationException {
-            return getField(path);
         }
 
         @Override

--- a/sql/src/test/java/io/crate/analyze/relations/FieldProviderTest.java
+++ b/sql/src/test/java/io/crate/analyze/relations/FieldProviderTest.java
@@ -231,17 +231,12 @@ public class FieldProviderTest extends CrateUnitTest {
         }
 
         @Override
-        public Field getField(Path path) {
+        public Field getField(Path path, Operation operation) throws UnsupportedOperationException {
             ColumnIdent columnIdent = (ColumnIdent) path;
             if (supportedReference.contains(columnIdent.name())) {
                 return new Field(this, columnIdent, DataTypes.STRING);
             }
             return null;
-        }
-
-        @Override
-        public Field getField(Path path, Operation operation) throws UnsupportedOperationException {
-            return getField(path);
         }
 
         @Override


### PR DESCRIPTION
method is superseded by getField(Path, Operation)