### PR TITLE
removes useless ordering on outer relation of an outer join

### DIFF
--- a/sql/src/main/java/io/crate/analyze/relations/JoinPair.java
+++ b/sql/src/main/java/io/crate/analyze/relations/JoinPair.java
@@ -197,15 +197,22 @@ public class JoinPair {
      */
     static boolean isOuterRelation(QualifiedName name, List<JoinPair> joinPairs) {
         for (JoinPair joinPair : joinPairs) {
-            if (joinPair.joinType().isOuter()) {
-                if (joinPair.left.equals(name) &&
-                    (joinPair.joinType() == JoinType.RIGHT || joinPair.joinType() == JoinType.FULL)) {
-                    return true;
-                }
-                if (joinPair.right.equals(name) &&
-                    (joinPair.joinType() == JoinType.LEFT || joinPair.joinType() == JoinType.FULL)) {
-                    return true;
-                }
+            if (isOuterRelation(name, joinPair)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static boolean isOuterRelation(QualifiedName name, JoinPair joinPair) {
+        if (joinPair.joinType().isOuter()) {
+            if (joinPair.left.equals(name) &&
+                (joinPair.joinType() == JoinType.RIGHT || joinPair.joinType() == JoinType.FULL)) {
+                return true;
+            }
+            if (joinPair.right.equals(name) &&
+                (joinPair.joinType() == JoinType.LEFT || joinPair.joinType() == JoinType.FULL)) {
+                return true;
             }
         }
         return false;

--- a/sql/src/main/java/io/crate/planner/consumer/ManyTableConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/ManyTableConsumer.java
@@ -229,7 +229,8 @@ public class ManyTableConsumer implements Consumer {
             JoinPair joinPair = JoinPair.ofRelationsWithMergedConditions(leftName, rightName, joinPairs);
             mss.joinPairs().remove(joinPair);
 
-            // TODO: remove orderBy from left or right QuerySpec for outer join if orderBy is on outer table
+            removeOrderByOnOuterRelation(leftName, rightName, leftQuerySpec, rightSource.querySpec(), joinPair);
+
             // NestedLoop will add NULL rows - so order by needs to be applied after the NestedLoop
             TwoTableJoin join = new TwoTableJoin(
                 newQuerySpec,
@@ -298,18 +299,38 @@ public class ManyTableConsumer implements Consumer {
         }
     }
 
+    /**
+     * Removes order by on the outer relation of an outer join because it must be applied after the join anyway
+     */
+    private static void removeOrderByOnOuterRelation(QualifiedName left,
+                                                     QualifiedName right,
+                                                     QuerySpec leftQuerySpec,
+                                                     QuerySpec rightQuerySpec,
+                                                     JoinPair joinPair) {
+        if (JoinPair.isOuterRelation(left, joinPair)) {
+            leftQuerySpec.orderBy(null);
+        }
+        if (JoinPair.isOuterRelation(right, joinPair)) {
+            rightQuerySpec.orderBy(null);
+        }
+    }
 
-    private static TwoTableJoin twoTableJoin(MultiSourceSelect mss) {
+
+    static TwoTableJoin twoTableJoin(MultiSourceSelect mss) {
         assert mss.sources().size() == 2;
         Iterator<QualifiedName> it = getOrderedRelationNames(mss, ImmutableSet.<Set<QualifiedName>>of()).iterator();
         QualifiedName left = it.next();
         QualifiedName right = it.next();
         JoinPair joinPair = JoinPair.ofRelationsWithMergedConditions(left, right, mss.joinPairs());
+        MultiSourceSelect.Source leftSource = mss.sources().get(left);
+        MultiSourceSelect.Source rightSource = mss.sources().get(right);
+
+        removeOrderByOnOuterRelation(left, right, leftSource.querySpec(), rightSource.querySpec(), joinPair);
 
         return new TwoTableJoin(
             mss.querySpec(),
-            mss.sources().get(left),
-            mss.sources().get(right),
+            leftSource,
+            rightSource,
             mss.remainingOrderBy(),
             joinPair
         );


### PR DESCRIPTION
if the ordering is on the outer relation,
ordering must be (and is) applied on the join result anyway