### PR TITLE
Remove `tableParameter` from DDL statements which don't need it

### DIFF
--- a/sql/src/main/java/io/crate/analyze/AbstractDDLAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/AbstractDDLAnalyzedStatement.java
@@ -21,21 +21,11 @@
 
 package io.crate.analyze;
 
-public abstract class AbstractDDLAnalyzedStatement implements AnalyzedStatement {
+abstract class AbstractDDLAnalyzedStatement implements DDLStatement {
 
     protected final TableParameter tableParameter = new TableParameter();
 
-    @Override
-    public <C, R> R accept(AnalyzedStatementVisitor<C, R> analyzedStatementVisitor, C context) {
-        return analyzedStatementVisitor.visitDDLAnalyzedStatement(this, context);
-    }
-
     public TableParameter tableParameter() {
         return tableParameter;
-    }
-
-    @Override
-    public boolean isWriteOperation() {
-        return true;
     }
 }

--- a/sql/src/main/java/io/crate/analyze/AbstractDropTableAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/AbstractDropTableAnalyzedStatement.java
@@ -24,7 +24,7 @@ package io.crate.analyze;
 import io.crate.metadata.TableIdent;
 import io.crate.metadata.table.TableInfo;
 
-public abstract class AbstractDropTableAnalyzedStatement<T extends TableInfo> extends AbstractDDLAnalyzedStatement {
+public abstract class AbstractDropTableAnalyzedStatement<T extends TableInfo> implements DDLStatement {
 
     private final boolean dropIfExists;
     private final boolean isNoop;

--- a/sql/src/main/java/io/crate/analyze/AddColumnAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/AddColumnAnalyzedStatement.java
@@ -25,7 +25,7 @@ import io.crate.metadata.Schemas;
 import io.crate.metadata.TableIdent;
 import io.crate.metadata.doc.DocTableInfo;
 
-public class AddColumnAnalyzedStatement extends AbstractDDLAnalyzedStatement {
+public class AddColumnAnalyzedStatement implements DDLStatement {
 
     private final Schemas schemas;
     private DocTableInfo tableInfo;

--- a/sql/src/main/java/io/crate/analyze/AnalyzedStatementVisitor.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedStatementVisitor.java
@@ -42,11 +42,11 @@ public class AnalyzedStatementVisitor<C, R> {
     }
 
     protected R visitCreateTableStatement(CreateTableAnalyzedStatement analysis, C context) {
-        return visitDDLAnalyzedStatement(analysis, context);
+        return visitDDLStatement(analysis, context);
     }
 
     protected R visitCreateRepositoryAnalyzedStatement(CreateRepositoryAnalyzedStatement analysis, C context) {
-        return visitDDLAnalyzedStatement(analysis, context);
+        return visitDDLStatement(analysis, context);
     }
 
     protected R visitDeleteStatement(DeleteAnalyzedStatement analysis, C context) {
@@ -70,39 +70,39 @@ public class AnalyzedStatementVisitor<C, R> {
     }
 
     protected R visitDropTableStatement(DropTableAnalyzedStatement analysis, C context) {
-        return visitDDLAnalyzedStatement(analysis, context);
+        return visitDDLStatement(analysis, context);
     }
 
     protected R visitCreateAnalyzerStatement(CreateAnalyzerAnalyzedStatement analysis, C context) {
-        return visitDDLAnalyzedStatement(analysis, context);
+        return visitDDLStatement(analysis, context);
     }
 
-    protected R visitDDLAnalyzedStatement(AbstractDDLAnalyzedStatement analysis, C context) {
+    protected R visitDDLStatement(DDLStatement analysis, C context) {
         return visitAnalyzedStatement(analysis, context);
     }
 
     public R visitCreateBlobTableStatement(CreateBlobTableAnalyzedStatement analysis, C context) {
-        return visitDDLAnalyzedStatement(analysis, context);
+        return visitDDLStatement(analysis, context);
     }
 
     public R visitDropBlobTableStatement(DropBlobTableAnalyzedStatement analysis, C context) {
-        return visitDDLAnalyzedStatement(analysis, context);
+        return visitDDLStatement(analysis, context);
     }
 
     public R visitOptimizeTableStatement(OptimizeTableAnalyzedStatement analysis, C context) {
-        return visitDDLAnalyzedStatement(analysis, context);
+        return visitDDLStatement(analysis, context);
     }
 
     public R visitRefreshTableStatement(RefreshTableAnalyzedStatement analysis, C context) {
-        return visitDDLAnalyzedStatement(analysis, context);
+        return visitDDLStatement(analysis, context);
     }
 
     public R visitAlterTableStatement(AlterTableAnalyzedStatement analysis, C context) {
-        return visitDDLAnalyzedStatement(analysis, context);
+        return visitDDLStatement(analysis, context);
     }
 
     public R visitAlterBlobTableStatement(AlterBlobTableAnalyzedStatement analysis, C context) {
-        return visitDDLAnalyzedStatement(analysis, context);
+        return visitDDLStatement(analysis, context);
     }
 
     public R visitSetStatement(SetAnalyzedStatement analysis, C context) {
@@ -110,7 +110,7 @@ public class AnalyzedStatementVisitor<C, R> {
     }
 
     public R visitAddColumnStatement(AddColumnAnalyzedStatement analysis, C context) {
-        return visitDDLAnalyzedStatement(analysis, context);
+        return visitDDLStatement(analysis, context);
     }
 
     public R visitKillAnalyzedStatement(KillAnalyzedStatement analysis, C context) {
@@ -126,19 +126,19 @@ public class AnalyzedStatementVisitor<C, R> {
     }
 
     public R visitDropRepositoryAnalyzedStatement(DropRepositoryAnalyzedStatement analysis, C context) {
-        return visitDDLAnalyzedStatement(analysis, context);
+        return visitDDLStatement(analysis, context);
     }
 
     public R visitDropSnapshotAnalyzedStatement(DropSnapshotAnalyzedStatement analysis, C context) {
-        return visitDDLAnalyzedStatement(analysis, context);
+        return visitDDLStatement(analysis, context);
     }
 
     public R visitCreateSnapshotAnalyzedStatement(CreateSnapshotAnalyzedStatement analysis, C context) {
-        return visitDDLAnalyzedStatement(analysis, context);
+        return visitDDLStatement(analysis, context);
     }
 
     public R visitRestoreSnapshotAnalyzedStatement(RestoreSnapshotAnalyzedStatement analysis, C context) {
-        return visitDDLAnalyzedStatement(analysis, context);
+        return visitDDLStatement(analysis, context);
     }
 
     public R visitResetAnalyzedStatement(ResetAnalyzedStatement resetAnalyzedStatement, C context) {

--- a/sql/src/main/java/io/crate/analyze/CreateRepositoryAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/CreateRepositoryAnalyzedStatement.java
@@ -26,7 +26,7 @@ import org.elasticsearch.common.settings.Settings;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
-public class CreateRepositoryAnalyzedStatement extends AbstractDDLAnalyzedStatement {
+public class CreateRepositoryAnalyzedStatement implements DDLStatement {
 
     private final String repositoryName;
     private final String repositoryType;

--- a/sql/src/main/java/io/crate/analyze/CreateSnapshotAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/CreateSnapshotAnalyzedStatement.java
@@ -28,7 +28,7 @@ import org.elasticsearch.common.settings.Settings;
 
 import java.util.List;
 
-public class CreateSnapshotAnalyzedStatement extends AbstractDDLAnalyzedStatement {
+public class CreateSnapshotAnalyzedStatement implements DDLStatement {
 
     public static final List<String> ALL_INDICES = ImmutableList.of("_all");
 

--- a/sql/src/main/java/io/crate/analyze/CreateTableAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/CreateTableAnalyzedStatement.java
@@ -22,7 +22,10 @@
 package io.crate.analyze;
 
 import io.crate.exceptions.TableAlreadyExistsException;
-import io.crate.metadata.*;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.PartitionName;
+import io.crate.metadata.Schemas;
+import io.crate.metadata.TableIdent;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
@@ -31,7 +34,6 @@ import java.util.Map;
 
 public class CreateTableAnalyzedStatement extends AbstractDDLAnalyzedStatement {
 
-    private final FulltextAnalyzerResolver fulltextAnalyzerResolver;
     private AnalyzedTableElements analyzedTableElements;
     private Map<String, Object> mapping;
     private ColumnIdent routingColumn;
@@ -39,8 +41,7 @@ public class CreateTableAnalyzedStatement extends AbstractDDLAnalyzedStatement {
     private boolean noOp = false;
     private boolean ifNotExists = false;
 
-    public CreateTableAnalyzedStatement(FulltextAnalyzerResolver fulltextAnalyzerResolver) {
-        this.fulltextAnalyzerResolver = fulltextAnalyzerResolver;
+    public CreateTableAnalyzedStatement() {
     }
 
     public void table(TableIdent tableIdent, boolean ifNotExists, Schemas schemas) {
@@ -129,10 +130,6 @@ public class CreateTableAnalyzedStatement extends AbstractDDLAnalyzedStatement {
             mapping.putAll(tableParameter.mappings());
         }
         return mapping;
-    }
-
-    public FulltextAnalyzerResolver fulltextAnalyzerResolver() {
-        return fulltextAnalyzerResolver;
     }
 
     public TableIdent tableIdent() {

--- a/sql/src/main/java/io/crate/analyze/CreateTableStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateTableStatementAnalyzer.java
@@ -80,7 +80,7 @@ public class CreateTableStatementAnalyzer extends DefaultTraversalVisitor<Create
     @Override
     public CreateTableAnalyzedStatement visitCreateTable(CreateTable node, Context context) {
         assert context.statement == null : "context.statement must be null";
-        context.statement = new CreateTableAnalyzedStatement(fulltextAnalyzerResolver);
+        context.statement = new CreateTableAnalyzedStatement();
         setTableIdent(node, context);
 
         // apply default in case it is not specified in the genericProperties,
@@ -92,7 +92,7 @@ public class CreateTableStatementAnalyzer extends DefaultTraversalVisitor<Create
         context.statement.analyzedTableElements(TableElementsAnalyzer.analyze(
             node.tableElements(),
             context.analysis.parameterContext(),
-            context.statement.fulltextAnalyzerResolver(),
+            fulltextAnalyzerResolver,
             null));
 
         // validate table elements

--- a/sql/src/main/java/io/crate/analyze/DDLStatement.java
+++ b/sql/src/main/java/io/crate/analyze/DDLStatement.java
@@ -22,30 +22,15 @@
 
 package io.crate.analyze;
 
-import org.elasticsearch.common.settings.Settings;
+public interface DDLStatement extends AnalyzedStatement {
 
-import java.util.Set;
-
-public class OptimizeTableAnalyzedStatement implements DDLStatement {
-
-    private final Set<String> indexNames;
-    private final Settings settings;
-
-    public OptimizeTableAnalyzedStatement(Set<String> indexNames, Settings settings) {
-        this.indexNames = indexNames;
-        this.settings = settings;
-    }
-
-    public Set<String> indexNames() {
-        return indexNames;
-    }
-
-    public Settings settings() {
-        return settings;
+    @Override
+    default boolean isWriteOperation() {
+        return true;
     }
 
     @Override
-    public <C, R> R accept(AnalyzedStatementVisitor<C, R> analyzedStatementVisitor, C context) {
-        return analyzedStatementVisitor.visitOptimizeTableStatement(this, context);
+    default <C, R> R accept(AnalyzedStatementVisitor<C, R> visitor, C context) {
+        return visitor.visitDDLStatement(this, context);
     }
 }

--- a/sql/src/main/java/io/crate/analyze/DropRepositoryAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/DropRepositoryAnalyzedStatement.java
@@ -22,7 +22,7 @@
 
 package io.crate.analyze;
 
-public class DropRepositoryAnalyzedStatement extends AbstractDDLAnalyzedStatement {
+public class DropRepositoryAnalyzedStatement implements DDLStatement {
 
     private final String repositoryName;
 

--- a/sql/src/main/java/io/crate/analyze/DropSnapshotAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/DropSnapshotAnalyzedStatement.java
@@ -21,7 +21,7 @@
 
 package io.crate.analyze;
 
-public class DropSnapshotAnalyzedStatement extends AbstractDDLAnalyzedStatement {
+public class DropSnapshotAnalyzedStatement implements DDLStatement {
 
     private final String repository;
     private final String snapshot;

--- a/sql/src/main/java/io/crate/analyze/RefreshTableAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/RefreshTableAnalyzedStatement.java
@@ -23,7 +23,7 @@ package io.crate.analyze;
 
 import java.util.Set;
 
-public class RefreshTableAnalyzedStatement extends AbstractDDLAnalyzedStatement {
+public class RefreshTableAnalyzedStatement implements DDLStatement {
 
     private final Set<String> indexNames;
 
@@ -39,5 +39,4 @@ public class RefreshTableAnalyzedStatement extends AbstractDDLAnalyzedStatement 
     public <C, R> R accept(AnalyzedStatementVisitor<C, R> analyzedStatementVisitor, C context) {
         return analyzedStatementVisitor.visitRefreshTableStatement(this, context);
     }
-
 }

--- a/sql/src/main/java/io/crate/analyze/RestoreSnapshotAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/RestoreSnapshotAnalyzedStatement.java
@@ -27,7 +27,7 @@ import org.elasticsearch.common.settings.Settings;
 
 import java.util.List;
 
-public class RestoreSnapshotAnalyzedStatement extends AbstractDDLAnalyzedStatement {
+public class RestoreSnapshotAnalyzedStatement implements DDLStatement {
 
     private static final List<String> ALL_INDICES = ImmutableList.of();
 

--- a/sql/src/main/java/io/crate/planner/Planner.java
+++ b/sql/src/main/java/io/crate/planner/Planner.java
@@ -446,7 +446,7 @@ public class Planner extends AnalyzedStatementVisitor<Planner.Context, Plan> {
     }
 
     @Override
-    protected Plan visitDDLAnalyzedStatement(AbstractDDLAnalyzedStatement statement, Context context) {
+    protected Plan visitDDLStatement(DDLStatement statement, Context context) {
         return new GenericDDLPlan(context.jobId(), statement);
     }
 
@@ -455,7 +455,7 @@ public class Planner extends AnalyzedStatementVisitor<Planner.Context, Plan> {
         if (analysis.noop()) {
             return new NoopPlan(context.jobId());
         }
-        return visitDDLAnalyzedStatement(analysis, context);
+        return visitDDLStatement(analysis, context);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/node/ddl/GenericDDLPlan.java
+++ b/sql/src/main/java/io/crate/planner/node/ddl/GenericDDLPlan.java
@@ -21,7 +21,7 @@
 
 package io.crate.planner.node.ddl;
 
-import io.crate.analyze.AbstractDDLAnalyzedStatement;
+import io.crate.analyze.DDLStatement;
 import io.crate.planner.PlanVisitor;
 import io.crate.planner.UnnestablePlan;
 
@@ -30,9 +30,9 @@ import java.util.UUID;
 public class GenericDDLPlan extends UnnestablePlan {
 
     private final UUID id;
-    private final AbstractDDLAnalyzedStatement statement;
+    private final DDLStatement statement;
 
-    public GenericDDLPlan(UUID jobId, AbstractDDLAnalyzedStatement statement) {
+    public GenericDDLPlan(UUID jobId, DDLStatement statement) {
         id = jobId;
         this.statement = statement;
     }
@@ -47,7 +47,7 @@ public class GenericDDLPlan extends UnnestablePlan {
         return id;
     }
 
-    public AbstractDDLAnalyzedStatement statement() {
+    public DDLStatement statement() {
         return statement;
     }
 }


### PR DESCRIPTION
All DDLStatement classes which inherited from
AbstractDDLAnalyzedStatement got a `tableParameter` property which in
many cases didn't make any sense.

E.g. All snapshot/repository statement classes shouldn't have any
tableParameters.