### PR TITLE
Remove filter handling out of NestedLoopOperation

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,7 @@ Changes for Crate
 Unreleased
 ==========
 
- - Added outer join support.
+ - Added support for outer joins: LEFT, RIGHT and FULL.
 
  - Fix: JAR conflict if HDFS plugin with Hadoop 2.x is used.
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Added outer join support.
+
  - Fix: JAR conflict if HDFS plugin with Hadoop 2.x is used.
 
  - Fix: Now it is also possible to restore a snapshot of a single partition

--- a/blackbox/docs/architecture/joins.txt
+++ b/blackbox/docs/architecture/joins.txt
@@ -70,8 +70,9 @@ An outer join has following types:
 Joins in Crate
 ==============
 
-Crate supports (a) CROSS JOIN, (b) INNER JOIN, and (c) EQUI JOIN. To implement
-these, the nested loop join algorithm is implemented with a few optimizations.
+Crate supports (a) CROSS JOIN, (b) INNER JOIN, (c) EQUI JOIN, (d) LEFT JOIN,
+(e) RIGHT JOIN and (f) FULL JOIN. To implement these, the nested loop join
+algorithm is implemented with a few optimizations.
 
 Nested Loop Join
 ----------------

--- a/blackbox/docs/sql/joins.txt
+++ b/blackbox/docs/sql/joins.txt
@@ -83,32 +83,32 @@ Left Outer Joins
 like **Inner** join. Additionally it returns tuples for all other records from ​*left*​ that don't
 match any record on the ​*right*​ by using null values for the columns of the ​*right*​ relation::
 
-    cr> select e.name || ' ' || e.surname as employee, d.name as manager_of_department
+    cr> select e.name || ' ' || e.surname as employee, coalesce(d.name, '') as manager_of_department
     ... from employees e left join departments d
     ... on e.id = d.manager_id
     ... order by e.id;
-    +-------------------------------+-----------------------+
-    | employee                      | manager_of_department |
-    +-------------------------------+-----------------------+
-    | John Doe                      | Administration        |
-    | John Smith                    | IT                    |
-    | Sean Lee                      |                       |
-    | Rebecca Sean                  |                       |
-    | Tim Ducan                     |                       |
-    | Robert Duval                  |                       |
-    | Clint Johnson                 |                       |
-    | Sarrah Mcmillan               |                       |
-    | David Limb                    |                       |
-    | David Bowe                    |                       |
-    | Smith Clark                   | Marketing             |
-    | Ted Kennedy                   |                       |
-    | Ronald Reagan                 |                       |
-    | Franlkin Rossevelt            |                       |
-    | Sam Malone                    |                       |
-    | Marry Georgia                 |                       |
-    | Tim Doe                       | Human Resources       |
-    | Tim Malone                    | Purchasing            |
-    +-------------------------------+-----------------------+
+    +--------------------+-----------------------+
+    | employee           | manager_of_department |
+    +--------------------+-----------------------+
+    | John Doe           | Administration        |
+    | John Smith         | IT                    |
+    | Sean Lee           |                       |
+    | Rebecca Sean       |                       |
+    | Tim Ducan          |                       |
+    | Robert Duval       |                       |
+    | Clint Johnson      |                       |
+    | Sarrah Mcmillan    |                       |
+    | David Limb         |                       |
+    | David Bowe         |                       |
+    | Smith Clark        | Marketing             |
+    | Ted Kennedy        |                       |
+    | Ronald Reagan      |                       |
+    | Franklin Rossevelt |                       |
+    | Sam Malone         |                       |
+    | Marry Georgia      |                       |
+    | Tim Doe            | Human Resources       |
+    | Tim Malone         | Purchasing            |
+    +--------------------+-----------------------+
     SELECT 18 rows in set (... sec)
 
 Right Outer Joins
@@ -122,16 +122,16 @@ match any record on the ​*left*​ by using null values for the columns of the
     ... from employees e right join departments d
     ... on e.id = d.manager_id
     ... order by d.id;
-    +-------------------------------+-----------------------+
-    | employee                      | manager_of_department |
-    +-------------------------------+-----------------------+
-    | John Doe                      | Administration        |
-    | Smith Clark                   | Marketing             |
-    | Tim Malone                    | Purchasing            |
-    | Tim Doe                       | Human Resources       |
-    |                               | Shipping              |
-    | John Smith                    | IT                    |
-    +-------------------------------+-----------------------+
+    +-------------+-----------------------+
+    | employee    | manager_of_department |
+    +-------------+-----------------------+
+    | John Doe    | Administration        |
+    | Smith Clark | Marketing             |
+    | Tim Malone  | Purchasing            |
+    | Tim Doe     | Human Resources       |
+    |             | Shipping              |
+    | John Smith  | IT                    |
+    +-------------+-----------------------+
     SELECT 6 rows in set (... sec)
 
 Full Outer Joins
@@ -143,33 +143,33 @@ match any record on the ​*right*​ by using null values for the columns of th
 Additionally it returns tuples for all other records from ​*right*​ that don't match any record on
 the ​*left*​ by using null values for the columns of the ​*left*​ relation::
 
-    cr> select e.name || ' ' || e.surname as employee, d.name as manager_of_department
+    cr> select e.name || ' ' || e.surname as employee, coalesce(d.name, '') as manager_of_department
     ... from employees e full join departments d
     ... on e.id = d.manager_id
     ... order by e.id;
-    +-------------------------------+-----------------------+
-    | employee                      | manager_of_department |
-    +-------------------------------+-----------------------+
-    | John Doe                      | Administration        |
-    | John Smith                    | IT                    |
-    | Sean Lee                      |                       |
-    | Rebecca Sean                  |                       |
-    | Tim Ducan                     |                       |
-    | Robert Duval                  |                       |
-    | Clint Johnson                 |                       |
-    | Sarrah Mcmillan               |                       |
-    | David Limb                    |                       |
-    | David Bowe                    |                       |
-    | Smith Clark                   | Marketing             |
-    | Ted Kennedy                   |                       |
-    | Ronald Reagan                 |                       |
-    | Franlkin Rossevelt            |                       |
-    | Sam Malone                    |                       |
-    | Marry Georgia                 |                       |
-    | Tim Doe                       | Human Resources       |
-    | Tim Malone                    | Purchasing            |
-    |                               | Shipping              |
-    +-------------------------------+-----------------------+
+    +--------------------+-----------------------+
+    | employee           | manager_of_department |
+    +--------------------+-----------------------+
+    | John Doe           | Administration        |
+    | John Smith         | IT                    |
+    | Sean Lee           |                       |
+    | Rebecca Sean       |                       |
+    | Tim Ducan          |                       |
+    | Robert Duval       |                       |
+    | Clint Johnson      |                       |
+    | Sarrah Mcmillan    |                       |
+    | David Limb         |                       |
+    | David Bowe         |                       |
+    | Smith Clark        | Marketing             |
+    | Ted Kennedy        |                       |
+    | Ronald Reagan      |                       |
+    | Franklin Rossevelt |                       |
+    | Sam Malone         |                       |
+    | Marry Georgia      |                       |
+    | Tim Doe            | Human Resources       |
+    | Tim Malone         | Purchasing            |
+    |                    | Shipping              |
+    +--------------------+-----------------------+
     SELECT 19 rows in set (... sec)
 
 Join Conditions

--- a/blackbox/docs/sql/joins.txt
+++ b/blackbox/docs/sql/joins.txt
@@ -76,6 +76,102 @@ the other table::
     +----+------------+------------------+
     SELECT 4 rows in set (... sec)
 
+Left Outer Joins
+----------------
+
+**Left** outer join returns tuples for all matching records of the ​*left*​ and ​*right*​ relation
+like **Inner** join. Additionally it returns tuples for all other records from ​*left*​ that don't
+match any record on the ​*right*​ by using null values for the columns of the ​*right*​ relation::
+
+    cr> select e.name || ' ' || e.surname as employee, d.name as manager_of_department
+    ... from employees e left join departments d
+    ... on e.id = d.manager_id
+    ... order by e.id;
+    +-------------------------------+-----------------------+
+    | employee                      | manager_of_department |
+    +-------------------------------+-----------------------+
+    | John Doe                      | Administration        |
+    | John Smith                    | IT                    |
+    | Sean Lee                      |                       |
+    | Rebecca Sean                  |                       |
+    | Tim Ducan                     |                       |
+    | Robert Duval                  |                       |
+    | Clint Johnson                 |                       |
+    | Sarrah Mcmillan               |                       |
+    | David Limb                    |                       |
+    | David Bowe                    |                       |
+    | Smith Clark                   | Marketing             |
+    | Ted Kennedy                   |                       |
+    | Ronald Reagan                 |                       |
+    | Franlkin Rossevelt            |                       |
+    | Sam Malone                    |                       |
+    | Marry Georgia                 |                       |
+    | Tim Doe                       | Human Resources       |
+    | Tim Malone                    | Purchasing            |
+    +-------------------------------+-----------------------+
+    SELECT 18 rows in set (... sec)
+
+Right Outer Joins
+-----------------
+
+**Right** outer join returns tuples for all matching records of the ​*right*​ and ​*left*​ relation
+like **Inner** join. Additionally it returns tuples for all other records from ​*right*​ that don't
+match any record on the ​*left*​ by using null values for the columns of the ​*left*​ relation::
+
+    cr> select e.name || ' ' || e.surname as employee, d.name as manager_of_department
+    ... from employees e right join departments d
+    ... on e.id = d.manager_id
+    ... order by d.id;
+    +-------------------------------+-----------------------+
+    | employee                      | manager_of_department |
+    +-------------------------------+-----------------------+
+    | John Doe                      | Administration        |
+    | Smith Clark                   | Marketing             |
+    | Tim Malone                    | Purchasing            |
+    | Tim Doe                       | Human Resources       |
+    |                               | Shipping              |
+    | John Smith                    | IT                    |
+    +-------------------------------+-----------------------+
+    SELECT 6 rows in set (... sec)
+
+Full Outer Joins
+----------------
+
+**Full** outer join returns tuples for all matching records of the ​*left*​ and ​*right*​ relation
+like **Inner** join. Additionally it returns tuples for all other records from ​*left*​ that don't
+match any record on the ​*right*​ by using null values for the columns of the ​*right*​ relation.
+Additionally it returns tuples for all other records from ​*right*​ that don't match any record on
+the ​*left*​ by using null values for the columns of the ​*left*​ relation::
+
+    cr> select e.name || ' ' || e.surname as employee, d.name as manager_of_department
+    ... from employees e full join departments d
+    ... on e.id = d.manager_id
+    ... order by e.id;
+    +-------------------------------+-----------------------+
+    | employee                      | manager_of_department |
+    +-------------------------------+-----------------------+
+    | John Doe                      | Administration        |
+    | John Smith                    | IT                    |
+    | Sean Lee                      |                       |
+    | Rebecca Sean                  |                       |
+    | Tim Ducan                     |                       |
+    | Robert Duval                  |                       |
+    | Clint Johnson                 |                       |
+    | Sarrah Mcmillan               |                       |
+    | David Limb                    |                       |
+    | David Bowe                    |                       |
+    | Smith Clark                   | Marketing             |
+    | Ted Kennedy                   |                       |
+    | Ronald Reagan                 |                       |
+    | Franlkin Rossevelt            |                       |
+    | Sam Malone                    |                       |
+    | Marry Georgia                 |                       |
+    | Tim Doe                       | Human Resources       |
+    | Tim Malone                    | Purchasing            |
+    |                               | Shipping              |
+    +-------------------------------+-----------------------+
+    SELECT 19 rows in set (... sec)
+
 Join Conditions
 ...............
 

--- a/blackbox/docs/sql/reference/select.txt
+++ b/blackbox/docs/sql/reference/select.txt
@@ -126,11 +126,11 @@ A ``joined_relation`` is a relation which joins two relations together. See
     relation { , | join_type JOIN } relation [ ON join_condition ]
 
 
-:join_type: Either CROSS or INNER. Other types are not supported
+:join_type: LEFT [OUTER], RIGHT [OUTER], FULL [OUTER], CROSS or INNER.
 
 :join_condition: An expression which specifies which rows in a join are
-                 considered a match. The join_condition is only applicable for
-                 joins of type INNER and must have a returning value of type
+                 considered a match. The join_condition is not applicable for
+                 joins of type CROSS and must have a returning value of type
                  ``boolean``.
 
 Table Function

--- a/core/src/main/java/io/crate/core/collections/RowNull.java
+++ b/core/src/main/java/io/crate/core/collections/RowNull.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.core.collections;
+
+/**
+ * A {@link Row} implementation which returns null for every column index
+ */
+public class RowNull implements Row {
+
+    final int size;
+
+    public RowNull(int size) {
+        this.size = size;
+    }
+
+    @Override
+    public int size() {
+        return size;
+    }
+
+    @Override
+    public Object get(int index) {
+        return null;
+    }
+
+    @Override
+    public Object[] materialize() {
+        return new Object[size];
+    }
+}

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -753,8 +753,11 @@ public class TestStatementBuilder {
         printStatement("select * from foo inner join bar on foo.id = bar.id");
 
         printStatement("select * from foo left outer join bar on foo.id = bar.id");
+        printStatement("select * from foo left join bar on foo.id = bar.id");
         printStatement("select * from foo right outer join bar on foo.id = bar.id");
+        printStatement("select * from foo right join bar on foo.id = bar.id");
         printStatement("select * from foo full outer join bar on foo.id = bar.id");
+        printStatement("select * from foo full join bar on foo.id = bar.id");
     }
 
     private static void printStatement(String sql)

