### PR TITLE
Fix memory leak caused by File#deleteOnExit

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed a memory leak that was caused by blob uploads.
+
  - Possibly BREAKING blob storage changes:
 
    - Changed blob storage to utilize all paths listed under `path.data`.

--- a/blob/src/main/java/io/crate/blob/BlobTransferStatus.java
+++ b/blob/src/main/java/io/crate/blob/BlobTransferStatus.java
@@ -22,9 +22,11 @@
 package io.crate.blob;
 
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.UUID;
 
-public class BlobTransferStatus {
+public class BlobTransferStatus implements Closeable {
 
     private final String index;
     private final UUID transferId;
@@ -46,5 +48,10 @@ public class BlobTransferStatus {
 
     public UUID transferId() {
         return transferId;
+    }
+
+    @Override
+    public void close() throws IOException {
+        digestBlob.close();
     }
 }

--- a/gradle/forbidden-signatures.txt
+++ b/gradle/forbidden-signatures.txt
@@ -1,0 +1,3 @@
+
+@defaultMessage File is added to a list in DeleteOnExitHook causing a memory leak since CrateDB is a long running process
+java.io.File#deleteOnExit()

--- a/gradle/javaModule.gradle
+++ b/gradle/javaModule.gradle
@@ -26,6 +26,7 @@ if (project.hasProperty('testLogging')) {
 
 forbiddenApisMain {
     bundledSignatures = ['jdk-unsafe', 'jdk-deprecated']
+    signaturesFiles = files('../gradle/forbidden-signatures.txt')
     ignoreFailures = false
 }
 


### PR DESCRIPTION
A temporary file is created for each blob that is uploaded. This
temporary file registered itself to the DeleteOnExitHook - but since
Crate is a long lived process this hook is never called and just keeps
growing.

To fix that the delete operation of the temporary files is now coupled
to the DigestBlob & TransferStatus instances.