### PR TITLE
Remove equals and hashCode implementations from Projection

### DIFF
--- a/sql/src/main/java/io/crate/planner/projection/AbstractIndexWriterProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/AbstractIndexWriterProjection.java
@@ -153,47 +153,6 @@ public abstract class AbstractIndexWriterProjection extends Projection {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof AbstractIndexWriterProjection)) return false;
-
-        AbstractIndexWriterProjection that = (AbstractIndexWriterProjection) o;
-
-        if (autoCreateIndices != that.autoCreateIndices) return false;
-        if (!bulkActions.equals(that.bulkActions)) return false;
-        if (clusteredByColumn != null ? !clusteredByColumn.equals(that.clusteredByColumn) :
-            that.clusteredByColumn != null)
-            return false;
-        if (clusteredBySymbol != null ? !clusteredBySymbol.equals(that.clusteredBySymbol) :
-            that.clusteredBySymbol != null)
-            return false;
-        if (!idSymbols.equals(that.idSymbols)) return false;
-        if (!partitionedBySymbols.equals(that.partitionedBySymbols))
-            return false;
-        if (!primaryKeys.equals(that.primaryKeys)) return false;
-        if (!tableIdent.equals(that.tableIdent)) return false;
-        if (partitionIdent != null ? !partitionIdent.equals(that.partitionIdent) : that.partitionIdent != null)
-            return false;
-
-        return true;
-    }
-
-    @Override
-    public int hashCode() {
-        int result = super.hashCode();
-        result = 31 * result + bulkActions.hashCode();
-        result = 31 * result + tableIdent.hashCode();
-        result = 31 * result + (partitionIdent != null ? partitionIdent.hashCode() : 0);
-        result = 31 * result + primaryKeys.hashCode();
-        result = 31 * result + (clusteredByColumn != null ? clusteredByColumn.hashCode() : 0);
-        result = 31 * result + idSymbols.hashCode();
-        result = 31 * result + partitionedBySymbols.hashCode();
-        result = 31 * result + (clusteredBySymbol != null ? clusteredBySymbol.hashCode() : 0);
-        result = 31 * result + (autoCreateIndices ? 1 : 0);
-        return result;
-    }
-
-    @Override
     public void writeTo(StreamOutput out) throws IOException {
         tableIdent.writeTo(out);
         out.writeOptionalString(partitionIdent);

--- a/sql/src/main/java/io/crate/planner/projection/AggregationProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/AggregationProjection.java
@@ -101,16 +101,4 @@ public class AggregationProjection extends Projection {
         Symbols.toStream(aggregations, out);
         RowGranularity.toStream(contextGranularity, out);
     }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        AggregationProjection that = (AggregationProjection) o;
-        if (aggregations != null ? !aggregations.equals(that.aggregations) : that.aggregations != null) return false;
-
-        return true;
-    }
-
 }

--- a/sql/src/main/java/io/crate/planner/projection/ColumnIndexWriterProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/ColumnIndexWriterProjection.java
@@ -128,31 +128,6 @@ public class ColumnIndexWriterProjection extends AbstractIndexWriterProjection {
         return ProjectionType.COLUMN_INDEX_WRITER;
     }
 
-    @SuppressWarnings("SimplifiableIfStatement")
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        if (!super.equals(o)) return false;
-
-        ColumnIndexWriterProjection that = (ColumnIndexWriterProjection) o;
-
-        if (!columnReferences.equals(that.columnReferences)) return false;
-        if (!columnSymbols.equals(that.columnSymbols)) return false;
-        return !(onDuplicateKeyAssignments != null ?
-                     !onDuplicateKeyAssignments.equals(that.onDuplicateKeyAssignments)
-                     : that.onDuplicateKeyAssignments != null);
-    }
-
-    @Override
-    public int hashCode() {
-        int result = super.hashCode();
-        result = 31 * result + columnSymbols.hashCode();
-        result = 31 * result + columnReferences.hashCode();
-        result = 31 * result + (onDuplicateKeyAssignments != null ? onDuplicateKeyAssignments.hashCode() : 0);
-        return result;
-    }
-
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);

--- a/sql/src/main/java/io/crate/planner/projection/DMLProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/DMLProjection.java
@@ -22,7 +22,6 @@
 
 package io.crate.planner.projection;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.Symbols;
