### PR TITLE
Add a EvalProjection

### DIFF
--- a/sql/src/main/java/io/crate/planner/consumer/CountConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/CountConsumer.java
@@ -41,7 +41,7 @@ import io.crate.planner.node.dql.CountPlan;
 import io.crate.planner.node.dql.MergePhase;
 import io.crate.planner.projection.MergeCountProjection;
 import io.crate.planner.projection.Projection;
-import io.crate.planner.projection.TopNProjection;
+import io.crate.planner.projection.builder.ProjectionBuilder;
 import io.crate.types.DataTypes;
 
 import java.util.Collections;
@@ -83,7 +83,7 @@ public class CountConsumer implements Consumer {
 
             List<Projection> projections;
             Limits limits = context.plannerContext().getLimits(querySpec);
-            TopNProjection topN = TopNProjection.createIfNeeded(
+            Projection topN = ProjectionBuilder.topNOrEvalIfNeeded(
                 limits.finalLimit(), limits.offset(), 1, Symbols.extractTypes(MergeCountProjection.INSTANCE.outputs()));
             if (topN == null) {
                 projections = Collections.singletonList(MergeCountProjection.INSTANCE);

--- a/sql/src/main/java/io/crate/planner/consumer/DistributedGroupByConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/DistributedGroupByConsumer.java
@@ -149,7 +149,7 @@ class DistributedGroupByConsumer implements Consumer {
             } else {
                 topNOutputs = querySpec.outputs();
             }
-            reducerProjections.add(ProjectionBuilder.topNProjection(
+            reducerProjections.add(ProjectionBuilder.topNOrEval(
                 collectOutputs,
                 optOrderBy.orNull(),
                 0,

--- a/sql/src/main/java/io/crate/planner/consumer/GlobalAggregateConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/GlobalAggregateConsumer.java
@@ -131,8 +131,8 @@ class GlobalAggregateConsumer implements Consumer {
             postAggregationProjections.add(ProjectionBuilder.filterProjection(splitPoints.aggregates(), having.get()));
         }
         Limits limits = plannerContext.getLimits(qs);
-        // topN is used even if there is no limit because outptus might contain scalars which need to be executed
-        postAggregationProjections.add(ProjectionBuilder.topNProjection(
+        // topN is used even if there is no limit because outputs might contain scalars which need to be executed
+        postAggregationProjections.add(ProjectionBuilder.topNOrEval(
             splitPoints.aggregates(), null, limits.offset(), limits.finalLimit(), qs.outputs()));
         return postAggregationProjections;
     }

--- a/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
@@ -264,7 +264,7 @@ class NestedLoopConsumer implements Consumer {
             }
 
             int limit = isDistributed ? limits.limitAndOffset() : limits.finalLimit();
-            Projection topN = ProjectionBuilder.topNProjection(
+            Projection topN = ProjectionBuilder.topNOrEval(
                 nlOutputs,
                 orderBy,
                 isDistributed ? 0 : limits.offset(),

--- a/sql/src/main/java/io/crate/planner/consumer/NonDistributedGroupByConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/NonDistributedGroupByConsumer.java
@@ -161,7 +161,7 @@ class NonDistributedGroupByConsumer implements Consumer {
             }
             Limits limits = context.plannerContext().getLimits(querySpec);
             List<Symbol> qsOutputs = querySpec.outputs();
-            mergeProjections.add(ProjectionBuilder.topNProjection(
+            mergeProjections.add(ProjectionBuilder.topNOrEval(
                 collectOutputs,
                 querySpec.orderBy().orNull(),
                 limits.offset(),

--- a/sql/src/main/java/io/crate/planner/consumer/ReduceOnCollectorGroupByConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/ReduceOnCollectorGroupByConsumer.java
@@ -140,7 +140,7 @@ class ReduceOnCollectorGroupByConsumer implements Consumer {
             OrderBy orderBy = querySpec.orderBy().orNull();
             Limits limits = context.plannerContext().getLimits(querySpec);
             List<Symbol> qsOutputs = querySpec.outputs();
-            projections.add(ProjectionBuilder.topNProjection(
+            projections.add(ProjectionBuilder.topNOrEval(
                 collectOutputs,
                 orderBy,
                 0, // no offset

--- a/sql/src/main/java/io/crate/planner/projection/EvalProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/EvalProjection.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.projection;
+
+import com.google.common.base.Function;
+import io.crate.analyze.symbol.Symbol;
+import io.crate.analyze.symbol.Symbols;
+import io.crate.collections.Lists2;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Projection which can evaluate functions or re-order columns
+ */
+public class EvalProjection extends Projection {
+
+    private final List<Symbol> outputs;
+
+    public EvalProjection(List<Symbol> outputs) {
+        this.outputs = outputs;
+    }
+
+    public EvalProjection(StreamInput in) throws IOException {
+        this.outputs = Symbols.listFromStream(in);
+    }
+
+    @Override
+    public void replaceSymbols(Function<Symbol, Symbol> replaceFunction) {
+        Lists2.replaceItems(outputs, replaceFunction);
+    }
+
+    @Override
+    public ProjectionType projectionType() {
+        return ProjectionType.EVAL;
+    }
+
+    @Override
+    public <C, R> R accept(ProjectionVisitor<C, R> visitor, C context) {
+        return visitor.visitEvalProjection(this, context);
+    }
+
+    @Override
+    public List<? extends Symbol> outputs() {
+        return outputs;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        Symbols.toStream(outputs, out);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        EvalProjection that = (EvalProjection) o;
+
+        return outputs.equals(that.outputs);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + outputs.hashCode();
+        return result;
+    }
+}

--- a/sql/src/main/java/io/crate/planner/projection/ProjectionType.java
+++ b/sql/src/main/java/io/crate/planner/projection/ProjectionType.java
@@ -39,7 +39,8 @@ public enum ProjectionType {
     SYS_UPDATE(SysUpdateProjection::new),
     DELETE(DeleteProjection::new),
     FETCH(null),
-    TOPN_ORDERED(OrderedTopNProjection::new);
+    TOPN_ORDERED(OrderedTopNProjection::new),
+    EVAL(EvalProjection::new);
 
     private final Projection.ProjectionFactory factory;
 

--- a/sql/src/main/java/io/crate/planner/projection/ProjectionVisitor.java
+++ b/sql/src/main/java/io/crate/planner/projection/ProjectionVisitor.java
@@ -85,5 +85,9 @@ public class ProjectionVisitor<C, R> {
     public R visitOrderedTopN(OrderedTopNProjection orderedTopNProjection, C context) {
         return visitProjection(orderedTopNProjection, context);
     }
+
+    public R visitEvalProjection(EvalProjection evalProjection, C context) {
+        return visitProjection(evalProjection, context);
+    }
 }
 

--- a/sql/src/main/java/io/crate/planner/projection/TopNProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/TopNProjection.java
@@ -42,6 +42,8 @@ public class TopNProjection extends Projection {
     private final List<Symbol> outputs;
 
     public TopNProjection(int limit, int offset, List<Symbol> outputs) {
+        assert limit > TopN.NO_LIMIT : "limit of TopNProjection must not be negative/unlimited";
+
         this.limit = limit;
         this.offset = offset;
         this.outputs = outputs;
@@ -118,20 +120,4 @@ public class TopNProjection extends Projection {
                '}';
     }
 
-    @Nullable
-    public static TopNProjection createIfNeeded(Integer limit,
-                                                int offset,
-                                                int numOutputs,
-                                                List<DataType> inputTypes) {
-        if (limit == null) {
-            limit = TopN.NO_LIMIT;
-        }
-        if (limit == TopN.NO_LIMIT && offset == 0 && numOutputs >= inputTypes.size()) {
-            return null;
-        }
-        if (numOutputs < inputTypes.size()) {
-            inputTypes = inputTypes.subList(0, numOutputs);
-        }
-        return new TopNProjection(limit, offset, InputColumn.fromTypes(inputTypes));
-    }
 }


### PR DESCRIPTION
So far the TopNProjection was used to do column-re-ordering and
evaluation of functions.

This commit adds a separate EvalProjection to be more explicit.