### PR TITLE
COPY FROM now correctly resolves files within symlinked folders

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - ``COPY FROM`` now correctly resolves files within symlinked folders when a
+   wildcard is used in the path.
+
  - Fixed an issue that caused join query to get stuck when an
    expression evaluation related to both relations caused an error.
 

--- a/sql/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
@@ -22,6 +22,7 @@
 package io.crate.integrationtests;
 
 import com.carrotsearch.randomizedtesting.LifecycleScope;
+import com.google.common.collect.ImmutableList;
 import io.crate.action.sql.SQLActionException;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.TestingHelpers;
@@ -33,6 +34,7 @@ import org.junit.rules.TemporaryFolder;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
+import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
@@ -42,6 +44,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.newTempDir;
 import static org.hamcrest.Matchers.*;
@@ -526,10 +529,10 @@ public class CopyIntegrationTest extends SQLHttpIntegrationTest {
     }
 
     @Test
-    public void copyFromIntoTableWithClusterBy() throws Exception {
+    public void testCopyFromIntoTableWithClusterBy() throws Exception {
         execute("create table quotes (id int, quote string) " +
-            "clustered by (id)" +
-            "with (number_of_replicas = 0)");
+                "clustered by (id)" +
+                "with (number_of_replicas = 0)");
         ensureYellow();
 
         execute("copy quotes from ? with (shared = true)", new Object[]{copyFilePath + "test_copy_from.json"});
@@ -541,7 +544,7 @@ public class CopyIntegrationTest extends SQLHttpIntegrationTest {
     }
 
     @Test
-    public void copyFromIntoTableWithPkAndClusterBy() throws Exception {
+    public void testCopyFromIntoTableWithPkAndClusterBy() throws Exception {
         execute("create table quotes (id int primary key, quote string) " +
             "clustered by (id)" +
             "with (number_of_replicas = 0)");
@@ -553,5 +556,57 @@ public class CopyIntegrationTest extends SQLHttpIntegrationTest {
 
         execute("select quote from quotes where id = 3");
         assertThat((String) response.rows()[0][0], containsString("Time is an illusion."));
+    }
+
+    private Path setUpTableAndSymlink(String tableName) throws IOException {
+        execute(String.format(Locale.ENGLISH,
+            "create table %s (a int) with (number_of_replicas = 0)",
+            tableName));
+
+        Path tmpDir = newTempDir(LifecycleScope.TEST);
+        Path target = Files.createDirectories(tmpDir.resolve("target"));
+        File file = new File(target.toFile(), "integers.json");
+        String r1 = "{\"a\": 1}";
+        String r2 = "{\"a\": 2}";
+        String r3 = "{\"a\": 3}";
+        Files.write(file.toPath(), ImmutableList.of(r1, r2, r3), StandardCharsets.UTF_8);
+
+        return Files.createSymbolicLink(tmpDir.resolve("link"), target);
+    }
+
+    @Test
+    public void testCopyFromSymlinkFolderWithWildcard() throws Exception {
+        Path link = setUpTableAndSymlink("t");
+        execute("copy t from ? with (shared=true)", new Object[]{
+            link.toUri().toString() + "*"
+        });
+        assertThat(response.rowCount(), is(3L));
+    }
+
+    @Test
+    public void testCopyFromSymlinkFolderWithPrefixedWildcard() throws Exception {
+        Path link = setUpTableAndSymlink("t");
+        execute("copy t from ? with (shared=true)", new Object[]{
+            link.toUri().toString() + "i*"
+        });
+        assertThat(response.rowCount(), is(3L));
+    }
+
+    @Test
+    public void testCopyFromSymlinkFolderWithSuffixedWildcard() throws Exception {
+        Path link = setUpTableAndSymlink("t");
+        execute("copy t from ? with (shared=true)", new Object[]{
+            link.toUri().toString() + "*.json"
+        });
+        assertThat(response.rowCount(), is(3L));
+    }
+
+    @Test
+    public void testCopyFromFileInSymlinkFolder() throws Exception {
+        Path link = setUpTableAndSymlink("t");
+        execute("copy t from ? with (shared=true)", new Object[]{
+            link.toUri().toString() + "integers.json"
+        });
+        assertThat(response.rowCount(), is(3L));
     }
 }


### PR DESCRIPTION
when wildcard is used in the path

e.g. on OSX the /tmp folder symlinks to /private/tmp
previously files that were placed in this folder were ignored when used
`/tmp/*` as copy from url.

this war really only an issue if the wildcard is directly after the
symlinked folder. if you place your files in a subfolder of a symlinked
folder, the problem did not occur.

@mfussenegger please review