### PR TITLE
idea: Enable formatter tags

### DIFF
--- a/idea/codeStyle.xml
+++ b/idea/codeStyle.xml
@@ -9,6 +9,7 @@
       <option name="INSERT_INNER_CLASS_IMPORTS" value="false" />
       <option name="RIGHT_MARGIN" value="120"/>
       <option name="CONTINUATION_INDENT_SIZE" value="4"/>
+      <option name="FORMATTER_TAGS_ENABLED" value="true" />
       <codeStyleSettings language="JAVA">
         <option name="KEEP_LINE_BREAKS" value="true"/>
         <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="true"/>


### PR DESCRIPTION
This allows us to use

`// @formatter:off` and `// @formatter:on` around code blocks to prevent
Intellij from applying autoformatting.

This is useful in certain cases where non-standard indentation improves
readability. For example when working with the XContentBuilder:

    XContentBuilder builder = XContentFactory.jsonBuilder()
        .startObject()
            .startObject("_meta")
                .startObject("generated_columns")
                    .field("week", "date_trunc('week', ts)")
                .endObject()
            .endObject()
            .startObject("properties")
                .startObject("ts").field("type", "date").endObject()
                .startObject("week").field("type", "long").endObject()
            .endObject()
        .endObject();

Doesn't get reformatted to

    XContentBuilder builder = XContentFactory.jsonBuilder()
        .startObject()
        .startObject("_meta")
        .startObject("generated_columns")
        .field("week", "date_trunc('week', ts)")
        .endObject()
        .endObject()
        .startObject("properties")
        .startObject("ts").field("type", "date").endObject()
        .startObject("week").field("type", "long").endObject()
        .endObject()
        .endObject();

Thus, it is easier to see if start/end calls match.