### PR TITLE
allow semi-colon in the end of statements

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Allow semi-colon (;) in the end of simple SQL statements.
+
  - Enhanced performance optimisation of full joins by rewriting them to left,
    right or inner joins when conditions in ``WHERE`` exclude null values.
 

--- a/sql-parser/src/main/antlr/SqlBase.g4
+++ b/sql-parser/src/main/antlr/SqlBase.g4
@@ -23,7 +23,7 @@
 grammar SqlBase;
 
 singleStatement
-    : statement EOF
+    : statement SEMICOLON? EOF
     ;
 
 singleExpression
@@ -775,6 +775,7 @@ SLASH: '/';
 PERCENT: '%';
 CONCAT: '||';
 CAST_OPERATOR: '::';
+SEMICOLON: ';';
 
 STRING
     : '\'' ( ~'\'' | '\'\'' )* '\''

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -75,6 +75,11 @@ public class TestStatementBuilder {
     }
 
     @Test
+    public void testStmtWithSemicolonBuilder() {
+        printStatement("select 1;");
+    }
+
+    @Test
     public void testShowTablesStmtBuilder() {
         printStatement("show tables");
         printStatement("show tables like '.*'");

--- a/sql/src/main/java/io/crate/protocols/postgres/ConnectionContext.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/ConnectionContext.java
@@ -553,10 +553,6 @@ class ConnectionContext {
             Messages.sendReadyForQuery(channel);
             return;
         }
-        // TODO: support multiple statements
-        if (query.endsWith(";")) {
-            query = query.substring(0, query.length() - 1);
-        }
         try {
             session.parse("", query, Collections.<DataType>emptyList());
             session.bind("", "", Collections.emptyList(), null);


### PR DESCRIPTION
Already documented in the lexical structure.
![image](https://cloud.githubusercontent.com/assets/7442373/21317981/aa342a82-c607-11e6-8cd4-de9f5ec19f7d.png)

Discussed this change with dobe. It is fine to support only ';' in the end of stmt and don't do anything about multiple statements handling yet.