### PR TITLE
tests: Fix flaky testTableAlias

### DIFF
--- a/sql/src/test/java/io/crate/metadata/ReferenceInfosITest.java
+++ b/sql/src/test/java/io/crate/metadata/ReferenceInfosITest.java
@@ -86,7 +86,7 @@ public class ReferenceInfosITest extends SQLTransportIntegrationTest {
         IndicesAliasesRequest request = new IndicesAliasesRequest();
         request.addAlias("entsafter", "terminator");
         client().admin().indices().aliases(request).actionGet();
-        ensureGreen();
+        ensureYellow();
 
         DocTableInfo terminatorTable = (DocTableInfo) schemas.getTableInfo(new TableIdent(null, "terminator"));
         DocTableInfo entsafterTable = (DocTableInfo) schemas.getTableInfo(new TableIdent(null, "entsafter"));


### PR DESCRIPTION
If the randomized number of replicas was greater than the number of
nodes ensureGreen ran into a timeout.