### PR TITLE
Prohibit batch operatios with mixed statements

### DIFF
--- a/sql/src/test/java/io/crate/integrationtests/PostgresITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PostgresITest.java
@@ -191,16 +191,9 @@ public class PostgresITest extends SQLTransportIntegrationTest {
             statement.addBatch("insert into t (x) values (1)");
             statement.addBatch("insert into t (x) values (2)");
 
-            int[] results = statement.executeBatch();
-            assertThat(results, is(new int[] {1, 1}));
-
-            statement.executeUpdate("refresh table t");
-            ResultSet resultSet = statement.executeQuery("select * from t order by x");
-            assertThat(resultSet.next(), is(true));
-            assertThat(resultSet.getInt(1), is(1));
-
-            assertThat(resultSet.next(), is(true));
-            assertThat(resultSet.getInt(1), is(2));
+            // mixed statements not supported
+            expectedException.expect(BatchUpdateException.class);
+            statement.executeBatch();
         }
     }
 


### PR DESCRIPTION
`testExecuteBatchWithDifferentStatements` which tested that this works
was flaky.

Disable support for now so we can get initial psql support into master.
We will re-add this functionality later on.