### PR TITLE
calcluate thresholds for low/high disk watermarks correctly

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed inconsistency in the calculation of low/high disk watermark
+   thresholds for node checks and logs.
+
  - Fixed an issue with certain subselects which led to incorrect results.
    (E.g.: ``select sum(x) from (select x from t limit 1)``)
 

--- a/sql/src/main/java/io/crate/operation/reference/sys/check/node/DiskWatermarkNodesSysCheck.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/check/node/DiskWatermarkNodesSysCheck.java
@@ -72,12 +72,12 @@ abstract class DiskWatermarkNodesSysCheck extends AbstractSysNodeCheck {
 
     protected boolean validate(FsInfo fsInfo, double diskWatermarkPercents, long diskWatermarkBytes) {
         for (FsInfo.Path path : fsInfo) {
-            double usedDiskAsPercentage = 100.0 - (path.getFree().bytes() / (double) path.getTotal().bytes()) * 100.0;
+            double usedDiskAsPercentage = 100.0 - (path.getAvailable().bytes() / (double) path.getTotal().bytes()) * 100.0;
 
             // Byte values refer to free disk space
             // Percentage values refer to used disk space
             if ((usedDiskAsPercentage > diskWatermarkPercents)
-                || (path.getFree().bytes() < diskWatermarkBytes)) {
+                || (path.getAvailable().bytes() < diskWatermarkBytes)) {
                 return false;
             }
         }

--- a/sql/src/test/java/io/crate/operation/reference/sys/check/node/SysNodeChecksTest.java
+++ b/sql/src/test/java/io/crate/operation/reference/sys/check/node/SysNodeChecksTest.java
@@ -185,20 +185,20 @@ public class SysNodeChecksTest extends CrateUnitTest {
         assertThat(highDiskWatermarkNodesSysCheck.severity(), is(SysCheck.Severity.HIGH));
 
         // Percentage values refer to used disk space
-        // sda: 170b is free;
-        // sdc: 150b is free
+        // sda: 160b is available
+        // sdc: 140b is available
         List<FsInfo.Path> sameSizeDisksGroup = ImmutableList.of(
             new FsInfo.Path("/middle", "/dev/sda", 300, 170, 160),
             new FsInfo.Path("/most", "/dev/sdc", 300, 150, 140)
         );
 
+        // disk.watermark.high: 139b
+        when(fsInfo.iterator()).thenReturn(sameSizeDisksGroup.iterator());
+        assertThat(highDiskWatermarkNodesSysCheck.validate(fsInfo, 100.0, 139), is(true));
+
         // disk.watermark.high: 140b
         when(fsInfo.iterator()).thenReturn(sameSizeDisksGroup.iterator());
-        assertThat(highDiskWatermarkNodesSysCheck.validate(fsInfo, 100.0, 140), is(true));
-
-        // disk.watermark.high: 160b
-        when(fsInfo.iterator()).thenReturn(sameSizeDisksGroup.iterator());
-        assertThat(highDiskWatermarkNodesSysCheck.validate(fsInfo, 100.0, 160), is(false));
+        assertThat(highDiskWatermarkNodesSysCheck.validate(fsInfo, 100.0, 150), is(false));
     }
 
     @Test
@@ -211,11 +211,11 @@ public class SysNodeChecksTest extends CrateUnitTest {
         assertThat(lowDiskWatermarkNodesSysCheck.severity(), is(SysCheck.Severity.HIGH));
 
         // Percentage values refer to used disk space
-        // sda: 60% is used;
+        // sda: 70% is used
         // sdc: 50% is used
         List<FsInfo.Path> differentSizeDisksGroup = ImmutableList.of(
             new FsInfo.Path("/middle", "/dev/sda", 100, 40, 30),
-            new FsInfo.Path("/most", "/dev/sdc", 300, 150, 140)
+            new FsInfo.Path("/most", "/dev/sdc", 300, 130, 150)
         );
 
         // disk.watermark.high: 75%
@@ -226,5 +226,4 @@ public class SysNodeChecksTest extends CrateUnitTest {
         when(fsInfo.iterator()).thenReturn(differentSizeDisksGroup.iterator());
         assertThat(lowDiskWatermarkNodesSysCheck.validate(fsInfo, 55.0, 0), is(false));
     }
-
 }


### PR DESCRIPTION
Use available disk space instead of free disk space.

The ES disk threshold decider uses the available disk space for
thresholds calculation and Crate node check use free disk
space for the same purpose. This commit unifies the calculation.