### PR TITLE
Use profile to enable logging output for gradlew test

### DIFF
--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -46,7 +46,7 @@ sure that there is a python executable called ``python3`` in the global system
 Before you can build the documentation, you need to setup a development
 environment by running `bootstrap.sh` inside the ``blackbox`` directory::
 
-    
+
     $ cd blackbox
     $ ./bootstrap.sh
 
@@ -115,6 +115,16 @@ Other common tasks are:
  - Running tests during development::
 
     ./gradlew --parallel :sql:test -PtestForks=2 itest gtest
+
+    To enable logging for tests::
+
+    ./gradlew -PtestLogging test
+
+    Use @TestLogging(["<packageName1>:<logLevel1>", ...]) on your
+    test class or test method to enable more detailed logging.
+
+    Example:
+    @TestLogging("io.crate:DEBUG","io.crate.planner.consumer.NestedLoopConsumer:TRACE")
 
  - Run a single test::
 

--- a/gradle/javaModule.gradle
+++ b/gradle/javaModule.gradle
@@ -9,3 +9,9 @@ repositories {
 sourceCompatibility = "7"
 targetCompatibility = "7"
 
+if (project.hasProperty('testLogging')) {
+    // Used to enable logging for tests
+    test {
+        testLogging.showStandardStreams = true
+    }
+}

--- a/sql/build.gradle
+++ b/sql/build.gradle
@@ -44,15 +44,8 @@ clean.dependsOn(cleanTest)
 sourceSets {
     test {
         resources {
-            srcDir 'src/test/java'
-            include '**/*.Plugin'
-            include '**/*.rst'
-            include '**/*.json'
-            include '**/*.gz'
-            include '**/*.zip'
-            include '**/*.sql'
-            include '**/*.html'
-            include '**/*.jsonp'
+            srcDir 'src/test/resources'
+
         }
     }
     benchmarks {

--- a/testing/src/main/resources/log4j.properties
+++ b/testing/src/main/resources/log4j.properties
@@ -1,0 +1,16 @@
+es.logger.level=INFO
+log4j.rootLogger=${es.logger.level}, out
+
+log4j.logger.org.apache.http=INFO, out
+log4j.additivity.org.apache.http=false
+
+log4j.logger.test.external=${es.logger.level}, unformatted
+log4j.additivity.test.external=false
+
+log4j.appender.out=org.apache.log4j.ConsoleAppender
+log4j.appender.out.layout=org.apache.log4j.PatternLayout
+log4j.appender.out.layout.conversionPattern=[%d{ISO8601}][%-5p][%-25c] %m%n
+
+log4j.appender.unformatted=org.apache.log4j.ConsoleAppender
+log4j.appender.unformatted.layout=org.apache.log4j.PatternLayout
+log4j.appender.unformatted.layout.conversionPattern=%m%n


### PR DESCRIPTION
@mfussenegger Please review
We can also do it with a new task instead of profile.