### PR TITLE
fix `cleanIdeaBuild` gradle task execution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,8 +113,10 @@ allprojects {
         }
     }
 
-    task cleanIdeaBuild << {
-        tasks.clean.execute()
+    if (!it.name.equals('es')) {
+        task cleanIdeaBuild << {
+            tasks.clean.execute()
+        }
     }
 }
 


### PR DESCRIPTION
`es` submodule hasn't tasks by its own anymore
so don't create a `cleanIdeaBuild` task for it,
it doesn't work because of missing `clean` dependency