### PR TITLE
Don't save evaluated current_timestamp into table meta mapping

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,11 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed an issue which caused `current_timestamp` as part of a generated
+   expression to not work correctly.
+   This fix will only affect new tables. Tables which already contain a
+   generated column which uses `current_timestamp` will need to be recreated.
+
  - Fixed an issue when ordering by a function on a joined query.
 
  - Fix: Arrays of geo_point can be used in insert/update

--- a/sql/src/main/java/io/crate/analyze/AlterTableAddColumnAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/AlterTableAddColumnAnalyzer.java
@@ -80,7 +80,7 @@ public class AlterTableAddColumnAnalyzer extends DefaultTraversalVisitor<AddColu
         addExistingPrimaryKeys(statement);
         ensureNoIndexDefinitions(statement.analyzedTableElements().columns());
         statement.analyzedTableElements().finalizeAndValidate(
-                statement.table().ident(), statement.table(), analysisMetaData, analysis.parameterContext());
+                statement.table().ident(), statement.table(), analysisMetaData, analysis.parameterContext(), analysis.statementContext());
 
         int numCurrentPks = statement.table().primaryKey().size();
         if (statement.table().primaryKey().contains(DocSysColumns.ID)) {

--- a/sql/src/main/java/io/crate/analyze/Analysis.java
+++ b/sql/src/main/java/io/crate/analyze/Analysis.java
@@ -22,14 +22,17 @@
 package io.crate.analyze;
 
 import io.crate.analyze.relations.AnalyzedRelation;
+import io.crate.metadata.StmtCtx;
 
 public class Analysis {
 
     private final ParameterContext parameterContext;
+    private final StmtCtx stmtCtx;
     private AnalyzedStatement analyzedStatement;
     private AnalyzedRelation rootRelation;
 
     public Analysis(ParameterContext parameterContext) {
+        this.stmtCtx = new StmtCtx();
         this.parameterContext = parameterContext;
     }
 
@@ -51,5 +54,9 @@ public class Analysis {
 
     public AnalyzedRelation rootRelation(){
         return rootRelation;
+    }
+
+    public StmtCtx statementContext() {
+        return stmtCtx;
     }
 }

--- a/sql/src/main/java/io/crate/analyze/AnalyzedTableElements.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedTableElements.java
@@ -207,9 +207,11 @@ public class AnalyzedTableElements {
     public void finalizeAndValidate(TableIdent tableIdent,
                                     @Nullable TableInfo tableInfo,
                                     AnalysisMetaData analysisMetaData,
-                                    ParameterContext parameterContext) {
+                                    ParameterContext parameterContext,
+                                    StmtCtx stmtCtx
+                                    ) {
         expandColumnIdents();
-        validateGeneratedColumns(tableIdent, tableInfo, analysisMetaData, parameterContext);
+        validateGeneratedColumns(tableIdent, tableInfo, analysisMetaData, parameterContext, stmtCtx);
         for (AnalyzedColumnDefinition column : columns) {
             column.validate();
             addCopyToInfo(column);
@@ -221,7 +223,8 @@ public class AnalyzedTableElements {
     private void validateGeneratedColumns(TableIdent tableIdent,
                                           @Nullable TableInfo tableInfo,
                                           AnalysisMetaData analysisMetaData,
-                                          ParameterContext parameterContext) {
+                                          ParameterContext parameterContext,
+                                          StmtCtx stmtCtx) {
         List<ReferenceInfo> tableReferenceInfos = new ArrayList<>();
         for (AnalyzedColumnDefinition columnDefinition : columns) {
             buildReferenceInfo(tableIdent, columnDefinition, tableReferenceInfos);
@@ -235,7 +238,7 @@ public class AnalyzedTableElements {
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
                 analysisMetaData, parameterContext, tableReferenceResolver, null);
         SymbolPrinter printer = new SymbolPrinter(analysisMetaData.functions());
-        ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext();
+        ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext(stmtCtx);
         for (AnalyzedColumnDefinition columnDefinition : columns) {
             if (columnDefinition.generatedExpression() != null) {
                 processGeneratedExpression(expressionAnalyzer, printer, columnDefinition, expressionAnalysisContext);

--- a/sql/src/main/java/io/crate/analyze/CreateTableStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateTableStatementAnalyzer.java
@@ -92,7 +92,11 @@ public class CreateTableStatementAnalyzer extends DefaultTraversalVisitor<Create
 
         // validate table elements
         context.statement.analyzedTableElements().finalizeAndValidate(
-                context.statement.tableIdent(), null, analysisMetaData, context.analysis.parameterContext());
+            context.statement.tableIdent(),
+            null,
+            analysisMetaData,
+            context.analysis.parameterContext(),
+            context.analysis.statementContext());
 
         // update table settings
         context.statement.tableParameter().settingsBuilder().put(context.statement.analyzedTableElements().settings());

--- a/sql/src/main/java/io/crate/analyze/HavingClause.java
+++ b/sql/src/main/java/io/crate/analyze/HavingClause.java
@@ -22,6 +22,7 @@
 package io.crate.analyze;
 
 import io.crate.analyze.symbol.Symbol;
+import io.crate.metadata.StmtCtx;
 
 import javax.annotation.Nullable;
 
@@ -31,11 +32,11 @@ public class HavingClause extends QueryClause {
         super(query);
     }
 
-    public HavingClause normalize(EvaluatingNormalizer normalizer) {
+    public HavingClause normalize(EvaluatingNormalizer normalizer, StmtCtx stmtCtx) {
         if (noMatch || query == null) {
             return this;
         }
-        Symbol normalizedQuery = normalizer.normalize(query);
+        Symbol normalizedQuery = normalizer.normalize(query, stmtCtx);
         if (normalizedQuery == query) {
             return this;
         }

--- a/sql/src/main/java/io/crate/analyze/InsertFromSubQueryAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/InsertFromSubQueryAnalyzer.java
@@ -33,10 +33,7 @@ import io.crate.analyze.symbol.format.SymbolFormatter;
 import io.crate.analyze.symbol.format.SymbolPrinter;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.exceptions.UnsupportedFeatureException;
-import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.ReferenceInfo;
-import io.crate.metadata.RowGranularity;
-import io.crate.metadata.TableIdent;
+import io.crate.metadata.*;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.Assignment;
@@ -107,11 +104,12 @@ public class InsertFromSubQueryAnalyzer {
         Map<Reference, Symbol> onDuplicateKeyAssignments = null;
         if (!node.onDuplicateKeyAssignments().isEmpty()) {
             onDuplicateKeyAssignments = processUpdateAssignments(
-                    tableRelation,
-                    targetColumns,
-                    analysis.parameterContext(),
-                    fieldProvider,
-                    node.onDuplicateKeyAssignments());
+                tableRelation,
+                targetColumns,
+                analysis.parameterContext(),
+                analysis.statementContext(),
+                fieldProvider,
+                node.onDuplicateKeyAssignments());
         }
 
         return new InsertFromSubQueryAnalyzedStatement(
@@ -192,14 +190,20 @@ public class InsertFromSubQueryAnalyzer {
     private Map<Reference, Symbol> processUpdateAssignments(DocTableRelation tableRelation,
                                                             List<Reference> targetColumns,
                                                             ParameterContext parameterContext,
+                                                            StmtCtx stmtCtx,
                                                             FieldProvider fieldProvider,
                                                             List<Assignment> assignments) {
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
                 analysisMetaData, parameterContext, fieldProvider, tableRelation);
-        ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext();
+        ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext(stmtCtx);
 
-        ValueNormalizer valuesNormalizer = new ValueNormalizer(analysisMetaData.schemas(), new EvaluatingNormalizer(
-                analysisMetaData.functions(), RowGranularity.CLUSTER, analysisMetaData.referenceResolver(), tableRelation, false));
+        ValueNormalizer valuesNormalizer = new ValueNormalizer(analysisMetaData.schemas(),
+            new EvaluatingNormalizer(
+                analysisMetaData.functions(),
+                RowGranularity.CLUSTER,
+                analysisMetaData.referenceResolver(),
+                tableRelation,
+                false));
 
         ValuesResolver valuesResolver = new ValuesResolver(tableRelation, targetColumns);
         ValuesAwareExpressionAnalyzer valuesAwareExpressionAnalyzer = new ValuesAwareExpressionAnalyzer(
@@ -212,8 +216,9 @@ public class InsertFromSubQueryAnalyzer {
             assert columnName != null;
 
             Symbol assignmentExpression = valuesNormalizer.normalizeInputForReference(
-                    valuesAwareExpressionAnalyzer.convert(assignment.expression(), expressionAnalysisContext),
-                    columnName);
+                valuesAwareExpressionAnalyzer.convert(assignment.expression(), expressionAnalysisContext),
+                columnName,
+                stmtCtx);
 
             updateAssignments.put(columnName, assignmentExpression);
         }

--- a/sql/src/main/java/io/crate/analyze/InsertFromValuesAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/InsertFromValuesAnalyzer.java
@@ -97,7 +97,7 @@ public class InsertFromValuesAnalyzer extends AbstractInsertAnalyzer {
         FieldProvider fieldProvider = new NameFieldProvider(tableRelation);
         ExpressionAnalyzer expressionAnalyzer =
                 new ExpressionAnalyzer(analysisMetaData, analysis.parameterContext(), fieldProvider, tableRelation);
-        ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext();
+        ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext(analysis.statementContext());
         expressionAnalyzer.setResolveFieldsOperation(Operation.INSERT);
 
         ValuesResolver valuesResolver = new ValuesResolver(tableRelation);
@@ -115,8 +115,13 @@ public class InsertFromValuesAnalyzer extends AbstractInsertAnalyzer {
         ReferenceToLiteralConverter.Context referenceToLiteralContext = new ReferenceToLiteralConverter.Context(
                 statement.columns(), allReferencedReferences);
 
-        ValueNormalizer valuesNormalizer = new ValueNormalizer(analysisMetaData.schemas(), new EvaluatingNormalizer(
-                analysisMetaData.functions(), RowGranularity.CLUSTER, analysisMetaData.referenceResolver(), tableRelation, false));
+        ValueNormalizer valuesNormalizer = new ValueNormalizer(analysisMetaData.schemas(),
+            new EvaluatingNormalizer(
+                analysisMetaData.functions(),
+                RowGranularity.CLUSTER,
+                analysisMetaData.referenceResolver(),
+                tableRelation,
+                false));
         for (ValuesList valuesList : node.valuesLists()) {
             analyzeValues(
                     tableRelation,
@@ -247,7 +252,8 @@ public class InsertFromValuesAnalyzer extends AbstractInsertAnalyzer {
             final ColumnIdent columnIdent = column.info().ident().columnIdent();
             Object value;
             try {
-                valuesSymbol = valueNormalizer.normalizeInputForReference(valuesSymbol, column);
+                valuesSymbol = valueNormalizer.normalizeInputForReference(
+                    valuesSymbol, column, expressionAnalysisContext.statementContext());
                 value = ((Input) valuesSymbol).value();
             } catch (IllegalArgumentException | UnsupportedOperationException e) {
                 throw new ColumnValidationException(columnIdent.sqlFqn(), e);
@@ -303,9 +309,12 @@ public class InsertFromValuesAnalyzer extends AbstractInsertAnalyzer {
                 assert columnName != null;
 
                 Symbol assignmentExpression = valueNormalizer.normalizeInputForReference(
-                        valuesAwareExpressionAnalyzer.convert(assignment.expression(), expressionAnalysisContext),
-                        columnName);
-                assignmentExpression = valuesAwareExpressionAnalyzer.normalize(assignmentExpression);
+                    valuesAwareExpressionAnalyzer.convert(assignment.expression(), expressionAnalysisContext),
+                    columnName,
+                    expressionAnalysisContext.statementContext()
+                );
+                assignmentExpression = valuesAwareExpressionAnalyzer.normalize(
+                    assignmentExpression, expressionAnalysisContext.statementContext());
                 onDupKeyAssignments[i] = assignmentExpression;
 
                 if (valuesResolver.assignmentColumns.size() == i) {
@@ -318,8 +327,15 @@ public class InsertFromValuesAnalyzer extends AbstractInsertAnalyzer {
         }
 
         // process generated column expressions and add columns + values
-        GeneratedExpressionContext ctx = new GeneratedExpressionContext(tableRelation, context, expressionAnalyzer,
-                referenceToLiteralContext, primaryKeyValues, insertValues, routingValue);
+        GeneratedExpressionContext ctx = new GeneratedExpressionContext(
+            tableRelation,
+            context,
+            expressionAnalyzer,
+            expressionAnalysisContext.statementContext(),
+            referenceToLiteralContext,
+            primaryKeyValues,
+            insertValues,
+            routingValue);
         processGeneratedExpressions(ctx);
         insertValues = ctx.insertValues;
         routingValue = ctx.routingValue;
@@ -394,6 +410,7 @@ public class InsertFromValuesAnalyzer extends AbstractInsertAnalyzer {
         private final InsertFromValuesAnalyzedStatement analyzedStatement;
         private final ExpressionAnalyzer expressionAnalyzer;
         private final ReferenceToLiteralConverter.Context referenceToLiteralContext;
+        private final StmtCtx stmtCtx;
         private final List<BytesRef> primaryKeyValues;
 
         private Object[] insertValues;
@@ -402,6 +419,7 @@ public class InsertFromValuesAnalyzer extends AbstractInsertAnalyzer {
         private GeneratedExpressionContext(DocTableRelation tableRelation,
                                            InsertFromValuesAnalyzedStatement analyzedStatement,
                                            ExpressionAnalyzer expressionAnalyzer,
+                                           StmtCtx stmtCtx,
                                            ReferenceToLiteralConverter.Context referenceToLiteralContext,
                                            List<BytesRef> primaryKeyValues,
                                            Object[] insertValues,
@@ -409,6 +427,7 @@ public class InsertFromValuesAnalyzer extends AbstractInsertAnalyzer {
             this.tableRelation = tableRelation;
             this.analyzedStatement = analyzedStatement;
             this.expressionAnalyzer = expressionAnalyzer;
+            this.stmtCtx = stmtCtx;
             this.primaryKeyValues = primaryKeyValues;
             this.insertValues = insertValues;
             this.routingValue = routingValue;
@@ -422,7 +441,7 @@ public class InsertFromValuesAnalyzer extends AbstractInsertAnalyzer {
         for (GeneratedReferenceInfo referenceInfo : context.tableRelation.tableInfo().generatedColumns()) {
             Reference reference = new Reference(referenceInfo);
             Symbol valueSymbol = TO_LITERAL_CONVERTER.process(referenceInfo.generatedExpression(), context.referenceToLiteralContext);
-            valueSymbol = context.expressionAnalyzer.normalize(valueSymbol);
+            valueSymbol = context.expressionAnalyzer.normalize(valueSymbol, context.stmtCtx);
             if (valueSymbol.symbolType() == SymbolType.LITERAL) {
                 Object value = ((Input) valueSymbol).value();
                 if (primaryKey.contains(referenceInfo.ident().columnIdent()) && context.analyzedStatement.columns().indexOf(reference) == -1) {

--- a/sql/src/main/java/io/crate/analyze/OrderBy.java
+++ b/sql/src/main/java/io/crate/analyze/OrderBy.java
@@ -25,6 +25,7 @@ import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Lists;
 import io.crate.analyze.symbol.Symbol;
+import io.crate.metadata.StmtCtx;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
@@ -66,8 +67,8 @@ public class OrderBy implements Streamable {
         return nullsFirst;
     }
 
-    public void normalize(EvaluatingNormalizer normalizer) {
-        normalizer.normalizeInplace(orderBySymbols);
+    public void normalize(EvaluatingNormalizer normalizer, StmtCtx stmtCtx) {
+        normalizer.normalizeInplace(orderBySymbols, stmtCtx);
     }
 
 

--- a/sql/src/main/java/io/crate/analyze/QueriedTableRelation.java
+++ b/sql/src/main/java/io/crate/analyze/QueriedTableRelation.java
@@ -27,6 +27,7 @@ import io.crate.analyze.symbol.Field;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.ColumnIndex;
 import io.crate.metadata.Path;
+import io.crate.metadata.StmtCtx;
 import io.crate.metadata.table.Operation;
 
 import javax.annotation.Nullable;
@@ -68,9 +69,9 @@ public abstract class QueriedTableRelation<TR extends AbstractTableRelation> imp
         return tableRelation;
     }
 
-    public void normalize(AnalysisMetaData analysisMetaData){
+    public void normalize(AnalysisMetaData analysisMetaData, StmtCtx stmtCtx){
         EvaluatingNormalizer normalizer = new EvaluatingNormalizer(analysisMetaData, tableRelation, true);
-        querySpec().normalize(normalizer);
+        querySpec().normalize(normalizer, stmtCtx);
     }
 
     @Nullable

--- a/sql/src/main/java/io/crate/analyze/QuerySpec.java
+++ b/sql/src/main/java/io/crate/analyze/QuerySpec.java
@@ -29,6 +29,7 @@ import io.crate.analyze.symbol.DefaultTraversalSymbolVisitor;
 import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.RelationColumn;
 import io.crate.analyze.symbol.Symbol;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.scalar.cast.CastFunctionResolver;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -132,21 +133,21 @@ public class QuerySpec {
         return limit.isPresent() || offset > 0;
     }
 
-    public void normalize(EvaluatingNormalizer normalizer) {
+    public void normalize(EvaluatingNormalizer normalizer, StmtCtx context) {
         if (groupBy.isPresent()) {
-            normalizer.normalizeInplace(groupBy.get());
+            normalizer.normalizeInplace(groupBy.get(), context);
         }
         if (orderBy.isPresent()) {
-            orderBy.get().normalize(normalizer);
+            orderBy.get().normalize(normalizer, context);
         }
         if (outputs != null) {
-            normalizer.normalizeInplace(outputs);
+            normalizer.normalizeInplace(outputs, context);
         }
         if (where != null && where != WhereClause.MATCH_ALL) {
-            this.where(where.normalize(normalizer));
+            this.where(where.normalize(normalizer, context));
         }
         if (having.isPresent()) {
-            Optional.of(having.get().normalize(normalizer));
+            Optional.of(having.get().normalize(normalizer, context));
         }
     }
 

--- a/sql/src/main/java/io/crate/analyze/WhereClause.java
+++ b/sql/src/main/java/io/crate/analyze/WhereClause.java
@@ -28,6 +28,7 @@ import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.ValueSymbolVisitor;
 import io.crate.analyze.where.DocKeys;
+import io.crate.metadata.StmtCtx;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -69,11 +70,11 @@ public class WhereClause extends QueryClause implements Streamable {
         super(query);
     }
 
-    public WhereClause normalize(EvaluatingNormalizer normalizer) {
+    public WhereClause normalize(EvaluatingNormalizer normalizer, StmtCtx stmtCtx) {
         if (noMatch || query == null) {
             return this;
         }
-        Symbol normalizedQuery = normalizer.normalize(query);
+        Symbol normalizedQuery = normalizer.normalize(query, stmtCtx);
         if (normalizedQuery == query) {
             return this;
         }

--- a/sql/src/main/java/io/crate/analyze/expressions/ValueNormalizer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ValueNormalizer.java
@@ -36,10 +36,14 @@ import io.crate.exceptions.ConversionException;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.ReferenceInfo;
 import io.crate.metadata.Schemas;
+import io.crate.metadata.StmtCtx;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.ColumnPolicy;
 import io.crate.metadata.table.TableInfo;
-import io.crate.types.*;
+import io.crate.types.ArrayType;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+import io.crate.types.ObjectType;
 
 import java.util.Locale;
 import java.util.Map;
@@ -62,9 +66,8 @@ public class ValueNormalizer {
      * @return the normalized Symbol, should be a literal
      * @throws io.crate.exceptions.ColumnValidationException
      */
-    public Symbol normalizeInputForReference(Symbol valueSymbol, Reference reference) {
-
-        valueSymbol = normalizer.normalize(valueSymbol);
+    public Symbol normalizeInputForReference(Symbol valueSymbol, Reference reference, StmtCtx stmtCtx) {
+        valueSymbol = normalizer.normalize(valueSymbol, stmtCtx);
         assert valueSymbol != null : "valueSymbol must not be null";
 
         DataType<?> targetType = getTargetType(valueSymbol, reference);

--- a/sql/src/main/java/io/crate/analyze/relations/QueriedDocTable.java
+++ b/sql/src/main/java/io/crate/analyze/relations/QueriedDocTable.java
@@ -26,6 +26,7 @@ import io.crate.analyze.QueriedTableRelation;
 import io.crate.analyze.QuerySpec;
 import io.crate.analyze.where.WhereClauseAnalyzer;
 import io.crate.metadata.Path;
+import io.crate.metadata.StmtCtx;
 
 import java.util.Collection;
 
@@ -44,8 +45,8 @@ public class QueriedDocTable extends QueriedTableRelation<DocTableRelation> {
         return visitor.visitQueriedDocTable(this, context);
     }
 
-    public void analyzeWhereClause(AnalysisMetaData analysisMetaData) {
+    public void analyzeWhereClause(AnalysisMetaData analysisMetaData, StmtCtx stmtCtx) {
         WhereClauseAnalyzer whereClauseAnalyzer = new WhereClauseAnalyzer(analysisMetaData, tableRelation());
-        querySpec().where(whereClauseAnalyzer.analyze(querySpec().where()));
+        querySpec().where(whereClauseAnalyzer.analyze(querySpec().where(), stmtCtx));
     }
 }

--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalysisContext.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalysisContext.java
@@ -27,6 +27,7 @@ import io.crate.analyze.AnalysisMetaData;
 import io.crate.analyze.ParameterContext;
 import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
+import io.crate.metadata.StmtCtx;
 import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.QualifiedName;
 
@@ -48,11 +49,14 @@ public class RelationAnalysisContext {
     @Nullable
     private List<Expression> joinExpressions;
 
-    RelationAnalysisContext(ParameterContext parameterContext, AnalysisMetaData analysisMetaData, boolean aliasedRelation) {
+    RelationAnalysisContext(ParameterContext parameterContext,
+                            StmtCtx stmtCtx,
+                            AnalysisMetaData analysisMetaData,
+                            boolean aliasedRelation) {
         this.parameterContext = parameterContext;
         this.analysisMetaData = analysisMetaData;
         this.aliasedRelation = aliasedRelation;
-        expressionAnalysisContext = new ExpressionAnalysisContext();
+        expressionAnalysisContext = new ExpressionAnalysisContext(stmtCtx);
     }
 
     public boolean isAliasedRelation() {

--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -70,11 +70,13 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
 
     public AnalyzedRelation analyze(Node node, StatementAnalysisContext relationAnalysisContext) {
         AnalyzedRelation relation = process(node, relationAnalysisContext);
-        return RelationNormalizer.normalize(relation, analysisMetaData);
+        return RelationNormalizer.normalize(relation, analysisMetaData,
+            relationAnalysisContext.stmtCtx());
     }
 
     public AnalyzedRelation analyze(Node node, Analysis analysis) {
-        return analyze(node, new StatementAnalysisContext(analysis.parameterContext(), analysisMetaData));
+        return analyze(node, new StatementAnalysisContext(
+            analysis.parameterContext(), analysis.statementContext(), analysisMetaData));
     }
 
     @Override
@@ -163,7 +165,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
                 relation = new QueriedSelectRelation((QueriedRelation) source, selectAnalysis.outputNames(), querySpec);
             }
             if (tableRelation != null) {
-                tableRelation.normalize(analysisMetaData);
+                tableRelation.normalize(analysisMetaData, context.expressionAnalysisContext().statementContext());
                 relation = tableRelation;
             }
         } else {
@@ -294,7 +296,8 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
             }
             Symbol symbol = context.expressionAnalyzer().convert(having.get(), context.expressionAnalysisContext());
             HavingSymbolValidator.validate(symbol, groupBy);
-            return new HavingClause(context.expressionAnalyzer().normalize(symbol));
+            return new HavingClause(context.expressionAnalyzer().normalize(
+                symbol, context.expressionAnalysisContext().statementContext()));
         }
         return null;
     }
@@ -316,7 +319,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
                 query = new Function(AndOperator.INFO, Arrays.asList(query, joinCondition));
             }
         }
-        query = context.expressionAnalyzer().normalize(query);
+        query = context.expressionAnalyzer().normalize(query, context.expressionAnalysisContext().statementContext());
         return new WhereClause(query);
     }
 

--- a/sql/src/main/java/io/crate/analyze/relations/StatementAnalysisContext.java
+++ b/sql/src/main/java/io/crate/analyze/relations/StatementAnalysisContext.java
@@ -23,6 +23,7 @@ package io.crate.analyze.relations;
 
 import io.crate.analyze.AnalysisMetaData;
 import io.crate.analyze.ParameterContext;
+import io.crate.metadata.StmtCtx;
 import io.crate.metadata.table.Operation;
 
 import java.util.ArrayList;
@@ -32,23 +33,32 @@ public class StatementAnalysisContext {
 
     private final Operation currentOperation;
     private final ParameterContext parameterContext;
+    private final StmtCtx stmtCtx;
     private final AnalysisMetaData analysisMetaData;
     private final List<RelationAnalysisContext> lastRelationContextQueue = new ArrayList<>();
 
-    StatementAnalysisContext(ParameterContext parameterContext, AnalysisMetaData analysisMetaData) {
-        this(parameterContext, analysisMetaData, Operation.READ);
+    StatementAnalysisContext(ParameterContext parameterContext,
+                             StmtCtx stmtCtx,
+                             AnalysisMetaData analysisMetaData) {
+        this(parameterContext, stmtCtx, analysisMetaData, Operation.READ);
     }
 
     public StatementAnalysisContext(ParameterContext parameterContext,
+                                    StmtCtx stmtCtx,
                                     AnalysisMetaData analysisMetaData,
                                     Operation currentOperation) {
         this.parameterContext = parameterContext;
+        this.stmtCtx = stmtCtx;
         this.analysisMetaData = analysisMetaData;
         this.currentOperation = currentOperation;
     }
 
     public ParameterContext parameterContext() {
         return parameterContext;
+    }
+
+    public StmtCtx stmtCtx() {
+        return stmtCtx;
     }
 
     Operation currentOperation() {
@@ -60,7 +70,8 @@ public class StatementAnalysisContext {
     }
 
     RelationAnalysisContext startRelation(boolean aliasedRelation) {
-        RelationAnalysisContext currentRelationContext = new RelationAnalysisContext(parameterContext, analysisMetaData, aliasedRelation);
+        RelationAnalysisContext currentRelationContext = new RelationAnalysisContext(
+            parameterContext, stmtCtx, analysisMetaData, aliasedRelation);
         lastRelationContextQueue.add(currentRelationContext);
         return currentRelationContext;
     }

--- a/sql/src/main/java/io/crate/analyze/where/EqualityExtractor.java
+++ b/sql/src/main/java/io/crate/analyze/where/EqualityExtractor.java
@@ -28,6 +28,7 @@ import io.crate.analyze.symbol.*;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.operator.EqOperator;
 import io.crate.operation.operator.any.AnyEqOperator;
 import io.crate.types.CollectionType;
@@ -54,14 +55,17 @@ public class EqualityExtractor {
         this.normalizer = normalizer;
     }
 
-    public List<List<Symbol>> extractParentMatches(List<ColumnIdent> columns, Symbol symbol){
-        return extractMatches(columns, symbol, false);
+    public List<List<Symbol>> extractParentMatches(List<ColumnIdent> columns, Symbol symbol, StmtCtx stmtCtx){
+        return extractMatches(columns, symbol, false, stmtCtx);
     }
-    public List<List<Symbol>> extractExactMatches(List<ColumnIdent> columns, Symbol symbol) {
-        return extractMatches(columns, symbol, true);
+    public List<List<Symbol>> extractExactMatches(List<ColumnIdent> columns, Symbol symbol, StmtCtx stmtCtx) {
+        return extractMatches(columns, symbol, true, stmtCtx);
     }
 
-    private List<List<Symbol>> extractMatches(Collection<ColumnIdent> columns, Symbol symbol, boolean exact){
+    private List<List<Symbol>> extractMatches(Collection<ColumnIdent> columns,
+                                              Symbol symbol,
+                                              boolean exact,
+                                              StmtCtx stmtCtx) {
         EqualityExtractor.ProxyInjectingVisitor.Context context =
                 new EqualityExtractor.ProxyInjectingVisitor.Context(columns, exact);
         Symbol proxiedTree = ProxyInjectingVisitor.INSTANCE.process(symbol, context);
@@ -84,7 +88,7 @@ public class EqualityExtractor {
                     anyNull = true;
                 }
             }
-            Symbol normalized = normalizer.normalize(proxiedTree);
+            Symbol normalized = normalizer.normalize(proxiedTree, stmtCtx);
             if (normalized == Literal.BOOLEAN_TRUE){
                 if (anyNull){
                     return null;

--- a/sql/src/main/java/io/crate/metadata/FunctionImplementation.java
+++ b/sql/src/main/java/io/crate/metadata/FunctionImplementation.java
@@ -23,9 +23,19 @@ package io.crate.metadata;
 
 import io.crate.analyze.symbol.Symbol;
 
+import javax.annotation.Nullable;
+
 public interface FunctionImplementation<SymbolType extends Symbol> {
 
     FunctionInfo info();
 
-    Symbol normalizeSymbol(SymbolType symbol);
+    /**
+     * Normalize a symbol into a simplified form.
+     * This may return the symbol as is if it cannot be normalized.
+     *
+     * @param stmtCtx context which is shared across normalizeSymbol calls during a statement-lifecycle.
+     *                This will only be present if normalizeSymbol is called on the handler node.
+     *                normalizeSymbol calls during execution won't receive a StmtCtx
+     */
+    Symbol normalizeSymbol(SymbolType symbol, @Nullable StmtCtx stmtCtx);
 }

--- a/sql/src/main/java/io/crate/metadata/Scalar.java
+++ b/sql/src/main/java/io/crate/metadata/Scalar.java
@@ -56,7 +56,7 @@ public abstract class Scalar<ReturnType, InputType> implements FunctionImplement
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol) {
+    public Symbol normalizeSymbol(Function symbol, StmtCtx stmtCtx) {
         return evaluateIfLiterals(this, symbol);
     }
 

--- a/sql/src/main/java/io/crate/metadata/StmtCtx.java
+++ b/sql/src/main/java/io/crate/metadata/StmtCtx.java
@@ -20,22 +20,26 @@
  * agreement.
  */
 
-package io.crate.planner.node.dql;
+package io.crate.metadata;
 
-import io.crate.analyze.EvaluatingNormalizer;
-import io.crate.analyze.symbol.Symbol;
-import io.crate.metadata.StmtCtx;
-import io.crate.planner.distribution.UpstreamPhase;
-import io.crate.planner.projection.Projection;
+import org.joda.time.DateTimeUtils;
 
-import java.util.List;
-import java.util.UUID;
+/**
+ * StatementContext that can be used to keep state which is valid on the handler during a "statement lifecycle".
+ *
+ */
+public class StmtCtx {
 
-public interface CollectPhase extends UpstreamPhase {
-    UUID jobId();
-    List<? extends Symbol> toCollect();
-    List<Projection> projections();
-    void addProjection(Projection projection);
+    private Long currentTimeMillis = null;
 
-    CollectPhase normalize(EvaluatingNormalizer phase, StmtCtx stmtCtx);
+    /**
+     * @return current timestamp in ms. Subsequent calls will always return the same value. (Not thread-safe)
+     */
+    public long currentTimeMillis() {
+        if (currentTimeMillis == null) {
+            // no synchronization because StmtCtx is mostly used during single-threaded analysis phase
+            currentTimeMillis = DateTimeUtils.currentTimeMillis();
+        }
+        return currentTimeMillis;
+    }
 }

--- a/sql/src/main/java/io/crate/metadata/doc/DocIndexMetaData.java
+++ b/sql/src/main/java/io/crate/metadata/doc/DocIndexMetaData.java
@@ -477,7 +477,7 @@ public class DocIndexMetaData {
         TableReferenceResolver tableReferenceResolver = new TableReferenceResolver(referenceInfos);
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
                 functions, null, ParameterContext.EMPTY, tableReferenceResolver, null);
-        ExpressionAnalysisContext context = new ExpressionAnalysisContext();
+        ExpressionAnalysisContext context = new ExpressionAnalysisContext(new StmtCtx());
         for (ReferenceInfo referenceInfo : generatedColumnReferences) {
             GeneratedReferenceInfo generatedReferenceInfo = (GeneratedReferenceInfo) referenceInfo;
             Expression expression = SqlParser.createExpression(generatedReferenceInfo.formattedGeneratedExpression());

--- a/sql/src/main/java/io/crate/operation/aggregation/AggregationFunction.java
+++ b/sql/src/main/java/io/crate/operation/aggregation/AggregationFunction.java
@@ -25,6 +25,7 @@ import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.Input;
 import io.crate.types.DataType;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
@@ -78,7 +79,7 @@ public abstract class AggregationFunction<TPartial, TFinal> implements FunctionI
     public abstract DataType partialType();
 
     @Override
-    public Symbol normalizeSymbol(Function symbol) {
+    public Symbol normalizeSymbol(Function symbol, StmtCtx stmtCtx) {
         return symbol;
     }
 }

--- a/sql/src/main/java/io/crate/operation/aggregation/impl/CountAggregation.java
+++ b/sql/src/main/java/io/crate/operation/aggregation/impl/CountAggregation.java
@@ -27,10 +27,7 @@ import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.breaker.RamAccountingContext;
-import io.crate.metadata.DynamicFunctionResolver;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionImplementation;
-import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.*;
 import io.crate.operation.Input;
 import io.crate.operation.aggregation.AggregationFunction;
 import io.crate.types.DataType;
@@ -99,7 +96,7 @@ public class CountAggregation extends AggregationFunction<CountAggregation.LongS
     }
 
     @Override
-    public Symbol normalizeSymbol(Function function) {
+    public Symbol normalizeSymbol(Function function, StmtCtx stmtCtx) {
         assert (function.arguments().size() <= 1);
 
         if (function.arguments().size() == 1) {

--- a/sql/src/main/java/io/crate/operation/collect/MapSideDataCollectOperation.java
+++ b/sql/src/main/java/io/crate/operation/collect/MapSideDataCollectOperation.java
@@ -96,7 +96,7 @@ public class MapSideDataCollectOperation {
     }
 
     private CollectPhase normalize(CollectPhase collectPhase) {
-        collectPhase = collectPhase.normalize(clusterNormalizer);
+        collectPhase = collectPhase.normalize(clusterNormalizer, null);
         if (collectPhase instanceof RoutedCollectPhase) {
             RoutedCollectPhase routedCollectPhase = (RoutedCollectPhase) collectPhase;
             switch (routedCollectPhase.maxRowGranularity()) {
@@ -104,7 +104,7 @@ public class MapSideDataCollectOperation {
                 case DOC:
                     EvaluatingNormalizer normalizer =
                             new EvaluatingNormalizer(functions, RowGranularity.NODE, new NodeSysReferenceResolver(nodeSysExpression));
-                    return collectPhase.normalize(normalizer);
+                    return collectPhase.normalize(normalizer, null);
             }
         }
         return collectPhase;

--- a/sql/src/main/java/io/crate/operation/collect/ShardCollectService.java
+++ b/sql/src/main/java/io/crate/operation/collect/ShardCollectService.java
@@ -150,7 +150,7 @@ public class ShardCollectService {
                 RowGranularity.SHARD,
                 new RecoveryShardReferenceResolver(shardResolver, indexShard)
         );
-        collectPhase =  collectPhase.normalize(shardNormalizer);
+        collectPhase =  collectPhase.normalize(shardNormalizer, null);
         if (collectPhase.whereClause().noMatch()) {
             return null;
         }
@@ -177,7 +177,7 @@ public class ShardCollectService {
                                           ShardProjectorChain projectorChain,
                                           JobCollectContext jobCollectContext) throws Exception {
         assert collectPhase.orderBy() == null : "getDocCollector shouldn't be called if there is an orderBy on the collectPhase";
-        RoutedCollectPhase normalizedCollectNode = collectPhase.normalize(shardNormalizer);
+        RoutedCollectPhase normalizedCollectNode = collectPhase.normalize(shardNormalizer, null);
 
         if (normalizedCollectNode.whereClause().noMatch()) {
             RowReceiver downstream = projectorChain.newShardDownstreamProjector(projectorVisitor);
@@ -246,7 +246,7 @@ public class ShardCollectService {
                                                    SharedShardContext sharedShardContext,
                                                    JobCollectContext jobCollectContext,
                                                    boolean requiresRepeat) {
-        RoutedCollectPhase normalizedCollectPhase = collectPhase.normalize(shardNormalizer);
+        RoutedCollectPhase normalizedCollectPhase = collectPhase.normalize(shardNormalizer, null);
 
         if (isBlobShard) {
             return getBlobOrderedDocCollector(normalizedCollectPhase, requiresRepeat);

--- a/sql/src/main/java/io/crate/operation/collect/sources/ShardCollectSource.java
+++ b/sql/src/main/java/io/crate/operation/collect/sources/ShardCollectSource.java
@@ -118,7 +118,7 @@ public class ShardCollectSource implements CollectSource {
         EvaluatingNormalizer nodeNormalizer = new EvaluatingNormalizer(functions,
                 RowGranularity.NODE,
                 referenceResolver);
-        RoutedCollectPhase normalizedPhase = collectPhase.normalize(nodeNormalizer);
+        RoutedCollectPhase normalizedPhase = collectPhase.normalize(nodeNormalizer, null);
 
         ProjectorFactory projectorFactory = new ProjectionToProjectorVisitor(
                 clusterService,

--- a/sql/src/main/java/io/crate/operation/operator/AndOperator.java
+++ b/sql/src/main/java/io/crate/operation/operator/AndOperator.java
@@ -25,6 +25,7 @@ import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.Input;
 import io.crate.types.DataTypes;
 
@@ -46,7 +47,7 @@ public class AndOperator extends Operator<Boolean> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function function) {
+    public Symbol normalizeSymbol(Function function, StmtCtx stmtCtx) {
         assert (function != null);
         assert function.arguments().size() == 2;
 

--- a/sql/src/main/java/io/crate/operation/operator/InOperator.java
+++ b/sql/src/main/java/io/crate/operation/operator/InOperator.java
@@ -26,6 +26,7 @@ import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.Input;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -57,7 +58,7 @@ public class InOperator extends Operator<Object> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function function) {
+    public Symbol normalizeSymbol(Function function, StmtCtx stmtCtx) {
         // ... where id in (1,2,3,4,...)
         // arguments.get(0) ... id
         // arguments.get(1) ... SetLiteral<Literal> (1,2,3,4,...)

--- a/sql/src/main/java/io/crate/operation/operator/OrOperator.java
+++ b/sql/src/main/java/io/crate/operation/operator/OrOperator.java
@@ -4,6 +4,7 @@ import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.Input;
 import io.crate.types.DataTypes;
 
@@ -22,7 +23,7 @@ public class OrOperator extends Operator<Boolean> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function function) {
+    public Symbol normalizeSymbol(Function function, StmtCtx stmtCtx) {
         assert (function != null);
         assert function.arguments().size() == 2;
 
@@ -33,7 +34,7 @@ public class OrOperator extends Operator<Boolean> {
             return Literal.newLiteral(evaluate((Input) left, (Input) right));
         }
 
-        /***
+        /*
          * true  or x    -> true
          * false or x    -> x
          * null  or x    -> null or true -> return function as is

--- a/sql/src/main/java/io/crate/operation/operator/RegexpMatchCaseInsensitiveOperator.java
+++ b/sql/src/main/java/io/crate/operation/operator/RegexpMatchCaseInsensitiveOperator.java
@@ -25,6 +25,7 @@ import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.Input;
 import io.crate.types.DataTypes;
 import org.apache.lucene.util.BytesRef;
@@ -64,7 +65,7 @@ public class RegexpMatchCaseInsensitiveOperator extends Operator<BytesRef> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol) {
+    public Symbol normalizeSymbol(Function symbol, StmtCtx stmtCtx) {
         assert (symbol != null);
         assert symbol.arguments().size() == 2;
 

--- a/sql/src/main/java/io/crate/operation/predicate/IsNullPredicate.java
+++ b/sql/src/main/java/io/crate/operation/predicate/IsNullPredicate.java
@@ -58,7 +58,7 @@ public class IsNullPredicate<T> extends Scalar<Boolean, T> implements FunctionFo
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol) {
+    public Symbol normalizeSymbol(Function symbol, StmtCtx stmtCtx) {
         assert (symbol != null);
         assert (symbol.arguments().size() == 1);
 

--- a/sql/src/main/java/io/crate/operation/predicate/MatchPredicate.java
+++ b/sql/src/main/java/io/crate/operation/predicate/MatchPredicate.java
@@ -29,6 +29,7 @@ import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.StmtCtx;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.elasticsearch.ElasticsearchParseException;
@@ -120,7 +121,7 @@ public class MatchPredicate implements FunctionImplementation<Function> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function function) {
+    public Symbol normalizeSymbol(Function function, StmtCtx stmtCtx) {
         return function;
     }
 }

--- a/sql/src/main/java/io/crate/operation/predicate/NotPredicate.java
+++ b/sql/src/main/java/io/crate/operation/predicate/NotPredicate.java
@@ -28,6 +28,7 @@ import io.crate.analyze.symbol.format.OperatorFormatSpec;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.Input;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -51,7 +52,7 @@ public class NotPredicate extends Scalar<Boolean, Boolean> implements OperatorFo
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol) {
+    public Symbol normalizeSymbol(Function symbol, StmtCtx stmtCtx) {
         assert (symbol != null);
         assert (symbol.arguments().size() == 1);
 

--- a/sql/src/main/java/io/crate/operation/scalar/CollectionAverageFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/CollectionAverageFunction.java
@@ -27,6 +27,7 @@ import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.Input;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -79,7 +80,7 @@ public class CollectionAverageFunction extends Scalar<Double, Set<Number>> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function function) {
+    public Symbol normalizeSymbol(Function function, StmtCtx stmtCtx) {
         return function;
     }
 }

--- a/sql/src/main/java/io/crate/operation/scalar/CollectionCountFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/CollectionCountFunction.java
@@ -65,7 +65,7 @@ public class CollectionCountFunction extends Scalar<Long, Collection<DataType>> 
     }
 
     @Override
-    public Symbol normalizeSymbol(Function function) {
+    public Symbol normalizeSymbol(Function function, StmtCtx stmtCtx) {
         return function;
     }
 

--- a/sql/src/main/java/io/crate/operation/scalar/ConcatFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/ConcatFunction.java
@@ -55,7 +55,7 @@ public abstract class ConcatFunction extends Scalar<BytesRef, BytesRef> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function function) {
+    public Symbol normalizeSymbol(Function function, StmtCtx stmtCtx) {
         if (anyNonLiterals(function.arguments())) {
             return function;
         }

--- a/sql/src/main/java/io/crate/operation/scalar/DateTruncFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/DateTruncFunction.java
@@ -28,6 +28,7 @@ import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.Input;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -114,7 +115,7 @@ public class DateTruncFunction extends Scalar<Long, Object> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol) {
+    public Symbol normalizeSymbol(Function symbol, StmtCtx stmtCtx) {
         assert symbol.arguments().size() > 1 && symbol.arguments().size() < 4 : "Invalid number of arguments";
 
         if (containsNullLiteral(symbol.arguments())) {

--- a/sql/src/main/java/io/crate/operation/scalar/arithmetic/RandomFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/arithmetic/RandomFunction.java
@@ -27,6 +27,7 @@ import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.Input;
 import io.crate.operation.scalar.ScalarFunctionModule;
 import io.crate.types.DataType;
@@ -50,7 +51,7 @@ public class RandomFunction extends Scalar<Double, Void> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol) {
+    public Symbol normalizeSymbol(Function symbol, StmtCtx stmtCtx) {
         /* There is no evaluation here, so the function is executed
            per row. Else every row would contain the same random value*/
         assert symbol.arguments().size() == 0;

--- a/sql/src/main/java/io/crate/operation/scalar/cast/AbstractCastFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/cast/AbstractCastFunction.java
@@ -28,13 +28,9 @@ import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.format.FunctionFormatSpec;
 import io.crate.exceptions.ConversionException;
-import io.crate.metadata.DynamicFunctionResolver;
-import io.crate.metadata.FunctionImplementation;
-import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.Scalar;
+import io.crate.metadata.*;
 import io.crate.operation.Input;
 import io.crate.types.DataType;
-import io.crate.types.IpType;
 
 import java.util.List;
 
@@ -71,7 +67,7 @@ public abstract class AbstractCastFunction<From, To> extends Scalar<To,From> imp
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol) {
+    public Symbol normalizeSymbol(Function symbol, StmtCtx stmtCtx) {
         assert symbol.arguments().size() == 1 : "Number of arguments must be 1";
         Symbol argument = symbol.arguments().get(0);
         if (argument.symbolType().isValueSymbol()) {

--- a/sql/src/main/java/io/crate/operation/scalar/geo/DistanceFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/geo/DistanceFunction.java
@@ -106,7 +106,7 @@ public class DistanceFunction extends Scalar<Double, Object> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol) {
+    public Symbol normalizeSymbol(Function symbol, StmtCtx stmtCtx) {
         Symbol arg1 = symbol.arguments().get(0);
         Symbol arg2 = symbol.arguments().get(1);
         DataType arg1Type = arg1.valueType();

--- a/sql/src/main/java/io/crate/operation/scalar/geo/IntersectsFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/geo/IntersectsFunction.java
@@ -32,6 +32,7 @@ import io.crate.geo.GeoJSONUtils;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.Input;
 import io.crate.operation.scalar.ScalarFunctionModule;
 import io.crate.types.DataType;
@@ -95,7 +96,7 @@ public class IntersectsFunction extends Scalar<Boolean, Object> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol) {
+    public Symbol normalizeSymbol(Function symbol, StmtCtx stmtCtx) {
         Symbol left = symbol.arguments().get(0);
         Symbol right = symbol.arguments().get(1);
         int numLiterals = 0;

--- a/sql/src/main/java/io/crate/operation/scalar/geo/WithinFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/geo/WithinFunction.java
@@ -33,6 +33,7 @@ import io.crate.geo.GeoJSONUtils;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.Input;
 import io.crate.operation.scalar.ScalarFunctionModule;
 import io.crate.types.DataType;
@@ -134,7 +135,7 @@ public class WithinFunction extends Scalar<Boolean, Object> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol) {
+    public Symbol normalizeSymbol(Function symbol, StmtCtx stmtCtx) {
         Symbol left = symbol.arguments().get(0);
         Symbol right = symbol.arguments().get(1);
 

--- a/sql/src/main/java/io/crate/operation/scalar/regex/MatchesFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/regex/MatchesFunction.java
@@ -71,7 +71,7 @@ public class MatchesFunction extends Scalar<BytesRef[], Object> implements Dynam
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol) {
+    public Symbol normalizeSymbol(Function symbol, StmtCtx stmtCtx) {
         final int size = symbol.arguments().size();
         assert (size >= 2 && size <= 3);
 

--- a/sql/src/main/java/io/crate/operation/scalar/regex/ReplaceFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/regex/ReplaceFunction.java
@@ -62,7 +62,7 @@ public class ReplaceFunction extends Scalar<BytesRef, Object> implements Dynamic
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol) {
+    public Symbol normalizeSymbol(Function symbol, StmtCtx stmtCtx) {
         final int size = symbol.arguments().size();
         assert (size >= 3 && size <= 4);
 

--- a/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
@@ -144,10 +144,10 @@ public class NestedLoopConsumer implements Consumer {
 
             // this normalization is required to replace fields of the table relations
             if (left instanceof QueriedTableRelation) {
-                ((QueriedTableRelation) left).normalize(analysisMetaData);
+                ((QueriedTableRelation) left).normalize(analysisMetaData, context.plannerContext().statementContext());
             }
             if (right instanceof QueriedTableRelation) {
-                ((QueriedTableRelation) right).normalize(analysisMetaData);
+                ((QueriedTableRelation) right).normalize(analysisMetaData, context.plannerContext().statementContext());
             }
 
             PlannedAnalyzedRelation leftPlan = context.plannerContext().planSubRelation(left, context);

--- a/sql/src/main/java/io/crate/planner/node/dql/FileUriCollectPhase.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/FileUriCollectPhase.java
@@ -24,6 +24,7 @@ package io.crate.planner.node.dql;
 import com.google.common.base.MoreObjects;
 import io.crate.analyze.EvaluatingNormalizer;
 import io.crate.analyze.symbol.Symbol;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.collect.files.FileReadingCollector;
 import io.crate.planner.distribution.DistributionInfo;
 import io.crate.planner.node.ExecutionPhaseVisitor;
@@ -103,9 +104,9 @@ public class FileUriCollectPhase extends AbstractProjectionsPhase implements Col
         return Type.FILE_URI_COLLECT;
     }
 
-    public FileUriCollectPhase normalize(EvaluatingNormalizer normalizer) {
-        List<Symbol> normalizedToCollect = normalizer.normalize(toCollect());
-        Symbol normalizedTargetUri = normalizer.normalize(targetUri);
+    public FileUriCollectPhase normalize(EvaluatingNormalizer normalizer, StmtCtx stmtCtx) {
+        List<Symbol> normalizedToCollect = normalizer.normalize(toCollect(), stmtCtx);
+        Symbol normalizedTargetUri = normalizer.normalize(targetUri, stmtCtx);
         boolean changed = normalizedToCollect != toCollect() || (normalizedTargetUri != targetUri);
         if (!changed) {
             return this;

--- a/sql/src/main/java/io/crate/planner/node/dql/RoutedCollectPhase.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/RoutedCollectPhase.java
@@ -30,6 +30,7 @@ import io.crate.analyze.relations.TableFunctionRelation;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.Routing;
 import io.crate.metadata.RowGranularity;
+import io.crate.metadata.StmtCtx;
 import io.crate.metadata.table.TableInfo;
 import io.crate.operation.Paging;
 import io.crate.planner.Planner;
@@ -263,12 +264,12 @@ public class RoutedCollectPhase extends AbstractProjectionsPhase implements Coll
      *
      * @return a normalized node, if no changes occurred returns this
      */
-    public RoutedCollectPhase normalize(EvaluatingNormalizer normalizer) {
+    public RoutedCollectPhase normalize(EvaluatingNormalizer normalizer, StmtCtx stmtCtx) {
         assert whereClause() != null;
         RoutedCollectPhase result = this;
-        List<Symbol> newToCollect = normalizer.normalize(toCollect());
+        List<Symbol> newToCollect = normalizer.normalize(toCollect(), stmtCtx);
         boolean changed = newToCollect != toCollect();
-        WhereClause newWhereClause = whereClause().normalize(normalizer);
+        WhereClause newWhereClause = whereClause().normalize(normalizer, stmtCtx);
         if (newWhereClause != whereClause()) {
             changed = changed || newWhereClause != whereClause();
         }

--- a/sql/src/main/java/io/crate/planner/projection/WriterProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/WriterProjection.java
@@ -226,8 +226,8 @@ public class WriterProjection extends Projection {
                 '}';
     }
 
-    public WriterProjection normalize(EvaluatingNormalizer normalizer) {
-        Symbol nUri = normalizer.normalize(uri);
+    public WriterProjection normalize(EvaluatingNormalizer normalizer, StmtCtx stmtCtx) {
+        Symbol nUri = normalizer.normalize(uri, stmtCtx);
         if (uri != nUri){
             WriterProjection p = new WriterProjection();
             p.uri = nUri;

--- a/sql/src/test/java/io/crate/analyze/CompoundLiteralTest.java
+++ b/sql/src/test/java/io/crate/analyze/CompoundLiteralTest.java
@@ -143,7 +143,7 @@ public class CompoundLiteralTest extends CrateUnitTest {
                 )),
                 null
         );
-        return expressionAnalyzer.convert(SqlParser.createExpression(expression), new ExpressionAnalysisContext());
+        return expressionAnalyzer.convert(SqlParser.createExpression(expression), new ExpressionAnalysisContext(new StmtCtx()));
     }
 
     @SuppressWarnings("ConstantConditions")

--- a/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -860,6 +860,18 @@ public class CreateAlterTableStatementAnalyzerTest extends BaseAnalyzerTest {
     }
 
     @Test
+    public void testCreateTableWithCurrentTimestampAsGeneratedColumnIsntNormalized() throws Exception {
+        CreateTableAnalyzedStatement analysis = analyze(
+            "create table foo (ts timestamp GENERATED ALWAYS as current_timestamp)");
+
+        Map<String, Object> metaMapping = ((Map) analysis.mapping().get("_meta"));
+        Map<String, String> generatedColumnsMapping = (Map<String, String>) metaMapping.get("generated_columns");
+        assertThat(generatedColumnsMapping.size(), is(1));
+        // current_timestamp used to get evaluated and then this contained the actual timestamp instead of the function name
+        assertThat(generatedColumnsMapping.get("ts"), is("current_timestamp(3)")); // 3 is the default precision
+    }
+
+    @Test
     public void testCreateTableGeneratedColumnWithSubscript() throws Exception {
         CreateTableAnalyzedStatement analysis = analyze(
                 "create table foo (user object as (name string), name as concat(user['name'], 'foo'))");

--- a/sql/src/test/java/io/crate/analyze/EvaluatingNormalizerTest.java
+++ b/sql/src/test/java/io/crate/analyze/EvaluatingNormalizerTest.java
@@ -30,6 +30,8 @@ public class EvaluatingNormalizerTest extends CrateUnitTest {
     private Functions functions;
     private ReferenceInfo dummyLoadInfo;
 
+    private final StmtCtx stmtCtx = new StmtCtx();
+
     @Before
     public void prepare() throws Exception {
         Map<ReferenceIdent, ReferenceImplementation> referenceImplementationMap = new HashMap<>(1, 1);
@@ -102,7 +104,7 @@ public class EvaluatingNormalizerTest extends CrateUnitTest {
 
         // the dummy reference load == 0.08 evaluates to true,
         // so the whole query can be normalized to a single boolean literal
-        Symbol query = visitor.normalize(op_or);
+        Symbol query = visitor.normalize(op_or, stmtCtx);
         assertThat(query, isLiteral(true));
     }
 
@@ -112,7 +114,7 @@ public class EvaluatingNormalizerTest extends CrateUnitTest {
                 functions, RowGranularity.CLUSTER, referenceResolver);
 
         Function op_or = prepareFunctionTree();
-        Symbol query = visitor.normalize(op_or);
+        Symbol query = visitor.normalize(op_or, stmtCtx);
         assertThat(query, instanceOf(Function.class));
     }
 

--- a/sql/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -72,7 +72,7 @@ public class ExpressionAnalyzerTest extends CrateUnitTest {
         mockedAnalysisMetaData = mock(AnalysisMetaData.class);
         emptyParameterContext = new ParameterContext(new Object[0], new Object[0][], null);
         dummySources = ImmutableMap.of(new QualifiedName("foo"), (AnalyzedRelation) new DummyRelation());
-        context = new ExpressionAnalysisContext();
+        context = new ExpressionAnalysisContext(new StmtCtx());
 
         analysisMetaData = new AnalysisMetaData(
                 getFunctions(),
@@ -91,7 +91,7 @@ public class ExpressionAnalyzerTest extends CrateUnitTest {
         expectedException.expectMessage("Unsupported expression IF(1, 3)");
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
                 mockedAnalysisMetaData, emptyParameterContext, new FullQualifedNameFieldProvider(dummySources), null);
-        ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext();
+        ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext(new StmtCtx());
 
         expressionAnalyzer.convert(SqlParser.createExpression("IF ( 1 , 3 )"), expressionAnalysisContext);
     }
@@ -102,7 +102,7 @@ public class ExpressionAnalyzerTest extends CrateUnitTest {
         expectedException.expectMessage("Unsupported expression current_time");
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
                 mockedAnalysisMetaData, emptyParameterContext, new FullQualifedNameFieldProvider(dummySources), null);
-        ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext();
+        ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext(new StmtCtx());
 
         expressionAnalyzer.convert(SqlParser.createExpression("current_time"), expressionAnalysisContext);
     }
@@ -114,7 +114,7 @@ public class ExpressionAnalyzerTest extends CrateUnitTest {
                 new ParameterContext(new Object[0], new Object[0][], null, EnumSet.of(SQLOperations.Option.ALLOW_QUOTED_SUBSCRIPT)),
                 new FullQualifedNameFieldProvider(dummySources),
                 null);
-        ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext();
+        ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext(new StmtCtx());
 
         Field field1 = (Field) expressionAnalyzer.convert(SqlParser.createExpression("obj['x']"), expressionAnalysisContext);
         Field field2 = (Field) expressionAnalyzer.convert(SqlParser.createExpression("\"obj['x']\""), expressionAnalysisContext);
@@ -175,7 +175,7 @@ public class ExpressionAnalyzerTest extends CrateUnitTest {
 
     @Test
     public void testNonDeterministicFunctionsAlwaysNew() throws Exception {
-        ExpressionAnalysisContext localContext = new ExpressionAnalysisContext();
+        ExpressionAnalysisContext localContext = new ExpressionAnalysisContext(new StmtCtx());
         FunctionInfo info1 = new FunctionInfo(
                 new FunctionIdent("inc", Arrays.<DataType>asList(DataTypes.BOOLEAN)),
                 DataTypes.INTEGER,

--- a/sql/src/test/java/io/crate/analyze/where/EqualityExtractorTest.java
+++ b/sql/src/test/java/io/crate/analyze/where/EqualityExtractorTest.java
@@ -52,6 +52,8 @@ import static org.hamcrest.core.Is.is;
 @SuppressWarnings("unchecked")
 public class EqualityExtractorTest extends BaseAnalyzerTest {
 
+    StmtCtx stmtCtx = new StmtCtx();
+
     @Override
     protected List<Module> getModules() {
         List<Module> modules = super.getModules();
@@ -63,8 +65,9 @@ public class EqualityExtractorTest extends BaseAnalyzerTest {
         return modules;
     }
 
+
     private List<List<Symbol>> analyzeParentX(Symbol query) {
-        return getExtractor().extractParentMatches(ImmutableList.of(Ref("x").ident().columnIdent()), query);
+        return getExtractor().extractParentMatches(ImmutableList.of(Ref("x").ident().columnIdent()), query, stmtCtx);
 
     }
 
@@ -79,7 +82,7 @@ public class EqualityExtractorTest extends BaseAnalyzerTest {
 
     private List<List<Symbol>> analyzeExact(Symbol query, List<ColumnIdent> cols) {
         EqualityExtractor ee = getExtractor();
-        return ee.extractExactMatches(cols, query);
+        return ee.extractExactMatches(cols, query, stmtCtx);
     }
 
     private EqualityExtractor getExtractor() {

--- a/sql/src/test/java/io/crate/analyze/where/WhereClauseAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/where/WhereClauseAnalyzerTest.java
@@ -81,6 +81,8 @@ public class WhereClauseAnalyzerTest extends CrateUnitTest {
     private AnalysisMetaData ctxMetaData;
     private ThreadPool threadPool;
 
+    private final StmtCtx stmtCtx = new StmtCtx();
+
     @Mock
     private SchemaInfo schemaInfo;
 
@@ -256,9 +258,9 @@ public class WhereClauseAnalyzerTest extends CrateUnitTest {
         });
         DocTableRelation tableRelation = statement.analyzedRelation();
         WhereClauseAnalyzer whereClauseAnalyzer = new WhereClauseAnalyzer(ctxMetaData, tableRelation);
-        assertThat(whereClauseAnalyzer.analyze(statement.whereClauses().get(0)).docKeys().get(), contains(isDocKey("1")));
-        assertThat(whereClauseAnalyzer.analyze(statement.whereClauses().get(1)).docKeys().get(), contains(isDocKey("2")));
-        assertThat(whereClauseAnalyzer.analyze(statement.whereClauses().get(2)).docKeys().get(), contains(isDocKey("3")));
+        assertThat(whereClauseAnalyzer.analyze(statement.whereClauses().get(0), stmtCtx).docKeys().get(), contains(isDocKey("1")));
+        assertThat(whereClauseAnalyzer.analyze(statement.whereClauses().get(1), stmtCtx).docKeys().get(), contains(isDocKey("2")));
+        assertThat(whereClauseAnalyzer.analyze(statement.whereClauses().get(2), stmtCtx).docKeys().get(), contains(isDocKey("3")));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/executor/transport/BaseTransportExecutorTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/BaseTransportExecutorTest.java
@@ -97,6 +97,6 @@ public class BaseTransportExecutorTest extends SQLTransportIntegrationTest {
     }
 
     protected Planner.Context newPlannerContext() {
-        return new Planner.Context(clusterService(), UUID.randomUUID(), null, 0, 0);
+        return new Planner.Context(clusterService(), UUID.randomUUID(), null, new StmtCtx(), 0, 0);
     }
 }

--- a/sql/src/test/java/io/crate/executor/transport/TransportExecutorTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/TransportExecutorTest.java
@@ -28,6 +28,7 @@ import io.crate.analyze.symbol.Symbol;
 import io.crate.executor.TaskResult;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RowGranularity;
+import io.crate.metadata.StmtCtx;
 import io.crate.metadata.TableIdent;
 import io.crate.operation.QueryResultRowDownstream;
 import io.crate.planner.Plan;
@@ -93,6 +94,6 @@ public class TransportExecutorTest extends BaseTransportExecutorTest {
     }
 
     protected Planner.Context newPlannerContext() {
-        return new Planner.Context(clusterService(), UUID.randomUUID(), null, 0, 0);
+        return new Planner.Context(clusterService(), UUID.randomUUID(), null, new StmtCtx(), 0, 0);
     }
 }

--- a/sql/src/test/java/io/crate/lucene/LuceneQueryBuilderTest.java
+++ b/sql/src/test/java/io/crate/lucene/LuceneQueryBuilderTest.java
@@ -27,6 +27,7 @@ import io.crate.analyze.WhereClause;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.TableRelation;
 import io.crate.metadata.Functions;
+import io.crate.metadata.StmtCtx;
 import io.crate.metadata.TableIdent;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.TestingTableInfo;
@@ -126,7 +127,7 @@ public class LuceneQueryBuilderTest extends CrateUnitTest {
     }
 
     private WhereClause asWhereClause(String expression) {
-        return new WhereClause(normalizer.normalize(expressions.asSymbol(expression)));
+        return new WhereClause(normalizer.normalize(expressions.asSymbol(expression), new StmtCtx()));
     }
 
     private Query convert(WhereClause clause) {
@@ -190,7 +191,7 @@ public class LuceneQueryBuilderTest extends CrateUnitTest {
     @Test
     public void testEqOnTwoArraysBecomesGenericFunctionQueryAllValuesNull() throws Exception {
         SqlExpressions sqlExpressions = new SqlExpressions(sources, new Object[]{new Object[] { null, null, null }});
-        Query query = convert(new WhereClause(normalizer.normalize(sqlExpressions.asSymbol("y_array = ?"))));
+        Query query = convert(new WhereClause(normalizer.normalize(sqlExpressions.asSymbol("y_array = ?"), new StmtCtx())));
         assertThat(query, instanceOf(LuceneQueryBuilder.Visitor.FunctionFilter.class));
     }
 
@@ -199,7 +200,7 @@ public class LuceneQueryBuilderTest extends CrateUnitTest {
         Object[] values = new Object[2000]; // should trigger the TooManyClauses exception
         Arrays.fill(values, 10L);
         SqlExpressions sqlExpressions = new SqlExpressions(sources, new Object[]{values});
-        Query query = convert(new WhereClause(normalizer.normalize(sqlExpressions.asSymbol("y_array = ?"))));
+        Query query = convert(new WhereClause(normalizer.normalize(sqlExpressions.asSymbol("y_array = ?"), new StmtCtx())));
         assertThat(query, instanceOf(BooleanQuery.class));
         BooleanQuery booleanQuery = (BooleanQuery) query;
         assertThat(booleanQuery.clauses().get(0).getQuery(), instanceOf(TermsQuery.class));

--- a/sql/src/test/java/io/crate/metadata/table/TestingTableInfo.java
+++ b/sql/src/test/java/io/crate/metadata/table/TestingTableInfo.java
@@ -276,7 +276,7 @@ public class TestingTableInfo extends DocTableInfo {
                     functions, null, null, tableReferenceResolver, null);
             for (GeneratedReferenceInfo generatedReferenceInfo : generatedColumns.build()) {
                 Expression expression = SqlParser.createExpression(generatedReferenceInfo.formattedGeneratedExpression());
-                ExpressionAnalysisContext context = new ExpressionAnalysisContext();
+                ExpressionAnalysisContext context = new ExpressionAnalysisContext(new StmtCtx());
                 generatedReferenceInfo.generatedExpression(expressionAnalyzer.convert(expression, context));
                 generatedReferenceInfo.referencedReferenceInfos(ImmutableList.copyOf(Lists.transform(tableReferenceResolver.references(), new Function<Reference, ReferenceInfo>() {
                     @Nullable

--- a/sql/src/test/java/io/crate/operation/ImplementationSymbolVisitorTest.java
+++ b/sql/src/test/java/io/crate/operation/ImplementationSymbolVisitorTest.java
@@ -77,7 +77,7 @@ public class ImplementationSymbolVisitorTest extends CrateUnitTest {
         }
 
         @Override
-        public Symbol normalizeSymbol(Function symbol) {
+        public Symbol normalizeSymbol(Function symbol, StmtCtx stmtCtx) {
             throw new UnsupportedOperationException();
         }
 

--- a/sql/src/test/java/io/crate/operation/operator/AndOperatorTest.java
+++ b/sql/src/test/java/io/crate/operation/operator/AndOperatorTest.java
@@ -4,6 +4,7 @@ import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Reference;
 import io.crate.analyze.symbol.Symbol;
+import io.crate.metadata.StmtCtx;
 import io.crate.test.integration.CrateUnitTest;
 import org.junit.Test;
 
@@ -14,12 +15,14 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 
 public class AndOperatorTest extends CrateUnitTest {
 
+    private final StmtCtx stmtCtx = new StmtCtx();
+
     @Test
     public void testNormalizeBooleanTrueAndNonLiteral() throws Exception {
         AndOperator operator = new AndOperator();
         Function function = new Function(
                 operator.info(), Arrays.<Symbol>asList(Literal.newLiteral(true), new Reference()));
-        Symbol symbol = operator.normalizeSymbol(function);
+        Symbol symbol = operator.normalizeSymbol(function, stmtCtx);
         assertThat(symbol, instanceOf(Reference.class));
     }
 
@@ -28,7 +31,7 @@ public class AndOperatorTest extends CrateUnitTest {
         AndOperator operator = new AndOperator();
         Function function = new Function(
                 operator.info(), Arrays.<Symbol>asList(Literal.newLiteral(false), new Reference()));
-        Symbol symbol = operator.normalizeSymbol(function);
+        Symbol symbol = operator.normalizeSymbol(function, stmtCtx);
 
         assertThat(symbol, isLiteral(false));
     }
@@ -38,7 +41,7 @@ public class AndOperatorTest extends CrateUnitTest {
         AndOperator operator = new AndOperator();
         Function function = new Function(
                 operator.info(), Arrays.<Symbol>asList(Literal.newLiteral(true), Literal.newLiteral(true)));
-        Symbol symbol = operator.normalizeSymbol(function);
+        Symbol symbol = operator.normalizeSymbol(function, stmtCtx);
         assertThat(symbol, isLiteral(true));
     }
 
@@ -47,7 +50,7 @@ public class AndOperatorTest extends CrateUnitTest {
         AndOperator operator = new AndOperator();
         Function function = new Function(
                 operator.info(), Arrays.<Symbol>asList(Literal.newLiteral(true), Literal.newLiteral(false)));
-        Symbol symbol = operator.normalizeSymbol(function);
+        Symbol symbol = operator.normalizeSymbol(function, stmtCtx);
         assertThat(symbol, isLiteral(false));
     }
 

--- a/sql/src/test/java/io/crate/operation/operator/CmpOperatorTest.java
+++ b/sql/src/test/java/io/crate/operation/operator/CmpOperatorTest.java
@@ -4,6 +4,7 @@ import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.Value;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.Input;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.types.DataTypes;
@@ -23,6 +24,8 @@ public class CmpOperatorTest extends CrateUnitTest {
     private LteOperator op_lte_long;
     private LtOperator op_lt_string;
 
+    private final StmtCtx stmtCtx = new StmtCtx();
+
     @Before
     public void prepare() {
         op_gt_string = new GtOperator(Operator.generateInfo(GtOperator.NAME, DataTypes.STRING));
@@ -37,7 +40,7 @@ public class CmpOperatorTest extends CrateUnitTest {
     }
 
     private Symbol normalize(Operator operator, Symbol... symbols) {
-        return operator.normalizeSymbol(getFunction(operator, symbols));
+        return operator.normalizeSymbol(getFunction(operator, symbols), stmtCtx);
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/operator/InOperatorTest.java
+++ b/sql/src/test/java/io/crate/operation/operator/InOperatorTest.java
@@ -25,6 +25,7 @@ import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Reference;
 import io.crate.analyze.symbol.Symbol;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.operator.input.ObjectInput;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.types.DataType;
@@ -44,6 +45,8 @@ import static org.hamcrest.Matchers.is;
 
 public class InOperatorTest extends CrateUnitTest{
 
+    private final StmtCtx stmtCtx = new StmtCtx();
+
     private static final DataType INTEGER_SET_TYPE = new SetType(DataTypes.INTEGER);
     private static final DataType STRING_SET_TYPE = new SetType(DataTypes.STRING);
 
@@ -58,7 +61,7 @@ public class InOperatorTest extends CrateUnitTest{
 
         InOperator op = new InOperator(Operator.generateInfo(InOperator.NAME, DataTypes.INTEGER));
         Function function = new Function(op.info(), arguments);
-        Symbol result = op.normalizeSymbol(function);
+        Symbol result = op.normalizeSymbol(function, stmtCtx);
 
         assertThat(result, isLiteral(true));
     }
@@ -75,7 +78,7 @@ public class InOperatorTest extends CrateUnitTest{
 
         InOperator op = new InOperator(Operator.generateInfo(InOperator.NAME, DataTypes.INTEGER));
         Function function = new Function(op.info(), arguments);
-        Symbol result = op.normalizeSymbol(function);
+        Symbol result = op.normalizeSymbol(function, stmtCtx);
 
         assertThat(result, isLiteral(false));
     }
@@ -91,7 +94,7 @@ public class InOperatorTest extends CrateUnitTest{
 
         InOperator op = new InOperator(Operator.generateInfo(InOperator.NAME, DataTypes.INTEGER));
         Function function = new Function(op.info(), arguments);
-        Symbol result = op.normalizeSymbol(function);
+        Symbol result = op.normalizeSymbol(function, stmtCtx);
 
         assertThat(result, isLiteral(false));
     }
@@ -107,7 +110,7 @@ public class InOperatorTest extends CrateUnitTest{
 
         InOperator op = new InOperator(Operator.generateInfo(InOperator.NAME, DataTypes.INTEGER));
         Function function = new Function(op.info(), arguments);
-        Symbol result = op.normalizeSymbol(function);
+        Symbol result = op.normalizeSymbol(function, stmtCtx);
 
         assertThat(result, instanceOf(Function.class));
         assertThat(((Function) result).info().ident().name(), is(InOperator.NAME));
@@ -132,7 +135,7 @@ public class InOperatorTest extends CrateUnitTest{
 
         InOperator op = new InOperator(Operator.generateInfo(InOperator.NAME, DataTypes.INTEGER));
         Function function = new Function(op.info(), arguments);
-        Symbol result = op.normalizeSymbol(function);
+        Symbol result = op.normalizeSymbol(function, stmtCtx);
 
         assertThat(result, isLiteral(true));
     }
@@ -156,7 +159,7 @@ public class InOperatorTest extends CrateUnitTest{
 
         InOperator op = new InOperator(Operator.generateInfo(InOperator.NAME, DataTypes.INTEGER));
         Function function = new Function(op.info(), arguments);
-        Symbol result = op.normalizeSymbol(function);
+        Symbol result = op.normalizeSymbol(function, stmtCtx);
 
         assertThat(result, isLiteral(false));
     }

--- a/sql/src/test/java/io/crate/operation/operator/LikeOperatorTest.java
+++ b/sql/src/test/java/io/crate/operation/operator/LikeOperatorTest.java
@@ -23,6 +23,7 @@ package io.crate.operation.operator;
 import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
+import io.crate.metadata.StmtCtx;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.types.DataTypes;
 import org.apache.lucene.util.BytesRef;
@@ -39,10 +40,10 @@ public class LikeOperatorTest extends CrateUnitTest {
                 LikeOperator.generateInfo(LikeOperator.NAME, DataTypes.STRING)
         );
         Function function = new Function(
-                op.info(), 
+                op.info(),
                 Arrays.<Symbol>asList(Literal.newLiteral(expression), Literal.newLiteral(pattern))
         );
-        return op.normalizeSymbol(function);
+        return op.normalizeSymbol(function, new StmtCtx());
     }
 
     private Boolean likeNormalize(String expression, String pattern) {

--- a/sql/src/test/java/io/crate/operation/operator/OrOperatorTest.java
+++ b/sql/src/test/java/io/crate/operation/operator/OrOperatorTest.java
@@ -4,6 +4,7 @@ import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Reference;
 import io.crate.analyze.symbol.Symbol;
+import io.crate.metadata.StmtCtx;
 import io.crate.test.integration.CrateUnitTest;
 import org.junit.Test;
 
@@ -20,7 +21,7 @@ public class OrOperatorTest extends CrateUnitTest {
 
         Function function = new Function(
                 operator.info(), Arrays.<Symbol>asList(new Reference(), Literal.newLiteral(true)));
-        Symbol normalizedSymbol = operator.normalizeSymbol(function);
+        Symbol normalizedSymbol = operator.normalizeSymbol(function, new StmtCtx());
         assertThat(normalizedSymbol, isLiteral(true));
     }
 
@@ -29,7 +30,7 @@ public class OrOperatorTest extends CrateUnitTest {
         OrOperator operator = new OrOperator();
         Function function = new Function(
                 operator.info(), Arrays.<Symbol>asList(new Reference(), Literal.newLiteral(false)));
-        Symbol normalizedSymbol = operator.normalizeSymbol(function);
+        Symbol normalizedSymbol = operator.normalizeSymbol(function, new StmtCtx());
         assertThat(normalizedSymbol, instanceOf(Reference.class));
     }
 
@@ -39,7 +40,7 @@ public class OrOperatorTest extends CrateUnitTest {
 
         Function function = new Function(
                 operator.info(), Arrays.<Symbol>asList(new Reference(), new Reference()));
-        Symbol normalizedSymbol = operator.normalizeSymbol(function);
+        Symbol normalizedSymbol = operator.normalizeSymbol(function, new StmtCtx());
         assertThat(normalizedSymbol, instanceOf(Function.class));
     }
 

--- a/sql/src/test/java/io/crate/operation/operator/RegexpMatchCaseInsensitiveOperatorTest.java
+++ b/sql/src/test/java/io/crate/operation/operator/RegexpMatchCaseInsensitiveOperatorTest.java
@@ -24,6 +24,7 @@ package io.crate.operation.operator;
 import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
+import io.crate.metadata.StmtCtx;
 import io.crate.test.integration.CrateUnitTest;
 import org.junit.Test;
 
@@ -39,7 +40,7 @@ public class RegexpMatchCaseInsensitiveOperatorTest extends CrateUnitTest {
                 op.info(),
                 Arrays.<Symbol>asList(Literal.newLiteral(source), Literal.newLiteral(pattern))
         );
-        return op.normalizeSymbol(function);
+        return op.normalizeSymbol(function, new StmtCtx());
     }
 
     private Boolean regexpNormalize(String source, String pattern) {

--- a/sql/src/test/java/io/crate/operation/operator/RegexpMatchOperatortest.java
+++ b/sql/src/test/java/io/crate/operation/operator/RegexpMatchOperatortest.java
@@ -24,6 +24,7 @@ package io.crate.operation.operator;
 import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
+import io.crate.metadata.StmtCtx;
 import io.crate.test.integration.CrateUnitTest;
 import org.junit.Test;
 
@@ -39,7 +40,7 @@ public class RegexpMatchOperatortest extends CrateUnitTest {
                 op.info(),
                 Arrays.<Symbol>asList(Literal.newLiteral(source), Literal.newLiteral(pattern))
         );
-        return op.normalizeSymbol(function);
+        return op.normalizeSymbol(function, new StmtCtx());
     }
 
     private Boolean regexpNormalize(String source, String pattern) {

--- a/sql/src/test/java/io/crate/operation/operator/any/AnyEqOperatorTest.java
+++ b/sql/src/test/java/io/crate/operation/operator/any/AnyEqOperatorTest.java
@@ -27,6 +27,7 @@ import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.operator.input.ObjectInput;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.types.ArrayType;
@@ -37,6 +38,8 @@ import org.junit.Test;
 import java.util.Arrays;
 
 public class AnyEqOperatorTest extends CrateUnitTest {
+
+    private final StmtCtx stmtCtx = new StmtCtx();
 
     private Boolean anyEq(Object value, Object arrayExpr) {
 
@@ -61,7 +64,7 @@ public class AnyEqOperatorTest extends CrateUnitTest {
                         Literal.newLiteral(DataTypes.INTEGER, value),
                         Literal.newLiteral(new ArrayType(DataTypes.INTEGER), arrayExpr))
         );
-        return (Boolean)((Literal)anyEqOperator.normalizeSymbol(function)).value();
+        return (Boolean)((Literal)anyEqOperator.normalizeSymbol(function, stmtCtx)).value();
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/operator/any/AnyLikeOperatorTest.java
+++ b/sql/src/test/java/io/crate/operation/operator/any/AnyLikeOperatorTest.java
@@ -25,6 +25,7 @@ import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.Input;
 import io.crate.operation.predicate.NotPredicate;
 import io.crate.test.integration.CrateUnitTest;
@@ -54,7 +55,7 @@ public class AnyLikeOperatorTest extends CrateUnitTest {
                 impl.info(),
                 Arrays.<Symbol>asList(patternLiteral, valuesLiteral)
         );
-        return impl.normalizeSymbol(function);
+        return impl.normalizeSymbol(function, new StmtCtx());
     }
 
     private Boolean anyLikeNormalize(String pattern, String ... expressions) {
@@ -158,7 +159,7 @@ public class AnyLikeOperatorTest extends CrateUnitTest {
                 Arrays.asList(DataTypes.STRING, valuesLiteral.valueType())
         );
         Function anyLikeFunction = new Function(impl.info(), Arrays.<Symbol>asList(patternLiteral, valuesLiteral));
-        Input<Boolean> normalized = (Input<Boolean>) impl.normalizeSymbol(anyLikeFunction);
+        Input<Boolean> normalized = (Input<Boolean>) impl.normalizeSymbol(anyLikeFunction, new StmtCtx());
         assertThat(normalized.value(), is(true));
         assertThat(new NotPredicate().evaluate(normalized), is(false));
     }

--- a/sql/src/test/java/io/crate/operation/operator/any/AnyNotLikeOperatorTest.java
+++ b/sql/src/test/java/io/crate/operation/operator/any/AnyNotLikeOperatorTest.java
@@ -25,6 +25,7 @@ import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.Input;
 import io.crate.operation.predicate.NotPredicate;
 import io.crate.test.integration.CrateUnitTest;
@@ -54,7 +55,7 @@ public class AnyNotLikeOperatorTest extends CrateUnitTest {
                 impl.info(),
                 Arrays.<Symbol>asList(patternLiteral, valuesLiteral)
         );
-        return impl.normalizeSymbol(function);
+        return impl.normalizeSymbol(function, new StmtCtx());
     }
 
     private Boolean anyNotLikeNormalize(String pattern, String ... expressions) {
@@ -158,7 +159,7 @@ public class AnyNotLikeOperatorTest extends CrateUnitTest {
                 Arrays.asList(DataTypes.STRING, valuesLiteral.valueType())
         );
         Function anyNotLikeFunction = new Function(impl.info(), Arrays.<Symbol>asList(patternLiteral, valuesLiteral));
-        Input<Boolean> normalized = (Input<Boolean>) impl.normalizeSymbol(anyNotLikeFunction);
+        Input<Boolean> normalized = (Input<Boolean>) impl.normalizeSymbol(anyNotLikeFunction, new StmtCtx());
         assertThat(normalized.value(), is(true));
         assertThat(new NotPredicate().evaluate(normalized), is(false));
     }

--- a/sql/src/test/java/io/crate/operation/predicate/IsNullPredicateTest.java
+++ b/sql/src/test/java/io/crate/operation/predicate/IsNullPredicateTest.java
@@ -42,17 +42,19 @@ public class IsNullPredicateTest extends CrateUnitTest {
             DataTypes.BOOLEAN
     ));
 
+    private final StmtCtx stmtCtx = new StmtCtx();
+
     @Test
     public void testNormalizeSymbolFalse() throws Exception {
         Function isNull = new Function(predicate.info(), Arrays.<Symbol>asList(Literal.newLiteral("a")));
-        Symbol symbol = predicate.normalizeSymbol(isNull);
+        Symbol symbol = predicate.normalizeSymbol(isNull, stmtCtx);
         assertThat(symbol, isLiteral(false));
     }
 
     @Test
     public void testNormalizeSymbolTrue() throws Exception {
         Function isNull = new Function(predicate.info(), Arrays.<Symbol>asList(Literal.NULL));
-        Symbol symbol = predicate.normalizeSymbol(isNull);
+        Symbol symbol = predicate.normalizeSymbol(isNull, stmtCtx);
         assertThat(symbol, isLiteral(true));
     }
 
@@ -63,7 +65,7 @@ public class IsNullPredicateTest extends CrateUnitTest {
                 RowGranularity.DOC,
                 DataTypes.STRING));
         Function isNull = new Function(predicate.info(), Arrays.<Symbol>asList(name_ref));
-        Symbol symbol = predicate.normalizeSymbol(isNull);
+        Symbol symbol = predicate.normalizeSymbol(isNull, stmtCtx);
         assertThat(symbol, instanceOf(Function.class));
     }
 
@@ -74,7 +76,7 @@ public class IsNullPredicateTest extends CrateUnitTest {
                 RowGranularity.DOC,
                 DataTypes.UNDEFINED));
         Function isNull = new Function(predicate.info(), Arrays.<Symbol>asList(name_ref));
-        Symbol symbol = predicate.normalizeSymbol(isNull);
+        Symbol symbol = predicate.normalizeSymbol(isNull, stmtCtx);
         assertThat(symbol, isLiteral(true));
     }
 
@@ -82,7 +84,7 @@ public class IsNullPredicateTest extends CrateUnitTest {
     public void testNormalizeSymbolWithStringLiteralThatIsNull() throws Exception {
         Function isNull = new Function(predicate.info(),
                 Arrays.<Symbol>asList(Literal.newLiteral(DataTypes.STRING, null)));
-        Symbol symbol = predicate.normalizeSymbol(isNull);
+        Symbol symbol = predicate.normalizeSymbol(isNull, stmtCtx);
         assertThat((Boolean) ((Input) symbol).value(), is(true));
     }
 

--- a/sql/src/test/java/io/crate/operation/predicate/NotPredicateTest.java
+++ b/sql/src/test/java/io/crate/operation/predicate/NotPredicateTest.java
@@ -39,12 +39,14 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 
 public class NotPredicateTest extends CrateUnitTest {
 
+    private final StmtCtx stmtCtx = new StmtCtx();
+
     @Test
     public void testNormalizeSymbolBoolean() throws Exception {
         NotPredicate predicate = new NotPredicate();
         Function not = new Function(predicate.info(), Arrays.<Symbol>asList(Literal.newLiteral(true)));
 
-        assertThat(predicate.normalizeSymbol(not), isLiteral(false));
+        assertThat(predicate.normalizeSymbol(not, stmtCtx), isLiteral(false));
     }
 
     @Test
@@ -65,7 +67,7 @@ public class NotPredicateTest extends CrateUnitTest {
         );
 
         Function not = new Function(notPredicate.info(), Arrays.<Symbol>asList(eqName));
-        Symbol normalized = notPredicate.normalizeSymbol(not);
+        Symbol normalized = notPredicate.normalizeSymbol(not, stmtCtx);
 
         assertThat(normalized, instanceOf(Function.class));
     }

--- a/sql/src/test/java/io/crate/operation/scalar/AbstractScalarFunctionsTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/AbstractScalarFunctionsTest.java
@@ -95,7 +95,7 @@ public abstract class AbstractScalarFunctionsTest extends CrateUnitTest {
 
         assertThat(impl, Matchers.notNullValue());
 
-        Symbol normalized = impl.normalizeSymbol(function);
+        Symbol normalized = impl.normalizeSymbol(function, new StmtCtx());
         assertThat(normalized, expectedSymbol);
 
         if (normalized instanceof Input && allArgsAreInputs(function.arguments())) {
@@ -181,6 +181,6 @@ public abstract class AbstractScalarFunctionsTest extends CrateUnitTest {
         }
         FunctionImplementation<Function> function = getFunction(functionName, argTypes);
         return function.normalizeSymbol(new Function(function.info(),
-                Arrays.asList(args)));
+                Arrays.asList(args)), new StmtCtx());
     }
 }

--- a/sql/src/test/java/io/crate/operation/scalar/ArrayCatFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/ArrayCatFunctionTest.java
@@ -27,6 +27,7 @@ import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.Input;
 import io.crate.testing.TestingHelpers;
 import io.crate.types.ArrayType;
@@ -51,6 +52,8 @@ public class ArrayCatFunctionTest extends AbstractScalarFunctionsTest {
     private static final ArrayType arrayOfBooleanType    = new ArrayType(DataTypes.BOOLEAN);
     private static final ArrayType arrayOfIpType         = new ArrayType(DataTypes.IP);
     private static final ArrayType arrayOfUndefinedType  = new ArrayType(DataTypes.UNDEFINED);
+
+    private final StmtCtx stmtCtx = new StmtCtx();
 
     private ArrayCatFunction getFunction(ArrayType... args) {
         List<DataType> argumentTypes = new ArrayList<>(args.length);
@@ -80,7 +83,7 @@ public class ArrayCatFunctionTest extends AbstractScalarFunctionsTest {
         Symbol symbol = function.normalizeSymbol(new Function(function.info(), Arrays.<Symbol>asList(
                 Literal.newLiteral(new Integer[]{10, 20}, arrayOfIntegerType),
                 Literal.newLiteral(new Integer[]{10, 30}, arrayOfIntegerType)
-        )));
+        )), stmtCtx);
 
         assertThat(symbol, isLiteral(new Integer[]{10, 20, 10, 30}, arrayOfIntegerType));
     }
@@ -93,7 +96,7 @@ public class ArrayCatFunctionTest extends AbstractScalarFunctionsTest {
                 TestingHelpers.createReference("foo", arrayOfIntegerType),
                 Literal.newLiteral(new Integer[]{10, 30}, arrayOfIntegerType)
         ));
-        Function symbol = (Function) function.normalizeSymbol(functionSymbol);
+        Function symbol = (Function) function.normalizeSymbol(functionSymbol, stmtCtx);
         assertThat(symbol, Matchers.sameInstance(functionSymbol));
     }
 

--- a/sql/src/test/java/io/crate/operation/scalar/ArrayDifferenceFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/ArrayDifferenceFunctionTest.java
@@ -27,6 +27,7 @@ import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.Input;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
@@ -51,6 +52,8 @@ public class ArrayDifferenceFunctionTest extends AbstractScalarFunctionsTest {
     private static final ArrayType arrayOfBooleanType    = new ArrayType(DataTypes.BOOLEAN);
     private static final ArrayType arrayOfIpType         = new ArrayType(DataTypes.IP);
     private static final ArrayType arrayOfUndefinedType  = new ArrayType(DataTypes.UNDEFINED);
+
+    private final StmtCtx stmtCtx = new StmtCtx();
 
     private ArrayDifferenceFunction getFunction(ArrayType... args) {
         List<DataType> argumentTypes = new ArrayList<>(args.length);
@@ -156,7 +159,7 @@ public class ArrayDifferenceFunctionTest extends AbstractScalarFunctionsTest {
         Symbol symbol = function.normalizeSymbol(new Function(function.info(), Arrays.<Symbol>asList(
                 Literal.newLiteral(new Integer[]{10, 20}, type),
                 Literal.newLiteral(new Integer[]{10, 30}, type)
-        )));
+        )), stmtCtx);
 
         assertThat(symbol, isLiteral(new Integer[]{20}, type));
     }
@@ -170,7 +173,7 @@ public class ArrayDifferenceFunctionTest extends AbstractScalarFunctionsTest {
                 createReference("foo", type),
                 Literal.newLiteral(new Integer[]{10, 30}, type)
         ));
-        Function symbol = (Function) function.normalizeSymbol(functionSymbol);
+        Function symbol = (Function) function.normalizeSymbol(functionSymbol, stmtCtx);
         assertThat(symbol, Matchers.sameInstance(functionSymbol));
     }
 

--- a/sql/src/test/java/io/crate/operation/scalar/ArrayUniqueFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/ArrayUniqueFunctionTest.java
@@ -27,6 +27,7 @@ import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.Input;
 import io.crate.testing.TestingHelpers;
 import io.crate.types.ArrayType;
@@ -80,7 +81,7 @@ public class ArrayUniqueFunctionTest extends AbstractScalarFunctionsTest {
         Symbol symbol = function.normalizeSymbol(new Function(function.info(), Arrays.<Symbol>asList(
                 Literal.newLiteral(new Integer[]{10, 20}, arrayOfIntegerType),
                 Literal.newLiteral(new Integer[]{10, 30}, arrayOfIntegerType)
-        )));
+        )), new StmtCtx());
 
         assertThat(symbol, isLiteral(new Integer[]{10, 20, 30}, arrayOfIntegerType));
     }
@@ -93,7 +94,7 @@ public class ArrayUniqueFunctionTest extends AbstractScalarFunctionsTest {
                 TestingHelpers.createReference("foo", arrayOfIntegerType),
                 Literal.newLiteral(new Integer[]{10, 30}, arrayOfIntegerType)
         ));
-        Function symbol = (Function) function.normalizeSymbol(functionSymbol);
+        Function symbol = (Function) function.normalizeSymbol(functionSymbol, new StmtCtx());
         assertThat(symbol, Matchers.sameInstance(functionSymbol));
     }
 

--- a/sql/src/test/java/io/crate/operation/scalar/ConcatFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/ConcatFunctionTest.java
@@ -27,6 +27,7 @@ import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.Input;
 import io.crate.testing.TestingHelpers;
 import io.crate.types.ArrayType;
@@ -48,6 +49,8 @@ public class ConcatFunctionTest extends AbstractScalarFunctionsTest {
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
+
+    private final StmtCtx stmtCtx = new StmtCtx();
 
     private static class ObjectInput implements Input<Object> {
 
@@ -109,11 +112,11 @@ public class ConcatFunctionTest extends AbstractScalarFunctionsTest {
         Scalar scalar = ((Scalar) functions.get(new FunctionIdent(ConcatFunction.NAME, argumentTypes)));
 
         Symbol symbol = scalar.normalizeSymbol(new Function(scalar.info(),
-                Arrays.<Symbol>asList(Literal.newLiteral("foo"), Literal.newLiteral("bar"))));
+                Arrays.<Symbol>asList(Literal.newLiteral("foo"), Literal.newLiteral("bar"))), stmtCtx);
         assertThat(symbol, isLiteral("foobar"));
 
         symbol = scalar.normalizeSymbol(new Function(scalar.info(),
-                Arrays.<Symbol>asList(createReference("col1", DataTypes.STRING), Literal.newLiteral("bar"))));
+                Arrays.<Symbol>asList(createReference("col1", DataTypes.STRING), Literal.newLiteral("bar"))), stmtCtx);
         assertThat(symbol, isFunction(ConcatFunction.NAME));
     }
 

--- a/sql/src/test/java/io/crate/operation/scalar/DateTruncFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/DateTruncFunctionTest.java
@@ -22,10 +22,7 @@ package io.crate.operation.scalar;
 
 import com.google.common.collect.ImmutableList;
 import io.crate.analyze.symbol.*;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.ReferenceInfo;
-import io.crate.metadata.Scalar;
+import io.crate.metadata.*;
 import io.crate.operation.Input;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -69,14 +66,16 @@ public class DateTruncFunctionTest extends AbstractScalarFunctionsTest {
         }
     }
 
+    private final StmtCtx stmtCtx = new StmtCtx();
+
     public Symbol normalize(Symbol interval, Symbol timestamp) {
         Function function = new Function(func.info(), Arrays.asList(interval, timestamp));
-        return func.normalizeSymbol(function);
+        return func.normalizeSymbol(function, stmtCtx);
     }
 
     public Symbol normalize(Symbol interval, Symbol tz, Symbol timestamp) {
         Function function = new Function(funcTZ.info(), Arrays.asList(interval, tz, timestamp));
-        return funcTZ.normalizeSymbol(function);
+        return funcTZ.normalizeSymbol(function, stmtCtx);
     }
 
     private void assertTruncated(String interval, Long timestamp, Long expected) throws Exception {
@@ -128,7 +127,7 @@ public class DateTruncFunctionTest extends AbstractScalarFunctionsTest {
                 Literal.newLiteral("day"),
                 Literal.newLiteral(1401777485000L)
         ));
-        Literal day = (Literal)implementation.normalizeSymbol(function);
+        Literal day = (Literal)implementation.normalizeSymbol(function, stmtCtx);
         assertThat((Long) day.value(), is(1401753600000L));
     }
 
@@ -143,7 +142,7 @@ public class DateTruncFunctionTest extends AbstractScalarFunctionsTest {
                 Literal.newLiteral("day"),
                 Literal.newLiteral("2014-06-03")
         ));
-        Literal day = (Literal)implementation.normalizeSymbol(function);
+        Literal day = (Literal)implementation.normalizeSymbol(function, stmtCtx);
         assertThat((Long) day.value(), is(1401753600000L));
     }
 
@@ -151,7 +150,7 @@ public class DateTruncFunctionTest extends AbstractScalarFunctionsTest {
     public void testNormalizeSymbolReferenceTimestamp() throws Exception {
         Function function = new Function(func.info(),
                 Arrays.<Symbol>asList(new Reference(new ReferenceInfo(null,null, DataTypes.STRING)), new Reference(new ReferenceInfo(null,null, DataTypes.TIMESTAMP))));
-        Symbol result = func.normalizeSymbol(function);
+        Symbol result = func.normalizeSymbol(function, stmtCtx);
         assertSame(function, result);
     }
 
@@ -241,7 +240,7 @@ public class DateTruncFunctionTest extends AbstractScalarFunctionsTest {
                 Literal.newLiteral("Europe/Vienna"),
                 Literal.newLiteral("2014-06-03")
         ));
-        Literal day = (Literal)implementation.normalizeSymbol(function);
+        Literal day = (Literal)implementation.normalizeSymbol(function, stmtCtx);
         assertThat((Long) day.value(), is(1401746400000L));
     }
 
@@ -250,7 +249,7 @@ public class DateTruncFunctionTest extends AbstractScalarFunctionsTest {
         Function function = new Function(funcTZ.info(),
                 Arrays.<Symbol>asList(Literal.newLiteral("day"), Literal.newLiteral("+01:00"),
                         new Reference(new ReferenceInfo(null,null,DataTypes.TIMESTAMP))));
-        Symbol result = funcTZ.normalizeSymbol(function);
+        Symbol result = funcTZ.normalizeSymbol(function, stmtCtx);
         assertSame(function, result);
     }
 

--- a/sql/src/test/java/io/crate/operation/scalar/SubscriptFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/SubscriptFunctionTest.java
@@ -23,6 +23,7 @@ package io.crate.operation.scalar;
 
 import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Symbol;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.Input;
 import io.crate.types.DataTypes;
 import org.apache.lucene.util.BytesRef;
@@ -33,6 +34,8 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
 public class SubscriptFunctionTest extends AbstractScalarFunctionsTest {
+
+    private final StmtCtx stmtCtx = new StmtCtx();
 
     @Test
     public void testEvaluate() throws Exception {
@@ -52,13 +55,13 @@ public class SubscriptFunctionTest extends AbstractScalarFunctionsTest {
         Function function = (Function) sqlExpressions.asSymbol("subscript(['Youri', 'Ruben'], cast(1 as integer))");
         SubscriptFunction subscriptFunction = (SubscriptFunction) functions.get(function.info().ident());
 
-        Symbol actual = subscriptFunction.normalizeSymbol(function);
+        Symbol actual = subscriptFunction.normalizeSymbol(function, stmtCtx);
         assertThat(actual, isLiteral(new BytesRef("Youri")));
 
 
         function = (Function) sqlExpressions.asSymbol("subscript(tags, cast(1 as integer))");
 
-        Symbol result = subscriptFunction.normalizeSymbol(function);
+        Symbol result = subscriptFunction.normalizeSymbol(function, stmtCtx);
         assertThat(result, instanceOf(Function.class));
         assertThat((Function)result, is(function));
     }
@@ -68,8 +71,7 @@ public class SubscriptFunctionTest extends AbstractScalarFunctionsTest {
         Function function = (Function) sqlExpressions.asSymbol("subscript(['Youri', 'Ruben'], cast(3 as integer))");
         SubscriptFunction subscriptFunction = (SubscriptFunction) functions.get(function.info().ident());
 
-        Symbol result = subscriptFunction.normalizeSymbol(function);
+        Symbol result = subscriptFunction.normalizeSymbol(function, stmtCtx);
         assertThat(result, isLiteral(null, DataTypes.STRING));
     }
-
 }

--- a/sql/src/test/java/io/crate/operation/scalar/arithmetic/AbsFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/arithmetic/AbsFunctionTest.java
@@ -26,6 +26,7 @@ import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Reference;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.Input;
 import io.crate.operation.scalar.AbstractScalarFunctionsTest;
 import io.crate.types.DataType;
@@ -53,7 +54,7 @@ public class AbsFunctionTest extends AbstractScalarFunctionsTest {
     private Symbol normalize(Number number, DataType type) {
         AbsFunction function = getFunction(type);
         return function.normalizeSymbol(new Function(function.info(),
-                Arrays.<Symbol>asList(Literal.newLiteral(type, number))));
+                Arrays.<Symbol>asList(Literal.newLiteral(type, number))), new StmtCtx());
     }
 
     @Test
@@ -114,7 +115,7 @@ public class AbsFunctionTest extends AbstractScalarFunctionsTest {
         Reference height = createReference("height", DataTypes.DOUBLE);
         AbsFunction abs = getFunction(DataTypes.DOUBLE);
         Function function = new Function(abs.info(), Arrays.<Symbol>asList(height));
-        Function normalized = (Function) abs.normalizeSymbol(function);
+        Function normalized = (Function) abs.normalizeSymbol(function, new StmtCtx());
         assertThat(normalized, Matchers.sameInstance(function));
     }
 }

--- a/sql/src/test/java/io/crate/operation/scalar/arithmetic/LogFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/arithmetic/LogFunctionTest.java
@@ -26,6 +26,7 @@ import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Reference;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.Input;
 import io.crate.operation.scalar.AbstractScalarFunctionsTest;
 import io.crate.types.DataType;
@@ -41,6 +42,8 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsNull.nullValue;
 
 public class LogFunctionTest extends AbstractScalarFunctionsTest {
+
+    private StmtCtx stmtCtx = new StmtCtx();
 
     private LogFunction getFunction(String name, DataType value) {
         return (LogFunction) functions.get(new FunctionIdent(name, Arrays.asList(value)));
@@ -62,14 +65,13 @@ public class LogFunctionTest extends AbstractScalarFunctionsTest {
 
     private Symbol normalize(Number value, DataType valueType, LogFunction function) {
         return function.normalizeSymbol(new Function(function.info(),
-                        Arrays.<Symbol>asList(Literal.newLiteral(valueType, value)))
-        );
+                        Arrays.<Symbol>asList(Literal.newLiteral(valueType, value))), stmtCtx);
     }
 
     private Symbol normalizeLog(Number value, DataType valueType, Number base, DataType baseType) {
         LogFunction function = getFunction(LogFunction.NAME, valueType, baseType);
         return function.normalizeSymbol(new Function(function.info(),
-                Arrays.<Symbol>asList(Literal.newLiteral(valueType, value), Literal.newLiteral(baseType, base))));
+                Arrays.<Symbol>asList(Literal.newLiteral(valueType, value), Literal.newLiteral(baseType, base))), stmtCtx);
     }
 
     private Number evaluateLog(Number value, DataType valueType) {
@@ -166,22 +168,22 @@ public class LogFunctionTest extends AbstractScalarFunctionsTest {
 
         LogFunction log10 = getFunction(LogFunction.NAME, DataTypes.DOUBLE);
         Function function = new Function(log10.info(), Arrays.<Symbol>asList(dB));
-        Function normalized = (Function) log10.normalizeSymbol(function);
+        Function normalized = (Function) log10.normalizeSymbol(function, stmtCtx);
         assertThat(normalized, Matchers.sameInstance(function));
 
         LogFunction ln = getFunction(LogFunction.LnFunction.NAME, DataTypes.DOUBLE);
         function = new Function(ln.info(), Arrays.<Symbol>asList(dB));
-        normalized = (Function) ln.normalizeSymbol(function);
+        normalized = (Function) ln.normalizeSymbol(function, stmtCtx);
         assertThat(normalized, Matchers.sameInstance(function));
 
         LogFunction logBase = getFunction(LogFunction.NAME, DataTypes.DOUBLE, DataTypes.LONG);
         function = new Function(logBase.info(), Arrays.<Symbol>asList(dB, Literal.newLiteral(10L)));
-        normalized = (Function) logBase.normalizeSymbol(function);
+        normalized = (Function) logBase.normalizeSymbol(function, stmtCtx);
         assertThat(normalized, Matchers.sameInstance(function));
 
         Reference base = createReference("base", DataTypes.INTEGER);
         function = new Function(logBase.info(), Arrays.<Symbol>asList(dB, base));
-        normalized = (Function) logBase.normalizeSymbol(function);
+        normalized = (Function) logBase.normalizeSymbol(function, stmtCtx);
         assertThat(normalized, Matchers.sameInstance(function));
     }
 

--- a/sql/src/test/java/io/crate/operation/scalar/arithmetic/RandomFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/arithmetic/RandomFunctionTest.java
@@ -24,6 +24,7 @@ package io.crate.operation.scalar.arithmetic;
 import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.Input;
 import io.crate.operation.scalar.AbstractScalarFunctionsTest;
 import io.crate.types.DataType;
@@ -55,7 +56,7 @@ public class RandomFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void normalizeReference() {
         Function function = new Function(random.info(), Collections.<Symbol>emptyList());
-        Function normalized = (Function) random.normalizeSymbol(function);
+        Function normalized = (Function) random.normalizeSymbol(function, new StmtCtx());
         assertThat(normalized, sameInstance(function));
     }
 

--- a/sql/src/test/java/io/crate/operation/scalar/arithmetic/RoundFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/arithmetic/RoundFunctionTest.java
@@ -26,6 +26,7 @@ import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Reference;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.Input;
 import io.crate.operation.scalar.AbstractScalarFunctionsTest;
 import io.crate.types.DataType;
@@ -64,7 +65,7 @@ public class RoundFunctionTest extends AbstractScalarFunctionsTest {
     private Symbol normalize(Number number, DataType type) {
         RoundFunction function = getFunction(Arrays.asList(type));
         return function.normalizeSymbol(new Function(function.info(),
-                Arrays.<Symbol>asList(Literal.newLiteral(type, number))));
+                Arrays.<Symbol>asList(Literal.newLiteral(type, number))), new StmtCtx());
     }
 
     @Test
@@ -99,7 +100,7 @@ public class RoundFunctionTest extends AbstractScalarFunctionsTest {
         Reference height = createReference("height", DataTypes.DOUBLE);
         RoundFunction round = getFunction(Arrays.<DataType>asList(DataTypes.DOUBLE));
         Function function = new Function(round.info(), Arrays.<Symbol>asList(height));
-        Function normalized = (Function) round.normalizeSymbol(function);
+        Function normalized = (Function) round.normalizeSymbol(function, new StmtCtx());
         assertThat(normalized, Matchers.sameInstance(function));
     }
 }

--- a/sql/src/test/java/io/crate/operation/scalar/arithmetic/SquareRootFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/arithmetic/SquareRootFunctionTest.java
@@ -26,6 +26,7 @@ import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Reference;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.Input;
 import io.crate.operation.scalar.AbstractScalarFunctionsTest;
 import io.crate.types.DataType;
@@ -69,10 +70,12 @@ public class SquareRootFunctionTest extends AbstractScalarFunctionsTest {
         return (SquareRootFunction)functions.get(new FunctionIdent(SquareRootFunction.NAME, dataTypes));
     }
 
+    private final StmtCtx stmtCtx = new StmtCtx();
+
     private Symbol normalize(Number number, DataType type) {
         SquareRootFunction function = getFunction(Arrays.asList(type));
         return function.normalizeSymbol(new Function(function.info(),
-                Arrays.<Symbol>asList(Literal.newLiteral(type, number))));
+                Arrays.<Symbol>asList(Literal.newLiteral(type, number))), stmtCtx);
     }
 
     @Test
@@ -123,7 +126,7 @@ public class SquareRootFunctionTest extends AbstractScalarFunctionsTest {
         Reference height = createReference("height", DataTypes.DOUBLE);
         SquareRootFunction sqrt = getFunction(Arrays.<DataType>asList(DataTypes.DOUBLE));
         Function function = new Function(sqrt.info(), Arrays.<Symbol>asList(height));
-        Function normalized = (Function) sqrt.normalizeSymbol(function);
+        Function normalized = (Function) sqrt.normalizeSymbol(function, stmtCtx);
         assertThat(normalized, Matchers.sameInstance(function));
     }
 }

--- a/sql/src/test/java/io/crate/operation/scalar/cast/ArrayCastTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/cast/ArrayCastTest.java
@@ -29,6 +29,7 @@ import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.Input;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
@@ -46,7 +47,7 @@ public class ArrayCastTest {
         Scalar impl = (Scalar) functions.get(new FunctionIdent(functionName, ImmutableList.of(arrayType)));
 
         Literal input = Literal.newLiteral(arrayType, objects);
-        Symbol normalized = impl.normalizeSymbol(new Function(impl.info(), Arrays.<Symbol>asList(input)));
+        Symbol normalized = impl.normalizeSymbol(new Function(impl.info(), Arrays.<Symbol>asList(input)), new StmtCtx());
         Object[] integers = (Object[]) impl.evaluate(input);
 
         assertThat(integers, is(((Input) normalized).value()));

--- a/sql/src/test/java/io/crate/operation/scalar/cast/ToBooleanFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/cast/ToBooleanFunctionTest.java
@@ -27,6 +27,7 @@ import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.exceptions.ConversionException;
 import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.Input;
 import io.crate.operation.scalar.AbstractScalarFunctionsTest;
 import io.crate.types.DataType;
@@ -51,10 +52,12 @@ public class ToBooleanFunctionTest extends AbstractScalarFunctionsTest {
         return (Boolean) getFunction(type).evaluate(input);
     }
 
+    private final StmtCtx stmtCtx = new StmtCtx();
+
     private Symbol normalize(Object value, DataType type) {
         ToPrimitiveFunction function = getFunction(type);
         return function.normalizeSymbol(new Function(function.info(),
-                Collections.<Symbol>singletonList(Literal.newLiteral(type, value))));
+                Collections.<Symbol>singletonList(Literal.newLiteral(type, value))), stmtCtx);
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/scalar/cast/ToByteFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/cast/ToByteFunctionTest.java
@@ -27,6 +27,7 @@ import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.exceptions.ConversionException;
 import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.Input;
 import io.crate.operation.scalar.AbstractScalarFunctionsTest;
 import io.crate.types.DataType;
@@ -56,7 +57,7 @@ public class ToByteFunctionTest extends AbstractScalarFunctionsTest {
     private Symbol normalize(Object value, DataType type) {
         ToPrimitiveFunction function = getFunction(type);
         return function.normalizeSymbol(new Function(function.info(),
-                Collections.<Symbol>singletonList(Literal.newLiteral(type, value))));
+                Collections.<Symbol>singletonList(Literal.newLiteral(type, value))), new StmtCtx());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/scalar/cast/ToDoubleFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/cast/ToDoubleFunctionTest.java
@@ -27,6 +27,7 @@ import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.exceptions.ConversionException;
 import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.Input;
 import io.crate.operation.scalar.AbstractScalarFunctionsTest;
 import io.crate.types.DataType;
@@ -52,10 +53,12 @@ public class ToDoubleFunctionTest extends AbstractScalarFunctionsTest {
         return (Double) getFunction(type).evaluate(input);
     }
 
+    private final StmtCtx stmtCtx = new StmtCtx();
+
     private Symbol normalize(Object value, DataType type) {
         ToPrimitiveFunction function = getFunction(type);
         return function.normalizeSymbol(new Function(function.info(),
-                Collections.<Symbol>singletonList(Literal.newLiteral(type, value))));
+                Collections.<Symbol>singletonList(Literal.newLiteral(type, value))), stmtCtx);
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/scalar/cast/ToFloatFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/cast/ToFloatFunctionTest.java
@@ -27,6 +27,7 @@ import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.exceptions.ConversionException;
 import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.Input;
 import io.crate.operation.scalar.AbstractScalarFunctionsTest;
 import io.crate.types.DataType;
@@ -55,7 +56,7 @@ public class ToFloatFunctionTest extends AbstractScalarFunctionsTest {
     private Symbol normalize(Object value, DataType type) {
         ToPrimitiveFunction function = getFunction(type);
         return function.normalizeSymbol(new Function(function.info(),
-                Collections.<Symbol>singletonList(Literal.newLiteral(type, value))));
+                Collections.<Symbol>singletonList(Literal.newLiteral(type, value))), new StmtCtx());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/scalar/cast/ToGeoPointFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/cast/ToGeoPointFunctionTest.java
@@ -27,6 +27,7 @@ import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.exceptions.ConversionException;
 import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.scalar.AbstractScalarFunctionsTest;
 import io.crate.testing.TestingHelpers;
 import io.crate.types.DataType;
@@ -56,7 +57,7 @@ public class ToGeoPointFunctionTest extends AbstractScalarFunctionsTest {
     public void testNormalizeCastFromString() throws Exception {
         ToGeoFunction fn = getFunction(DataTypes.STRING);
         Symbol normalized = fn.normalizeSymbol(new Function(fn.info(),
-                Collections.<Symbol>singletonList(Literal.newLiteral(DataTypes.STRING, "POINT (0 0)"))));
+                Collections.<Symbol>singletonList(Literal.newLiteral(DataTypes.STRING, "POINT (0 0)"))), new StmtCtx());
         assertThat(normalized, TestingHelpers.isLiteral(new Double[]{0.0, 0.0}));
     }
 

--- a/sql/src/test/java/io/crate/operation/scalar/cast/ToIntArrayFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/cast/ToIntArrayFunctionTest.java
@@ -27,6 +27,7 @@ import io.crate.analyze.symbol.Reference;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.exceptions.ConversionException;
 import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.scalar.AbstractScalarFunctionsTest;
 import io.crate.testing.TestingHelpers;
 import io.crate.types.ArrayType;
@@ -94,7 +95,7 @@ public class ToIntArrayFunctionTest extends AbstractScalarFunctionsTest {
                         ImmutableList.of(arrayType)));
 
         Reference foo = TestingHelpers.createReference("foo", arrayType);
-        Symbol symbol = impl.normalizeSymbol(new Function(impl.info(), Collections.<Symbol>singletonList(foo)));
+        Symbol symbol = impl.normalizeSymbol(new Function(impl.info(), Collections.<Symbol>singletonList(foo)), new StmtCtx());
         assertThat(symbol, instanceOf(Function.class));
     }
 

--- a/sql/src/test/java/io/crate/operation/scalar/cast/ToIntFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/cast/ToIntFunctionTest.java
@@ -27,12 +27,11 @@ import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.exceptions.ConversionException;
 import io.crate.metadata.FunctionIdent;
-import io.crate.operation.Input;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.scalar.AbstractScalarFunctionsTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.apache.lucene.util.BytesRef;
-import org.codehaus.groovy.ast.expr.CastExpression;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -44,6 +43,8 @@ public class ToIntFunctionTest extends AbstractScalarFunctionsTest {
 
     private final String functionName = CastFunctionResolver.FunctionNames.TO_INTEGER;
 
+    private final StmtCtx stmtCtx = new StmtCtx();
+
     @Test
     @SuppressWarnings("unchecked")
     public void testNormalizeSymbol() throws Exception {
@@ -51,13 +52,13 @@ public class ToIntFunctionTest extends AbstractScalarFunctionsTest {
         ToPrimitiveFunction castStringToInteger = getFunction(functionName, DataTypes.STRING);
 
         Function function = new Function(castStringToInteger.info(), Collections.<Symbol>singletonList(Literal.newLiteral("123")));
-        Symbol result = castStringToInteger.normalizeSymbol(function);
+        Symbol result = castStringToInteger.normalizeSymbol(function, stmtCtx);
         assertThat(result, isLiteral(123));
 
         ToPrimitiveFunction castFloatToInteger = getFunction(functionName, DataTypes.FLOAT);
 
         function = new Function(castFloatToInteger.info(), Collections.<Symbol>singletonList(Literal.newLiteral(12.5f)));
-        result = castStringToInteger.normalizeSymbol(function);
+        result = castStringToInteger.normalizeSymbol(function, stmtCtx);
         assertThat(result, isLiteral(12));
     }
 
@@ -74,7 +75,7 @@ public class ToIntFunctionTest extends AbstractScalarFunctionsTest {
         expectedException.expectMessage("cannot cast 'hello' to type integer");
         ToPrimitiveFunction castStringToInteger = getFunction(functionName, DataTypes.STRING);
         Function function = new Function(castStringToInteger.info(), Collections.<Symbol>singletonList(Literal.newLiteral("hello")));
-        castStringToInteger.normalizeSymbol(function);
+        castStringToInteger.normalizeSymbol(function, stmtCtx);
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/scalar/cast/ToIpArrayFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/cast/ToIpArrayFunctionTest.java
@@ -27,6 +27,7 @@ import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.Input;
 import io.crate.operation.scalar.AbstractScalarFunctionsTest;
 import io.crate.types.ArrayType;
@@ -57,7 +58,7 @@ public class ToIpArrayFunctionTest extends AbstractScalarFunctionsTest {
                 new FunctionIdent(CastFunctionResolver.FunctionNames.TO_IP_ARRAY, ImmutableList.of(arrayType)));
 
         Literal input = Literal.newLiteral(objects, arrayType);
-        Symbol normalized = impl.normalizeSymbol(new Function(impl.info(), Collections.<Symbol>singletonList(input)));
+        Symbol normalized = impl.normalizeSymbol(new Function(impl.info(), Collections.<Symbol>singletonList(input)), new StmtCtx());
         Object[] integers = impl.evaluate(input);
 
         assertThat(integers, is(((Input) normalized).value()));

--- a/sql/src/test/java/io/crate/operation/scalar/cast/ToLongArrayFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/cast/ToLongArrayFunctionTest.java
@@ -27,6 +27,7 @@ import io.crate.analyze.symbol.Reference;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.exceptions.ConversionException;
 import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.scalar.AbstractScalarFunctionsTest;
 import io.crate.testing.TestingHelpers;
 import io.crate.types.ArrayType;
@@ -93,7 +94,7 @@ public class ToLongArrayFunctionTest extends AbstractScalarFunctionsTest {
                 new FunctionIdent(CastFunctionResolver.FunctionNames.TO_LONG_ARRAY, ImmutableList.of(arrayType)));
 
         Reference foo = TestingHelpers.createReference("foo", arrayType);
-        Symbol symbol = impl.normalizeSymbol(new Function(impl.info(), Collections.<Symbol>singletonList(foo)));
+        Symbol symbol = impl.normalizeSymbol(new Function(impl.info(), Collections.<Symbol>singletonList(foo)), new StmtCtx());
         assertThat(symbol, instanceOf(Function.class));
     }
 

--- a/sql/src/test/java/io/crate/operation/scalar/cast/ToLongFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/cast/ToLongFunctionTest.java
@@ -27,6 +27,7 @@ import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.exceptions.ConversionException;
 import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.Input;
 import io.crate.operation.scalar.AbstractScalarFunctionsTest;
 import io.crate.types.DataType;
@@ -53,7 +54,7 @@ public class ToLongFunctionTest extends AbstractScalarFunctionsTest {
     private Symbol normalize(Object value, DataType type) {
         ToPrimitiveFunction function = getFunction(functionName, type);
         return function.normalizeSymbol(new Function(function.info(),
-                Collections.<Symbol>singletonList(Literal.newLiteral(type, value))));
+                Collections.<Symbol>singletonList(Literal.newLiteral(type, value))), new StmtCtx());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/scalar/cast/ToShortFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/cast/ToShortFunctionTest.java
@@ -27,6 +27,7 @@ import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.exceptions.ConversionException;
 import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.Input;
 import io.crate.operation.scalar.AbstractScalarFunctionsTest;
 import io.crate.types.DataType;
@@ -43,6 +44,8 @@ public class ToShortFunctionTest extends AbstractScalarFunctionsTest {
 
     private final String functionName = CastFunctionResolver.FunctionNames.TO_SHORT;
 
+    private final StmtCtx stmtCtx = new StmtCtx();
+
     private Short evaluate(Object value, DataType type) {
         Input[] input = {(Input)Literal.newLiteral(type, value)};
         ToPrimitiveFunction fn = getFunction(functionName, type);
@@ -52,7 +55,7 @@ public class ToShortFunctionTest extends AbstractScalarFunctionsTest {
     private Symbol normalize(Object value, DataType type) {
         ToPrimitiveFunction function = getFunction(functionName, type);
         return function.normalizeSymbol(new Function(function.info(),
-                Collections.<Symbol>singletonList(Literal.newLiteral(type, value))));
+                Collections.<Symbol>singletonList(Literal.newLiteral(type, value))), stmtCtx);
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/scalar/cast/ToStringFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/cast/ToStringFunctionTest.java
@@ -25,6 +25,7 @@ import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.Input;
 import io.crate.operation.scalar.AbstractScalarFunctionsTest;
 import io.crate.types.DataTypes;
@@ -40,6 +41,8 @@ public class ToStringFunctionTest extends AbstractScalarFunctionsTest {
 
     private final String functionName = CastFunctionResolver.FunctionNames.TO_STRING;
 
+    private final StmtCtx stmtCtx = new StmtCtx();
+
     @Test
     @SuppressWarnings("unchecked")
     public void testNormalizeSymbol() throws Exception {
@@ -47,17 +50,17 @@ public class ToStringFunctionTest extends AbstractScalarFunctionsTest {
         FunctionImplementation castIntegerToString = getFunction(functionName, DataTypes.INTEGER);
 
         Function function = new Function(castIntegerToString.info(), Collections.<Symbol>singletonList(Literal.newLiteral(123)));
-        Symbol result = castIntegerToString.normalizeSymbol(function);
+        Symbol result = castIntegerToString.normalizeSymbol(function, stmtCtx);
         assertThat(result, isLiteral("123"));
 
         FunctionImplementation castFloatToString = getFunction(functionName, DataTypes.FLOAT);
         function = new Function(castFloatToString.info(), Collections.<Symbol>singletonList(Literal.newLiteral(0.5f)));
-        result = castFloatToString.normalizeSymbol(function);
+        result = castFloatToString.normalizeSymbol(function, stmtCtx);
         assertThat(result, isLiteral("0.5"));
 
         FunctionImplementation castStringToString = getFunction(functionName, DataTypes.STRING);
         function = new Function(castStringToString.info(), Collections.<Symbol>singletonList(Literal.newLiteral("hello")));
-        result = castStringToString.normalizeSymbol(function);
+        result = castStringToString.normalizeSymbol(function, stmtCtx);
         assertThat(result, isLiteral("hello"));
     }
 

--- a/sql/src/test/java/io/crate/operation/scalar/geo/DistanceFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/geo/DistanceFunctionTest.java
@@ -27,6 +27,7 @@ import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.Symbols;
 import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.Input;
 import io.crate.operation.scalar.AbstractScalarFunctionsTest;
 import io.crate.types.ArrayType;
@@ -62,7 +63,7 @@ public class DistanceFunctionTest extends AbstractScalarFunctionsTest {
     @SuppressWarnings("unchecked")
     private Symbol normalize(List<? extends Symbol> args) {
         DistanceFunction distanceFunction = functionFromArgs(args);
-        return distanceFunction.normalizeSymbol(new Function(distanceFunction.info(), (List<Symbol>)args));
+        return distanceFunction.normalizeSymbol(new Function(distanceFunction.info(), (List<Symbol>)args), new StmtCtx());
     }
 
     @Test
@@ -180,7 +181,7 @@ public class DistanceFunctionTest extends AbstractScalarFunctionsTest {
                 createReference("foo2", DataTypes.GEO_POINT));
         DistanceFunction distanceFunction = functionFromArgs(args);
         Function functionSymbol = new Function(distanceFunction.info(), args);
-        Function normalizedFunction = (Function)distanceFunction.normalizeSymbol(functionSymbol);
+        Function normalizedFunction = (Function)distanceFunction.normalizeSymbol(functionSymbol, new StmtCtx());
         assertThat(functionSymbol, Matchers.sameInstance(normalizedFunction));
     }
 

--- a/sql/src/test/java/io/crate/planner/PlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/PlannerTest.java
@@ -1548,7 +1548,7 @@ public class PlannerTest extends AbstractPlannerTest {
     public void testBuildReaderAllocations() throws Exception {
         TableIdent custom = new TableIdent("custom", "t1");
         TableInfo tableInfo = TestingTableInfo.builder(custom, shardRouting("t1")).add("id", DataTypes.INTEGER, null).build();
-        Planner.Context plannerContext = new Planner.Context(clusterService, UUID.randomUUID(), null, 0, 0);
+        Planner.Context plannerContext = new Planner.Context(clusterService, UUID.randomUUID(), null, new StmtCtx(), 0, 0);
         plannerContext.allocateRouting(tableInfo, WhereClause.MATCH_ALL, null);
 
         Planner.Context.ReaderAllocations readerAllocations = plannerContext.buildReaderAllocations();
@@ -1578,7 +1578,7 @@ public class PlannerTest extends AbstractPlannerTest {
     public void testAllocateRouting() throws Exception {
         TableIdent custom = new TableIdent("custom", "t1");
         TableInfo tableInfo = TestingTableInfo.builder(custom, shardRouting("t1")).add("id", DataTypes.INTEGER, null).build();
-        Planner.Context plannerContext = new Planner.Context(clusterService, UUID.randomUUID(), null, 0, 0);
+        Planner.Context plannerContext = new Planner.Context(clusterService, UUID.randomUUID(), null, new StmtCtx(), 0, 0);
 
         WhereClause whereClause = new WhereClause(
                 new Function(new FunctionInfo(
@@ -1600,7 +1600,7 @@ public class PlannerTest extends AbstractPlannerTest {
 
     @Test
     public void testExecutionPhaseIdSequence() throws Exception {
-        Planner.Context plannerContext = new Planner.Context(clusterService, UUID.randomUUID(), null, 0, 0);
+        Planner.Context plannerContext = new Planner.Context(clusterService, UUID.randomUUID(), null, new StmtCtx(), 0, 0);
 
         assertThat(plannerContext.nextExecutionPhaseId(), is(0));
         assertThat(plannerContext.nextExecutionPhaseId(), is(1));

--- a/sql/src/test/java/io/crate/planner/consumer/NestedLoopConsumerTest.java
+++ b/sql/src/test/java/io/crate/planner/consumer/NestedLoopConsumerTest.java
@@ -28,10 +28,7 @@ import io.crate.analyze.repositories.RepositorySettingsModule;
 import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.exceptions.ValidationException;
-import io.crate.metadata.MetaDataModule;
-import io.crate.metadata.Routing;
-import io.crate.metadata.Schemas;
-import io.crate.metadata.TableIdent;
+import io.crate.metadata.*;
 import io.crate.metadata.doc.DocSchemaInfo;
 import io.crate.metadata.information.MetaDataInformationModule;
 import io.crate.metadata.table.SchemaInfo;
@@ -91,7 +88,7 @@ public class NestedLoopConsumerTest extends CrateUnitTest {
 
     private final ClusterService clusterService = mock(ClusterService.class);
     private NestedLoopConsumer consumer;
-    private final Planner.Context plannerContext = new Planner.Context(clusterService, UUID.randomUUID(), null, 0, 0);
+    private final Planner.Context plannerContext = new Planner.Context(clusterService, UUID.randomUUID(), null, new StmtCtx(), 0, 0);
     private TableStatsService statsService;
 
     @Before

--- a/sql/src/test/java/io/crate/testing/LuceneDocCollectorProvider.java
+++ b/sql/src/test/java/io/crate/testing/LuceneDocCollectorProvider.java
@@ -32,6 +32,7 @@ import io.crate.breaker.RamAccountingContext;
 import io.crate.jobs.JobContextService;
 import io.crate.jobs.JobExecutionContext;
 import io.crate.metadata.Routing;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.collect.CrateCollector;
 import io.crate.operation.collect.JobCollectContext;
 import io.crate.operation.collect.MapSideDataCollectOperation;
@@ -94,7 +95,7 @@ public class LuceneDocCollectorProvider implements AutoCloseable {
             SqlParser.createStatement(statement), new ParameterContext(args, new Object[0][], null));
         PlannedAnalyzedRelation plannedAnalyzedRelation = queryAndFetchConsumer.consume(
             analysis.rootRelation(),
-            new ConsumerContext(analysis.rootRelation(), new Planner.Context(cluster.clusterService(), UUID.randomUUID(), null, 0, 0)));
+            new ConsumerContext(analysis.rootRelation(), new Planner.Context(cluster.clusterService(), UUID.randomUUID(), null, new StmtCtx(), 0, 0)));
         final RoutedCollectPhase collectPhase = ((RoutedCollectPhase) ((CollectAndMerge) plannedAnalyzedRelation.plan()).collectPhase());
         collectPhase.nodePageSizeHint(nodePageSizeHint);
         Routing routing = collectPhase.routing();

--- a/sql/src/test/java/io/crate/testing/SleepScalarFunction.java
+++ b/sql/src/test/java/io/crate/testing/SleepScalarFunction.java
@@ -26,6 +26,7 @@ import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.Input;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -48,7 +49,7 @@ public class SleepScalarFunction extends Scalar<Boolean, Long> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol) {
+    public Symbol normalizeSymbol(Function symbol, StmtCtx stmtCtx) {
         return symbol;
     }
 

--- a/sql/src/test/java/io/crate/testing/SqlExpressions.java
+++ b/sql/src/test/java/io/crate/testing/SqlExpressions.java
@@ -88,7 +88,7 @@ public class SqlExpressions {
                 new ParameterContext(parameters == null ? new Object[0] : parameters, new Object[0][], null),
                 new FullQualifedNameFieldProvider(sources),
                 fieldResolver);
-        expressionAnalysisCtx = new ExpressionAnalysisContext();
+        expressionAnalysisCtx = new ExpressionAnalysisContext(new StmtCtx());
     }
 
     public Symbol asSymbol(String expression) {
@@ -96,7 +96,7 @@ public class SqlExpressions {
     }
 
     public Symbol normalize(Symbol symbol) {
-        return expressionAnalyzer.normalize(symbol);
+        return expressionAnalyzer.normalize(symbol, expressionAnalysisCtx.statementContext());
     }
 
     public <T> T getInstance(Class<T> clazz) {


### PR DESCRIPTION
`create table t (ts as current_timestamp)` created a
`_meta.generated_columns` mapping which contained the actual evaluated
timestamp instead of the function name.

This commit changes the ExpressionAnalyzer behavior to not eagerly
evaluate `current_timestamp`. Instead `normalizeSymbol` does that.

A new `StatementContext` is used to ensure multiple `current_timestamp`
occurrences within a statement all result in the same value.