### PR TITLE
ensure that CrateDocCollector always releases the searchcontext upon …

### DIFF
--- a/sql/src/main/java/io/crate/operation/collect/collectors/CrateDocCollector.java
+++ b/sql/src/main/java/io/crate/operation/collect/collectors/CrateDocCollector.java
@@ -155,6 +155,7 @@ public class CrateDocCollector implements CrateCollector, RepeatHandle {
 
     @Override
     public void doCollect() {
+        debugLog("doCollect");
         for (LuceneCollectorExpression<?> expression : expressions) {
             expression.startCollect(collectorContext);
         }
@@ -253,7 +254,9 @@ public class CrateDocCollector implements CrateCollector, RepeatHandle {
 
     @Override
     public void kill(@Nullable Throwable throwable) {
+        debugLog("kill searchContext=" + searchContext);
         rowReceiver.kill(throwable);
+        searchContext.clearReleasables(SearchContext.Lifetime.PHASE);
     }
 
     @Override

--- a/sql/src/test/java/io/crate/operation/collect/collectors/CrateDocCollectorTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/collectors/CrateDocCollectorTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.operation.collect.collectors;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.MoreExecutors;
+import io.crate.action.sql.query.CrateSearchContext;
+import io.crate.operation.Input;
+import io.crate.operation.projectors.RowReceiver;
+import io.crate.operation.reference.doc.lucene.LuceneCollectorExpression;
+import org.elasticsearch.search.internal.SearchContext;
+import org.junit.Test;
+import org.mockito.Answers;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+public class CrateDocCollectorTest {
+
+    @Test
+    public void testCollectorKill() throws Exception {
+        CrateSearchContext sc = mock(CrateSearchContext.class, Answers.RETURNS_MOCKS.get());
+        RowReceiver rowReceiver = mock(RowReceiver.class, Answers.RETURNS_MOCKS.get());
+        CrateDocCollector c = new CrateDocCollector(sc, MoreExecutors.directExecutor(), false, null,
+            rowReceiver, ImmutableList.<Input<?>>of(), ImmutableList.<LuceneCollectorExpression<?>>of());
+
+        c.kill(null);
+
+        verify(sc, times(1)).clearReleasables(any(SearchContext.Lifetime.class));
+        verify(rowReceiver, only()).kill(any(Throwable.class));
+    }
+}


### PR DESCRIPTION
…kill