### PR TITLE
remove ``geo_point`` from the ``intersects`` supported types

### DIFF
--- a/sql/src/main/java/io/crate/operation/scalar/geo/IntersectsFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/geo/IntersectsFunction.java
@@ -56,8 +56,7 @@ public class IntersectsFunction extends Scalar<Boolean, Object> {
     private static final Set<DataType> SUPPORTED_TYPES = ImmutableSet.<DataType>of(
             DataTypes.STRING,
             DataTypes.OBJECT,
-            DataTypes.GEO_SHAPE,
-            DataTypes.GEO_POINT
+            DataTypes.GEO_SHAPE
     );
 
     public static void register(ScalarFunctionModule module) {


### PR DESCRIPTION
it was mistakenly introduced in #3793