--- a/sql/src/benchmarks/java/io/crate/operation/join/NestedLoopOperationBenchmark.java
+++ b/sql/src/benchmarks/java/io/crate/operation/join/NestedLoopOperationBenchmark.java
@@ -124,7 +124,8 @@ public class NestedLoopOperationBenchmark {
         Iterable<Row> right = RowSender.rowRange(0, rightSize);
 
         RowCountRowReceiver receiver = new RowCountRowReceiver();
-        NestedLoopOperation operation = new NestedLoopOperation(0, receiver, Predicates.<Row>alwaysTrue(), JoinType.CROSS, 0);
+        NestedLoopOperation operation = new NestedLoopOperation(0, receiver, Predicates.<Row>alwaysTrue(),
+            JoinType.CROSS, 0, 0);
         ListenableRowReceiver leftSide = operation.leftRowReceiver();
         ListenableRowReceiver rightSide = operation.rightRowReceiver();
 

--- a/sql/src/benchmarks/java/io/crate/operation/join/NestedLoopOperationBenchmark.java
+++ b/sql/src/benchmarks/java/io/crate/operation/join/NestedLoopOperationBenchmark.java
@@ -28,9 +28,11 @@ import com.carrotsearch.junitbenchmarks.annotation.AxisRange;
 import com.carrotsearch.junitbenchmarks.annotation.BenchmarkHistoryChart;
 import com.carrotsearch.junitbenchmarks.annotation.BenchmarkMethodChart;
 import com.carrotsearch.junitbenchmarks.annotation.LabelType;
+import com.google.common.base.Predicates;
 import io.crate.core.collections.Bucket;
 import io.crate.core.collections.Row;
 import io.crate.operation.projectors.ListenableRowReceiver;
+import io.crate.planner.node.dql.join.JoinType;
 import io.crate.testing.RowCountRowReceiver;
 import io.crate.testing.RowSender;
 import org.elasticsearch.common.unit.TimeValue;
@@ -122,7 +124,7 @@ public class NestedLoopOperationBenchmark {
         Iterable<Row> right = RowSender.rowRange(0, rightSize);
 
         RowCountRowReceiver receiver = new RowCountRowReceiver();
-        NestedLoopOperation operation = new NestedLoopOperation(0, receiver);
+        NestedLoopOperation operation = new NestedLoopOperation(0, receiver, Predicates.<Row>alwaysTrue(), JoinType.CROSS, 0);
         ListenableRowReceiver leftSide = operation.leftRowReceiver();
         ListenableRowReceiver rightSide = operation.rightRowReceiver();
 

--- a/sql/src/benchmarks/java/io/crate/operation/join/NestedLoopOperationBenchmark.java
+++ b/sql/src/benchmarks/java/io/crate/operation/join/NestedLoopOperationBenchmark.java
@@ -124,8 +124,8 @@ public class NestedLoopOperationBenchmark {
         Iterable<Row> right = RowSender.rowRange(0, rightSize);
 
         RowCountRowReceiver receiver = new RowCountRowReceiver();
-        NestedLoopOperation operation = new NestedLoopOperation(0, receiver, Predicates.<Row>alwaysTrue(),
-            JoinType.CROSS, 0, 0);
+        NestedLoopOperation operation = new NestedLoopOperation(
+            0, receiver, Predicates.<Row>alwaysTrue(), Predicates.<Row>alwaysTrue(), JoinType.CROSS, 0, 0);
         ListenableRowReceiver leftSide = operation.leftRowReceiver();
         ListenableRowReceiver rightSide = operation.rightRowReceiver();
 

--- a/sql/src/benchmarks/java/io/crate/operation/join/NestedLoopOperationBenchmark.java
+++ b/sql/src/benchmarks/java/io/crate/operation/join/NestedLoopOperationBenchmark.java
@@ -125,7 +125,7 @@ public class NestedLoopOperationBenchmark {
 
         RowCountRowReceiver receiver = new RowCountRowReceiver();
         NestedLoopOperation operation = new NestedLoopOperation(
-            0, receiver, Predicates.<Row>alwaysTrue(), Predicates.<Row>alwaysTrue(), JoinType.CROSS, 0, 0);
+            0, receiver, Predicates.<Row>alwaysTrue(), JoinType.CROSS, 0, 0);
         ListenableRowReceiver leftSide = operation.leftRowReceiver();
         ListenableRowReceiver rightSide = operation.rightRowReceiver();
 

--- a/sql/src/main/java/io/crate/action/job/ContextPreparer.java
+++ b/sql/src/main/java/io/crate/action/job/ContextPreparer.java
@@ -573,6 +573,7 @@ public class ContextPreparer extends AbstractComponent {
                 flatProjectorChain.firstProjector(),
                 rowFilter,
                 phase.joinType(),
+                phase.numLeftOutputs(),
                 phase.numRightOutputs());
             PageDownstreamContext left = pageDownstreamContextForNestedLoop(
                 phase.executionPhaseId(),

--- a/sql/src/main/java/io/crate/action/job/ContextPreparer.java
+++ b/sql/src/main/java/io/crate/action/job/ContextPreparer.java
@@ -571,7 +571,8 @@ public class ContextPreparer extends AbstractComponent {
             NestedLoopOperation nestedLoopOperation = new NestedLoopOperation(
                 phase.executionPhaseId(),
                 flatProjectorChain.firstProjector(),
-                rowFilter);
+                rowFilter,
+                phase.joinType());
             PageDownstreamContext left = pageDownstreamContextForNestedLoop(
                 phase.executionPhaseId(),
                 context,

--- a/sql/src/main/java/io/crate/action/job/ContextPreparer.java
+++ b/sql/src/main/java/io/crate/action/job/ContextPreparer.java
@@ -572,7 +572,8 @@ public class ContextPreparer extends AbstractComponent {
                 phase.executionPhaseId(),
                 flatProjectorChain.firstProjector(),
                 rowFilter,
-                phase.joinType());
+                phase.joinType(),
+                phase.numRightOutputs());
             PageDownstreamContext left = pageDownstreamContextForNestedLoop(
                 phase.executionPhaseId(),
                 context,

--- a/sql/src/main/java/io/crate/action/job/ContextPreparer.java
+++ b/sql/src/main/java/io/crate/action/job/ContextPreparer.java
@@ -567,11 +567,13 @@ public class ContextPreparer extends AbstractComponent {
             }
 
             Predicate<Row> rowFilter = RowFilter.create(symbolVisitor, phase.filterSymbol());
+            Predicate<Row> joinCondition = RowFilter.create(symbolVisitor, phase.joinCondition());
 
             NestedLoopOperation nestedLoopOperation = new NestedLoopOperation(
                 phase.executionPhaseId(),
                 flatProjectorChain.firstProjector(),
                 rowFilter,
+                joinCondition,
                 phase.joinType(),
                 phase.numLeftOutputs(),
                 phase.numRightOutputs());

--- a/sql/src/main/java/io/crate/action/job/ContextPreparer.java
+++ b/sql/src/main/java/io/crate/action/job/ContextPreparer.java
@@ -565,14 +565,11 @@ public class ContextPreparer extends AbstractComponent {
             } else {
                 flatProjectorChain = FlatProjectorChain.withReceivers(Collections.singletonList(downstreamRowReceiver));
             }
-
-            Predicate<Row> rowFilter = RowFilter.create(symbolVisitor, phase.filterSymbol());
             Predicate<Row> joinCondition = RowFilter.create(symbolVisitor, phase.joinCondition());
 
             NestedLoopOperation nestedLoopOperation = new NestedLoopOperation(
                 phase.executionPhaseId(),
                 flatProjectorChain.firstProjector(),
-                rowFilter,
                 joinCondition,
                 phase.joinType(),
                 phase.numLeftOutputs(),

--- a/sql/src/main/java/io/crate/analyze/TwoTableJoin.java
+++ b/sql/src/main/java/io/crate/analyze/TwoTableJoin.java
@@ -30,6 +30,7 @@ import io.crate.exceptions.ColumnUnknownException;
 import io.crate.metadata.ColumnIndex;
 import io.crate.metadata.Path;
 import io.crate.metadata.table.Operation;
+import io.crate.planner.node.dql.join.JoinType;
 import io.crate.sql.tree.QualifiedName;
 
 import java.util.ArrayList;
@@ -45,13 +46,15 @@ public class TwoTableJoin implements QueriedRelation {
     private final Optional<OrderBy> remainingOrderBy;
     private final List<Field> fields;
     private final QualifiedName name;
+    private final JoinType joinType;
 
     public TwoTableJoin(QuerySpec querySpec,
                         QualifiedName leftName,
                         MultiSourceSelect.Source left,
                         QualifiedName rightName,
                         MultiSourceSelect.Source right,
-                        Optional<OrderBy> remainingOrderBy) {
+                        Optional<OrderBy> remainingOrderBy,
+                        JoinType joinType) {
         this.querySpec = querySpec;
         this.leftName = leftName;
         this.left = left;
@@ -59,6 +62,7 @@ public class TwoTableJoin implements QueriedRelation {
         this.right = right;
         this.name = QualifiedName.of("join", leftName.toString(), rightName.toString());
         this.remainingOrderBy = remainingOrderBy;
+        this.joinType = joinType;
         fields = new ArrayList<>(querySpec.outputs().size());
         for (int i = 0; i < querySpec.outputs().size(); i++) {
             fields.add(new Field(this, new ColumnIndex(i), querySpec.outputs().get(i).valueType()));
@@ -80,6 +84,10 @@ public class TwoTableJoin implements QueriedRelation {
     @Override
     public QuerySpec querySpec() {
         return querySpec;
+    }
+
+    public JoinType joinType() {
+        return joinType;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/analyze/TwoTableJoin.java
+++ b/sql/src/main/java/io/crate/analyze/TwoTableJoin.java
@@ -24,13 +24,13 @@ package io.crate.analyze;
 
 import com.google.common.base.Optional;
 import io.crate.analyze.relations.AnalyzedRelationVisitor;
+import io.crate.analyze.relations.JoinPair;
 import io.crate.analyze.relations.QueriedRelation;
 import io.crate.analyze.symbol.Field;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.metadata.ColumnIndex;
 import io.crate.metadata.Path;
 import io.crate.metadata.table.Operation;
-import io.crate.planner.node.dql.join.JoinType;
 import io.crate.sql.tree.QualifiedName;
 
 import java.util.ArrayList;
@@ -46,23 +46,21 @@ public class TwoTableJoin implements QueriedRelation {
     private final Optional<OrderBy> remainingOrderBy;
     private final List<Field> fields;
     private final QualifiedName name;
-    private final JoinType joinType;
+    private final JoinPair joinPair;
 
     public TwoTableJoin(QuerySpec querySpec,
-                        QualifiedName leftName,
                         MultiSourceSelect.Source left,
-                        QualifiedName rightName,
                         MultiSourceSelect.Source right,
                         Optional<OrderBy> remainingOrderBy,
-                        JoinType joinType) {
+                        JoinPair joinPair) {
         this.querySpec = querySpec;
-        this.leftName = leftName;
+        this.leftName = joinPair.left();
         this.left = left;
-        this.rightName = rightName;
+        this.rightName = joinPair.right();
         this.right = right;
         this.name = QualifiedName.of("join", leftName.toString(), rightName.toString());
         this.remainingOrderBy = remainingOrderBy;
-        this.joinType = joinType;
+        this.joinPair = joinPair;
         fields = new ArrayList<>(querySpec.outputs().size());
         for (int i = 0; i < querySpec.outputs().size(); i++) {
             fields.add(new Field(this, new ColumnIndex(i), querySpec.outputs().get(i).valueType()));
@@ -86,8 +84,8 @@ public class TwoTableJoin implements QueriedRelation {
         return querySpec;
     }
 
-    public JoinType joinType() {
-        return joinType;
+    public JoinPair joinPair() {
+        return joinPair;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/analyze/relations/JoinPair.java
+++ b/sql/src/main/java/io/crate/analyze/relations/JoinPair.java
@@ -25,15 +25,10 @@ package io.crate.analyze.relations;
 import com.google.common.base.Function;
 import com.google.common.base.Objects;
 import io.crate.analyze.symbol.Symbol;
-import io.crate.operation.operator.AndOperator;
 import io.crate.planner.node.dql.join.JoinType;
 import io.crate.sql.tree.QualifiedName;
 
 import javax.annotation.Nullable;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 
 public class JoinPair {
 
@@ -92,11 +87,15 @@ public class JoinPair {
         return Objects.hashCode(left, right, joinType, condition);
     }
 
-    private boolean equalsNames(QualifiedName left, QualifiedName right) {
+    public void replaceCondition(Function<? super Symbol, Symbol> replaceFunction) {
+        condition = replaceFunction.apply(condition);
+    }
+
+    boolean equalsNames(QualifiedName left, QualifiedName right) {
         return this.left.equals(left) && this.right.equals(right);
     }
 
-    private void replaceNames(QualifiedName left, QualifiedName right, QualifiedName newName) {
+    void replaceNames(QualifiedName left, QualifiedName right, QualifiedName newName) {
         if (this.left.equals(left) || this.left.equals(right)) {
             this.left = newName;
         }
@@ -105,117 +104,15 @@ public class JoinPair {
         }
     }
 
-    public void replaceCondition(Function<? super Symbol, Symbol> replaceFunction) {
-        condition = replaceFunction.apply(condition);
-    }
-
-    /**
-     * Find and return a {@link JoinPair} for the given relation names, also check for reversed names.
-     * If the {@link JoinType} is INNER and a pair is found for the reversed names, merge the join conditions.
-     */
-    public static JoinPair ofRelationsWithMergedConditions(QualifiedName left,
-                                                           QualifiedName right,
-                                                           List<JoinPair> joinPairs) {
-        JoinPair joinPair = JoinPair.ofRelations(left, right, joinPairs, true);
-        if (joinPair == null) {
-            // default to cross join (or inner, doesn't matter)
-            joinPair = new JoinPair(left, right, JoinType.CROSS);
-        }
-        // if it's an INNER, lets check for reverse relations and merge conditions
-        if (joinPair.joinType() == JoinType.INNER) {
-            JoinPair joinPairReverse = JoinPair.ofRelations(right, left, joinPairs, false);
-            if (joinPairReverse != null) {
-                joinPair.condition(AndOperator.join(Arrays.asList(joinPair.condition(), joinPairReverse.condition())));
+    boolean isOuterRelation(QualifiedName name) {
+        if (joinType.isOuter()) {
+            if (left.equals(name) && (joinType == JoinType.RIGHT || joinType == JoinType.FULL)) {
+                return true;
             }
-        }
-
-        return joinPair;
-    }
-
-    /**
-     * Returns the {@link JoinPair} of a pair of relation names based on the given list of join pairs.
-     * If <p>checkReversePairs</p> is true, also check for any {@link JoinPair} with switched names.
-     */
-    @Nullable
-    public static JoinPair ofRelations(QualifiedName left,
-                                       QualifiedName right,
-                                       List<JoinPair> joinPairs,
-                                       boolean checkReversePair) {
-        for (JoinPair joinPair : joinPairs) {
-            if (joinPair.equalsNames(left, right)) {
-                return joinPair;
-            }
-        }
-        // check if relations were switched due to some optimization
-        if (checkReversePair) {
-            for (JoinPair joinPair : joinPairs) {
-                if (joinPair.equalsNames(right, left)) {
-                    JoinPair reverseJoinPair = new JoinPair(
-                        joinPair.right,
-                        joinPair.left,
-                        joinPair.joinType().invert(),
-                        joinPair.condition);
-                    joinPairs.add(reverseJoinPair);
-                    return reverseJoinPair;
-                }
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * Returns all relation names which are part of an outer join.
-     */
-    public static Set<QualifiedName> outerJoinRelations(List<JoinPair> joinPairs) {
-        Set<QualifiedName> outerJoinRelations = new HashSet<>();
-        for (JoinPair joinPair : joinPairs) {
-            if (joinPair.joinType().isOuter()) {
-                outerJoinRelations.add(joinPair.left);
-                outerJoinRelations.add(joinPair.right);
-            }
-        }
-        return outerJoinRelations;
-    }
-
-    /**
-     * Rewrite names of matching join pair relations and inside the condition function
-     */
-    public static void rewriteNames(QualifiedName left,
-                                    QualifiedName right,
-                                    QualifiedName newName,
-                                    Function<? super Symbol, Symbol> replaceFunction,
-                                    List<JoinPair> joinPairs) {
-        for (JoinPair joinPair : joinPairs) {
-            joinPair.replaceNames(left, right, newName);
-            joinPair.replaceCondition(replaceFunction);
-        }
-    }
-
-    /**
-     * Returns true if relation name is part of an outer join and on the outer side.
-     */
-    static boolean isOuterRelation(QualifiedName name, List<JoinPair> joinPairs) {
-        for (JoinPair joinPair : joinPairs) {
-            if (isOuterRelation(name, joinPair)) {
+            if (right.equals(name) && (joinType == JoinType.LEFT || joinType == JoinType.FULL)) {
                 return true;
             }
         }
         return false;
     }
-
-    public static boolean isOuterRelation(QualifiedName name, JoinPair joinPair) {
-        if (joinPair.joinType().isOuter()) {
-            if (joinPair.left.equals(name) &&
-                (joinPair.joinType() == JoinType.RIGHT || joinPair.joinType() == JoinType.FULL)) {
-                return true;
-            }
-            if (joinPair.right.equals(name) &&
-                (joinPair.joinType() == JoinType.LEFT || joinPair.joinType() == JoinType.FULL)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
 }

--- a/sql/src/main/java/io/crate/analyze/relations/JoinPair.java
+++ b/sql/src/main/java/io/crate/analyze/relations/JoinPair.java
@@ -197,15 +197,22 @@ public class JoinPair {
      */
     static boolean isOuterRelation(QualifiedName name, List<JoinPair> joinPairs) {
         for (JoinPair joinPair : joinPairs) {
-            if (joinPair.joinType().isOuter()) {
-                if (joinPair.left.equals(name) &&
-                    (joinPair.joinType() == JoinType.RIGHT || joinPair.joinType() == JoinType.FULL)) {
-                    return true;
-                }
-                if (joinPair.right.equals(name) &&
-                    (joinPair.joinType() == JoinType.LEFT || joinPair.joinType() == JoinType.FULL)) {
-                    return true;
-                }
+            if (isOuterRelation(name, joinPair)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static boolean isOuterRelation(QualifiedName name, JoinPair joinPair) {
+        if (joinPair.joinType().isOuter()) {
+            if (joinPair.left.equals(name) &&
+                (joinPair.joinType() == JoinType.RIGHT || joinPair.joinType() == JoinType.FULL)) {
+                return true;
+            }
+            if (joinPair.right.equals(name) &&
+                (joinPair.joinType() == JoinType.LEFT || joinPair.joinType() == JoinType.FULL)) {
+                return true;
             }
         }
         return false;

--- a/sql/src/main/java/io/crate/analyze/relations/JoinPair.java
+++ b/sql/src/main/java/io/crate/analyze/relations/JoinPair.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.analyze.relations;
+
+import com.google.common.base.Objects;
+import io.crate.planner.node.dql.join.JoinType;
+import io.crate.sql.tree.QualifiedName;
+
+public class JoinPair {
+
+    private QualifiedName left;
+    private QualifiedName right;
+    private final JoinType joinType;
+
+    JoinPair(QualifiedName left, QualifiedName right, JoinType joinType) {
+        this.left = left;
+        this.right = right;
+        this.joinType = joinType;
+    }
+
+    public boolean equalsNames(QualifiedName left, QualifiedName right) {
+        return this.left.equals(left) && this.right.equals(right);
+    }
+
+    public void replaceNames(QualifiedName left, QualifiedName right, QualifiedName newName) {
+        if (this.left.equals(left) || this.left.equals(right)) {
+            this.left = newName;
+        }
+        if (this.right.equals(right) || this.right.equals(left)) {
+            this.right = newName;
+        }
+    }
+
+    public JoinType joinType() {
+        return joinType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        JoinPair that = (JoinPair) o;
+        return Objects.equal(left, that.left) &&
+               Objects.equal(right, that.right) &&
+               joinType == that.joinType;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(left, right, joinType);
+    }
+}

--- a/sql/src/main/java/io/crate/analyze/relations/JoinPair.java
+++ b/sql/src/main/java/io/crate/analyze/relations/JoinPair.java
@@ -22,32 +22,81 @@
 
 package io.crate.analyze.relations;
 
+import com.google.common.base.Function;
 import com.google.common.base.Objects;
+import io.crate.analyze.symbol.Symbol;
+import io.crate.operation.operator.AndOperator;
 import io.crate.planner.node.dql.join.JoinType;
 import io.crate.sql.tree.QualifiedName;
 
 import javax.annotation.Nullable;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 public class JoinPair {
 
-    private QualifiedName left;
-    private QualifiedName right;
     private final JoinType joinType;
 
+    private QualifiedName left;
+    private QualifiedName right;
+    @Nullable
+    private Symbol condition;
+
     public JoinPair(QualifiedName left, QualifiedName right, JoinType joinType) {
+        this(left, right, joinType, null);
+    }
+
+    public JoinPair(QualifiedName left, QualifiedName right, JoinType joinType, @Nullable Symbol condition) {
         this.left = left;
         this.right = right;
         this.joinType = joinType;
+        this.condition = condition;
     }
 
-    public boolean equalsNames(QualifiedName left, QualifiedName right) {
+    public QualifiedName left() {
+        return left;
+    }
+
+    public QualifiedName right() {
+        return right;
+    }
+
+    public JoinType joinType() {
+        return joinType;
+    }
+
+    @Nullable
+    public Symbol condition() {
+        return condition;
+    }
+
+    public void condition(Symbol condition) {
+        this.condition = condition;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        JoinPair joinPair = (JoinPair) o;
+        return Objects.equal(left, joinPair.left) &&
+               Objects.equal(right, joinPair.right) &&
+               joinType == joinPair.joinType &&
+               Objects.equal(condition, joinPair.condition);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(left, right, joinType, condition);
+    }
+
+    private boolean equalsNames(QualifiedName left, QualifiedName right) {
         return this.left.equals(left) && this.right.equals(right);
     }
 
-    public void replaceNames(QualifiedName left, QualifiedName right, QualifiedName newName) {
+    private void replaceNames(QualifiedName left, QualifiedName right, QualifiedName newName) {
         if (this.left.equals(left) || this.left.equals(right)) {
             this.left = newName;
         }
@@ -56,45 +105,58 @@ public class JoinPair {
         }
     }
 
-    public JoinType joinType() {
-        return joinType;
+    public void replaceCondition(Function<? super Symbol, Symbol> replaceFunction) {
+        condition = replaceFunction.apply(condition);
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        JoinPair that = (JoinPair) o;
-        return Objects.equal(left, that.left) &&
-               Objects.equal(right, that.right) &&
-               joinType == that.joinType;
+    /**
+     * Find and return a {@link JoinPair} for the given relation names, also check for reversed names.
+     * If the {@link JoinType} is INNER and a pair is found for the reversed names, merge the join conditions.
+     */
+    public static JoinPair ofRelationsWithMergedConditions(QualifiedName left,
+                                                           QualifiedName right,
+                                                           List<JoinPair> joinPairs) {
+        JoinPair joinPair = JoinPair.ofRelations(left, right, joinPairs, true);
+        if (joinPair == null) {
+            // default to cross join (or inner, doesn't matter)
+            joinPair = new JoinPair(left, right, JoinType.CROSS);
+        }
+        // if it's an INNER, lets check for reverse relations and merge conditions
+        if (joinPair.joinType() == JoinType.INNER) {
+            JoinPair joinPairReverse = JoinPair.ofRelations(right, left, joinPairs, false);
+            if (joinPairReverse != null) {
+                joinPair.condition(AndOperator.join(Arrays.asList(joinPair.condition(), joinPairReverse.condition())));
+            }
+        }
+
+        return joinPair;
     }
 
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(left, right, joinType);
-    }
-
+    /**
+     * Returns the {@link JoinPair} of a pair of relation names based on the given list of join pairs.
+     * If <p>checkReversePairs</p> is true, also check for any {@link JoinPair} with switched names.
+     */
     @Nullable
-    public static JoinType joinTypeForRelations(QualifiedName left, QualifiedName right, List<JoinPair> joinPairs) {
-        return joinTypeForRelations(left, right, joinPairs, true);
-    }
-
-    @Nullable
-    public static JoinType joinTypeForRelations(QualifiedName left,
-                                                QualifiedName right,
-                                                List<JoinPair> joinPairs,
-                                                boolean checkReversePair) {
+    public static JoinPair ofRelations(QualifiedName left,
+                                       QualifiedName right,
+                                       List<JoinPair> joinPairs,
+                                       boolean checkReversePair) {
         for (JoinPair joinPair : joinPairs) {
             if (joinPair.equalsNames(left, right)) {
-                return joinPair.joinType();
+                return joinPair;
             }
         }
         // check if relations were switched due to some optimization
         if (checkReversePair) {
             for (JoinPair joinPair : joinPairs) {
                 if (joinPair.equalsNames(right, left)) {
-                    return joinPair.joinType().invert();
+                    JoinPair reverseJoinPair = new JoinPair(
+                        joinPair.right,
+                        joinPair.left,
+                        joinPair.joinType().invert(),
+                        joinPair.condition);
+                    joinPairs.add(reverseJoinPair);
+                    return reverseJoinPair;
                 }
             }
         }
@@ -102,6 +164,9 @@ public class JoinPair {
         return null;
     }
 
+    /**
+     * Returns all relation names which are part of an outer join.
+     */
     public static Set<QualifiedName> outerJoinRelations(List<JoinPair> joinPairs) {
         Set<QualifiedName> outerJoinRelations = new HashSet<>();
         for (JoinPair joinPair : joinPairs) {
@@ -112,4 +177,38 @@ public class JoinPair {
         }
         return outerJoinRelations;
     }
+
+    /**
+     * Rewrite names of matching join pair relations and inside the condition function
+     */
+    public static void rewriteNames(QualifiedName left,
+                                    QualifiedName right,
+                                    QualifiedName newName,
+                                    Function<? super Symbol, Symbol> replaceFunction,
+                                    List<JoinPair> joinPairs) {
+        for (JoinPair joinPair : joinPairs) {
+            joinPair.replaceNames(left, right, newName);
+            joinPair.replaceCondition(replaceFunction);
+        }
+    }
+
+    /**
+     * Returns true if relation name is part of an outer join and on the outer side.
+     */
+    static boolean isOuterRelation(QualifiedName name, List<JoinPair> joinPairs) {
+        for (JoinPair joinPair : joinPairs) {
+            if (joinPair.joinType().isOuter()) {
+                if (joinPair.left.equals(name) &&
+                    (joinPair.joinType() == JoinType.RIGHT || joinPair.joinType() == JoinType.FULL)) {
+                    return true;
+                }
+                if (joinPair.right.equals(name) &&
+                    (joinPair.joinType() == JoinType.LEFT || joinPair.joinType() == JoinType.FULL)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
 }

--- a/sql/src/main/java/io/crate/analyze/relations/JoinPairs.java
+++ b/sql/src/main/java/io/crate/analyze/relations/JoinPairs.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.analyze.relations;
+
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
+import io.crate.analyze.QuerySpec;
+import io.crate.analyze.symbol.Symbol;
+import io.crate.operation.operator.AndOperator;
+import io.crate.planner.node.dql.join.JoinType;
+import io.crate.sql.tree.QualifiedName;
+
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public final class JoinPairs {
+
+    /**
+     * Find and return a {@link JoinPair} for the given relation names, also check for reversed names.
+     * If the {@link JoinType} is INNER and a pair is found for the reversed names, merge the join conditions.
+     * Found join pairs will be removed from the list.
+     */
+    public static JoinPair ofRelationsWithMergedConditions(QualifiedName left,
+                                                           QualifiedName right,
+                                                           List<JoinPair> joinPairs) {
+        JoinPair joinPair = ofRelations(left, right, joinPairs, true);
+        if (joinPair == null) {
+            // default to cross join (or inner, doesn't matter)
+            return new JoinPair(left, right, JoinType.CROSS);
+        }
+        assert !(joinPairs instanceof ImmutableList) : "joinPairs list must be mutable if it contains items";
+        // if it's an INNER, lets check for reverse relations and merge conditions
+        if (joinPair.joinType() == JoinType.INNER) {
+            JoinPair joinPairReverse = ofRelations(right, left, joinPairs, false);
+            if (joinPairReverse != null) {
+                joinPair.condition(AndOperator.join(Arrays.asList(joinPair.condition(), joinPairReverse.condition())));
+                joinPairs.remove(joinPairReverse);
+            }
+        }
+        joinPairs.remove(joinPair);
+
+        return joinPair;
+    }
+
+    /**
+     * Returns the {@link JoinPair} of a pair of relation names based on the given list of join pairs.
+     * If <p>checkReversePairs</p> is true, also check for any {@link JoinPair} with switched names.
+     */
+    @Nullable
+    public static JoinPair ofRelations(QualifiedName left,
+                                       QualifiedName right,
+                                       List<JoinPair> joinPairs,
+                                       boolean checkReversePair) {
+        for (JoinPair joinPair : joinPairs) {
+            if (joinPair.equalsNames(left, right)) {
+                return joinPair;
+            }
+        }
+        // check if relations were switched due to some optimization
+        if (checkReversePair) {
+            for (JoinPair joinPair : joinPairs) {
+                if (joinPair.equalsNames(right, left)) {
+                    JoinPair reverseJoinPair = new JoinPair(
+                        joinPair.right(),
+                        joinPair.left(),
+                        joinPair.joinType().invert(),
+                        joinPair.condition());
+                    joinPairs.add(reverseJoinPair);
+                    return reverseJoinPair;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns all relation names which are part of an outer join.
+     */
+    public static Set<QualifiedName> outerJoinRelations(List<JoinPair> joinPairs) {
+        Set<QualifiedName> outerJoinRelations = new HashSet<>();
+        for (JoinPair joinPair : joinPairs) {
+            if (joinPair.joinType().isOuter()) {
+                outerJoinRelations.add(joinPair.left());
+                outerJoinRelations.add(joinPair.right());
+            }
+        }
+        return outerJoinRelations;
+    }
+
+    /**
+     * Rewrite names of matching join pair relations and inside the condition function
+     */
+    public static void rewriteNames(QualifiedName left,
+                                    QualifiedName right,
+                                    QualifiedName newName,
+                                    Function<? super Symbol, Symbol> replaceFunction,
+                                    List<JoinPair> joinPairs) {
+        for (JoinPair joinPair : joinPairs) {
+            joinPair.replaceNames(left, right, newName);
+            joinPair.replaceCondition(replaceFunction);
+        }
+    }
+
+    /**
+     * Returns true if relation name is part of an outer join and on the outer side.
+     */
+    static boolean isOuterRelation(QualifiedName name, List<JoinPair> joinPairs) {
+        for (JoinPair joinPair : joinPairs) {
+            if (joinPair.isOuterRelation(name)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Removes order by on the outer relation of an outer join because it must be applied after the join anyway
+     */
+    public static void removeOrderByOnOuterRelation(QualifiedName left,
+                                                    QualifiedName right,
+                                                    QuerySpec leftQuerySpec,
+                                                    QuerySpec rightQuerySpec,
+                                                    JoinPair joinPair) {
+        if (joinPair.isOuterRelation(left)) {
+            leftQuerySpec.orderBy(null);
+        }
+        if (joinPair.isOuterRelation(right)) {
+            rightQuerySpec.orderBy(null);
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/analyze/relations/QuerySplittingVisitor.java
+++ b/sql/src/main/java/io/crate/analyze/relations/QuerySplittingVisitor.java
@@ -27,12 +27,13 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
 import io.crate.analyze.symbol.*;
 import io.crate.metadata.ReplacingSymbolVisitor;
-import io.crate.metadata.TableIdent;
 import io.crate.operation.operator.AndOperator;
-import io.crate.sql.tree.QualifiedName;
 
 import javax.annotation.Nullable;
-import java.util.*;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Set;
 
 class QuerySplittingVisitor extends ReplacingSymbolVisitor<QuerySplittingVisitor.Context> {
 
@@ -152,11 +153,7 @@ class QuerySplittingVisitor extends ReplacingSymbolVisitor<QuerySplittingVisitor
             context.multiRelation = context.seenRelations.size() > 1;
             if (context.seenRelations.size() == 1) {
                 context.seenRelation = Iterables.getOnlyElement(context.seenRelations);
-                assert context.seenRelation instanceof  AbstractTableRelation :
-                    "expecting relation is instance of AbstractTableRelation";
-                TableIdent tableIdent = ((AbstractTableRelation) context.seenRelation).tableInfo().ident();
-                QualifiedName name = new QualifiedName(Arrays.asList(tableIdent.schema(), tableIdent.name()));
-                if (JoinPairs.isOuterRelation(name, context.joinPairs)) {
+                if (JoinPairs.isOuterRelation(context.seenRelation.getQualifiedName(), context.joinPairs)) {
                     // don't split by marking as multi relation
                     context.multiRelation = true;
                 }

--- a/sql/src/main/java/io/crate/analyze/relations/QuerySplittingVisitor.java
+++ b/sql/src/main/java/io/crate/analyze/relations/QuerySplittingVisitor.java
@@ -156,7 +156,7 @@ class QuerySplittingVisitor extends ReplacingSymbolVisitor<QuerySplittingVisitor
                     "expecting relation is instance of AbstractTableRelation";
                 TableIdent tableIdent = ((AbstractTableRelation) context.seenRelation).tableInfo().ident();
                 QualifiedName name = new QualifiedName(Arrays.asList(tableIdent.schema(), tableIdent.name()));
-                if (JoinPair.isOuterRelation(name, context.joinPairs)) {
+                if (JoinPairs.isOuterRelation(name, context.joinPairs)) {
                     // don't split by marking as multi relation
                     context.multiRelation = true;
                 }

--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalysisContext.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalysisContext.java
@@ -114,7 +114,7 @@ public class RelationAnalysisContext {
 
     List<JoinPair> joinPairs() {
         if (joinPairs == null) {
-            return ImmutableList.of();
+            return new ArrayList<>();
         }
         return joinPairs;
     }

--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalysisContext.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalysisContext.java
@@ -93,7 +93,7 @@ public class RelationAnalysisContext {
         joinPairs.add(joinType);
     }
 
-    void addJoinType(JoinType joinType) {
+    void addJoinType(JoinType joinType, @Nullable Symbol joinCondition) {
         int size = sources.size();
         assert size >= 2 : "sources must be added first, cannot add join type for only 1 source";
         Iterator<QualifiedName> it = sources.keySet().iterator();
@@ -109,7 +109,7 @@ public class RelationAnalysisContext {
             }
             idx++;
         }
-        addJoinPair(new JoinPair(left, right, joinType));
+        addJoinPair(new JoinPair(left, right, joinType, joinCondition));
     }
 
     List<JoinPair> joinPairs() {

--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalysisContext.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalysisContext.java
@@ -86,6 +86,7 @@ public class RelationAnalysisContext {
         joinConditions.add(symbol);
     }
 
+
     private void addJoinPair(JoinPair joinType) {
         if (joinPairs == null) {
             joinPairs = new ArrayList<>();
@@ -114,7 +115,7 @@ public class RelationAnalysisContext {
 
     List<JoinPair> joinPairs() {
         if (joinPairs == null) {
-            return new ArrayList<>();
+            return ImmutableList.of();
         }
         return joinPairs;
     }

--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -63,7 +63,8 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
 
     private final ClusterService clusterService;
     private final AnalysisMetaData analysisMetaData;
-    private static final EnumSet<Join.Type> ALLOWED_JOIN_TYPES = EnumSet.of(Join.Type.CROSS, Join.Type.INNER, Join.Type.LEFT);
+    private static final EnumSet<Join.Type> ALLOWED_JOIN_TYPES =
+        EnumSet.of(Join.Type.CROSS, Join.Type.INNER, Join.Type.LEFT, Join.Type.RIGHT, Join.Type.FULL);
 
     @Inject
     public RelationAnalyzer(ClusterService clusterService, AnalysisMetaData analysisMetaData) {

--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -102,13 +102,11 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
         process(node.getRight(), statementContext);
 
         RelationAnalysisContext relationContext = statementContext.currentRelationContext();
-        relationContext.addJoinType(JoinType.values()[node.getType().ordinal()]);
-
         Optional<JoinCriteria> optCriteria = node.getCriteria();
+        Symbol joinCondition = null;
         if (optCriteria.isPresent()) {
             JoinCriteria joinCriteria = optCriteria.get();
             if (joinCriteria instanceof JoinOn) {
-                Symbol joinCondition;
                 try {
                     joinCondition = relationContext.expressionAnalyzer().convert(
                         ((JoinOn) joinCriteria).getExpression(), relationContext.expressionAnalysisContext());
@@ -116,12 +114,13 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
                     throw new ValidationException(String.format(Locale.ENGLISH,
                         "missing FROM-clause entry for relation '%s'", e.qualifiedName()));
                 }
-                relationContext.addJoinCondition(joinCondition);
             } else {
                 throw new UnsupportedOperationException(String.format(Locale.ENGLISH, "join criteria %s not supported",
                         joinCriteria.getClass().getSimpleName()));
             }
         }
+
+        relationContext.addJoinType(JoinType.values()[node.getType().ordinal()], joinCondition);
         return null;
     }
 

--- a/sql/src/main/java/io/crate/analyze/relations/RelationNormalizer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationNormalizer.java
@@ -106,7 +106,8 @@ final class RelationNormalizer extends AnalyzedRelationVisitor<RelationNormalize
         if (context.querySpec != null) {
             QuerySpec querySpec = mergeAndReplaceFields(multiSourceSelect, context.querySpec);
             // must create a new MultiSourceSelect because paths and query spec changed
-            relation = new MultiSourceSelect(mapSourceRelations(multiSourceSelect), context.paths(), querySpec);
+            relation = new MultiSourceSelect(mapSourceRelations(multiSourceSelect), context.paths(), querySpec,
+                multiSourceSelect.joinPairs());
         }
         relation.pushDownQuerySpecs();
         return relation;

--- a/sql/src/main/java/io/crate/analyze/relations/RelationSplitter.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationSplitter.java
@@ -174,7 +174,10 @@ public final class RelationSplitter {
         for (Symbol symbol : orderBy.orderBySymbols()) {
             relations.clear();
             RelationCounter.INSTANCE.process(symbol, relations);
-            if (relations.size() > 1) {
+
+            if (relations.size() > 1 ||
+                // Outer Join requires post-order-by because the nested loop adds rows which affects ordering
+                JoinPairs.isOuterRelation(relations.iterator().next().getQualifiedName(), joinPairs)) {
                 remainingOrderBy = new RemainingOrderBy();
                 break;
             }

--- a/sql/src/main/java/io/crate/operation/fetch/FetchRowInputSymbolVisitor.java
+++ b/sql/src/main/java/io/crate/operation/fetch/FetchRowInputSymbolVisitor.java
@@ -46,6 +46,7 @@ public class FetchRowInputSymbolVisitor extends BaseImplementationSymbolVisitor<
         private Map<TableIdent, FetchSource> fetchSources;
         private final FetchProjector.ArrayBackedRow inputRow = new FetchProjector.ArrayBackedRow();
         private final int[] docIdPositions;
+        private final Object[][] nullCells;
 
         public Context(Map<TableIdent, FetchSource> fetchSources) {
             assert !fetchSources.isEmpty();
@@ -59,6 +60,7 @@ public class FetchRowInputSymbolVisitor extends BaseImplementationSymbolVisitor<
             this.fetchRows = new FetchProjector.ArrayBackedRow[numDocIds];
             this.docIdPositions = new int[numDocIds];
             this.partitionRows = new FetchProjector.ArrayBackedRow[numDocIds];
+            nullCells = new Object[numDocIds][];
 
             int idx = 0;
             for (FetchSource fetchSource : fetchSources.values()) {
@@ -68,6 +70,7 @@ public class FetchRowInputSymbolVisitor extends BaseImplementationSymbolVisitor<
                     if (!fetchSource.partitionedByColumns().isEmpty()) {
                         partitionRows[idx] = new FetchProjector.ArrayBackedRow();
                     }
+                    nullCells[idx] = new Object[fetchSource.references().size()];
                     idx++;
                 }
             }
@@ -90,6 +93,10 @@ public class FetchRowInputSymbolVisitor extends BaseImplementationSymbolVisitor<
 
         public FetchProjector.ArrayBackedRow inputRow() {
             return inputRow;
+        }
+
+        public Object[][] nullCells() {
+            return nullCells;
         }
 
         public Input<?> allocateInput(int index) {

--- a/sql/src/main/java/io/crate/operation/join/BitSet.java
+++ b/sql/src/main/java/io/crate/operation/join/BitSet.java
@@ -24,8 +24,6 @@ package io.crate.operation.join;
 
 import org.apache.lucene.util.LongBitSet;
 
-import java.util.ArrayList;
-
 /**
  * This BitSet is used to mark matched rows between left and right in {@link NestedLoopOperation}
  *
@@ -37,8 +35,8 @@ import java.util.ArrayList;
  * each time size is reached.
  */
 class LuceneLongBitSetWrapper {
-    long size = 1024;
-    LongBitSet bitSet = new LongBitSet(size);
+    private long size = 1024;
+    private LongBitSet bitSet = new LongBitSet(size);
 
     void set(long idx) {
         if (idx >= size) {

--- a/sql/src/main/java/io/crate/operation/join/BitSet.java
+++ b/sql/src/main/java/io/crate/operation/join/BitSet.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.operation.join;
+
+import org.apache.lucene.util.LongBitSet;
+
+import java.util.ArrayList;
+
+/**
+ * This BitSet is used to mark matched rows between left and right in {@link NestedLoopOperation}
+ *
+ * Each bit true if the rows in the respective position are matched and therefore we need
+ * a structure capable of holding <pre>long</pre> size of bits so java.util.BitSet cannot be used.
+ *
+ * We chose to use {@link LongBitSet} from Lucence and add another layer of segments on top in
+ * order to further optimize performance by growing the capacity of the backing array by double
+ * each time size is reached.
+ */
+class LuceneLongBitSetWrapper {
+    long size = 1024;
+    LongBitSet bitSet = new LongBitSet(size);
+
+    void set(long idx) {
+        if (idx >= size) {
+            size *= 2;
+            bitSet = LongBitSet.ensureCapacity(bitSet, size);
+        }
+        bitSet.set(idx);
+    }
+
+    boolean get(long idx) {
+        return bitSet.get(idx);
+    }
+}

--- a/sql/src/main/java/io/crate/operation/join/LuceneLongBitSetWrapper.java
+++ b/sql/src/main/java/io/crate/operation/join/LuceneLongBitSetWrapper.java
@@ -30,9 +30,9 @@ import org.apache.lucene.util.LongBitSet;
  * Each bit true if the rows in the respective position are matched and therefore we need
  * a structure capable of holding <pre>long</pre> size of bits so java.util.BitSet cannot be used.
  *
- * We chose to use {@link LongBitSet} from Lucence and add another layer of segments on top in
- * order to further optimize performance by growing the capacity of the backing array by double
- * each time size is reached.
+ * We chose to use {@link LongBitSet} from Lucence and add another layer on top in
+ * order to further optimize performance by growing the capacity of the backing array
+ * by double each time size is reached.
  */
 class LuceneLongBitSetWrapper {
     private long size = 1024;

--- a/sql/src/main/java/io/crate/operation/join/NestedLoopOperation.java
+++ b/sql/src/main/java/io/crate/operation/join/NestedLoopOperation.java
@@ -21,9 +21,7 @@
 
 package io.crate.operation.join;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Predicate;
-import com.google.common.base.Predicates;
 import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;

--- a/sql/src/main/java/io/crate/operation/join/NestedLoopOperation.java
+++ b/sql/src/main/java/io/crate/operation/join/NestedLoopOperation.java
@@ -128,7 +128,6 @@ public class NestedLoopOperation implements CompletionListenable, RepeatHandle {
 
     private final int phaseId;
     private final RowReceiver downstream;
-    private final Predicate<Row> rowFilterPredicate;
     private final Predicate<Row> joinPredicate;
     private final JoinType joinType;
 
@@ -145,14 +144,12 @@ public class NestedLoopOperation implements CompletionListenable, RepeatHandle {
 
     public NestedLoopOperation(int phaseId,
                                RowReceiver rowReceiver,
-                               Predicate<Row> rowFilterPredicate,
                                Predicate<Row> joinPredicate,
                                JoinType joinType,
                                int leftNumOutputs,
                                int rightNumOutputs) {
         this.phaseId = phaseId;
         this.downstream = rowReceiver;
-        this.rowFilterPredicate = rowFilterPredicate;
         this.joinPredicate = joinPredicate;
         this.joinType = joinType;
         left = new LeftRowReceiver();
@@ -419,12 +416,6 @@ public class NestedLoopOperation implements CompletionListenable, RepeatHandle {
             combinedRow.outerRow = left.lastRow;
             combinedRow.innerRow = row;
 
-            // Check where clause filter
-            if (!rowFilterPredicate.apply(combinedRow)) {
-                // if the filter does not match, null rows must not be emitted, so set as matched
-                matchedJoinPredicate = true;
-                return Result.CONTINUE;
-            }
             // Check join condition
             if (!joinPredicate.apply(combinedRow)) {
                 return Result.CONTINUE;
@@ -580,13 +571,6 @@ public class NestedLoopOperation implements CompletionListenable, RepeatHandle {
                 combinedRow.outerRow = left.lastRow;
                 combinedRow.innerRow = row;
 
-                // Check where clause filter
-                if (!rowFilterPredicate.apply(combinedRow)) {
-                    // if the filter does not match, null rows must not be emitted, so set as matched
-                    matchedJoinPredicate = true;
-                    matchedJoinRows.set(rowPosition);
-                    return Result.CONTINUE;
-                }
                 // Check join condition
                 if (!joinPredicate.apply(combinedRow)) {
                     return Result.CONTINUE;

--- a/sql/src/main/java/io/crate/planner/consumer/ManyTableConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/ManyTableConsumer.java
@@ -327,13 +327,6 @@ public class ManyTableConsumer implements Consumer {
 
         JoinPairs.removeOrderByOnOuterRelation(left, right, leftSource.querySpec(), rightSource.querySpec(), joinPair);
 
-        // TODO: enable optimization for all join types after RIGHT OUTER JOIN is implemented
-        if (joinPair.joinType().ordinal() < JoinType.INNER.ordinal()) {
-            it = getOrderedRelationNames(mss, ImmutableSet.<Set<QualifiedName>>of()).iterator();
-            left = it.next();
-            right = it.next();
-        }
-
         Optional<OrderBy> remainingOrderByToApply = Optional.absent();
         if (mss.remainingOrderBy().isPresent() && mss.remainingOrderBy().get().validForRelations(Sets.newHashSet(left, right))) {
             remainingOrderByToApply = Optional.of(mss.remainingOrderBy().get().orderBy());

--- a/sql/src/main/java/io/crate/planner/consumer/ManyTableConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/ManyTableConsumer.java
@@ -64,6 +64,7 @@ public class ManyTableConsumer implements Consumer {
      *
      *
      * @param relations all relations, e.g. [t1, t2, t3, t3]
+     * @param implicitJoinedRelations contains all relations that have a join condition e.g. {{t1, t2}, {t2, t3}}
      * @param joinPairs contains a list of {@link JoinPair}.
      * @param preSorted a ordered subset of the relations. The result will start with those relations.
      *                  E.g. [t3] - This would cause the result to start with [t3]

--- a/sql/src/main/java/io/crate/planner/consumer/ManyTableConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/ManyTableConsumer.java
@@ -283,7 +283,7 @@ public class ManyTableConsumer implements Consumer {
 
     private static TwoTableJoin twoTableJoin(MultiSourceSelect mss) {
         assert mss.sources().size() == 2;
-        Iterator<QualifiedName> it = mss.sources().keySet().iterator();
+        Iterator<QualifiedName> it = getOrderedRelationNames(mss, ImmutableSet.<Set<QualifiedName>>of()).iterator();
         QualifiedName left = it.next();
         QualifiedName right = it.next();
         JoinType joinType = mss.joinTypeForRelations(left, right);

--- a/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
@@ -254,6 +254,7 @@ public class NestedLoopConsumer implements Consumer {
                 nlExecutionNodes,
                 joinType,
                 filterSymbol,
+                left.querySpec().outputs().size(),
                 right.querySpec().outputs().size()
             );
             MergePhase localMergePhase = null;

--- a/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
@@ -160,6 +160,7 @@ public class NestedLoopConsumer implements Consumer {
                 return new NoopPlannedAnalyzedRelation(statement, context.plannerContext().jobId());
             }
 
+            JoinType joinType = statement.joinType();
             boolean broadcastLeftTable = false;
             if (isDistributed) {
                 broadcastLeftTable = isLeftSmallerThanRight(left, right);
@@ -171,6 +172,7 @@ public class NestedLoopConsumer implements Consumer {
                     QueriedRelation tmpRelation = left;
                     left = right;
                     right = tmpRelation;
+                    joinType = joinType.invert();
                 }
             }
             Set<String> handlerNodes = ImmutableSet.of(clusterService.localNode().id());
@@ -250,7 +252,7 @@ public class NestedLoopConsumer implements Consumer {
                 leftMerge,
                 rightMerge,
                 nlExecutionNodes,
-                JoinType.INNER,
+                joinType,
                 filterSymbol,
                 right.querySpec().outputs().size()
             );

--- a/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
@@ -235,12 +235,16 @@ public class NestedLoopConsumer implements Consumer {
             }
 
             Planner.Context.Limits limits = context.plannerContext().getLimits(context.isRoot(), querySpec);
+            OrderBy orderBy = statement.remainingOrderBy().orNull();
+            if (orderBy == null && joinType.isOuter()) {
+                orderBy = orderByBeforeSplit;
+            }
             TopNProjection topN = ProjectionBuilder.topNProjection(
-                    nlOutputs,
-                    statement.remainingOrderBy().orNull(),
-                    isDistributed ? 0 : querySpec.offset(),
-                    isDistributed ? limits.limitAndOffset() : limits.finalLimit(),
-                    postNLOutputs
+                nlOutputs,
+                orderBy,
+                isDistributed ? 0 : querySpec.offset(),
+                isDistributed ? limits.limitAndOffset() : limits.finalLimit(),
+                postNLOutputs
             );
             projections.add(topN);
 

--- a/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
@@ -37,6 +37,7 @@ import io.crate.planner.distribution.DistributionInfo;
 import io.crate.planner.distribution.UpstreamPhase;
 import io.crate.planner.node.NoopPlannedAnalyzedRelation;
 import io.crate.planner.node.dql.MergePhase;
+import io.crate.planner.node.dql.join.JoinType;
 import io.crate.planner.node.dql.join.NestedLoop;
 import io.crate.planner.node.dql.join.NestedLoopPhase;
 import io.crate.planner.projection.Projection;
@@ -249,6 +250,7 @@ public class NestedLoopConsumer implements Consumer {
                 leftMerge,
                 rightMerge,
                 nlExecutionNodes,
+                JoinType.INNER,
                 filterSymbol
             );
             MergePhase localMergePhase = null;

--- a/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
@@ -127,10 +127,11 @@ public class NestedLoopConsumer implements Consumer {
                 MappingSymbolVisitor.inPlace().processInplace(statement.remainingOrderBy().get().orderBySymbols(), symbolMap);
             }
 
+            JoinType joinType = statement.joinType();
             WhereClause where = querySpec.where();
             boolean filterNeeded = where.hasQuery() && !(where.query() instanceof Literal);
             boolean hasDocTables = left instanceof QueriedDocTable || right instanceof QueriedDocTable;
-            boolean isDistributed = hasDocTables && filterNeeded;
+            boolean isDistributed = hasDocTables && filterNeeded && !joinType.isOuter();
 
             if (filterNeeded || statement.remainingOrderBy().isPresent()) {
                 left.querySpec().limit(null);
@@ -160,7 +161,6 @@ public class NestedLoopConsumer implements Consumer {
                 return new NoopPlannedAnalyzedRelation(statement, context.plannerContext().jobId());
             }
 
-            JoinType joinType = statement.joinType();
             boolean broadcastLeftTable = false;
             if (isDistributed) {
                 broadcastLeftTable = isLeftSmallerThanRight(left, right);

--- a/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
@@ -251,7 +251,8 @@ public class NestedLoopConsumer implements Consumer {
                 rightMerge,
                 nlExecutionNodes,
                 JoinType.INNER,
-                filterSymbol
+                filterSymbol,
+                right.querySpec().outputs().size()
             );
             MergePhase localMergePhase = null;
             // TODO: build local merge phases somewhere else for any subplan

--- a/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
@@ -40,6 +40,7 @@ import io.crate.planner.node.dql.MergePhase;
 import io.crate.planner.node.dql.join.JoinType;
 import io.crate.planner.node.dql.join.NestedLoop;
 import io.crate.planner.node.dql.join.NestedLoopPhase;
+import io.crate.planner.projection.FilterProjection;
 import io.crate.planner.projection.Projection;
 import io.crate.planner.projection.TopNProjection;
 import io.crate.planner.projection.builder.InputCreatingVisitor;
@@ -226,11 +227,11 @@ public class NestedLoopConsumer implements Consumer {
             }
             List<Projection> projections = new ArrayList<>();
 
-            Symbol filterSymbol = null;
             if (filterNeeded) {
                 InputCreatingVisitor.Context inputVisitorContext = new InputCreatingVisitor.Context(nlOutputs);
-                filterSymbol = InputCreatingVisitor.INSTANCE.process(where.query(), inputVisitorContext);
+                Symbol filterSymbol = InputCreatingVisitor.INSTANCE.process(where.query(), inputVisitorContext);
                 assert filterSymbol instanceof Function : "Only function symbols are allowed for filtering";
+                projections.add(new FilterProjection(filterSymbol));
             }
             if (joinCondition != null) {
                 InputCreatingVisitor.Context inputVisitorContext = new InputCreatingVisitor.Context(nlOutputs);
@@ -271,7 +272,6 @@ public class NestedLoopConsumer implements Consumer {
                 nlExecutionNodes,
                 joinType,
                 joinCondition,
-                filterSymbol,
                 left.querySpec().outputs().size(),
                 right.querySpec().outputs().size()
             );

--- a/sql/src/main/java/io/crate/planner/node/dql/join/JoinType.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/join/JoinType.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.node.dql.join;
+
+public enum JoinType {
+    CROSS,
+    INNER,
+    LEFT,
+    RIGHT,
+    FULL
+}

--- a/sql/src/main/java/io/crate/planner/node/dql/join/JoinType.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/join/JoinType.java
@@ -42,4 +42,8 @@ public enum JoinType {
     public JoinType invert() {
         return this;
     }
+
+    public boolean isOuter() {
+        return ordinal() > INNER.ordinal();
+    }
 }

--- a/sql/src/main/java/io/crate/planner/node/dql/join/JoinType.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/join/JoinType.java
@@ -25,7 +25,21 @@ package io.crate.planner.node.dql.join;
 public enum JoinType {
     CROSS,
     INNER,
-    LEFT,
-    RIGHT,
-    FULL
+    LEFT {
+        @Override
+        public JoinType invert() {
+            return RIGHT;
+        }
+    },
+    RIGHT {
+        @Override
+        public JoinType invert() {
+            return LEFT;
+        }
+    },
+    FULL;
+
+    public JoinType invert() {
+        return this;
+    }
 }

--- a/sql/src/main/java/io/crate/planner/node/dql/join/NestedLoopPhase.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/join/NestedLoopPhase.java
@@ -58,6 +58,7 @@ public class NestedLoopPhase extends AbstractProjectionsPhase implements Upstrea
     private JoinType joinType;
     @Nullable
     private Symbol filterSymbol;
+    private int numLeftOutputs;
     private int numRightOutputs;
 
     public NestedLoopPhase() {}
@@ -71,6 +72,7 @@ public class NestedLoopPhase extends AbstractProjectionsPhase implements Upstrea
                            Collection<String> executionNodes,
                            JoinType joinType,
                            @Nullable Symbol filterSymbol,
+                           int numLeftOutputs,
                            int numRightOutputs) {
         super(jobId, executionNodeId, name, projections);
         Projection lastProjection = Iterables.getLast(projections, null);
@@ -81,6 +83,7 @@ public class NestedLoopPhase extends AbstractProjectionsPhase implements Upstrea
         this.executionNodes = executionNodes;
         this.joinType = joinType;
         this.filterSymbol = filterSymbol;
+        this.numLeftOutputs = numLeftOutputs;
         this.numRightOutputs = numRightOutputs;
     }
 
@@ -115,6 +118,10 @@ public class NestedLoopPhase extends AbstractProjectionsPhase implements Upstrea
 
     public JoinType joinType() {
         return joinType;
+    }
+
+    public int numLeftOutputs() {
+        return numLeftOutputs;
     }
 
     public int numRightOutputs() {
@@ -152,6 +159,7 @@ public class NestedLoopPhase extends AbstractProjectionsPhase implements Upstrea
             filterSymbol = Symbols.fromStream(in);
         }
         joinType = JoinType.values()[in.readVInt()];
+        numLeftOutputs = in.readVInt();
         numRightOutputs = in.readVInt();
     }
 
@@ -191,6 +199,7 @@ public class NestedLoopPhase extends AbstractProjectionsPhase implements Upstrea
         }
 
         out.writeVInt(joinType.ordinal());
+        out.writeVInt(numLeftOutputs);
         out.writeVInt(numRightOutputs);
     }
 
@@ -199,6 +208,7 @@ public class NestedLoopPhase extends AbstractProjectionsPhase implements Upstrea
         MoreObjects.ToStringHelper helper = MoreObjects.toStringHelper(this)
                 .add("executionPhaseId", executionPhaseId())
                 .add("name", name())
+                .add("joinType", joinType)
                 .add("outputTypes", outputTypes)
                 .add("jobId", jobId())
                 .add("executionNodes", executionNodes)

--- a/sql/src/main/java/io/crate/planner/node/dql/join/NestedLoopPhase.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/join/NestedLoopPhase.java
@@ -58,6 +58,7 @@ public class NestedLoopPhase extends AbstractProjectionsPhase implements Upstrea
     private JoinType joinType;
     @Nullable
     private Symbol filterSymbol;
+    private int numRightOutputs;
 
     public NestedLoopPhase() {}
 
@@ -69,7 +70,8 @@ public class NestedLoopPhase extends AbstractProjectionsPhase implements Upstrea
                            @Nullable MergePhase rightMergePhase,
                            Collection<String> executionNodes,
                            JoinType joinType,
-                           @Nullable Symbol filterSymbol) {
+                           @Nullable Symbol filterSymbol,
+                           int numRightOutputs) {
         super(jobId, executionNodeId, name, projections);
         Projection lastProjection = Iterables.getLast(projections, null);
         assert lastProjection != null;
@@ -79,6 +81,7 @@ public class NestedLoopPhase extends AbstractProjectionsPhase implements Upstrea
         this.executionNodes = executionNodes;
         this.joinType = joinType;
         this.filterSymbol = filterSymbol;
+        this.numRightOutputs = numRightOutputs;
     }
 
     @Override
@@ -114,6 +117,10 @@ public class NestedLoopPhase extends AbstractProjectionsPhase implements Upstrea
         return joinType;
     }
 
+    public int numRightOutputs() {
+        return numRightOutputs;
+    }
+
     @Override
     public <C, R> R accept(ExecutionPhaseVisitor<C, R> visitor, C context) {
         return visitor.visitNestedLoopPhase(this, context);
@@ -145,6 +152,7 @@ public class NestedLoopPhase extends AbstractProjectionsPhase implements Upstrea
             filterSymbol = Symbols.fromStream(in);
         }
         joinType = JoinType.values()[in.readVInt()];
+        numRightOutputs = in.readVInt();
     }
 
     @Override
@@ -183,6 +191,7 @@ public class NestedLoopPhase extends AbstractProjectionsPhase implements Upstrea
         }
 
         out.writeVInt(joinType.ordinal());
+        out.writeVInt(numRightOutputs);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/node/dql/join/NestedLoopPhase.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/join/NestedLoopPhase.java
@@ -55,6 +55,7 @@ public class NestedLoopPhase extends AbstractProjectionsPhase implements Upstrea
     private MergePhase leftMergePhase;
     private MergePhase rightMergePhase;
     private DistributionInfo distributionInfo = DistributionInfo.DEFAULT_BROADCAST;
+    private JoinType joinType;
     @Nullable
     private Symbol filterSymbol;
 
@@ -67,6 +68,7 @@ public class NestedLoopPhase extends AbstractProjectionsPhase implements Upstrea
                            @Nullable MergePhase leftMergePhase,
                            @Nullable MergePhase rightMergePhase,
                            Collection<String> executionNodes,
+                           JoinType joinType,
                            @Nullable Symbol filterSymbol) {
         super(jobId, executionNodeId, name, projections);
         Projection lastProjection = Iterables.getLast(projections, null);
@@ -75,6 +77,7 @@ public class NestedLoopPhase extends AbstractProjectionsPhase implements Upstrea
         this.leftMergePhase = leftMergePhase;
         this.rightMergePhase = rightMergePhase;
         this.executionNodes = executionNodes;
+        this.joinType = joinType;
         this.filterSymbol = filterSymbol;
     }
 
@@ -107,6 +110,10 @@ public class NestedLoopPhase extends AbstractProjectionsPhase implements Upstrea
         return filterSymbol;
     }
 
+    public JoinType joinType() {
+        return joinType;
+    }
+
     @Override
     public <C, R> R accept(ExecutionPhaseVisitor<C, R> visitor, C context) {
         return visitor.visitNestedLoopPhase(this, context);
@@ -137,6 +144,7 @@ public class NestedLoopPhase extends AbstractProjectionsPhase implements Upstrea
         if (in.readBoolean()) {
             filterSymbol = Symbols.fromStream(in);
         }
+        joinType = JoinType.values()[in.readVInt()];
     }
 
     @Override
@@ -173,6 +181,8 @@ public class NestedLoopPhase extends AbstractProjectionsPhase implements Upstrea
             out.writeBoolean(true);
             Symbols.toStream(filterSymbol, out);
         }
+
+        out.writeVInt(joinType.ordinal());
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/node/dql/join/NestedLoopPhase.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/join/NestedLoopPhase.java
@@ -56,8 +56,7 @@ public class NestedLoopPhase extends AbstractProjectionsPhase implements Upstrea
     private MergePhase rightMergePhase;
     private DistributionInfo distributionInfo = DistributionInfo.DEFAULT_BROADCAST;
     private JoinType joinType;
-    @Nullable
-    private Symbol filterSymbol;
+
     @Nullable
     private Symbol joinCondition;
     private int numLeftOutputs;
@@ -74,7 +73,6 @@ public class NestedLoopPhase extends AbstractProjectionsPhase implements Upstrea
                            Collection<String> executionNodes,
                            JoinType joinType,
                            @Nullable Symbol joinCondition,
-                           @Nullable Symbol filterSymbol,
                            int numLeftOutputs,
                            int numRightOutputs) {
         super(jobId, executionNodeId, name, projections);
@@ -86,7 +84,6 @@ public class NestedLoopPhase extends AbstractProjectionsPhase implements Upstrea
         this.executionNodes = executionNodes;
         this.joinType = joinType;
         this.joinCondition = joinCondition;
-        this.filterSymbol = filterSymbol;
         this.numLeftOutputs = numLeftOutputs;
         this.numRightOutputs = numRightOutputs;
     }
@@ -113,11 +110,6 @@ public class NestedLoopPhase extends AbstractProjectionsPhase implements Upstrea
     @Nullable
     public MergePhase rightMergePhase() {
         return rightMergePhase;
-    }
-
-    @Nullable
-    public Symbol filterSymbol() {
-        return filterSymbol;
     }
 
     @Nullable
@@ -167,9 +159,6 @@ public class NestedLoopPhase extends AbstractProjectionsPhase implements Upstrea
         if (in.readBoolean()) {
             joinCondition = Symbols.fromStream(in);
         }
-        if (in.readBoolean()) {
-            filterSymbol = Symbols.fromStream(in);
-        }
         joinType = JoinType.values()[in.readVInt()];
         numLeftOutputs = in.readVInt();
         numRightOutputs = in.readVInt();
@@ -209,12 +198,6 @@ public class NestedLoopPhase extends AbstractProjectionsPhase implements Upstrea
             out.writeBoolean(true);
             Symbols.toStream(joinCondition, out);
         }
-        if (filterSymbol == null) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            Symbols.toStream(filterSymbol, out);
-        }
 
         out.writeVInt(joinType.ordinal());
         out.writeVInt(numLeftOutputs);
@@ -230,8 +213,7 @@ public class NestedLoopPhase extends AbstractProjectionsPhase implements Upstrea
                 .add("joinCondition", joinCondition)
                 .add("outputTypes", outputTypes)
                 .add("jobId", jobId())
-                .add("executionNodes", executionNodes)
-                .add("filterSymbol", filterSymbol);
+                .add("executionNodes", executionNodes);
         return helper.toString();
     }
 

--- a/sql/src/main/resources/sql_features.tsv
+++ b/sql/src/main/resources/sql_features.tsv
@@ -162,10 +162,10 @@ F034	Extended REVOKE statement	3	REVOKE statement to revoke a privilege that the
 F041	Basic joined table			NO		
 F041	Basic joined table	1	Inner join (but not necessarily the INNER keyword)	YES		
 F041	Basic joined table	2	INNER keyword	YES		
-F041	Basic joined table	3	LEFT OUTER JOIN	NO		
-F041	Basic joined table	4	RIGHT OUTER JOIN	NO		
-F041	Basic joined table	5	Outer joins can be nested	NO		
-F041	Basic joined table	7	The inner table in a left or right outer join can also be used in an inner join	NO		
+F041	Basic joined table	3	LEFT OUTER JOIN	YES		
+F041	Basic joined table	4	RIGHT OUTER JOIN	YES		
+F041	Basic joined table	5	Outer joins can be nested	YES		
+F041	Basic joined table	7	The inner table in a left or right outer join can also be used in an inner join	YES		
 F041	Basic joined table	8	All comparison operators are supported (rather than just =)	YES		
 F051	Basic date and time			NO		only timestamp type
 F051	Basic date and time	1	DATE data type (including support of DATE literal)	NO		
@@ -251,7 +251,7 @@ F393	Unicode escapes in literals			NO
 F394	Optional normal form specification			NO		
 F401	Extended joined table			NO		
 F401	Extended joined table	1	NATURAL JOIN	NO		
-F401	Extended joined table	2	FULL OUTER JOIN	NO		
+F401	Extended joined table	2	FULL OUTER JOIN	YES		
 F401	Extended joined table	4	CROSS JOIN	YES		
 F402	Named column joins for LOBs, arrays, and multisets			NO		
 F403	Partitioned joined tables			NO		

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -814,18 +814,6 @@ public class SelectStatementAnalyzerTest extends BaseAnalyzerTest {
     }
 
     @Test
-    public void testRightOuterJoinSyntaxIsNotSupported() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
-        analyze("select * from users right outer join users_multi_pk on users.id = users_multi_pk.id");
-    }
-
-    @Test
-    public void testFullOuterJoinSyntaxIsNotSupported() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
-        analyze("select * from users full outer join users_multi_pk on users.id = users_multi_pk.id");
-    }
-
-    @Test
     public void testJoinUsingSyntax() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
         analyze("select * from users join users_multi_pk using (id)");

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -814,9 +814,9 @@ public class SelectStatementAnalyzerTest extends BaseAnalyzerTest {
     }
 
     @Test
-    public void testLeftOuterJoinSyntaxIsNotSupported() throws Exception {
+    public void testRightOuterJoinSyntaxIsNotSupported() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        analyze("select * from users left outer join users_multi_pk on users.id = users_multi_pk.id");
+        analyze("select * from users right outer join users_multi_pk on users.id = users_multi_pk.id");
     }
 
     @Test

--- a/sql/src/test/java/io/crate/analyze/SubSelectAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SubSelectAnalyzerTest.java
@@ -27,7 +27,6 @@ import io.crate.exceptions.AmbiguousColumnAliasException;
 import io.crate.operation.scalar.ScalarFunctionModule;
 import io.crate.testing.MockedClusterServiceModule;
 import org.elasticsearch.common.inject.Module;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;

--- a/sql/src/test/java/io/crate/analyze/relations/RelationNormalizerTest.java
+++ b/sql/src/test/java/io/crate/analyze/relations/RelationNormalizerTest.java
@@ -29,7 +29,6 @@ import io.crate.analyze.SelectAnalyzedStatement;
 import io.crate.operation.aggregation.impl.AggregationImplModule;
 import io.crate.operation.operator.OperatorModule;
 import io.crate.operation.scalar.ScalarFunctionModule;
-import io.crate.sql.tree.QualifiedName;
 import io.crate.testing.MockedClusterServiceModule;
 import io.crate.testing.T3;
 import org.elasticsearch.common.inject.Module;
@@ -246,9 +245,9 @@ public class RelationNormalizerTest extends BaseAnalyzerTest {
             "SELECT doc.t1.a, doc.t2.i ORDER BY doc.t2.y"));
 
         // make sure that where clause was pushed down and didn't disappear somehow
-        MultiSourceSelect.Source t1 = ((MultiSourceSelect) relation).sources().get(QualifiedName.of("doc", "t1"));
+        MultiSourceSelect.Source t1 = ((MultiSourceSelect) relation).sources().get(T3.T1);
         assertThat(t1.querySpec().where().query(), isSQL("(true AND (doc.t1.a = 'a'))"));
-        MultiSourceSelect.Source t2 = ((MultiSourceSelect) relation).sources().get(QualifiedName.of("doc", "t2"));
+        MultiSourceSelect.Source t2 = ((MultiSourceSelect) relation).sources().get(T3.T2);
         assertThat(t2.querySpec().where().query(), isSQL("(doc.t2.y > 60)"));
     }
 
@@ -284,9 +283,9 @@ public class RelationNormalizerTest extends BaseAnalyzerTest {
         assertThat(((MultiSourceSelect)relation).joinPairs().get(0).condition(), isSQL("(doc.t1.a = doc.t2.b)"));
 
         // make sure that where clause was pushed down and didn't disappear somehow
-        MultiSourceSelect.Source t1 = ((MultiSourceSelect) relation).sources().get(QualifiedName.of("doc", "t1"));
+        MultiSourceSelect.Source t1 = ((MultiSourceSelect) relation).sources().get(T3.T1);
         assertThat(t1.querySpec().where().query(), isSQL("null"));
-        MultiSourceSelect.Source t2 = ((MultiSourceSelect) relation).sources().get(QualifiedName.of("doc", "t2"));
+        MultiSourceSelect.Source t2 = ((MultiSourceSelect) relation).sources().get(T3.T2);
         assertThat(t2.querySpec().where().query(), isSQL("(doc.t2.i = 10)"));
     }
 
@@ -302,9 +301,9 @@ public class RelationNormalizerTest extends BaseAnalyzerTest {
             "SELECT doc.t1.a, doc.t2.i WHERE ((doc.t2.y > 60) AND (doc.t1.a = 'a')) ORDER BY doc.t2.y"));
 
         // make sure that where clause wasn't pushed down since but be applied after the FULL join
-        MultiSourceSelect.Source t1 = ((MultiSourceSelect) relation).sources().get(QualifiedName.of("doc", "t1"));
+        MultiSourceSelect.Source t1 = ((MultiSourceSelect) relation).sources().get(T3.T1);
         assertThat(t1.querySpec().where().query(), isSQL("null"));
-        MultiSourceSelect.Source t2 = ((MultiSourceSelect) relation).sources().get(QualifiedName.of("doc", "t2"));
+        MultiSourceSelect.Source t2 = ((MultiSourceSelect) relation).sources().get(T3.T2);
         assertThat(t2.querySpec().where().query(), isSQL("null"));
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -571,44 +571,4 @@ public class JoinIntegrationTest extends SQLTransportIntegrationTest {
             throw Exceptions.unwrap(t);
         }
     }
-
-    private void setupLeftJoinTestData() {
-        execute("create table employees (id integer, name string, office_id integer, professions_id integer)");
-        execute("create table offices (id integer, name string)");
-        execute("create table professions (id integer, name string)");
-        ensureYellow();
-        execute("insert into employees (id, name, office_id, profession_id) values" +
-                " (1, 'Trillian', 2, 3), (2, 'Ford Perfect', 4, 2), (3, 'Douglas Adams', 3, 1)");
-        execute("insert into offices (id, name) values (1, 'Hobbit House'), (2, 'Entresol'), (3, 'Chief Office')");
-        execute("insert into professions (id, name) values (1, 'Writer'), (2, 'Traveler'), (3, 'Commander'), (4, 'Janitor')");
-        execute("refresh table employees, offices, professions");
-    }
-
-    @Test
-    public void testLeftOuterJoin() throws Exception {
-        setupLeftJoinTestData();
-
-        // which employee works in which office?
-        execute("select persons.name, offices.name from" +
-                " employees as persons left join offices on office_id = offices.id" +
-                " order by offices.id");
-        assertThat(printedTable(response.rows()), is(
-                                                     "Trillian| Entresol\n" +
-                                                     "Douglas Adams| Chief Office\n" +
-                                                     "Ford Perfect| NULL\n"));
-    }
-
-    @Test
-    public void test3TableLeftOuterJoin() throws Exception {
-        setupLeftJoinTestData();
-        execute(
-            "select professions.name, employees.name, offices.name from" +
-            " professions left join employees on profession_id = professions.id" +
-            " left join offices on office_id = offices.id" +
-            " order by professions.id");
-        assertThat(printedTable(response.rows()), is("Writer| Douglas Adams| Chief Office\n" +
-                                                     "Traveler| Ford Perfect| NULL\n" +
-                                                     "Commander| Trillian| Entresol\n" +
-                                                     "Janitor| NULL| NULL\n"));
-    }
 }

--- a/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -571,4 +571,44 @@ public class JoinIntegrationTest extends SQLTransportIntegrationTest {
             throw Exceptions.unwrap(t);
         }
     }
+
+    private void setupLeftJoinTestData() {
+        execute("create table employees (id integer, name string, office_id integer, professions_id integer)");
+        execute("create table offices (id integer, name string)");
+        execute("create table professions (id integer, name string)");
+        ensureYellow();
+        execute("insert into employees (id, name, office_id, profession_id) values" +
+                " (1, 'Trillian', 2, 3), (2, 'Ford Perfect', 4, 2), (3, 'Douglas Adams', 3, 1)");
+        execute("insert into offices (id, name) values (1, 'Hobbit House'), (2, 'Entresol'), (3, 'Chief Office')");
+        execute("insert into professions (id, name) values (1, 'Writer'), (2, 'Traveler'), (3, 'Commander'), (4, 'Janitor')");
+        execute("refresh table employees, offices, professions");
+    }
+
+    @Test
+    public void testLeftOuterJoin() throws Exception {
+        setupLeftJoinTestData();
+
+        // which employee works in which office?
+        execute("select persons.name, offices.name from" +
+                " employees as persons left join offices on office_id = offices.id" +
+                " order by offices.id");
+        assertThat(printedTable(response.rows()), is(
+                                                     "Trillian| Entresol\n" +
+                                                     "Douglas Adams| Chief Office\n" +
+                                                     "Ford Perfect| NULL\n"));
+    }
+
+    @Test
+    public void test3TableLeftOuterJoin() throws Exception {
+        setupLeftJoinTestData();
+        execute(
+            "select professions.name, employees.name, offices.name from" +
+            " professions left join employees on profession_id = professions.id" +
+            " left join offices on office_id = offices.id" +
+            " order by professions.id");
+        assertThat(printedTable(response.rows()), is("Writer| Douglas Adams| Chief Office\n" +
+                                                     "Traveler| Ford Perfect| NULL\n" +
+                                                     "Commander| Trillian| Entresol\n" +
+                                                     "Janitor| NULL| NULL\n"));
+    }
 }

--- a/sql/src/test/java/io/crate/integrationtests/OuterJoinIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/OuterJoinIntegrationTest.java
@@ -50,10 +50,10 @@ public class OuterJoinIntegrationTest extends SQLTransportIntegrationTest {
         // which employee works in which office?
         execute("select persons.name, offices.name from" +
                 " employees as persons left join offices on office_id = offices.id" +
-                " order by offices.id");
+                " order by persons.id");
         assertThat(printedTable(response.rows()), is("Trillian| Entresol\n" +
-                                                     "Douglas Adams| Chief Office\n" +
-                                                     "Ford Perfect| NULL\n"));
+                                                     "Ford Perfect| NULL\n" +
+                                                     "Douglas Adams| Chief Office\n"));
     }
 
     public void testLeftOuterJoinOrderOnOuterTable() throws Exception {

--- a/sql/src/test/java/io/crate/integrationtests/OuterJoinIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/OuterJoinIntegrationTest.java
@@ -127,6 +127,17 @@ public class OuterJoinIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    public void testOuterJoinWithFunctionsInOrderBy() throws Exception {
+        execute("select coalesce(persons.name, ''), coalesce(offices.name, '') from" +
+                " offices full join employees as persons on office_id = offices.id" +
+                " order by 1, 2");
+        assertThat(printedTable(response.rows()), is("| Hobbit House\n" +
+                                                     "Douglas Adams| Chief Office\n" +
+                                                     "Ford Perfect| \n" +
+                                                     "Trillian| Entresol\n"));
+    }
+
+    @Test
     public void testLeftJoinWithFilterOnInner() throws Exception {
         execute("select employees.name, offices.name from" +
                 " employees left join offices on office_id = offices.id" +

--- a/sql/src/test/java/io/crate/integrationtests/OuterJoinIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/OuterJoinIntegrationTest.java
@@ -35,12 +35,12 @@ public class OuterJoinIntegrationTest extends SQLTransportIntegrationTest {
     @Before
     public void setupTestData() {
         execute("create table employees (id integer, name string, office_id integer, profession_id integer)");
-        execute("create table offices (id integer, name string)");
+        execute("create table offices (id integer, name string, size integer)");
         execute("create table professions (id integer, name string)");
         ensureYellow();
         execute("insert into employees (id, name, office_id, profession_id) values" +
                 " (1, 'Trillian', 2, 3), (2, 'Ford Perfect', 4, 2), (3, 'Douglas Adams', 3, 1)");
-        execute("insert into offices (id, name) values (1, 'Hobbit House'), (2, 'Entresol'), (3, 'Chief Office')");
+        execute("insert into offices (id, name, size) values (1, 'Hobbit House', 10), (2, 'Entresol', 70), (3, 'Chief Office', 150)");
         execute("insert into professions (id, name) values (1, 'Writer'), (2, 'Traveler'), (3, 'Commander'), (4, 'Janitor')");
         execute("refresh table employees, offices, professions");
     }
@@ -124,5 +124,24 @@ public class OuterJoinIntegrationTest extends SQLTransportIntegrationTest {
                                                      "Trillian| Entresol\n" +
                                                      "Douglas Adams| Chief Office\n" +
                                                      "Ford Perfect| NULL\n"));
+    }
+
+    @Test
+    public void testLeftJoinWithFilterOnInner() throws Exception {
+        execute("select employees.name, offices.name from" +
+                " employees left join offices on office_id = offices.id" +
+                " where employees.id < 3" +
+                " order by offices.id");
+        assertThat(printedTable(response.rows()), is("Trillian| Entresol\n" +
+                                                     "Ford Perfect| NULL\n"));
+    }
+
+    @Test
+    public void testLeftJoinWithFilterOnOuter() throws Exception {
+        execute("select employees.name, offices.name from" +
+                " employees left join offices on office_id = offices.id" +
+                " where offices.size > 100" +
+                " order by offices.id");
+        assertThat(printedTable(response.rows()), is("Douglas Adams| Chief Office\n"));
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/OuterJoinIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/OuterJoinIntegrationTest.java
@@ -23,7 +23,6 @@
 package io.crate.integrationtests;
 
 import io.crate.testing.UseJdbc;
-import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -57,6 +56,16 @@ public class OuterJoinIntegrationTest extends SQLTransportIntegrationTest {
                                                      "Ford Perfect| NULL\n"));
     }
 
+    public void testLeftOuterJoinOrderOnOuterTable() throws Exception {
+        // which employee works in which office?
+        execute("select persons.name, offices.name from" +
+                " employees as persons left join offices on office_id = offices.id" +
+                " order by offices.name nulls first");
+        assertThat(printedTable(response.rows()), is("Ford Perfect| NULL\n" +
+                                                     "Douglas Adams| Chief Office\n" +
+                                                     "Trillian| Entresol\n"));
+    }
+
     @Test
     public void test3TableLeftOuterJoin() throws Exception {
         execute(
@@ -68,6 +77,19 @@ public class OuterJoinIntegrationTest extends SQLTransportIntegrationTest {
                                                      "Traveler| Ford Perfect| NULL\n" +
                                                      "Commander| Trillian| Entresol\n" +
                                                      "Janitor| NULL| NULL\n"));
+    }
+
+    @Test
+    public void test3TableLeftOuterJoinOrderByOuterTable() throws Exception {
+        execute(
+            "select professions.name, employees.name, offices.name from" +
+            " professions left join employees on profession_id = professions.id" +
+            " left join offices on office_id = offices.id" +
+            " order by offices.name nulls first, professions.id nulls first");
+        assertThat(printedTable(response.rows()), is("Traveler| Ford Perfect| NULL\n" +
+                                                     "Janitor| NULL| NULL\n" +
+                                                     "Writer| Douglas Adams| Chief Office\n" +
+                                                     "Commander| Trillian| Entresol\n"));
     }
 
     @Test
@@ -84,12 +106,13 @@ public class OuterJoinIntegrationTest extends SQLTransportIntegrationTest {
     public void test3TableLeftAndRightOuterJoin() throws Exception {
         execute(
             "select professions.name, employees.name, offices.name from" +
-            " offices left join employees on profession_id = professions.id" +
-            " right join professions on office_id = offices.id" +
+            " offices left join employees on office_id = offices.id" +
+            " right join professions on profession_id = professions.id" +
             " order by professions.id");
         assertThat(printedTable(response.rows()), is("Writer| Douglas Adams| Chief Office\n" +
+                                                     "Traveler| NULL| NULL\n" +
                                                      "Commander| Trillian| Entresol\n" +
-                                                     "NULL| NULL| Hobbit House\n"));
+                                                     "Janitor| NULL| NULL\n"));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/OuterJoinIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/OuterJoinIntegrationTest.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.integrationtests;
+
+import io.crate.testing.UseJdbc;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.junit.Test;
+
+import static io.crate.testing.TestingHelpers.printedTable;
+import static org.hamcrest.core.Is.is;
+
+@ESIntegTestCase.ClusterScope(numDataNodes = 2)
+@UseJdbc
+public class OuterJoinIntegrationTest extends SQLTransportIntegrationTest {
+
+    private void setupOuterJoinTestData() {
+        execute("create table employees (id integer, name string, office_id integer, profession_id integer)");
+        execute("create table offices (id integer, name string)");
+        execute("create table professions (id integer, name string)");
+        ensureYellow();
+        execute("insert into employees (id, name, office_id, profession_id) values" +
+                " (1, 'Trillian', 2, 3), (2, 'Ford Perfect', 4, 2), (3, 'Douglas Adams', 3, 1)");
+        execute("insert into offices (id, name) values (1, 'Hobbit House'), (2, 'Entresol'), (3, 'Chief Office')");
+        execute("insert into professions (id, name) values (1, 'Writer'), (2, 'Traveler'), (3, 'Commander'), (4, 'Janitor')");
+        execute("refresh table employees, offices, professions");
+    }
+
+    @Test
+    public void testLeftOuterJoin() throws Exception {
+        setupOuterJoinTestData();
+
+        // which employee works in which office?
+        execute("select persons.name, offices.name from" +
+                " employees as persons left join offices on office_id = offices.id" +
+                " order by offices.id");
+        assertThat(printedTable(response.rows()), is("Trillian| Entresol\n" +
+                                                     "Douglas Adams| Chief Office\n" +
+                                                     "Ford Perfect| NULL\n"));
+    }
+
+    @Test
+    public void test3TableLeftOuterJoin() throws Exception {
+        setupOuterJoinTestData();
+        execute(
+            "select professions.name, employees.name, offices.name from" +
+            " professions left join employees on profession_id = professions.id" +
+            " left join offices on office_id = offices.id" +
+            " order by professions.id");
+        assertThat(printedTable(response.rows()), is("Writer| Douglas Adams| Chief Office\n" +
+                                                     "Traveler| Ford Perfect| NULL\n" +
+                                                     "Commander| Trillian| Entresol\n" +
+                                                     "Janitor| NULL| NULL\n"));
+    }
+
+    @Test
+    public void testRightOuterJoin() throws Exception {
+        setupOuterJoinTestData();
+
+        // which employee works in which office?
+        execute("select persons.name, offices.name from" +
+                " offices right join employees as persons on office_id = offices.id" +
+                " order by offices.id");
+        assertThat(printedTable(response.rows()), is("Trillian| Entresol\n" +
+                                                     "Douglas Adams| Chief Office\n" +
+                                                     "Ford Perfect| NULL\n"));
+    }
+
+    @Test
+    public void test3TableRightOuterJoin() throws Exception {
+        setupOuterJoinTestData();
+        execute(
+            "select professions.name, employees.name, offices.name from" +
+            " offices right join employees on profession_id = professions.id" +
+            " right join professions on office_id = offices.id" +
+            " order by professions.id");
+        assertThat(printedTable(response.rows()), is("Writer| Douglas Adams| Chief Office\n" +
+                                                     "Traveler| Ford Perfect| NULL\n" +
+                                                     "Commander| Trillian| Entresol\n" +
+                                                     "Janitor| NULL| NULL\n"));
+    }
+
+    @Test
+    public void testFullOuterJoin() throws Exception {
+        setupOuterJoinTestData();
+
+        execute("select persons.name, offices.name from" +
+                " offices full join employees as persons on office_id = offices.id" +
+                " order by offices.id");
+        assertThat(printedTable(response.rows()), is("NULL| Hobbit House\n" +
+                                                     "Trillian| Entresol\n" +
+                                                     "Douglas Adams| Chief Office\n" +
+                                                     "Ford Perfect| NULL\n"));
+    }
+}

--- a/sql/src/test/java/io/crate/operation/join/NestedLoopOperationTest.java
+++ b/sql/src/test/java/io/crate/operation/join/NestedLoopOperationTest.java
@@ -62,15 +62,17 @@ import static org.hamcrest.core.Is.is;
 public class NestedLoopOperationTest extends CrateUnitTest {
 
     private Bucket executeNestedLoop(List<Row> leftRows, List<Row> rightRows) throws Exception {
-        return executeNestedLoop(leftRows, rightRows, Predicates.<Row>alwaysTrue(), JoinType.INNER);
+        return executeNestedLoop(leftRows, rightRows, Predicates.<Row>alwaysTrue(), JoinType.CROSS, 0);
     }
 
     private Bucket executeNestedLoop(List<Row> leftRows,
                                      List<Row> rightRows,
                                      Predicate<Row> filterPredicate,
-                                     JoinType joinType) throws Exception {
+                                     JoinType joinType,
+                                     int rightRowSize) throws Exception {
         CollectingRowReceiver rowReceiver = new CollectingRowReceiver();
-        final NestedLoopOperation nestedLoopOperation = new NestedLoopOperation(0, rowReceiver, filterPredicate, joinType);
+        final NestedLoopOperation nestedLoopOperation = new NestedLoopOperation(0, rowReceiver, filterPredicate,
+            joinType, rightRowSize);
 
         PageDownstream leftPageDownstream = pageDownstream(nestedLoopOperation.leftRowReceiver());
         PageDownstream rightPageDownstream = pageDownstream(nestedLoopOperation.rightRowReceiver());
@@ -80,6 +82,10 @@ public class NestedLoopOperationTest extends CrateUnitTest {
         t1.join();
         t2.join();
         return rowReceiver.result();
+    }
+
+    private static NestedLoopOperation unfilteredNestedLoopOperation(int phaseId, RowReceiver rowReceiver) {
+        return new NestedLoopOperation(phaseId, rowReceiver, Predicates.<Row>alwaysTrue(), JoinType.CROSS, 0);
     }
 
     private PageDownstream pageDownstream(RowReceiver rowReceiver) {
@@ -101,7 +107,7 @@ public class NestedLoopOperationTest extends CrateUnitTest {
     @Test
     public void testRightSideFinishesBeforeLeftSideStarts() throws Exception {
         CollectingRowReceiver rowReceiver = new CollectingRowReceiver();
-        final NestedLoopOperation nestedLoopOperation = new NestedLoopOperation(0, rowReceiver);
+        final NestedLoopOperation nestedLoopOperation = unfilteredNestedLoopOperation(0, rowReceiver);
 
         final PageDownstream leftBucketMerger = pageDownstream(nestedLoopOperation.leftRowReceiver());
         final PageDownstream rightBucketMerger = pageDownstream(nestedLoopOperation.rightRowReceiver());
@@ -143,7 +149,7 @@ public class NestedLoopOperationTest extends CrateUnitTest {
     @Test
     public void testNestedLoopWithPausingDownstream() throws Exception {
         CollectingRowReceiver rowReceiver = CollectingRowReceiver.withPauseAfter(1);
-        NestedLoopOperation nl = new NestedLoopOperation(0, rowReceiver);
+        NestedLoopOperation nl = unfilteredNestedLoopOperation(0, rowReceiver);
 
         RowSender leftSender = new RowSender(asRows(1, 2, 3), nl.leftRowReceiver(), MoreExecutors.directExecutor());
         RowSender rightSender = new RowSender(asRows(10, 20), nl.rightRowReceiver(), MoreExecutors.directExecutor());
@@ -173,8 +179,8 @@ public class NestedLoopOperationTest extends CrateUnitTest {
          *     finalOutput
          */
         CollectingRowReceiver finalOutput = new CollectingRowReceiver();
-        NestedLoopOperation childNl = new NestedLoopOperation(1, finalOutput);
-        NestedLoopOperation parentNl = new NestedLoopOperation(0, childNl.leftRowReceiver());
+        NestedLoopOperation childNl = unfilteredNestedLoopOperation(1, finalOutput);
+        NestedLoopOperation parentNl = unfilteredNestedLoopOperation(0, childNl.leftRowReceiver());
 
         RowSender rsA = new RowSender(
                 asRows(1, 2), parentNl.leftRowReceiver(), MoreExecutors.directExecutor());
@@ -234,7 +240,7 @@ public class NestedLoopOperationTest extends CrateUnitTest {
                 1
         );
         topNProjector.downstream(rowReceiver);
-        NestedLoopOperation nestedLoopOperation = new NestedLoopOperation(0, topNProjector);
+        NestedLoopOperation nestedLoopOperation = unfilteredNestedLoopOperation(0, topNProjector);
 
         PageDownstream leftBucketMerger = pageDownstream(nestedLoopOperation.leftRowReceiver());
         PageDownstream rightBucketMerger = pageDownstream(nestedLoopOperation.rightRowReceiver());
@@ -293,7 +299,7 @@ public class NestedLoopOperationTest extends CrateUnitTest {
     @Test
     public void testFinishOnPausedLeftDoesNotCauseDeadlocksIfRightGotKilled() throws Exception {
         CollectingRowReceiver receiver = new CollectingRowReceiver();
-        final NestedLoopOperation nl = new NestedLoopOperation(0, receiver);
+        final NestedLoopOperation nl = unfilteredNestedLoopOperation(0, receiver);
 
         // initiate RowSender so that the RowReceiver has an upstream that can receive pause
         new RowSender(Collections.<Row>emptyList(), nl.leftRowReceiver(), MoreExecutors.directExecutor());
@@ -330,7 +336,7 @@ public class NestedLoopOperationTest extends CrateUnitTest {
                 return input.get(0) == input.get(1);
             }
         };
-        Bucket rows = executeNestedLoop(leftRows, rightRows, rowFilterPredicate, JoinType.LEFT);
+        Bucket rows = executeNestedLoop(leftRows, rightRows, rowFilterPredicate, JoinType.LEFT, 1);
 
         assertThat(TestingHelpers.printedTable(rows), is(
                                                          "1| NULL\n" +
@@ -340,7 +346,7 @@ public class NestedLoopOperationTest extends CrateUnitTest {
 
 
     private static List<ListenableRowReceiver> getRandomLeftAndRightRowReceivers(CollectingRowReceiver receiver) {
-        NestedLoopOperation nestedLoopOperation = new NestedLoopOperation(0, receiver);
+        NestedLoopOperation nestedLoopOperation = unfilteredNestedLoopOperation(0, receiver);
 
         List<ListenableRowReceiver> listenableRowReceivers =
                 Arrays.asList(nestedLoopOperation.rightRowReceiver(), nestedLoopOperation.leftRowReceiver());

--- a/sql/src/test/java/io/crate/operation/join/NestedLoopOperationTest.java
+++ b/sql/src/test/java/io/crate/operation/join/NestedLoopOperationTest.java
@@ -357,6 +357,19 @@ public class NestedLoopOperationTest extends CrateUnitTest {
                                                          "NULL| 4\n"));
     }
 
+    @Test
+    public void testNestedLoopOperationWithFullOuterJoin() throws Exception {
+        List<Row> leftRows = asRows(3, 5, 6, 7);
+        List<Row> rightRows = asRows(1, 2, 3, 4, 5);
+        Bucket rows = executeNestedLoop(leftRows, rightRows, ROW_FILTER_PREDICATE, JoinType.FULL, 1, 1);
+        assertThat(TestingHelpers.printedTable(rows), is("3| 3\n" +
+                                                         "5| 5\n" +
+                                                         "6| NULL\n" +
+                                                         "7| NULL\n" +
+                                                         "NULL| 1\n" +
+                                                         "NULL| 2\n" +
+                                                         "NULL| 4\n"));
+    }
 
     private static List<ListenableRowReceiver> getRandomLeftAndRightRowReceivers(CollectingRowReceiver receiver) {
         NestedLoopOperation nestedLoopOperation = unfilteredNestedLoopOperation(0, receiver);

--- a/sql/src/test/java/io/crate/operation/join/NestedLoopOperationTest.java
+++ b/sql/src/test/java/io/crate/operation/join/NestedLoopOperationTest.java
@@ -70,19 +70,18 @@ public class NestedLoopOperationTest extends CrateUnitTest {
 
     private Bucket executeNestedLoop(List<Row> leftRows, List<Row> rightRows) throws Exception {
         return executeNestedLoop(
-            leftRows, rightRows, Predicates.<Row>alwaysTrue(), Predicates.<Row>alwaysTrue(), JoinType.CROSS, 0, 0);
+            leftRows, rightRows, Predicates.<Row>alwaysTrue(), JoinType.CROSS, 0, 0);
     }
 
     private Bucket executeNestedLoop(List<Row> leftRows,
                                      List<Row> rightRows,
-                                     Predicate<Row> filterPredicate,
                                      Predicate<Row> joinPredicate,
                                      JoinType joinType,
                                      int leftRowSize,
                                      int rightRowSize) throws Exception {
         CollectingRowReceiver rowReceiver = new CollectingRowReceiver();
         final NestedLoopOperation nestedLoopOperation = new NestedLoopOperation(
-            0, rowReceiver, filterPredicate, joinPredicate, joinType, leftRowSize, rightRowSize);
+            0, rowReceiver, joinPredicate, joinType, leftRowSize, rightRowSize);
 
         PageDownstream leftPageDownstream = pageDownstream(nestedLoopOperation.leftRowReceiver());
         PageDownstream rightPageDownstream = pageDownstream(nestedLoopOperation.rightRowReceiver());
@@ -96,7 +95,7 @@ public class NestedLoopOperationTest extends CrateUnitTest {
 
     private static NestedLoopOperation unfilteredNestedLoopOperation(int phaseId, RowReceiver rowReceiver) {
         return new NestedLoopOperation(
-            phaseId, rowReceiver, Predicates.<Row>alwaysTrue(), Predicates.<Row>alwaysTrue(), JoinType.CROSS, 0, 0);
+            phaseId, rowReceiver, Predicates.<Row>alwaysTrue(), JoinType.CROSS, 0, 0);
     }
 
     private PageDownstream pageDownstream(RowReceiver rowReceiver) {
@@ -341,7 +340,7 @@ public class NestedLoopOperationTest extends CrateUnitTest {
         List<Row> leftRows = asRows(1, 2, 3, 4, 5);
         List<Row> rightRows = asRows(3, 5);
         Bucket rows = executeNestedLoop(
-            leftRows, rightRows, Predicates.<Row>alwaysTrue(), JOIN_CONDITION_PREDICATE, JoinType.LEFT, 1, 1);
+            leftRows, rightRows, JOIN_CONDITION_PREDICATE, JoinType.LEFT, 1, 1);
         assertThat(TestingHelpers.printedTable(rows), is("1| NULL\n" +
                                                          "2| NULL\n" +
                                                          "3| 3\n" +
@@ -354,7 +353,7 @@ public class NestedLoopOperationTest extends CrateUnitTest {
         List<Row> leftRows = asRows(3, 5);
         List<Row> rightRows = asRows(1, 2, 3, 4, 5);
         Bucket rows = executeNestedLoop(
-            leftRows, rightRows, Predicates.<Row>alwaysTrue(), JOIN_CONDITION_PREDICATE, JoinType.RIGHT, 1, 1);
+            leftRows, rightRows, JOIN_CONDITION_PREDICATE, JoinType.RIGHT, 1, 1);
         assertThat(TestingHelpers.printedTable(rows), is("3| 3\n" +
                                                          "5| 5\n" +
                                                          "NULL| 1\n" +
@@ -367,7 +366,7 @@ public class NestedLoopOperationTest extends CrateUnitTest {
         List<Row> leftRows = asRows(3, 5, 6, 7);
         List<Row> rightRows = asRows(1, 2, 3, 4, 5);
         Bucket rows = executeNestedLoop(
-            leftRows, rightRows, Predicates.<Row>alwaysTrue(), JOIN_CONDITION_PREDICATE, JoinType.FULL, 1, 1);
+            leftRows, rightRows, JOIN_CONDITION_PREDICATE, JoinType.FULL, 1, 1);
         assertThat(TestingHelpers.printedTable(rows), is("3| 3\n" +
                                                          "5| 5\n" +
                                                          "6| NULL\n" +

--- a/sql/src/test/java/io/crate/planner/node/dql/NestedLoopPhaseTest.java
+++ b/sql/src/test/java/io/crate/planner/node/dql/NestedLoopPhaseTest.java
@@ -69,6 +69,7 @@ public class NestedLoopPhaseTest extends CrateUnitTest {
             Sets.newHashSet("node1", "node2"),
             JoinType.INNER,
             filterCondition,
+            1,
             1
             );
 
@@ -85,6 +86,7 @@ public class NestedLoopPhaseTest extends CrateUnitTest {
         assertThat(node.outputTypes(), is(node2.outputTypes()));
         assertThat(node.filterSymbol(), is(node2.filterSymbol()));
         assertThat(node.joinType(), is(node2.joinType()));
+        assertThat(node.numLeftOutputs(), is(node2.numLeftOutputs()));
         assertThat(node.numRightOutputs(), is(node2.numRightOutputs()));
     }
 }

--- a/sql/src/test/java/io/crate/planner/node/dql/NestedLoopPhaseTest.java
+++ b/sql/src/test/java/io/crate/planner/node/dql/NestedLoopPhaseTest.java
@@ -68,7 +68,8 @@ public class NestedLoopPhaseTest extends CrateUnitTest {
             mp2,
             Sets.newHashSet("node1", "node2"),
             JoinType.INNER,
-            filterCondition
+            filterCondition,
+            1
             );
 
         BytesStreamOutput output = new BytesStreamOutput();
@@ -84,5 +85,6 @@ public class NestedLoopPhaseTest extends CrateUnitTest {
         assertThat(node.outputTypes(), is(node2.outputTypes()));
         assertThat(node.filterSymbol(), is(node2.filterSymbol()));
         assertThat(node.joinType(), is(node2.joinType()));
+        assertThat(node.numRightOutputs(), is(node2.numRightOutputs()));
     }
 }

--- a/sql/src/test/java/io/crate/planner/node/dql/NestedLoopPhaseTest.java
+++ b/sql/src/test/java/io/crate/planner/node/dql/NestedLoopPhaseTest.java
@@ -58,7 +58,8 @@ public class NestedLoopPhaseTest extends CrateUnitTest {
                 ImmutableList.<Projection>of(),
                 DistributionInfo.DEFAULT_BROADCAST);
         SqlExpressions sqlExpressions = new SqlExpressions(T3.SOURCES, T3.TR_1);
-        Symbol filterCondition = sqlExpressions.normalize(sqlExpressions.asSymbol("a = 'foo'"));
+        Symbol joinCondition = sqlExpressions.normalize(sqlExpressions.asSymbol("t1.x = t1.i"));
+        Symbol filterSymbol = sqlExpressions.normalize(sqlExpressions.asSymbol("a = 'foo'"));
         NestedLoopPhase node = new NestedLoopPhase(
             jobId,
             1,
@@ -68,7 +69,8 @@ public class NestedLoopPhaseTest extends CrateUnitTest {
             mp2,
             Sets.newHashSet("node1", "node2"),
             JoinType.INNER,
-            filterCondition,
+            joinCondition,
+            filterSymbol,
             1,
             1
             );

--- a/sql/src/test/java/io/crate/planner/node/dql/NestedLoopPhaseTest.java
+++ b/sql/src/test/java/io/crate/planner/node/dql/NestedLoopPhaseTest.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.planner.distribution.DistributionInfo;
+import io.crate.planner.node.dql.join.JoinType;
 import io.crate.planner.node.dql.join.NestedLoopPhase;
 import io.crate.planner.projection.Projection;
 import io.crate.planner.projection.TopNProjection;
@@ -66,6 +67,7 @@ public class NestedLoopPhaseTest extends CrateUnitTest {
             mp1,
             mp2,
             Sets.newHashSet("node1", "node2"),
+            JoinType.INNER,
             filterCondition
             );
 
@@ -81,5 +83,6 @@ public class NestedLoopPhaseTest extends CrateUnitTest {
         assertThat(node.name(), is(node2.name()));
         assertThat(node.outputTypes(), is(node2.outputTypes()));
         assertThat(node.filterSymbol(), is(node2.filterSymbol()));
+        assertThat(node.joinType(), is(node2.joinType()));
     }
 }

--- a/sql/src/test/java/io/crate/planner/node/dql/NestedLoopPhaseTest.java
+++ b/sql/src/test/java/io/crate/planner/node/dql/NestedLoopPhaseTest.java
@@ -59,7 +59,6 @@ public class NestedLoopPhaseTest extends CrateUnitTest {
                 DistributionInfo.DEFAULT_BROADCAST);
         SqlExpressions sqlExpressions = new SqlExpressions(T3.SOURCES, T3.TR_1);
         Symbol joinCondition = sqlExpressions.normalize(sqlExpressions.asSymbol("t1.x = t1.i"));
-        Symbol filterSymbol = sqlExpressions.normalize(sqlExpressions.asSymbol("a = 'foo'"));
         NestedLoopPhase node = new NestedLoopPhase(
             jobId,
             1,
@@ -70,7 +69,6 @@ public class NestedLoopPhaseTest extends CrateUnitTest {
             Sets.newHashSet("node1", "node2"),
             JoinType.INNER,
             joinCondition,
-            filterSymbol,
             1,
             1
             );
@@ -86,7 +84,6 @@ public class NestedLoopPhaseTest extends CrateUnitTest {
         assertThat(node.jobId(), Is.is(node2.jobId()));
         assertThat(node.name(), is(node2.name()));
         assertThat(node.outputTypes(), is(node2.outputTypes()));
-        assertThat(node.filterSymbol(), is(node2.filterSymbol()));
         assertThat(node.joinType(), is(node2.joinType()));
         assertThat(node.numLeftOutputs(), is(node2.numLeftOutputs()));
         assertThat(node.numRightOutputs(), is(node2.numRightOutputs()));

--- a/sql/src/test/java/io/crate/testing/T3.java
+++ b/sql/src/test/java/io/crate/testing/T3.java
@@ -37,6 +37,7 @@ import io.crate.metadata.table.TestingTableInfo;
 import io.crate.sql.tree.QualifiedName;
 import io.crate.types.DataTypes;
 
+import java.util.Arrays;
 import java.util.Map;
 
 import static org.mockito.Mockito.mock;
@@ -77,9 +78,9 @@ public class T3 {
         }
     };
 
-    public static final QualifiedName T1 = new QualifiedName("t1");
-    public static final QualifiedName T2 = new QualifiedName("t2");
-    public static final QualifiedName T3 = new QualifiedName("t3");
+    public static final QualifiedName T1 = new QualifiedName(Arrays.asList(Schemas.DEFAULT_SCHEMA_NAME, "t1"));
+    public static final QualifiedName T2 = new QualifiedName(Arrays.asList(Schemas.DEFAULT_SCHEMA_NAME, "t2"));
+    public static final QualifiedName T3 = new QualifiedName(Arrays.asList(Schemas.DEFAULT_SCHEMA_NAME, "t3"));
 
     public static final ImmutableList<AnalyzedRelation> RELATIONS = ImmutableList.<AnalyzedRelation>of(TR_1, TR_2, TR_3);
     public static final Map<QualifiedName, AnalyzedRelation> SOURCES = ImmutableMap.<QualifiedName, AnalyzedRelation>of(


### PR DESCRIPTION
It is only necessary to handle the joinCondition within the
NestedLoopOperation directly.

The rest of the WhereClause is logically executed after the join and so
can be handled as a FilterProjection in order to reduce complexity of
the NestedLoopOperation.