### PR TITLE
The array comparison no longer requires extra parentheses for subselects.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,9 +5,13 @@ Changes for Crate
 Unreleased
 ==========
 
+ - The array comparison no longer requires extra parentheses for subselects.
+   Now it's possible to use `` = ANY (SELECT ...)`` instead of
+   `` = ANY ((SELECT ...))``
+
  - Fix issue where fulltext search with fuzziness='AUTO' throws
    NumberFormatException.
- 
+
  - BREAKING: Serve admin ui from ``/``
    Admin UI is not accessible via ``_plugin/crate-admin`` anymore. Only via
    ``/admin`` or ``/``.

--- a/sql-parser/src/main/antlr/SqlBase.g4
+++ b/sql-parser/src/main/antlr/SqlBase.g4
@@ -190,10 +190,10 @@ predicated
 
 predicate[ParserRuleContext value]
     : cmpOp right=valueExpression                                                    #comparison
-    | cmpOp setCmpQuantifier '(' primaryExpression ')'                               #quantifiedComparison
+    | cmpOp setCmpQuantifier parenthesizedPrimaryExpressionOrSubquery                #quantifiedComparison
     | NOT? BETWEEN lower=valueExpression AND upper=valueExpression                   #between
     | NOT? IN '(' expr (',' expr)* ')'                                               #inList
-    | NOT? IN '(' query ')'                                                          #inSubquery
+    | NOT? IN subqueryExpression                                                     #inSubquery
     | NOT? LIKE pattern=valueExpression (ESCAPE escape=valueExpression)?             #like
     | NOT? LIKE quant=setCmpQuantifier '(' v=valueExpression')'
         (ESCAPE escape=valueExpression)?                                             #arrayLike
@@ -216,7 +216,7 @@ primaryExpression
     | qname '(' ASTERISK ')' over?                                                   #functionCall
     | ident                                                                          #columnReference
     | qname '(' (setQuant? expr (',' expr)*)? ')' over?                              #functionCall
-    | '(' query ')'                                                                  #subqueryExpression
+    | subqueryExpression                                                             #subqueryExpressionDefault
     // This case handles a simple parenthesized expression.
     | '(' expr ')'                                                                   #nestedExpression
     // This is an extension to ANSI SQL, which considers EXISTS to be a <boolean expression>
@@ -234,6 +234,19 @@ primaryExpression
     | CASE valueExpression whenClause+ (ELSE elseExpr=expr)? END                     #simpleCase
     | CASE whenClause+ (ELSE elseExpr=expr)? END                                     #searchedCase
     | IF '('condition=expr ',' trueValue=expr (',' falseValue=expr)? ')'             #ifCase
+    ;
+
+parenthesizedPrimaryExpressionOrSubquery
+    : parenthesizedPrimaryExpression
+    | subqueryExpression
+    ;
+
+subqueryExpression
+    : '(' query ')'
+    ;
+
+parenthesizedPrimaryExpression
+    : '(' primaryExpression ')'
     ;
 
 identExpr

--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -871,7 +871,7 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     public Node visitInSubquery(SqlBaseParser.InSubqueryContext context) {
         Expression result = new InPredicate(
             (Expression) visit(context.value),
-            new SubqueryExpression((Query) visit(context.query())));
+            (Expression) visit(context.subqueryExpression()));
 
         if (context.NOT() != null) {
             result = new NotExpression(result);
@@ -890,7 +890,7 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
             getComparisonOperator(((TerminalNode) context.cmpOp().getChild(0)).getSymbol()),
             getComparisonQuantifier(((TerminalNode) context.setCmpQuantifier().getChild(0)).getSymbol()),
             (Expression) visit(context.value),
-            (Expression) visit(context.primaryExpression()));
+            (Expression) visit(context.parenthesizedPrimaryExpressionOrSubquery()));
     }
 
     @Override
@@ -997,6 +997,11 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     @Override
     public Node visitSubqueryExpression(SqlBaseParser.SubqueryExpressionContext context) {
         return new SubqueryExpression((Query) visit(context.query()));
+    }
+
+    @Override
+    public Node visitParenthesizedPrimaryExpression(SqlBaseParser.ParenthesizedPrimaryExpressionContext context) {
+        return visit(context.primaryExpression());
     }
 
     @Override

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -757,6 +757,24 @@ public class TestStatementBuilder {
     }
 
     @Test
+    public void testArrayComparisonSubselect() throws Exception {
+        Expression anyExpression = SqlParser.createExpression("1 = ANY ((SELECT 5))");
+        assertThat(anyExpression, instanceOf(ArrayComparisonExpression.class));
+        ArrayComparisonExpression arrayComparisonExpression = (ArrayComparisonExpression) anyExpression;
+        assertThat(arrayComparisonExpression.quantifier(), is(ArrayComparisonExpression.Quantifier.ANY));
+        assertThat(arrayComparisonExpression.getLeft(), instanceOf(LongLiteral.class));
+        assertThat(arrayComparisonExpression.getRight(), instanceOf(SubqueryExpression.class));
+
+        // It's possible to ommit the parenthesis
+        anyExpression = SqlParser.createExpression("1 = ANY (SELECT 5)");
+        assertThat(anyExpression, instanceOf(ArrayComparisonExpression.class));
+        arrayComparisonExpression = (ArrayComparisonExpression) anyExpression;
+        assertThat(arrayComparisonExpression.quantifier(), is(ArrayComparisonExpression.Quantifier.ANY));
+        assertThat(arrayComparisonExpression.getLeft(), instanceOf(LongLiteral.class));
+        assertThat(arrayComparisonExpression.getRight(), instanceOf(SubqueryExpression.class));
+    }
+
+    @Test
     public void testArrayLikeExpression() {
         Expression expression = SqlParser.createExpression("'books%' LIKE ANY(race['interests'])");
         assertThat(expression, instanceOf(ArrayLikePredicate.class));


### PR DESCRIPTION
Now it's possible to use `` = ANY (SELECT ...)`` instead of `` = ANY ((SELECT ...))``