### PR TITLE
Use FlatProjectorChain for sys.shards queries

### DIFF
--- a/sql/src/main/java/io/crate/planner/projection/Projection.java
+++ b/sql/src/main/java/io/crate/planner/projection/Projection.java
@@ -34,13 +34,20 @@ public abstract class Projection implements Streamable {
 
     /**
      * The granularity required to run this projection
+     *
+     * For example:
+     *
+     *  CLUSTER - projection may run in any context on the cluster and receive any rows.
+     *
+     *  SHARD - projection must be run in a shard-context and it must only receive rows from a
+     *  single shard.
      */
     public RowGranularity requiredGranularity() {
         return RowGranularity.CLUSTER;
     }
 
     public interface ProjectionFactory<T extends Projection> {
-        public T newInstance();
+        T newInstance();
     }
 
     public abstract ProjectionType projectionType();

--- a/sql/src/main/java/io/crate/planner/projection/builder/ProjectionBuilder.java
+++ b/sql/src/main/java/io/crate/planner/projection/builder/ProjectionBuilder.java
@@ -30,6 +30,7 @@ import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Functions;
+import io.crate.metadata.RowGranularity;
 import io.crate.operation.aggregation.AggregationFunction;
 import io.crate.planner.projection.*;
 
@@ -60,15 +61,14 @@ public class ProjectionBuilder {
     }
 
 
-    public AggregationProjection aggregationProjection(
-            Collection<? extends Symbol> inputs,
-            Collection<Function> aggregates,
-            Aggregation.Step fromStep,
-            Aggregation.Step toStep){
+    public AggregationProjection aggregationProjection(Collection<? extends Symbol> inputs,
+                                                       Collection<Function> aggregates,
+                                                       Aggregation.Step fromStep,
+                                                       Aggregation.Step toStep,
+                                                       RowGranularity granularity) {
         InputCreatingVisitor.Context context = new InputCreatingVisitor.Context(inputs);
-        ArrayList<Aggregation> aggregations = getAggregations(aggregates, fromStep,
-                toStep, context);
-        return new AggregationProjection(aggregations);
+        ArrayList<Aggregation> aggregations = getAggregations(aggregates, fromStep, toStep, context);
+        return new AggregationProjection(aggregations, granularity);
     }
 
     public GroupProjection groupProjection(
@@ -76,7 +76,7 @@ public class ProjectionBuilder {
             Collection<Symbol> keys,
             Collection<Function> values,
             Aggregation.Step fromStep,
-            Aggregation.Step toStep){
+            Aggregation.Step toStep) {
 
         InputCreatingVisitor.Context context = new InputCreatingVisitor.Context(inputs);
         ArrayList<Aggregation> aggregations = getAggregations(values, fromStep, toStep, context);

--- a/sql/src/test/java/io/crate/operation/projectors/ProjectionToProjectorVisitorTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/ProjectionToProjectorVisitorTest.java
@@ -34,7 +34,10 @@ import io.crate.operation.ImplementationSymbolVisitor;
 import io.crate.operation.aggregation.impl.AverageAggregation;
 import io.crate.operation.aggregation.impl.CountAggregation;
 import io.crate.operation.operator.EqOperator;
-import io.crate.planner.projection.*;
+import io.crate.planner.projection.AggregationProjection;
+import io.crate.planner.projection.FilterProjection;
+import io.crate.planner.projection.GroupProjection;
+import io.crate.planner.projection.TopNProjection;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.testing.CollectingRowReceiver;
 import io.crate.testing.RowSender;
@@ -157,11 +160,10 @@ public class ProjectionToProjectorVisitorTest extends CrateUnitTest {
 
     @Test
     public void testAggregationProjector() throws Exception {
-        AggregationProjection projection = new AggregationProjection();
-        projection.aggregations(Arrays.asList(
+        AggregationProjection projection = new AggregationProjection(Arrays.asList(
                 Aggregation.finalAggregation(avgInfo, Arrays.<Symbol>asList(new InputColumn(1)), Aggregation.Step.ITER),
                 Aggregation.finalAggregation(countInfo, Arrays.<Symbol>asList(new InputColumn(0)), Aggregation.Step.ITER)
-        ));
+        ), RowGranularity.SHARD);
         Projector projector = visitor.create(projection, RAM_ACCOUNTING_CONTEXT, UUID.randomUUID());
 
         CollectingRowReceiver collectingProjector = new CollectingRowReceiver();

--- a/sql/src/test/java/io/crate/planner/PlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/PlannerTest.java
@@ -1665,8 +1665,8 @@ public class PlannerTest extends AbstractPlannerTest {
 
     @Test
     public void testDistributedGroupByProjectionHasShardLevelGranularity() throws Exception {
-        CollectAndMerge nonDistributedGroup = plan("select count(*) from sys.cluster group by name");
-        RoutedCollectPhase collectPhase = ((RoutedCollectPhase) nonDistributedGroup.collectPhase());
+        DistributedGroupBy distributedGroupBy = plan("select count(*) from users group by name");
+        RoutedCollectPhase collectPhase = distributedGroupBy.collectNode();
         assertThat(collectPhase.projections().size(), is(1));
         assertThat(collectPhase.projections().get(0), instanceOf(GroupProjection.class));
         assertThat(collectPhase.projections().get(0).requiredGranularity(), is(RowGranularity.SHARD));


### PR DESCRIPTION
sys.shards queries are always single threaded and use a single
RowsCollector. So there is no need to create a ShardProjectorChain
because shard-level projections wouldn't run in parallel anyway.