### PR TITLE
fixed fs paths to be compatible with Windows

### DIFF
--- a/sql/src/test/java/io/crate/operation/reference/sys/SysNodesExpressionsTest.java
+++ b/sql/src/test/java/io/crate/operation/reference/sys/SysNodesExpressionsTest.java
@@ -205,21 +205,6 @@ public class SysNodesExpressionsTest extends CrateUnitTest {
         }
     }
 
-    /**
-     * Resolve canonical path (platform independent)
-     *
-     * @param path the path to be resolved (e.g. /dev/sda1)
-     * @return full canonical path (e.g. linux will resolve to /dev/sda1, windows to C:\dev\sda1)
-     */
-    private String resolveCanonicalPath(String path) {
-        try {
-            return new File(path).getCanonicalPath();
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-        return null;
-    }
-
     @Before
     public void prepare() throws Exception {
         MonitorModule monitorModule = new MonitorModule(NODE_SETTINGS);
@@ -344,20 +329,20 @@ public class SysNodesExpressionsTest extends CrateUnitTest {
         Object[] disks = (Object[]) v.get("disks");
         assertThat(disks.length, is(2));
         Map<String, Object> disk0 = (Map<String, Object>) disks[0];
-        assertThat((String) disk0.get("dev"), is(resolveCanonicalPath("/dev/sda1")));
+        assertThat((String) disk0.get("dev"), is("/dev/sda1"));
         assertThat((Long) disk0.get("size"), is(42L));
 
         Map<String, Object> disk1 = (Map<String, Object>) disks[1];
-        assertThat((String) disk1.get("dev"), is(resolveCanonicalPath("/dev/sda2")));
+        assertThat((String) disk1.get("dev"), is("/dev/sda2"));
         assertThat((Long) disk0.get("used"), is(42L));
 
         Object[] data = (Object[]) v.get("data");
         assertThat(data.length, is(2));
-        assertThat((String) ((Map<String, Object>) data[0]).get("dev"), is(resolveCanonicalPath("/dev/sda1")));
-        assertThat((String) ((Map<String, Object>) data[0]).get("path"), is(resolveCanonicalPath("/foo")));
+        assertThat((String) ((Map<String, Object>) data[0]).get("dev"), is("/dev/sda1"));
+        assertThat((String) ((Map<String, Object>) data[0]).get("path"), is("/foo"));
 
-        assertThat((String) ((Map<String, Object>) data[1]).get("dev"), is(resolveCanonicalPath("/dev/sda2")));
-        assertThat((String) ((Map<String, Object>) data[1]).get("path"), is(resolveCanonicalPath("/bar")));
+        assertThat((String) ((Map<String, Object>) data[1]).get("dev"), is("/dev/sda2"));
+        assertThat((String) ((Map<String, Object>) data[1]).get("path"), is("/bar"));
 
         refInfo = refInfo("sys.nodes.fs", DataTypes.STRING, RowGranularity.NODE, "data", "dev");
         NestedObjectExpression fsRef =

--- a/sql/src/test/java/io/crate/operation/reference/sys/node/local/SysNodesExpressionsOnHandlerTest.java
+++ b/sql/src/test/java/io/crate/operation/reference/sys/node/local/SysNodesExpressionsOnHandlerTest.java
@@ -232,31 +232,31 @@ public class SysNodesExpressionsOnHandlerTest extends CrateUnitTest {
         Object[] disks = (Object[]) v.get("disks");
         assertThat(disks.length, is(2));
         Map<String, Object> disk0 = (Map<String, Object>) disks[0];
-        assertThat((BytesRef) disk0.get("dev"), is(BytesRefs.toBytesRef(resolveCanonicalPath("/dev/sda1"))));
+        assertThat((BytesRef) disk0.get("dev"), is(BytesRefs.toBytesRef("/dev/sda1")));
         assertThat((Long) disk0.get("size"), is(42L));
 
         Map<String, Object> disk1 = (Map<String, Object>) disks[1];
-        assertThat((BytesRef) disk1.get("dev"), is(BytesRefs.toBytesRef(resolveCanonicalPath("/dev/sda2"))));
+        assertThat((BytesRef) disk1.get("dev"), is(BytesRefs.toBytesRef("/dev/sda2")));
         assertThat((Long) disk0.get("used"), is(42L));
 
         Object[] data = (Object[]) v.get("data");
         assertThat(data.length, is(2));
         assertThat(
             (BytesRef) ((Map<String, Object>) data[0]).get("dev"),
-            is(BytesRefs.toBytesRef(resolveCanonicalPath("/dev/sda1")))
+            is(BytesRefs.toBytesRef("/dev/sda1"))
         );
         assertThat(
             (BytesRef) ((Map<String, Object>) data[0]).get("path"),
-            is(BytesRefs.toBytesRef(resolveCanonicalPath("/foo")))
+            is(BytesRefs.toBytesRef("/foo"))
         );
 
         assertThat(
             (BytesRef) ((Map<String, Object>) data[1]).get("dev"),
-            is(BytesRefs.toBytesRef(resolveCanonicalPath("/dev/sda2")))
+            is(BytesRefs.toBytesRef("/dev/sda2"))
         );
         assertThat(
             (BytesRef) ((Map<String, Object>) data[1]).get("path"),
-            is(BytesRefs.toBytesRef(resolveCanonicalPath("/bar")))
+            is(BytesRefs.toBytesRef("/bar"))
         );
 
         refInfo = refInfo("sys.nodes.fs", DataTypes.STRING, RowGranularity.NODE, "data", "dev");
@@ -265,10 +265,6 @@ public class SysNodesExpressionsOnHandlerTest extends CrateUnitTest {
         for (Object arrayElement : (Object[]) collectExpression.value()) {
             assertThat(arrayElement, instanceOf(BytesRef.class));
         }
-    }
-
-    private String resolveCanonicalPath(String path) {
-        return new File(path).getPath().replace("\\", "/");
     }
 
     @Test


### PR DESCRIPTION
Windows platforms do not resolve the device path in the tests into ~`C:\dev\sda1`~ (with drive prefix and backslash). It results in the same as on Unix platforms like e.g. `/dev/sda1`.

@seut can you take a look a it?