### PR TITLE
also remove current statement that disabled stats

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Do not display current statement in ``sys.jobs`` that disabled stats.
+
  - Added support for the double colon (::) cast operator.
 
  - Fixed NPE that occurred when an ``UPDATE`` statement inserted ``NULL`` value

--- a/sql/src/main/java/io/crate/operation/collect/StatsTables.java
+++ b/sql/src/main/java/io/crate/operation/collect/StatsTables.java
@@ -142,11 +142,8 @@ public class StatsTables {
      */
     public void logExecutionEnd(UUID jobId, @Nullable String errorMessage) {
         activeRequests.decrement();
-        if (!isEnabled()) {
-            return;
-        }
         JobContext jobContext = jobsTable.remove(jobId);
-        if (jobContext == null) {
+        if (!isEnabled() || jobContext == null) {
             return;
         }
         Queue<JobContextLog> jobContextLogs = jobsLog.get();

--- a/sql/src/test/java/io/crate/integrationtests/PostgresStatsTablesITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PostgresStatsTablesITest.java
@@ -52,7 +52,10 @@ public class PostgresStatsTablesITest extends SQLTransportIntegrationTest {
     @Before
     public void initDriverAndStats() throws Exception {
         try (Connection conn = DriverManager.getConnection(JDBC_POSTGRESQL_URL)) {
-            conn.createStatement().execute("set global stats.enabled=true");
+            conn.createStatement().execute("set global stats.enabled = true");
+            ResultSet rs = conn.createStatement().executeQuery("select stmt from sys.jobs");
+            assertTrue("sys.jobs must contain statement", rs.next());
+            assertEquals(rs.getString(1), "select stmt from sys.jobs");
         }
     }
 
@@ -60,6 +63,8 @@ public class PostgresStatsTablesITest extends SQLTransportIntegrationTest {
     public void resetStats() throws Exception {
         try (Connection conn = DriverManager.getConnection(JDBC_POSTGRESQL_URL)) {
             conn.createStatement().execute("reset global stats.enabled");
+            ResultSet rs = conn.createStatement().executeQuery("select stmt from sys.jobs");
+            assertFalse("sys.jobs must not contain entries", rs.next());
         }
     }
 


### PR DESCRIPTION
previously `set global stats.enabled = false` was remaining in sys.jobs and was never removed