### PR TITLE
fix NPE in percentile aggregation function

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed NPE in the ``percentile`` aggregation fucntion. The NPE occured
+   when queried shards have no records.
+
  - Log unhandled HTTP related exceptions as `debug` instead of `error`.
 
  - Fixed NPE that can occur on invalid HTTP requests.

--- a/blackbox/docs/sql/aggregation.txt
+++ b/blackbox/docs/sql/aggregation.txt
@@ -336,16 +336,19 @@ percentile
 The ``percentile`` aggregation function computes a `Percentile`_ over numeric
 non-null values in a column.
 
-Percentiles show the point at which a certain percentage of observed values occur.
-For example, the 98th percentile is the value which is greater than 98% of the observed values.
-The result is defined and computed as an interpolated weighted average. According to that it
-allows the median of the input data to be defined conveniently as the 50th percentile.
+Percentiles show the point at which a certain percentage of observed values
+occur. For example, the 98th percentile is the value which is greater than 98%
+of the observed values. The result is defined and computed as an interpolated
+weighted average. According to that it allows the median of the input data to
+be defined conveniently as the 50th percentile.
 
-The function expects a single fraction or an array of fractions and a column name. Independent
-of the input column data type the result of ``percentile`` always returns a double. If the
-value at the specified column is ``null`` the row is ignored. Fractions must be double
-precision values between 0 and 1. When supplied a single fraction, the function will return
-a single value corresponding to the percentile of the specified fraction::
+The function expects a single fraction or an array of fractions and a column
+name. Independent of the input column data type the result of ``percentile``
+always returns a double. If the value at the specified column is ``null`` the
+row is ignored. Fractions must be double precision values between 0 and 1.
+However, a null fraction value produces a null result. When supplied a single
+fraction, the function will return a single value corresponding to the
+percentile of the specified fraction::
 
     cr> select percentile(position, 0.95), kind from locations
     ... group by kind order by kind;
@@ -371,11 +374,12 @@ corresponding to the percentile of each fraction specified::
     SELECT 1 row in set (... sec)
 
 
-To be able to calculate percentiles over a huge amount of data and to scale out crate calculates
-approximate instead of accurate percentiles. The algorithm used by the percentile metric is called
-`TDigest`_. The accuracy/size trade-off of the algorithm is defined by a single compression
-parameter which has a constant value of ``100``. However, there are a few guidelines to keep in mind
-in this implementation:
+To be able to calculate percentiles over a huge amount of data and to scale
+out crate calculates approximate instead of accurate percentiles. The
+algorithm used by the percentile metric is called `TDigest`_. The accuracy/size
+trade-off of the algorithm is defined by a single compression parameter which
+has a constant value of ``100``. However, there are a few guidelines to keep in
+mind in this implementation:
 
     - Extreme percentiles (e.g. 99%) are more accurate
     - For small sets percentiles are highly accurate

--- a/sql/src/main/java/io/crate/operation/aggregation/impl/PercentileAggregation.java
+++ b/sql/src/main/java/io/crate/operation/aggregation/impl/PercentileAggregation.java
@@ -1,22 +1,23 @@
 /*
- * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
- * license agreements.  See the NOTICE file distributed with this work for
- * additional information regarding copyright ownership.  Crate licenses
- * this file to you under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.  You may
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
  * obtain a copy of the License at
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
  *
  * However, if you have executed another commercial license agreement
  * with Crate these terms will supersede the license and you may use the
- * software solely pursuant to the terms of the relevant commercial agreement.
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
  */
 
 package io.crate.operation.aggregation.impl;
@@ -31,27 +32,47 @@ import io.crate.operation.aggregation.AggregationFunction;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
-import javax.annotation.Nullable;
-import java.util.Arrays;
+import java.util.List;
 
