### PR TITLE
Add support for sub-queries in selectList and as root symbol

### DIFF
--- a/sql/src/main/java/io/crate/collections/Lists2.java
+++ b/sql/src/main/java/io/crate/collections/Lists2.java
@@ -22,8 +22,13 @@
 
 package io.crate.collections;
 
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
+
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.ListIterator;
 
 public class Lists2 {
 
@@ -36,5 +41,21 @@ public class Lists2 {
             }
         }
         return result;
+    }
+
+    /**
+     * Apply the replace function on each item of the list and replaces the item.
+     *
+     * This is similar to {@link Lists#transform(List, Function)}, but instead of creating a view on a backing list
+     * this function is actually mutating the provided list
+     */
+    public static <T> void replaceItems(@Nullable List<T> list, Function<T, T> replaceFunction) {
+        if (list == null || list.isEmpty()) {
+            return;
+        }
+        ListIterator<T> it = list.listIterator();
+        while (it.hasNext()) {
+            it.set(replaceFunction.apply(it.next()));
+        }
     }
 }

--- a/sql/src/main/java/io/crate/executor/transport/DelayedTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/DelayedTask.java
@@ -22,6 +22,7 @@
 
 package io.crate.executor.transport;
 
+import com.google.common.base.Supplier;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -38,9 +39,9 @@ import java.util.List;
 class DelayedTask implements Task {
 
     private final ListenableFuture<?> listenableFuture;
-    private final Task rootTask;
+    private final Supplier<Task> rootTask;
 
-    DelayedTask(ListenableFuture<?> listenableFuture, Task rootTask) {
+    DelayedTask(ListenableFuture<?> listenableFuture, Supplier<Task> rootTask) {
         this.listenableFuture = listenableFuture;
         this.rootTask = rootTask;
     }
@@ -50,7 +51,7 @@ class DelayedTask implements Task {
         Futures.addCallback(listenableFuture, new FutureCallback<Object>() {
             @Override
             public void onSuccess(@Nullable Object result) {
-                rootTask.execute(rowReceiver);
+                rootTask.get().execute(rowReceiver);
             }
 
             @Override

--- a/sql/src/main/java/io/crate/planner/consumer/ESGetStatementPlanner.java
+++ b/sql/src/main/java/io/crate/planner/consumer/ESGetStatementPlanner.java
@@ -48,10 +48,6 @@ public class ESGetStatementPlanner {
         if (docKeys.withVersions()){
             throw new VersionInvalidException();
         }
-        if (docKeys.size() == 1 && docKeys.iterator().next().id() == null) {
-            // handle: where id in (null)
-            return new NoopPlan(context.jobId());
-        }
         Limits limits = context.getLimits(true, querySpec);
         if (limits.hasLimit() && limits.finalLimit() == 0) {
             return new NoopPlan(context.jobId());

--- a/sql/src/main/java/io/crate/planner/node/dql/AbstractProjectionsPhase.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/AbstractProjectionsPhase.java
@@ -21,6 +21,7 @@
 
 package io.crate.planner.node.dql;
 
+import com.google.common.base.Function;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
@@ -101,6 +102,12 @@ public abstract class AbstractProjectionsPhase implements Streamable, ExecutionP
             return Optional.absent();
         } else {
             return Optional.of(projections.get(projections.size() - 1));
+        }
+    }
+
+    public void replaceSymbols(Function<Symbol, Symbol> replaceFunction) {
+        for (Projection projection : projections) {
+            projection.replaceSymbols(replaceFunction);
         }
     }
 

--- a/sql/src/main/java/io/crate/planner/node/dql/CollectPhase.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/CollectPhase.java
@@ -22,6 +22,7 @@
 
 package io.crate.planner.node.dql;
 
+import com.google.common.base.Function;
 import io.crate.analyze.EvaluatingNormalizer;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.TransactionContext;
@@ -34,11 +35,13 @@ import java.util.UUID;
 public interface CollectPhase extends UpstreamPhase {
     UUID jobId();
 
-    List<? extends Symbol> toCollect();
+    List<Symbol> toCollect();
 
     List<Projection> projections();
 
     void addProjection(Projection projection);
 
     CollectPhase normalize(EvaluatingNormalizer phase, TransactionContext transactionContext);
+
+    void replaceSymbols(Function<Symbol, Symbol> replaceFunction);
 }

--- a/sql/src/main/java/io/crate/planner/node/dql/MergePhase.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/MergePhase.java
@@ -21,6 +21,7 @@
 
 package io.crate.planner.node.dql;
 
+import com.google.common.base.Function;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -231,7 +232,6 @@ public class MergePhase extends AbstractProjectionsPhase implements UpstreamPhas
     public Boolean[] nullsFirst() {
         return nullsFirst;
     }
-
 
     @Override
     public <C, R> R accept(ExecutionPhaseVisitor<C, R> visitor, C context) {

--- a/sql/src/main/java/io/crate/planner/projection/AggregationProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/AggregationProjection.java
@@ -21,6 +21,7 @@
 
 package io.crate.planner.projection;
 
+import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import io.crate.analyze.symbol.Aggregation;
 import io.crate.analyze.symbol.Symbol;
@@ -60,6 +61,10 @@ public class AggregationProjection extends Projection {
     @Override
     public RowGranularity requiredGranularity() {
         return contextGranularity;
+    }
+
+    @Override
+    public void replaceSymbols(Function<Symbol, Symbol> replaceFunction) {
     }
 
     public List<Aggregation> aggregations() {

--- a/sql/src/main/java/io/crate/planner/projection/ColumnIndexWriterProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/ColumnIndexWriterProjection.java
@@ -21,9 +21,11 @@
 
 package io.crate.planner.projection;
 
+import com.google.common.base.Function;
 import io.crate.analyze.symbol.InputColumn;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.Symbols;
+import io.crate.collections.Lists2;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
 import io.crate.metadata.TableIdent;
@@ -109,6 +111,16 @@ public class ColumnIndexWriterProjection extends AbstractIndexWriterProjection {
     @Override
     public <C, R> R accept(ProjectionVisitor<C, R> visitor, C context) {
         return visitor.visitColumnIndexWriterProjection(this, context);
+    }
+
+    @Override
+    public void replaceSymbols(Function<Symbol, Symbol> replaceFunction) {
+        Lists2.replaceItems(columnSymbols, replaceFunction);
+        if (onDuplicateKeyAssignments != null && !onDuplicateKeyAssignments.isEmpty()) {
+            for (Map.Entry<Reference, Symbol> entry : onDuplicateKeyAssignments.entrySet()) {
+                entry.setValue(replaceFunction.apply(entry.getValue()));
+            }
+        }
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/projection/DeleteProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/DeleteProjection.java
@@ -22,6 +22,7 @@
 
 package io.crate.planner.projection;
 
+import com.google.common.base.Function;
 import io.crate.analyze.symbol.Symbol;
 
 public class DeleteProjection extends DMLProjection {
@@ -38,6 +39,11 @@ public class DeleteProjection extends DMLProjection {
     }
 
     public DeleteProjection() {
+    }
+
+    @Override
+    public void replaceSymbols(Function<Symbol, Symbol> replaceFunction) {
+        uidSymbol = replaceFunction.apply(uidSymbol);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/projection/FetchProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/FetchProjection.java
@@ -22,7 +22,9 @@
 package io.crate.planner.projection;
 
 import com.carrotsearch.hppc.IntSet;
+import com.google.common.base.Function;
 import io.crate.analyze.symbol.Symbol;
+import io.crate.collections.Lists2;
 import io.crate.metadata.TableIdent;
 import io.crate.planner.node.fetch.FetchSource;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -85,6 +87,11 @@ public class FetchProjection extends Projection {
 
     public Map<String, TableIdent> indicesToIdents() {
         return indicesToIdents;
+    }
+
+    @Override
+    public void replaceSymbols(Function<Symbol, Symbol> replaceFunction) {
+        Lists2.replaceItems(outputSymbols, replaceFunction);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/projection/FilterProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/FilterProjection.java
@@ -21,9 +21,11 @@
 
 package io.crate.planner.projection;
 
+import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.Symbols;
+import io.crate.collections.Lists2;
 import io.crate.metadata.RowGranularity;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -51,6 +53,12 @@ public class FilterProjection extends Projection {
     @Override
     public RowGranularity requiredGranularity() {
         return requiredGranularity;
+    }
+
+    @Override
+    public void replaceSymbols(Function<Symbol, Symbol> replaceFunction) {
+        query = replaceFunction.apply(query);
+        Lists2.replaceItems(outputs, replaceFunction);
     }
 
     public void requiredGranularity(RowGranularity requiredRowGranularity) {

--- a/sql/src/main/java/io/crate/planner/projection/GroupProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/GroupProjection.java
@@ -21,9 +21,11 @@
 
 package io.crate.planner.projection;
 
+import com.google.common.base.Function;
 import io.crate.analyze.symbol.Aggregation;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.Symbols;
+import io.crate.collections.Lists2;
 import io.crate.metadata.RowGranularity;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -53,6 +55,12 @@ public class GroupProjection extends Projection {
     public GroupProjection(List<Symbol> keys, List<Aggregation> values) {
         this.keys = keys;
         this.values = values;
+    }
+
+    @Override
+    public void replaceSymbols(Function<Symbol, Symbol> replaceFunction) {
+        Lists2.replaceItems(keys, replaceFunction);
+        Lists2.replaceItems(outputs, replaceFunction);
     }
 
     public List<Symbol> keys() {

--- a/sql/src/main/java/io/crate/planner/projection/MergeCountProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/MergeCountProjection.java
@@ -22,6 +22,7 @@
 
 package io.crate.planner.projection;
 
+import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.Value;
@@ -72,6 +73,10 @@ public class MergeCountProjection extends Projection {
     @Override
     public RowGranularity requiredGranularity() {
         return RowGranularity.CLUSTER;
+    }
+
+    @Override
+    public void replaceSymbols(Function<Symbol, Symbol> replaceFunction) {
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/projection/Projection.java
+++ b/sql/src/main/java/io/crate/planner/projection/Projection.java
@@ -21,6 +21,7 @@
 
 package io.crate.planner.projection;
 
+import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import io.crate.analyze.symbol.Symbol;
@@ -56,6 +57,8 @@ public abstract class Projection implements Streamable {
     public RowGranularity requiredGranularity() {
         return RowGranularity.CLUSTER;
     }
+
+    public abstract void replaceSymbols(Function<Symbol, Symbol> replaceFunction);
 
     public interface ProjectionFactory<T extends Projection> {
         T newInstance();

--- a/sql/src/main/java/io/crate/planner/projection/SourceIndexWriterProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/SourceIndexWriterProjection.java
@@ -21,6 +21,7 @@
 
 package io.crate.planner.projection;
 
+import com.google.common.base.Function;
 import io.crate.analyze.symbol.InputColumn;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
@@ -155,6 +156,10 @@ public class SourceIndexWriterProjection extends AbstractIndexWriterProjection {
     @Nullable
     public String[] excludes() {
         return excludes;
+    }
+
+    @Override
+    public void replaceSymbols(Function<Symbol, Symbol> replaceFunction) {
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/projection/SysUpdateProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/SysUpdateProjection.java
@@ -22,6 +22,7 @@
 
 package io.crate.planner.projection;
 
+import com.google.common.base.Function;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.Symbols;
 import io.crate.analyze.symbol.Value;
@@ -50,6 +51,16 @@ public class SysUpdateProjection extends Projection {
 
     public SysUpdateProjection(Map<Reference, Symbol> assignments) {
         this.assignments = assignments;
+    }
+
+    @Override
+    public void replaceSymbols(Function<Symbol, Symbol> replaceFunction) {
+        if (assignments.isEmpty()) {
+            return;
+        }
+        for (Map.Entry<Reference, Symbol> entry : assignments.entrySet()) {
+            entry.setValue(replaceFunction.apply(entry.getValue()));
+        }
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/projection/TopNProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/TopNProjection.java
@@ -21,10 +21,12 @@
 
 package io.crate.planner.projection;
 
+import com.google.common.base.Function;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.Symbols;
+import io.crate.collections.Lists2;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -110,6 +112,12 @@ public class TopNProjection extends Projection {
         return reverseFlags != null && reverseFlags.length > 0;
     }
 
+
+    @Override
+    public void replaceSymbols(Function<Symbol, Symbol> replaceFunction) {
+        Lists2.replaceItems(outputs, replaceFunction);
+        Lists2.replaceItems(orderBy, replaceFunction);
+    }
 
     @Override
     public ProjectionType projectionType() {

--- a/sql/src/main/java/io/crate/planner/projection/UpdateProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/UpdateProjection.java
@@ -21,6 +21,7 @@
 
 package io.crate.planner.projection;
 
+import com.google.common.base.Function;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.Symbols;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -69,6 +70,14 @@ public class UpdateProjection extends DMLProjection {
     @Nullable
     public Long requiredVersion() {
         return requiredVersion;
+    }
+
+    @Override
+    public void replaceSymbols(Function<Symbol, Symbol> replaceFunction) {
+        for (int i = 0; i < assignments.length; i++) {
+            assignments[i] = replaceFunction.apply(assignments[i]);
+        }
+        uidSymbol = replaceFunction.apply(uidSymbol);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/projection/WriterProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/WriterProjection.java
@@ -24,6 +24,7 @@ package io.crate.planner.projection;
 import com.google.common.collect.ImmutableList;
 import io.crate.analyze.EvaluatingNormalizer;
 import io.crate.analyze.symbol.*;
+import io.crate.collections.Lists2;
 import io.crate.metadata.*;
 import io.crate.metadata.sys.SysShardsTableInfo;
 import io.crate.operation.scalar.FormatFunction;
@@ -121,6 +122,14 @@ public class WriterProjection extends Projection {
 
     public List<Symbol> inputs() {
         return inputs;
+    }
+
+    @Override
+    public void replaceSymbols(com.google.common.base.Function<Symbol, Symbol> replaceFunction) {
+        Lists2.replaceItems(inputs, replaceFunction);
+        for (Map.Entry<ColumnIdent, Symbol> entry : overwrites.entrySet()) {
+            entry.setValue(replaceFunction.apply(entry.getValue()));
+        }
     }
 
     @Override

--- a/sql/src/test/java/io/crate/executor/transport/SubSelectSymbolReplacerTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/SubSelectSymbolReplacerTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.executor.transport;
+
+import io.crate.analyze.symbol.SelectSymbol;
+import io.crate.planner.MultiPhasePlan;
+import io.crate.planner.node.dql.ESGet;
+import io.crate.test.integration.CrateUnitTest;
+import io.crate.testing.SQLExecutor;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.test.cluster.NoopClusterService;
+import org.junit.Test;
+
+import static io.crate.testing.SymbolMatchers.isLiteral;
+import static org.hamcrest.Matchers.contains;
+
+public class SubSelectSymbolReplacerTest extends CrateUnitTest {
+
+    private SQLExecutor e = SQLExecutor.builder(new NoopClusterService()).enableDefaultTables().build();
+
+    @Test
+    public void testSelectSymbolsAreReplacedInSelectListOfPrimaryKeyLookups() throws Exception {
+        MultiPhasePlan plan = e.plan("select (select 'foo' from sys.cluster) from users where id = 10");
+        ESGet esGet = (ESGet) plan.rootPlan();
+        SelectSymbol subSelect = (SelectSymbol) esGet.outputs().get(0);
+
+        SubSelectSymbolReplacer replacer = new SubSelectSymbolReplacer(esGet, subSelect);
+        replacer.onSuccess(new BytesRef("foo"));
+
+        assertThat(esGet.outputs(), contains(isLiteral("foo")));
+    }
+}

--- a/sql/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
@@ -298,4 +298,15 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
         expectedException.expectMessage("Subquery returned more than 1 row");
         execute("select name from sys.cluster where 1 = (select x from t1)");
     }
+
+    @Test
+    public void testSingleRowSubSelectCanBeUsedInSelectListAndWhereOfPrimaryKeyLookup() throws Exception {
+        execute("create table t1 (x long primary key)");
+        ensureYellow();
+        execute("insert into t1 (x) values (1), (2)");
+        execute("refresh table t1");
+
+        execute("select x, (select 'foo') from t1 where x = (select 1)");
+        assertThat(TestingHelpers.printedTable(response.rows()), is("1| foo\n"));
+    }
 }

--- a/sql/src/test/java/io/crate/planner/SingleRowSubselectPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/SingleRowSubselectPlannerTest.java
@@ -23,6 +23,7 @@
 package io.crate.planner;
 
 import io.crate.planner.node.dql.CollectAndMerge;
+import io.crate.planner.node.dql.ESGet;
 import io.crate.planner.node.dql.QueryThenFetch;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.testing.SQLExecutor;
@@ -47,6 +48,20 @@ public class SingleRowSubselectPlannerTest extends CrateUnitTest {
     public void testPlanSelectOnSysTablesWithSingleRowSubselectInWhere() throws Exception {
         MultiPhasePlan plan = e.plan("select name from sys.cluster where name = (select 'foo')");
         assertThat(plan.rootPlan(), instanceOf(CollectAndMerge.class));
+        assertThat(plan.dependencies().keySet(), contains(instanceOf(CollectAndMerge.class)));
+    }
+
+    @Test
+    public void testSingleRowSubSelectInSelectList() throws Exception {
+        MultiPhasePlan plan = e.plan("select (select b from t2 limit 1) from t1");
+        assertThat(plan.rootPlan(), instanceOf(CollectAndMerge.class));
+        assertThat(plan.dependencies().keySet(), contains(instanceOf(QueryThenFetch.class)));
+    }
+
+    @Test
+    public void testSingleRowSubSelectAndDocKeysInWhereClause() throws Exception {
+        MultiPhasePlan plan = e.plan("select (select 'foo' from sys.cluster) from users where id = 10");
+        assertThat(plan.rootPlan(), instanceOf(ESGet.class));
         assertThat(plan.dependencies().keySet(), contains(instanceOf(CollectAndMerge.class)));
     }
 }


### PR DESCRIPTION
This changes the replacement logic to not depend on the QuerySpec but on
the Plan.

Replacement on the QuerySpec only worked if the SelectSymbol was a child
of a Function.
But it is not possible to replace SelectSymbols which are at the root
level because the QuerySpec itself isn't used in plans.