### PR TITLE
fixed a race condition in the jobinittracker which lead to hiding the

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed an issue wich could lead to wrong Error messages due to a
+   race condition.
+
  - Added support for subselect statements that can be rewritten as a single query.
 
  - BREAKING: Column names returned on queries does not include the table and schema

--- a/sql/src/main/java/io/crate/executor/transport/executionphases/ExecutionPhasesTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/executionphases/ExecutionPhasesTask.java
@@ -170,7 +170,7 @@ public class ExecutionPhasesTask extends JobTask {
 
         if (!localNodeOperations.isEmpty()) {
             if (directResponseFutures.isEmpty()) {
-                initializationTracker.jobInitialized(null);
+                initializationTracker.jobInitialized();
             } else {
                 Futures.addCallback(Futures.allAsList(directResponseFutures),
                     new SetBucketAction(pageBucketReceivers, bucketIdx, initializationTracker));

--- a/sql/src/main/java/io/crate/executor/transport/executionphases/FailureOnlyResponseListener.java
+++ b/sql/src/main/java/io/crate/executor/transport/executionphases/FailureOnlyResponseListener.java
@@ -42,7 +42,7 @@ class FailureOnlyResponseListener implements ActionListener<JobResponse> {
 
     @Override
     public void onResponse(JobResponse jobResponse) {
-        initializationTracker.jobInitialized(null);
+        initializationTracker.jobInitialized();
         if (jobResponse.directResponse().size() > 0) {
             for (Tuple<ExecutionPhase, RowReceiver> rowReceiver : rowReceivers) {
                 rowReceiver.v2().fail(new IllegalStateException("Got a directResponse but didn't expect one"));
@@ -52,7 +52,7 @@ class FailureOnlyResponseListener implements ActionListener<JobResponse> {
 
     @Override
     public void onFailure(Throwable e) {
-        initializationTracker.jobInitialized(null);
+        initializationTracker.jobInitialized();
         // could be a preparation failure - in that case the regular error propagation doesn't work as it hasn't been set up yet
         // so fail rowReceivers directly
         for (Tuple<ExecutionPhase, RowReceiver> rowReceiver : rowReceivers) {

--- a/sql/src/main/java/io/crate/executor/transport/executionphases/InitializationTracker.java
+++ b/sql/src/main/java/io/crate/executor/transport/executionphases/InitializationTracker.java
@@ -24,7 +24,6 @@ package io.crate.executor.transport.executionphases;
 
 import com.google.common.util.concurrent.SettableFuture;
 
-import javax.annotation.Nullable;
 import java.util.concurrent.atomic.AtomicInteger;
 
 class InitializationTracker {
@@ -41,11 +40,9 @@ class InitializationTracker {
         serverToInitialize = new AtomicInteger(numServer);
     }
 
-    void jobInitialized(@Nullable Throwable t) {
-        if (failure == null || failure instanceof InterruptedException) {
-            failure = t;
-        }
+    void jobInitialized() {
         if (serverToInitialize.decrementAndGet() <= 0) {
+            // no need to synchronize here, since there cannot be a failure after all servers have finished
             if (failure == null) {
                 future.set(null);
             } else {
@@ -53,4 +50,14 @@ class InitializationTracker {
             }
         }
     }
+
+    void jobInitializationFailed(Throwable t) {
+        synchronized (this) {
+            if (failure == null || failure instanceof InterruptedException) {
+                failure = t;
+            }
+        }
+        jobInitialized();
+    }
+
 }

--- a/sql/src/main/java/io/crate/executor/transport/executionphases/SetBucketAction.java
+++ b/sql/src/main/java/io/crate/executor/transport/executionphases/SetBucketAction.java
@@ -47,7 +47,7 @@ class SetBucketAction implements FutureCallback<List<Bucket>>, ActionListener<Jo
 
     @Override
     public void onSuccess(@Nullable List<Bucket> result) {
-        initializationTracker.jobInitialized(null);
+        initializationTracker.jobInitialized();
         if (result == null) {
             onFailure(new NullPointerException("result is null"));
             return;
@@ -61,7 +61,7 @@ class SetBucketAction implements FutureCallback<List<Bucket>>, ActionListener<Jo
 
     @Override
     public void onResponse(JobResponse jobResponse) {
-        initializationTracker.jobInitialized(null);
+        initializationTracker.jobInitialized();
         for (int i = 0; i < pageBucketReceivers.size(); i++) {
             PageBucketReceiver pageBucketReceiver = pageBucketReceivers.get(i);
             jobResponse.streamers(pageBucketReceiver.streamer());
@@ -71,7 +71,7 @@ class SetBucketAction implements FutureCallback<List<Bucket>>, ActionListener<Jo
 
     @Override
     public void onFailure(@Nonnull Throwable t) {
-        initializationTracker.jobInitialized(t);
+        initializationTracker.jobInitializationFailed(t);
         for (PageBucketReceiver pageBucketReceiver : pageBucketReceivers) {
             pageBucketReceiver.failure(bucketIdx, t);
         }


### PR DESCRIPTION
root exception of executionphasestasks

there is no explicit test here, but the KillIntegrationsTest should be
less flaky now.