### PR TITLE
Use jdbc client randomly in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: java
 jdk:
-  - openjdk7
   - oraclejdk8
 
 sudo: false

--- a/blackbox/docs/protocols/postgres.txt
+++ b/blackbox/docs/protocols/postgres.txt
@@ -108,6 +108,7 @@ Crate::
     |  oid | typdelim | typelem | typname     |
     +------+----------+---------+-------------+
     |   16 | ,        |       0 | bool        |
+    |   18 | ,        |       0 | char        |
     |   20 | ,        |       0 | int8        |
     |   21 | ,        |       0 | int2        |
     |   23 | ,        |       0 | int4        |
@@ -115,6 +116,7 @@ Crate::
     |  700 | ,        |       0 | float4      |
     |  701 | ,        |       0 | float8      |
     | 1000 | ,        |      16 | _bool       |
+    | 1002 | ,        |      18 | _char       |
     | 1005 | ,        |      21 | _int2       |
     | 1007 | ,        |      23 | _int4       |
     | 1015 | ,        |    1043 | _varchar    |
@@ -122,11 +124,10 @@ Crate::
     | 1021 | ,        |     700 | _float4     |
     | 1022 | ,        |     701 | _float8     |
     | 1043 | ,        |       0 | varchar     |
-    | 1043 | ,        |       0 | varchar     |
     | 1184 | ,        |       0 | timestampz  |
     | 1185 | ,        |    1184 | _timestampz |
     +------+----------+---------+-------------+
-    SELECT 18 rows in set (... sec)
+    SELECT 19 rows in set (... sec)
 
 
 Connection failover and load balancing

--- a/gradle/javaModule.gradle
+++ b/gradle/javaModule.gradle
@@ -3,6 +3,7 @@ apply plugin: "maven"
 
 repositories {
     mavenCentral()
+    maven { url "https://jitpack.io" }
 }
 
 sourceCompatibility = "7"

--- a/sql/build.gradle
+++ b/sql/build.gradle
@@ -20,7 +20,9 @@ dependencies {
     testCompile project(':testing')
     testCompile 'org.skyscreamer:jsonassert:1.2.0'
     testCompile 'org.hamcrest:hamcrest-all:1.3'
-    testCompile 'org.postgresql:postgresql:9.4.1209.jre7'
+    testCompile ('com.github.pgjdbc:pgjdbc:01b65c3642') {
+        exclude group: 'org.openjdk.jmh', module: 'jmh-core'
+    }
     benchmarksCompile 'com.carrotsearch:junit-benchmarks:0.7.2'
     benchmarksCompile 'com.h2database:h2:1.3.173'
 

--- a/sql/src/main/java/io/crate/analyze/SafeExpressionToStringVisitor.java
+++ b/sql/src/main/java/io/crate/analyze/SafeExpressionToStringVisitor.java
@@ -25,6 +25,7 @@ import io.crate.sql.tree.AstVisitor;
 import io.crate.sql.tree.Node;
 import io.crate.sql.tree.ParameterExpression;
 import io.crate.sql.tree.StringLiteral;
+import org.apache.lucene.util.BytesRef;
 
 import javax.annotation.Nullable;
 import java.util.Locale;
@@ -46,6 +47,9 @@ public class SafeExpressionToStringVisitor extends AstVisitor<String, Object[]> 
     @Override
     public String visitParameterExpression(ParameterExpression node, Object[] parameters) {
         Object value = parameters[node.index()];
+        if (value instanceof BytesRef) {
+            return ((BytesRef) value).utf8ToString();
+        }
         if (!(value instanceof String)) {
             throw new IllegalArgumentException(String.format(Locale.ENGLISH, "Parameter %s not a string value, can't handle this.", value));
         }

--- a/sql/src/main/java/io/crate/protocols/postgres/types/CharType.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/CharType.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.protocols.postgres.types;
+
+import org.jboss.netty.buffer.ChannelBuffer;
+
+import javax.annotation.Nonnull;
+import java.nio.charset.StandardCharsets;
+
+class CharType extends PGType {
+
+    public static final PGType INSTANCE = new CharType();
+    static final int OID = 18;
+
+
+    private CharType() {
+        super(OID, 1, -1, "char");
+    }
+
+    @Override
+    public int writeAsBinary(ChannelBuffer buffer, @Nonnull Object value) {
+        buffer.writeInt(1);
+        buffer.writeByte(((byte) value));
+        return 5;
+    }
+
+    @Override
+    public Object readBinaryValue(ChannelBuffer buffer, int valueLength) {
+        assert valueLength == 1: "char must have 1 byte";
+        return buffer.readByte();
+    }
+
+    @Override
+    byte[] encodeAsUTF8Text(@Nonnull Object value) {
+        return Byte.toString((byte) value).getBytes(StandardCharsets.UTF_8);
+    }
+
+    @Override
+    Object decodeUTF8Text(byte[] bytes) {
+        return Byte.parseByte(new String(bytes, StandardCharsets.UTF_8));
+    }
+}

--- a/sql/src/test/java/io/crate/integrationtests/AnyIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/AnyIntegrationTest.java
@@ -22,6 +22,7 @@
 package io.crate.integrationtests;
 
 import io.crate.testing.TestingHelpers;
+import io.crate.testing.UseJdbc;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.Is;
 import org.junit.Rule;
@@ -30,6 +31,7 @@ import org.junit.rules.ExpectedException;
 
 import static org.hamcrest.Matchers.is;
 
+@UseJdbc
 public class AnyIntegrationTest extends SQLTransportIntegrationTest {
 
     @Rule

--- a/sql/src/test/java/io/crate/integrationtests/ArithmeticIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ArithmeticIntegrationTest.java
@@ -23,6 +23,7 @@ package io.crate.integrationtests;
 
 import io.crate.action.sql.SQLActionException;
 import io.crate.testing.TestingHelpers;
+import io.crate.testing.UseJdbc;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -34,6 +35,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 
 
+@UseJdbc
 public class ArithmeticIntegrationTest extends SQLTransportIntegrationTest {
 
     @Rule
@@ -148,8 +150,7 @@ public class ArithmeticIntegrationTest extends SQLTransportIntegrationTest {
         execute("insert into t (d, i) values (?, ?), (?, ?), (?, ?)", new Object[]{
                 1.3d, 1,
                 1.6d, 2,
-                2.2d, 9,
-                -3.4, 6});
+                2.2d, 9});
         execute("refresh table t");
 
         execute("select i from t where round(d) = i order by i");
@@ -165,8 +166,7 @@ public class ArithmeticIntegrationTest extends SQLTransportIntegrationTest {
         execute("insert into t (x, base) values (?, ?), (?, ?), (?, ?)", new Object[]{
                 144L, 12L, // 2
                 65536L, 2L, // 16
-                9L, 3L, // 2
-                700L, 3L // 5.9630...
+                9L, 3L // 2
         });
         execute("refresh table t");
 

--- a/sql/src/test/java/io/crate/integrationtests/CastIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/CastIntegrationTest.java
@@ -22,6 +22,7 @@
 
 package io.crate.integrationtests;
 
+import io.crate.testing.UseJdbc;
 import org.hamcrest.Matcher;
 import org.junit.Rule;
 import org.junit.Test;
@@ -32,6 +33,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.collection.IsArrayContainingInOrder.arrayContaining;
 
 
+@UseJdbc
 public class CastIntegrationTest extends SQLTransportIntegrationTest {
 
     @Rule

--- a/sql/src/test/java/io/crate/integrationtests/ClientNodeIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ClientNodeIntegrationTest.java
@@ -40,6 +40,11 @@ public class ClientNodeIntegrationTest extends SQLTransportIntegrationTest {
                         // make sure we use a client node (started with client=true)
                         return internalCluster().clientNodeClient();
                     }
+
+                    @Override
+                    public String pgUrl() {
+                        return null;
+                    }
                 }
         ));
     }

--- a/sql/src/test/java/io/crate/integrationtests/ColumnPolicyIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ColumnPolicyIntegrationTest.java
@@ -28,6 +28,7 @@ import io.crate.metadata.PartitionName;
 import io.crate.metadata.TableIdent;
 import io.crate.metadata.table.ColumnPolicy;
 import io.crate.testing.TestingHelpers;
+import io.crate.testing.UseJdbc;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesResponse;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
@@ -51,6 +52,7 @@ import java.util.Map;
 import static org.hamcrest.Matchers.*;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 1)
