### PR TITLE
Fix and NPE (CombinedRow.leftRow = null) that can occur in NestedLoopOperation

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed NPE that that can occur in join queries when left table
+   has no matching records.
+
  - Fixed issue that caused join queries to get stuck when killed.
 
  - Improved error message if function is unsupported with `distinct`


### PR DESCRIPTION
Fix and NPE (CombinedRow.leftRow = null) that can occur in NestedLoopOperation.RightRowReceiver
caused by CompositeCollector calling doCollect() even if a Result.STOP is received.