### PR TITLE
Remove `extends Streamable` from Symbol to make most of them immutable

### DIFF
--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -656,7 +656,7 @@ public class ExpressionAnalyzer {
                 mapArgs.add(process(e.getValue(), context));
             }
             Function options = context.allocateFunction(MapFunction.createInfo(Symbols.extractTypes(mapArgs)), mapArgs);
-            return new io.crate.analyze.symbol.MatchPredicate(identBoostMap, columnType, queryTerm, matchType, options);
+            return new io.crate.analyze.symbol.MatchPredicate(identBoostMap, queryTerm, matchType, options);
         }
 
         @Override

--- a/sql/src/main/java/io/crate/analyze/relations/RelationNormalizer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationNormalizer.java
@@ -262,7 +262,7 @@ final class RelationNormalizer extends AnalyzedRelationVisitor<RelationNormalize
         }
 
         public Collection<? extends Path> paths() {
-            return Collections2.transform(fields, Field.TO_PATH);
+            return Collections2.transform(fields, Field::path);
         }
     }
 

--- a/sql/src/main/java/io/crate/analyze/symbol/Aggregation.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/Aggregation.java
@@ -34,18 +34,18 @@ import java.util.List;
 
 public class Aggregation extends Symbol {
 
-    public static final SymbolFactory<Aggregation> FACTORY = new SymbolFactory<Aggregation>() {
-        @Override
-        public Aggregation newInstance() {
-            return new Aggregation();
-        }
-    };
+    public Aggregation(StreamInput in) throws IOException {
+        functionInfo = new FunctionInfo();
+        functionInfo.readFrom(in);
 
-    public Aggregation() {
+        fromStep = Step.readFrom(in);
+        toStep = Step.readFrom(in);
 
+        valueType = DataTypes.fromStream(in);
+        inputs = Symbols.listFromStream(in);
     }
 
-    public static enum Step {
+    public enum Step {
         ITER, PARTIAL, FINAL;
 
         static void writeTo(Step step, StreamOutput out) throws IOException {
@@ -111,18 +111,6 @@ public class Aggregation extends Symbol {
 
     public Step toStep() {
         return toStep;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        functionInfo = new FunctionInfo();
-        functionInfo.readFrom(in);
-
-        fromStep = Step.readFrom(in);
-        toStep = Step.readFrom(in);
-
-        valueType = DataTypes.fromStream(in);
-        inputs = Symbols.listFromStream(in);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/analyze/symbol/DynamicReference.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/DynamicReference.java
@@ -27,17 +27,14 @@ import io.crate.metadata.RowGranularity;
 import io.crate.metadata.table.ColumnPolicy;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+import org.elasticsearch.common.io.stream.StreamInput;
+
+import java.io.IOException;
 
 public class DynamicReference extends Reference {
 
-    public static final SymbolFactory FACTORY = new SymbolFactory() {
-        @Override
-        public Symbol newInstance() {
-            return new DynamicReference();
-        }
-    };
-
-    public DynamicReference() {
+    public DynamicReference(StreamInput in) throws IOException {
+        super(in);
     }
 
     public DynamicReference(ReferenceIdent ident, RowGranularity granularity) {

--- a/sql/src/main/java/io/crate/analyze/symbol/FetchReference.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/FetchReference.java
@@ -62,8 +62,7 @@ public class FetchReference extends Symbol {
         return ref;
     }
 
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
+    public FetchReference(StreamInput in) throws IOException {
         throw new UnsupportedOperationException("FetchReference cannot be streamed");
     }
 

--- a/sql/src/main/java/io/crate/analyze/symbol/Field.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/Field.java
@@ -33,31 +33,18 @@ import java.io.IOException;
 
 public class Field extends Symbol {
 
-    public static final SymbolFactory<Field> FACTORY = new SymbolFactory<Field>() {
-        @Override
-        public Field newInstance() {
-            return new Field();
-        }
-    };
-
-    public static final com.google.common.base.Function<Field, Path> TO_PATH = new com.google.common.base.Function<Field, Path>() {
-        @Override
-        public Path apply(Field input) {
-            return input.path();
-        }
-    };
-
     private AnalyzedRelation relation;
     private Path path;
     private DataType valueType;
+
+    public Field(StreamInput in) {
+        throw new UnsupportedOperationException("Field is not streamable");
+    }
 
     public Field(AnalyzedRelation relation, Path path, DataType valueType) {
         this.relation = relation;
         this.path = path;
         this.valueType = valueType;
-    }
-
-    private Field() {
     }
 
     public Path path() {
@@ -81,11 +68,6 @@ public class Field extends Symbol {
     @Override
     public DataType valueType() {
         return valueType;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        throw new UnsupportedOperationException("Field is not streamable");
     }
 
     @Override
@@ -140,5 +122,4 @@ public class Field extends Symbol {
         assert idx >= 0;
         return idx;
     }
-
 }

--- a/sql/src/main/java/io/crate/analyze/symbol/Function.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/Function.java
@@ -15,14 +15,14 @@ import java.util.Locale;
 
 public class Function extends Symbol implements Cloneable {
 
-    public static final SymbolFactory<Function> FACTORY = new SymbolFactory<Function>() {
-        @Override
-        public Function newInstance() {
-            return new Function();
-        }
-    };
-    private List<Symbol> arguments;
-    private FunctionInfo info;
+    private final List<Symbol> arguments;
+    private final FunctionInfo info;
+
+    public Function(StreamInput in) throws IOException {
+        info = new FunctionInfo();
+        info.readFrom(in);
+        arguments = Symbols.listFromStream(in);
+    }
 
     public Function(FunctionInfo info, List<Symbol> arguments) {
         Preconditions.checkNotNull(info, "function info is null");
@@ -33,10 +33,6 @@ public class Function extends Symbol implements Cloneable {
         assert arguments.isEmpty() || !(arguments instanceof ImmutableList) :
             "must not be an immutable list - would break setArgument";
         this.arguments = arguments;
-    }
-
-    private Function() {
-
     }
 
     public List<Symbol> arguments() {
@@ -64,13 +60,6 @@ public class Function extends Symbol implements Cloneable {
     @Override
     public <C, R> R accept(SymbolVisitor<C, R> visitor, C context) {
         return visitor.visitFunction(this, context);
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        info = new FunctionInfo();
-        info.readFrom(in);
-        arguments = Symbols.listFromStream(in);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/analyze/symbol/InputColumn.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/InputColumn.java
@@ -38,16 +38,8 @@ import java.util.List;
  */
 public class InputColumn extends Symbol implements Comparable<InputColumn> {
 
-    public static final SymbolFactory<InputColumn> FACTORY = new SymbolFactory<InputColumn>() {
-        @Override
-        public InputColumn newInstance() {
-            return new InputColumn();
-        }
-    };
-
-    private DataType dataType;
-
-    private int index;
+    private final DataType dataType;
+    private final int index;
 
     public static List<Symbol> numInputs(int size) {
         List<Symbol> inputColumns = new ArrayList<>(size);
@@ -82,11 +74,13 @@ public class InputColumn extends Symbol implements Comparable<InputColumn> {
         this.dataType = MoreObjects.firstNonNull(dataType, DataTypes.UNDEFINED);
     }
 
-    public InputColumn(int index) {
-        this(index, null);
+    public InputColumn(StreamInput in) throws IOException {
+        index = in.readVInt();
+        dataType = DataTypes.fromStream(in);
     }
 
-    protected InputColumn() {
+    public InputColumn(int index) {
+        this(index, null);
     }
 
     public int index() {
@@ -106,12 +100,6 @@ public class InputColumn extends Symbol implements Comparable<InputColumn> {
     @Override
     public <C, R> R accept(SymbolVisitor<C, R> visitor, C context) {
         return visitor.visitInputColumn(this, context);
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        index = in.readVInt();
-        dataType = DataTypes.fromStream(in);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/analyze/symbol/Literal.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/Literal.java
@@ -17,25 +17,16 @@ import java.io.IOException;
 import java.util.*;
 
 
-public class Literal<ReturnType>
-    extends Symbol
-    implements Input<ReturnType>, Comparable<Literal> {
+public class Literal<ReturnType> extends Symbol implements Input<ReturnType>, Comparable<Literal> {
 
-    protected Object value;
-    protected DataType type;
+    private final Object value;
+    private final DataType type;
 
     public final static Literal<Void> NULL = new Literal<>(DataTypes.UNDEFINED, null);
     public final static Literal<Boolean> BOOLEAN_TRUE = new Literal<>(DataTypes.BOOLEAN, true);
     public final static Literal<Boolean> BOOLEAN_FALSE = new Literal<>(DataTypes.BOOLEAN, false);
     public final static Literal<Integer> ZERO = Literal.of(0);
     public static final Literal<Map<String, Object>> EMPTY_OBJECT = Literal.of(Collections.<String, Object>emptyMap());
-
-    public static final SymbolFactory<Literal> FACTORY = new SymbolFactory<Literal>() {
-        @Override
-        public Literal newInstance() {
-            return new Literal();
-        }
-    };
 
     public static Collection<Literal> explodeCollection(Literal collectionLiteral) {
         Preconditions.checkArgument(DataTypes.isCollectionType(collectionLiteral.valueType()));
@@ -60,7 +51,9 @@ public class Literal<ReturnType>
         return literals;
     }
 
-    private Literal() {
+    public Literal(StreamInput in) throws IOException {
+        type = DataTypes.fromStream(in);
+        value = type.streamer().readValueFrom(in);
     }
 
     private Literal(DataType type, ReturnType value) {
@@ -152,13 +145,6 @@ public class Literal<ReturnType>
                "value=" + BytesRefs.toString(value) +
                ", type=" + type +
                '}';
-    }
-
-    @Override
-    @SuppressWarnings("unchecked")
-    public void readFrom(StreamInput in) throws IOException {
-        type = DataTypes.fromStream(in);
-        value = type.streamer().readValueFrom(in);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/analyze/symbol/MatchPredicate.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/MatchPredicate.java
@@ -23,7 +23,6 @@ package io.crate.analyze.symbol;
 
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
-import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
@@ -31,27 +30,21 @@ import java.util.Map;
 
 public class MatchPredicate extends Symbol {
 
-    public static final SymbolFactory FACTORY = new SymbolFactory() {
-        @Override
-        public Symbol newInstance() {
-            throw new UnsupportedOperationException("Streaming a MatchPredicate is not supported");
-        }
+    public static final SymbolFactory FACTORY = (SymbolFactory) (in) -> {
+        throw new UnsupportedOperationException("Streaming a MatchPredicate is not supported");
     };
 
     private final Map<Field, Symbol> identBoostMap;
-    private final DataType columnType;
     private final Symbol queryTerm;
     private final String matchType;
     private final Symbol options;
 
     public MatchPredicate(Map<Field, Symbol> identBoostMap,
-                          DataType columnType,
                           Symbol queryTerm,
                           String matchType,
                           Symbol options) {
         assert options.valueType().equals(DataTypes.OBJECT) : "options symbol must be of type object";
         this.identBoostMap = identBoostMap;
-        this.columnType = columnType;
         this.queryTerm = queryTerm;
         this.matchType = matchType;
         this.options = options;
@@ -73,10 +66,6 @@ public class MatchPredicate extends Symbol {
         return options;
     }
 
-    public DataType columnType() {
-        return columnType;
-    }
-
     @Override
     public SymbolType symbolType() {
         return SymbolType.MATCH_PREDICATE;
@@ -90,11 +79,6 @@ public class MatchPredicate extends Symbol {
     @Override
     public DataType valueType() {
         return DataTypes.BOOLEAN;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        throw new UnsupportedOperationException("Cannot stream MatchPredicate");
     }
 
     @Override

--- a/sql/src/main/java/io/crate/analyze/symbol/ParameterSymbol.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/ParameterSymbol.java
@@ -31,25 +31,15 @@ import java.io.IOException;
 
 public class ParameterSymbol extends Symbol {
 
-    public static final SymbolFactory<ParameterSymbol> FACTORY = new SymbolFactory<ParameterSymbol>() {
-        @Override
-        public ParameterSymbol newInstance() {
-            return new ParameterSymbol();
-        }
-    };
-    private int index;
-    private DataType type;
+    private final int index;
+    private final DataType type;
 
     public ParameterSymbol(int index, DataType type) {
         this.index = index;
         this.type = type;
     }
 
-    private ParameterSymbol() {
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
+    public ParameterSymbol(StreamInput in) throws IOException {
         index = in.readVInt();
         type = DataTypes.fromStream(in);
     }

--- a/sql/src/main/java/io/crate/analyze/symbol/RelationColumn.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/RelationColumn.java
@@ -35,22 +35,11 @@ import java.util.Objects;
 
 public class RelationColumn extends InputColumn {
 
-    public static final SymbolFactory<RelationColumn> FACTORY = new SymbolFactory<RelationColumn>() {
-        @Override
-        public RelationColumn newInstance() {
-            return new RelationColumn();
-        }
-    };
-
-    private QualifiedName relationName;
+    private final QualifiedName relationName;
 
     public RelationColumn(QualifiedName relationName, int index, @Nullable DataType dataType) {
         super(index, dataType);
         this.relationName = relationName;
-    }
-
-    private RelationColumn() {
-
     }
 
     public QualifiedName relationName() {
@@ -81,9 +70,8 @@ public class RelationColumn extends InputColumn {
         return visitor.visitRelationColumn(this, context);
     }
 
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
+    public RelationColumn(StreamInput in) throws IOException {
+        super(in);
         int numParts = in.readVInt();
         List<String> parts = new ArrayList<>();
         for (int i = 0; i < numParts; i++) {

--- a/sql/src/main/java/io/crate/analyze/symbol/SelectSymbol.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/SelectSymbol.java
@@ -46,15 +46,7 @@ public class SelectSymbol extends Symbol {
         return relation;
     }
 
-    public static final SymbolFactory FACTORY = new SymbolFactory() {
-        @Override
-        public Symbol newInstance() {
-            throw new UnsupportedOperationException("Cannot stream SelectSymbol");
-        }
-    };
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
+    public SelectSymbol(StreamInput in) throws IOException {
         throw new UnsupportedOperationException("Cannot stream SelectSymbol");
     }
 

--- a/sql/src/main/java/io/crate/analyze/symbol/Symbol.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/Symbol.java
@@ -22,9 +22,12 @@
 package io.crate.analyze.symbol;
 
 import io.crate.types.DataType;
-import org.elasticsearch.common.io.stream.Streamable;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 
-public abstract class Symbol implements Streamable {
+import java.io.IOException;
+
+public abstract class Symbol {
 
     public static boolean isLiteral(Symbol symbol, DataType expectedType) {
         return symbol.symbolType() == SymbolType.LITERAL
@@ -32,7 +35,7 @@ public abstract class Symbol implements Streamable {
     }
 
     public interface SymbolFactory<T extends Symbol> {
-        T newInstance();
+        T newInstance(StreamInput in) throws IOException;
     }
 
     public abstract SymbolType symbolType();
@@ -40,4 +43,6 @@ public abstract class Symbol implements Streamable {
     public abstract <C, R> R accept(SymbolVisitor<C, R> visitor, C context);
 
     public abstract DataType valueType();
+
+    public abstract void writeTo(StreamOutput out) throws IOException;
 }

--- a/sql/src/main/java/io/crate/analyze/symbol/SymbolType.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/SymbolType.java
@@ -25,25 +25,28 @@ import io.crate.metadata.GeneratedReference;
 import io.crate.metadata.GeoReference;
 import io.crate.metadata.IndexReference;
 import io.crate.metadata.Reference;
+import org.elasticsearch.common.io.stream.StreamInput;
+
+import java.io.IOException;
 
 public enum SymbolType {
 
-    AGGREGATION(Aggregation.FACTORY),
-    REFERENCE(Reference.FACTORY),
-    RELATION_OUTPUT(Field.FACTORY),
-    FUNCTION(Function.FACTORY),
-    LITERAL(Literal.FACTORY),
-    INPUT_COLUMN(InputColumn.FACTORY),
-    DYNAMIC_REFERENCE(DynamicReference.FACTORY),
-    VALUE(Value.FACTORY),
+    AGGREGATION(Aggregation::new),
+    REFERENCE(Reference::new),
+    RELATION_OUTPUT(Field::new),
+    FUNCTION(Function::new),
+    LITERAL(Literal::new),
+    INPUT_COLUMN(InputColumn::new),
+    DYNAMIC_REFERENCE(DynamicReference::new),
+    VALUE(Value::new),
     MATCH_PREDICATE(MatchPredicate.FACTORY),
     FETCH_REFERENCE(null),
-    RELATION_COLUMN(RelationColumn.FACTORY),
-    INDEX_REFERENCE(IndexReference.FACTORY),
-    GEO_REFERENCE(GeoReference.FACTORY),
-    GENERATED_REFERENCE(GeneratedReference.FACTORY),
-    PARAMETER(ParameterSymbol.FACTORY),
-    SELECT_SYMBOL(SelectSymbol.FACTORY);
+    RELATION_COLUMN(RelationColumn::new),
+    INDEX_REFERENCE(IndexReference::new),
+    GEO_REFERENCE(GeoReference::new),
+    GENERATED_REFERENCE(GeneratedReference::new),
+    PARAMETER(ParameterSymbol::new),
+    SELECT_SYMBOL(SelectSymbol::new);
 
     private final Symbol.SymbolFactory factory;
 
@@ -51,8 +54,8 @@ public enum SymbolType {
         this.factory = factory;
     }
 
-    public Symbol newInstance() {
-        return factory.newInstance();
+    public Symbol newInstance(StreamInput in) throws IOException {
+        return factory.newInstance(in);
     }
 
     public boolean isValueSymbol() {

--- a/sql/src/main/java/io/crate/analyze/symbol/Symbols.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/Symbols.java
@@ -116,10 +116,7 @@ public class Symbols {
     }
 
     public static Symbol fromStream(StreamInput in) throws IOException {
-        Symbol symbol = SymbolType.values()[in.readVInt()].newInstance();
-        symbol.readFrom(in);
-
-        return symbol;
+        return SymbolType.values()[in.readVInt()].newInstance(in);
     }
 
     private static class HasColumnVisitor extends SymbolVisitor<ColumnIdent, Boolean> {

--- a/sql/src/main/java/io/crate/analyze/symbol/Value.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/Value.java
@@ -30,21 +30,14 @@ import java.io.IOException;
 
 public class Value extends Symbol {
 
-    public static final SymbolFactory<Value> FACTORY = new SymbolFactory<Value>() {
-        @Override
-        public Value newInstance() {
-            return new Value();
-        }
-    };
-
-    private DataType type;
+    private final DataType type;
 
     public Value(DataType type) {
         this.type = type;
     }
 
-    public Value() {
-
+    public Value(StreamInput in) throws IOException {
+        type = DataTypes.fromStream(in);
     }
 
     public DataType valueType() {
@@ -59,11 +52,6 @@ public class Value extends Symbol {
     @Override
     public <C, R> R accept(SymbolVisitor<C, R> visitor, C context) {
         return visitor.visitValue(this, context);
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        type = DataTypes.fromStream(in);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/analyze/symbol/ValueSymbolVisitor.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/ValueSymbolVisitor.java
@@ -63,7 +63,7 @@ public abstract class ValueSymbolVisitor<T> extends SymbolVisitor<Void, T> {
     public static final ValueSymbolVisitor<BytesRef> BYTES_REF = new ValueSymbolVisitor<BytesRef>() {
         @Override
         public BytesRef visitLiteral(Literal symbol, Void context) {
-            return DataTypes.STRING.value(symbol.value);
+            return DataTypes.STRING.value(symbol.value());
         }
     };
 

--- a/sql/src/main/java/io/crate/analyze/where/EqualityExtractor.java
+++ b/sql/src/main/java/io/crate/analyze/where/EqualityExtractor.java
@@ -31,7 +31,6 @@ import io.crate.operation.operator.any.AnyEqOperator;
 import io.crate.types.CollectionType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
-import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import javax.annotation.Nullable;
@@ -242,11 +241,6 @@ public class EqualityExtractor {
         @Override
         public DataType valueType() {
             return current.valueType();
-        }
-
-        @Override
-        public void readFrom(StreamInput in) throws IOException {
-            throw new UnsupportedOperationException();
         }
 
         @Override

--- a/sql/src/main/java/io/crate/metadata/GeneratedReference.java
+++ b/sql/src/main/java/io/crate/metadata/GeneratedReference.java
@@ -37,18 +37,20 @@ import java.util.List;
 
 public class GeneratedReference extends Reference {
 
-    public static final SymbolFactory<GeneratedReference> FACTORY = new SymbolFactory<GeneratedReference>() {
-        @Override
-        public GeneratedReference newInstance() {
-            return new GeneratedReference();
-        }
-    };
+    private final String formattedGeneratedExpression;
 
-    private String formattedGeneratedExpression;
     private Symbol generatedExpression;
     private List<Reference> referencedReferences;
 
-    private GeneratedReference() {
+    public GeneratedReference(StreamInput in) throws IOException {
+        super(in);
+        formattedGeneratedExpression = in.readString();
+        generatedExpression = Symbols.fromStream(in);
+        int size = in.readVInt();
+        referencedReferences = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            referencedReferences.add(Reference.fromStream(in));
+        }
     }
 
     public GeneratedReference(ReferenceIdent ident,
@@ -120,18 +122,6 @@ public class GeneratedReference extends Reference {
                ", generatedExpression=" + generatedExpression +
                ", referencedReferences=" + referencedReferences +
                '}';
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        formattedGeneratedExpression = in.readString();
-        generatedExpression = Symbols.fromStream(in);
-        int size = in.readVInt();
-        referencedReferences = new ArrayList<>(size);
-        for (int i = 0; i < size; i++) {
-            referencedReferences.add(Reference.fromStream(in));
-        }
     }
 
     @Override

--- a/sql/src/main/java/io/crate/metadata/GeoReference.java
+++ b/sql/src/main/java/io/crate/metadata/GeoReference.java
@@ -33,28 +33,18 @@ import java.io.IOException;
 
 public class GeoReference extends Reference {
 
-    public static final SymbolFactory<GeoReference> FACTORY = new SymbolFactory<GeoReference>() {
-        @Override
-        public GeoReference newInstance() {
-            return new GeoReference();
-        }
-    };
-
     private static final String DEFAULT_TREE = "geohash";
 
-    private String geoTree;
-    private
-    @Nullable
-    String precision;
-    private
-    @Nullable
-    Integer treeLevels;
-    private
-    @Nullable
-    Double distanceErrorPct;
+    private final String geoTree;
 
-    private GeoReference() {
-    }
+    @Nullable
+    private final String precision;
+
+    @Nullable
+    private final Integer treeLevels;
+
+    @Nullable
+    private final Double distanceErrorPct;
 
     public GeoReference(ReferenceIdent ident,
                         @Nullable String tree,
@@ -119,9 +109,8 @@ public class GeoReference extends Reference {
                '}';
     }
 
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
+    public GeoReference(StreamInput in) throws IOException {
+        super(in);
         geoTree = in.readString();
         precision = in.readOptionalString();
         treeLevels = in.readBoolean() ? null : in.readVInt();

--- a/sql/src/main/java/io/crate/metadata/IndexReference.java
+++ b/sql/src/main/java/io/crate/metadata/IndexReference.java
@@ -39,13 +39,6 @@ import java.util.List;
 
 public class IndexReference extends Reference {
 
-    public static final SymbolFactory<IndexReference> FACTORY = new SymbolFactory<IndexReference>() {
-        @Override
-        public IndexReference newInstance() {
-            return new IndexReference();
-        }
-    };
-
     public static class Builder {
         private final ReferenceIdent ident;
         private IndexType indexType = IndexType.ANALYZED;
@@ -78,10 +71,17 @@ public class IndexReference extends Reference {
     }
 
     @Nullable
-    private String analyzer;
-    private List<Reference> columns;
+    private final String analyzer;
+    private final List<Reference> columns;
 
-    private IndexReference() {
+    public IndexReference(StreamInput in) throws IOException {
+        super(in);
+        analyzer = in.readOptionalString();
+        int size = in.readVInt();
+        columns = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            columns.add(Reference.fromStream(in));
+        }
     }
 
     public IndexReference(ReferenceIdent ident,
@@ -128,17 +128,6 @@ public class IndexReference extends Reference {
                "analyzer='" + analyzer + '\'' +
                ", columns=" + columns +
                '}';
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        analyzer = in.readOptionalString();
-        int size = in.readVInt();
-        columns = new ArrayList<>(size);
-        for (int i = 0; i < size; i++) {
-            columns.add(Reference.fromStream(in));
-        }
     }
 
     @Override

--- a/sql/src/main/java/io/crate/metadata/Reference.java
+++ b/sql/src/main/java/io/crate/metadata/Reference.java
@@ -32,14 +32,13 @@ import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.Comparator;
 import java.util.Locale;
 
-public class Reference extends Symbol implements Streamable {
+public class Reference extends Symbol {
 
     public static final Comparator<Reference> COMPARE_BY_COLUMN_IDENT = new Comparator<Reference>() {
         @Override
@@ -74,19 +73,23 @@ public class Reference extends Symbol implements Streamable {
         }
     }
 
-    public static final SymbolFactory<Reference> FACTORY = new SymbolFactory<Reference>() {
-        @Override
-        public Reference newInstance() {
-            return new Reference();
-        }
-    };
-
     protected DataType type;
     private ReferenceIdent ident;
     private ColumnPolicy columnPolicy = ColumnPolicy.DYNAMIC;
     private RowGranularity granularity;
     private IndexType indexType = IndexType.NOT_ANALYZED;
     private boolean nullable = true;
+
+    public Reference(StreamInput in) throws IOException {
+        ident = new ReferenceIdent();
+        ident.readFrom(in);
+        type = DataTypes.fromStream(in);
+        granularity = RowGranularity.fromStream(in);
+
+        columnPolicy = ColumnPolicy.values()[in.readVInt()];
+        indexType = IndexType.values()[in.readVInt()];
+        nullable = in.readBoolean();
+    }
 
     public Reference() {
 
@@ -196,18 +199,6 @@ public class Reference extends Symbol implements Streamable {
     }
 
     @Override
-    public void readFrom(StreamInput in) throws IOException {
-        ident = new ReferenceIdent();
-        ident.readFrom(in);
-        type = DataTypes.fromStream(in);
-        granularity = RowGranularity.fromStream(in);
-
-        columnPolicy = ColumnPolicy.values()[in.readVInt()];
-        indexType = IndexType.values()[in.readVInt()];
-        nullable = in.readBoolean();
-    }
-
-    @Override
     public void writeTo(StreamOutput out) throws IOException {
         ident.writeTo(out);
         DataTypes.toStream(type, out);
@@ -225,8 +216,6 @@ public class Reference extends Symbol implements Streamable {
     }
 
     public static <R extends Reference> R fromStream(StreamInput in) throws IOException {
-        Symbol symbol = SymbolType.values()[in.readVInt()].newInstance();
-        symbol.readFrom(in);
-        return (R) symbol;
+        return (R) SymbolType.values()[in.readVInt()].newInstance(in);
     }
 }

--- a/sql/src/test/java/io/crate/analyze/symbol/ParameterSymbolTest.java
+++ b/sql/src/test/java/io/crate/analyze/symbol/ParameterSymbolTest.java
@@ -40,8 +40,7 @@ public class ParameterSymbolTest extends CrateUnitTest {
         ps1.writeTo(out);
 
         StreamInput in = StreamInput.wrap(out.bytes());
-        ParameterSymbol ps2 = ParameterSymbol.FACTORY.newInstance();
-        ps2.readFrom(in);
+        ParameterSymbol ps2 = new ParameterSymbol(in);
 
         assertThat(ps2.index(), is(ps1.index()));
         assertThat(ps2.valueType(), is(ps1.valueType()));


### PR DESCRIPTION
We already use Symbols.toStream/fromStream to serialize symbols so it is
not required for them to implement Streamable.

We can have a custom method/interface that allows us to make the
attributes final