### PR TITLE
implement kill() on PageDownstream

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed issue that caused join queries to get stuck when killed.
+
  - Improved error message if function is unsupported with `distinct`
 
  - Nested numeric factors do not require brackets any more;

--- a/sql/src/main/java/io/crate/jobs/PageDownstreamContext.java
+++ b/sql/src/main/java/io/crate/jobs/PageDownstreamContext.java
@@ -201,7 +201,9 @@ public class PageDownstreamContext extends AbstractExecutionSubContext implement
 
     @Override
     protected void innerKill(@Nonnull Throwable t) {
-        innerClose(t);
+        pageDownstream.kill(t);
+        future.bytesUsed(ramAccountingContext.totalBytes());
+        ramAccountingContext.close();
     }
 
     @Override

--- a/sql/src/main/java/io/crate/operation/PageDownstream.java
+++ b/sql/src/main/java/io/crate/operation/PageDownstream.java
@@ -39,4 +39,9 @@ public interface PageDownstream {
     void finish();
 
     void fail(Throwable t);
+
+    /**
+     * Kill an PageDownstream and stop execution.
+     */
+    void kill(Throwable t);
 }

--- a/sql/src/main/java/io/crate/operation/merge/IteratorPageDownstream.java
+++ b/sql/src/main/java/io/crate/operation/merge/IteratorPageDownstream.java
@@ -184,4 +184,9 @@ public class IteratorPageDownstream implements PageDownstream, ResumeHandle, Rep
             lastListener.finish();
         }
     }
+
+    @Override
+    public void kill(Throwable t) {
+        rowReceiver.kill(t);
+    }
 }

--- a/sql/src/test/java/io/crate/jobs/PageDownstreamContextTest.java
+++ b/sql/src/test/java/io/crate/jobs/PageDownstreamContextTest.java
@@ -101,6 +101,6 @@ public class PageDownstreamContextTest extends CrateUnitTest {
 
         ctx.kill(null);
         assertThat(throwable.get(), Matchers.instanceOf(InterruptedException.class));
-        verify(downstream, times(1)).fail(any(InterruptedException.class));
+        verify(downstream, times(1)).kill(any(InterruptedException.class));
     }
 }


### PR DESCRIPTION
fail() was mis-used for kill and the exception was
not forwarded to the row-receivers if the PageDownstream
was repeating. this is true for a valid fail, but not for kill.