### PR TITLE
testing: Add value() calls assertion to avoid duplicate evaluations

### DIFF
--- a/sql/src/main/java/io/crate/metadata/Scalar.java
+++ b/sql/src/main/java/io/crate/metadata/Scalar.java
@@ -69,15 +69,6 @@ public abstract class Scalar<ReturnType, InputType> implements FunctionImplement
         return false;
     }
 
-    protected static boolean hasNullInputs(Input[] args) {
-        for (Input arg : args) {
-            if (arg.value() == null) {
-                return true;
-            }
-        }
-        return false;
-    }
-
     protected static boolean containsNullLiteral(Collection<Symbol> symbols) {
         return Iterables.any(symbols, NULL_LITERAL);
     }

--- a/sql/src/main/java/io/crate/operation/scalar/DateFormatFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/DateFormatFunction.java
@@ -72,25 +72,31 @@ public class DateFormatFunction extends Scalar<BytesRef, Object> {
 
     @Override
     public BytesRef evaluate(Input<Object>... args) {
-        if (hasNullInputs(args)) {
-            return null;
-        }
         BytesRef format;
         Input<?> timezoneLiteral = null;
         if (args.length == 1) {
             format = DEFAULT_FORMAT;
         } else {
             format = (BytesRef) args[0].value();
+            if (format == null) {
+                return null;
+            }
             if (args.length == 3) {
                 timezoneLiteral = args[1];
             }
         }
         Object tsValue = args[args.length - 1].value();
+        if (tsValue == null) {
+            return null;
+        }
         Long timestamp = TimestampType.INSTANCE.value(tsValue);
         DateTimeZone timezone = DateTimeZone.UTC;
         if (timezoneLiteral != null) {
-            timezone = TimeZoneParser.parseTimeZone(
-                BytesRefs.toBytesRef(timezoneLiteral.value()));
+            Object timezoneValue = timezoneLiteral.value();
+            if (timezoneValue == null) {
+                return null;
+            }
+            timezone = TimeZoneParser.parseTimeZone(BytesRefs.toBytesRef(timezoneValue));
         }
         DateTime dateTime = new DateTime(timestamp, timezone);
         return TimestampFormatter.format(format, dateTime);

--- a/sql/src/main/java/io/crate/operation/scalar/SubstrFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/SubstrFunction.java
@@ -63,17 +63,25 @@ public class SubstrFunction extends Scalar<BytesRef, Object> implements DynamicF
     @Override
     public BytesRef evaluate(Input[] args) {
         assert (args.length >= 2 && args.length <= 3);
-        if (hasNullInputs(args)) {
+        final Object val = args[0].value();
+        if (val == null) {
             return null;
         }
-        final Object val = args[0].value();
+        Number beginIdx = (Number) args[1].value();
+        if (beginIdx == null) {
+            return null;
+        }
         if (args.length == 3) {
+            Number len = (Number) args[2].value();
+            if (len == null) {
+                return null;
+            }
             return evaluate(BytesRefs.toBytesRef(val),
-                ((Number) args[1].value()).intValue(),
-                ((Number) args[2].value()).intValue());
+                (beginIdx).intValue(),
+                len.intValue());
 
         }
-        return evaluate(BytesRefs.toBytesRef(val), ((Number) args[1].value()).intValue());
+        return evaluate(BytesRefs.toBytesRef(val), (beginIdx).intValue());
     }
 
     private static BytesRef evaluate(@Nonnull BytesRef inputStr, int beginIdx) {


### PR DESCRIPTION
We've had performance issues in the past due to repetitive input.value()
calls. See 9dc24196f2cf0c3d900ac61389473dfffb51e117

This commit extends AbstractScalarFunctionsTest to wrap inputs into an
asserting Input which verifies that `value()` only receives one call per
evaluation.