### PR TITLE
register missing variation of the ``intersects`` function

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fix: the ``intersects`` scalar function now allows using the ``geo_point`` data
+   type as arguments.
+
  - Implemented basic conditional functions
    (``coalesce()``, ``greatest()``, ``least()``, ``nullif()``).
 

--- a/sql/src/main/java/io/crate/operation/scalar/geo/IntersectsFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/geo/IntersectsFunction.java
@@ -56,6 +56,7 @@ public class IntersectsFunction extends Scalar<Boolean, Object> {
     private static final Set<DataType> SUPPORTED_TYPES = ImmutableSet.<DataType>of(
             DataTypes.STRING,
             DataTypes.OBJECT,
+            DataTypes.GEO_POINT,
             DataTypes.GEO_SHAPE
     );
 

--- a/sql/src/test/java/io/crate/operation/scalar/AbstractScalarFunctionsTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/AbstractScalarFunctionsTest.java
@@ -68,6 +68,8 @@ public abstract class AbstractScalarFunctionsTest extends CrateUnitTest {
             .add("time_format", DataTypes.STRING)
             .add("long_array", new ArrayType(DataTypes.LONG))
             .add("regex_pattern", DataTypes.STRING)
+            .add("geopoint", DataTypes.GEO_POINT)
+            .add("geoshape", DataTypes.GEO_SHAPE)
             .build();
         TableRelation tableRelation = new TableRelation(tableInfo);
         tableSources = ImmutableMap.<QualifiedName, AnalyzedRelation>of(new QualifiedName("users"), tableRelation);


### PR DESCRIPTION
Previously, using geo_point data type in
with the intersects function was only possible
if they were provided WKT strings.

Therefore, we register additional scalar functions:

 - intersects(geo_point, ...)
 - intersects(..., geo_point)