### PR TITLE
Remove blobsPath setter from BlobEnvironment

### DIFF
--- a/blob/src/main/java/io/crate/blob/BlobEnvironment.java
+++ b/blob/src/main/java/io/crate/blob/BlobEnvironment.java
@@ -24,6 +24,7 @@ package io.crate.blob;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsException;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.Index;
@@ -47,19 +48,19 @@ public class BlobEnvironment {
     private File blobsPath;
 
     @Inject
-    public BlobEnvironment(NodeEnvironment nodeEnvironment, ClusterName clusterName) {
+    public BlobEnvironment(Settings settings, NodeEnvironment nodeEnvironment, ClusterName clusterName) {
         this.nodeEnvironment = nodeEnvironment;
         this.clusterName = clusterName;
+        String customBlobsPathRoot = settings.get(SETTING_BLOBS_PATH);
+        if (customBlobsPathRoot != null) {
+            blobsPath = new File(customBlobsPathRoot);
+            validateBlobsPath(blobsPath);
+        }
     }
 
     @Nullable
     public File blobsPath() {
         return blobsPath;
-    }
-
-    public void blobsPath(File blobPath) {
-        validateBlobsPath(blobPath);
-        this.blobsPath = blobPath;
     }
 
     /**
@@ -105,7 +106,7 @@ public class BlobEnvironment {
     /**
      * Validates a given blobs data path
      */
-    public void validateBlobsPath(File blobsPath) {
+    public static void validateBlobsPath(File blobsPath) {
         if (blobsPath.exists()) {
             if (blobsPath.isFile()) {
                 throw new SettingsException(
@@ -128,11 +129,11 @@ public class BlobEnvironment {
     /**
      * Check if a given blob data path contains no indices and non crate related path
      */
-    public boolean isCustomBlobPathEmpty(File root) {
+    public static boolean isCustomBlobPathEmpty(File root) {
         return isCustomBlobPathEmpty(root, true);
     }
 
-    private boolean isCustomBlobPathEmpty(File file, boolean isRoot) {
+    private static boolean isCustomBlobPathEmpty(File file, boolean isRoot) {
         if (file == null || !file.exists() || !file.isDirectory()) {
             return false;
         }

--- a/blob/src/main/java/io/crate/blob/BlobService.java
+++ b/blob/src/main/java/io/crate/blob/BlobService.java
@@ -40,27 +40,22 @@ import org.elasticsearch.http.HttpServer;
 import org.elasticsearch.indices.recovery.BlobRecoverySource;
 import org.elasticsearch.transport.TransportService;
 
-import java.io.File;
-
 public class BlobService extends AbstractLifecycleComponent<BlobService> {
 
     private final Injector injector;
     private final BlobHeadRequestHandler blobHeadRequestHandler;
 
     private final ClusterService clusterService;
-    private final BlobEnvironment blobEnvironment;
 
     @Inject
     public BlobService(Settings settings,
                        ClusterService clusterService,
                        Injector injector,
-                       BlobHeadRequestHandler blobHeadRequestHandler,
-                       BlobEnvironment blobEnvironment) {
+                       BlobHeadRequestHandler blobHeadRequestHandler) {
         super(settings);
         this.clusterService = clusterService;
         this.injector = injector;
         this.blobHeadRequestHandler = blobHeadRequestHandler;
-        this.blobEnvironment = blobEnvironment;
     }
 
     public RemoteDigestBlob newBlob(String index, String digest) {
@@ -81,12 +76,6 @@ public class BlobService extends AbstractLifecycleComponent<BlobService> {
         transportServiceLogger.setLevel("ERROR");
         injector.getInstance(BlobRecoverySource.class).registerHandler();
         transportServiceLogger.setLevel(previousLevel);
-
-        // validate the optional blob path setting
-        String globalBlobPathPrefix = settings.get(BlobEnvironment.SETTING_BLOBS_PATH);
-        if (globalBlobPathPrefix != null) {
-            blobEnvironment.blobsPath(new File(globalBlobPathPrefix));
-        }
 
         blobHeadRequestHandler.registerHandler();
 

--- a/blob/src/main/java/io/crate/blob/v2/BlobIndicesService.java
+++ b/blob/src/main/java/io/crate/blob/v2/BlobIndicesService.java
@@ -297,7 +297,7 @@ public class BlobIndicesService extends AbstractLifecycleComponent<BlobIndicesSe
         }
 
         // check if custom index blobs path is empty, if so delete whole path
-        if (customBlobsPath != null && blobEnvironment.isCustomBlobPathEmpty(customBlobsPath)) {
+        if (customBlobsPath != null && BlobEnvironment.isCustomBlobPathEmpty(customBlobsPath)) {
             logger.debug("[{}] Empty per table defined blobs path found, deleting leftover folders inside {}",
                 index, customBlobsPath.getAbsolutePath());
             try {

--- a/blob/src/main/java/io/crate/blob/v2/BlobShard.java
+++ b/blob/src/main/java/io/crate/blob/v2/BlobShard.java
@@ -79,7 +79,7 @@ public class BlobShard extends AbstractIndexShardComponent {
     private File blobDir(BlobEnvironment blobEnvironment) {
         if (indexSettings.get(BlobIndicesService.SETTING_INDEX_BLOBS_PATH) != null) {
             File blobPath = new File(indexSettings.get(BlobIndicesService.SETTING_INDEX_BLOBS_PATH));
-            blobEnvironment.validateBlobsPath(blobPath);
+            BlobEnvironment.validateBlobsPath(blobPath);
             return blobEnvironment.shardLocation(shardId, blobPath);
         } else {
             return blobEnvironment.shardLocation(shardId);

--- a/blob/src/test/java/io/crate/BlobEnvironmentTest.java
+++ b/blob/src/test/java/io/crate/BlobEnvironmentTest.java
@@ -56,7 +56,7 @@ public class BlobEnvironmentTest extends CrateUnitTest {
             .put("path.data", dataPath.toAbsolutePath()).build();
         Environment environment = new Environment(settings);
         nodeEnvironment = new NodeEnvironment(settings, environment);
-        blobEnvironment = new BlobEnvironment(nodeEnvironment, new ClusterName("test"));
+        blobEnvironment = new BlobEnvironment(settings, nodeEnvironment, new ClusterName("test"));
     }
 
     @After


### PR DESCRIPTION
The BlobEnvironment can resolve the blobsPath itself instead of having
the BlobService do it from outside.