### PR TITLE
Run shard projections on remote node on remote collect

### DIFF
--- a/sql/src/main/java/io/crate/operation/collect/RemoteCollectorFactory.java
+++ b/sql/src/main/java/io/crate/operation/collect/RemoteCollectorFactory.java
@@ -22,35 +22,21 @@
 
 package io.crate.operation.collect;
 
-import io.crate.analyze.EvaluatingNormalizer;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.core.collections.TreeMapBuilder;
 import io.crate.executor.transport.TransportActionProvider;
 import io.crate.jobs.JobContextService;
-import io.crate.metadata.Functions;
-import io.crate.metadata.NestedReferenceResolver;
 import io.crate.metadata.Routing;
-import io.crate.metadata.RowGranularity;
-import io.crate.operation.ImplementationSymbolVisitor;
 import io.crate.operation.collect.collectors.RemoteCollector;
-import io.crate.operation.projectors.FlatProjectorChain;
-import io.crate.operation.projectors.ProjectionToProjectorVisitor;
-import io.crate.operation.projectors.ProjectorFactory;
 import io.crate.operation.projectors.RowReceiver;
 import io.crate.planner.distribution.DistributionInfo;
 import io.crate.planner.node.dql.RoutedCollectPhase;
-import io.crate.planner.projection.Projection;
 import io.crate.planner.projection.Projections;
-import org.elasticsearch.action.bulk.BulkRetryCoordinatorPool;
 import org.elasticsearch.cluster.ClusterService;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.index.shard.ShardId;
-import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.*;
 
@@ -63,37 +49,16 @@ public class RemoteCollectorFactory {
 
     private static final int SENDER_PHASE_ID = 0;
     private final ClusterService clusterService;
-    private final Functions functions;
-    private final ThreadPool threadPool;
     private final JobContextService jobContextService;
-    private final Settings settings;
     private final TransportActionProvider transportActionProvider;
-    private final BulkRetryCoordinatorPool bulkRetryCoordinatorPool;
-    private final IndexNameExpressionResolver indexNameExpressionResolver;
-    private final EvaluatingNormalizer normalizer;
-    private final ImplementationSymbolVisitor implementationVisitor;
 
     @Inject
     public RemoteCollectorFactory(ClusterService clusterService,
-                                  Functions functions,
-                                  ThreadPool threadPool,
                                   JobContextService jobContextService,
-                                  Settings settings,
-                                  TransportActionProvider transportActionProvider,
-                                  BulkRetryCoordinatorPool bulkRetryCoordinatorPool,
-                                  IndexNameExpressionResolver indexNameExpressionResolver,
-                                  NestedReferenceResolver referenceResolver) {
+                                  TransportActionProvider transportActionProvider) {
         this.clusterService = clusterService;
-        this.functions = functions;
-        this.threadPool = threadPool;
         this.jobContextService = jobContextService;
-        this.settings = settings;
         this.transportActionProvider = transportActionProvider;
-        this.bulkRetryCoordinatorPool = bulkRetryCoordinatorPool;
-        this.indexNameExpressionResolver = indexNameExpressionResolver;
-
-        normalizer = new EvaluatingNormalizer(functions, RowGranularity.NODE, referenceResolver);
-        implementationVisitor = new ImplementationSymbolVisitor(functions);
     }
 
     /**
@@ -118,39 +83,9 @@ public class RemoteCollectorFactory {
         final String localNodeId = clusterService.localNode().id();
         final RoutedCollectPhase newCollectPhase = createNewCollectPhase(childJobId, collectPhase, index, shardId, remoteNodeId);
 
-        Collection<? extends Projection> shardProjections = Projections.shardProjections(collectPhase.projections());
-        final FlatProjectorChain.Builder chainBuilder;
-        if (shardProjections.isEmpty()) {
-            chainBuilder = null;
-        } else {
-            ProjectorFactory projectorFactory = new ProjectionToProjectorVisitor(
-                clusterService,
-                functions,
-                indexNameExpressionResolver,
-                threadPool,
-                settings,
-                transportActionProvider,
-                bulkRetryCoordinatorPool,
-                implementationVisitor,
-                normalizer,
-                new ShardId(index, shardId));
-
-            chainBuilder = new FlatProjectorChain.Builder(
-                collectPhase.jobId(),
-                ramAccountingContext,
-                projectorFactory,
-                shardProjections
-            );
-        }
-
         return new CrateCollector.Builder() {
             @Override
             public CrateCollector build(RowReceiver rowReceiver) {
-                if (chainBuilder != null) {
-                    FlatProjectorChain chain = chainBuilder.build(rowReceiver);
-                    chain.prepare();
-                    rowReceiver = chain.firstProjector();
-                }
                 return new RemoteCollector(
                     childJobId,
                     localNodeId,
@@ -177,9 +112,7 @@ public class RemoteCollectorFactory {
             routing,
             collectPhase.maxRowGranularity(),
             collectPhase.toCollect(),
-
-            // the projector chain is already here on this node, don't need to run projections on the other node
-            Collections.<Projection>emptyList(),
+            new ArrayList<>(Projections.shardProjections(collectPhase.projections())),
             collectPhase.whereClause(),
             DistributionInfo.DEFAULT_BROADCAST
         );


### PR DESCRIPTION
The RemoteCollectorFactory faked a shard context to create shard
projections, but this didn't work in some cases were the projection
requires a real shard context.

The WriterProjection for example couldn't resolve the `DIRECTORY`
keyword of `COPY TO`.

This changes the remote collect to execute the shard level projections
on the remote node as well. In addition to solving the aforementioned
issue this should be better performing as well.