@@ -57,19 +56,6 @@ public abstract class DMLProjection extends Projection {
 
     public Symbol uidSymbol() {
         return uidSymbol;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        DMLProjection that = (DMLProjection) o;
-        return Objects.equal(uidSymbol, that.uidSymbol);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hashCode(super.hashCode(), uidSymbol);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/projection/FetchProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/FetchProjection.java
@@ -110,19 +110,6 @@ public class FetchProjection extends Projection {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        FetchProjection that = (FetchProjection) o;
-        return collectPhaseId == that.collectPhaseId;
-    }
-
-    @Override
-    public int hashCode() {
-        return collectPhaseId;
-    }
-
-    @Override
     public void readFrom(StreamInput in) throws IOException {
         throw new UnsupportedOperationException();
     }

--- a/sql/src/main/java/io/crate/planner/projection/FilterProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/FilterProjection.java
@@ -32,7 +32,6 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Objects;
 
 public class FilterProjection extends Projection {
 
@@ -103,16 +102,6 @@ public class FilterProjection extends Projection {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        FilterProjection that = (FilterProjection) o;
-
-        return Objects.equals(query, that.query);
-    }
-
-    @Override
     public void readFrom(StreamInput in) throws IOException {
         query = Symbols.fromStream(in);
         outputs = Symbols.listFromStream(in);
@@ -124,11 +113,5 @@ public class FilterProjection extends Projection {
         Symbols.toStream(query, out);
         Symbols.toStream(outputs, out);
         RowGranularity.toStream(requiredGranularity, out);
-    }
-
-    @Override
-    public int hashCode() {
-        int result = super.hashCode();
-        return 31 * result + (query != null ? query.hashCode() : 0);
     }
 }

--- a/sql/src/main/java/io/crate/planner/projection/GroupProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/GroupProjection.java
@@ -115,19 +115,6 @@ public class GroupProjection extends Projection {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        GroupProjection that = (GroupProjection) o;
-
-        if (!keys.equals(that.keys)) return false;
-        if (values != null ? !values.equals(that.values) : that.values != null) return false;
-
-        return true;
-    }
-
-    @Override
     public RowGranularity requiredGranularity() {
         return requiredGranularity;
     }

--- a/sql/src/main/java/io/crate/planner/projection/MergeCountProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/MergeCountProjection.java
@@ -58,11 +58,6 @@ public class MergeCountProjection extends Projection {
     }
 
     @Override
-    public boolean equals(Object o) {
-        return this == o;
-    }
-
-    @Override
     public void readFrom(StreamInput in) throws IOException {
     }
 

--- a/sql/src/main/java/io/crate/planner/projection/Projection.java
+++ b/sql/src/main/java/io/crate/planner/projection/Projection.java
@@ -81,13 +81,4 @@ public abstract class Projection implements Streamable {
 
         return projection;
     }
-
-    // force subclasses to implement equality
-    @Override
-    public abstract boolean equals(Object obj);
-
-    @Override
-    public int hashCode() {
-        return projectionType().hashCode();
-    }
 }

--- a/sql/src/main/java/io/crate/planner/projection/SourceIndexWriterProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/SourceIndexWriterProjection.java
@@ -39,7 +39,6 @@ import org.elasticsearch.common.settings.Settings;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -56,8 +55,8 @@ public class SourceIndexWriterProjection extends AbstractIndexWriterProjection {
     @Nullable
     String[] excludes;
 
-    protected Reference rawSourceReference;
-    protected InputColumn rawSourceSymbol;
+    private Reference rawSourceReference;
+    private InputColumn rawSourceSymbol;
 
     private final static String OVERWRITE_DUPLICATES = "overwrite_duplicates";
     private final static boolean OVERWRITE_DUPLICATES_DEFAULT = false;
@@ -70,7 +69,7 @@ public class SourceIndexWriterProjection extends AbstractIndexWriterProjection {
             }
         };
 
-    protected SourceIndexWriterProjection() {
+    private SourceIndexWriterProjection() {
     }
 
     public SourceIndexWriterProjection(TableIdent tableIdent,
@@ -165,28 +164,6 @@ public class SourceIndexWriterProjection extends AbstractIndexWriterProjection {
     @Override
     public ProjectionType projectionType() {
         return ProjectionType.INDEX_WRITER;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        if (!super.equals(o)) return false;
-
-        SourceIndexWriterProjection that = (SourceIndexWriterProjection) o;
-
-        if (!Arrays.equals(excludes, that.excludes)) return false;
-        if (!Arrays.equals(includes, that.includes)) return false;
-        return rawSourceSymbol.equals(that.rawSourceSymbol);
-    }
-
-    @Override
-    public int hashCode() {
-        int result = super.hashCode();
-        result = 31 * result + (includes != null ? Arrays.hashCode(includes) : 0);
-        result = 31 * result + (excludes != null ? Arrays.hashCode(excludes) : 0);
-        result = 31 * result + rawSourceSymbol.hashCode();
-        return result;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/projection/SysUpdateProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/SysUpdateProjection.java
@@ -32,7 +32,10 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class SysUpdateProjection extends Projection {
 
@@ -98,18 +101,5 @@ public class SysUpdateProjection extends Projection {
             Reference.toStream(e.getKey(), out);
             Symbols.toStream(e.getValue(), out);
         }
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        SysUpdateProjection that = (SysUpdateProjection) o;
-        return Objects.equals(assignments, that.assignments);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(super.hashCode(), assignments);
     }
 }

--- a/sql/src/main/java/io/crate/planner/projection/TopNProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/TopNProjection.java
@@ -181,34 +181,6 @@ public class TopNProjection extends Projection {
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        TopNProjection that = (TopNProjection) o;
-
-        if (limit != that.limit) return false;
-        if (offset != that.offset) return false;
-        if (!orderBy.equals(that.orderBy)) return false;
-        if (!outputs.equals(that.outputs)) return false;
-        if (!Arrays.equals(reverseFlags, that.reverseFlags)) return false;
-        if (!Arrays.equals(nullsFirst, that.nullsFirst)) return false;
-
-        return true;
-    }
-
-    @Override
-    public int hashCode() {
-        int result = limit;
-        result = 31 * result + offset;
-        result = 31 * result + outputs.hashCode();
-        result = 31 * result + orderBy.hashCode();
-        result = 31 * result + Arrays.hashCode(reverseFlags);
-        result = 31 * result + Arrays.hashCode(nullsFirst);
-        return result;
-    }
-
-    @Override
     public String toString() {
         return "TopNProjection{" +
                "outputs=" + outputs +

--- a/sql/src/main/java/io/crate/planner/projection/UpdateProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/UpdateProjection.java
@@ -29,7 +29,6 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
-import java.util.Arrays;
 
 public class UpdateProjection extends DMLProjection {
 
@@ -56,7 +55,7 @@ public class UpdateProjection extends DMLProjection {
         this.requiredVersion = requiredVersion;
     }
 
-    public UpdateProjection() {
+    private UpdateProjection() {
     }
 
     public String[] assignmentsColumns() {
@@ -88,32 +87,6 @@ public class UpdateProjection extends DMLProjection {
     @Override
     public <C, R> R accept(ProjectionVisitor<C, R> visitor, C context) {
         return visitor.visitUpdateProjection(this, context);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        UpdateProjection that = (UpdateProjection) o;
-
-        if (!Arrays.equals(assignments, that.assignments)) return false;
-        if (!Arrays.equals(assignmentsColumns, that.assignmentsColumns)) return false;
-        if (requiredVersion != null ? !requiredVersion.equals(that.requiredVersion) : that.requiredVersion != null)
-            return false;
-        if (!uidSymbol.equals(that.uidSymbol)) return false;
-
-        return true;
-    }
-
-    @Override
-    public int hashCode() {
-        int result = super.hashCode();
-        result = 31 * result + Arrays.hashCode(assignments);
-        result = 31 * result + Arrays.hashCode(assignmentsColumns);
-        result = 31 * result + (requiredVersion != null ? requiredVersion.hashCode() : 0);
-        result = 31 * result + uidSymbol.hashCode();
-        return result;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/projection/WriterProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/WriterProjection.java
@@ -82,7 +82,7 @@ public class WriterProjection extends Projection {
         GZIP
     }
 
-    public WriterProjection() {
+    private WriterProjection() {
     }
 
     public WriterProjection(List<Symbol> inputs,
@@ -199,35 +199,6 @@ public class WriterProjection extends Projection {
         }
         out.writeInt(compressionType != null ? compressionType.ordinal() : -1);
         out.writeInt(outputFormat.ordinal());
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        WriterProjection that = (WriterProjection) o;
-
-        if (outputNames != null ? !outputNames.equals(that.outputNames) : that.outputNames != null)
-            return false;
-        if (!uri.equals(that.uri)) return false;
-        if (!overwrites.equals(that.overwrites)) return false;
-        if (compressionType != null ? !compressionType.equals(that.compressionType) : that.compressionType != null)
-            return false;
-        if (!outputFormat.equals(that.outputFormat)) return false;
-
-        return true;
-    }
-
-    @Override
-    public int hashCode() {
-        int result = super.hashCode();
-        result = 31 * result + uri.hashCode();
-        result = 31 * result + (outputNames != null ? outputNames.hashCode() : 0);
-        result = 31 * result + overwrites.hashCode();
-        result = 31 * result + (compressionType != null ? compressionType.hashCode() : 0);
-        result = 31 * result + outputFormat.hashCode();
-        return result;
     }
 
     @Override


### PR DESCRIPTION
There are currently never any equals checks done on projections and
they're also never hashed as part of a Set or HashMap.

And there was at least one projection (TopNProjection) which was broken
and would have resulted in a NPE.