### PR TITLE
added new gradle tasks "buildDocs" to easily build documentation

### DIFF
--- a/blackbox/bin/sphinx
+++ b/blackbox/bin/sphinx
@@ -1,18 +1,19 @@
 #!/bin/sh
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 declare -i RESULT=0
 echo "\033[1mCleaning output folder ...\033[0m"
-rm -rf docs/out/ && rm -rf docs/clients/out/
+rm -rf $DIR/docs/out/ && rm -rf $DIR/docs/clients/out/
 RESULT+=$?
 echo "\033[1;44mBuilding server docs (html) ...\033[0m"
-.venv/bin/sphinx-build -n -W -c docs/ -b html -E docs/ docs/out/html
+$DIR/.venv/bin/sphinx-build -n -W -c $DIR/docs/ -b html -E $DIR/docs/ $DIR/docs/out/html
 RESULT+=$?
 echo "\033[1;44mBuilding server docs (text) ...\033[0m"
-.venv/bin/sphinx-build -c docs/ -b text -E docs/ docs/out/text
+$DIR/.venv/bin/sphinx-build -c $DIR/docs/ -b text -E $DIR/docs/ $DIR/docs/out/text
 RESULT+=$?
 echo "\033[1;44mBuilding client docs (html) ...\033[0m"
-.venv/bin/sphinx-build -c docs/ -b html -E docs/clients docs/clients/out/html
+$DIR/.venv/bin/sphinx-build -c $DIR/docs/ -b html -E docs/clients docs/clients/out/html
 RESULT+=$?
 echo "\033[1;44mBuilding client docs (text) ...\033[0m"
-.venv/bin/sphinx-build -c docs/ -b text -E docs/clients docs/clients/out/text
+$DIR/.venv/bin/sphinx-build -c $DIR/docs/ -b text -E $DIR/docs/clients $DIR/docs/clients/out/text
 RESULT+=$?
 exit $RESULT

--- a/blackbox/bootstrap.sh
+++ b/blackbox/bootstrap.sh
@@ -3,7 +3,7 @@
 # travis and jenkins have python3.4 installed
 if hash python3.4 2> /dev/null; then
     python3.4 -m venv .venv --without-pip
-    wget https://bootstrap.pypa.io/get-pip.py
+    curl -s https://bootstrap.pypa.io/get-pip.py -o get-pip.py
     .venv/bin/python get-pip.py
 elif hash python3 2> /dev/null; then
     # fallback for dev machines, this should be >= 3.3

--- a/blackbox/build.gradle
+++ b/blackbox/build.gradle
@@ -60,6 +60,10 @@ task gtest (type:Exec) {
     commandLine "$projectDir/bin/test", '-1', '-t', 'process_test'
 }
 
+task buildDocs (type:Exec, dependsOn: bootstrap) {
+    commandLine "$projectDir/bin/sphinx"
+}
+
 
 hdfsTest.dependsOn(unpackDistTar, bootstrap, lessLogging, ignoreDiskThreshold, project(':es-repository-hdfs').distZipHadoop2)
 sigarTest.dependsOn(unpackDistTar, bootstrap, lessLogging, ignoreDiskThreshold)


### PR DESCRIPTION
Now you can simply run
```bash
./gradlew buildDocs
```
to generate HTML documentation.