### PR TITLE
Enforce the constraints validation on shards

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fix: Inserting in tables which have a generated column with
+  `current_timestamp` failed.
+
  - Fix: Dropping a partition while inserting by primary key into same
    partition should not raise an exception but returns a 0 row count instead.
 

--- a/sql/src/main/java/io/crate/executor/transport/ShardUpsertRequest.java
+++ b/sql/src/main/java/io/crate/executor/transport/ShardUpsertRequest.java
@@ -30,6 +30,7 @@ import io.crate.metadata.doc.DocSysColumns;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.bulk.BulkShardProcessor;
 import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.support.replication.ReplicationRequest;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -71,7 +72,7 @@ public class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, ShardUp
     public ShardUpsertRequest() {
     }
 
-    public ShardUpsertRequest(ShardId shardId,
+    private ShardUpsertRequest(ShardId shardId,
                               @Nullable String[] updateColumns,
                               @Nullable Reference[] insertColumns,
                               @Nullable String routing,
@@ -414,6 +415,16 @@ public class ShardUpsertRequest extends ShardRequest<ShardUpsertRequest, ShardUp
                        @Nullable Reference[] missingAssignmentsColumns,
                        UUID jobId) {
             this(timeout, overwriteDuplicates, continueOnError, assignmentsColumns, missingAssignmentsColumns, jobId, true);
+        }
+
+        public Builder(boolean overwriteDuplicates,
+                       boolean continueOnError,
+                       @Nullable String[] assignmentsColumns,
+                       @Nullable Reference[] missingAssignmentsColumns,
+                       UUID jobId,
+                       boolean validateGeneratedColumns) {
+            this(ReplicationRequest.DEFAULT_TIMEOUT, overwriteDuplicates, continueOnError,
+                assignmentsColumns, missingAssignmentsColumns, jobId, validateGeneratedColumns);
         }
 
         public Builder(TimeValue timeout,

--- a/sql/src/main/java/io/crate/executor/transport/TransportShardUpsertAction.java
+++ b/sql/src/main/java/io/crate/executor/transport/TransportShardUpsertAction.java
@@ -298,7 +298,9 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
             }
         }
 
-        processGeneratedColumns(tableInfo, pathsToUpdate, updatedGeneratedColumns, request.validateConstraints(), getResult);
+        // For updates we always have to enforce the validation of constraints on shards.
+        // Currently the validation is done only for generated columns.
+        processGeneratedColumns(tableInfo, pathsToUpdate, updatedGeneratedColumns, true, getResult);
 
         updateSourceByPaths(updatedSourceAsMap, pathsToUpdate);
 
@@ -323,6 +325,8 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
         } else {
             XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
 
+            // For direct inserts it is enough to have constraints validation on a handler.
+            // validateConstraints() of ShardUpsertRequest should result in false in this case.
             if (request.validateConstraints()) {
                 ConstraintsValidator.validateConstraintsForNotUsedColumns(notUsedNonGeneratedColumns, tableInfo);
             }

--- a/sql/src/main/java/io/crate/executor/transport/task/UpsertByIdTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/UpsertByIdTask.java
@@ -196,9 +196,15 @@ public class UpsertByIdTask extends JobTask {
             }
         }
 
-        ShardUpsertRequest upsertRequest = new ShardUpsertRequest(
-            shardId, upsertById.updateColumns(), upsertById.insertColumns(), item.routing(), jobId());
-        upsertRequest.continueOnError(false);
+        ShardUpsertRequest upsertRequest = new ShardUpsertRequest.Builder(
+            false,
+            false,
+            upsertById.updateColumns(),
+            upsertById.insertColumns(),
+            jobId(),
+            false
+        ).newRequest(shardId, item.routing());
+
         ShardUpsertRequest.Item requestItem = new ShardUpsertRequest.Item(
             item.id(), item.updateAssignments(), item.insertValues(), item.version());
         upsertRequest.add(0, requestItem);

