### PR TITLE
don't apply soft limit on unlimited sub-plans

### DIFF
--- a/sql/src/main/java/io/crate/planner/Planner.java
+++ b/sql/src/main/java/io/crate/planner/Planner.java
@@ -110,16 +110,20 @@ public class Planner extends AnalyzedStatementVisitor<Planner.Context, Plan> {
 
         public Limits getLimits(boolean isRootRelation, QuerySpec querySpec) {
             Optional<Integer> optLimit = querySpec.limit();
-            if (!isRootRelation && optLimit.isPresent()) {
+            if (!isRootRelation) {
                 /**
                  * Don't apply softLimit or maxRows on child-relations,
                  * The parent-relations might need more data to produce the correct result.
                  * If the limit is present on the query it means the parent relation wanted it there, so keep it.
                  */
 
-                //noinspection OptionalGetWithoutIsPresent it's present!
-                Integer limit = optLimit.get();
-                return new Limits(limit, querySpec.offset());
+                if (optLimit.isPresent()) {
+                    //noinspection OptionalGetWithoutIsPresent it's present!
+                    Integer limit = optLimit.get();
+                    return new Limits(limit, querySpec.offset());
+                } else {
+                    return new Limits(TopN.NO_LIMIT, TopN.NO_OFFSET);
+                }
             }
             int finalLimit = finalLimit(optLimit.orNull(), softLimit);
             return new Limits(finalLimit, querySpec.offset());

--- a/sql/src/test/java/io/crate/planner/PlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/PlannerTest.java
@@ -4,6 +4,7 @@ import com.carrotsearch.hppc.IntSet;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import io.crate.analyze.QuerySpec;
 import io.crate.analyze.WhereClause;
 import io.crate.analyze.relations.PlannedAnalyzedRelation;
 import io.crate.analyze.symbol.*;
@@ -1744,5 +1745,13 @@ public class PlannerTest extends AbstractPlannerTest {
              "  select i + i as ii, xx from (" +
              "    select i, sum(x) as xx from t1 group by i) as t) as tt " +
              "where (ii * 2) > 4 and (xx * 2) > 120");
+    }
+
+    @Test
+    public void testNoSoftLimitOnUnlimitedChildRelation() throws Exception {
+        int softLimit = 10_000;
+        Planner.Context plannerContext = new Planner.Context(clusterService, UUID.randomUUID(), null, new StmtCtx(), softLimit, 0);
+        Planner.Context.Limits limits = plannerContext.getLimits(false, new QuerySpec());
+        assertThat(limits.finalLimit(), is(TopN.NO_LIMIT));
     }
 }


### PR DESCRIPTION
this issue resulted in wrong row counts on filtered joins. the soft limit was applied on the sub plans and so not all rows were processed by the nested loop, it just stopped when the soft limit was reached.