### PR TITLE
Remove readFrom from Projection

### DIFF
--- a/sql/src/main/java/io/crate/analyze/symbol/Symbol.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/Symbol.java
@@ -21,7 +21,6 @@
 
 package io.crate.analyze.symbol;
 
-import io.crate.metadata.ReplacingSymbolVisitor;
 import io.crate.types.DataType;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;

--- a/sql/src/main/java/io/crate/planner/projection/AggregationProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/AggregationProjection.java
@@ -42,14 +42,13 @@ public class AggregationProjection extends Projection {
     private RowGranularity contextGranularity;
     private List<Aggregation> aggregations = ImmutableList.of();
 
-    public static final ProjectionFactory<AggregationProjection> FACTORY = new ProjectionFactory<AggregationProjection>() {
-        @Override
-        public AggregationProjection newInstance() {
-            return new AggregationProjection();
+    public AggregationProjection(StreamInput in) throws IOException {
+        int size = in.readVInt();
+        aggregations = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            aggregations.add((Aggregation) Symbols.fromStream(in));
         }
-    };
-
-    private AggregationProjection() {
+        contextGranularity = RowGranularity.fromStream(in);
     }
 
     public AggregationProjection(List<Aggregation> aggregations, RowGranularity contextGranularity) {
@@ -84,16 +83,6 @@ public class AggregationProjection extends Projection {
     @Override
     public List<? extends Symbol> outputs() {
         return aggregations;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        int size = in.readVInt();
-        aggregations = new ArrayList<>(size);
-        for (int i = 0; i < size; i++) {
-            aggregations.add((Aggregation) Symbols.fromStream(in));
-        }
-        contextGranularity = RowGranularity.fromStream(in);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/projection/ColumnIndexWriterProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/ColumnIndexWriterProjection.java
@@ -47,17 +47,6 @@ public class ColumnIndexWriterProjection extends AbstractIndexWriterProjection {
     @Nullable
     private Map<Reference, Symbol> onDuplicateKeyAssignments;
 
-    public static final ProjectionFactory<ColumnIndexWriterProjection> FACTORY =
-        new ProjectionFactory<ColumnIndexWriterProjection>() {
-            @Override
-            public ColumnIndexWriterProjection newInstance() {
-                return new ColumnIndexWriterProjection();
-            }
-        };
-
-    private ColumnIndexWriterProjection() {
-    }
-
     /**
      * @param tableIdent                identifying the table to write to
      * @param columns                   the columnReferences of all the columns to be written in order of appearance
@@ -92,6 +81,29 @@ public class ColumnIndexWriterProjection extends AbstractIndexWriterProjection {
                 columnReferences.remove(i);
             } else {
                 this.columnSymbols.add(new InputColumn(i, ref.valueType()));
+            }
+        }
+    }
+
+    ColumnIndexWriterProjection(StreamInput in) throws IOException {
+        super(in);
+
+        if (in.readBoolean()) {
+            columnSymbols = Symbols.listFromStream(in);
+        }
+        if (in.readBoolean()) {
+            int length = in.readVInt();
+            columnReferences = new ArrayList<>(length);
+            for (int i = 0; i < length; i++) {
+                columnReferences.add(Reference.fromStream(in));
+            }
+        }
+
+        if (in.readBoolean()) {
+            int mapSize = in.readVInt();
+            onDuplicateKeyAssignments = new HashMap<>(mapSize);
+            for (int i = 0; i < mapSize; i++) {
+                onDuplicateKeyAssignments.put(Reference.fromStream(in), Symbols.fromStream(in));
             }
         }
     }
@@ -151,30 +163,6 @@ public class ColumnIndexWriterProjection extends AbstractIndexWriterProjection {
         result = 31 * result + columnReferences.hashCode();
         result = 31 * result + (onDuplicateKeyAssignments != null ? onDuplicateKeyAssignments.hashCode() : 0);
         return result;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-
-        if (in.readBoolean()) {
-            columnSymbols = Symbols.listFromStream(in);
-        }
-        if (in.readBoolean()) {
-            int length = in.readVInt();
-            columnReferences = new ArrayList<>(length);
-            for (int i = 0; i < length; i++) {
-                columnReferences.add(Reference.fromStream(in));
-            }
-        }
-
-        if (in.readBoolean()) {
-            int mapSize = in.readVInt();
-            onDuplicateKeyAssignments = new HashMap<>(mapSize);
-            for (int i = 0; i < mapSize; i++) {
-                onDuplicateKeyAssignments.put(Reference.fromStream(in), Symbols.fromStream(in));
-            }
-        }
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/projection/DMLProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/DMLProjection.java
@@ -37,17 +37,18 @@ import java.util.List;
 
 public abstract class DMLProjection extends Projection {
 
-    protected final static List<Symbol> OUTPUTS = ImmutableList.<Symbol>of(
+    private final static List<Symbol> OUTPUTS = ImmutableList.<Symbol>of(
         new Value(DataTypes.LONG)  // number of rows updated
     );
 
-    protected Symbol uidSymbol;
+    Symbol uidSymbol;
 
-    public DMLProjection(Symbol uidSymbol) {
+    DMLProjection(Symbol uidSymbol) {
         this.uidSymbol = uidSymbol;
     }
 
-    public DMLProjection() {
+    DMLProjection(StreamInput in) throws IOException {
+        uidSymbol = Symbols.fromStream(in);
     }
 
     @Override
@@ -70,11 +71,6 @@ public abstract class DMLProjection extends Projection {
     @Override
     public int hashCode() {
         return Objects.hashCode(super.hashCode(), uidSymbol);
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        uidSymbol = Symbols.fromStream(in);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/projection/DeleteProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/DeleteProjection.java
@@ -24,21 +24,18 @@ package io.crate.planner.projection;
 
 import com.google.common.base.Function;
 import io.crate.analyze.symbol.Symbol;
+import org.elasticsearch.common.io.stream.StreamInput;
+
+import java.io.IOException;
 
 public class DeleteProjection extends DMLProjection {
-
-    public static final ProjectionFactory<DeleteProjection> FACTORY = new ProjectionFactory<DeleteProjection>() {
-        @Override
-        public DeleteProjection newInstance() {
-            return new DeleteProjection();
-        }
-    };
 
     public DeleteProjection(Symbol uidSymbol) {
         super(uidSymbol);
     }
 
-    public DeleteProjection() {
+    DeleteProjection(StreamInput in) throws IOException {
+        super(in);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/projection/FetchProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/FetchProjection.java
@@ -27,7 +27,6 @@ import io.crate.analyze.symbol.Symbol;
 import io.crate.collections.Lists2;
 import io.crate.metadata.TableIdent;
 import io.crate.planner.node.fetch.FetchSource;
-import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
@@ -120,11 +119,6 @@ public class FetchProjection extends Projection {
     @Override
     public int hashCode() {
         return collectPhaseId;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/projection/FilterProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/FilterProjection.java
@@ -36,19 +36,9 @@ import java.util.Objects;
 
 public class FilterProjection extends Projection {
 
-    public static final ProjectionFactory<FilterProjection> FACTORY = new ProjectionFactory<FilterProjection>() {
-        @Override
-        public FilterProjection newInstance() {
-            return new FilterProjection();
-        }
-    };
-
     private Symbol query;
     private List<Symbol> outputs = ImmutableList.of();
     private RowGranularity requiredGranularity = RowGranularity.CLUSTER;
-
-    public FilterProjection() {
-    }
 
     @Override
     public RowGranularity requiredGranularity() {
@@ -74,9 +64,10 @@ public class FilterProjection extends Projection {
         this.query = query;
     }
 
-
-    public void query(Symbol query) {
-        this.query = query;
+    public FilterProjection(StreamInput in) throws IOException {
+        query = Symbols.fromStream(in);
+        outputs = Symbols.listFromStream(in);
+        requiredGranularity = RowGranularity.fromStream(in);
     }
 
     public Symbol query() {
@@ -110,13 +101,6 @@ public class FilterProjection extends Projection {
         FilterProjection that = (FilterProjection) o;
 
         return Objects.equals(query, that.query);
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        query = Symbols.fromStream(in);
-        outputs = Symbols.listFromStream(in);
-        requiredGranularity = RowGranularity.fromStream(in);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/projection/GroupProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/GroupProjection.java
@@ -42,20 +42,20 @@ public class GroupProjection extends Projection {
 
     private RowGranularity requiredGranularity = RowGranularity.CLUSTER;
 
-    public static final ProjectionFactory<GroupProjection> FACTORY = new ProjectionFactory<GroupProjection>() {
-        @Override
-        public GroupProjection newInstance() {
-            return new GroupProjection();
-        }
-    };
-
-    private GroupProjection() {
-    }
-
     public GroupProjection(List<Symbol> keys, List<Aggregation> values, RowGranularity requiredGranularity) {
         this.keys = keys;
         this.values = values;
         this.requiredGranularity = requiredGranularity;
+    }
+
+    public GroupProjection(StreamInput in) throws IOException {
+        keys = Symbols.listFromStream(in);
+        int size = in.readVInt();
+        values = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            values.add((Aggregation) Symbols.fromStream(in));
+        }
+        requiredGranularity = RowGranularity.fromStream(in);
     }
 
     @Override
@@ -94,17 +94,6 @@ public class GroupProjection extends Projection {
             outputs.addAll(values);
         }
         return outputs;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        keys = Symbols.listFromStream(in);
-        int size = in.readVInt();
-        values = new ArrayList<>(size);
-        for (int i = 0; i < size; i++) {
-            values.add((Aggregation) Symbols.fromStream(in));
-        }
-        requiredGranularity = RowGranularity.fromStream(in);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/projection/MergeCountProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/MergeCountProjection.java
@@ -28,7 +28,6 @@ import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.Value;
 import io.crate.metadata.RowGranularity;
 import io.crate.types.DataTypes;
-import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
@@ -38,14 +37,7 @@ public class MergeCountProjection extends Projection {
 
     public static final MergeCountProjection INSTANCE = new MergeCountProjection();
 
-    public static final ProjectionFactory<MergeCountProjection> FACTORY = new ProjectionFactory<MergeCountProjection>() {
-        @Override
-        public MergeCountProjection newInstance() {
-            return INSTANCE;
-        }
-    };
-
-    protected final static List<Symbol> OUTPUTS = ImmutableList.<Symbol>of(
+    private final static List<Symbol> OUTPUTS = ImmutableList.<Symbol>of(
         new Value(DataTypes.LONG)  // number of rows updated
     );
 
@@ -62,9 +54,6 @@ public class MergeCountProjection extends Projection {
         return this == o;
     }
 
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-    }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {

--- a/sql/src/main/java/io/crate/planner/projection/Projection.java
+++ b/sql/src/main/java/io/crate/planner/projection/Projection.java
@@ -28,13 +28,12 @@ import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.RowGranularity;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.List;
 
-public abstract class Projection implements Streamable {
+public abstract class Projection {
 
     public static final Predicate<Projection> IS_SHARD_PROJECTION = new Predicate<Projection>() {
         @Override
@@ -61,7 +60,7 @@ public abstract class Projection implements Streamable {
     public abstract void replaceSymbols(Function<Symbol, Symbol> replaceFunction);
 
     public interface ProjectionFactory<T extends Projection> {
-        T newInstance();
+        T newInstance(StreamInput in) throws IOException;
     }
 
     public abstract ProjectionType projectionType();
@@ -76,11 +75,10 @@ public abstract class Projection implements Streamable {
     }
 
     public static Projection fromStream(StreamInput in) throws IOException {
-        Projection projection = ProjectionType.values()[in.readVInt()].newInstance();
-        projection.readFrom(in);
-
-        return projection;
+        return ProjectionType.values()[in.readVInt()].newInstance(in);
     }
+
+    public abstract void writeTo(StreamOutput out) throws IOException;
 
     // force subclasses to implement equality
     @Override

--- a/sql/src/main/java/io/crate/planner/projection/ProjectionType.java
+++ b/sql/src/main/java/io/crate/planner/projection/ProjectionType.java
@@ -21,19 +21,23 @@
 
 package io.crate.planner.projection;
 
+import org.elasticsearch.common.io.stream.StreamInput;
+
+import java.io.IOException;
+
 public enum ProjectionType {
 
-    TOPN(TopNProjection.FACTORY),
-    GROUP(GroupProjection.FACTORY),
-    AGGREGATION(AggregationProjection.FACTORY),
-    MERGE_COUNT_AGGREGATION(MergeCountProjection.FACTORY),
-    FILTER(FilterProjection.FACTORY),
-    WRITER(WriterProjection.FACTORY),
-    INDEX_WRITER(SourceIndexWriterProjection.FACTORY),
-    COLUMN_INDEX_WRITER(ColumnIndexWriterProjection.FACTORY),
-    UPDATE(UpdateProjection.FACTORY),
-    SYS_UPDATE(SysUpdateProjection.FACTORY),
-    DELETE(DeleteProjection.FACTORY),
+    TOPN(TopNProjection::new),
+    GROUP(GroupProjection::new),
+    AGGREGATION(AggregationProjection::new),
+    MERGE_COUNT_AGGREGATION(i -> MergeCountProjection.INSTANCE),
+    FILTER(FilterProjection::new),
+    WRITER(WriterProjection::new),
+    INDEX_WRITER(SourceIndexWriterProjection::new),
+    COLUMN_INDEX_WRITER(ColumnIndexWriterProjection::new),
+    UPDATE(UpdateProjection::new),
+    SYS_UPDATE(SysUpdateProjection::new),
+    DELETE(DeleteProjection::new),
     FETCH(null);
 
     private final Projection.ProjectionFactory factory;
@@ -42,8 +46,7 @@ public enum ProjectionType {
         this.factory = factory;
     }
 
-    public Projection newInstance() {
-        return factory.newInstance();
+    public Projection newInstance(StreamInput in) throws IOException {
+        return factory.newInstance(in);
     }
-
 }

--- a/sql/src/main/java/io/crate/planner/projection/SourceIndexWriterProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/SourceIndexWriterProjection.java
@@ -62,17 +62,6 @@ public class SourceIndexWriterProjection extends AbstractIndexWriterProjection {
     private final static String OVERWRITE_DUPLICATES = "overwrite_duplicates";
     private final static boolean OVERWRITE_DUPLICATES_DEFAULT = false;
 
-    public static final ProjectionFactory<SourceIndexWriterProjection> FACTORY =
-        new ProjectionFactory<SourceIndexWriterProjection>() {
-            @Override
-            public SourceIndexWriterProjection newInstance() {
-                return new SourceIndexWriterProjection();
-            }
-        };
-
-    protected SourceIndexWriterProjection() {
-    }
-
     public SourceIndexWriterProjection(TableIdent tableIdent,
                                        @Nullable String partitionIdent,
                                        Reference rawSourceReference,
@@ -140,6 +129,29 @@ public class SourceIndexWriterProjection extends AbstractIndexWriterProjection {
         rawSourceSymbol = new InputColumn(currentInputIndex, DataTypes.STRING);
     }
 
+    public SourceIndexWriterProjection(StreamInput in) throws IOException {
+        super(in);
+        overwriteDuplicates = in.readBoolean();
+        rawSourceReference = Reference.fromStream(in);
+        rawSourceSymbol = (InputColumn) Symbols.fromStream(in);
+
+
+        if (in.readBoolean()) {
+            int length = in.readVInt();
+            includes = new String[length];
+            for (int i = 0; i < length; i++) {
+                includes[i] = in.readString();
+            }
+        }
+        if (in.readBoolean()) {
+            int length = in.readVInt();
+            excludes = new String[length];
+            for (int i = 0; i < length; i++) {
+                excludes[i] = in.readString();
+            }
+        }
+    }
+
     @Override
     public <C, R> R accept(ProjectionVisitor<C, R> visitor, C context) {
         return visitor.visitSourceIndexWriterProjection(this, context);
@@ -192,30 +204,6 @@ public class SourceIndexWriterProjection extends AbstractIndexWriterProjection {
         result = 31 * result + (excludes != null ? Arrays.hashCode(excludes) : 0);
         result = 31 * result + rawSourceSymbol.hashCode();
         return result;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        overwriteDuplicates = in.readBoolean();
-        rawSourceReference = Reference.fromStream(in);
-        rawSourceSymbol = (InputColumn) Symbols.fromStream(in);
-
-
-        if (in.readBoolean()) {
-            int length = in.readVInt();
-            includes = new String[length];
-            for (int i = 0; i < length; i++) {
-                includes[i] = in.readString();
-            }
-        }
-        if (in.readBoolean()) {
-            int length = in.readVInt();
-            excludes = new String[length];
-            for (int i = 0; i < length; i++) {
-                excludes[i] = in.readString();
-            }
-        }
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/projection/SysUpdateProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/SysUpdateProjection.java
@@ -36,21 +36,20 @@ import java.util.*;
 
 public class SysUpdateProjection extends Projection {
 
-    public static final ProjectionFactory<SysUpdateProjection> FACTORY = new ProjectionFactory<SysUpdateProjection>() {
-        @Override
-        public SysUpdateProjection newInstance() {
-            return new SysUpdateProjection();
-        }
-    };
     private static final List<Value> OUTPUTS = Collections.singletonList(new Value(DataTypes.LONG));
 
     private Map<Reference, Symbol> assignments;
 
-    private SysUpdateProjection() {
-    }
-
     public SysUpdateProjection(Map<Reference, Symbol> assignments) {
         this.assignments = assignments;
+    }
+
+    public SysUpdateProjection(StreamInput in) throws IOException {
+        int numAssignments = in.readVInt();
+        assignments = new HashMap<>(numAssignments, 1.0f);
+        for (int i = 0; i < numAssignments; i++) {
+            assignments.put(Reference.fromStream(in), Symbols.fromStream(in));
+        }
     }
 
     @Override
@@ -80,15 +79,6 @@ public class SysUpdateProjection extends Projection {
 
     public Map<Reference, Symbol> assignments() {
         return assignments;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        int numAssignments = in.readVInt();
-        assignments = new HashMap<>(numAssignments, 1.0f);
-        for (int i = 0; i < numAssignments; i++) {
-            assignments.put(Reference.fromStream(in), Symbols.fromStream(in));
-        }
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/projection/UpdateProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/UpdateProjection.java
@@ -33,13 +33,6 @@ import java.util.Arrays;
 
 public class UpdateProjection extends DMLProjection {
 
-    public static final ProjectionFactory<UpdateProjection> FACTORY = new ProjectionFactory<UpdateProjection>() {
-        @Override
-        public UpdateProjection newInstance() {
-            return new UpdateProjection();
-        }
-    };
-
     private Symbol[] assignments;
     // All values of this list are expected to be a FQN columnIdent.
     private String[] assignmentsColumns;
@@ -56,7 +49,22 @@ public class UpdateProjection extends DMLProjection {
         this.requiredVersion = requiredVersion;
     }
 
-    public UpdateProjection() {
+    public UpdateProjection(StreamInput in) throws IOException {
+        super(in);
+        int assignmentColumnsSize = in.readVInt();
+        assignmentsColumns = new String[assignmentColumnsSize];
+        for (int i = 0; i < assignmentColumnsSize; i++) {
+            assignmentsColumns[i] = in.readString();
+        }
+        int assignmentsSize = in.readVInt();
+        assignments = new Symbol[assignmentsSize];
+        for (int i = 0; i < assignmentsSize; i++) {
+            assignments[i] = Symbols.fromStream(in);
+        }
+        requiredVersion = in.readVLong();
+        if (requiredVersion == 0) {
+            requiredVersion = null;
+        }
     }
 
     public String[] assignmentsColumns() {
@@ -116,24 +124,6 @@ public class UpdateProjection extends DMLProjection {
         return result;
     }
 
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        int assignmentColumnsSize = in.readVInt();
-        assignmentsColumns = new String[assignmentColumnsSize];
-        for (int i = 0; i < assignmentColumnsSize; i++) {
-            assignmentsColumns[i] = in.readString();
-        }
-        int assignmentsSize = in.readVInt();
-        assignments = new Symbol[assignmentsSize];
-        for (int i = 0; i < assignmentsSize; i++) {
-            assignments[i] = Symbols.fromStream(in);
-        }
-        requiredVersion = in.readVLong();
-        if (requiredVersion == 0) {
-            requiredVersion = null;
-        }
-    }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {

--- a/sql/src/test/java/io/crate/planner/projection/FilterProjectionTest.java
+++ b/sql/src/test/java/io/crate/planner/projection/FilterProjectionTest.java
@@ -38,10 +38,11 @@ public class FilterProjectionTest extends CrateUnitTest {
     public void testStreaming() throws Exception {
         SqlExpressions sqlExpressions = new SqlExpressions(T3.SOURCES, T3.TR_1);
 
-        FilterProjection p = new FilterProjection();
-        p.outputs(ImmutableList.<Symbol>of(new InputColumn(1)));
+        FilterProjection p = new FilterProjection(
+            sqlExpressions.normalize(sqlExpressions.asSymbol("a = 'foo'")),
+            ImmutableList.<Symbol>of(new InputColumn(1))
+        );
         p.requiredGranularity(RowGranularity.SHARD);
-        p.query(sqlExpressions.normalize(sqlExpressions.asSymbol("a = 'foo'")));
 
         BytesStreamOutput out = new BytesStreamOutput();
         Projection.toStream(p, out);


### PR DESCRIPTION
In order to enforce proper initialization of projections.
Some of them exposed a public empty constructor which could be used to
create invalid projections.