--- a/sql/src/test/java/io/crate/executor/transport/ShardUpsertRequestTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/ShardUpsertRequestTest.java
@@ -41,25 +41,27 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class ShardUpsertRequestTest extends CrateUnitTest {
 
-    TableIdent charactersIdent = new TableIdent(null, "characters");
+    private static final TableIdent CHARACTERS_IDENTS = new TableIdent(null, "characters");
 
-    Reference idRef = new Reference(
-            new ReferenceIdent(charactersIdent, "id"), RowGranularity.DOC, DataTypes.INTEGER);
-    Reference nameRef = new Reference(
-            new ReferenceIdent(charactersIdent, "name"), RowGranularity.DOC, DataTypes.STRING);
+    private static final Reference ID_REF = new Reference(
+            new ReferenceIdent(CHARACTERS_IDENTS, "id"), RowGranularity.DOC, DataTypes.INTEGER);
+    private static final Reference NAME_REF = new Reference(
+            new ReferenceIdent(CHARACTERS_IDENTS, "name"), RowGranularity.DOC, DataTypes.STRING);
 
     @Test
     public void testStreaming() throws Exception {
         ShardId shardId = new ShardId("test", 1);
         String[] assignmentColumns = new String[]{"id", "name"};
         UUID jobId = UUID.randomUUID();
-        Reference[] missingAssignmentColumns = new Reference[]{idRef, nameRef};
-        ShardUpsertRequest request = new ShardUpsertRequest(
-                shardId,
-                assignmentColumns,
-                missingAssignmentColumns,
-                "42",
-                jobId);
+        Reference[] missingAssignmentColumns = new Reference[]{ID_REF, NAME_REF};
+        ShardUpsertRequest request = new ShardUpsertRequest.Builder(
+            false,
+            false,
+            assignmentColumns,
+            missingAssignmentColumns,
+            jobId,
+            false
+        ).newRequest(shardId, "42");
         request.validateConstraints(false);
 
         request.add(123, new ShardUpsertRequest.Item(

--- a/sql/src/test/java/io/crate/executor/transport/TransportShardUpsertActionTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/TransportShardUpsertActionTest.java
@@ -153,8 +153,14 @@ public class TransportShardUpsertActionTest extends CrateUnitTest {
     @Test
     public void testExceptionWhileProcessingItemsNotContinueOnError() throws Exception {
         ShardId shardId = new ShardId(TABLE_IDENT.indexName(), 0);
-        final ShardUpsertRequest request = new ShardUpsertRequest(
-                shardId, null, new Reference[]{ID_REF}, null, UUID.randomUUID());
+        ShardUpsertRequest request = new ShardUpsertRequest.Builder(
+            false,
+            false,
+            null,
+            new Reference[]{ID_REF},
+            UUID.randomUUID(),
+            false
+        ).newRequest(shardId, null);
         request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null));
 
         ShardResponse shardResponse = transportShardUpsertAction.processRequestItems(
@@ -166,10 +172,15 @@ public class TransportShardUpsertActionTest extends CrateUnitTest {
     @Test
     public void testExceptionWhileProcessingItemsContinueOnError() throws Exception {
         ShardId shardId = new ShardId(TABLE_IDENT.indexName(), 0);
-        final ShardUpsertRequest request = new ShardUpsertRequest(
-                shardId, null, new Reference[]{ID_REF}, null, UUID.randomUUID());
+        ShardUpsertRequest request = new ShardUpsertRequest.Builder(
+            false,
+            true,
+            null,
+            new Reference[]{ID_REF},
+            UUID.randomUUID(),
+            false
+        ).newRequest(shardId, null);
         request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null));
-        request.continueOnError(true);
 
         ShardResponse response = transportShardUpsertAction.processRequestItems(
                 shardId, request, new AtomicBoolean(false));
@@ -370,8 +381,14 @@ public class TransportShardUpsertActionTest extends CrateUnitTest {
     @Test
     public void testKilledSetWhileProcessingItemsDoesNotThrowException() throws Exception {
         ShardId shardId = new ShardId(TABLE_IDENT.indexName(), 0);
-        final ShardUpsertRequest request = new ShardUpsertRequest(
-            shardId, null, new Reference[]{ID_REF}, null, UUID.randomUUID());
+        ShardUpsertRequest request = new ShardUpsertRequest.Builder(
+            false,
+            false,
+            null,
+            new Reference[]{ID_REF},
+            UUID.randomUUID(),
+            false
+        ).newRequest(shardId, null);
         request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null));
 
         ShardResponse shardResponse = transportShardUpsertAction.processRequestItems(
@@ -383,8 +400,14 @@ public class TransportShardUpsertActionTest extends CrateUnitTest {
     @Test
     public void testItemsWithoutSourceAreSkippedOnReplicaOperation() throws Exception {
         ShardId shardId = new ShardId(TABLE_IDENT.indexName(), 0);
-        final ShardUpsertRequest request = new ShardUpsertRequest(
-            shardId, null, new Reference[]{ID_REF}, null, UUID.randomUUID());
+        ShardUpsertRequest request = new ShardUpsertRequest.Builder(
+            false,
+            false,
+            null,
+            new Reference[]{ID_REF},
+            UUID.randomUUID(),
+            false
+        ).newRequest(shardId, null);
         request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null));
 
         reset(indexShard);

--- a/sql/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
@@ -935,6 +935,17 @@ public class InsertIntoIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    public void testInsertOnCurrentTimestampGeneratedColumn() {
+        execute("create table t (id int, created timestamp generated always as current_timestamp)");
+        ensureYellow();
+        execute("insert into t (id) values(1)");
+        execute("refresh table t");
+        execute("select id, created from t");
+        assertThat((int) response.rows()[0][0], is(1));
+        assertThat(response.rows()[0][1], notNullValue());
+    }
+
+    @Test
     public void testInsertNullSourceForNotNullGeneratedColumn() {
         execute("create table generated_column (" +
                 " id int primary key," +


### PR DESCRIPTION
This change will enforce the constraints validation for
updates on shards and validation for insertions will be
done only on a handler.

Therefore, for cases like:

    create table t (id int, created timestamp generated as current_timestamp)
    insert into t (id) values (1)

the validation will not fail.