### PR TITLE
Fix prepared statement handling

### DIFF
--- a/sql/src/main/java/io/crate/action/sql/PreparedStmt.java
+++ b/sql/src/main/java/io/crate/action/sql/PreparedStmt.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.action.sql;
+
+import io.crate.sql.tree.Statement;
+import io.crate.types.DataType;
+
+import java.util.List;
+
+public class PreparedStmt {
+
+    private final Statement statement;
+    private final String query;
+    private final List<DataType> paramTypes;
+
+    public PreparedStmt(Statement statement, String query, List<DataType> paramTypes) {
+        this.statement = statement;
+        this.query = query;
+        this.paramTypes = paramTypes;
+    }
+
+    public Statement statement() {
+        return statement;
+    }
+
+    public List<DataType> paramTypes() {
+        return paramTypes;
+    }
+
+    public String query() {
+        return query;
+    }
+}

--- a/sql/src/main/java/io/crate/action/sql/SQLOperations.java
+++ b/sql/src/main/java/io/crate/action/sql/SQLOperations.java
@@ -142,18 +142,6 @@ public class SQLOperations {
      * sync()
      * </pre>
      *
-     * If during one of the operation an error occurs the error will be raised and all subsequent methods will become
-     * no-op operations until sync() is called which will again raise an error and "clear" it. (to be able to process new statements)
-     *
-     * This is done for compatibility with the postgres extended spec:
-     *
-     * > The purpose of Sync is to provide a resynchronization point for error recovery.
-     * > When an error is detected while processing any extended-query message, the backend issues ErrorResponse,
-     * > then reads and discards messages until a Sync is reached,
-     * > then issues ReadyForQuery and returns to normal message processing.
-     * > (But note that no skipping occurs if an error is detected while processing Sync —
-     * > this ensures that there is one and only one ReadyForQuery sent for each Sync.)
-     *
      * (https://www.postgresql.org/docs/9.2/static/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY)
      */
     public class Session {
@@ -276,6 +264,7 @@ public class SQLOperations {
                 portal.sync(planner, statsTables, CompletionListener.NO_OP);
                 clearState();
             } else {
+                // delay execution to be able to bundle bulk operations
                 pendingExecutions.add(portal);
             }
         }

--- a/sql/src/main/java/io/crate/protocols/postgres/ConnectionContext.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/ConnectionContext.java
@@ -390,7 +390,7 @@ class ConnectionContext {
             if (valueLength == -1) {
                 params.add(null);
             } else {
-                DataType paramType = session.getParamType(i);
+                DataType paramType = session.getParamType(statementName, i);
                 PGType pgType = PGTypes.get(paramType);
                 FormatCodes.FormatCode formatCode = getFormatCode(formatCodes, i);
                 switch (formatCode) {
@@ -493,7 +493,7 @@ class ConnectionContext {
     private void handleClose(ChannelBuffer buffer, Channel channel) {
         byte b = buffer.readByte();
         String portalOrStatementName = readCString(buffer);
-        session.closePortal(b, portalOrStatementName);
+        session.close(b, portalOrStatementName);
         Messages.sendCloseComplete(channel);
     }
 

--- a/sql/src/main/java/io/crate/protocols/postgres/SimplePortal.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/SimplePortal.java
@@ -29,6 +29,7 @@ import io.crate.action.sql.SQLOperations;
 import io.crate.analyze.Analysis;
 import io.crate.analyze.Analyzer;
 import io.crate.analyze.ParameterContext;
+import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.symbol.Field;
 import io.crate.analyze.symbol.Symbols;
 import io.crate.concurrent.CompletionListener;
@@ -132,6 +133,10 @@ public class SimplePortal extends AbstractPortal {
                     EMPTY_BULK_ARGS,
                     sessionData.getDefaultSchema(),
                     sessionData.options()));
+            AnalyzedRelation rootRelation = analysis.rootRelation();
+            if (rootRelation != null) {
+                this.outputTypes = Symbols.extractTypes(rootRelation.fields());
+            }
         }
         return this;
     }
@@ -141,9 +146,7 @@ public class SimplePortal extends AbstractPortal {
         if (analysis.rootRelation() == null) {
             return null;
         }
-        List<Field> fields = analysis.rootRelation().fields();
-        this.outputTypes = Symbols.extractTypes(fields);
-        return fields;
+        return analysis.rootRelation().fields();
     }
 
     @Override

--- a/sql/src/test/java/io/crate/integrationtests/PostgresITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PostgresITest.java
@@ -37,6 +37,7 @@ import java.sql.*;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Properties;
 
 import static org.hamcrest.core.Is.is;
 
@@ -71,6 +72,27 @@ public class PostgresITest extends SQLTransportIntegrationTest {
     @Before
     public void initDriver() throws Exception {
         Class.forName("org.postgresql.Driver");
+    }
+
+    @Test
+    public void testPreparedStatementHandling() throws Exception {
+        Properties properties = new Properties();
+        properties.setProperty("prepareThreshold", "-1");
+        try (Connection conn = DriverManager.getConnection(JDBC_POSTGRESQL_URL, properties)) {
+            PreparedStatement p1 = conn.prepareStatement("select 1 from sys.cluster");
+            ResultSet resultSet = p1.executeQuery();
+            assertThat(resultSet.next(), is(true));
+            assertThat(resultSet.getInt(1), is(1));
+
+            PreparedStatement p2 = conn.prepareStatement("select 2 from sys.cluster");
+            resultSet = p2.executeQuery();
+            assertThat(resultSet.next(), is(true));
+            assertThat(resultSet.getInt(1), is(2));
+
+            resultSet = p1.executeQuery();
+            assertThat(resultSet.next(), is(true));
+            assertThat(resultSet.getInt(1), is(1));
+        }
     }
 
     @Test


### PR DESCRIPTION
Previously we've ignored the statementName.

There is still an issue with statements using parameters which return a
result-set because the Analyzer requires parameters.