-public class PercentileAggregation extends AggregationFunction<TDigestState, Object> {
+/**
+ * The {@code PercentileAggregation} function computes a percentile over
+ * numeric non-null values in a column.
+ * <br/>
+ *
+ * The function expects a single fraction or an array of fractions and
+ * a column name, e.g.
+ * <pre>
+ *      percentile(col, [.85, .9])
+ * </pre>
+ *
+ * The function output for some corner cases are following:
+ * <pre>
+ *      percentile(col, [null, .85]) and
+ *      percentile(col, null)
+ *           returns a null result only for the null value fraction.
+ * </pre>
+ */
+class PercentileAggregation extends AggregationFunction<TDigestState, Object> {
 
-    public static final String NAME = "percentile";
+    private static final String NAME = "percentile";
     private static final int COMPRESSION = 100;
+    private static final List<DataType> ALLOWED_FRACTION_DATA_TYPES = ImmutableList.of(
+        DataTypes.DOUBLE, DataTypes.DOUBLE_ARRAY, DataTypes.UNDEFINED
+    );
+
     private final FunctionInfo info;
 
     public static void register(AggregationImplModule mod) {
-        for (DataType<?> t : DataTypes.NUMERIC_PRIMITIVE_TYPES) {
-            mod.register(new PercentileAggregation(new FunctionInfo(
-                new FunctionIdent(NAME, ImmutableList.<DataType>of(t, DataTypes.DOUBLE)), DataTypes.DOUBLE,
-                FunctionInfo.Type.AGGREGATE)));
-            mod.register(new PercentileAggregation(new FunctionInfo(
-                new FunctionIdent(NAME, ImmutableList.of(t, DataTypes.DOUBLE_ARRAY)), DataTypes.DOUBLE_ARRAY,
-                FunctionInfo.Type.AGGREGATE)));
+        for (DataType<?> fractionDT : ALLOWED_FRACTION_DATA_TYPES) {
+            for (DataType<?> t : DataTypes.NUMERIC_PRIMITIVE_TYPES) {
+                mod.register(new PercentileAggregation(new FunctionInfo(
+                    new FunctionIdent(NAME, ImmutableList.of(t, fractionDT)), fractionDT, FunctionInfo.Type.AGGREGATE))
+                );
+            }
         }
     }
 
-    public PercentileAggregation(FunctionInfo info) {
+    PercentileAggregation(FunctionInfo info) {
         this.info = info;
     }
 
@@ -60,18 +81,22 @@ public class PercentileAggregation extends AggregationFunction<TDigestState, Obj
         return info;
     }
 
-    @Nullable
     @Override
     public TDigestState newState(RamAccountingContext ramAccountingContext) {
-        return null;
+        return new TDigestState(COMPRESSION, new Double[]{});
     }
 
     @Override
-    public TDigestState iterate(RamAccountingContext ramAccountingContext, TDigestState state, Input... args) throws CircuitBreakingException {
-        if (state == null) {
-            Object argValue = args[1].value();
-            state = initState(argValue);
+    public TDigestState iterate(RamAccountingContext ramAccountingContext, TDigestState state, Input... args)
+        throws CircuitBreakingException {
+        // The new states will be updated with fraction values on the iterate
+        // method call. Despite that it is not required for further iterate
+        // calls on the same state. This behaviour is caused by the current
+        // design of the AggregationFunction.
+        if (state.fractions().length == 0) {
+            state.fractions(fractionsFromInputValue(args[1].value()));
         }
+
         Double value = DataTypes.DOUBLE.value(args[0].value());
         if (value != null) {
             state.add(value);
@@ -79,89 +104,66 @@ public class PercentileAggregation extends AggregationFunction<TDigestState, Obj
         return state;
     }
 
-    private TDigestState initState(Object argValue) {
-        if (argValue != null) {
-            double[] fractions;
-            if (argValue.getClass().isArray()) {
-                Object[] values = (Object[]) argValue;
-                if (values.length == 0 || Arrays.asList(values).contains(null)) {
-                    throw new IllegalArgumentException("no fraction value specified");
-                }
-                fractions = toDoubleArray(values);
-            } else {
-                fractions = new double[1];
-                fractions[0] = DataTypes.DOUBLE.value(argValue);
-            }
-            return new TDigestState(COMPRESSION, fractions);
-        } else {
-            return new TDigestState(COMPRESSION, null);
+    private Double[] fractionsFromInputValue(Object value) {
+        if (value != null && value.getClass().isArray()) {
+            Object[] values = (Object[]) value;
+            return toDoubleFractionsArray(values);
         }
+        return new Double[]{DataTypes.DOUBLE.value(value)};
     }
 
-    private static double[] toDoubleArray(Object[] array) {
-        Object value;
-        double[] values = new double[array.length];
-        for (int i = 0; i < array.length; i++) {
-            value = array[i];
-            values[i] = DataTypes.DOUBLE.value(value);
+    private Double[] toDoubleFractionsArray(Object[] values) {
+        Double[] fractions = new Double[values.length];
+        for (int i = 0; i < values.length; i++) {
+            Double fraction = DataTypes.DOUBLE.value(values[i]);
+            fractions[i] = fraction;
         }
-        return values;
+        return fractions;
     }
 
     @Override
     public TDigestState reduce(RamAccountingContext ramAccountingContext, TDigestState state1, TDigestState state2) {
-        if (state1 == null) {
-            return state2;
-        }
-        if (state2 != null) {
+        if (state1.fractions().length == 0) {
             state1.add(state2);
-            validateFraction(state1.fractions());
+            return state1;
         }
 
-        return state1;
+        state2.add(state1);
+        return state2;
     }
 
     @Override
     public Object terminatePartial(RamAccountingContext ramAccountingContext, TDigestState state) {
-        if (state.fractions() != null) {
-            Double[] percentiles = new Double[state.fractions().length];
-            if (state.fractions().length > 1) {
-                for (int i = 0; i < state.fractions().length; i++) {
-                    Double percentile = state.quantile(state.fractions()[i]);
-                    if (percentile.isNaN()) {
-                        percentiles[i] = null;
-                    } else {
-                        percentiles[i] = percentile;
-                    }
-                }
-                return percentiles;
-            } else {
-                Double percentile = state.quantile(state.fractions()[0]);
-                if (percentile.isNaN()) {
-                    return null;
-                } else {
-                    return percentile;
-                }
-            }
+        if (state.fractions().length == 1) {
+            return calcPercentile(state, 0);
         } else {
+            return calcPercentiles(state);
+        }
+    }
+
+    private Object calcPercentiles(TDigestState state) {
+        Double[] percentiles = new Double[state.fractions().length];
+        for (int i = 0; i < state.fractions().length; i++) {
+            percentiles[i] = calcPercentile(state, i);
+        }
+        return percentiles;
+    }
+
+    private Double calcPercentile(TDigestState state, int idx) {
+        Double fraction = state.fractions()[idx];
+        if (fraction == null) {
             return null;
         }
+
+        Double percentile = state.quantile(fraction);
+        if (percentile.isNaN()) {
+            return null;
+        }
+        return percentile;
     }
 
     @Override
     public DataType partialType() {
         return TDigestStateType.INSTANCE;
-    }
-
-    private static void validateFraction(double[] fractions) {
-        if (fractions != null) {
-            double fraction;
-            for (int i = 0; i < fractions.length; i++) {
-                fraction = fractions[i];
-                if (fraction < 0 || fraction > 1) {
-                    throw new IllegalArgumentException("fraction should be in range [0,1], got " + fraction);
-                }
-            }
-        }
     }
 }

--- a/sql/src/test/java/io/crate/operation/aggregation/impl/PercentileAggregationTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/impl/PercentileAggregationTest.java
@@ -1,22 +1,23 @@
 /*
- * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
- * license agreements.  See the NOTICE file distributed with this work for
- * additional information regarding copyright ownership.  Crate licenses
- * this file to you under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.  You may
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
  * obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
- * License for the specific language governing permissions and limitations
- * under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
  *
  * However, if you have executed another commercial license agreement
  * with Crate these terms will supersede the license and you may use the
- * software solely pursuant to the terms of the relevant commercial agreement.
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
  */
 
 package io.crate.operation.aggregation.impl;
@@ -29,25 +30,35 @@ import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.mock;
 
 public class PercentileAggregationTest extends AggregationTest {
 
     private static final String NAME = "percentile";
 
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
     private Object[][] executeAggregation(DataType dataType, Object[][] data) throws Exception {
-        String name = "percentile";
-        return executeAggregation(name, dataType, data, ImmutableList.of(dataType, DataTypes.DOUBLE));
+        return executeAggregation(NAME, dataType, data, ImmutableList.of(dataType, DataTypes.DOUBLE));
     }
 
     @Test
     public void testReturnTypes() throws Exception {
-        FunctionIdent synopsis1 = new FunctionIdent(NAME, ImmutableList.<DataType>of(DataTypes.DOUBLE, DataTypes.DOUBLE));
+        FunctionIdent synopsis1 =
+            new FunctionIdent(NAME, ImmutableList.of(DataTypes.DOUBLE, DataTypes.DOUBLE));
         assertEquals(DataTypes.DOUBLE, functions.get(synopsis1).info().returnType());
 
-        FunctionIdent synopsis2 = new FunctionIdent(NAME, ImmutableList.<DataType>of(DataTypes.DOUBLE, new ArrayType(DataTypes.DOUBLE)));
+        FunctionIdent synopsis2 =
+            new FunctionIdent(NAME, ImmutableList.of(DataTypes.DOUBLE, new ArrayType(DataTypes.DOUBLE)));
         assertEquals(new ArrayType(DataTypes.DOUBLE), functions.get(synopsis2).info().returnType());
     }
 
@@ -66,87 +77,99 @@ public class PercentileAggregationTest extends AggregationTest {
                 };
             }
             Object[][] result = executeAggregation(dataType, rows);
-            assertEquals(4.5, result[0][0]);
+            assertThat(result[0][0], is(4.5));
+
             result = executeAggregation(dataType, rowsArray);
-            assertTrue(result[0][0].getClass().isArray());
-            assertEquals(2, ((Object[]) result[0][0]).length);
-            assertEquals(4.5, ((Object[]) result[0][0])[0]);
-            assertEquals(7.2, ((Object[]) result[0][0])[1]);
+            assertThat(result[0][0].getClass().isArray(), is(true));
+            assertThat(((Object[]) result[0][0])[0], is(4.5));
+            assertThat(((Object[]) result[0][0])[1], is(7.2));
         }
     }
 
     @Test
     public void testNullPercentile() throws Exception {
-        Object[][] result = executeAggregation(DataTypes.INTEGER, new Object[][]{
-            {1, null},
-            {10, null}
-        });
-
-        assertTrue(result[0][0] == null);
+        Object[][] result = executeAggregation(DataTypes.INTEGER, new Object[][]{{1, null}});
+        assertThat(result[0][0], is(nullValue()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testEmptyPercentile() throws Exception {
-        Object[][] result = executeAggregation(DataTypes.INTEGER, new Object[][]{
-            {1, new Object[]{}},
-            {10, new Object[]{}}
-        });
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testNullMultiplePercentiles() throws Exception {
+    @Test
+    public void testPercentileArrayWithNulls() throws Exception {
         Double[] fractions = new Double[]{0.25, null};
         Object[][] result = executeAggregation(DataTypes.INTEGER, new Object[][]{
             {1, fractions},
             {10, fractions}
         });
+        assertThat(((Object[]) result[0][0])[0], is(3.25));
+        assertThat(((Object[]) result[0][0])[1], is(nullValue()));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
+    public void testPercentileFunctionWithEmptyRows() throws Exception {
+        Object[][] result = executeAggregation(DataTypes.INTEGER, new Object[][]{});
+        assertThat(((Object[]) result[0][0]).length, is(0));
+    }
+
+    @Test
+    public void tesMultiplePercentiles() throws Exception {
+        Double[] fractions = new Double[]{0.25, 0.5};
+        Object[][] result = executeAggregation(DataTypes.INTEGER, new Object[][]{{1, fractions}, {10, fractions}});
+        assertThat(((Object[]) result[0][0])[0], is(3.25));
+        assertThat(((Object[]) result[0][0])[1], is(5.5));
+    }
+
+    @Test
     public void testNegativePercentile() throws Exception {
-        Object[][] result = executeAggregation(DataTypes.INTEGER, new Object[][]{
-            {1, -1.2},
-            {10, -1.2}
-        });
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage(containsString("should be in [0,1]"));
+        executeAggregation(DataTypes.INTEGER, new Object[][]{{1, -0.2}});
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testTooLargePercentile() throws Exception {
-        Object[][] result = executeAggregation(DataTypes.INTEGER, new Object[][]{
-            {1, 1.5},
-            {10, 1.5}
-        });
+    @Test
+    public void testNotValidPercentile() throws Exception {
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage(containsString("should be in [0,1]"));
+        executeAggregation(DataTypes.INTEGER, new Object[][]{{1, 1.5}});
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testUnsupportedType() throws Exception {
-        Object[][] result = executeAggregation(DataTypes.STRING, new Object[][]{
-            {"Akira", 0.5},
-            {"Tetsuo", 0.5}
-        });
+        exception.expect(NullPointerException.class);
+        executeAggregation(DataTypes.STRING, new Object[][]{{"Akira", 0.5}, {"Tetsuo", 0.5}});
     }
 
     @Test
-    public void testNullInputValuesReturnNull() throws Exception {
-        Object[][] result = executeAggregation(DataTypes.LONG, new Object[][]{
-            {null, 0.5},
-            {null, 0.5}
-        });
-        assertEquals(result[0][0], null);
+    public void testNullValues() throws Exception {
+        Object[][] result = executeAggregation(DataTypes.LONG, new Object[][]{{null, 0.5}, {null, 0.5}});
+        assertThat(result[0][0], is(nullValue()));
     }
 
     @Test
-    public void testNullStateResult() throws Exception {
-        PercentileAggregation percAggr = new PercentileAggregation(new FunctionInfo(
-            new FunctionIdent(NAME, ImmutableList.<DataType>of(DataTypes.INTEGER, DataTypes.DOUBLE)), DataTypes.DOUBLE,
-            FunctionInfo.Type.AGGREGATE));
-        TDigestState state = percAggr.iterate(null, null, Literal.of(1), Literal.of(0.5));
-        assertNotNull(state);
-        assertThat(0.5, is(state.fractions()[0]));
+    public void testIterate() throws Exception {
+        PercentileAggregation pa = new PercentileAggregation(mock(FunctionInfo.class));
+        TDigestState state = pa.iterate(null, new TDigestState(100, new Double[]{}), Literal.of(1), Literal.of(0.5));
+        assertThat(state, is(notNullValue()));
+        assertThat(state.fractions()[0], is(0.5));
+    }
 
-        TDigestState reducedState = percAggr.reduce(null, null, state);
-        assertEquals(state, reducedState);
+    @Test
+    public void testReduceStage() throws Exception {
+        PercentileAggregation pa = new PercentileAggregation(mock(FunctionInfo.class));
+
+        // state 1 -> state 2
+        TDigestState state1 = new TDigestState(100, new Double[]{});
+        TDigestState state2 = new TDigestState(100, new Double[]{0.5});
+        state2.add(20.0);
+        TDigestState reducedState = pa.reduce(null, state1, state2);
+        assertThat(reducedState.fractions()[0], is(0.5));
+        assertThat(reducedState.centroidCount(), is(1));
+
+        // state 2 -> state 1
+        state1 = new TDigestState(100, new Double[]{0.5});
+        state1.add(22.0);
+        state1.add(20.0);
+        state2 = new TDigestState(100, new Double[]{});
+        reducedState = pa.reduce(null, state1, state2);
+        assertThat(reducedState.fractions()[0], is(0.5));
+        assertThat(reducedState.centroidCount(), is(2));
     }
 }
-
-

--- a/sql/src/test/java/io/crate/operation/aggregation/impl/TDigestStateStreamingTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/impl/TDigestStateStreamingTest.java
@@ -27,13 +27,14 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 
-public class TDigestStateTest {
+public class TDigestStateStreamingTest {
 
     @Test
-    public void testStreaming() throws Exception {
-        TDigestState digestState1 = new TDigestState(250, new double[]{0.5, 0.8});
+    public void testTDigestStreaming() throws Exception {
+        TDigestState digestState1 = new TDigestState(250, new Double[]{0.5, 0.8});
         BytesStreamOutput out = new BytesStreamOutput();
         TDigestStateType digestStateType = TDigestStateType.INSTANCE;
         Streamer streamer = digestStateType.create().streamer();
@@ -41,8 +42,23 @@ public class TDigestStateTest {
         StreamInput in = StreamInput.wrap(out.bytes());
         TDigestState digestState2 = (TDigestState) streamer.readValueFrom(in);
 
-        assertEquals(digestState1.compression(), digestState2.compression(), 0.001d);
-        assertEquals(digestState1.fractions()[0], digestState2.fractions()[0], 0.001d);
-        assertEquals(digestState1.fractions()[1], digestState2.fractions()[1], 0.001d);
+        assertThat(digestState1.fractions()[0], is(digestState2.fractions()[0]));
+        assertThat(digestState1.fractions()[1], is(digestState2.fractions()[1]));
+        assertThat(digestState1.compression(), is(digestState2.compression()));
+    }
+
+    @Test
+    public void testTDigestStreamingWithNulls() throws Exception {
+        TDigestState digestState1 = new TDigestState(250, new Double[]{null, 0.8});
+        BytesStreamOutput out = new BytesStreamOutput();
+        TDigestStateType digestStateType = TDigestStateType.INSTANCE;
+        Streamer streamer = digestStateType.create().streamer();
+        streamer.writeValueTo(out, digestState1);
+        StreamInput in = StreamInput.wrap(out.bytes());
+        TDigestState digestState2 = (TDigestState) streamer.readValueFrom(in);
+
+        assertThat(digestState1.fractions()[0], is(digestState2.fractions()[0]));
+        assertThat(digestState1.fractions()[1], is(digestState2.fractions()[1]));
+        assertThat(digestState1.compression(), is(digestState2.compression()));
     }
 }


### PR DESCRIPTION
NPE was occurring for cases when the queried shards had no
records. The reason of NPE was an attempt of serialization of
the new state which remains null until the first call of the iterate
method. If shards have no rows the iterate won't be called and the
state won't be initialized.

This commit also adds logic for handling some corner cases.

    percentile(col, [.85, null]) -> [result, null]
    percentile(col, null) -> null