### PR TITLE
splits processing of explicit join conditions and where clauses

### DIFF
--- a/sql/src/benchmarks/java/io/crate/operation/join/NestedLoopOperationBenchmark.java
+++ b/sql/src/benchmarks/java/io/crate/operation/join/NestedLoopOperationBenchmark.java
@@ -124,8 +124,8 @@ public class NestedLoopOperationBenchmark {
         Iterable<Row> right = RowSender.rowRange(0, rightSize);
 
         RowCountRowReceiver receiver = new RowCountRowReceiver();
-        NestedLoopOperation operation = new NestedLoopOperation(0, receiver, Predicates.<Row>alwaysTrue(),
-            JoinType.CROSS, 0, 0);
+        NestedLoopOperation operation = new NestedLoopOperation(
+            0, receiver, Predicates.<Row>alwaysTrue(), Predicates.<Row>alwaysTrue(), JoinType.CROSS, 0, 0);
         ListenableRowReceiver leftSide = operation.leftRowReceiver();
         ListenableRowReceiver rightSide = operation.rightRowReceiver();
 

--- a/sql/src/main/java/io/crate/action/job/ContextPreparer.java
+++ b/sql/src/main/java/io/crate/action/job/ContextPreparer.java
@@ -567,11 +567,13 @@ public class ContextPreparer extends AbstractComponent {
             }
 
             Predicate<Row> rowFilter = RowFilter.create(symbolVisitor, phase.filterSymbol());
+            Predicate<Row> joinCondition = RowFilter.create(symbolVisitor, phase.joinCondition());
 
             NestedLoopOperation nestedLoopOperation = new NestedLoopOperation(
                 phase.executionPhaseId(),
                 flatProjectorChain.firstProjector(),
                 rowFilter,
+                joinCondition,
                 phase.joinType(),
                 phase.numLeftOutputs(),
                 phase.numRightOutputs());

--- a/sql/src/main/java/io/crate/analyze/MultiSourceSelect.java
+++ b/sql/src/main/java/io/crate/analyze/MultiSourceSelect.java
@@ -27,7 +27,6 @@ import io.crate.analyze.symbol.Field;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.Path;
 import io.crate.metadata.table.Operation;
-import io.crate.planner.node.dql.join.JoinType;
 import io.crate.sql.tree.QualifiedName;
 
 import java.util.*;
@@ -45,7 +44,7 @@ public class MultiSourceSelect implements QueriedRelation {
                              QuerySpec querySpec,
                              List<JoinPair> joinPairs) {
         assert sources.size() > 1 : "MultiSourceSelect requires at least 2 relations";
-        this.splitter = new RelationSplitter(querySpec, sources.values());
+        this.splitter = new RelationSplitter(querySpec, sources.values(), joinPairs);
         this.sources = initializeSources(sources);
         this.querySpec = querySpec;
         this.joinPairs = joinPairs;
@@ -71,33 +70,6 @@ public class MultiSourceSelect implements QueriedRelation {
 
     public List<JoinPair> joinPairs() {
         return joinPairs;
-    }
-
-    public JoinType joinTypeForRelations(QualifiedName left, QualifiedName right) {
-        JoinType joinType = JoinPair.joinTypeForRelations(left, right, joinPairs);
-        if (joinType == null) {
-            // default to cross join (or inner, doesn't matter)
-            return JoinType.CROSS;
-        }
-        return joinType;
-    }
-
-    public void rewriteNamesOfJoinPairs(QualifiedName left, QualifiedName right, QualifiedName newName) {
-        for (JoinPair joinPair : joinPairs) {
-            joinPair.replaceNames(left, right, newName);
-        }
-    }
-
-    public void addImplicitInnerJoinPairs(Set<Set<QualifiedName>> innerJoinPairs) {
-        for (Set<QualifiedName> relationPairs : innerJoinPairs) {
-            assert relationPairs.size() == 2 : "relation pair is not a valid pair (size is not 2)";
-            Iterator<QualifiedName> it = relationPairs.iterator();
-            QualifiedName left = it.next();
-            QualifiedName right = it.next();
-            if (JoinPair.joinTypeForRelations(left, right, joinPairs) == null) {
-                joinPairs.add(new JoinPair(left, right, JoinType.INNER));
-            }
-        }
     }
 
     @Override

--- a/sql/src/main/java/io/crate/analyze/TwoTableJoin.java
+++ b/sql/src/main/java/io/crate/analyze/TwoTableJoin.java
@@ -24,13 +24,13 @@ package io.crate.analyze;
 
 import com.google.common.base.Optional;
 import io.crate.analyze.relations.AnalyzedRelationVisitor;
+import io.crate.analyze.relations.JoinPair;
 import io.crate.analyze.relations.QueriedRelation;
 import io.crate.analyze.symbol.Field;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.metadata.ColumnIndex;
 import io.crate.metadata.Path;
 import io.crate.metadata.table.Operation;
-import io.crate.planner.node.dql.join.JoinType;
 import io.crate.sql.tree.QualifiedName;
 
 import java.util.ArrayList;
@@ -46,23 +46,21 @@ public class TwoTableJoin implements QueriedRelation {
     private final Optional<OrderBy> remainingOrderBy;
     private final List<Field> fields;
     private final QualifiedName name;
-    private final JoinType joinType;
+    private final JoinPair joinPair;
 
     public TwoTableJoin(QuerySpec querySpec,
-                        QualifiedName leftName,
                         MultiSourceSelect.Source left,
-                        QualifiedName rightName,
                         MultiSourceSelect.Source right,
                         Optional<OrderBy> remainingOrderBy,
-                        JoinType joinType) {
+                        JoinPair joinPair) {
         this.querySpec = querySpec;
-        this.leftName = leftName;
+        this.leftName = joinPair.left();
         this.left = left;
-        this.rightName = rightName;
+        this.rightName = joinPair.right();
         this.right = right;
         this.name = QualifiedName.of("join", leftName.toString(), rightName.toString());
         this.remainingOrderBy = remainingOrderBy;
-        this.joinType = joinType;
+        this.joinPair = joinPair;
         fields = new ArrayList<>(querySpec.outputs().size());
         for (int i = 0; i < querySpec.outputs().size(); i++) {
             fields.add(new Field(this, new ColumnIndex(i), querySpec.outputs().get(i).valueType()));
@@ -86,8 +84,8 @@ public class TwoTableJoin implements QueriedRelation {
         return querySpec;
     }
 
-    public JoinType joinType() {
-        return joinType;
+    public JoinPair joinPair() {
+        return joinPair;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/analyze/relations/JoinPair.java
+++ b/sql/src/main/java/io/crate/analyze/relations/JoinPair.java
@@ -22,32 +22,81 @@
 
 package io.crate.analyze.relations;
 
+import com.google.common.base.Function;
 import com.google.common.base.Objects;
+import io.crate.analyze.symbol.Symbol;
+import io.crate.operation.operator.AndOperator;
 import io.crate.planner.node.dql.join.JoinType;
 import io.crate.sql.tree.QualifiedName;
 
 import javax.annotation.Nullable;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 public class JoinPair {
 
-    private QualifiedName left;
-    private QualifiedName right;
     private final JoinType joinType;
 
+    private QualifiedName left;
+    private QualifiedName right;
+    @Nullable
+    private Symbol condition;
+
     public JoinPair(QualifiedName left, QualifiedName right, JoinType joinType) {
+        this(left, right, joinType, null);
+    }
+
+    public JoinPair(QualifiedName left, QualifiedName right, JoinType joinType, @Nullable Symbol condition) {
         this.left = left;
         this.right = right;
         this.joinType = joinType;
+        this.condition = condition;
     }
 
-    public boolean equalsNames(QualifiedName left, QualifiedName right) {
+    public QualifiedName left() {
+        return left;
+    }
+
+    public QualifiedName right() {
+        return right;
+    }
+
+    public JoinType joinType() {
+        return joinType;
+    }
+
+    @Nullable
+    public Symbol condition() {
+        return condition;
+    }
+
+    public void condition(Symbol condition) {
+        this.condition = condition;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        JoinPair joinPair = (JoinPair) o;
+        return Objects.equal(left, joinPair.left) &&
+               Objects.equal(right, joinPair.right) &&
+               joinType == joinPair.joinType &&
+               Objects.equal(condition, joinPair.condition);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(left, right, joinType, condition);
+    }
+
+    private boolean equalsNames(QualifiedName left, QualifiedName right) {
         return this.left.equals(left) && this.right.equals(right);
     }
 
-    public void replaceNames(QualifiedName left, QualifiedName right, QualifiedName newName) {
+    private void replaceNames(QualifiedName left, QualifiedName right, QualifiedName newName) {
         if (this.left.equals(left) || this.left.equals(right)) {
             this.left = newName;
         }
@@ -56,45 +105,58 @@ public class JoinPair {
         }
     }
 
-    public JoinType joinType() {
-        return joinType;
+    public void replaceCondition(Function<? super Symbol, Symbol> replaceFunction) {
+        condition = replaceFunction.apply(condition);
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        JoinPair that = (JoinPair) o;
-        return Objects.equal(left, that.left) &&
-               Objects.equal(right, that.right) &&
-               joinType == that.joinType;
+    /**
+     * Find and return a {@link JoinPair} for the given relation names, also check for reversed names.
+     * If the {@link JoinType} is INNER and a pair is found for the reversed names, merge the join conditions.
+     */
+    public static JoinPair ofRelationsWithMergedConditions(QualifiedName left,
+                                                           QualifiedName right,
+                                                           List<JoinPair> joinPairs) {
+        JoinPair joinPair = JoinPair.ofRelations(left, right, joinPairs, true);
+        if (joinPair == null) {
+            // default to cross join (or inner, doesn't matter)
+            joinPair = new JoinPair(left, right, JoinType.CROSS);
+        }
+        // if it's an INNER, lets check for reverse relations and merge conditions
+        if (joinPair.joinType() == JoinType.INNER) {
+            JoinPair joinPairReverse = JoinPair.ofRelations(right, left, joinPairs, false);
+            if (joinPairReverse != null) {
+                joinPair.condition(AndOperator.join(Arrays.asList(joinPair.condition(), joinPairReverse.condition())));
+            }
+        }
+
+        return joinPair;
     }
 
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(left, right, joinType);
-    }
-
+    /**
+     * Returns the {@link JoinPair} of a pair of relation names based on the given list of join pairs.
+     * If <p>checkReversePairs</p> is true, also check for any {@link JoinPair} with switched names.
+     */
     @Nullable
-    public static JoinType joinTypeForRelations(QualifiedName left, QualifiedName right, List<JoinPair> joinPairs) {
-        return joinTypeForRelations(left, right, joinPairs, true);
-    }
-
-    @Nullable
-    public static JoinType joinTypeForRelations(QualifiedName left,
-                                                QualifiedName right,
-                                                List<JoinPair> joinPairs,
-                                                boolean checkReversePair) {
+    public static JoinPair ofRelations(QualifiedName left,
+                                       QualifiedName right,
+                                       List<JoinPair> joinPairs,
+                                       boolean checkReversePair) {
         for (JoinPair joinPair : joinPairs) {
             if (joinPair.equalsNames(left, right)) {
-                return joinPair.joinType();
+                return joinPair;
             }
         }
         // check if relations were switched due to some optimization
         if (checkReversePair) {
             for (JoinPair joinPair : joinPairs) {
                 if (joinPair.equalsNames(right, left)) {
-                    return joinPair.joinType().invert();
+                    JoinPair reverseJoinPair = new JoinPair(
+                        joinPair.right,
+                        joinPair.left,
+                        joinPair.joinType().invert(),
+                        joinPair.condition);
+                    joinPairs.add(reverseJoinPair);
+                    return reverseJoinPair;
                 }
             }
         }
@@ -102,6 +164,9 @@ public class JoinPair {
         return null;
     }
 
+    /**
+     * Returns all relation names which are part of an outer join.
+     */
     public static Set<QualifiedName> outerJoinRelations(List<JoinPair> joinPairs) {
         Set<QualifiedName> outerJoinRelations = new HashSet<>();
         for (JoinPair joinPair : joinPairs) {
@@ -112,4 +177,38 @@ public class JoinPair {
         }
         return outerJoinRelations;
     }
+
+    /**
+     * Rewrite names of matching join pair relations and inside the condition function
+     */
+    public static void rewriteNames(QualifiedName left,
+                                    QualifiedName right,
+                                    QualifiedName newName,
+                                    Function<? super Symbol, Symbol> replaceFunction,
+                                    List<JoinPair> joinPairs) {
+        for (JoinPair joinPair : joinPairs) {
+            joinPair.replaceNames(left, right, newName);
+            joinPair.replaceCondition(replaceFunction);
+        }
+    }
+
+    /**
+     * Returns true if relation name is part of an outer join and on the outer side.
+     */
+    static boolean isOuterRelation(QualifiedName name, List<JoinPair> joinPairs) {
+        for (JoinPair joinPair : joinPairs) {
+            if (joinPair.joinType().isOuter()) {
+                if (joinPair.left.equals(name) &&
+                    (joinPair.joinType() == JoinType.RIGHT || joinPair.joinType() == JoinType.FULL)) {
+                    return true;
+                }
+                if (joinPair.right.equals(name) &&
+                    (joinPair.joinType() == JoinType.LEFT || joinPair.joinType() == JoinType.FULL)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
 }

--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalysisContext.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalysisContext.java
@@ -27,6 +27,7 @@ import io.crate.analyze.AnalysisMetaData;
 import io.crate.analyze.ParameterContext;
 import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
+import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.StmtCtx;
 import io.crate.planner.node.dql.join.JoinType;
 import io.crate.sql.tree.Expression;
@@ -91,7 +92,7 @@ public class RelationAnalysisContext {
         joinPairs.add(joinType);
     }
 
-    void addJoinType(JoinType joinType) {
+    void addJoinType(JoinType joinType, @Nullable Symbol joinCondition) {
         int size = sources.size();
         assert size >= 2 : "sources must be added first, cannot add join type for only 1 source";
         Iterator<QualifiedName> it = sources.keySet().iterator();
@@ -107,7 +108,7 @@ public class RelationAnalysisContext {
             }
             idx++;
         }
-        addJoinPair(new JoinPair(left, right, joinType));
+        addJoinPair(new JoinPair(left, right, joinType, joinCondition));
     }
 
     List<JoinPair> joinPairs() {

--- a/sql/src/main/java/io/crate/analyze/relations/RelationSplitter.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationSplitter.java
@@ -54,12 +54,23 @@ public final class RelationSplitter {
 
     private Optional<OrderBy> remainingOrderBy = Optional.absent();
     private final Map<AnalyzedRelation, QuerySpec> specs;
+    private final List<JoinPair> joinPairs;
+    private final List<Symbol> joinConditions;
 
-    public RelationSplitter(QuerySpec querySpec, Collection<? extends AnalyzedRelation> relations) {
+    public RelationSplitter(QuerySpec querySpec,
+                            Collection<? extends AnalyzedRelation> relations,
+                            List<JoinPair> joinPairs) {
         this.querySpec = querySpec;
         specs = new IdentityHashMap<>(relations.size());
         for (AnalyzedRelation relation : relations) {
             specs.put(relation, new QuerySpec());
+        }
+        this.joinPairs = joinPairs;
+        joinConditions = new ArrayList<>(joinPairs.size());
+        for (JoinPair joinPair : joinPairs) {
+            if (joinPair.condition() != null) {
+                joinConditions.add(joinPair.condition());
+            }
         }
     }
 
@@ -99,6 +110,9 @@ public final class RelationSplitter {
             FieldCollectingVisitor.INSTANCE.process(querySpec.where().query(), context);
         }
 
+        // collect all fields from all join conditions
+        FieldCollectingVisitor.INSTANCE.process(joinConditions, context);
+
         // set the limit and offset where possible
         if (querySpec.limit().isPresent()) {
             for (AnalyzedRelation rel : Sets.difference(specs.keySet(), context.fields.keySet())) {
@@ -136,7 +150,7 @@ public final class RelationSplitter {
         }
         Symbol query = querySpec.where().query();
         assert query != null;
-        QuerySplittingVisitor.Context context = QuerySplittingVisitor.INSTANCE.process(querySpec.where().query());
+        QuerySplittingVisitor.Context context = QuerySplittingVisitor.INSTANCE.process(querySpec.where().query(), joinPairs);
         querySpec.where(new WhereClause(context.query()));
         for (Map.Entry<AnalyzedRelation, Collection<Symbol>> entry : context.queries().asMap().entrySet()) {
             getSpec(entry.getKey()).where(new WhereClause(AndOperator.join(entry.getValue())));

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -795,9 +795,11 @@ public class SelectStatementAnalyzerTest extends BaseAnalyzerTest {
     }
 
     @Test
-    public void testInnerJoinSyntaxExtendsWhereClause() throws Exception {
+    public void testInnerJoinSyntaxDoesNotExtendsWhereClause() throws Exception {
         SelectAnalyzedStatement analysis = analyze("select * from users inner join users_multi_pk on users.id = users_multi_pk.id");
-        assertThat(analysis.relation().querySpec().where().query(),
+        MultiSourceSelect relation = (MultiSourceSelect) analysis.relation();
+        assertThat(relation.querySpec().where().query(), isSQL("null"));
+        assertThat(relation.joinPairs().get(0).condition(),
                 isSQL("(doc.users.id = doc.users_multi_pk.id)"));
     }
 
@@ -806,8 +808,13 @@ public class SelectStatementAnalyzerTest extends BaseAnalyzerTest {
         SelectAnalyzedStatement analysis = analyze("select * from users u1 " +
                                                    "join users_multi_pk u2 on u1.id = u2.id " +
                                                    "join users_clustered_by_only u3 on u2.id = u3.id ");
-        assertThat(analysis.relation().querySpec().where().query(),
-                isSQL("((doc.users.id = doc.users_multi_pk.id) AND (doc.users_multi_pk.id = doc.users_clustered_by_only.id))"));
+        MultiSourceSelect relation = (MultiSourceSelect) analysis.relation();
+        assertThat(relation.querySpec().where().query(), isSQL("null"));
+
+        assertThat(relation.joinPairs().get(0).condition(),
+                isSQL("(doc.users.id = doc.users_multi_pk.id)"));
+        assertThat(relation.joinPairs().get(1).condition(),
+                isSQL("(doc.users_multi_pk.id = doc.users_clustered_by_only.id)"));
     }
 
     @Test
@@ -833,10 +840,13 @@ public class SelectStatementAnalyzerTest extends BaseAnalyzerTest {
         SelectAnalyzedStatement analysis = analyze(
                 "select * from users join users_multi_pk on users.id = users_multi_pk.id " +
                 "where users.name = 'Arthur'");
-        assertThat(analysis.relation().querySpec().where().query(),
-                isSQL("(true AND (doc.users.id = doc.users_multi_pk.id))"));
+
+        MultiSourceSelect relation = (MultiSourceSelect) analysis.relation();
+        assertThat(relation.joinPairs().get(0).condition(),
+                isSQL("(doc.users.id = doc.users_multi_pk.id)"));
 
         // make sure that where clause was pushed down and didn't disappear somehow
+        assertThat(relation.querySpec().where().query(), isSQL("null"));
         MultiSourceSelect.Source users =
                 ((MultiSourceSelect) analysis.relation()).sources().get(QualifiedName.of("doc", "users"));
         assertThat(users.querySpec().where().query(), isSQL("(doc.users.name = 'Arthur')"));

--- a/sql/src/test/java/io/crate/analyze/relations/RelationSplitterTest.java
+++ b/sql/src/test/java/io/crate/analyze/relations/RelationSplitterTest.java
@@ -21,12 +21,14 @@
 
 package io.crate.analyze.relations;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.QuerySpec;
 import io.crate.analyze.WhereClause;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
+import io.crate.planner.node.dql.join.JoinType;
 import io.crate.sql.tree.QualifiedName;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.testing.SqlExpressions;
@@ -56,7 +58,11 @@ public class RelationSplitterTest extends CrateUnitTest {
     private static final SqlExpressions expressions = new SqlExpressions(sources);
 
     private RelationSplitter split(QuerySpec querySpec) {
-        RelationSplitter splitter = new RelationSplitter(querySpec, T3.RELATIONS);
+        return split(querySpec, ImmutableList.<JoinPair>of());
+    }
+
+    private RelationSplitter split(QuerySpec querySpec, List<JoinPair> joinPairs) {
+        RelationSplitter splitter = new RelationSplitter(querySpec, T3.RELATIONS, joinPairs);
         splitter.process();
         return splitter;
     }
@@ -241,5 +247,16 @@ public class RelationSplitterTest extends CrateUnitTest {
         ));
         RelationSplitter splitter = split(querySpec);
         assertThat(splitter.canBeFetched(), containsInAnyOrder(asSymbol("a")));
+    }
+
+    @Test
+    public void testNoSplitOnOuterJoinRelation() throws Exception {
+        QuerySpec querySpec = fromQuery("t2.y < 10");
+        JoinPair joinPair = new JoinPair(T3.T1, T3.T2, JoinType.LEFT, asSymbol("t1.a = t2.b"));
+        RelationSplitter splitter = split(querySpec, Arrays.asList(joinPair));
+
+        assertThat(querySpec, isSQL("SELECT true WHERE (doc.t2.y < 10)"));
+        assertThat(splitter.getSpec(T3.TR_1), isSQL("SELECT doc.t1.a"));
+        assertThat(splitter.getSpec(T3.TR_2), isSQL("SELECT doc.t2.y, doc.t2.b"));
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/OuterJoinIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/OuterJoinIntegrationTest.java
@@ -35,12 +35,12 @@ public class OuterJoinIntegrationTest extends SQLTransportIntegrationTest {
     @Before
     public void setupTestData() {
         execute("create table employees (id integer, name string, office_id integer, profession_id integer)");
-        execute("create table offices (id integer, name string)");
+        execute("create table offices (id integer, name string, size integer)");
         execute("create table professions (id integer, name string)");
         ensureYellow();
         execute("insert into employees (id, name, office_id, profession_id) values" +
                 " (1, 'Trillian', 2, 3), (2, 'Ford Perfect', 4, 2), (3, 'Douglas Adams', 3, 1)");
-        execute("insert into offices (id, name) values (1, 'Hobbit House'), (2, 'Entresol'), (3, 'Chief Office')");
+        execute("insert into offices (id, name, size) values (1, 'Hobbit House', 10), (2, 'Entresol', 70), (3, 'Chief Office', 150)");
         execute("insert into professions (id, name) values (1, 'Writer'), (2, 'Traveler'), (3, 'Commander'), (4, 'Janitor')");
         execute("refresh table employees, offices, professions");
     }
@@ -124,5 +124,24 @@ public class OuterJoinIntegrationTest extends SQLTransportIntegrationTest {
                                                      "Trillian| Entresol\n" +
                                                      "Douglas Adams| Chief Office\n" +
                                                      "Ford Perfect| NULL\n"));
+    }
+
+    @Test
+    public void testLeftJoinWithFilterOnInner() throws Exception {
+        execute("select employees.name, offices.name from" +
+                " employees left join offices on office_id = offices.id" +
+                " where employees.id < 3" +
+                " order by offices.id");
+        assertThat(printedTable(response.rows()), is("Trillian| Entresol\n" +
+                                                     "Ford Perfect| NULL\n"));
+    }
+
+    @Test
+    public void testLeftJoinWithFilterOnOuter() throws Exception {
+        execute("select employees.name, offices.name from" +
+                " employees left join offices on office_id = offices.id" +
+                " where offices.size > 100" +
+                " order by offices.id");
+        assertThat(printedTable(response.rows()), is("Douglas Adams| Chief Office\n"));
     }
 }

--- a/sql/src/test/java/io/crate/planner/node/dql/NestedLoopPhaseTest.java
+++ b/sql/src/test/java/io/crate/planner/node/dql/NestedLoopPhaseTest.java
@@ -58,7 +58,8 @@ public class NestedLoopPhaseTest extends CrateUnitTest {
                 ImmutableList.<Projection>of(),
                 DistributionInfo.DEFAULT_BROADCAST);
         SqlExpressions sqlExpressions = new SqlExpressions(T3.SOURCES, T3.TR_1);
-        Symbol filterCondition = sqlExpressions.normalize(sqlExpressions.asSymbol("a = 'foo'"));
+        Symbol joinCondition = sqlExpressions.normalize(sqlExpressions.asSymbol("t1.x = t1.i"));
+        Symbol filterSymbol = sqlExpressions.normalize(sqlExpressions.asSymbol("a = 'foo'"));
         NestedLoopPhase node = new NestedLoopPhase(
             jobId,
             1,
@@ -68,7 +69,8 @@ public class NestedLoopPhaseTest extends CrateUnitTest {
             mp2,
             Sets.newHashSet("node1", "node2"),
             JoinType.INNER,
-            filterCondition,
+            joinCondition,
+            filterSymbol,
             1,
             1
             );

--- a/sql/src/test/java/io/crate/testing/T3.java
+++ b/sql/src/test/java/io/crate/testing/T3.java
@@ -37,6 +37,7 @@ import io.crate.metadata.table.TestingTableInfo;
 import io.crate.sql.tree.QualifiedName;
 import io.crate.types.DataTypes;
 
+import java.util.Arrays;
 import java.util.Map;
 
 import static org.mockito.Mockito.mock;
@@ -77,9 +78,9 @@ public class T3 {
         }
     };
 
-    public static final QualifiedName T1 = new QualifiedName("t1");
-    public static final QualifiedName T2 = new QualifiedName("t2");
-    public static final QualifiedName T3 = new QualifiedName("t3");
+    public static final QualifiedName T1 = new QualifiedName(Arrays.asList(Schemas.DEFAULT_SCHEMA_NAME, "t1"));
+    public static final QualifiedName T2 = new QualifiedName(Arrays.asList(Schemas.DEFAULT_SCHEMA_NAME, "t2"));
+    public static final QualifiedName T3 = new QualifiedName(Arrays.asList(Schemas.DEFAULT_SCHEMA_NAME, "t3"));
 
     public static final ImmutableList<AnalyzedRelation> RELATIONS = ImmutableList.<AnalyzedRelation>of(TR_1, TR_2, TR_3);
     public static final Map<QualifiedName, AnalyzedRelation> SOURCES = ImmutableMap.<QualifiedName, AnalyzedRelation>of(


### PR DESCRIPTION
before explicit join conditions where merged into the where clause
query which is ok for cross and inner joins, but not for outer ones.
at outer joins, nulls rows must only emitted if the join condition
doesn't match, but not if a where clause doesn't match.