### PR TITLE
do not fetch table stats when node is not fully available yet

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,10 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fix: Do not fetch table stats when node is not fully available yet.
+   This could have led to NullPointerExceptions during long recovery
+   process on node start.
+
  - Fixed an issue which prevented running join queries on empty partitioned
    tables.
 


### PR DESCRIPTION
this could have led to NPE during long recovery on node start

fixes #3791 