### PR TITLE
switch echo to printf for portability

### DIFF
--- a/blackbox/bin/sphinx
+++ b/blackbox/bin/sphinx
@@ -2,13 +2,13 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 declare -i RESULT=0
-echo "\033[1mCleaning output folder ...\033[0m"
+printf "\033[1mCleaning output folder ...\033[0m\n"
 rm -rf $DIR/docs/out/
 RESULT+=$?
-echo "\033[1;44mBuilding server docs (html) ...\033[0m"
+printf "\033[1;44mBuilding server docs (html) ...\033[0m\n"
 $DIR/.venv/bin/sphinx-build -n -W -c $DIR/docs/ -b html -E $DIR/docs/ $DIR/docs/out/html
 RESULT+=$?
-echo "\033[1;44mBuilding server docs (text) ...\033[0m"
+printf "\033[1;44mBuilding server docs (text) ...\033[0m\n"
 $DIR/.venv/bin/sphinx-build -c $DIR/docs/ -b text -E $DIR/docs/ $DIR/docs/out/text
 RESULT+=$?
 exit $RESULT


### PR DESCRIPTION
`echo` on OS X (and some other systems) does not support escape sequences

without escape support, `bin/sphinx` output looks likes this:

![image](https://cloud.githubusercontent.com/assets/23469/21014833/c3d6a92a-bd5f-11e6-9ea3-8ab58b266c92.png)

`printf` is available on most systems

new output looks like this:

![image](https://cloud.githubusercontent.com/assets/23469/21014866/e75acc64-bd5f-11e6-9510-9375c1091e60.png)
