### PR TITLE
Fix NPE in BulkPortal

### DIFF
--- a/sql/src/main/java/io/crate/executor/Task.java
+++ b/sql/src/main/java/io/crate/executor/Task.java
@@ -26,25 +26,20 @@ import io.crate.operation.projectors.RowReceiver;
 
 import java.util.List;
 
-/**
- * A task gets executed as part of or in the context of a
- * {@linkplain io.crate.executor.Job} and returns a result asynchronously
- * as a list of futures.
- * <p>
- * create a task, call {@linkplain #execute(RowReceiver)} or {@linkplain #executeBulk()}
- * and wait for the futures returned to fetch the result or raise an exception.
- *
- * @see io.crate.executor.Job
- */
 public interface Task {
 
     /**
-     * execute the task
+     * execute the task if it represents a single operation.
+     *
+     * The result will be fed into the RowReceiver.
      */
     void execute(RowReceiver rowReceiver);
 
     /**
-     * execute the bulk operation
+     * execute the task if it represents a bulk operation.
+     *
+     * The result will be a List containing the row-counts per operation.
+     * Elements of the list cannot be null, but will be -1 if unknown and -2 if an error occurred.
      *
      * @throws UnsupportedOperationException if the task doesn't support bulk operations
      */

--- a/sql/src/main/java/io/crate/executor/transport/task/UpsertByIdTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/UpsertByIdTask.java
@@ -156,7 +156,7 @@ public class UpsertByIdTask extends JobTask {
     public ListenableFuture<List<Long>> executeBulk() {
         try {
             List<SettableFuture<Long>> resultList = executeBulkShardProcessor();
-            return Futures.successfulAsList(resultList);
+            return Futures.allAsList(resultList);
         } catch (Throwable throwable) {
             return Futures.immediateFailedFuture(throwable);
         }


### PR DESCRIPTION
`executeBulk` of UpsertByIdTask could return a List containing null
entries. This caused a NPE in the BulkPortal because it casts to `long`.

Since it is unclear to the consumer if `null` indicates an error or
unknown-row-count this commit also clarifies the contract of
`executeBulk` to not allow null values at all.

Relates to d4203e9c0d24ea03c4639f73417c3d2ef160b673 and fixes one
possible `testKilledAllLog` failure.