### PR TITLE
Rename StatementContext to TransactionContext

### DIFF
--- a/sql-parser/src/main/java/io/crate/sql/tree/QueryUtil.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/QueryUtil.java
@@ -35,20 +35,7 @@ public class QueryUtil {
         return new Select(false, items.build());
     }
 
-    public static Select selectList(SelectItem... items) {
-        return new Select(false, ImmutableList.copyOf(items));
-    }
-
     public static List<Relation> table(QualifiedName name) {
         return ImmutableList.<Relation>of(new Table(name));
     }
-
-    public static List<Relation> subquery(Query query) {
-        return ImmutableList.<Relation>of(new TableSubquery(query));
-    }
-
-    public static Expression equal(Expression left, Expression right) {
-        return new ComparisonExpression(ComparisonExpression.Type.EQUAL, left, right);
-    }
-
 }

--- a/sql/src/main/java/io/crate/analyze/AlterTableAddColumnAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/AlterTableAddColumnAnalyzer.java
@@ -82,7 +82,7 @@ public class AlterTableAddColumnAnalyzer extends DefaultTraversalVisitor<AddColu
         ensureNoIndexDefinitions(statement.analyzedTableElements().columns());
         statement.analyzedTableElements().finalizeAndValidate(
             statement.table().ident(), statement.table(), analysisMetaData,
-            analysis.parameterContext(), analysis.sessionContext(), analysis.statementContext());
+            analysis.parameterContext(), analysis.sessionContext(), analysis.transactionContext());
 
         int numCurrentPks = statement.table().primaryKey().size();
         if (statement.table().primaryKey().contains(DocSysColumns.ID)) {

--- a/sql/src/main/java/io/crate/analyze/Analysis.java
+++ b/sql/src/main/java/io/crate/analyze/Analysis.java
@@ -23,12 +23,12 @@ package io.crate.analyze;
 
 import io.crate.action.sql.SessionContext;
 import io.crate.analyze.relations.AnalyzedRelation;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 
 public class Analysis {
 
     private final ParameterContext parameterContext;
-    private final StmtCtx stmtCtx;
+    private final TransactionContext transactionContext;
 
     private final SessionContext sessionContext;
     private final ParamTypeHints paramTypeHints;
@@ -38,7 +38,7 @@ public class Analysis {
     public Analysis(SessionContext sessionContext, ParameterContext parameterContext, ParamTypeHints paramTypeHints) {
         this.sessionContext = sessionContext;
         this.paramTypeHints = paramTypeHints;
-        this.stmtCtx = new StmtCtx();
+        this.transactionContext = new TransactionContext();
         this.parameterContext = parameterContext;
     }
 
@@ -62,8 +62,8 @@ public class Analysis {
         return rootRelation;
     }
 
-    public StmtCtx statementContext() {
-        return stmtCtx;
+    public TransactionContext transactionContext() {
+        return transactionContext;
     }
 
     public SessionContext sessionContext() {

--- a/sql/src/main/java/io/crate/analyze/AnalyzedTableElements.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedTableElements.java
@@ -210,10 +210,10 @@ public class AnalyzedTableElements {
                                     AnalysisMetaData analysisMetaData,
                                     ParameterContext parameterContext,
                                     SessionContext sessionContext,
-                                    StmtCtx stmtCtx
+                                    TransactionContext transactionContext
     ) {
         expandColumnIdents();
-        validateGeneratedColumns(tableIdent, tableInfo, analysisMetaData, parameterContext, sessionContext, stmtCtx);
+        validateGeneratedColumns(tableIdent, tableInfo, analysisMetaData, parameterContext, sessionContext, transactionContext);
         for (AnalyzedColumnDefinition column : columns) {
             column.validate();
             addCopyToInfo(column);
@@ -227,7 +227,7 @@ public class AnalyzedTableElements {
                                           AnalysisMetaData analysisMetaData,
                                           ParameterContext parameterContext,
                                           SessionContext sessionContext,
-                                          StmtCtx stmtCtx) {
+                                          TransactionContext transactionContext) {
         List<Reference> tableReferences = new ArrayList<>();
         for (AnalyzedColumnDefinition columnDefinition : columns) {
             buildReference(tableIdent, columnDefinition, tableReferences);
@@ -241,7 +241,7 @@ public class AnalyzedTableElements {
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
             analysisMetaData, sessionContext, parameterContext, tableReferenceResolver, null);
         SymbolPrinter printer = new SymbolPrinter(analysisMetaData.functions());
-        ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext(stmtCtx);
+        ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext(transactionContext);
         for (AnalyzedColumnDefinition columnDefinition : columns) {
             if (columnDefinition.generatedExpression() != null) {
                 processGeneratedExpression(expressionAnalyzer, printer, columnDefinition, expressionAnalysisContext);

--- a/sql/src/main/java/io/crate/analyze/CreateTableStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateTableStatementAnalyzer.java
@@ -108,7 +108,7 @@ public class CreateTableStatementAnalyzer extends DefaultTraversalVisitor<Create
             analysisMetaData,
             context.analysis.parameterContext(),
             context.analysis.sessionContext(),
-            context.analysis.statementContext());
+            context.analysis.transactionContext());
 
         // update table settings
         context.statement.tableParameter().settingsBuilder().put(context.statement.analyzedTableElements().settings());

--- a/sql/src/main/java/io/crate/analyze/DeleteAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/DeleteAnalyzer.java
@@ -49,7 +49,7 @@ class DeleteAnalyzer {
             public Void visitDelete(Delete node, InnerAnalysisContext context) {
                 WhereClause whereClause = context.whereClauseAnalyzer.analyze(
                     context.expressionAnalyzer.generateWhereClause(node.getWhere(), context.expressionAnalysisContext),
-                    context.expressionAnalysisContext.statementContext());
+                    context.expressionAnalysisContext.transactionContext());
                 if (!whereClause.docKeys().isPresent() &&
                     Symbols.containsColumn(whereClause.query(), DocSysColumns.VERSION)) {
                     throw VERSION_SEARCH_EX;
@@ -92,7 +92,7 @@ class DeleteAnalyzer {
         StatementAnalysisContext statementAnalysisContext = new StatementAnalysisContext(
             analysis.sessionContext(),
             convertParamFunction,
-            analysis.statementContext(),
+            analysis.transactionContext(),
             analysisMetaData,
             Operation.DELETE);
         RelationAnalysisContext relationAnalysisContext = statementAnalysisContext.startRelation();
@@ -108,7 +108,7 @@ class DeleteAnalyzer {
                 convertParamFunction,
                 new FullQualifedNameFieldProvider(relationAnalysisContext.sources()),
                 docTableRelation),
-            new ExpressionAnalysisContext(analysis.statementContext()),
+            new ExpressionAnalysisContext(analysis.transactionContext()),
             deleteAnalyzedStatement,
             new WhereClauseAnalyzer(analysisMetaData, deleteAnalyzedStatement.analyzedRelation())
         );

--- a/sql/src/main/java/io/crate/analyze/HavingClause.java
+++ b/sql/src/main/java/io/crate/analyze/HavingClause.java
@@ -22,7 +22,7 @@
 package io.crate.analyze;
 
 import io.crate.analyze.symbol.Symbol;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 
 import javax.annotation.Nullable;
 
@@ -32,11 +32,11 @@ public class HavingClause extends QueryClause {
         super(query);
     }
 
-    public HavingClause normalize(EvaluatingNormalizer normalizer, StmtCtx stmtCtx) {
+    public HavingClause normalize(EvaluatingNormalizer normalizer, TransactionContext transactionContext) {
         if (noMatch || query == null) {
             return this;
         }
-        Symbol normalizedQuery = normalizer.normalize(query, stmtCtx);
+        Symbol normalizedQuery = normalizer.normalize(query, transactionContext);
         if (normalizedQuery == query) {
             return this;
         }

--- a/sql/src/main/java/io/crate/analyze/InsertFromSubQueryAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/InsertFromSubQueryAnalyzer.java
@@ -101,7 +101,7 @@ public class InsertFromSubQueryAnalyzer {
                 targetColumns,
                 analysis.sessionContext(),
                 analysis.parameterContext(),
-                analysis.statementContext(),
+                analysis.transactionContext(),
                 fieldProvider,
                 node.onDuplicateKeyAssignments());
         }
@@ -185,12 +185,12 @@ public class InsertFromSubQueryAnalyzer {
                                                             List<Reference> targetColumns,
                                                             SessionContext sessionContext,
                                                             ParameterContext parameterContext,
-                                                            StmtCtx stmtCtx,
+                                                            TransactionContext transactionContext,
                                                             FieldProvider fieldProvider,
                                                             List<Assignment> assignments) {
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
             analysisMetaData, sessionContext, parameterContext, fieldProvider, tableRelation);
-        ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext(stmtCtx);
+        ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext(transactionContext);
 
         ValueNormalizer valuesNormalizer = new ValueNormalizer(analysisMetaData.schemas(),
             new EvaluatingNormalizer(
@@ -213,7 +213,7 @@ public class InsertFromSubQueryAnalyzer {
             Symbol assignmentExpression = valuesNormalizer.normalizeInputForReference(
                 valuesAwareExpressionAnalyzer.convert(assignment.expression(), expressionAnalysisContext),
                 columnName,
-                stmtCtx);
+                transactionContext);
 
             updateAssignments.put(columnName, assignmentExpression);
         }

--- a/sql/src/main/java/io/crate/analyze/OrderBy.java
+++ b/sql/src/main/java/io/crate/analyze/OrderBy.java
@@ -28,7 +28,7 @@ import com.google.common.primitives.Booleans;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.Symbols;
 import io.crate.exceptions.AmbiguousOrderByException;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
@@ -68,8 +68,8 @@ public class OrderBy implements Streamable {
         return nullsFirst;
     }
 
-    public void normalize(EvaluatingNormalizer normalizer, StmtCtx stmtCtx) {
-        normalizer.normalizeInplace(orderBySymbols, stmtCtx);
+    public void normalize(EvaluatingNormalizer normalizer, TransactionContext transactionContext) {
+        normalizer.normalizeInplace(orderBySymbols, transactionContext);
     }
 
 

--- a/sql/src/main/java/io/crate/analyze/QueriedTableRelation.java
+++ b/sql/src/main/java/io/crate/analyze/QueriedTableRelation.java
@@ -27,7 +27,7 @@ import io.crate.analyze.symbol.Field;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.ColumnIndex;
 import io.crate.metadata.Path;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.QualifiedName;
 
@@ -70,9 +70,9 @@ public abstract class QueriedTableRelation<TR extends AbstractTableRelation> imp
         return tableRelation;
     }
 
-    public void normalize(AnalysisMetaData analysisMetaData, StmtCtx stmtCtx) {
+    public void normalize(AnalysisMetaData analysisMetaData, TransactionContext transactionContext) {
         EvaluatingNormalizer normalizer = new EvaluatingNormalizer(analysisMetaData, tableRelation, true);
-        querySpec().normalize(normalizer, stmtCtx);
+        querySpec().normalize(normalizer, transactionContext);
     }
 
     @Nullable

--- a/sql/src/main/java/io/crate/analyze/QuerySpec.java
+++ b/sql/src/main/java/io/crate/analyze/QuerySpec.java
@@ -29,7 +29,7 @@ import io.crate.analyze.symbol.DefaultTraversalSymbolVisitor;
 import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.RelationColumn;
 import io.crate.analyze.symbol.Symbol;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.operation.scalar.cast.CastFunctionResolver;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -130,7 +130,7 @@ public class QuerySpec {
         return this;
     }
 
-    public void normalize(EvaluatingNormalizer normalizer, StmtCtx context) {
+    public void normalize(EvaluatingNormalizer normalizer, TransactionContext context) {
         if (groupBy.isPresent()) {
             normalizer.normalizeInplace(groupBy.get(), context);
         }

--- a/sql/src/main/java/io/crate/analyze/UpdateAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/UpdateAnalyzer.java
@@ -82,7 +82,7 @@ public class UpdateAnalyzer {
         StatementAnalysisContext statementAnalysisContext = new StatementAnalysisContext(
             analysis.sessionContext(),
             analysis.parameterContext(),
-            analysis.statementContext(),
+            analysis.transactionContext(),
             analysisMetaData,
             Operation.UPDATE);
         RelationAnalysisContext currentRelationContext = statementAnalysisContext.startRelation();
@@ -107,7 +107,7 @@ public class UpdateAnalyzer {
                 analysis.parameterContext(),
                 new FullQualifedNameFieldProvider(currentRelationContext.sources()),
                 fieldResolver);
-        ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext(analysis.statementContext());
+        ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext(analysis.transactionContext());
 
         int numNested = 1;
         if (analysis.parameterContext().numBulkParams() > 0) {
@@ -126,7 +126,7 @@ public class UpdateAnalyzer {
 
             WhereClause whereClause = expressionAnalyzer.generateWhereClause(node.whereClause(), expressionAnalysisContext);
             if (whereClauseAnalyzer != null) {
-                whereClause = whereClauseAnalyzer.analyze(whereClause, analysis.statementContext());
+                whereClause = whereClauseAnalyzer.analyze(whereClause, analysis.transactionContext());
             }
 
             if (!whereClause.docKeys().isPresent() &&
@@ -163,7 +163,7 @@ public class UpdateAnalyzer {
         // unknown columns in strict objects handled in here
         Reference reference = (Reference) columnExpressionAnalyzer.normalize(
             columnExpressionAnalyzer.convert(node.columnName(), expressionAnalysisContext),
-            expressionAnalysisContext.statementContext());
+            expressionAnalysisContext.transactionContext());
 
         final ColumnIdent ident = reference.ident().columnIdent();
         if (hasMatchingParent(tableInfo, reference, IS_OBJECT_ARRAY)) {
@@ -172,9 +172,9 @@ public class UpdateAnalyzer {
         }
         Symbol value = expressionAnalyzer.normalize(
             expressionAnalyzer.convert(node.expression(), expressionAnalysisContext),
-            expressionAnalysisContext.statementContext());
+            expressionAnalysisContext.transactionContext());
         try {
-            value = valueNormalizer.normalizeInputForReference(value, reference, expressionAnalysisContext.statementContext());
+            value = valueNormalizer.normalizeInputForReference(value, reference, expressionAnalysisContext.transactionContext());
         } catch (IllegalArgumentException | UnsupportedOperationException e) {
             throw new ColumnValidationException(ident.sqlFqn(), e);
         }

--- a/sql/src/main/java/io/crate/analyze/WhereClause.java
+++ b/sql/src/main/java/io/crate/analyze/WhereClause.java
@@ -29,7 +29,7 @@ import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.Symbols;
 import io.crate.analyze.symbol.ValueSymbolVisitor;
 import io.crate.analyze.where.DocKeys;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.operation.operator.AndOperator;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -72,11 +72,11 @@ public class WhereClause extends QueryClause implements Streamable {
         super(query);
     }
 
-    public WhereClause normalize(EvaluatingNormalizer normalizer, StmtCtx stmtCtx) {
+    public WhereClause normalize(EvaluatingNormalizer normalizer, TransactionContext transactionContext) {
         if (noMatch || query == null) {
             return this;
         }
-        Symbol normalizedQuery = normalizer.normalize(query, stmtCtx);
+        Symbol normalizedQuery = normalizer.normalize(query, transactionContext);
         if (normalizedQuery == query) {
             return this;
         }

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalysisContext.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalysisContext.java
@@ -24,18 +24,18 @@ package io.crate.analyze.expressions;
 import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 
 import java.util.List;
 
 public class ExpressionAnalysisContext {
 
-    private final StmtCtx stmtCtx;
+    private final TransactionContext transactionContext;
 
     public boolean hasAggregates = false;
 
-    public ExpressionAnalysisContext(StmtCtx stmtCtx) {
-        this.stmtCtx = stmtCtx;
+    public ExpressionAnalysisContext(TransactionContext transactionContext) {
+        this.transactionContext = transactionContext;
     }
 
     public Function allocateFunction(FunctionInfo functionInfo, List<Symbol> arguments) {
@@ -44,7 +44,7 @@ public class ExpressionAnalysisContext {
         return newFunction;
     }
 
-    public StmtCtx statementContext() {
-        return stmtCtx;
+    public TransactionContext transactionContext() {
+        return transactionContext;
     }
 }

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -110,7 +110,7 @@ public class ExpressionAnalyzer {
     /**
      * Use to normalize a symbol. (For example to normalize a function that contains only literals to a literal)
      */
-    public Symbol normalize(Symbol symbol, StmtCtx context) {
+    public Symbol normalize(Symbol symbol, TransactionContext context) {
         return normalizer.normalize(symbol, context);
     }
 
@@ -132,7 +132,7 @@ public class ExpressionAnalyzer {
 
     public WhereClause generateWhereClause(Optional<Expression> whereExpression, ExpressionAnalysisContext context) {
         if (whereExpression.isPresent()) {
-            return new WhereClause(normalize(convert(whereExpression.get(), context), context.statementContext()), null, null);
+            return new WhereClause(normalize(convert(whereExpression.get(), context), context.transactionContext()), null, null);
         } else {
             return WhereClause.MATCH_ALL;
         }
@@ -422,8 +422,8 @@ public class ExpressionAnalyzer {
                 throw new UnsupportedFeatureException("ALL is not supported");
             }
 
-            Symbol arraySymbol = normalize(process(node.getRight(), context), context.statementContext());
-            Symbol leftSymbol = normalize(process(node.getLeft(), context), context.statementContext());
+            Symbol arraySymbol = normalize(process(node.getRight(), context), context.transactionContext());
+            Symbol leftSymbol = normalize(process(node.getLeft(), context), context.transactionContext());
             DataType rightType = arraySymbol.valueType();
 
             if (!DataTypes.isCollectionType(rightType)) {
@@ -454,8 +454,8 @@ public class ExpressionAnalyzer {
             if (node.getEscape() != null) {
                 throw new UnsupportedOperationException("ESCAPE is not supported.");
             }
-            Symbol rightSymbol = normalize(process(node.getValue(), context), context.statementContext());
-            Symbol leftSymbol = normalize(process(node.getPattern(), context), context.statementContext());
+            Symbol rightSymbol = normalize(process(node.getValue(), context), context.transactionContext());
+            Symbol leftSymbol = normalize(process(node.getPattern(), context), context.transactionContext());
             DataType rightType = rightSymbol.valueType();
 
             if (!DataTypes.isCollectionType(rightType)) {

--- a/sql/src/main/java/io/crate/analyze/expressions/ValueNormalizer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ValueNormalizer.java
@@ -35,7 +35,7 @@ import io.crate.exceptions.ConversionException;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
 import io.crate.metadata.Schemas;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.ColumnPolicy;
 import io.crate.metadata.table.TableInfo;
@@ -65,8 +65,8 @@ public class ValueNormalizer {
      * @return the normalized Symbol, should be a literal
      * @throws io.crate.exceptions.ColumnValidationException
      */
-    public Symbol normalizeInputForReference(Symbol valueSymbol, Reference reference, StmtCtx stmtCtx) {
-        valueSymbol = normalizer.normalize(valueSymbol, stmtCtx);
+    public Symbol normalizeInputForReference(Symbol valueSymbol, Reference reference, TransactionContext transactionContext) {
+        valueSymbol = normalizer.normalize(valueSymbol, transactionContext);
         assert valueSymbol != null : "valueSymbol must not be null";
 
         DataType<?> targetType = getTargetType(valueSymbol, reference);

--- a/sql/src/main/java/io/crate/analyze/relations/QueriedDocTable.java
+++ b/sql/src/main/java/io/crate/analyze/relations/QueriedDocTable.java
@@ -26,7 +26,7 @@ import io.crate.analyze.QueriedTableRelation;
 import io.crate.analyze.QuerySpec;
 import io.crate.analyze.where.WhereClauseAnalyzer;
 import io.crate.metadata.Path;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 
 import java.util.Collection;
 
@@ -45,8 +45,8 @@ public class QueriedDocTable extends QueriedTableRelation<DocTableRelation> {
         return visitor.visitQueriedDocTable(this, context);
     }
 
-    public void analyzeWhereClause(AnalysisMetaData analysisMetaData, StmtCtx stmtCtx) {
+    public void analyzeWhereClause(AnalysisMetaData analysisMetaData, TransactionContext transactionContext) {
         WhereClauseAnalyzer whereClauseAnalyzer = new WhereClauseAnalyzer(analysisMetaData, tableRelation());
-        querySpec().where(whereClauseAnalyzer.analyze(querySpec().where(), stmtCtx));
+        querySpec().where(whereClauseAnalyzer.analyze(querySpec().where(), transactionContext));
     }
 }

--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalysisContext.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalysisContext.java
@@ -29,7 +29,7 @@ import io.crate.analyze.AnalysisMetaData;
 import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.symbol.Symbol;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.planner.node.dql.join.JoinType;
 import io.crate.sql.tree.ParameterExpression;
 import io.crate.sql.tree.QualifiedName;
@@ -55,14 +55,14 @@ public class RelationAnalysisContext {
 
     RelationAnalysisContext(SessionContext sessionContext,
                             Function<ParameterExpression, Symbol> convertParamFunction,
-                            StmtCtx stmtCtx,
+                            TransactionContext transactionContext,
                             AnalysisMetaData analysisMetaData,
                             boolean aliasedRelation) {
         this.sessionContext = sessionContext;
         this.convertParamFunction = convertParamFunction;
         this.analysisMetaData = analysisMetaData;
         this.aliasedRelation = aliasedRelation;
-        expressionAnalysisContext = new ExpressionAnalysisContext(stmtCtx);
+        expressionAnalysisContext = new ExpressionAnalysisContext(transactionContext);
     }
 
     boolean isAliasedRelation() {

--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -82,7 +82,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
     public AnalyzedRelation analyze(Node node, StatementAnalysisContext relationAnalysisContext) {
         AnalyzedRelation relation = process(node, relationAnalysisContext);
         return RelationNormalizer.normalize(relation, analysisMetaData,
-            relationAnalysisContext.stmtCtx());
+            relationAnalysisContext.transactionContext());
     }
 
     public AnalyzedRelation analyzeUnbound(Query query, SessionContext sessionContext, ParamTypeHints paramTypeHints) {
@@ -100,7 +100,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
             new StatementAnalysisContext(
                 analysis.sessionContext(),
                 analysis.parameterContext(),
-                analysis.statementContext(),
+                analysis.transactionContext(),
                 analysisMetaData,
                 Operation.READ
             )
@@ -200,7 +200,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
                 relation = new QueriedSelectRelation((QueriedRelation) source, selectAnalysis.outputNames(), querySpec);
             }
             if (tableRelation != null) {
-                tableRelation.normalize(analysisMetaData, context.expressionAnalysisContext().statementContext());
+                tableRelation.normalize(analysisMetaData, context.expressionAnalysisContext().transactionContext());
                 relation = tableRelation;
             }
         } else {
@@ -311,7 +311,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
             Symbol symbol = context.expressionAnalyzer().convert(having.get(), context.expressionAnalysisContext());
             HavingSymbolValidator.validate(symbol, groupBy);
             return new HavingClause(context.expressionAnalyzer().normalize(
-                symbol, context.expressionAnalysisContext().statementContext()));
+                symbol, context.expressionAnalysisContext().transactionContext()));
         }
         return null;
     }

--- a/sql/src/main/java/io/crate/analyze/relations/RelationNormalizer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationNormalizer.java
@@ -57,8 +57,8 @@ final class RelationNormalizer extends AnalyzedRelationVisitor<RelationNormalize
 
     public static AnalyzedRelation normalize(AnalyzedRelation relation,
                                              AnalysisMetaData analysisMetaData,
-                                             StmtCtx stmtCtx) {
-        return INSTANCE.process(relation, new Context(analysisMetaData, relation.fields(), stmtCtx));
+                                             TransactionContext transactionContext) {
+        return INSTANCE.process(relation, new Context(analysisMetaData, relation.fields(), transactionContext));
     }
 
     @Override
@@ -84,7 +84,7 @@ final class RelationNormalizer extends AnalyzedRelationVisitor<RelationNormalize
 
         QuerySpec querySpec = mergeAndReplaceFields(table, context.querySpec);
         QueriedTable relation = new QueriedTable(table.tableRelation(), context.paths(), querySpec);
-        relation.normalize(context.analysisMetaData, context.stmtCtx);
+        relation.normalize(context.analysisMetaData, context.transactionContext);
         return relation;
     }
 
@@ -94,9 +94,9 @@ final class RelationNormalizer extends AnalyzedRelationVisitor<RelationNormalize
         if (context.querySpec != null) {
             QuerySpec querySpec = mergeAndReplaceFields(table, context.querySpec);
             relation = new QueriedDocTable(table.tableRelation(), context.paths(), querySpec);
-            relation.normalize(context.analysisMetaData, context.stmtCtx);
+            relation.normalize(context.analysisMetaData, context.transactionContext);
         }
-        relation.analyzeWhereClause(context.analysisMetaData, context.stmtCtx);
+        relation.analyzeWhereClause(context.analysisMetaData, context.transactionContext);
         return relation;
     }
 
@@ -224,14 +224,14 @@ final class RelationNormalizer extends AnalyzedRelationVisitor<RelationNormalize
     static class Context {
         private final AnalysisMetaData analysisMetaData;
         private final List<Field> fields;
-        private final StmtCtx stmtCtx;
+        private final TransactionContext transactionContext;
 
         private QuerySpec querySpec;
 
-        public Context(AnalysisMetaData analysisMetaData, List<Field> fields, StmtCtx stmtCtx) {
+        public Context(AnalysisMetaData analysisMetaData, List<Field> fields, TransactionContext transactionContext) {
             this.analysisMetaData = analysisMetaData;
             this.fields = fields;
-            this.stmtCtx = stmtCtx;
+            this.transactionContext = transactionContext;
         }
 
         public Collection<? extends Path> paths() {

--- a/sql/src/main/java/io/crate/analyze/relations/StatementAnalysisContext.java
+++ b/sql/src/main/java/io/crate/analyze/relations/StatementAnalysisContext.java
@@ -25,7 +25,7 @@ import com.google.common.base.Function;
 import io.crate.action.sql.SessionContext;
 import io.crate.analyze.AnalysisMetaData;
 import io.crate.analyze.symbol.Symbol;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.ParameterExpression;
 
@@ -37,24 +37,24 @@ public class StatementAnalysisContext {
     private final Operation currentOperation;
     private final SessionContext sessionContext;
     private final Function<ParameterExpression, Symbol> convertParamFunction;
-    private final StmtCtx stmtCtx;
+    private final TransactionContext transactionContext;
     private final AnalysisMetaData analysisMetaData;
     private final List<RelationAnalysisContext> lastRelationContextQueue = new ArrayList<>();
 
     public StatementAnalysisContext(SessionContext sessionContext,
                                     Function<ParameterExpression, Symbol> convertParamFunction,
-                                    StmtCtx stmtCtx,
+                                    TransactionContext transactionContext,
                                     AnalysisMetaData analysisMetaData,
                                     Operation currentOperation) {
         this.sessionContext = sessionContext;
         this.convertParamFunction = convertParamFunction;
-        this.stmtCtx = stmtCtx;
+        this.transactionContext = transactionContext;
         this.analysisMetaData = analysisMetaData;
         this.currentOperation = currentOperation;
     }
 
-    public StmtCtx stmtCtx() {
-        return stmtCtx;
+    public TransactionContext transactionContext() {
+        return transactionContext;
     }
 
     Operation currentOperation() {
@@ -67,7 +67,7 @@ public class StatementAnalysisContext {
 
     RelationAnalysisContext startRelation(boolean aliasedRelation) {
         RelationAnalysisContext currentRelationContext = new RelationAnalysisContext(
-            sessionContext, convertParamFunction, stmtCtx, analysisMetaData, aliasedRelation);
+            sessionContext, convertParamFunction, transactionContext, analysisMetaData, aliasedRelation);
         lastRelationContextQueue.add(currentRelationContext);
         return currentRelationContext;
     }

--- a/sql/src/main/java/io/crate/analyze/where/EqualityExtractor.java
+++ b/sql/src/main/java/io/crate/analyze/where/EqualityExtractor.java
@@ -52,18 +52,18 @@ public class EqualityExtractor {
         this.normalizer = normalizer;
     }
 
-    public List<List<Symbol>> extractParentMatches(List<ColumnIdent> columns, Symbol symbol, @Nullable StmtCtx stmtCtx) {
-        return extractMatches(columns, symbol, false, stmtCtx);
+    public List<List<Symbol>> extractParentMatches(List<ColumnIdent> columns, Symbol symbol, @Nullable TransactionContext transactionContext) {
+        return extractMatches(columns, symbol, false, transactionContext);
     }
 
-    public List<List<Symbol>> extractExactMatches(List<ColumnIdent> columns, Symbol symbol, @Nullable StmtCtx stmtCtx) {
-        return extractMatches(columns, symbol, true, stmtCtx);
+    public List<List<Symbol>> extractExactMatches(List<ColumnIdent> columns, Symbol symbol, @Nullable TransactionContext transactionContext) {
+        return extractMatches(columns, symbol, true, transactionContext);
     }
 
     private List<List<Symbol>> extractMatches(Collection<ColumnIdent> columns,
                                               Symbol symbol,
                                               boolean exact,
-                                              @Nullable StmtCtx stmtCtx) {
+                                              @Nullable TransactionContext transactionContext) {
         EqualityExtractor.ProxyInjectingVisitor.Context context =
             new EqualityExtractor.ProxyInjectingVisitor.Context(columns, exact);
         Symbol proxiedTree = ProxyInjectingVisitor.INSTANCE.process(symbol, context);
@@ -86,7 +86,7 @@ public class EqualityExtractor {
                     anyNull = true;
                 }
             }
-            Symbol normalized = normalizer.normalize(proxiedTree, stmtCtx);
+            Symbol normalized = normalizer.normalize(proxiedTree, transactionContext);
             if (normalized == Literal.BOOLEAN_TRUE) {
                 if (anyNull) {
                     return null;

--- a/sql/src/main/java/io/crate/analyze/where/WhereClauseAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/where/WhereClauseAnalyzer.java
@@ -55,7 +55,7 @@ public class WhereClauseAnalyzer {
         this.eqExtractor = new EqualityExtractor(normalizer);
     }
 
-    public WhereClause analyze(WhereClause whereClause, StmtCtx stmtCtx) {
+    public WhereClause analyze(WhereClause whereClause, TransactionContext transactionContext) {
         if (!whereClause.hasQuery()) {
             return whereClause;
         }
@@ -64,7 +64,7 @@ public class WhereClauseAnalyzer {
             WhereClauseValidator.validate(whereClause);
             Symbol query = GENERATED_COLUMN_COMPARISON_REPLACER.replaceIfPossible(whereClause.query(), tableInfo);
             if (!whereClause.query().equals(query)) {
-                whereClause = new WhereClause(normalizer.normalize(query, stmtCtx));
+                whereClause = new WhereClause(normalizer.normalize(query, transactionContext));
             }
         }
 
@@ -77,7 +77,7 @@ public class WhereClauseAnalyzer {
         } else {
             pkCols = tableInfo.primaryKey();
         }
-        List<List<Symbol>> pkValues = eqExtractor.extractExactMatches(pkCols, whereClause.query(), stmtCtx);
+        List<List<Symbol>> pkValues = eqExtractor.extractExactMatches(pkCols, whereClause.query(), transactionContext);
 
         if (!pkCols.isEmpty() && pkValues != null) {
             int clusterdIdx = -1;
@@ -103,23 +103,23 @@ public class WhereClauseAnalyzer {
                 whereClause.clusteredBy(clusteredBy);
             }
         } else {
-            clusteredBy = getClusteredByLiterals(whereClause, eqExtractor, stmtCtx);
+            clusteredBy = getClusteredByLiterals(whereClause, eqExtractor, transactionContext);
         }
         if (clusteredBy != null) {
             whereClause.clusteredBy(clusteredBy);
         }
         if (tableInfo.isPartitioned() && !whereClause.docKeys().isPresent()) {
-            whereClause = resolvePartitions(whereClause, tableInfo, analysisMetaData, stmtCtx);
+            whereClause = resolvePartitions(whereClause, tableInfo, analysisMetaData, transactionContext);
         }
         return whereClause;
     }
 
     @Nullable
-    private Set<Symbol> getClusteredByLiterals(WhereClause whereClause, EqualityExtractor ee, StmtCtx stmtCtx) {
+    private Set<Symbol> getClusteredByLiterals(WhereClause whereClause, EqualityExtractor ee, TransactionContext transactionContext) {
         if (tableInfo.clusteredBy() != null) {
             List<List<Symbol>> clusteredValues = ee.extractParentMatches(
                 ImmutableList.of(tableInfo.clusteredBy()),
-                whereClause.query(), stmtCtx);
+                whereClause.query(), transactionContext);
             if (clusteredValues != null) {
                 Set<Symbol> clusteredBy = new HashSet<>(clusteredValues.size());
                 for (List<Symbol> row : clusteredValues) {
@@ -146,7 +146,7 @@ public class WhereClauseAnalyzer {
     public static WhereClause resolvePartitions(WhereClause whereClause,
                                                 DocTableInfo tableInfo,
                                                 AnalysisMetaData analysisMetaData,
-                                                StmtCtx stmtCtx) {
+                                                TransactionContext transactionContext) {
         assert tableInfo.isPartitioned() : "table must be partitioned in order to resolve partitions";
         assert whereClause.partitions().isEmpty() : "partitions must not be analyzed twice";
         if (tableInfo.partitions().isEmpty()) {
@@ -166,7 +166,7 @@ public class WhereClauseAnalyzer {
             for (PartitionExpression partitionExpression : partitionReferenceResolver.expressions()) {
                 partitionExpression.setNextRow(partitionName);
             }
-            normalized = normalizer.normalize(whereClause.query(), stmtCtx);
+            normalized = normalizer.normalize(whereClause.query(), transactionContext);
             assert normalized != null : "normalizing a query must not return null";
 
             if (normalized.equals(whereClause.query())) {
@@ -193,7 +193,7 @@ public class WhereClauseAnalyzer {
             whereClause.partitions(entry.getValue());
             return whereClause;
         } else if (queryPartitionMap.size() > 0) {
-            return tieBreakPartitionQueries(normalizer, queryPartitionMap, whereClause, stmtCtx);
+            return tieBreakPartitionQueries(normalizer, queryPartitionMap, whereClause, transactionContext);
         } else {
             return WhereClause.NO_MATCH;
         }
@@ -202,7 +202,7 @@ public class WhereClauseAnalyzer {
     private static WhereClause tieBreakPartitionQueries(EvaluatingNormalizer normalizer,
                                                         Map<Symbol, List<Literal>> queryPartitionMap,
                                                         WhereClause whereClause,
-                                                        StmtCtx stmtCtx) throws UnsupportedOperationException {
+                                                        TransactionContext transactionContext) throws UnsupportedOperationException {
         /*
          * Got multiple normalized queries which all could match.
          * This might be the case if one partition resolved to null
@@ -232,7 +232,7 @@ public class WhereClauseAnalyzer {
             List<Literal> partitions = entry.getValue();
 
             Symbol symbol = referenceToTrueVisitor.process(query, null);
-            Symbol normalized = normalizer.normalize(symbol, stmtCtx);
+            Symbol normalized = normalizer.normalize(symbol, transactionContext);
 
             assert normalized instanceof Literal && normalized.valueType().equals(DataTypes.BOOLEAN) :
                 "after normalization and replacing all reference occurrences with true there must only be a boolean left";

--- a/sql/src/main/java/io/crate/metadata/FunctionImplementation.java
+++ b/sql/src/main/java/io/crate/metadata/FunctionImplementation.java
@@ -33,9 +33,9 @@ public interface FunctionImplementation<SymbolType extends Symbol> {
      * Normalize a symbol into a simplified form.
      * This may return the symbol as is if it cannot be normalized.
      *
-     * @param stmtCtx context which is shared across normalizeSymbol calls during a statement-lifecycle.
+     * @param transactionContext context which is shared across normalizeSymbol calls during a statement-lifecycle.
      *                This will only be present if normalizeSymbol is called on the handler node.
      *                normalizeSymbol calls during execution won't receive a StmtCtx
      */
-    Symbol normalizeSymbol(SymbolType symbol, @Nullable StmtCtx stmtCtx);
+    Symbol normalizeSymbol(SymbolType symbol, @Nullable TransactionContext transactionContext);
 }

--- a/sql/src/main/java/io/crate/metadata/Scalar.java
+++ b/sql/src/main/java/io/crate/metadata/Scalar.java
@@ -56,7 +56,7 @@ public abstract class Scalar<ReturnType, InputType> implements FunctionImplement
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol, StmtCtx stmtCtx) {
+    public Symbol normalizeSymbol(Function symbol, TransactionContext transactionContext) {
         return evaluateIfLiterals(this, symbol);
     }
 

--- a/sql/src/main/java/io/crate/metadata/TransactionContext.java
+++ b/sql/src/main/java/io/crate/metadata/TransactionContext.java
@@ -25,9 +25,12 @@ package io.crate.metadata;
 import org.joda.time.DateTimeUtils;
 
 /**
- * StatementContext that can be used to keep state which is valid on the handler during a "statement lifecycle".
+ * TransactionContext is a context that is used to keep state which is valid during a transaction.
+ *
+ * In Crate a transaction is always bound to the lifecycle of a single query/statement execution as there is no
+ * transaction support.
  */
-public class StmtCtx {
+public class TransactionContext {
 
     private Long currentTimeMillis = null;
 

--- a/sql/src/main/java/io/crate/metadata/doc/DocIndexMetaData.java
+++ b/sql/src/main/java/io/crate/metadata/doc/DocIndexMetaData.java
@@ -481,7 +481,7 @@ public class DocIndexMetaData {
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
             new AnalysisMetaData(functions, null, null),
             SessionContext.SYSTEM_SESSION, ParamTypeHints.EMPTY, tableReferenceResolver, null);
-        ExpressionAnalysisContext context = new ExpressionAnalysisContext(new StmtCtx());
+        ExpressionAnalysisContext context = new ExpressionAnalysisContext(new TransactionContext());
         for (Reference reference : generatedColumnReferences) {
             GeneratedReference generatedReference = (GeneratedReference) reference;
             Expression expression = SqlParser.createExpression(generatedReference.formattedGeneratedExpression());

--- a/sql/src/main/java/io/crate/operation/aggregation/AggregationFunction.java
+++ b/sql/src/main/java/io/crate/operation/aggregation/AggregationFunction.java
@@ -25,7 +25,7 @@ import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.metadata.FunctionImplementation;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.operation.Input;
 import io.crate.types.DataType;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
@@ -80,7 +80,7 @@ public abstract class AggregationFunction<TPartial, TFinal> implements FunctionI
     public abstract DataType partialType();
 
     @Override
-    public Symbol normalizeSymbol(Function symbol, StmtCtx stmtCtx) {
+    public Symbol normalizeSymbol(Function symbol, TransactionContext transactionContext) {
         return symbol;
     }
 }

--- a/sql/src/main/java/io/crate/operation/aggregation/impl/CountAggregation.java
+++ b/sql/src/main/java/io/crate/operation/aggregation/impl/CountAggregation.java
@@ -97,7 +97,7 @@ public class CountAggregation extends AggregationFunction<CountAggregation.LongS
     }
 
     @Override
-    public Symbol normalizeSymbol(Function function, StmtCtx stmtCtx) {
+    public Symbol normalizeSymbol(Function function, TransactionContext transactionContext) {
         assert (function.arguments().size() <= 1);
 
         if (function.arguments().size() == 1) {

--- a/sql/src/main/java/io/crate/operation/operator/AndOperator.java
+++ b/sql/src/main/java/io/crate/operation/operator/AndOperator.java
@@ -25,7 +25,7 @@ import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.operation.Input;
 import io.crate.types.DataTypes;
 
@@ -47,7 +47,7 @@ public class AndOperator extends Operator<Boolean> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function function, StmtCtx stmtCtx) {
+    public Symbol normalizeSymbol(Function function, TransactionContext transactionContext) {
         assert (function != null);
         assert function.arguments().size() == 2;
 

--- a/sql/src/main/java/io/crate/operation/operator/InOperator.java
+++ b/sql/src/main/java/io/crate/operation/operator/InOperator.java
@@ -26,7 +26,7 @@ import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.operation.Input;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -58,7 +58,7 @@ public class InOperator extends Operator<Object> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function function, StmtCtx stmtCtx) {
+    public Symbol normalizeSymbol(Function function, TransactionContext transactionContext) {
         // ... where id in (1,2,3,4,...)
         // arguments.get(0) ... id
         // arguments.get(1) ... SetLiteral<Literal> (1,2,3,4,...)

--- a/sql/src/main/java/io/crate/operation/operator/OrOperator.java
+++ b/sql/src/main/java/io/crate/operation/operator/OrOperator.java
@@ -4,7 +4,7 @@ import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.operation.Input;
 import io.crate.types.DataTypes;
 
@@ -23,7 +23,7 @@ public class OrOperator extends Operator<Boolean> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function function, StmtCtx stmtCtx) {
+    public Symbol normalizeSymbol(Function function, TransactionContext transactionContext) {
         assert (function != null);
         assert function.arguments().size() == 2;
 

--- a/sql/src/main/java/io/crate/operation/operator/RegexpMatchCaseInsensitiveOperator.java
+++ b/sql/src/main/java/io/crate/operation/operator/RegexpMatchCaseInsensitiveOperator.java
@@ -25,7 +25,7 @@ import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.operation.Input;
 import io.crate.types.DataTypes;
 import org.apache.lucene.util.BytesRef;
@@ -65,7 +65,7 @@ public class RegexpMatchCaseInsensitiveOperator extends Operator<BytesRef> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol, StmtCtx stmtCtx) {
+    public Symbol normalizeSymbol(Function symbol, TransactionContext transactionContext) {
         assert (symbol != null);
         assert symbol.arguments().size() == 2;
 

--- a/sql/src/main/java/io/crate/operation/predicate/IsNullPredicate.java
+++ b/sql/src/main/java/io/crate/operation/predicate/IsNullPredicate.java
@@ -58,7 +58,7 @@ public class IsNullPredicate<T> extends Scalar<Boolean, T> implements FunctionFo
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol, StmtCtx stmtCtx) {
+    public Symbol normalizeSymbol(Function symbol, TransactionContext transactionContext) {
         assert (symbol != null);
         assert (symbol.arguments().size() == 1);
 

--- a/sql/src/main/java/io/crate/operation/predicate/MatchPredicate.java
+++ b/sql/src/main/java/io/crate/operation/predicate/MatchPredicate.java
@@ -29,7 +29,7 @@ import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.elasticsearch.ElasticsearchParseException;
@@ -121,7 +121,7 @@ public class MatchPredicate implements FunctionImplementation<Function> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function function, StmtCtx stmtCtx) {
+    public Symbol normalizeSymbol(Function function, TransactionContext transactionContext) {
         return function;
     }
 }

--- a/sql/src/main/java/io/crate/operation/predicate/NotPredicate.java
+++ b/sql/src/main/java/io/crate/operation/predicate/NotPredicate.java
@@ -28,7 +28,7 @@ import io.crate.analyze.symbol.format.OperatorFormatSpec;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.operation.Input;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -52,7 +52,7 @@ public class NotPredicate extends Scalar<Boolean, Boolean> implements OperatorFo
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol, StmtCtx stmtCtx) {
+    public Symbol normalizeSymbol(Function symbol, TransactionContext transactionContext) {
         assert (symbol != null);
         assert (symbol.arguments().size() == 1);
 

--- a/sql/src/main/java/io/crate/operation/projectors/ProjectionToProjectorVisitor.java
+++ b/sql/src/main/java/io/crate/operation/projectors/ProjectionToProjectorVisitor.java
@@ -204,14 +204,14 @@ public class ProjectionToProjectorVisitor
                 inputs.add(symbolVisitor.process(symbol, symbolContext));
             }
         }
-        Map<ColumnIdent, Object> overwrites = symbolMapToObject(projection.overwrites(), symbolContext, context.stmtCtx);
+        Map<ColumnIdent, Object> overwrites = symbolMapToObject(projection.overwrites(), symbolContext, context.transactionContext);
 
-        projection = projection.normalize(normalizer, context.stmtCtx);
+        projection = projection.normalize(normalizer, context.transactionContext);
         String uri = ValueSymbolVisitor.STRING.process(projection.uri());
         assert uri != null : "URI must not be null";
 
         StringBuilder sb = new StringBuilder(uri);
-        Symbol resolvedFileName = normalizer.normalize(WriterProjection.DIRECTORY_TO_FILENAME, context.stmtCtx);
+        Symbol resolvedFileName = normalizer.normalize(WriterProjection.DIRECTORY_TO_FILENAME, context.transactionContext);
         assert resolvedFileName instanceof Literal : "resolvedFileName must be a Literal, but is: " + resolvedFileName;
         assert resolvedFileName.valueType() == StringType.INSTANCE;
         String fileName = ValueSymbolVisitor.STRING.process(resolvedFileName);
@@ -238,14 +238,14 @@ public class ProjectionToProjectorVisitor
 
     private Map<ColumnIdent, Object> symbolMapToObject(Map<ColumnIdent, Symbol> symbolMap,
                                                        ImplementationSymbolVisitor.Context symbolContext,
-                                                       StmtCtx stmtCtx) {
+                                                       TransactionContext transactionContext) {
         Map<ColumnIdent, Object> objectMap = new HashMap<>(symbolMap.size());
         for (Map.Entry<ColumnIdent, Symbol> entry : symbolMap.entrySet()) {
             Symbol symbol = entry.getValue();
             assert symbol != null;
             objectMap.put(
                 entry.getKey(),
-                symbolVisitor.process(normalizer.normalize(symbol, stmtCtx), symbolContext).value()
+                symbolVisitor.process(normalizer.normalize(symbol, transactionContext), symbolContext).value()
             );
         }
         return objectMap;
@@ -434,7 +434,7 @@ public class ProjectionToProjectorVisitor
 
         private final RamAccountingContext ramAccountingContext;
         private final UUID jobId;
-        private final StmtCtx stmtCtx = new StmtCtx();
+        private final TransactionContext transactionContext = new TransactionContext();
 
         public Context(RamAccountingContext ramAccountingContext, UUID jobId) {
             this.ramAccountingContext = ramAccountingContext;

--- a/sql/src/main/java/io/crate/operation/scalar/CollectionAverageFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/CollectionAverageFunction.java
@@ -27,7 +27,7 @@ import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.operation.Input;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -80,7 +80,7 @@ public class CollectionAverageFunction extends Scalar<Double, Set<Number>> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function function, StmtCtx stmtCtx) {
+    public Symbol normalizeSymbol(Function function, TransactionContext transactionContext) {
         return function;
     }
 }

--- a/sql/src/main/java/io/crate/operation/scalar/CollectionCountFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/CollectionCountFunction.java
@@ -65,7 +65,7 @@ public class CollectionCountFunction extends Scalar<Long, Collection<DataType>> 
     }
 
     @Override
-    public Symbol normalizeSymbol(Function function, StmtCtx stmtCtx) {
+    public Symbol normalizeSymbol(Function function, TransactionContext transactionContext) {
         return function;
     }
 

--- a/sql/src/main/java/io/crate/operation/scalar/ConcatFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/ConcatFunction.java
@@ -55,7 +55,7 @@ public abstract class ConcatFunction extends Scalar<BytesRef, BytesRef> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function function, StmtCtx stmtCtx) {
+    public Symbol normalizeSymbol(Function function, TransactionContext transactionContext) {
         if (anyNonLiterals(function.arguments())) {
             return function;
         }

--- a/sql/src/main/java/io/crate/operation/scalar/DateTruncFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/DateTruncFunction.java
@@ -28,7 +28,7 @@ import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.operation.Input;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -115,7 +115,7 @@ public class DateTruncFunction extends Scalar<Long, Object> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol, StmtCtx stmtCtx) {
+    public Symbol normalizeSymbol(Function symbol, TransactionContext transactionContext) {
         assert symbol.arguments().size() > 1 && symbol.arguments().size() < 4 : "Invalid number of arguments";
 
         if (containsNullLiteral(symbol.arguments())) {

--- a/sql/src/main/java/io/crate/operation/scalar/ExtractFunctions.java
+++ b/sql/src/main/java/io/crate/operation/scalar/ExtractFunctions.java
@@ -137,7 +137,7 @@ public class ExtractFunctions {
         }
 
         @Override
-        public Symbol normalizeSymbol(Function symbol, StmtCtx stmtCtx) {
+        public Symbol normalizeSymbol(Function symbol, TransactionContext transactionContext) {
             Symbol arg1 = symbol.arguments().get(0);
             if (arg1.symbolType().isValueSymbol()) {
                 String field = ValueSymbolVisitor.STRING.process(arg1);
@@ -145,9 +145,9 @@ public class ExtractFunctions {
                 Scalar<Number, Long> scalar = getScalar(Extract.Field.valueOf(field.toUpperCase(Locale.ENGLISH)));
                 //noinspection ArraysAsListWithZeroOrOneArgument # need mutable list as arg to function
                 Function function = new Function(scalar.info(), Arrays.asList(symbol.arguments().get(1)));
-                return scalar.normalizeSymbol(function, stmtCtx);
+                return scalar.normalizeSymbol(function, transactionContext);
             }
-            return super.normalizeSymbol(symbol, stmtCtx);
+            return super.normalizeSymbol(symbol, transactionContext);
         }
 
         @Override

--- a/sql/src/main/java/io/crate/operation/scalar/arithmetic/RandomFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/arithmetic/RandomFunction.java
@@ -27,7 +27,7 @@ import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.operation.Input;
 import io.crate.operation.scalar.ScalarFunctionModule;
 import io.crate.types.DataType;
@@ -51,7 +51,7 @@ public class RandomFunction extends Scalar<Double, Void> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol, StmtCtx stmtCtx) {
+    public Symbol normalizeSymbol(Function symbol, TransactionContext transactionContext) {
         /* There is no evaluation here, so the function is executed
            per row. Else every row would contain the same random value*/
         assert symbol.arguments().size() == 0;

--- a/sql/src/main/java/io/crate/operation/scalar/cast/CastFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/cast/CastFunction.java
@@ -70,7 +70,7 @@ public class CastFunction extends Scalar<Object, Object> implements FunctionForm
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol, StmtCtx stmtCtx) {
+    public Symbol normalizeSymbol(Function symbol, TransactionContext transactionContext) {
         assert symbol.arguments().size() == 1 : "Number of arguments must be 1";
         Symbol argument = symbol.arguments().get(0);
         if (argument.symbolType().isValueSymbol()) {

--- a/sql/src/main/java/io/crate/operation/scalar/geo/DistanceFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/geo/DistanceFunction.java
@@ -106,7 +106,7 @@ public class DistanceFunction extends Scalar<Double, Object> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol, StmtCtx stmtCtx) {
+    public Symbol normalizeSymbol(Function symbol, TransactionContext transactionContext) {
         Symbol arg1 = symbol.arguments().get(0);
         Symbol arg2 = symbol.arguments().get(1);
         DataType arg1Type = arg1.valueType();

--- a/sql/src/main/java/io/crate/operation/scalar/geo/IntersectsFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/geo/IntersectsFunction.java
@@ -32,7 +32,7 @@ import io.crate.geo.GeoJSONUtils;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.operation.Input;
 import io.crate.operation.scalar.ScalarFunctionModule;
 import io.crate.types.DataType;
@@ -96,7 +96,7 @@ public class IntersectsFunction extends Scalar<Boolean, Object> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol, StmtCtx stmtCtx) {
+    public Symbol normalizeSymbol(Function symbol, TransactionContext transactionContext) {
         Symbol left = symbol.arguments().get(0);
         Symbol right = symbol.arguments().get(1);
         int numLiterals = 0;

--- a/sql/src/main/java/io/crate/operation/scalar/geo/WithinFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/geo/WithinFunction.java
@@ -33,7 +33,7 @@ import io.crate.geo.GeoJSONUtils;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.operation.Input;
 import io.crate.operation.scalar.ScalarFunctionModule;
 import io.crate.types.DataType;
@@ -135,7 +135,7 @@ public class WithinFunction extends Scalar<Boolean, Object> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol, StmtCtx stmtCtx) {
+    public Symbol normalizeSymbol(Function symbol, TransactionContext transactionContext) {
         Symbol left = symbol.arguments().get(0);
         Symbol right = symbol.arguments().get(1);
 

--- a/sql/src/main/java/io/crate/operation/scalar/regex/MatchesFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/regex/MatchesFunction.java
@@ -72,7 +72,7 @@ public class MatchesFunction extends Scalar<BytesRef[], Object> implements Dynam
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol, StmtCtx stmtCtx) {
+    public Symbol normalizeSymbol(Function symbol, TransactionContext transactionContext) {
         final int size = symbol.arguments().size();
         assert (size >= 2 && size <= 3);
 

--- a/sql/src/main/java/io/crate/operation/scalar/regex/ReplaceFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/regex/ReplaceFunction.java
@@ -63,7 +63,7 @@ public class ReplaceFunction extends Scalar<BytesRef, Object> implements Dynamic
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol, StmtCtx stmtCtx) {
+    public Symbol normalizeSymbol(Function symbol, TransactionContext transactionContext) {
         final int size = symbol.arguments().size();
         assert (size >= 3 && size <= 4);
 

--- a/sql/src/main/java/io/crate/operation/scalar/timestamp/CurrentTimestampFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/timestamp/CurrentTimestampFunction.java
@@ -30,7 +30,7 @@ import io.crate.analyze.symbol.format.FunctionFormatSpec;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.operation.Input;
 import io.crate.operation.scalar.ScalarFunctionModule;
 import io.crate.types.DataType;
@@ -93,12 +93,12 @@ public class CurrentTimestampFunction extends Scalar<Long, Integer> implements F
     }
 
     @Override
-    public Symbol normalizeSymbol(Function function, StmtCtx stmtCtx) {
-        if (stmtCtx == null) {
+    public Symbol normalizeSymbol(Function function, TransactionContext transactionContext) {
+        if (transactionContext == null) {
             return eval(function, DateTimeUtils.currentTimeMillis());
         }
         // use evaluatedFunctions map to make sure multiple occurrences of current_timestamp within a query result in the same result
-        return eval(function, stmtCtx.currentTimeMillis());
+        return eval(function, transactionContext.currentTimeMillis());
     }
 
     private Symbol eval(Function function, long currentTimeMillis) {

--- a/sql/src/main/java/io/crate/planner/Planner.java
+++ b/sql/src/main/java/io/crate/planner/Planner.java
@@ -84,7 +84,7 @@ public class Planner extends AnalyzedStatementVisitor<Planner.Context, Plan> {
         private final UUID jobId;
         private final ConsumingPlanner consumingPlanner;
         private final EvaluatingNormalizer normalizer;
-        private final StmtCtx stmtCtx;
+        private final TransactionContext transactionContext;
         private final int softLimit;
         private final int fetchSize;
         private int executionPhaseId = 0;
@@ -96,14 +96,14 @@ public class Planner extends AnalyzedStatementVisitor<Planner.Context, Plan> {
                        UUID jobId,
                        ConsumingPlanner consumingPlanner,
                        EvaluatingNormalizer normalizer,
-                       StmtCtx stmtCtx,
+                       TransactionContext transactionContext,
                        int softLimit,
                        int fetchSize) {
             this.clusterService = clusterService;
             this.jobId = jobId;
             this.consumingPlanner = consumingPlanner;
             this.normalizer = normalizer;
-            this.stmtCtx = stmtCtx;
+            this.transactionContext = transactionContext;
             this.softLimit = softLimit;
             this.fetchSize = fetchSize;
         }
@@ -124,7 +124,7 @@ public class Planner extends AnalyzedStatementVisitor<Planner.Context, Plan> {
             if (symbol == null) {
                 return null;
             }
-            io.crate.operation.Input input = (io.crate.operation.Input) (normalizer.normalize(symbol, stmtCtx));
+            io.crate.operation.Input input = (io.crate.operation.Input) (normalizer.normalize(symbol, transactionContext));
             return DataTypes.INTEGER.value(input.value());
         }
 
@@ -156,8 +156,8 @@ public class Planner extends AnalyzedStatementVisitor<Planner.Context, Plan> {
             return fetchSize;
         }
 
-        public StmtCtx statementContext() {
-            return stmtCtx;
+        public TransactionContext transactionContext() {
+            return transactionContext;
         }
 
         static class ReaderAllocations {
@@ -388,7 +388,7 @@ public class Planner extends AnalyzedStatementVisitor<Planner.Context, Plan> {
     public Plan plan(Analysis analysis, UUID jobId, int softLimit, int fetchSize) {
         AnalyzedStatement analyzedStatement = analysis.analyzedStatement();
         return process(analyzedStatement, new Context(
-            clusterService, jobId, consumingPlanner, normalizer, analysis.statementContext(), softLimit, fetchSize));
+            clusterService, jobId, consumingPlanner, normalizer, analysis.transactionContext(), softLimit, fetchSize));
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
@@ -155,10 +155,10 @@ public class NestedLoopConsumer implements Consumer {
 
             // this normalization is required to replace fields of the table relations
             if (left instanceof QueriedTableRelation) {
-                ((QueriedTableRelation) left).normalize(analysisMetaData, context.plannerContext().statementContext());
+                ((QueriedTableRelation) left).normalize(analysisMetaData, context.plannerContext().transactionContext());
             }
             if (right instanceof QueriedTableRelation) {
-                ((QueriedTableRelation) right).normalize(analysisMetaData, context.plannerContext().statementContext());
+                ((QueriedTableRelation) right).normalize(analysisMetaData, context.plannerContext().transactionContext());
             }
 
             PlannedAnalyzedRelation leftPlan = context.plannerContext().planSubRelation(left, context);

--- a/sql/src/main/java/io/crate/planner/node/dql/CollectPhase.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/CollectPhase.java
@@ -24,7 +24,7 @@ package io.crate.planner.node.dql;
 
 import io.crate.analyze.EvaluatingNormalizer;
 import io.crate.analyze.symbol.Symbol;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.planner.distribution.UpstreamPhase;
 import io.crate.planner.projection.Projection;
 
@@ -40,5 +40,5 @@ public interface CollectPhase extends UpstreamPhase {
 
     void addProjection(Projection projection);
 
-    CollectPhase normalize(EvaluatingNormalizer phase, StmtCtx stmtCtx);
+    CollectPhase normalize(EvaluatingNormalizer phase, TransactionContext transactionContext);
 }

--- a/sql/src/main/java/io/crate/planner/node/dql/FileUriCollectPhase.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/FileUriCollectPhase.java
@@ -25,7 +25,7 @@ import com.google.common.base.MoreObjects;
 import io.crate.analyze.EvaluatingNormalizer;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.Symbols;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.operation.collect.files.FileReadingCollector;
 import io.crate.planner.distribution.DistributionInfo;
 import io.crate.planner.node.ExecutionPhaseVisitor;
@@ -105,9 +105,9 @@ public class FileUriCollectPhase extends AbstractProjectionsPhase implements Col
         return Type.FILE_URI_COLLECT;
     }
 
-    public FileUriCollectPhase normalize(EvaluatingNormalizer normalizer, StmtCtx stmtCtx) {
-        List<Symbol> normalizedToCollect = normalizer.normalize(toCollect(), stmtCtx);
-        Symbol normalizedTargetUri = normalizer.normalize(targetUri, stmtCtx);
+    public FileUriCollectPhase normalize(EvaluatingNormalizer normalizer, TransactionContext transactionContext) {
+        List<Symbol> normalizedToCollect = normalizer.normalize(toCollect(), transactionContext);
+        Symbol normalizedTargetUri = normalizer.normalize(targetUri, transactionContext);
         boolean changed = normalizedToCollect != toCollect() || (normalizedTargetUri != targetUri);
         if (!changed) {
             return this;

--- a/sql/src/main/java/io/crate/planner/node/dql/RoutedCollectPhase.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/RoutedCollectPhase.java
@@ -31,7 +31,7 @@ import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.Symbols;
 import io.crate.metadata.Routing;
 import io.crate.metadata.RowGranularity;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.table.TableInfo;
 import io.crate.operation.Paging;
 import io.crate.planner.Planner;
@@ -274,12 +274,12 @@ public class RoutedCollectPhase extends AbstractProjectionsPhase implements Coll
      *
      * @return a normalized node, if no changes occurred returns this
      */
-    public RoutedCollectPhase normalize(EvaluatingNormalizer normalizer, StmtCtx stmtCtx) {
+    public RoutedCollectPhase normalize(EvaluatingNormalizer normalizer, TransactionContext transactionContext) {
         assert whereClause() != null;
         RoutedCollectPhase result = this;
-        List<Symbol> newToCollect = normalizer.normalize(toCollect(), stmtCtx);
+        List<Symbol> newToCollect = normalizer.normalize(toCollect(), transactionContext);
         boolean changed = newToCollect != toCollect();
-        WhereClause newWhereClause = whereClause().normalize(normalizer, stmtCtx);
+        WhereClause newWhereClause = whereClause().normalize(normalizer, transactionContext);
         if (newWhereClause != whereClause()) {
             changed = changed || newWhereClause != whereClause();
         }
@@ -309,7 +309,7 @@ public class RoutedCollectPhase extends AbstractProjectionsPhase implements Coll
             TableFunctionRelation tableFunctionRelation = (TableFunctionRelation) table.tableRelation();
             List<Symbol> args = new ArrayList<>();
             args.addAll(tableFunctionRelation.arguments());
-            plannerContext.normalizer().normalizeInplace(args, plannerContext.statementContext());
+            plannerContext.normalizer().normalizeInplace(args, plannerContext.transactionContext());
             return new TableFunctionCollectPhase(
                 plannerContext.jobId(),
                 plannerContext.nextExecutionPhaseId(),

--- a/sql/src/main/java/io/crate/planner/projection/WriterProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/WriterProjection.java
@@ -231,8 +231,8 @@ public class WriterProjection extends Projection {
                '}';
     }
 
-    public WriterProjection normalize(EvaluatingNormalizer normalizer, StmtCtx stmtCtx) {
-        Symbol nUri = normalizer.normalize(uri, stmtCtx);
+    public WriterProjection normalize(EvaluatingNormalizer normalizer, TransactionContext transactionContext) {
+        Symbol nUri = normalizer.normalize(uri, transactionContext);
         if (uri != nUri) {
             WriterProjection p = new WriterProjection();
             p.uri = nUri;

--- a/sql/src/test/java/io/crate/analyze/EvaluatingNormalizerTest.java
+++ b/sql/src/test/java/io/crate/analyze/EvaluatingNormalizerTest.java
@@ -29,7 +29,7 @@ public class EvaluatingNormalizerTest extends CrateUnitTest {
     private Functions functions;
     private Reference dummyLoadInfo;
 
-    private final StmtCtx stmtCtx = new StmtCtx();
+    private final TransactionContext transactionContext = new TransactionContext();
 
     @Before
     public void prepare() throws Exception {
@@ -100,7 +100,7 @@ public class EvaluatingNormalizerTest extends CrateUnitTest {
 
         // the dummy reference load == 0.08 evaluates to true,
         // so the whole query can be normalized to a single boolean literal
-        Symbol query = visitor.normalize(op_or, stmtCtx);
+        Symbol query = visitor.normalize(op_or, transactionContext);
         assertThat(query, isLiteral(true));
     }
 
@@ -110,7 +110,7 @@ public class EvaluatingNormalizerTest extends CrateUnitTest {
             functions, RowGranularity.CLUSTER, referenceResolver);
 
         Function op_or = prepareFunctionTree();
-        Symbol query = visitor.normalize(op_or, stmtCtx);
+        Symbol query = visitor.normalize(op_or, transactionContext);
         assertThat(query, instanceOf(Function.class));
     }
 

--- a/sql/src/test/java/io/crate/analyze/ValueNormalizerTest.java
+++ b/sql/src/test/java/io/crate/analyze/ValueNormalizerTest.java
@@ -87,7 +87,7 @@ public class ValueNormalizerTest extends CrateUnitTest {
 
     private ValueNormalizer valueNormalizer;
     private ThreadPool threadPool;
-    private final StmtCtx stmtCtx = new StmtCtx();
+    private final TransactionContext transactionContext = new TransactionContext();
 
 
     @Before
@@ -137,12 +137,12 @@ public class ValueNormalizerTest extends CrateUnitTest {
         );
         Literal<Boolean> trueLiteral = Literal.of(true);
 
-        assertThat(valueNormalizer.normalizeInputForReference(trueLiteral, ref, stmtCtx),
+        assertThat(valueNormalizer.normalizeInputForReference(trueLiteral, ref, transactionContext),
             Matchers.<Symbol>is(trueLiteral));
 
-        assertThat(valueNormalizer.normalizeInputForReference(Literal.of("true"), ref, stmtCtx),
+        assertThat(valueNormalizer.normalizeInputForReference(Literal.of("true"), ref, transactionContext),
             Matchers.<Symbol>is(trueLiteral));
-        assertThat(valueNormalizer.normalizeInputForReference(Literal.of("false"), ref, stmtCtx),
+        assertThat(valueNormalizer.normalizeInputForReference(Literal.of("false"), ref, transactionContext),
             Matchers.<Symbol>is(Literal.of(false)));
     }
 
@@ -153,7 +153,7 @@ public class ValueNormalizerTest extends CrateUnitTest {
             RowGranularity.DOC,
             DataTypes.DOUBLE);
         Function f = new Function(TEST_FUNCTION_INFO, Arrays.<Symbol>asList(Literal.of(-9.9)));
-        assertThat(valueNormalizer.normalizeInputForReference(f, info, stmtCtx), Matchers.<Symbol>is(Literal.of(9.9)));
+        assertThat(valueNormalizer.normalizeInputForReference(f, info, transactionContext), Matchers.<Symbol>is(Literal.of(9.9)));
     }
 
     @Test
@@ -164,7 +164,7 @@ public class ValueNormalizerTest extends CrateUnitTest {
         map.put("time", "2014-02-16T00:00:01");
         map.put("false", true);
         Literal<Map<String, Object>> normalized = (Literal) valueNormalizer.normalizeInputForReference(
-            Literal.of(map), objRef, stmtCtx);
+            Literal.of(map), objRef, transactionContext);
         assertThat((String) normalized.value().get("time"), is("2014-02-16T00:00:01"));
         assertThat((Boolean) normalized.value().get("false"), is(true));
     }
@@ -174,7 +174,7 @@ public class ValueNormalizerTest extends CrateUnitTest {
         Reference objRef = userTableInfo.getReference(new ColumnIdent("dyn"));
         Map<String, Object> map = new HashMap<>();
         map.put("d", "2014-02-16T00:00:01");
-        valueNormalizer.normalizeInputForReference(Literal.of(map), objRef, stmtCtx);
+        valueNormalizer.normalizeInputForReference(Literal.of(map), objRef, transactionContext);
     }
 
     @Test
@@ -184,7 +184,7 @@ public class ValueNormalizerTest extends CrateUnitTest {
         map.put("d", "2.9");
 
         Symbol normalized = valueNormalizer.normalizeInputForReference(
-            Literal.of(map), objInfo, stmtCtx);
+            Literal.of(map), objInfo, transactionContext);
         assertThat(normalized, instanceOf(Literal.class));
         assertThat(((Literal<Map<String, Object>>) normalized).value().get("d"), Matchers.<Object>is(2.9d));
     }
@@ -198,10 +198,10 @@ public class ValueNormalizerTest extends CrateUnitTest {
                 put("double", "-88.7");
             }});
         }};
-        valueNormalizer.normalizeInputForReference(Literal.of(map), objInfo, stmtCtx);
+        valueNormalizer.normalizeInputForReference(Literal.of(map), objInfo, transactionContext);
 
         Symbol normalized = valueNormalizer.normalizeInputForReference(
-            Literal.of(map), objInfo, stmtCtx);
+            Literal.of(map), objInfo, transactionContext);
         assertThat(normalized, instanceOf(Literal.class));
         assertThat(((Literal<Map<String, Object>>) normalized).value().get("d"), Matchers.<Object>is(2.9d));
         assertThat(((Literal<Map<String, Object>>) normalized).value().get("inner_strict"),
@@ -218,7 +218,7 @@ public class ValueNormalizerTest extends CrateUnitTest {
         map.put("d", 2.9d);
         map.put("half", "1.45");
         Symbol normalized = valueNormalizer.normalizeInputForReference(
-            Literal.of(map), objInfo, stmtCtx);
+            Literal.of(map), objInfo, transactionContext);
         assertThat(normalized, instanceOf(Literal.class));
         assertThat(((Literal) normalized).value(), Matchers.<Object>is(map)); // stays the same
     }
@@ -231,7 +231,7 @@ public class ValueNormalizerTest extends CrateUnitTest {
         map.put("inner_d", 2.9d);
         map.put("half", "1.45");
         valueNormalizer.normalizeInputForReference(
-            Literal.of(map), objInfo, stmtCtx);
+            Literal.of(map), objInfo, transactionContext);
     }
 
     @Test(expected = ColumnUnknownException.class)
@@ -243,7 +243,7 @@ public class ValueNormalizerTest extends CrateUnitTest {
             put("much_inner", "yaw");
         }});
         valueNormalizer.normalizeInputForReference(
-            Literal.of(map), objInfo, stmtCtx);
+            Literal.of(map), objInfo, transactionContext);
     }
 
     @Test(expected = ColumnUnknownException.class)
@@ -257,7 +257,7 @@ public class ValueNormalizerTest extends CrateUnitTest {
         }});
         map.put("half", "1.45");
         valueNormalizer.normalizeInputForReference(
-            Literal.of(map), objInfo, stmtCtx);
+            Literal.of(map), objInfo, transactionContext);
     }
 
     @Test
@@ -268,7 +268,7 @@ public class ValueNormalizerTest extends CrateUnitTest {
         }};
         Literal<Map<String, Object>> literal = (Literal) valueNormalizer.normalizeInputForReference(
             Literal.of(map),
-            objInfo, stmtCtx);
+            objInfo, transactionContext);
         assertThat((String) literal.value().get("time"), is("1970-01-01T00:00:00"));
     }
 
@@ -280,7 +280,7 @@ public class ValueNormalizerTest extends CrateUnitTest {
         }};
         Literal<Map<String, Object>> literal = (Literal) valueNormalizer.normalizeInputForReference(
             Literal.of(map),
-            objInfo, stmtCtx);
+            objInfo, transactionContext);
         assertThat((String) literal.value().get("time"), is("1970-01-01T00:00:00"));
     }
 
@@ -292,7 +292,7 @@ public class ValueNormalizerTest extends CrateUnitTest {
         }};
         Literal<Map<String, Object>> literal = (Literal) valueNormalizer.normalizeInputForReference(
             Literal.of(map),
-            objInfo, stmtCtx);
+            objInfo, transactionContext);
         assertThat((String) literal.value().get("no_time"), is("1970"));
     }
 
@@ -301,7 +301,7 @@ public class ValueNormalizerTest extends CrateUnitTest {
         Reference objInfo = userTableInfo.getReference(new ColumnIdent("d"));
         Literal<BytesRef> stringDoubleLiteral = Literal.of("298.444");
         Literal literal = (Literal) valueNormalizer.normalizeInputForReference(
-            stringDoubleLiteral, objInfo, stmtCtx);
+            stringDoubleLiteral, objInfo, transactionContext);
         assertThat(literal, isLiteral(298.444d, DataTypes.DOUBLE));
     }
 }

--- a/sql/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -75,7 +75,7 @@ public class ExpressionAnalyzerTest extends CrateUnitTest {
         paramTypeHints = ParamTypeHints.EMPTY;
         DummyRelation dummyRelation = new DummyRelation("obj.x", "myObj.x", "myObj.x.AbC");
         dummySources = ImmutableMap.of(new QualifiedName("foo"), (AnalyzedRelation) dummyRelation);
-        context = new ExpressionAnalysisContext(new StmtCtx());
+        context = new ExpressionAnalysisContext(new TransactionContext());
 
         analysisMetaData = new AnalysisMetaData(
             getFunctions(),
@@ -94,7 +94,7 @@ public class ExpressionAnalyzerTest extends CrateUnitTest {
         expectedException.expectMessage("Unsupported expression IF(1, 3)");
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
             mockedAnalysisMetaData, SessionContext.SYSTEM_SESSION, paramTypeHints, new FullQualifedNameFieldProvider(dummySources), null);
-        ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext(new StmtCtx());
+        ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext(new TransactionContext());
 
         expressionAnalyzer.convert(SqlParser.createExpression("IF ( 1 , 3 )"), expressionAnalysisContext);
     }
@@ -105,7 +105,7 @@ public class ExpressionAnalyzerTest extends CrateUnitTest {
         expectedException.expectMessage("Unsupported expression current_time");
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
             mockedAnalysisMetaData, SessionContext.SYSTEM_SESSION, paramTypeHints, new FullQualifedNameFieldProvider(dummySources), null);
-        ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext(new StmtCtx());
+        ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext(new TransactionContext());
 
         expressionAnalyzer.convert(SqlParser.createExpression("current_time"), expressionAnalysisContext);
     }
@@ -118,7 +118,7 @@ public class ExpressionAnalyzerTest extends CrateUnitTest {
             paramTypeHints,
             new FullQualifedNameFieldProvider(dummySources),
             null);
-        ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext(new StmtCtx());
+        ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext(new TransactionContext());
 
         Field field1 = (Field) expressionAnalyzer.convert(SqlParser.createExpression("obj['x']"), expressionAnalysisContext);
         Field field2 = (Field) expressionAnalyzer.convert(SqlParser.createExpression("\"obj['x']\""), expressionAnalysisContext);
@@ -180,7 +180,7 @@ public class ExpressionAnalyzerTest extends CrateUnitTest {
 
     @Test
     public void testNonDeterministicFunctionsAlwaysNew() throws Exception {
-        ExpressionAnalysisContext localContext = new ExpressionAnalysisContext(new StmtCtx());
+        ExpressionAnalysisContext localContext = new ExpressionAnalysisContext(new TransactionContext());
         FunctionInfo info1 = new FunctionInfo(
             new FunctionIdent("inc", Arrays.<DataType>asList(DataTypes.BOOLEAN)),
             DataTypes.INTEGER,

--- a/sql/src/test/java/io/crate/analyze/where/EqualityExtractorTest.java
+++ b/sql/src/test/java/io/crate/analyze/where/EqualityExtractorTest.java
@@ -51,7 +51,7 @@ import static org.hamcrest.core.Is.is;
 @SuppressWarnings("unchecked")
 public class EqualityExtractorTest extends BaseAnalyzerTest {
 
-    StmtCtx stmtCtx = new StmtCtx();
+    TransactionContext transactionContext = new TransactionContext();
 
     @Override
     protected List<Module> getModules() {
@@ -66,7 +66,7 @@ public class EqualityExtractorTest extends BaseAnalyzerTest {
 
 
     private List<List<Symbol>> analyzeParentX(Symbol query) {
-        return getExtractor().extractParentMatches(ImmutableList.of(Ref("x").ident().columnIdent()), query, stmtCtx);
+        return getExtractor().extractParentMatches(ImmutableList.of(Ref("x").ident().columnIdent()), query, transactionContext);
 
     }
 
@@ -81,7 +81,7 @@ public class EqualityExtractorTest extends BaseAnalyzerTest {
 
     private List<List<Symbol>> analyzeExact(Symbol query, List<ColumnIdent> cols) {
         EqualityExtractor ee = getExtractor();
-        return ee.extractExactMatches(cols, query, stmtCtx);
+        return ee.extractExactMatches(cols, query, transactionContext);
     }
 
     private EqualityExtractor getExtractor() {

--- a/sql/src/test/java/io/crate/analyze/where/WhereClauseAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/where/WhereClauseAnalyzerTest.java
@@ -82,7 +82,7 @@ public class WhereClauseAnalyzerTest extends CrateUnitTest {
     private AnalysisMetaData ctxMetaData;
     private ThreadPool threadPool;
 
-    private final StmtCtx stmtCtx = new StmtCtx();
+    private final TransactionContext transactionContext = new TransactionContext();
 
     @Mock
     private SchemaInfo schemaInfo;
@@ -262,9 +262,9 @@ public class WhereClauseAnalyzerTest extends CrateUnitTest {
         });
         DocTableRelation tableRelation = statement.analyzedRelation();
         WhereClauseAnalyzer whereClauseAnalyzer = new WhereClauseAnalyzer(ctxMetaData, tableRelation);
-        assertThat(whereClauseAnalyzer.analyze(statement.whereClauses().get(0), stmtCtx).docKeys().get(), contains(isDocKey("1")));
-        assertThat(whereClauseAnalyzer.analyze(statement.whereClauses().get(1), stmtCtx).docKeys().get(), contains(isDocKey("2")));
-        assertThat(whereClauseAnalyzer.analyze(statement.whereClauses().get(2), stmtCtx).docKeys().get(), contains(isDocKey("3")));
+        assertThat(whereClauseAnalyzer.analyze(statement.whereClauses().get(0), transactionContext).docKeys().get(), contains(isDocKey("1")));
+        assertThat(whereClauseAnalyzer.analyze(statement.whereClauses().get(1), transactionContext).docKeys().get(), contains(isDocKey("2")));
+        assertThat(whereClauseAnalyzer.analyze(statement.whereClauses().get(2), transactionContext).docKeys().get(), contains(isDocKey("3")));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/lucene/LuceneQueryBuilderTest.java
+++ b/sql/src/test/java/io/crate/lucene/LuceneQueryBuilderTest.java
@@ -27,7 +27,7 @@ import io.crate.analyze.WhereClause;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.TableRelation;
 import io.crate.metadata.Functions;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.TableIdent;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.TestingTableInfo;
@@ -127,7 +127,7 @@ public class LuceneQueryBuilderTest extends CrateUnitTest {
     }
 
     private WhereClause asWhereClause(String expression) {
-        return new WhereClause(normalizer.normalize(expressions.asSymbol(expression), new StmtCtx()));
+        return new WhereClause(normalizer.normalize(expressions.asSymbol(expression), new TransactionContext()));
     }
 
     private Query convert(WhereClause clause) {
@@ -191,7 +191,7 @@ public class LuceneQueryBuilderTest extends CrateUnitTest {
     @Test
     public void testEqOnTwoArraysBecomesGenericFunctionQueryAllValuesNull() throws Exception {
         SqlExpressions sqlExpressions = new SqlExpressions(sources, new Object[]{new Object[]{null, null, null}});
-        Query query = convert(new WhereClause(normalizer.normalize(sqlExpressions.asSymbol("y_array = ?"), new StmtCtx())));
+        Query query = convert(new WhereClause(normalizer.normalize(sqlExpressions.asSymbol("y_array = ?"), new TransactionContext())));
         assertThat(query, instanceOf(GenericFunctionQuery.class));
     }
 
@@ -200,7 +200,7 @@ public class LuceneQueryBuilderTest extends CrateUnitTest {
         Object[] values = new Object[2000]; // should trigger the TooManyClauses exception
         Arrays.fill(values, 10L);
         SqlExpressions sqlExpressions = new SqlExpressions(sources, new Object[]{values});
-        Query query = convert(new WhereClause(normalizer.normalize(sqlExpressions.asSymbol("y_array = ?"), new StmtCtx())));
+        Query query = convert(new WhereClause(normalizer.normalize(sqlExpressions.asSymbol("y_array = ?"), new TransactionContext())));
         assertThat(query, instanceOf(BooleanQuery.class));
         BooleanQuery booleanQuery = (BooleanQuery) query;
         assertThat(booleanQuery.clauses().get(0).getQuery(), instanceOf(TermsQuery.class));

--- a/sql/src/test/java/io/crate/metadata/table/TestingTableInfo.java
+++ b/sql/src/test/java/io/crate/metadata/table/TestingTableInfo.java
@@ -281,7 +281,7 @@ public class TestingTableInfo extends DocTableInfo {
                 new AnalysisMetaData(functions, null, null), SessionContext.SYSTEM_SESSION, null, tableReferenceResolver, null);
             for (GeneratedReference generatedReferenceInfo : generatedColumns.build()) {
                 Expression expression = SqlParser.createExpression(generatedReferenceInfo.formattedGeneratedExpression());
-                ExpressionAnalysisContext context = new ExpressionAnalysisContext(new StmtCtx());
+                ExpressionAnalysisContext context = new ExpressionAnalysisContext(new TransactionContext());
                 generatedReferenceInfo.generatedExpression(expressionAnalyzer.convert(expression, context));
                 generatedReferenceInfo.referencedReferences(ImmutableList.copyOf(tableReferenceResolver.references()));
                 tableReferenceResolver.references().clear();

--- a/sql/src/test/java/io/crate/operation/ImplementationSymbolVisitorTest.java
+++ b/sql/src/test/java/io/crate/operation/ImplementationSymbolVisitorTest.java
@@ -77,7 +77,7 @@ public class ImplementationSymbolVisitorTest extends CrateUnitTest {
         }
 
         @Override
-        public Symbol normalizeSymbol(Function symbol, StmtCtx stmtCtx) {
+        public Symbol normalizeSymbol(Function symbol, TransactionContext transactionContext) {
             throw new UnsupportedOperationException();
         }
 

--- a/sql/src/test/java/io/crate/operation/aggregation/AggregationTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/AggregationTest.java
@@ -30,7 +30,7 @@ import io.crate.core.collections.ArrayBucket;
 import io.crate.core.collections.Row;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.Functions;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.operation.collect.InputCollectExpression;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.types.DataType;
@@ -103,6 +103,6 @@ public abstract class AggregationTest extends CrateUnitTest {
         }
         AggregationFunction function =
             (AggregationFunction) functions.get(new FunctionIdent(functionName, Arrays.asList(argTypes)));
-        return function.normalizeSymbol(new Function(function.info(), Arrays.asList(args)), new StmtCtx());
+        return function.normalizeSymbol(new Function(function.info(), Arrays.asList(args)), new TransactionContext());
     }
 }

--- a/sql/src/test/java/io/crate/operation/operator/AndOperatorTest.java
+++ b/sql/src/test/java/io/crate/operation/operator/AndOperatorTest.java
@@ -4,7 +4,7 @@ import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.Reference;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.test.integration.CrateUnitTest;
 import org.junit.Test;
 
@@ -15,14 +15,14 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 
 public class AndOperatorTest extends CrateUnitTest {
 
-    private final StmtCtx stmtCtx = new StmtCtx();
+    private final TransactionContext transactionContext = new TransactionContext();
 
     @Test
     public void testNormalizeBooleanTrueAndNonLiteral() throws Exception {
         AndOperator operator = new AndOperator();
         Function function = new Function(
             operator.info(), Arrays.<Symbol>asList(Literal.of(true), new Reference()));
-        Symbol symbol = operator.normalizeSymbol(function, stmtCtx);
+        Symbol symbol = operator.normalizeSymbol(function, transactionContext);
         assertThat(symbol, instanceOf(Reference.class));
     }
 
@@ -31,7 +31,7 @@ public class AndOperatorTest extends CrateUnitTest {
         AndOperator operator = new AndOperator();
         Function function = new Function(
             operator.info(), Arrays.<Symbol>asList(Literal.of(false), new Reference()));
-        Symbol symbol = operator.normalizeSymbol(function, stmtCtx);
+        Symbol symbol = operator.normalizeSymbol(function, transactionContext);
 
         assertThat(symbol, isLiteral(false));
     }
@@ -41,7 +41,7 @@ public class AndOperatorTest extends CrateUnitTest {
         AndOperator operator = new AndOperator();
         Function function = new Function(
             operator.info(), Arrays.<Symbol>asList(Literal.of(true), Literal.of(true)));
-        Symbol symbol = operator.normalizeSymbol(function, stmtCtx);
+        Symbol symbol = operator.normalizeSymbol(function, transactionContext);
         assertThat(symbol, isLiteral(true));
     }
 
@@ -50,7 +50,7 @@ public class AndOperatorTest extends CrateUnitTest {
         AndOperator operator = new AndOperator();
         Function function = new Function(
             operator.info(), Arrays.<Symbol>asList(Literal.of(true), Literal.of(false)));
-        Symbol symbol = operator.normalizeSymbol(function, stmtCtx);
+        Symbol symbol = operator.normalizeSymbol(function, transactionContext);
         assertThat(symbol, isLiteral(false));
     }
 

--- a/sql/src/test/java/io/crate/operation/operator/CmpOperatorTest.java
+++ b/sql/src/test/java/io/crate/operation/operator/CmpOperatorTest.java
@@ -4,7 +4,7 @@ import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.Value;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.operation.Input;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.types.DataTypes;
@@ -24,7 +24,7 @@ public class CmpOperatorTest extends CrateUnitTest {
     private LteOperator op_lte_long;
     private LtOperator op_lt_string;
 
-    private final StmtCtx stmtCtx = new StmtCtx();
+    private final TransactionContext transactionContext = new TransactionContext();
 
     @Before
     public void prepare() {
@@ -40,7 +40,7 @@ public class CmpOperatorTest extends CrateUnitTest {
     }
 
     private Symbol normalize(Operator operator, Symbol... symbols) {
-        return operator.normalizeSymbol(getFunction(operator, symbols), stmtCtx);
+        return operator.normalizeSymbol(getFunction(operator, symbols), transactionContext);
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/operator/InOperatorTest.java
+++ b/sql/src/test/java/io/crate/operation/operator/InOperatorTest.java
@@ -25,7 +25,7 @@ import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.Reference;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.operation.operator.input.ObjectInput;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.types.DataType;
@@ -45,7 +45,7 @@ import static org.hamcrest.Matchers.is;
 
 public class InOperatorTest extends CrateUnitTest {
 
-    private final StmtCtx stmtCtx = new StmtCtx();
+    private final TransactionContext transactionContext = new TransactionContext();
 
     private static final DataType INTEGER_SET_TYPE = new SetType(DataTypes.INTEGER);
     private static final DataType STRING_SET_TYPE = new SetType(DataTypes.STRING);
@@ -61,7 +61,7 @@ public class InOperatorTest extends CrateUnitTest {
 
         InOperator op = new InOperator(Operator.generateInfo(InOperator.NAME, DataTypes.INTEGER));
         Function function = new Function(op.info(), arguments);
-        Symbol result = op.normalizeSymbol(function, stmtCtx);
+        Symbol result = op.normalizeSymbol(function, transactionContext);
 
         assertThat(result, isLiteral(true));
     }
@@ -78,7 +78,7 @@ public class InOperatorTest extends CrateUnitTest {
 
         InOperator op = new InOperator(Operator.generateInfo(InOperator.NAME, DataTypes.INTEGER));
         Function function = new Function(op.info(), arguments);
-        Symbol result = op.normalizeSymbol(function, stmtCtx);
+        Symbol result = op.normalizeSymbol(function, transactionContext);
 
         assertThat(result, isLiteral(false));
     }
@@ -94,7 +94,7 @@ public class InOperatorTest extends CrateUnitTest {
 
         InOperator op = new InOperator(Operator.generateInfo(InOperator.NAME, DataTypes.INTEGER));
         Function function = new Function(op.info(), arguments);
-        Symbol result = op.normalizeSymbol(function, stmtCtx);
+        Symbol result = op.normalizeSymbol(function, transactionContext);
 
         assertThat(result, isLiteral(false));
     }
@@ -110,7 +110,7 @@ public class InOperatorTest extends CrateUnitTest {
 
         InOperator op = new InOperator(Operator.generateInfo(InOperator.NAME, DataTypes.INTEGER));
         Function function = new Function(op.info(), arguments);
-        Symbol result = op.normalizeSymbol(function, stmtCtx);
+        Symbol result = op.normalizeSymbol(function, transactionContext);
 
         assertThat(result, instanceOf(Function.class));
         assertThat(((Function) result).info().ident().name(), is(InOperator.NAME));
@@ -135,7 +135,7 @@ public class InOperatorTest extends CrateUnitTest {
 
         InOperator op = new InOperator(Operator.generateInfo(InOperator.NAME, DataTypes.INTEGER));
         Function function = new Function(op.info(), arguments);
-        Symbol result = op.normalizeSymbol(function, stmtCtx);
+        Symbol result = op.normalizeSymbol(function, transactionContext);
 
         assertThat(result, isLiteral(true));
     }
@@ -159,7 +159,7 @@ public class InOperatorTest extends CrateUnitTest {
 
         InOperator op = new InOperator(Operator.generateInfo(InOperator.NAME, DataTypes.INTEGER));
         Function function = new Function(op.info(), arguments);
-        Symbol result = op.normalizeSymbol(function, stmtCtx);
+        Symbol result = op.normalizeSymbol(function, transactionContext);
 
         assertThat(result, isLiteral(false));
     }

--- a/sql/src/test/java/io/crate/operation/operator/OrOperatorTest.java
+++ b/sql/src/test/java/io/crate/operation/operator/OrOperatorTest.java
@@ -4,7 +4,7 @@ import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.Reference;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.test.integration.CrateUnitTest;
 import org.junit.Test;
 
@@ -21,7 +21,7 @@ public class OrOperatorTest extends CrateUnitTest {
 
         Function function = new Function(
             operator.info(), Arrays.<Symbol>asList(new Reference(), Literal.of(true)));
-        Symbol normalizedSymbol = operator.normalizeSymbol(function, new StmtCtx());
+        Symbol normalizedSymbol = operator.normalizeSymbol(function, new TransactionContext());
         assertThat(normalizedSymbol, isLiteral(true));
     }
 
@@ -30,7 +30,7 @@ public class OrOperatorTest extends CrateUnitTest {
         OrOperator operator = new OrOperator();
         Function function = new Function(
             operator.info(), Arrays.<Symbol>asList(new Reference(), Literal.of(false)));
-        Symbol normalizedSymbol = operator.normalizeSymbol(function, new StmtCtx());
+        Symbol normalizedSymbol = operator.normalizeSymbol(function, new TransactionContext());
         assertThat(normalizedSymbol, instanceOf(Reference.class));
     }
 
@@ -40,7 +40,7 @@ public class OrOperatorTest extends CrateUnitTest {
 
         Function function = new Function(
             operator.info(), Arrays.<Symbol>asList(new Reference(), new Reference()));
-        Symbol normalizedSymbol = operator.normalizeSymbol(function, new StmtCtx());
+        Symbol normalizedSymbol = operator.normalizeSymbol(function, new TransactionContext());
         assertThat(normalizedSymbol, instanceOf(Function.class));
     }
 

--- a/sql/src/test/java/io/crate/operation/operator/RegexpMatchCaseInsensitiveOperatorTest.java
+++ b/sql/src/test/java/io/crate/operation/operator/RegexpMatchCaseInsensitiveOperatorTest.java
@@ -24,7 +24,7 @@ package io.crate.operation.operator;
 import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.test.integration.CrateUnitTest;
 import org.junit.Test;
 
@@ -40,7 +40,7 @@ public class RegexpMatchCaseInsensitiveOperatorTest extends CrateUnitTest {
             op.info(),
             Arrays.<Symbol>asList(Literal.of(source), Literal.of(pattern))
         );
-        return op.normalizeSymbol(function, new StmtCtx());
+        return op.normalizeSymbol(function, new TransactionContext());
     }
 
     private Boolean regexpNormalize(String source, String pattern) {

--- a/sql/src/test/java/io/crate/operation/operator/RegexpMatchOperatortest.java
+++ b/sql/src/test/java/io/crate/operation/operator/RegexpMatchOperatortest.java
@@ -24,7 +24,7 @@ package io.crate.operation.operator;
 import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.test.integration.CrateUnitTest;
 import org.junit.Test;
 
@@ -40,7 +40,7 @@ public class RegexpMatchOperatortest extends CrateUnitTest {
             op.info(),
             Arrays.<Symbol>asList(Literal.of(source), Literal.of(pattern))
         );
-        return op.normalizeSymbol(function, new StmtCtx());
+        return op.normalizeSymbol(function, new TransactionContext());
     }
 
     private Boolean regexpNormalize(String source, String pattern) {

--- a/sql/src/test/java/io/crate/operation/operator/any/AnyEqOperatorTest.java
+++ b/sql/src/test/java/io/crate/operation/operator/any/AnyEqOperatorTest.java
@@ -27,7 +27,7 @@ import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.operation.operator.input.ObjectInput;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.types.ArrayType;
@@ -39,7 +39,7 @@ import java.util.Arrays;
 
 public class AnyEqOperatorTest extends CrateUnitTest {
 
-    private final StmtCtx stmtCtx = new StmtCtx();
+    private final TransactionContext transactionContext = new TransactionContext();
 
     private Boolean anyEq(Object value, Object arrayExpr) {
 
@@ -64,7 +64,7 @@ public class AnyEqOperatorTest extends CrateUnitTest {
                 Literal.of(DataTypes.INTEGER, value),
                 Literal.of(new ArrayType(DataTypes.INTEGER), arrayExpr))
         );
-        return (Boolean) ((Literal) anyEqOperator.normalizeSymbol(function, stmtCtx)).value();
+        return (Boolean) ((Literal) anyEqOperator.normalizeSymbol(function, transactionContext)).value();
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/operator/any/AnyLikeOperatorTest.java
+++ b/sql/src/test/java/io/crate/operation/operator/any/AnyLikeOperatorTest.java
@@ -25,7 +25,7 @@ import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionImplementation;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.operation.Input;
 import io.crate.operation.predicate.NotPredicate;
 import io.crate.test.integration.CrateUnitTest;
@@ -55,7 +55,7 @@ public class AnyLikeOperatorTest extends CrateUnitTest {
             impl.info(),
             Arrays.<Symbol>asList(patternLiteral, valuesLiteral)
         );
-        return impl.normalizeSymbol(function, new StmtCtx());
+        return impl.normalizeSymbol(function, new TransactionContext());
     }
 
     private Boolean anyLikeNormalize(String pattern, String... expressions) {
@@ -159,7 +159,7 @@ public class AnyLikeOperatorTest extends CrateUnitTest {
             Arrays.asList(DataTypes.STRING, valuesLiteral.valueType())
         );
         Function anyLikeFunction = new Function(impl.info(), Arrays.<Symbol>asList(patternLiteral, valuesLiteral));
-        Input<Boolean> normalized = (Input<Boolean>) impl.normalizeSymbol(anyLikeFunction, new StmtCtx());
+        Input<Boolean> normalized = (Input<Boolean>) impl.normalizeSymbol(anyLikeFunction, new TransactionContext());
         assertThat(normalized.value(), is(true));
         assertThat(new NotPredicate().evaluate(normalized), is(false));
     }

--- a/sql/src/test/java/io/crate/operation/operator/any/AnyNotLikeOperatorTest.java
+++ b/sql/src/test/java/io/crate/operation/operator/any/AnyNotLikeOperatorTest.java
@@ -25,7 +25,7 @@ import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionImplementation;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.operation.Input;
 import io.crate.operation.predicate.NotPredicate;
 import io.crate.test.integration.CrateUnitTest;
@@ -55,7 +55,7 @@ public class AnyNotLikeOperatorTest extends CrateUnitTest {
             impl.info(),
             Arrays.<Symbol>asList(patternLiteral, valuesLiteral)
         );
-        return impl.normalizeSymbol(function, new StmtCtx());
+        return impl.normalizeSymbol(function, new TransactionContext());
     }
 
     private Boolean anyNotLikeNormalize(String pattern, String... expressions) {
@@ -159,7 +159,7 @@ public class AnyNotLikeOperatorTest extends CrateUnitTest {
             Arrays.asList(DataTypes.STRING, valuesLiteral.valueType())
         );
         Function anyNotLikeFunction = new Function(impl.info(), Arrays.<Symbol>asList(patternLiteral, valuesLiteral));
-        Input<Boolean> normalized = (Input<Boolean>) impl.normalizeSymbol(anyNotLikeFunction, new StmtCtx());
+        Input<Boolean> normalized = (Input<Boolean>) impl.normalizeSymbol(anyNotLikeFunction, new TransactionContext());
         assertThat(normalized.value(), is(true));
         assertThat(new NotPredicate().evaluate(normalized), is(false));
     }

--- a/sql/src/test/java/io/crate/operation/predicate/IsNullPredicateTest.java
+++ b/sql/src/test/java/io/crate/operation/predicate/IsNullPredicateTest.java
@@ -45,19 +45,19 @@ public class IsNullPredicateTest extends CrateUnitTest {
         DataTypes.BOOLEAN
     ));
 
-    private final StmtCtx stmtCtx = new StmtCtx();
+    private final TransactionContext transactionContext = new TransactionContext();
 
     @Test
     public void testNormalizeSymbolFalse() throws Exception {
         Function isNull = new Function(predicate.info(), Arrays.<Symbol>asList(Literal.of("a")));
-        Symbol symbol = predicate.normalizeSymbol(isNull, stmtCtx);
+        Symbol symbol = predicate.normalizeSymbol(isNull, transactionContext);
         assertThat(symbol, isLiteral(false));
     }
 
     @Test
     public void testNormalizeSymbolTrue() throws Exception {
         Function isNull = new Function(predicate.info(), Arrays.<Symbol>asList(Literal.NULL));
-        Symbol symbol = predicate.normalizeSymbol(isNull, stmtCtx);
+        Symbol symbol = predicate.normalizeSymbol(isNull, transactionContext);
         assertThat(symbol, isLiteral(true));
     }
 
@@ -68,7 +68,7 @@ public class IsNullPredicateTest extends CrateUnitTest {
             RowGranularity.DOC,
             DataTypes.STRING);
         Function isNull = new Function(predicate.info(), Arrays.<Symbol>asList(name_ref));
-        Symbol symbol = predicate.normalizeSymbol(isNull, stmtCtx);
+        Symbol symbol = predicate.normalizeSymbol(isNull, transactionContext);
         assertThat(symbol, instanceOf(Function.class));
     }
 
@@ -77,7 +77,7 @@ public class IsNullPredicateTest extends CrateUnitTest {
         DynamicReference name_ref = new DynamicReference(
             new ReferenceIdent(new TableIdent(null, "dummy"), "name"), RowGranularity.DOC);
         Function isNull = new Function(predicate.info(), Arrays.<Symbol>asList(name_ref));
-        Symbol symbol = predicate.normalizeSymbol(isNull, stmtCtx);
+        Symbol symbol = predicate.normalizeSymbol(isNull, transactionContext);
         assertThat(symbol, isLiteral(true));
     }
 
@@ -85,7 +85,7 @@ public class IsNullPredicateTest extends CrateUnitTest {
     public void testNormalizeSymbolWithStringLiteralThatIsNull() throws Exception {
         Function isNull = new Function(predicate.info(),
             Arrays.<Symbol>asList(Literal.of(DataTypes.STRING, null)));
-        Symbol symbol = predicate.normalizeSymbol(isNull, stmtCtx);
+        Symbol symbol = predicate.normalizeSymbol(isNull, transactionContext);
         assertThat((Boolean) ((Input) symbol).value(), is(true));
     }
 

--- a/sql/src/test/java/io/crate/operation/predicate/NotPredicateTest.java
+++ b/sql/src/test/java/io/crate/operation/predicate/NotPredicateTest.java
@@ -38,14 +38,14 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 
 public class NotPredicateTest extends CrateUnitTest {
 
-    private final StmtCtx stmtCtx = new StmtCtx();
+    private final TransactionContext transactionContext = new TransactionContext();
 
     @Test
     public void testNormalizeSymbolNull() throws Exception {
         NotPredicate predicate = new NotPredicate();
         Function not = new Function(predicate.info(), Arrays.<Symbol>asList(Literal.NULL));
 
-        assertThat(predicate.normalizeSymbol(not, stmtCtx), isLiteral(null));
+        assertThat(predicate.normalizeSymbol(not, transactionContext), isLiteral(null));
     }
 
     @Test
@@ -53,7 +53,7 @@ public class NotPredicateTest extends CrateUnitTest {
         NotPredicate predicate = new NotPredicate();
         Function not = new Function(predicate.info(), Arrays.<Symbol>asList(Literal.of(true)));
 
-        assertThat(predicate.normalizeSymbol(not, stmtCtx), isLiteral(false));
+        assertThat(predicate.normalizeSymbol(not, transactionContext), isLiteral(false));
     }
 
     @Test
@@ -73,7 +73,7 @@ public class NotPredicateTest extends CrateUnitTest {
         );
 
         Function not = new Function(notPredicate.info(), Arrays.<Symbol>asList(eqName));
-        Symbol normalized = notPredicate.normalizeSymbol(not, stmtCtx);
+        Symbol normalized = notPredicate.normalizeSymbol(not, transactionContext);
 
         assertThat(normalized, instanceOf(Function.class));
     }

--- a/sql/src/test/java/io/crate/operation/scalar/AbstractScalarFunctionsTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/AbstractScalarFunctionsTest.java
@@ -185,6 +185,6 @@ public abstract class AbstractScalarFunctionsTest extends CrateUnitTest {
         }
         FunctionImplementation<Function> function = getFunction(functionName, argTypes);
         return function.normalizeSymbol(new Function(function.info(),
-            Arrays.asList(args)), new StmtCtx());
+            Arrays.asList(args)), new TransactionContext());
     }
 }

--- a/sql/src/test/java/io/crate/operation/scalar/ArrayCatFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/ArrayCatFunctionTest.java
@@ -27,7 +27,7 @@ import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.Scalar;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.operation.Input;
 import io.crate.testing.TestingHelpers;
 import io.crate.types.ArrayType;
@@ -53,7 +53,7 @@ public class ArrayCatFunctionTest extends AbstractScalarFunctionsTest {
     private static final ArrayType arrayOfIpType = new ArrayType(DataTypes.IP);
     private static final ArrayType arrayOfUndefinedType = new ArrayType(DataTypes.UNDEFINED);
 
-    private final StmtCtx stmtCtx = new StmtCtx();
+    private final TransactionContext transactionContext = new TransactionContext();
 
     private ArrayCatFunction getFunction(ArrayType... args) {
         List<DataType> argumentTypes = new ArrayList<>(args.length);
@@ -83,7 +83,7 @@ public class ArrayCatFunctionTest extends AbstractScalarFunctionsTest {
         Symbol symbol = function.normalizeSymbol(new Function(function.info(), Arrays.<Symbol>asList(
             Literal.of(new Integer[]{10, 20}, arrayOfIntegerType),
             Literal.of(new Integer[]{10, 30}, arrayOfIntegerType)
-        )), stmtCtx);
+        )), transactionContext);
 
         assertThat(symbol, isLiteral(new Integer[]{10, 20, 10, 30}, arrayOfIntegerType));
     }
@@ -96,7 +96,7 @@ public class ArrayCatFunctionTest extends AbstractScalarFunctionsTest {
             TestingHelpers.createReference("foo", arrayOfIntegerType),
             Literal.of(new Integer[]{10, 30}, arrayOfIntegerType)
         ));
-        Function symbol = (Function) function.normalizeSymbol(functionSymbol, stmtCtx);
+        Function symbol = (Function) function.normalizeSymbol(functionSymbol, transactionContext);
         assertThat(symbol, Matchers.sameInstance(functionSymbol));
     }
 

--- a/sql/src/test/java/io/crate/operation/scalar/ArrayDifferenceFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/ArrayDifferenceFunctionTest.java
@@ -27,7 +27,7 @@ import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.Scalar;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.operation.Input;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
@@ -53,7 +53,7 @@ public class ArrayDifferenceFunctionTest extends AbstractScalarFunctionsTest {
     private static final ArrayType arrayOfIpType = new ArrayType(DataTypes.IP);
     private static final ArrayType arrayOfUndefinedType = new ArrayType(DataTypes.UNDEFINED);
 
-    private final StmtCtx stmtCtx = new StmtCtx();
+    private final TransactionContext transactionContext = new TransactionContext();
 
     private ArrayDifferenceFunction getFunction(ArrayType... args) {
         List<DataType> argumentTypes = new ArrayList<>(args.length);
@@ -159,7 +159,7 @@ public class ArrayDifferenceFunctionTest extends AbstractScalarFunctionsTest {
         Symbol symbol = function.normalizeSymbol(new Function(function.info(), Arrays.<Symbol>asList(
             Literal.of(new Integer[]{10, 20}, type),
             Literal.of(new Integer[]{10, 30}, type)
-        )), stmtCtx);
+        )), transactionContext);
 
         assertThat(symbol, isLiteral(new Integer[]{20}, type));
     }
@@ -173,7 +173,7 @@ public class ArrayDifferenceFunctionTest extends AbstractScalarFunctionsTest {
             createReference("foo", type),
             Literal.of(new Integer[]{10, 30}, type)
         ));
-        Function symbol = (Function) function.normalizeSymbol(functionSymbol, stmtCtx);
+        Function symbol = (Function) function.normalizeSymbol(functionSymbol, transactionContext);
         assertThat(symbol, Matchers.sameInstance(functionSymbol));
     }
 

--- a/sql/src/test/java/io/crate/operation/scalar/ArrayUniqueFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/ArrayUniqueFunctionTest.java
@@ -27,7 +27,7 @@ import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.Scalar;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.operation.Input;
 import io.crate.testing.TestingHelpers;
 import io.crate.types.ArrayType;
@@ -81,7 +81,7 @@ public class ArrayUniqueFunctionTest extends AbstractScalarFunctionsTest {
         Symbol symbol = function.normalizeSymbol(new Function(function.info(), Arrays.<Symbol>asList(
             Literal.of(new Integer[]{10, 20}, arrayOfIntegerType),
             Literal.of(new Integer[]{10, 30}, arrayOfIntegerType)
-        )), new StmtCtx());
+        )), new TransactionContext());
 
         assertThat(symbol, isLiteral(new Integer[]{10, 20, 30}, arrayOfIntegerType));
     }
@@ -94,7 +94,7 @@ public class ArrayUniqueFunctionTest extends AbstractScalarFunctionsTest {
             TestingHelpers.createReference("foo", arrayOfIntegerType),
             Literal.of(new Integer[]{10, 30}, arrayOfIntegerType)
         ));
-        Function symbol = (Function) function.normalizeSymbol(functionSymbol, new StmtCtx());
+        Function symbol = (Function) function.normalizeSymbol(functionSymbol, new TransactionContext());
         assertThat(symbol, Matchers.sameInstance(functionSymbol));
     }
 

--- a/sql/src/test/java/io/crate/operation/scalar/ConcatFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/ConcatFunctionTest.java
@@ -27,7 +27,7 @@ import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.Scalar;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.operation.Input;
 import io.crate.testing.TestingHelpers;
 import io.crate.types.ArrayType;
@@ -50,7 +50,7 @@ public class ConcatFunctionTest extends AbstractScalarFunctionsTest {
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
-    private final StmtCtx stmtCtx = new StmtCtx();
+    private final TransactionContext transactionContext = new TransactionContext();
 
     private static class ObjectInput implements Input<Object> {
 
@@ -112,11 +112,11 @@ public class ConcatFunctionTest extends AbstractScalarFunctionsTest {
         Scalar scalar = ((Scalar) functions.get(new FunctionIdent(ConcatFunction.NAME, argumentTypes)));
 
         Symbol symbol = scalar.normalizeSymbol(new Function(scalar.info(),
-            Arrays.<Symbol>asList(Literal.of("foo"), Literal.of("bar"))), stmtCtx);
+            Arrays.<Symbol>asList(Literal.of("foo"), Literal.of("bar"))), transactionContext);
         assertThat(symbol, isLiteral("foobar"));
 
         symbol = scalar.normalizeSymbol(new Function(scalar.info(),
-            Arrays.<Symbol>asList(createReference("col1", DataTypes.STRING), Literal.of("bar"))), stmtCtx);
+            Arrays.<Symbol>asList(createReference("col1", DataTypes.STRING), Literal.of("bar"))), transactionContext);
         assertThat(symbol, isFunction(ConcatFunction.NAME));
     }
 

--- a/sql/src/test/java/io/crate/operation/scalar/DateTruncFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/DateTruncFunctionTest.java
@@ -71,16 +71,16 @@ public class DateTruncFunctionTest extends AbstractScalarFunctionsTest {
         }
     }
 
-    private final StmtCtx stmtCtx = new StmtCtx();
+    private final TransactionContext transactionContext = new TransactionContext();
 
     public Symbol normalize(Symbol interval, Symbol timestamp) {
         Function function = new Function(func.info(), Arrays.asList(interval, timestamp));
-        return func.normalizeSymbol(function, stmtCtx);
+        return func.normalizeSymbol(function, transactionContext);
     }
 
     public Symbol normalize(Symbol interval, Symbol tz, Symbol timestamp) {
         Function function = new Function(funcTZ.info(), Arrays.asList(interval, tz, timestamp));
-        return funcTZ.normalizeSymbol(function, stmtCtx);
+        return funcTZ.normalizeSymbol(function, transactionContext);
     }
 
     private void assertTruncated(String interval, Long timestamp, Long expected) throws Exception {
@@ -132,7 +132,7 @@ public class DateTruncFunctionTest extends AbstractScalarFunctionsTest {
             Literal.of("day"),
             Literal.of(1401777485000L)
         ));
-        Literal day = (Literal) implementation.normalizeSymbol(function, stmtCtx);
+        Literal day = (Literal) implementation.normalizeSymbol(function, transactionContext);
         assertThat((Long) day.value(), is(1401753600000L));
     }
 
@@ -147,7 +147,7 @@ public class DateTruncFunctionTest extends AbstractScalarFunctionsTest {
             Literal.of("day"),
             Literal.of("2014-06-03")
         ));
-        Literal day = (Literal) implementation.normalizeSymbol(function, stmtCtx);
+        Literal day = (Literal) implementation.normalizeSymbol(function, transactionContext);
         assertThat((Long) day.value(), is(1401753600000L));
     }
 
@@ -155,7 +155,7 @@ public class DateTruncFunctionTest extends AbstractScalarFunctionsTest {
     public void testNormalizeSymbolReferenceTimestamp() throws Exception {
         Function function = new Function(func.info(),
             Arrays.<Symbol>asList(new Reference(null, null, DataTypes.STRING), new Reference(null, null, DataTypes.TIMESTAMP)));
-        Symbol result = func.normalizeSymbol(function, stmtCtx);
+        Symbol result = func.normalizeSymbol(function, transactionContext);
         assertSame(function, result);
     }
 
@@ -245,7 +245,7 @@ public class DateTruncFunctionTest extends AbstractScalarFunctionsTest {
             Literal.of("Europe/Vienna"),
             Literal.of("2014-06-03")
         ));
-        Literal day = (Literal) implementation.normalizeSymbol(function, stmtCtx);
+        Literal day = (Literal) implementation.normalizeSymbol(function, transactionContext);
         assertThat((Long) day.value(), is(1401746400000L));
     }
 
@@ -254,7 +254,7 @@ public class DateTruncFunctionTest extends AbstractScalarFunctionsTest {
         Function function = new Function(funcTZ.info(),
             Arrays.<Symbol>asList(Literal.of("day"), Literal.of("+01:00"),
                 new Reference(null, null, DataTypes.TIMESTAMP)));
-        Symbol result = funcTZ.normalizeSymbol(function, stmtCtx);
+        Symbol result = funcTZ.normalizeSymbol(function, transactionContext);
         assertSame(function, result);
     }
 

--- a/sql/src/test/java/io/crate/operation/scalar/arithmetic/LogFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/arithmetic/LogFunctionTest.java
@@ -26,7 +26,7 @@ import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.Reference;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.operation.Input;
 import io.crate.operation.scalar.AbstractScalarFunctionsTest;
 import io.crate.types.DataType;
@@ -43,7 +43,7 @@ import static org.hamcrest.core.IsNull.nullValue;
 
 public class LogFunctionTest extends AbstractScalarFunctionsTest {
 
-    private StmtCtx stmtCtx = new StmtCtx();
+    private TransactionContext transactionContext = new TransactionContext();
 
     private LogFunction getFunction(String name, DataType value) {
         return (LogFunction) functions.get(new FunctionIdent(name, Arrays.asList(value)));
@@ -65,13 +65,13 @@ public class LogFunctionTest extends AbstractScalarFunctionsTest {
 
     private Symbol normalize(Number value, DataType valueType, LogFunction function) {
         return function.normalizeSymbol(new Function(function.info(),
-            Arrays.<Symbol>asList(Literal.of(valueType, value))), stmtCtx);
+            Arrays.<Symbol>asList(Literal.of(valueType, value))), transactionContext);
     }
 
     private Symbol normalizeLog(Number value, DataType valueType, Number base, DataType baseType) {
         LogFunction function = getFunction(LogFunction.NAME, valueType, baseType);
         return function.normalizeSymbol(new Function(function.info(),
-            Arrays.<Symbol>asList(Literal.of(valueType, value), Literal.of(baseType, base))), stmtCtx);
+            Arrays.<Symbol>asList(Literal.of(valueType, value), Literal.of(baseType, base))), transactionContext);
     }
 
     private Number evaluateLog(Number value, DataType valueType) {
@@ -168,22 +168,22 @@ public class LogFunctionTest extends AbstractScalarFunctionsTest {
 
         LogFunction log10 = getFunction(LogFunction.NAME, DataTypes.DOUBLE);
         Function function = new Function(log10.info(), Arrays.<Symbol>asList(dB));
-        Function normalized = (Function) log10.normalizeSymbol(function, stmtCtx);
+        Function normalized = (Function) log10.normalizeSymbol(function, transactionContext);
         assertThat(normalized, Matchers.sameInstance(function));
 
         LogFunction ln = getFunction(LogFunction.LnFunction.NAME, DataTypes.DOUBLE);
         function = new Function(ln.info(), Arrays.<Symbol>asList(dB));
-        normalized = (Function) ln.normalizeSymbol(function, stmtCtx);
+        normalized = (Function) ln.normalizeSymbol(function, transactionContext);
         assertThat(normalized, Matchers.sameInstance(function));
 
         LogFunction logBase = getFunction(LogFunction.NAME, DataTypes.DOUBLE, DataTypes.LONG);
         function = new Function(logBase.info(), Arrays.<Symbol>asList(dB, Literal.of(10L)));
-        normalized = (Function) logBase.normalizeSymbol(function, stmtCtx);
+        normalized = (Function) logBase.normalizeSymbol(function, transactionContext);
         assertThat(normalized, Matchers.sameInstance(function));
 
         Reference base = createReference("base", DataTypes.INTEGER);
         function = new Function(logBase.info(), Arrays.<Symbol>asList(dB, base));
-        normalized = (Function) logBase.normalizeSymbol(function, stmtCtx);
+        normalized = (Function) logBase.normalizeSymbol(function, transactionContext);
         assertThat(normalized, Matchers.sameInstance(function));
     }
 

--- a/sql/src/test/java/io/crate/operation/scalar/arithmetic/RandomFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/arithmetic/RandomFunctionTest.java
@@ -24,7 +24,7 @@ package io.crate.operation.scalar.arithmetic;
 import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.operation.Input;
 import io.crate.operation.scalar.AbstractScalarFunctionsTest;
 import io.crate.types.DataType;
@@ -56,7 +56,7 @@ public class RandomFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void normalizeReference() {
         Function function = new Function(random.info(), Collections.<Symbol>emptyList());
-        Function normalized = (Function) random.normalizeSymbol(function, new StmtCtx());
+        Function normalized = (Function) random.normalizeSymbol(function, new TransactionContext());
         assertThat(normalized, sameInstance(function));
     }
 

--- a/sql/src/test/java/io/crate/operation/scalar/geo/DistanceFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/geo/DistanceFunctionTest.java
@@ -27,7 +27,7 @@ import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.Symbols;
 import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.operation.Input;
 import io.crate.operation.scalar.AbstractScalarFunctionsTest;
 import io.crate.types.ArrayType;
@@ -63,7 +63,7 @@ public class DistanceFunctionTest extends AbstractScalarFunctionsTest {
     @SuppressWarnings("unchecked")
     private Symbol normalize(List<? extends Symbol> args) {
         DistanceFunction distanceFunction = functionFromArgs(args);
-        return distanceFunction.normalizeSymbol(new Function(distanceFunction.info(), (List<Symbol>) args), new StmtCtx());
+        return distanceFunction.normalizeSymbol(new Function(distanceFunction.info(), (List<Symbol>) args), new TransactionContext());
     }
 
     @Test
@@ -181,7 +181,7 @@ public class DistanceFunctionTest extends AbstractScalarFunctionsTest {
             createReference("foo2", DataTypes.GEO_POINT));
         DistanceFunction distanceFunction = functionFromArgs(args);
         Function functionSymbol = new Function(distanceFunction.info(), args);
-        Function normalizedFunction = (Function) distanceFunction.normalizeSymbol(functionSymbol, new StmtCtx());
+        Function normalizedFunction = (Function) distanceFunction.normalizeSymbol(functionSymbol, new TransactionContext());
         assertThat(functionSymbol, Matchers.sameInstance(normalizedFunction));
     }
 

--- a/sql/src/test/java/io/crate/planner/PlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/PlannerTest.java
@@ -1550,7 +1550,7 @@ public class PlannerTest extends AbstractPlannerTest {
         TableInfo tableInfo = TestingTableInfo.builder(
             custom, shardRouting("t1")).add("id", DataTypes.INTEGER, null).build();
         Planner.Context plannerContext = new Planner.Context(
-            clusterService, UUID.randomUUID(), null, normalizer, new StmtCtx(), 0, 0);
+            clusterService, UUID.randomUUID(), null, normalizer, new TransactionContext(), 0, 0);
         plannerContext.allocateRouting(tableInfo, WhereClause.MATCH_ALL, null);
 
         Planner.Context.ReaderAllocations readerAllocations = plannerContext.buildReaderAllocations();
@@ -1584,7 +1584,7 @@ public class PlannerTest extends AbstractPlannerTest {
         TableInfo tableInfo2 =
             TestingTableInfo.builder(custom, shardRoutingForReplicas("t1")).add("id", DataTypes.INTEGER, null).build();
         Planner.Context plannerContext =
-            new Planner.Context(clusterService, UUID.randomUUID(), null, normalizer, new StmtCtx(), 0, 0);
+            new Planner.Context(clusterService, UUID.randomUUID(), null, normalizer, new TransactionContext(), 0, 0);
 
         WhereClause whereClause = new WhereClause(
             new Function(new FunctionInfo(
@@ -1614,7 +1614,7 @@ public class PlannerTest extends AbstractPlannerTest {
     @Test
     public void testExecutionPhaseIdSequence() throws Exception {
         Planner.Context plannerContext = new Planner.Context(
-            clusterService, UUID.randomUUID(), null, normalizer, new StmtCtx(), 0, 0);
+            clusterService, UUID.randomUUID(), null, normalizer, new TransactionContext(), 0, 0);
 
         assertThat(plannerContext.nextExecutionPhaseId(), is(0));
         assertThat(plannerContext.nextExecutionPhaseId(), is(1));
@@ -1801,7 +1801,7 @@ public class PlannerTest extends AbstractPlannerTest {
     public void testNoSoftLimitOnUnlimitedChildRelation() throws Exception {
         int softLimit = 10_000;
         Planner.Context plannerContext = new Planner.Context(
-            clusterService, UUID.randomUUID(), null, normalizer, new StmtCtx(), softLimit, 0);
+            clusterService, UUID.randomUUID(), null, normalizer, new TransactionContext(), softLimit, 0);
         Limits limits = plannerContext.getLimits(false, new QuerySpec());
         assertThat(limits.finalLimit(), is(TopN.NO_LIMIT));
     }

--- a/sql/src/test/java/io/crate/planner/consumer/NestedLoopConsumerTest.java
+++ b/sql/src/test/java/io/crate/planner/consumer/NestedLoopConsumerTest.java
@@ -115,7 +115,7 @@ public class NestedLoopConsumerTest extends CrateUnitTest {
                 }
             }
         );
-        plannerContext = new Planner.Context(clusterService, UUID.randomUUID(), null, normalizer, new StmtCtx(), 0, 0);
+        plannerContext = new Planner.Context(clusterService, UUID.randomUUID(), null, normalizer, new TransactionContext(), 0, 0);
         consumer = new NestedLoopConsumer(clusterService, mock(AnalysisMetaData.class), statsService);
     }
 

--- a/sql/src/test/java/io/crate/testing/LuceneDocCollectorProvider.java
+++ b/sql/src/test/java/io/crate/testing/LuceneDocCollectorProvider.java
@@ -113,7 +113,7 @@ public class LuceneDocCollectorProvider implements AutoCloseable {
         PlannedAnalyzedRelation plannedAnalyzedRelation = queryAndFetchConsumer.consume(
             analysis.rootRelation(),
             new ConsumerContext(analysis.rootRelation(), new Planner.Context(
-                cluster.clusterService(), UUID.randomUUID(), null, normalizer, new StmtCtx(), 0, 0)));
+                cluster.clusterService(), UUID.randomUUID(), null, normalizer, new TransactionContext(), 0, 0)));
         final RoutedCollectPhase collectPhase = ((RoutedCollectPhase) ((CollectAndMerge) plannedAnalyzedRelation.plan()).collectPhase());
         collectPhase.nodePageSizeHint(nodePageSizeHint);
         Routing routing = collectPhase.routing();

--- a/sql/src/test/java/io/crate/testing/SleepScalarFunction.java
+++ b/sql/src/test/java/io/crate/testing/SleepScalarFunction.java
@@ -26,7 +26,7 @@ import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
-import io.crate.metadata.StmtCtx;
+import io.crate.metadata.TransactionContext;
 import io.crate.operation.Input;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -49,7 +49,7 @@ public class SleepScalarFunction extends Scalar<Boolean, Long> {
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol, StmtCtx stmtCtx) {
+    public Symbol normalizeSymbol(Function symbol, TransactionContext transactionContext) {
         return symbol;
     }
 

--- a/sql/src/test/java/io/crate/testing/SqlExpressions.java
+++ b/sql/src/test/java/io/crate/testing/SqlExpressions.java
@@ -96,7 +96,7 @@ public class SqlExpressions {
                 : new ParameterContext(new RowN(parameters), Collections.<Row>emptyList()),
             new FullQualifedNameFieldProvider(sources),
             fieldResolver);
-        expressionAnalysisCtx = new ExpressionAnalysisContext(new StmtCtx());
+        expressionAnalysisCtx = new ExpressionAnalysisContext(new TransactionContext());
     }
 
     public Symbol asSymbol(String expression) {
@@ -104,7 +104,7 @@ public class SqlExpressions {
     }
 
     public Symbol normalize(Symbol symbol) {
-        return expressionAnalyzer.normalize(symbol, expressionAnalysisCtx.statementContext());
+        return expressionAnalyzer.normalize(symbol, expressionAnalysisCtx.transactionContext());
     }
 
     public <T> T getInstance(Class<T> clazz) {


### PR DESCRIPTION
There is another "StatementAnalysisContxt". Renaming StatementContext to
TransactionContext should make it easier to distinguish these two.