### PR TITLE
Clean-up naming in PartitionExpression

### DIFF
--- a/sql/src/main/java/io/crate/metadata/PartitionReferenceResolver.java
+++ b/sql/src/main/java/io/crate/metadata/PartitionReferenceResolver.java
@@ -29,7 +29,7 @@ import java.util.Map;
 
 public class PartitionReferenceResolver implements NestedReferenceResolver {
 
-    private final Map<ReferenceIdent, PartitionExpression> expressionMap = new HashMap<>();
+    private final Map<ReferenceIdent, PartitionExpression> expressionMap;
     private final NestedReferenceResolver fallbackResolver;
     private final List<PartitionExpression> partitionExpressions;
 
@@ -37,15 +37,16 @@ public class PartitionReferenceResolver implements NestedReferenceResolver {
                                       List<PartitionExpression> partitionExpressions) {
         this.fallbackResolver = fallbackReferenceResolver;
         this.partitionExpressions = partitionExpressions;
+        this.expressionMap = new HashMap<>(partitionExpressions.size(), 1.0f);
         for (PartitionExpression partitionExpression : partitionExpressions) {
-            expressionMap.put(partitionExpression.info().ident(), partitionExpression);
+            expressionMap.put(partitionExpression.reference().ident(), partitionExpression);
         }
     }
 
     @Override
-    public ReferenceImplementation getImplementation(Reference refInfo) {
-        PartitionExpression expression = expressionMap.get(refInfo.ident());
-        assert expression != null || fallbackResolver.getImplementation(refInfo) == null
+    public ReferenceImplementation getImplementation(Reference ref) {
+        PartitionExpression expression = expressionMap.get(ref.ident());
+        assert expression != null || fallbackResolver.getImplementation(ref) == null
                 : "granularity < PARTITION should have been resolved already";
         return expression;
     }

--- a/sql/src/main/java/io/crate/operation/reference/partitioned/PartitionExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/partitioned/PartitionExpression.java
@@ -27,21 +27,21 @@ import io.crate.metadata.RowContextCollectorExpression;
 
 public class PartitionExpression extends RowContextCollectorExpression<PartitionName, Object> {
 
-    private final Reference info;
+    private final Reference ref;
     private final int valuesIndex;
 
-    public PartitionExpression(Reference info, int valuesIndex) {
-        this.info = info;
+    public PartitionExpression(Reference ref, int valuesIndex) {
+        this.ref = ref;
         this.valuesIndex = valuesIndex;
     }
 
     @Override
     public Object value() {
         assert row != null : "row shouldn't be null for PartitionExpression";
-        return info.valueType().value(row.values().get(valuesIndex));
+        return ref.valueType().value(row.values().get(valuesIndex));
     }
 
-    public Reference info() {
-        return info;
+    public Reference reference() {
+        return ref;
     }
 }


### PR DESCRIPTION
Still used "info" which was a left-over from when we had a class called
`ReferenceInfo`.