### PR TITLE
Extend gradle logging to include stacktraces

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -208,6 +208,9 @@ project.gradle.addListener(new TestListener() {
             testOutputs[test].each { e ->
                 print e
             }
+            result.getExceptions().each { e ->
+                e.printStackTrace();
+            }
         }
         testOutputs.remove(test)
     }

--- a/sql/src/main/java/io/crate/exceptions/Exceptions.java
+++ b/sql/src/main/java/io/crate/exceptions/Exceptions.java
@@ -26,6 +26,8 @@ import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.crate.action.sql.SQLActionException;
 import io.crate.metadata.PartitionName;
 import io.crate.sql.parser.ParsingException;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.util.concurrent.UncategorizedExecutionException;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.engine.DocumentAlreadyExistsException;
@@ -48,6 +50,8 @@ import java.util.concurrent.ExecutionException;
 
 public class Exceptions {
 
+    private final static ESLogger LOGGER = Loggers.getLogger(Exceptions.class);
+
     public static Throwable unwrap(@Nonnull Throwable t) {
         int counter = 0;
         Throwable result = t;
@@ -63,6 +67,7 @@ public class Exceptions {
                 return result;
             }
             if (counter > 10) {
+                LOGGER.warn("Exception cause unwrapping ran for 10 levels. Aborting unwrap", t);
                 return result;
             }
             counter++;


### PR DESCRIPTION
Before on an error only the exception message was printed without the
stacktrace:

    SQLActionException: INTERNAL_SERVER_ERROR 5000 VersionConflictEngineException: [default][1]: version conflict, current [2], provided [1]

Now the the stacktraces are printed as well. This should make it easier
to investigate failures happening on travis or jenkins:

    SQLActionException: INTERNAL_SERVER_ERROR 5000 VersionConflictEngineException: [default][1]: version conflict, current [2], provided [1]
	at __randomizedtesting.SeedInfo.seed([77EA16E28A5A1C17:90F9683BBC4E8210]:0)
	at org.elasticsearch.index.engine.InternalEngine.innerDelete(InternalEngine.java:598)
	at org.elasticsearch.index.engine.InternalEngine.delete(InternalEngine.java:558)
        [...]