### PR TITLE
Encapsulate some deps in a DocTableInfoFactory

### DIFF
--- a/sql/src/main/java/io/crate/metadata/doc/DocSchemaInfoFactory.java
+++ b/sql/src/main/java/io/crate/metadata/doc/DocSchemaInfoFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.doc;
+
+import io.crate.metadata.table.SchemaInfo;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
+
+@Singleton
+public class DocSchemaInfoFactory {
+
+    private final DocTableInfoFactory docTableInfoFactory;
+
+    @Inject
+    public DocSchemaInfoFactory(DocTableInfoFactory docTableInfoFactory) {
+        this.docTableInfoFactory = docTableInfoFactory;
+    }
+
+    public SchemaInfo create(String schemaName, ClusterService clusterService) {
+        return new DocSchemaInfo(schemaName, clusterService, docTableInfoFactory);
+    }
+}

--- a/sql/src/main/java/io/crate/metadata/doc/DocTableInfoFactory.java
+++ b/sql/src/main/java/io/crate/metadata/doc/DocTableInfoFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.doc;
+
+import io.crate.metadata.TableIdent;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.common.inject.ImplementedBy;
+
+@ImplementedBy(InternalDocTableInfoFactory.class)
+interface DocTableInfoFactory {
+    DocTableInfo create(TableIdent ident, ClusterService clusterService);
+}

--- a/sql/src/main/java/io/crate/metadata/doc/InternalDocTableInfoFactory.java
+++ b/sql/src/main/java/io/crate/metadata/doc/InternalDocTableInfoFactory.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.doc;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.crate.metadata.Functions;
+import io.crate.metadata.TableIdent;
+import org.elasticsearch.action.admin.indices.template.put.TransportPutIndexTemplateAction;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Provider;
+import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.threadpool.ThreadPool;
+
+import java.util.concurrent.ExecutorService;
+
+@Singleton
+public class InternalDocTableInfoFactory implements DocTableInfoFactory {
+
+    private final Functions functions;
+    private final IndexNameExpressionResolver indexNameExpressionResolver;
+    private final Provider<TransportPutIndexTemplateAction> putIndexTemplateActionProvider;
+    private final ExecutorService executorService;
+
+    @Inject
+    public InternalDocTableInfoFactory(Functions functions,
+                                       IndexNameExpressionResolver indexNameExpressionResolver,
+                                       Provider<TransportPutIndexTemplateAction> putIndexTemplateActionProvider,
+                                       ThreadPool threadPool) {
+        this(functions,
+            indexNameExpressionResolver,
+            putIndexTemplateActionProvider,
+            (ExecutorService) threadPool.executor(ThreadPool.Names.SUGGEST));
+    }
+
+    @VisibleForTesting
+    InternalDocTableInfoFactory(Functions functions,
+                                IndexNameExpressionResolver indexNameExpressionResolver,
+                                Provider<TransportPutIndexTemplateAction> transportPutIndexTemplateActionProvider,
+                                ExecutorService executorService) {
+        this.functions = functions;
+        this.indexNameExpressionResolver = indexNameExpressionResolver;
+        putIndexTemplateActionProvider = transportPutIndexTemplateActionProvider;
+        this.executorService = executorService;
+    }
+
+    @Override
+    public DocTableInfo create(TableIdent ident, ClusterService clusterService) {
+        boolean checkAliasSchema = clusterService.state().metaData().settings().getAsBoolean("crate.table_alias.schema_check", true);
+        DocTableInfoBuilder builder = new DocTableInfoBuilder(
+            functions,
+            ident,
+            clusterService,
+            indexNameExpressionResolver,
+            putIndexTemplateActionProvider.get(),
+            executorService,
+            checkAliasSchema
+        );
+        return builder.build();
+    }
+}

--- a/sql/src/test/java/io/crate/metadata/ReferenceInfosTest.java
+++ b/sql/src/test/java/io/crate/metadata/ReferenceInfosTest.java
@@ -21,19 +21,17 @@
 
 package io.crate.metadata;
 
+import io.crate.metadata.doc.DocSchemaInfoFactory;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.SchemaInfo;
 import io.crate.metadata.table.TableInfo;
 import org.elasticsearch.action.admin.indices.template.put.TransportPutIndexTemplateAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.inject.Provider;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -113,13 +111,6 @@ public class ReferenceInfosTest {
     private Schemas getReferenceInfos(SchemaInfo schemaInfo) {
         Map<String, SchemaInfo> builtInSchema = new HashMap<>();
         builtInSchema.put(schemaInfo.name(), schemaInfo);
-
-        return new ReferenceInfos(
-            builtInSchema,
-            clusterService,
-            new IndexNameExpressionResolver(Settings.EMPTY),
-            mock(ThreadPool.class),
-            transportPutIndexTemplateActionProvider,
-            functions);
+        return new ReferenceInfos(builtInSchema, clusterService, mock(DocSchemaInfoFactory.class));
     }
 }


### PR DESCRIPTION
Most dependencies of ReferenceInfos & DocSchemaInfo were there because
they're required to create a DocTableInfo.

Due to this we mostly mock Schemas, SchemaInfo or DocSchemaInfo in
tests.
The goal of this commit is to make it easier to use the real instances.
The advantage is that we test more production code and less mocks.