### PR TITLE
Stream symbols using a immutable `values()` copy.

### DIFF
--- a/sql/src/main/java/io/crate/analyze/symbol/SymbolType.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/SymbolType.java
@@ -21,6 +21,7 @@
 
 package io.crate.analyze.symbol;
 
+import com.google.common.collect.ImmutableList;
 import io.crate.metadata.GeneratedReference;
 import io.crate.metadata.GeoReference;
 import io.crate.metadata.IndexReference;
@@ -28,6 +29,7 @@ import io.crate.metadata.Reference;
 import org.elasticsearch.common.io.stream.StreamInput;
 
 import java.io.IOException;
+import java.util.List;
 
 public enum SymbolType {
 
@@ -47,6 +49,8 @@ public enum SymbolType {
     GENERATED_REFERENCE(GeneratedReference::new),
     PARAMETER(ParameterSymbol::new),
     SELECT_SYMBOL(SelectSymbol::new);
+
+    public static final List<SymbolType> VALUES = ImmutableList.copyOf(values());
 
     private final Symbol.SymbolFactory factory;
 

--- a/sql/src/main/java/io/crate/analyze/symbol/Symbols.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/Symbols.java
@@ -116,7 +116,7 @@ public class Symbols {
     }
 
     public static Symbol fromStream(StreamInput in) throws IOException {
-        return SymbolType.values()[in.readVInt()].newInstance(in);
+        return SymbolType.VALUES.get(in.readVInt()).newInstance(in);
     }
 
     private static class HasColumnVisitor extends SymbolVisitor<ColumnIdent, Boolean> {

--- a/sql/src/main/java/io/crate/metadata/Reference.java
+++ b/sql/src/main/java/io/crate/metadata/Reference.java
@@ -216,6 +216,6 @@ public class Reference extends Symbol {
     }
 
     public static <R extends Reference> R fromStream(StreamInput in) throws IOException {
-        return (R) SymbolType.values()[in.readVInt()].newInstance(in);
+        return (R) SymbolType.VALUES.get(in.readVInt()).newInstance(in);
     }
 }


### PR DESCRIPTION
`values()` on an enum creates an array each time. (Since arrays are
mutable, it has to do so).

~8% improvement:

    testStreamNew  thrpt   20  17721294.219 ± 397890.829  ops/s
    testStreamOld  thrpt   20  16221032.170 ± 258195.918  ops/s