### PR TITLE
Run fetch operations threaded per reader

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fetch operations are now threaded per shard instead of per node.
+
  - BREAKING: On Hunspell dictionary configuration, the parameter
    indices.analysis.hunspell.dictionary.location has been removed and <path.conf>/hunspell
    is always used.


### PR DESCRIPTION
Improves the execution speed of queries with > 1 shard per node.

For example:

    250 iterations
    select * from uservisits limit 1000
    Before: mean: 281.639 +/- 60.773
    After:  mean: 139.511 +/- 17.454

Note that this was measured on an otherwise idle node. If all CPU cores
are busy or mostly busy this change won't be as noticeable.