### PR TITLE
tests: Don't sleep in KillIntegrationTest

### DIFF
--- a/sql/src/test/java/io/crate/testing/SQLTransportExecutor.java
+++ b/sql/src/test/java/io/crate/testing/SQLTransportExecutor.java
@@ -364,7 +364,7 @@ public class SQLTransportExecutor {
         }
     }
 
-    private ActionFuture<SQLResponse> execute(SQLRequest request) {
+    public ActionFuture<SQLResponse> execute(SQLRequest request) {
         AdapterActionFuture<SQLResponse, SQLResponse> actionFuture = new TestTransportActionFuture<>();
         clientProvider.client().execute(SQLAction.INSTANCE, request, actionFuture);
         return actionFuture;


### PR DESCRIPTION
There was a `sleep(100)` to wait for the query which should be killed to
start executing.
Instead of that it will now always wait for a `sys.jobs` entry to
appear.
That was already the case anyway for tests using `KILL <jobId>` instead
of `KILL ALLL`.