### PR TITLE
fixes failure handling on upsert-by-id

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fix: Dropping a partition while inserting by primary key into same
+   partition should not raise an exception but returns a 0 row count instead.
+
  - Fix: JAR conflict if HDFS plugin with Hadoop 2.x is used.
 
  - Fix: Now it is also possible to restore a snapshot of a single partition

--- a/sql/src/main/java/io/crate/jobs/UpsertByIdContext.java
+++ b/sql/src/main/java/io/crate/jobs/UpsertByIdContext.java
@@ -101,14 +101,16 @@ public class UpsertByIdContext extends AbstractExecutionSubContext {
                         || e instanceof VersionConflictEngineException)) {
                     // on updates, set affected row to 0 if document is not found or version conflicted
                     resultFuture.set(0L);
+                    close(null);
                 } else if (PartitionName.isPartition(request.index())
                            && e instanceof IndexNotFoundException) {
                     // index missing exception on a partition should never bubble, set affected row to 0
                     resultFuture.set(0L);
+                    close(null);
                 } else {
                     resultFuture.setException(e);
+                    close(e);
                 }
-                close(e);
             }
         });
     }


### PR DESCRIPTION
we catch some concrete failures and set rowCount
to 0 instead of bubbling the failure but we missed out
the `instead` and bubbled it in addition