### PR TITLE
Fix a race condition in FetchProjector which could cause queries to get stuck

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed a race condition which could cause select statements to get stuck
+
  - Fixed an issue which prevents java client from running explain
    statements.
 


### PR DESCRIPTION
`remainingRequests == 0` case wasn't handeld in the `toFetch.isEmpty`
branch.

If the first node is the local node it is very likely to be executed
like this:

    FetchProjector  - sendRequest to n1
    FetchProjector  - fetchOperation.fetch
    FetchProjector  - fetchOperation onSuccess remainingRequests=1
    FetchProjector  - sendRequest to n2
    FetchProjector  - toFetch isEmpty remainingRequests=0

`testFetchSize` failed sometimes because of this.