### PR TITLE
Create StatsTables entries before execution instead of before parse.

### DIFF
--- a/sql/src/main/java/io/crate/protocols/postgres/AbstractPortal.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/AbstractPortal.java
@@ -22,12 +22,9 @@
 
 package io.crate.protocols.postgres;
 
-import io.crate.action.sql.RowReceiverToResultReceiver;
 import io.crate.analyze.Analyzer;
 import io.crate.executor.Executor;
 import io.crate.executor.transport.kill.TransportKillJobsNodeAction;
-
-import java.util.UUID;
 
 abstract class AbstractPortal implements Portal {
 
@@ -35,14 +32,13 @@ abstract class AbstractPortal implements Portal {
     protected final SessionData sessionData;
 
     AbstractPortal(String name,
-                   UUID jobId,
                    String defaultSchema,
                    Analyzer analyzer,
                    Executor executor,
                    TransportKillJobsNodeAction transportKillJobsNodeAction,
                    boolean isReadOnly) {
         this.name = name;
-        sessionData = new SessionData(jobId, defaultSchema, analyzer, executor,
+        sessionData = new SessionData(defaultSchema, analyzer, executor,
             transportKillJobsNodeAction, isReadOnly);
     }
 
@@ -60,29 +56,23 @@ abstract class AbstractPortal implements Portal {
     }
 
     static class SessionData {
-        private final UUID jobId;
+
         private final Analyzer analyzer;
         private final Executor executor;
         private final String defaultSchema;
         private final TransportKillJobsNodeAction transportKillJobsNodeAction;
         private final boolean isReadOnly;
 
-        private SessionData(UUID jobId,
-                            String defaultSchema,
+        private SessionData(String defaultSchema,
                             Analyzer analyzer,
                             Executor executor,
                             TransportKillJobsNodeAction transportKillJobsNodeAction,
                             boolean isReadOnly) {
-            this.jobId = jobId;
             this.defaultSchema = defaultSchema;
             this.analyzer = analyzer;
             this.executor = executor;
             this.transportKillJobsNodeAction = transportKillJobsNodeAction;
             this.isReadOnly = isReadOnly;
-        }
-
-        UUID getJobId() {
-            return jobId;
         }
 
         Analyzer getAnalyzer() {

--- a/sql/src/main/java/io/crate/protocols/postgres/StatsTablesUpdateListener.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/StatsTablesUpdateListener.java
@@ -41,11 +41,11 @@ public class StatsTablesUpdateListener implements CompletionListener {
     }
     @Override
     public void onSuccess(@Nullable CompletionState result) {
-        statsTables.jobFinished(jobId, null);
+        statsTables.logExecutionEnd(jobId, null);
     }
 
     @Override
     public void onFailure(Throwable t) {
-        statsTables.jobFinished(jobId, Exceptions.messageOf(t));
+        statsTables.logExecutionEnd(jobId, Exceptions.messageOf(t));
     }
 }

--- a/sql/src/test/java/io/crate/cluster/gracefulstop/DecommissioningServiceTest.java
+++ b/sql/src/test/java/io/crate/cluster/gracefulstop/DecommissioningServiceTest.java
@@ -76,7 +76,7 @@ public class DecommissioningServiceTest {
 
     @Test
     public void testNoExitIfRequestAreActive() throws Exception {
-        statsTables.jobFinished(UUID.randomUUID(), null);
+        statsTables.logExecutionEnd(UUID.randomUUID(), null);
         decommissioningService.exitIfNoActiveRequests(System.nanoTime());
         assertThat(decommissioningService.exited, is(false));
         assertThat(decommissioningService.forceStopOrAbortCalled, is(false));
@@ -85,7 +85,7 @@ public class DecommissioningServiceTest {
 
     @Test
     public void testAbortOrForceStopIsCalledOnTimeout() throws Exception {
-        statsTables.jobFinished(UUID.randomUUID(), null);
+        statsTables.logExecutionEnd(UUID.randomUUID(), null);
         decommissioningService.exitIfNoActiveRequests(System.nanoTime() - TimeValue.timeValueHours(3).nanos());
         assertThat(decommissioningService.forceStopOrAbortCalled, is(true));
     }


### PR DESCRIPTION
Because prepared statements can be re-used and so `parse` no longer
indicates the start of a job execution.