### PR TITLE
always include global meta data for snapshots

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,11 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fix: Now it is also possible to restore a snapshot of a single partition
+   of a partitioned table in a non-existent table.
+   This requires that the snapshot has been created with version ``0.55.5``
+   or greater!
+
  - Added the sys.summits table. The table contains the information about
    mountains in the Alps higher than 2000 meters, which are used as node names.
 

--- a/blackbox/docs/sql/snapshot_restore.txt
+++ b/blackbox/docs/sql/snapshot_restore.txt
@@ -160,6 +160,14 @@ table the partition belongs to.
 Or if no matching partition table exists, it will be implicitly
 created during restore.
 
+.. note::
+
+    This is only possible with Crate version 0.55.5 or greater!
+    Snapshots of single partitions that have been created with earlier versions
+    of Crate may be restored, but lead to orphaned partitions!
+    When using Crate prior to 0.55.5 you will have to create the table schema
+    first before restoring.
+
 ::
 
     cr> DROP TABLE parted_table;

--- a/sql/src/test/java/io/crate/analyze/SnapshotRestoreAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SnapshotRestoreAnalyzerTest.java
@@ -177,9 +177,9 @@ public class SnapshotRestoreAnalyzerTest extends BaseAnalyzerTest {
     }
 
     @Test
-    public void testCreateSnapshotDontIncludeMetadataWithPartitionOnly() throws Exception {
+    public void testCreateSnapshotIncludeMetadataWithPartitionOnly() throws Exception {
         CreateSnapshotAnalyzedStatement statement = (CreateSnapshotAnalyzedStatement) analyze("CREATE SNAPSHOT my_repo.my_snapshot TABLE parted PARTITION (date=null)");
-        assertThat(statement.includeMetadata(), is(false));
+        assertThat(statement.includeMetadata(), is(true));
     }
 
     @Test
@@ -188,7 +188,7 @@ public class SnapshotRestoreAnalyzerTest extends BaseAnalyzerTest {
         assertThat(statement.indices(), containsInAnyOrder("users", "locations"));
         assertThat(statement.isAllSnapshot(), is(false));
         assertThat(statement.snapshotId(), is(new SnapshotId("my_repo", "my_snapshot")));
-        assertThat(statement.includeMetadata(), is(false));
+        assertThat(statement.includeMetadata(), is(true));
         assertThat(statement.snapshotSettings().getAsMap().size(), is(2));
         assertThat(statement.snapshotSettings().getAsMap(),
                 allOf(


### PR DESCRIPTION
This allows to also restore a snapshot of a single partition into a non-existent
table. This, however, requires that the snapshot has been created with version
``0.55.5`` or greater!

the initial fix was on `0.55` branch: https://github.com/crate/crate/commit/bba8553ed3a52b057dbfb1c880bc0eb740bced68