### PR TITLE
add explicit 'application/json' header to curl commands

### DIFF
--- a/blackbox/docs/protocols/http.txt
+++ b/blackbox/docs/protocols/http.txt
@@ -5,26 +5,30 @@ Crate SQL HTTP Endpoint
 =======================
 
 Crate provides a HTTP Endpoint that can be used to submit SQL queries. The
-endpoint is accessible under `<servername:port>/_sql`
+endpoint is accessible under ``<servername:port>/_sql``.
 
-SQL statements are sent to the `_sql` endpoint in ``json`` format,
+SQL statements are sent to the ``_sql`` endpoint in ``json`` format,
 whereby the statement is sent as value associated to the key ``stmt``.
 
 .. seealso::
 
     :doc:`../sql/dml`
 
-A simple `SELECT` statement can be submitted like this::
+A simple ``SELECT`` statement can be submitted like this::
 
-    sh$ curl -sSXPOST '127.0.0.1:4200/_sql?pretty' -d '{
-    ... "stmt":"select name, position from locations order by id limit 2"
-    ... }'
+    sh$ curl -sS -H 'Content-Type: application/json' \
+    ... -X POST '127.0.0.1:4200/_sql?pretty' \
+    ... -d '{"stmt":"select name, position from locations order by id limit 2"}'
     {
       "cols" : [ "name", "position" ],
       "rows" : [ [ "North West Ripple", 1 ], [ "Arkintoofle Minor", 3 ] ],
       "rowcount" : 2,
       "duration" : ...
     }
+
+.. note::
+
+    We're using a simple command line invokation of ``curl`` here so you can see how to run this by hand in the terminal. For the rest of the examples in this document, we use `here documents`_ (i.e. ``EOF``) for multiline readability.
 
 .. _parameter_substitution:
 
@@ -41,11 +45,13 @@ etc.) or unnumbered using a question mark ``?``.
 The placeholders will then be substituted with values from an array that is
 expected under the ``args`` key::
 
