### PR TITLE
do not allow restoring a snapshot of a single partition into non-existent table

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fix: do not allow restoring a snapshot of a single partition if the table
+   does not exists. Previously this caused an orphaned partition.
+
  - Fix: Join conditions were not properly validated and an expression
    with a not yet defined relation could be used.
 

--- a/blackbox/docs/sql/snapshot_restore.txt
+++ b/blackbox/docs/sql/snapshot_restore.txt
@@ -157,10 +157,8 @@ table the partition belongs to.
     RESTORE OK, 1 row affected (... sec)
 
 
-Or if no matching partition table exists, it will be implicitly
-created during restore.
-
-::
+A single snapshotted partition can only be restored to an existing table.
+If the table does not exist, restoring the single partition will fail::
 
     cr> DROP TABLE parted_table;
     DROP OK, 1 row affected (... sec)
@@ -168,7 +166,7 @@ created during restore.
     cr> RESTORE SNAPSHOT where_my_snapshots_go.snapshot3 TABLE
     ...    parted_table PARTITION (date=0)
     ... WITH (wait_for_completion=true);
-    RESTORE OK, 1 row affected (... sec)
+    SQLActionException[UnsupportedFeatureException: Cannot restore snapshot of single partition [.partitioned.parted_table.04130] into non-existent table.]
 
 
 Cleanup
@@ -207,8 +205,6 @@ repository in the cluster state, so it's not accessible any more.
 
 .. Hidden: cleanup
 
-    cr> DROP TABLE parted_table;
-    DROP OK, 1 row affected (... sec)
     cr> DROP SNAPSHOT where_my_snapshots_go.snapshot1;
     DROP OK, 1 row affected (... sec)
     cr> DROP SNAPSHOT where_my_snapshots_go.snapshot2;

--- a/sql/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
@@ -24,7 +24,6 @@ package io.crate.integrationtests;
 
 import com.google.common.base.Joiner;
 import io.crate.action.sql.SQLActionException;
-import io.crate.exceptions.UnsupportedFeatureException;
 import io.crate.testing.TestingHelpers;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.cluster.SnapshotsInProgress;
@@ -69,7 +68,8 @@ public class SnapshotRestoreIntegrationTest extends SQLTransportIntegrationTest 
 
     @After
     public void resetSettings() throws Exception {
-        execute("reset GLOBAL cluster.routing.allocation.enable");
+        execute("DROP REPOSITORY " + REPOSITORY_NAME);
+        execute("RESET GLOBAL cluster.routing.allocation.enable");
         waitNoPendingTasksOnAll();
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
@@ -296,7 +296,7 @@ public class SnapshotRestoreIntegrationTest extends SQLTransportIntegrationTest 
     }
 
     @Test
-    public void testSnapshotRestoreSnapshotSinglePartitionWithDroppedPartition() throws Exception {
+    public void testRestoreSinglePartitionSnapshotIntoDroppedPartition() throws Exception {
         createTable("parted_table", true);
         execute("CREATE SNAPSHOT " + snapshotName() + " TABLE parted_table PARTITION (date=0) WITH (wait_for_completion=true)");
         execute("delete from parted_table where date=0");
@@ -309,7 +309,7 @@ public class SnapshotRestoreIntegrationTest extends SQLTransportIntegrationTest 
     }
 
     @Test
-    public void testSnapshotRestoreSnapshotSinglePartitionWithDroppedTable() throws Exception {
+    public void testRestoreSinglePartitionSnapshotIntoDroppedTable() throws Exception {
         expectedException.expect(SQLActionException.class);
         expectedException.expectMessage("Cannot restore snapshot of single partition [.partitioned.parted_table.04130] into non-existent table.");
         createTable("parted_table", true);
@@ -322,7 +322,7 @@ public class SnapshotRestoreIntegrationTest extends SQLTransportIntegrationTest 
     }
 
     @Test
-    public void testRestoreSnapshotSinglePartitionWithDroppedTable() throws Exception {
+    public void testRestoreFullPartedTableSnapshotSinglePartitionIntoDroppedTable() throws Exception {
         createTableAndSnapshot("my_parted_table", SNAPSHOT_NAME, true);
 
         execute("drop table my_parted_table");


### PR DESCRIPTION
upstream change: https://github.com/crate/elasticsearch/pull/91

@mfussenegger can you take a look please