### PR TITLE
fix setting the default schema via HTTP header

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fix: Setting of a default schema was not possible by using the HTTP REST
+   endpoint.
+
  - Fix: Error was thrown in case of primary key bulk delete statement
    with null bulk arguments.
 

--- a/sql/src/main/java/io/crate/rest/action/RestSQLAction.java
+++ b/sql/src/main/java/io/crate/rest/action/RestSQLAction.java
@@ -41,6 +41,7 @@ import java.util.Locale;
 public class RestSQLAction extends BaseRestHandler {
 
     private static final String REQUEST_HEADER_USER = "User";
+    private static final String REQUEST_HEADER_SCHEMA = "Default-Schema";
 
     @Inject
     public RestSQLAction(Settings settings, Client client, RestController controller) {
@@ -108,6 +109,7 @@ public class RestSQLAction extends BaseRestHandler {
         requestBuilder.args(context.args());
         requestBuilder.includeTypesOnResponse(request.paramAsBoolean("types", false));
         addFlags(requestBuilder, request);
+        requestBuilder.setSchema(request.header(REQUEST_HEADER_SCHEMA));
         requestBuilder.execute(RestSQLAction.<SQLResponse>newListener(request, channel));
     }
 
@@ -117,6 +119,7 @@ public class RestSQLAction extends BaseRestHandler {
         requestBuilder.bulkArgs(context.bulkArgs());
         requestBuilder.includeTypesOnResponse(request.paramAsBoolean("types", false));
         addFlags(requestBuilder, request);
+        requestBuilder.setSchema(request.header(REQUEST_HEADER_SCHEMA));
         requestBuilder.execute(RestSQLAction.<SQLBulkResponse>newListener(request, channel));
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/RestSQLActionIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/RestSQLActionIntegrationTest.java
@@ -22,24 +22,27 @@
 package io.crate.integrationtests;
 
 
+import org.apache.http.Header;
 import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.message.BasicHeader;
 import org.apache.http.util.EntityUtils;
 import org.junit.Test;
 
 import java.io.IOException;
 
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.StringStartsWith.startsWith;
 
 public class RestSQLActionIntegrationTest extends SQLHttpIntegrationTest {
 
-
     @Test
     public void testWithoutBody() throws IOException {
-        CloseableHttpResponse response = post();
+        CloseableHttpResponse response = post(null);
         assertEquals(400, response.getStatusLine().getStatusCode());
         String bodyAsString = EntityUtils.toString(response.getEntity());
-        assertThat(bodyAsString, startsWith(
-                "{\"error\":{\"message\":\"SQLActionException[missing request body]\",\"code\":4000},\"error_trace\":\"SQLActionException:"
+        assertThat(bodyAsString, startsWith("{\"error\":{\"message\":\"SQLActionException[missing request body]\"," +
+            "\"code\":4000},\"error_trace\":\"SQLActionException:"
         ));
     }
 
@@ -48,17 +51,33 @@ public class RestSQLActionIntegrationTest extends SQLHttpIntegrationTest {
         CloseableHttpResponse response = post("{\"foo\": \"bar\"}");
         assertEquals(400, response.getStatusLine().getStatusCode());
         String bodyAsString = EntityUtils.toString(response.getEntity());
-        assertThat(bodyAsString, startsWith(
-                "{\"error\":{\"message\":\"SQLActionException[Failed to parse source [{\\\"foo\\\": \\\"bar\\\"}]]\",\"code\":4000},\"error_trace\":\""));
+        assertThat(bodyAsString, startsWith("{\"error\":{\"message\":\"SQLActionException[Failed to parse source" +
+            " [{\\\"foo\\\": \\\"bar\\\"}]]\",\"code\":4000},\"error_trace\":\"")
+        );
     }
 
     @Test
     public void testWithArgsAndBulkArgs() throws IOException {
-        CloseableHttpResponse response = post("{\"stmt\": \"INSERT INTO foo (bar) values (?)\", \"args\": [0], \"bulk_args\": [[0], [1]]}");
+        CloseableHttpResponse response
+            = post("{\"stmt\": \"INSERT INTO foo (bar) values (?)\", \"args\": [0], \"bulk_args\": [[0], [1]]}");
         assertEquals(400, response.getStatusLine().getStatusCode());
         String bodyAsString = EntityUtils.toString(response.getEntity());
-        assertThat(bodyAsString, startsWith(
-                "{\"error\":{\"message\":\"SQLActionException[request body contains args and bulk_args. It's forbidden to provide both]\",\"code\":4000},\"error_trace\":\"SQLActionException:"
+        assertThat(bodyAsString, startsWith("{\"error\":{\"message\":\"SQLActionException[request body contains args" +
+            " and bulk_args. It's forbidden to provide both]\",\"code\":4000},\"error_trace\":\"SQLActionException:"
         ));
+    }
+
+    @Test
+    public void testSetCustomSchema() throws IOException {
+        execute("create table custom.foo (id string)");
+        Header[] headers = new Header[]{
+            new BasicHeader("Default-Schema", "custom")
+        };
+        CloseableHttpResponse response = post("{\"stmt\": \"select * from foo\"}", headers);
+        assertThat(response.getStatusLine().getStatusCode(), is(200));
+
+        response = post("{\"stmt\": \"select * from foo\"}");
+        assertThat(response.getStatusLine().getStatusCode(), is(404));
+        assertThat(EntityUtils.toString(response.getEntity()), containsString("TableUnknownException"));
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/SQLHttpIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SQLHttpIntegrationTest.java
@@ -24,13 +24,15 @@ package io.crate.integrationtests;
 
 import io.crate.common.Hex;
 import io.crate.test.utils.Blobs;
-import org.apache.http.StatusLine;
+import org.apache.http.Header;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
+import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
+import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
 import org.elasticsearch.http.HttpServerTransport;
@@ -45,7 +47,8 @@ import static org.hamcrest.Matchers.is;
 public abstract class SQLHttpIntegrationTest extends SQLTransportIntegrationTest {
 
     private HttpPost httpPost;
-    protected InetSocketAddress address;
+    private InetSocketAddress address;
+    private CloseableHttpClient httpClient = HttpClients.createDefault();
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {
@@ -64,18 +67,18 @@ public abstract class SQLHttpIntegrationTest extends SQLTransportIntegrationTest
         httpPost = new HttpPost(String.format(Locale.ENGLISH, "http://%s:%s/_sql?error_trace", address.getHostName(), address.getPort()));
     }
 
-    protected CloseableHttpClient httpClient = HttpClients.createDefault();
 
-    protected CloseableHttpResponse post(String body) throws IOException {
-        if(body != null){
-            StringEntity bodyEntity = new StringEntity(body);
+    protected CloseableHttpResponse post(String body, @Nullable Header[] headers) throws IOException {
+        if (body != null) {
+            StringEntity bodyEntity = new StringEntity(body, ContentType.APPLICATION_JSON);
             httpPost.setEntity(bodyEntity);
         }
+        httpPost.setHeaders(headers);
         return httpClient.execute(httpPost);
     }
 
-    protected CloseableHttpResponse post() throws IOException {
-        return post(null);
+    protected CloseableHttpResponse post(String body) throws IOException {
+        return post(body, null);
     }
 
     protected String upload(String table, String content) throws IOException {


### PR DESCRIPTION
It was broken by discarding the logic for setting the schema in RestSQLAction by
https://github.com/crate/crate/commit/1568d08f37b2c4e0b92ffe89baa04266460b3230

Previously we didn't have any integrations for setting a custom schema via HTTP headers.  