### PR TITLE
Use _map function for match analysis

### DIFF
--- a/sql-parser/src/main/java/io/crate/sql/tree/GenericProperties.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/GenericProperties.java
@@ -106,4 +106,8 @@ public class GenericProperties extends Node {
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
         return visitor.visitGenericProperties(this, context);
     }
+
+    public int size() {
+        return properties.size();
+    }
 }

--- a/sql/src/main/java/io/crate/analyze/MatchOptionsAnalysis.java
+++ b/sql/src/main/java/io/crate/analyze/MatchOptionsAnalysis.java
@@ -24,30 +24,27 @@ package io.crate.analyze;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableMap;
-import io.crate.analyze.expressions.ExpressionToObjectVisitor;
-import io.crate.core.collections.Row;
-import io.crate.sql.tree.Expression;
-import io.crate.sql.tree.GenericProperties;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.lucene.BytesRefs;
 
 import javax.annotation.Nullable;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
 public class MatchOptionsAnalysis {
 
-    static final Predicate<Object> POSITIVE_NUMBER = new Predicate<Object>() {
+    private static final Predicate<Object> POSITIVE_NUMBER = new Predicate<Object>() {
         @Override
         public boolean apply(@Nullable Object input) {
             return input != null && input instanceof Number && ((Number) input).doubleValue() > 0;
         }
     };
-    static final Predicate<Object> IS_STRING = Predicates.instanceOf(String.class);
-    static final Predicate<Object> IS_NUMBER = Predicates.instanceOf(Number.class);
-    static final Predicate<Object> NUMBER_OR_STRING = Predicates.or(IS_STRING, IS_NUMBER);
+    private static final Predicate<Object> IS_STRING = Predicates.instanceOf(BytesRef.class);
+    private static final Predicate<Object> IS_NUMBER = Predicates.instanceOf(Number.class);
+    private static final Predicate<Object> NUMBER_OR_STRING = Predicates.or(IS_STRING, IS_NUMBER);
 
-    static final Map<String, Predicate<Object>> ALLOWED_SETTINGS = ImmutableMap.<String, Predicate<Object>>builder()
+    private static final Map<String, Predicate<Object>> ALLOWED_SETTINGS = ImmutableMap.<String, Predicate<Object>>builder()
         .put("analyzer", IS_STRING)
         .put("boost", POSITIVE_NUMBER)
         .put("cutoff_frequency", POSITIVE_NUMBER)
@@ -55,7 +52,11 @@ public class MatchOptionsAnalysis {
         .put("fuzzy_rewrite", IS_STRING)
         .put("max_expansions", POSITIVE_NUMBER)
         .put("minimum_should_match", NUMBER_OR_STRING)
-        .put("operator", Predicates.in(Arrays.<Object>asList("or", "and", "OR", "AND")))
+        .put("operator", Predicates.in(Arrays.<Object>asList(
+            new BytesRef("or"),
+            new BytesRef("and"),
+            new BytesRef("OR"),
+            new BytesRef("AND"))))
         .put("prefix_length", POSITIVE_NUMBER)
         .put("rewrite", IS_STRING)
         .put("slop", POSITIVE_NUMBER)
@@ -63,21 +64,19 @@ public class MatchOptionsAnalysis {
         .put("zero_terms_query", IS_STRING)
         .build();
 
-    public static Map<String, Object> process(GenericProperties properties, Row parameters) {
-        Map<String, Object> processed = new HashMap<>(properties.properties().size());
-        for (Map.Entry<String, Expression> option : properties.properties().entrySet()) {
-            Predicate<Object> validator = ALLOWED_SETTINGS.get(option.getKey());
+    public static void validate(Map<String, Object> options) {
+        for (Map.Entry<String, Object> e : options.entrySet()) {
+            String optionName = e.getKey();
+            Predicate<Object> validator = ALLOWED_SETTINGS.get(optionName);
             if (validator == null) {
                 throw new IllegalArgumentException(
-                    String.format(Locale.ENGLISH, "unknown match option '%s'", option.getKey()));
+                    String.format(Locale.ENGLISH, "unknown match option '%s'", optionName));
             }
-            Object value = ExpressionToObjectVisitor.convert(option.getValue(), parameters);
+            Object value = e.getValue();
             if (!validator.apply(value)) {
                 throw new IllegalArgumentException(String.format(Locale.ENGLISH,
-                    "invalid value for option '%s': %s", option.getKey(), value));
+                    "invalid value for option '%s': %s", optionName, BytesRefs.toString(value)));
             }
-            processed.put(option.getKey(), value);
         }
-        return processed;
     }
 }

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -608,7 +608,7 @@ public class ExpressionAnalyzer {
 
         @Override
         public Symbol visitMatchPredicate(MatchPredicate node, ExpressionAnalysisContext context) {
-            Map<Field, Double> identBoostMap = new HashMap<>(node.idents().size());
+            Map<Field, Symbol> identBoostMap = new HashMap<>(node.idents().size());
             DataType columnType = null;
             for (MatchPredicateColumnIdent ident : node.idents()) {
                 Symbol column = process(ident.columnIdent(), context);
@@ -618,16 +618,21 @@ public class ExpressionAnalyzer {
                 Preconditions.checkArgument(
                     column instanceof Field,
                     SymbolFormatter.format("can only MATCH on columns, not on %s", column));
-                Number boost = ExpressionToNumberVisitor.convert(ident.boost(), parameterContext.parameters());
-                identBoostMap.put(((Field) column), boost == null ? null : boost.doubleValue());
+                Symbol boost = process(ident.boost(), context);
+                identBoostMap.put(((Field) column), boost);
             }
             assert columnType != null : "columnType must not be null";
             verifyTypesForMatch(identBoostMap.keySet(), columnType);
 
-            Object queryTerm = ExpressionToObjectVisitor.convert(node.value(), parameterContext.parameters());
-            queryTerm = columnType.value(queryTerm);
+            Symbol queryTerm = castIfNeededOrFail(process(node.value(), context), columnType);
             String matchType = io.crate.operation.predicate.MatchPredicate.getMatchType(node.matchType(), columnType);
-            Map<String, Object> options = MatchOptionsAnalysis.process(node.properties(), parameterContext.parameters());
+
+            List<Symbol> mapArgs = new ArrayList<>(node.properties().size() * 2);
+            for (Map.Entry<String, Expression> e : node.properties().properties().entrySet()) {
+                mapArgs.add(Literal.of(e.getKey()));
+                mapArgs.add(process(e.getValue(), context));
+            }
+            Function options = context.allocateFunction(MapFunction.createInfo(Symbols.extractTypes(mapArgs)), mapArgs);
             return new io.crate.analyze.symbol.MatchPredicate(identBoostMap, columnType, queryTerm, matchType, options);
         }
 

--- a/sql/src/main/java/io/crate/analyze/symbol/MatchPredicate.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/MatchPredicate.java
@@ -38,17 +38,18 @@ public class MatchPredicate extends Symbol {
         }
     };
 
-    private final Map<Field, Double> identBoostMap;
+    private final Map<Field, Symbol> identBoostMap;
     private final DataType columnType;
-    private final Object queryTerm;
+    private final Symbol queryTerm;
     private final String matchType;
-    private final Map<String, Object> options;
+    private final Symbol options;
 
-    public MatchPredicate(Map<Field, Double> identBoostMap,
+    public MatchPredicate(Map<Field, Symbol> identBoostMap,
                           DataType columnType,
-                          Object queryTerm,
+                          Symbol queryTerm,
                           String matchType,
-                          Map<String, Object> options) {
+                          Symbol options) {
+        assert options.valueType().equals(DataTypes.OBJECT) : "options symbol must be of type object";
         this.identBoostMap = identBoostMap;
         this.columnType = columnType;
         this.queryTerm = queryTerm;
@@ -56,11 +57,11 @@ public class MatchPredicate extends Symbol {
         this.options = options;
     }
 
-    public Map<Field, Double> identBoostMap() {
+    public Map<Field, Symbol> identBoostMap() {
         return identBoostMap;
     }
 
-    public Object queryTerm() {
+    public Symbol queryTerm() {
         return queryTerm;
     }
 
@@ -68,7 +69,7 @@ public class MatchPredicate extends Symbol {
         return matchType;
     }
 
-    public Map<String, Object> options() {
+    public Symbol options() {
         return options;
     }
 

--- a/sql/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
+++ b/sql/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
@@ -33,6 +33,7 @@ import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.CoordinateArrays;
 import com.vividsolutions.jts.geom.Geometry;
 import io.crate.Constants;
+import io.crate.analyze.MatchOptionsAnalysis;
 import io.crate.analyze.WhereClause;
 import io.crate.analyze.symbol.*;
 import io.crate.analyze.symbol.format.SymbolFormatter;
@@ -788,8 +789,10 @@ public class LuceneQueryBuilder {
                 Map<String, Object> fields = (Map) ((Literal) arguments.get(0)).value();
                 BytesRef queryString = (BytesRef) ((Literal) queryTerm).value();
                 BytesRef matchType = (BytesRef) ((Literal) arguments.get(2)).value();
-                Map options = (Map) ((Literal) arguments.get(3)).value();
+                //noinspection unchecked
+                Map<String, Object> options = (Map<String, Object>) ((Literal) arguments.get(3)).value();
 
+                MatchOptionsAnalysis.validate(options);
                 checkArgument(queryString != null, "cannot use NULL as query term in match predicate");
 
                 MatchQueryBuilder queryBuilder;

--- a/sql/src/main/java/io/crate/operation/scalar/arithmetic/MapFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/arithmetic/MapFunction.java
@@ -41,6 +41,8 @@ import java.util.Map;
  * args must be a multiple of 2
  *
  * k: must be a string
+ *
+ * Note that keys will be returned as String while values of type String will be BytesRef
  */
 public class MapFunction extends Scalar<Object, Object> {
 


### PR DESCRIPTION
In order to defer value evaluation so that the ParameterContext
dependency can later on be removed from the ExpressionAnalyzer.