### PR TITLE
Extract a BlobAdminClient from BlobIndicesService

### DIFF
--- a/blob/src/main/java/io/crate/blob/BlobService.java
+++ b/blob/src/main/java/io/crate/blob/BlobService.java
@@ -23,7 +23,7 @@ package io.crate.blob;
 
 import io.crate.blob.exceptions.MissingHTTPEndpointException;
 import io.crate.blob.pending_transfer.BlobHeadRequestHandler;
-import io.crate.blob.v2.BlobIndicesService;
+import io.crate.blob.v2.BlobIndex;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -129,7 +129,7 @@ public class BlobService extends AbstractLifecycleComponent<BlobService> {
             DiscoveryNode node = nodes.get(shard.currentNodeId());
             String httpAddress = node.getAttributes().get("http_address");
             if (httpAddress != null) {
-                return httpAddress + "/_blobs/" + BlobIndicesService.indexName(index) + "/" + digest;
+                return httpAddress + "/_blobs/" + BlobIndex.stripPrefix(index) + "/" + digest;
             }
         }
         throw new MissingHTTPEndpointException("Can't find a suitable http server to serve the blob");

--- a/blob/src/main/java/io/crate/blob/v2/BlobAdminClient.java
+++ b/blob/src/main/java/io/crate/blob/v2/BlobAdminClient.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.blob.v2;
+
+import com.google.common.base.Functions;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import io.crate.action.FutureActionListener;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
+import org.elasticsearch.action.admin.indices.create.TransportCreateIndexAction;
+import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.elasticsearch.action.admin.indices.delete.DeleteIndexResponse;
+import org.elasticsearch.action.admin.indices.delete.TransportDeleteIndexAction;
+import org.elasticsearch.action.admin.indices.settings.put.TransportUpdateSettingsAction;
+import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
+import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsResponse;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.common.settings.Settings;
+
+import static io.crate.blob.v2.BlobIndex.fullIndexName;
+import static io.crate.blob.v2.BlobIndicesService.SETTING_INDEX_BLOBS_ENABLED;
+
+/**
+ * DDL Client for blob tables - used to create, update or delete blob tables.
+ */
+@Singleton
+public class BlobAdminClient {
+
+    private final TransportUpdateSettingsAction updateSettingsAction;
+    private final TransportCreateIndexAction createIndexAction;
+    private final TransportDeleteIndexAction deleteIndexAction;
+
+    @Inject
+    public BlobAdminClient(TransportUpdateSettingsAction updateSettingsAction,
+                           TransportCreateIndexAction createIndexAction,
+                           TransportDeleteIndexAction deleteIndexAction) {
+        this.updateSettingsAction = updateSettingsAction;
+        this.createIndexAction = createIndexAction;
+        this.deleteIndexAction = deleteIndexAction;
+    }
+
+    /**
+     * can be used to alter the number of replicas.
+     *
+     * @param tableName     name of the blob table
+     * @param indexSettings updated index settings
+     */
+    public ListenableFuture<Void> alterBlobTable(String tableName, Settings indexSettings) {
+        FutureActionListener<UpdateSettingsResponse, Void> listener =
+            new FutureActionListener<>(Functions.<Void>constant(null));
+
+        updateSettingsAction.execute(
+            new UpdateSettingsRequest(indexSettings, fullIndexName(tableName)), listener);
+        return listener;
+    }
+
+    public ListenableFuture<Void> createBlobTable(String tableName, Settings indexSettings) {
+        Settings.Builder builder = Settings.builder();
+        builder.put(indexSettings);
+        builder.put(SETTING_INDEX_BLOBS_ENABLED, true);
+
+        final SettableFuture<Void> result = SettableFuture.create();
+        createIndexAction.execute(new CreateIndexRequest(fullIndexName(tableName), builder.build()),
+            new ActionListener<CreateIndexResponse>() {
+                @Override
+                public void onResponse(CreateIndexResponse createIndexResponse) {
+                    assert createIndexResponse.isAcknowledged();
+                    result.set(null);
+                }
+
+                @Override
+                public void onFailure(Throwable e) {
+                    result.setException(e);
+                }
+            });
+        return result;
+    }
+
+    public ListenableFuture<Void> dropBlobTable(final String tableName) {
+        FutureActionListener<DeleteIndexResponse, Void> listener = new FutureActionListener<>(Functions.<Void>constant(null));
+        deleteIndexAction.execute(new DeleteIndexRequest(fullIndexName(tableName)), listener);
+        return listener;
+    }
+}

