### PR TITLE
prefer milliseconds unit for timestamps that are ambiguous

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,12 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Prefer milliseconds unit for timestamps that are ambiguous, such as ``"1000"``,
+   which could be interpreted as ``1000-01-01T00:00:00Z`` (as in year ``1000AD``)
+   or ``1970-01-01T00:00:01Z`` (as in ``1000ms`` since-the-epoch).
+   This change only effects INSERTs into tables that have been created after this
+   change.
+
  - Added support for BETWEEN
 
  - Updated crate-admin to ``0.20.2`` which includes following changes:

--- a/sql/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
@@ -214,6 +214,14 @@ public class AnalyzedColumnDefinition {
         Map<String, Object> mapping = new HashMap<>();
 
         mapping.put("type", dataType());
+
+        if ("date".equals(dataType())) {
+            /**
+             * We want 1000 not be be interpreted as year 1000AD but as 1970-01-01T00:00:01.000
+             * so prefer date mapping format epoch_millis over strict_date_optional_time
+             */
+            mapping.put("format", "epoch_millis||strict_date_optional_time");
+        }
         if (!NO_DOC_VALUES_SUPPORT.contains(dataType)) {
             mapping.put("doc_values", docValues());
             mapping.put("index", index());

--- a/sql/src/test/java/io/crate/analyze/CreateAlterPartitionedTableAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateAlterPartitionedTableAnalyzerTest.java
@@ -125,7 +125,7 @@ public class CreateAlterPartitionedTableAnalyzerTest extends BaseAnalyzerTest {
         assertThat(analysis.partitionedBy().size(), is(2));
         Map<String, Object> properties = analysis.mappingProperties();
         assertThat(mapToSortedString(properties),
-            is("date={doc_values=false, index=no, store=false, type=date}, " +
+            is("date={doc_values=false, format=epoch_millis||strict_date_optional_time, index=no, store=false, type=date}, " +
                "name={doc_values=false, index=no, store=false, type=string}"));
         assertThat((Map<String, Object>) ((Map) analysis.mapping().get("_meta")).get("columns"),
             allOf(

--- a/sql/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -679,8 +679,8 @@ public class DDLIntegrationTest extends SQLTransportIntegrationTest {
                                  "\"_meta\":{\"generated_columns\":{\"day\":\"date_trunc('day', ts)\"}}," +
                                  "\"_all\":{\"enabled\":false}," +
                                  "\"properties\":{" +
-                                 "\"day\":{\"type\":\"date\",\"format\":\"strict_date_optional_time||epoch_millis\"}," +
-                                 "\"ts\":{\"type\":\"date\",\"format\":\"strict_date_optional_time||epoch_millis\"}" +
+                                 "\"day\":{\"type\":\"date\",\"format\":\"epoch_millis||strict_date_optional_time\"}," +
+                                 "\"ts\":{\"type\":\"date\",\"format\":\"epoch_millis||strict_date_optional_time\"}" +
                                  "}}}";
 
         assertEquals(expectedMapping, getIndexMapping("test"));

--- a/sql/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
@@ -541,4 +541,16 @@ public class SQLTypeMappingTest extends SQLTransportIntegrationTest {
         SQLResponse response = execute("select * from ts_table order by ts desc");
         assertEquals(response.rowCount(), 3L);
     }
+
+    @Test
+    public void testInsertTimestampPreferMillis() throws Exception {
+        execute("create table ts_table (ts timestamp) clustered into 2 shards with (number_of_replicas=0)");
+        ensureYellow();
+        execute("insert into ts_table (ts) values (?)", new Object[]{ 1000L });
+        execute("insert into ts_table (ts) values (?)", new Object[]{ "2016" });
+        refresh();
+        SQLResponse response = execute("select ts from ts_table order by ts asc");
+        assertThat((Long) response.rows()[0][0], is(1000L));
+        assertThat((Long) response.rows()[1][0], is(2016L));
+    }
 }


### PR DESCRIPTION
such as `"1000"`, which could be interpreted as `1000-01-01T00:00:00Z`
(as in year `1000AD`) or `1970-01-01T00:00:01Z` (as in `1000ms`
since-the-epoch).

This change only effects INSERTs into tables that have been created after this
change.

@dobe please review