### PR TITLE
Remove NoopPlan transformation from NestedLoopConsumer

### DIFF
--- a/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -105,11 +105,14 @@ public class JoinIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
-    public void testJoinOnEmptyPartitionedTables() throws Exception {
+    public void testJoinOnEmptyPartitionedTablesWithAndWithoutJoinCondition() throws Exception {
         execute("create table foo (id long) partitioned by (id)");
         execute("create table bar (id long) partitioned by (id)");
         ensureYellow();
         execute("select * from foo f, bar b where f.id = b.id");
+        assertThat(printedTable(response.rows()), is(""));
+
+        execute("select * from foo f, bar b");
         assertThat(printedTable(response.rows()), is(""));
     }
 

--- a/sql/src/test/java/io/crate/planner/consumer/NestedLoopConsumerTest.java
+++ b/sql/src/test/java/io/crate/planner/consumer/NestedLoopConsumerTest.java
@@ -314,6 +314,6 @@ public class NestedLoopConsumerTest extends CrateUnitTest {
     @Test
     public void testEmptyRoutingSource() throws Exception {
         Plan plan = plan("select e.nope, u.name from empty e, users u order by e.nope, u.name");
-        assertThat(plan, instanceOf(NoopPlan.class));
+        assertThat(plan, instanceOf(NestedLoop.class));
     }
 }


### PR DESCRIPTION
Just because a sub-plan doesn't have any executionNodes doesn't mean
it's allowed to return a NoopPlan instead of a NestedLoop.

This only worked because we don't have aggregations on joins yet. Once
that is supported it wouldn't work because even with empty tables
aggregations still result in 1 row.