### PR TITLE
Rename Literal.newLiteral to Literal.of

### DIFF
--- a/sql/src/main/java/io/crate/analyze/EvaluatingNormalizer.java
+++ b/sql/src/main/java/io/crate/analyze/EvaluatingNormalizer.java
@@ -129,10 +129,10 @@ public class EvaluatingNormalizer {
                 return new Function(
                         io.crate.operation.predicate.MatchPredicate.INFO,
                         Arrays.<Symbol>asList(
-                                Literal.newLiteral(fqnBoostMap),
-                                Literal.newLiteral(matchPredicate.columnType(), matchPredicate.queryTerm()),
-                                Literal.newLiteral(matchPredicate.matchType()),
-                                Literal.newLiteral(matchPredicate.options())));
+                                Literal.of(fqnBoostMap),
+                                Literal.of(matchPredicate.columnType(), matchPredicate.queryTerm()),
+                                Literal.of(matchPredicate.matchType()),
+                                Literal.of(matchPredicate.options())));
             }
             return matchPredicate;
         }
@@ -158,7 +158,7 @@ public class EvaluatingNormalizer {
 
             Input input = referenceResolver.getImplementation(symbol);
             if (input != null) {
-                return Literal.newLiteral(symbol.valueType(), input.value());
+                return Literal.of(symbol.valueType(), input.value());
             }
 
             if (logger.isTraceEnabled()) {

--- a/sql/src/main/java/io/crate/analyze/InsertFromSubQueryAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/InsertFromSubQueryAnalyzedStatement.java
@@ -145,7 +145,7 @@ public class InsertFromSubQueryAnalyzedStatement implements AnalyzedRelation, An
             FunctionIdent functionIdent = new FunctionIdent(SubscriptObjectFunction.NAME,
                     ImmutableList.<DataType>of(DataTypes.OBJECT, DataTypes.STRING));
             symbol = new Function(new FunctionInfo(functionIdent, returnType),
-                    Arrays.asList(symbol, Literal.newLiteral(key)));
+                    Arrays.asList(symbol, Literal.of(key)));
         }
         return symbol;
     }

--- a/sql/src/main/java/io/crate/analyze/InsertFromValuesAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/InsertFromValuesAnalyzer.java
@@ -82,7 +82,7 @@ public class InsertFromValuesAnalyzer extends AbstractInsertAnalyzer {
             assert columnReference != null;
             DataType returnType = columnReference.valueType();
             assignmentColumns.add(columnReference.ident().columnIdent().fqn());
-            return Literal.newLiteral(returnType, returnType.value(insertValues[columns.indexOf(columnReference)]));
+            return Literal.of(returnType, returnType.value(insertValues[columns.indexOf(columnReference)]));
         }
     }
 

--- a/sql/src/main/java/io/crate/analyze/NegativeLiteralVisitor.java
+++ b/sql/src/main/java/io/crate/analyze/NegativeLiteralVisitor.java
@@ -35,15 +35,15 @@ public class NegativeLiteralVisitor extends SymbolVisitor<Void, Literal> {
         }
         switch (symbol.valueType().id()) {
             case DoubleType.ID:
-                return Literal.newLiteral(symbol.valueType(), (Double)symbol.value() * -1);
+                return Literal.of(symbol.valueType(), (Double)symbol.value() * -1);
             case FloatType.ID:
-                return Literal.newLiteral(symbol.valueType(), (Double)symbol.value() * -1);
+                return Literal.of(symbol.valueType(), (Double)symbol.value() * -1);
             case ShortType.ID:
-                return Literal.newLiteral(symbol.valueType(), (Short)symbol.value() * -1);
+                return Literal.of(symbol.valueType(), (Short)symbol.value() * -1);
             case IntegerType.ID:
-                return Literal.newLiteral(symbol.valueType(), (Integer)symbol.value() * -1);
+                return Literal.of(symbol.valueType(), (Integer)symbol.value() * -1);
             case LongType.ID:
-                return Literal.newLiteral(symbol.valueType(), (Long)symbol.value() * -1);
+                return Literal.of(symbol.valueType(), (Long)symbol.value() * -1);
             default:
                 return symbol;
         }

--- a/sql/src/main/java/io/crate/analyze/ParameterContext.java
+++ b/sql/src/main/java/io/crate/analyze/ParameterContext.java
@@ -22,6 +22,7 @@
 package io.crate.analyze;
 
 import io.crate.action.sql.SQLOperations;
+import io.crate.analyze.symbol.Literal;
 import io.crate.core.collections.Row;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -32,7 +33,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
