### PR TITLE
removes invalid assertion which was thrown by a valid race condition

### DIFF
--- a/sql/src/main/java/io/crate/jobs/JobExecutionContext.java
+++ b/sql/src/main/java/io/crate/jobs/JobExecutionContext.java
@@ -158,7 +158,6 @@ public class JobExecutionContext implements CompletionListenable {
     }
 
     public void start() throws Throwable {
-        assert failure == null;
         for (Integer id : orderedContextIds) {
             ExecutionSubContext subContext = subContexts.get(id);
             if (subContext == null || closed.get()) {


### PR DESCRIPTION
on job context start, it was asserted to not have a failure already but if the context was killed before it was started, having a failure set is totally valid.
this solves flakyness of the `testKilledAllLog` test.