--- a/blob/src/main/java/io/crate/blob/v2/BlobIndex.java
+++ b/blob/src/main/java/io/crate/blob/v2/BlobIndex.java
@@ -29,10 +29,43 @@ import java.nio.file.Path;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-class BlobIndex {
+public class BlobIndex {
+
+    private static final String INDEX_PREFIX = ".blob_";
+
+    /**
+     * check if this index is a blob table
+     * <p>
+     * This only works for indices that were created via SQL.
+     */
+    public static boolean isBlobIndex(String indexName) {
+        return indexName.startsWith(INDEX_PREFIX);
+    }
+
+    /**
+     * Returns the full index name, adds blob index prefix.
+     */
+    public static String fullIndexName(String indexName) {
+        if (isBlobIndex(indexName)) {
+            return indexName;
+        }
+        return INDEX_PREFIX + indexName;
+    }
+
+    /**
+     * Strips the blob index prefix from a full index name
+     */
+    public static String stripPrefix(String indexName) {
+        if (!isBlobIndex(indexName)) {
+            return indexName;
+        }
+        return indexName.substring(INDEX_PREFIX.length());
+    }
+
 
     private final Map<Integer, BlobShard> shards = new ConcurrentHashMap<>();
     private final Path globalBlobPath;
+
 
     BlobIndex(@Nullable Path globalBlobPath) {
         this.globalBlobPath = globalBlobPath;

--- a/blob/src/main/java/io/crate/http/netty/HttpBlobHandler.java
+++ b/blob/src/main/java/io/crate/http/netty/HttpBlobHandler.java
@@ -27,6 +27,7 @@ import io.crate.blob.RemoteDigestBlob;
 import io.crate.blob.exceptions.DigestMismatchException;
 import io.crate.blob.exceptions.DigestNotFoundException;
 import io.crate.blob.exceptions.MissingHTTPEndpointException;
+import io.crate.blob.v2.BlobIndex;
 import io.crate.blob.v2.BlobIndicesService;
 import io.crate.blob.v2.BlobShard;
 import io.crate.blob.v2.BlobsDisabledException;
@@ -157,7 +158,7 @@ public class HttpBlobHandler extends SimpleChannelUpstreamHandler implements
         LOGGER.trace("matches index:{} digest:{}", index, digest);
         LOGGER.trace("HTTPMessage:%n{}", request);
 
-        index = BlobIndicesService.fullIndexName(index);
+        index = BlobIndex.fullIndexName(index);
 
         if (possibleRedirect(request, index, digest)) {
             reset();

--- a/blob/src/main/java/org/elasticsearch/indices/recovery/BlobRecoverySourceHandler.java
+++ b/blob/src/main/java/org/elasticsearch/indices/recovery/BlobRecoverySourceHandler.java
@@ -24,6 +24,7 @@ package org.elasticsearch.indices.recovery;
 import com.google.common.collect.Iterables;
 import io.crate.blob.BlobTransferTarget;
 import io.crate.blob.recovery.BlobRecoveryHandler;
+import io.crate.blob.v2.BlobIndex;
 import io.crate.blob.v2.BlobIndicesService;
 import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.index.IndexFormatTooNewException;
@@ -124,7 +125,7 @@ public class BlobRecoverySourceHandler extends RecoverySourceHandler {
         this.shardId = this.request.shardId().id();
 
         this.response = new RecoveryResponse();
-        if (BlobIndicesService.isBlobIndex(shard.shardId().getIndex())) {
+        if (BlobIndex.isBlobIndex(shard.shardId().getIndex())) {
             blobRecoveryHandler = new BlobRecoveryHandler(
                 transportService, recoverySettings, blobTransferTarget, blobIndicesService, shard, request);
         } else {

--- a/blob/src/test/java/io/crate/blob/v2/BlobIndicesServiceTest.java
+++ b/blob/src/test/java/io/crate/blob/v2/BlobIndicesServiceTest.java
@@ -46,9 +46,6 @@ public class BlobIndicesServiceTest extends CrateUnitTest {
         CompletableFuture<IndicesLifecycle.Listener> listenerFuture = new CompletableFuture<>();
         BlobIndicesService blobIndicesService = new BlobIndicesService(
             Settings.EMPTY,
-            null,
-            null,
-            null,
             new NoopClusterService(),
             new IndicesLifecycle() {
                 @Override

--- a/blob/src/test/java/io/crate/integrationtests/BlobHttpIntegrationTest.java
+++ b/blob/src/test/java/io/crate/integrationtests/BlobHttpIntegrationTest.java
@@ -24,7 +24,7 @@ package io.crate.integrationtests;
 
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
-import io.crate.blob.v2.BlobIndicesService;
+import io.crate.blob.v2.BlobAdminClient;
 import io.crate.test.utils.Blobs;
 import org.apache.http.Header;
 import org.apache.http.client.methods.*;
@@ -64,14 +64,14 @@ public abstract class BlobHttpIntegrationTest extends BlobIntegrationTestBase {
         Iterator<HttpServerTransport> httpTransports = transports.iterator();
         address = ((InetSocketTransportAddress) httpTransports.next().boundAddress().publishAddress()).address();
         address2 = ((InetSocketTransportAddress) httpTransports.next().boundAddress().publishAddress()).address();
-        BlobIndicesService blobIndicesService = internalCluster().getInstance(BlobIndicesService.class);
+        BlobAdminClient blobAdminClient = internalCluster().getInstance(BlobAdminClient.class);
 
         Settings indexSettings = Settings.builder()
             .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
             .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 2)
             .build();
-        blobIndicesService.createBlobTable("test", indexSettings).get();
-        blobIndicesService.createBlobTable("test_blobs2", indexSettings).get();
+        blobAdminClient.createBlobTable("test", indexSettings).get();
+        blobAdminClient.createBlobTable("test_blobs2", indexSettings).get();
 
         client().admin().indices().prepareCreate("test_no_blobs")
             .setSettings(

--- a/blob/src/test/java/io/crate/integrationtests/BlobPathITest.java
+++ b/blob/src/test/java/io/crate/integrationtests/BlobPathITest.java
@@ -22,6 +22,7 @@
 
 package io.crate.integrationtests;
 
+import io.crate.blob.v2.BlobAdminClient;
 import io.crate.blob.v2.BlobIndicesService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
@@ -48,7 +49,7 @@ import static org.hamcrest.core.Is.is;
 public class BlobPathITest extends BlobIntegrationTestBase {
 
     private BlobHttpClient client;
-    private BlobIndicesService blobIndicesService;
+    private BlobAdminClient blobAdminClient;
     private Path globalBlobPath;
 
     private Settings configureGlobalBlobPath() {
@@ -70,7 +71,7 @@ public class BlobPathITest extends BlobIntegrationTestBase {
         // using numDataNodes = 1 to launch the node doesn't work:
         // if globalBlobPath is created within nodeSetting it is sometimes not available for the tests
         internalCluster().startNode(settings);
-        blobIndicesService = internalCluster().getInstance(BlobIndicesService.class);
+        blobAdminClient = internalCluster().getInstance(BlobAdminClient.class);
 
         HttpServerTransport httpServerTransport = internalCluster().getInstance(HttpServerTransport.class);
         InetSocketAddress address = ((InetSocketTransportAddress) httpServerTransport
@@ -83,7 +84,7 @@ public class BlobPathITest extends BlobIntegrationTestBase {
         launchNodeAndInitClient(configureGlobalBlobPath());
 
         Settings indexSettings = oneShardAndZeroReplicas();
-        blobIndicesService.createBlobTable("test", indexSettings).get();
+        blobAdminClient.createBlobTable("test", indexSettings).get();
 
         client.put("test", "abcdefg");
         String digest = "2fb5e13419fc89246865e7a324f476ec624e8740";
@@ -100,7 +101,7 @@ public class BlobPathITest extends BlobIntegrationTestBase {
             .put(oneShardAndZeroReplicas())
             .put(BlobIndicesService.SETTING_INDEX_BLOBS_PATH, tableBlobPath.toString())
             .build();
-        blobIndicesService.createBlobTable("test", indexSettings).get();
+        blobAdminClient.createBlobTable("test", indexSettings).get();
 
         client.put("test", "abcdefg");
         String digest = "2fb5e13419fc89246865e7a324f476ec624e8740";
@@ -122,7 +123,7 @@ public class BlobPathITest extends BlobIntegrationTestBase {
             .put(SETTING_NUMBER_OF_REPLICAS, 0)
             .put(SETTING_NUMBER_OF_SHARDS, 2)
             .build();
-        blobIndicesService.createBlobTable("test", indexSettings).get();
+        blobAdminClient.createBlobTable("test", indexSettings).get();
 
         for (int i = 0; i < 10; i++) {
             client.put("test", "body" + i);

--- a/blob/src/test/java/io/crate/integrationtests/RecoveryTests.java
+++ b/blob/src/test/java/io/crate/integrationtests/RecoveryTests.java
@@ -27,6 +27,8 @@ import io.crate.blob.PutChunkAction;
 import io.crate.blob.PutChunkRequest;
 import io.crate.blob.StartBlobAction;
 import io.crate.blob.StartBlobRequest;
+import io.crate.blob.v2.BlobAdminClient;
+import io.crate.blob.v2.BlobIndex;
 import io.crate.blob.v2.BlobIndicesService;
 import io.crate.blob.v2.BlobShard;
 import io.crate.common.Hex;
@@ -106,11 +108,11 @@ public class RecoveryTests extends BlobIntegrationTestBase {
         BytesArray bytes = new BytesArray(new byte[]{contentBytes[0]});
         if (content.length() == 1) {
             client.execute(StartBlobAction.INSTANCE,
-                new StartBlobRequest(BlobIndicesService.fullIndexName("test"), digest, bytes, true))
+                new StartBlobRequest(BlobIndex.fullIndexName("test"), digest, bytes, true))
                 .actionGet();
         } else {
             StartBlobRequest startBlobRequest = new StartBlobRequest(
-                BlobIndicesService.fullIndexName("test"), digest, bytes, false);
+                BlobIndex.fullIndexName("test"), digest, bytes, false);
             client.execute(StartBlobAction.INSTANCE, startBlobRequest).actionGet();
             for (int i = 1; i < contentBytes.length; i++) {
                 try {
@@ -122,7 +124,7 @@ public class RecoveryTests extends BlobIntegrationTestBase {
                 try {
                     client.execute(PutChunkAction.INSTANCE,
                         new PutChunkRequest(
-                            BlobIndicesService.fullIndexName("test"), digest,
+                            BlobIndex.fullIndexName("test"), digest,
                             startBlobRequest.transferId(), bytes, i,
                             (i + 1) == content.length())
                     ).actionGet();
@@ -158,14 +160,14 @@ public class RecoveryTests extends BlobIntegrationTestBase {
 
         final String node1 = internalCluster().startNode();
 
-        BlobIndicesService blobIndicesService = internalCluster().getInstance(BlobIndicesService.class, node1);
+        BlobAdminClient blobAdminClient = internalCluster().getInstance(BlobAdminClient.class, node1);
 
         logger.trace("--> creating test index ...");
         Settings indexSettings = Settings.builder()
             .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 0)
             .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
             .build();
-        blobIndicesService.createBlobTable("test", indexSettings).get();
+        blobAdminClient.createBlobTable("test", indexSettings).get();
 
         logger.trace("--> starting [node2] ...");
         final String node2 = internalCluster().startNode();
@@ -221,7 +223,7 @@ public class RecoveryTests extends BlobIntegrationTestBase {
             String toNode = node1.equals(fromNode) ? node2 : node1;
             logger.trace("--> START relocate the shard from {} to {}", fromNode, toNode);
             internalCluster().client(node1).admin().cluster().prepareReroute()
-                .add(new MoveAllocationCommand(new ShardId(BlobIndicesService.fullIndexName("test"), 0), fromNode, toNode))
+                .add(new MoveAllocationCommand(new ShardId(BlobIndex.fullIndexName("test"), 0), fromNode, toNode))
                 .execute().actionGet();
             ClusterHealthResponse clusterHealthResponse = internalCluster().client(node1).admin().cluster()
                 .prepareHealth()
@@ -249,9 +251,9 @@ public class RecoveryTests extends BlobIntegrationTestBase {
         logger.trace("--> expected {} got {}", indexCounter.get(), uploadedDigests.size());
         assertEquals(indexCounter.get(), uploadedDigests.size());
 
-        blobIndicesService = internalCluster().getInstance(BlobIndicesService.class, node2);
+        BlobIndicesService blobIndicesService = internalCluster().getInstance(BlobIndicesService.class, node2);
         for (String digest : uploadedDigests) {
-            BlobShard blobShard = blobIndicesService.localBlobShard(BlobIndicesService.fullIndexName("test"), digest);
+            BlobShard blobShard = blobIndicesService.localBlobShard(BlobIndex.fullIndexName("test"), digest);
             long length = blobShard.blobContainer().getFile(digest).length();
             assertThat(length, greaterThanOrEqualTo(1L));
         }

--- a/sql/src/main/java/io/crate/lucene/CrateDocIndexService.java
+++ b/sql/src/main/java/io/crate/lucene/CrateDocIndexService.java
@@ -22,7 +22,7 @@
 
 package io.crate.lucene;
 
-import io.crate.blob.v2.BlobIndicesService;
+import io.crate.blob.v2.BlobIndex;
 import io.crate.metadata.Functions;
 import io.crate.operation.Input;
 import io.crate.operation.collect.CollectInputSymbolVisitor;
@@ -42,7 +42,7 @@ public class CrateDocIndexService {
 
     @Inject
     public CrateDocIndexService(Index index, Functions functions, MapperService mapperService) {
-        if (BlobIndicesService.isBlobIndex(index.name())) {
+        if (BlobIndex.isBlobIndex(index.name())) {
             docInputSymbolVisitor = new CollectInputSymbolVisitor<>(functions, BlobReferenceResolver.INSTANCE);
         } else {
             ReferenceResolver<? extends Input<?>> resolver = new LuceneReferenceResolver(mapperService);

--- a/sql/src/main/java/io/crate/metadata/blob/BlobSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/blob/BlobSchemaInfo.java
@@ -27,7 +27,7 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.FluentIterable;
 import com.google.common.util.concurrent.UncheckedExecutionException;
-import io.crate.blob.v2.BlobIndicesService;
+import io.crate.blob.v2.BlobIndex;
 import io.crate.exceptions.ResourceUnknownException;
 import io.crate.exceptions.UnhandledServerException;
 import io.crate.metadata.TableIdent;
@@ -122,8 +122,8 @@ public class BlobSchemaInfo implements SchemaInfo {
         // and add  state info to the TableInfo.
         return FluentIterable
             .from(Arrays.asList(clusterService.state().metaData().concreteAllOpenIndices()))
-            .filter(BlobIndicesService.indicesFilter)
-            .transform(BlobIndicesService.STRIP_PREFIX);
+            .filter(BlobIndex::isBlobIndex)
+            .transform(BlobIndex::stripPrefix);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/metadata/blob/InternalBlobTableInfoFactory.java
+++ b/sql/src/main/java/io/crate/metadata/blob/InternalBlobTableInfoFactory.java
@@ -23,6 +23,7 @@ package io.crate.metadata.blob;
 
 import io.crate.analyze.NumberOfReplicas;
 import io.crate.analyze.TableParameterInfo;
+import io.crate.blob.v2.BlobIndex;
 import io.crate.blob.v2.BlobIndicesService;
 import io.crate.exceptions.TableUnknownException;
 import io.crate.metadata.TableIdent;
@@ -55,7 +56,7 @@ public class InternalBlobTableInfoFactory implements BlobTableInfoFactory {
     }
 
     private IndexMetaData resolveIndexMetaData(String tableName, ClusterState state) {
-        String index = BlobIndicesService.fullIndexName(tableName);
+        String index = BlobIndex.fullIndexName(tableName);
         String[] concreteIndices;
         try {
             concreteIndices = indexNameExpressionResolver.concreteIndices(

--- a/sql/src/main/java/io/crate/metadata/doc/DocSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/doc/DocSchemaInfo.java
@@ -35,7 +35,7 @@ import com.google.common.collect.Collections2;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.UnmodifiableIterator;
 import com.google.common.util.concurrent.UncheckedExecutionException;
-import io.crate.blob.v2.BlobIndicesService;
+import io.crate.blob.v2.BlobIndex;
 import io.crate.exceptions.ResourceUnknownException;
 import io.crate.exceptions.UnhandledServerException;
 import io.crate.metadata.PartitionName;
@@ -108,7 +108,7 @@ public class DocSchemaInfo implements SchemaInfo {
                 if (input == null) {
                     return null;
                 }
-                if (BlobIndicesService.isBlobIndex(input)) {
+                if (BlobIndex.isBlobIndex(input)) {
                     return null;
                 }
                 if (PartitionName.isPartition(input)) {

--- a/sql/src/main/java/io/crate/metadata/shard/unassigned/UnassignedShard.java
+++ b/sql/src/main/java/io/crate/metadata/shard/unassigned/UnassignedShard.java
@@ -1,6 +1,6 @@
 package io.crate.metadata.shard.unassigned;
 
-import io.crate.blob.v2.BlobIndicesService;
+import io.crate.blob.v2.BlobIndex;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.blob.BlobSchemaInfo;
@@ -71,12 +71,12 @@ public class UnassignedShard {
                            Boolean primary,
                            ShardRoutingState state) {
         String index = shardId.index().name();
-        boolean isBlobIndex = BlobIndicesService.isBlobIndex(index);
+        boolean isBlobIndex = BlobIndex.isBlobIndex(index);
         String tableName;
         String ident = "";
         if (isBlobIndex) {
             this.schemaName = BlobSchemaInfo.NAME;
-            tableName = BlobIndicesService.STRIP_PREFIX.apply(index);
+            tableName = BlobIndex.stripPrefix(index);
         } else if (PartitionName.isPartition(index)) {
             PartitionName partitionName = PartitionName.fromIndexOrTemplate(index);
             schemaName = partitionName.tableIdent().schema();

--- a/sql/src/main/java/io/crate/operation/collect/ShardCollectService.java
+++ b/sql/src/main/java/io/crate/operation/collect/ShardCollectService.java
@@ -28,6 +28,7 @@ import io.crate.action.sql.query.CrateSearchContext;
 import io.crate.action.sql.query.LuceneSortGenerator;
 import io.crate.analyze.EvaluatingNormalizer;
 import io.crate.analyze.symbol.Symbols;
+import io.crate.blob.v2.BlobIndex;
 import io.crate.blob.v2.BlobIndicesService;
 import io.crate.core.collections.Row;
 import io.crate.executor.transport.TransportActionProvider;
@@ -118,7 +119,7 @@ public class ShardCollectService {
         this.blobIndicesService = blobIndicesService;
         this.mapperService = mapperService;
         this.indexFieldDataService = indexFieldDataService;
-        isBlobShard = BlobIndicesService.isBlobShard(this.shardId);
+        isBlobShard = BlobIndex.isBlobIndex(shardId.getIndex());
 
         if (isBlobShard) {
             shardResolver = new BlobShardReferenceResolver(blobIndicesService.blobShardSafe(shardId));

--- a/sql/src/main/java/io/crate/operation/reference/sys/shard/blob/BlobShardTableNameExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/shard/blob/BlobShardTableNameExpression.java
@@ -21,7 +21,7 @@
 
 package io.crate.operation.reference.sys.shard.blob;
 
-import io.crate.blob.v2.BlobIndicesService;
+import io.crate.blob.v2.BlobIndex;
 import io.crate.metadata.SimpleObjectExpression;
 import io.crate.metadata.shard.blob.BlobShardReferenceImplementation;
 import org.apache.lucene.util.BytesRef;
@@ -35,7 +35,7 @@ public class BlobShardTableNameExpression extends SimpleObjectExpression<BytesRe
 
     @Inject
     public BlobShardTableNameExpression(ShardId shardId) {
-        this.tableName = BytesRefs.toBytesRef(BlobIndicesService.STRIP_PREFIX.apply(shardId.index().name()));
+        this.tableName = BytesRefs.toBytesRef(BlobIndex.stripPrefix(shardId.index().name()));
     }
 
     @Override

--- a/sql/src/test/java/io/crate/integrationtests/ShardStatsTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ShardStatsTest.java
@@ -21,7 +21,7 @@
 
 package io.crate.integrationtests;
 
-import io.crate.blob.v2.BlobIndicesService;
+import io.crate.blob.v2.BlobAdminClient;
 import io.crate.testing.UseJdbc;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.settings.Settings;
@@ -101,12 +101,12 @@ public class ShardStatsTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testTableNameBlobTable() throws Exception {
-        BlobIndicesService blobIndicesService = internalCluster().getInstance(BlobIndicesService.class);
+        BlobAdminClient blobAdminClient = internalCluster().getInstance(BlobAdminClient.class);
         Settings indexSettings = Settings.builder()
             .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 1)
             .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 1)
             .build();
-        blobIndicesService.createBlobTable("blobs", indexSettings).get();
+        blobAdminClient.createBlobTable("blobs", indexSettings).get();
         ensureGreen();
 
         execute("select schema_name, table_name from sys.shards where table_name = 'blobs'");

--- a/sql/src/test/java/io/crate/integrationtests/SysShardsTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysShardsTest.java
@@ -22,7 +22,7 @@
 package io.crate.integrationtests;
 
 import io.crate.action.sql.SQLActionException;
-import io.crate.blob.v2.BlobIndicesService;
+import io.crate.blob.v2.BlobAdminClient;
 import io.crate.metadata.PartitionName;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.TestingHelpers;
@@ -51,12 +51,12 @@ public class SysShardsTest extends SQLTransportIntegrationTest {
         setup.groupBySetup();
         sqlExecutor.exec(
             "create table quotes (id integer primary key, quote string) with(number_of_replicas=1)");
-        BlobIndicesService blobIndicesService = internalCluster().getInstance(BlobIndicesService.class);
+        BlobAdminClient blobAdminClient = internalCluster().getInstance(BlobAdminClient.class);
         Settings indexSettings = Settings.builder()
             .put(IndexMetaData.SETTING_NUMBER_OF_REPLICAS, 1)
             .put(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 5)
             .build();
-        blobIndicesService.createBlobTable("blobs", indexSettings);
+        blobAdminClient.createBlobTable("blobs", indexSettings);
         sqlExecutor.ensureGreen();
     }
 


### PR DESCRIPTION
The BlobIndicesService should just be concerned with the life-cycle of
blob indices & shards. Nothing else.

`alterBlobTable`, `createBlobTable` and `dropBlobTable` fit better into
a dedicated `BlobAdminClient` class.

Similarly, the `fullIndexName`, `isBlobIndex` and `stripPrefix` methods
fit better into `BlobIndex`.