### PR TITLE
Replace custom attributes usage with a RedirectService

### DIFF
--- a/blob/src/main/java/io/crate/blob/BlobService.java
+++ b/blob/src/main/java/io/crate/blob/BlobService.java
@@ -21,22 +21,14 @@
 
 package io.crate.blob;
 
-import io.crate.blob.exceptions.MissingHTTPEndpointException;
 import io.crate.blob.pending_transfer.BlobHeadRequestHandler;
-import io.crate.blob.v2.BlobIndex;
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.cluster.ClusterService;
-import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.cluster.node.DiscoveryNodes;
-import org.elasticsearch.cluster.routing.ShardIterator;
-import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Injector;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.http.HttpServer;
 import org.elasticsearch.indices.recovery.BlobRecoverySource;
 import org.elasticsearch.transport.TransportService;
 
@@ -45,15 +37,11 @@ public class BlobService extends AbstractLifecycleComponent<BlobService> {
     private final Injector injector;
     private final BlobHeadRequestHandler blobHeadRequestHandler;
 
-    private final ClusterService clusterService;
-
     @Inject
     public BlobService(Settings settings,
-                       ClusterService clusterService,
                        Injector injector,
                        BlobHeadRequestHandler blobHeadRequestHandler) {
         super(settings);
-        this.clusterService = clusterService;
         this.injector = injector;
         this.blobHeadRequestHandler = blobHeadRequestHandler;
     }
@@ -79,60 +67,16 @@ public class BlobService extends AbstractLifecycleComponent<BlobService> {
 
         blobHeadRequestHandler.registerHandler();
 
-        // by default the http server is started after the discovery service.
-        // For the BlobService this is too late.
-
-        // The HttpServer has to be started before so that the boundAddress
-        // can be added to DiscoveryNodes - this is required for the redirect logic.
-        if (settings.getAsBoolean("http.enabled", true)) {
-            injector.getInstance(HttpServer.class).start();
-        } else {
+        if (!settings.getAsBoolean("http.enabled", true)) {
             logger.warn("Http server should be enabled for blob support");
         }
     }
 
     @Override
     protected void doStop() throws ElasticsearchException {
-        if (settings.getAsBoolean("http.enabled", true)) {
-            injector.getInstance(HttpServer.class).stop();
-        }
     }
 
     @Override
     protected void doClose() throws ElasticsearchException {
-        if (settings.getAsBoolean("http.enabled", true)) {
-            injector.getInstance(HttpServer.class).close();
-        }
     }
-
-    /**
-     * @param index  the name of blob-enabled index
-     * @param digest sha-1 hash value of the file
-     * @return null if no redirect is required, Otherwise the address to which should be redirected.
-     */
-    public String getRedirectAddress(String index, String digest) throws MissingHTTPEndpointException {
-        ShardIterator shards = clusterService.operationRouting().getShards(
-            clusterService.state(), index, null, null, digest, "_local");
-
-        String localNodeId = clusterService.state().nodes().getLocalNodeId();
-        DiscoveryNodes nodes = clusterService.state().getNodes();
-        ShardRouting shard;
-        while ((shard = shards.nextOrNull()) != null) {
-            if (!shard.active()) {
-                continue;
-            }
-            if (shard.currentNodeId().equals(localNodeId)) {
-                // no redirect required if the shard is on this node
-                return null;
-            }
-
-            DiscoveryNode node = nodes.get(shard.currentNodeId());
-            String httpAddress = node.getAttributes().get("http_address");
-            if (httpAddress != null) {
-                return httpAddress + "/_blobs/" + BlobIndex.stripPrefix(index) + "/" + digest;
-            }
-        }
-        throw new MissingHTTPEndpointException("Can't find a suitable http server to serve the blob");
-    }
-
 }

--- a/blob/src/main/java/io/crate/blob/exceptions/RedirectService.java
+++ b/blob/src/main/java/io/crate/blob/exceptions/RedirectService.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.blob.exceptions;
+
+import io.crate.blob.v2.BlobIndex;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
+import org.elasticsearch.action.admin.cluster.node.info.NodesInfoRequest;
+import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterService;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateListener;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.ShardIterator;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.common.component.AbstractLifecycleComponent;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.transport.TransportAddress;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Stream;
+
+/**
+ * Keeps track of http urls of other nodes in the Cluster to provide redirects for blob operations
+ */
+public class RedirectService extends AbstractLifecycleComponent<RedirectService> {
+
+    private final ClusterService clusterService;
+    private final ConcurrentMap<String, String> nodeIdToHttpAddr = new ConcurrentHashMap<>();
+    private final Client client;
+    private Listener listener = null;
+
+    @Inject
+    public RedirectService(Settings settings, ClusterService clusterService, Client client) {
+        super(settings);
+        this.clusterService = clusterService;
+        this.client = client;
+    }
+
+    private void fetchHttpAddress(Stream<String> newNodeIds) {
+        final String[] nodeIds = newNodeIds.toArray(String[]::new);
+        client.admin().cluster().nodesInfo(
+            new NodesInfoRequest(nodeIds).http(true), new ActionListener<NodesInfoResponse>() {
+                @Override
+                public void onResponse(NodesInfoResponse nodeInfos) {
+                    fillMapFromResponse(nodeInfos, nodeIds);
+                }
+
+                @Override
+                public void onFailure(Throwable e) {
+                }
+            }
+        );
+    }
+
+    private void fillMapFromResponse(NodesInfoResponse nodeInfos, String[] nodeIds) {
+        for (int i = 0; i < nodeIds.length; i++) {
+            String httpAddress = getHttpAddress(nodeInfos.getAt(i));
+            nodeIdToHttpAddr.put(nodeIds[i], httpAddress);
+        }
+    }
+
+    private String getHttpAddress(NodeInfo nodeInfo) {
+        TransportAddress publishAddress = nodeInfo.getHttp().address().publishAddress();
+        return publishAddress.getHost() + ":" + publishAddress.getPort();
+    }
+
+
+    /**
+     * @param index  the name of blob-enabled index
+     * @param digest sha-1 hash value of the file
+     * @return null if no redirect is required, Otherwise the address to which should be redirected.
+     */
+    public String getRedirectAddress(String index, String digest) throws MissingHTTPEndpointException {
+        ClusterState state = clusterService.state();
+        ShardIterator shards = clusterService.operationRouting().getShards(
+            state, index, null, null, digest, "_local");
+        DiscoveryNodes nodes = state.getNodes();
+        String localNodeId = nodes.getLocalNodeId();
+        ShardRouting shard;
+        while ((shard = shards.nextOrNull()) != null) {
+            if (!shard.active()) {
+                continue;
+            }
+            String shardNodeId = shard.currentNodeId();
+            if (shardNodeId.equals(localNodeId)) {
+                // no redirect required if the shard is on this node
+                return null;
+            }
+            String httpAddress;
+            // containsKey check because it's necessary to differentiate between "no entry yet" and "no http url"
+            if (nodeIdToHttpAddr.containsKey(shardNodeId)) {
+                httpAddress = nodeIdToHttpAddr.get(shardNodeId);
+                if (httpAddress == null) {
+                    continue;
+                }
+            } else {
+                // this case mostly occurs during node-startup
+                // where the nodeIdToHttpAddr map isn't fully initialized
+                NodesInfoResponse nodeInfos = client.admin().cluster().nodesInfo(new NodesInfoRequest(shardNodeId)).actionGet();
+                httpAddress = getHttpAddress(nodeInfos.iterator().next());
+                nodeIdToHttpAddr.put(shardNodeId, httpAddress);
+            }
+            return httpAddress + "/_blobs/" + BlobIndex.stripPrefix(index) + "/" + digest;
+        }
+        throw new MissingHTTPEndpointException("Can't find a suitable http server to serve the blob");
+    }
+
+    @Override
+    protected void doStart() {
+        listener = new Listener();
+        clusterService.add(listener);
+    }
+
+    @Override
+    protected void doStop() {
+        if (listener != null) {
+            clusterService.remove(listener);
+        }
+    }
+
+    @Override
+    protected void doClose() {
+
+    }
+
+    private class Listener implements ClusterStateListener {
+
+        @Override
+        public void clusterChanged(ClusterChangedEvent event) {
+            if (!event.nodesChanged()) {
+                return;
+            }
+            DiscoveryNodes.Delta delta = event.nodesDelta();
+            fetchHttpAddress(delta.addedNodes()
+                .stream()
+                .map(DiscoveryNode::getId)
+            );
+            for (DiscoveryNode removedNode : delta.removedNodes()) {
+                nodeIdToHttpAddr.remove(removedNode.getId());
+            }
+        }
+    }
+}

--- a/blob/src/main/java/io/crate/http/netty/CrateNettyHttpServerTransport.java
+++ b/blob/src/main/java/io/crate/http/netty/CrateNettyHttpServerTransport.java
@@ -22,10 +22,9 @@
 
 package io.crate.http.netty;
 
-import com.google.common.collect.ImmutableMap;
 import io.crate.blob.BlobService;
+import io.crate.blob.exceptions.RedirectService;
 import io.crate.blob.v2.BlobIndicesService;
-import org.elasticsearch.cluster.node.DiscoveryNodeService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Settings;
@@ -35,56 +34,43 @@ import org.jboss.netty.channel.ChannelPipeline;
 import org.jboss.netty.channel.ChannelPipelineFactory;
 import org.jboss.netty.handler.stream.ChunkedWriteHandler;
 
-import java.util.Map;
-
 public class CrateNettyHttpServerTransport extends NettyHttpServerTransport {
 
     private final BlobService blobService;
+    protected final RedirectService redirectService;
     private final BlobIndicesService blobIndicesService;
-    private final DiscoveryNodeService discoveryNodeService;
 
     @Inject
     public CrateNettyHttpServerTransport(Settings settings,
                                          NetworkService networkService,
                                          BigArrays bigArrays,
                                          BlobService blobService,
-                                         BlobIndicesService blobIndicesService,
-                                         DiscoveryNodeService discoveryNodeService) {
+                                         RedirectService redirectService,
+                                         BlobIndicesService blobIndicesService) {
         super(settings, networkService, bigArrays);
         this.blobService = blobService;
+        this.redirectService = redirectService;
         this.blobIndicesService = blobIndicesService;
-        this.discoveryNodeService = discoveryNodeService;
-    }
-
-    @Override
-    protected void doStart() {
-        super.doStart();
-
-        final String httpAddress =
-            boundAddress.publishAddress().getHost() + ":" + boundAddress.publishAddress().getPort();
-        discoveryNodeService.addCustomAttributeProvider(new DiscoveryNodeService.CustomAttributesProvider() {
-            @Override
-            public Map<String, String> buildAttributes() {
-                return ImmutableMap.<String, String>builder().put("http_address", httpAddress).build();
-            }
-        });
     }
 
     @Override
     public ChannelPipelineFactory configureServerChannelPipelineFactory() {
-        return new CrateHttpChannelPipelineFactory(this, false, detailedErrorsEnabled);
+        return new CrateHttpChannelPipelineFactory(this, redirectService, false, detailedErrorsEnabled);
     }
 
     protected static class CrateHttpChannelPipelineFactory extends HttpChannelPipelineFactory {
 
         private final CrateNettyHttpServerTransport transport;
+        private final RedirectService redirectService;
         private final boolean sslEnabled;
 
         public CrateHttpChannelPipelineFactory(CrateNettyHttpServerTransport transport,
+                                               RedirectService redirectService,
                                                boolean sslEnabled,
                                                boolean detailedErrorsEnabled) {
             super(transport, detailedErrorsEnabled);
             this.transport = transport;
+            this.redirectService = redirectService;
             this.sslEnabled = sslEnabled;
         }
 
@@ -92,7 +78,8 @@ public class CrateNettyHttpServerTransport extends NettyHttpServerTransport {
         public ChannelPipeline getPipeline() throws Exception {
             ChannelPipeline pipeline = super.getPipeline();
 
-            HttpBlobHandler blobHandler = new HttpBlobHandler(transport.blobService, transport.blobIndicesService, sslEnabled);
+            HttpBlobHandler blobHandler = new HttpBlobHandler(
+                transport.blobService, redirectService, transport.blobIndicesService, sslEnabled);
             pipeline.addBefore("aggregator", "blob_handler", blobHandler);
 
             if (sslEnabled) {

--- a/blob/src/test/java/io/crate/testing/SslDummyPlugin.java
+++ b/blob/src/test/java/io/crate/testing/SslDummyPlugin.java
@@ -23,10 +23,10 @@
 package io.crate.testing;
 
 import io.crate.blob.BlobService;
+import io.crate.blob.exceptions.RedirectService;
 import io.crate.blob.v2.BlobIndicesService;
 import io.crate.http.netty.CrateNettyHttpServerTransport;
 import io.crate.plugin.BlobPlugin;
-import org.elasticsearch.cluster.node.DiscoveryNodeService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Settings;
@@ -61,20 +61,23 @@ public class SslDummyPlugin extends BlobPlugin {
                                       NetworkService networkService,
                                       BigArrays bigArrays,
                                       BlobService blobService,
-                                      BlobIndicesService blobIndicesService,
-                                      DiscoveryNodeService discoveryNodeService) {
-            super(settings, networkService, bigArrays, blobService, blobIndicesService, discoveryNodeService);
+                                      RedirectService redirectService,
+                                      BlobIndicesService blobIndicesService) {
+            super(settings, networkService, bigArrays, blobService, redirectService, blobIndicesService);
         }
 
         @Override
         public ChannelPipelineFactory configureServerChannelPipelineFactory() {
-            return new SslChannelPipelineFactory(this, true, detailedErrorsEnabled);
+            return new SslChannelPipelineFactory(this, redirectService, true, detailedErrorsEnabled);
         }
 
         public static class SslChannelPipelineFactory extends CrateNettyHttpServerTransport.CrateHttpChannelPipelineFactory {
 
-            public SslChannelPipelineFactory(CrateNettyHttpServerTransport transport, boolean sslEnabled, boolean detailedErrorsEnabled) {
-                super(transport, sslEnabled, detailedErrorsEnabled);
+            public SslChannelPipelineFactory(CrateNettyHttpServerTransport transport,
+                                             RedirectService redirectService,
+                                             boolean sslEnabled,
+                                             boolean detailedErrorsEnabled) {
+                super(transport, redirectService, sslEnabled, detailedErrorsEnabled);
             }
         }
     }


### PR DESCRIPTION
The DiscoveryNodeService and the ability to inject custom attributes is
gone in ES5.