### PR TITLE
Change TransportKillJobsNodeAction to a eager singleton

### DIFF
--- a/sql/src/main/java/io/crate/executor/transport/TransportExecutorModule.java
+++ b/sql/src/main/java/io/crate/executor/transport/TransportExecutorModule.java
@@ -26,6 +26,7 @@ import io.crate.action.job.TransportJobAction;
 import io.crate.executor.Executor;
 import io.crate.executor.transport.distributed.TransportDistributedResultAction;
 import io.crate.executor.transport.kill.TransportKillAllNodeAction;
+import io.crate.executor.transport.kill.TransportKillJobsNodeAction;
 import io.crate.lucene.LuceneQueryBuilder;
 import org.elasticsearch.common.inject.AbstractModule;
 
@@ -44,5 +45,6 @@ public class TransportExecutorModule extends AbstractModule {
         bind(TransportShardDeleteAction.class).asEagerSingleton();
         bind(TransportFetchNodeAction.class).asEagerSingleton();
         bind(TransportKillAllNodeAction.class).asEagerSingleton();
+        bind(TransportKillJobsNodeAction.class).asEagerSingleton();
     }
 }


### PR DESCRIPTION
Otherwise the transport handler is registered lazy and could still be
missing if a KillRequest arrived.

The KillIntegrationTest suite was flaky because of this and sometimes
failed with `No handler for action [Action [crate/sql/kill_jobs] not found]`