### PR TITLE
Move scalar subquery planning into ConsumingPlanner

### DIFF
--- a/sql/src/main/java/io/crate/executor/transport/SubSelectSymbolReplacer.java
+++ b/sql/src/main/java/io/crate/executor/transport/SubSelectSymbolReplacer.java
@@ -32,6 +32,7 @@ import io.crate.collections.Lists2;
 import io.crate.metadata.ReplaceMode;
 import io.crate.metadata.ReplacingSymbolVisitor;
 import io.crate.planner.Merge;
+import io.crate.planner.MultiPhasePlan;
 import io.crate.planner.Plan;
 import io.crate.planner.PlanVisitor;
 import io.crate.planner.node.dql.*;
@@ -78,6 +79,12 @@ class SubSelectSymbolReplacer implements FutureCallback<Object> {
         @Override
         protected Void visitPlan(Plan plan, SymbolReplacer context) {
             throw new UnsupportedOperationException("Subselect not supported in " + plan);
+        }
+
+        @Override
+        public Void visitMultiPhasePlan(MultiPhasePlan multiPhasePlan, SymbolReplacer replacer) {
+            process(multiPhasePlan.rootPlan(), replacer);
+            return null;
         }
 
         @Override

--- a/sql/src/main/java/io/crate/executor/transport/TransportExecutor.java
+++ b/sql/src/main/java/io/crate/executor/transport/TransportExecutor.java
@@ -22,9 +22,7 @@
 
 package io.crate.executor.transport;
 
-import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
-import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.crate.action.job.ContextPreparer;
 import io.crate.action.sql.DDLStatementDispatcher;
@@ -77,6 +75,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 
 import javax.annotation.Nullable;
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
 
 @Singleton
 public class TransportExecutor implements Executor {
@@ -97,6 +96,7 @@ public class TransportExecutor implements Executor {
     private final BulkRetryCoordinatorPool bulkRetryCoordinatorPool;
 
     private final ProjectionToProjectorVisitor globalProjectionToProjectionVisitor;
+    private final MultiPhaseExecutor multiPhaseExecutor = new MultiPhaseExecutor();
 
     private final static BulkNodeOperationTreeGenerator BULK_NODE_OPERATION_VISITOR = new BulkNodeOperationTreeGenerator();
 
@@ -141,7 +141,10 @@ public class TransportExecutor implements Executor {
 
     @Override
     public void execute(Plan plan, RowReceiver rowReceiver, Row parameters) {
-        plan2TaskVisitor.process(plan, null).execute(rowReceiver, parameters);
+        CompletableFuture<Plan> planFuture = multiPhaseExecutor.process(plan, null);
+        planFuture
+            .thenAccept(p -> plan2TaskVisitor.process(p, null).execute(rowReceiver, parameters))
+            .exceptionally(t -> { rowReceiver.fail(t); return null; });
     }
 
     @Override
@@ -260,53 +263,75 @@ public class TransportExecutor implements Executor {
 
         @Override
         public Task visitMultiPhasePlan(MultiPhasePlan multiPhasePlan, final Void context) {
-            /*
-             * This triggers a sequential execution of a multiPhasePlan:
-             * First the dependencies (concurrently)
-             * Then via a DelayedTask the root plan.
-             *
-             * The rootTask and each dependency will be executed as separate job.
-             *
-             * This can be recursive.
-             * E.g.
-             *
-             * MultiPhaseTask
-             *      rootPlan: QueryThenFetch
-             *      deps: [
-             *          MultiPhasePlan
-             *              rootPlan: QueryThenFetch
-             *              deps: [CollectAndMerge, CollectAndMerge]
-             *      ]
-             *
-             * Note that a MultiPhaseTask always has to be the parent. Something like:
-             *
-             *      QueryThenFetch
-             *          subPlan: MultiPhaseTask
-             *
-             * Wouldn't work because QueryThenFetch would be handled by the NodeOperationTreeGenerator
-             */
+            throw new UnsupportedOperationException("MultiPhasePlan should have been processed by MultiPhaseExecutor");
+        }
+    }
+
+    /**
+     * Executor that triggers the execution of MultiPhasePlans.
+     * E.g.:
+     *
+     * processing a Plan that looks as follows:
+     * <pre>
+     *     QTF
+     *      |
+     *      +-- MultiPhasePlan
+     *              root: Collect3
+     *              deps: [Collect1, Collect2]
+     * </pre>
+     *
+     * Executions will be triggered for collect1 and collect2, and if those are completed, Collect3 will be returned
+     * as future which encapsulated the execution
+     */
+    private class MultiPhaseExecutor extends PlanVisitor<Void, CompletableFuture<Plan>> {
+
+        @Override
+        protected CompletableFuture<Plan> visitPlan(Plan plan, Void context) {
+            return CompletableFuture.completedFuture(plan);
+        }
+
+        @Override
+        public CompletableFuture<Plan> visitMerge(Merge merge, Void context) {
+            return process(merge.subPlan(), context).thenApply(p -> merge);
+        }
+
+        @Override
+        public CompletableFuture<Plan> visitNestedLoop(NestedLoop plan, Void context) {
+            CompletableFuture<Plan> fLeft = process(plan.left(), context);
+            CompletableFuture<Plan> fRight = process(plan.right(), context);
+            return CompletableFuture.allOf(fLeft, fRight).thenApply(x -> plan);
+        }
+
+        @Override
+        public CompletableFuture<Plan> visitQueryThenFetch(QueryThenFetch qtf, Void context) {
+            return process(qtf.subPlan(), context).thenApply(x -> qtf);
+        }
+
+        @Override
+        public CompletableFuture<Plan> visitMultiPhasePlan(MultiPhasePlan multiPhasePlan, Void context) {
             Map<Plan, SelectSymbol> dependencies = multiPhasePlan.dependencies();
-            List<ListenableFuture<?>> futures = new ArrayList<>();
-            final Plan rootPlan = multiPhasePlan.rootPlan();
-            for (final Map.Entry<Plan, SelectSymbol> entry : dependencies.entrySet()) {
-                Plan dependency = entry.getKey();
-                Task task = process(dependency, context);
-                SingleRowSingleValueRowReceiver singleRowSingleValueRowReceiver = new SingleRowSingleValueRowReceiver(
-                    rootPlan, entry.getValue());
-                futures.add(singleRowSingleValueRowReceiver.completionFuture());
-                task.execute(singleRowSingleValueRowReceiver, Row.EMPTY);
+            List<CompletableFuture<?>> dependencyFutures = new ArrayList<>();
+            Plan rootPlan = multiPhasePlan.rootPlan();
+            for (Map.Entry<Plan, SelectSymbol> entry : dependencies.entrySet()) {
+                Plan plan = entry.getKey();
+                SingleRowSingleValueRowReceiver singleRowSingleValueRowReceiver =
+                    new SingleRowSingleValueRowReceiver(rootPlan, entry.getValue());
+
+                CompletableFuture<Plan> planFuture = process(plan, context);
+                planFuture.whenComplete((p, e) -> {
+                    if (e == null) {
+                        // must use plan2TaskVisitor instead of calling execute
+                        // to avoid triggering MultiPhasePlans inside p again (they're already processed).
+                        // since plan's are not mutated to remove them they're still part of the plan tree
+                        plan2TaskVisitor.process(p, null).execute(singleRowSingleValueRowReceiver, Row.EMPTY);
+                    } else {
+                        singleRowSingleValueRowReceiver.fail(e);
+                    }
+                });
+                dependencyFutures.add(singleRowSingleValueRowReceiver.completionFuture());
             }
-            // Creation of the rootTask is delayed until the DelayedTask actually wants to use it.
-            // This is done because some Tasks might access the Symbols in the constructor and they might not be able
-            // to handle SelectSymbols.
-            // This ensures the Symbols are replaced once accessed
-            Supplier<Task> rootTaskSupplier = new Supplier<Task>() {
-                @Override
-                public Task get() {
-                    return process(rootPlan, context);
-                }
-            };
-            return new DelayedTask(Futures.allAsList(futures), rootTaskSupplier);
+            CompletableFuture[] cfs = dependencyFutures.toArray(new CompletableFuture[0]);
+            return CompletableFuture.allOf(cfs).thenCompose(x -> process(rootPlan, context));
         }
     }
 
@@ -528,6 +553,15 @@ public class TransportExecutor implements Executor {
         public Void visitQueryThenFetch(QueryThenFetch node, NodeOperationTreeContext context) {
             process(node.subPlan(), context);
             context.addContextPhase(node.fetchPhase());
+            return null;
+        }
+
+        @Override
+        public Void visitMultiPhasePlan(MultiPhasePlan multiPhasePlan, NodeOperationTreeContext context) {
+            // MultiPhasePlan's should be executed by the MultiPhaseExecutor, but it doesn't remove
+            // them from the tree in order to avoid re-creating plans with the MultiPhasePlan removed,
+            // so here it's fine to just skip over the multiPhasePlan because it has already been executed
+            process(multiPhasePlan.rootPlan(), context);
             return null;
         }
 

--- a/sql/src/main/java/io/crate/planner/MultiPhasePlan.java
+++ b/sql/src/main/java/io/crate/planner/MultiPhasePlan.java
@@ -48,7 +48,7 @@ public class MultiPhasePlan implements Plan {
     private final Plan rootPlan;
     private final Map<Plan, SelectSymbol> dependencies;
 
-    static Plan createIfNeeded(Plan subPlan, Map<Plan, SelectSymbol> dependencies) {
+    public static Plan createIfNeeded(Plan subPlan, Map<Plan, SelectSymbol> dependencies) {
         if (dependencies.isEmpty()) {
             return subPlan;
         }

--- a/sql/src/main/java/io/crate/planner/SelectStatementPlanner.java
+++ b/sql/src/main/java/io/crate/planner/SelectStatementPlanner.java
@@ -42,7 +42,6 @@ import io.crate.planner.node.dql.QueryThenFetch;
 import io.crate.planner.node.fetch.FetchPhase;
 import io.crate.planner.node.fetch.FetchSource;
 import io.crate.planner.projection.FetchProjection;
-import io.crate.sql.tree.QualifiedName;
 
 import java.util.ArrayList;
 import java.util.Map;
@@ -79,7 +78,11 @@ class SelectStatementPlanner {
         }
 
         private Plan invokeConsumingPlanner(AnalyzedRelation relation, Planner.Context context) {
-            return Merge.mergeToHandler(consumingPlanner.plan(relation, context), context);
+            Plan plan = consumingPlanner.plan(relation, context);
+            if (plan == null) {
+                throw new UnsupportedOperationException("Cannot create plan for: " + relation);
+            }
+            return Merge.mergeToHandler(plan, context);
         }
 
         @Override
@@ -89,25 +92,20 @@ class SelectStatementPlanner {
 
         @Override
         public Plan visitQueriedTable(QueriedTable table, Planner.Context context) {
-            SubqueryPlanner subqueryPlanner = new SubqueryPlanner(context);
-            QuerySpec querySpec = table.querySpec();
-            context.applySoftLimit(querySpec);
-            Map<Plan, SelectSymbol> subQueries = subqueryPlanner.planSubQueries(querySpec);
-            Plan plan = super.visitQueriedTable(table, context);
-            return MultiPhasePlan.createIfNeeded(plan, subQueries);
+            context.applySoftLimit(table.querySpec());
+            return super.visitQueriedTable(table, context);
         }
 
         @Override
         public Plan visitQueriedDocTable(QueriedDocTable table, Planner.Context context) {
             QuerySpec querySpec = table.querySpec();
             context.applySoftLimit(querySpec);
-            SubqueryPlanner subqueryPlanner = new SubqueryPlanner(context);
-            Map<Plan, SelectSymbol> subQueries = subqueryPlanner.planSubQueries(querySpec);
             if (querySpec.hasAggregates() || querySpec.groupBy().isPresent()) {
-                Plan subPlan = invokeConsumingPlanner(table, context);
-                return MultiPhasePlan.createIfNeeded(subPlan, subQueries);
+                return invokeConsumingPlanner(table, context);
             }
             if (querySpec.where().docKeys().isPresent() && !table.tableRelation().tableInfo().isAlias()) {
+                SubqueryPlanner subqueryPlanner = new SubqueryPlanner(context);
+                Map<Plan, SelectSymbol> subQueries = subqueryPlanner.planSubQueries(table.querySpec());
                 return MultiPhasePlan.createIfNeeded(ESGetStatementPlanner.convert(table, context), subQueries);
             }
             if (querySpec.where().hasVersions()) {
@@ -122,7 +120,7 @@ class SelectStatementPlanner {
             FetchPushDown fetchPushDown = new FetchPushDown(querySpec, table.tableRelation());
             QueriedDocTable subRelation = fetchPushDown.pushDown();
             if (subRelation == null) {
-                return MultiPhasePlan.createIfNeeded(invokeConsumingPlanner(table, context), subQueries);
+                return invokeConsumingPlanner(table, context);
             }
             Plan plannedSubQuery = subPlan(subRelation, context);
             assert plannedSubQuery != null : "consumingPlanner should have created a subPlan";
@@ -141,8 +139,7 @@ class SelectStatementPlanner {
                 table, querySpec, fetchPushDown, readerAllocations, fetchPhase, context.fetchSize());
             plannedSubQuery.addProjection(fp, null, null, fp.outputs().size(), null);
 
-            QueryThenFetch queryThenFetch = new QueryThenFetch(plannedSubQuery, fetchPhase);
-            return MultiPhasePlan.createIfNeeded(queryThenFetch, subQueries);
+            return new QueryThenFetch(plannedSubQuery, fetchPhase);
         }
 
         @Override
@@ -152,13 +149,8 @@ class SelectStatementPlanner {
             if (querySpec.where().noMatch() && !querySpec.hasAggregates()) {
                 return new NoopPlan(context.jobId());
             }
-            SubqueryPlanner subqueryPlanner = new SubqueryPlanner(context);
-            Map<Plan, SelectSymbol> subQueries = subqueryPlanner.planSubQueries(querySpec);
-            for (Map.Entry<QualifiedName, RelationSource> entry : mss.sources().entrySet()) {
-                subQueries.putAll(subqueryPlanner.planSubQueries(entry.getValue().querySpec()));
-            }
             if (mss.canBeFetched().isEmpty()) {
-                return MultiPhasePlan.createIfNeeded(invokeConsumingPlanner(mss, context), subQueries);
+                return invokeConsumingPlanner(mss, context);
             }
             MultiSourceFetchPushDown pd = MultiSourceFetchPushDown.pushDown(mss);
             Plan plannedSubQuery = invokeConsumingPlanner(mss, context);
@@ -187,8 +179,7 @@ class SelectStatementPlanner {
                 readerAllocations.indicesToIdents());
 
             plannedSubQuery.addProjection(fp, null, null, fp.outputs().size(), null);
-            QueryThenFetch queryThenFetch = new QueryThenFetch(plannedSubQuery, fetchPhase);
-            return MultiPhasePlan.createIfNeeded(Merge.mergeToHandler(queryThenFetch, context), subQueries);
+            return new QueryThenFetch(plannedSubQuery, fetchPhase);
         }
 
         @Override

--- a/sql/src/main/java/io/crate/planner/SubqueryPlanner.java
+++ b/sql/src/main/java/io/crate/planner/SubqueryPlanner.java
@@ -34,13 +34,13 @@ import org.elasticsearch.common.util.Consumer;
 import java.util.HashMap;
 import java.util.Map;
 
-class SubqueryPlanner {
+public class SubqueryPlanner {
 
     private final Planner.Context plannerContext;
     private final Visitor visitor;
     private final Map<Plan, SelectSymbol> subQueries = new HashMap<>();
 
-    SubqueryPlanner(Planner.Context plannerContext) {
+    public SubqueryPlanner(Planner.Context plannerContext) {
         this.plannerContext = plannerContext;
         this.visitor = new Visitor();
     }
@@ -52,7 +52,7 @@ class SubqueryPlanner {
         subQueries.put(subPlan, selectSymbol);
     }
 
-    Map<Plan, SelectSymbol> planSubQueries(QuerySpec querySpec) {
+    public Map<Plan, SelectSymbol> planSubQueries(QuerySpec querySpec) {
         querySpec.visitSymbols(visitor);
         return subQueries;
     }


### PR DESCRIPTION
Scalar subqueries were only planned on the root relation. With the
upcoming "subquery in FROM" support it is necessary to do the
scalar subquery planning for each sub relation as well.