### PR TITLE
Fix scalar subquery execution in query-then-fetch

### DIFF
--- a/sql/src/main/java/io/crate/planner/SelectStatementPlanner.java
+++ b/sql/src/main/java/io/crate/planner/SelectStatementPlanner.java
@@ -24,7 +24,10 @@ package io.crate.planner;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import io.crate.analyze.*;
+import io.crate.analyze.MultiSourceSelect;
+import io.crate.analyze.QueriedTable;
+import io.crate.analyze.QuerySpec;
+import io.crate.analyze.SelectAnalyzedStatement;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.AnalyzedRelationVisitor;
 import io.crate.analyze.relations.QueriedDocTable;
@@ -138,7 +141,10 @@ class SelectStatementPlanner {
                 table, querySpec, fetchPushDown, readerAllocations, fetchPhase, context.fetchSize());
             plannedSubQuery.addProjection(fp, null, null, fp.outputs().size(), null);
 
-            return new QueryThenFetch(plannedSubQuery, fetchPhase);
+            QueryThenFetch qtf = new QueryThenFetch(plannedSubQuery, fetchPhase);
+            SubqueryPlanner subqueryPlanner = new SubqueryPlanner(context);
+            Map<Plan, SelectSymbol> subqueries = subqueryPlanner.planSubQueries(querySpec);
+            return MultiPhasePlan.createIfNeeded(qtf, subqueries);
         }
 
         @Override

--- a/sql/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
@@ -394,4 +394,17 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
         execute("select sum(x) from (select min(col1) as x from unnest([1])) as t where x = 2");
         assertThat(TestingHelpers.printedTable(response.rows()), is("NULL\n"));
     }
+
+    @Test
+    public void testSubQueryInSelectListOnDocTable() throws Exception {
+        execute("create table t (x int)");
+        ensureYellow();
+        execute("insert into t (x) values (1), (1)");
+        execute("refresh table t");
+
+        execute("select (select 2), x from t");
+        assertThat(TestingHelpers.printedTable(response.rows()),
+            is("2| 1\n" +
+               "2| 1\n"));
+    }
 }


### PR DESCRIPTION
Fixes a regression introduced by c5e6798e4646587a5b33aa1afba581b20a2a1823