### PR TITLE
perf: Don't execute orderBy in finalTopN in NestedLoops

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Improved the performance of sorted join queries
+
  - Optimized sys.nodes queries
 
  - Queries on the `sys.nodes` table will now short circuit in case some nodes

--- a/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
@@ -258,7 +258,7 @@ public class NestedLoopConsumer implements Consumer {
                 assert localMergePhase != null : "local merge phase must not be null";
                 TopNProjection finalTopN = ProjectionBuilder.topNProjection(
                         postNLOutputs,
-                        orderByBeforeSplit,
+                        null, // orderBy = null because mergePhase receives data sorted
                         querySpec.offset(),
                         limits.finalLimit(),
                         querySpec.outputs()


### PR DESCRIPTION
The MergePhase receives the data pre-sorted and keeps the ordering.