### PR TITLE
always include global meta data for snapshots

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,11 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fix: Now it is also possible to restore a snapshot of a single partition
+   of a partitioned table in a non-existent table.
+   This requires that the snapshot has been created with version ``0.55.5``
+   or greater!
+
  - Fix: Join conditions were not properly validated and an expression
    with a not yet defined relation could be used.
 

--- a/blackbox/docs/sql/snapshot_restore.txt
+++ b/blackbox/docs/sql/snapshot_restore.txt
@@ -160,6 +160,14 @@ table the partition belongs to.
 Or if no matching partition table exists, it will be implicitly
 created during restore.
 
+.. note::
+
+    This is only possible with Crate version 0.55.5 or greater!
+    Snapshots of single partitions that have been created with earlier versions
+    of Crate may be restored, but lead to orphaned partitions!
+    When using Crate prior to 0.55.5 you will have to create the table schema
+    first before restoring.
+
 ::
 
     cr> DROP TABLE parted_table;

--- a/sql/src/main/java/io/crate/analyze/CreateSnapshotStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateSnapshotStatementAnalyzer.java
@@ -94,7 +94,6 @@ public class CreateSnapshotStatementAnalyzer extends AbstractRepositoryDDLAnalyz
         if (node.tableList().isPresent()) {
             List<Table> tableList = node.tableList().get();
             Set<String> snapshotIndices = new HashSet<>(tableList.size());
-            boolean includeMetadata = false;
             for (Table table : tableList) {
                 TableInfo tableInfo;
                 try {
@@ -114,9 +113,6 @@ public class CreateSnapshotStatementAnalyzer extends AbstractRepositoryDDLAnalyz
                 Operation.blockedRaiseException(tableInfo, Operation.READ);
                 DocTableInfo docTableInfo = (DocTableInfo)tableInfo;
                 if (table.partitionProperties().isEmpty()) {
-                    if (docTableInfo.isPartitioned()) {
-                        includeMetadata = true;
-                    }
                     snapshotIndices.addAll(Arrays.asList(docTableInfo.concreteIndices()));
                 } else {
                     PartitionName partitionName = PartitionPropertiesAnalyzer.toPartitionName(
@@ -131,14 +127,21 @@ public class CreateSnapshotStatementAnalyzer extends AbstractRepositoryDDLAnalyz
                             LOGGER.info("ignoring unknown partition of table '{}' with ident '{}'", partitionName.tableIdent(), partitionName.ident());
                         }
                     } else {
-                        // we don't include metadata when snapshotting partitions
-                        // thus, they cant be recreated without a partitioned table or
-                        // turned into a partitioned table with itself as single partition again
                         snapshotIndices.add(partitionName.asIndexName());
                     }
                 }
             }
-            return CreateSnapshotAnalyzedStatement.forTables(snapshotId, settings, ImmutableList.copyOf(snapshotIndices), includeMetadata);
+            /**
+             * For now, we always (in case there are indices to restore) include the globalMetaData,
+             * not only if one of the tables in the table list is partitioned.
+             * Previously we only included it in snapshots of full partitioned tables.
+             * However, to make restoring of shapshots of single partitions work
+             * we also need to include the global metadata (index templates).
+             */
+            return CreateSnapshotAnalyzedStatement.forTables(snapshotId,
+                settings,
+                ImmutableList.copyOf(snapshotIndices),
+                !snapshotIndices.isEmpty());
         } else {
             for (SchemaInfo schemaInfo : schemas) {
                 for (TableInfo tableInfo : schemaInfo) {

--- a/sql/src/test/java/io/crate/analyze/SnapshotRestoreAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SnapshotRestoreAnalyzerTest.java
@@ -177,9 +177,9 @@ public class SnapshotRestoreAnalyzerTest extends BaseAnalyzerTest {
     }
 
     @Test
-    public void testCreateSnapshotDontIncludeMetadataWithPartitionOnly() throws Exception {
+    public void testCreateSnapshotIncludeMetadataWithPartitionOnly() throws Exception {
         CreateSnapshotAnalyzedStatement statement = (CreateSnapshotAnalyzedStatement) analyze("CREATE SNAPSHOT my_repo.my_snapshot TABLE parted PARTITION (date=null)");
-        assertThat(statement.includeMetadata(), is(false));
+        assertThat(statement.includeMetadata(), is(true));
     }
 
     @Test
@@ -188,7 +188,7 @@ public class SnapshotRestoreAnalyzerTest extends BaseAnalyzerTest {
         assertThat(statement.indices(), containsInAnyOrder("users", "locations"));
         assertThat(statement.isAllSnapshot(), is(false));
         assertThat(statement.snapshotId(), is(new SnapshotId("my_repo", "my_snapshot")));
-        assertThat(statement.includeMetadata(), is(false));
+        assertThat(statement.includeMetadata(), is(true));
         assertThat(statement.snapshotSettings().getAsMap().size(), is(2));
         assertThat(statement.snapshotSettings().getAsMap(),
                 allOf(

--- a/sql/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
@@ -69,8 +69,12 @@ public class SnapshotRestoreIntegrationTest extends SQLTransportIntegrationTest 
 
     @After
     public void resetSettings() throws Exception {
-        execute("reset GLOBAL cluster.routing.allocation.enable");
-        waitNoPendingTasksOnAll();
+        try {
+            execute("DROP REPOSITORY " + REPOSITORY_NAME);
+        } finally {
+            execute("RESET GLOBAL cluster.routing.allocation.enable");
+            waitNoPendingTasksOnAll();
+        }
     }
 
     private void createTableAndSnapshot(String tableName, String snapshotName) {
@@ -89,7 +93,7 @@ public class SnapshotRestoreIntegrationTest extends SQLTransportIntegrationTest 
                 "  date timestamp " + (partitioned ? "primary key," : ",") +
                 "  ft string index using fulltext with (analyzer='german')" +
                 ") " + (partitioned ? "partitioned by (date) " : "") +
-                "with (number_of_replicas=0)");
+                "clustered into 1 shards with (number_of_replicas=0)");
         ensureYellow();
         execute("INSERT INTO " + tableName + " (id, name, date, ft) VALUES (?, ?, ?, ?)", new Object[][]{
                 {1L, "foo", "1970-01-01", "The quick brown fox jumps over the lazy dog."},
@@ -296,7 +300,33 @@ public class SnapshotRestoreIntegrationTest extends SQLTransportIntegrationTest 
     }
 
     @Test
-    public void testRestoreSnapshotSinglePartitionWithDroppedTable() throws Exception {
+    public void testRestoreSinglePartitionSnapshotIntoDroppedPartition() throws Exception {
+        createTable("parted_table", true);
+        execute("CREATE SNAPSHOT " + snapshotName() + " TABLE parted_table PARTITION (date=0) WITH (wait_for_completion=true)");
+        execute("delete from parted_table where date=0");
+        waitNoPendingTasksOnAll();
+        execute("RESTORE SNAPSHOT " + snapshotName() + " TABLE parted_table PARTITION (date=0) with (" +
+                "ignore_unavailable=false, " +
+                "wait_for_completion=true)");
+        execute("select date from parted_table order by id");
+        assertThat(TestingHelpers.printedTable(response.rows()), is("0\n1445941740000\n626572800000\n"));
+    }
+
+    @Test
+    public void testRestoreSinglePartitionSnapshotIntoDroppedTable() throws Exception {
+        createTable("parted_table", true);
+        execute("CREATE SNAPSHOT " + snapshotName() + " TABLE parted_table PARTITION (date=0) WITH (wait_for_completion=true)");
+        execute("drop table parted_table");
+        waitNoPendingTasksOnAll();
+        execute("RESTORE SNAPSHOT " + snapshotName() + " TABLE parted_table PARTITION (date=0) with (" +
+                "ignore_unavailable=false, " +
+                "wait_for_completion=true)");
+        execute("select date from parted_table order by id");
+        assertThat(TestingHelpers.printedTable(response.rows()), is("0\n"));
+    }
+
+    @Test
+    public void testRestoreFullPartedTableSnapshotSinglePartitionIntoDroppedTable() throws Exception {
         createTableAndSnapshot("my_parted_table", SNAPSHOT_NAME, true);
 
         execute("drop table my_parted_table");


### PR DESCRIPTION
This allows to also restore a snapshot of a single partition into a non-existent
table. This, however, requires that the snapshot has been created with version
``0.55.5`` or greater!

@seut @mfussenegger please