### PR TITLE
Change Analyzer to create sub-analyzer without injection

### DIFF
--- a/sql/src/main/java/io/crate/analyze/AlterTableAddColumnAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/AlterTableAddColumnAnalyzer.java
@@ -30,24 +30,20 @@ import io.crate.sql.tree.DefaultTraversalVisitor;
 import io.crate.sql.tree.Node;
 import io.crate.sql.tree.Table;
 import io.crate.types.CollectionType;
-import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.inject.Singleton;
 
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Locale;
 
-@Singleton
-public class AlterTableAddColumnAnalyzer extends DefaultTraversalVisitor<AddColumnAnalyzedStatement, Analysis> {
+class AlterTableAddColumnAnalyzer extends DefaultTraversalVisitor<AddColumnAnalyzedStatement, Analysis> {
 
     private final Schemas schemas;
     private final FulltextAnalyzerResolver fulltextAnalyzerResolver;
     private final Functions functions;
 
-    @Inject
-    public AlterTableAddColumnAnalyzer(Schemas schemas,
-                                       FulltextAnalyzerResolver fulltextAnalyzerResolver,
-                                       Functions functions) {
+    AlterTableAddColumnAnalyzer(Schemas schemas,
+                                FulltextAnalyzerResolver fulltextAnalyzerResolver,
+                                Functions functions) {
         this.schemas = schemas;
         this.fulltextAnalyzerResolver = fulltextAnalyzerResolver;
         this.functions = functions;

--- a/sql/src/main/java/io/crate/analyze/AlterTableAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/AlterTableAnalyzer.java
@@ -27,18 +27,14 @@ import io.crate.metadata.TableIdent;
 import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.*;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
-import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.settings.Settings;
 
-@Singleton
-public class AlterTableAnalyzer extends DefaultTraversalVisitor<AlterTableAnalyzedStatement, Analysis> {
+class AlterTableAnalyzer extends DefaultTraversalVisitor<AlterTableAnalyzedStatement, Analysis> {
 
     private static final TablePropertiesAnalyzer TABLE_PROPERTIES_ANALYZER = new TablePropertiesAnalyzer();
     private final Schemas schemas;
 
-    @Inject
-    public AlterTableAnalyzer(Schemas schemas) {
+    AlterTableAnalyzer(Schemas schemas) {
         this.schemas = schemas;
     }
 

--- a/sql/src/main/java/io/crate/analyze/CreateAnalyzerStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateAnalyzerStatementAnalyzer.java
@@ -27,8 +27,6 @@ import io.crate.metadata.FulltextAnalyzerResolver;
 import io.crate.sql.tree.*;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
@@ -36,16 +34,14 @@ import org.elasticsearch.common.settings.Settings;
 import java.util.Locale;
 import java.util.Map;
 
-@Singleton
-public class CreateAnalyzerStatementAnalyzer extends DefaultTraversalVisitor<
+class CreateAnalyzerStatementAnalyzer extends DefaultTraversalVisitor<
     CreateAnalyzerAnalyzedStatement, CreateAnalyzerStatementAnalyzer.Context> {
 
     private final FulltextAnalyzerResolver fulltextAnalyzerResolver;
 
     private final DeprecationLogger deprecationLogger;
 
-    @Inject
-    public CreateAnalyzerStatementAnalyzer(FulltextAnalyzerResolver fulltextAnalyzerResolver, Settings settings) {
+    CreateAnalyzerStatementAnalyzer(FulltextAnalyzerResolver fulltextAnalyzerResolver, Settings settings) {
         this.fulltextAnalyzerResolver = fulltextAnalyzerResolver;
         deprecationLogger = new DeprecationLogger(Loggers.getLogger(CreateAnalyzerStatementAnalyzer.class, settings));
     }

--- a/sql/src/main/java/io/crate/analyze/CreateRepositoryAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateRepositoryAnalyzer.java
@@ -25,18 +25,14 @@ import io.crate.analyze.repositories.RepositoryParamValidator;
 import io.crate.exceptions.RepositoryAlreadyExistsException;
 import io.crate.executor.transport.RepositoryService;
 import io.crate.sql.tree.CreateRepository;
-import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.settings.Settings;
 
-@Singleton
-public class CreateRepositoryAnalyzer {
+class CreateRepositoryAnalyzer {
 
     private final RepositoryParamValidator repositoryParamValidator;
     private final RepositoryService repositoryService;
 
-    @Inject
-    public CreateRepositoryAnalyzer(RepositoryService repositoryService, RepositoryParamValidator repositoryParamValidator) {
+    CreateRepositoryAnalyzer(RepositoryService repositoryService, RepositoryParamValidator repositoryParamValidator) {
         this.repositoryService = repositoryService;
         this.repositoryParamValidator = repositoryParamValidator;
     }

--- a/sql/src/main/java/io/crate/analyze/CreateSnapshotAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateSnapshotAnalyzer.java
@@ -42,8 +42,6 @@ import io.crate.sql.tree.CreateSnapshot;
 import io.crate.sql.tree.QualifiedName;
 import io.crate.sql.tree.Table;
 import org.elasticsearch.cluster.metadata.SnapshotId;
-import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
@@ -53,8 +51,7 @@ import java.util.*;
 import static io.crate.analyze.SnapshotSettings.IGNORE_UNAVAILABLE;
 import static io.crate.analyze.SnapshotSettings.WAIT_FOR_COMPLETION;
 
-@Singleton
-public class CreateSnapshotAnalyzer {
+class CreateSnapshotAnalyzer {
 
     private static final ESLogger LOGGER = Loggers.getLogger(CreateSnapshotAnalyzer.class);
     private final RepositoryService repositoryService;
@@ -66,8 +63,7 @@ public class CreateSnapshotAnalyzer {
         .build();
 
 
-    @Inject
-    public CreateSnapshotAnalyzer(RepositoryService repositoryService, Schemas schemas) {
+    CreateSnapshotAnalyzer(RepositoryService repositoryService, Schemas schemas) {
         this.repositoryService = repositoryService;
         this.schemas = schemas;
     }

--- a/sql/src/main/java/io/crate/analyze/CreateTableStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateTableStatementAnalyzer.java
@@ -28,13 +28,10 @@ import io.crate.metadata.pg_catalog.PgCatalogSchemaInfo;
 import io.crate.metadata.sys.SysSchemaInfo;
 import io.crate.sql.tree.*;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
-import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.inject.Singleton;
 
 import java.util.Collection;
 import java.util.Locale;
 
-@Singleton
 public class CreateTableStatementAnalyzer extends DefaultTraversalVisitor<CreateTableAnalyzedStatement,
     CreateTableStatementAnalyzer.Context> {
 
@@ -64,7 +61,6 @@ public class CreateTableStatementAnalyzer extends DefaultTraversalVisitor<Create
         return super.process(node, new Context(analysis));
     }
 
-    @Inject
     public CreateTableStatementAnalyzer(Schemas schemas,
                                         FulltextAnalyzerResolver fulltextAnalyzerResolver,
                                         Functions functions,

--- a/sql/src/main/java/io/crate/analyze/DropRepositoryAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/DropRepositoryAnalyzer.java
@@ -24,16 +24,12 @@ package io.crate.analyze;
 
 import io.crate.executor.transport.RepositoryService;
 import io.crate.sql.tree.DropRepository;
-import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.inject.Singleton;
 
-@Singleton
-public class DropRepositoryAnalyzer {
+class DropRepositoryAnalyzer {
 
     private final RepositoryService repositoryService;
 
-    @Inject
-    public DropRepositoryAnalyzer(RepositoryService repositoryService) {
+    DropRepositoryAnalyzer(RepositoryService repositoryService) {
         this.repositoryService = repositoryService;
     }
 

--- a/sql/src/main/java/io/crate/analyze/DropSnapshotAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/DropSnapshotAnalyzer.java
@@ -24,18 +24,16 @@ package io.crate.analyze;
 import com.google.common.base.Preconditions;
 import io.crate.executor.transport.RepositoryService;
 import io.crate.sql.tree.DropSnapshot;
-import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
 
 import java.util.List;
 
 @Singleton
-public class DropSnapshotAnalyzer {
+class DropSnapshotAnalyzer {
 
     private final RepositoryService repositoryService;
 
-    @Inject
-    public DropSnapshotAnalyzer(RepositoryService repositoryService) {
+    DropSnapshotAnalyzer(RepositoryService repositoryService) {
         this.repositoryService = repositoryService;
     }
 

--- a/sql/src/main/java/io/crate/analyze/InsertFromSubQueryAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/InsertFromSubQueryAnalyzer.java
@@ -38,13 +38,10 @@ import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.Assignment;
 import io.crate.sql.tree.InsertFromSubquery;
-import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.inject.Singleton;
 
 import java.util.*;
 
-@Singleton
-public class InsertFromSubQueryAnalyzer {
+class InsertFromSubQueryAnalyzer {
 
     private final Functions functions;
     private final Schemas schemas;
@@ -75,8 +72,7 @@ public class InsertFromSubQueryAnalyzer {
         }
     }
 
-    @Inject
-    public InsertFromSubQueryAnalyzer(Functions functions, Schemas schemas, RelationAnalyzer relationAnalyzer) {
+    InsertFromSubQueryAnalyzer(Functions functions, Schemas schemas, RelationAnalyzer relationAnalyzer) {
         this.functions = functions;
         this.schemas = schemas;
         this.relationAnalyzer = relationAnalyzer;

--- a/sql/src/main/java/io/crate/analyze/InsertFromValuesAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/InsertFromValuesAnalyzer.java
@@ -44,15 +44,12 @@ import io.crate.sql.tree.*;
 import io.crate.types.DataType;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.Nullable;
-import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.lucene.BytesRefs;
 
 import java.io.IOException;
 import java.util.*;
 
-@Singleton
-public class InsertFromValuesAnalyzer extends AbstractInsertAnalyzer {
+class InsertFromValuesAnalyzer extends AbstractInsertAnalyzer {
 
     private static final ReferenceToLiteralConverter TO_LITERAL_CONVERTER = new ReferenceToLiteralConverter();
 
@@ -83,8 +80,7 @@ public class InsertFromValuesAnalyzer extends AbstractInsertAnalyzer {
         }
     }
 
-    @Inject
-    public InsertFromValuesAnalyzer(Functions functions, Schemas schemas) {
+    InsertFromValuesAnalyzer(Functions functions, Schemas schemas) {
         super(functions, schemas);
     }
 

--- a/sql/src/main/java/io/crate/analyze/RestoreSnapshotAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/RestoreSnapshotAnalyzer.java
@@ -37,8 +37,6 @@ import io.crate.metadata.settings.SettingsAppliers;
 import io.crate.metadata.table.TableInfo;
 import io.crate.sql.tree.RestoreSnapshot;
 import io.crate.sql.tree.Table;
-import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.settings.Settings;
 
 import java.util.HashSet;
@@ -49,8 +47,7 @@ import java.util.Set;
 import static io.crate.analyze.SnapshotSettings.IGNORE_UNAVAILABLE;
 import static io.crate.analyze.SnapshotSettings.WAIT_FOR_COMPLETION;
 
-@Singleton
-public class RestoreSnapshotAnalyzer {
+class RestoreSnapshotAnalyzer {
 
     private static final ImmutableMap<String, SettingsApplier> SETTINGS = ImmutableMap.<String, SettingsApplier>builder()
         .put(IGNORE_UNAVAILABLE.name(), new SettingsAppliers.BooleanSettingsApplier(IGNORE_UNAVAILABLE))
@@ -60,8 +57,7 @@ public class RestoreSnapshotAnalyzer {
     private final RepositoryService repositoryService;
     private final Schemas schemas;
 
-    @Inject
-    public RestoreSnapshotAnalyzer(RepositoryService repositoryService, Schemas schemas) {
+    RestoreSnapshotAnalyzer(RepositoryService repositoryService, Schemas schemas) {
         this.repositoryService = repositoryService;
         this.schemas = schemas;
     }

--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -57,8 +57,6 @@ import io.crate.planner.node.dql.join.JoinType;
 import io.crate.sql.tree.*;
 import io.crate.types.DataTypes;
 import org.elasticsearch.cluster.ClusterService;
-import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.inject.Singleton;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -67,7 +65,6 @@ import java.util.List;
 import java.util.Locale;
 
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-@Singleton
 public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, StatementAnalysisContext> {
 
     private final ClusterService clusterService;
@@ -79,7 +76,6 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
         )
     );
 
-    @Inject
     public RelationAnalyzer(ClusterService clusterService, Functions functions, Schemas schemas) {
         this.clusterService = clusterService;
         this.functions = functions;

--- a/sql/src/test/java/io/crate/analyze/CreateDropRepositoryAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateDropRepositoryAnalyzerTest.java
@@ -54,8 +54,8 @@ public class CreateDropRepositoryAnalyzerTest extends BaseAnalyzerTest {
     private class MyMockedClusterServiceModule extends MockedClusterServiceModule {
 
         @Override
-        protected void configureMetaData(MetaData metaData) {
-            when(metaData.custom(RepositoriesMetaData.TYPE)).thenReturn(repositoriesMetaData);
+        protected void extendMetaData(MetaData.Builder builder) {
+            builder.putCustom(RepositoriesMetaData.TYPE, repositoriesMetaData);
         }
 
     }

--- a/sql/src/test/java/io/crate/analyze/SnapshotRestoreAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SnapshotRestoreAnalyzerTest.java
@@ -56,9 +56,10 @@ public class SnapshotRestoreAnalyzerTest extends BaseAnalyzerTest {
     private RepositoriesMetaData repositoriesMetaData;
 
     private class MyMockedClusterServiceModule extends MockedClusterServiceModule {
+
         @Override
-        protected void configureMetaData(MetaData metaData) {
-            when(metaData.custom(RepositoriesMetaData.TYPE)).thenReturn(repositoriesMetaData);
+        protected void extendMetaData(MetaData.Builder builder) {
+            builder.putCustom(RepositoriesMetaData.TYPE, repositoriesMetaData);
         }
     }
 

--- a/sql/src/test/java/io/crate/testing/MockedClusterServiceModule.java
+++ b/sql/src/test/java/io/crate/testing/MockedClusterServiceModule.java
@@ -21,13 +21,14 @@
 
 package io.crate.testing;
 
+import com.google.common.base.Throwables;
 import io.crate.executor.transport.TransportActionProvider;
+import io.crate.metadata.FulltextAnalyzerResolver;
 import org.elasticsearch.action.admin.cluster.repositories.delete.TransportDeleteRepositoryAction;
 import org.elasticsearch.action.admin.cluster.repositories.put.TransportPutRepositoryAction;
 import org.elasticsearch.action.admin.indices.template.put.TransportPutIndexTemplateAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
@@ -38,6 +39,8 @@ import org.elasticsearch.discovery.Discovery;
 import org.elasticsearch.monitor.os.OsService;
 import org.elasticsearch.monitor.os.OsStats;
 
+import java.io.IOException;
+
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -46,13 +49,9 @@ public class MockedClusterServiceModule extends AbstractModule {
     protected void configure() {
         ClusterService clusterService = mock(ClusterService.class);
         ClusterState state = mock(ClusterState.class);
-        MetaData metaData = mock(MetaData.class);
-        when(metaData.settings()).thenReturn(Settings.EMPTY);
-        when(metaData.persistentSettings()).thenReturn(Settings.EMPTY);
-        when(metaData.transientSettings()).thenReturn(Settings.EMPTY);
-        when(metaData.concreteAllOpenIndices()).thenReturn(new String[0]);
-        when(metaData.getTemplates()).thenReturn(ImmutableOpenMap.<String, IndexTemplateMetaData>of());
-        when(metaData.templates()).thenReturn(ImmutableOpenMap.<String, IndexTemplateMetaData>of());
+        MetaData.Builder builder = MetaData.builder();
+        extendMetaData(builder);
+        MetaData metaData = builder.build();
         when(state.metaData()).thenReturn(metaData);
         when(clusterService.state()).thenReturn(state);
         bind(ClusterService.class).toInstance(clusterService);
@@ -90,7 +89,6 @@ public class MockedClusterServiceModule extends AbstractModule {
 
         configureClusterService(clusterService);
         configureClusterState(state);
-        configureMetaData(metaData);
     }
 
     protected void configureClusterService(ClusterService clusterService) {
@@ -99,6 +97,6 @@ public class MockedClusterServiceModule extends AbstractModule {
     protected void configureClusterState(ClusterState clusterState) {
     }
 
-    protected void configureMetaData(MetaData metaData) {
+    protected void extendMetaData(MetaData.Builder builder) {
     }
 }


### PR DESCRIPTION
Currently creating an analyzer for unit test purposes involves a lot of
trial and error to figure out which modules are necessary to bind
because the dependencies are not clear at all.

The goal here is to be less reliant on guice and do more stuff directly.
The advantage is that dependencies are more explicit and we can make
more stuff package-private.
It also forces us to think more about dependencies. Adding dependencies
will hurt so we'll try to reduce them.

This is also the main disadvantage: More files have to be touched if a
dependency is added.

With this change creating an analyzer in a test would look as follows:

    analyzer = new Analyzer(
        Settings.EMPTY,
        schemas,
        getFunctions(),
        new NoopClusterService(),
        mock(IndicesAnalysisService.class),
        mock(RepositoryService.class),
        new RepositoryParamValidator(Collections.<String, TypeSettings>emptyMap()));