### PR TITLE
Handle FetchContext kill in NodeFetchOperation

### DIFF
--- a/sql/src/main/java/io/crate/operation/fetch/FetchContext.java
+++ b/sql/src/main/java/io/crate/operation/fetch/FetchContext.java
@@ -40,6 +40,7 @@ import org.elasticsearch.index.shard.ShardId;
 
 import javax.annotation.Nonnull;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class FetchContext extends AbstractExecutionSubContext {
 
@@ -52,6 +53,7 @@ public class FetchContext extends AbstractExecutionSubContext {
     private final TreeMap<Integer, TableIdent> tableIdents = new TreeMap<>();
     private final Iterable<? extends Routing> routingIterable;
     private final Map<TableIdent, Collection<Reference>> toFetch;
+    private final AtomicBoolean isKilled = new AtomicBoolean(false);
 
     public FetchContext(FetchPhase phase,
                         String localNodeId,
@@ -67,6 +69,10 @@ public class FetchContext extends AbstractExecutionSubContext {
 
     public Map<TableIdent, Collection<Reference>> toFetch() {
         return toFetch;
+    }
+
+    AtomicBoolean isKilled() {
+        return isKilled;
     }
 
     @Override
@@ -132,6 +138,11 @@ public class FetchContext extends AbstractExecutionSubContext {
             // the bases are fetched in the prepare phase therefore this context can be closed
             close();
         }
+    }
+
+    @Override
+    protected void innerKill(@Nonnull Throwable t) {
+        isKilled.set(true);
     }
 
     @Override


### PR DESCRIPTION
The fetch operation continued running if a FetchContext got killed.
This could cause exceptions as the underlying reader might no longer be
valid once the reader is being released due to the kill.