### PR TITLE
Set encoding to UTF-8 to prevent compilation errors in systems with other lang config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,7 @@ allprojects {
     tasks.withType(JavaCompile) {
         sourceCompatibility = "1.7"
         targetCompatibility = "1.7"
+        options.encoding = 'UTF-8'
     }
 
     tasks.withType(Test) {


### PR DESCRIPTION
@mfussenegger plz review