### PR TITLE
Fixed an issue with select queries returning duplicate outputs

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,10 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed an issue with select queries returning duplicate outputs
+   when `where` uses `=` with `primary key` and an order by which is
+   also part of the selected fields is used.
+
  -  Fixed adding a column to an existing object array using `ALTER TABLE`
 
  - Log unhandled HTTP related exceptions as `debug` instead of `error`.

--- a/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/ESGetTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/ESGetTask.java
@@ -30,6 +30,7 @@ import io.crate.analyze.symbol.InputColumn;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.ValueSymbolVisitor;
 import io.crate.analyze.where.DocKeys;
+import io.crate.collections.Lists2;
 import io.crate.core.collections.Row;
 import io.crate.executor.JobTask;
 import io.crate.executor.transport.TransportActionProvider;
@@ -327,10 +328,8 @@ public class ESGetTask extends JobTask {
     private static List<Function<GetResponse, Object>> getFieldExtractors(ESGet node, GetResponseContext ctx) {
         List<Function<GetResponse, Object>> extractors = new ArrayList<>(
             node.outputs().size() + node.sortSymbols().size());
-        for (Symbol symbol : node.outputs()) {
-            extractors.add(SYMBOL_TO_FIELD_EXTRACTOR.convert(symbol, ctx));
-        }
-        for (Symbol symbol : node.sortSymbols()) {
+        List<Symbol> concatenated = Lists2.concatUnique(node.outputs(), node.sortSymbols());
+        for (Symbol symbol : concatenated) {
             extractors.add(SYMBOL_TO_FIELD_EXTRACTOR.convert(symbol, ctx));
         }
         return extractors;

--- a/sql/src/test/java/io/crate/integrationtests/WherePKIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/WherePKIntegrationTest.java
@@ -98,6 +98,22 @@ public class WherePKIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    public void testWherePKWithOrderBySymbolThatIsAlsoInSelectList() throws Exception {
+        execute("create table users (" +
+                "   id int primary key," +
+                "   name string" +
+                ") clustered into 2 shards with (number_of_replicas = 0)");
+        ensureYellow();
+        execute("insert into users (id, name) values (?, ?)", new Object[][]{
+            new Object[]{1, "Arthur"},
+            new Object[]{2, "Trillian"},
+            });
+        execute("refresh table users");
+        execute("select name from users where id = 1 order by name desc");
+        assertThat(TestingHelpers.printedTable(response.rows()), is("Arthur\n"));
+    }
+
+    @Test
     public void testWherePkColLimit0() throws Exception {
         execute("create table users (id int primary key, name string) " +
                 "clustered into 1 shards with (number_of_replicas = 0)");


### PR DESCRIPTION
when `where` uses `=` with `primary key` and an order by which is
also part of the selected fields is used.