### PR TITLE
Fixed an issue with >=3 tables joins and limit applied before filtering

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed issue in joins with 3 or more tables where limit was applied
+   before `where` clause filtering which produced  wrong results.
+
  - Updated Crash to `0.20.0` which includes the following change:
 
     - Updated information_schema metadata queries to reflect the current state

--- a/sql/src/main/java/io/crate/planner/consumer/ManyTableConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/ManyTableConsumer.java
@@ -28,10 +28,7 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.*;
 import io.crate.analyze.*;
 import io.crate.analyze.relations.*;
-import io.crate.analyze.symbol.DefaultTraversalSymbolVisitor;
-import io.crate.analyze.symbol.Field;
-import io.crate.analyze.symbol.RelationColumn;
-import io.crate.analyze.symbol.Symbol;
+import io.crate.analyze.symbol.*;
 import io.crate.exceptions.ValidationException;
 import io.crate.metadata.ReplaceMode;
 import io.crate.metadata.ReplacingSymbolVisitor;
@@ -208,6 +205,7 @@ public class ManyTableConsumer implements Consumer {
         QuerySpec leftQuerySpec = leftSource.querySpec();
         Optional<RemainingOrderBy> remainingOrderBy = mss.remainingOrderBy();
         List<JoinPair> joinPairs = mss.joinPairs();
+        List<TwoTableJoin> twoTableJoinList = new ArrayList<>(orderedRelationNames.size());
 
         QualifiedName rightName;
         RelationSource rightSource;
@@ -269,11 +267,27 @@ public class ManyTableConsumer implements Consumer {
             leftQuerySpec = newQuerySpec.copyAndReplace(replaceFunction);
             leftRelation = join;
             leftName = join.name();
+            twoTableJoinList.add(join);
         }
         TwoTableJoin join = (TwoTableJoin) leftRelation;
         if (!splitQuery.isEmpty()) {
             join.querySpec().where(new WhereClause(AndOperator.join(splitQuery.values())));
         }
+
+        // Find the last join pair that contains a filtering
+        int index = 0;
+        for (int i = twoTableJoinList.size() - 1; i >=0; i--) {
+            index = i;
+            WhereClause where = twoTableJoinList.get(i).querySpec().where();
+            if (where.hasQuery() && !(where.query() instanceof Literal)) {
+                break;
+            }
+        }
+        // Remove limit from all join pairs before the last filtered one
+        for (int i = 0; i < index; i++) {
+            twoTableJoinList.get(i).querySpec().limit(Optional.absent());
+        }
+
         return join;
     }
 

--- a/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
@@ -378,5 +378,4 @@ class NestedLoopConsumer implements Consumer {
             throw new ValidationException("JOIN with sub queries is not supported");
         }
     }
-
 }


### PR DESCRIPTION
Fixed an issue with >=3 tables joins that implicit or explicit
limit was applied on join pairs before any subsequent filtering.