### PR TITLE
remove duplicate rowcount from http response

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Removed the duplicate `rowcount` field from the HTTP response.
+
  - Added the ``search_path`` session setting parameter. The default table
    schema can be set with ``SET SESSION search_path = schema_name``.
 

--- a/sql/src/main/java/io/crate/rest/action/RestResultSetReceiver.java
+++ b/sql/src/main/java/io/crate/rest/action/RestResultSetReceiver.java
@@ -44,6 +44,7 @@ class RestResultSetReceiver extends BaseResultReceiver {
     private final List<Field> outputFields;
     private final ResultToXContentBuilder builder;
     private long startTime;
+    private long rowCount;
 
     RestResultSetReceiver(RestChannel channel,
                           List<Field> outputFields,
@@ -72,6 +73,7 @@ class RestResultSetReceiver extends BaseResultReceiver {
     public void setNextRow(Row row) {
         try {
             builder.addRow(row, outputFields.size());
+            rowCount++;
         } catch (IOException e) {
             fail(e);
         }
@@ -99,7 +101,9 @@ class RestResultSetReceiver extends BaseResultReceiver {
     }
 
     XContentBuilder finishBuilder() throws IOException {
-        return builder.finishRows()
+        return builder
+            .finishRows()
+            .rowCount(rowCount)
             .duration(startTime)
             .build();
     }

--- a/sql/src/main/java/io/crate/rest/action/RestRowCountReceiver.java
+++ b/sql/src/main/java/io/crate/rest/action/RestRowCountReceiver.java
@@ -22,7 +22,6 @@
 
 package io.crate.rest.action;
 
-import com.google.common.annotations.VisibleForTesting;
 import io.crate.action.sql.BaseResultReceiver;
 import io.crate.analyze.symbol.Field;
 import io.crate.core.collections.Row;

--- a/sql/src/main/java/io/crate/rest/action/ResultToXContentBuilder.java
+++ b/sql/src/main/java/io/crate/rest/action/ResultToXContentBuilder.java
@@ -35,7 +35,6 @@ import java.util.List;
 
 class ResultToXContentBuilder {
 
-    private long rowCount;
 
     static final class FIELDS {
         static final XContentBuilderString RESULTS = new XContentBuilderString("results");
@@ -96,7 +95,6 @@ class ResultToXContentBuilder {
      * startRows() must be called before first setNextRow()
      */
     ResultToXContentBuilder startRows() throws IOException {
-        rowCount = 0;
         builder.startArray(FIELDS.ROWS);
         return this;
     }
@@ -106,7 +104,6 @@ class ResultToXContentBuilder {
      */
     ResultToXContentBuilder finishRows() throws IOException {
         builder.endArray();
-        rowCount(rowCount);
         return this;
     }
 
@@ -122,7 +119,6 @@ class ResultToXContentBuilder {
             builder.value(row.get(j));
         }
         builder.endArray();
-        rowCount++;
         return this;
     }
 

--- a/sql/src/test/java/io/crate/rest/action/RestActionReceiversTest.java
+++ b/sql/src/test/java/io/crate/rest/action/RestActionReceiversTest.java
@@ -106,6 +106,7 @@ public class RestActionReceiversTest extends CrateUnitTest {
             builder.addRow(row, 3);
         }
         builder.finishRows();
+        builder.rowCount(rows.size());
 
         assertXContentBuilder(actualBuilder, builder.build());
     }


### PR DESCRIPTION
now
```
{"cols":[],"rows":[[]],"rowcount":1,"duration": ...}
```
was
```
{"cols":[],"rows":[[]],"rowcount":1,"rowcount":1,"duration": ...}
```