### PR TITLE
Fix NPE in PutHeadChunkRunnable

### DIFF
--- a/blob/src/main/java/io/crate/blob/pending_transfer/PutHeadChunkRunnable.java
+++ b/blob/src/main/java/io/crate/blob/pending_transfer/PutHeadChunkRunnable.java
@@ -78,6 +78,9 @@ public class PutHeadChunkRunnable implements Runnable {
             File pendingFile;
             try {
                 pendingFile = digestBlob.file();
+                if (pendingFile == null) {
+                    pendingFile = digestBlob.getContainerFile();
+                }
                 fileInputStream = new FileInputStream(pendingFile);
             } catch (FileNotFoundException e) {
                 // this happens if the file has already been moved from tmpDirectory to containerDirectory


### PR DESCRIPTION
Uncovered by flaky RecoveryTests.
The NPE was caused by my changes in bcbd83c5a9e26f2b21d8821e1596277ca03c2ecb