### PR TITLE
Fix NL right-outer join error handling

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed an issue in the runtime error handling that could cause
+   right-outer-join queries to get stuck.
+
  - Changed `<literal> = ANY([null])` to no longer result in a cast exception
    but return null.
 

--- a/sql/src/main/java/io/crate/operation/join/NestedLoopOperation.java
+++ b/sql/src/main/java/io/crate/operation/join/NestedLoopOperation.java
@@ -207,11 +207,11 @@ public class NestedLoopOperation implements CompletionListenable {
             if (!left.upstreamFinished || !right.upstreamFinished) {
                 return false;
             }
-            if ((JoinType.RIGHT == joinType || JoinType.FULL == joinType) && !emitRightJoin) {
-                emitRightJoin = true;
-                return false;
-            }
             if (upstreamFailure == null) {
+                if ((JoinType.RIGHT == joinType || JoinType.FULL == joinType) && !emitRightJoin) {
+                    emitRightJoin = true;
+                    return false;
+                }
                 downstream.finish(RepeatHandle.UNSUPPORTED);
                 completionFuture.set(null);
                 left.finished.set(null);

--- a/sql/src/test/java/io/crate/integrationtests/OuterJoinIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/OuterJoinIntegrationTest.java
@@ -56,6 +56,7 @@ public class OuterJoinIntegrationTest extends SQLTransportIntegrationTest {
                                                      "Douglas Adams| Chief Office\n"));
     }
 
+    @Test
     public void testLeftOuterJoinOrderOnOuterTable() throws Exception {
         // which employee works in which office?
         execute("select persons.name, offices.name from" +

--- a/sql/src/test/java/io/crate/operation/join/NestedLoopOperationTest.java
+++ b/sql/src/test/java/io/crate/operation/join/NestedLoopOperationTest.java
@@ -265,6 +265,42 @@ public class NestedLoopOperationTest extends CrateUnitTest {
     }
 
     @Test
+    public void testRightJoinLeftUpstreamFails() throws Exception {
+        CollectingRowReceiver receiver = new CollectingRowReceiver();
+
+        NestedLoopOperation nl = new NestedLoopOperation(1, receiver, COL0_EQ_COL1, JoinType.RIGHT, 1, 1);
+        nl.leftRowReceiver().fail(new InterruptedException("Job killed"));
+        RowSender.generateRowsInRangeAndEmit(0, 10, nl.rightRowReceiver());
+
+        expectedException.expect(instanceOf(RuntimeException.class));
+        receiver.result();
+    }
+
+    @Test
+    public void testRightJoinRightUpstreamFails() throws Exception {
+        CollectingRowReceiver receiver = new CollectingRowReceiver();
+        NestedLoopOperation nl = new NestedLoopOperation(1, receiver, COL0_EQ_COL1, JoinType.RIGHT, 1, 1);
+
+        nl.rightRowReceiver().fail(new InterruptedException("Job killed"));
+        RowSender.generateRowsInRangeAndEmit(0, 10, nl.leftRowReceiver());
+
+        expectedException.expect(instanceOf(RuntimeException.class));
+        receiver.result();
+    }
+
+    @Test
+    public void testRightJoinDownstreamFailure() throws Exception {
+        CollectingRowReceiver receiver = CollectingRowReceiver.withFailure();
+        NestedLoopOperation nl = new NestedLoopOperation(1, receiver, COL0_EQ_COL1, JoinType.RIGHT, 1, 1);
+
+        RowSender.generateRowsInRangeAndEmit(0, 5, nl.leftRowReceiver());
+        RowSender.generateRowsInRangeAndEmit(0, 5, nl.rightRowReceiver());
+
+        expectedException.expect(instanceOf(IllegalStateException.class));
+        receiver.result();
+    }
+
+    @Test
     public void testFailIsOnlyForwardedOnce() throws Exception {
         CollectingRowReceiver receiver = new CollectingRowReceiver();
         List<ListenableRowReceiver> listenableRowReceivers = getRandomLeftAndRightRowReceivers(receiver);


### PR DESCRIPTION
It got stuck when the right upstream called `fail`.

`testRightJoinRightUpstreamFails` triggered the bug. The other two test
cases are just for the sake of completness.