### PR TITLE
Fix jmh and update jmh plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 }
 
 plugins {
-    id 'me.champeau.gradle.jmh' version '0.2.0'
+    id 'me.champeau.gradle.jmh' version '0.3.0'
 }
 
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -5,10 +5,6 @@ apply plugin: 'de.thetaphi.forbiddenapis'
 
 archivesBaseName = 'crate-core'
 
-configurations {
-    all*.exclude group: 'org.apache.commons', module: 'commons-math3'
-}
-
 dependencies {
     compile project(':es:es-core')
     testCompile project(':testing')


### PR DESCRIPTION
The commons-math3 exclude broke the jmh task (unfortunately that was
only visible by looking at the files in the reports folder - the jmh
task itself indicated no errors)

This commons-math3 exclude was added in
52090fe63848db128b07e8554d7fb74b9ef78e3f to fix a JarHell issue caused
by jmh.

I've not been able to reproduce this JarHell (tried running itest,
regular tests, starting crate from distTar)