### PR TITLE
Add `SHOW TRANSACTION ISOLATION LEVEL` support

### DIFF
--- a/blackbox/docs/protocols/postgres.txt
+++ b/blackbox/docs/protocols/postgres.txt
@@ -130,6 +130,21 @@ Crate::
     SELECT 20 rows in set (... sec)
 
 
+show transaction isolation
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For compatibility with JDBC the `SHOW TRANSACTION ISOLATION LEVEL` statement is
+implemented::
+
+    cr> show transaction isolation level;
+    +-----------------------+
+    | transaction_isolation |
+    +-----------------------+
+    | read uncommitted      |
+    +-----------------------+
+    SHOW 1 row in set (... sec)
+
+
 Connection failover and load balancing
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/sql-parser/src/main/java/io/crate/sql/parser/Statement.g
+++ b/sql-parser/src/main/java/io/crate/sql/parser/Statement.g
@@ -74,6 +74,7 @@ tokens {
     NEGATIVE;
     QNAME;
     SHOW_TABLES;
+    SHOW_TRANSACTION;
     SHOW_SCHEMAS;
     SHOW_CATALOGS;
     SHOW_COLUMNS;
@@ -205,6 +206,7 @@ statement
     | explainStmt
     | showSchemasStmt
     | showTablesStmt
+    | showTransactionStmt
 //    | showCatalogsStmt
     | showColumnsStmt
 //    | showPartitionsStmt
@@ -673,6 +675,10 @@ showTablesStmt
     : SHOW TABLES fromOrIn? likeOrWhere? -> ^(SHOW_TABLES fromOrIn? likeOrWhere?)
     ;
 
+showTransactionStmt
+    : SHOW TRANSACTION ISOLATION LEVEL -> ^(SHOW_TRANSACTION)
+    ;
+
 showSchemasStmt
     : SHOW SCHEMAS likeOrWhere? -> ^(SHOW_SCHEMAS likeOrWhere?)
     ;
@@ -1123,6 +1129,7 @@ nonReserved
     | SHARDS | SHOW | STRICT | SYSTEM | TABLES | TABLESAMPLE | TEXT | TIME
     | TIMESTAMP | TO | TOKENIZER | TOKEN_FILTERS | TYPE | VALUES | VIEW | YEAR
     | REPOSITORY | SNAPSHOT | RESTORE | GENERATED | ALWAYS | BEGIN
+    | ISOLATION | TRANSACTION | LEVEL
     ;
 
 SELECT: 'SELECT';
@@ -1241,6 +1248,9 @@ DISTRIBUTED: 'DISTRIBUTED';
 CAST: 'CAST';
 TRY_CAST: 'TRY_CAST';
 SHOW: 'SHOW';
+TRANSACTION: 'TRANSACTION';
+ISOLATION: 'ISOLATION';
+LEVEL: 'LEVEL';
 TABLES: 'TABLES';
 SCHEMAS: 'SCHEMAS';
 CATALOGS: 'CATALOGS';

--- a/sql-parser/src/main/java/io/crate/sql/parser/StatementBuilder.g
+++ b/sql-parser/src/main/java/io/crate/sql/parser/StatementBuilder.g
@@ -71,6 +71,7 @@ statement returns [Statement value]
     : query                     { $value = $query.value; }
     | explain                   { $value = $explain.value; }
     | showTables                { $value = $showTables.value; }
+    | showTransaction           { $value = $showTransaction.value; }
     | showSchemas               { $value = $showSchemas.value; }
     | showCatalogs              { $value = $showCatalogs.value; }
     | showColumns               { $value = $showColumns.value; }
@@ -588,6 +589,10 @@ explainOption returns [ExplainOption value]
 
 showTables returns [Statement value]
     : ^(SHOW_TABLES schema=fromOrIn? (likePattern | whereClause)?) { $value = new ShowTables($schema.value, $likePattern.value, $whereClause.value); }
+    ;
+
+showTransaction returns [Statement value]
+    : SHOW_TRANSACTION { $value = new ShowTransaction(); }
     ;
 
 showSchemas returns [Statement value]

--- a/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
@@ -614,4 +614,8 @@ public abstract class AstVisitor<R, C>
     public R visitBegin(BeginStatement node, C context) {
         return visitStatement(node, context);
     }
+
+    public R visitShowTransaction(ShowTransaction showTransaction, C context) {
+        return visitStatement(showTransaction, context);
+    }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/ShowTransaction.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/ShowTransaction.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.sql.tree;
+
+public class ShowTransaction extends Statement {
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitShowTransaction(this, context);
+    }
+
+    @Override
+    public int hashCode() {
+        return 0;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return this == obj;
+    }
+
+    @Override
+    public String toString() {
+        return "SHOW TRANSACTION";
+    }
+}

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -299,6 +299,11 @@ public class TestStatementBuilder {
     }
 
     @Test
+    public void testShowTransactionLevel() throws Exception {
+        printStatement("show transaction isolation level");
+    }
+
+    @Test
     public void testTableFunctions() throws Exception {
         printStatement("select * from unnest([1, 2], ['Arthur', 'Marvin'])");
         printStatement("select * from unnest(?, ?)");

--- a/sql/src/main/java/io/crate/analyze/Analyzer.java
+++ b/sql/src/main/java/io/crate/analyze/Analyzer.java
@@ -175,6 +175,11 @@ public class Analyzer {
             return showStatementAnalyzer.analyze(node, analysis);
         }
 
+        @Override
+        public AnalyzedStatement visitShowTransaction(ShowTransaction showTransaction, Analysis context) {
+            return showStatementAnalyzer.analyze(showTransaction, context);
+        }
+
         public AnalyzedStatement visitShowTables(ShowTables node, Analysis analysis) {
             return showStatementAnalyzer.analyze(node, analysis);
         }

--- a/sql/src/test/java/io/crate/integrationtests/PostgresITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PostgresITest.java
@@ -72,6 +72,14 @@ public class PostgresITest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    public void testGetTransactionIsolation() throws Exception {
+        try (Connection conn = DriverManager.getConnection(JDBC_POSTGRESQL_URL, properties)) {
+            int var = conn.getTransactionIsolation();
+            assertThat(var, is(Connection.TRANSACTION_READ_UNCOMMITTED));
+        }
+    }
+
+    @Test
     public void testUseOfUnsupportedType() throws Exception {
         try (Connection conn = DriverManager.getConnection(JDBC_POSTGRESQL_URL, properties)) {
             PreparedStatement stmt = conn.prepareStatement("select ? from sys.cluster");


### PR DESCRIPTION
In order to support `conn.getTransactionIsolation()` in JDBC.

In postgres it is also possible to use `show transaction_isolation`. But
since JDBC doesn't use it, it is not part of this commit.