### PR TITLE
fixes validation of join conditions

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fix: Join conditions were not properly validated and an expression
+   with a not yet defined relation could be used.
+
  - Remove limitation that prevented usage of columns from multiple tables
    in the same order by expression.
    eg: FROM t1, t2, t3 ORDER BY t1.x - t2.y + t3.z

--- a/sql/src/main/java/io/crate/analyze/relations/FullQualifedNameFieldProvider.java
+++ b/sql/src/main/java/io/crate/analyze/relations/FullQualifedNameFieldProvider.java
@@ -24,6 +24,7 @@ package io.crate.analyze.relations;
 import io.crate.analyze.symbol.Field;
 import io.crate.exceptions.AmbiguousColumnException;
 import io.crate.exceptions.ColumnUnknownException;
+import io.crate.exceptions.RelationUnknownException;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.QualifiedName;
@@ -111,12 +112,8 @@ public class FullQualifedNameFieldProvider implements FieldProvider<Field> {
             }
         }
         if (lastField == null) {
-            if (!schemaMatched) {
-                throw new IllegalArgumentException(String.format(Locale.ENGLISH,
-                        "Cannot resolve relation '%s.%s'", columnSchema, columnTableName));
-            }
-            if (!tableNameMatched) {
-                throw new IllegalArgumentException(String.format(Locale.ENGLISH, "Cannot resolve relation '%s'", columnTableName));
+            if (!schemaMatched || !tableNameMatched) {
+                throw RelationUnknownException.of(columnSchema, columnTableName);
             }
             throw new ColumnUnknownException(columnIdent.sqlFqn());
         }

--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalysisContext.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalysisContext.java
@@ -27,8 +27,8 @@ import io.crate.analyze.AnalysisMetaData;
 import io.crate.analyze.ParameterContext;
 import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
+import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.StmtCtx;
-import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.QualifiedName;
 
 import javax.annotation.Nullable;
@@ -47,7 +47,7 @@ public class RelationAnalysisContext {
     private ExpressionAnalyzer expressionAnalyzer;
     private FieldProvider fieldProvider;
     @Nullable
-    private List<Expression> joinExpressions;
+    private List<Symbol> joinConditions;
 
     RelationAnalysisContext(ParameterContext parameterContext,
                             StmtCtx stmtCtx,
@@ -67,18 +67,18 @@ public class RelationAnalysisContext {
         return sources;
     }
 
-    List<Expression> joinExpressions() {
-        if (joinExpressions == null) {
+    List<Symbol> joinConditions() {
+        if (joinConditions == null) {
             return ImmutableList.of();
         }
-        return joinExpressions;
+        return joinConditions;
     }
 
-    void addJoinExpression(Expression expression) {
-        if (joinExpressions == null) {
-            joinExpressions = new ArrayList<>();
+    void addJoinCondition(Symbol symbol) {
+        if (joinConditions == null) {
+            joinConditions = new ArrayList<>();
         }
-        joinExpressions.add(expression);
+        joinConditions.add(symbol);
     }
 
     private void addSourceRelation(QualifiedName qualifiedName, AnalyzedRelation relation) {

--- a/sql/src/main/java/io/crate/exceptions/RelationUnknownException.java
+++ b/sql/src/main/java/io/crate/exceptions/RelationUnknownException.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.exceptions;
+
+import io.crate.sql.tree.QualifiedName;
+
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.Locale;
+
+public class RelationUnknownException extends ResourceUnknownException {
+
+    private final QualifiedName qualifiedName;
+
+    public static RelationUnknownException of(@Nullable String schemaName, String tableName) {
+        QualifiedName qualifiedName;
+        if (schemaName == null) {
+            qualifiedName = new QualifiedName(tableName);
+        } else {
+            qualifiedName = new QualifiedName(Arrays.asList(schemaName, tableName));
+        }
+        return new RelationUnknownException(qualifiedName);
+    }
+
+    private RelationUnknownException(QualifiedName qualifiedName) {
+        super(String.format(Locale.ENGLISH, "Cannot resolve relation '%s'", qualifiedName));
+        this.qualifiedName = qualifiedName;
+    }
+
+    public QualifiedName qualifiedName() {
+        return qualifiedName;
+    }
+}

--- a/sql/src/test/java/io/crate/analyze/DeleteAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/DeleteAnalyzerTest.java
@@ -23,6 +23,7 @@ package io.crate.analyze;
 
 import io.crate.analyze.relations.DocTableRelation;
 import io.crate.analyze.symbol.Function;
+import io.crate.exceptions.RelationUnknownException;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.MetaDataModule;
 import io.crate.metadata.RowGranularity;
@@ -40,7 +41,6 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.List;
 
-import static io.crate.testing.TestingHelpers.isField;
 import static io.crate.testing.TestingHelpers.isLiteral;
 import static io.crate.testing.TestingHelpers.isReference;
 import static org.hamcrest.Matchers.equalTo;
@@ -108,7 +108,7 @@ public class DeleteAnalyzerTest extends BaseAnalyzerTest {
 
     @Test
     public void testDeleteWhereSysColumn() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expect(RelationUnknownException.class);
         expectedException.expectMessage("Cannot resolve relation 'sys.nodes'");
         analyze("delete from users where sys.nodes.id = 'node_1'");
     }

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -26,10 +26,7 @@ import com.google.common.collect.Lists;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.QueriedRelation;
 import io.crate.analyze.symbol.*;
-import io.crate.exceptions.AmbiguousColumnAliasException;
-import io.crate.exceptions.ColumnUnknownException;
-import io.crate.exceptions.ConversionException;
-import io.crate.exceptions.UnsupportedFeatureException;
+import io.crate.exceptions.*;
 import io.crate.metadata.*;
 import io.crate.metadata.doc.DocSchemaInfo;
 import io.crate.metadata.doc.DocTableInfo;
@@ -774,7 +771,7 @@ public class SelectStatementAnalyzerTest extends BaseAnalyzerTest {
 
     @Test
     public void testOrderByQualifiedName() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expect(RelationUnknownException.class);
         expectedException.expectMessage("Cannot resolve relation 'friends'");
         analyze("select * from users order by friends.id");
     }
@@ -985,7 +982,7 @@ public class SelectStatementAnalyzerTest extends BaseAnalyzerTest {
 
     @Test
     public void testTableAliasWrongUse() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expect(RelationUnknownException.class);
         // caused by where users.awesome, would have to use where u.awesome = true instead
         expectedException.expectMessage("Cannot resolve relation 'users'");
         analyze("select * from users as u where users.awesome = true");
@@ -993,9 +990,9 @@ public class SelectStatementAnalyzerTest extends BaseAnalyzerTest {
 
     @Test
     public void testTableAliasFullQualifiedName() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expect(RelationUnknownException.class);
         // caused by where users.awesome, would have to use where u.awesome = true instead
-        expectedException.expectMessage("Cannot resolve relation 'users'");
+        expectedException.expectMessage("Cannot resolve relation 'doc.users'");
         analyze("select * from users as u where doc.users.awesome = true");
     }
 

--- a/sql/src/test/java/io/crate/analyze/relations/FieldProviderTest.java
+++ b/sql/src/test/java/io/crate/analyze/relations/FieldProviderTest.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableMap;
 import io.crate.analyze.symbol.Field;
 import io.crate.exceptions.AmbiguousColumnException;
 import io.crate.exceptions.ColumnUnknownException;
+import io.crate.exceptions.RelationUnknownException;
 import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.QualifiedName;
 import io.crate.test.integration.CrateUnitTest;
@@ -64,7 +65,7 @@ public class FieldProviderTest extends CrateUnitTest {
 
     @Test
     public void testUnknownSchema() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expect(RelationUnknownException.class);
         expectedException.expectMessage("Cannot resolve relation 'invalid.table'");
         FieldProvider<Field>resolver = new FullQualifedNameFieldProvider(dummySources);
         resolver.resolveField(newQN("invalid.table.name"), Operation.READ);
@@ -72,15 +73,15 @@ public class FieldProviderTest extends CrateUnitTest {
 
     @Test
     public void testUnknownTable() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Cannot resolve relation 'invalid'");
+        expectedException.expect(RelationUnknownException.class);
+        expectedException.expectMessage("Cannot resolve relation 'dummy.invalid'");
         FieldProvider<Field>resolver = new FullQualifedNameFieldProvider(dummySources);
         resolver.resolveField(newQN("dummy.invalid.name"), Operation.READ);
     }
 
     @Test
     public void testSysColumnWithoutSourceRelation() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expect(RelationUnknownException.class);
         expectedException.expectMessage("Cannot resolve relation 'sys.nodes'");
         FieldProvider<Field>resolver = new FullQualifedNameFieldProvider(dummySources);
 

--- a/sql/src/test/java/io/crate/analyze/relations/RelationAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/relations/RelationAnalyzerTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.analyze.relations;
+
+import io.crate.analyze.BaseAnalyzerTest;
+import io.crate.exceptions.ValidationException;
+import io.crate.operation.operator.OperatorModule;
+import io.crate.testing.MockedClusterServiceModule;
+import io.crate.testing.T3;
+import org.elasticsearch.common.inject.Module;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.List;
+
+public class RelationAnalyzerTest extends BaseAnalyzerTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Override
+    protected List<Module> getModules() {
+        List<Module> modules = super.getModules();
+        modules.add(new MockedClusterServiceModule());
+        modules.add(new OperatorModule());
+        modules.add(T3.META_DATA_MODULE);
+        return modules;
+    }
+    @Test
+    public void testValidateUsedRelationsInJoinConditions() throws Exception {
+        expectedException.expect(ValidationException.class);
+        expectedException.expectMessage("missing FROM-clause entry for relation 't3'");
+        analyze("select * from t1 join t2 on t1.a = t3.c join t3 on t2.b = t3.c");
+    }
+}

--- a/sql/src/test/java/io/crate/integrationtests/SysShardsTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysShardsTest.java
@@ -264,7 +264,7 @@ public class SysShardsTest extends SQLTransportIntegrationTest {
     @Test
     public void testSelectShardIdFromSysNodes() throws Exception {
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("Cannot resolve relation 'shards'");
+        expectedException.expectMessage("Cannot resolve relation 'sys.shards'");
         execute("select sys.shards.id from sys.nodes");
     }
 


### PR DESCRIPTION
it was possible to use a symbol of a not yet defined relation
as a join condition, like e.g. 
`from t1 join t2 on t1.id = t3.id join t3 on...`