### PR TITLE
Fix flaky FetchProjectorTest

### DIFF
--- a/sql/src/test/java/io/crate/operation/projectors/FetchProjectorTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/FetchProjectorTest.java
@@ -46,6 +46,7 @@ import io.crate.testing.CollectingRowReceiver;
 import io.crate.testing.RowSender;
 import io.crate.testing.TestingHelpers;
 import io.crate.types.LongType;
+import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -88,6 +89,7 @@ public class FetchProjectorTest extends CrateUnitTest {
             @Override
             public void run() {
                 assertThat(rowReceiver.rows.size(), is(2));
+                assertThat(rowReceiver.numPauseProcessed(), is(1));
             }
         });
         assertThat(rowReceiver.getNumFailOrFinishCalls(), is(0));
@@ -110,7 +112,7 @@ public class FetchProjectorTest extends CrateUnitTest {
                 assertThat(rowSender.numPauses(), is(3));
             }
         });
-        assertThat(fetchOperation.numFetches, is(5));
+        assertThat(fetchOperation.numFetches, Matchers.greaterThan(1));
 
         Bucket projected = rowReceiver.result();
         assertThat(projected.size(), is(10));

--- a/sql/src/test/java/io/crate/testing/CollectingRowReceiver.java
+++ b/sql/src/test/java/io/crate/testing/CollectingRowReceiver.java
@@ -38,12 +38,14 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class CollectingRowReceiver implements RowReceiver {
 
     public final List<Object[]> rows = new ArrayList<>();
     final SettableFuture<Bucket> resultFuture = SettableFuture.create();
     int numFailOrFinish = 0;
+    private AtomicInteger numPauseProcessed = new AtomicInteger(0);
     private ResumeHandle resumeable;
     private RepeatHandle repeatHandle;
 
@@ -80,6 +82,7 @@ public class CollectingRowReceiver implements RowReceiver {
 
     @Override
     public void pauseProcessed(ResumeHandle resumeable) {
+        this.numPauseProcessed.incrementAndGet();
         this.resumeable = resumeable;
     }
 
@@ -131,6 +134,10 @@ public class CollectingRowReceiver implements RowReceiver {
 
     public void repeatUpstream() {
         repeatHandle.repeat();
+    }
+
+    public int numPauseProcessed() {
+        return numPauseProcessed.get();
     }
 
     private static class LimitingReceiver extends CollectingRowReceiver {


### PR DESCRIPTION
`testPauseSupport` could throw a NullPointerException if
`resumeUpstream` got called before `pauseProcessed` was called on the
CollectingRowReceiver.

`testMultipleFetchRequests` could fail due to a lower numFetches number.
This is okay because the fetch operations happen async.