### PR TITLE
fix backport of making system schemas read-only

### DIFF
--- a/sql/src/main/java/io/crate/analyze/CreateTableStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateTableStatementAnalyzer.java
@@ -27,7 +27,6 @@ import io.crate.metadata.FulltextAnalyzerResolver;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.TableIdent;
 import io.crate.metadata.information.InformationSchemaInfo;
-import io.crate.metadata.pg_catalog.PgCatalogSchemaInfo;
 import io.crate.metadata.sys.SysSchemaInfo;
 import io.crate.sql.tree.*;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
@@ -50,8 +49,7 @@ public class CreateTableStatementAnalyzer extends DefaultTraversalVisitor<Create
 
     static final Collection<String> READ_ONLY_SCHEMAS = ImmutableList.of(
         SysSchemaInfo.NAME,
-        InformationSchemaInfo.NAME,
-        PgCatalogSchemaInfo.NAME
+        InformationSchemaInfo.NAME
     );
 
     static class Context {


### PR DESCRIPTION
removed  `PgCatalogSchemaInfo.NAME` which does not exist in `0.55` yet

@seut can you take a look please :)