### PR TITLE
fix npe in distinct 

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fix the NPE that occured if `distinct` was applied on expressions
+   which resulted in null values.
+
  - Upgraded Elasticsearch to 2.4.1
 
  - Improved parameter de-serialization of the "Bind" message. If a Client

--- a/core/src/main/java/io/crate/types/BooleanType.java
+++ b/core/src/main/java/io/crate/types/BooleanType.java
@@ -28,6 +28,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
+import java.util.Comparator;
 import java.util.Locale;
 import java.util.Map;
 
@@ -35,6 +36,12 @@ public class BooleanType extends DataType<Boolean> implements DataTypeFactory, S
 
     public static final int ID = 3;
     public static final BooleanType INSTANCE = new BooleanType();
+    private static final Comparator<Boolean> CMP = new Comparator<Boolean>() {
+        @Override
+        public int compare(Boolean v1, Boolean v2) {
+            return Boolean.compare(v1, v2);
+        }
+    };
 
     private BooleanType() {
     }
@@ -98,7 +105,7 @@ public class BooleanType extends DataType<Boolean> implements DataTypeFactory, S
 
     @Override
     public int compareValueTo(Boolean val1, Boolean val2) {
-        return Boolean.compare(val1, val2);
+        return nullSafeCompareValueTo(val1, val2, CMP);
     }
 
     @Override

