### PR TITLE
Fix flaky testQueryNameFromSysOperations

### DIFF
--- a/sql/src/test/java/io/crate/integrationtests/SysOperationsTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysOperationsTest.java
@@ -60,11 +60,11 @@ public class SysOperationsTest extends SQLTransportIntegrationTest {
     public void testQueryNameFromSysOperations() throws Exception {
         SQLResponse resp = execute("select name, job_id from sys.operations order by name asc");
 
-        // usually this should return collect on 2 nodes, localMerge on 1 node
+        // usually this should return collect per node and an optional merge on handler
         // but it could be that the collect is finished before the localMerge task is started in which
         // case it is missing.
 
-        assertThat(resp.rowCount(), Matchers.greaterThanOrEqualTo(2L));
+        assertThat(resp.rowCount(), Matchers.greaterThanOrEqualTo((long) internalCluster().numDataNodes()));
         List<String> names = new ArrayList<>();
         for (Object[] objects : resp.rows()) {
             names.add((String) objects[0]);


### PR DESCRIPTION
Due to the planner changes it can be that there is no MergePhase at all
if there is only one node in the cluster.

Due to timing it can than be that the sys.operations entry of itself
isn't picked up.