### PR TITLE
Documentation typo fix

### DIFF
--- a/blackbox/docs/protocols/http.txt
+++ b/blackbox/docs/protocols/http.txt
@@ -35,7 +35,7 @@ In addition to the ``stmt`` key the request body may also contain an ``args`` ke
 which can be used for SQL parameter substitution.
 
 The SQL statement has to be changed to use placeholders where the values should
-be inserted. Placeholders can either bei numbered (in the form of ``$1``, ``$2``,
+be inserted. Placeholders can either be numbered (in the form of ``$1``, ``$2``,
 etc.) or unnumbered using a question mark ``?``.
 
 The placeholders will then be substituted with values from an array that is

--- a/blackbox/docs/sql/reference/alter_table.txt
+++ b/blackbox/docs/sql/reference/alter_table.txt
@@ -72,7 +72,7 @@ If the table is partitioned this clause can be used to alter only a single parti
 
 .. note:: BLOB tables cannot be partitioned and hence this clause cannot be used.
 
-This clause identifies a single partition. It takes one ore more partition
+This clause identifies a single partition. It takes one or more partition
 columns with a value each to identify the partition to alter.
 
 ::


### PR DESCRIPTION
Two very minor typos in the documentation