### PR TITLE
registers `node.sql.read-only` properly as an es setting

### DIFF
--- a/sql/src/main/java/io/crate/action/sql/SQLOperations.java
+++ b/sql/src/main/java/io/crate/action/sql/SQLOperations.java
@@ -43,6 +43,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Provider;
 import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.transport.NodeDisconnectedException;
 
@@ -53,7 +54,8 @@ import java.util.*;
 @Singleton
 public class SQLOperations {
 
-    public final static String NODE_READ_ONLY_SETTING = "node.sql.read_only";
+    public final static Setting<Boolean> NODE_READ_ONLY_SETTING = Setting.boolSetting("node.sql.read_only", false,
+        Setting.Property.NodeScope);
     private final static Logger LOGGER = Loggers.getLogger(SQLOperations.class);
 
     // Parser can't handle empty statement but postgres requires support for it.
@@ -80,7 +82,7 @@ public class SQLOperations {
         this.executorProvider = executorProvider;
         this.statsTables = statsTables;
         this.clusterService = clusterService;
-        this.isReadOnly = settings.getAsBoolean(NODE_READ_ONLY_SETTING, false);
+        this.isReadOnly = NODE_READ_ONLY_SETTING.get(settings);
     }
 
     public Session createSession(@Nullable String defaultSchema, Set<Option> options, int defaultLimit) {

--- a/sql/src/main/java/io/crate/plugin/SQLPlugin.java
+++ b/sql/src/main/java/io/crate/plugin/SQLPlugin.java
@@ -22,6 +22,7 @@
 package io.crate.plugin;
 
 import com.google.common.collect.ImmutableList;
+import io.crate.action.sql.SQLOperations;
 import io.crate.analyze.repositories.RepositorySettingsModule;
 import io.crate.breaker.CircuitBreakerModule;
 import io.crate.breaker.CrateCircuitBreakerService;
@@ -107,6 +108,7 @@ public class SQLPlugin extends Plugin implements ActionPlugin, MapperPlugin {
         settings.add(CrateCircuitBreakerService.QUERY_CIRCUIT_BREAKER_LIMIT_SETTING);
         settings.add(CrateCircuitBreakerService.QUERY_CIRCUIT_BREAKER_OVERHEAD_SETTING);
         settings.add(DecommissioningService.DECOMMISSION_INTERNAL_SETTING_GROUP);
+        settings.add(SQLOperations.NODE_READ_ONLY_SETTING);
 
         addESSettings(settings::add, CrateSettings.CRATE_SETTINGS);
         return settings;

--- a/sql/src/test/java/io/crate/integrationtests/PostgresITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PostgresITest.java
@@ -56,7 +56,7 @@ public class PostgresITest extends SQLTransportIntegrationTest {
         if ((nodeOrdinal + 1) % 2 == 0) {
             builder.put("psql.port", "4242");
         } else {
-            builder.put(SQLOperations.NODE_READ_ONLY_SETTING, true);
+            builder.put(SQLOperations.NODE_READ_ONLY_SETTING.getKey(), true);
             builder.put("psql.port", "4243");
         }
         return builder.build();

--- a/sql/src/test/java/io/crate/integrationtests/ReadOnlyNodeIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ReadOnlyNodeIntegrationTest.java
@@ -76,7 +76,7 @@ public class ReadOnlyNodeIntegrationTest extends SQLTransportIntegrationTest {
         Settings.Builder builder = Settings.builder();
         builder.put(super.nodeSettings(nodeOrdinal));
         if ((nodeOrdinal + 1) % 2 == 0) {
-            builder.put(SQLOperations.NODE_READ_ONLY_SETTING, true);
+            builder.put(SQLOperations.NODE_READ_ONLY_SETTING.getKey(), true);
         }
         return builder.build();
     }


### PR DESCRIPTION
fixes postgres and read-only itests