### PR TITLE
Don't send error in ReadyForQueryListener

### DIFF
--- a/sql/src/main/java/io/crate/protocols/postgres/ConnectionContext.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/ConnectionContext.java
@@ -220,7 +220,6 @@ class ConnectionContext {
 
         @Override
         public void onFailure(@Nonnull Throwable t) {
-            Messages.sendErrorResponse(channel, Exceptions.messageOf(t));
             Messages.sendReadyForQuery(channel);
         }
     }


### PR DESCRIPTION
The ResultReceivers already send the error, no need to send it again.