### PR TITLE
fixed writing documents to the replica if an error happened

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fix: Prevent writing a row to the replica when an error happened on the
+   primary shard.
+
  - Fix: Querying a partitioned table by a single primary key raised an
    exception instead of responding whith a zero row count.
 

--- a/sql/src/main/java/io/crate/executor/transport/TransportShardUpsertAction.java
+++ b/sql/src/main/java/io/crate/executor/transport/TransportShardUpsertAction.java
@@ -158,6 +158,9 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
                 logger.debug("{} failed to execute upsert for [{}]/[{}]",
                         t, request.shardId(), request.type(), item.id());
                 if (!request.continueOnError()) {
+                    // *mark* the item as failed by set the source to null
+                    // to prevent the replica operation from processing this concrete item
+                    item.source(null);
                     shardResponse.failure(t);
                     break;
                 }


### PR DESCRIPTION
if a documents failed to be written on the primary
shard after preprocessing succeeded, the record was
still written to the replica