### PR TITLE
Remove transactionContext from ExpressionAnalysisContext

### DIFF
--- a/sql/src/main/java/io/crate/analyze/AlterTableAddColumnAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/AlterTableAddColumnAnalyzer.java
@@ -81,8 +81,11 @@ public class AlterTableAddColumnAnalyzer extends DefaultTraversalVisitor<AddColu
         addExistingPrimaryKeys(statement);
         ensureNoIndexDefinitions(statement.analyzedTableElements().columns());
         statement.analyzedTableElements().finalizeAndValidate(
-            statement.table().ident(), statement.table(), analysisMetaData,
-            analysis.parameterContext(), analysis.sessionContext(), analysis.transactionContext());
+            statement.table().ident(),
+            statement.table(),
+            analysisMetaData,
+            analysis.parameterContext(),
+            analysis.sessionContext());
 
         int numCurrentPks = statement.table().primaryKey().size();
         if (statement.table().primaryKey().contains(DocSysColumns.ID)) {

--- a/sql/src/main/java/io/crate/analyze/AnalyzedTableElements.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedTableElements.java
@@ -209,11 +209,9 @@ public class AnalyzedTableElements {
                                     @Nullable TableInfo tableInfo,
                                     AnalysisMetaData analysisMetaData,
                                     ParameterContext parameterContext,
-                                    SessionContext sessionContext,
-                                    TransactionContext transactionContext
-    ) {
+                                    SessionContext sessionContext) {
         expandColumnIdents();
-        validateGeneratedColumns(tableIdent, tableInfo, analysisMetaData, parameterContext, sessionContext, transactionContext);
+        validateGeneratedColumns(tableIdent, tableInfo, analysisMetaData, parameterContext, sessionContext);
         for (AnalyzedColumnDefinition column : columns) {
             column.validate();
             addCopyToInfo(column);
@@ -226,8 +224,7 @@ public class AnalyzedTableElements {
                                           @Nullable TableInfo tableInfo,
                                           AnalysisMetaData analysisMetaData,
                                           ParameterContext parameterContext,
-                                          SessionContext sessionContext,
-                                          TransactionContext transactionContext) {
+                                          SessionContext sessionContext) {
         List<Reference> tableReferences = new ArrayList<>();
         for (AnalyzedColumnDefinition columnDefinition : columns) {
             buildReference(tableIdent, columnDefinition, tableReferences);
@@ -241,7 +238,7 @@ public class AnalyzedTableElements {
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
             analysisMetaData, sessionContext, parameterContext, tableReferenceResolver, null);
         SymbolPrinter printer = new SymbolPrinter(analysisMetaData.functions());
-        ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext(transactionContext);
+        ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext();
         for (AnalyzedColumnDefinition columnDefinition : columns) {
             if (columnDefinition.generatedExpression() != null) {
                 processGeneratedExpression(expressionAnalyzer, printer, columnDefinition, expressionAnalysisContext);

--- a/sql/src/main/java/io/crate/analyze/AnalyzedTableElements.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedTableElements.java
@@ -236,7 +236,7 @@ public class AnalyzedTableElements {
 
         TableReferenceResolver tableReferenceResolver = new TableReferenceResolver(tableReferences);
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
-            analysisMetaData, sessionContext, parameterContext, tableReferenceResolver, null);
+            analysisMetaData.functions(), sessionContext, parameterContext, tableReferenceResolver);
         SymbolPrinter printer = new SymbolPrinter(analysisMetaData.functions());
         ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext();
         for (AnalyzedColumnDefinition columnDefinition : columns) {

--- a/sql/src/main/java/io/crate/analyze/Analyzer.java
+++ b/sql/src/main/java/io/crate/analyze/Analyzer.java
@@ -51,7 +51,7 @@ public class Analyzer {
     private final AlterTableAddColumnAnalyzer alterTableAddColumnAnalyzer;
     private final InsertFromValuesAnalyzer insertFromValuesAnalyzer;
     private final InsertFromSubQueryAnalyzer insertFromSubQueryAnalyzer;
-    private final CopyStatementAnalyzer copyStatementAnalyzer;
+    private final CopyAnalyzer copyAnalyzer;
     private final UpdateAnalyzer updateAnalyzer;
     private final DeleteAnalyzer deleteAnalyzer;
     private final DropRepositoryAnalyzer dropRepositoryAnalyzer;
@@ -71,7 +71,6 @@ public class Analyzer {
                     AlterTableAddColumnAnalyzer alterTableAddColumnAnalyzer,
                     InsertFromValuesAnalyzer insertFromValuesAnalyzer,
                     InsertFromSubQueryAnalyzer insertFromSubQueryAnalyzer,
-                    CopyStatementAnalyzer copyStatementAnalyzer,
                     DropRepositoryAnalyzer dropRepositoryAnalyzer,
                     CreateRepositoryAnalyzer createRepositoryAnalyzer,
                     DropSnapshotAnalyzer dropSnapshotAnalyzer,
@@ -95,7 +94,7 @@ public class Analyzer {
         this.alterTableAddColumnAnalyzer = alterTableAddColumnAnalyzer;
         this.insertFromValuesAnalyzer = insertFromValuesAnalyzer;
         this.insertFromSubQueryAnalyzer = insertFromSubQueryAnalyzer;
-        this.copyStatementAnalyzer = copyStatementAnalyzer;
+        this.copyAnalyzer = new CopyAnalyzer(analysisMetaData);
         this.updateAnalyzer = new UpdateAnalyzer(analysisMetaData, relationAnalyzer);
         this.deleteAnalyzer = new DeleteAnalyzer(analysisMetaData, relationAnalyzer);
         this.dropRepositoryAnalyzer = dropRepositoryAnalyzer;
@@ -153,12 +152,12 @@ public class Analyzer {
 
         @Override
         public AnalyzedStatement visitCopyFrom(CopyFrom node, Analysis context) {
-            return copyStatementAnalyzer.convertCopyFrom(node, context);
+            return copyAnalyzer.convertCopyFrom(node, context);
         }
 
         @Override
         public AnalyzedStatement visitCopyTo(CopyTo node, Analysis context) {
-            return copyStatementAnalyzer.convertCopyTo(node, context);
+            return copyAnalyzer.convertCopyTo(node, context);
         }
 
         @Override

--- a/sql/src/main/java/io/crate/analyze/CopyStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CopyStatementAnalyzer.java
@@ -248,7 +248,8 @@ public class CopyStatementAnalyzer {
         if (node.whereClause().isPresent()) {
             WhereClauseAnalyzer whereClauseAnalyzer = new WhereClauseAnalyzer(analysisMetaData, tableRelation);
             whereClause = whereClauseAnalyzer.analyze(
-                context.expressionAnalyzer.generateWhereClause(node.whereClause(), context.expressionAnalysisContext),
+                context.expressionAnalyzer.generateWhereClause(
+                    node.whereClause(), context.expressionAnalysisContext, transactionContext),
                 transactionContext);
         }
 
@@ -318,7 +319,7 @@ public class CopyStatementAnalyzer {
                        TransactionContext transactionContext,
                        DocTableRelation tableRelation,
                        Operation operation) {
-            expressionAnalysisContext = new ExpressionAnalysisContext(transactionContext);
+            expressionAnalysisContext = new ExpressionAnalysisContext();
             this.transactionContext = transactionContext;
             expressionAnalyzer = new ExpressionAnalyzer(
                 analysisMetaData,

--- a/sql/src/main/java/io/crate/analyze/CreateTableStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateTableStatementAnalyzer.java
@@ -107,8 +107,7 @@ public class CreateTableStatementAnalyzer extends DefaultTraversalVisitor<Create
             null,
             analysisMetaData,
             context.analysis.parameterContext(),
-            context.analysis.sessionContext(),
-            context.analysis.transactionContext());
+            context.analysis.sessionContext());
 
         // update table settings
         context.statement.tableParameter().settingsBuilder().put(context.statement.analyzedTableElements().settings());

--- a/sql/src/main/java/io/crate/analyze/InsertFromSubQueryAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/InsertFromSubQueryAnalyzer.java
@@ -189,7 +189,7 @@ public class InsertFromSubQueryAnalyzer {
                                                             FieldProvider fieldProvider,
                                                             List<Assignment> assignments) {
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
-            analysisMetaData, sessionContext, parameterContext, fieldProvider, tableRelation);
+            analysisMetaData.functions(), sessionContext, parameterContext, fieldProvider);
         ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext();
 
         ValueNormalizer valuesNormalizer = new ValueNormalizer(analysisMetaData.schemas(),
@@ -202,7 +202,7 @@ public class InsertFromSubQueryAnalyzer {
 
         ValuesResolver valuesResolver = new ValuesResolver(tableRelation, targetColumns);
         ValuesAwareExpressionAnalyzer valuesAwareExpressionAnalyzer = new ValuesAwareExpressionAnalyzer(
-            analysisMetaData, sessionContext, parameterContext, fieldProvider, valuesResolver);
+            analysisMetaData.functions(), sessionContext, parameterContext, fieldProvider, valuesResolver);
 
         Map<Reference, Symbol> updateAssignments = new HashMap<>(assignments.size());
         for (Assignment assignment : assignments) {

--- a/sql/src/main/java/io/crate/analyze/InsertFromSubQueryAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/InsertFromSubQueryAnalyzer.java
@@ -190,7 +190,7 @@ public class InsertFromSubQueryAnalyzer {
                                                             List<Assignment> assignments) {
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
             analysisMetaData, sessionContext, parameterContext, fieldProvider, tableRelation);
-        ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext(transactionContext);
+        ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext();
 
         ValueNormalizer valuesNormalizer = new ValueNormalizer(analysisMetaData.schemas(),
             new EvaluatingNormalizer(

--- a/sql/src/main/java/io/crate/analyze/InsertFromValuesAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/InsertFromValuesAnalyzer.java
@@ -102,7 +102,7 @@ public class InsertFromValuesAnalyzer extends AbstractInsertAnalyzer {
             convertParamFunction,
             fieldProvider,
             tableRelation);
-        ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext(analysis.transactionContext());
+        ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext();
         expressionAnalyzer.setResolveFieldsOperation(Operation.INSERT);
 
         ValuesResolver valuesResolver = new ValuesResolver(tableRelation);
@@ -137,6 +137,7 @@ public class InsertFromValuesAnalyzer extends AbstractInsertAnalyzer {
                 valuesNormalizer,
                 expressionAnalyzer,
                 expressionAnalysisContext,
+                analysis.transactionContext(),
                 valuesResolver,
                 valuesAwareExpressionAnalyzer,
                 valuesList,
@@ -177,6 +178,7 @@ public class InsertFromValuesAnalyzer extends AbstractInsertAnalyzer {
                                ValueNormalizer valueNormalizer,
                                ExpressionAnalyzer expressionAnalyzer,
                                ExpressionAnalysisContext expressionAnalysisContext,
+                               TransactionContext transactionContext,
                                ValuesResolver valuesResolver,
                                ExpressionAnalyzer valuesAwareExpressionAnalyzer,
                                ValuesList node,
@@ -199,6 +201,7 @@ public class InsertFromValuesAnalyzer extends AbstractInsertAnalyzer {
                         valueNormalizer,
                         expressionAnalyzer,
                         expressionAnalysisContext,
+                        transactionContext,
                         valuesResolver,
                         valuesAwareExpressionAnalyzer,
                         node,
@@ -216,6 +219,7 @@ public class InsertFromValuesAnalyzer extends AbstractInsertAnalyzer {
                     valueNormalizer,
                     expressionAnalyzer,
                     expressionAnalysisContext,
+                    transactionContext,
                     valuesResolver,
                     valuesAwareExpressionAnalyzer,
                     node,
@@ -236,6 +240,7 @@ public class InsertFromValuesAnalyzer extends AbstractInsertAnalyzer {
                            ValueNormalizer valueNormalizer,
                            ExpressionAnalyzer expressionAnalyzer,
                            ExpressionAnalysisContext expressionAnalysisContext,
+                           TransactionContext transactionContext,
                            ValuesResolver valuesResolver,
                            ExpressionAnalyzer valuesAwareExpressionAnalyzer,
                            ValuesList node,
@@ -262,8 +267,7 @@ public class InsertFromValuesAnalyzer extends AbstractInsertAnalyzer {
             final ColumnIdent columnIdent = column.ident().columnIdent();
             Object value;
             try {
-                valuesSymbol = valueNormalizer.normalizeInputForReference(
-                    valuesSymbol, column, expressionAnalysisContext.transactionContext());
+                valuesSymbol = valueNormalizer.normalizeInputForReference(valuesSymbol, column, transactionContext);
                 value = ((Input) valuesSymbol).value();
             } catch (IllegalArgumentException | UnsupportedOperationException e) {
                 throw new ColumnValidationException(columnIdent.sqlFqn(), e);
@@ -321,10 +325,9 @@ public class InsertFromValuesAnalyzer extends AbstractInsertAnalyzer {
                 Symbol assignmentExpression = valueNormalizer.normalizeInputForReference(
                     valuesAwareExpressionAnalyzer.convert(assignment.expression(), expressionAnalysisContext),
                     columnName,
-                    expressionAnalysisContext.transactionContext()
+                    transactionContext
                 );
-                assignmentExpression = valuesAwareExpressionAnalyzer.normalize(
-                    assignmentExpression, expressionAnalysisContext.transactionContext());
+                assignmentExpression = valuesAwareExpressionAnalyzer.normalize(assignmentExpression, transactionContext);
                 onDupKeyAssignments[i] = assignmentExpression;
 
                 if (valuesResolver.assignmentColumns.size() == i) {
@@ -341,7 +344,7 @@ public class InsertFromValuesAnalyzer extends AbstractInsertAnalyzer {
             tableRelation,
             context,
             expressionAnalyzer,
-            expressionAnalysisContext.transactionContext(),
+            transactionContext,
             referenceToLiteralContext,
             primaryKeyValues,
             insertValues,

--- a/sql/src/main/java/io/crate/analyze/QuerySpec.java
+++ b/sql/src/main/java/io/crate/analyze/QuerySpec.java
@@ -144,7 +144,7 @@ public class QuerySpec {
             this.where(where.normalize(normalizer, context));
         }
         if (having.isPresent()) {
-            Optional.of(having.get().normalize(normalizer, context));
+            having = Optional.of(having.get().normalize(normalizer, context));
         }
     }
 

--- a/sql/src/main/java/io/crate/analyze/ValuesAwareExpressionAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/ValuesAwareExpressionAnalyzer.java
@@ -29,6 +29,7 @@ import io.crate.analyze.relations.FieldProvider;
 import io.crate.analyze.symbol.Field;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.format.SymbolFormatter;
+import io.crate.metadata.Functions;
 import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.FunctionCall;
 import io.crate.sql.tree.ParameterExpression;
@@ -66,17 +67,17 @@ public class ValuesAwareExpressionAnalyzer extends ExpressionAnalyzer {
     /**
      * used to resolve the argument column in VALUES (&lt;argumentColumn&gt;) to the literal or reference
      */
-    public interface ValuesResolver {
+    interface ValuesResolver {
 
         Symbol allocateAndResolve(Field argumentColumn);
     }
 
-    public ValuesAwareExpressionAnalyzer(AnalysisMetaData analysisMetaData,
-                                         SessionContext sessionContext,
-                                         Function<ParameterExpression, Symbol> convertParamFunction,
-                                         FieldProvider fieldProvider,
-                                         ValuesResolver valuesResolver) {
-        super(analysisMetaData, sessionContext, convertParamFunction, fieldProvider, null);
+    ValuesAwareExpressionAnalyzer(Functions functions,
+                                  SessionContext sessionContext,
+                                  Function<ParameterExpression, Symbol> convertParamFunction,
+                                  FieldProvider fieldProvider,
+                                  ValuesResolver valuesResolver) {
+        super(functions, sessionContext, convertParamFunction, fieldProvider);
         this.valuesResolver = valuesResolver;
     }
 

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalysisContext.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalysisContext.java
@@ -24,27 +24,16 @@ package io.crate.analyze.expressions;
 import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.TransactionContext;
 
 import java.util.List;
 
 public class ExpressionAnalysisContext {
 
-    private final TransactionContext transactionContext;
-
     public boolean hasAggregates = false;
-
-    public ExpressionAnalysisContext(TransactionContext transactionContext) {
-        this.transactionContext = transactionContext;
-    }
 
     public Function allocateFunction(FunctionInfo functionInfo, List<Symbol> arguments) {
         Function newFunction = new Function(functionInfo, arguments);
         hasAggregates = hasAggregates || functionInfo.type() == FunctionInfo.Type.AGGREGATE;
         return newFunction;
-    }
-
-    public TransactionContext transactionContext() {
-        return transactionContext;
     }
 }

--- a/sql/src/main/java/io/crate/analyze/expressions/ValueNormalizer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ValueNormalizer.java
@@ -181,4 +181,8 @@ public class ValueNormalizer {
             );
         }
     }
+
+    public Symbol normalize(Symbol symbol, TransactionContext transactionContext) {
+        return normalizer.normalize(symbol, transactionContext);
+    }
 }

--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalysisContext.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalysisContext.java
@@ -29,7 +29,6 @@ import io.crate.analyze.AnalysisMetaData;
 import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.symbol.Symbol;
-import io.crate.metadata.TransactionContext;
 import io.crate.planner.node.dql.join.JoinType;
 import io.crate.sql.tree.ParameterExpression;
 import io.crate.sql.tree.QualifiedName;
@@ -55,14 +54,13 @@ public class RelationAnalysisContext {
 
     RelationAnalysisContext(SessionContext sessionContext,
                             Function<ParameterExpression, Symbol> convertParamFunction,
-                            TransactionContext transactionContext,
                             AnalysisMetaData analysisMetaData,
                             boolean aliasedRelation) {
         this.sessionContext = sessionContext;
         this.convertParamFunction = convertParamFunction;
         this.analysisMetaData = analysisMetaData;
         this.aliasedRelation = aliasedRelation;
-        expressionAnalysisContext = new ExpressionAnalysisContext(transactionContext);
+        expressionAnalysisContext = new ExpressionAnalysisContext();
     }
 
     boolean isAliasedRelation() {

--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalysisContext.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalysisContext.java
@@ -126,7 +126,7 @@ public class RelationAnalysisContext {
     public ExpressionAnalyzer expressionAnalyzer() {
         if (expressionAnalyzer == null) {
             expressionAnalyzer = new ExpressionAnalyzer(
-                analysisMetaData, sessionContext, convertParamFunction, new FullQualifedNameFieldProvider(sources), null);
+                analysisMetaData.functions(), sessionContext, convertParamFunction, new FullQualifedNameFieldProvider(sources));
         }
         return expressionAnalyzer;
     }

--- a/sql/src/main/java/io/crate/analyze/relations/RelationNormalizer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationNormalizer.java
@@ -103,6 +103,7 @@ final class RelationNormalizer extends AnalyzedRelationVisitor<RelationNormalize
     @Override
     public AnalyzedRelation visitMultiSourceSelect(MultiSourceSelect multiSourceSelect, Context context) {
         MultiSourceSelect relation = multiSourceSelect;
+        multiSourceSelect.querySpec().normalize(context.normalizer, context.transactionContext);
         if (context.querySpec != null) {
             QuerySpec querySpec = mergeAndReplaceFields(multiSourceSelect, context.querySpec);
             // must create a new MultiSourceSelect because paths and query spec changed
@@ -225,10 +226,12 @@ final class RelationNormalizer extends AnalyzedRelationVisitor<RelationNormalize
         private final AnalysisMetaData analysisMetaData;
         private final List<Field> fields;
         private final TransactionContext transactionContext;
+        private final EvaluatingNormalizer normalizer;
 
         private QuerySpec querySpec;
 
         public Context(AnalysisMetaData analysisMetaData, List<Field> fields, TransactionContext transactionContext) {
+            this.normalizer = new EvaluatingNormalizer(analysisMetaData, null, false);
             this.analysisMetaData = analysisMetaData;
             this.fields = fields;
             this.transactionContext = transactionContext;

--- a/sql/src/main/java/io/crate/analyze/relations/StatementAnalysisContext.java
+++ b/sql/src/main/java/io/crate/analyze/relations/StatementAnalysisContext.java
@@ -67,7 +67,7 @@ public class StatementAnalysisContext {
 
     RelationAnalysisContext startRelation(boolean aliasedRelation) {
         RelationAnalysisContext currentRelationContext = new RelationAnalysisContext(
-            sessionContext, convertParamFunction, transactionContext, analysisMetaData, aliasedRelation);
+            sessionContext, convertParamFunction, analysisMetaData, aliasedRelation);
         lastRelationContextQueue.add(currentRelationContext);
         return currentRelationContext;
     }

--- a/sql/src/main/java/io/crate/analyze/symbol/SymbolVisitors.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/SymbolVisitors.java
@@ -28,23 +28,23 @@ public class SymbolVisitors {
 
     private static final AnyPredicateVisitor ANY_VISITOR = new AnyPredicateVisitor();
 
-    public static boolean any(Predicate<Symbol> symbolPredicate, Symbol... symbols) {
+    public static boolean any(Predicate<? super Symbol> symbolPredicate, Symbol symbol) {
+        return ANY_VISITOR.process(symbol, symbolPredicate);
+    }
+
+    public static boolean any(Predicate<? super Symbol> symbolPredicate, Symbol... symbols) {
         for (Symbol symbol : symbols) {
-            if (ANY_VISITOR.any(symbol, symbolPredicate)) {
+            if (ANY_VISITOR.process(symbol, symbolPredicate)) {
                 return true;
             }
         }
         return false;
     }
 
-    public static class AnyPredicateVisitor extends SymbolVisitor<Predicate<Symbol>, Boolean> {
-
-        public boolean any(Symbol symbol, Predicate<Symbol> symbolPredicate) {
-            return process(symbol, symbolPredicate);
-        }
+    private static class AnyPredicateVisitor extends SymbolVisitor<Predicate<? super Symbol>, Boolean> {
 
         @Override
-        public Boolean visitFunction(Function symbol, Predicate<Symbol> symbolPredicate) {
+        public Boolean visitFunction(Function symbol, Predicate<? super Symbol> symbolPredicate) {
             if (symbolPredicate.apply(symbol)) {
                 return true;
             }
@@ -57,14 +57,14 @@ public class SymbolVisitors {
         }
 
         @Override
-        public Boolean visitFetchReference(FetchReference fetchReference, Predicate<Symbol> symbolPredicate) {
+        public Boolean visitFetchReference(FetchReference fetchReference, Predicate<? super Symbol> symbolPredicate) {
             return symbolPredicate.apply(fetchReference)
                    || fetchReference.docId().accept(this, symbolPredicate)
                    || fetchReference.ref().accept(this, symbolPredicate);
         }
 
         @Override
-        public Boolean visitMatchPredicate(MatchPredicate matchPredicate, Predicate<Symbol> symbolPredicate) {
+        public Boolean visitMatchPredicate(MatchPredicate matchPredicate, Predicate<? super Symbol> symbolPredicate) {
             if (symbolPredicate.apply(matchPredicate)) {
                 return true;
             }
@@ -77,7 +77,7 @@ public class SymbolVisitors {
         }
 
         @Override
-        protected Boolean visitSymbol(Symbol symbol, Predicate<Symbol> symbolPredicate) {
+        protected Boolean visitSymbol(Symbol symbol, Predicate<? super Symbol> symbolPredicate) {
             return symbolPredicate.apply(symbol);
         }
     }

--- a/sql/src/main/java/io/crate/metadata/doc/DocIndexMetaData.java
+++ b/sql/src/main/java/io/crate/metadata/doc/DocIndexMetaData.java
@@ -481,7 +481,7 @@ public class DocIndexMetaData {
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
             new AnalysisMetaData(functions, null, null),
             SessionContext.SYSTEM_SESSION, ParamTypeHints.EMPTY, tableReferenceResolver, null);
-        ExpressionAnalysisContext context = new ExpressionAnalysisContext(new TransactionContext());
+        ExpressionAnalysisContext context = new ExpressionAnalysisContext();
         for (Reference reference : generatedColumnReferences) {
             GeneratedReference generatedReference = (GeneratedReference) reference;
             Expression expression = SqlParser.createExpression(generatedReference.formattedGeneratedExpression());

--- a/sql/src/main/java/io/crate/metadata/doc/DocIndexMetaData.java
+++ b/sql/src/main/java/io/crate/metadata/doc/DocIndexMetaData.java
@@ -25,7 +25,6 @@ import com.google.common.base.MoreObjects;
 import com.google.common.collect.*;
 import io.crate.Constants;
 import io.crate.action.sql.SessionContext;
-import io.crate.analyze.AnalysisMetaData;
 import io.crate.analyze.NumberOfReplicas;
 import io.crate.analyze.ParamTypeHints;
 import io.crate.analyze.TableParameterInfo;
@@ -479,8 +478,7 @@ public class DocIndexMetaData {
         Collection<Reference> references = this.references.values();
         TableReferenceResolver tableReferenceResolver = new TableReferenceResolver(references);
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
-            new AnalysisMetaData(functions, null, null),
-            SessionContext.SYSTEM_SESSION, ParamTypeHints.EMPTY, tableReferenceResolver, null);
+            functions, SessionContext.SYSTEM_SESSION, ParamTypeHints.EMPTY, tableReferenceResolver);
         ExpressionAnalysisContext context = new ExpressionAnalysisContext();
         for (Reference reference : generatedColumnReferences) {
             GeneratedReference generatedReference = (GeneratedReference) reference;

--- a/sql/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -75,7 +75,7 @@ public class ExpressionAnalyzerTest extends CrateUnitTest {
         paramTypeHints = ParamTypeHints.EMPTY;
         DummyRelation dummyRelation = new DummyRelation("obj.x", "myObj.x", "myObj.x.AbC");
         dummySources = ImmutableMap.of(new QualifiedName("foo"), (AnalyzedRelation) dummyRelation);
-        context = new ExpressionAnalysisContext(new TransactionContext());
+        context = new ExpressionAnalysisContext();
 
         analysisMetaData = new AnalysisMetaData(
             getFunctions(),
@@ -94,7 +94,7 @@ public class ExpressionAnalyzerTest extends CrateUnitTest {
         expectedException.expectMessage("Unsupported expression IF(1, 3)");
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
             mockedAnalysisMetaData, SessionContext.SYSTEM_SESSION, paramTypeHints, new FullQualifedNameFieldProvider(dummySources), null);
-        ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext(new TransactionContext());
+        ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext();
 
         expressionAnalyzer.convert(SqlParser.createExpression("IF ( 1 , 3 )"), expressionAnalysisContext);
     }
@@ -105,7 +105,7 @@ public class ExpressionAnalyzerTest extends CrateUnitTest {
         expectedException.expectMessage("Unsupported expression current_time");
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
             mockedAnalysisMetaData, SessionContext.SYSTEM_SESSION, paramTypeHints, new FullQualifedNameFieldProvider(dummySources), null);
-        ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext(new TransactionContext());
+        ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext();
 
         expressionAnalyzer.convert(SqlParser.createExpression("current_time"), expressionAnalysisContext);
     }
@@ -118,7 +118,7 @@ public class ExpressionAnalyzerTest extends CrateUnitTest {
             paramTypeHints,
             new FullQualifedNameFieldProvider(dummySources),
             null);
-        ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext(new TransactionContext());
+        ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext();
 
         Field field1 = (Field) expressionAnalyzer.convert(SqlParser.createExpression("obj['x']"), expressionAnalysisContext);
         Field field2 = (Field) expressionAnalyzer.convert(SqlParser.createExpression("\"obj['x']\""), expressionAnalysisContext);
@@ -180,7 +180,7 @@ public class ExpressionAnalyzerTest extends CrateUnitTest {
 
     @Test
     public void testNonDeterministicFunctionsAlwaysNew() throws Exception {
-        ExpressionAnalysisContext localContext = new ExpressionAnalysisContext(new TransactionContext());
+        ExpressionAnalysisContext localContext = new ExpressionAnalysisContext();
         FunctionInfo info1 = new FunctionInfo(
             new FunctionIdent("inc", Arrays.<DataType>asList(DataTypes.BOOLEAN)),
             DataTypes.INTEGER,

--- a/sql/src/test/java/io/crate/analyze/symbol/format/SymbolPrinterTest.java
+++ b/sql/src/test/java/io/crate/analyze/symbol/format/SymbolPrinterTest.java
@@ -54,10 +54,10 @@ import static org.hamcrest.Matchers.is;
 
 public class SymbolPrinterTest extends CrateUnitTest {
 
-    SqlExpressions sqlExpressions;
-    SymbolPrinter printer;
+    private SqlExpressions sqlExpressions;
+    private SymbolPrinter printer;
 
-    public static final String TABLE_NAME = "formatter";
+    private static final String TABLE_NAME = "formatter";
 
     @Before
     public void prepare() throws Exception {
@@ -350,13 +350,13 @@ public class SymbolPrinterTest extends CrateUnitTest {
 
     @Test
     public void testPrintAnyEqOperator() throws Exception {
-        assertPrintingRoundTrip("foo = ANY (['a', 'b', 'c'])", "(doc.formatter.foo = ANY(['a', 'b', 'c']))");
+        assertPrintingRoundTrip("foo = ANY (['a', 'b', 'c'])", "(doc.formatter.foo = ANY(_array('a', 'b', 'c')))");
         assertPrintingRoundTrip("foo = ANY(s_arr)", "(doc.formatter.foo = ANY(doc.formatter.s_arr))");
     }
 
     @Test
     public void testAnyNeqOperator() throws Exception {
-        assertPrintingRoundTrip("not foo != ANY (['a', 'b', 'c'])", "(NOT (doc.formatter.foo <> ANY(['a', 'b', 'c'])))");
+        assertPrintingRoundTrip("not foo != ANY (['a', 'b', 'c'])", "(NOT (doc.formatter.foo <> ANY(_array('a', 'b', 'c'))))");
         assertPrintingRoundTrip("not foo != ANY(s_arr)", "(NOT (doc.formatter.foo <> ANY(doc.formatter.s_arr)))");
     }
 
@@ -368,6 +368,6 @@ public class SymbolPrinterTest extends CrateUnitTest {
     @Test
     public void testAnyLikeOperator() throws Exception {
         assertPrintingRoundTrip("foo LIKE ANY (s_arr)", "(doc.formatter.foo LIKE ANY(doc.formatter.s_arr))");
-        assertPrintingRoundTrip("foo NOT LIKE ANY (['a', 'b', 'c'])", "(doc.formatter.foo NOT LIKE ANY(['a', 'b', 'c']))");
+        assertPrintingRoundTrip("foo NOT LIKE ANY (['a', 'b', 'c'])", "(doc.formatter.foo NOT LIKE ANY(_array('a', 'b', 'c')))");
     }
 }

--- a/sql/src/test/java/io/crate/metadata/table/TestingTableInfo.java
+++ b/sql/src/test/java/io/crate/metadata/table/TestingTableInfo.java
@@ -26,7 +26,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import io.crate.action.sql.SessionContext;
-import io.crate.analyze.AnalysisMetaData;
 import io.crate.analyze.WhereClause;
 import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
@@ -278,7 +277,7 @@ public class TestingTableInfo extends DocTableInfo {
         private void initializeGeneratedExpressions(Functions functions, Collection<Reference> columns) {
             TableReferenceResolver tableReferenceResolver = new TableReferenceResolver(columns);
             ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
-                new AnalysisMetaData(functions, null, null), SessionContext.SYSTEM_SESSION, null, tableReferenceResolver, null);
+                functions, SessionContext.SYSTEM_SESSION, null, tableReferenceResolver);
             for (GeneratedReference generatedReferenceInfo : generatedColumns.build()) {
                 Expression expression = SqlParser.createExpression(generatedReferenceInfo.formattedGeneratedExpression());
                 ExpressionAnalysisContext context = new ExpressionAnalysisContext();

--- a/sql/src/test/java/io/crate/metadata/table/TestingTableInfo.java
+++ b/sql/src/test/java/io/crate/metadata/table/TestingTableInfo.java
@@ -281,7 +281,7 @@ public class TestingTableInfo extends DocTableInfo {
                 new AnalysisMetaData(functions, null, null), SessionContext.SYSTEM_SESSION, null, tableReferenceResolver, null);
             for (GeneratedReference generatedReferenceInfo : generatedColumns.build()) {
                 Expression expression = SqlParser.createExpression(generatedReferenceInfo.formattedGeneratedExpression());
-                ExpressionAnalysisContext context = new ExpressionAnalysisContext(new TransactionContext());
+                ExpressionAnalysisContext context = new ExpressionAnalysisContext();
                 generatedReferenceInfo.generatedExpression(expressionAnalyzer.convert(expression, context));
                 generatedReferenceInfo.referencedReferences(ImmutableList.copyOf(tableReferenceResolver.references()));
                 tableReferenceResolver.references().clear();

--- a/sql/src/test/java/io/crate/testing/SqlExpressions.java
+++ b/sql/src/test/java/io/crate/testing/SqlExpressions.java
@@ -56,6 +56,7 @@ public class SqlExpressions {
     private final ExpressionAnalysisContext expressionAnalysisCtx;
     private final Injector injector;
     private final AnalysisMetaData analysisMetaData;
+    private final TransactionContext transactionContext;
 
     public SqlExpressions(Map<QualifiedName, AnalyzedRelation> sources) {
         this(sources, null, null);
@@ -96,7 +97,8 @@ public class SqlExpressions {
                 : new ParameterContext(new RowN(parameters), Collections.<Row>emptyList()),
             new FullQualifedNameFieldProvider(sources),
             fieldResolver);
-        expressionAnalysisCtx = new ExpressionAnalysisContext(new TransactionContext());
+        expressionAnalysisCtx = new ExpressionAnalysisContext();
+        transactionContext = new TransactionContext();
     }
 
     public Symbol asSymbol(String expression) {
@@ -104,7 +106,7 @@ public class SqlExpressions {
     }
 
     public Symbol normalize(Symbol symbol) {
-        return expressionAnalyzer.normalize(symbol, expressionAnalysisCtx.transactionContext());
+        return expressionAnalyzer.normalize(symbol, transactionContext);
     }
 
     public <T> T getInstance(Class<T> clazz) {


### PR DESCRIPTION
The ExpressionAnalysisContext was used as messeneger to pass around
the TransactionContext.

This was done for convenience to not have to pass around multiple
parameters, but it is bad for separation of concerns.

In addition this commit also removes all internal normalize calls from within
the ExpressionAnalyzer. It was inconsistent that *some*
expressions/symbols were eagerly normalized, because most were not.