### PR TITLE
add support for the search_path session parameter

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Added the ``search_path`` session setting parameter. The default table
+   schema can be set with ``SET SESSION search_path = schema_name``.
+
  - Fix: Certain subselects with nested ``order by`` and ``limit`` or ``offset``
    produced incorrect results.
    eg. select * from (select a, b from t1 order by a limit 3) as t order by b limit 2

--- a/blackbox/docs/configuration.txt
+++ b/blackbox/docs/configuration.txt
@@ -1582,6 +1582,23 @@ Metadata Gateway
   number of nodes in the cluster.
 
 
+.. _conf-session-settings:
+
+Session Setting Parameters
+==========================
+
+The section lists the session setting parameters supported by Crate.
+Parameters can be set with the ``SET/SET SESSION`` statement, see :ref:`ref-set`.
+
+**search_path**
+  | *Default:* ``doc``
+
+   This parameter holds the default schema for a session that should be used when
+   no schema is provided in queries.
+   The value of ``search_path`` can be either a string or a comma-separated
+   list of strings. However, Crate only considers the first element when a
+   list is provided.
+
 Logging
 =======
 

--- a/blackbox/docs/sql/reference/set.txt
+++ b/blackbox/docs/sql/reference/set.txt
@@ -32,7 +32,8 @@ keywords to set a persistent level.
 
 ``SET/SET SESSION`` may affect the current session if the setting is supported.
 Setting the unsupported settings will be ignored and logged with the ``WARN``
-logging level.
+logging level. See :ref:`conf-session-settings`, to get an overview of the
+supported session setting parameters.
 
 ``SET LOCAL`` does not have any effect on Crate configurations.
 All ``SET LOCAL`` statements will be ignored by Crate and logged

