### PR TITLE
MultiUpstreamRowReceiver must not call prepare() on its delegate

### DIFF
--- a/sql/src/main/java/io/crate/operation/projectors/MultiUpstreamRowReceiver.java
+++ b/sql/src/main/java/io/crate/operation/projectors/MultiUpstreamRowReceiver.java
@@ -63,7 +63,6 @@ public class MultiUpstreamRowReceiver implements RowReceiver, RowDownstream {
     private final RowReceiver delegate;
     private final List<ResumeHandle> resumeHandles = Collections.synchronizedList(new ArrayList<ResumeHandle>());
     private final AtomicInteger activeUpstreams = new AtomicInteger(0);
-    private final AtomicBoolean prepared = new AtomicBoolean(false);
     private final AtomicBoolean pauseTriggered = new AtomicBoolean(false);
     private final AtomicReference<Throwable> failure = new AtomicReference<>();
     private final Object lock = new Object();
@@ -199,9 +198,7 @@ public class MultiUpstreamRowReceiver implements RowReceiver, RowDownstream {
 
     @Override
     public void prepare() {
-        if (prepared.compareAndSet(false, true)) {
-            delegate.prepare();
-        }
+        // this is just a multi-upstream wrapper, delegates should be prepared elsewhere already
     }
 
     @Override


### PR DESCRIPTION
Preparation of the delegate must be done elsewhere.
Actually it is already like that, and so multiple
prepare() calls could falsely happen.
(e.g. the delegate is a projector chain member which
caused the delegate to be prepared through the projector 
chain and by this)