### PR TITLE
Use different jobId for retries

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed an issue that might cause queries to fail with a `Same bucket of a
+   page set more than once` error.
+
  - Deprecated the ``CrateClient`` class
    You should start using the PostgreSQL JDBC driver instead.
 

--- a/blackbox/docs/sql/system.txt
+++ b/blackbox/docs/sql/system.txt
@@ -998,6 +998,12 @@ system column in the query::
     SELECT 1 row in set (... sec)
 
 
+.. note::
+
+    In some cases internal "sub-jobs" are created. Parts of these sub-jobs may
+    appear in `sys.operations`. These entries don't have corresponding entries
+    in `sys.jobs`.
+
 .. _sys-logs:
 
 Logs

--- a/sql/src/main/java/io/crate/protocols/postgres/SimplePortal.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/SimplePortal.java
@@ -263,10 +263,11 @@ public class SimplePortal extends AbstractPortal {
         }
 
         private void retry() {
-            LOGGER.debug("Retrying statement due to a shard failure, attempt={}, jobId={}", attempt, jobId);
+            UUID newJobId = UUID.randomUUID();
+            LOGGER.debug("Retrying statement due to a shard failure, attempt={}, jobId={}->{}", attempt, jobId, newJobId);
             Analysis analysis = analyzer.boundAnalyze(portal.statement, sessionContext,
                 new ParameterContext(new RowN(portal.params.toArray()), Collections.<Row>emptyList()));
-            Plan plan = planner.plan(analysis, jobId, 0, portal.maxRows);
+            Plan plan = planner.plan(analysis, newJobId, 0, portal.maxRows);
             executor.execute(plan, portal.rowReceiver);
         }
 


### PR DESCRIPTION
This is a workaround to fix the `Same bucket of a page set more than
once` error.

The internal kill logic doesn't (yet) wait for operations to complete.
On a shard failure this kill logic is invoked and afterwards the same
query is re-executed.

Now there is an edge case that there could have been in-flight requests
from the *first* execution that arrive after the *second* execution has
started and by doing so mess everything up.

This fix is not optimal because there will be `sys.operations` entries
with this new id - those might be confusing.

But it's better to have confusing log entries than queries which fail.