### PR TITLE
only request required nodes if a sys.node query which is filtered by …

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Avoid requesting unnecessary nodes when a sys.nodes query is performed
+
  - Queries on the `sys.nodes` table will now short circuit in case some nodes
    in the cluster are unresponsive. All columns of the unresponsive nodes will
    contain null values except `id` and `name`.

--- a/sql/src/main/java/io/crate/analyze/EvaluatingNormalizer.java
+++ b/sql/src/main/java/io/crate/analyze/EvaluatingNormalizer.java
@@ -223,7 +223,7 @@ public class EvaluatingNormalizer {
      *
      * @param symbols the list to be normalized
      */
-    public void normalizeInplace(@Nullable List<Symbol> symbols, StmtCtx context) {
+    public void normalizeInplace(@Nullable List<Symbol> symbols, @Nullable StmtCtx context) {
         if (symbols != null) {
             for (int i = 0; i < symbols.size(); i++) {
                 symbols.set(i, normalize(symbols.get(i), context));
@@ -231,7 +231,7 @@ public class EvaluatingNormalizer {
         }
     }
 
-    public Symbol normalize(@Nullable Symbol symbol, StmtCtx context) {
+    public Symbol normalize(@Nullable Symbol symbol, @Nullable StmtCtx context) {
         if (symbol == null) {
             return null;
         }

--- a/sql/src/main/java/io/crate/analyze/where/EqualityExtractor.java
+++ b/sql/src/main/java/io/crate/analyze/where/EqualityExtractor.java
@@ -55,17 +55,17 @@ public class EqualityExtractor {
         this.normalizer = normalizer;
     }
 
-    public List<List<Symbol>> extractParentMatches(List<ColumnIdent> columns, Symbol symbol, StmtCtx stmtCtx){
+    public List<List<Symbol>> extractParentMatches(List<ColumnIdent> columns, Symbol symbol, @Nullable StmtCtx stmtCtx){
         return extractMatches(columns, symbol, false, stmtCtx);
     }
-    public List<List<Symbol>> extractExactMatches(List<ColumnIdent> columns, Symbol symbol, StmtCtx stmtCtx) {
+    public List<List<Symbol>> extractExactMatches(List<ColumnIdent> columns, Symbol symbol, @Nullable StmtCtx stmtCtx) {
         return extractMatches(columns, symbol, true, stmtCtx);
     }
 
     private List<List<Symbol>> extractMatches(Collection<ColumnIdent> columns,
                                               Symbol symbol,
                                               boolean exact,
-                                              StmtCtx stmtCtx) {
+                                              @Nullable StmtCtx stmtCtx) {
         EqualityExtractor.ProxyInjectingVisitor.Context context =
                 new EqualityExtractor.ProxyInjectingVisitor.Context(columns, exact);
         Symbol proxiedTree = ProxyInjectingVisitor.INSTANCE.process(symbol, context);

--- a/sql/src/main/java/io/crate/operation/collect/collectors/NodeStatsCollector.java
+++ b/sql/src/main/java/io/crate/operation/collect/collectors/NodeStatsCollector.java
@@ -39,7 +39,6 @@ import io.crate.operation.reference.sys.node.NodeStatsContext;
 import io.crate.planner.node.dql.RoutedCollectPhase;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.transport.ReceiveTimeoutTransportException;
 
@@ -52,7 +51,7 @@ public class NodeStatsCollector implements CrateCollector {
     private final TransportNodeStatsAction transportStatTablesAction;
     private final RowReceiver rowReceiver;
     private final RoutedCollectPhase collectPhase;
-    private final DiscoveryNodes nodes;
+    private final Collection<DiscoveryNode> nodes;
     private final CollectInputSymbolVisitor<RowCollectExpression<?, ?>> inputSymbolVisitor;
     private final TopLevelColumnIdentVisitor topLevelColumnIdentVisitor = TopLevelColumnIdentVisitor.INSTANCE;
     private final AtomicInteger remainingRequests = new AtomicInteger();
@@ -60,7 +59,7 @@ public class NodeStatsCollector implements CrateCollector {
     public NodeStatsCollector(TransportNodeStatsAction transportStatTablesAction,
                               RowReceiver rowReceiver,
                               RoutedCollectPhase collectPhase,
-                              DiscoveryNodes nodes,
+                              Collection<DiscoveryNode> nodes,
                               CollectInputSymbolVisitor<RowCollectExpression<?, ?>> inputSymbolVisitor) {
         this.transportStatTablesAction = transportStatTablesAction;
         this.rowReceiver = rowReceiver;

--- a/sql/src/test/java/io/crate/operation/collect/sources/NodeStatsCollectSourceTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/sources/NodeStatsCollectSourceTest.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.operation.collect.sources;
+
+import com.google.common.collect.ImmutableMap;
+import io.crate.analyze.WhereClause;
+import io.crate.analyze.relations.AnalyzedRelation;
+import io.crate.analyze.relations.TableRelation;
+import io.crate.executor.transport.TransportActionProvider;
+import io.crate.metadata.*;
+import io.crate.metadata.sys.SysNodesTableInfo;
+import io.crate.operation.collect.CrateCollector;
+import io.crate.operation.collect.collectors.NodeStatsCollector;
+import io.crate.planner.node.dql.RoutedCollectPhase;
+import io.crate.sql.tree.QualifiedName;
+import io.crate.test.integration.CrateUnitTest;
+import io.crate.testing.SqlExpressions;
+import io.crate.types.DataTypes;
+import org.elasticsearch.Version;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.RoutingTable;
+import org.elasticsearch.test.cluster.NoopClusterService;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static io.crate.testing.TestingHelpers.getFunctions;
+import static org.elasticsearch.test.ESAllocationTestCase.newNode;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class NodeStatsCollectSourceTest extends CrateUnitTest {
+
+    private ClusterService clusterService;
+
+    @Before
+    public void prepare() throws Exception {
+
+        MetaData metaData = MetaData.builder()
+            .put(IndexMetaData.builder("parted").settings(settings(Version.CURRENT)).numberOfShards(2).numberOfReplicas(0))
+            .build();
+        RoutingTable routingTable = RoutingTable.builder()
+            .addAsNew(metaData.index("parted")).build();
+        ClusterState state = ClusterState
+            .builder(org.elasticsearch.cluster.ClusterName.DEFAULT)
+            .metaData(metaData)
+            .routingTable(routingTable)
+            .build();
+
+        state = ClusterState.builder(state).nodes(
+            DiscoveryNodes.builder()
+                .put(newNode("nodeOne"))
+                .put(newNode("nodeTwo"))
+                .put(newNode("nodeThree"))
+                .localNodeId("nodeOne")).build();
+        clusterService = new NoopClusterService(state);
+
+    }
+
+    @Test
+    public void testFilterNodes() throws Exception {
+        String id = "nodeThree";
+
+        // build where clause with id = ?
+        SysNodesTableInfo tableInfo = mock(SysNodesTableInfo.class);
+        when(tableInfo.getReferenceInfo(new ColumnIdent("id"))).thenReturn(
+            new ReferenceInfo(new ReferenceIdent(new TableIdent("sys", "nodes"), "id"), RowGranularity.DOC, DataTypes.STRING));
+
+        TableRelation tableRelation = new TableRelation(tableInfo);
+        Map<QualifiedName, AnalyzedRelation> tableSources = ImmutableMap.<QualifiedName, AnalyzedRelation>of(
+            new QualifiedName("sys.nodes"), tableRelation);
+        SqlExpressions sqlExpressions = new SqlExpressions(tableSources, tableRelation);
+        String where = String.format("id = '%s'", id);
+        WhereClause whereClause = new WhereClause(sqlExpressions.normalize(sqlExpressions.asSymbol(where)));
+
+        RoutedCollectPhase collectPhase = mock(RoutedCollectPhase.class);
+        when(collectPhase.whereClause()).thenReturn(whereClause);
+
+        NodeStatsCollectSource nodeStatsCollectSource = new NodeStatsCollectSource(
+            mock(TransportActionProvider.class),
+            clusterService,
+            getFunctions()
+        );
+
+        Collection<CrateCollector> collectors = nodeStatsCollectSource.getCollectors(collectPhase, null, null);
+        assertThat(collectors.size(), is(1));
+
+        // check that the collector has only the requested node
+        NodeStatsCollector collector = (NodeStatsCollector)collectors.iterator().next();
+        final Field collectorNodes = NodeStatsCollector.class.getDeclaredField("nodes");
+        collectorNodes.setAccessible(true);
+        List<DiscoveryNode> discoveryNodes = (List<DiscoveryNode>)collectorNodes.get(collector);
+        assertThat(discoveryNodes.size(), is(1));
+        assertThat(discoveryNodes.get(0).getId(), is(id));
+    }
+}


### PR DESCRIPTION
…id is performed, to avoid unnecessary

requests