### PR TITLE
fixed NPE in constraints validator

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed NPE that occurred when an ``UPDATE`` statement inserted ``NULL`` value
+   into a column that did not exist before.
+
  - It is not possible any more to circumvent ``NOT NULL`` column constraint by
    omitting the column in the ``INSERT`` statement.
 

--- a/sql/src/main/java/io/crate/analyze/ConstraintsValidator.java
+++ b/sql/src/main/java/io/crate/analyze/ConstraintsValidator.java
@@ -32,6 +32,7 @@ import java.util.Locale;
 public final class ConstraintsValidator {
 
     public static void validate(Object value, Reference targetColumn) {
+        assert targetColumn != null: "targetColumn is required to be able to validate it";
         // Validate NOT NULL constraint
         if (value == null && !targetColumn.isNullable()) {
             throw new IllegalArgumentException(String.format(Locale.ENGLISH,

--- a/sql/src/main/java/io/crate/executor/transport/TransportShardUpsertAction.java
+++ b/sql/src/main/java/io/crate/executor/transport/TransportShardUpsertAction.java
@@ -283,7 +283,7 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
         Map<String, Object> pathsToUpdate = new LinkedHashMap<>();
         Map<String, Object> updatedGeneratedColumns = new LinkedHashMap<>();
         for (int i = 0; i < request.updateColumns().length; i++) {
-            /**
+            /*
              * NOTE: mapping isn't applied. So if an Insert was done using the ES Rest Endpoint
              * the data might be returned in the wrong format (date as string instead of long)
              */
@@ -291,7 +291,13 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
             Object value = SYMBOL_TO_FIELD_EXTRACTOR.convert(item.updateAssignments()[i], ctx).apply(getResult);
             Reference reference = tableInfo.getReference(ColumnIdent.fromPath(columnPath));
 
-            ConstraintsValidator.validate(value, reference);
+            if (reference != null) {
+                /*
+                 * it is possible to insert NULL into column that does not exist yet.
+                 * if there is no column reference, we must not validate!
+                 */
+                ConstraintsValidator.validate(value, reference);
+            }
 
             if (reference instanceof GeneratedReference) {
                 updatedGeneratedColumns.put(columnPath, value);

--- a/sql/src/test/java/io/crate/integrationtests/UpdateIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/UpdateIntegrationTest.java
@@ -82,7 +82,22 @@ public class UpdateIntegrationTest extends SQLTransportIntegrationTest {
         expectedException.expect(SQLActionException.class);
         expectedException.expectMessage("SQLParseException: Cannot insert null value for column message");
         execute("update test set message=null where id=1");
-        assertEquals(0, response.rowCount());
+    }
+
+    @Test
+    public void testUpdateNullDynamicColumn() {
+        /*
+         * Regression test
+         * validating dynamically generated columns with NULL values led to NPE
+         */
+        execute("create table test (id int primary key)");
+        ensureYellow();
+        execute("insert into test (id) values (1)");
+        refresh();
+
+        execute("update test set dynamic_col=null");
+        refresh();
+        assertEquals(1, response.rowCount());
     }
 
     @Test


### PR DESCRIPTION
that occurred when inserting ``NULL`` value into column that did not exist before

see https://github.com/crate/crate/issues/4594