### PR TITLE
Split TopNProjection into TopN and OrderedTopN

### DIFF
--- a/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
@@ -39,7 +39,6 @@ import io.crate.planner.node.dql.join.NestedLoop;
 import io.crate.planner.node.dql.join.NestedLoopPhase;
 import io.crate.planner.projection.FilterProjection;
 import io.crate.planner.projection.Projection;
-import io.crate.planner.projection.TopNProjection;
 import io.crate.planner.projection.builder.InputCreatingVisitor;
 import io.crate.planner.projection.builder.ProjectionBuilder;
 import io.crate.sql.tree.QualifiedName;
@@ -265,7 +264,7 @@ class NestedLoopConsumer implements Consumer {
             }
 
             int limit = isDistributed ? limits.limitAndOffset() : limits.finalLimit();
-            TopNProjection topN = ProjectionBuilder.topNProjection(
+            Projection topN = ProjectionBuilder.topNProjection(
                 nlOutputs,
                 orderBy,
                 isDistributed ? 0 : limits.offset(),

--- a/sql/src/main/java/io/crate/planner/projection/OrderedTopNProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/OrderedTopNProjection.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.projection;
+
+import com.google.common.base.Function;
+import io.crate.analyze.symbol.Symbol;
+import io.crate.analyze.symbol.Symbols;
+import io.crate.collections.Lists2;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class OrderedTopNProjection extends Projection {
+
+    private final int limit;
+    private final int offset;
+    private final List<Symbol> outputs;
+    private final List<Symbol> orderBy;
+    private final boolean[] reverseFlags;
+    private final Boolean[] nullsFirst;
+
+    public OrderedTopNProjection(int limit,
+                                 int offset,
+                                 List<Symbol> outputs,
+                                 List<Symbol> orderBy,
+                                 boolean[] reverseFlags,
+                                 Boolean[] nullsFirst) {
+        assert orderBy.size() == reverseFlags.length : "reverse flags length does not match orderBy items count";
+        assert orderBy.size() == nullsFirst.length : "nullsFirst length does not match orderBy items count";
+
+        this.limit = limit;
+        this.offset = offset;
+        this.outputs = outputs;
+        this.orderBy = orderBy;
+        this.reverseFlags = reverseFlags;
+        this.nullsFirst = nullsFirst;
+    }
+
+    public OrderedTopNProjection(StreamInput in) throws IOException {
+        limit = in.readVInt();
+        offset = in.readVInt();
+        outputs = Symbols.listFromStream(in);
+        int numOrderBy = in.readVInt();
+        if (numOrderBy == 0) {
+            orderBy = Collections.emptyList();
+            reverseFlags = new boolean[0];
+            nullsFirst = new Boolean[0];
+        } else {
+            orderBy = new ArrayList<>(numOrderBy);
+            reverseFlags = new boolean[numOrderBy];
+            nullsFirst = new Boolean[numOrderBy];
+            for (int i = 0; i < numOrderBy; i++) {
+                orderBy.add(Symbols.fromStream(in));
+                reverseFlags[i] = in.readBoolean();
+                nullsFirst[i] = in.readOptionalBoolean();
+            }
+        }
+    }
+
+    public List<Symbol> orderBy() {
+        return orderBy;
+    }
+
+    public int limit() {
+        return limit;
+    }
+
+    public int offset() {
+        return offset;
+    }
+
+    public boolean[] reverseFlags() {
+        return reverseFlags;
+    }
+
+    public Boolean[] nullsFirst() {
+        return nullsFirst;
+    }
+
+    @Override
+    public void replaceSymbols(Function<Symbol, Symbol> replaceFunction) {
+        Lists2.replaceItems(outputs, replaceFunction);
+        Lists2.replaceItems(orderBy, replaceFunction);
+    }
+
+    @Override
+    public ProjectionType projectionType() {
+        return ProjectionType.TOPN_ORDERED;
+    }
+
+    @Override
+    public <C, R> R accept(ProjectionVisitor<C, R> visitor, C context) {
+        return visitor.visitOrderedTopN(this, context);
+    }
+
+    @Override
+    public List<? extends Symbol> outputs() {
+        return outputs;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVInt(limit);
+        out.writeVInt(offset);
+        Symbols.toStream(outputs, out);
+        out.writeVInt(orderBy.size());
+        for (int i = 0; i < orderBy.size(); i++) {
+            Symbols.toStream(orderBy.get(i), out);
+            out.writeBoolean(reverseFlags[i]);
+            out.writeOptionalBoolean(nullsFirst[i]);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        OrderedTopNProjection that = (OrderedTopNProjection) o;
+
+        if (limit != that.limit) return false;
+        if (offset != that.offset) return false;
+        if (!outputs.equals(that.outputs)) return false;
+        if (!orderBy.equals(that.orderBy)) return false;
+        if (!Arrays.equals(reverseFlags, that.reverseFlags)) return false;
+        return Arrays.equals(nullsFirst, that.nullsFirst);
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + limit;
+        result = 31 * result + offset;
+        result = 31 * result + outputs.hashCode();
+        result = 31 * result + orderBy.hashCode();
+        result = 31 * result + Arrays.hashCode(reverseFlags);
+        result = 31 * result + Arrays.hashCode(nullsFirst);
+        return result;
+    }
+}

--- a/sql/src/main/java/io/crate/planner/projection/ProjectionType.java
+++ b/sql/src/main/java/io/crate/planner/projection/ProjectionType.java
@@ -38,7 +38,8 @@ public enum ProjectionType {
     UPDATE(UpdateProjection::new),
     SYS_UPDATE(SysUpdateProjection::new),
     DELETE(DeleteProjection::new),
-    FETCH(null);
+    FETCH(null),
+    TOPN_ORDERED(OrderedTopNProjection::new);
 
     private final Projection.ProjectionFactory factory;
 

--- a/sql/src/main/java/io/crate/planner/projection/ProjectionVisitor.java
+++ b/sql/src/main/java/io/crate/planner/projection/ProjectionVisitor.java
@@ -81,5 +81,9 @@ public class ProjectionVisitor<C, R> {
     public R visitSysUpdateProjection(SysUpdateProjection projection, C context) {
         return visitProjection(projection, context);
     }
+
+    public R visitOrderedTopN(OrderedTopNProjection orderedTopNProjection, C context) {
+        return visitProjection(orderedTopNProjection, context);
+    }
 }
 

--- a/sql/src/main/java/io/crate/planner/projection/builder/ProjectionBuilder.java
+++ b/sql/src/main/java/io/crate/planner/projection/builder/ProjectionBuilder.java
@@ -131,7 +131,7 @@ public class ProjectionBuilder {
         return new FilterProjection(query, outputs);
     }
 
-    public static TopNProjection topNProjection(
+    public static Projection topNProjection(
         Collection<? extends Symbol> inputs,
         @Nullable OrderBy orderBy,
         int offset,
@@ -147,16 +147,13 @@ public class ProjectionBuilder {
             outputsProcessed = inputVisitor.process(outputs, context);
         }
 
-        TopNProjection result;
         if (orderBy == null) {
-            result = new TopNProjection(limit, offset, outputsProcessed);
-        } else {
-            result = new TopNProjection(limit, offset, outputsProcessed,
-                inputVisitor.process(orderBy.orderBySymbols(), context),
-                orderBy.reverseFlags(),
-                orderBy.nullsFirst());
+            return new TopNProjection(limit, offset, outputsProcessed);
         }
-        return result;
+        return new OrderedTopNProjection(limit, offset, outputsProcessed,
+            inputVisitor.process(orderBy.orderBySymbols(), context),
+            orderBy.reverseFlags(),
+            orderBy.nullsFirst());
     }
 
     public static WriterProjection writerProjection(Collection<? extends Symbol> inputs,

--- a/sql/src/test/java/io/crate/operation/PageDownstreamFactoryTest.java
+++ b/sql/src/test/java/io/crate/operation/PageDownstreamFactoryTest.java
@@ -43,8 +43,8 @@ import io.crate.operation.projectors.TopN;
 import io.crate.planner.distribution.DistributionInfo;
 import io.crate.planner.node.dql.MergePhase;
 import io.crate.planner.projection.GroupProjection;
+import io.crate.planner.projection.OrderedTopNProjection;
 import io.crate.planner.projection.Projection;
-import io.crate.planner.projection.TopNProjection;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.testing.CollectingRowReceiver;
 import io.crate.types.DataType;
@@ -104,7 +104,7 @@ public class PageDownstreamFactoryTest extends CrateUnitTest {
 
     @Test
     public void testMergeSingleResult() throws Exception {
-        TopNProjection topNProjection = new TopNProjection(3, TopN.NO_OFFSET, InputColumn.numInputs(2),
+        OrderedTopNProjection topNProjection = new OrderedTopNProjection(3, TopN.NO_OFFSET, InputColumn.numInputs(2),
             Arrays.<Symbol>asList(new InputColumn(0)), new boolean[]{false}, new Boolean[]{null});
 
         MergePhase mergeNode = new MergePhase(

--- a/sql/src/test/java/io/crate/operation/projectors/ProjectionToProjectorVisitorTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/ProjectionToProjectorVisitorTest.java
@@ -34,10 +34,7 @@ import io.crate.operation.ImplementationSymbolVisitor;
 import io.crate.operation.aggregation.impl.AverageAggregation;
 import io.crate.operation.aggregation.impl.CountAggregation;
 import io.crate.operation.operator.EqOperator;
-import io.crate.planner.projection.AggregationProjection;
-import io.crate.planner.projection.FilterProjection;
-import io.crate.planner.projection.GroupProjection;
-import io.crate.planner.projection.TopNProjection;
+import io.crate.planner.projection.*;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.testing.CollectingRowReceiver;
 import io.crate.testing.RowSender;
@@ -137,7 +134,7 @@ public class ProjectionToProjectorVisitorTest extends CrateUnitTest {
     @Test
     public void testSortingTopNProjection() throws Exception {
         List<Symbol> outputs = Arrays.<Symbol>asList(Literal.of("foo"), new InputColumn(0), new InputColumn(1));
-        TopNProjection projection = new TopNProjection(10, 0, outputs,
+        OrderedTopNProjection projection = new OrderedTopNProjection(10, 0, outputs,
             Arrays.<Symbol>asList(new InputColumn(0), new InputColumn(1)),
             new boolean[]{false, false},
             new Boolean[]{null, null}
@@ -149,7 +146,7 @@ public class ProjectionToProjectorVisitorTest extends CrateUnitTest {
     @Test
     public void testTopNProjectionToSortingProjector() throws Exception {
         List<Symbol> outputs = Arrays.asList(Literal.of("foo"), new InputColumn(0), new InputColumn(1));
-        TopNProjection projection = new TopNProjection(TopN.NO_LIMIT, TopN.NO_OFFSET, outputs,
+        OrderedTopNProjection projection = new OrderedTopNProjection(TopN.NO_LIMIT, TopN.NO_OFFSET, outputs,
             Arrays.<Symbol>asList(new InputColumn(0), new InputColumn(1)),
             new boolean[]{false, false},
             new Boolean[]{null, null}
@@ -196,7 +193,7 @@ public class ProjectionToProjectorVisitorTest extends CrateUnitTest {
         List<Symbol> outputs = Arrays.<Symbol>asList(
             new InputColumn(0, DataTypes.STRING), new InputColumn(1, DataTypes.STRING),
             new InputColumn(2, DataTypes.DOUBLE), new InputColumn(3, DataTypes.LONG));
-        TopNProjection topNProjection = new TopNProjection(10, 0, outputs,
+        OrderedTopNProjection topNProjection = new OrderedTopNProjection(10, 0, outputs,
             ImmutableList.<Symbol>of(new InputColumn(2, DataTypes.DOUBLE)),
             new boolean[]{false},
             new Boolean[]{null});

--- a/sql/src/test/java/io/crate/planner/PlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/PlannerTest.java
@@ -152,7 +152,6 @@ public class PlannerTest extends AbstractPlannerTest {
         List<Projection> projections = collectPhase.projections();
         assertThat(projections.size(), is(1));
         assertThat(projections.get(0), instanceOf(TopNProjection.class));
-        assertThat(((TopNProjection) projections.get(0)).isOrdered(), is(false));
 
         MergePhase mergeNode = merge.mergePhase();
 
@@ -173,7 +172,6 @@ public class PlannerTest extends AbstractPlannerTest {
 
         TopNProjection topNProjection = (TopNProjection) collectPhase.projections().get(0);
         assertThat(topNProjection.limit(), is(10));
-        assertThat(topNProjection.isOrdered(), is(false));
 
         MergePhase mergePhase = merge.mergePhase();
         assertThat(mergePhase.outputTypes().size(), is(1));
@@ -221,7 +219,6 @@ public class PlannerTest extends AbstractPlannerTest {
         TopNProjection topN = (TopNProjection) mergeNode.projections().get(0);
         assertThat(topN.limit(), is(100_000));
         assertThat(topN.offset(), is(0));
-        assertNull(topN.orderBy());
 
         FetchProjection fetchProjection = (FetchProjection) mergeNode.projections().get(1);
 
@@ -238,7 +235,6 @@ public class PlannerTest extends AbstractPlannerTest {
         topN = (TopNProjection) mergeNode.projections().get(0);
         assertThat(topN.limit(), is(100_000));
         assertThat(topN.offset(), is(20));
-        assertNull(topN.orderBy());
 
         fetchProjection = (FetchProjection) mergeNode.projections().get(1);
     }

--- a/sql/src/test/java/io/crate/planner/consumer/NestedLoopConsumerTest.java
+++ b/sql/src/test/java/io/crate/planner/consumer/NestedLoopConsumerTest.java
@@ -39,10 +39,7 @@ import io.crate.planner.distribution.DistributionType;
 import io.crate.planner.node.dql.*;
 import io.crate.planner.node.dql.join.NestedLoop;
 import io.crate.planner.node.dql.join.NestedLoopPhase;
-import io.crate.planner.projection.AggregationProjection;
-import io.crate.planner.projection.FetchProjection;
-import io.crate.planner.projection.FilterProjection;
-import io.crate.planner.projection.TopNProjection;
+import io.crate.planner.projection.*;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.types.DataTypes;
@@ -295,7 +292,7 @@ public class NestedLoopConsumerTest extends CrateUnitTest {
     @Test
     public void testOrderByOnJoinCondition() throws Exception {
         NestedLoop nl = plan("select u1.name || u2.name from users u1, users u2 order by u1.name, u1.name || u2.name");
-        List<Symbol> orderBy = ((TopNProjection) nl.nestedLoopPhase().projections().get(0)).orderBy();
+        List<Symbol> orderBy = ((OrderedTopNProjection) nl.nestedLoopPhase().projections().get(0)).orderBy();
         assertThat(orderBy, notNullValue());
         assertThat(orderBy.size(), is(2));
         assertThat(orderBy.get(0), isInputColumn(0));

--- a/sql/src/test/java/io/crate/planner/projection/OrderedTopNProjectionTest.java
+++ b/sql/src/test/java/io/crate/planner/projection/OrderedTopNProjectionTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.projection;
+
+import io.crate.analyze.symbol.InputColumn;
+import io.crate.analyze.symbol.Literal;
+import io.crate.test.integration.CrateUnitTest;
+import io.crate.types.DataTypes;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class OrderedTopNProjectionTest extends CrateUnitTest {
+
+    @Test
+    public void testStreaming() throws Exception {
+        Projection p = new OrderedTopNProjection(
+            10,
+            20,
+            Collections.singletonList(Literal.of("foobar")),
+            Collections.singletonList(new InputColumn(0, DataTypes.STRING)),
+            new boolean[] { true },
+            new Boolean[] { null }
+        );
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        Projection.toStream(p, out);
+
+        StreamInput in = StreamInput.wrap(out.bytes());
+        Projection projection = Projection.fromStream(in);
+
+        assertThat(projection, equalTo(p));
+    }
+}

--- a/sql/src/test/java/io/crate/planner/projection/TopNProjectionTest.java
+++ b/sql/src/test/java/io/crate/planner/projection/TopNProjectionTest.java
@@ -30,19 +30,12 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.junit.Test;
 
-import static io.crate.testing.TestingHelpers.createReference;
-
 public class TopNProjectionTest extends CrateUnitTest {
 
     @Test
     public void testStreaming() throws Exception {
-
         ImmutableList<Symbol> outputs = ImmutableList.of(new Value(DataTypes.BOOLEAN), new Value(DataTypes.INTEGER));
-        TopNProjection p = new TopNProjection(5, 10, outputs,
-            ImmutableList.<Symbol>of(createReference("foo", DataTypes.BOOLEAN)),
-            new boolean[]{true},
-            new Boolean[]{null});
-
+        TopNProjection p = new TopNProjection(5, 10, outputs);
 
         BytesStreamOutput out = new BytesStreamOutput();
         Projection.toStream(p, out);


### PR DESCRIPTION
TopNProjection contained a broken equals function (could have led to
NPEs because of nullable orderBy related fields).

It should also make it easier to debug stuff as it is easier to see if a
TopNProjection contains ordering or not (when looking at a plan).