-import static io.crate.analyze.symbol.Literal.newLiteral;
 
 
 public class ParameterContext {
@@ -116,7 +116,7 @@ public class ParameterContext {
             Object value = parameters().get(index);
             DataType type = guessTypeSafe(value);
             // use type.value because some types need conversion (String to BytesRef, List to Array)
-            return newLiteral(type, type.value(value));
+            return Literal.of(type, type.value(value));
         } catch (ArrayIndexOutOfBoundsException e) {
             throw new IllegalArgumentException(String.format(Locale.ENGLISH,
                     "Tried to resolve a parameter but the arguments provided with the " +

--- a/sql/src/main/java/io/crate/analyze/ReferenceToTrueVisitor.java
+++ b/sql/src/main/java/io/crate/analyze/ReferenceToTrueVisitor.java
@@ -57,10 +57,10 @@ public class ReferenceToTrueVisitor extends SymbolVisitor<Void, Symbol> {
         if (functionName.equals(NotPredicate.NAME)) {
             Symbol argument = symbol.arguments().get(0);
             if (argument instanceof Reference) {
-                return Literal.newLiteral(true);
+                return Literal.of(true);
             } else if (argument instanceof Function) {
                 if (!Operators.LOGICAL_OPERATORS.contains(((Function) argument).info().ident().name())) {
-                    return Literal.newLiteral(true);
+                    return Literal.of(true);
                 }
             }
         }
@@ -71,13 +71,13 @@ public class ReferenceToTrueVisitor extends SymbolVisitor<Void, Symbol> {
             }
             return new Function(symbol.info(), newArgs);
         } else {
-            return Literal.newLiteral(true);
+            return Literal.of(true);
         }
     }
 
     @Override
     public Symbol visitMatchPredicate(MatchPredicate matchPredicate, Void context) {
-        return Literal.newLiteral(true);
+        return Literal.of(true);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/analyze/VersionRewriter.java
+++ b/sql/src/main/java/io/crate/analyze/VersionRewriter.java
@@ -75,7 +75,7 @@ public class VersionRewriter {
                 if (DocSysColumns.VERSION.equals(columnIdent)) {
                     assert context.version == null;
                     context.version = right;
-                    return Literal.newLiteral(true);
+                    return Literal.of(true);
                 }
             }
             return function;

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -63,7 +63,6 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static io.crate.analyze.symbol.Literal.newLiteral;
 
 /**
  * <p>This Analyzer can be used to convert Expression from the SQL AST into symbols.</p>
@@ -275,7 +274,7 @@ public class ExpressionAnalyzer {
                 visitExpression(node, context);
             }
             List<Symbol> args = Lists.<Symbol>newArrayList(
-                    Literal.newLiteral(node.getPrecision().or(CurrentTimestampFunction.DEFAULT_PRECISION))
+                    Literal.of(node.getPrecision().or(CurrentTimestampFunction.DEFAULT_PRECISION))
             );
             return context.allocateFunction(CurrentTimestampFunction.INFO, args);
         }
@@ -356,7 +355,7 @@ public class ExpressionAnalyzer {
                 Symbols.addValuesToCollection(values, targetType, symbols);
                 return context.allocateFunction(
                         AnyEqOperator.createInfo(targetType),
-                        Arrays.asList(left,Literal.newLiteral(new SetType(targetType), values)));
+                        Arrays.asList(left,Literal.of(new SetType(targetType), values)));
             }
 
             Set<Function> comparisons = new HashSet<>(expressions.size());
@@ -416,7 +415,7 @@ public class ExpressionAnalyzer {
                 FunctionIdent functionIdent = new FunctionIdent(SubscriptFunction.NAME,
                         ImmutableList.of(subscriptSymbol.valueType(), DataTypes.INTEGER));
                 return context.allocateFunction(getFunctionInfo(functionIdent),
-                        Arrays.asList(subscriptSymbol, newLiteral(index)));
+                        Arrays.asList(subscriptSymbol, Literal.of(index)));
             }
             return subscriptSymbol;
         }
@@ -600,27 +599,27 @@ public class ExpressionAnalyzer {
 
         @Override
         protected Symbol visitBooleanLiteral(BooleanLiteral node, ExpressionAnalysisContext context) {
-            return newLiteral(node.getValue());
+            return Literal.of(node.getValue());
         }
 
         @Override
         protected Symbol visitStringLiteral(StringLiteral node, ExpressionAnalysisContext context) {
-            return newLiteral(node.getValue());
+            return Literal.of(node.getValue());
         }
 
         @Override
         protected Symbol visitDoubleLiteral(DoubleLiteral node, ExpressionAnalysisContext context) {
-            return newLiteral(node.getValue());
+            return Literal.of(node.getValue());
         }
 
         @Override
         protected Symbol visitLongLiteral(LongLiteral node, ExpressionAnalysisContext context) {
-            return newLiteral(node.getValue());
+            return Literal.of(node.getValue());
         }
 
         @Override
         protected Symbol visitNullLiteral(NullLiteral node, ExpressionAnalysisContext context) {
-            return newLiteral(UndefinedType.INSTANCE, null);
+            return Literal.of(UndefinedType.INSTANCE, null);
         }
 
         @Override
@@ -631,7 +630,7 @@ public class ExpressionAnalyzer {
 
         private Literal toArrayLiteral(List<Expression> values, ExpressionAnalysisContext context) {
             if (values.isEmpty()) {
-                return newLiteral(new ArrayType(UndefinedType.INSTANCE), new Object[0]);
+                return Literal.of(new ArrayType(UndefinedType.INSTANCE), new Object[0]);
             } else {
                 DataType innerType = null;
                 Object[] innerValues = new Object[values.size()];
@@ -655,7 +654,7 @@ public class ExpressionAnalyzer {
                         innerValues[i] = innerType.value(innerValues[i]);
                     }
                 }
-                return Literal.newLiteral(new ArrayType(innerType), innerValues);
+                return Literal.of(new ArrayType(innerType), innerValues);
             }
         }
 
@@ -682,7 +681,7 @@ public class ExpressionAnalyzer {
                                     entry.getKey()));
                 }
             }
-            return newLiteral(values);
+            return Literal.of(values);
         }
 
         @Override

--- a/sql/src/main/java/io/crate/analyze/symbol/Literal.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/Literal.java
@@ -165,49 +165,49 @@ public class Literal<ReturnType>
         type.streamer().writeValueTo(out, value);
     }
 
-    public static Literal<Map<String, Object>> newLiteral(Map<String, Object> value) {
+    public static Literal<Map<String, Object>> of(Map<String, Object> value) {
         return new Literal<>(DataTypes.OBJECT, value);
     }
 
-    public static Literal<Object[]> newLiteral(Object[] value, DataType dataType) {
+    public static Literal<Object[]> of(Object[] value, DataType dataType) {
         return new Literal<>(dataType, value);
     }
 
-    public static Literal<Long> newLiteral(Long value) {
+    public static Literal<Long> of(Long value) {
         return new Literal<>(DataTypes.LONG, value);
     }
 
-    public static Literal<Object> newLiteral(DataType type, Object value) {
+    public static Literal<Object> of(DataType type, Object value) {
         return new Literal<>(type, value);
     }
 
-    public static Literal<Integer> newLiteral(Integer value) {
+    public static Literal<Integer> of(Integer value) {
         return new Literal<>(DataTypes.INTEGER, value);
     }
 
-    public static Literal<BytesRef> newLiteral(String value) {
+    public static Literal<BytesRef> of(String value) {
         if (value == null) {
             return new Literal<>(DataTypes.STRING, null);
         }
         return new Literal<>(DataTypes.STRING, new BytesRef(value));
     }
 
-    public static Literal<BytesRef> newLiteral(BytesRef value) {
+    public static Literal<BytesRef> of(BytesRef value) {
         return new Literal<>(DataTypes.STRING, value);
     }
 
-    public static Literal<Boolean> newLiteral(Boolean value) {
+    public static Literal<Boolean> of(Boolean value) {
         if (value == null) {
             return new Literal<>(DataTypes.BOOLEAN, null);
         }
         return value ? BOOLEAN_TRUE : BOOLEAN_FALSE;
     }
 
-    public static Literal<Double> newLiteral(Double value) {
+    public static Literal<Double> of(Double value) {
         return new Literal<>(DataTypes.DOUBLE, value);
     }
 
-    public static Literal<Float> newLiteral(Float value) {
+    public static Literal<Float> of(Float value) {
         return new Literal<>(DataTypes.FLOAT, value);
     }
 
@@ -235,7 +235,7 @@ public class Literal<ReturnType>
             return literal;
         }
         try {
-            return newLiteral(type, type.value(literal.value()));
+            return of(type, type.value(literal.value()));
         } catch (IllegalArgumentException | ClassCastException e) {
             throw new ConversionException(symbol, type);
         }

--- a/sql/src/main/java/io/crate/analyze/where/WhereClauseAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/where/WhereClauseAnalyzer.java
@@ -181,7 +181,7 @@ public class WhereClauseAnalyzer {
                     partitions = new ArrayList<>();
                     queryPartitionMap.put(normalized, partitions);
                 }
-                partitions.add(Literal.newLiteral(partitionName.asIndexName()));
+                partitions.add(Literal.of(partitionName.asIndexName()));
             }
         }
 

--- a/sql/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
+++ b/sql/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
@@ -1124,7 +1124,7 @@ public class LuceneQueryBuilder {
                     Reference ref = (Reference) left;
                     if (ref.ident().columnIdent().equals(DocSysColumns.ID)) {
                         function.setArgument(0, DocSysColumns.forTable(ref.ident().tableIdent(), DocSysColumns.UID));
-                        function.setArgument(1, Literal.newLiteral(Uid.createUid(Constants.DEFAULT_MAPPING_TYPE,
+                        function.setArgument(1, Literal.of(Uid.createUid(Constants.DEFAULT_MAPPING_TYPE,
                                 ValueSymbolVisitor.STRING.process(right))));
                     } else {
                         String unsupportedMessage = context.unsupportedMessage(ref.ident().columnIdent().name());

--- a/sql/src/main/java/io/crate/metadata/ReferenceToLiteralConverter.java
+++ b/sql/src/main/java/io/crate/metadata/ReferenceToLiteralConverter.java
@@ -80,11 +80,11 @@ public class ReferenceToLiteralConverter extends ReplacingSymbolVisitor<Referenc
                 } else {
                     value = values[inputColumn.index()];
                 }
-                return Literal.newLiteral(dataType, dataType.value(value));
+                return Literal.of(dataType, dataType.value(value));
             }
 
             DataType dataType = reference.valueType();
-            return Literal.newLiteral(dataType, dataType.value(null));
+            return Literal.of(dataType, dataType.value(null));
         }
 
     }

--- a/sql/src/main/java/io/crate/metadata/Scalar.java
+++ b/sql/src/main/java/io/crate/metadata/Scalar.java
@@ -100,6 +100,6 @@ public abstract class Scalar<ReturnType, InputType> implements FunctionImplement
             }
         }
         //noinspection unchecked
-        return Literal.newLiteral(function.info().returnType(), scalar.evaluate(inputs));
+        return Literal.of(function.info().returnType(), scalar.evaluate(inputs));
     }
 }

--- a/sql/src/main/java/io/crate/operation/aggregation/impl/CountAggregation.java
+++ b/sql/src/main/java/io/crate/operation/aggregation/impl/CountAggregation.java
@@ -102,7 +102,7 @@ public class CountAggregation extends AggregationFunction<CountAggregation.LongS
         if (function.arguments().size() == 1) {
             if (function.arguments().get(0).symbolType().isValueSymbol()) {
                 if ((function.arguments().get(0)).valueType() == DataTypes.UNDEFINED) {
-                    return Literal.newLiteral(0L);
+                    return Literal.of(0L);
                 } else {
                     return new Function(COUNT_STAR_FUNCTION, ImmutableList.<Symbol>of());
                 }

--- a/sql/src/main/java/io/crate/operation/operator/AndOperator.java
+++ b/sql/src/main/java/io/crate/operation/operator/AndOperator.java
@@ -55,7 +55,7 @@ public class AndOperator extends Operator<Boolean> {
         Symbol right = function.arguments().get(1);
 
         if (left instanceof Input && right instanceof Input) {
-            return Literal.newLiteral(evaluate((Input) left, (Input) right));
+            return Literal.of(evaluate((Input) left, (Input) right));
         }
 
         /**
@@ -71,7 +71,7 @@ public class AndOperator extends Operator<Boolean> {
             if ((Boolean) value) {
                 return right;
             } else {
-                return Literal.newLiteral(false);
+                return Literal.of(false);
             }
         }
         if (right instanceof Input) {
@@ -82,7 +82,7 @@ public class AndOperator extends Operator<Boolean> {
             if ((Boolean) value) {
                 return left;
             } else {
-                return Literal.newLiteral(false);
+                return Literal.of(false);
             }
         }
         return function;

--- a/sql/src/main/java/io/crate/operation/operator/InOperator.java
+++ b/sql/src/main/java/io/crate/operation/operator/InOperator.java
@@ -72,10 +72,10 @@ public class InOperator extends Operator<Object> {
         Set values = (Set)inList.value();
 
         if (!values.contains(inValue)) {
-            return Literal.newLiteral(false);
+            return Literal.of(false);
         }
 
-        return Literal.newLiteral(true);
+        return Literal.of(true);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/operation/operator/OrOperator.java
+++ b/sql/src/main/java/io/crate/operation/operator/OrOperator.java
@@ -31,7 +31,7 @@ public class OrOperator extends Operator<Boolean> {
         Symbol right = function.arguments().get(1);
 
         if (left.symbolType().isValueSymbol() && right.symbolType().isValueSymbol()) {
-            return Literal.newLiteral(evaluate((Input) left, (Input) right));
+            return Literal.of(evaluate((Input) left, (Input) right));
         }
 
         /*
@@ -46,7 +46,7 @@ public class OrOperator extends Operator<Boolean> {
             }
             assert value instanceof Boolean;
             if ((Boolean) value) {
-                return Literal.newLiteral(true);
+                return Literal.of(true);
             } else {
                 return right;
             }
@@ -59,7 +59,7 @@ public class OrOperator extends Operator<Boolean> {
             }
             assert value instanceof Boolean;
             if ((Boolean) value) {
-                return Literal.newLiteral(true);
+                return Literal.of(true);
             } else {
                 return left;
             }

--- a/sql/src/main/java/io/crate/operation/operator/RegexpMatchCaseInsensitiveOperator.java
+++ b/sql/src/main/java/io/crate/operation/operator/RegexpMatchCaseInsensitiveOperator.java
@@ -77,7 +77,7 @@ public class RegexpMatchCaseInsensitiveOperator extends Operator<BytesRef> {
             return Literal.NULL;
         }
 
-        return Literal.newLiteral(
+        return Literal.of(
                 evaluate(
                         (Literal) symbol.arguments().get(0),
                         (Literal) symbol.arguments().get(1)

--- a/sql/src/main/java/io/crate/operation/predicate/IsNullPredicate.java
+++ b/sql/src/main/java/io/crate/operation/predicate/IsNullPredicate.java
@@ -64,9 +64,9 @@ public class IsNullPredicate<T> extends Scalar<Boolean, T> implements FunctionFo
 
         Symbol arg = symbol.arguments().get(0);
         if (arg.equals(Literal.NULL) || arg.valueType().equals(DataTypes.UNDEFINED)) {
-            return Literal.newLiteral(true);
+            return Literal.of(true);
         } else if (arg.symbolType().isValueSymbol()) {
-            return Literal.newLiteral(((Input) arg).value() == null);
+            return Literal.of(((Input) arg).value() == null);
         }
         return symbol;
     }

--- a/sql/src/main/java/io/crate/operation/predicate/NotPredicate.java
+++ b/sql/src/main/java/io/crate/operation/predicate/NotPredicate.java
@@ -63,7 +63,7 @@ public class NotPredicate extends Scalar<Boolean, Boolean> implements OperatorFo
                 return Literal.BOOLEAN_TRUE;
             }
             if (value instanceof Boolean) {
-                return Literal.newLiteral(!((Boolean) value));
+                return Literal.of(!((Boolean) value));
             }
         }
         return symbol;

--- a/sql/src/main/java/io/crate/operation/scalar/ConcatFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/ConcatFunction.java
@@ -64,7 +64,7 @@ public abstract class ConcatFunction extends Scalar<BytesRef, BytesRef> {
             inputs[i] = ((Input) function.arguments().get(i));
         }
         //noinspection unchecked
-        return Literal.newLiteral(functionInfo.returnType(), evaluate(inputs));
+        return Literal.of(functionInfo.returnType(), evaluate(inputs));
     }
 
     private static class StringConcatFunction extends ConcatFunction {

--- a/sql/src/main/java/io/crate/operation/scalar/DateTruncFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/DateTruncFunction.java
@@ -138,7 +138,7 @@ public class DateTruncFunction extends Scalar<Long, Object> {
             tsSymbol = (Literal)symbol.arguments().get(2);
         }
 
-        return Literal.newLiteral(
+        return Literal.of(
                 DataTypes.TIMESTAMP,
                 evaluate(new Input[]{interval, timezone, tsSymbol})
         );

--- a/sql/src/main/java/io/crate/operation/scalar/TimeZoneParser.java
+++ b/sql/src/main/java/io/crate/operation/scalar/TimeZoneParser.java
@@ -35,7 +35,7 @@ import java.util.concurrent.ConcurrentMap;
 public class TimeZoneParser {
 
     public static final DateTimeZone DEFAULT_TZ = DateTimeZone.UTC;
-    public static final Literal<BytesRef> DEFAULT_TZ_LITERAL = Literal.newLiteral("UTC");
+    public static final Literal<BytesRef> DEFAULT_TZ_LITERAL = Literal.of("UTC");
     public static final BytesRef DEFAULT_TZ_BYTES_REF = DEFAULT_TZ_LITERAL.value();
 
     private static final ConcurrentMap<BytesRef, DateTimeZone> TIME_ZONE_MAP = new ConcurrentHashMap<>();

--- a/sql/src/main/java/io/crate/operation/scalar/cast/AbstractCastFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/cast/AbstractCastFunction.java
@@ -73,7 +73,7 @@ public abstract class AbstractCastFunction<From, To> extends Scalar<To,From> imp
         if (argument.symbolType().isValueSymbol()) {
             Object value = ((Input) argument).value();
             try {
-                return Literal.newLiteral(returnType, returnType.value(value));
+                return Literal.of(returnType, returnType.value(value));
             } catch (ClassCastException | IllegalArgumentException | ConversionException e) {
                 return onNormalizeException(argument);
             }

--- a/sql/src/main/java/io/crate/operation/scalar/geo/DistanceFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/geo/DistanceFunction.java
@@ -138,7 +138,7 @@ public class DistanceFunction extends Scalar<Double, Object> {
         }
 
         if (numLiterals == 2) {
-            return Literal.newLiteral(evaluate((Input) arg1, (Input) arg2));
+            return Literal.of(evaluate((Input) arg1, (Input) arg2));
         }
 
         // ensure reference is the first argument.

--- a/sql/src/main/java/io/crate/operation/scalar/geo/IntersectsFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/geo/IntersectsFunction.java
@@ -121,7 +121,7 @@ public class IntersectsFunction extends Scalar<Boolean, Object> {
         }
 
         if (numLiterals == 2) {
-            return Literal.newLiteral(evaluate((Input)left, (Input)right));
+            return Literal.of(evaluate((Input)left, (Input)right));
         }
 
         if (literalConverted) {

--- a/sql/src/main/java/io/crate/operation/scalar/geo/WithinFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/geo/WithinFunction.java
@@ -161,7 +161,7 @@ public class WithinFunction extends Scalar<Boolean, Object> {
         }
 
         if (numLiterals == 2) {
-            return Literal.newLiteral(evaluate((Input) left, (Input) right));
+            return Literal.of(evaluate((Input) left, (Input) right));
         }
 
         if (literalConverted) {

--- a/sql/src/main/java/io/crate/operation/scalar/regex/MatchesFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/regex/MatchesFunction.java
@@ -94,7 +94,7 @@ public class MatchesFunction extends Scalar<BytesRef[], Object> implements Dynam
         if (size == 3) {
             args[2] = (Input)symbol.arguments().get(2);
         }
-        return Literal.newLiteral(evaluate(args), arrayStringType);
+        return Literal.of(evaluate(args), arrayStringType);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/operation/scalar/regex/ReplaceFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/regex/ReplaceFunction.java
@@ -88,7 +88,7 @@ public class ReplaceFunction extends Scalar<BytesRef, Object> implements Dynamic
         if (size == 4) {
             args[3] = (Input)symbol.arguments().get(3);
         }
-        return Literal.newLiteral(evaluate(args));
+        return Literal.of(evaluate(args));
     }
 
     @Override

--- a/sql/src/main/java/io/crate/operation/scalar/timestamp/CurrentTimestampFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/timestamp/CurrentTimestampFunction.java
@@ -104,11 +104,11 @@ public class CurrentTimestampFunction extends Scalar<Long, Integer> implements F
     private Symbol eval(Function function, long currentTimeMillis) {
         Symbol symbol;
         if (function.arguments().isEmpty()) {
-            symbol = Literal.newLiteral(INFO.returnType(), currentTimeMillis);
+            symbol = Literal.of(INFO.returnType(), currentTimeMillis);
         } else {
             Symbol precision = function.arguments().get(0);
             if (precision.symbolType().isValueSymbol()) {
-                symbol = Literal.newLiteral(INFO.returnType(),
+                symbol = Literal.of(INFO.returnType(),
                     applyPrecision(currentTimeMillis, (Integer) ((Input) precision).value()));
             } else {
                 throw new IllegalArgumentException(String.format(Locale.ENGLISH, "Invalid argument to %s", NAME));

--- a/sql/src/main/java/io/crate/planner/projection/SourceIndexWriterProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/SourceIndexWriterProjection.java
@@ -111,7 +111,7 @@ public class SourceIndexWriterProjection extends AbstractIndexWriterProjection {
                 if (idx > -1) {
                     // copy from into partition where partitioned column is a primary key
                     // set partition value as primary key input
-                    idSymbols.set(idx, Literal.newLiteral(partitionValues.get(i)));
+                    idSymbols.set(idx, Literal.of(partitionValues.get(i)));
                 }
                 continue;
             }

--- a/sql/src/main/java/io/crate/planner/projection/WriterProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/WriterProjection.java
@@ -53,7 +53,7 @@ public class WriterProjection extends Projection {
             new FunctionIdent(FormatFunction.NAME, Arrays.<DataType>asList(StringType.INSTANCE,
                     StringType.INSTANCE, StringType.INSTANCE, StringType.INSTANCE)),
             StringType.INSTANCE),
-            Arrays.<Symbol>asList(Literal.newLiteral("%s_%s_%s.json"), TABLE_NAME_REF, SHARD_ID_REF, PARTITION_IDENT_REF)
+            Arrays.<Symbol>asList(Literal.of("%s_%s_%s.json"), TABLE_NAME_REF, SHARD_ID_REF, PARTITION_IDENT_REF)
     );
 
     private Symbol uri;

--- a/sql/src/test/groovy/io/crate/operation/tablefunctions/UnnestTest.groovy
+++ b/sql/src/test/groovy/io/crate/operation/tablefunctions/UnnestTest.groovy
@@ -31,7 +31,7 @@ import io.crate.types.DataTypes
 import org.junit.Before
 import org.junit.Test
 
-import static io.crate.analyze.symbol.Literal.newLiteral
+import static io.crate.analyze.symbol.Literal.of
 
 class UnnestTest extends RandomizedTest {
 
@@ -48,8 +48,8 @@ class UnnestTest extends RandomizedTest {
 
     @Test
     void testExecute() {
-        Literal numbers = newLiteral(longArray, $(1L, 2L))
-        Literal names = newLiteral(stringArray, $("Marvin", "Trillian"))
+        Literal numbers = of(longArray, $(1L, 2L))
+        Literal names = of(stringArray, $("Marvin", "Trillian"))
         Bucket bucket = unnest.execute([numbers, names])
 
         assert TestingHelpers.printedTable(bucket) == "1| Marvin\n" +
@@ -58,8 +58,8 @@ class UnnestTest extends RandomizedTest {
 
     @Test
     public void testExecuteFirstArrayShorter() throws Exception {
-        Literal numbers = newLiteral(longArray, $(1L))
-        Literal names = newLiteral(stringArray, $("Marvin", "Trillian"))
+        Literal numbers = of(longArray, $(1L))
+        Literal names = of(stringArray, $("Marvin", "Trillian"))
 
         Bucket bucket = unnest.execute([numbers, names])
         def table = TestingHelpers.printedTable(bucket)
@@ -68,8 +68,8 @@ class UnnestTest extends RandomizedTest {
 
     @Test
     public void testExecuteSecondArrayShorter() throws Exception {
-        Literal numbers = newLiteral(longArray, $(1L, 2L, 3L))
-        Literal names = newLiteral(stringArray, $("Marvin"))
+        Literal numbers = of(longArray, $(1L, 2L, 3L))
+        Literal names = of(stringArray, $("Marvin"))
 
         Bucket bucket = unnest.execute([numbers, names])
         def table = TestingHelpers.printedTable(bucket)

--- a/sql/src/test/java/io/crate/analyze/EvaluatingNormalizerTest.java
+++ b/sql/src/test/java/io/crate/analyze/EvaluatingNormalizerTest.java
@@ -61,7 +61,7 @@ public class EvaluatingNormalizerTest extends CrateUnitTest {
     private Function prepareFunctionTree() {
 
         Reference load_1 = dummyLoadInfo;
-        Literal<Double> d01 = Literal.newLiteral(0.08);
+        Literal<Double> d01 = Literal.of(0.08);
         Function load_eq_01 = new Function(
                 functionInfo(EqOperator.NAME, DataTypes.DOUBLE), Arrays.<Symbol>asList(load_1, d01));
 
@@ -69,8 +69,8 @@ public class EvaluatingNormalizerTest extends CrateUnitTest {
                         new ReferenceIdent(new TableIdent(null, "foo"), "name"),
                         RowGranularity.DOC,
                         DataTypes.STRING);
-        Symbol x_literal = Literal.newLiteral("x");
-        Symbol y_literal = Literal.newLiteral("y");
+        Symbol x_literal = Literal.of("x");
+        Symbol y_literal = Literal.of("y");
 
         Function name_eq_x = new Function(
                 functionInfo(EqOperator.NAME, DataTypes.STRING), Arrays.<Symbol>asList(name_ref, x_literal));

--- a/sql/src/test/java/io/crate/analyze/ValueNormalizerTest.java
+++ b/sql/src/test/java/io/crate/analyze/ValueNormalizerTest.java
@@ -135,15 +135,15 @@ public class ValueNormalizerTest extends CrateUnitTest {
                 RowGranularity.DOC,
                 DataTypes.BOOLEAN
         );
-        Literal<Boolean> trueLiteral = Literal.newLiteral(true);
+        Literal<Boolean> trueLiteral = Literal.of(true);
 
         assertThat(valueNormalizer.normalizeInputForReference(trueLiteral, ref, stmtCtx),
                 Matchers.<Symbol>is(trueLiteral));
 
-        assertThat(valueNormalizer.normalizeInputForReference(Literal.newLiteral("true"), ref, stmtCtx),
+        assertThat(valueNormalizer.normalizeInputForReference(Literal.of("true"), ref, stmtCtx),
                 Matchers.<Symbol>is(trueLiteral));
-        assertThat(valueNormalizer.normalizeInputForReference(Literal.newLiteral("false"), ref, stmtCtx),
-                Matchers.<Symbol>is(Literal.newLiteral(false)));
+        assertThat(valueNormalizer.normalizeInputForReference(Literal.of("false"), ref, stmtCtx),
+                Matchers.<Symbol>is(Literal.of(false)));
     }
 
     @Test
@@ -152,8 +152,8 @@ public class ValueNormalizerTest extends CrateUnitTest {
                 new ReferenceIdent(TEST_TABLE_IDENT, new ColumnIdent("double")),
                 RowGranularity.DOC,
                 DataTypes.DOUBLE);
-        Function f = new Function(TEST_FUNCTION_INFO, Arrays.<Symbol>asList(Literal.newLiteral(-9.9)));
-        assertThat(valueNormalizer.normalizeInputForReference(f, info, stmtCtx), Matchers.<Symbol>is(Literal.newLiteral(9.9)));
+        Function f = new Function(TEST_FUNCTION_INFO, Arrays.<Symbol>asList(Literal.of(-9.9)));
+        assertThat(valueNormalizer.normalizeInputForReference(f, info, stmtCtx), Matchers.<Symbol>is(Literal.of(9.9)));
     }
 
     @Test
@@ -164,7 +164,7 @@ public class ValueNormalizerTest extends CrateUnitTest {
         map.put("time", "2014-02-16T00:00:01");
         map.put("false", true);
         Literal<Map<String, Object>> normalized = (Literal)valueNormalizer.normalizeInputForReference(
-                Literal.newLiteral(map), objRef, stmtCtx);
+                Literal.of(map), objRef, stmtCtx);
         assertThat((String) normalized.value().get("time"), is("2014-02-16T00:00:01"));
         assertThat((Boolean)normalized.value().get("false"), is(true));
     }
@@ -174,7 +174,7 @@ public class ValueNormalizerTest extends CrateUnitTest {
         Reference objRef = userTableInfo.getReference(new ColumnIdent("dyn"));
         Map<String, Object> map = new HashMap<>();
         map.put("d", "2014-02-16T00:00:01");
-        valueNormalizer.normalizeInputForReference(Literal.newLiteral(map), objRef, stmtCtx);
+        valueNormalizer.normalizeInputForReference(Literal.of(map), objRef, stmtCtx);
     }
 
     @Test
@@ -184,7 +184,7 @@ public class ValueNormalizerTest extends CrateUnitTest {
         map.put("d", "2.9");
 
         Symbol normalized = valueNormalizer.normalizeInputForReference(
-                Literal.newLiteral(map), objInfo, stmtCtx);
+                Literal.of(map), objInfo, stmtCtx);
         assertThat(normalized, instanceOf(Literal.class));
         assertThat(((Literal<Map<String, Object>>)normalized).value().get("d"), Matchers.<Object>is(2.9d));
     }
@@ -198,10 +198,10 @@ public class ValueNormalizerTest extends CrateUnitTest {
                 put("double", "-88.7");
             }});
         }};
-        valueNormalizer.normalizeInputForReference(Literal.newLiteral(map), objInfo, stmtCtx);
+        valueNormalizer.normalizeInputForReference(Literal.of(map), objInfo, stmtCtx);
 
         Symbol normalized = valueNormalizer.normalizeInputForReference(
-                Literal.newLiteral(map), objInfo, stmtCtx);
+                Literal.of(map), objInfo, stmtCtx);
         assertThat(normalized, instanceOf(Literal.class));
         assertThat(((Literal<Map<String, Object>>)normalized).value().get("d"), Matchers.<Object>is(2.9d));
         assertThat(((Literal<Map<String, Object>>)normalized).value().get("inner_strict"),
@@ -218,7 +218,7 @@ public class ValueNormalizerTest extends CrateUnitTest {
         map.put("d", 2.9d);
         map.put("half", "1.45");
         Symbol normalized = valueNormalizer.normalizeInputForReference(
-                Literal.newLiteral(map), objInfo, stmtCtx);
+                Literal.of(map), objInfo, stmtCtx);
         assertThat(normalized, instanceOf(Literal.class));
         assertThat(((Literal)normalized).value(), Matchers.<Object>is(map)); // stays the same
     }
@@ -231,7 +231,7 @@ public class ValueNormalizerTest extends CrateUnitTest {
         map.put("inner_d", 2.9d);
         map.put("half", "1.45");
         valueNormalizer.normalizeInputForReference(
-                Literal.newLiteral(map), objInfo, stmtCtx);
+                Literal.of(map), objInfo, stmtCtx);
     }
 
     @Test(expected = ColumnUnknownException.class)
@@ -243,7 +243,7 @@ public class ValueNormalizerTest extends CrateUnitTest {
             put("much_inner", "yaw");
         }});
        valueNormalizer.normalizeInputForReference(
-               Literal.newLiteral(map), objInfo, stmtCtx);
+               Literal.of(map), objInfo, stmtCtx);
     }
 
     @Test(expected = ColumnUnknownException.class)
@@ -257,7 +257,7 @@ public class ValueNormalizerTest extends CrateUnitTest {
         }});
         map.put("half", "1.45");
         valueNormalizer.normalizeInputForReference(
-                Literal.newLiteral(map), objInfo, stmtCtx);
+                Literal.of(map), objInfo, stmtCtx);
     }
 
     @Test
@@ -267,7 +267,7 @@ public class ValueNormalizerTest extends CrateUnitTest {
             put("time", "1970-01-01T00:00:00");
         }};
         Literal<Map<String, Object>> literal = (Literal)valueNormalizer.normalizeInputForReference(
-                Literal.newLiteral(map),
+                Literal.of(map),
                 objInfo, stmtCtx);
         assertThat((String) literal.value().get("time"), is("1970-01-01T00:00:00"));
     }
@@ -279,7 +279,7 @@ public class ValueNormalizerTest extends CrateUnitTest {
             put("time", "1970-01-01T00:00:00");
         }};
         Literal<Map<String, Object>> literal = (Literal)valueNormalizer.normalizeInputForReference(
-                Literal.newLiteral(map),
+                Literal.of(map),
                 objInfo, stmtCtx);
         assertThat((String)literal.value().get("time"), is("1970-01-01T00:00:00"));
     }
@@ -291,7 +291,7 @@ public class ValueNormalizerTest extends CrateUnitTest {
             put("no_time", "1970");
         }};
         Literal<Map<String, Object>> literal = (Literal)valueNormalizer.normalizeInputForReference(
-                Literal.newLiteral(map),
+                Literal.of(map),
                 objInfo, stmtCtx);
         assertThat((String)literal.value().get("no_time"), is("1970"));
     }
@@ -299,7 +299,7 @@ public class ValueNormalizerTest extends CrateUnitTest {
     @Test
     public void testNormalizeStringToNumberColumn() throws Exception {
         Reference objInfo = userTableInfo.getReference(new ColumnIdent("d"));
-        Literal<BytesRef> stringDoubleLiteral = Literal.newLiteral("298.444");
+        Literal<BytesRef> stringDoubleLiteral = Literal.of("298.444");
         Literal literal = (Literal)valueNormalizer.normalizeInputForReference(
                 stringDoubleLiteral, objInfo, stmtCtx);
         assertThat(literal, isLiteral(298.444d, DataTypes.DOUBLE));

--- a/sql/src/test/java/io/crate/analyze/symbol/LiteralTest.java
+++ b/sql/src/test/java/io/crate/analyze/symbol/LiteralTest.java
@@ -49,7 +49,7 @@ public class LiteralTest extends CrateUnitTest {
             Object nestedValue = new Object[][] {
                     new Object[] { value }
             };
-            Literal nestedLiteral = Literal.newLiteral(nestedType, nestedValue);
+            Literal nestedLiteral = Literal.of(nestedType, nestedValue);
             assertThat(nestedLiteral.valueType(), is(nestedType));
             assertThat(nestedLiteral.value(), is(nestedValue));
         }

--- a/sql/src/test/java/io/crate/analyze/symbol/MappingSymbolVisitorTest.java
+++ b/sql/src/test/java/io/crate/analyze/symbol/MappingSymbolVisitorTest.java
@@ -36,7 +36,7 @@ public class MappingSymbolVisitorTest {
     public void testProcess() throws Exception {
         Symbol f = Literal.BOOLEAN_FALSE;
         Symbol t = Literal.BOOLEAN_TRUE;
-        Symbol one = Literal.newLiteral(1);
+        Symbol one = Literal.of(1);
 
         Map<Symbol, ? extends Symbol> fieldMap = ImmutableMap.of(f, t);
 

--- a/sql/src/test/java/io/crate/analyze/symbol/format/SymbolFormatterTest.java
+++ b/sql/src/test/java/io/crate/analyze/symbol/format/SymbolFormatterTest.java
@@ -43,7 +43,7 @@ public class SymbolFormatterTest extends CrateUnitTest {
     public void testFormat() throws Exception {
         Function f = new Function(new FunctionInfo(
                 new FunctionIdent("foo", Arrays.<DataType>asList(DataTypes.STRING, DataTypes.UNDEFINED)), DataTypes.DOUBLE),
-                Arrays.<Symbol>asList(Literal.newLiteral("bar"), Literal.newLiteral(3.4)));
+                Arrays.<Symbol>asList(Literal.of("bar"), Literal.of(3.4)));
         assertThat(SymbolFormatter.format("This Symbol is formatted %s", f), is("This Symbol is formatted foo('bar', 3.4)"));
     }
 
@@ -51,6 +51,6 @@ public class SymbolFormatterTest extends CrateUnitTest {
     public void testFormatInvalidEscape() throws Exception {
         expectedException.expect(IllegalFormatConversionException.class);
         expectedException.expectMessage("d != java.lang.String");
-        assertThat(SymbolFormatter.format("%d", Literal.newLiteral(42L)), is(""));
+        assertThat(SymbolFormatter.format("%d", Literal.of(42L)), is(""));
     }
 }

--- a/sql/src/test/java/io/crate/analyze/symbol/format/SymbolPrinterTest.java
+++ b/sql/src/test/java/io/crate/analyze/symbol/format/SymbolPrinterTest.java
@@ -107,7 +107,7 @@ public class SymbolPrinterTest extends CrateUnitTest {
     public void testFormatFunction() throws Exception {
         Function f = new Function(new FunctionInfo(
                 new FunctionIdent("foo", Arrays.<DataType>asList(DataTypes.STRING, DataTypes.DOUBLE)), DataTypes.DOUBLE),
-                Arrays.<Symbol>asList(Literal.newLiteral("bar"), Literal.newLiteral(3.4)));
+                Arrays.<Symbol>asList(Literal.of("bar"), Literal.of(3.4)));
         assertPrint(f, "foo('bar', 3.4)");
     }
 
@@ -123,7 +123,7 @@ public class SymbolPrinterTest extends CrateUnitTest {
     public void testSubstrFunction() throws Exception {
         Function f = new Function(new FunctionInfo(
                 new FunctionIdent("substr", Arrays.<DataType>asList(DataTypes.STRING, DataTypes.LONG)), DataTypes.STRING),
-                Arrays.<Symbol>asList(Literal.newLiteral("foobar"), Literal.newLiteral(4)));
+                Arrays.<Symbol>asList(Literal.of("foobar"), Literal.of(4)));
         assertPrint(f, "substr('foobar', 4)");
     }
 
@@ -131,7 +131,7 @@ public class SymbolPrinterTest extends CrateUnitTest {
     public void testSubstrFunctionWithLength() throws Exception {
         Function f = new Function(new FunctionInfo(
                 new FunctionIdent("substr", Arrays.<DataType>asList(DataTypes.STRING, DataTypes.LONG, DataTypes.LONG)), DataTypes.STRING),
-                Arrays.<Symbol>asList(Literal.newLiteral("foobar"), Literal.newLiteral(4), Literal.newLiteral(1)));
+                Arrays.<Symbol>asList(Literal.of("foobar"), Literal.of(4), Literal.of(1)));
         assertPrint(f, "substr('foobar', 4, 1)");
     }
 
@@ -139,7 +139,7 @@ public class SymbolPrinterTest extends CrateUnitTest {
     public void testFormatAggregation() throws Exception {
         Aggregation a = Aggregation.partialAggregation(new FunctionInfo(
                 new FunctionIdent("agg", Collections.<DataType>singletonList(DataTypes.INTEGER)), DataTypes.LONG, FunctionInfo.Type.AGGREGATE
-        ), DataTypes.LONG, Collections.<Symbol>singletonList(Literal.newLiteral(-127)));
+        ), DataTypes.LONG, Collections.<Symbol>singletonList(Literal.of(-127)));
 
         assertPrint(a, "agg(-127)");
     }
@@ -181,13 +181,13 @@ public class SymbolPrinterTest extends CrateUnitTest {
 
     @Test
     public void testLiteralEscaped() throws Exception {
-        assertPrint(Literal.newLiteral("bla'bla"), "'bla''bla'");
+        assertPrint(Literal.of("bla'bla"), "'bla''bla'");
 
     }
 
     @Test
     public void testObjectLiteral() throws Exception {
-        Literal<Map<String, Object>> l = Literal.newLiteral(new HashMap<String, Object>(){{
+        Literal<Map<String, Object>> l = Literal.of(new HashMap<String, Object>(){{
             put("field", "value");
             put("array", new Integer[]{1,2,3});
             put("nestedMap", new HashMap<String, Object>(){{
@@ -199,27 +199,27 @@ public class SymbolPrinterTest extends CrateUnitTest {
 
     @Test
     public void testBooleanLiteral() throws Exception {
-        Literal<Boolean> f = Literal.newLiteral(false);
+        Literal<Boolean> f = Literal.of(false);
         assertPrint(f, "false");
-        Literal<Boolean> t = Literal.newLiteral(true);
+        Literal<Boolean> t = Literal.of(true);
         assertPrint(t, "true");
     }
 
     @Test
     public void visitStringLiteral() throws Exception {
-        Literal<BytesRef> l = Literal.newLiteral("fooBar");
+        Literal<BytesRef> l = Literal.of("fooBar");
         assertPrint(l, "'fooBar'");
     }
 
     @Test
     public void visitDoubleLiteral() throws Exception {
-        Literal<Double> d = Literal.newLiteral(-500.88765d);
+        Literal<Double> d = Literal.of(-500.88765d);
         assertPrint(d, "-500.88765");
     }
 
     @Test
     public void visitFloatLiteral() throws Exception {
-        Literal<Float> f = Literal.newLiteral(500.887f);
+        Literal<Float> f = Literal.of(500.887f);
         assertPrint(f, "500.887");
     }
 
@@ -250,18 +250,18 @@ public class SymbolPrinterTest extends CrateUnitTest {
 
     @Test
     public void testNull() throws Exception {
-        assertPrint(Literal.newLiteral(DataTypes.UNDEFINED, null) , "NULL");
+        assertPrint(Literal.of(DataTypes.UNDEFINED, null) , "NULL");
     }
 
     @Test
     public void testNullKey() throws Exception {
-        assertPrint(Literal.newLiteral(new HashMap<String, Object>(){{ put("null", null);}}), "{\"null\"=NULL}");
+        assertPrint(Literal.of(new HashMap<String, Object>(){{ put("null", null);}}), "{\"null\"=NULL}");
     }
 
     @Test
     public void testNativeArray() throws Exception {
         assertPrint(
-                Literal.newLiteral(DataTypes.GEO_SHAPE, ImmutableMap.of("type", "Point", "coordinates", new double[]{1.0d, 2.0d})),
+                Literal.of(DataTypes.GEO_SHAPE, ImmutableMap.of("type", "Point", "coordinates", new double[]{1.0d, 2.0d})),
                 "{\"coordinates\"=[1.0, 2.0], \"type\"='Point'}");
     }
 
@@ -331,7 +331,7 @@ public class SymbolPrinterTest extends CrateUnitTest {
         Symbol inQuery = sqlExpressions.asSymbol("bar in (1)");
         assertPrint(inQuery, "(doc.formatter.bar = ANY([1]))"); // internal in is rewritten to ANY
         FunctionImplementation impl = sqlExpressions.analysisMD().functions().getSafe(new FunctionIdent(InOperator.NAME, Arrays.<DataType>asList(DataTypes.LONG, new SetType(DataTypes.LONG))));
-        Function fn = new Function(impl.info(), Arrays.asList(sqlExpressions.asSymbol("bar"), Literal.newLiteral(new SetType(DataTypes.LONG), ImmutableSet.of(1L, 2L))));
+        Function fn = new Function(impl.info(), Arrays.asList(sqlExpressions.asSymbol("bar"), Literal.of(new SetType(DataTypes.LONG), ImmutableSet.of(1L, 2L))));
         assertPrint(fn, "(doc.formatter.bar IN (1, 2))");
         inQuery = sqlExpressions.asSymbol("bar in (1, abs(-10), 9)");
         assertPrint(inQuery, "(doc.formatter.bar = ANY([1, 9, 10]))");

--- a/sql/src/test/java/io/crate/analyze/where/DocKeysTest.java
+++ b/sql/src/test/java/io/crate/analyze/where/DocKeysTest.java
@@ -37,7 +37,7 @@ public class DocKeysTest extends CrateUnitTest {
     public void testClusteredIsFirstInId() throws Exception {
         // if a the table is clustered and has a pk, the clustering value is put in front in the id computation
         List<List<Symbol>> pks = ImmutableList.<List<Symbol>>of(
-                ImmutableList.<Symbol>of(Literal.newLiteral(1), Literal.newLiteral("Ford"))
+                ImmutableList.<Symbol>of(Literal.of(1), Literal.of("Ford"))
         );
         DocKeys docKeys = new DocKeys(pks, false, 1, null);
         DocKeys.DocKey key = docKeys.getOnlyKey();

--- a/sql/src/test/java/io/crate/analyze/where/EqualityExtractorTest.java
+++ b/sql/src/test/java/io/crate/analyze/where/EqualityExtractorTest.java
@@ -133,14 +133,14 @@ public class EqualityExtractorTest extends BaseAnalyzerTest {
     }
 
     private Function Eq(String name, Integer i) {
-        return Eq(Ref(name), Literal.newLiteral(i));
+        return Eq(Ref(name), Literal.of(i));
     }
 
     @Test
     public void testNoExtract2ColPKWithOr() throws Exception {
         Symbol query = Or(
-                Eq(Ref("x"), Literal.newLiteral(1)),
-                Eq(Ref("y"), Literal.newLiteral(2))
+                Eq(Ref("x"), Literal.of(1)),
+                Eq(Ref("y"), Literal.of(2))
         );
 
         List<List<Symbol>> matches = analyzeExactXY(query);
@@ -297,10 +297,10 @@ public class EqualityExtractorTest extends BaseAnalyzerTest {
     @Test
     public void testNoExtract2ColPKFromAndEq1PartAnd2ForeignColumns() throws Exception {
         Symbol query = And(
-                Eq(Ref("x"), Literal.newLiteral(1)),
+                Eq(Ref("x"), Literal.of(1)),
                 Or(
-                        Eq(Ref("a"), Literal.newLiteral(2)),
-                        Eq(Ref("z"), Literal.newLiteral(3))
+                        Eq(Ref("a"), Literal.of(2)),
+                        Eq(Ref("z"), Literal.of(3))
                 ));
 
         List<List<Symbol>> matches = analyzeExactXY(query);
@@ -342,10 +342,10 @@ public class EqualityExtractorTest extends BaseAnalyzerTest {
     @Test
     public void testExtract2ColPKFrom1PartAndOtherPart2EqOr() throws Exception {
         Symbol query = And(
-                Eq(Ref("x"), Literal.newLiteral(1)),
+                Eq(Ref("x"), Literal.of(1)),
                 Or(
-                        Eq(Ref("y"), Literal.newLiteral(2)),
-                        Eq(Ref("y"), Literal.newLiteral(3))
+                        Eq(Ref("y"), Literal.of(2)),
+                        Eq(Ref("y"), Literal.of(3))
                 ));
 
         List<List<Symbol>> matches = analyzeExactXY(query);
@@ -358,14 +358,14 @@ public class EqualityExtractorTest extends BaseAnalyzerTest {
 
     @Test
     public void testNoExtract2ColPKFromOnly1Part() throws Exception {
-        Symbol query = Eq(Ref("x"), Literal.newLiteral(1));
+        Symbol query = Eq(Ref("x"), Literal.of(1));
         List<List<Symbol>> matches = analyzeExactXY(query);
         assertNull(matches);
     }
 
     @Test
     public void testExtractSinglePKFromAnyEq() throws Exception {
-        Symbol query = AnyEq(Ref("x"), Literal.newLiteral(new ArrayType(DataTypes.STRING), new Object[]{new BytesRef("a"), new BytesRef("b"), new BytesRef("c")}));
+        Symbol query = AnyEq(Ref("x"), Literal.of(new ArrayType(DataTypes.STRING), new Object[]{new BytesRef("a"), new BytesRef("b"), new BytesRef("c")}));
         List<List<Symbol>> matches = analyzeExactX(query);
         assertThat(matches.size(), is(3));
         assertThat(matches, containsInAnyOrder(
@@ -378,7 +378,7 @@ public class EqualityExtractorTest extends BaseAnalyzerTest {
     @Test
     public void testExtract2ColPKFromAnyEq() throws Exception {
         Symbol query = And(
-                AnyEq(Ref("x"), Literal.newLiteral(new ArrayType(DataTypes.STRING), new Object[]{new BytesRef("a"), new BytesRef("b"), new BytesRef("c")})),
+                AnyEq(Ref("x"), Literal.of(new ArrayType(DataTypes.STRING), new Object[]{new BytesRef("a"), new BytesRef("b"), new BytesRef("c")})),
                 Eq("y", 4));
         List<List<Symbol>> matches = analyzeExactXY(query);
         assertThat(matches.size(), is(3));
@@ -394,8 +394,8 @@ public class EqualityExtractorTest extends BaseAnalyzerTest {
     @Test
     public void testExtractSinglePKFromAnyEqInOr() throws Exception {
         Symbol query = Or(
-                AnyEq(Ref("x"), Literal.newLiteral(new ArrayType(DataTypes.STRING), new Object[]{new BytesRef("a"), new BytesRef("b"), new BytesRef("c")})),
-                AnyEq(Ref("x"), Literal.newLiteral(new ArrayType(DataTypes.STRING), new Object[]{new BytesRef("d"), new BytesRef("e"), new BytesRef("c")}))
+                AnyEq(Ref("x"), Literal.of(new ArrayType(DataTypes.STRING), new Object[]{new BytesRef("a"), new BytesRef("b"), new BytesRef("c")})),
+                AnyEq(Ref("x"), Literal.of(new ArrayType(DataTypes.STRING), new Object[]{new BytesRef("d"), new BytesRef("e"), new BytesRef("c")}))
                 );
         List<List<Symbol>> matches = analyzeExactX(query);
         assertThat(matches.size(), is(5));
@@ -425,8 +425,8 @@ public class EqualityExtractorTest extends BaseAnalyzerTest {
     @Test
     public void testExtractSinglePK1FromAndAnyEq() throws Exception {
         Symbol query = And(
-                AnyEq(Ref("x"), Literal.newLiteral(new ArrayType(DataTypes.STRING), new Object[]{new BytesRef("a"), new BytesRef("b"), new BytesRef("c")})),
-                AnyEq(Ref("x"), Literal.newLiteral(new ArrayType(DataTypes.STRING), new Object[]{new BytesRef("d"), new BytesRef("e"), new BytesRef("c")}))
+                AnyEq(Ref("x"), Literal.of(new ArrayType(DataTypes.STRING), new Object[]{new BytesRef("a"), new BytesRef("b"), new BytesRef("c")})),
+                AnyEq(Ref("x"), Literal.of(new ArrayType(DataTypes.STRING), new Object[]{new BytesRef("d"), new BytesRef("e"), new BytesRef("c")}))
         );
         List<List<Symbol>> matches = analyzeExactX(query);
         assertThat(matches, is(notNullValue()));
@@ -439,8 +439,8 @@ public class EqualityExtractorTest extends BaseAnalyzerTest {
     @Test
     public void testExtract2ColPKFromAnyEqAnd() throws Exception {
         Symbol query = And(
-                AnyEq(Ref("x"), Literal.newLiteral(new ArrayType(DataTypes.STRING), new Object[]{new BytesRef("a"), new BytesRef("b"), new BytesRef("c")})),
-                AnyEq(Ref("y"), Literal.newLiteral(new ArrayType(DataTypes.STRING), new Object[]{new BytesRef("a"), new BytesRef("b"), new BytesRef("c")}))
+                AnyEq(Ref("x"), Literal.of(new ArrayType(DataTypes.STRING), new Object[]{new BytesRef("a"), new BytesRef("b"), new BytesRef("c")})),
+                AnyEq(Ref("y"), Literal.of(new ArrayType(DataTypes.STRING), new Object[]{new BytesRef("a"), new BytesRef("b"), new BytesRef("c")}))
         );
         List<List<Symbol>> matches = analyzeExactXY(query);
         assertThat(matches.size(), is(9)); // cartesian product: 3 * 3

--- a/sql/src/test/java/io/crate/executor/transport/BaseTransportExecutorTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/BaseTransportExecutorTest.java
@@ -66,7 +66,7 @@ public class BaseTransportExecutorTest extends SQLTransportIntegrationTest {
         querySpec.outputs(outputs);
         List<List<Symbol>> keys = new ArrayList<>(singleStringKeys.size());
         for (String v : singleStringKeys) {
-            keys.add(ImmutableList.<Symbol>of(Literal.newLiteral(v)));
+            keys.add(ImmutableList.<Symbol>of(Literal.of(v)));
         }
         WhereClause whereClause = new WhereClause(null, new DocKeys(keys, false, -1, null), null);
         querySpec.where(whereClause);

--- a/sql/src/test/java/io/crate/executor/transport/ShardUpsertRequestTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/ShardUpsertRequestTest.java
@@ -71,7 +71,7 @@ public class ShardUpsertRequestTest extends CrateUnitTest {
                 null));
         request.add(5, new ShardUpsertRequest.Item(
                 "42",
-                new Symbol[]{Literal.newLiteral(42), Literal.newLiteral("Deep Thought") },
+                new Symbol[]{Literal.of(42), Literal.of("Deep Thought") },
                 null,
                 2L));
 

--- a/sql/src/test/java/io/crate/executor/transport/TransportExecutorUpsertTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/TransportExecutorUpsertTest.java
@@ -189,7 +189,7 @@ public class TransportExecutorUpsertTest extends BaseTransportExecutorTest {
             0,
             new String[]{nameRef.ident().columnIdent().fqn()},
             null);
-        upsertById.add("characters", "1", "1", new Symbol[]{Literal.newLiteral("Vogon lyric fan")}, null);
+        upsertById.add("characters", "1", "1", new Symbol[]{Literal.of("Vogon lyric fan")}, null);
 
         CollectingRowReceiver rowReceiver = new CollectingRowReceiver();
         executor.execute(upsertById, rowReceiver);
@@ -218,7 +218,7 @@ public class TransportExecutorUpsertTest extends BaseTransportExecutorTest {
             new String[]{nameRef.ident().columnIdent().fqn()},
             new Reference[]{idRef, nameRef, femaleRef});
 
-        upsertById.add("characters", "5", "5", new Symbol[]{Literal.newLiteral("Zaphod Beeblebrox")}, null, missingAssignments);
+        upsertById.add("characters", "5", "5", new Symbol[]{Literal.of("Zaphod Beeblebrox")}, null, missingAssignments);
         CollectingRowReceiver rowReceiver = new CollectingRowReceiver();
         executor.execute(upsertById, rowReceiver);
         assertThat(rowReceiver.result(), contains(isRow(1L)));
@@ -245,7 +245,7 @@ public class TransportExecutorUpsertTest extends BaseTransportExecutorTest {
             0,
             new String[]{femaleRef.ident().columnIdent().fqn()},
             new Reference[]{idRef, nameRef, femaleRef});
-        upsertById.add("characters", "1", "1", new Symbol[]{Literal.newLiteral(true)}, null, missingAssignments);
+        upsertById.add("characters", "1", "1", new Symbol[]{Literal.of(true)}, null, missingAssignments);
         CollectingRowReceiver rowReceiver = new CollectingRowReceiver();
         executor.execute(upsertById, rowReceiver);
         assertThat(rowReceiver.result(), contains(isRow(1L)));
@@ -278,12 +278,12 @@ public class TransportExecutorUpsertTest extends BaseTransportExecutorTest {
         Function query = new Function(new FunctionInfo(
             new FunctionIdent(EqOperator.NAME, Arrays.<DataType>asList(DataTypes.BOOLEAN, DataTypes.BOOLEAN)),
             DataTypes.BOOLEAN),
-            Arrays.asList(femaleRef, Literal.newLiteral(true)));
+            Arrays.asList(femaleRef, Literal.of(true)));
 
         UpdateProjection updateProjection = new UpdateProjection(
             new InputColumn(0, DataTypes.STRING),
             new String[]{"name"},
-            new Symbol[]{Literal.newLiteral("Zaphod Beeblebrox")},
+            new Symbol[]{Literal.of("Zaphod Beeblebrox")},
             null);
 
         WhereClause whereClause = new WhereClause(query);
@@ -310,7 +310,7 @@ public class TransportExecutorUpsertTest extends BaseTransportExecutorTest {
         Function query2 = new Function(new FunctionInfo(
             new FunctionIdent(EqOperator.NAME, Arrays.<DataType>asList(DataTypes.BOOLEAN, DataTypes.BOOLEAN)),
             DataTypes.BOOLEAN),
-            Arrays.asList(femaleRef, Literal.newLiteral(true)));
+            Arrays.asList(femaleRef, Literal.of(true)));
 
         final WhereClause whereClause1 = new WhereClause(query2);
         RoutedCollectPhase collectPhase2 = new RoutedCollectPhase(

--- a/sql/src/test/java/io/crate/operation/aggregation/impl/PercentileAggregationTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/impl/PercentileAggregationTest.java
@@ -140,7 +140,7 @@ public class PercentileAggregationTest extends AggregationTest {
         PercentileAggregation percAggr = new PercentileAggregation(new FunctionInfo(
                 new FunctionIdent(NAME, ImmutableList.<DataType>of(DataTypes.INTEGER, DataTypes.DOUBLE)), DataTypes.DOUBLE,
                 FunctionInfo.Type.AGGREGATE));
-        TDigestState state = percAggr.iterate(null, null, Literal.newLiteral(1), Literal.newLiteral(0.5));
+        TDigestState state = percAggr.iterate(null, null, Literal.of(1), Literal.of(0.5));
         assertNotNull(state);
         assertThat(0.5, is(state.fractions()[0]));
 

--- a/sql/src/test/java/io/crate/operation/collect/DocLevelCollectTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/DocLevelCollectTest.java
@@ -156,7 +156,7 @@ public class DocLevelCollectTest extends SQLTransportIntegrationTest {
         List<Symbol> toCollect = Collections.<Symbol>singletonList(testDocLevelReference);
         WhereClause whereClause = new WhereClause(new Function(
                 op.info(),
-                Arrays.<Symbol>asList(testDocLevelReference, Literal.newLiteral(2)))
+                Arrays.<Symbol>asList(testDocLevelReference, Literal.of(2)))
         );
         RoutedCollectPhase collectNode = getCollectNode(toCollect, whereClause);
 

--- a/sql/src/test/java/io/crate/operation/collect/HandlerSideLevelCollectTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/HandlerSideLevelCollectTest.java
@@ -119,7 +119,7 @@ public class HandlerSideLevelCollectTest extends SQLTransportIntegrationTest {
         FunctionImplementation eqImpl = functions.get(new FunctionIdent(EqOperator.NAME,
                 ImmutableList.<DataType>of(DataTypes.STRING, DataTypes.STRING)));
         Function whereClause = new Function(eqImpl.info(),
-                Arrays.asList(tableNameRef, Literal.newLiteral("shards")));
+                Arrays.asList(tableNameRef, Literal.of("shards")));
 
         RoutedCollectPhase collectNode = collectNode(routing, toCollect, RowGranularity.DOC, new WhereClause(whereClause));
         Bucket result = collect(collectNode);

--- a/sql/src/test/java/io/crate/operation/collect/MapSideDataCollectOperationTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/MapSideDataCollectOperationTest.java
@@ -98,7 +98,7 @@ public class MapSideDataCollectOperationTest extends CrateUnitTest {
                 0,
                 "test",
                 Collections.singletonList("noop_id"),
-                Literal.newLiteral(Paths.get(tmpFile.toURI()).toUri().toString()),
+                Literal.of(Paths.get(tmpFile.toURI()).toUri().toString()),
                 Arrays.<Symbol>asList(
                         createReference("name", DataTypes.STRING),
                         createReference(new ColumnIdent("details", "age"), DataTypes.INTEGER)

--- a/sql/src/test/java/io/crate/operation/operator/AndOperatorTest.java
+++ b/sql/src/test/java/io/crate/operation/operator/AndOperatorTest.java
@@ -21,7 +21,7 @@ public class AndOperatorTest extends CrateUnitTest {
     public void testNormalizeBooleanTrueAndNonLiteral() throws Exception {
         AndOperator operator = new AndOperator();
         Function function = new Function(
-                operator.info(), Arrays.<Symbol>asList(Literal.newLiteral(true), new Reference()));
+                operator.info(), Arrays.<Symbol>asList(Literal.of(true), new Reference()));
         Symbol symbol = operator.normalizeSymbol(function, stmtCtx);
         assertThat(symbol, instanceOf(Reference.class));
     }
@@ -30,7 +30,7 @@ public class AndOperatorTest extends CrateUnitTest {
     public void testNormalizeBooleanFalseAndNonLiteral() throws Exception {
         AndOperator operator = new AndOperator();
         Function function = new Function(
-                operator.info(), Arrays.<Symbol>asList(Literal.newLiteral(false), new Reference()));
+                operator.info(), Arrays.<Symbol>asList(Literal.of(false), new Reference()));
         Symbol symbol = operator.normalizeSymbol(function, stmtCtx);
 
         assertThat(symbol, isLiteral(false));
@@ -40,7 +40,7 @@ public class AndOperatorTest extends CrateUnitTest {
     public void testNormalizeLiteralAndLiteral() throws Exception {
         AndOperator operator = new AndOperator();
         Function function = new Function(
-                operator.info(), Arrays.<Symbol>asList(Literal.newLiteral(true), Literal.newLiteral(true)));
+                operator.info(), Arrays.<Symbol>asList(Literal.of(true), Literal.of(true)));
         Symbol symbol = operator.normalizeSymbol(function, stmtCtx);
         assertThat(symbol, isLiteral(true));
     }
@@ -49,14 +49,14 @@ public class AndOperatorTest extends CrateUnitTest {
     public void testNormalizeLiteralAndLiteralFalse() throws Exception {
         AndOperator operator = new AndOperator();
         Function function = new Function(
-                operator.info(), Arrays.<Symbol>asList(Literal.newLiteral(true), Literal.newLiteral(false)));
+                operator.info(), Arrays.<Symbol>asList(Literal.of(true), Literal.of(false)));
         Symbol symbol = operator.normalizeSymbol(function, stmtCtx);
         assertThat(symbol, isLiteral(false));
     }
 
     private Boolean and(Boolean left, Boolean right) {
         AndOperator operator = new AndOperator();
-        return operator.evaluate(Literal.newLiteral(left), Literal.newLiteral(right));
+        return operator.evaluate(Literal.of(left), Literal.of(right));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/operator/CmpOperatorTest.java
+++ b/sql/src/test/java/io/crate/operation/operator/CmpOperatorTest.java
@@ -45,71 +45,71 @@ public class CmpOperatorTest extends CrateUnitTest {
 
     @Test
     public void testLteNormalizeSymbolTwoLiteral() throws Exception {
-        Symbol symbol = normalize(op_lte_long, Literal.newLiteral(8L), Literal.newLiteral(200L));
+        Symbol symbol = normalize(op_lte_long, Literal.of(8L), Literal.of(200L));
         assertThat(symbol, isLiteral(true));
 
-        symbol = normalize(op_lte_long, Literal.newLiteral(8L), Literal.newLiteral(8L));
+        symbol = normalize(op_lte_long, Literal.of(8L), Literal.of(8L));
         assertThat(symbol, isLiteral(true));
 
-        symbol = normalize(op_lte_long, Literal.newLiteral(16L), Literal.newLiteral(8L));
+        symbol = normalize(op_lte_long, Literal.of(16L), Literal.of(8L));
         assertThat(symbol, isLiteral(false));
     }
 
     @Test
     public void testGteNormalizeSymbolTwoLiteral() throws Exception {
-        Symbol symbol = normalize(op_gte_double, Literal.newLiteral(0.03), Literal.newLiteral(0.4));
+        Symbol symbol = normalize(op_gte_double, Literal.of(0.03), Literal.of(0.4));
         assertThat(symbol, isLiteral(false));
 
-        symbol = normalize(op_gte_double, Literal.newLiteral(0.4), Literal.newLiteral(0.4));
+        symbol = normalize(op_gte_double, Literal.of(0.4), Literal.of(0.4));
         assertThat(symbol, isLiteral(true));
 
-        symbol = normalize(op_gte_double, Literal.newLiteral(0.6), Literal.newLiteral(0.4));
+        symbol = normalize(op_gte_double, Literal.of(0.6), Literal.of(0.4));
         assertThat(symbol, isLiteral(true));
     }
 
     @Test
     public void testLtNormalizeSymbolTwoLiteralTrue() throws Exception {
-        Symbol symbol = normalize(op_lt_int, Literal.newLiteral(2), Literal.newLiteral(4));
+        Symbol symbol = normalize(op_lt_int, Literal.of(2), Literal.of(4));
         assertThat(symbol, isLiteral(true));
     }
 
     @Test
     public void testLtNormalizeSymbolTwoLiteralFalse() throws Exception {
-        Symbol symbol = normalize(op_lt_int, Literal.newLiteral(4), Literal.newLiteral(2));
+        Symbol symbol = normalize(op_lt_int, Literal.of(4), Literal.of(2));
         assertThat(symbol, isLiteral(false));
     }
 
     @Test
     public void testLtNormalizeSymbolTwoLiteralFalseEq() throws Exception {
-        Symbol symbol = normalize(op_lt_int, Literal.newLiteral(4), Literal.newLiteral(4));
+        Symbol symbol = normalize(op_lt_int, Literal.of(4), Literal.of(4));
         assertThat(symbol, isLiteral(false));
     }
 
     @Test
     public void testGtNormalizeSymbolTwoLiteralFalse() throws Exception {
-        Symbol symbol = normalize(op_gt_string, Literal.newLiteral("aa"), Literal.newLiteral("bbb"));
+        Symbol symbol = normalize(op_gt_string, Literal.of("aa"), Literal.of("bbb"));
         assertThat(symbol, isLiteral(false));
     }
 
     @Test
     public void testCisGtThanA() throws Exception {
-        assertTrue(op_gt_string.evaluate((Input) Literal.newLiteral("c"), (Input) Literal.newLiteral("a")));
+        assertTrue(op_gt_string.evaluate((Input) Literal.of("c"), (Input) Literal.of("a")));
     }
 
     @Test
     public void testAisLtThanC() throws Exception {
-        assertTrue(op_lt_string.evaluate((Input) Literal.newLiteral("a"), (Input) Literal.newLiteral("c")));
+        assertTrue(op_lt_string.evaluate((Input) Literal.of("a"), (Input) Literal.of("c")));
     }
 
     @Test
     public void testNormalizeSymbolWithNull() throws Exception {
-        Literal literal = (Literal)normalize(op_gt_string, Literal.NULL, Literal.newLiteral("aa"));
+        Literal literal = (Literal)normalize(op_gt_string, Literal.NULL, Literal.of("aa"));
         assertThat(literal, isLiteral(null, DataTypes.BOOLEAN));
     }
 
     @Test
     public void testNormalizeSymbolNonLiteral() throws Exception {
-        Symbol symbol = normalize(op_gt_string, Literal.newLiteral("a"), new Value(DataTypes.STRING));
+        Symbol symbol = normalize(op_gt_string, Literal.of("a"), new Value(DataTypes.STRING));
         assertThat(symbol, instanceOf(Function.class));
     }
 }

--- a/sql/src/test/java/io/crate/operation/operator/InOperatorTest.java
+++ b/sql/src/test/java/io/crate/operation/operator/InOperatorTest.java
@@ -52,8 +52,8 @@ public class InOperatorTest extends CrateUnitTest{
 
     @Test
     public void testNormalizeSymbolSetLiteralIntegerIncluded() {
-        Literal<Integer> inValue = Literal.newLiteral(1);
-        Literal inListValues = Literal.newLiteral(INTEGER_SET_TYPE, Sets.newHashSet(1, 2, 4, 8));
+        Literal<Integer> inValue = Literal.of(1);
+        Literal inListValues = Literal.of(INTEGER_SET_TYPE, Sets.newHashSet(1, 2, 4, 8));
 
         List<Symbol> arguments = new ArrayList<>();
         arguments.add(inValue);
@@ -68,9 +68,9 @@ public class InOperatorTest extends CrateUnitTest{
 
     @Test
     public void testNormalizeSymbolSetLiteralIntegerNotIncluded() {
-        Literal<Integer> inValue = Literal.newLiteral(128);
+        Literal<Integer> inValue = Literal.of(128);
 
-        Literal inListValues = Literal.newLiteral(INTEGER_SET_TYPE, Sets.newHashSet(1, 2, 4, 8));
+        Literal inListValues = Literal.of(INTEGER_SET_TYPE, Sets.newHashSet(1, 2, 4, 8));
 
         List<Symbol> arguments = new ArrayList<>();
         arguments.add(inValue);
@@ -85,8 +85,8 @@ public class InOperatorTest extends CrateUnitTest{
 
     @Test
     public void testNormalizeSymbolSetLiteralDifferentDataTypeValue() {
-        Literal<Double> value = Literal.newLiteral(2.0);
-        Literal inListValues = Literal.newLiteral(INTEGER_SET_TYPE, Sets.newHashSet(1, 2, 4, 8));
+        Literal<Double> value = Literal.of(2.0);
+        Literal inListValues = Literal.of(INTEGER_SET_TYPE, Sets.newHashSet(1, 2, 4, 8));
 
         List<Symbol> arguments = new ArrayList<>();
         arguments.add(value);
@@ -102,7 +102,7 @@ public class InOperatorTest extends CrateUnitTest{
     @Test
     public void testNormalizeSymbolSetLiteralReference() {
         Reference reference = new Reference();
-        Literal inListValues = Literal.newLiteral(INTEGER_SET_TYPE, Sets.newHashSet(1, 2, 4, 8));
+        Literal inListValues = Literal.of(INTEGER_SET_TYPE, Sets.newHashSet(1, 2, 4, 8));
 
         List<Symbol> arguments = new ArrayList<>();
         arguments.add(reference);
@@ -118,8 +118,8 @@ public class InOperatorTest extends CrateUnitTest{
 
     @Test
     public void testNormalizeSymbolSetLiteralStringIncluded() {
-        Literal inValue = Literal.newLiteral("charlie");
-        Literal inListValues = Literal.newLiteral(
+        Literal inValue = Literal.of("charlie");
+        Literal inListValues = Literal.of(
                 STRING_SET_TYPE,
                 Sets.newHashSet(
                         new BytesRef("alpha"),
@@ -142,8 +142,8 @@ public class InOperatorTest extends CrateUnitTest{
 
     @Test
     public void testNormalizeSymbolSetLiteralStringNotIncluded() {
-        Literal inValue = Literal.newLiteral("not included");
-        Literal inListValues = Literal.newLiteral(
+        Literal inValue = Literal.of("not included");
+        Literal inListValues = Literal.of(
                 STRING_SET_TYPE,
                 Sets.newHashSet(
                         new BytesRef("alpha"),

--- a/sql/src/test/java/io/crate/operation/operator/LikeOperatorTest.java
+++ b/sql/src/test/java/io/crate/operation/operator/LikeOperatorTest.java
@@ -41,7 +41,7 @@ public class LikeOperatorTest extends CrateUnitTest {
         );
         Function function = new Function(
                 op.info(),
-                Arrays.<Symbol>asList(Literal.newLiteral(expression), Literal.newLiteral(pattern))
+                Arrays.<Symbol>asList(Literal.of(expression), Literal.of(pattern))
         );
         return op.normalizeSymbol(function, new StmtCtx());
     }
@@ -154,7 +154,7 @@ public class LikeOperatorTest extends CrateUnitTest {
         LikeOperator op = new LikeOperator(
                 LikeOperator.generateInfo(LikeOperator.NAME, DataTypes.STRING)
         );
-        return op.evaluate(Literal.newLiteral(expression), Literal.newLiteral(pattern));
+        return op.evaluate(Literal.of(expression), Literal.of(pattern));
     }
 
     @Test
@@ -168,9 +168,9 @@ public class LikeOperatorTest extends CrateUnitTest {
                 LikeOperator.generateInfo(LikeOperator.NAME, DataTypes.STRING)
         );
         BytesRef nullValue = null;
-        Literal<BytesRef> brNullValue = Literal.newLiteral(nullValue);
-        assertNull(op.evaluate(brNullValue, Literal.newLiteral("foobarbaz")));
-        assertNull(op.evaluate(Literal.newLiteral("foobarbaz"), brNullValue));
+        Literal<BytesRef> brNullValue = Literal.of(nullValue);
+        assertNull(op.evaluate(brNullValue, Literal.of("foobarbaz")));
+        assertNull(op.evaluate(Literal.of("foobarbaz"), brNullValue));
     }
 
 }

--- a/sql/src/test/java/io/crate/operation/operator/OrOperatorTest.java
+++ b/sql/src/test/java/io/crate/operation/operator/OrOperatorTest.java
@@ -20,7 +20,7 @@ public class OrOperatorTest extends CrateUnitTest {
         OrOperator operator = new OrOperator();
 
         Function function = new Function(
-                operator.info(), Arrays.<Symbol>asList(new Reference(), Literal.newLiteral(true)));
+                operator.info(), Arrays.<Symbol>asList(new Reference(), Literal.of(true)));
         Symbol normalizedSymbol = operator.normalizeSymbol(function, new StmtCtx());
         assertThat(normalizedSymbol, isLiteral(true));
     }
@@ -29,7 +29,7 @@ public class OrOperatorTest extends CrateUnitTest {
     public void testNormalizeSymbolReferenceAndLiteralFalse() throws Exception {
         OrOperator operator = new OrOperator();
         Function function = new Function(
-                operator.info(), Arrays.<Symbol>asList(new Reference(), Literal.newLiteral(false)));
+                operator.info(), Arrays.<Symbol>asList(new Reference(), Literal.of(false)));
         Symbol normalizedSymbol = operator.normalizeSymbol(function, new StmtCtx());
         assertThat(normalizedSymbol, instanceOf(Reference.class));
     }
@@ -46,7 +46,7 @@ public class OrOperatorTest extends CrateUnitTest {
 
     private Boolean or(Boolean left, Boolean right) {
         OrOperator operator = new OrOperator();
-        return operator.evaluate(Literal.newLiteral(left), Literal.newLiteral(right));
+        return operator.evaluate(Literal.of(left), Literal.of(right));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/operator/RegexpMatchCaseInsensitiveOperatorTest.java
+++ b/sql/src/test/java/io/crate/operation/operator/RegexpMatchCaseInsensitiveOperatorTest.java
@@ -38,7 +38,7 @@ public class RegexpMatchCaseInsensitiveOperatorTest extends CrateUnitTest {
         RegexpMatchCaseInsensitiveOperator op = new RegexpMatchCaseInsensitiveOperator();
         Function function = new Function(
                 op.info(),
-                Arrays.<Symbol>asList(Literal.newLiteral(source), Literal.newLiteral(pattern))
+                Arrays.<Symbol>asList(Literal.of(source), Literal.of(pattern))
         );
         return op.normalizeSymbol(function, new StmtCtx());
     }
@@ -68,7 +68,7 @@ public class RegexpMatchCaseInsensitiveOperatorTest extends CrateUnitTest {
 
     private Boolean regexpEvaluate(String source, String pattern) {
         RegexpMatchCaseInsensitiveOperator op = new RegexpMatchCaseInsensitiveOperator();
-        return op.evaluate(Literal.newLiteral(source), Literal.newLiteral(pattern));
+        return op.evaluate(Literal.of(source), Literal.of(pattern));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/operator/RegexpMatchOperatortest.java
+++ b/sql/src/test/java/io/crate/operation/operator/RegexpMatchOperatortest.java
@@ -38,7 +38,7 @@ public class RegexpMatchOperatortest extends CrateUnitTest {
         RegexpMatchOperator op = new RegexpMatchOperator();
         Function function = new Function(
                 op.info(),
-                Arrays.<Symbol>asList(Literal.newLiteral(source), Literal.newLiteral(pattern))
+                Arrays.<Symbol>asList(Literal.of(source), Literal.of(pattern))
         );
         return op.normalizeSymbol(function, new StmtCtx());
     }
@@ -68,7 +68,7 @@ public class RegexpMatchOperatortest extends CrateUnitTest {
 
     private Boolean regexpEvaluate(String source, String pattern) {
         RegexpMatchOperator op = new RegexpMatchOperator();
-        return op.evaluate(Literal.newLiteral(source), Literal.newLiteral(pattern));
+        return op.evaluate(Literal.of(source), Literal.of(pattern));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/operator/any/AnyEqOperatorTest.java
+++ b/sql/src/test/java/io/crate/operation/operator/any/AnyEqOperatorTest.java
@@ -61,8 +61,8 @@ public class AnyEqOperatorTest extends CrateUnitTest {
         Function function = new Function(
                 anyEqOperator.info(),
                 Arrays.<Symbol>asList(
-                        Literal.newLiteral(DataTypes.INTEGER, value),
-                        Literal.newLiteral(new ArrayType(DataTypes.INTEGER), arrayExpr))
+                        Literal.of(DataTypes.INTEGER, value),
+                        Literal.of(new ArrayType(DataTypes.INTEGER), arrayExpr))
         );
         return (Boolean)((Literal)anyEqOperator.normalizeSymbol(function, stmtCtx)).value();
     }

--- a/sql/src/test/java/io/crate/operation/operator/any/AnyLikeOperatorTest.java
+++ b/sql/src/test/java/io/crate/operation/operator/any/AnyLikeOperatorTest.java
@@ -41,12 +41,12 @@ import static org.hamcrest.Matchers.is;
 public class AnyLikeOperatorTest extends CrateUnitTest {
 
     private static Symbol normalizeSymbol(String pattern, String ... expressions) {
-        Literal patternLiteral = Literal.newLiteral(pattern);
+        Literal patternLiteral = Literal.of(pattern);
         Object[] value = new Object[expressions.length];
         for (int i=0; i < expressions.length; i++) {
             value[i] = expressions[i] == null ? null : new BytesRef(expressions[i]);
         }
-        Literal valuesLiteral = Literal.newLiteral(new ArrayType(DataTypes.STRING), value);
+        Literal valuesLiteral = Literal.of(new ArrayType(DataTypes.STRING), value);
         AnyLikeOperator impl = (AnyLikeOperator)new AnyLikeOperator.AnyLikeResolver().getForTypes(
                 Arrays.asList(patternLiteral.valueType(), valuesLiteral.valueType())
         );
@@ -63,12 +63,12 @@ public class AnyLikeOperatorTest extends CrateUnitTest {
     }
 
     private Boolean anyLike(String pattern, String ... expressions) {
-        Literal patternLiteral = Literal.newLiteral(pattern);
+        Literal patternLiteral = Literal.of(pattern);
         Object[] value = new Object[expressions.length];
         for (int i=0; i < expressions.length; i++) {
             value[i] = expressions[i] == null ? null : new BytesRef(expressions[i]);
         }
-        Literal valuesLiteral = Literal.newLiteral(new ArrayType(DataTypes.STRING), value);
+        Literal valuesLiteral = Literal.of(new ArrayType(DataTypes.STRING), value);
         AnyLikeOperator impl = (AnyLikeOperator)new AnyLikeOperator.AnyLikeResolver().getForTypes(
                 Arrays.asList(DataTypes.STRING, valuesLiteral.valueType())
         );
@@ -152,8 +152,8 @@ public class AnyLikeOperatorTest extends CrateUnitTest {
 
     @Test
     public void testNegateLike() throws Exception {
-        Literal patternLiteral = Literal.newLiteral("A");
-        Literal valuesLiteral = Literal.newLiteral(new ArrayType(DataTypes.STRING),
+        Literal patternLiteral = Literal.of("A");
+        Literal valuesLiteral = Literal.of(new ArrayType(DataTypes.STRING),
                 new Object[]{new BytesRef("A"), new BytesRef("B")});
         FunctionImplementation<Function> impl = new AnyLikeOperator.AnyLikeResolver().getForTypes(
                 Arrays.asList(DataTypes.STRING, valuesLiteral.valueType())

--- a/sql/src/test/java/io/crate/operation/operator/any/AnyNotLikeOperatorTest.java
+++ b/sql/src/test/java/io/crate/operation/operator/any/AnyNotLikeOperatorTest.java
@@ -41,12 +41,12 @@ import static org.hamcrest.Matchers.is;
 public class AnyNotLikeOperatorTest extends CrateUnitTest {
 
     private static Symbol normalizeSymbol(String pattern, String ... expressions) {
-        Literal patternLiteral = Literal.newLiteral(pattern);
+        Literal patternLiteral = Literal.of(pattern);
         Object[] value = new Object[expressions.length];
         for (int i=0; i < expressions.length; i++) {
             value[i] = expressions[i] == null ? null : new BytesRef(expressions[i]);
         }
-        Literal valuesLiteral = Literal.newLiteral(new ArrayType(DataTypes.STRING), value);
+        Literal valuesLiteral = Literal.of(new ArrayType(DataTypes.STRING), value);
         AnyNotLikeOperator impl = (AnyNotLikeOperator)new AnyNotLikeOperator.AnyNotLikeResolver().getForTypes(
                 Arrays.asList(patternLiteral.valueType(), valuesLiteral.valueType())
         );
@@ -63,12 +63,12 @@ public class AnyNotLikeOperatorTest extends CrateUnitTest {
     }
 
     private Boolean anyNotLike(String pattern, String ... expressions) {
-        Literal patternLiteral = Literal.newLiteral(pattern);
+        Literal patternLiteral = Literal.of(pattern);
         Object[] value = new Object[expressions.length];
         for (int i=0; i < expressions.length; i++) {
             value[i] = expressions[i] == null ? null : new BytesRef(expressions[i]);
         }
-        Literal valuesLiteral = Literal.newLiteral(new ArrayType(DataTypes.STRING), value);
+        Literal valuesLiteral = Literal.of(new ArrayType(DataTypes.STRING), value);
         AnyNotLikeOperator impl = (AnyNotLikeOperator)new AnyNotLikeOperator.AnyNotLikeResolver().getForTypes(
                 Arrays.asList(DataTypes.STRING, valuesLiteral.valueType())
         );
@@ -152,8 +152,8 @@ public class AnyNotLikeOperatorTest extends CrateUnitTest {
 
     @Test
     public void testNegateNotLike() throws Exception {
-        Literal patternLiteral = Literal.newLiteral("A");
-        Literal valuesLiteral = Literal.newLiteral(new ArrayType(DataTypes.STRING),
+        Literal patternLiteral = Literal.of("A");
+        Literal valuesLiteral = Literal.of(new ArrayType(DataTypes.STRING),
                 new Object[]{new BytesRef("A"), new BytesRef("B")});
         FunctionImplementation<Function> impl = new AnyNotLikeOperator.AnyNotLikeResolver().getForTypes(
                 Arrays.asList(DataTypes.STRING, valuesLiteral.valueType())

--- a/sql/src/test/java/io/crate/operation/predicate/IsNullPredicateTest.java
+++ b/sql/src/test/java/io/crate/operation/predicate/IsNullPredicateTest.java
@@ -49,7 +49,7 @@ public class IsNullPredicateTest extends CrateUnitTest {
 
     @Test
     public void testNormalizeSymbolFalse() throws Exception {
-        Function isNull = new Function(predicate.info(), Arrays.<Symbol>asList(Literal.newLiteral("a")));
+        Function isNull = new Function(predicate.info(), Arrays.<Symbol>asList(Literal.of("a")));
         Symbol symbol = predicate.normalizeSymbol(isNull, stmtCtx);
         assertThat(symbol, isLiteral(false));
     }
@@ -84,7 +84,7 @@ public class IsNullPredicateTest extends CrateUnitTest {
     @Test
     public void testNormalizeSymbolWithStringLiteralThatIsNull() throws Exception {
         Function isNull = new Function(predicate.info(),
-                Arrays.<Symbol>asList(Literal.newLiteral(DataTypes.STRING, null)));
+                Arrays.<Symbol>asList(Literal.of(DataTypes.STRING, null)));
         Symbol symbol = predicate.normalizeSymbol(isNull, stmtCtx);
         assertThat((Boolean) ((Input) symbol).value(), is(true));
     }

--- a/sql/src/test/java/io/crate/operation/predicate/NotPredicateTest.java
+++ b/sql/src/test/java/io/crate/operation/predicate/NotPredicateTest.java
@@ -43,7 +43,7 @@ public class NotPredicateTest extends CrateUnitTest {
     @Test
     public void testNormalizeSymbolBoolean() throws Exception {
         NotPredicate predicate = new NotPredicate();
-        Function not = new Function(predicate.info(), Arrays.<Symbol>asList(Literal.newLiteral(true)));
+        Function not = new Function(predicate.info(), Arrays.<Symbol>asList(Literal.of(true)));
 
         assertThat(predicate.normalizeSymbol(not, stmtCtx), isLiteral(false));
     }
@@ -61,7 +61,7 @@ public class NotPredicateTest extends CrateUnitTest {
                                 Arrays.<DataType>asList(DataTypes.STRING, DataTypes.STRING)),
                         DataTypes.BOOLEAN
                 ),
-                Arrays.<Symbol>asList(name_ref, Literal.newLiteral("foo"))
+                Arrays.<Symbol>asList(name_ref, Literal.of("foo"))
         );
 
         Function not = new Function(notPredicate.info(), Arrays.<Symbol>asList(eqName));

--- a/sql/src/test/java/io/crate/operation/projectors/ProjectionToProjectorVisitorTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/ProjectionToProjectorVisitorTest.java
@@ -119,7 +119,7 @@ public class ProjectionToProjectorVisitorTest extends CrateUnitTest {
     @Test
     public void testSimpleTopNProjection() throws Exception {
         TopNProjection projection = new TopNProjection(10, 2);
-        projection.outputs(Arrays.<Symbol>asList(Literal.newLiteral("foo"), new InputColumn(0)));
+        projection.outputs(Arrays.<Symbol>asList(Literal.of("foo"), new InputColumn(0)));
 
         CollectingRowReceiver collectingProjector = new CollectingRowReceiver();
         Projector projector = visitor.create(projection, RAM_ACCOUNTING_CONTEXT, UUID.randomUUID());
@@ -141,7 +141,7 @@ public class ProjectionToProjectorVisitorTest extends CrateUnitTest {
                 new boolean[]{false, false},
                 new Boolean[]{null, null}
         );
-        projection.outputs(Arrays.<Symbol>asList(Literal.newLiteral("foo"), new InputColumn(0), new InputColumn(1)));
+        projection.outputs(Arrays.<Symbol>asList(Literal.of("foo"), new InputColumn(0), new InputColumn(1)));
         Projector projector = visitor.create(projection, RAM_ACCOUNTING_CONTEXT, UUID.randomUUID());
         assertThat(projector, instanceOf(SortingTopNProjector.class));
     }
@@ -153,7 +153,7 @@ public class ProjectionToProjectorVisitorTest extends CrateUnitTest {
                 new boolean[]{false, false},
                 new Boolean[]{null, null}
         );
-        projection.outputs(Arrays.<Symbol>asList(Literal.newLiteral("foo"), new InputColumn(0), new InputColumn(1)));
+        projection.outputs(Arrays.<Symbol>asList(Literal.of("foo"), new InputColumn(0), new InputColumn(1)));
         Projector projector = visitor.create(projection, RAM_ACCOUNTING_CONTEXT, UUID.randomUUID());
         assertThat(projector, instanceOf(SortingProjector.class));
     }
@@ -237,7 +237,7 @@ public class ProjectionToProjectorVisitorTest extends CrateUnitTest {
         EqOperator op = (EqOperator) functions.get(
                 new FunctionIdent(EqOperator.NAME, ImmutableList.<DataType>of(DataTypes.INTEGER, DataTypes.INTEGER)));
         Function function = new Function(
-                op.info(), Arrays.<Symbol>asList(Literal.newLiteral(2), new InputColumn(1)));
+                op.info(), Arrays.<Symbol>asList(Literal.of(2), new InputColumn(1)));
         FilterProjection projection = new FilterProjection(function);
         projection.outputs(Arrays.<Symbol>asList(new InputColumn(0), new InputColumn(1)));
 

--- a/sql/src/test/java/io/crate/operation/projectors/SortingProjectorTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/SortingProjectorTest.java
@@ -42,7 +42,7 @@ public class SortingProjectorTest extends CrateUnitTest {
     private SortingProjector createProjector(int numOutputs, int offset, RowReceiver rowReceiver) {
         InputCollectExpression input = new InputCollectExpression(0);
         SortingProjector projector = new SortingProjector(
-            ImmutableList.of(input, Literal.newLiteral(true)),
+            ImmutableList.of(input, Literal.of(true)),
             ImmutableList.<CollectExpression<Row, ?>>of(input),
             numOutputs,
             OrderingByPosition.arrayOrdering(0, false, null),

--- a/sql/src/test/java/io/crate/operation/projectors/SortingTopNProjectorTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/SortingTopNProjectorTest.java
@@ -43,7 +43,7 @@ import static org.hamcrest.core.Is.is;
 public class SortingTopNProjectorTest extends CrateUnitTest {
 
     private static final InputCollectExpression INPUT = new InputCollectExpression(0);
-    private static final Literal<Boolean> TRUE_LITERAL = Literal.newLiteral(true);
+    private static final Literal<Boolean> TRUE_LITERAL = Literal.of(true);
     private static final List<Input<?>> INPUT_LITERAL_LIST = ImmutableList.of(INPUT, TRUE_LITERAL);
     private static final List<CollectExpression<Row, ?>> COLLECT_EXPRESSIONS = ImmutableList.<CollectExpression<Row, ?>>of(INPUT);
     private static final Ordering<Object[]> FIRST_CELL_ORDERING = OrderingByPosition.arrayOrdering(0, false, null);

--- a/sql/src/test/java/io/crate/operation/scalar/AbstractScalarFunctionsTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/AbstractScalarFunctionsTest.java
@@ -171,7 +171,7 @@ public abstract class AbstractScalarFunctionsTest extends CrateUnitTest {
     }
 
     protected Symbol normalize(String functionName, Object value, DataType type) {
-        return normalize(functionName, Literal.newLiteral(type, value));
+        return normalize(functionName, Literal.of(type, value));
     }
 
     protected Symbol normalize(String functionName, Symbol ...args) {

--- a/sql/src/test/java/io/crate/operation/scalar/ArrayCatFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/ArrayCatFunctionTest.java
@@ -81,8 +81,8 @@ public class ArrayCatFunctionTest extends AbstractScalarFunctionsTest {
         ArrayCatFunction function = getFunction(arrayOfIntegerType, arrayOfIntegerType);
 
         Symbol symbol = function.normalizeSymbol(new Function(function.info(), Arrays.<Symbol>asList(
-                Literal.newLiteral(new Integer[]{10, 20}, arrayOfIntegerType),
-                Literal.newLiteral(new Integer[]{10, 30}, arrayOfIntegerType)
+                Literal.of(new Integer[]{10, 20}, arrayOfIntegerType),
+                Literal.of(new Integer[]{10, 30}, arrayOfIntegerType)
         )), stmtCtx);
 
         assertThat(symbol, isLiteral(new Integer[]{10, 20, 10, 30}, arrayOfIntegerType));
@@ -94,7 +94,7 @@ public class ArrayCatFunctionTest extends AbstractScalarFunctionsTest {
 
         Function functionSymbol = new Function(function.info(), Arrays.<Symbol>asList(
                 TestingHelpers.createReference("foo", arrayOfIntegerType),
-                Literal.newLiteral(new Integer[]{10, 30}, arrayOfIntegerType)
+                Literal.of(new Integer[]{10, 30}, arrayOfIntegerType)
         ));
         Function symbol = (Function) function.normalizeSymbol(functionSymbol, stmtCtx);
         assertThat(symbol, Matchers.sameInstance(functionSymbol));
@@ -106,7 +106,7 @@ public class ArrayCatFunctionTest extends AbstractScalarFunctionsTest {
         expectedException.expectMessage("Argument 2 of the array_cat function cannot be converted to array");
         assertEval(
                 null,
-                Literal.newLiteral(new Object[]{1, 2, 3}, arrayOfIntegerType),
+                Literal.of(new Object[]{1, 2, 3}, arrayOfIntegerType),
                 Literal.NULL);
     }
 
@@ -135,7 +135,7 @@ public class ArrayCatFunctionTest extends AbstractScalarFunctionsTest {
     public void testOneArgument() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("array_cat function requires 2 arguments");
-        assertEval(new Object[]{}, Literal.newLiteral(new Object[]{1}, new ArrayType(DataTypes.INTEGER)));
+        assertEval(new Object[]{}, Literal.of(new Object[]{1}, new ArrayType(DataTypes.INTEGER)));
     }
 
     @Test
@@ -143,33 +143,33 @@ public class ArrayCatFunctionTest extends AbstractScalarFunctionsTest {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("array_cat function requires 2 arguments");
         assertEval(new Object[]{},
-                Literal.newLiteral(new Object[]{1}, new ArrayType(DataTypes.INTEGER)),
-                Literal.newLiteral(new Object[]{2}, new ArrayType(DataTypes.INTEGER)),
-                Literal.newLiteral(new Object[]{3}, new ArrayType(DataTypes.INTEGER)));
+                Literal.of(new Object[]{1}, new ArrayType(DataTypes.INTEGER)),
+                Literal.of(new Object[]{2}, new ArrayType(DataTypes.INTEGER)),
+                Literal.of(new Object[]{3}, new ArrayType(DataTypes.INTEGER)));
     }
 
     @Test
     public void testDifferentConvertableInnerTypes() throws Exception {
         assertEval(
                 new Object[]{1, 1},
-                Literal.newLiteral(new Object[]{1},  arrayOfIntegerType),
-                Literal.newLiteral(new Object[]{1L}, arrayOfLongType));
+                Literal.of(new Object[]{1},  arrayOfIntegerType),
+                Literal.of(new Object[]{1L}, arrayOfLongType));
     }
 
     @Test
     public void testStringToNumberCast() throws Exception {
         assertEval(
                 new Object[]{1, 2},
-                Literal.newLiteral(new Object[]{1},      arrayOfIntegerType),
-                Literal.newLiteral(new Object[]{"2"},    arrayOfStringType));
+                Literal.of(new Object[]{1},      arrayOfIntegerType),
+                Literal.of(new Object[]{"2"},    arrayOfStringType));
     }
 
     @Test
     public void testNumberToStringCast() throws Exception {
         assertEval(
                 new Object[]{new BytesRef("2"), new BytesRef("1")},
-                Literal.newLiteral(new Object[]{"2"},    arrayOfStringType),
-                Literal.newLiteral(new Object[]{1},      arrayOfIntegerType));
+                Literal.of(new Object[]{"2"},    arrayOfStringType),
+                Literal.of(new Object[]{1},      arrayOfIntegerType));
     }
 
     @Test
@@ -177,8 +177,8 @@ public class ArrayCatFunctionTest extends AbstractScalarFunctionsTest {
         expectedException.expect(NumberFormatException.class);
         assertEval(
                 null,
-                Literal.newLiteral(new Object[]{1},              arrayOfIntegerType),
-                Literal.newLiteral(new Object[]{"foo","bar"},    arrayOfStringType));
+                Literal.of(new Object[]{1},              arrayOfIntegerType),
+                Literal.of(new Object[]{"foo","bar"},    arrayOfStringType));
     }
 
     @Test
@@ -187,8 +187,8 @@ public class ArrayCatFunctionTest extends AbstractScalarFunctionsTest {
         expectedException.expectMessage("Second argument's inner type (ip) of the array_cat function cannot be converted to the first argument's inner type (boolean)");
         assertEval(
                 null,
-                Literal.newLiteral(new Object[]{true},                       arrayOfBooleanType),
-                Literal.newLiteral(new Object[]{new BytesRef("127.0.0.1")},  arrayOfIpType));
+                Literal.of(new Object[]{true},                       arrayOfBooleanType),
+                Literal.of(new Object[]{new BytesRef("127.0.0.1")},  arrayOfIpType));
 
     }
 
@@ -196,40 +196,40 @@ public class ArrayCatFunctionTest extends AbstractScalarFunctionsTest {
     public void testNullElements() throws Exception {
         assertEval(
                 new Object[]{1, null, 3, null, 2, 3},
-                Literal.newLiteral(new Object[]{1, null, 3}, arrayOfIntegerType),
-                Literal.newLiteral(new Object[]{null, 2, 3}, arrayOfIntegerType));
+                Literal.of(new Object[]{1, null, 3}, arrayOfIntegerType),
+                Literal.of(new Object[]{null, 2, 3}, arrayOfIntegerType));
     }
 
     @Test
     public void testTwoIntegerArguments() throws Exception {
         assertEval(
                 new Object[]{1,2,2,3},
-                Literal.newLiteral(new Object[]{1,2}, arrayOfIntegerType),
-                Literal.newLiteral(new Object[]{2,3}, arrayOfIntegerType));
+                Literal.of(new Object[]{1,2}, arrayOfIntegerType),
+                Literal.of(new Object[]{2,3}, arrayOfIntegerType));
     }
 
     @Test
     public void testTwoLongArguments() throws Exception {
         assertEval(
                 new Object[]{44L,55L,55L,66L},
-                Literal.newLiteral(new Object[]{44L, 55L}, arrayOfLongType),
-                Literal.newLiteral(new Object[]{55L, 66L}, arrayOfLongType));
+                Literal.of(new Object[]{44L, 55L}, arrayOfLongType),
+                Literal.of(new Object[]{55L, 66L}, arrayOfLongType));
     }
 
     @Test
     public void testTwoStringArguments() throws Exception {
         assertEval(
                 new Object[]{new BytesRef("foo"),new BytesRef("bar"),new BytesRef("bar"),new BytesRef("baz")},
-                Literal.newLiteral(new Object[]{"foo","bar"}, arrayOfStringType),
-                Literal.newLiteral(new Object[]{"bar","baz"}, arrayOfStringType));
+                Literal.of(new Object[]{"foo","bar"}, arrayOfStringType),
+                Literal.of(new Object[]{"bar","baz"}, arrayOfStringType));
     }
 
     @Test
     public void testEmptyArrayAndIntegerArray() throws Exception {
         assertEval(
                 new Object[]{1,2},
-                Literal.newLiteral(new Object[]{},      arrayOfUndefinedType),
-                Literal.newLiteral(new Object[]{1,2},   arrayOfIntegerType));
+                Literal.of(new Object[]{},      arrayOfUndefinedType),
+                Literal.of(new Object[]{1,2},   arrayOfIntegerType));
     }
 
     @Test
@@ -237,7 +237,7 @@ public class ArrayCatFunctionTest extends AbstractScalarFunctionsTest {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("One of the arguments of the array_cat function can be of undefined inner type, but not both");
         assertEval(null,
-                Literal.newLiteral(new Object[]{}, arrayOfUndefinedType),
-                Literal.newLiteral(new Object[]{}, arrayOfUndefinedType));
+                Literal.of(new Object[]{}, arrayOfUndefinedType),
+                Literal.of(new Object[]{}, arrayOfUndefinedType));
     }
 }

--- a/sql/src/test/java/io/crate/operation/scalar/ArrayDifferenceFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/ArrayDifferenceFunctionTest.java
@@ -80,8 +80,8 @@ public class ArrayDifferenceFunctionTest extends AbstractScalarFunctionsTest {
     public void testCompileWithValues() throws Exception {
         List<DataType> argumentTypes = Arrays.<DataType>asList(arrayOfIntegerType, arrayOfIntegerType);
         List<Symbol> arguments = Arrays.<Symbol>asList(
-                Literal.newLiteral(new Object[]{1, 2, 3},arrayOfIntegerType),
-                Literal.newLiteral(new Object[]{3, 4, 5}, arrayOfIntegerType)
+                Literal.of(new Object[]{1, 2, 3},arrayOfIntegerType),
+                Literal.of(new Object[]{3, 4, 5}, arrayOfIntegerType)
         );
 
         Scalar function = ((ArrayDifferenceFunction) functions.get(new FunctionIdent(ArrayDifferenceFunction.NAME, argumentTypes)));
@@ -95,7 +95,7 @@ public class ArrayDifferenceFunctionTest extends AbstractScalarFunctionsTest {
         DataType type = new ArrayType(DataTypes.INTEGER);
         List<DataType> argumentTypes = Arrays.<DataType>asList(type, type);
         List<Symbol> arguments = Arrays.<Symbol>asList(
-                Literal.newLiteral(new Object[]{1, 2, 3},type),
+                Literal.of(new Object[]{1, 2, 3},type),
                 createReference("foo", type)
         );
 
@@ -109,7 +109,7 @@ public class ArrayDifferenceFunctionTest extends AbstractScalarFunctionsTest {
     public void testCompileWithNullArgs() throws Exception {
         List<DataType> argumentTypes = Arrays.<DataType>asList(arrayOfIntegerType, arrayOfIntegerType);
         List<Symbol> arguments = Arrays.<Symbol>asList(
-                Literal.newLiteral(new Object[]{1, 2, 3},arrayOfIntegerType),
+                Literal.of(new Object[]{1, 2, 3},arrayOfIntegerType),
                 null
         );
 
@@ -123,7 +123,7 @@ public class ArrayDifferenceFunctionTest extends AbstractScalarFunctionsTest {
     public void testCompileWithNullArgValues() throws Exception {
         List<DataType> argumentTypes = Arrays.<DataType>asList(arrayOfIntegerType, arrayOfIntegerType);
         List<Symbol> arguments = Arrays.<Symbol>asList(
-                Literal.newLiteral(new Object[]{1, 2, 3}, arrayOfIntegerType),
+                Literal.of(new Object[]{1, 2, 3}, arrayOfIntegerType),
                 Literal.NULL
         );
 
@@ -135,8 +135,8 @@ public class ArrayDifferenceFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testCompiledEvaluation() throws Exception {
-        Literal arg1 = Literal.newLiteral(new Object[]{1, 2, 3},arrayOfIntegerType);
-        Literal arg2 = Literal.newLiteral(new Object[]{3, 4, 5}, arrayOfIntegerType);
+        Literal arg1 = Literal.of(new Object[]{1, 2, 3},arrayOfIntegerType);
+        Literal arg2 = Literal.of(new Object[]{3, 4, 5}, arrayOfIntegerType);
 
         List<DataType> argumentTypes = Arrays.<DataType>asList(arrayOfIntegerType, arrayOfIntegerType);
         List<Symbol>   arguments     = Arrays.<Symbol>asList(arg1, arg2);
@@ -157,8 +157,8 @@ public class ArrayDifferenceFunctionTest extends AbstractScalarFunctionsTest {
         ArrayDifferenceFunction function = getFunction(type, type);
 
         Symbol symbol = function.normalizeSymbol(new Function(function.info(), Arrays.<Symbol>asList(
-                Literal.newLiteral(new Integer[]{10, 20}, type),
-                Literal.newLiteral(new Integer[]{10, 30}, type)
+                Literal.of(new Integer[]{10, 20}, type),
+                Literal.of(new Integer[]{10, 30}, type)
         )), stmtCtx);
 
         assertThat(symbol, isLiteral(new Integer[]{20}, type));
@@ -171,7 +171,7 @@ public class ArrayDifferenceFunctionTest extends AbstractScalarFunctionsTest {
 
         Function functionSymbol = new Function(function.info(), Arrays.<Symbol>asList(
                 createReference("foo", type),
-                Literal.newLiteral(new Integer[]{10, 30}, type)
+                Literal.of(new Integer[]{10, 30}, type)
         ));
         Function symbol = (Function) function.normalizeSymbol(functionSymbol, stmtCtx);
         assertThat(symbol, Matchers.sameInstance(functionSymbol));
@@ -182,7 +182,7 @@ public class ArrayDifferenceFunctionTest extends AbstractScalarFunctionsTest {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Argument 2 of the array_difference function cannot be converted to array");
         assertEval(null,
-                Literal.newLiteral(new Object[]{1}, arrayOfIntegerType),
+                Literal.of(new Object[]{1}, arrayOfIntegerType),
                 Literal.NULL);
     }
 
@@ -206,7 +206,7 @@ public class ArrayDifferenceFunctionTest extends AbstractScalarFunctionsTest {
 
         Input[] inputs = new Input[]{
                 null,
-                Literal.newLiteral(new Object[]{22, 33, 44}, arrayOfIntegerType)
+                Literal.of(new Object[]{22, 33, 44}, arrayOfIntegerType)
         };
 
         Object[] evaluate = function.evaluate(inputs);
@@ -219,7 +219,7 @@ public class ArrayDifferenceFunctionTest extends AbstractScalarFunctionsTest {
 
         Input[] inputs = new Input[]{
                 Literal.NULL,
-                Literal.newLiteral(new Object[]{22, 33, 44}, arrayOfIntegerType)
+                Literal.of(new Object[]{22, 33, 44}, arrayOfIntegerType)
         };
 
         Object[] evaluate = function.evaluate(inputs);
@@ -231,7 +231,7 @@ public class ArrayDifferenceFunctionTest extends AbstractScalarFunctionsTest {
         ArrayDifferenceFunction function = getFunction(arrayOfIntegerType, arrayOfIntegerType);
 
         Input[] inputs = new Input[]{
-                Literal.newLiteral(new Object[]{22, 33, 44}, arrayOfIntegerType),
+                Literal.of(new Object[]{22, 33, 44}, arrayOfIntegerType),
                 null
         };
 
@@ -244,7 +244,7 @@ public class ArrayDifferenceFunctionTest extends AbstractScalarFunctionsTest {
         ArrayDifferenceFunction function = getFunction(arrayOfIntegerType, arrayOfIntegerType);
 
         Input[] inputs = new Input[]{
-                Literal.newLiteral(new Object[]{22, 33, 44}, arrayOfIntegerType),
+                Literal.of(new Object[]{22, 33, 44}, arrayOfIntegerType),
                 Literal.NULL
         };
 
@@ -264,14 +264,14 @@ public class ArrayDifferenceFunctionTest extends AbstractScalarFunctionsTest {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("array_difference function requires 2 arguments");
         assertEval(null,
-                Literal.newLiteral(new Object[]{1}, arrayOfIntegerType));
+                Literal.of(new Object[]{1}, arrayOfIntegerType));
     }
 
     @Test
     public void testDifferentBuConvertableInnerTypes() throws Exception {
         assertEval(new Object[]{},
-                Literal.newLiteral(new Object[]{1},  arrayOfIntegerType),
-                Literal.newLiteral(new Object[]{1L}, arrayOfLongType));
+                Literal.of(new Object[]{1},  arrayOfIntegerType),
+                Literal.of(new Object[]{1L}, arrayOfLongType));
     }
 
     @Test
@@ -279,8 +279,8 @@ public class ArrayDifferenceFunctionTest extends AbstractScalarFunctionsTest {
         expectedException.expect(NumberFormatException.class);
         assertEval(
                 null,
-                Literal.newLiteral(new Object[]{1},              arrayOfIntegerType),
-                Literal.newLiteral(new Object[]{"foo","bar"},    arrayOfStringType));
+                Literal.of(new Object[]{1},              arrayOfIntegerType),
+                Literal.of(new Object[]{"foo","bar"},    arrayOfStringType));
     }
 
     @Test
@@ -289,8 +289,8 @@ public class ArrayDifferenceFunctionTest extends AbstractScalarFunctionsTest {
         expectedException.expectMessage("Second argument's inner type (ip) of the array_difference function cannot be converted to the first argument's inner type (boolean)");
         assertEval(
                 null,
-                Literal.newLiteral(new Object[]{true},                       arrayOfBooleanType),
-                Literal.newLiteral(new Object[]{new BytesRef("127.0.0.1")},  arrayOfIpType));
+                Literal.of(new Object[]{true},                       arrayOfBooleanType),
+                Literal.of(new Object[]{new BytesRef("127.0.0.1")},  arrayOfIpType));
 
     }
 
@@ -298,44 +298,44 @@ public class ArrayDifferenceFunctionTest extends AbstractScalarFunctionsTest {
     public void testNullElements() throws Exception {
         assertEval(
                 new Object[]{1},
-                Literal.newLiteral(new Object[]{1,null,3},  arrayOfIntegerType),
-                Literal.newLiteral(new Object[]{null, 2,3}, arrayOfIntegerType));
+                Literal.of(new Object[]{1,null,3},  arrayOfIntegerType),
+                Literal.of(new Object[]{null, 2,3}, arrayOfIntegerType));
         assertEval(
                 new Object[]{1, null, 2, null},
-                Literal.newLiteral(new Object[]{1, null, 3, 2, null},  arrayOfIntegerType),
-                Literal.newLiteral(new Object[]{3},                    arrayOfIntegerType));
+                Literal.of(new Object[]{1, null, 3, 2, null},  arrayOfIntegerType),
+                Literal.of(new Object[]{3},                    arrayOfIntegerType));
     }
 
     @Test
     public void testTwoIntegerArguments() throws Exception {
         assertEval(
                 new Object[]{1},
-                Literal.newLiteral(new Object[]{1,2}, arrayOfIntegerType),
-                Literal.newLiteral(new Object[]{2,3}, arrayOfIntegerType));
+                Literal.of(new Object[]{1,2}, arrayOfIntegerType),
+                Literal.of(new Object[]{2,3}, arrayOfIntegerType));
     }
 
     @Test
     public void testTwoLongArguments() throws Exception {
         assertEval(
                 new Object[]{44L},
-                Literal.newLiteral(new Object[]{44L, 55L}, arrayOfLongType),
-                Literal.newLiteral(new Object[]{55L, 66L}, arrayOfLongType));
+                Literal.of(new Object[]{44L, 55L}, arrayOfLongType),
+                Literal.of(new Object[]{55L, 66L}, arrayOfLongType));
     }
 
     @Test
     public void testTwoStringArguments() throws Exception {
         assertEval(
                 new Object[]{new BytesRef("foo")},
-                Literal.newLiteral(new Object[]{"foo","bar"}, arrayOfStringType),
-                Literal.newLiteral(new Object[]{"bar","baz"}, arrayOfStringType));
+                Literal.of(new Object[]{"foo","bar"}, arrayOfStringType),
+                Literal.of(new Object[]{"bar","baz"}, arrayOfStringType));
     }
 
     @Test
     public void testEmptyArrayAndIntegerArray() throws Exception {
         assertEval(
                 new Object[]{},
-                Literal.newLiteral(new Object[]{},    arrayOfUndefinedType),
-                Literal.newLiteral(new Object[]{1,2}, arrayOfIntegerType));
+                Literal.of(new Object[]{},    arrayOfUndefinedType),
+                Literal.of(new Object[]{1,2}, arrayOfIntegerType));
     }
 
     @Test
@@ -343,7 +343,7 @@ public class ArrayDifferenceFunctionTest extends AbstractScalarFunctionsTest {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("One of the arguments of the array_difference function can be of undefined inner type, but not both");
         assertEval(null,
-                Literal.newLiteral(new Object[]{}, arrayOfUndefinedType),
-                Literal.newLiteral(new Object[]{}, arrayOfUndefinedType));
+                Literal.of(new Object[]{}, arrayOfUndefinedType),
+                Literal.of(new Object[]{}, arrayOfUndefinedType));
     }
 }

--- a/sql/src/test/java/io/crate/operation/scalar/ArrayUniqueFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/ArrayUniqueFunctionTest.java
@@ -79,8 +79,8 @@ public class ArrayUniqueFunctionTest extends AbstractScalarFunctionsTest {
         ArrayUniqueFunction function = getFunction(arrayOfIntegerType, arrayOfIntegerType);
 
         Symbol symbol = function.normalizeSymbol(new Function(function.info(), Arrays.<Symbol>asList(
-                Literal.newLiteral(new Integer[]{10, 20}, arrayOfIntegerType),
-                Literal.newLiteral(new Integer[]{10, 30}, arrayOfIntegerType)
+                Literal.of(new Integer[]{10, 20}, arrayOfIntegerType),
+                Literal.of(new Integer[]{10, 30}, arrayOfIntegerType)
         )), new StmtCtx());
 
         assertThat(symbol, isLiteral(new Integer[]{10, 20, 30}, arrayOfIntegerType));
@@ -92,7 +92,7 @@ public class ArrayUniqueFunctionTest extends AbstractScalarFunctionsTest {
 
         Function functionSymbol = new Function(function.info(), Arrays.<Symbol>asList(
                 TestingHelpers.createReference("foo", arrayOfIntegerType),
-                Literal.newLiteral(new Integer[]{10, 30}, arrayOfIntegerType)
+                Literal.of(new Integer[]{10, 30}, arrayOfIntegerType)
         ));
         Function symbol = (Function) function.normalizeSymbol(functionSymbol, new StmtCtx());
         assertThat(symbol, Matchers.sameInstance(functionSymbol));
@@ -102,7 +102,7 @@ public class ArrayUniqueFunctionTest extends AbstractScalarFunctionsTest {
     public void testNullArguments() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Argument 2 of the array_unique function cannot be converted to array");
-        assertEval(null, Literal.newLiteral(new Object[]{1}, arrayOfIntegerType), Literal.NULL);
+        assertEval(null, Literal.of(new Object[]{1}, arrayOfIntegerType), Literal.NULL);
     }
 
     @Test
@@ -130,15 +130,15 @@ public class ArrayUniqueFunctionTest extends AbstractScalarFunctionsTest {
     public void testOneArgument() throws Exception {
         assertEval(
                 new Object[]{new BytesRef("foo"), new BytesRef("bar"), new BytesRef("baz")},
-                Literal.newLiteral(new Object[]{"foo", "bar", "baz", "baz"}, arrayOfStringType));
+                Literal.of(new Object[]{"foo", "bar", "baz", "baz"}, arrayOfStringType));
     }
 
     @Test
     public void testDifferentButConvertableInnerTypes() throws Exception {
        assertEval(
                 new Object[]{1},
-                Literal.newLiteral(new Object[]{1},  arrayOfIntegerType),
-                Literal.newLiteral(new Object[]{1L}, arrayOfLongType));
+                Literal.of(new Object[]{1},  arrayOfIntegerType),
+                Literal.of(new Object[]{1L}, arrayOfLongType));
     }
 
     @Test
@@ -146,8 +146,8 @@ public class ArrayUniqueFunctionTest extends AbstractScalarFunctionsTest {
         expectedException.expect(NumberFormatException.class);
         assertEval(
                 null,
-                Literal.newLiteral(new Object[]{1},              arrayOfIntegerType),
-                Literal.newLiteral(new Object[]{"foo","bar"},    arrayOfStringType));
+                Literal.of(new Object[]{1},              arrayOfIntegerType),
+                Literal.of(new Object[]{"foo","bar"},    arrayOfStringType));
     }
 
     @Test
@@ -156,8 +156,8 @@ public class ArrayUniqueFunctionTest extends AbstractScalarFunctionsTest {
         expectedException.expectMessage("Second argument's inner type (ip) of the array_unique function cannot be converted to the first argument's inner type (boolean)");
         assertEval(
                 null,
-                Literal.newLiteral(new Object[]{true},                       arrayOfBooleanType),
-                Literal.newLiteral(new Object[]{new BytesRef("127.0.0.1")},  arrayOfIpType));
+                Literal.of(new Object[]{true},                       arrayOfBooleanType),
+                Literal.of(new Object[]{new BytesRef("127.0.0.1")},  arrayOfIpType));
 
     }
 
@@ -165,40 +165,40 @@ public class ArrayUniqueFunctionTest extends AbstractScalarFunctionsTest {
     public void testNullElements() throws Exception {
         assertEval(
                 new Object[]{1, null, 3, 2},
-                Literal.newLiteral(new Object[]{1, null, 3}, arrayOfIntegerType),
-                Literal.newLiteral(new Object[]{null, 2, 3}, arrayOfIntegerType));
+                Literal.of(new Object[]{1, null, 3}, arrayOfIntegerType),
+                Literal.of(new Object[]{null, 2, 3}, arrayOfIntegerType));
     }
 
     @Test
     public void testTwoIntegerArguments() throws Exception {
         assertEval(
                 new Object[]{1,2,3},
-                Literal.newLiteral(new Object[]{1,2}, arrayOfIntegerType),
-                Literal.newLiteral(new Object[]{2,3}, arrayOfIntegerType));
+                Literal.of(new Object[]{1,2}, arrayOfIntegerType),
+                Literal.of(new Object[]{2,3}, arrayOfIntegerType));
     }
 
     @Test
     public void testTwoLongArguments() throws Exception {
         assertEval(
                 new Object[]{44L, 55L, 66L},
-                Literal.newLiteral(new Object[]{44L, 55L}, arrayOfLongType),
-                Literal.newLiteral(new Object[]{55L, 66L}, arrayOfLongType));
+                Literal.of(new Object[]{44L, 55L}, arrayOfLongType),
+                Literal.of(new Object[]{55L, 66L}, arrayOfLongType));
     }
 
     @Test
     public void testTwoStringArguments() throws Exception {
         assertEval(
                 new Object[]{new BytesRef("foo"),new BytesRef("bar"),new BytesRef("baz")},
-                Literal.newLiteral(new Object[]{"foo","bar"}, arrayOfStringType),
-                Literal.newLiteral(new Object[]{"bar","baz"}, arrayOfStringType));
+                Literal.of(new Object[]{"foo","bar"}, arrayOfStringType),
+                Literal.of(new Object[]{"bar","baz"}, arrayOfStringType));
     }
 
     @Test
     public void testEmptyArrayAndIntegerArray() throws Exception {
         assertEval(
                 new Object[]{111, 222, 333},
-                Literal.newLiteral(new Object[]{},              arrayOfUndefinedType),
-                Literal.newLiteral(new Object[]{111, 222, 333}, arrayOfIntegerType));
+                Literal.of(new Object[]{},              arrayOfUndefinedType),
+                Literal.of(new Object[]{111, 222, 333}, arrayOfIntegerType));
     }
 
 
@@ -208,8 +208,8 @@ public class ArrayUniqueFunctionTest extends AbstractScalarFunctionsTest {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("One of the arguments of the array_unique function can be of undefined inner type, but not both");
         assertEval(new Object[]{},
-                Literal.newLiteral(new Object[]{}, arrayOfUndefinedType),
-                Literal.newLiteral(new Object[]{}, arrayOfUndefinedType));
+                Literal.of(new Object[]{}, arrayOfUndefinedType),
+                Literal.of(new Object[]{}, arrayOfUndefinedType));
     }
 
     @Test
@@ -218,6 +218,6 @@ public class ArrayUniqueFunctionTest extends AbstractScalarFunctionsTest {
         expectedException.expectMessage("When used with only one argument, the inner type of the array argument cannot be undefined");
         assertEval(
                 null,
-                Literal.newLiteral(new Object[]{}, arrayOfUndefinedType));
+                Literal.of(new Object[]{}, arrayOfUndefinedType));
     }
 }

--- a/sql/src/test/java/io/crate/operation/scalar/ConcatFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/ConcatFunctionTest.java
@@ -71,8 +71,8 @@ public class ConcatFunctionTest extends AbstractScalarFunctionsTest {
         Scalar scalar = ((Scalar) functions.get(new FunctionIdent(ConcatFunction.NAME, argumentTypes)));
 
         Input[] inputs = new Input[2];
-        inputs[0] = Literal.newLiteral(arg1);
-        inputs[1] = Literal.newLiteral(arg2);
+        inputs[0] = Literal.of(arg1);
+        inputs[1] = Literal.of(arg2);
         @SuppressWarnings("unchecked")
 
         BytesRef evaluate = (BytesRef) scalar.evaluate(inputs);
@@ -112,11 +112,11 @@ public class ConcatFunctionTest extends AbstractScalarFunctionsTest {
         Scalar scalar = ((Scalar) functions.get(new FunctionIdent(ConcatFunction.NAME, argumentTypes)));
 
         Symbol symbol = scalar.normalizeSymbol(new Function(scalar.info(),
-                Arrays.<Symbol>asList(Literal.newLiteral("foo"), Literal.newLiteral("bar"))), stmtCtx);
+                Arrays.<Symbol>asList(Literal.of("foo"), Literal.of("bar"))), stmtCtx);
         assertThat(symbol, isLiteral("foobar"));
 
         symbol = scalar.normalizeSymbol(new Function(scalar.info(),
-                Arrays.<Symbol>asList(createReference("col1", DataTypes.STRING), Literal.newLiteral("bar"))), stmtCtx);
+                Arrays.<Symbol>asList(createReference("col1", DataTypes.STRING), Literal.of("bar"))), stmtCtx);
         assertThat(symbol, isFunction(ConcatFunction.NAME));
     }
 
@@ -166,8 +166,8 @@ public class ConcatFunctionTest extends AbstractScalarFunctionsTest {
         Scalar scalar = ((Scalar) functions.get(new FunctionIdent(ConcatFunction.NAME, argumentTypes)));
 
         Input[] inputs = new Input[2];
-        inputs[0] = Literal.newLiteral(new Object[]{1, 2}, arrayType);
-        inputs[1] = Literal.newLiteral(new Object[]{2, 3}, arrayType);
+        inputs[0] = Literal.of(new Object[]{1, 2}, arrayType);
+        inputs[1] = Literal.of(new Object[]{2, 3}, arrayType);
 
         Object[] evaluate = (Object[]) scalar.evaluate(inputs);
         assertThat(evaluate, is(new Object[]{1, 2, 2, 3}));
@@ -182,8 +182,8 @@ public class ConcatFunctionTest extends AbstractScalarFunctionsTest {
         Scalar scalar = ((Scalar) functions.get(new FunctionIdent(ConcatFunction.NAME, argumentTypes)));
 
         Input[] inputs = new Input[2];
-        inputs[0] = Literal.newLiteral(new Object[]{},     arrayType0);
-        inputs[1] = Literal.newLiteral(new Object[]{1, 2}, arrayType1);
+        inputs[0] = Literal.of(new Object[]{},     arrayType0);
+        inputs[1] = Literal.of(new Object[]{1, 2}, arrayType1);
 
         Object[] evaluate = (Object[]) scalar.evaluate(inputs);
         assertThat(evaluate, is(new Object[]{1, 2}));

--- a/sql/src/test/java/io/crate/operation/scalar/DateFormatFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/DateFormatFunctionTest.java
@@ -52,14 +52,14 @@ public class DateFormatFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testEvaluateWithNullValues() throws Exception {
-        assertEvaluate("date_format('%d.%m.%Y %H:%i:%S', timestamp)", null, Literal.newLiteral(DataTypes.TIMESTAMP, null));
-        assertEvaluate("date_format(name, 'Europe/Berlin', 0)", null, Literal.newLiteral(DataTypes.STRING, null));
+        assertEvaluate("date_format('%d.%m.%Y %H:%i:%S', timestamp)", null, Literal.of(DataTypes.TIMESTAMP, null));
+        assertEvaluate("date_format(name, 'Europe/Berlin', 0)", null, Literal.of(DataTypes.STRING, null));
     }
 
     @Test
     public void testEvaluateDefault() throws Exception {
         assertEvaluate("date_format(timestamp)", new BytesRef("2015-06-10T07:03:00.004000Z"),
-            Literal.newLiteral(DataTypes.TIMESTAMP, DataTypes.TIMESTAMP.value("2015-06-10T09:03:00.004+02")));
+            Literal.of(DataTypes.TIMESTAMP, DataTypes.TIMESTAMP.value("2015-06-10T09:03:00.004+02")));
     }
 
     @Test
@@ -67,9 +67,9 @@ public class DateFormatFunctionTest extends AbstractScalarFunctionsTest {
         assertEvaluate("date_format(time_format, timestamp)",
             new BytesRef("Fri Jan 1 1st 01 1 000000 00 12 12 00 001 0 12 January 01 AM 12:00:00 AM " +
                          "00 00 00:00:00 00 00 52 53 Friday 5 2054 2054 2055 55"),
-            Literal.newLiteral("%a %b %c %D %d %e %f %H %h %I %i %j %k %l %M %m %p %r " +
-                               "%S %s %T %U %u %V %v %W %w %X %x %Y %y"),
-            Literal.newLiteral(DataTypes.TIMESTAMP, DataTypes.TIMESTAMP.value("2055-01-01")));
+            Literal.of("%a %b %c %D %d %e %f %H %h %I %i %j %k %l %M %m %p %r " +
+                       "%S %s %T %U %u %V %v %W %w %X %x %Y %y"),
+            Literal.of(DataTypes.TIMESTAMP, DataTypes.TIMESTAMP.value("2055-01-01")));
     }
 
     @Test
@@ -77,24 +77,24 @@ public class DateFormatFunctionTest extends AbstractScalarFunctionsTest {
         assertEvaluate("date_format(time_format, timezone, timestamp)",
             new BytesRef("Sun Jan 1 1st 01 1 000000 04 04 04 00 001 4 4 January 01 AM 04:00:00 AM " +
                          "00 00 04:00:00 01 00 01 52 Sunday 0 1871 1870 1871 71"),
-            Literal.newLiteral("%a %b %c %D %d %e %f %H %h %I %i %j %k %l %M %m %p %r " +
-                               "%S %s %T %U %u %V %v %W %w %X %x %Y %y"),
-            Literal.newLiteral("EST"),
-            Literal.newLiteral(DataTypes.TIMESTAMP, DataTypes.TIMESTAMP.value("1871-01-01T09:00:00.000Z")));
+            Literal.of("%a %b %c %D %d %e %f %H %h %I %i %j %k %l %M %m %p %r " +
+                       "%S %s %T %U %u %V %v %W %w %X %x %Y %y"),
+            Literal.of("EST"),
+            Literal.of(DataTypes.TIMESTAMP, DataTypes.TIMESTAMP.value("1871-01-01T09:00:00.000Z")));
     }
 
     @Test
     public void testNullInputs() throws Exception {
         assertEvaluate("date_format(time_format, timezone, timestamp)",
             null,
-            Literal.newLiteral("%d.%m.%Y %H:%i:%S"),
-            Literal.newLiteral(DataTypes.STRING, null),
-            Literal.newLiteral(DataTypes.TIMESTAMP, null));
+            Literal.of("%d.%m.%Y %H:%i:%S"),
+            Literal.of(DataTypes.STRING, null),
+            Literal.of(DataTypes.TIMESTAMP, null));
         assertEvaluate("date_format(time_format, timezone, timestamp)",
             null,
-            Literal.newLiteral(DataTypes.STRING, null),
-            Literal.newLiteral("Europe/Berlin"),
-            Literal.newLiteral(DataTypes.TIMESTAMP, 0L));
+            Literal.of(DataTypes.STRING, null),
+            Literal.of("Europe/Berlin"),
+            Literal.of(DataTypes.TIMESTAMP, 0L));
     }
 
     @Test
@@ -184,15 +184,15 @@ public class DateFormatFunctionTest extends AbstractScalarFunctionsTest {
     public void testEvaluateUTF8Support() throws Exception {
         assertEvaluate("date_format(time_format, timestamp)",
             "2000®01\uD834\uDD1E01 € 00:00:00",
-            Literal.newLiteral("%Y®%m\uD834\uDD1E%d € %H:%i:%S"),
-            Literal.newLiteral(DataTypes.TIMESTAMP, DataTypes.TIMESTAMP.value("2000-01-01")));
+            Literal.of("%Y®%m\uD834\uDD1E%d € %H:%i:%S"),
+            Literal.of(DataTypes.TIMESTAMP, DataTypes.TIMESTAMP.value("2000-01-01")));
     }
 
     @Test
     public void testInvalidFormats() throws Exception {
         assertEvaluate("date_format(time_format, timestamp)",
             "t%Z",
-            Literal.newLiteral("%t%%%Z"),
-            Literal.newLiteral(DataTypes.TIMESTAMP, DataTypes.TIMESTAMP.value("2000-01-01")));
+            Literal.of("%t%%%Z"),
+            Literal.of(DataTypes.TIMESTAMP, DataTypes.TIMESTAMP.value("2000-01-01")));
     }
 }

--- a/sql/src/test/java/io/crate/operation/scalar/DateTruncFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/DateTruncFunctionTest.java
@@ -87,9 +87,9 @@ public class DateTruncFunctionTest extends AbstractScalarFunctionsTest {
             ival = new BytesRef(interval);
         }
         Scalar<Long, Object> function = func.compile(Arrays.<Symbol>asList(
-                Literal.newLiteral(interval),
+                Literal.of(interval),
                 TimeZoneParser.DEFAULT_TZ_LITERAL,
-                Literal.newLiteral(timestamp)));
+                Literal.of(timestamp)));
         Input[] inputs = new Input[] {
                 new DateTruncInput(ival),
                 new DateTruncInput(timestamp),
@@ -107,9 +107,9 @@ public class DateTruncFunctionTest extends AbstractScalarFunctionsTest {
             tz = new BytesRef(timeZone);
         }
         Scalar<Long, Object> function = funcTZ.compile(Arrays.<Symbol>asList(
-                Literal.newLiteral(interval),
-                Literal.newLiteral(tz),
-                Literal.newLiteral(timestamp)));
+                Literal.of(interval),
+                Literal.of(tz),
+                Literal.of(timestamp)));
         Input[] inputs = new Input[] {
                 new DateTruncInput(ival),
                 new DateTruncInput(tz),
@@ -127,8 +127,8 @@ public class DateTruncFunctionTest extends AbstractScalarFunctionsTest {
         assertNotNull(implementation);
 
         Function function = new Function(implementation.info(), Arrays.<Symbol>asList(
-                Literal.newLiteral("day"),
-                Literal.newLiteral(1401777485000L)
+                Literal.of("day"),
+                Literal.of(1401777485000L)
         ));
         Literal day = (Literal)implementation.normalizeSymbol(function, stmtCtx);
         assertThat((Long) day.value(), is(1401753600000L));
@@ -142,8 +142,8 @@ public class DateTruncFunctionTest extends AbstractScalarFunctionsTest {
         assertNotNull(implementation);
 
         Function function = new Function(implementation.info(), Arrays.<Symbol>asList(
-                Literal.newLiteral("day"),
-                Literal.newLiteral("2014-06-03")
+                Literal.of("day"),
+                Literal.of("2014-06-03")
         ));
         Literal day = (Literal)implementation.normalizeSymbol(function, stmtCtx);
         assertThat((Long) day.value(), is(1401753600000L));
@@ -160,8 +160,8 @@ public class DateTruncFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testNormalizeSymbolTimestampLiteral() throws Exception {
         Symbol result = normalize(
-                Literal.newLiteral("day"),
-                Literal.newLiteral(DataTypes.TIMESTAMP, DataTypes.TIMESTAMP.value("2014-02-25T13:38:01.123")));
+                Literal.of("day"),
+                Literal.of(DataTypes.TIMESTAMP, DataTypes.TIMESTAMP.value("2014-02-25T13:38:01.123")));
         assertThat(result, isLiteral(1393286400000L, DataTypes.TIMESTAMP));
     }
 
@@ -169,7 +169,7 @@ public class DateTruncFunctionTest extends AbstractScalarFunctionsTest {
     public void testNullInterval() throws Exception {
         String val = null;
         assertThat(
-                normalize(Literal.newLiteral(val), Literal.newLiteral(TIMESTAMP)),
+                normalize(Literal.of(val), Literal.of(TIMESTAMP)),
                 isLiteral(null)
         );
     }
@@ -178,7 +178,7 @@ public class DateTruncFunctionTest extends AbstractScalarFunctionsTest {
     public void testInvalidInterval() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("invalid interval 'invalid interval' for scalar 'date_trunc'");
-        normalize(Literal.newLiteral("invalid interval"), Literal.newLiteral(TIMESTAMP));
+        normalize(Literal.of("invalid interval"), Literal.of(TIMESTAMP));
     }
 
     @Test
@@ -239,9 +239,9 @@ public class DateTruncFunctionTest extends AbstractScalarFunctionsTest {
         assertNotNull(implementation);
 
         Function function = new Function(implementation.info(), Arrays.<Symbol>asList(
-                Literal.newLiteral("day"),
-                Literal.newLiteral("Europe/Vienna"),
-                Literal.newLiteral("2014-06-03")
+                Literal.of("day"),
+                Literal.of("Europe/Vienna"),
+                Literal.of("2014-06-03")
         ));
         Literal day = (Literal)implementation.normalizeSymbol(function, stmtCtx);
         assertThat((Long) day.value(), is(1401746400000L));
@@ -250,7 +250,7 @@ public class DateTruncFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testNormalizeSymbolTzAwareReferenceTimestamp() throws Exception {
         Function function = new Function(funcTZ.info(),
-                Arrays.<Symbol>asList(Literal.newLiteral("day"), Literal.newLiteral("+01:00"),
+                Arrays.<Symbol>asList(Literal.of("day"), Literal.of("+01:00"),
                         new Reference(null,null,DataTypes.TIMESTAMP)));
         Symbol result = funcTZ.normalizeSymbol(function, stmtCtx);
         assertSame(function, result);
@@ -259,9 +259,9 @@ public class DateTruncFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testNormalizeSymbolTzAwareTimestampLiteral() throws Exception {
         Symbol result = normalize(
-                Literal.newLiteral("day"),
-                Literal.newLiteral("UTC"),
-                Literal.newLiteral(DataTypes.TIMESTAMP, DataTypes.TIMESTAMP.value("2014-02-25T13:38:01.123")));
+                Literal.of("day"),
+                Literal.of("UTC"),
+                Literal.of(DataTypes.TIMESTAMP, DataTypes.TIMESTAMP.value("2014-02-25T13:38:01.123")));
         assertThat(result, isLiteral(1393286400000L, DataTypes.TIMESTAMP));
     }
 
@@ -269,7 +269,7 @@ public class DateTruncFunctionTest extends AbstractScalarFunctionsTest {
     public void testNullTimezone() throws Exception {
         String tz = null;
         assertThat(
-                normalize(Literal.newLiteral("day"), Literal.newLiteral(tz), Literal.newLiteral(TIMESTAMP)),
+                normalize(Literal.of("day"), Literal.of(tz), Literal.of(TIMESTAMP)),
                 isLiteral(null)
         );
     }
@@ -278,7 +278,7 @@ public class DateTruncFunctionTest extends AbstractScalarFunctionsTest {
     public void testInvalidTimeZone() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("invalid time zone value 'no time zone'");
-        normalize(Literal.newLiteral("day"), Literal.newLiteral("no time zone"), Literal.newLiteral(TIMESTAMP));
+        normalize(Literal.of("day"), Literal.of("no time zone"), Literal.of(TIMESTAMP));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/scalar/ExtractFunctionsTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/ExtractFunctionsTest.java
@@ -37,14 +37,14 @@ public class ExtractFunctionsTest extends AbstractScalarFunctionsTest {
     private void assertEval(Extract.Field field, String datetimeString, int expected) {
         Scalar scalar = (Scalar)functions.get(ExtractFunctions.functionInfo(field).ident());
         @SuppressWarnings("unchecked")Integer actual =
-                (Integer) scalar.evaluate(Literal.newLiteral(DataTypes.TIMESTAMP, DataTypes.TIMESTAMP.value(datetimeString)));
+                (Integer) scalar.evaluate(Literal.of(DataTypes.TIMESTAMP, DataTypes.TIMESTAMP.value(datetimeString)));
         assertThat(actual, is(expected));
     }
 
     @Test
     public void testYayNullValue() throws Exception {
         Scalar scalar = (Scalar)functions.get(ExtractFunctions.functionInfo(Extract.Field.DAY).ident());
-        @SuppressWarnings("unchecked") Long result = (Long) scalar.evaluate(Literal.newLiteral(DataTypes.TIMESTAMP, null));
+        @SuppressWarnings("unchecked") Long result = (Long) scalar.evaluate(Literal.of(DataTypes.TIMESTAMP, null));
         assertThat(result, Matchers.nullValue());
     }
 

--- a/sql/src/test/java/io/crate/operation/scalar/FormatFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/FormatFunctionTest.java
@@ -39,12 +39,12 @@ public class FormatFunctionTest extends AbstractScalarFunctionsTest {
     public void testEvaluate() throws Exception {
         assertEvaluate("format('%s bla %s', name, age)",
                 "Arthur bla 38",
-                Literal.newLiteral("Arthur"),
-                Literal.newLiteral(38L));
+                Literal.of("Arthur"),
+                Literal.of(38L));
 
         assertEvaluate("format('%s bla %s', name, age)",
                 "Arthur bla 42",
-                Literal.newLiteral("Arthur"),
-                Literal.newLiteral(42L));
+                Literal.of("Arthur"),
+                Literal.of(42L));
     }
 }

--- a/sql/src/test/java/io/crate/operation/scalar/LengthFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/LengthFunctionTest.java
@@ -41,7 +41,7 @@ public class LengthFunctionTest extends AbstractScalarFunctionsTest {
 
     private Integer evaluate(String functionName, Object value, DataType dataType) {
         return ((LengthFunction) getFunction(functionName, dataType))
-                .evaluate((Input) Literal.newLiteral(dataType, value));
+                .evaluate((Input) Literal.of(dataType, value));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/scalar/SubstrFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/SubstrFunctionTest.java
@@ -58,31 +58,31 @@ public class SubstrFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testEvaluateWithArgsAsNonLiterals() throws Exception {
-        assertEvaluate("substr('cratedata', id, id)", "crate", Literal.newLiteral(1L), Literal.newLiteral(5L));
+        assertEvaluate("substr('cratedata', id, id)", "crate", Literal.of(1L), Literal.of(5L));
     }
 
     @Test
     public void testEvaluateWithArgsAsNonLiteralsIntShort() throws Exception {
         assertEvaluate("substr(name, id, id)", "crate",
-            Literal.newLiteral("cratedata"),
-            Literal.newLiteral(DataTypes.SHORT, (short) 1),
-            Literal.newLiteral(DataTypes.SHORT, (short) 5));
+            Literal.of("cratedata"),
+            Literal.of(DataTypes.SHORT, (short) 1),
+            Literal.of(DataTypes.SHORT, (short) 5));
     }
 
     @Test
     public void testNullInputs() throws Exception {
         assertEvaluate("substr(name, id, id)", null,
-            Literal.newLiteral(DataTypes.STRING, null),
-            Literal.newLiteral(1),
-            Literal.newLiteral(1));
+            Literal.of(DataTypes.STRING, null),
+            Literal.of(1),
+            Literal.of(1));
         assertEvaluate("substr(name, id, id)", null,
-            Literal.newLiteral("crate"),
-            Literal.newLiteral(DataTypes.INTEGER, null),
-            Literal.newLiteral(1));
+            Literal.of("crate"),
+            Literal.of(DataTypes.INTEGER, null),
+            Literal.of(1));
         assertEvaluate("substr(name, id, id)", null,
-            Literal.newLiteral("crate"),
-            Literal.newLiteral(1),
-            Literal.newLiteral(DataTypes.SHORT, null));
+            Literal.of("crate"),
+            Literal.of(1),
+            Literal.of(DataTypes.SHORT, null));
     }
 }
 

--- a/sql/src/test/java/io/crate/operation/scalar/arithmetic/LogFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/arithmetic/LogFunctionTest.java
@@ -65,27 +65,27 @@ public class LogFunctionTest extends AbstractScalarFunctionsTest {
 
     private Symbol normalize(Number value, DataType valueType, LogFunction function) {
         return function.normalizeSymbol(new Function(function.info(),
-                        Arrays.<Symbol>asList(Literal.newLiteral(valueType, value))), stmtCtx);
+                        Arrays.<Symbol>asList(Literal.of(valueType, value))), stmtCtx);
     }
 
     private Symbol normalizeLog(Number value, DataType valueType, Number base, DataType baseType) {
         LogFunction function = getFunction(LogFunction.NAME, valueType, baseType);
         return function.normalizeSymbol(new Function(function.info(),
-                Arrays.<Symbol>asList(Literal.newLiteral(valueType, value), Literal.newLiteral(baseType, base))), stmtCtx);
+                Arrays.<Symbol>asList(Literal.of(valueType, value), Literal.of(baseType, base))), stmtCtx);
     }
 
     private Number evaluateLog(Number value, DataType valueType) {
-        return getFunction(LogFunction.NAME, valueType).evaluate((Input) Literal.newLiteral(valueType, value));
+        return getFunction(LogFunction.NAME, valueType).evaluate((Input) Literal.of(valueType, value));
     }
 
     private Number evaluateLn(Number value, DataType valueType) {
-        return getFunction(LogFunction.LnFunction.NAME, valueType).evaluate((Input) Literal.newLiteral(valueType, value));
+        return getFunction(LogFunction.LnFunction.NAME, valueType).evaluate((Input) Literal.of(valueType, value));
     }
 
     private Number evaluateLog(Number value, DataType valueType, Number base, DataType baseType) {
         return getFunction(LogFunction.NAME, valueType, baseType).evaluate(
-                (Input) Literal.newLiteral(valueType, value),
-                (Input) Literal.newLiteral(baseType, base)
+                (Input) Literal.of(valueType, value),
+                (Input) Literal.of(baseType, base)
         );
     }
 
@@ -177,7 +177,7 @@ public class LogFunctionTest extends AbstractScalarFunctionsTest {
         assertThat(normalized, Matchers.sameInstance(function));
 
         LogFunction logBase = getFunction(LogFunction.NAME, DataTypes.DOUBLE, DataTypes.LONG);
-        function = new Function(logBase.info(), Arrays.<Symbol>asList(dB, Literal.newLiteral(10L)));
+        function = new Function(logBase.info(), Arrays.<Symbol>asList(dB, Literal.of(10L)));
         normalized = (Function) logBase.normalizeSymbol(function, stmtCtx);
         assertThat(normalized, Matchers.sameInstance(function));
 

--- a/sql/src/test/java/io/crate/operation/scalar/arithmetic/TrigonometricFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/arithmetic/TrigonometricFunctionTest.java
@@ -46,7 +46,7 @@ public class TrigonometricFunctionTest extends AbstractScalarFunctionsTest {
     }
 
     private Number evaluate(Number number, String name, DataType type) {
-        return getFunction(name, type).evaluate((Input) Literal.newLiteral(type, number));
+        return getFunction(name, type).evaluate((Input) Literal.of(type, number));
     }
 
     private Number evaluateSin(Number number, DataType type) {

--- a/sql/src/test/java/io/crate/operation/scalar/cast/ArrayCastTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/cast/ArrayCastTest.java
@@ -46,7 +46,7 @@ public class ArrayCastTest {
         final DataType arrayType = new ArrayType(innerType);
         Scalar impl = (Scalar) functions.get(new FunctionIdent(functionName, ImmutableList.of(arrayType)));
 
-        Literal input = Literal.newLiteral(arrayType, objects);
+        Literal input = Literal.of(arrayType, objects);
         Symbol normalized = impl.normalizeSymbol(new Function(impl.info(), Arrays.<Symbol>asList(input)), new StmtCtx());
         Object[] integers = (Object[]) impl.evaluate(input);
 

--- a/sql/src/test/java/io/crate/operation/scalar/cast/ToBooleanFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/cast/ToBooleanFunctionTest.java
@@ -48,7 +48,7 @@ public class ToBooleanFunctionTest extends AbstractScalarFunctionsTest {
     }
 
     private Boolean evaluate(Object value, DataType type) {
-        Input[] input = {(Input)Literal.newLiteral(type, value)};
+        Input[] input = {(Input)Literal.of(type, value)};
         return (Boolean) getFunction(type).evaluate(input);
     }
 
@@ -57,7 +57,7 @@ public class ToBooleanFunctionTest extends AbstractScalarFunctionsTest {
     private Symbol normalize(Object value, DataType type) {
         ToPrimitiveFunction function = getFunction(type);
         return function.normalizeSymbol(new Function(function.info(),
-                Collections.<Symbol>singletonList(Literal.newLiteral(type, value))), stmtCtx);
+                Collections.<Symbol>singletonList(Literal.of(type, value))), stmtCtx);
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/scalar/cast/ToByteFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/cast/ToByteFunctionTest.java
@@ -50,14 +50,14 @@ public class ToByteFunctionTest extends AbstractScalarFunctionsTest {
     }
 
     private Byte evaluate(Object value, DataType type) {
-        Input[] input = {(Input)Literal.newLiteral(type, value)};
+        Input[] input = {(Input)Literal.of(type, value)};
         return (Byte) getFunction(type).evaluate(input);
     }
 
     private Symbol normalize(Object value, DataType type) {
         ToPrimitiveFunction function = getFunction(type);
         return function.normalizeSymbol(new Function(function.info(),
-                Collections.<Symbol>singletonList(Literal.newLiteral(type, value))), new StmtCtx());
+                Collections.<Symbol>singletonList(Literal.of(type, value))), new StmtCtx());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/scalar/cast/ToDoubleFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/cast/ToDoubleFunctionTest.java
@@ -49,7 +49,7 @@ public class ToDoubleFunctionTest extends AbstractScalarFunctionsTest {
     }
 
     private Double evaluate(Object value, DataType type) {
-        Input[] input = {(Input)Literal.newLiteral(type, value)};
+        Input[] input = {(Input)Literal.of(type, value)};
         return (Double) getFunction(type).evaluate(input);
     }
 
@@ -58,7 +58,7 @@ public class ToDoubleFunctionTest extends AbstractScalarFunctionsTest {
     private Symbol normalize(Object value, DataType type) {
         ToPrimitiveFunction function = getFunction(type);
         return function.normalizeSymbol(new Function(function.info(),
-                Collections.<Symbol>singletonList(Literal.newLiteral(type, value))), stmtCtx);
+                Collections.<Symbol>singletonList(Literal.of(type, value))), stmtCtx);
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/scalar/cast/ToFloatFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/cast/ToFloatFunctionTest.java
@@ -49,14 +49,14 @@ public class ToFloatFunctionTest extends AbstractScalarFunctionsTest {
     }
 
     private Float evaluate(Object value, DataType type) {
-        Input[] input = {(Input)Literal.newLiteral(type, value)};
+        Input[] input = {(Input)Literal.of(type, value)};
         return (Float) getFunction(type).evaluate(input);
     }
 
     private Symbol normalize(Object value, DataType type) {
         ToPrimitiveFunction function = getFunction(type);
         return function.normalizeSymbol(new Function(function.info(),
-                Collections.<Symbol>singletonList(Literal.newLiteral(type, value))), new StmtCtx());
+                Collections.<Symbol>singletonList(Literal.of(type, value))), new StmtCtx());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/scalar/cast/ToGeoPointFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/cast/ToGeoPointFunctionTest.java
@@ -48,7 +48,7 @@ public class ToGeoPointFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testEvaluateCastFromString() throws Exception {
         ToGeoFunction fn = getFunction(DataTypes.STRING);
-        Object val = fn.evaluate(Literal.newLiteral(DataTypes.STRING, "POINT (0.0 0.1)"));
+        Object val = fn.evaluate(Literal.of(DataTypes.STRING, "POINT (0.0 0.1)"));
         assertThat(val, instanceOf(Double[].class));
         assertThat((Double[])val, arrayContaining(0.0d, 0.1d));
     }
@@ -57,7 +57,7 @@ public class ToGeoPointFunctionTest extends AbstractScalarFunctionsTest {
     public void testNormalizeCastFromString() throws Exception {
         ToGeoFunction fn = getFunction(DataTypes.STRING);
         Symbol normalized = fn.normalizeSymbol(new Function(fn.info(),
-                Collections.<Symbol>singletonList(Literal.newLiteral(DataTypes.STRING, "POINT (0 0)"))), new StmtCtx());
+                Collections.<Symbol>singletonList(Literal.of(DataTypes.STRING, "POINT (0 0)"))), new StmtCtx());
         assertThat(normalized, TestingHelpers.isLiteral(new Double[]{0.0, 0.0}));
     }
 
@@ -66,7 +66,7 @@ public class ToGeoPointFunctionTest extends AbstractScalarFunctionsTest {
         expectedException.expect(ConversionException.class);
         expectedException.expectMessage("cannot cast 'POINT ((0 0), (1 1))' to type geo_point");
         ToGeoFunction fn = getFunction(DataTypes.STRING);
-        fn.evaluate(Literal.newLiteral(DataTypes.STRING, "POINT ((0 0), (1 1))"));
+        fn.evaluate(Literal.of(DataTypes.STRING, "POINT ((0 0), (1 1))"));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/scalar/cast/ToGeoShapeFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/cast/ToGeoShapeFunctionTest.java
@@ -72,7 +72,7 @@ public class ToGeoShapeFunctionTest extends AbstractScalarFunctionsTest{
     @Test
     public void testEvaluateCastFromString() throws Exception {
         ToGeoFunction fn = getFunction(FUNCTION_NAME, DataTypes.STRING);
-        Object val = fn.evaluate(Literal.newLiteral(DataTypes.STRING, VALID_STR));
+        Object val = fn.evaluate(Literal.of(DataTypes.STRING, VALID_STR));
         assertThat(val, instanceOf(Map.class));
         assertThat((Map<String, Object>)val, allOf(
                 hasEntry("type", (Object)"Point"),
@@ -84,14 +84,14 @@ public class ToGeoShapeFunctionTest extends AbstractScalarFunctionsTest{
         expectedException.expect(ConversionException.class);
         expectedException.expectMessage("cannot cast 'POINTE ()' to type geo_shape");
         ToGeoFunction fn = getFunction(FUNCTION_NAME, DataTypes.STRING);
-        fn.evaluate(Literal.newLiteral(DataTypes.STRING, INVALID_STR));
+        fn.evaluate(Literal.of(DataTypes.STRING, INVALID_STR));
     }
 
     @Test
     public void testEvaluateCastFromObject() throws Exception {
         ToGeoFunction fn = getFunction(FUNCTION_NAME, DataTypes.OBJECT);
 
-        Object val = fn.evaluate(Literal.newLiteral(DataTypes.OBJECT, VALID_OBJECT));
+        Object val = fn.evaluate(Literal.of(DataTypes.OBJECT, VALID_OBJECT));
         assertThat(val, instanceOf(Map.class));
         Map<String, Object> valMap = (Map<String, Object>)val;
         assertThat(valMap.size(), is(2));
@@ -106,7 +106,7 @@ public class ToGeoShapeFunctionTest extends AbstractScalarFunctionsTest{
 
         expectedException.expect(ConversionException.class);
         expectedException.expectMessage(allOf(startsWith("cannot cast"), endsWith("to type geo_shape")));
-        fn.evaluate(Literal.newLiteral(DataTypes.OBJECT, INVALID_OBJECT));
+        fn.evaluate(Literal.of(DataTypes.OBJECT, INVALID_OBJECT));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/scalar/cast/ToIntFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/cast/ToIntFunctionTest.java
@@ -51,13 +51,13 @@ public class ToIntFunctionTest extends AbstractScalarFunctionsTest {
 
         ToPrimitiveFunction castStringToInteger = getFunction(functionName, DataTypes.STRING);
 
-        Function function = new Function(castStringToInteger.info(), Collections.<Symbol>singletonList(Literal.newLiteral("123")));
+        Function function = new Function(castStringToInteger.info(), Collections.<Symbol>singletonList(Literal.of("123")));
         Symbol result = castStringToInteger.normalizeSymbol(function, stmtCtx);
         assertThat(result, isLiteral(123));
 
         ToPrimitiveFunction castFloatToInteger = getFunction(functionName, DataTypes.FLOAT);
 
-        function = new Function(castFloatToInteger.info(), Collections.<Symbol>singletonList(Literal.newLiteral(12.5f)));
+        function = new Function(castFloatToInteger.info(), Collections.<Symbol>singletonList(Literal.of(12.5f)));
         result = castStringToInteger.normalizeSymbol(function, stmtCtx);
         assertThat(result, isLiteral(12));
     }
@@ -74,7 +74,7 @@ public class ToIntFunctionTest extends AbstractScalarFunctionsTest {
         expectedException.expect(ConversionException.class);
         expectedException.expectMessage("cannot cast 'hello' to type integer");
         ToPrimitiveFunction castStringToInteger = getFunction(functionName, DataTypes.STRING);
-        Function function = new Function(castStringToInteger.info(), Collections.<Symbol>singletonList(Literal.newLiteral("hello")));
+        Function function = new Function(castStringToInteger.info(), Collections.<Symbol>singletonList(Literal.of("hello")));
         castStringToInteger.normalizeSymbol(function, stmtCtx);
     }
 
@@ -82,12 +82,12 @@ public class ToIntFunctionTest extends AbstractScalarFunctionsTest {
     @SuppressWarnings("unchecked")
     public void testEvaluate() throws Exception {
         ToPrimitiveFunction stringFn = getFunction(functionName, DataTypes.STRING);
-        Literal arg1 = Literal.newLiteral("123");
+        Literal arg1 = Literal.of("123");
         Object result = stringFn.evaluate(arg1);
         assertThat((Integer)result, is(123));
 
         ToPrimitiveFunction floatFn = getFunction(functionName, DataTypes.FLOAT);
-        arg1 = Literal.newLiteral(42.5f);
+        arg1 = Literal.of(42.5f);
         result = floatFn.evaluate(arg1);
         assertThat((Integer)result, is(42));
     }
@@ -98,7 +98,7 @@ public class ToIntFunctionTest extends AbstractScalarFunctionsTest {
         expectedException.expect(ConversionException.class);
         expectedException.expectMessage("cannot cast 'hello' to type integer");
         ToPrimitiveFunction stringFn = getFunction(functionName, DataTypes.STRING);
-        Literal arg1 = Literal.newLiteral("hello");
+        Literal arg1 = Literal.of("hello");
 
         stringFn.evaluate(arg1);
     }
@@ -109,7 +109,7 @@ public class ToIntFunctionTest extends AbstractScalarFunctionsTest {
         expectedException.expect(ConversionException.class);
         expectedException.expectMessage("cannot cast 'hello' to type integer");
         ToPrimitiveFunction stringFn = getFunction(functionName, DataTypes.STRING);
-        Literal arg1 = Literal.newLiteral(new BytesRef("hello"));
+        Literal arg1 = Literal.of(new BytesRef("hello"));
 
         stringFn.evaluate(arg1);
     }

--- a/sql/src/test/java/io/crate/operation/scalar/cast/ToIpArrayFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/cast/ToIpArrayFunctionTest.java
@@ -57,7 +57,7 @@ public class ToIpArrayFunctionTest extends AbstractScalarFunctionsTest {
         ToArrayFunction impl = (ToArrayFunction) functions.get(
                 new FunctionIdent(CastFunctionResolver.FunctionNames.TO_IP_ARRAY, ImmutableList.of(arrayType)));
 
-        Literal input = Literal.newLiteral(objects, arrayType);
+        Literal input = Literal.of(objects, arrayType);
         Symbol normalized = impl.normalizeSymbol(new Function(impl.info(), Collections.<Symbol>singletonList(input)), new StmtCtx());
         Object[] integers = impl.evaluate(input);
 

--- a/sql/src/test/java/io/crate/operation/scalar/cast/ToIpFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/cast/ToIpFunctionTest.java
@@ -41,7 +41,7 @@ public class ToIpFunctionTest extends AbstractScalarFunctionsTest {
 
     private BytesRef evaluate(Object value, DataType type) {
         ToPrimitiveFunction fn = getFunction(functionName, type);
-        return (BytesRef) fn.evaluate(Literal.newLiteral(type, value));
+        return (BytesRef) fn.evaluate(Literal.of(type, value));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/scalar/cast/ToLongFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/cast/ToLongFunctionTest.java
@@ -46,7 +46,7 @@ public class ToLongFunctionTest extends AbstractScalarFunctionsTest {
     private final String functionName = CastFunctionResolver.FunctionNames.TO_LONG;
 
     private Long evaluate(Object value, DataType type) {
-        Input[] input = {(Input)Literal.newLiteral(type, value)};
+        Input[] input = {(Input)Literal.of(type, value)};
         ToPrimitiveFunction fn = getFunction(functionName, type);
         return (Long) fn.evaluate(input);
     }
@@ -54,7 +54,7 @@ public class ToLongFunctionTest extends AbstractScalarFunctionsTest {
     private Symbol normalize(Object value, DataType type) {
         ToPrimitiveFunction function = getFunction(functionName, type);
         return function.normalizeSymbol(new Function(function.info(),
-                Collections.<Symbol>singletonList(Literal.newLiteral(type, value))), new StmtCtx());
+                Collections.<Symbol>singletonList(Literal.of(type, value))), new StmtCtx());
     }
 
     @Test
@@ -106,7 +106,7 @@ public class ToLongFunctionTest extends AbstractScalarFunctionsTest {
         expectedException.expect(ConversionException.class);
         expectedException.expectMessage("cannot cast 'hello' to type long");
         ToPrimitiveFunction stringFn = getFunction(functionName, DataTypes.STRING);
-        Literal arg1 = Literal.newLiteral("hello");
+        Literal arg1 = Literal.of("hello");
 
         stringFn.evaluate(arg1);
     }
@@ -117,7 +117,7 @@ public class ToLongFunctionTest extends AbstractScalarFunctionsTest {
         expectedException.expect(ConversionException.class);
         expectedException.expectMessage("cannot cast 'hello' to type long");
         ToPrimitiveFunction stringFn = getFunction(functionName, DataTypes.STRING);
-        Literal arg1 = Literal.newLiteral(new BytesRef("hello"));
+        Literal arg1 = Literal.of(new BytesRef("hello"));
 
         stringFn.evaluate(arg1);
     }

--- a/sql/src/test/java/io/crate/operation/scalar/cast/ToShortFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/cast/ToShortFunctionTest.java
@@ -47,7 +47,7 @@ public class ToShortFunctionTest extends AbstractScalarFunctionsTest {
     private final StmtCtx stmtCtx = new StmtCtx();
 
     private Short evaluate(Object value, DataType type) {
-        Input[] input = {(Input)Literal.newLiteral(type, value)};
+        Input[] input = {(Input)Literal.of(type, value)};
         ToPrimitiveFunction fn = getFunction(functionName, type);
         return (Short) fn.evaluate(input);
     }
@@ -55,7 +55,7 @@ public class ToShortFunctionTest extends AbstractScalarFunctionsTest {
     private Symbol normalize(Object value, DataType type) {
         ToPrimitiveFunction function = getFunction(functionName, type);
         return function.normalizeSymbol(new Function(function.info(),
-                Collections.<Symbol>singletonList(Literal.newLiteral(type, value))), stmtCtx);
+                Collections.<Symbol>singletonList(Literal.of(type, value))), stmtCtx);
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/scalar/cast/ToStringArrayFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/cast/ToStringArrayFunctionTest.java
@@ -39,7 +39,7 @@ public class ToStringArrayFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testEvaluate() throws Exception {
         assertEvaluate("to_string_array(long_array)", new ArrayType(DataTypes.STRING).value(new Object[]{"1", "2", "3"}),
-            Literal.newLiteral(new Long[]{1L, 2L, 3L}, new ArrayType(DataTypes.LONG)));
+            Literal.of(new Long[]{1L, 2L, 3L}, new ArrayType(DataTypes.LONG)));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/scalar/cast/ToStringFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/cast/ToStringFunctionTest.java
@@ -49,17 +49,17 @@ public class ToStringFunctionTest extends AbstractScalarFunctionsTest {
 
         FunctionImplementation castIntegerToString = getFunction(functionName, DataTypes.INTEGER);
 
-        Function function = new Function(castIntegerToString.info(), Collections.<Symbol>singletonList(Literal.newLiteral(123)));
+        Function function = new Function(castIntegerToString.info(), Collections.<Symbol>singletonList(Literal.of(123)));
         Symbol result = castIntegerToString.normalizeSymbol(function, stmtCtx);
         assertThat(result, isLiteral("123"));
 
         FunctionImplementation castFloatToString = getFunction(functionName, DataTypes.FLOAT);
-        function = new Function(castFloatToString.info(), Collections.<Symbol>singletonList(Literal.newLiteral(0.5f)));
+        function = new Function(castFloatToString.info(), Collections.<Symbol>singletonList(Literal.of(0.5f)));
         result = castFloatToString.normalizeSymbol(function, stmtCtx);
         assertThat(result, isLiteral("0.5"));
 
         FunctionImplementation castStringToString = getFunction(functionName, DataTypes.STRING);
-        function = new Function(castStringToString.info(), Collections.<Symbol>singletonList(Literal.newLiteral("hello")));
+        function = new Function(castStringToString.info(), Collections.<Symbol>singletonList(Literal.of("hello")));
         result = castStringToString.normalizeSymbol(function, stmtCtx);
         assertThat(result, isLiteral("hello"));
     }

--- a/sql/src/test/java/io/crate/operation/scalar/conditional/ConditionalFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/conditional/ConditionalFunctionTest.java
@@ -76,7 +76,7 @@ public class ConditionalFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testNullIf() throws Exception {
         assertEvaluate("nullif(10, 12)", 10L);
-        assertEvaluate("nullif(name, 'foo')", null, Literal.newLiteral("foo"));
+        assertEvaluate("nullif(name, 'foo')", null, Literal.of("foo"));
         assertEvaluate("nullif(null, 'foo')", null);
     }
 

--- a/sql/src/test/java/io/crate/operation/scalar/geo/DistanceFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/geo/DistanceFunctionTest.java
@@ -85,8 +85,8 @@ public class DistanceFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testEvaluateWithTwoGeoPointLiterals() throws Exception {
         Double distance = evaluate(Arrays.<Literal>asList(
-                Literal.newLiteral(DataTypes.GEO_POINT, new Double[]{10.04, 28.02}),
-                Literal.newLiteral(DataTypes.GEO_POINT, DataTypes.GEO_POINT.value("POINT(10.30 29.3)"))));
+                Literal.of(DataTypes.GEO_POINT, new Double[]{10.04, 28.02}),
+                Literal.of(DataTypes.GEO_POINT, DataTypes.GEO_POINT.value("POINT(10.30 29.3)"))));
         assertThat(distance, is(144623.6842773458));
     }
 
@@ -94,8 +94,8 @@ public class DistanceFunctionTest extends AbstractScalarFunctionsTest {
     @SuppressWarnings("unchecked")
     public void testNormalizeWithStringTypes() throws Exception {
         Symbol symbol = normalize(Arrays.<Symbol>asList(
-                Literal.newLiteral("POINT (10 20)"),
-                Literal.newLiteral("POINT (11 21)")
+                Literal.of("POINT (10 20)"),
+                Literal.of("POINT (11 21)")
         ));
         assertThat(symbol, isLiteral(152462.70754934277));
     }
@@ -104,8 +104,8 @@ public class DistanceFunctionTest extends AbstractScalarFunctionsTest {
     public void testNormalizeWithDoubleArray() throws Exception {
         DataType type = new ArrayType(DataTypes.DOUBLE);
         Symbol symbol = normalize(Arrays.<Symbol>asList(
-                Literal.newLiteral(type, new Double[]{10.0, 20.0}),
-                Literal.newLiteral(type, new Double[]{11.0, 21.0})
+                Literal.of(type, new Double[]{10.0, 20.0}),
+                Literal.of(type, new Double[]{11.0, 21.0})
         ));
         assertThat(symbol, isLiteral(152462.70754934277));
     }
@@ -118,7 +118,7 @@ public class DistanceFunctionTest extends AbstractScalarFunctionsTest {
 
         normalize(Arrays.<Symbol>asList(
                 createReference("foo", DataTypes.STRING),
-                Literal.newLiteral(DataTypes.GEO_POINT, new Double[]{10.04, 28.02})
+                Literal.of(DataTypes.GEO_POINT, new Double[]{10.04, 28.02})
         ));
     }
 
@@ -126,14 +126,14 @@ public class DistanceFunctionTest extends AbstractScalarFunctionsTest {
     public void testNormalizeWithValidRefAndStringLiteral() throws Exception {
         Function symbol = (Function) normalize(Arrays.<Symbol>asList(
                 createReference("foo", DataTypes.GEO_POINT),
-                Literal.newLiteral("POINT(10 20)")
+                Literal.of("POINT(10 20)")
         ));
         assertThat(symbol.arguments().get(1),
                 isLiteral(new Double[]{10.0d, 20.0d}, DataTypes.GEO_POINT));
 
         // args reversed
         symbol = (Function) normalize(Arrays.<Symbol>asList(
-                Literal.newLiteral("POINT(10 20)"),
+                Literal.of("POINT(10 20)"),
                 createReference("foo", DataTypes.GEO_POINT)
         ));
         assertThat(symbol.arguments().get(1),
@@ -144,14 +144,14 @@ public class DistanceFunctionTest extends AbstractScalarFunctionsTest {
     public void testNormalizeWithValidRefAndGeoPointLiteral() throws Exception {
         Function symbol = (Function) normalize(Arrays.<Symbol>asList(
                 createReference("foo", DataTypes.GEO_POINT),
-                Literal.newLiteral(DataTypes.GEO_POINT, DataTypes.GEO_POINT.value("POINT (10 20)"))
+                Literal.of(DataTypes.GEO_POINT, DataTypes.GEO_POINT.value("POINT (10 20)"))
         ));
         assertThat(symbol.arguments().get(1),
                 isLiteral(new Double[]{10.0d, 20.0d}, DataTypes.GEO_POINT));
 
         // args reversed
         symbol = (Function) normalize(Arrays.<Symbol>asList(
-                Literal.newLiteral(DataTypes.GEO_POINT, DataTypes.GEO_POINT.value("POINT (10 20)")),
+                Literal.of(DataTypes.GEO_POINT, DataTypes.GEO_POINT.value("POINT (10 20)")),
                 createReference("foo", DataTypes.GEO_POINT)
         ));
         assertThat(symbol.arguments().get(1),
@@ -161,15 +161,15 @@ public class DistanceFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testNormalizeWithValidGeoPointLiterals() throws Exception {
         Literal symbol = (Literal) normalize(Arrays.<Symbol>asList(
-                Literal.newLiteral(DataTypes.GEO_POINT, DataTypes.GEO_POINT.value("POINT (10 20)")),
-                Literal.newLiteral(DataTypes.GEO_POINT, DataTypes.GEO_POINT.value("POINT (30 40)"))
+                Literal.of(DataTypes.GEO_POINT, DataTypes.GEO_POINT.value("POINT (10 20)")),
+                Literal.of(DataTypes.GEO_POINT, DataTypes.GEO_POINT.value("POINT (30 40)"))
         ));
         assertThat(symbol.value(), instanceOf(Double.class));
 
         // args reversed
         symbol = (Literal) normalize(Arrays.<Symbol>asList(
-                Literal.newLiteral(DataTypes.GEO_POINT, DataTypes.GEO_POINT.value("POINT (30 40)")),
-                Literal.newLiteral(DataTypes.GEO_POINT, DataTypes.GEO_POINT.value("POINT (10 20)"))
+                Literal.of(DataTypes.GEO_POINT, DataTypes.GEO_POINT.value("POINT (30 40)")),
+                Literal.of(DataTypes.GEO_POINT, DataTypes.GEO_POINT.value("POINT (10 20)"))
         ));
         assertThat(symbol.value(), instanceOf(Double.class));
     }
@@ -188,8 +188,8 @@ public class DistanceFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testWithNullValue() throws Exception {
         List<Literal> args = Arrays.<Literal>asList(
-                Literal.newLiteral(DataTypes.GEO_POINT, null),
-                Literal.newLiteral(DataTypes.GEO_POINT, DataTypes.GEO_POINT.value("POINT (10 20)"))
+                Literal.of(DataTypes.GEO_POINT, null),
+                Literal.of(DataTypes.GEO_POINT, DataTypes.GEO_POINT.value("POINT (10 20)"))
         );
         Double distance = evaluate(args);
         assertNull(distance);

--- a/sql/src/test/java/io/crate/operation/scalar/geo/IntersectsFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/geo/IntersectsFunctionTest.java
@@ -42,8 +42,8 @@ public class IntersectsFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testNormalizeFromStringLiterals() throws Exception {
         Symbol normalized = normalize(FUNCTION_NAME,
-                Literal.newLiteral("LINESTRING (0 0, 10 10)"),
-                Literal.newLiteral("LINESTRING (0 2, 0 -2)"));
+                Literal.of("LINESTRING (0 0, 10 10)"),
+                Literal.of("LINESTRING (0 2, 0 -2)"));
         assertThat(normalized, isLiteral(Boolean.TRUE));
     }
 
@@ -58,8 +58,8 @@ public class IntersectsFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testNormalizeFromMixedLiterals() throws Exception {
         Symbol normalized = normalize(FUNCTION_NAME,
-                Literal.newLiteral(DataTypes.OBJECT, jsonMap("{type:\"LineString\", coordinates:[[0, 0], [10, 10]]}")),
-                Literal.newLiteral("LINESTRING (0 2, 0 -2)"));
+                Literal.of(DataTypes.OBJECT, jsonMap("{type:\"LineString\", coordinates:[[0, 0], [10, 10]]}")),
+                Literal.of("LINESTRING (0 2, 0 -2)"));
         assertThat(normalized, isLiteral(Boolean.TRUE));
     }
 
@@ -68,8 +68,8 @@ public class IntersectsFunctionTest extends AbstractScalarFunctionsTest {
         expectedException.expect(ConversionException.class);
         expectedException.expectMessage(stringContainsInOrder(Arrays.asList("cannot cast", "to type geo_shape")));
         Symbol normalized = normalize(FUNCTION_NAME,
-                Literal.newLiteral(DataTypes.OBJECT, jsonMap("{type:\"LineString\", coordinates:[0, 0]}")),
-                Literal.newLiteral("LINESTRING (0 2, 0 -2)"));
+                Literal.of(DataTypes.OBJECT, jsonMap("{type:\"LineString\", coordinates:[0, 0]}")),
+                Literal.of("LINESTRING (0 2, 0 -2)"));
         assertThat(normalized, isLiteral(Boolean.TRUE));
     }
 
@@ -84,7 +84,7 @@ public class IntersectsFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testNormalizeWithNull() throws Exception {
         Symbol normalized = normalize(FUNCTION_NAME,
-                Literal.newLiteral(DataTypes.GEO_SHAPE, null),
+                Literal.of(DataTypes.GEO_SHAPE, null),
                 sqlExpressions.asSymbol("shape"));
         assertThat(normalized, isLiteral(null));
 
@@ -100,8 +100,8 @@ public class IntersectsFunctionTest extends AbstractScalarFunctionsTest {
     public void testEvaluateFromString() throws Exception {
         IntersectsFunction stringFn = getFunction(FUNCTION_NAME, DataTypes.STRING, DataTypes.STRING);
         Object value = stringFn.evaluate(
-                Literal.newLiteral(DataTypes.STRING, "POINT (0 0)"),
-                Literal.newLiteral(DataTypes.STRING, "POLYGON ((1 1, 1 -1, -1 -1, -1 1, 1 1))"));
+                Literal.of(DataTypes.STRING, "POINT (0 0)"),
+                Literal.of(DataTypes.STRING, "POLYGON ((1 1, 1 -1, -1 -1, -1 1, 1 1))"));
         assertThat(value, is((Object)Boolean.TRUE));
     }
 
@@ -109,8 +109,8 @@ public class IntersectsFunctionTest extends AbstractScalarFunctionsTest {
     public void testEvaluateMixed() throws Exception {
         IntersectsFunction stringFn = getFunction(FUNCTION_NAME, DataTypes.STRING, DataTypes.GEO_SHAPE); // actual types don't matter here
         Object value = stringFn.evaluate(
-                Literal.newLiteral(DataTypes.STRING, "POINT (100 0)"),
-                Literal.newLiteral(DataTypes.GEO_SHAPE, GeoJSONUtils.wkt2Map("POLYGON ((1 1, 1 -1, -1 -1, -1 1, 1 1))")));
+                Literal.of(DataTypes.STRING, "POINT (100 0)"),
+                Literal.of(DataTypes.GEO_SHAPE, GeoJSONUtils.wkt2Map("POLYGON ((1 1, 1 -1, -1 -1, -1 1, 1 1))")));
         assertThat(value, is((Object)Boolean.FALSE));
     }
 
@@ -118,8 +118,8 @@ public class IntersectsFunctionTest extends AbstractScalarFunctionsTest {
     public void testEvaluateLowercaseGeoJSON() throws Exception {
         IntersectsFunction stringFn = getFunction(FUNCTION_NAME, DataTypes.STRING, DataTypes.GEO_SHAPE); // actual types don't matter here
         Object value = stringFn.evaluate(
-                Literal.newLiteral(DataTypes.STRING, "POINT (100 0)"),
-                Literal.newLiteral(DataTypes.GEO_SHAPE, jsonMap("{type:\"linestring\", coordinates:[[0, 0], [10, 10]]}")));
+                Literal.of(DataTypes.STRING, "POINT (100 0)"),
+                Literal.of(DataTypes.GEO_SHAPE, jsonMap("{type:\"linestring\", coordinates:[[0, 0], [10, 10]]}")));
         assertThat(value, is((Object)Boolean.FALSE));
     }
 
@@ -128,13 +128,13 @@ public class IntersectsFunctionTest extends AbstractScalarFunctionsTest {
         // validate how exact the intersection detection is
         IntersectsFunction stringFn = getFunction(FUNCTION_NAME, DataTypes.STRING, DataTypes.GEO_SHAPE); // actual types don't matter here
         Object value = stringFn.evaluate(
-                Literal.newLiteral(DataTypes.STRING, "POINT (100.00000000000001 0.0)"),
-                Literal.newLiteral(DataTypes.GEO_SHAPE, jsonMap("{type:\"linestring\", coordinates:[[100.00000000000001, 0.0], [10, 10]]}")));
+                Literal.of(DataTypes.STRING, "POINT (100.00000000000001 0.0)"),
+                Literal.of(DataTypes.GEO_SHAPE, jsonMap("{type:\"linestring\", coordinates:[[100.00000000000001, 0.0], [10, 10]]}")));
         assertThat(value, is((Object)Boolean.TRUE));
 
         Object value2 = stringFn.evaluate(
-                Literal.newLiteral(DataTypes.STRING, "POINT (100.00000000000001 0.0)"),
-                Literal.newLiteral(DataTypes.GEO_SHAPE, jsonMap("{type:\"linestring\", coordinates:[[100.00000000000003, 0.0], [10, 10]]}")));
+                Literal.of(DataTypes.STRING, "POINT (100.00000000000001 0.0)"),
+                Literal.of(DataTypes.GEO_SHAPE, jsonMap("{type:\"linestring\", coordinates:[[100.00000000000003, 0.0], [10, 10]]}")));
         assertThat(value2, is((Object)Boolean.FALSE));
 
     }

--- a/sql/src/test/java/io/crate/operation/scalar/geo/WithinFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/geo/WithinFunctionTest.java
@@ -50,32 +50,32 @@ public class WithinFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testEvaluatePointLiteralWithinPolygonLiteral() {
         assertEvaluate("within(geopoint, geoshape)", true,
-                Literal.newLiteral(DataTypes.GEO_SHAPE, DataTypes.GEO_SHAPE.value("POINT (10 10)")),
-                Literal.newLiteral(DataTypes.GEO_SHAPE, DataTypes.GEO_SHAPE.value("POLYGON ((5 5, 20 5, 30 30, 5 30, 5 5))"))
+                Literal.of(DataTypes.GEO_SHAPE, DataTypes.GEO_SHAPE.value("POINT (10 10)")),
+                Literal.of(DataTypes.GEO_SHAPE, DataTypes.GEO_SHAPE.value("POLYGON ((5 5, 20 5, 30 30, 5 30, 5 5))"))
         );
     }
 
     @Test
     public void testEvaluateShapeWithinShape() {
         assertEvaluate("within(geoshape, geoshape)", true,
-                Literal.newLiteral(DataTypes.GEO_SHAPE, DataTypes.GEO_SHAPE.value("LINESTRING (8 15, 13 24)")),
-                Literal.newLiteral(DataTypes.GEO_SHAPE, DataTypes.GEO_SHAPE.value("POLYGON ((5 5, 20 5, 30 30, 5 30, 5 5))"))
+                Literal.of(DataTypes.GEO_SHAPE, DataTypes.GEO_SHAPE.value("LINESTRING (8 15, 13 24)")),
+                Literal.of(DataTypes.GEO_SHAPE, DataTypes.GEO_SHAPE.value("POLYGON ((5 5, 20 5, 30 30, 5 30, 5 5))"))
         );
     }
 
     @Test
     public void testEvaluateShapeIsNotWithinShape() {
         assertEvaluate("within(geoshape, geoshape)", false,
-                Literal.newLiteral(DataTypes.GEO_SHAPE, DataTypes.GEO_SHAPE.value("LINESTRING (8 15, 40 74)")),
-                Literal.newLiteral(DataTypes.GEO_SHAPE, DataTypes.GEO_SHAPE.value("POLYGON ((5 5, 20 5, 30 30, 5 30, 5 5))"))
+                Literal.of(DataTypes.GEO_SHAPE, DataTypes.GEO_SHAPE.value("LINESTRING (8 15, 40 74)")),
+                Literal.of(DataTypes.GEO_SHAPE, DataTypes.GEO_SHAPE.value("POLYGON ((5 5, 20 5, 30 30, 5 30, 5 5))"))
         );
     }
 
     @Test
     public void testEvaluateObjectWithinShape() {
         assertEvaluate("within(geopoint, geoshape)", true,
-                Literal.newLiteral(ImmutableMap.<String, Object>of("type", "Point", "coordinates", new double[]{10.0, 10.0})),
-                Literal.newLiteral(DataTypes.GEO_SHAPE, DataTypes.GEO_SHAPE.value("POLYGON ((5 5, 20 5, 30 30, 5 30, 5 5))"))
+                Literal.of(ImmutableMap.<String, Object>of("type", "Point", "coordinates", new double[]{10.0, 10.0})),
+                Literal.of(DataTypes.GEO_SHAPE, DataTypes.GEO_SHAPE.value("POLYGON ((5 5, 20 5, 30 30, 5 30, 5 5))"))
         );
     }
 
@@ -89,7 +89,7 @@ public class WithinFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testNormalizeNull() throws Exception {
         Symbol normalizedSymbol = normalize(FNAME,
-                Literal.newLiteral(DataTypes.GEO_POINT, null),
+                Literal.of(DataTypes.GEO_POINT, null),
                 createReference("foo", DataTypes.GEO_SHAPE));
         assertThat(normalizedSymbol, isLiteral(null));
     }
@@ -111,7 +111,7 @@ public class WithinFunctionTest extends AbstractScalarFunctionsTest {
     public void testNormalizeWithStringLiteralAndReference() throws Exception {
         Symbol normalized = normalize(FNAME,
                 createReference("point", DataTypes.GEO_POINT),
-                Literal.newLiteral("POLYGON ((5 5, 20 5, 30 30, 5 30, 5 5))"));
+                Literal.of("POLYGON ((5 5, 20 5, 30 30, 5 30, 5 5))"));
         assertThat(normalized, instanceOf(Function.class));
         Function function = (Function) normalized;
         Symbol symbol = function.arguments().get(1);
@@ -129,7 +129,7 @@ public class WithinFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testNormalizeWithSecondArgAsStringReference() throws Exception {
         Symbol normalized = normalize(FNAME,
-                Literal.newLiteral(DataTypes.GEO_POINT, new Double[]{0.0d, 0.0d}),
+                Literal.of(DataTypes.GEO_POINT, new Double[]{0.0d, 0.0d}),
                 createReference("location", DataTypes.STRING));
         assertThat(normalized.symbolType(), is(SymbolType.FUNCTION));
         assertThat(((Function) normalized).info().ident().name(), is(WithinFunction.NAME));
@@ -148,8 +148,8 @@ public class WithinFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testNormalizeFromObject() throws Exception {
         Symbol normalized = normalize(FNAME,
-                Literal.newLiteral("POINT (1.0 0.0)"),
-                Literal.newLiteral(ImmutableMap.<String, Object>of("type", "Point", "coordinates", new double[]{0.0, 1.0})));
+                Literal.of("POINT (1.0 0.0)"),
+                Literal.of(ImmutableMap.<String, Object>of("type", "Point", "coordinates", new double[]{0.0, 1.0})));
         assertThat(normalized.symbolType(), is(SymbolType.LITERAL));
         assertThat(((Literal) normalized).value(), is((Object) Boolean.FALSE));
     }

--- a/sql/src/test/java/io/crate/operation/scalar/regex/MatchesFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/regex/MatchesFunctionTest.java
@@ -41,7 +41,7 @@ public class MatchesFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testCompile() throws Exception {
-        final Literal<BytesRef> pattern = Literal.newLiteral(".*(ba).*");
+        final Literal<BytesRef> pattern = Literal.of(".*(ba).*");
 
         List<Symbol> arguments = Arrays.asList(
                 createReference("name", DataTypes.STRING),
@@ -60,7 +60,7 @@ public class MatchesFunctionTest extends AbstractScalarFunctionsTest {
         arguments = Arrays.asList(
                 createReference("name", DataTypes.STRING),
                 pattern,
-                Literal.newLiteral("usn")
+                Literal.of("usn")
         );
         regexpImpl.compile(arguments);
 
@@ -71,7 +71,7 @@ public class MatchesFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testEvaluateWithCompile() throws Exception {
-        final Literal<BytesRef> pattern = Literal.newLiteral(".*(ba).*");
+        final Literal<BytesRef> pattern = Literal.of(".*(ba).*");
 
         List<Symbol> arguments = Arrays.asList(
                 createReference("name", DataTypes.STRING),
@@ -133,7 +133,7 @@ public class MatchesFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testEvaluateWithFlags() throws Exception {
-        final Literal<BytesRef> flags = Literal.newLiteral("usn");
+        final Literal<BytesRef> flags = Literal.of("usn");
         List<Symbol> arguments = Arrays.<Symbol>asList(
                 createReference("text", DataTypes.STRING),
                 createReference("regex_pattern", DataTypes.STRING)

--- a/sql/src/test/java/io/crate/operation/scalar/regex/ReplaceFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/regex/ReplaceFunctionTest.java
@@ -35,7 +35,7 @@ public class ReplaceFunctionTest extends AbstractScalarFunctionsTest {
         assertEvaluate(
                 "regexp_replace(name, '(ba)', 'Crate')",
                 "fooCraterbequebaz bar",
-                Literal.newLiteral("foobarbequebaz bar"));
+                Literal.of("foobarbequebaz bar"));
     }
 
     @Test
@@ -43,7 +43,7 @@ public class ReplaceFunctionTest extends AbstractScalarFunctionsTest {
         assertEvaluate(
                 "regexp_replace(name, '(ba)', 'Crate', 'usn g')",
                 "fooCraterbequebaz bar",
-                Literal.newLiteral("foobarbequebaz bar"));
+                Literal.of("foobarbequebaz bar"));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/scalar/string/LowerFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/string/LowerFunctionTest.java
@@ -37,6 +37,6 @@ public class LowerFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testEvaluateNull() throws Exception {
-        assertEvaluate("lower(name)", null, Literal.newLiteral(DataTypes.STRING, null));
+        assertEvaluate("lower(name)", null, Literal.of(DataTypes.STRING, null));
     }
 }

--- a/sql/src/test/java/io/crate/operation/scalar/string/UpperFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/string/UpperFunctionTest.java
@@ -37,6 +37,6 @@ public class UpperFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testEvaluateNull() throws Exception {
-        assertEvaluate("upper(name)", null, Literal.newLiteral(DataTypes.STRING, null));
+        assertEvaluate("upper(name)", null, Literal.of(DataTypes.STRING, null));
     }
 }

--- a/sql/src/test/java/io/crate/operation/scalar/timestamp/CurrentTimestampFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/timestamp/CurrentTimestampFunctionTest.java
@@ -39,25 +39,25 @@ public class CurrentTimestampFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void precisionOfZeroDropsAllFractionsOfSeconds() {
-        Long timestamp = timestampFunction.evaluate(Literal.newLiteral(0));
+        Long timestamp = timestampFunction.evaluate(Literal.of(0));
         assertThat(timestamp, is(EXPECTED_TIMESTAMP - EXPECTED_TIMESTAMP % 1000));
     }
 
     @Test
     public void precisionOfOneDropsLastTwoDigitsOfFractionsOfSecond() {
-        Long timestamp = timestampFunction.evaluate(Literal.newLiteral(1));
+        Long timestamp = timestampFunction.evaluate(Literal.of(1));
         assertThat(timestamp, is(EXPECTED_TIMESTAMP - (EXPECTED_TIMESTAMP % 100)));
     }
 
     @Test
     public void precisionOfTwoDropsLastDigitOfFractionsOfSecond() {
-        Long timestamp = timestampFunction.evaluate(Literal.newLiteral(2));
+        Long timestamp = timestampFunction.evaluate(Literal.of(2));
         assertThat(timestamp, is(EXPECTED_TIMESTAMP - (EXPECTED_TIMESTAMP % 10)));
     }
 
     @Test
     public void precisionOfThreeKeepsAllFractionsOfSeconds() {
-        Long timestamp = timestampFunction.evaluate(Literal.newLiteral(2));
+        Long timestamp = timestampFunction.evaluate(Literal.of(2));
         assertThat(timestamp, is(EXPECTED_TIMESTAMP - (EXPECTED_TIMESTAMP % 10)));
     }
 
@@ -65,21 +65,21 @@ public class CurrentTimestampFunctionTest extends AbstractScalarFunctionsTest {
     public void precisionLessThanZeroRaisesException() {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Precision must be between 0 and 3");
-        timestampFunction.evaluate(Literal.newLiteral(-1));
+        timestampFunction.evaluate(Literal.of(-1));
     }
 
     @Test
     public void precisionLargerThan3RaisesException() {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Precision must be between 0 and 3");
-        timestampFunction.evaluate(Literal.newLiteral(4));
+        timestampFunction.evaluate(Literal.of(4));
     }
 
     @Test
     public void precisionOfNullLRaisesException() {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("NULL precision not supported for current_timestamp");
-        timestampFunction.evaluate(Literal.newLiteral((Integer) null));
+        timestampFunction.evaluate(Literal.of((Integer) null));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/planner/PlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/PlannerTest.java
@@ -1588,7 +1588,7 @@ public class PlannerTest extends AbstractPlannerTest {
                         DataTypes.BOOLEAN),
                         Arrays.asList(
                                 tableInfo.getReference(new ColumnIdent("id")),
-                                Literal.newLiteral(2))
+                                Literal.of(2))
                 ));
 
         plannerContext.allocateRouting(tableInfo, WhereClause.MATCH_ALL, null);

--- a/sql/src/test/java/io/crate/planner/consumer/OrderByPositionVisitorTest.java
+++ b/sql/src/test/java/io/crate/planner/consumer/OrderByPositionVisitorTest.java
@@ -36,7 +36,7 @@ public class OrderByPositionVisitorTest extends CrateUnitTest {
     public void testOrderByPositionInputs() throws Exception {
         int[] orderByPositions = OrderByPositionVisitor.orderByPositions(
                 ImmutableList.<Symbol>of(new InputColumn(0), new InputColumn(1), new InputColumn(0)),
-                ImmutableList.<Symbol>of(Literal.BOOLEAN_TRUE, Literal.newLiteral(1))
+                ImmutableList.<Symbol>of(Literal.BOOLEAN_TRUE, Literal.of(1))
         );
         assertArrayEquals(new int[]{0, 1, 0}, orderByPositions);
     }
@@ -46,7 +46,7 @@ public class OrderByPositionVisitorTest extends CrateUnitTest {
         Reference ref = TestingHelpers.createReference("column", DataTypes.STRING);
         int[] orderByPositions = OrderByPositionVisitor.orderByPositions(
                 ImmutableList.of(ref, new InputColumn(1), new InputColumn(0)),
-                ImmutableList.of(ref, Literal.newLiteral(1))
+                ImmutableList.of(ref, Literal.of(1))
         );
         assertArrayEquals(new int[]{0, 1, 0}, orderByPositions);
     }

--- a/sql/src/test/java/io/crate/planner/projection/UpdateProjectionTest.java
+++ b/sql/src/test/java/io/crate/planner/projection/UpdateProjectionTest.java
@@ -33,10 +33,10 @@ public class UpdateProjectionTest {
     @Test
     public void testEquals() throws Exception {
         UpdateProjection u1 = new UpdateProjection(
-                Literal.newLiteral(1), new String[] { "foo" }, new Symbol[] { Literal.newLiteral(1) }, null);
+                Literal.of(1), new String[] { "foo" }, new Symbol[] { Literal.of(1) }, null);
 
         UpdateProjection u2 = new UpdateProjection(
-                Literal.newLiteral(1), new String[] { "foo" }, new Symbol[] { Literal.newLiteral(1) }, null);
+                Literal.of(1), new String[] { "foo" }, new Symbol[] { Literal.of(1) }, null);
 
         assertThat(u2.equals(u1), is(true));
         assertThat(u1.equals(u2), is(true));

--- a/sql/src/test/java/io/crate/planner/projection/WriterProjectionTest.java
+++ b/sql/src/test/java/io/crate/planner/projection/WriterProjectionTest.java
@@ -38,10 +38,10 @@ public class WriterProjectionTest extends CrateUnitTest {
     public void testStreaming() throws Exception {
         WriterProjection p = new WriterProjection(
                 ImmutableList.<Symbol>of(new InputColumn(1)),
-                Literal.newLiteral("/foo.json"),
+                Literal.of("/foo.json"),
             WriterProjection.CompressionType.GZIP,
                 MapBuilder.<ColumnIdent, Symbol>newMapBuilder().put(
-                        new ColumnIdent("partitionColumn"), Literal.newLiteral(1)).map(),
+                        new ColumnIdent("partitionColumn"), Literal.of(1)).map(),
                 ImmutableList.of("foo"),
                 WriterProjection.OutputFormat.JSON_OBJECT
         );


### PR DESCRIPTION
`newLiteral` implies that a new instance is returned, but in some cases
existing instances are re-used.