--- a/sql/src/main/java/io/crate/action/sql/SessionContext.java
+++ b/sql/src/main/java/io/crate/action/sql/SessionContext.java
@@ -33,7 +33,7 @@ public class SessionContext {
     private final Set<Option> options;
 
     @Nullable
-    private final String defaultSchema;
+    private String defaultSchema;
 
     public SessionContext(int defaultLimit, Set<Option> options, @Nullable String defaultSchema ) {
         this.defaultLimit = defaultLimit;
@@ -48,6 +48,10 @@ public class SessionContext {
     @Nullable
     public String defaultSchema() {
         return defaultSchema;
+    }
+
+    public void setDefaultSchema(String schema) {
+        defaultSchema = schema;
     }
 
     public int defaultLimit() {

--- a/sql/src/main/java/io/crate/analyze/SetStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/SetStatementAnalyzer.java
@@ -41,8 +41,6 @@ class SetStatementAnalyzer {
         Map<String, List<Expression>> settings = new HashMap<>();
 
         if (!SetStatement.Scope.GLOBAL.equals(node.scope())) {
-            logger.warn("SET STATEMENT WITH SESSION OR LOCAL WILL BE IGNORED: {}", node);
-
             Assignment assignment = node.assignments().get(0);
             // parser does not allow using the parameter expressions as setting names in the SET statements,
             // therefore it is fine to convert the expression to string here.

--- a/sql/src/main/java/io/crate/executor/task/SetSessionTask.java
+++ b/sql/src/main/java/io/crate/executor/task/SetSessionTask.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.executor.task;
+
+import io.crate.action.sql.SessionContext;
+import io.crate.core.collections.Row;
+import io.crate.executor.JobTask;
+import io.crate.metadata.settings.session.SessionSettingApplier;
+import io.crate.metadata.settings.session.SessionSettingRegistry;
+import io.crate.operation.projectors.RepeatHandle;
+import io.crate.operation.projectors.RowReceiver;
+import io.crate.sql.tree.Expression;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public class SetSessionTask extends JobTask {
+
+    private static final ESLogger LOGGER = Loggers.getLogger(SetSessionTask.class);
+
+    private final SessionContext sessionContext;
+    private final Map<String, List<Expression>> settings;
+
+    public SetSessionTask(UUID jobId, Map<String, List<Expression>> settings, SessionContext sessionContext) {
+        super(jobId);
+        this.sessionContext = sessionContext;
+        this.settings = settings;
+    }
+
+    @Override
+    public void execute(RowReceiver rowReceiver, Row parameters) {
+        for (Map.Entry<String, List<Expression>> setting : settings.entrySet()) {
+            SessionSettingApplier applier = SessionSettingRegistry.getApplier(setting.getKey());
+            if (applier != null) {
+                // `search_path` is the only session setting currently supported.
+                // Possible variations of the setting values that might cause an exception
+                // are restricted by the parser. Therefore, for now we do not handle
+                // exceptions here, e.g. by calling fail on the upstream (rowReceiver.fail(...))
+                applier.apply(parameters, setting.getValue(), sessionContext);
+            } else {
+                LOGGER.warn("SET SESSION STATEMENT WILL BE IGNORED: {}", setting);
+            }
+            rowReceiver.finish(RepeatHandle.UNSUPPORTED);
+        }
+    }
+}
+

--- a/sql/src/main/java/io/crate/executor/transport/TransportExecutor.java
+++ b/sql/src/main/java/io/crate/executor/transport/TransportExecutor.java
@@ -1,22 +1,23 @@
 /*
- * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
- * license agreements.  See the NOTICE file distributed with this work for
- * additional information regarding copyright ownership.  Crate licenses
- * this file to you under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.  You may
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
  * obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
  *
  * However, if you have executed another commercial license agreement
  * with Crate these terms will supersede the license and you may use the
- * software solely pursuant to the terms of the relevant commercial agreement.
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
  */
 
 package io.crate.executor.transport;
@@ -36,6 +37,7 @@ import io.crate.executor.Task;
 import io.crate.executor.task.DDLTask;
 import io.crate.executor.task.ExplainTask;
 import io.crate.executor.task.NoopTask;
+import io.crate.executor.task.SetSessionTask;
 import io.crate.executor.transport.executionphases.ExecutionPhasesTask;
 import io.crate.executor.transport.task.*;
 import io.crate.executor.transport.task.elasticsearch.*;
@@ -158,7 +160,7 @@ public class TransportExecutor implements Executor {
 
         @Override
         public Task visitSetSessionPlan(SetSessionPlan plan, Void context) {
-            return NoopTask.INSTANCE;
+            return new SetSessionTask(plan.jobId(), plan.settings(), plan.sessionContext());
         }
 
         @Override

--- a/sql/src/main/java/io/crate/metadata/settings/session/SessionSettingApplier.java
+++ b/sql/src/main/java/io/crate/metadata/settings/session/SessionSettingApplier.java
@@ -20,44 +20,15 @@
  * agreement.
  */
 
-package io.crate.planner.statement;
+package io.crate.metadata.settings.session;
 
 import io.crate.action.sql.SessionContext;
-import io.crate.planner.PlanVisitor;
-import io.crate.planner.UnnestablePlan;
+import io.crate.core.collections.Row;
 import io.crate.sql.tree.Expression;
 
 import java.util.List;
-import java.util.Map;
-import java.util.UUID;
 
-public class SetSessionPlan extends UnnestablePlan {
+public interface SessionSettingApplier {
 
-    private final UUID id;
-    private final Map<String, List<Expression>> settings;
-    private final SessionContext sessionContext;
-
-    public SetSessionPlan(UUID id, Map<String, List<Expression>> settings, SessionContext sessionContext) {
-        this.id = id;
-        this.settings = settings;
-        this.sessionContext = sessionContext;
-    }
-
-    @Override
-    public <C, R> R accept(PlanVisitor<C, R> visitor, C context) {
-        return visitor.visitSetSessionPlan(this, context);
-    }
-
-    @Override
-    public UUID jobId() {
-        return id;
-    }
-
-    public Map<String, List<Expression>> settings() {
-        return settings;
-    }
-
-    public SessionContext sessionContext() {
-        return sessionContext;
-    }
+    void apply(Row parameters, List<Expression> expressions, SessionContext sessionContext);
 }

--- a/sql/src/main/java/io/crate/metadata/settings/session/SessionSettingRegistry.java
+++ b/sql/src/main/java/io/crate/metadata/settings/session/SessionSettingRegistry.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.settings.session;
+
+import com.google.common.collect.ImmutableMap;
+import io.crate.action.sql.SessionContext;
+import io.crate.analyze.expressions.ExpressionToStringVisitor;
+import io.crate.core.collections.Row;
+import io.crate.sql.tree.Expression;
+
+import java.util.List;
+import java.util.Map;
+
+public class SessionSettingRegistry {
+
+    private static final Map<String, SessionSettingApplier> SESSION_SETTINGS =
+        ImmutableMap.<String, SessionSettingApplier>builder()
+            .put("search_path", new SessionSettingApplier() {
+
+                @Override
+                public void apply(Row parameters, List<Expression> expressions, SessionContext context) {
+                    if (expressions.size() > 0) {
+                        // The search_path takes a schema name as a string or comma-separated list of schema names.
+                        // In the second case only the first schema in the list will be used.
+                        // Resetting the search path with `set search_path to default` results
+                        // in the empty list of expressions.
+                        String schema = ExpressionToStringVisitor.convert(expressions.get(0), parameters);
+                        context.setDefaultSchema(schema.trim());
+                    } else {
+                        context.setDefaultSchema(null);
+                    }
+                }
+            }).build();
+
+
+    public static SessionSettingApplier getApplier(String setting) {
+        return SESSION_SETTINGS.get(setting);
+    }
+}


### PR DESCRIPTION
The schema name can be set now with the `set session`
statement, e.g. `set session search_path = schema`