### PR TITLE
Add ResultDescription interface

### DIFF
--- a/sql/src/main/java/io/crate/breaker/RamAccountingContext.java
+++ b/sql/src/main/java/io/crate/breaker/RamAccountingContext.java
@@ -43,7 +43,7 @@ public class RamAccountingContext {
 
     public static RamAccountingContext forExecutionPhase(CircuitBreaker breaker, ExecutionPhase executionPhase) {
         String ramAccountingContextId = String.format(Locale.ENGLISH, "%s: %d",
-            executionPhase.name(), executionPhase.executionPhaseId());
+            executionPhase.name(), executionPhase.phaseId());
         return new RamAccountingContext(ramAccountingContextId, breaker);
     }
 

--- a/sql/src/main/java/io/crate/executor/transport/TransportExecutor.java
+++ b/sql/src/main/java/io/crate/executor/transport/TransportExecutor.java
@@ -454,9 +454,9 @@ public class TransportExecutor implements Executor {
                     previousPhase = currentBranch.phases.lastElement();
                 }
                 if (setDownstreamNodes) {
-                    assert saneConfiguration(executionPhase, previousPhase.executionNodes()) : String.format(Locale.ENGLISH,
+                    assert saneConfiguration(executionPhase, previousPhase.nodeIds()) : String.format(Locale.ENGLISH,
                         "NodeOperation with %s and %s as downstreams cannot work",
-                        ExecutionPhases.debugPrint(executionPhase), previousPhase.executionNodes());
+                        ExecutionPhases.debugPrint(executionPhase), previousPhase.nodeIds());
 
                     nodeOperations.add(NodeOperation.withDownstream(executionPhase, previousPhase, currentBranch.inputId, localNodeId));
                 } else {
@@ -469,7 +469,7 @@ public class TransportExecutor implements Executor {
                 if (executionPhase instanceof UpstreamPhase &&
                     ((UpstreamPhase) executionPhase).distributionInfo().distributionType() ==
                     DistributionType.SAME_NODE) {
-                    return downstreamNodes.isEmpty() || downstreamNodes.equals(executionPhase.executionNodes());
+                    return downstreamNodes.isEmpty() || downstreamNodes.equals(executionPhase.nodeIds());
                 }
                 return true;
             }

--- a/sql/src/main/java/io/crate/executor/transport/executionphases/ExecutionPhasesTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/executionphases/ExecutionPhasesTask.java
@@ -202,7 +202,7 @@ public class ExecutionPhasesTask extends JobTask {
                                                                List<Tuple<ExecutionPhase, RowReceiver>> handlerPhases) {
         final List<PageBucketReceiver> pageBucketReceivers = new ArrayList<>(handlerPhases.size());
         for (Tuple<ExecutionPhase, RowReceiver> handlerPhase : handlerPhases) {
-            ExecutionSubContext ctx = jobExecutionContext.getSubContextOrNull(handlerPhase.v1().executionPhaseId());
+            ExecutionSubContext ctx = jobExecutionContext.getSubContextOrNull(handlerPhase.v1().phaseId());
             if (ctx instanceof DownstreamExecutionSubContext) {
                 PageBucketReceiver pageBucketReceiver = ((DownstreamExecutionSubContext) ctx).getBucketReceiver((byte) 0);
                 pageBucketReceivers.add(pageBucketReceiver);

--- a/sql/src/main/java/io/crate/jobs/NestedLoopContext.java
+++ b/sql/src/main/java/io/crate/jobs/NestedLoopContext.java
@@ -49,7 +49,7 @@ public class NestedLoopContext extends AbstractExecutionSubContext implements Do
                              NestedLoopOperation nestedLoopOperation,
                              @Nullable PageBucketReceiver leftBucketReceiver,
                              @Nullable PageBucketReceiver rightBucketReceiver) {
-        super(nestedLoopPhase.executionPhaseId(), logger);
+        super(nestedLoopPhase.phaseId(), logger);
 
         this.nestedLoopPhase = nestedLoopPhase;
         this.flatProjectorChain = flatProjectorChain;
@@ -79,7 +79,7 @@ public class NestedLoopContext extends AbstractExecutionSubContext implements Do
 
     @Override
     public int id() {
-        return nestedLoopPhase.executionPhaseId();
+        return nestedLoopPhase.phaseId();
     }
 
     @Override

--- a/sql/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
+++ b/sql/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
@@ -1264,7 +1264,6 @@ public class LuceneQueryBuilder {
             return new GenericFunctionQuery(function, expressions, collectorContext, condition);
         }
 
-
         private static Query raiseUnsupported(Function function) {
             throw new UnsupportedOperationException(
                 SymbolFormatter.format("Cannot convert function %s into a query", function));

--- a/sql/src/main/java/io/crate/operation/NodeOperation.java
+++ b/sql/src/main/java/io/crate/operation/NodeOperation.java
@@ -73,12 +73,12 @@ public class NodeOperation implements Streamable {
                                                ExecutionPhase downstreamExecutionPhase,
                                                byte inputId,
                                                String localNodeId) {
-        if (downstreamExecutionPhase.executionNodes().isEmpty()) {
+        if (downstreamExecutionPhase.nodeIds().isEmpty()) {
             List<String> downstreamNodes;
-            if (executionPhase instanceof UpstreamPhase && executionPhase.executionNodes().size() == 1
-                && executionPhase.executionNodes().contains(localNodeId)) {
+            if (executionPhase instanceof UpstreamPhase && executionPhase.nodeIds().size() == 1
+                && executionPhase.nodeIds().contains(localNodeId)) {
                 LOGGER.trace("Phase uses SAME_NODE downstream, reason: ON HANDLER, executionNodes: {}, phase: {}",
-                    executionPhase.executionNodes(), executionPhase);
+                    executionPhase.nodeIds(), executionPhase);
 
                 downstreamNodes = Collections.emptyList();
             } else {
@@ -87,13 +87,13 @@ public class NodeOperation implements Streamable {
             return new NodeOperation(
                 executionPhase,
                 downstreamNodes,
-                downstreamExecutionPhase.executionPhaseId(),
+                downstreamExecutionPhase.phaseId(),
                 inputId);
         } else {
             return new NodeOperation(
                 executionPhase,
-                downstreamExecutionPhase.executionNodes(),
-                downstreamExecutionPhase.executionPhaseId(),
+                downstreamExecutionPhase.nodeIds(),
+                downstreamExecutionPhase.phaseId(),
                 inputId);
         }
     }

--- a/sql/src/main/java/io/crate/operation/collect/JobCollectContext.java
+++ b/sql/src/main/java/io/crate/operation/collect/JobCollectContext.java
@@ -72,7 +72,7 @@ public class JobCollectContext extends AbstractExecutionSubContext {
                              RamAccountingContext queryPhaseRamAccountingContext,
                              final RowReceiver rowReceiver,
                              SharedShardContexts sharedShardContexts) {
-        super(collectPhase.executionPhaseId(), LOGGER);
+        super(collectPhase.phaseId(), LOGGER);
         this.collectPhase = collectPhase;
         this.collectOperation = collectOperation;
         this.queryPhaseRamAccountingContext = queryPhaseRamAccountingContext;
@@ -181,7 +181,7 @@ public class JobCollectContext extends AbstractExecutionSubContext {
     }
 
     private void measureCollectTime() {
-        final StopWatch stopWatch = new StopWatch(collectPhase.executionPhaseId() + ": " + collectPhase.name());
+        final StopWatch stopWatch = new StopWatch(collectPhase.phaseId() + ": " + collectPhase.name());
         stopWatch.start("starting collectors");
         listenableRowReceiver.finishFuture().addListener(new Runnable() {
             @Override

--- a/sql/src/main/java/io/crate/operation/collect/sources/FileCollectSource.java
+++ b/sql/src/main/java/io/crate/operation/collect/sources/FileCollectSource.java
@@ -62,8 +62,8 @@ public class FileCollectSource implements CollectSource {
         FileUriCollectPhase fileUriCollectPhase = (FileUriCollectPhase) collectPhase;
         FileCollectInputSymbolVisitor.Context context = fileInputSymbolVisitor.extractImplementations(collectPhase.toCollect());
 
-        String[] readers = fileUriCollectPhase.executionNodes().toArray(
-            new String[fileUriCollectPhase.executionNodes().size()]);
+        String[] readers = fileUriCollectPhase.nodeIds().toArray(
+            new String[fileUriCollectPhase.nodeIds().size()]);
         Arrays.sort(readers);
 
         List<String> fileUris;

--- a/sql/src/main/java/io/crate/operation/fetch/FetchContext.java
+++ b/sql/src/main/java/io/crate/operation/fetch/FetchContext.java
@@ -57,7 +57,7 @@ public class FetchContext extends AbstractExecutionSubContext {
                         String localNodeId,
                         SharedShardContexts sharedShardContexts,
                         Iterable<? extends Routing> routingIterable) {
-        super(phase.executionPhaseId(), LOGGER);
+        super(phase.phaseId(), LOGGER);
         this.phase = phase;
         this.localNodeId = localNodeId;
         this.sharedShardContexts = sharedShardContexts;

--- a/sql/src/main/java/io/crate/operation/projectors/DistributingDownstreamFactory.java
+++ b/sql/src/main/java/io/crate/operation/projectors/DistributingDownstreamFactory.java
@@ -67,7 +67,7 @@ public class DistributingDownstreamFactory extends AbstractComponent {
         assert nodeOperation.downstreamNodes().size() > 0 : "must have at least one downstream";
 
         // TODO: set bucketIdx properly
-        ArrayList<String> server = Lists.newArrayList(nodeOperation.executionPhase().executionNodes());
+        ArrayList<String> server = Lists.newArrayList(nodeOperation.executionPhase().nodeIds());
         Collections.sort(server);
         int bucketIdx = Math.max(server.indexOf(clusterService.localNode().id()), 0);
 

--- a/sql/src/main/java/io/crate/planner/MultiPhasePlan.java
+++ b/sql/src/main/java/io/crate/planner/MultiPhasePlan.java
@@ -23,7 +23,6 @@
 package io.crate.planner;
 
 import io.crate.analyze.symbol.SelectSymbol;
-import io.crate.planner.distribution.UpstreamPhase;
 import io.crate.planner.projection.Projection;
 
 import java.util.Map;
@@ -83,12 +82,7 @@ public class MultiPhasePlan implements Plan {
     }
 
     @Override
-    public boolean resultIsDistributed() {
-        return rootPlan.resultIsDistributed();
-    }
-
-    @Override
-    public UpstreamPhase resultPhase() {
-        return rootPlan.resultPhase();
+    public ResultDescription resultDescription() {
+        return rootPlan.resultDescription();
     }
 }

--- a/sql/src/main/java/io/crate/planner/MultiPhasePlan.java
+++ b/sql/src/main/java/io/crate/planner/MultiPhasePlan.java
@@ -23,6 +23,7 @@
 package io.crate.planner;
 
 import io.crate.analyze.symbol.SelectSymbol;
+import io.crate.planner.distribution.DistributionInfo;
 import io.crate.planner.projection.Projection;
 
 import java.util.Map;
@@ -84,5 +85,10 @@ public class MultiPhasePlan implements Plan {
     @Override
     public ResultDescription resultDescription() {
         return rootPlan.resultDescription();
+    }
+
+    @Override
+    public void setDistributionInfo(DistributionInfo distributionInfo) {
+        rootPlan.setDistributionInfo(distributionInfo);
     }
 }

--- a/sql/src/main/java/io/crate/planner/Plan.java
+++ b/sql/src/main/java/io/crate/planner/Plan.java
@@ -21,7 +21,6 @@
 
 package io.crate.planner;
 
-import io.crate.planner.distribution.UpstreamPhase;
 import io.crate.planner.projection.Projection;
 
 import java.util.UUID;
@@ -34,7 +33,5 @@ public interface Plan {
 
     void addProjection(Projection projection);
 
-    boolean resultIsDistributed();
-
-    UpstreamPhase resultPhase();
+    ResultDescription resultDescription();
 }

--- a/sql/src/main/java/io/crate/planner/Plan.java
+++ b/sql/src/main/java/io/crate/planner/Plan.java
@@ -21,6 +21,7 @@
 
 package io.crate.planner;
 
+import io.crate.planner.distribution.DistributionInfo;
 import io.crate.planner.projection.Projection;
 
 import java.util.UUID;
@@ -34,4 +35,9 @@ public interface Plan {
     void addProjection(Projection projection);
 
     ResultDescription resultDescription();
+
+    /**
+     * Changes how the result will be distributed.
+     */
+    void setDistributionInfo(DistributionInfo distributionInfo);
 }

--- a/sql/src/main/java/io/crate/planner/PlanPrinter.java
+++ b/sql/src/main/java/io/crate/planner/PlanPrinter.java
@@ -95,9 +95,9 @@ public class PlanPrinter {
         protected ImmutableMap.Builder<String, Object> visitExecutionPhase(ExecutionPhase phase, Void context) {
             return newBuilder()
                 .put("phaseType", phase.type().toString())
-                .put("id", phase.executionPhaseId())
+                .put("id", phase.phaseId())
                 // Converting TreeMap.keySet() to be able to stream
-                .put("executionNodes", new ArrayList<>(phase.executionNodes())
+                .put("executionNodes", new ArrayList<>(phase.nodeIds())
                 );
         }
 

--- a/sql/src/main/java/io/crate/planner/Planner.java
+++ b/sql/src/main/java/io/crate/planner/Planner.java
@@ -93,6 +93,7 @@ public class Planner extends AnalyzedStatementVisitor<Planner.Context, Plan> {
         private final Multimap<TableIdent, TableRouting> tableRoutings = HashMultimap.create();
         private ReaderAllocations readerAllocations;
         private HashMultimap<TableIdent, String> tableIndices;
+        private String handlerNode;
 
         public Context(Planner planner,
                        ClusterService clusterService,
@@ -110,6 +111,7 @@ public class Planner extends AnalyzedStatementVisitor<Planner.Context, Plan> {
             this.transactionContext = transactionContext;
             this.softLimit = softLimit;
             this.fetchSize = fetchSize;
+            this.handlerNode = clusterService.localNode().id();
         }
 
         public EvaluatingNormalizer normalizer() {
@@ -156,6 +158,10 @@ public class Planner extends AnalyzedStatementVisitor<Planner.Context, Plan> {
             if (softLimit != 0 && !querySpec.limit().isPresent()) {
                 querySpec.limit(Optional.<Symbol>of(Literal.of((long) softLimit)));
             }
+        }
+
+        public String handlerNode() {
+            return handlerNode;
         }
 
         static class ReaderAllocations {

--- a/sql/src/main/java/io/crate/planner/ResultDescription.java
+++ b/sql/src/main/java/io/crate/planner/ResultDescription.java
@@ -22,8 +22,6 @@
 
 package io.crate.planner;
 
-import io.crate.planner.distribution.DistributionInfo;
-
 import java.util.Collection;
 
 /**
@@ -35,15 +33,5 @@ public interface ResultDescription {
      * @return the nodeIds of the nodes that this result is on.
      * If it's empty it is on the handler node.
      */
-    Collection<String> executionNodes();
-
-    /**
-     * Describes how the result will be distributed to a downstream
-     */
-    DistributionInfo distributionInfo();
-
-    /**
-     * Changes how the result will be distributed.
-     */
-    void distributionInfo(DistributionInfo distributionInfo);
+    Collection<String> nodeIds();
 }

--- a/sql/src/main/java/io/crate/planner/ResultDescription.java
+++ b/sql/src/main/java/io/crate/planner/ResultDescription.java
@@ -22,20 +22,28 @@
 
 package io.crate.planner;
 
-import io.crate.planner.projection.Projection;
+import io.crate.planner.distribution.DistributionInfo;
+
+import java.util.Collection;
 
 /**
- * A Plan that can only be used as root plan and cannot be used as sub-plan of another plan.
+ * Describes where a result resides and in which form
  */
-public abstract class UnnestablePlan implements Plan {
+public interface ResultDescription {
 
-    @Override
-    public void addProjection(Projection projection) {
-        throw new UnsupportedOperationException("addProjection() is not supported on: " + getClass().getSimpleName());
-    }
+    /**
+     * @return the nodeIds of the nodes that this result is on.
+     * If it's empty it is on the handler node.
+     */
+    Collection<String> executionNodes();
 
-    @Override
-    public ResultDescription resultDescription() {
-        throw new UnsupportedOperationException("resultDescription() is not supported on: " + getClass().getSimpleName());
-    }
+    /**
+     * Describes how the result will be distributed to a downstream
+     */
+    DistributionInfo distributionInfo();
+
+    /**
+     * Changes how the result will be distributed.
+     */
+    void distributionInfo(DistributionInfo distributionInfo);
 }

--- a/sql/src/main/java/io/crate/planner/SelectStatementPlanner.java
+++ b/sql/src/main/java/io/crate/planner/SelectStatementPlanner.java
@@ -40,6 +40,7 @@ import io.crate.planner.consumer.ESGetStatementPlanner;
 import io.crate.planner.consumer.SimpleSelect;
 import io.crate.planner.fetch.FetchPushDown;
 import io.crate.planner.fetch.MultiSourceFetchPushDown;
+import io.crate.planner.node.ExecutionPhases;
 import io.crate.planner.node.dql.CollectAndMerge;
 import io.crate.planner.node.dql.MergePhase;
 import io.crate.planner.node.dql.QueryThenFetch;
@@ -212,7 +213,8 @@ class SelectStatementPlanner {
                 return plannedSubQuery;
             }
             assert plannedSubQuery != null : "consumingPlanner should have created a subPlan";
-            assert !plannedSubQuery.resultIsDistributed() : "subQuery must not have a distributed result";
+            assert ExecutionPhases.executesOnHandler(context.handlerNode(), plannedSubQuery.resultDescription().executionNodes())
+                : "subPlan result should already be on handlerNode";
 
             Planner.Context.ReaderAllocations readerAllocations = context.buildReaderAllocations();
             ArrayList<Reference> docRefs = new ArrayList<>();

--- a/sql/src/main/java/io/crate/planner/SelectStatementPlanner.java
+++ b/sql/src/main/java/io/crate/planner/SelectStatementPlanner.java
@@ -165,7 +165,7 @@ class SelectStatementPlanner {
                     context.jobId(),
                     context.nextExecutionPhaseId(),
                     ImmutableList.of(topN, fp),
-                    collectPhase.executionNodes().size(),
+                    collectPhase.nodeIds().size(),
                     collectPhase.outputTypes()
                 );
             } else {
@@ -176,7 +176,7 @@ class SelectStatementPlanner {
                     collectPhase.toCollect(),
                     null,
                     ImmutableList.of(topN, fp),
-                    collectPhase.executionNodes().size(),
+                    collectPhase.nodeIds().size(),
                     collectPhase.outputTypes()
                 );
             }
@@ -213,7 +213,7 @@ class SelectStatementPlanner {
                 return plannedSubQuery;
             }
             assert plannedSubQuery != null : "consumingPlanner should have created a subPlan";
-            assert ExecutionPhases.executesOnHandler(context.handlerNode(), plannedSubQuery.resultDescription().executionNodes())
+            assert ExecutionPhases.executesOnHandler(context.handlerNode(), plannedSubQuery.resultDescription().nodeIds())
                 : "subPlan result should already be on handlerNode";
 
             Planner.Context.ReaderAllocations readerAllocations = context.buildReaderAllocations();
@@ -230,7 +230,7 @@ class SelectStatementPlanner {
                 docRefs
             );
             FetchProjection fp = new FetchProjection(
-                fetchPhase.executionPhaseId(),
+                fetchPhase.phaseId(),
                 context.fetchSize(),
                 pd.fetchSources(),
                 pd.remainingOutputs(),
@@ -261,7 +261,7 @@ class SelectStatementPlanner {
                 fetchPushDown.fetchRefs()));
 
         return new FetchProjection(
-            fetchPhase.executionPhaseId(),
+            fetchPhase.phaseId(),
             fetchSize,
             fetchSources,
             querySpec.outputs(),

--- a/sql/src/main/java/io/crate/planner/UnnestablePlan.java
+++ b/sql/src/main/java/io/crate/planner/UnnestablePlan.java
@@ -22,6 +22,7 @@
 
 package io.crate.planner;
 
+import io.crate.planner.distribution.DistributionInfo;
 import io.crate.planner.projection.Projection;
 
 /**
@@ -37,5 +38,10 @@ public abstract class UnnestablePlan implements Plan {
     @Override
     public ResultDescription resultDescription() {
         throw new UnsupportedOperationException("resultDescription() is not supported on: " + getClass().getSimpleName());
+    }
+
+    @Override
+    public void setDistributionInfo(DistributionInfo distributionInfo) {
+        throw new UnsupportedOperationException("Cannot change distributionInfo on: " + getClass().getSimpleName());
     }
 }

--- a/sql/src/main/java/io/crate/planner/consumer/CountConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/CountConsumer.java
@@ -87,7 +87,7 @@ public class CountConsumer implements Consumer {
                 plannerContext.jobId(),
                 plannerContext.nextExecutionPhaseId(),
                 "count-merge",
-                countNode.executionNodes().size(),
+                countNode.nodeIds().size(),
                 Collections.singletonList(DataTypes.LONG),
                 Collections.<Projection>singletonList(MergeCountProjection.INSTANCE),
                 DistributionInfo.DEFAULT_SAME_NODE

--- a/sql/src/main/java/io/crate/planner/consumer/DistributedGroupByConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/DistributedGroupByConsumer.java
@@ -164,12 +164,12 @@ class DistributedGroupByConsumer implements Consumer {
                 plannerContext.jobId(),
                 plannerContext.nextExecutionPhaseId(),
                 "distributed merge",
-                collectNode.executionNodes().size(),
+                collectNode.nodeIds().size(),
                 collectNode.outputTypes(),
                 reducerProjections,
                 DistributionInfo.DEFAULT_BROADCAST
             );
-            mergePhase.executionNodes(ImmutableSet.copyOf(collectNode.executionNodes()));
+            mergePhase.executionNodes(ImmutableSet.copyOf(collectNode.nodeIds()));
             // end: Reducer
 
             MergePhase localMergeNode = null;
@@ -185,7 +185,7 @@ class DistributedGroupByConsumer implements Consumer {
                     plannerContext.jobId(),
                     plannerContext.nextExecutionPhaseId(),
                     ImmutableList.<Projection>of(topN),
-                    mergePhase.executionNodes().size(),
+                    mergePhase.nodeIds().size(),
                     mergePhase.outputTypes());
                 localMergeNode.executionNodes(Sets.newHashSet(localNodeId));
             }

--- a/sql/src/main/java/io/crate/planner/consumer/GlobalAggregateConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/GlobalAggregateConsumer.java
@@ -162,7 +162,7 @@ class GlobalAggregateConsumer implements Consumer {
             plannerContext.jobId(),
             plannerContext.nextExecutionPhaseId(),
             projections,
-            collectPhase.executionNodes().size(),
+            collectPhase.nodeIds().size(),
             collectPhase.outputTypes());
         return new CollectAndMerge(collectPhase, localMergeNode);
     }

--- a/sql/src/main/java/io/crate/planner/consumer/InsertFromSubQueryConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/InsertFromSubQueryConsumer.java
@@ -100,14 +100,14 @@ public class InsertFromSubQueryConsumer implements Consumer {
 
             MergePhase mergeNode = null;
             ResultDescription resultDescription = plannedSubQuery.resultDescription();
-            if (!ExecutionPhases.executesOnHandler(plannerContext.handlerNode(), resultDescription.executionNodes())) {
+            if (!ExecutionPhases.executesOnHandler(plannerContext.handlerNode(), resultDescription.nodeIds())) {
                 // add local merge Node which aggregates the distributed results
                 MergeCountProjection mergeCountProjection = MergeCountProjection.INSTANCE;
                 mergeNode = MergePhase.localMerge(
                     plannerContext.jobId(),
                     plannerContext.nextExecutionPhaseId(),
                     ImmutableList.<Projection>of(mergeCountProjection),
-                    resultDescription.executionNodes().size(),
+                    resultDescription.nodeIds().size(),
                     Symbols.extractTypes(indexWriterProjection.outputs()));
                 mergeNode.executionNodes(Sets.newHashSet(plannerContext.clusterService().localNode().id()));
             }

--- a/sql/src/main/java/io/crate/planner/consumer/NonDistributedGroupByConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/NonDistributedGroupByConsumer.java
@@ -190,7 +190,7 @@ class NonDistributedGroupByConsumer implements Consumer {
                 context.plannerContext().jobId(),
                 context.plannerContext().nextExecutionPhaseId(),
                 projections,
-                collectPhase.executionNodes().size(),
+                collectPhase.nodeIds().size(),
                 collectPhase.outputTypes());
             return new CollectAndMerge(collectPhase, localMergeNode);
         }

--- a/sql/src/main/java/io/crate/planner/consumer/QueryAndFetchConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/QueryAndFetchConsumer.java
@@ -164,7 +164,7 @@ public class QueryAndFetchConsumer implements Consumer {
                     mergeNode = MergePhase.mergePhase(
                         context.plannerContext(),
                         ImmutableSet.<String>of(),
-                        collectPhase.executionNodes().size(),
+                        collectPhase.nodeIds().size(),
                         orderBy.orNull(),
                         orderBy.isPresent() ? InputColumn.fromSymbols(orderBy.get().orderBySymbols(), toCollect) : null,
                         mergeProjections,
@@ -183,7 +183,7 @@ public class QueryAndFetchConsumer implements Consumer {
                         plannerContext.jobId(),
                         plannerContext.nextExecutionPhaseId(),
                         ImmutableList.<Projection>of(),
-                        collectPhase.executionNodes().size(),
+                        collectPhase.nodeIds().size(),
                         collectPhase.outputTypes()
                     );
                 }

--- a/sql/src/main/java/io/crate/planner/consumer/ReduceOnCollectorGroupByConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/ReduceOnCollectorGroupByConsumer.java
@@ -194,7 +194,7 @@ class ReduceOnCollectorGroupByConsumer implements Consumer {
                     querySpec.outputs(),
                     null,
                     handlerProjections,
-                    collectPhase.executionNodes().size(),
+                    collectPhase.nodeIds().size(),
                     collectPhase.outputTypes()
                 );
             } else {
@@ -212,7 +212,7 @@ class ReduceOnCollectorGroupByConsumer implements Consumer {
                     context.plannerContext().jobId(),
                     context.plannerContext().nextExecutionPhaseId(),
                     handlerProjections,
-                    collectPhase.executionNodes().size(),
+                    collectPhase.nodeIds().size(),
                     collectPhase.outputTypes()
                 );
             }

--- a/sql/src/main/java/io/crate/planner/consumer/UpdateConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/UpdateConsumer.java
@@ -180,7 +180,7 @@ public class UpdateConsumer implements Consumer {
             plannerContext.jobId(),
             plannerContext.nextExecutionPhaseId(),
             Collections.<Projection>singletonList(MergeCountProjection.INSTANCE),
-            collectPhase.executionNodes().size(),
+            collectPhase.nodeIds().size(),
             collectPhase.outputTypes()
         );
         return new CollectAndMerge(collectPhase, mergePhase);
@@ -245,7 +245,7 @@ public class UpdateConsumer implements Consumer {
                 plannerContext.jobId(),
                 plannerContext.nextExecutionPhaseId(),
                 ImmutableList.<Projection>of(MergeCountProjection.INSTANCE),
-                collectPhase.executionNodes().size(),
+                collectPhase.nodeIds().size(),
                 collectPhase.outputTypes()
             );
             return new CollectAndMerge(collectPhase, mergeNode);

--- a/sql/src/main/java/io/crate/planner/node/ExecutionPhase.java
+++ b/sql/src/main/java/io/crate/planner/node/ExecutionPhase.java
@@ -62,9 +62,9 @@ public interface ExecutionPhase extends Streamable {
 
     String name();
 
-    int executionPhaseId();
+    int phaseId();
 
-    Collection<String> executionNodes();
+    Collection<String> nodeIds();
 
     <C, R> R accept(ExecutionPhaseVisitor<C, R> visitor, C context);
 }

--- a/sql/src/main/java/io/crate/planner/node/ExecutionPhases.java
+++ b/sql/src/main/java/io/crate/planner/node/ExecutionPhases.java
@@ -30,6 +30,23 @@ import java.util.Collection;
 
 public class ExecutionPhases {
 
+    /**
+     * @return true if the executionNodes indicate a execution on the handler node.
+     *
+     * size == 0 is also true
+     * (this currently is the case on MergePhases if there is a direct-response from previous phase to MergePhase)
+     */
+    public static boolean executesOnHandler(String handlerNode, Collection<String> executionNodes) {
+        switch (executionNodes.size()) {
+            case 0:
+                return true;
+            case 1:
+                return executionNodes.iterator().next().equals(handlerNode);
+            default:
+                return false;
+        }
+    }
+
     public static ExecutionPhase fromStream(StreamInput in) throws IOException {
         ExecutionPhase.Type type = ExecutionPhase.Type.values()[in.readVInt()];
         ExecutionPhase node = type.factory().create();

--- a/sql/src/main/java/io/crate/planner/node/ExecutionPhases.java
+++ b/sql/src/main/java/io/crate/planner/node/ExecutionPhases.java
@@ -70,12 +70,12 @@ public class ExecutionPhases {
 
     public static String debugPrint(ExecutionPhase phase) {
         StringBuilder sb = new StringBuilder("phase{id=");
-        sb.append(phase.executionPhaseId());
+        sb.append(phase.phaseId());
         sb.append("/");
         sb.append(phase.name());
         sb.append(", ");
         sb.append("nodes=");
-        sb.append(phase.executionNodes());
+        sb.append(phase.nodeIds());
         if (phase instanceof UpstreamPhase) {
             UpstreamPhase uPhase = (UpstreamPhase) phase;
             sb.append(", dist=");

--- a/sql/src/main/java/io/crate/planner/node/NodeOperationGrouper.java
+++ b/sql/src/main/java/io/crate/planner/node/NodeOperationGrouper.java
@@ -54,7 +54,7 @@ public class NodeOperationGrouper {
         Context ctx = new Context();
         for (NodeOperation nodeOperation : nodeOperations) {
             ctx.currentOperation = nodeOperation;
-            for (String server : nodeOperation.executionPhase().executionNodes()) {
+            for (String server : nodeOperation.executionPhase().nodeIds()) {
                 ctx.add(server);
             }
         }

--- a/sql/src/main/java/io/crate/planner/node/dml/CopyTo.java
+++ b/sql/src/main/java/io/crate/planner/node/dml/CopyTo.java
@@ -25,14 +25,13 @@ package io.crate.planner.node.dml;
 import com.google.common.base.Optional;
 import io.crate.planner.Plan;
 import io.crate.planner.PlanVisitor;
-import io.crate.planner.distribution.UpstreamPhase;
+import io.crate.planner.UnnestablePlan;
 import io.crate.planner.node.dql.MergePhase;
-import io.crate.planner.projection.Projection;
 
 import javax.annotation.Nullable;
 import java.util.UUID;
 
-public class CopyTo implements Plan {
+public class CopyTo extends UnnestablePlan {
 
     private final UUID id;
     private final Plan innerPlan;
@@ -60,20 +59,5 @@ public class CopyTo implements Plan {
 
     public Optional<MergePhase> handlerMergeNode() {
         return handlerMergeNode;
-    }
-
-    @Override
-    public void addProjection(Projection projection) {
-        throw new UnsupportedOperationException("addingProjection not supported");
-    }
-
-    @Override
-    public boolean resultIsDistributed() {
-        throw new UnsupportedOperationException("resultIsDistributed is not supported");
-    }
-
-    @Override
-    public UpstreamPhase resultPhase() {
-        throw new UnsupportedOperationException("resultPhase is not supported");
     }
 }

--- a/sql/src/main/java/io/crate/planner/node/dml/InsertFromSubQuery.java
+++ b/sql/src/main/java/io/crate/planner/node/dml/InsertFromSubQuery.java
@@ -25,14 +25,13 @@ package io.crate.planner.node.dml;
 import com.google.common.base.Optional;
 import io.crate.planner.Plan;
 import io.crate.planner.PlanVisitor;
-import io.crate.planner.distribution.UpstreamPhase;
+import io.crate.planner.UnnestablePlan;
 import io.crate.planner.node.dql.MergePhase;
-import io.crate.planner.projection.Projection;
 
 import javax.annotation.Nullable;
 import java.util.UUID;
 
-public class InsertFromSubQuery implements Plan {
+public class InsertFromSubQuery extends UnnestablePlan {
 
 
     private final Optional<MergePhase> handlerMergeNode;
@@ -63,20 +62,5 @@ public class InsertFromSubQuery implements Plan {
 
     public Optional<MergePhase> handlerMergeNode() {
         return handlerMergeNode;
-    }
-
-    @Override
-    public void addProjection(Projection projection) {
-        throw new UnsupportedOperationException("addingProjection not supported");
-    }
-
-    @Override
-    public boolean resultIsDistributed() {
-        throw new UnsupportedOperationException("resultIsDistributed is not supported");
-    }
-
-    @Override
-    public UpstreamPhase resultPhase() {
-        throw new UnsupportedOperationException("resultPhase is not supported");
     }
 }

--- a/sql/src/main/java/io/crate/planner/node/dml/Upsert.java
+++ b/sql/src/main/java/io/crate/planner/node/dml/Upsert.java
@@ -23,13 +23,13 @@ package io.crate.planner.node.dml;
 
 import io.crate.planner.Plan;
 import io.crate.planner.PlanVisitor;
-import io.crate.planner.distribution.UpstreamPhase;
+import io.crate.planner.UnnestablePlan;
 import io.crate.planner.projection.Projection;
 
 import java.util.List;
 import java.util.UUID;
 
-public class Upsert implements Plan {
+public class Upsert extends UnnestablePlan {
 
     private final List<Plan> nodes;
     private final UUID id;
@@ -57,15 +57,4 @@ public class Upsert implements Plan {
     public void addProjection(Projection projection) {
         throw new UnsupportedOperationException("adding projection not supported");
     }
-
-    @Override
-    public boolean resultIsDistributed() {
-        throw new UnsupportedOperationException("resultIsDistributed is not supported");
-    }
-
-    @Override
-    public UpstreamPhase resultPhase() {
-        throw new UnsupportedOperationException("resultPhase is not supported");
-    }
-
 }

--- a/sql/src/main/java/io/crate/planner/node/dml/UpsertById.java
+++ b/sql/src/main/java/io/crate/planner/node/dml/UpsertById.java
@@ -37,18 +37,8 @@ public class UpsertById implements Plan {
 
     private final static ResultDescription HANDLER_ROW_COUNT = new ResultDescription() {
         @Override
-        public Collection<String> executionNodes() {
+        public Collection<String> nodeIds() {
             return Collections.emptyList();
-        }
-
-        @Override
-        public DistributionInfo distributionInfo() {
-            return DistributionInfo.DEFAULT_BROADCAST;
-        }
-
-        @Override
-        public void distributionInfo(DistributionInfo distributionInfo) {
-            throw new UnsupportedOperationException("Cannot overwrite distributionInfo of HANLDER_ROW_COUNT ResultDescription");
         }
     };
 
@@ -60,6 +50,11 @@ public class UpsertById implements Plan {
     @Override
     public ResultDescription resultDescription() {
         return HANDLER_ROW_COUNT;
+    }
+
+    @Override
+    public void setDistributionInfo(DistributionInfo distributionInfo) {
+        throw new UnsupportedOperationException("Cannot set distributionInfo on UpsertById plan");
     }
 
     /**

--- a/sql/src/main/java/io/crate/planner/node/dml/UpsertById.java
+++ b/sql/src/main/java/io/crate/planner/node/dml/UpsertById.java
@@ -25,16 +25,32 @@ import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.Reference;
 import io.crate.planner.Plan;
 import io.crate.planner.PlanVisitor;
-import io.crate.planner.distribution.UpstreamPhase;
+import io.crate.planner.ResultDescription;
+import io.crate.planner.distribution.DistributionInfo;
 import io.crate.planner.projection.Projection;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.lucene.uid.Versions;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 public class UpsertById implements Plan {
+
+    private final static ResultDescription HANDLER_ROW_COUNT = new ResultDescription() {
+        @Override
+        public Collection<String> executionNodes() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public DistributionInfo distributionInfo() {
+            return DistributionInfo.DEFAULT_BROADCAST;
+        }
+
+        @Override
+        public void distributionInfo(DistributionInfo distributionInfo) {
+            throw new UnsupportedOperationException("Cannot overwrite distributionInfo of HANLDER_ROW_COUNT ResultDescription");
+        }
+    };
 
     @Override
     public void addProjection(Projection projection) {
@@ -42,13 +58,8 @@ public class UpsertById implements Plan {
     }
 
     @Override
-    public boolean resultIsDistributed() {
-        return false;
-    }
-
-    @Override
-    public UpstreamPhase resultPhase() {
-        throw new UnsupportedOperationException("UpsertById doesn't have a resultPhase");
+    public ResultDescription resultDescription() {
+        return HANDLER_ROW_COUNT;
     }
 
     /**

--- a/sql/src/main/java/io/crate/planner/node/dql/AbstractProjectionsPhase.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/AbstractProjectionsPhase.java
@@ -78,7 +78,7 @@ public abstract class AbstractProjectionsPhase implements Streamable, ExecutionP
     }
 
     @Override
-    public int executionPhaseId() {
+    public int phaseId() {
         return executionPhaseId;
     }
 

--- a/sql/src/main/java/io/crate/planner/node/dql/CollectAndMerge.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/CollectAndMerge.java
@@ -23,7 +23,7 @@ package io.crate.planner.node.dql;
 
 import io.crate.planner.Plan;
 import io.crate.planner.PlanVisitor;
-import io.crate.planner.distribution.UpstreamPhase;
+import io.crate.planner.ResultDescription;
 import io.crate.planner.projection.Projection;
 
 import javax.annotation.Nullable;
@@ -68,12 +68,7 @@ public class CollectAndMerge implements Plan {
     }
 
     @Override
-    public boolean resultIsDistributed() {
-        return localMerge == null;
-    }
-
-    @Override
-    public UpstreamPhase resultPhase() {
+    public ResultDescription resultDescription() {
         if (localMerge == null) {
             return collectPhase;
         }

--- a/sql/src/main/java/io/crate/planner/node/dql/CollectAndMerge.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/CollectAndMerge.java
@@ -24,6 +24,7 @@ package io.crate.planner.node.dql;
 import io.crate.planner.Plan;
 import io.crate.planner.PlanVisitor;
 import io.crate.planner.ResultDescription;
+import io.crate.planner.distribution.DistributionInfo;
 import io.crate.planner.projection.Projection;
 
 import javax.annotation.Nullable;
@@ -73,5 +74,14 @@ public class CollectAndMerge implements Plan {
             return collectPhase;
         }
         return localMerge;
+    }
+
+    @Override
+    public void setDistributionInfo(DistributionInfo distributionInfo) {
+        if (localMerge == null) {
+            collectPhase.distributionInfo(distributionInfo);
+        } else {
+            localMerge.distributionInfo(distributionInfo);
+        }
     }
 }

--- a/sql/src/main/java/io/crate/planner/node/dql/CollectPhase.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/CollectPhase.java
@@ -26,13 +26,14 @@ import com.google.common.base.Function;
 import io.crate.analyze.EvaluatingNormalizer;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.TransactionContext;
+import io.crate.planner.ResultDescription;
 import io.crate.planner.distribution.UpstreamPhase;
 import io.crate.planner.projection.Projection;
 
 import java.util.List;
 import java.util.UUID;
 
-public interface CollectPhase extends UpstreamPhase {
+public interface CollectPhase extends UpstreamPhase, ResultDescription {
     UUID jobId();
 
     List<Symbol> toCollect();

--- a/sql/src/main/java/io/crate/planner/node/dql/CountPhase.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/CountPhase.java
@@ -77,12 +77,12 @@ public class CountPhase implements UpstreamPhase {
     }
 
     @Override
-    public int executionPhaseId() {
+    public int phaseId() {
         return executionPhaseId;
     }
 
     @Override
-    public Set<String> executionNodes() {
+    public Set<String> nodeIds() {
         return routing.nodes();
     }
 

--- a/sql/src/main/java/io/crate/planner/node/dql/CountPlan.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/CountPlan.java
@@ -23,7 +23,7 @@ package io.crate.planner.node.dql;
 
 import io.crate.planner.Plan;
 import io.crate.planner.PlanVisitor;
-import io.crate.planner.distribution.UpstreamPhase;
+import io.crate.planner.ResultDescription;
 import io.crate.planner.projection.Projection;
 
 import java.util.UUID;
@@ -64,12 +64,7 @@ public class CountPlan implements Plan {
     }
 
     @Override
-    public boolean resultIsDistributed() {
-        return false;
-    }
-
-    @Override
-    public UpstreamPhase resultPhase() {
+    public ResultDescription resultDescription() {
         return mergeNode;
     }
 }

--- a/sql/src/main/java/io/crate/planner/node/dql/CountPlan.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/CountPlan.java
@@ -24,6 +24,7 @@ package io.crate.planner.node.dql;
 import io.crate.planner.Plan;
 import io.crate.planner.PlanVisitor;
 import io.crate.planner.ResultDescription;
+import io.crate.planner.distribution.DistributionInfo;
 import io.crate.planner.projection.Projection;
 
 import java.util.UUID;
@@ -66,5 +67,10 @@ public class CountPlan implements Plan {
     @Override
     public ResultDescription resultDescription() {
         return mergeNode;
+    }
+
+    @Override
+    public void setDistributionInfo(DistributionInfo distributionInfo) {
+        mergeNode.distributionInfo(distributionInfo);
     }
 }

--- a/sql/src/main/java/io/crate/planner/node/dql/DistributedGroupBy.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/DistributedGroupBy.java
@@ -23,7 +23,7 @@ package io.crate.planner.node.dql;
 
 import io.crate.planner.Plan;
 import io.crate.planner.PlanVisitor;
-import io.crate.planner.distribution.UpstreamPhase;
+import io.crate.planner.ResultDescription;
 import io.crate.planner.projection.Projection;
 
 import javax.annotation.Nullable;
@@ -75,12 +75,10 @@ public class DistributedGroupBy implements Plan {
     }
 
     @Override
-    public boolean resultIsDistributed() {
-        return localMergeNode == null;
-    }
-
-    @Override
-    public UpstreamPhase resultPhase() {
-        return localMergeNode != null ? localMergeNode : reducerMergeNode;
+    public ResultDescription resultDescription() {
+        if (localMergeNode == null) {
+            return reducerMergeNode;
+        }
+        return localMergeNode;
     }
 }

--- a/sql/src/main/java/io/crate/planner/node/dql/DistributedGroupBy.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/DistributedGroupBy.java
@@ -24,6 +24,7 @@ package io.crate.planner.node.dql;
 import io.crate.planner.Plan;
 import io.crate.planner.PlanVisitor;
 import io.crate.planner.ResultDescription;
+import io.crate.planner.distribution.DistributionInfo;
 import io.crate.planner.projection.Projection;
 
 import javax.annotation.Nullable;
@@ -80,5 +81,14 @@ public class DistributedGroupBy implements Plan {
             return reducerMergeNode;
         }
         return localMergeNode;
+    }
+
+    @Override
+    public void setDistributionInfo(DistributionInfo distributionInfo) {
+        if (localMergeNode == null) {
+            reducerMergeNode.distributionInfo(distributionInfo);
+        } else {
+            reducerMergeNode.distributionInfo(distributionInfo);
+        }
     }
 }

--- a/sql/src/main/java/io/crate/planner/node/dql/ESGet.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/ESGet.java
@@ -29,17 +29,15 @@ import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.Symbols;
 import io.crate.analyze.where.DocKeys;
 import io.crate.metadata.doc.DocTableInfo;
-import io.crate.planner.Plan;
 import io.crate.planner.PlanVisitor;
-import io.crate.planner.distribution.UpstreamPhase;
-import io.crate.planner.projection.Projection;
+import io.crate.planner.UnnestablePlan;
 import io.crate.types.DataType;
 
 import java.util.List;
 import java.util.UUID;
 
 
-public class ESGet implements Plan {
+public class ESGet extends UnnestablePlan {
 
     private final DocTableInfo tableInfo;
     private final List<Symbol> sortSymbols;
@@ -132,22 +130,6 @@ public class ESGet implements Plan {
             .add("docKeys", docKeys)
             .add("outputs", outputs)
             .toString();
-    }
-
-    @Override
-    public void addProjection(Projection projection) {
-        throw new UnsupportedOperationException("ESGetNode doesn't support projections");
-    }
-
-    @Override
-    public boolean resultIsDistributed() {
-        return false;
-    }
-
-    @Override
-    public UpstreamPhase resultPhase() {
-        //return this;
-        throw new UnsupportedOperationException("resultPhase is not supported");
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/node/dql/FileUriCollectPhase.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/FileUriCollectPhase.java
@@ -83,7 +83,7 @@ public class FileUriCollectPhase extends AbstractProjectionsPhase implements Col
     }
 
     @Override
-    public Collection<String> executionNodes() {
+    public Collection<String> nodeIds() {
         return executionNodes;
     }
 
@@ -114,7 +114,7 @@ public class FileUriCollectPhase extends AbstractProjectionsPhase implements Col
         }
         return new FileUriCollectPhase(
             jobId(),
-            executionPhaseId(),
+            phaseId(),
             name(),
             executionNodes,
             normalizedTargetUri,

--- a/sql/src/main/java/io/crate/planner/node/dql/MergePhase.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/MergePhase.java
@@ -21,7 +21,6 @@
 
 package io.crate.planner.node.dql;
 
-import com.google.common.base.Function;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -30,6 +29,7 @@ import io.crate.analyze.OrderBy;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.Symbols;
 import io.crate.planner.Planner;
+import io.crate.planner.ResultDescription;
 import io.crate.planner.consumer.OrderByPositionVisitor;
 import io.crate.planner.distribution.DistributionInfo;
 import io.crate.planner.distribution.UpstreamPhase;
@@ -47,7 +47,7 @@ import java.util.*;
 /**
  * A plan node which merges results from upstreams
  */
-public class MergePhase extends AbstractProjectionsPhase implements UpstreamPhase {
+public class MergePhase extends AbstractProjectionsPhase implements UpstreamPhase, ResultDescription {
 
     public static final ExecutionPhaseFactory<MergePhase> FACTORY = new ExecutionPhaseFactory<MergePhase>() {
         @Override

--- a/sql/src/main/java/io/crate/planner/node/dql/MergePhase.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/MergePhase.java
@@ -184,7 +184,7 @@ public class MergePhase extends AbstractProjectionsPhase implements UpstreamPhas
     }
 
     @Override
-    public Collection<String> executionNodes() {
+    public Collection<String> nodeIds() {
         if (executionNodes == null) {
             return ImmutableSet.of();
         } else {
@@ -310,7 +310,7 @@ public class MergePhase extends AbstractProjectionsPhase implements UpstreamPhas
     @Override
     public String toString() {
         MoreObjects.ToStringHelper helper = MoreObjects.toStringHelper(this)
-            .add("executionPhaseId", executionPhaseId())
+            .add("executionPhaseId", phaseId())
             .add("name", name())
             .add("projections", projections)
             .add("outputTypes", outputTypes)

--- a/sql/src/main/java/io/crate/planner/node/dql/QueryThenFetch.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/QueryThenFetch.java
@@ -24,7 +24,7 @@ package io.crate.planner.node.dql;
 
 import io.crate.planner.Plan;
 import io.crate.planner.PlanVisitor;
-import io.crate.planner.distribution.UpstreamPhase;
+import io.crate.planner.ResultDescription;
 import io.crate.planner.node.fetch.FetchPhase;
 import io.crate.planner.projection.Projection;
 
@@ -74,13 +74,7 @@ public class QueryThenFetch implements Plan {
     }
 
     @Override
-    public boolean resultIsDistributed() {
-        return false;
-    }
-
-    @Override
-    public UpstreamPhase resultPhase() {
-        assert localMerge != null;
+    public ResultDescription resultDescription() {
         return localMerge;
     }
 }

--- a/sql/src/main/java/io/crate/planner/node/dql/QueryThenFetch.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/QueryThenFetch.java
@@ -25,6 +25,7 @@ package io.crate.planner.node.dql;
 import io.crate.planner.Plan;
 import io.crate.planner.PlanVisitor;
 import io.crate.planner.ResultDescription;
+import io.crate.planner.distribution.DistributionInfo;
 import io.crate.planner.node.fetch.FetchPhase;
 import io.crate.planner.projection.Projection;
 
@@ -76,5 +77,14 @@ public class QueryThenFetch implements Plan {
     @Override
     public ResultDescription resultDescription() {
         return localMerge;
+    }
+
+    @Override
+    public void setDistributionInfo(DistributionInfo distributionInfo) {
+        if (localMerge == null) {
+            subPlan.setDistributionInfo(distributionInfo);
+        } else {
+            localMerge.distributionInfo(distributionInfo);
+        }
     }
 }

--- a/sql/src/main/java/io/crate/planner/node/dql/RoutedCollectPhase.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/RoutedCollectPhase.java
@@ -124,7 +124,7 @@ public class RoutedCollectPhase extends AbstractProjectionsPhase implements Coll
      * @return a set of node ids where this collect operation is executed,
      */
     @Override
-    public Set<String> executionNodes() {
+    public Set<String> nodeIds() {
         if (routing == null) {
             return ImmutableSet.of();
         }
@@ -173,7 +173,7 @@ public class RoutedCollectPhase extends AbstractProjectionsPhase implements Coll
      * pageSize is the total pageSize.
      */
     public void pageSizeHint(Integer pageSize) {
-        nodePageSizeHint(Paging.getWeightedPageSize(pageSize, 1.0d / Math.max(1, executionNodes().size())));
+        nodePageSizeHint(Paging.getWeightedPageSize(pageSize, 1.0d / Math.max(1, nodeIds().size())));
     }
 
     /**
@@ -304,7 +304,7 @@ public class RoutedCollectPhase extends AbstractProjectionsPhase implements Coll
         if (changed) {
             result = new RoutedCollectPhase(
                 jobId(),
-                executionPhaseId(),
+                phaseId(),
                 name(),
                 routing,
                 maxRowGranularity,

--- a/sql/src/main/java/io/crate/planner/node/dql/join/NestedLoop.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/join/NestedLoop.java
@@ -22,7 +22,7 @@ package io.crate.planner.node.dql.join;
 
 import io.crate.planner.Plan;
 import io.crate.planner.PlanVisitor;
-import io.crate.planner.distribution.UpstreamPhase;
+import io.crate.planner.ResultDescription;
 import io.crate.planner.node.dql.MergePhase;
 import io.crate.planner.projection.Projection;
 
@@ -54,7 +54,6 @@ import java.util.UUID;
  * If sth. else is selected a projection has to reorder those.
  */
 public class NestedLoop implements Plan {
-
 
     private final Plan left;
     private final Plan right;
@@ -126,13 +125,11 @@ public class NestedLoop implements Plan {
     }
 
     @Override
-    public boolean resultIsDistributed() {
-        return resultIsDistributed;
-    }
-
-    @Override
-    public UpstreamPhase resultPhase() {
-        return localMerge == null ? nestedLoopPhase : localMerge;
+    public ResultDescription resultDescription() {
+        if (localMerge == null) {
+            return nestedLoopPhase;
+        }
+        return localMerge;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/node/dql/join/NestedLoop.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/join/NestedLoop.java
@@ -23,6 +23,7 @@ package io.crate.planner.node.dql.join;
 import io.crate.planner.Plan;
 import io.crate.planner.PlanVisitor;
 import io.crate.planner.ResultDescription;
+import io.crate.planner.distribution.DistributionInfo;
 import io.crate.planner.node.dql.MergePhase;
 import io.crate.planner.projection.Projection;
 
@@ -100,7 +101,7 @@ public class NestedLoop implements Plan {
         this.right = right;
         this.nestedLoopPhase = nestedLoopPhase;
         this.localMerge = localMerge;
-        this.resultIsDistributed = localMerge == null && !nestedLoopPhase.executionNodes().equals(handlerNodes);
+        this.resultIsDistributed = localMerge == null && !nestedLoopPhase.nodeIds().equals(handlerNodes);
     }
 
     public Plan left() {
@@ -130,6 +131,15 @@ public class NestedLoop implements Plan {
             return nestedLoopPhase;
         }
         return localMerge;
+    }
+
+    @Override
+    public void setDistributionInfo(DistributionInfo distributionInfo) {
+        if (localMerge == null) {
+            nestedLoopPhase.distributionInfo(distributionInfo);
+        } else {
+            localMerge.distributionInfo(distributionInfo);
+        }
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/node/dql/join/NestedLoopPhase.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/join/NestedLoopPhase.java
@@ -26,6 +26,8 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.Symbols;
+import io.crate.operation.projectors.RowReceiver;
+import io.crate.planner.ResultDescription;
 import io.crate.planner.distribution.DistributionInfo;
 import io.crate.planner.distribution.UpstreamPhase;
 import io.crate.planner.node.ExecutionPhaseVisitor;
@@ -42,7 +44,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
 
-public class NestedLoopPhase extends AbstractProjectionsPhase implements UpstreamPhase {
+public class NestedLoopPhase extends AbstractProjectionsPhase implements UpstreamPhase, ResultDescription {
 
     public static final ExecutionPhaseFactory<NestedLoopPhase> FACTORY = new ExecutionPhaseFactory<NestedLoopPhase>() {
         @Override

--- a/sql/src/main/java/io/crate/planner/node/dql/join/NestedLoopPhase.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/join/NestedLoopPhase.java
@@ -26,7 +26,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.Symbols;
-import io.crate.operation.projectors.RowReceiver;
 import io.crate.planner.ResultDescription;
 import io.crate.planner.distribution.DistributionInfo;
 import io.crate.planner.distribution.UpstreamPhase;
@@ -97,7 +96,7 @@ public class NestedLoopPhase extends AbstractProjectionsPhase implements Upstrea
     }
 
     @Override
-    public Collection<String> executionNodes() {
+    public Collection<String> nodeIds() {
         if (executionNodes == null) {
             return ImmutableSet.of();
         } else {
@@ -210,7 +209,7 @@ public class NestedLoopPhase extends AbstractProjectionsPhase implements Upstrea
     @Override
     public String toString() {
         MoreObjects.ToStringHelper helper = MoreObjects.toStringHelper(this)
-            .add("executionPhaseId", executionPhaseId())
+            .add("executionPhaseId", phaseId())
             .add("name", name())
             .add("joinType", joinType)
             .add("joinCondition", joinCondition)

--- a/sql/src/main/java/io/crate/planner/node/fetch/FetchPhase.java
+++ b/sql/src/main/java/io/crate/planner/node/fetch/FetchPhase.java
@@ -79,12 +79,12 @@ public class FetchPhase implements ExecutionPhase {
     }
 
     @Override
-    public int executionPhaseId() {
+    public int phaseId() {
         return executionPhaseId;
     }
 
     @Override
-    public Set<String> executionNodes() {
+    public Set<String> nodeIds() {
         return executionNodes;
     }
 

--- a/sql/src/main/java/io/crate/planner/statement/CopyStatementPlanner.java
+++ b/sql/src/main/java/io/crate/planner/statement/CopyStatementPlanner.java
@@ -206,7 +206,7 @@ public class CopyStatementPlanner {
             context.jobId(),
             context.nextExecutionPhaseId(),
             ImmutableList.<Projection>of(MergeCountProjection.INSTANCE),
-            plan.resultPhase().executionNodes().size(),
+            plan.resultDescription().executionNodes().size(),
             Symbols.extractTypes(projection.outputs()));
 
         return new CopyTo(context.jobId(), plan, mergePhase);

--- a/sql/src/main/java/io/crate/planner/statement/CopyStatementPlanner.java
+++ b/sql/src/main/java/io/crate/planner/statement/CopyStatementPlanner.java
@@ -176,7 +176,7 @@ public class CopyStatementPlanner {
             context.jobId(),
             context.nextExecutionPhaseId(),
             ImmutableList.<Projection>of(MergeCountProjection.INSTANCE),
-            collectPhase.executionNodes().size(),
+            collectPhase.nodeIds().size(),
             collectPhase.outputTypes()));
     }
 
@@ -206,7 +206,7 @@ public class CopyStatementPlanner {
             context.jobId(),
             context.nextExecutionPhaseId(),
             ImmutableList.<Projection>of(MergeCountProjection.INSTANCE),
-            plan.resultDescription().executionNodes().size(),
+            plan.resultDescription().nodeIds().size(),
             Symbols.extractTypes(projection.outputs()));
 
         return new CopyTo(context.jobId(), plan, mergePhase);

--- a/sql/src/main/java/io/crate/planner/statement/DeleteStatementPlanner.java
+++ b/sql/src/main/java/io/crate/planner/statement/DeleteStatementPlanner.java
@@ -144,7 +144,7 @@ public final class DeleteStatementPlanner {
             plannerContext.jobId(),
             plannerContext.nextExecutionPhaseId(),
             ImmutableList.<Projection>of(MergeCountProjection.INSTANCE),
-            collectPhase.executionNodes().size(),
+            collectPhase.nodeIds().size(),
             collectPhase.outputTypes()
         );
         return new CollectAndMerge(collectPhase, mergeNode);

--- a/sql/src/test/groovy/io/crate/action/job/NodeOperationCtxTest.groovy
+++ b/sql/src/test/groovy/io/crate/action/job/NodeOperationCtxTest.groovy
@@ -36,7 +36,7 @@ class NodeOperationCtxTest {
         def p2 = StubPhases.newPhase(1, "n1", "n2")
         def p3 = StubPhases.newPhase(2, "n2")
 
-        def opCtx = new ContextPreparer.NodeOperationCtx([
+        def opCtx = new ContextPreparer.NodeOperationCtx("n1", [
                 NodeOperation.withDownstream(p1, p2, (byte)0, "n2"),
                 NodeOperation.withDownstream(p2, p3, (byte)0, "n2")])
 
@@ -49,7 +49,7 @@ class NodeOperationCtxTest {
     @Test
     void testFindLeafWithNodeOperationsThatHaveNoLeaf() {
         def p1 = StubPhases.newPhase(0, "n1");
-        def opCtx = new ContextPreparer.NodeOperationCtx([NodeOperation.withDownstream(p1, p1, (byte)0, "n1")])
+        def opCtx = new ContextPreparer.NodeOperationCtx("n1", [NodeOperation.withDownstream(p1, p1, (byte)0, "n1")])
 
         opCtx.findLeafs().size() == 0;
     }
@@ -58,7 +58,7 @@ class NodeOperationCtxTest {
     void testIsUpstreamOnSameNodeWithSameNodeOptimization() throws Exception {
         def p1 = StubPhases.newUpstreamPhase(0, DistributionInfo.DEFAULT_BROADCAST, "n1")
         def p2 = StubPhases.newPhase(1, "n1")
-        def opCtx = new ContextPreparer.NodeOperationCtx([NodeOperation.withDownstream(p1, p2, (byte)0, "n2")])
+        def opCtx = new ContextPreparer.NodeOperationCtx("n1", [NodeOperation.withDownstream(p1, p2, (byte)0, "n2")])
 
         // withDownstream set DistributionInfo to SAME_NODE because both phases are on n1
         assert opCtx.upstreamsAreOnSameNode(1)
@@ -68,9 +68,9 @@ class NodeOperationCtxTest {
     void testIsUpstreamOnSameNodeWithUpstreamOnOtherNode() throws Exception {
         def p1 = StubPhases.newUpstreamPhase(0, DistributionInfo.DEFAULT_BROADCAST, "n2")
         def p2 = StubPhases.newPhase(1, "n1")
-        def opCtx = new ContextPreparer.NodeOperationCtx([NodeOperation.withDownstream(p1, p2, (byte)0, "n1")])
+        def opCtx = new ContextPreparer.NodeOperationCtx("n1", [NodeOperation.withDownstream(p1, p2, (byte)0, "n1")])
 
-        assert opCtx.upstreamsAreOnSameNode(1) == false
+        assert !opCtx.upstreamsAreOnSameNode(1)
     }
 
     @Test
@@ -79,7 +79,7 @@ class NodeOperationCtxTest {
         def p2 = StubPhases.newUpstreamPhase(2, DistributionInfo.DEFAULT_SAME_NODE, "n2")
         def p3 = StubPhases.newPhase(3, "n2")
 
-        def opCtx = new ContextPreparer.NodeOperationCtx([
+        def opCtx = new ContextPreparer.NodeOperationCtx("n1",[
                 NodeOperation.withDownstream(p1, p3, (byte)0, "n1"),
                 NodeOperation.withDownstream(p2, p3, (byte)0, "n1")])
 

--- a/sql/src/test/groovy/io/crate/planner/CopyFromPlannerTest.groovy
+++ b/sql/src/test/groovy/io/crate/planner/CopyFromPlannerTest.groovy
@@ -47,7 +47,7 @@ class CopyFromPlannerTest extends AbstractPlannerTest {
         CollectAndMerge plan = plan("copy users from '/path/to/file.extension' with (num_readers=1)");
         assert plan.collectPhase() instanceof FileUriCollectPhase
         FileUriCollectPhase collectPhase = (FileUriCollectPhase) plan.collectPhase();
-        assert collectPhase.executionNodes().size() == 1
+        assert collectPhase.nodeIds().size() == 1
     }
 
     @Test
@@ -84,6 +84,6 @@ class CopyFromPlannerTest extends AbstractPlannerTest {
     @Test
     public void testNodeFiltersNoMatch() throws Exception {
         CollectAndMerge cm = plan("copy users from '/path' with (node_filters={name='foobar'})");
-        assert cm.collectPhase().executionNodes() == []
+        assert cm.collectPhase().nodeIds() == []
     }
 }

--- a/sql/src/test/java/io/crate/planner/PlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/PlannerTest.java
@@ -191,8 +191,8 @@ public class PlannerTest extends AbstractPlannerTest {
         RoutedCollectPhase collectPhase = ((RoutedCollectPhase) ((CollectAndMerge) plan).collectPhase());
         assertTrue(collectPhase.whereClause().hasQuery());
 
-        assertThat(((CollectAndMerge) plan).resultPhase(), instanceOf(MergePhase.class));
-        MergePhase mergePhase = (MergePhase) ((CollectAndMerge) plan).resultPhase();
+        assertThat(plan.resultDescription(), instanceOf(MergePhase.class));
+        MergePhase mergePhase = ((CollectAndMerge) plan).localMerge();
         assertThat(mergePhase.outputTypes().size(), is(1));
         assertEquals(DataTypes.STRING, mergePhase.outputTypes().get(0));
 

--- a/sql/src/test/java/io/crate/planner/PlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/PlannerTest.java
@@ -1185,10 +1185,10 @@ public class PlannerTest extends AbstractPlannerTest {
     @Test
     public void testLimitThatIsBiggerThanPageSizeCausesQTFPUshPlan() throws Exception {
         QueryThenFetch plan = plan("select * from users limit 2147483647 ");
-        assertThat(plan.localMerge().executionNodes().size(), is(1));
+        assertThat(plan.localMerge().nodeIds().size(), is(1));
 
         plan = plan("select * from users limit 2");
-        assertThat(plan.localMerge().executionNodes().size(), is(0));
+        assertThat(plan.localMerge().nodeIds().size(), is(0));
     }
 
     @Test
@@ -1210,21 +1210,21 @@ public class PlannerTest extends AbstractPlannerTest {
     public void testShardQueueSizeCalculation() throws Exception {
         CollectAndMerge plan = plan("select name from users order by name limit 100");
         int shardQueueSize = ((RoutedCollectPhase) plan.collectPhase()).shardQueueSize(
-            plan.collectPhase().executionNodes().iterator().next());
+            plan.collectPhase().nodeIds().iterator().next());
         assertThat(shardQueueSize, is(75));
     }
 
     @Test
     public void testQAFPagingIsEnabledOnHighLimit() throws Exception {
         CollectAndMerge plan = plan("select name from users order by name limit 1000000");
-        assertThat(plan.localMerge().executionNodes().size(), is(1)); // mergePhase with executionNode = paging enabled
+        assertThat(plan.localMerge().nodeIds().size(), is(1)); // mergePhase with executionNode = paging enabled
         assertThat(((RoutedCollectPhase) plan.collectPhase()).nodePageSizeHint(), is(750000));
     }
 
     @Test
     public void testQAFPagingIsEnabledOnHighOffset() throws Exception {
         CollectAndMerge plan = plan("select name from users order by name limit 10 offset 1000000");
-        assertThat(plan.localMerge().executionNodes().size(), is(1)); // mergePhase with executionNode = paging enabled
+        assertThat(plan.localMerge().nodeIds().size(), is(1)); // mergePhase with executionNode = paging enabled
         assertThat(((RoutedCollectPhase) plan.collectPhase()).nodePageSizeHint(), is(750007));
     }
 
@@ -1232,7 +1232,7 @@ public class PlannerTest extends AbstractPlannerTest {
     public void testQTFPagingIsEnabledOnHighLimit() throws Exception {
         QueryThenFetch plan = plan("select name, date from users order by name limit 1000000");
         RoutedCollectPhase collectPhase = ((RoutedCollectPhase) ((CollectAndMerge) plan.subPlan()).collectPhase());
-        assertThat(plan.localMerge().executionNodes().size(), is(1)); // mergePhase with executionNode = paging enabled
+        assertThat(plan.localMerge().nodeIds().size(), is(1)); // mergePhase with executionNode = paging enabled
         assertThat(collectPhase.nodePageSizeHint(), is(750000));
     }
 

--- a/sql/src/test/java/io/crate/planner/consumer/GroupByPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/consumer/GroupByPlannerTest.java
@@ -68,7 +68,7 @@ public class GroupByPlannerTest extends CrateUnitTest {
         // distributed collect
         RoutedCollectPhase collectPhase = distributedGroupBy.collectNode();
         assertThat(collectPhase.maxRowGranularity(), is(RowGranularity.DOC));
-        assertThat(collectPhase.executionNodes().size(), is(2));
+        assertThat(collectPhase.nodeIds().size(), is(2));
         assertThat(collectPhase.toCollect().size(), is(1));
         assertThat(collectPhase.projections().size(), is(1));
         assertThat(collectPhase.projections().get(0), instanceOf(GroupProjection.class));
@@ -79,7 +79,7 @@ public class GroupByPlannerTest extends CrateUnitTest {
         MergePhase mergeNode = distributedGroupBy.reducerMergeNode();
 
         assertThat(mergeNode.numUpstreams(), is(2));
-        assertThat(mergeNode.executionNodes().size(), is(2));
+        assertThat(mergeNode.nodeIds().size(), is(2));
         assertEquals(mergeNode.inputTypes(), collectPhase.outputTypes());
         assertThat(mergeNode.projections().size(), is(2)); // for the default limit there is always a TopNProjection
         assertThat(mergeNode.projections().get(1), instanceOf(TopNProjection.class));
@@ -96,8 +96,8 @@ public class GroupByPlannerTest extends CrateUnitTest {
         MergePhase localMerge = distributedGroupBy.localMergeNode();
 
         assertThat(localMerge.numUpstreams(), is(2));
-        assertThat(localMerge.executionNodes().size(), is(1));
-        assertThat(Iterables.getOnlyElement(localMerge.executionNodes()), is("noop_id"));
+        assertThat(localMerge.nodeIds().size(), is(1));
+        assertThat(Iterables.getOnlyElement(localMerge.nodeIds()), is("noop_id"));
         assertEquals(mergeNode.outputTypes(), localMerge.inputTypes());
 
         assertThat(localMerge.projections().get(0), instanceOf(TopNProjection.class));

--- a/sql/src/test/java/io/crate/planner/consumer/NestedLoopConsumerTest.java
+++ b/sql/src/test/java/io/crate/planner/consumer/NestedLoopConsumerTest.java
@@ -33,11 +33,9 @@ import io.crate.metadata.doc.DocSchemaInfo;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.TestingTableInfo;
 import io.crate.operation.projectors.TopN;
-import io.crate.planner.NoopPlan;
-import io.crate.planner.Plan;
-import io.crate.planner.Planner;
-import io.crate.planner.TableStatsService;
+import io.crate.planner.*;
 import io.crate.planner.distribution.DistributionType;
+import io.crate.planner.distribution.UpstreamPhase;
 import io.crate.planner.node.dql.*;
 import io.crate.planner.node.dql.join.NestedLoop;
 import io.crate.planner.node.dql.join.NestedLoopPhase;
@@ -192,7 +190,8 @@ public class NestedLoopConsumerTest extends CrateUnitTest {
         NestedLoop plan = plan("select users.name, u2.name from users, users_multi_pk u2 " +
                                "where users.name = u2.name " +
                                "order by users.name, u2.name ");
-        assertThat(plan.left().resultDescription().distributionInfo().distributionType(), is(DistributionType.BROADCAST));
+        ResultDescription resultDescription = plan.left().resultDescription();
+        assertThat(((UpstreamPhase) resultDescription).distributionInfo().distributionType(), is(DistributionType.BROADCAST));
     }
 
 

--- a/sql/src/test/java/io/crate/planner/node/MergeNodeTest.java
+++ b/sql/src/test/java/io/crate/planner/node/MergeNodeTest.java
@@ -83,10 +83,10 @@ public class MergeNodeTest extends CrateUnitTest {
         node2.readFrom(input);
 
         assertThat(node.numUpstreams(), is(node2.numUpstreams()));
-        assertThat(node.executionNodes(), is(node2.executionNodes()));
+        assertThat(node.nodeIds(), is(node2.nodeIds()));
         assertThat(node.jobId(), is(node2.jobId()));
         assertEquals(node.inputTypes(), node2.inputTypes());
-        assertThat(node.executionPhaseId(), is(node2.executionPhaseId()));
+        assertThat(node.phaseId(), is(node2.phaseId()));
         assertThat(node.distributionInfo(), is(node2.distributionInfo()));
     }
 }

--- a/sql/src/test/java/io/crate/planner/node/RoutedCollectPhaseTest.java
+++ b/sql/src/test/java/io/crate/planner/node/RoutedCollectPhaseTest.java
@@ -71,9 +71,9 @@ public class RoutedCollectPhaseTest extends CrateUnitTest {
         assertThat(cn, equalTo(cn2));
 
         assertThat(cn.toCollect(), is(cn2.toCollect()));
-        assertThat(cn.executionNodes(), is(cn2.executionNodes()));
+        assertThat(cn.nodeIds(), is(cn2.nodeIds()));
         assertThat(cn.jobId(), is(cn2.jobId()));
-        assertThat(cn.executionPhaseId(), is(cn2.executionPhaseId()));
+        assertThat(cn.phaseId(), is(cn2.phaseId()));
         assertThat(cn.maxRowGranularity(), is(cn2.maxRowGranularity()));
         assertThat(cn.distributionInfo(), is(cn2.distributionInfo()));
     }

--- a/sql/src/test/java/io/crate/planner/node/dql/CountNodeTest.java
+++ b/sql/src/test/java/io/crate/planner/node/dql/CountNodeTest.java
@@ -58,8 +58,8 @@ public class CountNodeTest extends CrateUnitTest {
         CountPhase streamedNode = CountPhase.FACTORY.create();
         streamedNode.readFrom(in);
 
-        assertThat(streamedNode.executionPhaseId(), is(1));
-        assertThat(streamedNode.executionNodes(), containsInAnyOrder("n1", "n2"));
+        assertThat(streamedNode.phaseId(), is(1));
+        assertThat(streamedNode.nodeIds(), containsInAnyOrder("n1", "n2"));
         assertThat(streamedNode.routing(), equalTo(routing));
         assertThat(streamedNode.distributionInfo(), equalTo(DistributionInfo.DEFAULT_BROADCAST));
     }

--- a/sql/src/test/java/io/crate/planner/node/dql/NestedLoopPhaseTest.java
+++ b/sql/src/test/java/io/crate/planner/node/dql/NestedLoopPhaseTest.java
@@ -80,7 +80,7 @@ public class NestedLoopPhaseTest extends CrateUnitTest {
         NestedLoopPhase node2 = new NestedLoopPhase();
         node2.readFrom(input);
 
-        assertThat(node.executionNodes(), Is.is(node2.executionNodes()));
+        assertThat(node.nodeIds(), Is.is(node2.nodeIds()));
         assertThat(node.jobId(), Is.is(node2.jobId()));
         assertThat(node.name(), is(node2.name()));
         assertThat(node.outputTypes(), is(node2.outputTypes()));

--- a/sql/src/test/java/io/crate/planner/node/fetch/FetchPhaseTest.java
+++ b/sql/src/test/java/io/crate/planner/node/fetch/FetchPhaseTest.java
@@ -74,8 +74,8 @@ public class FetchPhaseTest {
         StreamInput in = StreamInput.wrap(out.bytes());
         FetchPhase streamed = (FetchPhase) ExecutionPhases.fromStream(in);
 
-        assertThat(orig.executionPhaseId(), is(streamed.executionPhaseId()));
-        assertThat(orig.executionNodes(), is(streamed.executionNodes()));
+        assertThat(orig.phaseId(), is(streamed.phaseId()));
+        assertThat(orig.nodeIds(), is(streamed.nodeIds()));
         assertThat(orig.fetchRefs(), is(streamed.fetchRefs()));
         assertThat(orig.bases(), is(streamed.bases()));
         assertThat(orig.tableIndices(), is(streamed.tableIndices()));

--- a/sql/src/test/java/io/crate/testing/StubPhases.java
+++ b/sql/src/test/java/io/crate/testing/StubPhases.java
@@ -67,12 +67,12 @@ public class StubPhases {
         }
 
         @Override
-        public int executionPhaseId() {
+        public int phaseId() {
             return phaseId;
         }
 
         @Override
-        public Collection<String> executionNodes() {
+        public Collection<String> nodeIds() {
             return executionNodes;
         }
 


### PR DESCRIPTION
It replaces `isDistributed()` and `upstreamPhase()` on the Plan
interface.

It will eventually receive more properties - all that are required to
create another MergePhase from a parent plan/relation.