+@UseJdbc
 public class ColumnPolicyIntegrationTest extends SQLTransportIntegrationTest {
 
     private String copyFilePath = getClass().getResource("/essetup/data/copy").getPath();

--- a/sql/src/test/java/io/crate/integrationtests/ConcurrencyIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ConcurrencyIntegrationTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.integrationtests;
 
+import io.crate.testing.UseJdbc;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -31,6 +32,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+@UseJdbc
 public class ConcurrencyIntegrationTest extends SQLTransportIntegrationTest {
 
     private ExecutorService executor;

--- a/sql/src/test/java/io/crate/integrationtests/CountStarIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/CountStarIntegrationTest.java
@@ -22,12 +22,14 @@
 package io.crate.integrationtests;
 
 import io.crate.action.sql.SQLActionException;
+import io.crate.testing.UseJdbc;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import static org.hamcrest.core.Is.is;
 
+@UseJdbc
 public class CountStarIntegrationTest extends SQLTransportIntegrationTest {
 
     @Rule

--- a/sql/src/test/java/io/crate/integrationtests/CrateSettingsIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/CrateSettingsIntegrationTest.java
@@ -2,10 +2,12 @@ package io.crate.integrationtests;
 
 
 import io.crate.action.sql.SQLResponse;
+import io.crate.testing.UseJdbc;
 import org.junit.Test;
 
 import java.util.Locale;
 
+@UseJdbc
 public class CrateSettingsIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/CreateTableIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/CreateTableIntegrationTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.integrationtests;
 
+import io.crate.testing.UseJdbc;
 import org.junit.Test;
 
 import java.util.concurrent.ExecutorService;
@@ -30,6 +31,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.hamcrest.Matchers.is;
 
+@UseJdbc
 public class CreateTableIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/CustomSchemaIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/CustomSchemaIntegrationTest.java
@@ -22,11 +22,13 @@
 package io.crate.integrationtests;
 
 import io.crate.testing.TestingHelpers;
+import io.crate.testing.UseJdbc;
 import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsRequest;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
 
+@UseJdbc
 public class CustomSchemaIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -25,6 +25,7 @@ import io.crate.Version;
 import io.crate.action.sql.SQLActionException;
 import io.crate.metadata.PartitionName;
 import io.crate.testing.TestingHelpers;
+import io.crate.testing.UseJdbc;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsRequest;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
@@ -43,10 +44,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(randomDynamicTemplates = false)
+@UseJdbc
 public class DDLIntegrationTest extends SQLTransportIntegrationTest {
 
     @Rule
@@ -534,6 +537,7 @@ public class DDLIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    @UseJdbc(false) // drop table has no rowcount
     public void testDropTable() throws Exception {
         execute("create table test (col1 integer primary key, col2 string)");
         ensureYellow();
@@ -564,6 +568,7 @@ public class DDLIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    @UseJdbc(false) // drop table has no rowcount
     public void testDropTableIfExists() {
         execute("create table test (col1 integer primary key, col2 string)");
         ensureYellow();
@@ -593,6 +598,7 @@ public class DDLIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    @UseJdbc(false) // drop table has no rowcount
     public void testDropIfExistsBlobTable() throws Exception {
         execute("create blob table screenshots with (number_of_replicas=0)");
         execute("drop blob table if exists screenshots");
@@ -651,6 +657,7 @@ public class DDLIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    @UseJdbc(false) // estoCrateException rewrite is missing
     public void testCreateTableWithIllegalCustomSchemaCheckedByES() throws Exception {
         expectedException.expect(SQLActionException.class);
         expectedException.expectMessage("table name \"AAA.t\" is invalid.");
@@ -658,6 +665,7 @@ public class DDLIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    @UseJdbc(false) // drop table has no rowcount
     public void testDropTableWithCustomSchema() throws Exception {
         execute("create table a.t (name string) with (number_of_replicas=0)");
         ensureYellow();

--- a/sql/src/test/java/io/crate/integrationtests/DeleteIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/DeleteIntegrationTest.java
@@ -22,11 +22,13 @@
 
 package io.crate.integrationtests;
 
+import io.crate.testing.UseJdbc;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.core.Is.is;
 
+@UseJdbc
 public class DeleteIntegrationTest extends SQLTransportIntegrationTest {
 
     private Setup setup = new Setup(sqlExecutor);

--- a/sql/src/test/java/io/crate/integrationtests/EmptyStringRoutingIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/EmptyStringRoutingIntegrationTest.java
@@ -22,6 +22,7 @@
 package io.crate.integrationtests;
 
 import io.crate.action.sql.SQLResponse;
+import io.crate.testing.UseJdbc;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -38,6 +39,7 @@ import static org.hamcrest.core.Is.is;
  * the contract of having the same value of the routing field on only one shard. So in Crate the behaviour is
  * different and is asserted via tests in this class.
  */
+@UseJdbc
 public class EmptyStringRoutingIntegrationTest extends SQLTransportIntegrationTest {
 
     @Rule
@@ -109,6 +111,7 @@ public class EmptyStringRoutingIntegrationTest extends SQLTransportIntegrationTe
     }
 
     @Test
+    @UseJdbc(false) // copy has no rowcount
     public void testCopyFromEmptyStringRouting() throws Exception {
         execute("create table t (i int primary key, c string primary key, a int) clustered by (c)");
         ensureYellow();

--- a/sql/src/test/java/io/crate/integrationtests/FetchOperationIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/FetchOperationIntegrationTest.java
@@ -32,6 +32,7 @@ import io.crate.planner.node.dql.QueryThenFetch;
 import io.crate.planner.projection.FetchProjection;
 import io.crate.sql.parser.SqlParser;
 import io.crate.testing.CollectingRowReceiver;
+import io.crate.testing.UseJdbc;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.After;
@@ -45,6 +46,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 2, numClientNodes = 0)
+@UseJdbc
 public class FetchOperationIntegrationTest extends SQLTransportIntegrationTest {
 
     TransportExecutor executor;

--- a/sql/src/test/java/io/crate/integrationtests/FulltextAnalyzerResolverTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/FulltextAnalyzerResolverTest.java
@@ -27,6 +27,7 @@ import com.google.common.collect.Sets;
 import io.crate.action.sql.SQLActionException;
 import io.crate.action.sql.SQLResponse;
 import io.crate.metadata.FulltextAnalyzerResolver;
+import io.crate.testing.UseJdbc;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.common.settings.Settings;
 import org.junit.*;
@@ -42,6 +43,7 @@ import static org.hamcrest.Matchers.*;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
 import static org.hamcrest.collection.IsMapContaining.hasKey;
 
+@UseJdbc
 public class FulltextAnalyzerResolverTest extends SQLTransportIntegrationTest {
 
     @Rule

--- a/sql/src/test/java/io/crate/integrationtests/GroupByAggregateBreakerTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/GroupByAggregateBreakerTest.java
@@ -24,12 +24,14 @@ package io.crate.integrationtests;
 import io.crate.action.sql.SQLActionException;
 import io.crate.breaker.CrateCircuitBreakerService;
 import io.crate.breaker.RamAccountingContext;
+import io.crate.testing.UseJdbc;
 import org.elasticsearch.common.settings.Settings;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+@UseJdbc
 public class GroupByAggregateBreakerTest extends SQLTransportIntegrationTest {
 
 

--- a/sql/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
@@ -28,6 +28,7 @@ import io.crate.action.sql.SQLResponse;
 import io.crate.core.collections.ArrayBucket;
 import io.crate.operation.Paging;
 import io.crate.testing.TestingHelpers;
+import io.crate.testing.UseJdbc;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.hamcrest.core.Is;
 import org.junit.Before;
@@ -42,6 +43,7 @@ import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.isIn;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 2, numClientNodes = 0)
+@UseJdbc
 public class GroupByAggregateTest extends SQLTransportIntegrationTest {
 
     private Setup setup = new Setup(sqlExecutor);

--- a/sql/src/test/java/io/crate/integrationtests/InformationSchemaQueryTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InformationSchemaQueryTest.java
@@ -22,6 +22,7 @@
 package io.crate.integrationtests;
 
 import io.crate.action.sql.SQLResponse;
+import io.crate.testing.UseJdbc;
 import org.elasticsearch.action.admin.indices.close.CloseIndexRequest;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -29,6 +30,7 @@ import org.junit.Test;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
+@UseJdbc
 public class InformationSchemaQueryTest extends SQLTransportIntegrationTest {
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -28,6 +28,7 @@ import io.crate.action.sql.SQLAction;
 import io.crate.action.sql.SQLActionException;
 import io.crate.action.sql.SQLRequest;
 import io.crate.testing.TestingHelpers;
+import io.crate.testing.UseJdbc;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.hamcrest.Matchers;
@@ -42,6 +43,7 @@ import static org.hamcrest.Matchers.*;
 
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 2)
+@UseJdbc
 public class InformationSchemaTest extends SQLTransportIntegrationTest {
 
     final static Joiner commaJoiner = Joiner.on(", ");
@@ -972,11 +974,9 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
         execute("select table_name, partition_ident, values from information_schema.table_partitions order by table_name, partition_ident");
         assertEquals(2, response.rowCount());
 
-        Object[] row1 = new Object[] { "my_table", "04130", ImmutableMap.of("metadata['date']", 0L) };
-        Object[] row2 = new Object[] { "my_table", "04732d1g64p36d9i60o30c1g", ImmutableMap.of("metadata['date']", 1401235200000L) };
-
-        assertArrayEquals(row1, response.rows()[0]);
-        assertArrayEquals(row2, response.rows()[1]);
+        assertThat(TestingHelpers.printedTable(response.rows()),
+            is("my_table| 04130| {metadata['date']=0}\n" +
+               "my_table| 04732d1g64p36d9i60o30c1g| {metadata['date']=1401235200000}\n"));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/JobContextIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/JobContextIntegrationTest.java
@@ -23,6 +23,7 @@ package io.crate.integrationtests;
 
 import io.crate.jobs.JobContextService;
 import io.crate.jobs.JobExecutionContext;
+import io.crate.testing.UseJdbc;
 import org.junit.Test;
 
 import java.lang.reflect.Field;
@@ -32,6 +33,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.core.Is.is;
 
+@UseJdbc
 public class JobContextIntegrationTest extends SQLTransportIntegrationTest {
 
     Setup setup = new Setup(sqlExecutor);

--- a/sql/src/test/java/io/crate/integrationtests/JobIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/JobIntegrationTest.java
@@ -25,6 +25,7 @@ package io.crate.integrationtests;
 import io.crate.action.sql.SQLActionException;
 import io.crate.plugin.CrateCorePlugin;
 import io.crate.testing.SQLTransportExecutor;
+import io.crate.testing.UseJdbc;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -32,7 +33,10 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import javax.annotation.Nullable;
+
 @ESIntegTestCase.ClusterScope(numDataNodes = 1, numClientNodes = 1, randomDynamicTemplates = false)
+@UseJdbc
 public class JobIntegrationTest extends SQLTransportIntegrationTest {
 
     @Rule
@@ -53,6 +57,12 @@ public class JobIntegrationTest extends SQLTransportIntegrationTest {
                     @Override
                     public Client client() {
                         return internalCluster().clientNodeClient();
+                    }
+
+                    @Nullable
+                    @Override
+                    public String pgUrl() {
+                        return null;
                     }
                 }
         ));

--- a/sql/src/test/java/io/crate/integrationtests/JobLogIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/JobLogIntegrationTest.java
@@ -23,6 +23,7 @@ package io.crate.integrationtests;
 
 import io.crate.action.sql.SQLResponse;
 import io.crate.metadata.settings.CrateSettings;
+import io.crate.testing.UseJdbc;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.hamcrest.Matchers;
 import org.junit.After;
@@ -33,6 +34,7 @@ import org.junit.rules.ExpectedException;
 import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 2, numClientNodes = 0)
+@UseJdbc
 public class JobLogIntegrationTest extends SQLTransportIntegrationTest {
 
     @Rule
@@ -45,6 +47,7 @@ public class JobLogIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    @UseJdbc(false) // SET extra_float_digits = 3 gets added to the jobs_log
     public void testJobLogWithEnabledAndDisabledStats() throws Exception {
         sqlExecutor.exec("select name from sys.cluster");
         SQLResponse response = sqlExecutor.exec("select * from sys.jobs_log");
@@ -69,6 +72,7 @@ public class JobLogIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    @UseJdbc(false) // set has no rowcount
     public void testSetSingleStatement() throws Exception {
         SQLResponse response = sqlExecutor.exec("select settings['stats']['jobs_log_size'] from sys.cluster");
         assertThat(response.rowCount(), is(1L));

--- a/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -26,6 +26,7 @@ import io.crate.core.collections.CollectionBucket;
 import io.crate.exceptions.Exceptions;
 import io.crate.operation.projectors.sorting.OrderingByPosition;
 import io.crate.testing.TestingHelpers;
+import io.crate.testing.UseJdbc;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Rule;
@@ -43,6 +44,7 @@ import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(minNumDataNodes = 2)
+@UseJdbc
 public class JoinIntegrationTest extends SQLTransportIntegrationTest {
 
     @Rule

--- a/sql/src/test/java/io/crate/integrationtests/JoinSingleNodeIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/JoinSingleNodeIntegrationTest.java
@@ -21,9 +21,11 @@
 
 package io.crate.integrationtests;
 
+import io.crate.testing.UseJdbc;
 import org.elasticsearch.test.ESIntegTestCase;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 1, numClientNodes = 0)
+@UseJdbc
 public class JoinSingleNodeIntegrationTest extends JoinIntegrationTest {
 
     /**

--- a/sql/src/test/java/io/crate/integrationtests/KillIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/KillIntegrationTest.java
@@ -25,6 +25,7 @@ import io.crate.action.sql.SQLActionException;
 import io.crate.action.sql.SQLResponse;
 import io.crate.exceptions.Exceptions;
 import io.crate.plugin.CrateCorePlugin;
+import io.crate.testing.UseJdbc;
 import io.crate.testing.plugin.CrateTestingPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -45,6 +46,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.hamcrest.Matchers.*;
 
+@UseJdbc
 public class KillIntegrationTest extends SQLTransportIntegrationTest {
 
     private Setup setup = new Setup(sqlExecutor);
@@ -161,11 +163,13 @@ public class KillIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    @UseJdbc(false)
     public void testKillSelectSysTableJobById() throws Exception {
         assertGotCancelled("SELECT sleep(500) FROM sys.nodes", null, false);
     }
 
     @Test
+    @UseJdbc(false) // UUID type mapping is missing
     public void testKillNonExisitingJob() throws Exception {
         UUID jobId = UUID.randomUUID();
         SQLResponse killResponse = execute("KILL ?", new Object[]{jobId});

--- a/sql/src/test/java/io/crate/integrationtests/LuceneQueryBuilderIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/LuceneQueryBuilderIntegrationTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.integrationtests;
 
+import io.crate.testing.UseJdbc;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Test;
 
@@ -29,6 +30,7 @@ import static com.carrotsearch.randomizedtesting.RandomizedTest.$$;
 import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope (randomDynamicTemplates = false, transportClientRatio = 0)
+@UseJdbc
 public class LuceneQueryBuilderIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test
@@ -124,6 +126,7 @@ public class LuceneQueryBuilderIntegrationTest extends SQLTransportIntegrationTe
     }
 
     @Test
+    @UseJdbc(false) // geo_point missing
     public void testWithinGenericFunction() throws Exception {
         execute("create table shaped (id int, point geo_point, shape geo_shape) with (number_of_replicas=0)");
         ensureYellow();

--- a/sql/src/test/java/io/crate/integrationtests/MappingDefaultsTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/MappingDefaultsTest.java
@@ -22,11 +22,13 @@
 package io.crate.integrationtests;
 
 import io.crate.action.sql.SQLResponse;
+import io.crate.testing.UseJdbc;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.junit.Test;
 
+@UseJdbc
 public class MappingDefaultsTest extends SQLTransportIntegrationTest {
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/NodeStatsTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/NodeStatsTest.java
@@ -23,6 +23,7 @@ package io.crate.integrationtests;
 
 import io.crate.Version;
 import io.crate.action.sql.SQLResponse;
+import io.crate.testing.UseJdbc;
 import org.apache.lucene.util.Constants;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -37,6 +38,7 @@ import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(numClientNodes = 0, numDataNodes = 2)
+@UseJdbc
 public class NodeStatsTest extends SQLTransportIntegrationTest {
 
     @Test
@@ -61,6 +63,7 @@ public class NodeStatsTest extends SQLTransportIntegrationTest {
 
     @SuppressWarnings("ConstantConditions")
     @Test
+    @UseJdbc(false) // because of json some values are transfered as integer instead of long
     public void testThreadPools() throws Exception {
         SQLResponse response = execute("select thread_pools from sys.nodes limit 1");
 
@@ -160,6 +163,7 @@ public class NodeStatsTest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    @UseJdbc(false) // because of json some values are transfered as integer instead of long
     public void testSysNodesOs() throws Exception {
         SQLResponse response = execute("select os from sys.nodes limit 1");
         Map results = (Map) response.rows()[0][0];
@@ -214,6 +218,7 @@ public class NodeStatsTest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    @UseJdbc(false) // because of json some values are transfered as integer instead of long
     public void testFs() throws Exception {
         SQLResponse response = execute("select fs from sys.nodes limit 1");
         assertThat(response.rowCount(), is(1L));

--- a/sql/src/test/java/io/crate/integrationtests/OptimizeTableIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/OptimizeTableIntegrationTest.java
@@ -24,6 +24,7 @@ package io.crate.integrationtests;
 
 import io.crate.action.sql.SQLActionException;
 import io.crate.executor.TaskResult;
+import io.crate.testing.UseJdbc;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Rule;
 import org.junit.Test;
@@ -34,6 +35,7 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(minNumDataNodes = 2)
+@UseJdbc(false) // optimize has no rowcount
 public class OptimizeTableIntegrationTest extends SQLTransportIntegrationTest {
 
     @Rule

--- a/sql/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
@@ -27,6 +27,7 @@ import io.crate.action.sql.SQLResponse;
 import io.crate.executor.TaskResult;
 import io.crate.metadata.PartitionName;
 import io.crate.testing.SQLTransportExecutor;
+import io.crate.testing.UseJdbc;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteRequestBuilder;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
@@ -51,6 +52,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 2)
+@UseJdbc
 public class PartitionedTableConcurrentIntegrationTest extends SQLTransportIntegrationTest {
 
     private final TimeValue ACCEPTABLE_RELOCATION_TIME = new TimeValue(10, TimeUnit.SECONDS);

--- a/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -28,6 +28,7 @@ import io.crate.action.sql.SQLActionException;
 import io.crate.action.sql.SQLResponse;
 import io.crate.metadata.PartitionName;
 import io.crate.testing.TestingHelpers;
+import io.crate.testing.UseJdbc;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.action.admin.indices.alias.exists.AliasesExistResponse;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
@@ -61,6 +62,7 @@ import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 2)
+@UseJdbc(false) // lots of stuff failing
 public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest {
 
     private Setup setup = new Setup(sqlExecutor);

--- a/sql/src/test/java/io/crate/integrationtests/PostgresITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PostgresITest.java
@@ -26,7 +26,6 @@ import io.crate.action.sql.TransportBaseSQLAction;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.hamcrest.Matchers;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -66,11 +65,6 @@ public class PostgresITest extends SQLTransportIntegrationTest {
             builder.put("psql.port", "4243");
         }
         return builder.build();
-    }
-
-    @Before
-    public void initDriver() throws Exception {
-        Class.forName("org.postgresql.Driver");
     }
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/QueryThenFetchIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/QueryThenFetchIntegrationTest.java
@@ -24,6 +24,7 @@ package io.crate.integrationtests;
 import io.crate.action.sql.SQLActionException;
 import io.crate.operation.Paging;
 import io.crate.testing.TestingHelpers;
+import io.crate.testing.UseJdbc;
 import org.hamcrest.core.Is;
 import org.junit.Rule;
 import org.junit.Test;
@@ -32,6 +33,7 @@ import org.junit.rules.ExpectedException;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
+@UseJdbc
 public class QueryThenFetchIntegrationTest extends SQLTransportIntegrationTest {
 
     @Rule
@@ -124,6 +126,7 @@ public class QueryThenFetchIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    @UseJdbc(false) // byte/short are returned as 0 instead of NULL
     public void testOrderBySortTypes() throws Exception {
         execute("create table xxx (" +
                 "  b byte," +

--- a/sql/src/test/java/io/crate/integrationtests/ReadOnlyNodeIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ReadOnlyNodeIntegrationTest.java
@@ -38,7 +38,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
-import java.nio.file.Paths;
+import javax.annotation.Nullable;
 
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
@@ -61,6 +61,11 @@ public class ReadOnlyNodeIntegrationTest extends SQLTransportIntegrationTest {
                     public Client client() {
                         // make sure we use the read-only client
                         return internalCluster().client(internalCluster().getNodeNames()[1]);
+                    }
+
+                    @Override
+                    public String pgUrl() {
+                        return null;
                     }
                 }
         ));
@@ -93,6 +98,12 @@ public class ReadOnlyNodeIntegrationTest extends SQLTransportIntegrationTest {
                         public Client client() {
                             // make sure we use NOT the read-only client
                             return internalCluster().client(internalCluster().getNodeNames()[0]);
+                        }
+
+                        @Nullable
+                        @Override
+                        public String pgUrl() {
+                            return null;
                         }
                     }
             );

--- a/sql/src/test/java/io/crate/integrationtests/RegexpIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/RegexpIntegrationTest.java
@@ -22,12 +22,14 @@
 package io.crate.integrationtests;
 
 import io.crate.action.sql.SQLActionException;
+import io.crate.testing.UseJdbc;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import static org.hamcrest.core.Is.is;
 
+@UseJdbc
 public class RegexpIntegrationTest extends SQLTransportIntegrationTest {
 
     private Setup setup = new Setup(sqlExecutor);

--- a/sql/src/test/java/io/crate/integrationtests/RemoteCollectorIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/RemoteCollectorIntegrationTest.java
@@ -24,6 +24,7 @@ package io.crate.integrationtests;
 
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import io.crate.testing.TestingHelpers;
+import io.crate.testing.UseJdbc;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.allocation.command.MoveAllocationCommand;
@@ -38,6 +39,7 @@ import java.util.concurrent.TimeUnit;
 import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 2)
+@UseJdbc
 public class RemoteCollectorIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/RepositoryIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/RepositoryIntegrationTest.java
@@ -23,6 +23,7 @@
 package io.crate.integrationtests;
 
 import io.crate.action.sql.SQLActionException;
+import io.crate.testing.UseJdbc;
 import org.elasticsearch.common.settings.Settings;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -35,6 +36,7 @@ import java.util.HashMap;
 
 import static org.hamcrest.Matchers.is;
 
+@UseJdbc
 public class RepositoryIntegrationTest extends SQLTransportIntegrationTest {
 
     @Rule
@@ -51,6 +53,7 @@ public class RepositoryIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    @UseJdbc(false) // drop repository has no rowcount
     public void testDropExistingRepository() throws Exception {
         execute("CREATE REPOSITORY existing_repo TYPE \"fs\" with (location=?, compress=True)",
                 new Object[]{
@@ -66,6 +69,7 @@ public class RepositoryIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    @UseJdbc(false) // result contains bytesref instead of string
     public void testCreateRepository() throws Throwable {
         String repoLocation = TEMPORARY_FOLDER.newFolder().getAbsolutePath();
         execute("CREATE REPOSITORY \"myRepo\" TYPE \"fs\" with (location=?, compress=True)",

--- a/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
@@ -48,6 +48,7 @@ import io.crate.operation.QueryResultRowDownstream;
 import io.crate.planner.Plan;
 import io.crate.planner.Planner;
 import io.crate.plugin.CrateCorePlugin;
+import io.crate.protocols.postgres.PostgresNetty;
 import io.crate.sql.parser.SqlParser;
 import io.crate.test.GroovyTestSanitizer;
 import io.crate.testing.SQLTransportExecutor;
@@ -61,6 +62,7 @@ import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.InetSocketTransportAddress;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -74,10 +76,12 @@ import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.hamcrest.Matchers;
 import org.junit.After;
+import org.junit.Before;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.Collection;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -96,6 +100,19 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
     protected final SQLTransportExecutor sqlExecutor;
 
     @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put("psql.enabled", true)
+            .build();
+    }
+
+    @Before
+    public void initDriver() throws Exception {
+        Class.forName("org.postgresql.Driver");
+    }
+
+    @Override
     protected Collection<Class<? extends Plugin>> nodePlugins() {
         return pluginList(CrateCorePlugin.class);
     }
@@ -109,6 +126,19 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
                     @Override
                     public Client client() {
                         return ESIntegTestCase.client();
+                    }
+
+                    @Override
+                    public String pgUrl() {
+                        PostgresNetty postgresNetty = internalCluster().getDataNodeInstance(PostgresNetty.class);
+                        for (InetSocketTransportAddress address : postgresNetty.boundAddresses()) {
+                            if (address.getAddress().startsWith("::")) {
+                                continue;
+                            }
+                            return String.format(Locale.ENGLISH, "jdbc:postgresql://%s:%d/",
+                                address.getHost(), address.getPort());
+                        }
+                        return null;
                     }
                 }
         ));

--- a/sql/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
@@ -27,6 +27,7 @@ import io.crate.action.sql.SQLActionException;
 import io.crate.action.sql.SQLRequest;
 import io.crate.action.sql.SQLResponse;
 import io.crate.testing.TestingHelpers;
+import io.crate.testing.UseJdbc;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.IntegerType;
@@ -43,6 +44,7 @@ import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 
 @ESIntegTestCase.ClusterScope(minNumDataNodes = 2)
+@UseJdbc(false) // lots of stuff failing
 public class SQLTypeMappingTest extends SQLTransportIntegrationTest {
 
     @Rule

--- a/sql/src/test/java/io/crate/integrationtests/ShardStatsTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ShardStatsTest.java
@@ -22,6 +22,7 @@
 package io.crate.integrationtests;
 
 import io.crate.blob.v2.BlobIndices;
+import io.crate.testing.UseJdbc;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -32,6 +33,7 @@ import static org.hamcrest.Matchers.is;
 
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 2)
+@UseJdbc
 public class ShardStatsTest extends SQLTransportIntegrationTest {
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -24,6 +24,7 @@ package io.crate.integrationtests;
 import io.crate.action.sql.SQLActionException;
 import io.crate.analyze.NumberOfShards;
 import io.crate.testing.TestingHelpers;
+import io.crate.testing.UseJdbc;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -33,6 +34,7 @@ import java.util.Locale;
 import static org.hamcrest.core.Is.is;
 
 
+@UseJdbc
 public class ShowIntegrationTest extends SQLTransportIntegrationTest {
 
     @Rule

--- a/sql/src/test/java/io/crate/integrationtests/SqlAlchemyIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SqlAlchemyIntegrationTest.java
@@ -21,8 +21,10 @@
 
 package io.crate.integrationtests;
 
+import io.crate.testing.UseJdbc;
 import org.junit.Test;
 
+@UseJdbc
 public class SqlAlchemyIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/StaticInformationSchemaQueryTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/StaticInformationSchemaQueryTest.java
@@ -22,12 +22,14 @@
 package io.crate.integrationtests;
 
 import io.crate.action.sql.SQLActionException;
+import io.crate.testing.UseJdbc;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 
+@UseJdbc
 public class StaticInformationSchemaQueryTest extends SQLTransportIntegrationTest {
 
     @Rule

--- a/sql/src/test/java/io/crate/integrationtests/SysCheckerIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysCheckerIntegrationTest.java
@@ -24,6 +24,7 @@ package io.crate.integrationtests;
 import io.crate.action.sql.SQLResponse;
 import io.crate.operation.reference.sys.check.SysCheck.Severity;
 import io.crate.testing.TestingHelpers;
+import io.crate.testing.UseJdbc;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.After;
@@ -33,6 +34,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope(minNumDataNodes = 2)
+@UseJdbc
 public class SysCheckerIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/SysClusterSettingsTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysClusterSettingsTest.java
@@ -22,6 +22,7 @@
 package io.crate.integrationtests;
 
 import io.crate.metadata.settings.CrateSettings;
+import io.crate.testing.UseJdbc;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.After;
@@ -32,6 +33,7 @@ import java.util.Map;
 import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope
+@UseJdbc
 public class SysClusterSettingsTest extends SQLTransportIntegrationTest {
 
     @Override

--- a/sql/src/test/java/io/crate/integrationtests/SysClusterTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysClusterTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.integrationtests;
 
+import io.crate.testing.UseJdbc;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -29,6 +30,7 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.is;
 
+@UseJdbc
 public class SysClusterTest extends SQLTransportIntegrationTest {
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/SysNodeCheckerIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysNodeCheckerIntegrationTest.java
@@ -25,6 +25,7 @@ package io.crate.integrationtests;
 import io.crate.action.sql.SQLResponse;
 import io.crate.operation.reference.sys.check.SysCheck;
 import io.crate.testing.TestingHelpers;
+import io.crate.testing.UseJdbc;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Test;
 
@@ -32,6 +33,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 2, numClientNodes = 0)
+@UseJdbc
 public class SysNodeCheckerIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test
@@ -47,6 +49,7 @@ public class SysNodeCheckerIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    @UseJdbc(false) // column index is out of range
     public void testUpdateAcknowledge() throws Exception {
         // gateway.expected_nodes is -1 in the test setup so this test always fails
         SQLResponse resp = execute("select id, passed from sys.node_checks where passed = false");

--- a/sql/src/test/java/io/crate/integrationtests/SysOperationsTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysOperationsTest.java
@@ -22,6 +22,7 @@
 package io.crate.integrationtests;
 
 import io.crate.action.sql.SQLResponse;
+import io.crate.testing.UseJdbc;
 import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
@@ -34,6 +35,7 @@ import java.util.List;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 
+@UseJdbc
 public class SysOperationsTest extends SQLTransportIntegrationTest {
 
 

--- a/sql/src/test/java/io/crate/integrationtests/SysRepositoriesTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysRepositoriesTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.integrationtests;
 
+import io.crate.testing.UseJdbc;
 import io.crate.types.DataType;
 import io.crate.types.ObjectType;
 import io.crate.types.StringType;
@@ -42,6 +43,7 @@ import java.util.Map;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
+@UseJdbc(false) // missing column types
 public class SysRepositoriesTest extends SQLTransportIntegrationTest {
 
     @ClassRule

--- a/sql/src/test/java/io/crate/integrationtests/SysShardsTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysShardsTest.java
@@ -26,6 +26,7 @@ import io.crate.action.sql.SQLResponse;
 import io.crate.blob.v2.BlobIndices;
 import io.crate.metadata.PartitionName;
 import io.crate.testing.TestingHelpers;
+import io.crate.testing.UseJdbc;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -42,6 +43,7 @@ import java.util.concurrent.TimeUnit;
 import static org.hamcrest.Matchers.*;
 
 @ESIntegTestCase.ClusterScope(numClientNodes = 0, numDataNodes = 2)
+@UseJdbc
 public class SysShardsTest extends SQLTransportIntegrationTest {
 
 

--- a/sql/src/test/java/io/crate/integrationtests/SysSnapshotsTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysSnapshotsTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.integrationtests;
 
+import io.crate.testing.UseJdbc;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.StringType;
@@ -32,7 +33,10 @@ import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotRes
 import org.elasticsearch.action.admin.cluster.snapshots.delete.DeleteSnapshotResponse;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.snapshots.SnapshotState;
-import org.junit.*;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
@@ -43,6 +47,7 @@ import java.util.List;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.*;
 
+@UseJdbc(false) // missing column types
 public class SysSnapshotsTest extends SQLTransportIntegrationTest {
 
     @ClassRule

--- a/sql/src/test/java/io/crate/integrationtests/TableAliasIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TableAliasIntegrationTest.java
@@ -22,6 +22,7 @@
 package io.crate.integrationtests;
 
 import io.crate.action.sql.SQLActionException;
+import io.crate.testing.UseJdbc;
 import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesResponse;
 import org.elasticsearch.cluster.metadata.AliasMetaData;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
@@ -35,6 +36,7 @@ import java.util.Locale;
 import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 1, numClientNodes = 0)
+@UseJdbc
 public class TableAliasIntegrationTest extends SQLTransportIntegrationTest {
 
     @Rule

--- a/sql/src/test/java/io/crate/integrationtests/TableBlocksIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TableBlocksIntegrationTest.java
@@ -22,6 +22,7 @@
 package io.crate.integrationtests;
 
 import io.crate.action.sql.SQLActionException;
+import io.crate.testing.UseJdbc;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.hamcrest.core.Is;
@@ -33,6 +34,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 1)
+@UseJdbc
 public class TableBlocksIntegrationTest extends SQLTransportIntegrationTest {
 
     @Rule

--- a/sql/src/test/java/io/crate/integrationtests/TableSettingsTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TableSettingsTest.java
@@ -22,6 +22,7 @@
 package io.crate.integrationtests;
 
 import io.crate.action.sql.SQLActionException;
+import io.crate.testing.UseJdbc;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -29,6 +30,7 @@ import org.junit.rules.ExpectedException;
 
 import java.util.Map;
 
+@UseJdbc
 public class TableSettingsTest extends SQLTransportIntegrationTest {
 
     @Rule

--- a/sql/src/test/java/io/crate/integrationtests/ThreadPoolsExhaustedIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ThreadPoolsExhaustedIntegrationTest.java
@@ -24,6 +24,7 @@ package io.crate.integrationtests;
 import io.crate.action.sql.SQLAction;
 import io.crate.action.sql.SQLRequest;
 import io.crate.action.sql.SQLResponse;
+import io.crate.testing.UseJdbc;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -35,6 +36,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 @ESIntegTestCase.ClusterScope(maxNumDataNodes = 2)
+@UseJdbc
 public class ThreadPoolsExhaustedIntegrationTest extends SQLTransportIntegrationTest {
 
     @Override

--- a/sql/src/test/java/io/crate/integrationtests/TransportSQLActionClassLifecycleTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TransportSQLActionClassLifecycleTest.java
@@ -28,6 +28,7 @@ import io.crate.action.sql.SQLResponse;
 import io.crate.metadata.settings.CrateSettings;
 import io.crate.testing.SQLTransportExecutor;
 import io.crate.testing.TestingHelpers;
+import io.crate.testing.UseJdbc;
 import org.apache.lucene.util.Constants;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.hamcrest.Matchers;
@@ -54,6 +55,7 @@ import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(numClientNodes = 0, numDataNodes = 2)
+@UseJdbc
 public class TransportSQLActionClassLifecycleTest extends SQLTransportIntegrationTest {
 
     @Rule
@@ -261,6 +263,7 @@ public class TransportSQLActionClassLifecycleTest extends SQLTransportIntegratio
     }
 
     @Test
+    @UseJdbc(false) // NPE because of unused null parameter
     public void testCountWithGroupByNullArgs() throws Exception {
         SQLResponse response = execute("select count(*), race from characters group by race", new Object[]{null});
         assertEquals(3, response.rowCount());
@@ -377,6 +380,7 @@ public class TransportSQLActionClassLifecycleTest extends SQLTransportIntegratio
     }
 
     @Test
+    @UseJdbc(false) // copy has no rowcount
     public void testCopyToDirectoryOnPartitionedTableWithPartitionClause() throws Exception {
         String uriTemplate = Paths.get(folder.getRoot().toURI()).toUri().toString();
         SQLResponse response = execute("copy parted partition (date='2014-01-01') to DIRECTORY ?", $(uriTemplate));
@@ -397,6 +401,7 @@ public class TransportSQLActionClassLifecycleTest extends SQLTransportIntegratio
     }
 
     @Test
+    @UseJdbc(false) // COPY has no rowcount
     public void testCopyToDirectoryOnPartitionedTableWithoutPartitionClause() throws Exception {
         String uriTemplate = Paths.get(folder.getRoot().toURI()).toUri().toString();
         SQLResponse response = execute("copy parted to DIRECTORY ?", $(uriTemplate));
@@ -437,6 +442,7 @@ public class TransportSQLActionClassLifecycleTest extends SQLTransportIntegratio
     }
 
     @Test
+    @UseJdbc(false) // set has no rowcount
     public void testSetMultipleStatement() throws Exception {
         SQLResponse response = execute(
                 "select settings['stats']['operations_log_size'], settings['stats']['enabled'] from sys.cluster");
@@ -605,6 +611,7 @@ public class TransportSQLActionClassLifecycleTest extends SQLTransportIntegratio
     }
 
     @Test
+    @UseJdbc(false) // wrong timestamp returned
     public void selectCurrentTimestamp() throws Exception {
         long before = System.currentTimeMillis();
         SQLResponse response = execute("select current_timestamp from sys.cluster");

--- a/sql/src/test/java/io/crate/integrationtests/TransportSQLActionSingleNodeTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TransportSQLActionSingleNodeTest.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.SettableFuture;
 import io.crate.action.sql.*;
 import io.crate.testing.TestingHelpers;
+import io.crate.testing.UseJdbc;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.After;
 import org.junit.Rule;
@@ -40,6 +41,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 1, numClientNodes = 0)
+@UseJdbc
 public class TransportSQLActionSingleNodeTest extends SQLTransportIntegrationTest {
 
     @Rule

--- a/sql/src/test/java/io/crate/integrationtests/UnassignedShardsTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/UnassignedShardsTest.java
@@ -22,12 +22,14 @@
 package io.crate.integrationtests;
 
 import io.crate.testing.TestingHelpers;
+import io.crate.testing.UseJdbc;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 2)
+@UseJdbc
 public class UnassignedShardsTest extends SQLTransportIntegrationTest {
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/UpdateIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/UpdateIntegrationTest.java
@@ -25,6 +25,7 @@ import io.crate.action.sql.SQLActionException;
 import io.crate.action.sql.SQLBulkResponse;
 import io.crate.analyze.UpdateStatementAnalyzer;
 import io.crate.testing.TestingHelpers;
+import io.crate.testing.UseJdbc;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.junit.Rule;
 import org.junit.Test;
@@ -40,6 +41,7 @@ import static com.google.common.collect.Maps.newHashMap;
 import static io.crate.testing.TestingHelpers.mapToSortedString;
 import static org.hamcrest.core.Is.is;
 
+@UseJdbc(false) // exception rewrite missing
 public class UpdateIntegrationTest extends SQLTransportIntegrationTest {
 
     private Setup setup = new Setup(sqlExecutor);

--- a/sql/src/test/java/io/crate/integrationtests/VersionHandlingIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/VersionHandlingIntegrationTest.java
@@ -23,6 +23,7 @@ package io.crate.integrationtests;
 
 import io.crate.action.sql.SQLActionException;
 import io.crate.analyze.UpdateStatementAnalyzer;
+import io.crate.testing.UseJdbc;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -32,6 +33,7 @@ import java.io.IOException;
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.core.Is.is;
 
+@UseJdbc
 public class VersionHandlingIntegrationTest extends SQLTransportIntegrationTest {
 
     private Setup setup = new Setup(sqlExecutor);

--- a/sql/src/test/java/io/crate/integrationtests/WherePKIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/WherePKIntegrationTest.java
@@ -22,6 +22,7 @@
 package io.crate.integrationtests;
 
 import io.crate.testing.TestingHelpers;
+import io.crate.testing.UseJdbc;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -30,6 +31,7 @@ import java.util.Arrays;
 
 import static org.hamcrest.core.Is.is;
 
+@UseJdbc
 public class WherePKIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test
@@ -156,6 +158,7 @@ public class WherePKIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    @UseJdbc(false) // geo_point missing
     public void testEmptyClusteredByUnderId() throws Exception {
         // regression test that empty routing executes correctly
         execute("create table auto_id (" +
@@ -174,6 +177,7 @@ public class WherePKIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    @UseJdbc(false) // geo_point missing
     public void testEmptyClusteredByExplicit() throws Exception {
         // regression test that empty routing executes correctly
         execute("create table explicit_routing (" +
@@ -228,6 +232,7 @@ public class WherePKIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    @UseJdbc(false) // geo_point missing
     public void testDeleteByQueryCommaRouting() throws Exception {
         execute("create table explicit_routing (" +
                 "  name string," +

--- a/sql/src/test/java/io/crate/protocols/postgres/types/PGArrayTest.java
+++ b/sql/src/test/java/io/crate/protocols/postgres/types/PGArrayTest.java
@@ -22,9 +22,12 @@
 
 package io.crate.protocols.postgres.types;
 
+import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -49,6 +52,32 @@ public class PGArrayTest {
         assertThat(s, is("{\"10\",NULL,\"20\"}"));
         Object o = pgArray.decodeUTF8Text(bytes);
         assertThat(((Object[]) o), is(array));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testJsonArrayEncodeDecode() throws Exception {
+        String s = "{\"{\"names\":[\"Arthur\",\"Trillian\"]}\",\"{\"names\":[\"Ford\",\"Slarti\"]}\"}";
+        Object[] values = (Object[]) PGArray.JSON_ARRAY.decodeUTF8Text(s.getBytes(StandardCharsets.UTF_8));
+
+        List<String> firstNames = (List<String>) ((Map) values[0]).get("names");
+        assertThat(firstNames, Matchers.contains("Arthur", "Trillian"));
+
+        List<String> secondNames = (List<String>) ((Map) values[1]).get("names");
+        assertThat(secondNames, Matchers.contains("Ford", "Slarti"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testDecodeEncodeEscapedJson() throws Exception {
+        String s = "{\"{\\\"names\\\":[\\\"Arthur\\\",\\\"Trillian\\\"]}\",\"{\\\"names\\\":[\\\"Ford\\\",\\\"Slarti\\\"]}\"}";
+        Object[] values = (Object[]) PGArray.JSON_ARRAY.decodeUTF8Text(s.getBytes(StandardCharsets.UTF_8));
+
+        List<String> firstNames = (List<String>) ((Map) values[0]).get("names");
+        assertThat(firstNames, Matchers.contains("Arthur", "Trillian"));
+
+        List<String> secondNames = (List<String>) ((Map) values[1]).get("names");
+        assertThat(secondNames, Matchers.contains("Ford", "Slarti"));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/protocols/postgres/types/PGTypesTest.java
+++ b/sql/src/test/java/io/crate/protocols/postgres/types/PGTypesTest.java
@@ -80,7 +80,8 @@ public class PGTypesTest {
             new Entry(DataTypes.DOUBLE, 42.00003),
             new Entry(DataTypes.BOOLEAN, true),
             new Entry(DataTypes.TIMESTAMP, DataTypes.TIMESTAMP.value("2014-05-08")),
-            new Entry(DataTypes.IP, new BytesRef("192.168.1.1"))
+            new Entry(DataTypes.IP, new BytesRef("192.168.1.1")),
+            new Entry(DataTypes.BYTE, (byte) 20)
         )) {
 
             PGType pgType = PGTypes.get(entry.type);

--- a/sql/src/test/java/io/crate/testing/UseJdbc.java
+++ b/sql/src/test/java/io/crate/testing/UseJdbc.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.testing;
+
+import java.lang.annotation.*;
+
+/**
+ * Mark a test as executable via JDBC.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Inherited
+public @interface UseJdbc {
+
+    boolean value() default true;
+}


### PR DESCRIPTION
This also adds more type mappings to make some of the existing
IntegrationTests work with the JDBC client.