### PR TITLE
Remove restriction that the pattern of like must be a literal

### DIFF
--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -534,13 +534,7 @@ public class ExpressionAnalyzer {
                 return Literal.NULL;
             }
             expression = castIfNeededOrFail(expression, DataTypes.STRING);
-            Symbol pattern = normalize(
-                castIfNeededOrFail(process(node.getPattern(), context), DataTypes.STRING),
-                context.statementContext());
-            assert pattern != null : "pattern must not be null";
-            if (!pattern.symbolType().isValueSymbol()) {
-                throw new UnsupportedOperationException("<expression> LIKE <pattern>: pattern must not be a reference.");
-            }
+            Symbol pattern = castIfNeededOrFail(process(node.getPattern(), context), DataTypes.STRING);
             FunctionIdent functionIdent = FunctionIdent.of(LikeOperator.NAME, expression.valueType(), pattern.valueType());
             return context.allocateFunction(getFunctionInfo(functionIdent), Arrays.asList(expression, pattern));
         }

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -701,12 +701,6 @@ public class SelectStatementAnalyzerTest extends BaseAnalyzerTest {
         assertThat((BytesRef) stringLiteral.value(), is(new BytesRef("1")));
     }
 
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testLikeReferenceInPatternInWhereQuery() {
-        analyze("select * from sys.nodes where 1 like name");
-    }
-
     @Test
     public void testLikeLongDataTypeInWhereQuery() {
         SelectAnalyzedStatement analysis = analyze("select * from sys.nodes where 1 like 2");

--- a/sql/src/test/java/io/crate/lucene/LuceneQueryBuilderTest.java
+++ b/sql/src/test/java/io/crate/lucene/LuceneQueryBuilderTest.java
@@ -404,6 +404,12 @@ public class LuceneQueryBuilderTest extends CrateUnitTest {
     }
 
     @Test
+    public void testLikeWithBothSidesReferences() throws Exception {
+        Query query = convert("name like name");
+        assertThat(query, instanceOf(LuceneQueryBuilder.Visitor.FunctionFilter.class));
+    }
+
+    @Test
     public void testWithinFunctionWithShapeReference() throws Exception {
         // shape references cannot use the inverted index, so use generic function here
         Query eqWithinQuery = convert("within(point, shape)");

--- a/sql/src/test/java/io/crate/operation/operator/LikeOperatorTest.java
+++ b/sql/src/test/java/io/crate/operation/operator/LikeOperatorTest.java
@@ -24,7 +24,7 @@ import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.StmtCtx;
-import io.crate.test.integration.CrateUnitTest;
+import io.crate.operation.scalar.AbstractScalarFunctionsTest;
 import io.crate.types.DataTypes;
 import org.apache.lucene.util.BytesRef;
 import org.junit.Test;
@@ -33,7 +33,7 @@ import java.util.Arrays;
 
 import static io.crate.operation.operator.LikeOperator.DEFAULT_ESCAPE;
 
-public class LikeOperatorTest extends CrateUnitTest {
+public class LikeOperatorTest extends AbstractScalarFunctionsTest {
 
     private static Symbol normalizeSymbol(String expression, String pattern) {
         LikeOperator op = new LikeOperator(
@@ -54,6 +54,12 @@ public class LikeOperatorTest extends CrateUnitTest {
     public void testNormalizeSymbolEqual() {
         assertTrue(likeNormalize("foo", "foo"));
         assertFalse(likeNormalize("notFoo", "foo"));
+    }
+
+    @Test
+    public void testPatternIsNoLiteral() throws Exception {
+        assertEvaluate("name like timezone", false, Literal.of("foo"), Literal.of("bar"));
+        assertEvaluate("name like name", true, Literal.of("foo"), Literal.of("foo"));
     }
 
     @Test


### PR DESCRIPTION
The restriction was artificial. `Like` can be executed the same way as
we execute `col1 = col2`.