### PR TITLE
Fix QuerySplitter to not loose query parts

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed an issue that could cause joins on 3+ tables to produce the wrong
+   result.
+
  - Fix: Inserting in tables which have a generated column with
   `current_timestamp` failed.
 

--- a/sql/src/main/java/io/crate/analyze/relations/QuerySplitter.java
+++ b/sql/src/main/java/io/crate/analyze/relations/QuerySplitter.java
@@ -30,10 +30,7 @@ import io.crate.operation.operator.AndOperator;
 import io.crate.planner.consumer.ManyTableConsumer;
 import io.crate.sql.tree.QualifiedName;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 public class QuerySplitter {
 
@@ -94,7 +91,10 @@ public class QuerySplitter {
             if (!function.info().equals(AndOperator.INFO)) {
                 HashSet<QualifiedName> qualifiedNames = new HashSet<>();
                 ManyTableConsumer.QualifiedNameCounter.INSTANCE.process(function, qualifiedNames);
-                splits.put(qualifiedNames, function);
+                Symbol prevQuery = splits.put(qualifiedNames, function);
+                if (prevQuery != null) {
+                    splits.put(qualifiedNames, AndOperator.join(Arrays.asList(prevQuery, function)));
+                }
                 return null;
             }
 

--- a/sql/src/test/java/io/crate/analyze/relations/QuerySplitterTest.java
+++ b/sql/src/test/java/io/crate/analyze/relations/QuerySplitterTest.java
@@ -65,6 +65,15 @@ public class QuerySplitterTest {
     }
 
     @Test
+    public void testSplitWithQueryMerge() throws Exception {
+        Symbol symbol = asSymbol("t1.a = 10 and (t2.b = 30 or t2.b = 20) and t1.x = 1");
+        Map<Set<QualifiedName>, Symbol> split = QuerySplitter.split(symbol);
+        assertThat(split.size(), is(2));
+        assertThat(split.get(Sets.newHashSet(tr1)), isSQL("((RELCOL(tr1, 0) = '10') AND (RELCOL(tr1, 1) = 1))"));
+        assertThat(split.get(Sets.newHashSet(tr2)), isSQL("((RELCOL(tr2, 0) = '30') OR (RELCOL(tr2, 0) = '20'))"));
+    }
+
+    @Test
     public void testSplitDownTo1Relation() throws Exception {
         Symbol symbol = asSymbol("t1.a = 10 and (t2.b = 30 or t2.b = 20)");
         Map<Set<QualifiedName>, Symbol> split = QuerySplitter.split(symbol);


### PR DESCRIPTION
The QuerySplitter overwrote previous query parts it found.
In a query like:

    t1.a = 10 and (t2.b = 30 or t2.b = 20) and t1.x = 1

It would only keep

    t1 -> t1.x = 1
    t2 -> t2.b = 30 or t2.b = 20

instead of:

    t1 -> t1.x = 1 and t1.a = 10
    t2 -> t2.b = 30 or t2.b = 20