### PR TITLE
don’t request unnecessary nodes on sys.nodes

### DIFF
--- a/sql/src/main/java/io/crate/metadata/LocalSysColReferenceResolver.java
+++ b/sql/src/main/java/io/crate/metadata/LocalSysColReferenceResolver.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata;
+
+import io.crate.operation.reference.sys.node.SysNodesExpressionFactories;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class LocalSysColReferenceResolver implements NestedReferenceResolver {
+
+    private final Map<ColumnIdent, RowContextCollectorExpression> expressionMap = new HashMap<>();
+
+    public LocalSysColReferenceResolver(List<ColumnIdent> localAvailable) {
+        for (ColumnIdent ident : localAvailable) {
+            RowContextCollectorExpression expr = (RowContextCollectorExpression) SysNodesExpressionFactories.getSysNodesTableInfoFactories().get(ident).create();
+            expressionMap.put(ident, expr);
+        }
+    }
+
+    @Override
+    public ReferenceImplementation<?> getImplementation(Reference ref) {
+        return expressionMap.get(ref.ident().columnIdent());
+    }
+
+    public Collection<RowContextCollectorExpression> expressions() {
+        return expressionMap.values();
+    }
+}

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/SysNodesExpressionFactories.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/SysNodesExpressionFactories.java
@@ -40,8 +40,7 @@ public class SysNodesExpressionFactories {
     public SysNodesExpressionFactories() {
     }
 
-    public static Map<ColumnIdent, RowCollectExpressionFactory> getSysNodesTableInfoFactories() {
-        return ImmutableMap.<ColumnIdent, RowCollectExpressionFactory>builder()
+    private static Map<ColumnIdent, RowCollectExpressionFactory> sysNodeTableInfoFactories = ImmutableMap.<ColumnIdent, RowCollectExpressionFactory>builder()
             .put(SysNodesTableInfo.Columns.ID, new RowCollectExpressionFactory() {
                 @Override
                 public RowCollectExpression create() {
@@ -435,5 +434,9 @@ public class SysNodesExpressionFactories {
                 }
             })
             .build();
+
+    public static Map<ColumnIdent, RowCollectExpressionFactory> getSysNodesTableInfoFactories() {
+        return sysNodeTableInfoFactories;
     }
+
 }

--- a/sql/src/test/java/io/crate/integrationtests/SysNodeResiliencyIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysNodeResiliencyIntegrationTest.java
@@ -77,4 +77,10 @@ public class SysNodeResiliencyIntegrationTest extends SQLTransportIntegrationTes
         assertThat(response.rows()[0][2], is(notNullValue()));
         assertThat((String)response.rows()[0][3], is(unluckyNode));
     }
+
+    @Test
+    public void testNoMatchingNode() throws Exception {
+        execute("select id, name, hostname from sys.nodes where id = 'does-not-exist'");
+        assertThat(response.rowCount(), is(0L));
+    }
 }

--- a/sql/src/test/java/io/crate/operation/collect/sources/NodeStatsCollectSourceTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/sources/NodeStatsCollectSourceTest.java
@@ -23,35 +23,21 @@
 package io.crate.operation.collect.sources;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
 import io.crate.analyze.WhereClause;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.TableRelation;
-import io.crate.executor.transport.TransportActionProvider;
 import io.crate.metadata.*;
 import io.crate.metadata.sys.SysNodesTableInfo;
-import io.crate.operation.collect.CrateCollector;
-import io.crate.operation.collect.collectors.NodeStatsCollector;
-import io.crate.planner.node.dql.RoutedCollectPhase;
 import io.crate.sql.tree.QualifiedName;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.testing.SqlExpressions;
 import io.crate.types.DataTypes;
