### PR TITLE
fix NPE if invalid http was sent (empty headers)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed NPE that can occur on invalid HTTP requests.
+
  - Fixed an issue at the `date_trunc` scalar evaluation that caused an
    error to be thrown if the given `interval` is a reference and
    evaluates to `NULL`.

--- a/blob/src/main/java/io/crate/http/netty/HttpBlobHandler.java
+++ b/blob/src/main/java/io/crate/http/netty/HttpBlobHandler.java
@@ -221,7 +221,7 @@ public class HttpBlobHandler extends SimpleChannelUpstreamHandler implements
 
     private void sendResponse(HttpResponse response) {
         ChannelFuture cf = ctx.getChannel().write(response);
-        if (!HttpHeaders.isKeepAlive(currentMessage)) {
+        if (currentMessage != null && !HttpHeaders.isKeepAlive(currentMessage)) {
             cf.addListener(ChannelFutureListener.CLOSE);
         }
     }


### PR DESCRIPTION
backport of https://github.com/crate/crate/pull/4395/commits/6e9979779c4bee013c37307cd75096292393c9bc, fix only