### PR TITLE
resolve hostname for the hostname column in sys.nodes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,12 +5,15 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fix: the ``hostname`` column of the ``sys.nodes`` table returns a hostname
+   instead of an IP address.
+
  - Added initial experimental support for the postgres wire protocol. This is
    disabled by default.
 
  - Fixed an issue that caused select statements to get stuck if used as part of
    a bulk request. Now a proper error is raised.
-   
+
  - Updated Elasticsearch to 2.3.4
 
  - Improved the error message of `COPY FROM` statements which fail due to

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/NodeHostnameExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/NodeHostnameExpression.java
@@ -22,24 +22,20 @@
 package io.crate.operation.reference.sys.node;
 
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.cluster.ClusterService;
-import org.elasticsearch.cluster.node.DiscoveryNode;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 
 public class NodeHostnameExpression extends SysNodeExpression<BytesRef> {
 
-    private final ClusterService clusterService;
-
-    public NodeHostnameExpression(ClusterService clusterService) {
-        this.clusterService = clusterService;
-    }
-
     @Override
     public BytesRef value() {
-        DiscoveryNode localNode = clusterService.localNode();
-        if (localNode != null) {
-            return new BytesRef(localNode.getHostName());
+        try {
+            String hostname = InetAddress.getLocalHost().getHostName();
+            return new BytesRef(hostname);
+        } catch (UnknownHostException e) {
+            return null;
         }
-        return null;
     }
 
 }

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/NodeSysExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/NodeSysExpression.java
@@ -29,7 +29,6 @@ import io.crate.operation.reference.sys.node.fs.NodeFsExpression;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.discovery.Discovery;
-import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.monitor.jvm.JvmService;
 import org.elasticsearch.monitor.os.OsService;
 import org.elasticsearch.node.service.NodeService;
@@ -57,7 +56,7 @@ public class NodeSysExpression extends NestedObjectExpression {
         this.jvmService = jvmService;
         this.extendedNodeInfo = extendedNodeInfo;
         childImplementations.put(SysNodesTableInfo.SYS_COL_HOSTNAME,
-                new NodeHostnameExpression(clusterService));
+                new NodeHostnameExpression());
         childImplementations.put(SysNodesTableInfo.SYS_COL_REST_URL,
                 new NodeRestUrlExpression(clusterService));
         childImplementations.put(SysNodesTableInfo.SYS_COL_ID,

--- a/sql/src/test/java/io/crate/operation/reference/sys/SysNodesExpressionsTest.java
+++ b/sql/src/test/java/io/crate/operation/reference/sys/SysNodesExpressionsTest.java
@@ -21,6 +21,7 @@
 package io.crate.operation.reference.sys;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.net.InetAddresses;
 import io.crate.Build;
 import io.crate.Version;
 import io.crate.metadata.NestedReferenceResolver;
@@ -42,6 +43,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.inject.Injector;
 import org.elasticsearch.common.inject.ModulesBuilder;
+import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
@@ -76,6 +78,7 @@ import static io.crate.testing.TestingHelpers.mapToSortedString;
 import static io.crate.testing.TestingHelpers.refInfo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -133,7 +136,7 @@ public class SysNodesExpressionsTest extends CrateUnitTest {
             }
 
             DiscoveryNode node = mock(DiscoveryNode.class);
-            when(node.getHostName()).thenReturn("localhost");
+            when(node.getHostAddress()).thenReturn("127.0.0.1");
             when(nodeStats.getNode()).thenReturn(node);
             when(clusterService.localNode()).thenReturn(node);
 
@@ -272,8 +275,10 @@ public class SysNodesExpressionsTest extends CrateUnitTest {
     @Test
     public void testHostname() throws Exception {
         ReferenceInfo refInfo = refInfo("sys.nodes.hostname", DataTypes.STRING, RowGranularity.NODE);
-        SimpleObjectExpression<BytesRef> hostname = (SimpleObjectExpression<BytesRef>) resolver.getImplementation(refInfo);
-        assertEquals(new BytesRef("localhost"), hostname.value());
+        SimpleObjectExpression<BytesRef> expression = (SimpleObjectExpression) resolver.getImplementation(refInfo);
+        BytesRef hostname = expression.value();
+        assertThat(hostname, notNullValue());
+        assertThat(InetAddresses.isInetAddress(BytesRefs.toString(hostname)), is(false));
     }
 
     @Test


### PR DESCRIPTION
The host name resolution was previously done in
InetSocketTransportAddres, but removed after ES 2.0.0.

https://github.com/elastic/elasticsearch/issues/13014