### PR TITLE
exclude BETWEEN NULL queries in sqllogic tests

### DIFF
--- a/blackbox/sqllogictest/src/sqllogictest.py
+++ b/blackbox/sqllogictest/src/sqllogictest.py
@@ -23,6 +23,7 @@ tqdm.monitor_interval = 0
 
 QUERY_WHITELIST = [re.compile(o, re.IGNORECASE) for o in [
     'CREATE INDEX.*',                        # CREATE INDEX is not supported, but raises SQLParseException
+    '.*BETWEEN.*NULL.*',
 ]]
 
 varchar_to_string = partial(re.compile('VARCHAR\(\d+\)').sub, 'STRING')


### PR DESCRIPTION
as CrateDB delivers different results than
postgresql or sqlite in some cases