### PR TITLE
Prevent remoteCollect usage if it's a fetch query

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,10 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed a rare race condition that could happen on select queries during a
+   shard relocation leading to a `ArrayIndexOutOfBoundsException` or a wrong
+   result.
+
  - Fix: Creating new partitions could have failed in case the partitioned table
   was created prior to CrateDB version ``0.55.0`` and the table contained a
   ``object`` column.


### PR DESCRIPTION
It's not possible to use RemoteCollect if it is query-then-fetch because
the remote node lacks the fetch-context, so the readerId doesn't exist
there and any docIds collected there are invalid.

In the initial commit where the remote collect functionality was added
(757ad56d7cd2b2b871f5e2761daad896d923ba42) the assumption was that the
creation of the FetchContext would fail, so the query would be aborted
and a global retry would be done. Seems like this is not
necessarily always the case.

`OuterJoinIntegrationTest.test3TableLeftOuterJoin` failed sometimes
because of this issue (Seed 7F98C30CDE8B1E09).
Sometimes with a wrong result (because the docId could randomly match a
real document). Sometimes with a ArrayIndexOutOfboundException (because
the readerIndex was invalid).