### PR TITLE
Throw an error if an unsupported type is used with JDBC

### DIFF
--- a/sql/src/main/java/io/crate/protocols/postgres/ConnectionContext.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/ConnectionContext.java
@@ -32,7 +32,6 @@ import io.crate.concurrent.CompletionState;
 import io.crate.protocols.postgres.types.PGType;
 import io.crate.protocols.postgres.types.PGTypes;
 import io.crate.types.DataType;
-import io.crate.types.DataTypes;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.jboss.netty.buffer.ChannelBuffer;
@@ -350,8 +349,8 @@ class ConnectionContext {
             int oid = buffer.readInt();
             DataType dataType = PGTypes.fromOID(oid);
             if (dataType == null) {
-                LOGGER.warn("Can't map PGType with oid={} to Crate type", oid);
-                dataType = DataTypes.UNDEFINED;
+                throw new IllegalArgumentException(
+                    String.format(Locale.ENGLISH, "Can't map PGType with oid=%d to Crate type", oid));
             }
             paramTypes.add(dataType);
         }

--- a/sql/src/test/java/io/crate/integrationtests/PostgresITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PostgresITest.java
@@ -33,10 +33,7 @@ import org.junit.rules.Timeout;
 import org.postgresql.util.PSQLException;
 
 import java.sql.*;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Properties;
+import java.util.*;
 
 import static org.hamcrest.core.Is.is;
 
@@ -76,6 +73,17 @@ public class PostgresITest extends SQLTransportIntegrationTest {
     public void initProperties() throws Exception {
         if (randomBoolean()) {
             properties.setProperty("prepareThreshold", "-1"); // force binary transfer
+        }
+    }
+
+    @Test
+    public void testUseOfUnsupportedType() throws Exception {
+        try (Connection conn = DriverManager.getConnection(JDBC_POSTGRESQL_URL, properties)) {
+            PreparedStatement stmt = conn.prepareStatement("select ? from sys.cluster");
+            stmt.setObject(1, UUID.randomUUID());
+
+            expectedException.expectMessage("Can't map PGType with oid=2950 to Crate type");
+            stmt.executeQuery();
         }
     }
 


### PR DESCRIPTION
Before the query got stuck.