### PR TITLE
Enable Transport Client for integration tests.

### DIFF
--- a/sql/src/main/java/io/crate/planner/TableStatsService.java
+++ b/sql/src/main/java/io/crate/planner/TableStatsService.java
@@ -23,8 +23,8 @@
 package io.crate.planner;
 
 
-import com.carrotsearch.hppc.ObjectLongMap;
 import com.carrotsearch.hppc.ObjectLongHashMap;
+import com.carrotsearch.hppc.ObjectLongMap;
 import io.crate.action.sql.SQLRequest;
 import io.crate.action.sql.SQLResponse;
 import io.crate.action.sql.TransportSQLAction;
@@ -44,7 +44,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.util.concurrent.TimeUnit;
 
 @Singleton
 public class TableStatsService extends AbstractComponent implements Runnable {
@@ -120,10 +119,6 @@ public class TableStatsService extends AbstractComponent implements Runnable {
      */
     public long numDocs(TableIdent tableIdent) {
         ObjectLongMap<TableIdent> stats = tableStats;
-        if (stats == null && clusterService.localNode() != null) {
-            stats = statsFromResponse(transportSQLAction.get().execute(REQUEST).actionGet(30, TimeUnit.SECONDS));
-            tableStats = stats;
-        }
         if (stats != null && stats.containsKey(tableIdent)) {
             return stats.get(tableIdent);
         }

--- a/sql/src/test/java/io/crate/integrationtests/AnyIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/AnyIntegrationTest.java
@@ -24,16 +24,11 @@ package io.crate.integrationtests;
 import io.crate.testing.TestingHelpers;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.Is;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import static org.hamcrest.Matchers.is;
 
 public class AnyIntegrationTest extends SQLTransportIntegrationTest {
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void testAnyOnArrayLiteralDeleteUpdateSelect() throws Exception {

--- a/sql/src/test/java/io/crate/integrationtests/ArithmeticIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ArithmeticIntegrationTest.java
@@ -23,21 +23,17 @@ package io.crate.integrationtests;
 
 import io.crate.action.sql.SQLActionException;
 import io.crate.testing.TestingHelpers;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.Locale;
 
+import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 
 
 public class ArithmeticIntegrationTest extends SQLTransportIntegrationTest {
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void testMathFunctionNullArguments() throws Exception {
@@ -215,7 +211,7 @@ public class ArithmeticIntegrationTest extends SQLTransportIntegrationTest {
 
         execute("select regexp_matches(s, '^(bar).*') from regex_noindex order by i");
         assertThat(response.rows()[0][0], nullValue());
-        assertThat(((String[]) response.rows()[1][0])[0], is("bar"));
+        assertThat((Object[]) response.rows()[1][0], arrayContaining(new Object[] {"bar"}));
         assertThat(response.rows()[2][0], nullValue());
     }
 
@@ -224,10 +220,10 @@ public class ArithmeticIntegrationTest extends SQLTransportIntegrationTest {
         execute("create table regex_fulltext (i integer, s string INDEX USING FULLTEXT) clustered into 3 shards with (number_of_replicas=0)");
         ensureYellow();
         execute("insert into regex_fulltext (i, s) values (?, ?)", new Object[][]{
-                new Object[]{1, "foo is first"},
-                new Object[]{2, "bar is second"},
-                new Object[]{3, "foobar is great"},
-                new Object[]{4, "crate is greater"}
+            new Object[]{1, "foo is first"},
+            new Object[]{2, "bar is second"},
+            new Object[]{3, "foobar is great"},
+            new Object[]{4, "crate is greater"}
         });
         refresh();
 
@@ -239,21 +235,17 @@ public class ArithmeticIntegrationTest extends SQLTransportIntegrationTest {
         assertThat((String) response.rows()[3][0], is("crate was greater"));
 
         execute("select regexp_matches(s, '(\\w+) is (\\w+)') from regex_fulltext order by i");
-        String[] match1 = (String[]) response.rows()[0][0];
-        assertThat(match1[0], is("foo"));
-        assertThat(match1[1], is("first"));
+        Object[] match1 = (Object[]) response.rows()[0][0];
+        assertThat(match1, arrayContaining(new Object[]{"foo", "first"}));
 
-        String[] match2 = (String[]) response.rows()[1][0];
-        assertThat(match2[0], is("bar"));
-        assertThat(match2[1], is("second"));
+        Object[] match2 = (Object[]) response.rows()[1][0];
+        assertThat(match2, arrayContaining(new Object[]{"bar", "second"}));
 
-        String[] match3 = (String[]) response.rows()[2][0];
-        assertThat(match3[0], is("foobar"));
-        assertThat(match3[1], is("great"));
+        Object[] match3 = (Object[]) response.rows()[2][0];
+        assertThat(match3, arrayContaining(new Object[]{"foobar", "great"}));
 
-        String[] match4 = (String[]) response.rows()[3][0];
-        assertThat(match4[0], is("crate"));
-        assertThat(match4[1], is("greater"));
+        Object[] match4 = (Object[]) response.rows()[3][0];
+        assertThat(match4, arrayContaining(new Object[]{"crate", "greater"}));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/CastIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/CastIntegrationTest.java
@@ -23,9 +23,7 @@
 package io.crate.integrationtests;
 
 import org.hamcrest.Matcher;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
@@ -33,9 +31,6 @@ import static org.hamcrest.collection.IsArrayContainingInOrder.arrayContaining;
 
 
 public class CastIntegrationTest extends SQLTransportIntegrationTest {
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void testTryCastValidLiteralCasting() {

--- a/sql/src/test/java/io/crate/integrationtests/ColumnPolicyIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ColumnPolicyIntegrationTest.java
@@ -38,9 +38,7 @@ import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.hamcrest.Matchers;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -54,9 +52,6 @@ import static org.hamcrest.Matchers.*;
 public class ColumnPolicyIntegrationTest extends SQLTransportIntegrationTest {
 
     private String copyFilePath = getClass().getResource("/essetup/data/copy").getPath();
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     public MappingMetaData getMappingMetadata(String index){
         return clusterService().state().metaData().indices()

--- a/sql/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
@@ -29,7 +29,6 @@ import io.crate.testing.TestingHelpers;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.BufferedWriter;
@@ -59,10 +58,6 @@ public class CopyIntegrationTest extends SQLHttpIntegrationTest {
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
 
     @Test
     public void testCopyFromFile() throws Exception {

--- a/sql/src/test/java/io/crate/integrationtests/CountStarIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/CountStarIntegrationTest.java
@@ -22,16 +22,11 @@
 package io.crate.integrationtests;
 
 import io.crate.action.sql.SQLActionException;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import static org.hamcrest.core.Is.is;
 
 public class CountStarIntegrationTest extends SQLTransportIntegrationTest {
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void testCountWithPartitionFilter() throws Exception {

--- a/sql/src/test/java/io/crate/integrationtests/EmptyStringRoutingIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/EmptyStringRoutingIntegrationTest.java
@@ -24,7 +24,6 @@ package io.crate.integrationtests;
 import io.crate.action.sql.SQLResponse;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 import java.nio.file.Paths;
@@ -39,9 +38,6 @@ import static org.hamcrest.core.Is.is;
  * different and is asserted via tests in this class.
  */
 public class EmptyStringRoutingIntegrationTest extends SQLTransportIntegrationTest {
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();

--- a/sql/src/test/java/io/crate/integrationtests/FulltextAnalyzerResolverTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/FulltextAnalyzerResolverTest.java
@@ -28,9 +28,12 @@ import io.crate.action.sql.SQLActionException;
 import io.crate.action.sql.SQLResponse;
 import io.crate.metadata.FulltextAnalyzerResolver;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
+import org.elasticsearch.common.io.stream.NotSerializableExceptionWrapper;
 import org.elasticsearch.common.settings.Settings;
-import org.junit.*;
-import org.junit.rules.ExpectedException;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -43,9 +46,6 @@ import static org.hamcrest.collection.IsMapContaining.hasEntry;
 import static org.hamcrest.collection.IsMapContaining.hasKey;
 
 public class FulltextAnalyzerResolverTest extends SQLTransportIntegrationTest {
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     private static FulltextAnalyzerResolver fulltextAnalyzerResolver;
 
@@ -409,8 +409,7 @@ public class FulltextAnalyzerResolverTest extends SQLTransportIntegrationTest {
     }
 
     @Test
-    public void reuseExistingTokenizer() throws Exception {
-
+    public void reuseExistingTokenizer() {
         execute("CREATE ANALYZER a9 (" +
                 "  TOKENIZER a9tok WITH (" +
                 "    type='nGram'," +

--- a/sql/src/test/java/io/crate/integrationtests/GroupByAggregateBreakerTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/GroupByAggregateBreakerTest.java
@@ -26,16 +26,9 @@ import io.crate.breaker.CrateCircuitBreakerService;
 import io.crate.breaker.RamAccountingContext;
 import org.elasticsearch.common.settings.Settings;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class GroupByAggregateBreakerTest extends SQLTransportIntegrationTest {
-
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {

--- a/sql/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
@@ -31,9 +31,7 @@ import io.crate.testing.TestingHelpers;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.hamcrest.core.Is;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.HashMap;
 
@@ -45,9 +43,6 @@ import static org.hamcrest.Matchers.isIn;
 public class GroupByAggregateTest extends SQLTransportIntegrationTest {
 
     private Setup setup = new Setup(sqlExecutor);
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Before
     public void initTestData() {

--- a/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -31,9 +31,7 @@ import io.crate.testing.TestingHelpers;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.hamcrest.Matchers;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -45,9 +43,6 @@ import static org.hamcrest.Matchers.*;
 public class InformationSchemaTest extends SQLTransportIntegrationTest {
 
     final static Joiner commaJoiner = Joiner.on(", ");
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     private void serviceSetup() {
         execute("create table t1 (col1 integer primary key, " +
@@ -248,7 +243,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
         assertEquals(4, response.rows()[0][1]);
         assertEquals("1", response.rows()[0][2]);
         assertEquals("id", response.rows()[0][3]);
-        assertArrayEquals(new String[]{"id"}, (String[]) response.rows()[0][4]);
+        assertThat((Object[]) response.rows()[0][4], arrayContaining(new Object[]{"id"}));
     }
 
     @Test
@@ -291,7 +286,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
                 "table_name from information_schema.table_constraints where schema_name='doc'");
         assertEquals(1L, response.rowCount());
         assertEquals("PRIMARY_KEY", response.rows()[0][0]);
-        assertThat(commaJoiner.join((String[]) response.rows()[0][1]), is("col1"));
+        assertThat(commaJoiner.join((Object[]) response.rows()[0][1]), is("col1"));
         assertEquals("test", response.rows()[0][2]);
     }
 
@@ -303,7 +298,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
                 ".table_constraints where schema_name='doc'");
         assertEquals(1L, response.rowCount());
         assertEquals("test", response.rows()[0][0]);
-        assertThat(commaJoiner.join((String[]) response.rows()[0][1]), is("col1"));
+        assertThat(commaJoiner.join((Object[]) response.rows()[0][1]), is("col1"));
 
         execute("create table test2 (col1a string primary key, col2a timestamp)");
         ensureGreen();
@@ -311,7 +306,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
 
         assertEquals(2L, response.rowCount());
         assertEquals("test2", response.rows()[1][0]);
-        assertThat(commaJoiner.join((String[]) response.rows()[1][1]), is("col1a"));
+        assertThat(commaJoiner.join((Object[]) response.rows()[1][1]), is("col1a"));
     }
 
     @Test
@@ -758,10 +753,10 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
         execute("select * from information_schema.tables " +
                 "where schema_name = 'doc' order by table_name");
 
-        String[] row1 = new String[] { "name", "content" };
-        String[] row2 = new String[] { "name" };
-        assertArrayEquals((String[]) response.rows()[0][5], row1);
-        assertArrayEquals((String[]) response.rows()[1][5], row2);
+        Object[] row1 = new String[] { "name", "content" };
+        Object[] row2 = new String[] { "name" };
+        assertThat((Object[]) response.rows()[0][5], arrayContaining(row1));
+        assertThat((Object[]) response.rows()[1][5], arrayContaining(row2));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
@@ -23,37 +23,26 @@ package io.crate.integrationtests;
 
 import io.crate.action.sql.SQLActionException;
 import io.crate.action.sql.SQLBulkResponse;
-import io.crate.action.sql.SQLRequest;
 import io.crate.action.sql.SQLResponse;
 import io.crate.testing.TestingHelpers;
-import io.crate.types.ArrayType;
-import io.crate.types.GeoPointType;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.hamcrest.Matchers;
 import org.hamcrest.core.IsNull;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$$;
-import static org.hamcrest.Matchers.arrayContaining;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 2, numClientNodes = 0, randomDynamicTemplates = false)
 public class InsertIntoIntegrationTest extends SQLTransportIntegrationTest {
 
     private Setup setup = new Setup(sqlExecutor);
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void testInsertWithColumnNames() throws Exception {

--- a/sql/src/test/java/io/crate/integrationtests/JobIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/JobIntegrationTest.java
@@ -28,15 +28,10 @@ import io.crate.testing.SQLTransportExecutor;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 1, numClientNodes = 1, randomDynamicTemplates = false)
 public class JobIntegrationTest extends SQLTransportIntegrationTest {
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {

--- a/sql/src/test/java/io/crate/integrationtests/JobLogIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/JobLogIntegrationTest.java
@@ -26,17 +26,12 @@ import io.crate.metadata.settings.CrateSettings;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.hamcrest.Matchers;
 import org.junit.After;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 2, numClientNodes = 0)
 public class JobLogIntegrationTest extends SQLTransportIntegrationTest {
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @After
     public void resetSettings() throws Exception {

--- a/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -28,9 +28,7 @@ import io.crate.operation.projectors.sorting.OrderingByPosition;
 import io.crate.testing.TestingHelpers;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -44,9 +42,6 @@ import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(minNumDataNodes = 2)
 public class JoinIntegrationTest extends SQLTransportIntegrationTest {
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void testCrossJoinOrderByOnBothTables() throws Exception {

--- a/sql/src/test/java/io/crate/integrationtests/KillIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/KillIntegrationTest.java
@@ -32,7 +32,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 import javax.annotation.Nullable;
@@ -56,9 +55,6 @@ public class KillIntegrationTest extends SQLTransportIntegrationTest {
                 CrateTestingPlugin.class
         );
     }
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();

--- a/sql/src/test/java/io/crate/integrationtests/ObjectColumnTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ObjectColumnTest.java
@@ -25,17 +25,12 @@ import io.crate.action.sql.SQLActionException;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.hamcrest.Matchers;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.HashMap;
 import java.util.Map;
 
 public class ObjectColumnTest extends SQLTransportIntegrationTest {
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     private Setup setup = new Setup(sqlExecutor);
 

--- a/sql/src/test/java/io/crate/integrationtests/OdbcIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/OdbcIntegrationTest.java
@@ -25,15 +25,12 @@ import io.crate.action.sql.SQLAction;
 import io.crate.action.sql.SQLBaseRequest;
 import io.crate.action.sql.SQLRequestBuilder;
 import io.crate.action.sql.SQLResponse;
+import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
+@ESIntegTestCase.ClusterScope(transportClientRatio = 0)
 public class OdbcIntegrationTest extends SQLTransportIntegrationTest {
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     private Setup setup = new Setup(sqlExecutor);
 

--- a/sql/src/test/java/io/crate/integrationtests/OptimizeTableIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/OptimizeTableIntegrationTest.java
@@ -27,7 +27,6 @@ import io.crate.executor.TaskResult;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
@@ -35,9 +34,6 @@ import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(minNumDataNodes = 2)
 public class OptimizeTableIntegrationTest extends SQLTransportIntegrationTest {
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();

--- a/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -48,7 +48,6 @@ import org.hamcrest.core.Is;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.BufferedWriter;
@@ -69,9 +68,6 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @After
     public void resetSettings() throws Exception {

--- a/sql/src/test/java/io/crate/integrationtests/PostgresITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PostgresITest.java
@@ -29,7 +29,6 @@ import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.Timeout;
 import org.postgresql.util.PSQLException;
 
@@ -49,9 +48,6 @@ public class PostgresITest extends SQLTransportIntegrationTest {
 
     @Rule
     public Timeout globalTimeout = new Timeout(120000); // 2 minutes timeout
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     private Properties properties = new Properties();
 

--- a/sql/src/test/java/io/crate/integrationtests/QueryThenFetchIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/QueryThenFetchIntegrationTest.java
@@ -25,17 +25,12 @@ import io.crate.action.sql.SQLActionException;
 import io.crate.operation.Paging;
 import io.crate.testing.TestingHelpers;
 import org.hamcrest.core.Is;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
 public class QueryThenFetchIntegrationTest extends SQLTransportIntegrationTest {
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void testCrateSearchServiceSupportsOrderByOnFunctionWithBooleanReturnType() throws Exception {

--- a/sql/src/test/java/io/crate/integrationtests/ReadOnlyNodeIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ReadOnlyNodeIntegrationTest.java
@@ -35,19 +35,15 @@ import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 
-@ESIntegTestCase.ClusterScope(numDataNodes = 1, numClientNodes = 1)
+@ESIntegTestCase.ClusterScope(numDataNodes = 1, numClientNodes = 1, transportClientRatio = 0)
 public class ReadOnlyNodeIntegrationTest extends SQLTransportIntegrationTest {
 
     private SQLTransportExecutor readOnlyExecutor;
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();

--- a/sql/src/test/java/io/crate/integrationtests/RegexpIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/RegexpIntegrationTest.java
@@ -22,18 +22,13 @@
 package io.crate.integrationtests;
 
 import io.crate.action.sql.SQLActionException;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import static org.hamcrest.core.Is.is;
 
 public class RegexpIntegrationTest extends SQLTransportIntegrationTest {
 
     private Setup setup = new Setup(sqlExecutor);
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void testRegexpMatchesIsNull() throws Exception {

--- a/sql/src/test/java/io/crate/integrationtests/RepositoryIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/RepositoryIntegrationTest.java
@@ -25,9 +25,7 @@ package io.crate.integrationtests;
 import io.crate.action.sql.SQLActionException;
 import org.elasticsearch.common.settings.Settings;
 import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
@@ -36,9 +34,6 @@ import java.util.HashMap;
 import static org.hamcrest.Matchers.is;
 
 public class RepositoryIntegrationTest extends SQLTransportIntegrationTest {
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @ClassRule
     public static TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();

--- a/sql/src/test/java/io/crate/integrationtests/RestSqlActionTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/RestSqlActionTest.java
@@ -26,10 +26,12 @@ import io.crate.action.sql.parser.SQLXContentSourceContext;
 import io.crate.action.sql.parser.SQLXContentSourceParser;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Before;
 import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
+@ESIntegTestCase.ClusterScope(transportClientRatio = 0)
 public class RestSqlActionTest extends SQLTransportIntegrationTest {
 
     @Before
@@ -220,8 +222,10 @@ public class RestSqlActionTest extends SQLTransportIntegrationTest {
                 "}", json, true);
     }
 
-    @Test(expected = SQLActionException.class)
+    @Test
     public void testSqlRequestWithWrongSchema() throws Exception {
+        expectedException.expect(SQLActionException.class);
+        expectedException.expectMessage("TableUnknownException: Table 'doc.foo2' unknown");
         restSQLExecute("{\"stmt\": \"create table foo2 (id string)\"}", false, "bar2");
         ensureYellow();
 

--- a/sql/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
@@ -32,9 +32,7 @@ import io.crate.types.DataType;
 import io.crate.types.IntegerType;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.util.*;
@@ -42,11 +40,8 @@ import java.util.*;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 
-@ESIntegTestCase.ClusterScope(minNumDataNodes = 2)
+@ESIntegTestCase.ClusterScope(minNumDataNodes = 2, transportClientRatio = 0)
 public class SQLTypeMappingTest extends SQLTransportIntegrationTest {
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     private void setUpSimple() throws IOException {
         setUpSimple(2);

--- a/sql/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -22,11 +22,8 @@
 package io.crate.integrationtests;
 
 import io.crate.action.sql.SQLActionException;
-import io.crate.analyze.NumberOfShards;
 import io.crate.testing.TestingHelpers;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.Locale;
 
@@ -34,9 +31,6 @@ import static org.hamcrest.core.Is.is;
 
 
 public class ShowIntegrationTest extends SQLTransportIntegrationTest {
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void testShowCrateSystemTable() throws Exception {

--- a/sql/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
@@ -31,8 +31,10 @@ import org.elasticsearch.cluster.metadata.SnapshotId;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.snapshots.SnapshotInfo;
-import org.junit.*;
-import org.junit.rules.ExpectedException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.util.List;
@@ -45,9 +47,6 @@ public class SnapshotRestoreIntegrationTest extends SQLTransportIntegrationTest 
 
     private static final String REPOSITORY_NAME = "my_repo";
     private static final String SNAPSHOT_NAME = "my_snapshot";
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @ClassRule
     public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();

--- a/sql/src/test/java/io/crate/integrationtests/StaticInformationSchemaQueryTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/StaticInformationSchemaQueryTest.java
@@ -23,15 +23,10 @@ package io.crate.integrationtests;
 
 import io.crate.action.sql.SQLActionException;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 
 public class StaticInformationSchemaQueryTest extends SQLTransportIntegrationTest {
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Before
     public void tableCreation() throws Exception {

--- a/sql/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
@@ -24,18 +24,13 @@ package io.crate.integrationtests;
 
 import io.crate.action.sql.SQLActionException;
 import io.crate.testing.TestingHelpers;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import static org.hamcrest.Matchers.is;
 
 public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
 
     private Setup setup = new Setup(sqlExecutor);
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void testSubSelectOrderBy() throws Exception {

--- a/sql/src/test/java/io/crate/integrationtests/SysClusterTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysClusterTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.integrationtests;
 
+import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -29,6 +30,8 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.is;
 
+// FIXME: remove once explain statements are streamed correctly
+@ESIntegTestCase.ClusterScope(transportClientRatio = 0)
 public class SysClusterTest extends SQLTransportIntegrationTest {
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/SysRepositoriesTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysRepositoriesTest.java
@@ -27,6 +27,7 @@ import io.crate.types.StringType;
 import org.elasticsearch.action.admin.cluster.repositories.delete.DeleteRepositoryResponse;
 import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryResponse;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -42,6 +43,7 @@ import java.util.Map;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
+@ESIntegTestCase.ClusterScope(transportClientRatio = 0)
 public class SysRepositoriesTest extends SQLTransportIntegrationTest {
 
     @ClassRule

--- a/sql/src/test/java/io/crate/integrationtests/SysShardsTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysShardsTest.java
@@ -30,9 +30,7 @@ import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.Arrays;
 import java.util.List;
@@ -43,10 +41,6 @@ import static org.hamcrest.Matchers.*;
 
 @ESIntegTestCase.ClusterScope(numClientNodes = 0, numDataNodes = 2)
 public class SysShardsTest extends SQLTransportIntegrationTest {
-
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Before
     public void initTestData() throws Exception {

--- a/sql/src/test/java/io/crate/integrationtests/SysSnapshotsTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysSnapshotsTest.java
@@ -32,7 +32,11 @@ import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotRes
 import org.elasticsearch.action.admin.cluster.snapshots.delete.DeleteSnapshotResponse;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.snapshots.SnapshotState;
-import org.junit.*;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
@@ -43,6 +47,7 @@ import java.util.List;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.*;
 
+@ESIntegTestCase.ClusterScope(transportClientRatio = 0)
 public class SysSnapshotsTest extends SQLTransportIntegrationTest {
 
     @ClassRule

--- a/sql/src/test/java/io/crate/integrationtests/TableAliasIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TableAliasIntegrationTest.java
@@ -26,9 +26,7 @@ import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesResp
 import org.elasticsearch.cluster.metadata.AliasMetaData;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.Locale;
 
@@ -36,9 +34,6 @@ import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 1, numClientNodes = 0)
 public class TableAliasIntegrationTest extends SQLTransportIntegrationTest {
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     private String tableAliasSetup() throws Exception {
         String tableName = "mytable";
@@ -241,7 +236,7 @@ public class TableAliasIntegrationTest extends SQLTransportIntegrationTest {
         assertThat(t.alias(), is("t"));
 
         execute("select partitioned_by from information_schema.tables where table_name = 't'");
-        assertThat(((String[]) response.rows()[0][0])[0], is("p"));
+        assertThat((String) ((Object[]) response.rows()[0][0])[0], is("p"));
     }
 
 }

--- a/sql/src/test/java/io/crate/integrationtests/TableBlocksIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TableBlocksIntegrationTest.java
@@ -27,16 +27,11 @@ import org.elasticsearch.test.ESIntegTestCase;
 import org.hamcrest.core.Is;
 import org.junit.After;
 import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 1)
 public class TableBlocksIntegrationTest extends SQLTransportIntegrationTest {
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @ClassRule
     public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();

--- a/sql/src/test/java/io/crate/integrationtests/TableSettingsTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TableSettingsTest.java
@@ -23,16 +23,11 @@ package io.crate.integrationtests;
 
 import io.crate.action.sql.SQLActionException;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.Map;
 
 public class TableSettingsTest extends SQLTransportIntegrationTest {
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Before
     public void prepare() throws Exception {

--- a/sql/src/test/java/io/crate/integrationtests/TransportSQLActionClassLifecycleTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TransportSQLActionClassLifecycleTest.java
@@ -29,13 +29,13 @@ import io.crate.metadata.settings.CrateSettings;
 import io.crate.testing.SQLTransportExecutor;
 import io.crate.testing.TestingHelpers;
 import org.apache.lucene.util.Constants;
+import org.elasticsearch.common.io.stream.NotSerializableExceptionWrapper;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 import java.nio.charset.StandardCharsets;
@@ -58,9 +58,6 @@ public class TransportSQLActionClassLifecycleTest extends SQLTransportIntegratio
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Before
     public void initTestData() throws Exception {
@@ -218,8 +215,10 @@ public class TransportSQLActionClassLifecycleTest extends SQLTransportIntegratio
         assertEquals(55.25d, response.rows()[0][3]);
     }
 
-    @Test(expected = SQLActionException.class)
+    @Test
     public void selectMultiGetRequestFromNonExistentTable() throws Exception {
+        expectedException.expect(SQLActionException.class);
+        expectedException.expectMessage("TableUnknownException: Table 'doc.non_existent' unknown");
         execute("SELECT * FROM \"non_existent\" WHERE \"_id\" in (?,?)", new Object[]{"1", "2"});
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/TransportSQLActionSingleNodeTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TransportSQLActionSingleNodeTest.java
@@ -28,9 +28,7 @@ import io.crate.action.sql.*;
 import io.crate.testing.TestingHelpers;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.After;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -41,9 +39,6 @@ import static org.hamcrest.Matchers.notNullValue;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 1, numClientNodes = 0)
 public class TransportSQLActionSingleNodeTest extends SQLTransportIntegrationTest {
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void testUnassignedShards() throws Exception {

--- a/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -35,15 +35,14 @@ import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsReques
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.collect.MapBuilder;
+import org.elasticsearch.common.io.stream.NotSerializableExceptionWrapper;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.hamcrest.Matchers;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 import javax.annotation.Nullable;
@@ -59,9 +58,6 @@ import static org.hamcrest.core.Is.is;
 public class TransportSQLActionTest extends SQLTransportIntegrationTest {
 
     private Setup setup = new Setup(sqlExecutor);
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
@@ -1447,8 +1443,8 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
         execute("select p from geo_point_table order by id desc");
 
         assertThat(response.rowCount(), is(2L));
-        assertThat(((Double[]) response.rows()[0][0]), Matchers.arrayContaining(57.22, 7.12));
-        assertThat(((Double[]) response.rows()[1][0]), Matchers.arrayContaining(47.22, 12.09));
+        assertThat(((Object[]) response.rows()[0][0]), arrayContaining(new Object[] {57.22, 7.12}));
+        assertThat(((Object[]) response.rows()[1][0]), arrayContaining(new Object[] {47.22, 12.09}));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/UpdateIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/UpdateIntegrationTest.java
@@ -26,9 +26,7 @@ import io.crate.action.sql.SQLBulkResponse;
 import io.crate.analyze.UpdateStatementAnalyzer;
 import io.crate.testing.TestingHelpers;
 import org.elasticsearch.common.collect.MapBuilder;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -43,9 +41,6 @@ import static org.hamcrest.core.Is.is;
 public class UpdateIntegrationTest extends SQLTransportIntegrationTest {
 
     private Setup setup = new Setup(sqlExecutor);
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void testUpdate() throws Exception {

--- a/sql/src/test/java/io/crate/integrationtests/VersionHandlingIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/VersionHandlingIntegrationTest.java
@@ -23,9 +23,7 @@ package io.crate.integrationtests;
 
 import io.crate.action.sql.SQLActionException;
 import io.crate.analyze.UpdateStatementAnalyzer;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 
@@ -36,10 +34,6 @@ public class VersionHandlingIntegrationTest extends SQLTransportIntegrationTest 
 
     private Setup setup = new Setup(sqlExecutor);
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
-
     @Test
     public void selectMultiGetRequestWithColumnAlias() throws IOException {
         this.setup.createTestTableWithPrimaryKey();
@@ -47,7 +41,7 @@ public class VersionHandlingIntegrationTest extends SQLTransportIntegrationTest 
         execute("insert into test (pk_col, message) values ('2', 'bar')");
         execute("insert into test (pk_col, message) values ('3', 'baz')");
         refresh();
-        execute("SELECT pk_col as id, message from test where pk_col IN (?,?)", new Object[]{'1', '2'});
+        execute("SELECT pk_col as id, message from test where pk_col IN (?,?)", new Object[]{"1", "2"});
         assertThat(response.rowCount(), is(2L));
         assertThat(response.cols(), arrayContainingInAnyOrder("id", "message"));
         assertThat(new String[]{(String) response.rows()[0][0], (String) response.rows()[1][0]}, arrayContainingInAnyOrder("1", "2"));

--- a/sql/src/test/java/io/crate/metadata/doc/array/ArrayMapperTest.java
+++ b/sql/src/test/java/io/crate/metadata/doc/array/ArrayMapperTest.java
@@ -42,9 +42,7 @@ import org.elasticsearch.index.mapper.core.StringFieldMapper;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.hamcrest.Matchers;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 
@@ -55,9 +53,6 @@ public class ArrayMapperTest extends SQLTransportIntegrationTest {
 
     public static final String INDEX = "my_index";
     public static final String TYPE = "type";
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     /**
      * create index with type and mapping and validate DocumentMapper serialization

--- a/sql/src/test/java/io/crate/operation/collect/LuceneDocCollectorTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/LuceneDocCollectorTest.java
@@ -36,7 +36,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 import java.util.ArrayList;
@@ -56,9 +55,6 @@ public class LuceneDocCollectorTest extends SQLTransportIntegrationTest {
     private CollectingRowReceiver rowReceiver = new CollectingRowReceiver();
 
     private LuceneDocCollectorProvider collectorProvider;
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();

--- a/sql/src/test/java/org/elasticsearch/action/admin/indices/create/TransportBulkCreateIndicesActionTest.java
+++ b/sql/src/test/java/org/elasticsearch/action/admin/indices/create/TransportBulkCreateIndicesActionTest.java
@@ -31,9 +31,7 @@ import org.elasticsearch.common.collect.ImmutableOpenIntMap;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.indices.InvalidIndexNameException;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
@@ -45,9 +43,6 @@ import static org.hamcrest.Matchers.is;
 public class TransportBulkCreateIndicesActionTest extends SQLTransportIntegrationTest {
 
     TransportBulkCreateIndicesAction action;
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Mock
     public ActionListener<BulkCreateIndicesResponse> responseActionListener;


### PR DESCRIPTION
Enable Transport Client for tests.

- Added an AdapterActionFuture to unwrap the `NotSerializableExceptionWrapper`.
- Fixed all failing tests when Transport Client was enabled.
- Disable Transport Client for specific classes.
- Moved ExpectedException to the parent test: `SQLTransportIntegrationTest`