### PR TITLE
Decouple transport / nodeFetchOperation

### DIFF
--- a/sql/src/main/java/io/crate/executor/transport/TransportFetchNodeAction.java
+++ b/sql/src/main/java/io/crate/executor/transport/TransportFetchNodeAction.java
@@ -26,25 +26,15 @@ import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.crate.Streamer;
-import io.crate.breaker.CrateCircuitBreakerService;
-import io.crate.breaker.RamAccountingContext;
-import io.crate.exceptions.Exceptions;
-import io.crate.jobs.JobContextService;
-import io.crate.jobs.JobExecutionContext;
-import io.crate.operation.collect.StatsTables;
-import io.crate.operation.fetch.FetchContext;
 import io.crate.operation.fetch.NodeFetchOperation;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
-import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Locale;
 
 @Singleton
 public class TransportFetchNodeAction implements NodeAction<NodeFetchRequest, NodeFetchResponse> {
@@ -54,23 +44,14 @@ public class TransportFetchNodeAction implements NodeAction<NodeFetchRequest, No
     private static final String RESPONSE_EXECUTOR = ThreadPool.Names.SAME;
 
     private final Transports transports;
-    private final StatsTables statsTables;
     private final NodeFetchOperation nodeFetchOperation;
-    private final CircuitBreaker circuitBreaker;
-    private final JobContextService jobContextService;
 
     @Inject
     public TransportFetchNodeAction(TransportService transportService,
                                     Transports transports,
-                                    StatsTables statsTables,
-                                    CircuitBreakerService breakerService,
-                                    JobContextService jobContextService,
                                     NodeFetchOperation nodeFetchOperation) {
         this.transports = transports;
-        this.statsTables = statsTables;
         this.nodeFetchOperation = nodeFetchOperation;
-        this.circuitBreaker = breakerService.getBreaker(CrateCircuitBreakerService.QUERY);
-        this.jobContextService = jobContextService;
 
         transportService.registerRequestHandler(TRANSPORT_ACTION,
             NodeFetchRequest.class,
@@ -93,60 +74,23 @@ public class TransportFetchNodeAction implements NodeAction<NodeFetchRequest, No
 
     @Override
     public void nodeOperation(final NodeFetchRequest request,
-                              final ActionListener<NodeFetchResponse> fetchResponse) {
-
-        String ramAccountingContextId = String.format(Locale.ENGLISH, "%s: %d", request.jobId(), request.fetchPhaseId());
-        final RamAccountingContext ramAccountingContext = new RamAccountingContext(ramAccountingContextId, circuitBreaker);
-        try {
-            statsTables.operationStarted(request.fetchPhaseId(), request.jobId(), "fetch");
-
-            // nothing to fetch, just close
-            if (request.toFetch() == null && request.isCloseContext()) {
-                JobExecutionContext ctx = jobContextService.getContextOrNull(request.jobId());
-                if (ctx != null) {
-                    FetchContext fetchContext = ctx.getSubContextOrNull(request.fetchPhaseId());
-                    if (fetchContext != null) {
-                        fetchContext.close();
-                    }
-                }
-                fetchResponse.onResponse(NodeFetchResponse.EMPTY);
-                return;
+                              final ActionListener<NodeFetchResponse> responseListener) {
+        ListenableFuture<IntObjectMap<StreamBucket>> resultFuture = nodeFetchOperation.fetch(
+            request.jobId(),
+            request.fetchPhaseId(),
+            request.toFetch(),
+            request.isCloseContext()
+        );
+        Futures.addCallback(resultFuture, new FutureCallback<IntObjectMap<StreamBucket>>() {
+            @Override
+            public void onSuccess(@Nullable IntObjectMap<StreamBucket> result) {
+                responseListener.onResponse(NodeFetchResponse.forSending(result));
             }
 
-            JobExecutionContext jobExecutionContext = jobContextService.getContext(request.jobId());
-            final FetchContext fetchContext = jobExecutionContext.getSubContext(request.fetchPhaseId());
-
-            ListenableFuture<IntObjectMap<StreamBucket>> fetchedBucketFuture =
-                nodeFetchOperation.doFetch(fetchContext, request.toFetch());
-
-            Futures.addCallback(fetchedBucketFuture, new FutureCallback<IntObjectMap<StreamBucket>>() {
-                @Override
-                public void onSuccess(@Nullable IntObjectMap<StreamBucket> result) {
-                    assert result != null : "result of nodeFetchOperation.doFetch must not be null";
-                    NodeFetchResponse response = NodeFetchResponse.forSending(result);
-                    if (request.isCloseContext()) {
-                        fetchContext.close();
-                    }
-                    fetchResponse.onResponse(response);
-                    statsTables.operationFinished(request.fetchPhaseId(), request.jobId(), null,
-                        ramAccountingContext.totalBytes());
-                    ramAccountingContext.close();
-                }
-
-                @Override
-                public void onFailure(@Nonnull Throwable t) {
-                    fetchContext.kill(t);
-                    fetchResponse.onFailure(t);
-                    statsTables.operationFinished(request.fetchPhaseId(), request.jobId(), Exceptions.messageOf(t),
-                        ramAccountingContext.totalBytes());
-                    ramAccountingContext.close();
-                }
-            });
-        } catch (Throwable t) {
-            fetchResponse.onFailure(t);
-            statsTables.operationFinished(request.fetchPhaseId(), request.jobId(), Exceptions.messageOf(t),
-                ramAccountingContext.totalBytes());
-            ramAccountingContext.close();
-        }
+            @Override
+            public void onFailure(@Nonnull Throwable t) {
+                responseListener.onFailure(t);
+            }
+        });
     }
 }

--- a/sql/src/main/java/io/crate/operation/fetch/CloseContextCallback.java
+++ b/sql/src/main/java/io/crate/operation/fetch/CloseContextCallback.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.operation.fetch;
+
+import com.google.common.util.concurrent.FutureCallback;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+class CloseContextCallback implements FutureCallback<Object> {
+
+    private final FetchContext fetchContext;
+
+    CloseContextCallback(FetchContext fetchContext) {
+        this.fetchContext = fetchContext;
+    }
+
+    @Override
+    public void onSuccess(@Nullable Object result) {
+        fetchContext.close();
+    }
+
+    @Override
+    public void onFailure(@Nonnull Throwable t) {
+        fetchContext.kill(t);
+    }
+}

--- a/sql/src/main/java/io/crate/operation/fetch/NodeFetchOperation.java
+++ b/sql/src/main/java/io/crate/operation/fetch/NodeFetchOperation.java
@@ -25,14 +25,19 @@ import com.carrotsearch.hppc.IntContainer;
 import com.carrotsearch.hppc.IntObjectHashMap;
 import com.carrotsearch.hppc.IntObjectMap;
 import com.carrotsearch.hppc.cursors.IntObjectCursor;
+import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.crate.Streamer;
 import io.crate.analyze.symbol.Symbols;
+import io.crate.exceptions.Exceptions;
 import io.crate.executor.transport.StreamBucket;
+import io.crate.jobs.JobContextService;
+import io.crate.jobs.JobExecutionContext;
 import io.crate.metadata.Reference;
 import io.crate.metadata.TableIdent;
+import io.crate.operation.collect.StatsTables;
 import io.crate.operation.reference.doc.lucene.LuceneCollectorExpression;
 import io.crate.operation.reference.doc.lucene.LuceneReferenceResolver;
 import org.elasticsearch.common.inject.Inject;
@@ -41,11 +46,9 @@ import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.threadpool.ThreadPool;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -55,6 +58,8 @@ import java.util.concurrent.atomic.AtomicReference;
 public class NodeFetchOperation {
 
     private final Executor executor;
+    private final StatsTables statsTables;
+    private final JobContextService jobContextService;
 
     private static class TableFetchInfo {
 
@@ -87,8 +92,62 @@ public class NodeFetchOperation {
     }
 
     @Inject
-    public NodeFetchOperation(ThreadPool threadPool) {
+    public NodeFetchOperation(ThreadPool threadPool, StatsTables statsTables, JobContextService jobContextService) {
         executor = threadPool.executor(ThreadPool.Names.SEARCH);
+        this.statsTables = statsTables;
+        this.jobContextService = jobContextService;
+    }
+
+    public ListenableFuture<IntObjectMap<StreamBucket>> fetch(UUID jobId,
+                                                              int phaseId,
+                                                              @Nullable IntObjectMap<? extends IntContainer> docIdsToFetch,
+                                                              boolean closeContextOnFinish) {
+        SettableFuture<IntObjectMap<StreamBucket>> resultFuture = SettableFuture.create();
+        logStartAndSetupLogFinished(jobId, phaseId, resultFuture);
+
+        if (docIdsToFetch == null) {
+            if (closeContextOnFinish) {
+                tryCloseContext(jobId, phaseId);
+            }
+            return Futures.immediateFuture(new IntObjectHashMap<>(0));
+        }
+
+        JobExecutionContext context = jobContextService.getContext(jobId);
+        FetchContext fetchContext = context.getSubContext(phaseId);
+        if (closeContextOnFinish) {
+            Futures.addCallback(resultFuture, new CloseContextCallback(fetchContext));
+        }
+        try {
+            doFetch(fetchContext, resultFuture, docIdsToFetch);
+        } catch (Throwable t) {
+            resultFuture.setException(t);
+        }
+        return resultFuture;
+    }
+
+    private void logStartAndSetupLogFinished(final UUID jobId, final int phaseId, ListenableFuture<?> resultFuture) {
+        statsTables.operationStarted(phaseId, jobId, "fetch");
+        Futures.addCallback(resultFuture, new FutureCallback<Object>() {
+        @Override
+            public void onSuccess(@Nullable Object result) {
+                statsTables.operationFinished(phaseId, jobId, null, 0);
+            }
+
+            @Override
+            public void onFailure(@Nonnull Throwable t) {
+                statsTables.operationFinished(phaseId, jobId, Exceptions.messageOf(t), 0);
+            }
+        });
+    }
+
+    private void tryCloseContext(UUID jobId, int phaseId) {
+        JobExecutionContext ctx = jobContextService.getContextOrNull(jobId);
+        if (ctx != null) {
+            FetchContext fetchContext = ctx.getSubContextOrNull(phaseId);
+            if (fetchContext != null) {
+                fetchContext.close();
+            }
+        }
     }
 
     private HashMap<TableIdent, TableFetchInfo> getTableFetchInfos(FetchContext fetchContext) {
@@ -100,18 +159,15 @@ public class NodeFetchOperation {
         return result;
     }
 
-    public ListenableFuture<IntObjectMap<StreamBucket>> doFetch(
-        final FetchContext fetchContext, @Nullable IntObjectMap<? extends IntContainer> toFetch) throws Exception {
-        if (toFetch == null) {
-            return Futures.<IntObjectMap<StreamBucket>>immediateFuture(new IntObjectHashMap<StreamBucket>(0));
-        }
+    private void doFetch(FetchContext fetchContext,
+                         SettableFuture<IntObjectMap<StreamBucket>> resultFuture,
+                         @Nullable IntObjectMap<? extends IntContainer> toFetch) throws Exception {
 
         final IntObjectHashMap<StreamBucket> fetched = new IntObjectHashMap<>(toFetch.size());
         HashMap<TableIdent, TableFetchInfo> tableFetchInfos = getTableFetchInfos(fetchContext);
         final AtomicReference<Throwable> lastThrowable = new AtomicReference<>(null);
         final AtomicInteger threadLatch = new AtomicInteger(toFetch.size());
 
-        final SettableFuture<IntObjectMap<StreamBucket>> resultFuture = SettableFuture.create();
         for (IntObjectCursor<? extends IntContainer> toFetchCursor : toFetch) {
             final int readerId = toFetchCursor.key;
             final IntContainer docIds = toFetchCursor.value;
@@ -135,7 +191,6 @@ public class NodeFetchOperation {
                 runnable.run();
             }
         }
-        return resultFuture;
     }
 
     private static class CollectRunnable implements Runnable {
@@ -184,4 +239,5 @@ public class NodeFetchOperation {
             }
         }
     }
+
 }


### PR DESCRIPTION
Moving some more logic into NodeFetchOperation so that
TransportFetchNodeAction is only a small wrapper doing networking.

This also removes the RamAccountingContext creation because it was
unused. (The `totalBytes()` call always returned 0 because there were no
`addBytes()` calls)