### PR TITLE
don't count null values

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fix: The ``count`` aggregation function counts null values.
+   E.g. count(cast(null as string))
+
  - Fixed evaluation of ``NOT NULL`` (=> ``NULL``) in ``WHERE`` clause
 
  - Fix: Prevented usage of ``MATCH`` predicates on columns of both relations

--- a/sql/src/main/java/io/crate/operation/aggregation/impl/CountAggregation.java
+++ b/sql/src/main/java/io/crate/operation/aggregation/impl/CountAggregation.java
@@ -26,6 +26,7 @@ import io.crate.Streamer;
 import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
+import io.crate.analyze.symbol.ValueSymbolVisitor;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.metadata.*;
 import io.crate.operation.Input;
@@ -101,7 +102,7 @@ public class CountAggregation extends AggregationFunction<CountAggregation.LongS
 
         if (function.arguments().size() == 1) {
             if (function.arguments().get(0).symbolType().isValueSymbol()) {
-                if ((function.arguments().get(0)).valueType() == DataTypes.UNDEFINED) {
+                if (ValueSymbolVisitor.VALUE.process(function.arguments().get(0)) == null) {
                     return Literal.of(0L);
                 } else {
                     return new Function(COUNT_STAR_FUNCTION, ImmutableList.<Symbol>of());

--- a/sql/src/test/java/io/crate/operation/aggregation/AggregationTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/AggregationTest.java
@@ -22,11 +22,15 @@
 package io.crate.operation.aggregation;
 
 import com.google.common.collect.ImmutableList;
+import io.crate.analyze.symbol.Function;
+import io.crate.analyze.symbol.Literal;
+import io.crate.analyze.symbol.Symbol;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.core.collections.ArrayBucket;
 import io.crate.core.collections.Row;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.Functions;
+import io.crate.metadata.StmtCtx;
 import io.crate.operation.collect.InputCollectExpression;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.types.DataType;
@@ -34,6 +38,7 @@ import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.junit.Before;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static io.crate.testing.TestingHelpers.getFunctions;
@@ -87,4 +92,17 @@ public abstract class AggregationTest extends CrateUnitTest {
         return new Object[][]{{state}};
     }
 
+    protected Symbol normalize(String functionName, Object value, DataType type) {
+        return normalize(functionName, Literal.of(type, value));
+    }
+
+    protected Symbol normalize(String functionName, Symbol... args) {
+        DataType[] argTypes = new DataType[args.length];
+        for (int i = 0; i < args.length; i++) {
+            argTypes[i] = args[i].valueType();
+        }
+        AggregationFunction function =
+            (AggregationFunction) functions.get(new FunctionIdent(functionName, Arrays.asList(argTypes)));
+        return function.normalizeSymbol(new Function(function.info(), Arrays.asList(args)), new StmtCtx());
+    }
 }

--- a/sql/src/test/java/io/crate/operation/aggregation/impl/CountAggregationTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/impl/CountAggregationTest.java
@@ -31,6 +31,8 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.junit.Test;
 
+import static io.crate.testing.TestingHelpers.isLiteral;
+
 public class CountAggregationTest extends AggregationTest {
 
     private Object[][] executeAggregation(DataType dataType, Object[][] data) throws Exception {
@@ -84,6 +86,12 @@ public class CountAggregationTest extends AggregationTest {
         Object[][] result = executeAggregation(DataTypes.STRING, new Object[][]{{"Youri"}, {"Ruben"}});
 
         assertEquals(2L, result[0][0]);
+    }
+
+    @Test
+    public void testNormalizeWithNullLiteral() {
+        assertThat(normalize("count", null, DataTypes.STRING), isLiteral(0L));
+        assertThat(normalize("count", null, null), isLiteral(0L));
     }
 
     @Test


### PR DESCRIPTION
 The ``count`` aggregation function don't count null values
 in cases like:

```sh
    count(cast(null as string))
```