### PR TITLE
pgwire: Set server version to 9500

### DIFF
--- a/sql/src/main/java/io/crate/protocols/postgres/ConnectionContext.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/ConnectionContext.java
@@ -259,8 +259,7 @@ class ConnectionContext {
                     session = readStartupMessage(buffer);
                     Messages.sendAuthenticationOK(channel);
 
-                    // version between 7.3 and 8 to get simpler pg_type queries from jdbc client
-                    Messages.sendParameterStatus(channel, "server_version", "79000");
+                    Messages.sendParameterStatus(channel, "server_version", "95000");
                     Messages.sendParameterStatus(channel, "server_encoding", "UTF8");
                     Messages.sendParameterStatus(channel, "client_encoding", "UTF8");
                     Messages.sendParameterStatus(channel, "datestyle", "ISO");


### PR DESCRIPTION
After the client version upgrade the workaround of decreasing the server
version is no longer requied.