### PR TITLE
execute sphinx script via `bash`

### DIFF
--- a/blackbox/bin/sphinx
+++ b/blackbox/bin/sphinx
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 declare -i RESULT=0
 echo "\033[1mCleaning output folder ...\033[0m"


### PR DESCRIPTION
since ubuntu 6.10 the default shell `/bin/sh` was changed to dash (debian
almquist shell). `dash` has problems with `${...}` syntax that performs
variable expansion (especially with arrays).

@mfussenegger maybe you can take a look - thanks