### PR TITLE
fix: ANY operator fails with subscript argument

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,10 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fix: ``ANY`` operator fails in the ``WHERE`` clause if a subscript is
+   used as an expression.
+   E.g. 'value' = any(obj_array[1]['a']['b'])
+
  - Support ``SELECT`` queries without the ``FROM`` clause. Such queries are
    executed against the ``sys.cluster`` table.
 

--- a/sql/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
+++ b/sql/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
@@ -292,8 +292,12 @@ public class LuceneQueryBuilder {
                     "invalid argument for ANY expression");
                 if (left.symbolType().isValueSymbol()) {
                     // 1 = any (array_col) - simple eq
-                    assert collectionSymbol instanceof Reference : "no reference found in ANY expression";
-                    return applyArrayReference((Reference) collectionSymbol, (Literal) left, context);
+                    if (collectionSymbol instanceof Reference) {
+                        return applyArrayReference((Reference) collectionSymbol, (Literal) left, context);
+                    } else {
+                        // no reference found (maybe subscript) in ANY expression -> fallback to slow generic function filter
+                        return null;
+                    }
                 } else if (left instanceof Reference && collectionSymbol.symbolType().isValueSymbol()) {
                     return applyArrayLiteral((Reference) left, (Literal) collectionSymbol, context);
                 } else {

--- a/sql/src/test/java/io/crate/integrationtests/LuceneQueryBuilderIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/LuceneQueryBuilderIntegrationTest.java
@@ -93,6 +93,18 @@ public class LuceneQueryBuilderIntegrationTest extends SQLTransportIntegrationTe
     }
 
     @Test
+    public void testAnyFunctionWithSubscript() throws Exception {
+        execute("create table t (a array(object as (b array(object as (s string))))) " +
+                "clustered into 1 shards with (number_of_replicas = 0)");
+        ensureYellow();
+        execute("insert into t (a) values ([{b=[{s='hello world'}, {s='hello world2'}, {s='hello world3'}]}])");
+        refresh();
+
+        execute("select * from t where 'hello world' = any(a[1]['b']['s'])");
+        assertThat(response.rowCount(), is(1L));
+    }
+
+    @Test
     public void testWhereSubstringWithSysColumn() throws Exception {
         execute("create table t (dummy string) clustered into 2 shards with (number_of_replicas = 1)");
         ensureYellow();


### PR DESCRIPTION
use (slow) generic function filter if subscript is passed as an argument
in ANY operator.