### PR TITLE
Fix: selecting os_info['jvm']['vm_vendor'] and os_info['jvm']['name']

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fix: selecting os_info['jvm']['vm_vendor'] and os_info['jvm']['name'] caused
+   ColumnUnknownExceptions
+
  - Fixed an issue that causes outer joins to fail with an exception
    if columns are referenced in a where clause but not as select items.
 

--- a/sql/src/main/java/io/crate/metadata/sys/SysNodesTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysNodesTableInfo.java
@@ -138,8 +138,8 @@ public class SysNodesTableInfo extends StaticTableInfo {
         public static final ColumnIdent OS_INFO_VERSION = new ColumnIdent(SYS_COL_OS_INFO, ImmutableList.of("version"));
         public static final ColumnIdent OS_INFO_JVM = new ColumnIdent(SYS_COL_OS_INFO, ImmutableList.of("jvm"));
         public static final ColumnIdent OS_INFO_JVM_VERSION = new ColumnIdent(SYS_COL_OS_INFO, ImmutableList.of("jvm", "version"));
-        public static final ColumnIdent OS_INFO_JVM_NAME = new ColumnIdent(SYS_COL_OS_INFO, ImmutableList.of("jvm", "name"));
-        public static final ColumnIdent OS_INFO_JVM_VENDOR = new ColumnIdent(SYS_COL_OS_INFO, ImmutableList.of("jvm", "vendor"));
+        public static final ColumnIdent OS_INFO_JVM_NAME = new ColumnIdent(SYS_COL_OS_INFO, ImmutableList.of("jvm", "vm_name"));
+        public static final ColumnIdent OS_INFO_JVM_VENDOR = new ColumnIdent(SYS_COL_OS_INFO, ImmutableList.of("jvm", "vm_vendor"));
         public static final ColumnIdent OS_INFO_JVM_VM_VERSION = new ColumnIdent(SYS_COL_OS_INFO, ImmutableList.of("jvm", "vm_version"));
 
         public static final ColumnIdent PROCESS = new ColumnIdent(SYS_COL_PROCESS);

--- a/sql/src/test/java/io/crate/metadata/SysNodesTableInfoTest.java
+++ b/sql/src/test/java/io/crate/metadata/SysNodesTableInfoTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata;
+
+import io.crate.metadata.sys.SysNodesTableInfo;
+import io.crate.operation.reference.sys.RowContextReferenceResolver;
+import io.crate.test.integration.CrateUnitTest;
+import org.elasticsearch.cluster.ClusterService;
+import org.junit.Test;
+
+import java.util.Iterator;
+
+import static org.mockito.Mockito.mock;
+
+public class SysNodesTableInfoTest extends CrateUnitTest {
+
+    private ClusterService clusterService = mock(ClusterService.class);
+
+    /**
+     *  Ensures that all columns registered in SysNodesTableInfo can actually be resolved
+     */
+    @Test
+    public void testRegistered() {
+        SysNodesTableInfo info = new SysNodesTableInfo(clusterService);
+        RowContextReferenceResolver referenceResolver = RowContextReferenceResolver.INSTANCE;
+        Iterator<Reference> iter = info.iterator();
+        while (iter.hasNext()) {
+            assertNotNull(referenceResolver.getImplementation(iter.next()));
+        }
+    }
+}


### PR DESCRIPTION
Fixed typos which caused ColumnUnkonwnExceptions when selecting os_info[‘jvm’][‘vm_vendor’] and os_info[‘jvm’][‘name’]

- Added a test which ensures that all registered columns can actually be resolved to prevent such typos