### PR TITLE
Fix unintended field replacement on sources

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed an issue when ordering by a function on a joined query.
+
  - Fix: Arrays of geo_point can be used in insert/update
    statements as literals as well as bind arguments.
 

--- a/sql/src/main/java/io/crate/planner/consumer/ManyTableConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/ManyTableConsumer.java
@@ -414,7 +414,7 @@ public class ManyTableConsumer implements Consumer {
 
     private static class FieldToRelationColumnVisitor extends ReplacingSymbolVisitor<FieldToRelationColumnCtx> {
 
-        private static final FieldToRelationColumnVisitor INSTANCE = new FieldToRelationColumnVisitor(true);
+        private static final FieldToRelationColumnVisitor INSTANCE = new FieldToRelationColumnVisitor(false);
 
         public FieldToRelationColumnVisitor(boolean inPlace) {
             super(inPlace);

--- a/sql/src/test/java/io/crate/planner/consumer/ManyTableConsumerTest.java
+++ b/sql/src/test/java/io/crate/planner/consumer/ManyTableConsumerTest.java
@@ -126,6 +126,16 @@ public class ManyTableConsumerTest {
     }
 
     @Test
+    public void testQuerySplittingReplacesCopiedSymbols() throws Exception {
+        MultiSourceSelect mss = analyze("select * from t1, t2 " +
+                                        "where t1.x = 1 or t2.y = 1 " +
+                                        "order by t1.x + t1.x");
+        TwoTableJoin root = ManyTableConsumer.buildTwoTableJoinTree(mss);
+        assertThat(root.querySpec().orderBy().get().orderBySymbols(), isSQL("add(RELCOL(doc.t1, 0), RELCOL(doc.t1, 0))"));
+        assertThat(root.left().querySpec().orderBy().get().orderBySymbols(), isSQL("add(doc.t1.x, doc.t1.x)"));
+    }
+
+    @Test
     public void testOptimizeJoin() throws Exception {
         Set<QualifiedName> pair1 = Sets.newHashSet(T3.T1, T3.T3);
         Set<QualifiedName> pair2 = Sets.newHashSet(T3.T3, T3.T2);


### PR DESCRIPTION
Fields that were referenced on the `MultiSourceSelect.querySpec` and
on a `source` where being replaced on both places by relation columns.
It is expected that the replacement occurrs only on the first.