### PR TITLE
pgwire: Fix varchar text format streaming

### DIFF
--- a/sql/src/main/java/io/crate/operation/scalar/SubstrFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/SubstrFunction.java
@@ -21,6 +21,7 @@
 
 package io.crate.operation.scalar;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import io.crate.analyze.symbol.Function;
 import io.crate.metadata.*;
@@ -82,7 +83,8 @@ public class SubstrFunction extends Scalar<BytesRef, Object> implements DynamicF
         return substring(inputStr, startPos, endPos);
     }
 
-    private static BytesRef evaluate(@Nonnull BytesRef inputStr, int beginIdx, int len) {
+    @VisibleForTesting
+    static BytesRef evaluate(@Nonnull BytesRef inputStr, int beginIdx, int len) {
         final int startPos = Math.max(0, beginIdx - 1);
         if (startPos > inputStr.length - 1) {
             return EMPTY_BYTES_REF;
@@ -94,7 +96,8 @@ public class SubstrFunction extends Scalar<BytesRef, Object> implements DynamicF
         return substring(inputStr, startPos, endPos);
     }
 
-    public static BytesRef substring(BytesRef utf8, int begin, int end) {
+    @VisibleForTesting
+    static BytesRef substring(BytesRef utf8, int begin, int end) {
         int pos = utf8.offset;
         final int limit = pos + utf8.length;
         final byte[] bytes = utf8.bytes;

--- a/sql/src/main/java/io/crate/protocols/postgres/types/PGType.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/PGType.java
@@ -80,7 +80,7 @@ public abstract class PGType {
      *
      * @return the number of bytes written. (4 (int32)  + N)
      */
-    public final int writeAsText(ChannelBuffer buffer, @Nonnull Object value) {
+    public int writeAsText(ChannelBuffer buffer, @Nonnull Object value) {
         byte[] bytes = encodeAsUTF8Text(value);
         buffer.writeInt(bytes.length);
         buffer.writeBytes(bytes);

--- a/sql/src/main/java/io/crate/protocols/postgres/types/VarCharType.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/VarCharType.java
@@ -57,6 +57,11 @@ class VarCharType extends PGType {
     }
 
     @Override
+    public int writeAsText(ChannelBuffer buffer, @Nonnull Object value) {
+        return writeAsBinary(buffer, value);
+    }
+
+    @Override
     protected byte[] encodeAsUTF8Text(@Nonnull Object value) {
         if (value instanceof String) {
             return ((String) value).getBytes(StandardCharsets.UTF_8);

--- a/sql/src/main/java/io/crate/protocols/postgres/types/VarCharType.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/VarCharType.java
@@ -65,7 +65,7 @@ class VarCharType extends PGType {
         if (bytesRef.offset == 0 && bytesRef.length == bytesRef.bytes.length) {
             return bytesRef.bytes;
         }
-        return Arrays.copyOfRange(bytesRef.bytes, bytesRef.offset, bytesRef.length);
+        return Arrays.copyOfRange(bytesRef.bytes, bytesRef.offset, bytesRef.length + bytesRef.offset);
     }
 
     @Override

--- a/sql/src/test/java/io/crate/operation/scalar/ConcatFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/ConcatFunctionTest.java
@@ -130,8 +130,8 @@ public class ConcatFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testTwoStrings() throws Exception {
         assertEval("foobar", "foo", "bar");
-        assertEval("foobar", TestingHelpers.addOffset(new BytesRef("foo")),
-                             TestingHelpers.addOffset(new BytesRef("bar")));
+        assertEval("foobar", TestingHelpers.bytesRef("foo", random()),
+                             TestingHelpers.bytesRef("bar", random()));
     }
 
     @Test
@@ -154,7 +154,7 @@ public class ConcatFunctionTest extends AbstractScalarFunctionsTest {
     public void testStringAndNumber() throws Exception {
         assertEval("foo3", new BytesRef("foo"), 3);
         assertEval("foo3", new BytesRef("foo"), 3L);
-        assertEval("foo3", TestingHelpers.addOffset(new BytesRef("foo")), 3L);
+        assertEval("foo3", TestingHelpers.bytesRef("foo", random()), 3L);
         assertEval("foo3", new BytesRef("foo"), (short)3);
     }
 

--- a/sql/src/test/java/io/crate/operation/scalar/SubstrFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/SubstrFunctionTest.java
@@ -47,7 +47,7 @@ public class SubstrFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testSubstring() throws Exception {
         assertThat(SubstrFunction.substring(new BytesRef("cratedata"), 2, 5), is(new BytesRef("ate")));
-        assertThat(SubstrFunction.substring(TestingHelpers.addOffset(new BytesRef("cratedata")), 2, 5),
+        assertThat(SubstrFunction.substring(TestingHelpers.bytesRef("cratedata", random()), 2, 5),
                                             is(new BytesRef("ate")));
     }
 

--- a/sql/src/test/java/io/crate/protocols/postgres/types/PGTypesTest.java
+++ b/sql/src/test/java/io/crate/protocols/postgres/types/PGTypesTest.java
@@ -23,17 +23,17 @@
 package io.crate.protocols.postgres.types;
 
 import com.google.common.collect.ImmutableList;
+import io.crate.test.integration.CrateUnitTest;
+import io.crate.testing.TestingHelpers;
 import io.crate.types.*;
-import org.apache.lucene.util.BytesRef;
 import org.jboss.netty.buffer.ChannelBuffer;
 import org.jboss.netty.buffer.ChannelBuffers;
 import org.junit.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.Is.is;
 
-public class PGTypesTest {
+public class PGTypesTest extends CrateUnitTest {
 
     @Test
     public void testCrate2PGType() throws Exception {
@@ -72,7 +72,7 @@ public class PGTypesTest {
     @Test
     public void testByteReadWrite() throws Exception {
         for (Entry entry : ImmutableList.of(
-            new Entry(DataTypes.STRING, new BytesRef("foobar")),
+            new Entry(DataTypes.STRING, TestingHelpers.bytesRef("foobar", random())),
             new Entry(DataTypes.LONG, 392873L),
             new Entry(DataTypes.INTEGER, 1234),
             new Entry(DataTypes.SHORT, (short)42),
@@ -81,7 +81,7 @@ public class PGTypesTest {
             new Entry(DataTypes.BOOLEAN, true),
             new Entry(DataTypes.TIMESTAMP, DataTypes.TIMESTAMP.value("2014-05-08")),
             new Entry(DataTypes.TIMESTAMP, DataTypes.TIMESTAMP.value("2014-05-08T16:34:33.123")),
-            new Entry(DataTypes.IP, new BytesRef("192.168.1.1")),
+            new Entry(DataTypes.IP, TestingHelpers.bytesRef("192.168.1.1", random())),
             new Entry(DataTypes.BYTE, (byte) 20)
         )) {
 

--- a/sql/src/test/java/io/crate/testing/TestingHelpers.java
+++ b/sql/src/test/java/io/crate/testing/TestingHelpers.java
@@ -55,6 +55,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.lang.reflect.Array;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.*;
@@ -657,10 +658,22 @@ public class TestingHelpers {
         }
     }
 
-    public static BytesRef addOffset(BytesRef bytesRef) {
-        byte[] result = new byte[bytesRef.length + 2];
-        System.arraycopy(new byte[]{0, 1}, 0, result, 0, 2); // OFFSET
-        System.arraycopy(bytesRef.bytes, 0, result, 2, bytesRef.length);
-        return new BytesRef(result, 2, bytesRef.length);
+    /**
+     * Convert {@param s} into UTF8 encoded BytesRef with random offset and extra length
+     *
+     * This should be preferred over `new BytesRef` in tests to make sure that implementations using BytesRef
+     * handle offset and length correctly (use {@link BytesRef#length} instead of {@link BytesRef#bytes#length}
+     */
+    public static BytesRef bytesRef(String s, Random random) {
+        byte[] strBytes = s.getBytes(StandardCharsets.UTF_8);
+        int extraLength = random.nextInt(100);
+        int offset = 0;
+        if (extraLength > 0) {
+            offset = random.nextInt(extraLength);
+        }
+        byte[] buffer = new byte[strBytes.length + extraLength];
+        random.nextBytes(buffer);
+        System.arraycopy(strBytes, 0, buffer, offset, strBytes.length);
+        return new BytesRef(buffer, offset, strBytes.length);
     }
 }


### PR DESCRIPTION
Didn't work correctly if the BytesRef instance had an offset.
`testTwoSubStrOnSameColumn` failed because of this.