### PR TITLE
Fixed an issue that causes ClassCastException on outer joins

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,11 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed an issue that causes ClassCastException on outer joins when
+   ``WHERE`` clause contains a condition that prevents null values on
+   the relation that may produce nulls.
+   e.g.: `select * from t1 left join t2 ON t1.id = t2.id WHERE t2.txt = 'foo'`
+
  - Do not display current statement in ``sys.jobs`` that disabled stats.
 
  - Added support for the double colon (::) cast operator.

--- a/sql/src/main/java/io/crate/analyze/relations/JoinPairs.java
+++ b/sql/src/main/java/io/crate/analyze/relations/JoinPairs.java
@@ -41,11 +41,12 @@ public final class JoinPairs {
     /**
      * Find and return a {@link JoinPair} for the given relation names, also check for reversed names.
      * If the {@link JoinType} is INNER and a pair is found for the reversed names, merge the join conditions.
-     * Found join pairs will be removed from the list.
+     * Found join pairs will be removed from the list if consume is true.
      */
     public static JoinPair ofRelationsWithMergedConditions(QualifiedName left,
                                                            QualifiedName right,
-                                                           List<JoinPair> joinPairs) {
+                                                           List<JoinPair> joinPairs,
+                                                           boolean consume) {
         JoinPair joinPair = ofRelations(left, right, joinPairs, true);
         if (joinPair == null) {
             // default to cross join (or inner, doesn't matter)
@@ -57,10 +58,14 @@ public final class JoinPairs {
             JoinPair joinPairReverse = ofRelations(right, left, joinPairs, false);
             if (joinPairReverse != null) {
                 joinPair.condition(AndOperator.join(Arrays.asList(joinPair.condition(), joinPairReverse.condition())));
-                joinPairs.remove(joinPairReverse);
+                if (consume) {
+                    joinPairs.remove(joinPairReverse);
+                }
             }
         }
-        joinPairs.remove(joinPair);
+        if (consume) {
+            joinPairs.remove(joinPair);
+        }
 
         return joinPair;
     }

--- a/sql/src/main/java/io/crate/analyze/symbol/Symbols.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/Symbols.java
@@ -150,24 +150,24 @@ public class Symbols {
         }
     }
 
-    private static class RCReplaceVisitor
-        extends ReplacingSymbolVisitor<com.google.common.base.Function<? super RelationColumn, ? extends Symbol>> {
+    private static class FieldReplaceVisitor
+        extends ReplacingSymbolVisitor<com.google.common.base.Function<? super Field, ? extends Symbol>> {
 
-        public final static RCReplaceVisitor INSTANCE = new RCReplaceVisitor();
+        public final static FieldReplaceVisitor INSTANCE = new FieldReplaceVisitor();
 
-        private RCReplaceVisitor() {
+        private FieldReplaceVisitor() {
             super(ReplaceMode.COPY);
         }
 
         @Override
-        public Symbol visitRelationColumn(RelationColumn relationColumn,
-                                          com.google.common.base.Function<? super RelationColumn, ? extends Symbol> replaceFunction) {
-            return replaceFunction.apply(relationColumn);
+        public Symbol visitField(Field field,
+                                 com.google.common.base.Function<? super Field, ? extends Symbol> replaceFunction) {
+            return replaceFunction.apply(field);
         }
     }
 
-    public static Symbol replaceRelationColumn(Symbol symbol,
-                                               com.google.common.base.Function<? super RelationColumn, ? extends Symbol> replaceFunction) {
-        return RCReplaceVisitor.INSTANCE.process(symbol, replaceFunction);
+    public static Symbol replaceField(Symbol symbol,
+                                      com.google.common.base.Function<? super Field, ? extends Symbol> replaceFunction) {
+        return FieldReplaceVisitor.INSTANCE.process(symbol, replaceFunction);
     }
 }

--- a/sql/src/main/java/io/crate/planner/consumer/ConsumingPlanner.java
+++ b/sql/src/main/java/io/crate/planner/consumer/ConsumingPlanner.java
@@ -22,7 +22,6 @@
 package io.crate.planner.consumer;
 
 import io.crate.analyze.QuerySpec;
-import io.crate.analyze.Rewriter;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.QueriedRelation;
 import io.crate.analyze.symbol.SelectSymbol;
@@ -51,7 +50,7 @@ public class ConsumingPlanner {
         consumers.add(new InsertFromSubQueryConsumer());
         consumers.add(new QueryAndFetchConsumer());
         consumers.add(new MultiSourceAggregationConsumer(functions));
-        consumers.add(new ManyTableConsumer(new Rewriter(functions)));
+        consumers.add(new ManyTableConsumer());
         consumers.add(new NestedLoopConsumer(clusterService, functions, tableStatsService));
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/OuterJoinIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/OuterJoinIntegrationTest.java
@@ -46,7 +46,7 @@ public class OuterJoinIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
-    public void testLeftOuterJoin() throws Exception {
+    public void testLeftOuterJoin() {
         // which employee works in which office?
         execute("select persons.name, offices.name from" +
                 " employees as persons left join offices on office_id = offices.id" +
@@ -57,7 +57,7 @@ public class OuterJoinIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
-    public void testLeftOuterJoinOrderOnOuterTable() throws Exception {
+    public void testLeftOuterJoinOrderOnOuterTable() {
         // which employee works in which office?
         execute("select persons.name, offices.name from" +
                 " employees as persons left join offices on office_id = offices.id" +
@@ -68,7 +68,7 @@ public class OuterJoinIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
-    public void test3TableLeftOuterJoin() throws Exception {
+    public void test3TableLeftOuterJoin() {
         execute(
             "select professions.name, employees.name, offices.name from" +
             " professions left join employees on profession_id = professions.id" +
@@ -81,7 +81,7 @@ public class OuterJoinIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
-    public void test3TableLeftOuterJoinOrderByOuterTable() throws Exception {
+    public void test3TableLeftOuterJoinOrderByOuterTable() {
         execute(
             "select professions.name, employees.name, offices.name from" +
             " professions left join employees on profession_id = professions.id" +
@@ -94,7 +94,7 @@ public class OuterJoinIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
-    public void testRightOuterJoin() throws Exception {
+    public void testRightOuterJoin() {
         execute("select offices.name, persons.name from" +
                 " employees as persons right join offices on office_id = offices.id" +
                 " order by offices.id");
@@ -104,7 +104,7 @@ public class OuterJoinIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
-    public void test3TableLeftAndRightOuterJoin() throws Exception {
+    public void test3TableLeftAndRightOuterJoin() {
         execute(
             "select professions.name, employees.name, offices.name from" +
             " offices left join employees on office_id = offices.id" +
@@ -117,7 +117,7 @@ public class OuterJoinIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
-    public void testFullOuterJoin() throws Exception {
+    public void testFullOuterJoin() {
         execute("select persons.name, offices.name from" +
                 " offices full join employees as persons on office_id = offices.id" +
                 " order by offices.id");
@@ -128,7 +128,7 @@ public class OuterJoinIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
-    public void testOuterJoinWithFunctionsInOrderBy() throws Exception {
+    public void testOuterJoinWithFunctionsInOrderBy() {
         execute("select coalesce(persons.name, ''), coalesce(offices.name, '') from" +
                 " offices full join employees as persons on office_id = offices.id" +
                 " order by 1, 2");
@@ -139,7 +139,7 @@ public class OuterJoinIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
-    public void testLeftJoinWithFilterOnInner() throws Exception {
+    public void testLeftJoinWithFilterOnInner() {
         execute("select employees.name, offices.name from" +
                 " employees left join offices on office_id = offices.id" +
                 " where employees.id < 3" +
@@ -149,7 +149,8 @@ public class OuterJoinIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
-    public void testLeftJoinWithFilterOnOuter() throws Exception {
+    public void testLeftJoinWithFilterOnOuter() {
+        // It's rewritten to an Inner Join because of the filtering condition in where clause
         execute("select employees.name, offices.name from" +
                 " employees left join offices on office_id = offices.id" +
                 " where offices.size > 100" +

--- a/sql/src/test/java/io/crate/planner/consumer/ManyTableConsumerTest.java
+++ b/sql/src/test/java/io/crate/planner/consumer/ManyTableConsumerTest.java
@@ -41,7 +41,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Set;
 
-import static io.crate.testing.TestingHelpers.getFunctions;
 import static io.crate.testing.TestingHelpers.isSQL;
 import static org.hamcrest.core.Is.is;
 
@@ -154,7 +153,7 @@ public class ManyTableConsumerTest extends CrateUnitTest {
         MultiSourceSelect mss = analyze("select * from t1 " +
                                         "left join t2 on t1.a = t2.b " +
                                         "order by t2.b");
-        TwoTableJoin root = ManyTableConsumer.twoTableJoin(new Rewriter(getFunctions()), mss);
+        TwoTableJoin root = ManyTableConsumer.twoTableJoin(mss);
 
         assertThat(root.right().querySpec().orderBy().isPresent(), is(false));
         assertThat(root.querySpec().orderBy().get(), isSQL("RELCOL(doc.t2, 0)"));
@@ -181,7 +180,7 @@ public class ManyTableConsumerTest extends CrateUnitTest {
         MultiSourceSelect mss = analyze("select t1.a from t1 " +
                                         "left join t2 on t1.a = t2.b " +
                                         "where t1.x = 1 and t2.y in (1)");
-        TwoTableJoin root = ManyTableConsumer.twoTableJoin(new Rewriter(getFunctions()), mss);
+        TwoTableJoin root = ManyTableConsumer.twoTableJoin(mss);
         // if Rewriter does not operate correctly on the joinPairs, t2 RelationColumn index would be 1 instead of 0
         // 2 outputs, t2.y + t2.b on t2 are rewritten to t2.b only because whereClause outputs must not be collected
         // so index for t2.b must be shifted


### PR DESCRIPTION
when they are rewritten to inner joins because of condition in where clause
that prevents nulls.

Move Rewriter to analysis phase to avoid changes after fetch pushDown is
computed.

https://github.com/crate/crate/issues/4595