### PR TITLE
Make sqllogictest python3.4 compatible

### DIFF
--- a/blackbox/sqllogictest/src/tests.py
+++ b/blackbox/sqllogictest/src/tests.py
@@ -1,7 +1,7 @@
 import unittest
 import os
 import faulthandler
-import glob
+import pathlib
 from functools import partial
 from testutils.ports import GLOBAL_PORT_POOL
 from testutils.paths import crate_path, project_root
@@ -11,8 +11,8 @@ from sqllogictest import run_file
 CRATE_HTTP_PORT = GLOBAL_PORT_POOL.get()
 CRATE_TRANSPORT_PORT = GLOBAL_PORT_POOL.get()
 
-tests_path = os.path.abspath(os.path.join(
-    project_root, 'blackbox', 'sqllogictest', 'testfiles', 'test'))
+tests_path = pathlib.Path(os.path.abspath(os.path.join(
+    project_root, 'blackbox', 'sqllogictest', 'testfiles', 'test')))
 
 # Enable to be able to dump threads in case something gets stuck
 faulthandler.enable()
@@ -27,15 +27,14 @@ whitelist = set([
 class TestMaker(type):
 
     def __new__(cls, name, bases, attrs):
-        glob_pattern = os.path.join(tests_path, '**/*.test')
-        for filename in glob.glob(glob_pattern, recursive=True):
-            filepath = os.path.join(tests_path, filename)
-            relpath = os.path.relpath(filepath, start=tests_path)
+        for filename in tests_path.glob('**/*.test'):
+            filepath = tests_path / filename
+            relpath = str(filepath.relative_to(tests_path))
             if relpath not in whitelist:
                 continue
-            attrs['test_' + filename] = partial(
+            attrs['test_' + relpath] = partial(
                 run_file,
-                fh=open(filepath, 'r', encoding='utf-8'),
+                fh=filepath.open('r', encoding='utf-8'),
                 hosts='localhost:' + str(CRATE_HTTP_PORT),
                 verbose=False,
                 failfast=True


### PR DESCRIPTION
Our Jenkins slave are still on python3.4.
`glob.glob(..., recursive=True)` was added in python3.5.

This commit replaces the glob usage with `pathlib` which is available in
py34 as well.