-import org.elasticsearch.Version;
-import org.elasticsearch.cluster.ClusterService;
-import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.metadata.IndexMetaData;
-import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.cluster.node.DiscoveryNodes;
-import org.elasticsearch.cluster.routing.RoutingTable;
-import org.elasticsearch.test.cluster.NoopClusterService;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.lang.reflect.Field;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static io.crate.testing.TestingHelpers.getFunctions;
 import static org.elasticsearch.test.ESAllocationTestCase.newNode;
@@ -61,66 +47,101 @@ import static org.mockito.Mockito.when;
 
 public class NodeStatsCollectSourceTest extends CrateUnitTest {
 
-    private ClusterService clusterService;
+    private Collection<DiscoveryNode> discoveryNodes;
 
     @Before
     public void prepare() throws Exception {
-
-        MetaData metaData = MetaData.builder()
-            .put(IndexMetaData.builder("parted").settings(settings(Version.CURRENT)).numberOfShards(2).numberOfReplicas(0))
-            .build();
-        RoutingTable routingTable = RoutingTable.builder()
-            .addAsNew(metaData.index("parted")).build();
-        ClusterState state = ClusterState
-            .builder(org.elasticsearch.cluster.ClusterName.DEFAULT)
-            .metaData(metaData)
-            .routingTable(routingTable)
-            .build();
-
-        state = ClusterState.builder(state).nodes(
-            DiscoveryNodes.builder()
-                .put(newNode("nodeOne"))
-                .put(newNode("nodeTwo"))
-                .put(newNode("nodeThree"))
-                .localNodeId("nodeOne")).build();
-        clusterService = new NoopClusterService(state);
-
+        discoveryNodes = new ArrayList<>();
+        discoveryNodes.add(newNode("Ford Perfect", "node-1", ImmutableMap.<String, String>of()));
+        discoveryNodes.add(newNode("Trillian", "node-2", ImmutableMap.<String, String>of()));
+        discoveryNodes.add(newNode("Arthur", "node-3", ImmutableMap.<String, String>of()));
     }
 
-    @Test
-    public void testFilterNodes() throws Exception {
-        String id = "nodeThree";
-
+    private List<DiscoveryNode>filterNodes(String where) throws NoSuchFieldException, IllegalAccessException {
         // build where clause with id = ?
         SysNodesTableInfo tableInfo = mock(SysNodesTableInfo.class);
         when(tableInfo.getReference(new ColumnIdent("id"))).thenReturn(
             new Reference(new ReferenceIdent(new TableIdent("sys", "nodes"), "id"), RowGranularity.DOC, DataTypes.STRING));
+        when(tableInfo.getReference(SysNodesTableInfo.Columns.NAME)).thenReturn(
+            new Reference(
+                new ReferenceIdent(SysNodesTableInfo.IDENT, SysNodesTableInfo.Columns.NAME),
+                RowGranularity.DOC, DataTypes.STRING)
+        );
+        when(tableInfo.getReference(SysNodesTableInfo.Columns.HOSTNAME)).thenReturn(
+            new Reference(
+                new ReferenceIdent(SysNodesTableInfo.IDENT, SysNodesTableInfo.Columns.HOSTNAME),
+                RowGranularity.DOC, DataTypes.STRING)
+        );
+
 
         TableRelation tableRelation = new TableRelation(tableInfo);
         Map<QualifiedName, AnalyzedRelation> tableSources = ImmutableMap.<QualifiedName, AnalyzedRelation>of(
             new QualifiedName("sys.nodes"), tableRelation);
         SqlExpressions sqlExpressions = new SqlExpressions(tableSources, tableRelation);
-        String where = String.format("id = '%s'", id);
         WhereClause whereClause = new WhereClause(sqlExpressions.normalize(sqlExpressions.asSymbol(where)));
 
-        RoutedCollectPhase collectPhase = mock(RoutedCollectPhase.class);
-        when(collectPhase.whereClause()).thenReturn(whereClause);
-
-        NodeStatsCollectSource nodeStatsCollectSource = new NodeStatsCollectSource(
-            mock(TransportActionProvider.class),
-            clusterService,
-            getFunctions()
-        );
-
-        Collection<CrateCollector> collectors = nodeStatsCollectSource.getCollectors(collectPhase, null, null);
-        assertThat(collectors.size(), is(1));
-
-        // check that the collector has only the requested node
-        NodeStatsCollector collector = (NodeStatsCollector)collectors.iterator().next();
-        final Field collectorNodes = NodeStatsCollector.class.getDeclaredField("nodes");
-        collectorNodes.setAccessible(true);
-        List<DiscoveryNode> discoveryNodes = (List<DiscoveryNode>)collectorNodes.get(collector);
-        assertThat(discoveryNodes.size(), is(1));
-        assertThat(discoveryNodes.get(0).getId(), is(id));
+        List<DiscoveryNode> nodes = Lists.newArrayList(NodeStatsCollectSource.nodeIds(whereClause,
+            discoveryNodes,
+            getFunctions()));
+        Collections.sort(nodes, new Comparator<DiscoveryNode>() {
+            @Override
+            public int compare(DiscoveryNode o1, DiscoveryNode o2) {
+                return o1.getId().compareTo(o2.getId());
+            }
+        });
+        return nodes;
     }
+
+    @Test
+    public void testFilterNodesById() throws Exception {
+        List<DiscoveryNode> discoveryNodes = filterNodes("id = 'node-3'");
+        assertThat(discoveryNodes.size(), is(1));
+        assertThat(discoveryNodes.get(0).getId(), is("node-3"));
+
+        // Filter for two nodes by id
+        discoveryNodes = filterNodes("id = 'node-3' or id ='node-2' or id='unknown'");
+        assertThat(discoveryNodes.size(), is(2));
+        assertThat(discoveryNodes.get(0).getId(), is("node-2"));
+        assertThat(discoveryNodes.get(1).getId(), is("node-3"));
+    }
+
+    @Test
+    public void testFilterNodesByName() throws Exception {
+        List<DiscoveryNode> discoveryNodes = filterNodes("name = 'Arthur'");
+        assertThat(discoveryNodes.size(), is(1));
+        assertThat(discoveryNodes.get(0).getId(), is("node-3"));
+
+        // Filter for two nodes by id
+        discoveryNodes = filterNodes("name = 'Arthur' or name ='Trillian' or name='unknown'");
+        assertThat(discoveryNodes.size(), is(2));
+        assertThat(discoveryNodes.get(0).getId(), is("node-2"));
+        assertThat(discoveryNodes.get(1).getId(), is("node-3"));
+    }
+
+    @Test
+    public void testMixedFilter() throws Exception {
+        List<DiscoveryNode> discoveryNodes = filterNodes("name = 'Arthur' or id ='node-2' or name='unknown'");
+        assertThat(discoveryNodes.size(), is(2));
+        assertThat(discoveryNodes.get(0).getId(), is("node-2"));
+        assertThat(discoveryNodes.get(1).getId(), is("node-3"));
+
+
+        discoveryNodes = filterNodes("name = 'Arthur' or id ='node-2' or hostname='unknown'");
+        assertThat(discoveryNodes.size(), is(3));
+
+        discoveryNodes = filterNodes("name = 'Arthur' or id ='node-2' and hostname='unknown'");
+        assertThat(discoveryNodes.size(), is(2));
+        assertThat(discoveryNodes.get(0).getId(), is("node-2"));
+        assertThat(discoveryNodes.get(1).getId(), is("node-3"));
+
+        discoveryNodes = filterNodes("name = 'Arthur' and id = 'node-2'");
+        assertThat(discoveryNodes.size(), is(0));
+    }
+
+    @Test
+    public void testNoLocalInfoInWhereClause() throws Exception {
+        List<DiscoveryNode> discoveryNodes = filterNodes("hostname = 'localhost'");
+        assertThat(discoveryNodes.size(), is(3));
+    }
+
 }


### PR DESCRIPTION
queries if a name filter is provided in where clause