### PR TITLE
Add support for operands with different types to CASE 

### DIFF
--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -305,7 +305,8 @@ public class ExpressionAnalyzer {
                 Symbol operandSymbol = operandRightSymbol;
 
                 if (operandLeftSymbol != null) {
-                    operandSymbol = EqOperator.createFunction(operandLeftSymbol, operandRightSymbol);
+                    operandSymbol = EqOperator.createFunction(
+                        operandLeftSymbol, castIfNeededOrFail(operandRightSymbol, operandLeftSymbol.valueType()));
                 }
 
                 operands.add(operandSymbol);

--- a/sql/src/main/java/io/crate/analyze/symbol/Literal.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/Literal.java
@@ -141,10 +141,7 @@ public class Literal<ReturnType> extends Symbol implements Input<ReturnType>, Co
 
     @Override
     public String toString() {
-        return "Literal{" +
-               "value=" + BytesRefs.toString(value) +
-               ", type=" + type +
-               '}';
+        return "Literal{" + BytesRefs.toString(value) + ", type=" + type + '}';
     }
 
     @Override

--- a/sql/src/main/java/io/crate/operation/aggregation/FunctionExpression.java
+++ b/sql/src/main/java/io/crate/operation/aggregation/FunctionExpression.java
@@ -24,6 +24,8 @@ package io.crate.operation.aggregation;
 import io.crate.metadata.Scalar;
 import io.crate.operation.Input;
 
+import java.util.Arrays;
+
 public class FunctionExpression<ReturnType, InputType> implements Input<ReturnType> {
 
     private final Input<InputType>[] childInputs;
@@ -37,5 +39,12 @@ public class FunctionExpression<ReturnType, InputType> implements Input<ReturnTy
     @Override
     public ReturnType value() {
         return functionImplementation.evaluate(childInputs);
+    }
+
+    @Override
+    public String toString() {
+        return "FuncExpr{" +
+               functionImplementation.info().ident().name() +
+               ", args=" + Arrays.toString(childInputs) + '}';
     }
 }

--- a/sql/src/test/java/io/crate/operation/scalar/AbstractScalarFunctionsTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/AbstractScalarFunctionsTest.java
@@ -62,6 +62,8 @@ public abstract class AbstractScalarFunctionsTest extends CrateUnitTest {
             .add("name", DataTypes.STRING)
             .add("tags", new ArrayType(DataTypes.STRING))
             .add("age", DataTypes.INTEGER)
+            .add("a", DataTypes.INTEGER)
+            .add("x", DataTypes.LONG)
             .add("shape", DataTypes.GEO_SHAPE)
             .add("timestamp", DataTypes.TIMESTAMP)
             .add("timezone", DataTypes.STRING)
@@ -74,7 +76,7 @@ public abstract class AbstractScalarFunctionsTest extends CrateUnitTest {
             .add("is_awesome", DataTypes.BOOLEAN)
             .build();
         TableRelation tableRelation = new TableRelation(tableInfo);
-        tableSources = ImmutableMap.<QualifiedName, AnalyzedRelation>of(new QualifiedName("users"), tableRelation);
+        tableSources = ImmutableMap.of(new QualifiedName("users"), tableRelation);
         sqlExpressions = new SqlExpressions(tableSources);
         functions = sqlExpressions.getInstance(Functions.class);
     }
@@ -216,6 +218,11 @@ public abstract class AbstractScalarFunctionsTest extends CrateUnitTest {
                 return delegate.value();
             }
             throw new AssertionError("Input.value() should only be called once");
+        }
+
+        @Override
+        public String toString() {
+            return delegate.toString();
         }
     }
 

--- a/sql/src/test/java/io/crate/operation/scalar/conditional/ConditionalFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/conditional/ConditionalFunctionTest.java
@@ -128,4 +128,14 @@ public class ConditionalFunctionTest extends AbstractScalarFunctionsTest {
         assertEvaluate("if(id = 0, 'zero', 'other')", "zero", Literal.of(0), Literal.of(0));
         assertEvaluate("if(id = 0, 'zero', if(id = 1, 'one', 'other'))", "one", Literal.of(1), Literal.of(1));
     }
+
+    @Test
+    public void testCaseWithDifferentOperandTypes() throws Exception {
+        // x = long
+        // a = integer
+        String expression = "case x + 1 when a then 111 end";
+        assertEvaluate(expression, 111L,
+            Literal.of(110L),    // x
+            Literal.of(111));    // a
+    }
 }


### PR DESCRIPTION
We enforce that all result-types match, but we didn't ensure that the
operand types match.

This led to `CASE x WHEN y THEN 10` to not match if x is an integer and y
is of type long, even if the value was the same.