### PR TITLE
Optimize evaluateIfLiterals

### DIFF
--- a/sql/src/main/java/io/crate/metadata/Scalar.java
+++ b/sql/src/main/java/io/crate/metadata/Scalar.java
@@ -68,16 +68,17 @@ public abstract class Scalar<ReturnType, InputType> implements FunctionImplement
      * Otherwise it will return the function as is or NULL in case it contains a null literal
      */
     private static <ReturnType, InputType> Symbol evaluateIfLiterals(Scalar<ReturnType, InputType> scalar, Function function) {
-        Input[] inputs = new Input[function.arguments().size()];
-        int idx = 0;
-        for (Symbol arg : function.arguments()) {
-            if (arg instanceof Input) {
-                Input inputArg = (Input) arg;
-                inputs[idx] = inputArg;
-                idx++;
-            } else {
+        List<Symbol> arguments = function.arguments();
+        for (Symbol argument : arguments) {
+            if (!(argument instanceof Input)) {
                 return function;
             }
+        }
+        Input[] inputs = new Input[arguments.size()];
+        int idx = 0;
+        for (Symbol arg : arguments) {
+            inputs[idx] = (Input) arg;
+            idx++;
         }
         //noinspection unchecked
         return Literal.of(function.info().returnType(), scalar.evaluate(inputs));


### PR DESCRIPTION
Avoids `Input[]` allocation in case that there are no literals.
For `normalizeSymbol` it is the common case that there are *no*
literals.

Result of a quick benchmark:

    newImpl     thrpt  200  34128919.011 ± 424106.373   ops/s
    oldImpl     thrpt  200  23035246.839 ± 136670.289   ops/s