### PR TITLE
Move normalization logic into collect-sources

### DIFF
--- a/sql/src/test/java/io/crate/operation/collect/MapSideDataCollectOperationTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/MapSideDataCollectOperationTest.java
@@ -23,11 +23,11 @@ package io.crate.operation.collect;
 
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
-import io.crate.metadata.*;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.Functions;
 import io.crate.operation.collect.files.FileInputFactory;
 import io.crate.operation.collect.sources.CollectSourceResolver;
 import io.crate.operation.collect.sources.FileCollectSource;
-import io.crate.operation.reference.sys.node.local.NodeSysExpression;
 import io.crate.planner.node.dql.FileUriCollectPhase;
 import io.crate.planner.node.dql.RoutedCollectPhase;
 import io.crate.test.integration.CrateUnitTest;
@@ -72,19 +72,10 @@ public class MapSideDataCollectOperationTest extends CrateUnitTest {
     public void testFileUriCollect() throws Exception {
         ClusterService clusterService = new NoopClusterService();
         Functions functions = getFunctions();
-        NestedReferenceResolver referenceResolver = new NestedReferenceResolver() {
-            @Override
-            public ReferenceImplementation getImplementation(Reference referenceInfo) {
-                return null;
-            }
-        };
         CollectSourceResolver collectSourceResolver = mock(CollectSourceResolver.class);
         when(collectSourceResolver.getService(any(RoutedCollectPhase.class)))
             .thenReturn(new FileCollectSource(functions, clusterService, Collections.<String, FileInputFactory>emptyMap()));
         MapSideDataCollectOperation collectOperation = new MapSideDataCollectOperation(
-            functions,
-            referenceResolver,
-            mock(NodeSysExpression.class),
             collectSourceResolver,
             threadPool
         );


### PR DESCRIPTION
We always normalized multiple times:

 1. Once in the analyzer
 2. Once per collect-node on cluster level
 3. Once per collect-node on node level
 4. Once per shard per collect-node on shard level

2 and 3 were mostly done for historical reasons: Back when there were
"global" expressions like ``sys.cluster.name`` which could be used in
any context.

After this change there are two places where normalizations usually
happens:

 1. Once in the analyzer
 2. Once shortly before execution in the respective collect source