### PR TITLE
Fixed :: use case when adding casted values

### DIFF
--- a/sql-parser/src/main/antlr/SqlBase.g4
+++ b/sql-parser/src/main/antlr/SqlBase.g4
@@ -182,7 +182,6 @@ booleanExpression
     | left=booleanExpression operator=OR right=booleanExpression                     #logicalBinary
     | MATCH '(' matchPredicateIdents ',' term=primaryExpression ')'
         (USING matchType=ident withProperties?)?                                     #match
-    | booleanExpression CAST_OPERATOR dataType                                       #doubleColonCast
     ;
 
 predicated
@@ -209,6 +208,7 @@ valueExpression
         right=valueExpression                                                        #arithmeticBinary
     | left=valueExpression operator=(PLUS | MINUS) right=valueExpression             #arithmeticBinary
     | left=valueExpression CONCAT right=valueExpression                              #concatenation
+    | valueExpression CAST_OPERATOR dataType                                         #doubleColonCast
     ;
 
 primaryExpression

--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -949,7 +949,7 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
 
     @Override
     public Node visitDoubleColonCast(SqlBaseParser.DoubleColonCastContext context) {
-        return new Cast((Expression) visit(context.booleanExpression()), (ColumnType) visit(context.dataType()));
+        return new Cast((Expression) visit(context.valueExpression()), (ColumnType) visit(context.dataType()));
     }
 
     // Primary expressions

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -672,6 +672,12 @@ public class TestStatementBuilder {
         printStatement("select [0,1,5]::array(boolean)");
         printStatement("select field::boolean");
         printStatement("select port['http']::boolean");
+        printStatement("select '4'::integer + 4");
+        printStatement("select 4::string || ' apples'");
+        printStatement("select '-4'::integer");
+        printStatement("select -4::string");
+        printStatement("select '-4'::integer + 10");
+        printStatement("select -4::string || ' apples'");
         // cast
         printStatement("select cast(1+4 as integer) from foo");
         printStatement("select cast('2' as integer) from foo");

--- a/sql/src/test/java/io/crate/operation/scalar/cast/CastFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/cast/CastFunctionTest.java
@@ -51,5 +51,10 @@ public class CastFunctionTest extends AbstractScalarFunctionsTest {
         assertEvaluate("10.4::string", new BytesRef("10.4"));
         assertEvaluate("[1, 2, 0]::array(boolean)", new Boolean[]{true, true, false});
         assertEvaluate("(1+3)/2::string", new BytesRef("2"));
+        assertEvaluate("'10'::long + 5", 15L);
+        assertEvaluate("-4::string", new BytesRef("-4"));
+        assertEvaluate("'-4'::long", -4L);
+        assertEvaluate("-4::string || ' apples'", new BytesRef("-4 apples"));
+        assertEvaluate("'-4'::long + 10", 6L);
     }
 }


### PR DESCRIPTION
This is to fix an issue where parentheses were needed when using :: in operations such as:

`select '4' :: integer + 5;`

and 

`select 5 :: string || ' apples'`