### PR TITLE
Removed arbitrary limit on timestamp values.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,11 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Removed arbitrary limit on timestamp values. Now also dates before
+   1653-02-10 and after 2286-11-20 are supported.
+   However, there is still a limitation that the year needs to be within in the
+   integer range (-292275054 <= year <= 292278993).
+
  - Expose bound psql port in ``sys.nodes``
 
  - BREAKING: Removed deprecated Plugin interface methods.

--- a/blackbox/docs/sql/data_types.txt
+++ b/blackbox/docs/sql/data_types.txt
@@ -152,14 +152,21 @@ Example::
 timestamp
 =========
 
-The timestamp type is a special type which maps to a formatted string. Internally it maps to
-the UTC milliseconds since 1970-01-01T00:00:00Z stored as ``long``. They are always returned as ``long``.
+The timestamp type is a special type which maps to a formatted string.
+Internally it maps to the UTC milliseconds since 1970-01-01T00:00:00Z stored
+as ``long``. Timestamps are always returned as ``long`` values.
 The default format is dateOptionalTime_ and cannot be changed currently.
 Formatted date strings containing timezone offset information will be converted to UTC.
 Formated string without timezone offset information will be treated as UTC.
 Timestamps will also accept a ``long`` representing UTC milliseconds since the epoch or
 a ``float`` or ``double`` representing UTC seconds since the epoch with milliseconds as
-fractions. Example::
+fractions.
+
+Due to internal date parsing, not the full ``long`` range is supported for
+timestamp values, but only dates between year ``292275054BC`` and ``292278993AD``,
+which is slightly smaller.
+
+Examples::
 
     cr> create table my_table4 (
     ...   id integer,
@@ -194,6 +201,11 @@ fractions. Example::
     cr> insert into my_table4 (id, first_column) values (3, 'wrong');
     SQLActionException[ColumnValidationException: Validation failed for first_column: 'wrong' cannot be cast to type timestamp]
 
+.. note::
+
+    When inserting timestamps smaller than ``-999999999999999`` (equals to
+    ``-29719-04-05T22:13:20.001Z``) or bigger than ``999999999999999`` (equals to
+    ``33658-09-27T01:46:39.999Z``) rouding issues may occur.
 
 .. note::
 

--- a/sql/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
@@ -26,9 +26,12 @@ import io.crate.action.sql.SQLAction;
 import io.crate.action.sql.SQLActionException;
 import io.crate.action.sql.SQLRequest;
 import io.crate.action.sql.SQLResponse;
+import io.crate.rest.CrateRestFilter;
 import io.crate.testing.TestingHelpers;
 import io.crate.testing.UseJdbc;
 import org.elasticsearch.client.Client;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.node.Node;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Test;
 
@@ -516,5 +519,26 @@ public class SQLTypeMappingTest extends SQLTransportIntegrationTest {
         SQLResponse response = execute("select categories[1]['subcategories']['id'] from assets");
         assertEquals(response.rowCount(), 1L);
         assertThat((Integer) response.rows()[0][0], is(10));
+    }
+
+    @Test
+    public void testInsertTimestamp() throws Exception {
+        // This is a regression test that we allow timestamps that have more than 13 digits.
+        execute("create table ts_table (ts timestamp) clustered into 2 shards with (number_of_replicas=0)");
+        ensureYellow();
+        // biggest Long that can be converted to Double without losing precision
+        // equivalent to 33658-09-27T01:46:39.999Z
+        long maxDateMillis = 999999999999999L;
+        // smallest Long that can be converted to Double without losing precision
+        // equivalent to -29719-04-05T22:13:20.001Z
+        long minDateMillis = -999999999999999L;
+
+        execute("insert into ts_table (ts) values (?)", new Object[]{ minDateMillis });
+        execute("insert into ts_table (ts) values (?)", new Object[]{ 0L });
+        execute("insert into ts_table (ts) values (?)", new Object[]{ maxDateMillis });
+        // TODO: select timestamps with correct sorting
+        refresh();
+        SQLResponse response = execute("select * from ts_table order by ts desc");
+        assertEquals(response.rowCount(), 3L);
     }
 }

--- a/sql/src/test/java/io/crate/protocols/postgres/types/PGTypesTest.java
+++ b/sql/src/test/java/io/crate/protocols/postgres/types/PGTypesTest.java
@@ -81,6 +81,8 @@ public class PGTypesTest extends CrateUnitTest {
             new Entry(DataTypes.BOOLEAN, true),
             new Entry(DataTypes.TIMESTAMP, DataTypes.TIMESTAMP.value("2014-05-08")),
             new Entry(DataTypes.TIMESTAMP, DataTypes.TIMESTAMP.value("2014-05-08T16:34:33.123")),
+            new Entry(DataTypes.TIMESTAMP, DataTypes.TIMESTAMP.value(999999999999999L)),
+            new Entry(DataTypes.TIMESTAMP, DataTypes.TIMESTAMP.value(-999999999999999L)),
             new Entry(DataTypes.IP, TestingHelpers.bytesRef("192.168.1.1", random())),
             new Entry(DataTypes.BYTE, (byte) 20),
             new Entry(new ArrayType(DataTypes.INTEGER), new Integer[] {10, null, 20}),


### PR DESCRIPTION
Now also dates before 1653-02-10 and after 2286-11-20 are supported.

corresponding ES commit: https://github.com/crate/elasticsearch/commit/ae3120e3121035cb2d7ac1eec9755c24520b3dbc

@dobe please