### PR TITLE
Remove expectsAffectedRows from Analysis

### DIFF
--- a/sql/src/main/java/io/crate/action/sql/TransportSQLBulkAction.java
+++ b/sql/src/main/java/io/crate/action/sql/TransportSQLBulkAction.java
@@ -85,7 +85,7 @@ public class TransportSQLBulkAction extends TransportBaseSQLAction<SQLBulkReques
                      final ActionListener<SQLBulkResponse> listener,
                      final SQLBulkRequest request,
                      final long startTime) {
-        if (!analysis.expectsAffectedRows()) {
+        if (analysis.rootRelation() != null && analysis.rootRelation().fields() != null) {
             listener.onFailure(new UnsupportedOperationException(
                 "Bulk operations for statements that return result sets is not supported"));
             return;

--- a/sql/src/main/java/io/crate/analyze/AbstractRepositoryDDLAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/AbstractRepositoryDDLAnalyzer.java
@@ -28,7 +28,6 @@ import io.crate.sql.tree.Node;
 public class AbstractRepositoryDDLAnalyzer extends DefaultTraversalVisitor<AnalyzedStatement, Analysis> {
 
     public AnalyzedStatement analyze(Node node, Analysis analysis) {
-        analysis.expectsAffectedRows(true);
         return process(node, analysis);
     }
 }

--- a/sql/src/main/java/io/crate/analyze/AlterTableAddColumnAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/AlterTableAddColumnAnalyzer.java
@@ -53,7 +53,6 @@ public class AlterTableAddColumnAnalyzer extends DefaultTraversalVisitor<AddColu
     }
 
     public AddColumnAnalyzedStatement analyze(Node node, Analysis analysis) {
-        analysis.expectsAffectedRows(true);
         return super.process(node, analysis);
     }
 

--- a/sql/src/main/java/io/crate/analyze/AlterTableAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/AlterTableAnalyzer.java
@@ -100,7 +100,6 @@ public class AlterTableAnalyzer extends DefaultTraversalVisitor<AlterTableAnalyz
     }
 
     public AnalyzedStatement analyze(Node node, Analysis analysis) {
-        analysis.expectsAffectedRows(true);
         return process(node, analysis);
     }
 }

