### PR TITLE
fix: kill job on all participating nodes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,9 @@ Changes for Crate
 
 Unreleased
 ==========
+ 
+ - Fixed an issue that causes hanging queries if a data node disconnects from
+   the cluster.
 
  - Fix: throw correct error if one tries to create a table starting with ``_``
 

--- a/sql/src/main/java/io/crate/executor/transport/executionphases/ExecutionPhasesTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/executionphases/ExecutionPhasesTask.java
@@ -189,7 +189,7 @@ public class ExecutionPhasesTask extends JobTask {
         List<Tuple<ExecutionPhase, RowReceiver>> handlerPhaseAndReceiver = createHandlerPhaseAndReceivers(
             handlerPhases, handlerReceivers, initializationTracker);
 
-        JobExecutionContext.Builder builder = jobContextService.newBuilder(jobId(), localNodeId);
+        JobExecutionContext.Builder builder = jobContextService.newBuilder(jobId(), localNodeId, operationByServer.keySet());
         List<ListenableFuture<Bucket>> directResponseFutures = contextPreparer.prepareOnHandler(
             localNodeOperations, builder, handlerPhaseAndReceiver, new SharedShardContexts(indicesService));
         JobExecutionContext localJobContext = jobContextService.createContext(builder);

--- a/sql/src/main/java/io/crate/executor/transport/kill/TransportKillNodeAction.java
+++ b/sql/src/main/java/io/crate/executor/transport/kill/TransportKillNodeAction.java
@@ -33,7 +33,6 @@ import io.crate.jobs.JobContextService;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -42,7 +41,11 @@ import org.elasticsearch.transport.TransportService;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.*;
 import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 abstract class TransportKillNodeAction<Request extends TransportRequest> extends AbstractComponent
     implements NodeAction<Request, KillResponse>, Callable<Request> {
@@ -90,9 +93,14 @@ abstract class TransportKillNodeAction<Request extends TransportRequest> extends
      * Broadcasts the given kill request to all nodes in the cluster
      */
     public void broadcast(Request request, ActionListener<KillResponse> listener) {
-        DiscoveryNodes nodes = clusterService.state().nodes();
+        broadcast(request, listener, Collections.emptyList());
+    }
 
-        listener = new MultiActionListener<>(nodes.size(), KillResponse.MERGE_FUNCTION, listener);
+    public void broadcast(Request request, ActionListener<KillResponse> listener, Collection<String> excludedNodeIds) {
+        Stream<DiscoveryNode> nodes = StreamSupport.stream(clusterService.state().nodes().spliterator(), false);
+        Collection<DiscoveryNode> filteredNodes = nodes.filter(node -> !excludedNodeIds.contains(node.getId())).collect(Collectors.toList());
+
+        listener = new MultiActionListener<>(filteredNodes.size(), KillResponse.MERGE_FUNCTION, listener);
         DefaultTransportResponseHandler<KillResponse> responseHandler =
             new DefaultTransportResponseHandler<KillResponse>(listener) {
                 @Override
@@ -100,7 +108,7 @@ abstract class TransportKillNodeAction<Request extends TransportRequest> extends
                     return new KillResponse(0);
                 }
             };
-        for (DiscoveryNode node : nodes) {
+        for (DiscoveryNode node : filteredNodes) {
             transportService.sendRequest(node, name, request, responseHandler);
         }
     }

--- a/sql/src/main/java/io/crate/jobs/transport/NodeDisconnectJobMonitorService.java
+++ b/sql/src/main/java/io/crate/jobs/transport/NodeDisconnectJobMonitorService.java
@@ -22,20 +22,25 @@
 
 package io.crate.jobs.transport;
 
-import com.google.common.collect.Collections2;
+import io.crate.executor.transport.kill.KillJobsRequest;
+import io.crate.executor.transport.kill.KillResponse;
+import io.crate.executor.transport.kill.TransportKillJobsNodeAction;
 import io.crate.jobs.JobContextService;
-import io.crate.jobs.JobExecutionContext;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportConnectionListener;
 import org.elasticsearch.transport.TransportService;
 
-import java.util.Collection;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * service that listens to node-disconnected-events and kills jobContexts that were started by the nodes that got disconnected
@@ -50,16 +55,20 @@ public class NodeDisconnectJobMonitorService
     private final TransportService transportService;
 
     private final static TimeValue DELAY = TimeValue.timeValueMinutes(1);
+    private final TransportKillJobsNodeAction killJobsNodeAction;
+    private final static ESLogger LOGGER = Loggers.getLogger(NodeDisconnectJobMonitorService.class);
 
     @Inject
     public NodeDisconnectJobMonitorService(Settings settings,
                                            ThreadPool threadPool,
                                            JobContextService jobContextService,
-                                           TransportService transportService) {
+                                           TransportService transportService,
+                                           TransportKillJobsNodeAction killJobsNodeAction) {
         super(settings);
         this.threadPool = threadPool;
         this.jobContextService = jobContextService;
         this.transportService = transportService;
+        this.killJobsNodeAction = killJobsNodeAction;
     }
 
 
@@ -83,16 +92,27 @@ public class NodeDisconnectJobMonitorService
 
     @Override
     public void onNodeDisconnected(final DiscoveryNode node) {
-        final Collection<JobExecutionContext> contexts = jobContextService.getContextsByCoordinatorNode(node.getId());
+        final Collection<UUID> contexts = jobContextService.getJobIdsByCoordinatorNode(node.getId()).collect(Collectors.toList());
         if (contexts.isEmpty()) {
-            return;
+            // Disconnected node is not a handler node --> kill jobs on all participated nodes
+            contexts.addAll(jobContextService.getJobIdsByParticipatingNodes(node.getId()).collect(Collectors.toList()));
+            KillJobsRequest killJobsRequest = new KillJobsRequest(contexts);
+            if (!contexts.isEmpty()) {
+                killJobsNodeAction.broadcast(killJobsRequest, new ActionListener<KillResponse>() {
+                    @Override
+                    public void onResponse(KillResponse killResponse) {
+                    }
+
+                    @Override
+                    public void onFailure(Throwable e) {
+                        LOGGER.warn("failed to send kill request to nodes");
+                    }
+                }, Arrays.asList(node.getId()));
+            } else {
+                return;
+            }
         }
 
-        threadPool.schedule(DELAY, ThreadPool.Names.GENERIC, new Runnable() {
-            @Override
-            public void run() {
-                jobContextService.killJobs(Collections2.transform(contexts, JobExecutionContext.TO_ID));
-            }
-        });
+        threadPool.schedule(DELAY, ThreadPool.Names.GENERIC, () -> jobContextService.killJobs(contexts));
     }
 }

--- a/sql/src/test/java/io/crate/jobs/JobContextServiceTest.java
+++ b/sql/src/test/java/io/crate/jobs/JobContextServiceTest.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
@@ -73,12 +74,12 @@ public class JobContextServiceTest extends CrateUnitTest {
         builder.addSubContext(new DummySubContext(1));
 
         JobExecutionContext ctx = jobContextService.createContext(builder);
-        Iterable<JobExecutionContext> contexts = jobContextService.getContextsByCoordinatorNode("wrongNodeId");
+        Iterable<UUID> contexts = jobContextService.getJobIdsByCoordinatorNode("wrongNodeId").collect(Collectors.toList());
 
         assertThat(contexts.iterator().hasNext(), is(false));
 
-        contexts = jobContextService.getContextsByCoordinatorNode("noop_id");
-        assertThat(contexts, contains(ctx));
+        contexts = jobContextService.getJobIdsByCoordinatorNode("noop_id").collect(Collectors.toList());
+        assertThat(contexts, contains(ctx.jobId()));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/jobs/JobExecutionContextTest.java
+++ b/sql/src/test/java/io/crate/jobs/JobExecutionContextTest.java
@@ -42,6 +42,7 @@ import org.mockito.Mockito;
 
 import javax.annotation.Nonnull;
 import java.lang.reflect.Field;
+import java.util.Collections;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentMap;
 
@@ -55,7 +56,7 @@ public class JobExecutionContextTest extends CrateUnitTest {
     @Test
     public void testAddTheSameContextTwiceThrowsAnError() throws Exception {
         JobExecutionContext.Builder builder =
-            new JobExecutionContext.Builder(UUID.randomUUID(), coordinatorNode, mock(StatsTables.class));
+            new JobExecutionContext.Builder(UUID.randomUUID(), coordinatorNode, Collections.emptyList(), mock(StatsTables.class));
         builder.addSubContext(new AbstractExecutionSubContextTest.TestingExecutionSubContext());
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("ExecutionSubContext for 0 already added");
@@ -65,7 +66,7 @@ public class JobExecutionContextTest extends CrateUnitTest {
     @Test
     public void testKillPropagatesToSubContexts() throws Exception {
         JobExecutionContext.Builder builder =
-            new JobExecutionContext.Builder(UUID.randomUUID(), coordinatorNode, mock(StatsTables.class));
+            new JobExecutionContext.Builder(UUID.randomUUID(), coordinatorNode, Collections.emptyList(), mock(StatsTables.class));
 
 
         AbstractExecutionSubContextTest.TestingExecutionSubContext ctx1 = new AbstractExecutionSubContextTest.TestingExecutionSubContext(1);
@@ -86,7 +87,7 @@ public class JobExecutionContextTest extends CrateUnitTest {
     public void testErrorMessageIsIncludedInStatsTableOnFailure() throws Exception {
         StatsTables statsTables = mock(StatsTables.class);
         JobExecutionContext.Builder builder =
-            new JobExecutionContext.Builder(UUID.randomUUID(), coordinatorNode, statsTables);
+            new JobExecutionContext.Builder(UUID.randomUUID(), coordinatorNode, Collections.emptyList(), statsTables);
 
         ExecutionSubContext executionSubContext = new AbstractExecutionSubContext(0, logger) {
             @Override
@@ -111,7 +112,7 @@ public class JobExecutionContextTest extends CrateUnitTest {
         when(collectPhase.maxRowGranularity()).thenReturn(RowGranularity.DOC);
 
         JobExecutionContext.Builder builder =
-            new JobExecutionContext.Builder(UUID.randomUUID(), coordinatorNode, mock(StatsTables.class));
+            new JobExecutionContext.Builder(UUID.randomUUID(), coordinatorNode, Collections.emptyList(), mock(StatsTables.class));
 
         JobCollectContext jobCollectContext = new JobCollectContext(
             collectPhase,

--- a/sql/src/test/java/io/crate/jobs/transport/NodeDisconnectJobMonitorServiceTest.java
+++ b/sql/src/test/java/io/crate/jobs/transport/NodeDisconnectJobMonitorServiceTest.java
@@ -23,13 +23,17 @@
 package io.crate.jobs.transport;
 
 import io.crate.exceptions.ContextMissingException;
+import io.crate.executor.transport.kill.KillJobsRequest;
+import io.crate.executor.transport.kill.TransportKillJobsNodeAction;
 import io.crate.jobs.DummySubContext;
 import io.crate.jobs.JobContextService;
 import io.crate.jobs.JobExecutionContext;
 import io.crate.operation.collect.StatsTables;
 import io.crate.test.integration.CrateUnitTest;
 import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.DummyTransportAddress;
 import org.elasticsearch.common.unit.TimeValue;
@@ -37,15 +41,14 @@ import org.elasticsearch.test.cluster.NoopClusterService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.junit.Test;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import java.util.Arrays;
 import java.util.UUID;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 public class NodeDisconnectJobMonitorServiceTest extends CrateUnitTest {
 
@@ -59,23 +62,53 @@ public class NodeDisconnectJobMonitorServiceTest extends CrateUnitTest {
         JobExecutionContext context = jobContextService.createContext(builder);
 
         ThreadPool threadPool = mock(ThreadPool.class);
-        when(threadPool.schedule(any(TimeValue.class), anyString(), any(Runnable.class))).thenAnswer(new Answer<Object>() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                ((Runnable) invocation.getArguments()[2]).run();
-                return null;
-            }
+        when(threadPool.schedule(any(TimeValue.class), anyString(), any(Runnable.class))).thenAnswer((Answer<Object>) invocation -> {
+            ((Runnable) invocation.getArguments()[2]).run();
+            return null;
         });
 
         NodeDisconnectJobMonitorService monitorService = new NodeDisconnectJobMonitorService(
             Settings.EMPTY,
             threadPool,
             jobContextService,
-            mock(TransportService.class));
+            mock(TransportService.class),
+            mock(TransportKillJobsNodeAction.class));
 
         monitorService.onNodeDisconnected(new DiscoveryNode("noop_id", DummyTransportAddress.INSTANCE, Version.CURRENT));
 
         expectedException.expect(ContextMissingException.class);
         jobContextService.getContext(context.jobId());
+    }
+
+    @Test
+    public void testOnParticipatingNodeDisconnectedKillsJob() throws Exception {
+        JobContextService jobContextService = new JobContextService(
+            Settings.EMPTY, new NoopClusterService(), mock(StatsTables.class));
+
+        DiscoveryNode coordinator_node = new DiscoveryNode("coordinator_node_id", DummyTransportAddress.INSTANCE, Version.CURRENT);
+        DiscoveryNode data_node = new DiscoveryNode("data_node_id", DummyTransportAddress.INSTANCE, Version.CURRENT);
+
+        DiscoveryNodes discoveryNodes = DiscoveryNodes.builder()
+            .localNodeId("coordinator_node_id")
+            .put(coordinator_node)
+            .put(data_node).build();
+
+        JobExecutionContext.Builder builder = jobContextService.newBuilder(UUID.randomUUID(), coordinator_node.getId(), Arrays.asList(coordinator_node.getId(), data_node.getId()));
+        builder.addSubContext(new DummySubContext());
+        jobContextService.createContext(builder);
+        TransportKillJobsNodeAction killAction = mock(TransportKillJobsNodeAction.class);
+
+        NodeDisconnectJobMonitorService monitorService = new NodeDisconnectJobMonitorService(
+            Settings.EMPTY,
+            mock(ThreadPool.class),
+            jobContextService,
+            mock(TransportService.class),
+            killAction);
+
+        monitorService.onNodeDisconnected(discoveryNodes.get("data_node_id"));
+        verify(killAction, times(1)).broadcast(
+            any(KillJobsRequest.class),
+            any(ActionListener.class),
+            eq(Arrays.asList(discoveryNodes.get("data_node_id").getId())));
     }
 }


### PR DESCRIPTION
if a node disconnects, all nodes receive a kill request if they participate
on a job context. This fixes an issue that could caused queries to hang if a
node disconnects.