### PR TITLE
Remove joinConditions from RelationAnalysisContext

### DIFF
--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalysisContext.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalysisContext.java
@@ -49,9 +49,6 @@ public class RelationAnalysisContext {
     private FieldProvider fieldProvider;
 
     @Nullable
-    private List<Symbol> joinConditions;
-
-    @Nullable
     private List<JoinPair> joinPairs;
 
     RelationAnalysisContext(ParameterContext parameterContext,
@@ -71,21 +68,6 @@ public class RelationAnalysisContext {
     public Map<QualifiedName, AnalyzedRelation> sources() {
         return sources;
     }
-
-    List<Symbol> joinConditions() {
-        if (joinConditions == null) {
-            return ImmutableList.of();
-        }
-        return joinConditions;
-    }
-
-    void addJoinCondition(Symbol symbol) {
-        if (joinConditions == null) {
-            joinConditions = new ArrayList<>();
-        }
-        joinConditions.add(symbol);
-    }
-
 
     private void addJoinPair(JoinPair joinType) {
         if (joinPairs == null) {

--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -44,7 +44,6 @@ import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.Operation;
 import io.crate.metadata.table.TableInfo;
 import io.crate.metadata.tablefunctions.TableFunctionImplementation;
-import io.crate.operation.operator.AndOperator;
 import io.crate.planner.consumer.OrderByWithAggregationValidator;
 import io.crate.planner.node.dql.join.JoinType;
 import io.crate.sql.tree.*;
@@ -319,8 +318,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
     }
 
     private WhereClause analyzeWhere(Optional<Expression> where, RelationAnalysisContext context) {
-        List<Symbol> joinConditions = context.joinConditions();
-        if (!where.isPresent() && joinConditions.isEmpty()) {
+        if (!where.isPresent()) {
             return WhereClause.MATCH_ALL;
         }
         Symbol query;
@@ -328,11 +326,6 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
             query = context.expressionAnalyzer().convert(where.get(), context.expressionAnalysisContext());
         } else {
             query = Literal.BOOLEAN_TRUE;
-        }
-        if (!joinConditions.isEmpty()) {
-            for (Symbol joinCondition : joinConditions) {
-                query = new Function(AndOperator.INFO, Arrays.asList(query, joinCondition));
-            }
         }
         query = context.expressionAnalyzer().normalize(query, context.expressionAnalysisContext().statementContext());
         return new WhereClause(query);


### PR DESCRIPTION
They have become part of the joinPairs - this was most likely a leftover
due to a merge mistake on a rebase.