### PR TITLE
Adapt behavior of stats.* cluster setting to match behavior of ES cluster wide settings

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Adapted behaviour of stats.enabled, stats.jobs_log_size and stats.operations_log_size settings
+   to match behaviour of other cluster wide settings like for example minimum_master_nodes.
+
  - Fixed an issue which prevented running join queries on empty partitioned
    tables.
 

--- a/blackbox/docs/configuration.txt
+++ b/blackbox/docs/configuration.txt
@@ -623,6 +623,9 @@ All current applied cluster settings can be read by querying the
 :ref:`sys.cluster.settings <sys-cluster-settings>` column. Most
 cluster settings can be changed at runtime using the
 :ref:`SET/RESET<ddl-set-reset>` statement. This is documented at each setting.
+It's not recommended to add cluster wide settings to the crate.yml file of each node,
+as this will result to each node having a different setting which can lead to
+a non-deterministic behavior of the cluster.
 
 .. _conf_collecting_stats:
 

--- a/sql/src/main/java/io/crate/metadata/settings/BoolSetting.java
+++ b/sql/src/main/java/io/crate/metadata/settings/BoolSetting.java
@@ -25,6 +25,8 @@ import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.elasticsearch.common.settings.Settings;
 
+import javax.annotation.Nonnull;
+
 public class BoolSetting extends Setting<Boolean, Boolean> {
 
     private final String name;
@@ -50,6 +52,11 @@ public class BoolSetting extends Setting<Boolean, Boolean> {
     @Override
     public Boolean extract(Settings settings) {
         return settings.getAsBoolean(settingName(), defaultValue());
+    }
+
+    @Override
+    public Boolean extract(Settings settings, @Nonnull Boolean defaultValue) {
+        return settings.getAsBoolean(settingName(), defaultValue);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/metadata/settings/ByteSizeSetting.java
+++ b/sql/src/main/java/io/crate/metadata/settings/ByteSizeSetting.java
@@ -26,6 +26,7 @@ import io.crate.types.DataTypes;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class ByteSizeSetting extends Setting<ByteSizeValue, String> {
@@ -80,6 +81,11 @@ public class ByteSizeSetting extends Setting<ByteSizeValue, String> {
     }
 
     @Override
+    public String extract(Settings settings, @Nonnull ByteSizeValue defaultValue) {
+        return extractByteSizeValue(settings, defaultValue).toString();
+    }
+
+    @Override
     public boolean isRuntime() {
         return isRuntime;
     }
@@ -88,7 +94,11 @@ public class ByteSizeSetting extends Setting<ByteSizeValue, String> {
         return extractByteSizeValue(settings).bytes();
     }
 
-    public ByteSizeValue extractByteSizeValue(Settings settings) {
+    private ByteSizeValue extractByteSizeValue(Settings settings) {
         return settings.getAsBytesSize(settingName(), defaultValue());
+    }
+
+    private ByteSizeValue extractByteSizeValue(Settings settings, @Nonnull ByteSizeValue defaultValue) {
+        return settings.getAsBytesSize(settingName(), defaultValue);
     }
 }

--- a/sql/src/main/java/io/crate/metadata/settings/DoubleSetting.java
+++ b/sql/src/main/java/io/crate/metadata/settings/DoubleSetting.java
@@ -25,6 +25,8 @@ import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.elasticsearch.common.settings.Settings;
 
+import javax.annotation.Nonnull;
+
 public abstract class DoubleSetting extends Setting<Double, Double> {
 
     public Double maxValue() {
@@ -43,5 +45,10 @@ public abstract class DoubleSetting extends Setting<Double, Double> {
     @Override
     public Double extract(Settings settings) {
         return settings.getAsDouble(settingName(), defaultValue());
+    }
+
+    @Override
+    public Double extract(Settings settings, @Nonnull Double defaultValue) {
+        return settings.getAsDouble(settingName(), defaultValue);
     }
 }

--- a/sql/src/main/java/io/crate/metadata/settings/FloatSetting.java
+++ b/sql/src/main/java/io/crate/metadata/settings/FloatSetting.java
@@ -25,6 +25,8 @@ import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.elasticsearch.common.settings.Settings;
 
+import javax.annotation.Nonnull;
+
 public abstract class FloatSetting extends Setting<Float, Float> {
 
     public Float maxValue() {
@@ -43,5 +45,10 @@ public abstract class FloatSetting extends Setting<Float, Float> {
     @Override
     public Float extract(Settings settings) {
         return settings.getAsFloat(settingName(), defaultValue());
+    }
+
+    @Override
+    public Float extract(Settings settings, @Nonnull Float defaultValue) {
+        return settings.getAsFloat(settingName(), defaultValue);
     }
 }

--- a/sql/src/main/java/io/crate/metadata/settings/IntSetting.java
+++ b/sql/src/main/java/io/crate/metadata/settings/IntSetting.java
@@ -25,6 +25,8 @@ import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.elasticsearch.common.settings.Settings;
 
+import javax.annotation.Nonnull;
+
 public class IntSetting extends Setting<Integer, Integer> {
 
     private final String name;
@@ -80,5 +82,10 @@ public class IntSetting extends Setting<Integer, Integer> {
     @Override
     public Integer extract(Settings settings) {
         return settings.getAsInt(settingName(), defaultValue());
+    }
+
+    @Override
+    public Integer extract(Settings settings, @Nonnull Integer defaultValue) {
+        return settings.getAsInt(settingName(), defaultValue);
     }
 }

--- a/sql/src/main/java/io/crate/metadata/settings/NestedSetting.java
+++ b/sql/src/main/java/io/crate/metadata/settings/NestedSetting.java
@@ -34,6 +34,11 @@ public abstract class NestedSetting extends Setting<Object, Object> {
     }
 
     @Override
+    public Object extract(Settings settings, Object defaultValue) {
+        return extract(settings);
+    }
+
+    @Override
     public DataType dataType() {
         return DataTypes.OBJECT;
     }

--- a/sql/src/main/java/io/crate/metadata/settings/Setting.java
+++ b/sql/src/main/java/io/crate/metadata/settings/Setting.java
@@ -27,6 +27,7 @@ import io.crate.types.DataType;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.settings.Settings;
 
+import javax.annotation.Nonnull;
 import java.util.List;
 
 public abstract class Setting<T, E> {
@@ -42,6 +43,8 @@ public abstract class Setting<T, E> {
     public abstract T defaultValue();
 
     public abstract E extract(Settings settings);
+
+    public abstract E extract(Settings settings, @Nonnull T defaultValue);
 
     public abstract boolean isRuntime();
 

--- a/sql/src/main/java/io/crate/metadata/settings/StringSetting.java
+++ b/sql/src/main/java/io/crate/metadata/settings/StringSetting.java
@@ -26,6 +26,7 @@ import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.elasticsearch.common.settings.Settings;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Locale;
 import java.util.Set;
@@ -90,6 +91,11 @@ public class StringSetting extends Setting<String, String> {
     @Override
     public String extract(Settings settings) {
         return settings.get(settingName(), defaultValue());
+    }
+
+    @Override
+    public String extract(Settings settings, @Nonnull String defaultValue) {
+        return settings.get(settingName(), defaultValue);
     }
 
     /**

--- a/sql/src/main/java/io/crate/metadata/settings/TimeSetting.java
+++ b/sql/src/main/java/io/crate/metadata/settings/TimeSetting.java
@@ -26,6 +26,8 @@ import io.crate.types.DataTypes;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 
+import javax.annotation.Nonnull;
+
 public abstract class TimeSetting extends Setting<TimeValue, String> {
 
     @Override
@@ -51,11 +53,20 @@ public abstract class TimeSetting extends Setting<TimeValue, String> {
         return extractTimeValue(settings).toString();
     }
 
+    @Override
+    public String extract(Settings settings, @Nonnull TimeValue defaultValue) {
+        return extractTimeValue(settings, defaultValue).toString();
+    }
+
     public long extractMillis(Settings settings) {
-        return extractTimeValue(settings).millis();
+        return extractTimeValue(settings, null).millis();
     }
 
     public TimeValue extractTimeValue(Settings settings) {
         return settings.getAsTime(settingName(), defaultValue());
+    }
+
+    private TimeValue extractTimeValue(Settings settings, @Nonnull TimeValue defaultValue) {
+        return settings.getAsTime(settingName(), defaultValue);
     }
 }

--- a/sql/src/test/java/io/crate/operation/collect/StatsTablesTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/StatsTablesTest.java
@@ -41,7 +41,6 @@ import static org.hamcrest.core.Is.is;
 
 public class StatsTablesTest extends CrateUnitTest {
 
-
     @Test
     public void testSettingsChanges() {
         NodeSettingsService nodeSettingsService = new NodeSettingsService(Settings.EMPTY);
@@ -54,12 +53,16 @@ public class StatsTablesTest extends CrateUnitTest {
         // even though logSizes are > 0 it must be a NoopQueue because the stats are disabled
         assertThat(stats.jobsLog.get(), Matchers.instanceOf(NoopQueue.class));
 
+        stats = new StatsTables(Settings.builder()
+            .put(CrateSettings.STATS_ENABLED.settingName(), true)
+            .put(CrateSettings.STATS_JOBS_LOG_SIZE.settingName(), 100)
+            .put(CrateSettings.STATS_OPERATIONS_LOG_SIZE.settingName(), 100).build(), nodeSettingsService);
+
         stats.listener.onRefreshSettings(Settings.builder()
-                .put(CrateSettings.STATS_ENABLED.settingName(), true)
                 .put(CrateSettings.STATS_OPERATIONS_LOG_SIZE.settingName(), 200).build());
 
         assertThat(stats.isEnabled(), is(true));
-        assertThat(stats.lastJobsLogSize, is(CrateSettings.STATS_JOBS_LOG_SIZE.defaultValue()));
+        assertThat(stats.lastJobsLogSize, is(100));
         assertThat(stats.lastOperationsLogSize, is(200));
 
         assertThat(stats.jobsLog.get(), Matchers.instanceOf(BlockingEvictingQueue.class));


### PR DESCRIPTION
See trello card for discovery.zen.minimum_master_nodes behavior:
https://trello.com/c/1aUofsJX/1775-fix-bug-with-stats-enabled