### PR TITLE
expose column idents in sys nodes table info

### DIFF
--- a/sql/src/main/java/io/crate/metadata/sys/SysNodesTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysNodesTableInfo.java
@@ -57,138 +57,242 @@ public class SysNodesTableInfo extends StaticTableInfo {
     public static final String SYS_COL_VERSION = "version";
     public static final String SYS_COL_THREAD_POOLS = "thread_pools";
     public static final String SYS_COL_NETWORK = "network";
-    public static final String SYS_COL_NETWORK_TCP = "tcp";
     public static final String SYS_COL_OS = "os";
-    public static final String SYS_COL_OS_CPU = "cpu";
     public static final String SYS_COL_OS_INFO = "os_info";
-    public static final String SYS_COL_OS_INFO_JVM = "jvm";
     public static final String SYS_COL_PROCESS = "process";
-    public static final String SYS_COL_PROCESS_CPU = "cpu";
     public static final String SYS_COL_FS = "fs";
-    public static final String SYS_COL_FS_TOTAL = "total";
-    public static final String SYS_COL_FS_DISKS = "disks";
-    public static final String SYS_COL_FS_DATA = "data";
 
     private static final DataType OBJECT_ARRAY_TYPE = new ArrayType(DataTypes.OBJECT);
+
+    public static class Columns {
+        public static final ColumnIdent ID = new ColumnIdent(SYS_COL_ID);
+        public static final ColumnIdent NAME = new ColumnIdent(SYS_COL_NODE_NAME);
+        public static final ColumnIdent HOSTNAME = new ColumnIdent(SYS_COL_HOSTNAME);
+        public static final ColumnIdent REST_URL = new ColumnIdent(SYS_COL_REST_URL);
+
+        public static final ColumnIdent PORT = new ColumnIdent(SYS_COL_PORT);
+        public static final ColumnIdent PORT_HTTP = new ColumnIdent(SYS_COL_PORT, ImmutableList.of("http"));
+        public static final ColumnIdent PORT_TRANSPORT = new ColumnIdent(SYS_COL_PORT, ImmutableList.of("transport"));
+
+        public static final ColumnIdent LOAD = new ColumnIdent(SYS_COL_LOAD);
+        public static final ColumnIdent LOAD_1 = new ColumnIdent(SYS_COL_LOAD, ImmutableList.of("1"));
+        public static final ColumnIdent LOAD_5 = new ColumnIdent(SYS_COL_LOAD, ImmutableList.of("5"));
+        public static final ColumnIdent LOAD_15 = new ColumnIdent(SYS_COL_LOAD, ImmutableList.of("15"));
+        public static final ColumnIdent LOAD_PROBE_TS = new ColumnIdent(SYS_COL_LOAD, ImmutableList.of("probe_timestamp"));
+
+        public static final ColumnIdent MEM = new ColumnIdent(SYS_COL_MEM);
+        public static final ColumnIdent MEM_FREE = new ColumnIdent(SYS_COL_MEM, ImmutableList.of("free"));
+        public static final ColumnIdent MEM_USED = new ColumnIdent(SYS_COL_MEM, ImmutableList.of("used"));
+        public static final ColumnIdent MEM_FREE_PERCENT = new ColumnIdent(SYS_COL_MEM, ImmutableList.of("free_percent"));
+        public static final ColumnIdent MEM_USED_PERCENT = new ColumnIdent(SYS_COL_MEM, ImmutableList.of("used_percent"));
+        public static final ColumnIdent MEM_PROBE_TS = new ColumnIdent(SYS_COL_MEM, ImmutableList.of("probe_timestamp"));
+
+        public static final ColumnIdent HEAP = new ColumnIdent(SYS_COL_HEAP);
+        public static final ColumnIdent HEAP_FREE = new ColumnIdent(SYS_COL_HEAP, ImmutableList.of("free"));
+        public static final ColumnIdent HEAP_USED = new ColumnIdent(SYS_COL_HEAP, ImmutableList.of("used"));
+        public static final ColumnIdent HEAP_MAX = new ColumnIdent(SYS_COL_HEAP, ImmutableList.of("max"));
+        public static final ColumnIdent HEAP_PROBE_TS = new ColumnIdent(SYS_COL_HEAP, ImmutableList.of("probe_timestamp"));
+
+        public static final ColumnIdent VERSION = new ColumnIdent(SYS_COL_VERSION);
+        public static final ColumnIdent VERSION_NUMBER = new ColumnIdent(SYS_COL_VERSION, ImmutableList.of("number"));
+        public static final ColumnIdent VERSION_BUILD_HASH = new ColumnIdent(SYS_COL_VERSION, ImmutableList.of("build_hash"));
+        public static final ColumnIdent VERSION_BUILD_SNAPSHOT = new ColumnIdent(SYS_COL_VERSION, ImmutableList.of("build_snapshot"));
+
+        public static final ColumnIdent THREAD_POOLS = new ColumnIdent(SYS_COL_THREAD_POOLS);
+        public static final ColumnIdent THREAD_POOLS_NAME = new ColumnIdent(SYS_COL_THREAD_POOLS, ImmutableList.of("name"));
+        public static final ColumnIdent THREAD_POOLS_ACTIVE = new ColumnIdent(SYS_COL_THREAD_POOLS, ImmutableList.of("active"));
+        public static final ColumnIdent THREAD_POOLS_REJECTED = new ColumnIdent(SYS_COL_THREAD_POOLS, ImmutableList.of("rejected"));
+        public static final ColumnIdent THREAD_POOLS_LARGEST = new ColumnIdent(SYS_COL_THREAD_POOLS, ImmutableList.of("largest"));
+        public static final ColumnIdent THREAD_POOLS_COMPLETED = new ColumnIdent(SYS_COL_THREAD_POOLS, ImmutableList.of("completed"));
+        public static final ColumnIdent THREAD_POOLS_THREADS = new ColumnIdent(SYS_COL_THREAD_POOLS, ImmutableList.of("threads"));
+        public static final ColumnIdent THREAD_POOLS_QUEUE = new ColumnIdent(SYS_COL_THREAD_POOLS, ImmutableList.of("queue"));
+
+        public static final ColumnIdent NETWORK = new ColumnIdent(SYS_COL_NETWORK);
+        public static final ColumnIdent NETWORK_PROBE_TS = new ColumnIdent(SYS_COL_NETWORK, ImmutableList.of("probe_timestamp"));
+        public static final ColumnIdent NETWORK_TCP = new ColumnIdent(SYS_COL_NETWORK, ImmutableList.of("tcp"));
+        public static final ColumnIdent NETWORK_TCP_CONNECTIONS = new ColumnIdent(SYS_COL_NETWORK, ImmutableList.of("tcp", "connections"));
+        public static final ColumnIdent NETWORK_TCP_CONNECTIONS_INITIATED = new ColumnIdent(SYS_COL_NETWORK, ImmutableList.of("tcp", "connections", "initiated"));
+        public static final ColumnIdent NETWORK_TCP_CONNECTIONS_ACCEPTED = new ColumnIdent(SYS_COL_NETWORK, ImmutableList.of("tcp", "connections", "accepted"));
+        public static final ColumnIdent NETWORK_TCP_CONNECTIONS_CURR_ESTABLISHED = new ColumnIdent(SYS_COL_NETWORK, ImmutableList.of("tcp", "connections", "curr_established"));
+        public static final ColumnIdent NETWORK_TCP_CONNECTIONS_DROPPED = new ColumnIdent(SYS_COL_NETWORK, ImmutableList.of("tcp", "connections", "dropped"));
+        public static final ColumnIdent NETWORK_TCP_CONNECTIONS_EMBRYONIC_DROPPED = new ColumnIdent(SYS_COL_NETWORK, ImmutableList.of("tcp", "connections", "embryonic_dropped"));
+        public static final ColumnIdent NETWORK_TCP_PACKETS = new ColumnIdent(SYS_COL_NETWORK, ImmutableList.of("tcp", "packets"));
+        public static final ColumnIdent NETWORK_TCP_PACKETS_SENT = new ColumnIdent(SYS_COL_NETWORK, ImmutableList.of("tcp", "packets", "sent"));
+        public static final ColumnIdent NETWORK_TCP_PACKETS_RECEIVED = new ColumnIdent(SYS_COL_NETWORK, ImmutableList.of("tcp", "packets", "received"));
+        public static final ColumnIdent NETWORK_TCP_PACKETS_RETRANSMITTED = new ColumnIdent(SYS_COL_NETWORK, ImmutableList.of("tcp", "packets", "retransmitted"));
+        public static final ColumnIdent NETWORK_TCP_PACKETS_ERRORS_RECEIVED = new ColumnIdent(SYS_COL_NETWORK, ImmutableList.of("tcp", "packets", "errors_received"));
+        public static final ColumnIdent NETWORK_TCP_PACKETS_RST_SENT = new ColumnIdent(SYS_COL_NETWORK, ImmutableList.of("tcp", "packets", "rst_sent"));
+
+        public static final ColumnIdent OS = new ColumnIdent(SYS_COL_OS);
+        public static final ColumnIdent OS_UPTIME = new ColumnIdent(SYS_COL_OS, ImmutableList.of("uptime"));
+        public static final ColumnIdent OS_TIMESTAMP = new ColumnIdent(SYS_COL_OS, ImmutableList.of("timestamp"));
+        public static final ColumnIdent OS_PROBE_TS = new ColumnIdent(SYS_COL_OS, ImmutableList.of("probe_timestamp"));
+        public static final ColumnIdent OS_CPU = new ColumnIdent(SYS_COL_OS, ImmutableList.of("cpu"));
+        public static final ColumnIdent OS_CPU_SYSTEM = new ColumnIdent(SYS_COL_OS, ImmutableList.of("cpu", "system"));
+        public static final ColumnIdent OS_CPU_USER = new ColumnIdent(SYS_COL_OS, ImmutableList.of("cpu", "user"));
+        public static final ColumnIdent OS_CPU_IDLE = new ColumnIdent(SYS_COL_OS, ImmutableList.of("cpu", "idle"));
+        public static final ColumnIdent OS_CPU_USED = new ColumnIdent(SYS_COL_OS, ImmutableList.of("cpu", "used"));
+        public static final ColumnIdent OS_CPU_STOLEN = new ColumnIdent(SYS_COL_OS, ImmutableList.of("cpu", "stolen"));
+
+        public static final ColumnIdent OS_INFO = new ColumnIdent(SYS_COL_OS_INFO);
+        public static final ColumnIdent OS_INFO_AVAIL_PROCESSORS = new ColumnIdent(SYS_COL_OS_INFO, ImmutableList.of("available_processors"));
+        public static final ColumnIdent OS_INFO_NAME = new ColumnIdent(SYS_COL_OS_INFO, ImmutableList.of("name"));
+        public static final ColumnIdent OS_INFO_ARCH = new ColumnIdent(SYS_COL_OS_INFO, ImmutableList.of("arch"));
+        public static final ColumnIdent OS_INFO_VERSION = new ColumnIdent(SYS_COL_OS_INFO, ImmutableList.of("version"));
+        public static final ColumnIdent OS_INFO_JVM = new ColumnIdent(SYS_COL_OS_INFO, ImmutableList.of("jvm"));
+        public static final ColumnIdent OS_INFO_JVM_VERSION = new ColumnIdent(SYS_COL_OS_INFO, ImmutableList.of("jvm", "version"));
+        public static final ColumnIdent OS_INFO_JVM_NAME = new ColumnIdent(SYS_COL_OS_INFO, ImmutableList.of("jvm", "name"));
+        public static final ColumnIdent OS_INFO_JVM_VENDOR = new ColumnIdent(SYS_COL_OS_INFO, ImmutableList.of("jvm", "vendor"));
+        public static final ColumnIdent OS_INFO_JVM_VM_VERSION = new ColumnIdent(SYS_COL_OS_INFO, ImmutableList.of("jvm", "vm_version"));
+
+        public static final ColumnIdent PROCESS = new ColumnIdent(SYS_COL_PROCESS);
+        public static final ColumnIdent PROCESS_OPEN_FILE_DESCR = new ColumnIdent(SYS_COL_PROCESS, ImmutableList.of("open_file_descriptors"));
+        public static final ColumnIdent PROCESS_MAX_OPEN_FILE_DESCR = new ColumnIdent(SYS_COL_PROCESS, ImmutableList.of("max_open_file_descriptors"));
+        public static final ColumnIdent PROCESS_PROBE_TS = new ColumnIdent(SYS_COL_PROCESS, ImmutableList.of("probe_timestamp"));
+        public static final ColumnIdent PROCESS_CPU = new ColumnIdent(SYS_COL_PROCESS, ImmutableList.of("cpu"));
+        public static final ColumnIdent PROCESS_CPU_PERCENT = new ColumnIdent(SYS_COL_PROCESS, ImmutableList.of("cpu", "percent"));
+        public static final ColumnIdent PROCESS_CPU_USER = new ColumnIdent(SYS_COL_PROCESS, ImmutableList.of("cpu", "user"));
+        public static final ColumnIdent PROCESS_CPU_SYSTEM = new ColumnIdent(SYS_COL_PROCESS, ImmutableList.of("cpu", "system"));
+
+        public static final ColumnIdent FS = new ColumnIdent(SYS_COL_FS);
+        public static final ColumnIdent FS_TOTAL = new ColumnIdent(SYS_COL_FS, ImmutableList.of("total"));
+        public static final ColumnIdent FS_TOTAL_SIZE = new ColumnIdent(SYS_COL_FS, ImmutableList.of("total", "size"));
+        public static final ColumnIdent FS_TOTAL_USED = new ColumnIdent(SYS_COL_FS, ImmutableList.of("total", "used"));
+        public static final ColumnIdent FS_TOTAL_AVAILABLE = new ColumnIdent(SYS_COL_FS, ImmutableList.of("total", "available"));
+        public static final ColumnIdent FS_TOTAL_READS = new ColumnIdent(SYS_COL_FS, ImmutableList.of("total", "reads"));
+        public static final ColumnIdent FS_TOTAL_BYTES_READ = new ColumnIdent(SYS_COL_FS, ImmutableList.of("total", "bytes_read"));
+        public static final ColumnIdent FS_TOTAL_WRITES = new ColumnIdent(SYS_COL_FS, ImmutableList.of("total", "writes"));
+        public static final ColumnIdent FS_TOTAL_BYTES_WRITTEN = new ColumnIdent(SYS_COL_FS, ImmutableList.of("total", "bytes_written"));
+        public static final ColumnIdent FS_DISKS = new ColumnIdent(SYS_COL_FS, ImmutableList.of("disks"));
+        public static final ColumnIdent FS_DISKS_DEV = new ColumnIdent(SYS_COL_FS, ImmutableList.of("disks", "dev"));
+        public static final ColumnIdent FS_DISKS_SIZE = new ColumnIdent(SYS_COL_FS, ImmutableList.of("disks", "size"));
+        public static final ColumnIdent FS_DISKS_USED = new ColumnIdent(SYS_COL_FS, ImmutableList.of("disks", "used"));
+        public static final ColumnIdent FS_DISKS_AVAILABLE = new ColumnIdent(SYS_COL_FS, ImmutableList.of("disks", "available"));
+        public static final ColumnIdent FS_DISKS_READS = new ColumnIdent(SYS_COL_FS, ImmutableList.of("disks", "reads"));
+        public static final ColumnIdent FS_DISKS_BYTES_READ = new ColumnIdent(SYS_COL_FS, ImmutableList.of("disks", "bytes_read"));
+        public static final ColumnIdent FS_DISKS_WRITES = new ColumnIdent(SYS_COL_FS, ImmutableList.of("disks", "writes"));
+        public static final ColumnIdent FS_DISKS_BYTES_WRITTEN = new ColumnIdent(SYS_COL_FS, ImmutableList.of("disks", "bytes_written"));
+        public static final ColumnIdent FS_DATA = new ColumnIdent(SYS_COL_FS, ImmutableList.of("data"));
+        public static final ColumnIdent FS_DATA_DEV = new ColumnIdent(SYS_COL_FS, ImmutableList.of("data", "dev"));
+        public static final ColumnIdent FS_DATA_PATH = new ColumnIdent(SYS_COL_FS, ImmutableList.of("data", "path"));
+    }
 
     private final TableColumn tableColumn;
     private final ClusterService service;
 
     public SysNodesTableInfo(ClusterService service) {
         super(IDENT, new ColumnRegistrar(IDENT, RowGranularity.NODE)
-                        .register(SYS_COL_ID, DataTypes.STRING, null)
-                        .register(SYS_COL_NODE_NAME, DataTypes.STRING, null)
-                        .register(SYS_COL_HOSTNAME, DataTypes.STRING, null)
-                        .register(SYS_COL_REST_URL, DataTypes.STRING, null)
+                        .register(Columns.ID, DataTypes.STRING)
+                        .register(Columns.NAME, DataTypes.STRING)
+                        .register(Columns.HOSTNAME, DataTypes.STRING)
+                        .register(Columns.REST_URL, DataTypes.STRING)
 
-                        .register(SYS_COL_PORT, DataTypes.OBJECT, null)
-                        .register(SYS_COL_PORT, DataTypes.INTEGER, ImmutableList.of("http"))
-                        .register(SYS_COL_PORT, DataTypes.INTEGER, ImmutableList.of("transport"))
+                        .register(Columns.PORT, DataTypes.OBJECT)
+                        .register(Columns.PORT_HTTP, DataTypes.INTEGER)
+                        .register(Columns.PORT_TRANSPORT, DataTypes.INTEGER)
 
-                        .register(SYS_COL_LOAD, DataTypes.OBJECT, null)
-                        .register(SYS_COL_LOAD, DataTypes.DOUBLE, ImmutableList.of("1"))
-                        .register(SYS_COL_LOAD, DataTypes.DOUBLE, ImmutableList.of("5"))
-                        .register(SYS_COL_LOAD, DataTypes.DOUBLE, ImmutableList.of("15"))
-                        .register(SYS_COL_LOAD, DataTypes.TIMESTAMP, ImmutableList.of("probe_timestamp"))
+                        .register(Columns.LOAD, DataTypes.OBJECT)
+                        .register(Columns.LOAD_1, DataTypes.DOUBLE)
+                        .register(Columns.LOAD_5, DataTypes.DOUBLE)
+                        .register(Columns.LOAD_15, DataTypes.DOUBLE)
+                        .register(Columns.LOAD_PROBE_TS, DataTypes.TIMESTAMP)
 
-                        .register(SYS_COL_MEM, DataTypes.OBJECT, null)
-                        .register(SYS_COL_MEM, DataTypes.LONG, ImmutableList.of("free"))
-                        .register(SYS_COL_MEM, DataTypes.LONG, ImmutableList.of("used"))
-                        .register(SYS_COL_MEM, DataTypes.SHORT, ImmutableList.of("free_percent"))
-                        .register(SYS_COL_MEM, DataTypes.SHORT, ImmutableList.of("used_percent"))
-                        .register(SYS_COL_MEM, DataTypes.TIMESTAMP, ImmutableList.of("probe_timestamp"))
+                        .register(Columns.MEM, DataTypes.OBJECT)
+                        .register(Columns.MEM_FREE, DataTypes.LONG)
+                        .register(Columns.MEM_USED, DataTypes.LONG)
+                        .register(Columns.MEM_FREE_PERCENT, DataTypes.SHORT)
+                        .register(Columns.MEM_USED_PERCENT, DataTypes.SHORT)
+                        .register(Columns.MEM_PROBE_TS, DataTypes.TIMESTAMP)
 
-                        .register(SYS_COL_HEAP, DataTypes.OBJECT, null)
-                        .register(SYS_COL_HEAP, DataTypes.LONG, ImmutableList.of("free"))
-                        .register(SYS_COL_HEAP, DataTypes.LONG, ImmutableList.of("used"))
-                        .register(SYS_COL_HEAP, DataTypes.LONG, ImmutableList.of("max"))
-                        .register(SYS_COL_HEAP, DataTypes.TIMESTAMP, ImmutableList.of("probe_timestamp"))
+                        .register(Columns.HEAP, DataTypes.OBJECT)
+                        .register(Columns.HEAP_FREE, DataTypes.LONG)
+                        .register(Columns.HEAP_USED, DataTypes.LONG)
+                        .register(Columns.HEAP_MAX, DataTypes.LONG)
+                        .register(Columns.HEAP_PROBE_TS, DataTypes.TIMESTAMP)
 
-                        .register(SYS_COL_VERSION, DataTypes.OBJECT, null)
-                        .register(SYS_COL_VERSION, StringType.INSTANCE, ImmutableList.of("number"))
-                        .register(SYS_COL_VERSION, StringType.INSTANCE, ImmutableList.of("build_hash"))
-                        .register(SYS_COL_VERSION, DataTypes.BOOLEAN, ImmutableList.of("build_snapshot"))
+                        .register(Columns.VERSION, DataTypes.OBJECT)
+                        .register(Columns.VERSION_NUMBER, StringType.INSTANCE)
+                        .register(Columns.VERSION_BUILD_HASH, StringType.INSTANCE)
+                        .register(Columns.VERSION_BUILD_SNAPSHOT, DataTypes.BOOLEAN)
 
-                        .register(SYS_COL_THREAD_POOLS, OBJECT_ARRAY_TYPE, null)
-                        .register(SYS_COL_THREAD_POOLS, StringType.INSTANCE, ImmutableList.of("name"))
-                        .register(SYS_COL_THREAD_POOLS, IntegerType.INSTANCE, ImmutableList.of("active"))
-                        .register(SYS_COL_THREAD_POOLS, LongType.INSTANCE, ImmutableList.of("rejected"))
-                        .register(SYS_COL_THREAD_POOLS, IntegerType.INSTANCE, ImmutableList.of("largest"))
-                        .register(SYS_COL_THREAD_POOLS, LongType.INSTANCE, ImmutableList.of("completed"))
-                        .register(SYS_COL_THREAD_POOLS, IntegerType.INSTANCE, ImmutableList.of("threads"))
-                        .register(SYS_COL_THREAD_POOLS, IntegerType.INSTANCE, ImmutableList.of("queue"))
+                        .register(Columns.THREAD_POOLS, OBJECT_ARRAY_TYPE)
+                        .register(Columns.THREAD_POOLS_NAME, StringType.INSTANCE)
+                        .register(Columns.THREAD_POOLS_ACTIVE, IntegerType.INSTANCE)
+                        .register(Columns.THREAD_POOLS_REJECTED, LongType.INSTANCE)
+                        .register(Columns.THREAD_POOLS_LARGEST, IntegerType.INSTANCE)
+                        .register(Columns.THREAD_POOLS_COMPLETED, LongType.INSTANCE)
+                        .register(Columns.THREAD_POOLS_THREADS, IntegerType.INSTANCE)
+                        .register(Columns.THREAD_POOLS_QUEUE, IntegerType.INSTANCE)
 
-                        .register(SYS_COL_NETWORK, DataTypes.OBJECT, null)
-                        .register(SYS_COL_NETWORK, DataTypes.TIMESTAMP, ImmutableList.of("probe_timestamp"))
-                        .register(SYS_COL_NETWORK, DataTypes.OBJECT, ImmutableList.of("tcp"))
-                        .register(SYS_COL_NETWORK, DataTypes.OBJECT, ImmutableList.of("tcp", "connections"))
-                        .register(SYS_COL_NETWORK, DataTypes.LONG, ImmutableList.of("tcp", "connections", "initiated"))
-                        .register(SYS_COL_NETWORK, DataTypes.LONG, ImmutableList.of("tcp", "connections", "accepted"))
-                        .register(SYS_COL_NETWORK, DataTypes.LONG, ImmutableList.of("tcp", "connections", "curr_established"))
-                        .register(SYS_COL_NETWORK, DataTypes.LONG, ImmutableList.of("tcp", "connections", "dropped"))
-                        .register(SYS_COL_NETWORK, DataTypes.LONG, ImmutableList.of("tcp", "connections", "embryonic_dropped"))
-                        .register(SYS_COL_NETWORK, DataTypes.OBJECT, ImmutableList.of("tcp", "packets"))
-                        .register(SYS_COL_NETWORK, DataTypes.LONG, ImmutableList.of("tcp", "packets", "sent"))
-                        .register(SYS_COL_NETWORK, DataTypes.LONG, ImmutableList.of("tcp", "packets", "received"))
-                        .register(SYS_COL_NETWORK, DataTypes.LONG, ImmutableList.of("tcp", "packets", "retransmitted"))
-                        .register(SYS_COL_NETWORK, DataTypes.LONG, ImmutableList.of("tcp", "packets", "errors_received"))
-                        .register(SYS_COL_NETWORK, DataTypes.LONG, ImmutableList.of("tcp", "packets", "rst_sent"))
+                        .register(Columns.NETWORK, DataTypes.OBJECT)
+                        .register(Columns.NETWORK_PROBE_TS, DataTypes.TIMESTAMP)
+                        .register(Columns.NETWORK_TCP, DataTypes.OBJECT)
+                        .register(Columns.NETWORK_TCP_CONNECTIONS, DataTypes.OBJECT)
+                        .register(Columns.NETWORK_TCP_CONNECTIONS_INITIATED, DataTypes.LONG)
+                        .register(Columns.NETWORK_TCP_CONNECTIONS_ACCEPTED, DataTypes.LONG)
+                        .register(Columns.NETWORK_TCP_CONNECTIONS_CURR_ESTABLISHED, DataTypes.LONG)
+                        .register(Columns.NETWORK_TCP_CONNECTIONS_DROPPED, DataTypes.LONG)
+                        .register(Columns.NETWORK_TCP_CONNECTIONS_EMBRYONIC_DROPPED, DataTypes.LONG)
+                        .register(Columns.NETWORK_TCP_PACKETS, DataTypes.OBJECT)
+                        .register(Columns.NETWORK_TCP_PACKETS_SENT, DataTypes.LONG)
+                        .register(Columns.NETWORK_TCP_PACKETS_RECEIVED, DataTypes.LONG)
+                        .register(Columns.NETWORK_TCP_PACKETS_RETRANSMITTED, DataTypes.LONG)
+                        .register(Columns.NETWORK_TCP_PACKETS_ERRORS_RECEIVED, DataTypes.LONG)
+                        .register(Columns.NETWORK_TCP_PACKETS_RST_SENT, DataTypes.LONG)
 
-                        .register(SYS_COL_OS, DataTypes.OBJECT, null)
-                        .register(SYS_COL_OS, DataTypes.LONG, ImmutableList.of("uptime"))
-                        .register(SYS_COL_OS, DataTypes.TIMESTAMP, ImmutableList.of("timestamp"))
-                        .register(SYS_COL_OS, DataTypes.TIMESTAMP, ImmutableList.of("probe_timestamp"))
-                        .register(SYS_COL_OS, DataTypes.OBJECT, ImmutableList.of("cpu"))
-                        .register(SYS_COL_OS, DataTypes.SHORT, ImmutableList.of("cpu", "system"))
-                        .register(SYS_COL_OS, DataTypes.SHORT, ImmutableList.of("cpu", "user"))
-                        .register(SYS_COL_OS, DataTypes.SHORT, ImmutableList.of("cpu", "idle"))
-                        .register(SYS_COL_OS, DataTypes.SHORT, ImmutableList.of("cpu", "used"))
-                        .register(SYS_COL_OS, DataTypes.SHORT, ImmutableList.of("cpu", "stolen"))
+                        .register(Columns.OS, DataTypes.OBJECT)
+                        .register(Columns.OS_UPTIME, DataTypes.LONG)
+                        .register(Columns.OS_TIMESTAMP, DataTypes.TIMESTAMP)
+                        .register(Columns.OS_PROBE_TS, DataTypes.TIMESTAMP)
+                        .register(Columns.OS_CPU, DataTypes.OBJECT)
+                        .register(Columns.OS_CPU_SYSTEM, DataTypes.SHORT)
+                        .register(Columns.OS_CPU_USER, DataTypes.SHORT)
+                        .register(Columns.OS_CPU_IDLE, DataTypes.SHORT)
+                        .register(Columns.OS_CPU_USED, DataTypes.SHORT)
+                        .register(Columns.OS_CPU_STOLEN, DataTypes.SHORT)
 
-                        .register(SYS_COL_OS_INFO, DataTypes.OBJECT, null)
-                        .register(SYS_COL_OS_INFO, DataTypes.INTEGER, ImmutableList.of("available_processors"))
-                        .register(SYS_COL_OS_INFO, DataTypes.STRING, ImmutableList.of("name"))
-                        .register(SYS_COL_OS_INFO, DataTypes.STRING, ImmutableList.of("arch"))
-                        .register(SYS_COL_OS_INFO, DataTypes.STRING, ImmutableList.of(SYS_COL_VERSION))
-                        .register(SYS_COL_OS_INFO, DataTypes.OBJECT, ImmutableList.of("jvm"))
-                        .register(SYS_COL_OS_INFO, DataTypes.STRING, ImmutableList.of("jvm", SYS_COL_VERSION))
-                        .register(SYS_COL_OS_INFO, DataTypes.STRING, ImmutableList.of("jvm", "vm_name"))
-                        .register(SYS_COL_OS_INFO, DataTypes.STRING, ImmutableList.of("jvm", "vm_vendor"))
-                        .register(SYS_COL_OS_INFO, DataTypes.STRING, ImmutableList.of("jvm", "vm_version"))
+                        .register(Columns.OS_INFO, DataTypes.OBJECT)
+                        .register(Columns.OS_INFO_AVAIL_PROCESSORS, DataTypes.INTEGER)
+                        .register(Columns.OS_INFO_NAME, DataTypes.STRING)
+                        .register(Columns.OS_INFO_ARCH, DataTypes.STRING)
+                        .register(Columns.OS_INFO_VERSION, DataTypes.STRING)
+                        .register(Columns.OS_INFO_JVM, DataTypes.OBJECT)
+                        .register(Columns.OS_INFO_JVM_VERSION, DataTypes.STRING)
+                        .register(Columns.OS_INFO_JVM_NAME, DataTypes.STRING)
+                        .register(Columns.OS_INFO_JVM_VENDOR, DataTypes.STRING)
+                        .register(Columns.OS_INFO_JVM_VM_VERSION, DataTypes.STRING)
 
-                        .register(SYS_COL_PROCESS, DataTypes.OBJECT, null)
-                        .register(SYS_COL_PROCESS, DataTypes.LONG, ImmutableList.of("open_file_descriptors"))
-                        .register(SYS_COL_PROCESS, DataTypes.LONG, ImmutableList.of("max_open_file_descriptors"))
-                        .register(SYS_COL_PROCESS, DataTypes.TIMESTAMP, ImmutableList.of("probe_timestamp"))
-                        .register(SYS_COL_PROCESS, DataTypes.OBJECT, ImmutableList.of("cpu"))
-                        .register(SYS_COL_PROCESS, DataTypes.SHORT, ImmutableList.of("cpu", "percent"))
-                        .register(SYS_COL_PROCESS, DataTypes.LONG, ImmutableList.of("cpu", "user"))
-                        .register(SYS_COL_PROCESS, DataTypes.LONG, ImmutableList.of("cpu", "system"))
+                        .register(Columns.PROCESS, DataTypes.OBJECT)
+                        .register(Columns.PROCESS_OPEN_FILE_DESCR, DataTypes.LONG)
+                        .register(Columns.PROCESS_MAX_OPEN_FILE_DESCR, DataTypes.LONG)
+                        .register(Columns.PROCESS_PROBE_TS, DataTypes.TIMESTAMP)
+                        .register(Columns.PROCESS_CPU, DataTypes.OBJECT)
+                        .register(Columns.PROCESS_CPU_PERCENT, DataTypes.SHORT)
+                        .register(Columns.PROCESS_CPU_USER, DataTypes.LONG)
+                        .register(Columns.PROCESS_CPU_SYSTEM, DataTypes.LONG)
 
-                        .register(SYS_COL_FS, DataTypes.OBJECT, null)
-                        .register(SYS_COL_FS, DataTypes.OBJECT, ImmutableList.of("total"))
-                        .register(SYS_COL_FS, DataTypes.LONG, ImmutableList.of("total", "size"))
-                        .register(SYS_COL_FS, DataTypes.LONG, ImmutableList.of("total", "used"))
-                        .register(SYS_COL_FS, DataTypes.LONG, ImmutableList.of("total", "available"))
-                        .register(SYS_COL_FS, DataTypes.LONG, ImmutableList.of("total", "reads"))
-                        .register(SYS_COL_FS, DataTypes.LONG, ImmutableList.of("total", "bytes_read"))
-                        .register(SYS_COL_FS, DataTypes.LONG, ImmutableList.of("total", "writes"))
-                        .register(SYS_COL_FS, DataTypes.LONG, ImmutableList.of("total", "bytes_written"))
-
-                        .register(SYS_COL_FS, OBJECT_ARRAY_TYPE, ImmutableList.of("disks"))
-                        .register(SYS_COL_FS, DataTypes.STRING, ImmutableList.of("disks", "dev"))
-                        .register(SYS_COL_FS, DataTypes.LONG, ImmutableList.of("disks", "size"))
-                        .register(SYS_COL_FS, DataTypes.LONG, ImmutableList.of("disks", "used"))
-                        .register(SYS_COL_FS, DataTypes.LONG, ImmutableList.of("disks", "available"))
-                        .register(SYS_COL_FS, DataTypes.LONG, ImmutableList.of("disks", "reads"))
-                        .register(SYS_COL_FS, DataTypes.LONG, ImmutableList.of("disks", "bytes_read"))
-                        .register(SYS_COL_FS, DataTypes.LONG, ImmutableList.of("disks", "writes"))
-                        .register(SYS_COL_FS, DataTypes.LONG, ImmutableList.of("disks", "bytes_written"))
-
-                        .register(SYS_COL_FS, OBJECT_ARRAY_TYPE, ImmutableList.of("data"))
-                        .register(SYS_COL_FS, DataTypes.STRING, ImmutableList.of("data", "dev"))
-                        .register(SYS_COL_FS, DataTypes.STRING, ImmutableList.of("data", "path")),
-                PRIMARY_KEY);
+                        .register(Columns.FS, DataTypes.OBJECT)
+                        .register(Columns.FS_TOTAL, DataTypes.OBJECT)
+                        .register(Columns.FS_TOTAL_SIZE, DataTypes.LONG)
+                        .register(Columns.FS_TOTAL_USED, DataTypes.LONG)
+                        .register(Columns.FS_TOTAL_AVAILABLE, DataTypes.LONG)
+                        .register(Columns.FS_TOTAL_READS, DataTypes.LONG)
+                        .register(Columns.FS_TOTAL_BYTES_READ, DataTypes.LONG)
+                        .register(Columns.FS_TOTAL_WRITES, DataTypes.LONG)
+                        .register(Columns.FS_TOTAL_BYTES_WRITTEN, DataTypes.LONG)
+                        .register(Columns.FS_DISKS, OBJECT_ARRAY_TYPE)
+                        .register(Columns.FS_DISKS_DEV, DataTypes.STRING)
+                        .register(Columns.FS_DISKS_SIZE, DataTypes.LONG)
+                        .register(Columns.FS_DISKS_USED, DataTypes.LONG)
+                        .register(Columns.FS_DISKS_AVAILABLE, DataTypes.LONG)
+                        .register(Columns.FS_DISKS_READS, DataTypes.LONG)
+                        .register(Columns.FS_DISKS_BYTES_READ, DataTypes.LONG)
+                        .register(Columns.FS_DISKS_WRITES, DataTypes.LONG)
+                        .register(Columns.FS_DISKS_BYTES_WRITTEN, DataTypes.LONG)
+                        .register(Columns.FS_DATA, OBJECT_ARRAY_TYPE)
+                        .register(Columns.FS_DATA_DEV, DataTypes.STRING)
+                        .register(Columns.FS_DATA_PATH, DataTypes.STRING),
+            PRIMARY_KEY);
         this.service = service;
         this.tableColumn = new TableColumn(SYS_COL_IDENT, columnMap);
     }

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/NodeHeapExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/NodeHeapExpression.java
@@ -29,12 +29,12 @@ public class NodeHeapExpression extends SysNodeObjectReference {
     abstract class HeapExpression extends SysNodeExpression<Object> {
     }
 
-    public static final String MAX = "max";
-    public static final String FREE = "free";
-    public static final String USED = "used";
-    public static final String PROBE_TIMESTAMP = "probe_timestamp";
+    private static final String MAX = "max";
+    private static final String FREE = "free";
+    private static final String USED = "used";
+    private static final String PROBE_TIMESTAMP = "probe_timestamp";
 
-    public NodeHeapExpression(JvmStats stats) {
+    NodeHeapExpression(JvmStats stats) {
         addChildImplementations(stats);
     }
 

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/NodeLoadExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/NodeLoadExpression.java
@@ -26,9 +26,9 @@ import io.crate.monitor.ExtendedOsStats;
 
 public class NodeLoadExpression extends SysNodeObjectReference {
 
-    public static final String ONE = "1";
-    public static final String FIVE = "5";
-    public static final String FIFTEEN = "15";
+    private static final String ONE = "1";
+    private static final String FIVE = "5";
+    private static final String FIFTEEN = "15";
     private static final String PROBE_TIMESTAMP = "probe_timestamp";
 
     public NodeLoadExpression(final ExtendedOsStats os) {

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/NodeMemoryExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/NodeMemoryExpression.java
@@ -29,11 +29,11 @@ public class NodeMemoryExpression extends SysNodeObjectReference {
     abstract class MemoryExpression extends SysNodeExpression<Object> {
     }
 
-    public static final String FREE = "free";
-    public static final String USED = "used";
-    public static final String FREE_PERCENT = "free_percent";
-    public static final String USED_PERCENT = "used_percent";
-    public static final String PROBE_TIMESTAMP = "probe_timestamp";
+    private static final String FREE = "free";
+    private static final String USED = "used";
+    private static final String FREE_PERCENT = "free_percent";
+    private static final String USED_PERCENT = "used_percent";
+    private static final String PROBE_TIMESTAMP = "probe_timestamp";
 
     public NodeMemoryExpression(final OsStats stats) {
         addChildImplementations(stats.getMem());

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/NodeNetworkExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/NodeNetworkExpression.java
@@ -21,7 +21,6 @@
 
 package io.crate.operation.reference.sys.node;
 
-import io.crate.metadata.sys.SysNodesTableInfo;
 import io.crate.operation.reference.sys.SysNodeObjectReference;
 import io.crate.monitor.ExtendedNetworkStats;
 import org.elasticsearch.common.inject.Inject;
@@ -30,7 +29,8 @@ import org.elasticsearch.common.inject.Singleton;
 @Singleton
 public class NodeNetworkExpression extends SysNodeObjectReference {
 
-    public static final String PROBE_TIMESTAMP = "probe_timestamp";
+    private static final String TCP = "tcp";
+    private static final String PROBE_TIMESTAMP = "probe_timestamp";
 
     @Inject
     public NodeNetworkExpression(final ExtendedNetworkStats stats) {
@@ -40,8 +40,7 @@ public class NodeNetworkExpression extends SysNodeObjectReference {
                 return stats.timestamp();
             }
         });
-        childImplementations.put(SysNodesTableInfo.SYS_COL_NETWORK_TCP,
-                new NodeNetworkTCPExpression(stats));
+        childImplementations.put(TCP, new NodeNetworkTCPExpression(stats));
     }
 
 }

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/NodeNetworkTCPExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/NodeNetworkTCPExpression.java
@@ -43,7 +43,7 @@ class NodeNetworkTCPExpression extends SysNodeObjectReference {
         private static final String DROPPED = "dropped";
         private static final String EMBRYONIC_DROPPED = "embryonic_dropped";
 
-        protected TCPConnectionsExpression(ExtendedNetworkStats stats) {
+        TCPConnectionsExpression(ExtendedNetworkStats stats) {
             addChildImplementations(stats.tcp());
         }
 
@@ -109,7 +109,7 @@ class NodeNetworkTCPExpression extends SysNodeObjectReference {
         private static final String ERRORS_RECEIVED = "errors_received";
         private static final String RST_SENT = "rst_sent";
 
-        protected TCPPacketsExpression(ExtendedNetworkStats stats) {
+        TCPPacketsExpression(ExtendedNetworkStats stats) {
             addChildImplementations(stats.tcp());
         }
 

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/NodeOsExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/NodeOsExpression.java
@@ -21,7 +21,6 @@
 
 package io.crate.operation.reference.sys.node;
 
-import io.crate.metadata.sys.SysNodesTableInfo;
 import io.crate.monitor.ExtendedOsStats;
 import io.crate.operation.reference.sys.SysNodeObjectReference;
 
@@ -31,9 +30,10 @@ public class NodeOsExpression extends SysNodeObjectReference {
     abstract class OsExpression extends SysNodeExpression<Object> {
     }
 
-    public static final String UPTIME = "uptime";
-    public static final String TIMESTAMP = "timestamp";
+    private static final String UPTIME = "uptime";
+    private static final String TIMESTAMP = "timestamp";
     private static final String PROBE_TIMESTAMP = "probe_timestamp";
+    private static final String CPU = "cpu";
 
     public NodeOsExpression(ExtendedOsStats extendedOsStats) {
         addChildImplementations(extendedOsStats);
@@ -60,8 +60,7 @@ public class NodeOsExpression extends SysNodeObjectReference {
                 return extendedOsStats.timestamp();
             }
         });
-        childImplementations.put(SysNodesTableInfo.SYS_COL_OS_CPU,
-                new NodeOsCpuExpression(extendedOsStats.cpu()));
+        childImplementations.put(CPU, new NodeOsCpuExpression(extendedOsStats.cpu()));
     }
 
 }

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/NodeOsInfoExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/NodeOsInfoExpression.java
@@ -21,7 +21,6 @@
 
 package io.crate.operation.reference.sys.node;
 
-import io.crate.metadata.sys.SysNodesTableInfo;
 import io.crate.operation.reference.sys.SysNodeObjectReference;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.Constants;
@@ -34,6 +33,7 @@ public class NodeOsInfoExpression extends SysNodeObjectReference {
     private static final String OS = "name";
     private static final String ARCH = "arch";
     private static final String VERSION = "version";
+    private static final String JVM = "jvm";
 
     private static final BytesRef OS_NAME = BytesRefs.toBytesRef(Constants.OS_NAME);
     private static final BytesRef OS_ARCH = BytesRefs.toBytesRef(Constants.OS_ARCH);
@@ -72,7 +72,7 @@ public class NodeOsInfoExpression extends SysNodeObjectReference {
                 return OS_VERSION;
             }
         });
-        childImplementations.put(SysNodesTableInfo.SYS_COL_OS_INFO_JVM, new NodeOsJvmExpression());
+        childImplementations.put(JVM, new NodeOsJvmExpression());
     }
 
 }

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/NodePortExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/NodePortExpression.java
@@ -35,8 +35,8 @@ public class NodePortExpression extends SysNodeObjectReference {
     abstract class PortExpression extends SysNodeExpression<Integer> {
     }
 
-    public static final String HTTP = "http";
-    public static final String TRANSPORT = "transport";
+    private static final String HTTP = "http";
+    private static final String TRANSPORT = "transport";
 
     private final NodeService nodeService;
 

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/NodeProcessExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/NodeProcessExpression.java
@@ -21,16 +21,17 @@
 
 package io.crate.operation.reference.sys.node;
 
-import io.crate.metadata.sys.SysNodesTableInfo;
 import io.crate.operation.reference.sys.SysNodeObjectReference;
 import io.crate.monitor.ExtendedProcessCpuStats;
 import org.elasticsearch.monitor.process.ProcessStats;
 
+
 public class NodeProcessExpression extends SysNodeObjectReference {
 
-    public static final String OPEN_FILE_DESCRIPTORS = "open_file_descriptors";
-    public static final String MAX_OPEN_FILE_DESCRIPTORS = "max_open_file_descriptors";
+    private static final String OPEN_FILE_DESCRIPTORS = "open_file_descriptors";
+    private static final String MAX_OPEN_FILE_DESCRIPTORS = "max_open_file_descriptors";
     private static final String PROBE_TIMESTAMP = "probe_timestamp";
+    private static final String CPU = "cpu";
 
 
     public NodeProcessExpression(ProcessStats processStats, ExtendedProcessCpuStats cpuStats) {
@@ -68,6 +69,6 @@ public class NodeProcessExpression extends SysNodeObjectReference {
                 }
             }
         });
-        childImplementations.put(SysNodesTableInfo.SYS_COL_PROCESS_CPU, new NodeProcessCpuExpression(cpuStats));
+        childImplementations.put(CPU, new NodeProcessCpuExpression(cpuStats));
     }
 }

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/NodeThreadPoolExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/NodeThreadPoolExpression.java
@@ -34,13 +34,13 @@ public class NodeThreadPoolExpression extends SysNodeObjectReference {
     abstract class ThreadPoolExpression<ChildType> extends SysNodeExpression<ChildType> {
     }
 
-    public static final String POOL_NAME = "name";
-    public static final String ACTIVE = "active";
-    public static final String REJECTED = "rejected";
-    public static final String LARGEST = "largest";
-    public static final String COMPLETED = "completed";
-    public static final String THREADS = "threads";
-    public static final String QUEUE = "queue";
+    private static final String POOL_NAME = "name";
+    private static final String ACTIVE = "active";
+    private static final String REJECTED = "rejected";
+    private static final String LARGEST = "largest";
+    private static final String COMPLETED = "completed";
+    private static final String THREADS = "threads";
+    private static final String QUEUE = "queue";
 
     private final ThreadPoolExecutor threadPoolExecutor;
     private final BytesRef name;

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/NodeVersionExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/NodeVersionExpression.java
@@ -28,9 +28,9 @@ import org.apache.lucene.util.BytesRef;
 
 public class NodeVersionExpression extends SysNodeObjectReference {
 
-    public static final String NUMBER = "number";
-    public static final String BUILD_HASH = "build_hash";
-    public static final String BUILD_SNAPSHOT = "build_snapshot";
+    private static final String NUMBER = "number";
+    private static final String BUILD_HASH = "build_hash";
+    private static final String BUILD_SNAPSHOT = "build_snapshot";
 
     protected NodeVersionExpression() {
         childImplementations.put(NUMBER, new VersionNumberExpression());

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/fs/NodeFsDisksExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/fs/NodeFsDisksExpression.java
@@ -30,6 +30,8 @@ import org.apache.lucene.util.BytesRef;
 import java.util.ArrayList;
 import java.util.List;
 
+import static io.crate.operation.reference.sys.node.fs.NodeFsExpression.*;
+
 public class NodeFsDisksExpression extends SysObjectArrayReference {
 
     private final ExtendedFsStats extendedFsStats;
@@ -49,14 +51,7 @@ public class NodeFsDisksExpression extends SysObjectArrayReference {
 
     private static class NodeFsDiskChildExpression extends SysNodeObjectReference {
 
-        public static final String DEV = "dev";
-        public static final String SIZE = "size";
-        public static final String USED = "used";
-        public static final String AVAILABLE = "available";
-        public static final String READS = "reads";
-        public static final String BYTES_READ = "bytes_read";
-        public static final String WRITES = "writes";
-        public static final String BYTES_WRITTEN = "bytes_written";
+        private static final String DEV = "dev";
 
         private final ExtendedFsStats.Info fsInfo;
 

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/fs/NodeFsExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/fs/NodeFsExpression.java
@@ -21,16 +21,30 @@
 
 package io.crate.operation.reference.sys.node.fs;
 
-import io.crate.metadata.sys.SysNodesTableInfo;
 import io.crate.operation.reference.sys.SysNodeObjectReference;
 import io.crate.monitor.ExtendedFsStats;
 
 public class NodeFsExpression extends SysNodeObjectReference {
 
+    private static final String TOTAL = "total";
+    private static final String DISKS = "disks";
+    private static final String DATA = "data";
+
+    /**
+     * Names of subcolumns that are common across NodeFSTotalExpression and NodeFsDiskExpression.
+     */
+    static final String SIZE = "size";
+    static final String USED = "used";
+    static final String AVAILABLE = "available";
+    static final String READS = "reads";
+    static final String BYTES_READ = "bytes_read";
+    static final String WRITES = "writes";
+    static final String BYTES_WRITTEN = "bytes_written";
+
     public NodeFsExpression(ExtendedFsStats fsStats) {
-        childImplementations.put(SysNodesTableInfo.SYS_COL_FS_TOTAL, new NodeFsTotalExpression(fsStats));
-        childImplementations.put(SysNodesTableInfo.SYS_COL_FS_DISKS, new NodeFsDisksExpression(fsStats));
-        childImplementations.put(SysNodesTableInfo.SYS_COL_FS_DATA, new NodeFsDataExpression(fsStats));
+        childImplementations.put(TOTAL, new NodeFsTotalExpression(fsStats));
+        childImplementations.put(DISKS, new NodeFsDisksExpression(fsStats));
+        childImplementations.put(DATA, new NodeFsDataExpression(fsStats));
     }
 
 }

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/fs/NodeFsTotalExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/fs/NodeFsTotalExpression.java
@@ -37,15 +37,10 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
+import static io.crate.operation.reference.sys.node.fs.NodeFsExpression.*;
+
 public class NodeFsTotalExpression extends SysNodeObjectReference {
 
-    public static final String SIZE = "size";
-    public static final String USED = "used";
-    public static final String AVAILABLE = "available";
-    public static final String READS = "reads";
-    public static final String BYTES_READ = "bytes_read";
-    public static final String WRITES = "writes";
-    public static final String BYTES_WRITTEN = "bytes_written";
 
     private static final List<String> ALL_TOTALS = ImmutableList.of(
             SIZE, USED, AVAILABLE, READS, BYTES_READ, WRITES, BYTES_WRITTEN);

--- a/sql/src/test/java/io/crate/operation/reference/sys/SysNodesExpressionsTest.java
+++ b/sql/src/test/java/io/crate/operation/reference/sys/SysNodesExpressionsTest.java
@@ -447,8 +447,8 @@ public class SysNodesExpressionsTest extends CrateUnitTest {
         refInfo = refInfo("sys.nodes.version", DataTypes.STRING, RowGranularity.NODE, "number");
         SysNodeExpression<BytesRef> versionNumber = (SysNodeExpression<BytesRef>) resolver.getImplementation(refInfo);
 
-        assertThat(version.value().get(NodeVersionExpression.NUMBER), instanceOf(String.class));
-        assertThat(versionNumber.value(), is(new BytesRef(version.value().get(NodeVersionExpression.NUMBER).toString())));
+        assertThat(version.value().get("number"), instanceOf(String.class));
+        assertThat(versionNumber.value(), is(new BytesRef(version.value().get("number").toString())));
 
     }
 

--- a/sql/src/test/java/io/crate/operation/reference/sys/node/NodeOsExpressionTest.java
+++ b/sql/src/test/java/io/crate/operation/reference/sys/node/NodeOsExpressionTest.java
@@ -35,7 +35,7 @@ public class NodeOsExpressionTest extends CrateUnitTest {
     public void testOsTimestampNotEvaluatedTwice() throws Exception {
         ExtendedOsStats osStats = mock(ExtendedOsStats.class);
         NodeOsExpression nodeOsExpression = new NodeOsExpression(osStats);
-        ReferenceImplementation timestampExpr = nodeOsExpression.getChildImplementation(NodeOsExpression.TIMESTAMP);
+        ReferenceImplementation timestampExpr = nodeOsExpression.getChildImplementation("timestamp");
         Long ts1 = (Long) timestampExpr.value();
         Thread.sleep(10L);
         Long ts2 = (Long) timestampExpr.value();

--- a/sql/src/test/java/io/crate/operation/reference/sys/node/NodePortExpressionTest.java
+++ b/sql/src/test/java/io/crate/operation/reference/sys/node/NodePortExpressionTest.java
@@ -41,7 +41,7 @@ public class NodePortExpressionTest extends CrateUnitTest {
 
 
         NodePortExpression nodePortExpression = new NodePortExpression(nodeService);
-        Object value = nodePortExpression.getChildImplementation(NodePortExpression.HTTP).value();
+        Object value = nodePortExpression.getChildImplementation("http").value();
         assertThat(value, Matchers.nullValue());
     }
 }


### PR DESCRIPTION
to follow same pattern as other table infos
this is required to use the column idents in the
rowcontextreferenceresolver later