### PR TITLE
Fixed an issue that causes UnhandledServerException on joins

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,13 +4,19 @@ Changes for Crate
 
 Unreleased
 ==========
- 
+
+ - Fixed an issue that causes UnhandledServerException on joins
+   when ``WHERE`` clause contains conditions on columns of array type
+   of both tables which are separated with the ``OR` operator.
+    e.g.: `SELECT * FROM t1 join t2 ON t1.id = t2.id
+           WHERE 'foo' = ANY(a.strArray) OR 'bar' = ANY(b.strArray)`
+
  - Fix: scalar functions `longitude/latitude` show misleading results.
 
  - Fixed an issue that causes ClassCastException on outer joins when
    ``WHERE`` clause contains a condition that prevents null values on
    the relation that may produce nulls.
-   e.g.: `select * from t1 left join t2 ON t1.id = t2.id WHERE t2.txt = 'foo'`
+   e.g.: `SELECT * FROM t1 LEFT JOIN t2 ON t1.id = t2.id WHERE t2.txt = 'foo'`
 
  - Do not display current statement in ``sys.jobs`` that disabled stats.
 

--- a/sql/src/main/java/io/crate/operation/reference/doc/lucene/LuceneReferenceResolver.java
+++ b/sql/src/main/java/io/crate/operation/reference/doc/lucene/LuceneReferenceResolver.java
@@ -24,6 +24,7 @@ package io.crate.operation.reference.doc.lucene;
 import io.crate.exceptions.UnhandledServerException;
 import io.crate.exceptions.UnsupportedFeatureException;
 import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.DocReferenceConverter;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RowGranularity;
 import io.crate.operation.reference.ReferenceResolver;
@@ -103,6 +104,9 @@ public class LuceneReferenceResolver implements ReferenceResolver<LuceneCollecto
                 return new GeoPointColumnReference(colName);
             case GeoShapeType.ID:
                 return new GeoShapeColumnReference(colName);
+            case ArrayType.ID:
+            case SetType.ID:
+                return DocCollectorExpression.create(DocReferenceConverter.toSourceLookup(refInfo));
             default:
                 throw new UnhandledServerException(String.format(Locale.ENGLISH, "unsupported type '%s'", refInfo.valueType().getName()));
         }

--- a/sql/src/test/java/io/crate/operation/reference/doc/lucene/LuceneReferenceResolverTest.java
+++ b/sql/src/test/java/io/crate/operation/reference/doc/lucene/LuceneReferenceResolverTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.operation.reference.doc.lucene;
+
+import io.crate.metadata.Reference;
+import io.crate.metadata.ReferenceIdent;
+import io.crate.metadata.RowGranularity;
+import io.crate.metadata.TableIdent;
+import io.crate.test.integration.CrateUnitTest;
+import io.crate.types.DataTypes;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.instanceOf;
+
+public class LuceneReferenceResolverTest extends CrateUnitTest {
+
+    private LuceneReferenceResolver luceneReferenceResolver = new LuceneReferenceResolver(null);
+
+    @Test
+    public void testGetImplementationWithColumnsOfTypeCollection() {
+        Reference arrayRef = new Reference(new ReferenceIdent(
+            new TableIdent("s", "t"), "a"),
+            RowGranularity.DOC,
+            DataTypes.ANY_ARRAY);
+        assertThat(luceneReferenceResolver.getImplementation(arrayRef),
+            instanceOf(DocCollectorExpression.ChildDocCollectorExpression.class));
+
+        Reference setRef = new Reference(new ReferenceIdent(
+            new TableIdent("s", "t"), "a"),
+            RowGranularity.DOC,
+            DataTypes.ANY_SET);
+        assertThat(luceneReferenceResolver.getImplementation(setRef),
+            instanceOf(DocCollectorExpression.ChildDocCollectorExpression.class));
+    }
+}


### PR DESCRIPTION
when ``WHERE`` clause contains conditions on columns of array type
of both tables which are separated with the ``OR` operator.

When columns of CollectionType need to be collected then convert
them to source lookup references.