### PR TITLE
Add cast function evaluation to ESGetTask

### DIFF
--- a/sql/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
@@ -301,7 +301,7 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testSingleRowSubSelectCanBeUsedInSelectListAndWhereOfPrimaryKeyLookup() throws Exception {
-        execute("create table t1 (x long primary key)");
+        execute("create table t1 (x int primary key)");
         ensureYellow();
         execute("insert into t1 (x) values (1), (2)");
         execute("refresh table t1");


### PR DESCRIPTION
The GetTask evaluates `id()` of DocKeys which internally uses a
SymbolToValueVisitor. This visitor can't evaluate cast functions.

For example:

    WHERE int_col = (select long_col)

    Becomes

    WHERE id = to_int((select long_col))

    Which after executing the subselect becomes

    WHERE id = to_int(10) <-- this then failed