### PR TITLE
Upgraded elasticsearch to 2.4.2

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Upgraded Elasticsearch to 2.4.2
+
  - Fixed a memory leak that was caused by blob uploads.
 
  - Possibly BREAKING blob storage changes:

--- a/core/src/main/java/io/crate/Version.java
+++ b/core/src/main/java/io/crate/Version.java
@@ -39,7 +39,7 @@ public class Version {
 
 
     public static final boolean SNAPSHOT = true;
-    public static final Version CURRENT = new Version(580099, SNAPSHOT, org.elasticsearch.Version.V_2_4_1);
+    public static final Version CURRENT = new Version(580099, SNAPSHOT, org.elasticsearch.Version.V_2_4_2);
 
     static {
         // safe-guard that we don't release a version with DEBUG_MODE set to true

--- a/gradle/version.properties
+++ b/gradle/version.properties
@@ -1,7 +1,7 @@
-# crate deps not defined in ES
+# crate and components deps
 guava=18.0
-jodatime=2.9.4
 antlr=3.5.2
+jodatime=2.9.5
 commonscli=1.3.1
 commonsmath=3.6.1
 commonslang3=3.5
@@ -12,7 +12,7 @@ jacksonasl=1.9.13
 elasticsearchhadoop=2.4.0
 
 # ES deps
-elasticsearch=2.4.1
+elasticsearch=2.4.2
 lucene=5.5.2
 
 # ES optional


### PR DESCRIPTION
ran mvn install on the es upstream https://github.com/crate/elasticsearch/tree/v2.4.2_cherry
![image](https://cloud.githubusercontent.com/assets/7442373/20625549/4bf93cb0-b314-11e6-8daf-2c769fe110e8.png)
