### PR TITLE
Remove PlannedAnalyzedRelation

### DIFF
--- a/sql/src/main/java/io/crate/planner/consumer/CountConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/CountConsumer.java
@@ -70,7 +70,7 @@ public class CountConsumer implements Consumer {
                 return null;
             }
 
-            Limits limits = context.plannerContext().getLimits(context.isRoot(), querySpec);
+            Limits limits = context.plannerContext().getLimits(querySpec);
             if ((limits.finalLimit() == 0 || limits.offset() > 0)) {
                 return new NoopPlan(context.plannerContext().jobId());
             }

--- a/sql/src/main/java/io/crate/planner/consumer/DistributedGroupByConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/DistributedGroupByConsumer.java
@@ -149,7 +149,7 @@ class DistributedGroupByConsumer implements Consumer {
                 }
             }
 
-            Limits limits = plannerContext.getLimits(context.isRoot(), querySpec);
+            Limits limits = plannerContext.getLimits(querySpec);
             boolean isRootRelation = context.rootRelation() == table;
             if (isRootRelation) {
                 reducerProjections.add(ProjectionBuilder.topNProjection(

--- a/sql/src/main/java/io/crate/planner/consumer/ESGetStatementPlanner.java
+++ b/sql/src/main/java/io/crate/planner/consumer/ESGetStatementPlanner.java
@@ -48,7 +48,7 @@ public class ESGetStatementPlanner {
         if (docKeys.withVersions()){
             throw new VersionInvalidException();
         }
-        Limits limits = context.getLimits(true, querySpec);
+        Limits limits = context.getLimits(querySpec);
         if (limits.hasLimit() && limits.finalLimit() == 0) {
             return new NoopPlan(context.jobId());
         }

--- a/sql/src/main/java/io/crate/planner/consumer/GlobalAggregateConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/GlobalAggregateConsumer.java
@@ -102,7 +102,7 @@ class GlobalAggregateConsumer implements Consumer {
         }
 
         Planner.Context plannerContext = context.plannerContext();
-        Limits limits = plannerContext.getLimits(context.isRoot(), table.querySpec());
+        Limits limits = plannerContext.getLimits(table.querySpec());
         if (limits.finalLimit() == 0 || limits.offset() > 0) {
             return new NoopPlan(plannerContext.jobId());
         }

--- a/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
@@ -142,7 +142,7 @@ class NestedLoopConsumer implements Consumer {
             boolean filterNeeded = where.hasQuery() && !(where.query() instanceof Literal);
             boolean hasDocTables = left instanceof QueriedDocTable || right instanceof QueriedDocTable;
             boolean isDistributed = hasDocTables && filterNeeded && !joinType.isOuter();
-            Limits limits = context.plannerContext().getLimits(context.isRoot(), querySpec);
+            Limits limits = context.plannerContext().getLimits(querySpec);
 
             if (filterNeeded || joinCondition != null || statement.remainingOrderBy().isPresent()) {
                 left.querySpec().limit(Optional.<Symbol>absent());

--- a/sql/src/main/java/io/crate/planner/consumer/NonDistributedGroupByConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/NonDistributedGroupByConsumer.java
@@ -176,7 +176,7 @@ class NonDistributedGroupByConsumer implements Consumer {
             boolean outputsMatch = table.querySpec().outputs().size() == collectOutputs.size() &&
                                    collectOutputs.containsAll(table.querySpec().outputs());
             if (isRootRelation || !outputsMatch) {
-                Limits limits = context.plannerContext().getLimits(context.isRoot(), table.querySpec());
+                Limits limits = context.plannerContext().getLimits(table.querySpec());
                 Integer offset = (isRootRelation ? limits.offset() : TopN.NO_OFFSET);
                 projections.add(ProjectionBuilder.topNProjection(
                     collectOutputs,

--- a/sql/src/main/java/io/crate/planner/consumer/QueryAndFetchConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/QueryAndFetchConsumer.java
@@ -116,7 +116,7 @@ public class QueryAndFetchConsumer implements Consumer {
             Optional<OrderBy> orderBy = querySpec.orderBy();
             Planner.Context plannerContext = context.plannerContext();
 
-            Limits limits = plannerContext.getLimits(context.isRoot(), querySpec);
+            Limits limits = plannerContext.getLimits(querySpec);
             if (limits.hasLimit() || orderBy.isPresent()) {
                 /**
                  * select id, name, order by id, date

--- a/sql/src/main/java/io/crate/planner/consumer/ReduceOnCollectorGroupByConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/ReduceOnCollectorGroupByConsumer.java
@@ -106,7 +106,7 @@ class ReduceOnCollectorGroupByConsumer implements Consumer {
             GroupByConsumer.validateGroupBySymbols(tableRelation, querySpec.groupBy().get());
             List<Symbol> groupBy = querySpec.groupBy().get();
 
-            Limits limits = context.plannerContext().getLimits(context.isRoot(), querySpec);
+            Limits limits = context.plannerContext().getLimits(querySpec);
             boolean ignoreSorting = context.rootRelation() != table
                                     && !limits.hasLimit()
                                     && limits.offset() == TopN.NO_OFFSET;

--- a/sql/src/test/java/io/crate/planner/PlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/PlannerTest.java
@@ -1320,7 +1320,7 @@ public class PlannerTest extends AbstractPlannerTest {
         int softLimit = 10_000;
         Planner.Context plannerContext = new Planner.Context(planner,
             clusterService, UUID.randomUUID(), null, normalizer, new TransactionContext(SessionContext.SYSTEM_SESSION), softLimit, 0);
-        Limits limits = plannerContext.getLimits(false, new QuerySpec());
+        Limits limits = plannerContext.getLimits(new QuerySpec());
         assertThat(limits.finalLimit(), is(TopN.NO_LIMIT));
     }
 }


### PR DESCRIPTION
There was no PlannedAnalyzedRelation which implemented AnalyzedRelation,
so we basically only had Plans.

This commit therefore removes PlannedAnalyzedRelation and moves the
functions that were specific to Plans into the Plan interface.