### PR TITLE
Change DistributingDownstream to avoid sending two pages concurrently

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,10 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed a race condition that could cause join statements or statements with a
+   very high limit to get stuck or result in a "Same bucket of a page set more
+   than once" error.
+
  - ``COPY FROM`` now correctly resolves files within symlinked folders when a
    wildcard is used in the path.
 


### PR DESCRIPTION
There was a race condition which could lead to a "Same bucket of a page
set more than once" error:

    upstreamFinished()
        hasUpstreamFinished = true
    onResponse()
        requestsPending.decrementAndGet() -> goes to 0