### PR TITLE
removed unused "format" from FileReadingCollector

### DIFF
--- a/sql/src/main/java/io/crate/operation/collect/files/FileReadingCollector.java
+++ b/sql/src/main/java/io/crate/operation/collect/files/FileReadingCollector.java
@@ -71,15 +71,10 @@ public class FileReadingCollector implements CrateCollector {
     };
     private final List<UriWithGlob> fileUris;
 
-    public enum FileFormat {
-        JSON
-    }
-
     public FileReadingCollector(Collection<String> fileUris,
                                 List<Input<?>> inputs,
                                 List<LineCollectorExpression<?>> collectorExpressions,
                                 RowReceiver downstream,
-                                FileFormat format,
                                 String compression,
                                 Map<String, FileInputFactory> fileInputFactories,
                                 Boolean shared,

--- a/sql/src/main/java/io/crate/operation/collect/sources/FileCollectSource.java
+++ b/sql/src/main/java/io/crate/operation/collect/sources/FileCollectSource.java
@@ -68,12 +68,11 @@ public class FileCollectSource implements CollectSource {
 
         List<String> fileUris;
         fileUris = targetUriToStringList(fileUriCollectPhase.targetUri());
-        return ImmutableList.<CrateCollector>of(new FileReadingCollector(
+        return ImmutableList.of(new FileReadingCollector(
             fileUris,
             context.topLevelInputs(),
             context.expressions(),
             downstream,
-            fileUriCollectPhase.fileFormat(),
             fileUriCollectPhase.compression(),
             fileInputFactoryMap,
             fileUriCollectPhase.sharedStorage(),

--- a/sql/src/main/java/io/crate/planner/node/dql/FileUriCollectPhase.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/FileUriCollectPhase.java
@@ -96,10 +96,6 @@ public class FileUriCollectPhase extends AbstractProjectionsPhase implements Col
         return toCollect;
     }
 
-    public FileReadingCollector.FileFormat fileFormat() {
-        return FileReadingCollector.FileFormat.JSON;
-    }
-
     @Override
     public Type type() {
         return Type.FILE_URI_COLLECT;

--- a/sql/src/test/java/io/crate/operation/collect/files/FileReadingCollectorTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/files/FileReadingCollectorTest.java
@@ -254,7 +254,6 @@ public class FileReadingCollectorTest extends CrateUnitTest {
             context.topLevelInputs(),
             context.expressions(),
             rowReceiver,
-            FileReadingCollector.FileFormat.JSON,
             compression,
             ImmutableMap.of(
                 LocalFsFileInputFactory.NAME, new LocalFsFileInputFactory(),


### PR DESCRIPTION
`format` in constructor is never used

@mfussenegger please