-    sh$ curl -sSXPOST '127.0.0.1:4200/_sql?pretty' -d@- <<- EOF
-    ... {"stmt":
+    sh$ curl -sS -H 'Content-Type: application/json' \
+    ... -X POST '127.0.0.1:4200/_sql?pretty' -d@- <<- EOF
+    ... {
+    ...   "stmt":
     ...     "select date,position from locations
     ...     where date <= \$1 and position < \$2 order by position",
-    ...  "args": ["1979-10-12", 3]
+    ...   "args": ["1979-10-12", 3]
     ... }
     ... EOF
     {
@@ -63,15 +69,17 @@ expected under the ``args`` key::
 .. warning::
 
     Parameter substition must not be used within subscript notation.
-    For example, column[?] is not allowed.
+    For example, ``column[?]`` is not allowed.
 
 The same query using question marks as placeholders looks like this::
 
-    sh$ curl -sSXPOST '127.0.0.1:4200/_sql?pretty' -d@- <<- EOF
-    ... {"stmt":
+    sh$ curl -sS -H 'Content-Type: application/json' \
+    ... -X POST '127.0.0.1:4200/_sql?pretty' -d@- <<- EOF
+    ... {
+    ...   "stmt":
     ...     "select date,position from locations
     ...     where date <= ? and position < ? order by position",
-    ...  "args": ["1979-10-12", 3]
+    ...   "args": ["1979-10-12", 3]
     ... }
     ... EOF
     {
@@ -84,7 +92,7 @@ The same query using question marks as placeholders looks like this::
 .. note::
 
     With some queries the row count is not ascertainable. In this cases
-    rowcount is -1.
+    rowcount is ``-1``.
 
 Default schema
 ==============
@@ -93,9 +101,13 @@ It is possible to set a default schema while querying the Crate cluster via
 ``_sql`` end point. In such case the HTTP request should contain the
 ``Default-Schema`` header with the specified schema name::
 
-    sh$ curl -sSXPOST '127.0.0.1:4200/_sql?pretty' -H 'Default-Schema: doc' -d '{
-    ... "stmt":"select name, position from locations order by id limit 2"
-    ... }'
+    sh$ curl -sS -H 'Content-Type: application/json' \
+    ... -X POST '127.0.0.1:4200/_sql?pretty' \
+    ... -H 'Default-Schema: doc' -d@- <<- EOF
+    ... {
+    ...   "stmt":"select name, position from locations order by id limit 2"
+    ... }
+    ... EOF
     {
       "cols" : [ "name", "position" ],
       "rows" : [ [ "North West Ripple", 1 ], [ "Arkintoofle Minor", 3 ] ],
@@ -116,11 +128,13 @@ is holding.
 In order to get the list of column data types, a ``types`` query
 parameter must be passed to the request::
 
-    sh$ curl -sSXPOST '127.0.0.1:4200/_sql?types&pretty' -d@- <<- EOF
-    ... {"stmt":
+    sh$ curl -sS -H 'Content-Type: application/json' \
+    ... -X POST '127.0.0.1:4200/_sql?types&pretty' -d@- <<- EOF
+    ... {
+    ...   "stmt":
     ...     "select date, position from locations
     ...      where date <= \$1 and position < \$2 order by position",
-    ...  "args": ["1979-10-12", 3]
+    ...   "args": ["1979-10-12", 3]
     ... }
     ... EOF
     {
@@ -139,10 +153,10 @@ Example of JSON representation of a column list of (String, Set<Integer[]>)::
 
   "column_types": [ 4, [ 101, [ 100, 9 ] ] ]
 
-Id's of all currently available data types:
+IDs of all currently available data types:
 
     ===== ===================
-    Id    Data Type
+    ID    Data Type
     ===== ===================
     0     Null
     ----- -------------------
@@ -187,13 +201,12 @@ Bulk Operations
 The REST endpoint allows to issue bulk operations which are executed as
 single calls on the back-end site. It can be compared to `prepared statement`_.
 
-A bulk operation can be expressed simply as an SQL statement. Supported
-statements are:
+A bulk operation can be expressed simply as an SQL statement.
+
+Supported bulk SQL statements are:
 
  - Insert
-
  - Update
-
  - Delete
 
 Instead of the ``args`` (:ref:`parameter_substitution`) key, use the
@@ -201,21 +214,23 @@ key ``bulk_args``. This allows to specify a list of lists, containing all
 the records which shall be processed. The inner lists need to match the
 specified columns.
 
-The bulk response contains a `results` array, with a rowcount for each
+The bulk response contains a ``results`` array, with a rowcount for each
 bulk operation. Those results are in the same order as the issued
 operations of the bulk operation.
 
 The following example describes how to issue an insert bulk operation and
 insert three records at once::
 
-    sh$ curl -sSXPOST '127.0.0.1:4200/_sql?pretty' -d@- <<- EOF
-    ... {"stmt": "INSERT INTO locations (id, name, kind, description)
-    ...          VALUES (?, ?, ?, ?)",
-    ... "bulk_args": [
+    sh$ curl -sS -H 'Content-Type: application/json' \
+    ... -X POST '127.0.0.1:4200/_sql?pretty' -d@- <<- EOF
+    ... {
+    ...   "stmt": "INSERT INTO locations (id, name, kind, description)
+    ...           VALUES (?, ?, ?, ?)",
+    ...   "bulk_args": [
     ...     [1337, "Earth", "Planet", "An awesome place to spend some time on."],
     ...     [1338, "Sun", "Star", "An extraordinarily hot place."],
     ...     [1339, "Titan", "Moon", "Titan, where it rains fossil fuels."]
-    ... ]
+    ...   ]
     ... }
     ... EOF
     {
@@ -241,9 +256,12 @@ cases additional arguments that are specific to the error code.
 Client libraries should use the error code to translate the error into an
 appropriate exception::
 
-    sh$ curl -sSXPOST '127.0.0.1:4200/_sql?pretty' -d '{
-    ... "stmt":"select name, position from foo.locations"
-    ... }'
+    sh$ curl -sS -H 'Content-Type: application/json' \
+    ... -X POST '127.0.0.1:4200/_sql?pretty' -d@- <<- EOF
+    ... {
+    ...   "stmt":"select name, position from foo.locations"
+    ... }
+    ... EOF
     {
       "error" : {
         "message" : "SQLActionException[SchemaUnknownException: Schema 'foo' unknown]",
@@ -251,12 +269,15 @@ appropriate exception::
       }
     }
 
-To get more insight into what exactly went wrong an additional `error_trace`
+To get more insight into what exactly went wrong an additional ``error_trace``
 GET parameter can be specified to return the stack trace::
 
-    sh$ curl -sSXPOST '127.0.0.1:4200/_sql?pretty&error_trace=True' -d '{
-    ... "stmt":"select name, position from foo.locations"
-    ... }'
+    sh$ curl -sS -H 'Content-Type: application/json' \
+    ... -X POST '127.0.0.1:4200/_sql?pretty&error_trace=True' -d@- <<- EOF
+    ... {
+    ...   "stmt":"select name, position from foo.locations"
+    ... }
+    ... EOF
     {
       "error" : {
         "message" : "SQLActionException[SchemaUnknownException: Schema 'foo' unknown]",
@@ -333,22 +354,24 @@ Currently the defined error codes are:
     ----- ---------------------------------------------------------------------
     5004  creating a snapshot failed
     ----- ---------------------------------------------------------------------
-    5030  the query was killed by a `kill` statement
+    5030  the query was killed by a ``kill`` statement
     ===== =====================================================================
 
 Bulk Errors
 -----------
 
-If a bulk operation fails, the resulting rowcount will be `-2` and
-the resulting object may contain an `error_message` depending on
+If a bulk operation fails, the resulting rowcount will be ``-2`` and
+the resulting object may contain an ``error_message`` depending on
 the resulting error::
 
-    sh$ curl -sSXPOST '127.0.0.1:4200/_sql?pretty' -d@- <<- EOF
-    ... {"stmt": "INSERT into locations (name, id) values (?,?)",
-    ... "bulk_args": [
+    sh$ curl -sS -H 'Content-Type: application/json' \
+    ... -X POST '127.0.0.1:4200/_sql?pretty' -d@- <<- EOF
+    ... {
+    ...   "stmt": "INSERT into locations (name, id) values (?,?)",
+    ...   "bulk_args": [
     ...     ["Mars", 1341],
     ...     ["Sun", 1341]
-    ... ]
+    ...   ]
     ... }
     ... EOF
     {
@@ -367,3 +390,5 @@ the resulting error::
     operation fails.
 
 .. _prepared statement: http://en.wikipedia.org/wiki/Prepared_statement
+
+.. _here documents: http://www.tldp.org/LDP/abs/html/here-docs.html


### PR DESCRIPTION
`curl` sends `x-www-form-urlencoded` content-type by default which, while ignored by CrateDB, has been misinterpreted to mean that this is the correct content-type for HTTP requests. updated the docs for more precision