--- a/sql/src/main/java/io/crate/analyze/Analysis.java
+++ b/sql/src/main/java/io/crate/analyze/Analysis.java
@@ -27,7 +27,6 @@ public class Analysis {
 
     private final ParameterContext parameterContext;
     private AnalyzedStatement analyzedStatement;
-    private boolean expectsAffectedRows = false;
     private AnalyzedRelation rootRelation;
 
     public Analysis(ParameterContext parameterContext) {
@@ -44,14 +43,6 @@ public class Analysis {
 
     public ParameterContext parameterContext() {
         return parameterContext;
-    }
-
-    public void expectsAffectedRows(boolean expectsAffectedRows) {
-        this.expectsAffectedRows = expectsAffectedRows;
-    }
-
-    public boolean expectsAffectedRows() {
-        return expectsAffectedRows;
     }
 
     public void rootRelation(AnalyzedRelation rootRelation) {

--- a/sql/src/main/java/io/crate/analyze/Analyzer.java
+++ b/sql/src/main/java/io/crate/analyze/Analyzer.java
@@ -226,19 +226,16 @@ public class Analyzer {
 
         @Override
         public AnalyzedStatement visitSetStatement(SetStatement node, Analysis context) {
-            context.expectsAffectedRows(true);
             return SetStatementAnalyzer.analyze(node, context.parameterContext());
         }
 
         @Override
         public AnalyzedStatement visitResetStatement(ResetStatement node, Analysis context) {
-            context.expectsAffectedRows(true);
             return SetStatementAnalyzer.analyze(node, context.parameterContext());
         }
 
         @Override
         public AnalyzedStatement visitKillStatement(KillStatement node, Analysis context) {
-            context.expectsAffectedRows(true);
             return KillAnalyzer.analyze(node, context.parameterContext());
         }
 

--- a/sql/src/main/java/io/crate/analyze/BlobTableAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/BlobTableAnalyzer.java
@@ -34,7 +34,6 @@ public abstract class BlobTableAnalyzer<StatementType extends AnalyzedStatement>
         extends DefaultTraversalVisitor<StatementType, Analysis> {
 
     public StatementType analyze(Node node, Analysis analysis) {
-        analysis.expectsAffectedRows(true);
         return super.process(node, analysis);
     }
 

--- a/sql/src/main/java/io/crate/analyze/CopyStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CopyStatementAnalyzer.java
@@ -83,8 +83,6 @@ public class CopyStatementAnalyzer {
     }
 
     public CopyFromAnalyzedStatement convertCopyFrom(CopyFrom node, Analysis analysis) {
-        analysis.expectsAffectedRows(true);
-
         DocTableInfo tableInfo = analysisMetaData.schemas().getWritableTable(
                 TableIdent.of(node.table(), analysis.parameterContext().defaultSchema()));
         DocTableRelation tableRelation = new DocTableRelation(tableInfo);
@@ -133,8 +131,6 @@ public class CopyStatementAnalyzer {
     }
 
     public CopyToAnalyzedStatement convertCopyTo(CopyTo node, Analysis analysis) {
-        analysis.expectsAffectedRows(true);
-
         if (!node.directoryUri()) {
             throw new UnsupportedOperationException("Using COPY TO without specifying a DIRECTORY is deprecated");
         }

--- a/sql/src/main/java/io/crate/analyze/CreateAnalyzerStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateAnalyzerStatementAnalyzer.java
@@ -50,7 +50,6 @@ public class CreateAnalyzerStatementAnalyzer extends DefaultTraversalVisitor<
     }
 
     public CreateAnalyzerAnalyzedStatement analyze(Node node, Analysis analysis) {
-        analysis.expectsAffectedRows(true);
         return super.process(node, new Context(analysis));
     }
 

--- a/sql/src/main/java/io/crate/analyze/CreateTableStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateTableStatementAnalyzer.java
@@ -53,7 +53,6 @@ public class CreateTableStatementAnalyzer extends DefaultTraversalVisitor<Create
     }
 
     public CreateTableAnalyzedStatement analyze(Node node, Analysis analysis) {
-        analysis.expectsAffectedRows(true);
         return super.process(node, new Context(analysis));
     }
 

--- a/sql/src/main/java/io/crate/analyze/DeleteStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/DeleteStatementAnalyzer.java
@@ -71,7 +71,6 @@ public class DeleteStatementAnalyzer extends DefaultTraversalVisitor<AnalyzedSta
     }
 
     public AnalyzedStatement analyze(Node node, Analysis analysis) {
-        analysis.expectsAffectedRows(true);
         return process(node, analysis);
     }
 

--- a/sql/src/main/java/io/crate/analyze/DropTableStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/DropTableStatementAnalyzer.java
@@ -52,7 +52,6 @@ public class DropTableStatementAnalyzer extends DefaultTraversalVisitor<DropTabl
     }
 
     public AnalyzedStatement analyze(Node node, Analysis analysis) {
-        analysis.expectsAffectedRows(true);
         return process(node, analysis);
     }
 }

--- a/sql/src/main/java/io/crate/analyze/ExplainStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/ExplainStatementAnalyzer.java
@@ -40,7 +40,6 @@ public class ExplainStatementAnalyzer {
         String columnName = SqlFormatter.formatSql(node);
         ExplainAnalyzedStatement explainAnalyzedStatement = new ExplainAnalyzedStatement(columnName, subStatement);
         analysis.rootRelation(explainAnalyzedStatement);
-        analysis.expectsAffectedRows(false);
         return explainAnalyzedStatement;
     }
 

--- a/sql/src/main/java/io/crate/analyze/InsertFromSubQueryAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/InsertFromSubQueryAnalyzer.java
@@ -85,8 +85,6 @@ public class InsertFromSubQueryAnalyzer {
 
 
     public AnalyzedStatement analyze(InsertFromSubquery node, Analysis analysis) {
-        analysis.expectsAffectedRows(true);
-
         DocTableInfo tableInfo = analysisMetaData.schemas().getWritableTable(
                 TableIdent.of(node.table(), analysis.parameterContext().defaultSchema()));
         Operation.blockedRaiseException(tableInfo, Operation.INSERT);

--- a/sql/src/main/java/io/crate/analyze/InsertFromValuesAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/InsertFromValuesAnalyzer.java
@@ -89,8 +89,6 @@ public class InsertFromValuesAnalyzer extends AbstractInsertAnalyzer {
     }
 
     public AnalyzedStatement analyze(InsertFromValues node, Analysis analysis) {
-        analysis.expectsAffectedRows(true);
-
         DocTableInfo tableInfo = analysisMetaData.schemas().getWritableTable(
                 TableIdent.of(node.table(), analysis.parameterContext().defaultSchema()));
         Operation.blockedRaiseException(tableInfo, Operation.INSERT);

--- a/sql/src/main/java/io/crate/analyze/OptimizeTableAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/OptimizeTableAnalyzer.java
@@ -54,7 +54,6 @@ public class OptimizeTableAnalyzer extends DefaultTraversalVisitor<OptimizeTable
     }
 
     public OptimizeTableAnalyzedStatement analyze(Node node, Analysis analysis) {
-        analysis.expectsAffectedRows(true);
         return super.process(node, analysis);
     }
 

--- a/sql/src/main/java/io/crate/analyze/RefreshTableAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/RefreshTableAnalyzer.java
@@ -41,7 +41,6 @@ public class RefreshTableAnalyzer extends DefaultTraversalVisitor<RefreshTableAn
     }
 
     public RefreshTableAnalyzedStatement analyze(Node node, Analysis analysis) {
-        analysis.expectsAffectedRows(true);
         return super.process(node, analysis);
     }
 

--- a/sql/src/main/java/io/crate/analyze/UpdateStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/UpdateStatementAnalyzer.java
@@ -87,7 +87,6 @@ public class UpdateStatementAnalyzer extends DefaultTraversalVisitor<AnalyzedSta
     }
 
     public AnalyzedStatement analyze(Node node, Analysis analysis) {
-        analysis.expectsAffectedRows(true);
         return process(node, analysis);
     }
 


### PR DESCRIPTION
It's possible to use the rootRelation() property to figure out if a
query returns a row count or a result set.