### PR TITLE
Fix collectPhase normalize to not lose orderBy information

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed ``ORDER BY`` clauses on scalar subqueries: In certain cases the ORDER
+   BY clause got removed resulting in an un-ordered result.
+
  - Fixed inconsistency in the calculation of low/high disk watermark
    thresholds for node checks and logs.
 

--- a/sql/src/test/java/io/crate/planner/node/RoutedCollectPhaseTest.java
+++ b/sql/src/test/java/io/crate/planner/node/RoutedCollectPhaseTest.java
@@ -23,11 +23,18 @@ package io.crate.planner.node;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.crate.action.sql.SessionContext;
+import io.crate.analyze.EvaluatingNormalizer;
+import io.crate.analyze.OrderBy;
 import io.crate.analyze.WhereClause;
+import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.Value;
+import io.crate.metadata.ReplaceMode;
 import io.crate.metadata.Routing;
 import io.crate.metadata.RowGranularity;
+import io.crate.metadata.TransactionContext;
+import io.crate.operation.scalar.cast.CastFunctionResolver;
 import io.crate.planner.distribution.DistributionInfo;
 import io.crate.planner.node.dql.RoutedCollectPhase;
 import io.crate.planner.projection.Projection;
@@ -37,12 +44,13 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
+import static io.crate.testing.TestingHelpers.getFunctions;
+import static org.hamcrest.Matchers.*;
 
 public class RoutedCollectPhaseTest extends CrateUnitTest {
 
@@ -76,5 +84,27 @@ public class RoutedCollectPhaseTest extends CrateUnitTest {
         assertThat(cn.phaseId(), is(cn2.phaseId()));
         assertThat(cn.maxRowGranularity(), is(cn2.maxRowGranularity()));
         assertThat(cn.distributionInfo(), is(cn2.distributionInfo()));
+    }
+
+    @Test
+    public void testNormalizeDoesNotRemoveOrderBy() throws Exception {
+        Symbol toInt10 = CastFunctionResolver.generateCastFunction(Literal.of(10L), DataTypes.INTEGER, false);
+        RoutedCollectPhase collect = new RoutedCollectPhase(
+            UUID.randomUUID(),
+            1,
+            "collect",
+            new Routing(Collections.emptyMap()),
+            RowGranularity.DOC,
+            Collections.singletonList(toInt10),
+            Collections.emptyList(),
+            WhereClause.MATCH_ALL,
+            DistributionInfo.DEFAULT_SAME_NODE
+        );
+        collect.orderBy(new OrderBy(Collections.singletonList(toInt10), new boolean[]{false}, new Boolean[]{null}));
+        EvaluatingNormalizer normalizer = EvaluatingNormalizer.functionOnlyNormalizer(getFunctions(), ReplaceMode.COPY);
+        RoutedCollectPhase normalizedCollect = collect.normalize(
+            normalizer, new TransactionContext(SessionContext.SYSTEM_SESSION));
+
+        assertThat(normalizedCollect.orderBy(), notNullValue());
     }
 }


### PR DESCRIPTION
Fixes a bug which was exposed due to the fact that using scalar
subqueries can cause the collectPhase to be normalized again on the
map-side.