### PR TITLE
Fix: An issue on self joins when columns from both relations are used in where clause.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,10 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fix: An issue on self joins when columns from both relations are
+   used in where clause.
+   E.g. FROM table t1, table t2 WHERE t1.col = 'foo' and t2.col = 'bar';
+
  - Added support for SET LOCAL|SESSION statements.
 
  - Fix: ``ANY`` operator fails in the ``WHERE`` clause if a subscript is

--- a/core/src/main/java/io/crate/core/collections/MapComparator.java
+++ b/core/src/main/java/io/crate/core/collections/MapComparator.java
@@ -49,7 +49,17 @@ public class MapComparator implements Comparator<Map> {
         for (Map.Entry<K, V> entry : m1.entrySet()) {
             V thisValue = entry.getValue();
             V otherValue = m2.get(entry.getKey());
+            if (thisValue == null) {
+                if (otherValue != null) {
+                    return 1;
+                } else {
+                    continue;
+                }
+            }
             if (!thisValue.equals(otherValue)) {
+                if (otherValue == null) {
+                    return -1;
+                }
                 if (!thisValue.getClass().equals(otherValue.getClass())) {
                     DataType leftType = DataTypes.guessType(thisValue);
                     int cmp = leftType.compareValueTo(thisValue, leftType.value(otherValue));

--- a/core/src/test/java/io/crate/core/collections/MapComparatorTest.java
+++ b/core/src/test/java/io/crate/core/collections/MapComparatorTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.core.collections;
+
+import io.crate.test.integration.CrateUnitTest;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.is;
+
+public class MapComparatorTest extends CrateUnitTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testCompareNullMaps() {
+        expectedException.expect(NullPointerException.class);
+        expectedException.expectMessage("map is null");
+        MapComparator.compareMaps(null, null);
+    }
+
+    @Test
+    public void testCompareMapsWithNullValues() {
+        Map<String, Integer> map1 = new HashMap<String, Integer>() {{
+            put("str1", 1);
+            put("str2", null);
+            put("str3", 3);
+        }};
+        Map<String, Integer> map2 = new HashMap<String, Integer>() {{
+            put("str1", 1);
+            put("str2", 2);
+            put("str3", 3);
+        }};
+        assertThat(MapComparator.compareMaps(map1, map2), is(1));
+        assertThat(MapComparator.compareMaps(map2, map1), is(-1));
+
+        map2.put("str2", null);
+        assertThat(MapComparator.compareMaps(map2, map1), is(0));
+    }
+
+    @Test
+    public void testCompareMapsWithValuesOfTheSameClass() {
+        Map<String, Integer> map1 = new HashMap<String, Integer>() {{
+            put("str1", 1);
+            put("str2", 2);
+            put("str3", 3);
+        }};
+        Map<String, Integer> map2 = new HashMap<String, Integer>() {{
+            put("str1", 1);
+            put("str2", 2);
+            put("str3", 3);
+        }};
+        assertThat(MapComparator.compareMaps(map1, map2), is(0));
+        assertThat(MapComparator.compareMaps(map2, map1), is(0));
+
+        map2.put("str2", 5);
+        assertThat(MapComparator.compareMaps(map1, map2), is(1));
+        assertThat(MapComparator.compareMaps(map2, map1), is(1));
+    }
+
+    public void testCompareMapsWithValuesOfDifferentClass() {
+        Map<String, Number> map1 = new HashMap<String, Number>() {{
+            put("str1", 1);
+            put("str2", 2);
+            put("str3", 3);
+        }};
+        Map<String, Number> map2 = new HashMap<String, Number>() {{
+            put("str1", 1);
+            put("str2", 2L);
+            put("str3", 3);
+        }};
+        assertThat(MapComparator.compareMaps(map1, map2), is(0));
+        assertThat(MapComparator.compareMaps(map2, map1), is(0));
+
+        map1.put("str2", 5.0);
+        assertThat(MapComparator.compareMaps(map1, map2), is(1));
+        assertThat(MapComparator.compareMaps(map2, map1), is(-1));
+    }
+}

--- a/sql/src/main/java/io/crate/analyze/relations/RelationSplitter.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationSplitter.java
@@ -35,6 +35,7 @@ import io.crate.analyze.fetch.FetchFieldExtractor;
 import io.crate.analyze.symbol.*;
 import io.crate.operation.operator.AndOperator;
 import io.crate.planner.Limits;
+import io.crate.sql.tree.QualifiedName;
 
 import javax.annotation.Nullable;
 import java.util.*;
@@ -44,6 +45,7 @@ public final class RelationSplitter {
     private final QuerySpec querySpec;
     private final Set<Symbol> requiredForQuery = new HashSet<>();
     private final Map<AnalyzedRelation, QuerySpec> specs;
+    private final Map<QualifiedName, AnalyzedRelation> relations;
     private final List<JoinPair> joinPairs;
     private final List<Symbol> joinConditions;
     private Set<Field> canBeFetched;
@@ -61,8 +63,10 @@ public final class RelationSplitter {
                             List<JoinPair> joinPairs) {
         this.querySpec = querySpec;
         specs = new IdentityHashMap<>(relations.size());
+        this.relations = new HashMap<>(relations.size());
         for (AnalyzedRelation relation : relations) {
             specs.put(relation, new QuerySpec());
+            this.relations.put(relation.getQualifiedName(), relation);
         }
         this.joinPairs = joinPairs;
         joinConditions = new ArrayList<>(joinPairs.size());
@@ -93,6 +97,10 @@ public final class RelationSplitter {
         processOrderBy();
         processWhere();
         processOutputs();
+    }
+
+    private QuerySpec getSpec(QualifiedName relationName) {
+        return specs.get(relations.get(relationName));
     }
 
     private void processOutputs() {
@@ -155,7 +163,7 @@ public final class RelationSplitter {
         QuerySplittingVisitor.Context context = QuerySplittingVisitor.INSTANCE.process(querySpec.where().query(), joinPairs);
         JoinConditionValidator.INSTANCE.process(context.query(), null);
         querySpec.where(new WhereClause(context.query()));
-        for (Map.Entry<AnalyzedRelation, Collection<Symbol>> entry : context.queries().asMap().entrySet()) {
+        for (Map.Entry<QualifiedName, Collection<Symbol>> entry : context.queries().asMap().entrySet()) {
             getSpec(entry.getKey()).where(new WhereClause(AndOperator.join(entry.getValue())));
         }
     }

--- a/sql/src/main/java/io/crate/metadata/Routing.java
+++ b/sql/src/main/java/io/crate/metadata/Routing.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableMap;
 import io.crate.core.collections.TreeMapBuilder;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
@@ -126,6 +127,66 @@ public class Routing implements Streamable {
             }
         }
         return false;
+    }
+
+    /**
+     * Update the locations of the current new routing by merging them with
+     * the {@paramref otherLocations} that have been computed in an other
+     * routing for the same table.
+     * <p>
+     * if a shard has been already routed in {@paramref otherLocations}
+     * then: use the existing node
+     * else: use the new node
+     *
+     * @param otherLocations locations already routed for the same table
+     */
+    public void mergeLocations(Map<String, Map<String, List<Integer>>> otherLocations) {
+        if (otherLocations.equals(locations)) {
+            return;
+        }
+
+        // All existing shards
+        Map<Tuple<String, Integer>, String> otherShards = new HashMap<>();
+        for (Map.Entry<String, Map<String, List<Integer>>> location : otherLocations.entrySet()) {
+            for (Map.Entry<String, List<Integer>> indexEntry : location.getValue().entrySet()) {
+                for (Integer shardId : indexEntry.getValue()) {
+                    otherShards.put(new Tuple<>(indexEntry.getKey(), shardId), location.getKey());
+                }
+            }
+        }
+
+        // Build new locations by merging existing with new ones
+        Map<String, Map<String, List<Integer>>> newLocations = new HashMap<>();
+        for (Map.Entry<String, Map<String, List<Integer>>> location : locations.entrySet()) {
+            for (Map.Entry<String, List<Integer>> indexEntry : location.getValue().entrySet()) {
+                for (Integer shardId : indexEntry.getValue()) {
+                    String nodeId = otherShards.get(new Tuple<>(indexEntry.getKey(), shardId));
+                    addShardRouting(newLocations,
+                                    indexEntry.getKey(),
+                                    shardId,
+                                    nodeId == null ? location.getKey() : nodeId);
+                }
+            }
+        }
+        locations = newLocations;
+        return;
+    }
+
+    private static void addShardRouting(Map<String, Map<String, List<Integer>>> newLocations,
+                                 String index,
+                                 Integer shardId,
+                                 String nodeId) {
+        Map<String, List<Integer>> indexMap = newLocations.get(nodeId);
+        if (indexMap == null) {
+            indexMap = new HashMap<>();
+            newLocations.put(nodeId, indexMap);
+        }
+        List<Integer> shards = indexMap.get(index);
+        if (shards == null) {
+            shards = new ArrayList<>();
+            indexMap.put(index, shards);
+        }
+        shards.add(shardId);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/Planner.java
+++ b/sql/src/main/java/io/crate/planner/Planner.java
@@ -23,6 +23,7 @@ package io.crate.planner;
 
 import com.carrotsearch.hppc.IntHashSet;
 import com.carrotsearch.hppc.IntSet;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.HashMultimap;
@@ -318,14 +319,18 @@ public class Planner extends AnalyzedStatementVisitor<Planner.Context, Plan> {
                         return existing.routing;
                     }
                 }
+
+                routing = tableInfo.getRouting(where, preference);
                 // ensure all routings of this table are allocated
+                // and update new routing by merging with existing ones
                 for (TableRouting existingRouting : existingRoutings) {
                     if (!existingRouting.nodesAllocated) {
                         allocateRoutingNodes(tableInfo.ident(), existingRouting.routing.locations());
                         existingRouting.nodesAllocated = true;
                     }
+                    // Merge locations with existing routing
+                    routing.mergeLocations(existingRouting.routing.locations());
                 }
-                routing = tableInfo.getRouting(where, preference);
                 if (!allocateRoutingNodes(tableInfo.ident(), routing.locations())) {
                     throw new UnsupportedOperationException(
                         "Nodes of existing routing are not allocated, routing rebuild needed");
@@ -336,7 +341,8 @@ public class Planner extends AnalyzedStatementVisitor<Planner.Context, Plan> {
         }
     }
 
-    private static class TableRouting {
+    @VisibleForTesting
+    static class TableRouting {
         final WhereClause where;
         final String preference;
         final Routing routing;

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -846,6 +846,22 @@ public class SelectStatementAnalyzerTest extends BaseAnalyzerTest {
         assertThat(users.querySpec().where().query(), isSQL("(doc.users.name = 'Arthur')"));
     }
 
+    public void testSelfJoinSyntaxWithWhereClause() throws Exception {
+        SelectAnalyzedStatement analysis = analyze("select t2.id from users as t1 join users as t2 on t1.id = t2.id " +
+                                                   "where t1.name = 'foo' and t2.name = 'bar'");
+
+        assertThat(analysis.relation().querySpec().where(), is(WhereClause.MATCH_ALL));
+        assertThat(analysis.relation(), instanceOf(MultiSourceSelect.class));
+
+        MultiSourceSelect.Source source1 = ((MultiSourceSelect) analysis.relation()).sources()
+                                                                                    .get(QualifiedName.of("t1"));
+        MultiSourceSelect.Source source2 = ((MultiSourceSelect) analysis.relation()).sources()
+                                                                                    .get(QualifiedName.of("t2"));
+
+        assertThat(source1.querySpec().where().query(), isSQL("(doc.users.name = 'foo')"));
+        assertThat(source2.querySpec().where().query(), isSQL("(true AND (doc.users.name = 'bar'))"));
+    }
+
     @Test
     public void testJoinWithOrderBy() throws Exception {
         SelectAnalyzedStatement analysis = analyze("select users.id from users, users_multi_pk order by users.id");
@@ -1096,7 +1112,6 @@ public class SelectStatementAnalyzerTest extends BaseAnalyzerTest {
         assertTrue(analysis.relation().querySpec().orderBy().isPresent());
         assertEquals(DistanceFunction.NAME, ((Function) analysis.relation().querySpec().orderBy().get().orderBySymbols().get(0)).info().ident().name());
     }
-
 
     @Test
     public void testWhereMatchOnColumn() throws Exception {

--- a/sql/src/test/java/io/crate/planner/AbstractPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/AbstractPlannerTest.java
@@ -86,13 +86,20 @@ public abstract class AbstractPlannerTest extends CrateUnitTest {
     protected static Routing shardRouting(String tableName) {
         return new Routing(TreeMapBuilder.<String, Map<String, List<Integer>>>newMapBuilder()
             .put("nodeOne", TreeMapBuilder.<String, List<Integer>>newMapBuilder().put(tableName, Arrays.asList(1, 2)).map())
-            .put("nodeTow", TreeMapBuilder.<String, List<Integer>>newMapBuilder().put(tableName, Arrays.asList(3, 4)).map())
+            .put("nodeTwo", TreeMapBuilder.<String, List<Integer>>newMapBuilder().put(tableName, Arrays.asList(3, 4)).map())
+            .map());
+    }
+
+    protected static Routing shardRoutingForReplicas(String tableName) {
+        return new Routing(TreeMapBuilder.<String, Map<String, List<Integer>>>newMapBuilder()
+            .put("nodeOne", TreeMapBuilder.<String, List<Integer>>newMapBuilder().put(tableName, Arrays.asList(3, 4)).map())
+            .put("nodeTwo", TreeMapBuilder.<String, List<Integer>>newMapBuilder().put(tableName, Arrays.asList(1, 2)).map())
             .map());
     }
 
     private static final Routing PARTED_ROUTING = new Routing(TreeMapBuilder.<String, Map<String, List<Integer>>>newMapBuilder()
         .put("nodeOne", TreeMapBuilder.<String, List<Integer>>newMapBuilder().put(".partitioned.parted.04232chj", Arrays.asList(1, 2)).map())
-        .put("nodeTow", TreeMapBuilder.<String, List<Integer>>newMapBuilder().map())
+        .put("nodeTwo", TreeMapBuilder.<String, List<Integer>>newMapBuilder().map())
         .map());
 
     private static final Routing CLUSTERED_PARTED_ROUTING = new Routing(TreeMapBuilder.<String, Map<String, List<Integer>>>newMapBuilder()

--- a/sql/src/test/java/io/crate/planner/PlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/PlannerTest.java
@@ -1,9 +1,9 @@
 package io.crate.planner;
 
 import com.carrotsearch.hppc.IntSet;
-import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Multimap;
 import io.crate.analyze.QuerySpec;
 import io.crate.analyze.WhereClause;
 import io.crate.analyze.relations.PlannedAnalyzedRelation;
@@ -1547,8 +1547,10 @@ public class PlannerTest extends AbstractPlannerTest {
     @Test
     public void testBuildReaderAllocations() throws Exception {
         TableIdent custom = new TableIdent("custom", "t1");
-        TableInfo tableInfo = TestingTableInfo.builder(custom, shardRouting("t1")).add("id", DataTypes.INTEGER, null).build();
-        Planner.Context plannerContext = new Planner.Context(clusterService, UUID.randomUUID(), null, normalizer, new StmtCtx(), 0, 0);
+        TableInfo tableInfo = TestingTableInfo.builder(
+            custom, shardRouting("t1")).add("id", DataTypes.INTEGER, null).build();
+        Planner.Context plannerContext = new Planner.Context(
+            clusterService, UUID.randomUUID(), null, normalizer, new StmtCtx(), 0, 0);
         plannerContext.allocateRouting(tableInfo, WhereClause.MATCH_ALL, null);
 
         Planner.Context.ReaderAllocations readerAllocations = plannerContext.buildReaderAllocations();
@@ -1562,7 +1564,7 @@ public class PlannerTest extends AbstractPlannerTest {
         assertTrue(n1.contains(1));
         assertTrue(n1.contains(2));
 
-        IntSet n2 = readerAllocations.nodeReaders().get("nodeTow");
+        IntSet n2 = readerAllocations.nodeReaders().get("nodeTwo");
         assertThat(n2.size(), is(2));
         assertTrue(n2.contains(3));
         assertTrue(n2.contains(4));
@@ -1577,25 +1579,36 @@ public class PlannerTest extends AbstractPlannerTest {
     @Test
     public void testAllocateRouting() throws Exception {
         TableIdent custom = new TableIdent("custom", "t1");
-        TableInfo tableInfo = TestingTableInfo.builder(custom, shardRouting("t1")).add("id", DataTypes.INTEGER, null).build();
-        Planner.Context plannerContext = new Planner.Context(clusterService, UUID.randomUUID(), null, normalizer, new StmtCtx(), 0, 0);
+        TableInfo tableInfo1 =
+            TestingTableInfo.builder(custom, shardRouting("t1")).add("id", DataTypes.INTEGER, null).build();
+        TableInfo tableInfo2 =
+            TestingTableInfo.builder(custom, shardRoutingForReplicas("t1")).add("id", DataTypes.INTEGER, null).build();
+        Planner.Context plannerContext =
+            new Planner.Context(clusterService, UUID.randomUUID(), null, normalizer, new StmtCtx(), 0, 0);
 
         WhereClause whereClause = new WhereClause(
             new Function(new FunctionInfo(
-                new FunctionIdent(EqOperator.NAME, Arrays.<DataType>asList(DataTypes.INTEGER, DataTypes.INTEGER)),
+                new FunctionIdent(EqOperator.NAME,
+                                  Arrays.<DataType>asList(DataTypes.INTEGER, DataTypes.INTEGER)),
                 DataTypes.BOOLEAN),
-                Arrays.asList(
-                    tableInfo.getReference(new ColumnIdent("id")),
-                    Literal.of(2))
+                         Arrays.asList(tableInfo1.getReference(new ColumnIdent("id")), Literal.of(2))
             ));
 
-        plannerContext.allocateRouting(tableInfo, WhereClause.MATCH_ALL, null);
-        plannerContext.allocateRouting(tableInfo, whereClause, null);
+        plannerContext.allocateRouting(tableInfo1, WhereClause.MATCH_ALL, null);
+        plannerContext.allocateRouting(tableInfo2, whereClause, null);
 
         // 2 routing allocations with different where clause must result in 2 allocated routings
         Field tableRoutings = Planner.Context.class.getDeclaredField("tableRoutings");
         tableRoutings.setAccessible(true);
-        assertThat(((HashMultimap) tableRoutings.get(plannerContext)).size(), is(2));
+        Multimap<TableIdent, Planner.TableRouting> routing =
+            (Multimap<TableIdent, Planner.TableRouting>) tableRoutings.get(plannerContext);
+        assertThat(routing.size(), is(2));
+
+        // The routings must be the same after merging the locations
+        Iterator<Planner.TableRouting> iterator = routing.values().iterator();
+        Routing routing1 = iterator.next().routing;
+        Routing routing2 = iterator.next().routing;
+        assertThat(routing1, is(routing2));
     }
 
     @Test
@@ -1606,7 +1619,6 @@ public class PlannerTest extends AbstractPlannerTest {
         assertThat(plannerContext.nextExecutionPhaseId(), is(0));
         assertThat(plannerContext.nextExecutionPhaseId(), is(1));
     }
-
 
     @SuppressWarnings("ConstantConditions")
     @Test


### PR DESCRIPTION
eg: FROM table t1, table t2 WHERE t1.col = 'foo' and t2.col = 'bar';
Relates to issue: https://github.com/crate/crate/issues/4091