### PR TITLE
Avoid generated expression initialization if there are none

### DIFF
--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -44,7 +44,6 @@ import io.crate.operation.operator.any.AnyLikeOperator;
 import io.crate.operation.operator.any.AnyNotLikeOperator;
 import io.crate.operation.operator.any.AnyOperator;
 import io.crate.operation.predicate.NotPredicate;
-import io.crate.operation.reference.ReferenceResolver;
 import io.crate.operation.scalar.ExtractFunctions;
 import io.crate.operation.scalar.SubscriptFunction;
 import io.crate.operation.scalar.arithmetic.ArrayFunction;
@@ -94,28 +93,18 @@ public class ExpressionAnalyzer {
 
     private static final Pattern SUBSCRIPT_SPLIT_PATTERN = Pattern.compile("^([^\\.\\[]+)(\\.*)([^\\[]*)(\\['.*'\\])");
 
-    public ExpressionAnalyzer(Functions functions,
-                              ReferenceResolver<? extends io.crate.operation.Input<?>> referenceResolver,
-                              SessionContext sessionContext,
-                              com.google.common.base.Function<ParameterExpression, Symbol> convertParamFunction,
-                              FieldProvider<?> fieldProvider,
-                              @Nullable FieldResolver fieldResolver) {
-        this.functions = functions;
-        this.sessionContext = sessionContext;
-        this.convertParamFunction = convertParamFunction;
-        this.fieldProvider = fieldProvider;
-        this.innerAnalyzer = new InnerExpressionAnalyzer();
-        this.normalizer = new EvaluatingNormalizer(
-            functions, RowGranularity.CLUSTER, referenceResolver, fieldResolver, false);
-    }
-
     public ExpressionAnalyzer(AnalysisMetaData analysisMetaData,
                               SessionContext sessionContext,
                               com.google.common.base.Function<ParameterExpression, Symbol> convertParamFunction,
                               FieldProvider fieldProvider,
                               @Nullable FieldResolver fieldResolver) {
-        this(analysisMetaData.functions(), analysisMetaData.referenceResolver(),
-            sessionContext, convertParamFunction, fieldProvider, fieldResolver);
+        this.functions = analysisMetaData.functions();
+        this.sessionContext = sessionContext;
+        this.convertParamFunction = convertParamFunction;
+        this.fieldProvider = fieldProvider;
+        this.innerAnalyzer = new InnerExpressionAnalyzer();
+        this.normalizer = new EvaluatingNormalizer(
+            functions, RowGranularity.CLUSTER, analysisMetaData.referenceResolver(), fieldResolver, false);
     }
 
     /**

--- a/sql/src/main/java/io/crate/metadata/doc/DocIndexMetaData.java
+++ b/sql/src/main/java/io/crate/metadata/doc/DocIndexMetaData.java
@@ -25,6 +25,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.collect.*;
 import io.crate.Constants;
 import io.crate.action.sql.SessionContext;
+import io.crate.analyze.AnalysisMetaData;
 import io.crate.analyze.NumberOfReplicas;
 import io.crate.analyze.ParamTypeHints;
 import io.crate.analyze.TableParameterInfo;
@@ -472,10 +473,14 @@ public class DocIndexMetaData {
     }
 
     private void initializeGeneratedExpressions() {
+        if (generatedColumnReferences.isEmpty()) {
+            return;
+        }
         Collection<Reference> references = this.references.values();
         TableReferenceResolver tableReferenceResolver = new TableReferenceResolver(references);
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
-            functions, null, SessionContext.SYSTEM_SESSION, ParamTypeHints.EMPTY, tableReferenceResolver, null);
+            new AnalysisMetaData(functions, null, null),
+            SessionContext.SYSTEM_SESSION, ParamTypeHints.EMPTY, tableReferenceResolver, null);
         ExpressionAnalysisContext context = new ExpressionAnalysisContext(new StmtCtx());
         for (Reference reference : generatedColumnReferences) {
             GeneratedReference generatedReference = (GeneratedReference) reference;

--- a/sql/src/test/java/io/crate/metadata/table/TestingTableInfo.java
+++ b/sql/src/test/java/io/crate/metadata/table/TestingTableInfo.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import io.crate.action.sql.SessionContext;
+import io.crate.analyze.AnalysisMetaData;
 import io.crate.analyze.WhereClause;
 import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
@@ -277,7 +278,7 @@ public class TestingTableInfo extends DocTableInfo {
         private void initializeGeneratedExpressions(Functions functions, Collection<Reference> columns) {
             TableReferenceResolver tableReferenceResolver = new TableReferenceResolver(columns);
             ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
-                functions, null, SessionContext.SYSTEM_SESSION, null, tableReferenceResolver, null);
+                new AnalysisMetaData(functions, null, null), SessionContext.SYSTEM_SESSION, null, tableReferenceResolver, null);
             for (GeneratedReference generatedReferenceInfo : generatedColumns.build()) {
                 Expression expression = SqlParser.createExpression(generatedReferenceInfo.formattedGeneratedExpression());
                 ExpressionAnalysisContext context = new ExpressionAnalysisContext(new StmtCtx());


### PR DESCRIPTION
This avoids a couple of allocations which were unnecessary.