### PR TITLE
Move insert-from-subquery validation from analyzer to planner

### DIFF
--- a/sql/src/main/java/io/crate/analyze/InsertFromSubQueryAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/InsertFromSubQueryAnalyzedStatement.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.AnalyzedRelationVisitor;
+import io.crate.analyze.relations.QueriedRelation;
 import io.crate.analyze.symbol.*;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.metadata.*;
@@ -45,7 +46,7 @@ import java.util.*;
 public class InsertFromSubQueryAnalyzedStatement implements AnalyzedRelation, AnalyzedStatement {
 
     private final DocTableInfo targetTable;
-    private final AnalyzedRelation subQueryRelation;
+    private final QueriedRelation subQueryRelation;
 
     @Nullable
     private final Map<Reference, Symbol> onDuplicateKeyAssignments;
@@ -54,7 +55,7 @@ public class InsertFromSubQueryAnalyzedStatement implements AnalyzedRelation, An
     private final List<Symbol> partitionedBySymbols;
     private final int clusteredByIdx;
 
-    public InsertFromSubQueryAnalyzedStatement(AnalyzedRelation subQueryRelation,
+    public InsertFromSubQueryAnalyzedStatement(QueriedRelation subQueryRelation,
                                                DocTableInfo tableInfo,
                                                List<Reference> targetColumns,
                                                @Nullable Map<Reference, Symbol> onDuplicateKeyAssignments) {
@@ -158,7 +159,7 @@ public class InsertFromSubQueryAnalyzedStatement implements AnalyzedRelation, An
         return targetTable;
     }
 
-    public AnalyzedRelation subQueryRelation() {
+    public QueriedRelation subQueryRelation() {
         return this.subQueryRelation;
     }
 

--- a/sql/src/main/java/io/crate/analyze/InsertFromSubQueryAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/InsertFromSubQueryAnalyzer.java
@@ -32,7 +32,6 @@ import io.crate.analyze.symbol.*;
 import io.crate.analyze.symbol.format.SymbolFormatter;
 import io.crate.analyze.symbol.format.SymbolPrinter;
 import io.crate.exceptions.ColumnUnknownException;
-import io.crate.exceptions.UnsupportedFeatureException;
 import io.crate.metadata.*;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.Operation;
@@ -90,13 +89,6 @@ public class InsertFromSubQueryAnalyzer {
         FieldProvider fieldProvider = new NameFieldProvider(tableRelation);
 
         QueriedRelation source = (QueriedRelation) relationAnalyzer.analyze(node.subQuery(), analysis);
-
-        // We forbid using limit/offset or order by until we've implemented ES paging support (aka 'scroll')
-        // TODO: move this to the consumer
-        if (source.querySpec().isLimited() || source.querySpec().orderBy().isPresent()) {
-            throw new UnsupportedFeatureException("Using limit, offset or order by is not " +
-                                                  "supported on insert using a sub-query");
-        }
 
         List<Reference> targetColumns = new ArrayList<>(resolveTargetColumns(node.columns(), tableInfo, source.fields().size()));
         validateColumnsAndAddCastsIfNecessary(targetColumns, source.querySpec());


### PR DESCRIPTION
The Planner doesn't support building a correct plan so the exception
should be raised there.