--- a/core/src/main/java/io/crate/types/ByteType.java
+++ b/core/src/main/java/io/crate/types/ByteType.java
@@ -27,11 +27,18 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
+import java.util.Comparator;
 
 public class ByteType extends DataType<Byte> implements DataTypeFactory, Streamer<Byte>, FixedWidthType {
 
     public final static ByteType INSTANCE = new ByteType();
     public final static int ID = 2;
+    private static final Comparator<Byte> CMP = new Comparator<Byte>() {
+        @Override
+        public int compare(Byte v1, Byte v2) {
+            return Byte.compare(v1, v2);
+        }
+    } ;
 
     private ByteType() {
     }
@@ -71,7 +78,7 @@ public class ByteType extends DataType<Byte> implements DataTypeFactory, Streame
 
     @Override
     public int compareValueTo(Byte val1, Byte val2) {
-        return Byte.compare(val1, val2);
+        return nullSafeCompareValueTo(val1, val2, CMP);
     }
 
     @Override

--- a/core/src/main/java/io/crate/types/DataType.java
+++ b/core/src/main/java/io/crate/types/DataType.java
@@ -21,25 +21,17 @@
 
 package io.crate.types;
 
-import com.google.common.base.Function;
 import io.crate.Streamer;
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
 
 import java.io.IOException;
+import java.util.Comparator;
+import java.util.Objects;
 import java.util.Set;
 
 public abstract class DataType<T> implements Comparable, Streamable {
-
-    public static final Function<DataType, String> TO_NAME = new Function<DataType, String>() {
-        @Nullable
-        @Override
-        public String apply(DataType input) {
-            return input == null ? null : input.getName();
-        }
-    };
 
     public abstract int id();
 
@@ -67,6 +59,19 @@ public abstract class DataType<T> implements Comparable, Streamable {
             return false;
         }
         return possibleConversions.contains(other);
+    }
+
+    static <T> int nullSafeCompareValueTo(T val1, T val2, Comparator<T> cmp) {
+        if (val1 == null) {
+            if (val2 == null) {
+                return 0;
+            }
+            return -1;
+        }
+        if (val2 == null) {
+            return 1;
+        }
+        return Objects.compare(val1, val2, cmp);
     }
 
     public int hashCode() {

--- a/core/src/main/java/io/crate/types/DoubleType.java
+++ b/core/src/main/java/io/crate/types/DoubleType.java
@@ -27,11 +27,18 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
+import java.util.Comparator;
 
 public class DoubleType extends DataType<Double> implements FixedWidthType, Streamer<Double>, DataTypeFactory {
 
     public static final DoubleType INSTANCE = new DoubleType();
     public static final int ID = 6;
+    private static final Comparator<Double> CMP = new Comparator<Double>() {
+        @Override
+        public int compare(Double v1, Double v2) {
+            return Double.compare(v1, v2);
+        }
+    };
 
     private DoubleType() {
     }
@@ -70,7 +77,7 @@ public class DoubleType extends DataType<Double> implements FixedWidthType, Stre
 
     @Override
     public int compareValueTo(Double val1, Double val2) {
-        return Double.compare(val1, val2);
+        return nullSafeCompareValueTo(val1, val2, CMP);
     }
 
     @Override

--- a/core/src/main/java/io/crate/types/FloatType.java
+++ b/core/src/main/java/io/crate/types/FloatType.java
@@ -27,11 +27,18 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
+import java.util.Comparator;
 
 public class FloatType extends DataType<Float> implements Streamer<Float>, DataTypeFactory, FixedWidthType {
 
     public static final FloatType INSTANCE = new FloatType();
     public static final int ID = 7;
+    private static final Comparator<Float> CMP = new Comparator<Float>() {
+        @Override
+        public int compare(Float v1, Float v2) {
+            return Float.compare(v1, v2);
+        }
+    };
 
     private FloatType() {
     }
@@ -74,7 +81,7 @@ public class FloatType extends DataType<Float> implements Streamer<Float>, DataT
 
     @Override
     public int compareValueTo(Float val1, Float val2) {
-        return Float.compare(val1, val2);
+        return nullSafeCompareValueTo(val1, val2, CMP);
     }
 
     @Override

--- a/core/src/main/java/io/crate/types/IntegerType.java
+++ b/core/src/main/java/io/crate/types/IntegerType.java
@@ -27,11 +27,18 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
+import java.util.Comparator;
 
 public class IntegerType extends DataType<Integer> implements Streamer<Integer>, DataTypeFactory, FixedWidthType {
 
     public static final IntegerType INSTANCE = new IntegerType();
     public static final int ID = 9;
+    private static final Comparator<Integer> CMP = new Comparator<Integer>() {
+        @Override
+        public int compare(Integer v1, Integer v2) {
+            return Integer.compare(v1, v2);
+        }
+    };
 
     private IntegerType() {
     }
@@ -75,9 +82,8 @@ public class IntegerType extends DataType<Integer> implements Streamer<Integer>,
 
     @Override
     public int compareValueTo(Integer val1, Integer val2) {
-        return Integer.compare(val1, val2);
+        return nullSafeCompareValueTo(val1, val2, CMP);
     }
-
 
     @Override
     public Integer readValueFrom(StreamInput in) throws IOException {

--- a/core/src/main/java/io/crate/types/LongType.java
+++ b/core/src/main/java/io/crate/types/LongType.java
@@ -27,12 +27,19 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
+import java.util.Comparator;
 
 public class
 LongType extends DataType<Long> implements FixedWidthType, Streamer<Long>, DataTypeFactory {
 
     public static final LongType INSTANCE = new LongType();
     public static final int ID = 10;
+    private static final Comparator<Long> CMP = new Comparator<Long>() {
+        @Override
+        public int compare(Long v1, Long v2) {
+            return Long.compare(v1, v2);
+        }
+    };
 
     @Override
     public int id() {
@@ -102,9 +109,7 @@ LongType extends DataType<Long> implements FixedWidthType, Streamer<Long>, DataT
             if (len == 1) { // lone '+' or '-'
                 throw new NumberFormatException(value.utf8ToString());
             }
-
             i++;
-            ;
         }
         multmin = limit / radix;
         while (i < len + value.offset) {
@@ -127,7 +132,7 @@ LongType extends DataType<Long> implements FixedWidthType, Streamer<Long>, DataT
 
     @Override
     public int compareValueTo(Long val1, Long val2) {
-        return Long.compare(val1, val2);
+        return nullSafeCompareValueTo(val1, val2, CMP);
     }
 
     @Override

--- a/core/src/main/java/io/crate/types/ShortType.java
+++ b/core/src/main/java/io/crate/types/ShortType.java
@@ -27,11 +27,18 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
+import java.util.Comparator;
 
 public class ShortType extends DataType<Short> implements DataTypeFactory, Streamer<Short>, FixedWidthType {
 
     public static final ShortType INSTANCE = new ShortType();
     public static final int ID = 8;
+    private static final Comparator<Short> CMP = new Comparator<Short>() {
+        @Override
+        public int compare(Short v1, Short v2) {
+            return Short.compare(v1, v2);
+        }
+    } ;
 
     private ShortType() {
     }
@@ -74,7 +81,7 @@ public class ShortType extends DataType<Short> implements DataTypeFactory, Strea
 
     @Override
     public int compareValueTo(Short val1, Short val2) {
-        return Short.compare(val1, val2);
+        return nullSafeCompareValueTo(val1, val2, CMP);
     }
 
     @Override

--- a/core/src/test/java/io/crate/types/DataTypesTest.java
+++ b/core/src/test/java/io/crate/types/DataTypesTest.java
@@ -29,7 +29,10 @@ import org.junit.Test;
 
 import java.util.*;
 
+import static org.apache.commons.lang3.ObjectUtils.firstNonNull;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.core.IsNot.not;
 
 public class DataTypesTest extends CrateUnitTest {
 
@@ -239,5 +242,77 @@ public class DataTypesTest extends CrateUnitTest {
     @Test(expected = ClassCastException.class)
     public void testConvertBooleanToByte() {
         DataTypes.BYTE.value(true);
+    }
+
+    @Test
+    public void testLongTypeCompareValueToWith() {
+        assertCompareValueTo(DataTypes.LONG, null, null, 0);
+        assertCompareValueTo(null, 2L, -1);
+        assertCompareValueTo(3L, 2L, 1);
+        assertCompareValueTo(2L, 2L, 0);
+        assertCompareValueTo(2L, null, 1);
+    }
+
+    @Test
+    public void testShortTypeCompareValueToWith() {
+        assertCompareValueTo(DataTypes.LONG, null, null, 0);
+        assertCompareValueTo(null, (short) 2, -1);
+        assertCompareValueTo((short) 3, (short) 2, 1);
+        assertCompareValueTo((short) 2, (short) 2, 0);
+        assertCompareValueTo((short) 2, null, 1);
+    }
+
+    @Test
+    public void testIntTypeCompareValueTo() {
+        assertCompareValueTo(DataTypes.INTEGER, null, null, 0);
+        assertCompareValueTo(null, 2, -1);
+        assertCompareValueTo(3, 2, 1);
+        assertCompareValueTo(2, 2, 0);
+        assertCompareValueTo(2, null, 1);
+    }
+
+    @Test
+    public void testDoubleTypeCompareValueTo() {
+        assertCompareValueTo(DataTypes.DOUBLE, null, null, 0);
+        assertCompareValueTo(null, 2.0d, -1);
+        assertCompareValueTo(3.0d, 2.0d, 1);
+        assertCompareValueTo(2.0d, 2.0d, 0);
+        assertCompareValueTo(2.0d, null, 1);
+    }
+
+    @Test
+    public void testFloatTypeCompareValueTo() {
+        assertCompareValueTo(DataTypes.FLOAT, null, null, 0);
+        assertCompareValueTo(null, 2.0f, -1);
+        assertCompareValueTo(2.0f, 3.0f, -1);
+        assertCompareValueTo(2.0f, 2.0f, 0);
+        assertCompareValueTo(2.0f, null, 1);
+    }
+
+    @Test
+    public void testByteTypeCompareValueTo() {
+        assertCompareValueTo(DataTypes.BYTE, null, null, 0);
+        assertCompareValueTo(null, (byte) 2, -1);
+        assertCompareValueTo((byte) 3, (byte) 2, 1);
+        assertCompareValueTo((byte) 2, (byte) 2, 0);
+        assertCompareValueTo((byte) 2, null, 1);
+    }
+
+    @Test
+    public void testBooleanTypeCompareValueTo() {
+        assertCompareValueTo(DataTypes.BOOLEAN, null, null, 0);
+        assertCompareValueTo(null, true, -1);
+        assertCompareValueTo(true, false, 1);
+        assertCompareValueTo(true, null, 1);
+    }
+
+    private static void assertCompareValueTo(Object val1, Object val2, int expected) {
+        DataType type = DataTypes.guessType(firstNonNull(val1, val2));
+        assertThat(type, not(instanceOf(DataTypes.UNDEFINED.getClass())));
+        assertCompareValueTo(type, val1, val2, expected);
+    }
+
+    private static void assertCompareValueTo(DataType dt, Object val1, Object val2, int expected) {
+        assertThat(dt.compareValueTo(dt.value(val1), dt.value(val2)), is(expected));
     }
 }


### PR DESCRIPTION
For cases like:

    select distinct cast(null as integer) + 1

The distinct function results in comparison of literals which
contains null values. The comparison logic was throwing NPE.