### PR TITLE
added lower bound scheduler for system logs

### DIFF
--- a/sql/src/main/java/io/crate/operation/collect/stats/TimeExpiring.java
+++ b/sql/src/main/java/io/crate/operation/collect/stats/TimeExpiring.java
@@ -34,18 +34,21 @@ import java.util.concurrent.TimeUnit;
 class TimeExpiring {
 
     /**
-     * clean interval in seconds
+     * clean interval in milliseconds
      */
-    private static final long QUEUE_CLEAN_INTERVAL = 5L;
+    private static final long DEFAULT_QUEUE_CLEAN_INTERVAL = 5000L;
 
-    private static TimeExpiring INSTANCE = new TimeExpiring(QUEUE_CLEAN_INTERVAL, 0L);
+    private static TimeExpiring INSTANCE = new TimeExpiring(DEFAULT_QUEUE_CLEAN_INTERVAL, 0L);
     private final long interval;
     private final long delay;
 
-    @VisibleForTesting
     TimeExpiring(long interval, long delay) {
         this.interval = interval;
         this.delay = delay;
+    }
+
+    public TimeExpiring(long interval) {
+        this(interval, 0L);
     }
 
     public static TimeExpiring instance() {
@@ -57,7 +60,7 @@ class TimeExpiring {
                                                    TimeValue expiration) {
         return scheduler.scheduleWithFixedDelay(
             () -> removeExpiredLogs(q, System.currentTimeMillis(), expiration.getMillis()),
-            delay, interval, TimeUnit.SECONDS);
+            delay, interval, TimeUnit.MILLISECONDS);
     }
 
     @VisibleForTesting

--- a/sql/src/test/java/io/crate/operation/collect/stats/RamAccountingQueueSinkTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/stats/RamAccountingQueueSinkTest.java
@@ -142,7 +142,7 @@ public class RamAccountingQueueSinkTest extends CrateUnitTest {
         ConcurrentLinkedQueue<NoopLog> q = new ConcurrentLinkedQueue<>();
         RamAccountingQueue<NoopLog> ramAccountingQueue = new RamAccountingQueue<>(q, breaker(), NOOP_ESTIMATOR);
         TimeValue timeValue = TimeValue.timeValueSeconds(1L);
-        TimeExpiring timeExiring = new TimeExpiring(1L, 1L);
+        TimeExpiring timeExiring = new TimeExpiring(1000L, 1000L);
         ScheduledFuture<?> task = timeExiring.registerTruncateTask(q, scheduler, timeValue);
         logSink = new QueueSink<>(ramAccountingQueue, () -> {
             task.cancel(false);

--- a/sql/src/test/java/io/crate/operation/collect/stats/StatsTablesTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/stats/StatsTablesTest.java
@@ -33,6 +33,7 @@ import io.crate.operation.reference.sys.operation.OperationContext;
 import io.crate.operation.reference.sys.operation.OperationContextLog;
 import io.crate.test.integration.CrateUnitTest;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
 import org.elasticsearch.node.settings.NodeSettingsService;
@@ -230,4 +231,13 @@ public class StatsTablesTest extends CrateUnitTest {
         assertTrue(entries.contains(new OperationContextLog(ctxA, null)));
     }
 
+    @Test
+    public void testLowerBoundScheduler() throws NoSuchMethodException {
+        StatsTablesService stats = new StatsTablesService(Settings.EMPTY, nodeSettingsService, scheduler, breakerService);
+        assertThat(stats.clearInterval(TimeValue.timeValueMillis(1L)), is(1000L));
+        assertThat(stats.clearInterval(TimeValue.timeValueSeconds(8L)), is(1000L));
+        assertThat(stats.clearInterval(TimeValue.timeValueSeconds(10L)), is(1000L));
+        assertThat(stats.clearInterval(TimeValue.timeValueSeconds(20L)), is(2000L));
+        assertThat(stats.clearInterval(TimeValue.timeValueHours(720L)), is(86_400_000L));  // 30 days
+    }
 }


### PR DESCRIPTION
This implementation sets the min. scheduled interval to `1s` if an expiration `<= 10s` is used