### PR TITLE
Remove value calls on ArrayLiteral & ObjectLiteral elements in ExpressionAnalyzer

### DIFF
--- a/sql-parser/src/main/java/io/crate/sql/tree/ObjectLiteral.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/ObjectLiteral.java
@@ -21,7 +21,6 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
 
@@ -32,7 +31,14 @@ public class ObjectLiteral extends Literal {
     private final Multimap<String, Expression> values;
 
     public ObjectLiteral(@Nullable Multimap<String, Expression> values) {
-        this.values = MoreObjects.firstNonNull(values, ImmutableMultimap.<String, Expression>of());
+        if (values == null) {
+            this.values = ImmutableMultimap.of();
+        } else {
+            this.values = values;
+            if (values.size() != values.keySet().size()) {
+                throw new IllegalArgumentException("object contains duplicate keys: " + values);
+            }
+        }
     }
 
     public Multimap<String, Expression> values() {

--- a/sql/src/main/java/io/crate/analyze/symbol/Literal.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/Literal.java
@@ -28,6 +28,7 @@ public class Literal<ReturnType>
     public final static Literal<Boolean> BOOLEAN_TRUE = new Literal<>(DataTypes.BOOLEAN, true);
     public final static Literal<Boolean> BOOLEAN_FALSE = new Literal<>(DataTypes.BOOLEAN, false);
     public final static Literal<Integer> ZERO = Literal.of(0);
+    public static final Literal<Map<String, Object>> EMPTY_OBJECT = Literal.of(Collections.<String, Object>emptyMap());
 
     public static final SymbolFactory<Literal> FACTORY = new SymbolFactory<Literal>() {
         @Override

--- a/sql/src/main/java/io/crate/operation/scalar/ScalarFunctionModule.java
+++ b/sql/src/main/java/io/crate/operation/scalar/ScalarFunctionModule.java
@@ -105,6 +105,7 @@ public class ScalarFunctionModule extends AbstractModule {
 
         LengthFunction.register(this);
 
+        MapFunction.register(this);
         ArrayFunction.register(this);
         ArrayCatFunction.register(this);
         ArrayDifferenceFunction.register(this);

--- a/sql/src/main/java/io/crate/operation/scalar/cast/CastFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/cast/CastFunction.java
@@ -138,13 +138,7 @@ public class CastFunction extends Scalar<Object, Object> implements FunctionForm
     }
 
     public static void register(ScalarFunctionModule module) {
-        for (Map.Entry<DataType, String> function : CastFunctionResolver.ARRAY_FUNCTION_MAP.entrySet()) {
-            module.register(function.getValue(), new Resolver(function.getKey(), function.getValue()));
-        }
-        for (Map.Entry<DataType, String> function : CastFunctionResolver.PRIMITIVE_FUNCTION_MAP.entrySet()) {
-            module.register(function.getValue(), new Resolver(function.getKey(), function.getValue()));
-        }
-        for (Map.Entry<DataType, String> function : CastFunctionResolver.GEO_FUNCTION_MAP.entrySet()) {
+        for (Map.Entry<DataType, String> function : CastFunctionResolver.FUNCTION_MAP.entrySet()) {
             module.register(function.getValue(), new Resolver(function.getKey(), function.getValue()));
         }
     }

--- a/sql/src/main/java/io/crate/operation/scalar/cast/CastFunctionResolver.java
+++ b/sql/src/main/java/io/crate/operation/scalar/cast/CastFunctionResolver.java
@@ -30,6 +30,7 @@ import io.crate.metadata.FunctionInfo;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+import io.crate.types.SetType;
 
 import java.util.Locale;
 import java.util.Map;
@@ -61,9 +62,19 @@ public class CastFunctionResolver {
         public static final String TO_IP_ARRAY = "to_ip_array";
         public static final String TO_GEO_POINT = "to_geo_point";
         public static final String TO_GEO_SHAPE = "to_geo_shape";
+
+        static final String TO_STRING_SET = "to_string_set";
+        static final String TO_LONG_SET = "to_long_set";
+        static final String TO_INTEGER_SET = "to_integer_set";
+        static final String TO_DOUBLE_SET = "to_double_set";
+        static final String TO_BOOLEAN_SET = "to_boolean_set";
+        static final String TO_BYTE_SET = "to_byte_set";
+        static final String TO_FLOAT_SET = "to_float_set";
+        static final String TO_SHORT_SET = "to_short_set";
+        static final String TO_IP_SET = "to_ip_set";
     }
 
-    static final ImmutableMap<DataType, String> PRIMITIVE_FUNCTION_MAP = new ImmutableMap.Builder<DataType, String>()
+    private static final ImmutableMap<DataType, String> PRIMITIVE_FUNCTION_MAP = new ImmutableMap.Builder<DataType, String>()
         .put(DataTypes.STRING, FunctionNames.TO_STRING)
         .put(DataTypes.INTEGER, FunctionNames.TO_INTEGER)
         .put(DataTypes.LONG, FunctionNames.TO_LONG)
@@ -76,12 +87,12 @@ public class CastFunctionResolver {
         .put(DataTypes.IP, FunctionNames.TO_IP)
         .build();
 
-    static final ImmutableMap<DataType, String> GEO_FUNCTION_MAP = new ImmutableMap.Builder<DataType, String>()
+    private static final ImmutableMap<DataType, String> GEO_FUNCTION_MAP = new ImmutableMap.Builder<DataType, String>()
         .put(DataTypes.GEO_POINT, FunctionNames.TO_GEO_POINT)
         .put(DataTypes.GEO_SHAPE, FunctionNames.TO_GEO_SHAPE)
         .build();
 
-    static final ImmutableMap<DataType, String> ARRAY_FUNCTION_MAP = new ImmutableMap.Builder<DataType, String>()
+    private static final ImmutableMap<DataType, String> ARRAY_FUNCTION_MAP = new ImmutableMap.Builder<DataType, String>()
         .put(new ArrayType(DataTypes.STRING), FunctionNames.TO_STRING_ARRAY)
         .put(new ArrayType(DataTypes.LONG), FunctionNames.TO_LONG_ARRAY)
         .put(new ArrayType(DataTypes.INTEGER), FunctionNames.TO_INTEGER_ARRAY)
@@ -93,11 +104,23 @@ public class CastFunctionResolver {
         .put(new ArrayType(DataTypes.IP), FunctionNames.TO_IP_ARRAY)
         .build();
 
-    // TODO: register all type conversion functions here
-    private static final ImmutableMap<DataType, String> FUNCTION_MAP = new ImmutableMap.Builder<DataType, String>()
+    private static final ImmutableMap<DataType, String> SET_FUNCTION_MAP = new ImmutableMap.Builder<DataType, String>()
+        .put(new SetType(DataTypes.STRING), FunctionNames.TO_STRING_SET)
+        .put(new SetType(DataTypes.LONG), FunctionNames.TO_LONG_SET)
+        .put(new SetType(DataTypes.INTEGER), FunctionNames.TO_INTEGER_SET)
+        .put(new SetType(DataTypes.DOUBLE), FunctionNames.TO_DOUBLE_SET)
+        .put(new SetType(DataTypes.BOOLEAN), FunctionNames.TO_BOOLEAN_SET)
+        .put(new SetType(DataTypes.BYTE), FunctionNames.TO_BYTE_SET)
+        .put(new SetType(DataTypes.FLOAT), FunctionNames.TO_FLOAT_SET)
+        .put(new SetType(DataTypes.SHORT), FunctionNames.TO_SHORT_SET)
+        .put(new SetType(DataTypes.IP), FunctionNames.TO_IP_SET)
+        .build();
+
+    static final ImmutableMap<DataType, String> FUNCTION_MAP = new ImmutableMap.Builder<DataType, String>()
         .putAll(PRIMITIVE_FUNCTION_MAP)
         .putAll(GEO_FUNCTION_MAP)
         .putAll(ARRAY_FUNCTION_MAP)
+        .putAll(SET_FUNCTION_MAP)
         .build();
 
     /**

--- a/sql/src/main/java/io/crate/planner/Planner.java
+++ b/sql/src/main/java/io/crate/planner/Planner.java
@@ -107,6 +107,10 @@ public class Planner extends AnalyzedStatementVisitor<Planner.Context, Plan> {
             this.fetchSize = fetchSize;
         }
 
+        public EvaluatingNormalizer normalizer() {
+            return normalizer;
+        }
+
         private static int finalLimit(@Nullable Integer queryLimit, int softLimit) {
             if (queryLimit == null) {
                 return softLimit > 0 ? softLimit : TopN.NO_LIMIT;

--- a/sql/src/main/java/io/crate/planner/node/dql/RoutedCollectPhase.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/RoutedCollectPhase.java
@@ -43,6 +43,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -306,12 +307,15 @@ public class RoutedCollectPhase extends AbstractProjectionsPhase implements Coll
         WhereClause where = table.querySpec().where();
         if (table.tableRelation() instanceof TableFunctionRelation) {
             TableFunctionRelation tableFunctionRelation = (TableFunctionRelation) table.tableRelation();
+            List<Symbol> args = new ArrayList<>();
+            args.addAll(tableFunctionRelation.arguments());
+            plannerContext.normalizer().normalizeInplace(args, plannerContext.statementContext());
             return new TableFunctionCollectPhase(
                 plannerContext.jobId(),
                 plannerContext.nextExecutionPhaseId(),
                 plannerContext.allocateRouting(tableInfo, where, null),
                 tableFunctionRelation.functionName(),
-                tableFunctionRelation.arguments(),
+                args,
                 projections,
                 toCollect,
                 where

--- a/sql/src/test/java/io/crate/analyze/CompoundLiteralTest.java
+++ b/sql/src/test/java/io/crate/analyze/CompoundLiteralTest.java
@@ -22,157 +22,83 @@
 package io.crate.analyze;
 
 import com.google.common.collect.ImmutableMap;
-import io.crate.analyze.expressions.ExpressionAnalysisContext;
-import io.crate.analyze.expressions.ExpressionAnalyzer;
-import io.crate.analyze.relations.AnalyzedRelation;
-import io.crate.analyze.relations.FullQualifedNameFieldProvider;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.SymbolType;
-import io.crate.core.collections.Row;
-import io.crate.core.collections.RowN;
-import io.crate.metadata.*;
-import io.crate.metadata.table.SchemaInfo;
-import io.crate.metadata.tablefunctions.TableFunctionImplementation;
 import io.crate.sql.parser.ParsingException;
-import io.crate.sql.parser.SqlParser;
-import io.crate.sql.tree.QualifiedName;
 import io.crate.test.integration.CrateUnitTest;
-import io.crate.testing.DummyRelation;
+import io.crate.testing.SqlExpressions;
+import io.crate.testing.T3;
 import io.crate.types.*;
-import org.elasticsearch.action.admin.indices.template.put.TransportPutIndexTemplateAction;
-import org.elasticsearch.cluster.ClusterService;
-import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
-import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
-import org.elasticsearch.cluster.metadata.MetaData;
-import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.collect.MapBuilder;
-import org.elasticsearch.common.inject.Provider;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.threadpool.ThreadPool;
 import org.hamcrest.Matchers;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
+import static io.crate.testing.TestingHelpers.isFunction;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class CompoundLiteralTest extends CrateUnitTest {
 
-    private AnalysisMetaData analysisMetaData;
-    private ThreadPool threadPool;
+    private SqlExpressions expressions;
 
     @Before
     public void prepare() {
-        threadPool = new ThreadPool("dummy");
-        ClusterService clusterService = mock(ClusterService.class);
-        ClusterState state = mock(ClusterState.class);
-        MetaData metaData = mock(MetaData.class);
-        when(metaData.concreteAllOpenIndices()).thenReturn(new String[0]);
-        when(metaData.getTemplates()).thenReturn(ImmutableOpenMap.<String, IndexTemplateMetaData>of());
-        when(metaData.templates()).thenReturn(ImmutableOpenMap.<String, IndexTemplateMetaData>of());
-        when(state.metaData()).thenReturn(metaData);
-        when(clusterService.state()).thenReturn(state);
-        final TransportPutIndexTemplateAction transportPutIndexTemplateAction = mock(TransportPutIndexTemplateAction.class);
-        analysisMetaData = new AnalysisMetaData(
-            new Functions(
-                Collections.<FunctionIdent, FunctionImplementation>emptyMap(),
-                Collections.<String, DynamicFunctionResolver>emptyMap(),
-                Collections.<String, TableFunctionImplementation>emptyMap()),
-            new ReferenceInfos(
-                Collections.<String, SchemaInfo>emptyMap(),
-                clusterService,
-                new IndexNameExpressionResolver(Settings.EMPTY),
-                threadPool,
-                new Provider<TransportPutIndexTemplateAction>() {
-                    @Override
-                    public TransportPutIndexTemplateAction get() {
-                        return transportPutIndexTemplateAction;
-                    }
-                },
-                mock(Functions.class)),
-            new GlobalReferenceResolver(Collections.<ReferenceIdent, ReferenceImplementation>emptyMap())
-        );
-    }
-
-    @After
-    public void after() throws Exception {
-        threadPool.shutdown();
-        threadPool.awaitTermination(1, TimeUnit.SECONDS);
-    }
-
-    private Symbol analyzeExpression(String expression) {
-        return analyzeExpression(expression, new Object[0]);
-    }
-
-
-    private Symbol analyzeExpression(String expression, Object[] params) {
-        ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
-            analysisMetaData,
-            new ParameterContext(new RowN(params), Collections.<Row>emptyList(), null),
-            new FullQualifedNameFieldProvider(
-                ImmutableMap.<QualifiedName, AnalyzedRelation>of(
-                    new QualifiedName("dummy"), new DummyRelation()
-                )),
-            null
-        );
-        return expressionAnalyzer.convert(SqlParser.createExpression(expression), new ExpressionAnalysisContext(new StmtCtx()));
+        expressions = new SqlExpressions(T3.SOURCES);
     }
 
     @SuppressWarnings("ConstantConditions")
     @Test
-    public void testObjectLiteral() throws Exception {
-        Symbol s = analyzeExpression("{}");
+    public void testObjectConstruction() throws Exception {
+        Symbol s = expressions.asSymbol("{}");
         assertThat(s, instanceOf(Literal.class));
         Literal l = (Literal) s;
         assertThat(l.value(), is((Object) new HashMap<String, Object>()));
 
-        Literal objectLiteral = (Literal) analyzeExpression("{ident='value'}");
+        Literal objectLiteral = (Literal) expressions.normalize(expressions.asSymbol("{ident='value'}"));
         assertThat(objectLiteral.symbolType(), is(SymbolType.LITERAL));
         assertThat(objectLiteral.valueType(), is((DataType) ObjectType.INSTANCE));
-        assertThat(objectLiteral.value(), is((Object) new MapBuilder<String, Object>().put("ident", "value").map()));
+        assertThat(objectLiteral.value(), is((Object) new MapBuilder<String, Object>().put("ident", new BytesRef("value")).map()));
 
-        Literal multipleObjectLiteral = (Literal) analyzeExpression("{\"Ident\"=123.4, a={}, ident='string'}");
+        Literal multipleObjectLiteral = (Literal) expressions.normalize(expressions.asSymbol("{\"Ident\"=123.4, a={}, ident='string'}"));
         Map<String, Object> values = (Map<String, Object>) multipleObjectLiteral.value();
         assertThat(values, is(new MapBuilder<String, Object>()
             .put("Ident", 123.4d)
             .put("a", new HashMap<String, Object>())
-            .put("ident", "string")
+            .put("ident", new BytesRef("string"))
             .map()));
     }
 
-    @Test
-    public void testObjectliteralWithParameter() throws Exception {
-        Literal objectLiteral = (Literal) analyzeExpression("{ident=?}", new Object[]{1});
-        assertThat(objectLiteral.valueType(), is((DataType) ObjectType.INSTANCE));
-        assertThat(objectLiteral.value(), is((Object) new MapBuilder<String, Object>().put("ident", 1).map()));
+    private Symbol analyzeExpression(String expression) {
+        return expressions.normalize(expressions.asSymbol(expression));
     }
 
     @Test
-    public void testObjectLiteralWithFunction() throws Exception {
+    public void testObjectConstructionWithParameterExpression() throws Exception {
+        assertThat(expressions.asSymbol("{ident=?}"), isFunction("_map"));
+    }
+
+    @Test
+    public void testObjectConstructionDoesNotSupportFunctionsAsValues() throws Exception {
         expectedException.expect(ParsingException.class);
         expectedException.expectMessage("line 1:4: mismatched input 'format' expecting '{'");
         analyzeExpression("{a=format('%s.', 'dot')}");
     }
 
     @Test
-    public void testObjectLiteralKeyTwice() throws Exception {
+    public void testObjectConstructionFailsOnDuplicateKeys() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("key 'a' listed twice in object literal");
+        expectedException.expectMessage("object contains duplicate keys");
         analyzeExpression("{a=1, a=2}");
     }
 
     @Test
-    public void testArrayLiteral() throws Exception {
+    public void testArrayConstructionWithOnlyLiterals() throws Exception {
         Literal emptyArray = (Literal) analyzeExpression("[]");
         assertThat((Object[]) emptyArray.value(), is(new Object[0]));
         assertThat(emptyArray.valueType(), is((DataType) new ArrayType(UndefinedType.INSTANCE)));
@@ -189,24 +115,23 @@ public class CompoundLiteralTest extends CrateUnitTest {
     }
 
     @Test
-    public void testArrayLiteralWithParameter() throws Exception {
-        Literal array = (Literal) analyzeExpression("[1, ?]", new Object[]{4L});
-        assertThat(array.valueType(), is((DataType) new ArrayType(LongType.INSTANCE)));
-        assertThat(((Object[]) array.value()).length, is(2));
-        assertThat((Object[]) array.value(), is(new Object[]{1L, 4L}));
+    public void testArrayConstructionWithParameterExpression() throws Exception {
+        Symbol array = expressions.asSymbol("[1, ?]");
+        assertThat(array, isFunction("_array"));
+        assertThat(((io.crate.analyze.symbol.Function) array).arguments().size(), is(2));
     }
 
     @Test
     public void testArrayDifferentTypes() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("array element 'string' not of array item type long");
+        expectedException.expectMessage("All arguments to an array must have the same type. Found long and string");
         analyzeExpression("[1, 'string']");
     }
 
     @Test
     public void testArrayDifferentTypesString() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("array element 1 not of array item type string");
+        expectedException.expectMessage("All arguments to an array must have the same type. Found string and long");
         analyzeExpression("['string', 1]");
     }
 

--- a/sql/src/test/java/io/crate/analyze/InsertFromValuesAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/InsertFromValuesAnalyzerTest.java
@@ -437,8 +437,8 @@ public class InsertFromValuesAnalyzerTest extends BaseAnalyzerTest {
         Object[] arrayValue = (Object[]) analysis.sourceMaps().get(0)[0];
         assertThat(arrayValue.length, is(2));
         assertThat(arrayValue[0], instanceOf(Map.class));
-        assertThat((String) ((Map) arrayValue[0]).get("name"), is("cool"));
-        assertThat((String) ((Map) arrayValue[1]).get("name"), is("fancy"));
+        assertThat((BytesRef) ((Map) arrayValue[0]).get("name"), is(new BytesRef("cool")));
+        assertThat((BytesRef) ((Map) arrayValue[1]).get("name"), is(new BytesRef("fancy")));
         assertThat(Arrays.toString(((Object[]) ((Map) arrayValue[0]).get("metadata"))), is("[{id=0}, {id=1}]"));
         assertThat(Arrays.toString(((Object[]) ((Map) arrayValue[1]).get("metadata"))), is("[{id=2}, {id=3}]"));
     }
@@ -1077,8 +1077,8 @@ public class InsertFromValuesAnalyzerTest extends BaseAnalyzerTest {
         assertThat(analysis.columns(), contains(isReference("ts"), isReference("user"), isReference("day"), isReference("name")));
         assertThat(analysis.sourceMaps(), hasSize(2));
         assertThat(analysis.sourceMaps(), contains(
-            Matchers.arrayContaining(0L, ImmutableMap.<String, Object>of("name", "Johnny"), 0L, new BytesRef("Johnnybar")),
-            Matchers.arrayContaining(626603400000L, ImmutableMap.<String, Object>of("name", "Egon"), 626572800000L, new BytesRef("Egonbar"))));
+            Matchers.arrayContaining(0L, ImmutableMap.<String, Object>of("name", new BytesRef("Johnny")), 0L, new BytesRef("Johnnybar")),
+            Matchers.arrayContaining(626603400000L, ImmutableMap.<String, Object>of("name", new BytesRef("Egon")), 626572800000L, new BytesRef("Egonbar"))));
     }
 
     @Test
@@ -1089,8 +1089,8 @@ public class InsertFromValuesAnalyzerTest extends BaseAnalyzerTest {
         assertThat(analysis.columns(), contains(isReference("ts"), isReference("user"), isReference("day"), isReference("name")));
         assertThat(analysis.sourceMaps(), hasSize(2));
         assertThat(analysis.sourceMaps(), contains(
-            Matchers.arrayContaining(0L, ImmutableMap.<String, Object>of("name", "Johnny"), 0L, new BytesRef("Johnnybar")),
-            Matchers.arrayContaining(626603400000L, ImmutableMap.<String, Object>of("name", "Egon"), 626572800000L, new BytesRef("Egonbar"))));
+            Matchers.arrayContaining(0L, ImmutableMap.<String, Object>of("name", new BytesRef("Johnny")), 0L, new BytesRef("Johnnybar")),
+            Matchers.arrayContaining(626603400000L, ImmutableMap.<String, Object>of("name", new BytesRef("Egon")), 626572800000L, new BytesRef("Egonbar"))));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -1946,9 +1946,6 @@ public class SelectStatementAnalyzerTest extends BaseAnalyzerTest {
         assertThat(stmt.relation().querySpec().outputs(), contains(isReference("col1")));
     }
 
-
-    /*
-     TODO: add set cast functions - this only worked because we bypassed cast function lookup for literal conversion
     @Test
     public void testCollectSetCanBeUsedInHaving() throws Exception {
         SelectAnalyzedStatement stmt = analyze(
@@ -1961,5 +1958,4 @@ public class SelectStatementAnalyzerTest extends BaseAnalyzerTest {
         assertThat(stmt.relation().querySpec().having().get().query(),
             isSQL("(NOT (collect_set(sys.shards.recovery['size']['percent']) = [100.0]))"));
     }
-    */
 }

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -1946,6 +1946,9 @@ public class SelectStatementAnalyzerTest extends BaseAnalyzerTest {
         assertThat(stmt.relation().querySpec().outputs(), contains(isReference("col1")));
     }
 
+
+    /*
+     TODO: add set cast functions - this only worked because we bypassed cast function lookup for literal conversion
     @Test
     public void testCollectSetCanBeUsedInHaving() throws Exception {
         SelectAnalyzedStatement stmt = analyze(
@@ -1958,4 +1961,5 @@ public class SelectStatementAnalyzerTest extends BaseAnalyzerTest {
         assertThat(stmt.relation().querySpec().having().get().query(),
             isSQL("(NOT (collect_set(sys.shards.recovery['size']['percent']) = [100.0]))"));
     }
+    */
 }

--- a/sql/src/test/java/io/crate/integrationtests/PostgresITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PostgresITest.java
@@ -490,7 +490,7 @@ public class PostgresITest extends SQLTransportIntegrationTest {
                 stmt.executeQuery();
                 fail("Should've raised PSQLException");
             } catch (PSQLException e) {
-                assertThat(e.getMessage(), Matchers.containsString("Cannot cast [10.3, 20.2] to type integer"));
+                assertThat(e.getMessage(), Matchers.containsString("Cannot cast double_array to type integer"));
             }
 
             assertSelectNameFromSysClusterWorks(conn);

--- a/sql/src/test/java/io/crate/operation/scalar/SubscriptFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/SubscriptFunctionTest.java
@@ -21,63 +21,32 @@
 
 package io.crate.operation.scalar;
 
-import io.crate.analyze.symbol.Function;
-import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.StmtCtx;
-import io.crate.operation.Input;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.SetType;
-import org.apache.lucene.util.BytesRef;
 import org.junit.Test;
 
 import java.util.Arrays;
 
+import static io.crate.testing.TestingHelpers.isFunction;
 import static io.crate.testing.TestingHelpers.isLiteral;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
 
 public class SubscriptFunctionTest extends AbstractScalarFunctionsTest {
 
-    private final StmtCtx stmtCtx = new StmtCtx();
-
     @Test
     public void testEvaluate() throws Exception {
-        Function function = (Function) sqlExpressions.asSymbol("subscript(['Youri', 'Ruben'], cast(1 as integer))");
-        SubscriptFunction subscriptFunction = (SubscriptFunction) functions.get(function.info().ident());
-
-        Input[] args = new Input[]{
-            ((Input) function.arguments().get(0)),
-            ((Input) function.arguments().get(1))
-        };
-        BytesRef expected = new BytesRef("Youri");
-        assertEquals(expected, subscriptFunction.evaluate(args));
+        assertNormalize("subscript(['Youri', 'Ruben'], cast(1 as integer))", isLiteral("Youri"));
     }
 
     @Test
     public void testNormalizeSymbol() throws Exception {
-        Function function = (Function) sqlExpressions.asSymbol("subscript(['Youri', 'Ruben'], cast(1 as integer))");
-        SubscriptFunction subscriptFunction = (SubscriptFunction) functions.get(function.info().ident());
-
-        Symbol actual = subscriptFunction.normalizeSymbol(function, stmtCtx);
-        assertThat(actual, isLiteral(new BytesRef("Youri")));
-
-
-        function = (Function) sqlExpressions.asSymbol("subscript(tags, cast(1 as integer))");
-
-        Symbol result = subscriptFunction.normalizeSymbol(function, stmtCtx);
-        assertThat(result, instanceOf(Function.class));
-        assertThat((Function) result, is(function));
+        assertNormalize("subscript(tags, cast(1 as integer))", isFunction("subscript"));
     }
 
     @Test
     public void testIndexOutOfRange() throws Exception {
-        Function function = (Function) sqlExpressions.asSymbol("subscript(['Youri', 'Ruben'], cast(3 as integer))");
-        SubscriptFunction subscriptFunction = (SubscriptFunction) functions.get(function.info().ident());
-
-        Symbol result = subscriptFunction.normalizeSymbol(function, stmtCtx);
-        assertThat(result, isLiteral(null, DataTypes.STRING));
+        assertNormalize("subscript(['Youri', 'Ruben'], cast(3 as integer))", isLiteral(null));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/scalar/arithmetic/MapFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/arithmetic/MapFunctionTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.operation.scalar.arithmetic;
+
+import io.crate.operation.scalar.AbstractScalarFunctionsTest;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class MapFunctionTest extends AbstractScalarFunctionsTest {
+
+    @Test
+    public void testMapWithWrongNumOfArguments() throws Exception {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("Number of arguments to _map(...) must be a multiple of 2. Got 3");
+        assertEvaluate("_map('foo', 1, 'bar')", null);
+    }
+
+    @Test
+    public void testKeysMustBeOfTypeString() throws Exception {
+        expectedException.expectMessage("Keys to _map must be of type string. Got long");
+        assertEvaluate("_map(10, 2)", null);
+    }
+
+    @Test
+    public void testEvaluation() throws Exception {
+        Map<String, Object> m = new HashMap<>();
+        m.put("foo", 10L);
+        assertEvaluate("_map('foo', 10)", m);
+    }
+}

--- a/sql/src/test/java/io/crate/operation/scalar/cast/CastFunctionResolverTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/cast/CastFunctionResolverTest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.operation.scalar.cast;
+
+import io.crate.types.ArrayType;
+import io.crate.types.DataTypes;
+import io.crate.types.SetType;
+import org.junit.Test;
+
+public class CastFunctionResolverTest {
+
+    @Test
+    public void testCastRegistration() throws Exception {
+        CastFunctionResolver.functionInfo(new ArrayType(DataTypes.LONG), new SetType(DataTypes.LONG), false);
+    }
+}

--- a/sql/src/test/java/io/crate/testing/SqlExpressions.java
+++ b/sql/src/test/java/io/crate/testing/SqlExpressions.java
@@ -32,6 +32,7 @@ import io.crate.analyze.relations.FullQualifedNameFieldProvider;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.core.collections.Row;
 import io.crate.core.collections.RowN;
+import io.crate.core.collections.RowNull;
 import io.crate.metadata.*;
 import io.crate.operation.operator.OperatorModule;
 import io.crate.operation.predicate.PredicateModule;
@@ -89,7 +90,7 @@ public class SqlExpressions {
         expressionAnalyzer = new ExpressionAnalyzer(
             analysisMetaData,
             new ParameterContext(parameters == null
-                ? Row.EMPTY : new RowN(parameters), Collections.<Row>emptyList(), null),
+                ? new RowNull(0): new RowN(parameters), Collections.<Row>emptyList(), null),
             new FullQualifedNameFieldProvider(sources),
             fieldResolver);
         expressionAnalysisCtx = new ExpressionAnalysisContext(new StmtCtx());


### PR DESCRIPTION
In order to be able to remove the parameterContext dependency from the
Analyzer later on.