### PR TITLE
adds decommission support to SQLOperations

### DIFF
--- a/sql/src/main/java/io/crate/action/sql/TransportSQLAction.java
+++ b/sql/src/main/java/io/crate/action/sql/TransportSQLAction.java
@@ -102,14 +102,6 @@ public class TransportSQLAction extends TransportAction<SQLRequest, SQLResponse>
         }
     }
 
-    /**
-     * @deprecated should become part of {@link SQLOperations} and
-     * {@link io.crate.cluster.gracefulstop.DecommissioningService} also needs to enable it again if decommissioning is aborted
-     */
-    @Deprecated
-    public void disable() {
-    }
-
     private static class ResultSetReceiver implements ResultReceiver {
 
         private final List<Object[]> rows = new ArrayList<>();

--- a/sql/src/main/java/io/crate/action/sql/TransportSQLBulkAction.java
+++ b/sql/src/main/java/io/crate/action/sql/TransportSQLBulkAction.java
@@ -112,15 +112,6 @@ public class TransportSQLBulkAction extends TransportAction<SQLBulkRequest, SQLB
     }
 
 
-    /**
-     * @deprecated should become part of {@link SQLOperations} and
-     * {@link io.crate.cluster.gracefulstop.DecommissioningService} also needs to enable it again if decommissioning is aborted
-     */
-    @Deprecated
-    public void disable() {
-
-    }
-
     private static class RowCountReceiver implements ResultReceiver {
 
         private final SQLBulkResponse.Result[] results;


### PR DESCRIPTION
DecommissionService calls enable/disable on SQLOperations
now instead of the transport sql actions in order
to forbid/allow processing of new sql statements