### PR TITLE
Add no-query assertion to SingleRowSource

### DIFF
--- a/sql/src/main/java/io/crate/operation/collect/sources/SingleRowSource.java
+++ b/sql/src/main/java/io/crate/operation/collect/sources/SingleRowSource.java
@@ -53,6 +53,8 @@ public class SingleRowSource implements CollectSource {
         if (collectPhase.whereClause().noMatch()) {
             return ImmutableList.<CrateCollector>of(RowsCollector.empty(downstream));
         }
+        assert !collectPhase.whereClause().hasQuery()
+            : "WhereClause should have been normalized to either MATCH_ALL or NO_MATCH";
         ImplementationSymbolVisitor.Context ctx = nodeImplementationSymbolVisitor.extractImplementations(collectPhase.toCollect());
         return ImmutableList.<CrateCollector>of(RowsCollector.single(new InputRow(ctx.topLevelInputs()), downstream));
     }


### PR DESCRIPTION
The SingleRowSource doesn't use a RowFilter so it needs to make sure
that there really is no query on the whereClause. Otherwise it would
return a row even if there is a query which hasn't been fully evaluated.