### PR TITLE
Remove isRootRelation flag from getLimits

### DIFF
--- a/sql/src/main/java/io/crate/planner/Planner.java
+++ b/sql/src/main/java/io/crate/planner/Planner.java
@@ -116,13 +116,6 @@ public class Planner extends AnalyzedStatementVisitor<Planner.Context, Plan> {
             return normalizer;
         }
 
-        private static int finalLimit(@Nullable Integer queryLimit, int softLimit) {
-            if (queryLimit == null) {
-                return softLimit > 0 ? softLimit : TopN.NO_LIMIT;
-            }
-            return queryLimit;
-        }
-
         @Nullable
         private Integer toInteger(@Nullable Symbol symbol) {
             if (symbol == null) {
@@ -132,28 +125,17 @@ public class Planner extends AnalyzedStatementVisitor<Planner.Context, Plan> {
             return DataTypes.INTEGER.value(input.value());
         }
 
-        public Limits getLimits(boolean isRootRelation, QuerySpec querySpec) {
+        public Limits getLimits(QuerySpec querySpec) {
             Optional<Symbol> optLimit = querySpec.limit();
-            if (!isRootRelation) {
-                /**
-                 * Don't apply softLimit or maxRows on child-relations,
-                 * The parent-relations might need more data to produce the correct result.
-                 * If the limit is present on the query it means the parent relation wanted it there, so keep it.
-                 */
-
-                if (optLimit.isPresent()) {
-                    //noinspection OptionalGetWithoutIsPresent it's present!
-                    Integer limit = toInteger(optLimit.get());
-                    Integer offset = toInteger(querySpec.offset().or(Literal.ZERO));
-                    return new Limits(limit, offset);
-                } else {
-                    return new Limits(TopN.NO_LIMIT, TopN.NO_OFFSET);
-                }
-            }
             Integer limit = toInteger(optLimit.orNull());
-            int finalLimit = finalLimit(limit, softLimit);
+            if (limit == null) {
+                limit = TopN.NO_LIMIT;
+            }
             Integer offset = toInteger(querySpec.offset().or(Literal.ZERO));
-            return new Limits(finalLimit, offset);
+            if (offset == null) {
+                offset = 0;
+            }
+            return new Limits(limit, offset);
         }
 
         public int fetchSize() {
@@ -168,6 +150,12 @@ public class Planner extends AnalyzedStatementVisitor<Planner.Context, Plan> {
             UUID subJobId = UUID.randomUUID();
             return planner.process(statement, new Planner.Context(
                 planner, clusterService, subJobId, consumingPlanner, normalizer, transactionContext, 2, 2));
+        }
+
+        void applySoftLimit(QuerySpec querySpec) {
+            if (softLimit != 0 && !querySpec.limit().isPresent()) {
+                querySpec.limit(Optional.<Symbol>of(Literal.of((long) softLimit)));
+            }
         }
 
         static class ReaderAllocations {

--- a/sql/src/main/java/io/crate/planner/SelectStatementPlanner.java
+++ b/sql/src/main/java/io/crate/planner/SelectStatementPlanner.java
@@ -94,6 +94,7 @@ class SelectStatementPlanner {
         public Plan visitQueriedTable(QueriedTable table, Planner.Context context) {
             SubqueryPlanner subqueryPlanner = new SubqueryPlanner(context);
             QuerySpec querySpec = table.querySpec();
+            context.applySoftLimit(querySpec);
             Map<Plan, SelectSymbol> subQueries = subqueryPlanner.planSubQueries(querySpec);
             Plan plan = super.visitQueriedTable(table, context);
             return MultiPhasePlan.createIfNeeded(plan, subQueries);
@@ -102,6 +103,7 @@ class SelectStatementPlanner {
         @Override
         public Plan visitQueriedDocTable(QueriedDocTable table, Planner.Context context) {
             QuerySpec querySpec = table.querySpec();
+            context.applySoftLimit(querySpec);
             SubqueryPlanner subqueryPlanner = new SubqueryPlanner(context);
             Map<Plan, SelectSymbol> subQueries = subqueryPlanner.planSubQueries(querySpec);
             if (querySpec.hasAggregates() || querySpec.groupBy().isPresent()) {
@@ -114,7 +116,7 @@ class SelectStatementPlanner {
             if (querySpec.where().hasVersions()) {
                 throw new VersionInvalidException();
             }
-            Limits limits = context.getLimits(true, querySpec);
+            Limits limits = context.getLimits(querySpec);
             if (querySpec.where().noMatch() || (querySpec.limit().isPresent() && limits.finalLimit() == 0)) {
                 return new NoopPlan(context.jobId());
             }
@@ -188,6 +190,7 @@ class SelectStatementPlanner {
         @Override
         public Plan visitMultiSourceSelect(MultiSourceSelect mss, Planner.Context context) {
             QuerySpec querySpec = mss.querySpec();
+            context.applySoftLimit(querySpec);
             if (querySpec.where().noMatch() && !querySpec.hasAggregates()) {
                 return new NoopPlan(context.jobId());
             }

--- a/sql/src/main/java/io/crate/planner/consumer/CountConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/CountConsumer.java
@@ -70,7 +70,7 @@ public class CountConsumer implements Consumer {
                 return null;
             }
 
-            Limits limits = context.plannerContext().getLimits(context.isRoot(), querySpec);
+            Limits limits = context.plannerContext().getLimits(querySpec);
             if ((limits.finalLimit() == 0 || limits.offset() > 0)) {
                 return new NoopPlan(context.plannerContext().jobId());
             }

--- a/sql/src/main/java/io/crate/planner/consumer/DistributedGroupByConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/DistributedGroupByConsumer.java
@@ -149,7 +149,7 @@ class DistributedGroupByConsumer implements Consumer {
                 }
             }
 
-            Limits limits = plannerContext.getLimits(context.isRoot(), querySpec);
+            Limits limits = plannerContext.getLimits(querySpec);
             boolean isRootRelation = context.rootRelation() == table;
             if (isRootRelation) {
                 reducerProjections.add(ProjectionBuilder.topNProjection(

--- a/sql/src/main/java/io/crate/planner/consumer/ESGetStatementPlanner.java
+++ b/sql/src/main/java/io/crate/planner/consumer/ESGetStatementPlanner.java
@@ -48,7 +48,7 @@ public class ESGetStatementPlanner {
         if (docKeys.withVersions()){
             throw new VersionInvalidException();
         }
-        Limits limits = context.getLimits(true, querySpec);
+        Limits limits = context.getLimits(querySpec);
         if (limits.hasLimit() && limits.finalLimit() == 0) {
             return new NoopPlan(context.jobId());
         }

--- a/sql/src/main/java/io/crate/planner/consumer/GlobalAggregateConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/GlobalAggregateConsumer.java
@@ -102,7 +102,7 @@ class GlobalAggregateConsumer implements Consumer {
         }
 
         Planner.Context plannerContext = context.plannerContext();
-        Limits limits = plannerContext.getLimits(context.isRoot(), table.querySpec());
+        Limits limits = plannerContext.getLimits(table.querySpec());
         if (limits.finalLimit() == 0 || limits.offset() > 0) {
             return new NoopPlan(plannerContext.jobId());
         }

--- a/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
@@ -142,7 +142,7 @@ class NestedLoopConsumer implements Consumer {
             boolean filterNeeded = where.hasQuery() && !(where.query() instanceof Literal);
             boolean hasDocTables = left instanceof QueriedDocTable || right instanceof QueriedDocTable;
             boolean isDistributed = hasDocTables && filterNeeded && !joinType.isOuter();
-            Limits limits = context.plannerContext().getLimits(context.isRoot(), querySpec);
+            Limits limits = context.plannerContext().getLimits(querySpec);
 
             if (filterNeeded || joinCondition != null || statement.remainingOrderBy().isPresent()) {
                 left.querySpec().limit(Optional.<Symbol>absent());

--- a/sql/src/main/java/io/crate/planner/consumer/NonDistributedGroupByConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/NonDistributedGroupByConsumer.java
@@ -176,7 +176,7 @@ class NonDistributedGroupByConsumer implements Consumer {
             boolean outputsMatch = table.querySpec().outputs().size() == collectOutputs.size() &&
                                    collectOutputs.containsAll(table.querySpec().outputs());
             if (isRootRelation || !outputsMatch) {
-                Limits limits = context.plannerContext().getLimits(context.isRoot(), table.querySpec());
+                Limits limits = context.plannerContext().getLimits(table.querySpec());
                 Integer offset = (isRootRelation ? limits.offset() : TopN.NO_OFFSET);
                 projections.add(ProjectionBuilder.topNProjection(
                     collectOutputs,

--- a/sql/src/main/java/io/crate/planner/consumer/QueryAndFetchConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/QueryAndFetchConsumer.java
@@ -116,7 +116,7 @@ public class QueryAndFetchConsumer implements Consumer {
             Optional<OrderBy> orderBy = querySpec.orderBy();
             Planner.Context plannerContext = context.plannerContext();
 
-            Limits limits = plannerContext.getLimits(context.isRoot(), querySpec);
+            Limits limits = plannerContext.getLimits(querySpec);
             if (limits.hasLimit() || orderBy.isPresent()) {
                 /**
                  * select id, name, order by id, date

--- a/sql/src/main/java/io/crate/planner/consumer/ReduceOnCollectorGroupByConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/ReduceOnCollectorGroupByConsumer.java
@@ -106,7 +106,7 @@ class ReduceOnCollectorGroupByConsumer implements Consumer {
             GroupByConsumer.validateGroupBySymbols(tableRelation, querySpec.groupBy().get());
             List<Symbol> groupBy = querySpec.groupBy().get();
 
-            Limits limits = context.plannerContext().getLimits(context.isRoot(), querySpec);
+            Limits limits = context.plannerContext().getLimits(querySpec);
             boolean ignoreSorting = context.rootRelation() != table
                                     && !limits.hasLimit()
                                     && limits.offset() == TopN.NO_OFFSET;
@@ -160,7 +160,7 @@ class ReduceOnCollectorGroupByConsumer implements Consumer {
                     collectOutputs,
                     querySpec.orderBy().orNull(),
                     0, // no offset
-                    context.isRoot() ? limits.limitAndOffset() : TopN.NO_LIMIT,
+                    limits.limitAndOffset(),
                     querySpec.outputs()
                 ));
             }

--- a/sql/src/test/java/io/crate/planner/PlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/PlannerTest.java
@@ -1320,7 +1320,7 @@ public class PlannerTest extends AbstractPlannerTest {
         int softLimit = 10_000;
         Planner.Context plannerContext = new Planner.Context(planner,
             clusterService, UUID.randomUUID(), null, normalizer, new TransactionContext(SessionContext.SYSTEM_SESSION), softLimit, 0);
-        Limits limits = plannerContext.getLimits(false, new QuerySpec());
+        Limits limits = plannerContext.getLimits(new QuerySpec());
         assertThat(limits.finalLimit(), is(TopN.NO_LIMIT));
     }
 }


### PR DESCRIPTION
It was used to decide if a softLimit should be applied or not.
This was checked on each relation on each consumer.

This commit changes the logic to apply the softLimit once on the
rootRelation.