### PR TITLE
fix: bug when selecting nested object in object array

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fix: Allow select statements on columns of multiple nested object array.
+
  - F501: Added SQL conformance info to ``information_schema.sql_features``
 
  - Updated crate-admin to ``0.19.0`` which contains following changes:


### PR DESCRIPTION
```sql
CREATE TABLE IF NOT EXISTS "doc"."x" (
   "a" ARRAY(OBJECT (DYNAMIC) AS (
      "b" OBJECT (DYNAMIC) AS (
         "s" STRING
      )
   ))
)
```
```sql
SELECT a[1]['b']['s'] FROM x;
```

lead to:
`SQLActionException[NotSerializableExceptionWrapper: class_cast_exception: java.lang.String cannot be cast to [Ljava.lang.Object;]`