### PR TITLE
Prevent push-down of aggregations if there is a limit in the subquery

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed an issue with certain subselects which led to incorrect results.
+   (E.g.: ``select sum(x) from (select x from t limit 1)``)
+
  - Fixed an issue which prevented inserting data using the ``COPY FROM``
    statement into tables created with the ``CLUSTERED BY`` clause.
 

--- a/sql/src/main/java/io/crate/analyze/QuerySpec.java
+++ b/sql/src/main/java/io/crate/analyze/QuerySpec.java
@@ -269,15 +269,15 @@ public class QuerySpec {
     }
 
     public void replace(com.google.common.base.Function<? super Symbol, Symbol> replaceFunction) {
-        ListIterator<Symbol> listIt = outputs.listIterator();
-        while (listIt.hasNext()) {
-            listIt.set(replaceFunction.apply(listIt.next()));
-        }
+        Lists2.replaceItems(outputs, replaceFunction);
         if (where.hasQuery()) {
             where = new WhereClause(replaceFunction.apply(where.query()), where.docKeys().orNull(), where.partitions());
         }
         if (orderBy.isPresent()) {
             orderBy.get().replace(replaceFunction);
+        }
+        if (groupBy.isPresent()) {
+            Lists2.replaceItems(groupBy.get(), replaceFunction);
         }
     }
 

--- a/sql/src/main/java/io/crate/collections/Lists2.java
+++ b/sql/src/main/java/io/crate/collections/Lists2.java
@@ -49,7 +49,7 @@ public class Lists2 {
      * This is similar to {@link Lists#transform(List, Function)}, but instead of creating a view on a backing list
      * this function is actually mutating the provided list
      */
-    public static <T> void replaceItems(@Nullable List<T> list, Function<T, T> replaceFunction) {
+    public static <T> void replaceItems(@Nullable List<T> list, Function<? super T, T> replaceFunction) {
         if (list == null || list.isEmpty()) {
             return;
         }

--- a/sql/src/test/java/io/crate/analyze/relations/RelationNormalizerTest.java
+++ b/sql/src/test/java/io/crate/analyze/relations/RelationNormalizerTest.java
@@ -219,6 +219,15 @@ public class RelationNormalizerTest extends CrateUnitTest {
         QueriedRelation relation = normalize(
             "select count(*), avg(x) as avgX from ( select * from (" +
             "  select * from t1 order by i) as tt) as ttt");
+        assertThat(relation, instanceOf(QueriedDocTable.class));
+        assertThat(relation.querySpec(),
+            isSQL("SELECT count(), avg(doc.t1.x)"));
+    }
+
+    @Test
+    public void testGlobalAggOnSubQueryWithLimit() throws Exception {
+        // need to apply limit before aggregation is done
+        QueriedRelation relation = normalize("select sum(x) from (select x from t1 limit 1) t");
         assertThat(relation, instanceOf(QueriedSelectRelation.class));
     }
 


### PR DESCRIPTION
This also enables certain rewrites where there is just an ORDER BY but
no limit in the subquery.