### PR TITLE
fixed postgres timestamp string format for dates before christ (B.C.)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,10 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Postgres clients do not accept negative years in timestamp string but
+   require ``BC`` suffix for dates before Christ. Now the correct date format
+   string is sent to client.
+
  - Removed arbitrary limit on timestamp values. Now also dates before
    1653-02-10 and after 2286-11-20 are supported.
    However, there is still a limitation that the year needs to be within in the

--- a/sql/src/main/java/io/crate/protocols/postgres/types/TimestampType.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/TimestampType.java
@@ -28,6 +28,7 @@ import org.joda.time.format.DateTimeFormatter;
 
 import javax.annotation.Nonnull;
 import java.nio.charset.StandardCharsets;
+import java.util.Locale;
 
 class TimestampType extends PGType {
 
@@ -48,7 +49,7 @@ class TimestampType extends PGType {
 
 
     // ISO is the default - postgres allows changing the format but that's currently not supported
-    private static final DateTimeFormatter ISO_FORMATTER = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.SSS +00").withZoneUTC();
+    private static final DateTimeFormatter ISO_FORMATTER = DateTimeFormat.forPattern("YYYY-MM-dd HH:mm:ss.SSS +00 G").withZoneUTC().withLocale(Locale.ENGLISH);
 
 
     private TimestampType() {
@@ -86,7 +87,7 @@ class TimestampType extends PGType {
 
     @Override
     byte[] encodeAsUTF8Text(@Nonnull Object value) {
-        return ISO_FORMATTER.print(((long) value)).getBytes(StandardCharsets.UTF_8);
+        return ISO_FORMATTER.print((long) value).getBytes(StandardCharsets.UTF_8);
     }
 
 


### PR DESCRIPTION
@mfussenegger please review