### PR TITLE
fix a bug in joining empty partitioned tables

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed an issue which prevented running join queries on empty partitioned
+   tables.
+
  - Fixed a bug that prevented join and sort on blob tables.
 
  - Fix: the ``hostname`` column of the ``sys.nodes`` table returns a hostname

--- a/sql/src/main/java/io/crate/planner/SelectStatementPlanner.java
+++ b/sql/src/main/java/io/crate/planner/SelectStatementPlanner.java
@@ -42,6 +42,7 @@ import io.crate.planner.consumer.ESGetStatementPlanner;
 import io.crate.planner.consumer.SimpleSelect;
 import io.crate.planner.fetch.FetchPushDown;
 import io.crate.planner.fetch.MultiSourceFetchPushDown;
+import io.crate.planner.node.NoopPlannedAnalyzedRelation;
 import io.crate.planner.node.dql.CollectAndMerge;
 import io.crate.planner.node.dql.MergePhase;
 import io.crate.planner.node.dql.QueryThenFetch;
@@ -192,6 +193,11 @@ public class SelectStatementPlanner {
             ConsumerContext consumerContext = new ConsumerContext(mss, context);
             // plan sub relation as if root so that it adds a mergePhase
             PlannedAnalyzedRelation plannedSubQuery = consumingPlanner.plan(mss, consumerContext);
+            // NestedLoopConsumer can return NoopPlannedAnalyzedRelation if its left or right plan
+            // is noop. E.g. it is the case with creating NestedLoopConsumer for empty partitioned tables.
+            if (plannedSubQuery instanceof NoopPlannedAnalyzedRelation) {
+                return new NoopPlan(context.jobId());
+            }
             assert plannedSubQuery != null : "consumingPlanner should have created a subPlan";
             assert !plannedSubQuery.resultIsDistributed() : "subQuery must not have a distributed result";
 

--- a/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -108,6 +108,15 @@ public class JoinIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    public void testJoinOnEmptyPartitionedTables() throws Exception {
+        execute("create table foo (id long) partitioned by (id)");
+        execute("create table bar (id long) partitioned by (id)");
+        ensureYellow();
+        execute("select * from foo f, bar b where f.id = b.id");
+        assertThat(printedTable(response.rows()), is(""));
+    }
+
+    @Test
     public void testCrossJoinJoinUnordered() throws Exception {
         execute("create table employees (size float, name string) clustered by (size) into 1 shards");
         execute("create table offices (height float, name string) clustered by (height) into 1 shards");


### PR DESCRIPTION
Return `NoopPlan` for `SelectStatementPlanner` if
the planned sub relation in `visitMultiSourceSelect` is
`NoopPlannedAnalyzedRelation`.