### PR TITLE
pgwire: Change server_version format to dotted notation

### DIFF
--- a/sql/src/main/java/io/crate/protocols/postgres/ConnectionContext.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/ConnectionContext.java
@@ -259,7 +259,7 @@ class ConnectionContext {
                     session = readStartupMessage(buffer);
                     Messages.sendAuthenticationOK(channel);
 
-                    Messages.sendParameterStatus(channel, "server_version", "95000");
+                    Messages.sendParameterStatus(channel, "server_version", "9.5.0");
                     Messages.sendParameterStatus(channel, "server_encoding", "UTF8");
                     Messages.sendParameterStatus(channel, "client_encoding", "UTF8");
                     Messages.sendParameterStatus(channel, "datestyle", "ISO");


### PR DESCRIPTION
Some clients can't handle the numeric form (For example npgsql).
libpg also parses the dotted notation so using this should be fine:

    https://git.postgresql.org/gitweb/?p=postgresql.git;a=blob;f=src/interfaces/libpq/fe-exec.c;h=87ff5659ff35ef63081af161e9e850cacbdfedb9;hb=HEAD#l985