### PR TITLE
add dev option for bin/script that autobuilds docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ addons:
         - deadsnakes
     packages:
         - python3.4
+        - python3.4-dev
         - oracle-java8-installer # use newer java8 then default travis oraclejdk8
   coverity_scan:
     project:

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -54,6 +54,12 @@ To build the HTML and text documentation, run::
 
     $ ./bin/sphinx
 
+If you're editing the docs and want live rebuilds, run::
+
+    $ ./bin/sphinx dev
+
+This command watches the file system for changes and rebuilds the docs, refreshing your open browser tab, as needed.
+
 To test that all examples in the documentation execute correctly run::
 
     $ ./bin/test

--- a/blackbox/bin/sphinx
+++ b/blackbox/bin/sphinx
@@ -1,14 +1,19 @@
 #!/bin/bash
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
-declare -i RESULT=0
-printf "\033[1mCleaning output folder ...\033[0m\n"
-rm -rf $DIR/docs/out/
-RESULT+=$?
-printf "\033[1;44mBuilding server docs (html) ...\033[0m\n"
-$DIR/.venv/bin/sphinx-build -n -W -c $DIR/docs/ -b html -E $DIR/docs/ $DIR/docs/out/html
-RESULT+=$?
-printf "\033[1;44mBuilding server docs (text) ...\033[0m\n"
-$DIR/.venv/bin/sphinx-build -c $DIR/docs/ -b text -E $DIR/docs/ $DIR/docs/out/text
-RESULT+=$?
-exit $RESULT
+PATH=$DIR/.venv/bin:$PATH
+if test "$1" == "dev"; then
+    sphinx-autobuild $DIR/docs $DIR/docs/out/html
+else
+    declare -i RESULT=0
+    printf "\033[1mCleaning output folder ...\033[0m\n"
+    rm -rf $DIR/docs/out/
+    RESULT+=$?
+    printf "\033[1;44mBuilding server docs (html) ...\033[0m\n"
+    sphinx-build -n -W -b html -E $DIR/docs $DIR/docs/out/html
+    RESULT+=$?
+    printf "\033[1;44mBuilding server docs (text) ...\033[0m\n"
+    sphinx-build -b text -E $DIR/docs $DIR/docs/out/text
+    RESULT+=$?
+    exit $RESULT
+fi

--- a/blackbox/requirements.txt
+++ b/blackbox/requirements.txt
@@ -16,6 +16,7 @@ pytz==2016.4
 six==1.10.0
 snowballstemmer==1.2.1
 Sphinx==1.4.4
+sphinx-autobuild==0.6.0
 sphinxcontrib-plantuml==0.8.1
 urllib3==1.16
 wcwidth==0.1.6


### PR DESCRIPTION
this adds `sphinx-autobuild` to the Python deps and integrates this into the `bin/sphinx` script with a new `dev` argument 

also makes a bunch of small improvements to the `bin/sphinx` script