### PR TITLE
Fix EqualityExtractor to not extracts PKs if foreign functions are present

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed an issue that could lead to incorrect results if the WHERE clause
+   contains primary key comparisons together with other functions like match.
+
  - Fixed an issue that caused select queries with bulk arguments to hang
    instead of throwing the proper error.
 

--- a/sql/src/main/java/io/crate/analyze/where/EqualityExtractor.java
+++ b/sql/src/main/java/io/crate/analyze/where/EqualityExtractor.java
@@ -27,6 +27,7 @@ import io.crate.analyze.EvaluatingNormalizer;
 import io.crate.analyze.symbol.*;
 import io.crate.metadata.*;
 import io.crate.operation.operator.EqOperator;
+import io.crate.operation.operator.Operators;
 import io.crate.operation.operator.any.AnyEqOperator;
 import io.crate.types.CollectionType;
 import io.crate.types.DataType;
@@ -368,20 +369,23 @@ class EqualityExtractor {
                         return comparison.add(function);
                     }
                 }
+            } else if (Operators.LOGICAL_OPERATORS.contains(functionName)) {
+                boolean proxyBelowPre = context.proxyBelow;
+                boolean proxyBelowPost = proxyBelowPre;
+                ArrayList<Symbol> args = new ArrayList<>(function.arguments().size());
+                for (Symbol arg : function.arguments()) {
+                    context.proxyBelow = proxyBelowPre;
+                    args.add(process(arg, context));
+                    proxyBelowPost = context.proxyBelow || proxyBelowPost;
+                }
+                context.proxyBelow = proxyBelowPost;
+                if (!context.proxyBelow && function.valueType().equals(DataTypes.BOOLEAN)) {
+                    return Literal.BOOLEAN_TRUE;
+                }
+                return new Function(function.info(), args);
             }
-            boolean proxyBelowPre = context.proxyBelow;
-            boolean proxyBelowPost = proxyBelowPre;
-            ArrayList<Symbol> args = new ArrayList<>(function.arguments().size());
-            for (Symbol arg : function.arguments()) {
-                context.proxyBelow = proxyBelowPre;
-                args.add(process(arg, context));
-                proxyBelowPost = context.proxyBelow || proxyBelowPost;
-            }
-            context.proxyBelow = proxyBelowPost;
-            if (!context.proxyBelow && function.valueType().equals(DataTypes.BOOLEAN)) {
-                return Literal.BOOLEAN_TRUE;
-            }
-            return new Function(function.info(), args);
+            context.seenUnknown = true;
+            return Literal.BOOLEAN_TRUE;
         }
     }
 }

--- a/sql/src/test/java/io/crate/analyze/where/EqualityExtractorTest.java
+++ b/sql/src/test/java/io/crate/analyze/where/EqualityExtractorTest.java
@@ -321,4 +321,18 @@ public class EqualityExtractorTest extends CrateUnitTest {
             contains(isLiteral(3), isLiteral(3))
         ));
     }
+
+    @Test
+    public void testNoPKExtractionIfMatchIsPresent() throws Exception {
+        Symbol query = query("x in (1, 2, 3) and match(a, 'Hello World')");
+        List<List<Symbol>> matches = analyzeExactX(query);
+        assertThat(matches, nullValue());
+    }
+
+    @Test
+    public void testNoPKExtractionIfFunctionUsingPKIsPresent() throws Exception {
+        Symbol query = query("x in (1, 2, 3) and substr(cast(x as string), 0) = 4");
+        List<List<Symbol>> matches = analyzeExactX(query);
+        assertThat(matches, nullValue());
+    }
 }

--- a/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner;
+
+import io.crate.analyze.TableDefinitions;
+import io.crate.planner.node.dql.QueryThenFetch;
+import io.crate.test.integration.CrateUnitTest;
+import io.crate.testing.SQLExecutor;
+import org.elasticsearch.test.cluster.NoopClusterService;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.instanceOf;
+
+public class SelectPlannerTest extends CrateUnitTest {
+
+    private SQLExecutor e = SQLExecutor.builder(new NoopClusterService())
+        .addDocTable(TableDefinitions.USER_TABLE_INFO)
+        .build();
+
+    @Test
+    public void testWherePKAndMatchDoesNotResultInESGet() throws Exception {
+        Plan plan = e.plan("select * from users where id in (1, 2, 3) and match(text, 'Hello')");
+        assertThat(plan, instanceOf(QueryThenFetch.class));
+    }
+}


### PR DESCRIPTION
Fix is in the second commit. The first commit only contains test refactoring. 