### PR TITLE
Fix error handling to provide stack_trace via http

### DIFF
--- a/sql/src/main/java/io/crate/rest/action/RestResultSetReceiver.java
+++ b/sql/src/main/java/io/crate/rest/action/RestResultSetReceiver.java
@@ -36,6 +36,8 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.List;
 
+import static io.crate.exceptions.Exceptions.createSQLActionException;
+
 class RestResultSetReceiver extends BaseResultReceiver {
 
     private static final ESLogger LOGGER = Loggers.getLogger(RestResultSetReceiver.class);
@@ -92,7 +94,7 @@ class RestResultSetReceiver extends BaseResultReceiver {
     @Override
     public void fail(@Nonnull Throwable t) {
         try {
-            channel.sendResponse(new CrateThrowableRestResponse(channel, t));
+            channel.sendResponse(new CrateThrowableRestResponse(channel, createSQLActionException(t)));
         } catch (Throwable e) {
             LOGGER.error("failed to send failure response", e);
         } finally {

--- a/sql/src/test/java/io/crate/integrationtests/RestSQLActionIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/RestSQLActionIntegrationTest.java
@@ -80,4 +80,11 @@ public class RestSQLActionIntegrationTest extends SQLHttpIntegrationTest {
         assertThat(response.getStatusLine().getStatusCode(), is(404));
         assertThat(EntityUtils.toString(response.getEntity()), containsString("TableUnknownException"));
     }
+
+    @Test
+    public void testExecutionErrorContainsStackTrace() throws Exception {
+        CloseableHttpResponse resp = post("{\"stmt\": \"select 1 / 0\"}");
+        String bodyAsString = EntityUtils.toString(resp.getEntity());
+        assertThat(bodyAsString, containsString("DivideFunction.java"));
+    }
 }


### PR DESCRIPTION
With the removal of the transport protocol from the http layer
(e9d5f6e3) the exception handling got broken.

Even if a stacktrace was requested via `/_sql?error_trace` it wasn't
generated on runtime errors.