### PR TITLE
Remove indexFieldData indirection to access docValues

### DIFF
--- a/sql/src/main/java/io/crate/lucene/GenericFunctionQuery.java
+++ b/sql/src/main/java/io/crate/lucene/GenericFunctionQuery.java
@@ -137,7 +137,7 @@ class GenericFunctionQuery extends Query {
         };
     }
 
-    private DocIdSet getDocIdSet(final LeafReaderContext context) {
+    private DocIdSet getDocIdSet(final LeafReaderContext context) throws IOException {
         for (LuceneCollectorExpression expression : expressions) {
             expression.setNextReader(context);
         }

--- a/sql/src/main/java/io/crate/operation/reference/doc/lucene/BooleanColumnReference.java
+++ b/sql/src/main/java/io/crate/operation/reference/doc/lucene/BooleanColumnReference.java
@@ -22,12 +22,15 @@
 package io.crate.operation.reference.doc.lucene;
 
 import io.crate.exceptions.GroupByOnArrayUnsupportedException;
+import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.index.fielddata.IndexFieldData;
+import org.elasticsearch.index.fielddata.FieldData;
 import org.elasticsearch.index.fielddata.SortedBinaryDocValues;
 
-public class BooleanColumnReference extends FieldCacheExpression<IndexFieldData, Boolean> {
+import java.io.IOException;
+
+public class BooleanColumnReference extends LuceneCollectorExpression<Boolean> {
 
     private static final BytesRef TRUE_BYTESREF = new BytesRef("1");
     private SortedBinaryDocValues values;
@@ -59,9 +62,9 @@ public class BooleanColumnReference extends FieldCacheExpression<IndexFieldData,
     }
 
     @Override
-    public void setNextReader(LeafReaderContext context) {
+    public void setNextReader(LeafReaderContext context) throws IOException {
         super.setNextReader(context);
-        values = indexFieldData.load(context).getBytesValues();
+        values = FieldData.toString(DocValues.getSortedNumeric(context.reader(), columnName));
     }
 
     @Override

--- a/sql/src/main/java/io/crate/operation/reference/doc/lucene/ByteColumnReference.java
+++ b/sql/src/main/java/io/crate/operation/reference/doc/lucene/ByteColumnReference.java
@@ -22,11 +22,13 @@
 package io.crate.operation.reference.doc.lucene;
 
 import io.crate.exceptions.GroupByOnArrayUnsupportedException;
+import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedNumericDocValues;
-import org.elasticsearch.index.fielddata.IndexNumericFieldData;
 
-public class ByteColumnReference extends FieldCacheExpression<IndexNumericFieldData, Byte> {
+import java.io.IOException;
+
+public class ByteColumnReference extends LuceneCollectorExpression<Byte> {
 
     private SortedNumericDocValues values;
     private Byte value;
@@ -57,9 +59,9 @@ public class ByteColumnReference extends FieldCacheExpression<IndexNumericFieldD
     }
 
     @Override
-    public void setNextReader(LeafReaderContext context) {
+    public void setNextReader(LeafReaderContext context) throws IOException {
         super.setNextReader(context);
-        values = indexFieldData.load(context).getLongValues();
+        values = DocValues.getSortedNumeric(context.reader(), columnName);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/operation/reference/doc/lucene/BytesRefColumnReference.java
+++ b/sql/src/main/java/io/crate/operation/reference/doc/lucene/BytesRefColumnReference.java
@@ -28,6 +28,8 @@ import org.apache.lucene.index.RandomAccessOrds;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.index.fielddata.IndexOrdinalsFieldData;
 
+import java.io.IOException;
+
 public class BytesRefColumnReference extends FieldCacheExpression<IndexOrdinalsFieldData, BytesRef> {
 
     private RandomAccessOrds values;
@@ -59,8 +61,11 @@ public class BytesRefColumnReference extends FieldCacheExpression<IndexOrdinalsF
     }
 
     @Override
-    public void setNextReader(LeafReaderContext context) {
+    public void setNextReader(LeafReaderContext context) throws IOException {
         super.setNextReader(context);
+        // String columns created via CREATE TABLE use docValues so we could use
+        //  `FieldData.maybeSlowRandomAccessOrds(DocValues.getSortedSet(reader, field));` for those.
+        // But dynamic columns don't use docValues so we need to use the fieldData abstraction layer.
         values = indexFieldData.load(context).getOrdinalsValues();
     }
 

--- a/sql/src/main/java/io/crate/operation/reference/doc/lucene/DocIdCollectorExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/doc/lucene/DocIdCollectorExpression.java
@@ -24,6 +24,8 @@ package io.crate.operation.reference.doc.lucene;
 import io.crate.metadata.doc.DocSysColumns;
 import org.apache.lucene.index.LeafReaderContext;
 
+import java.io.IOException;
+
 public class DocIdCollectorExpression extends LuceneCollectorExpression<Long> {
 
     public static final String COLUMN_NAME = DocSysColumns.DOCID.name();
@@ -54,7 +56,7 @@ public class DocIdCollectorExpression extends LuceneCollectorExpression<Long> {
     }
 
     @Override
-    public void setNextReader(LeafReaderContext context) {
+    public void setNextReader(LeafReaderContext context) throws IOException {
         super.setNextReader(context);
         docBase = context.docBase;
     }

--- a/sql/src/main/java/io/crate/operation/reference/doc/lucene/DoubleColumnReference.java
+++ b/sql/src/main/java/io/crate/operation/reference/doc/lucene/DoubleColumnReference.java
@@ -26,6 +26,8 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 
+import java.io.IOException;
+
 public class DoubleColumnReference extends FieldCacheExpression<IndexNumericFieldData, Double> {
 
     private SortedNumericDoubleValues values;
@@ -57,7 +59,7 @@ public class DoubleColumnReference extends FieldCacheExpression<IndexNumericFiel
     }
 
     @Override
-    public void setNextReader(LeafReaderContext context) {
+    public void setNextReader(LeafReaderContext context) throws IOException {
         super.setNextReader(context);
         values = indexFieldData.load(context).getDoubleValues();
     }

--- a/sql/src/main/java/io/crate/operation/reference/doc/lucene/FloatColumnReference.java
+++ b/sql/src/main/java/io/crate/operation/reference/doc/lucene/FloatColumnReference.java
@@ -26,6 +26,8 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
 
+import java.io.IOException;
+
 public class FloatColumnReference extends FieldCacheExpression<IndexNumericFieldData, Float> {
 
     private SortedNumericDoubleValues values;
@@ -57,7 +59,7 @@ public class FloatColumnReference extends FieldCacheExpression<IndexNumericField
     }
 
     @Override
-    public void setNextReader(LeafReaderContext context) {
+    public void setNextReader(LeafReaderContext context) throws IOException {
         super.setNextReader(context);
         values = indexFieldData.load(context).getDoubleValues();
     }

--- a/sql/src/main/java/io/crate/operation/reference/doc/lucene/GeoPointColumnReference.java
+++ b/sql/src/main/java/io/crate/operation/reference/doc/lucene/GeoPointColumnReference.java
@@ -27,6 +27,8 @@ import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
 import org.elasticsearch.index.fielddata.MultiGeoPointValues;
 
+import java.io.IOException;
+
 public class GeoPointColumnReference extends FieldCacheExpression<IndexGeoPointFieldData, Double[]> {
 
     private MultiGeoPointValues values;
@@ -59,7 +61,7 @@ public class GeoPointColumnReference extends FieldCacheExpression<IndexGeoPointF
     }
 
     @Override
-    public void setNextReader(LeafReaderContext context) {
+    public void setNextReader(LeafReaderContext context) throws IOException {
         super.setNextReader(context);
         values = indexFieldData.load(context).getGeoPointValues();
     }

--- a/sql/src/main/java/io/crate/operation/reference/doc/lucene/IntegerColumnReference.java
+++ b/sql/src/main/java/io/crate/operation/reference/doc/lucene/IntegerColumnReference.java
@@ -22,11 +22,13 @@
 package io.crate.operation.reference.doc.lucene;
 
 import io.crate.exceptions.GroupByOnArrayUnsupportedException;
+import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedNumericDocValues;
-import org.elasticsearch.index.fielddata.IndexNumericFieldData;
 
-public class IntegerColumnReference extends FieldCacheExpression<IndexNumericFieldData, Integer> {
+import java.io.IOException;
+
+public class IntegerColumnReference extends LuceneCollectorExpression<Integer> {
 
     private SortedNumericDocValues values;
     private Integer value;
@@ -57,9 +59,9 @@ public class IntegerColumnReference extends FieldCacheExpression<IndexNumericFie
     }
 
     @Override
-    public void setNextReader(LeafReaderContext context) {
+    public void setNextReader(LeafReaderContext context) throws IOException {
         super.setNextReader(context);
-        values = indexFieldData.load(context).getLongValues();
+        values = DocValues.getSortedNumeric(context.reader(), columnName);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/operation/reference/doc/lucene/IpColumnReference.java
+++ b/sql/src/main/java/io/crate/operation/reference/doc/lucene/IpColumnReference.java
@@ -22,13 +22,15 @@
 package io.crate.operation.reference.doc.lucene;
 
 import io.crate.exceptions.GroupByOnArrayUnsupportedException;
+import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedNumericDocValues;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.index.fielddata.IndexNumericFieldData;
 import org.elasticsearch.index.mapper.ip.IpFieldMapper;
 
-public class IpColumnReference extends FieldCacheExpression<IndexNumericFieldData, BytesRef> {
+import java.io.IOException;
+
+public class IpColumnReference extends LuceneCollectorExpression<BytesRef> {
 
     private SortedNumericDocValues values;
     private BytesRef value;
@@ -59,8 +61,8 @@ public class IpColumnReference extends FieldCacheExpression<IndexNumericFieldDat
     }
 
     @Override
-    public void setNextReader(LeafReaderContext context) {
+    public void setNextReader(LeafReaderContext context) throws IOException {
         super.setNextReader(context);
-        values = indexFieldData.load(context).getLongValues();
+        values = DocValues.getSortedNumeric(context.reader(), columnName);
     }
 }

--- a/sql/src/main/java/io/crate/operation/reference/doc/lucene/LongColumnReference.java
+++ b/sql/src/main/java/io/crate/operation/reference/doc/lucene/LongColumnReference.java
@@ -22,11 +22,13 @@
 package io.crate.operation.reference.doc.lucene;
 
 import io.crate.exceptions.GroupByOnArrayUnsupportedException;
+import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedNumericDocValues;
-import org.elasticsearch.index.fielddata.IndexNumericFieldData;
 
-public class LongColumnReference extends FieldCacheExpression<IndexNumericFieldData, Long> {
+import java.io.IOException;
+
+public class LongColumnReference extends LuceneCollectorExpression<Long> {
 
     private SortedNumericDocValues values;
     private Long value;
@@ -57,9 +59,9 @@ public class LongColumnReference extends FieldCacheExpression<IndexNumericFieldD
     }
 
     @Override
-    public void setNextReader(LeafReaderContext context) {
+    public void setNextReader(LeafReaderContext context) throws IOException {
         super.setNextReader(context);
-        values = indexFieldData.load(context).getLongValues();
+        values = DocValues.getSortedNumeric(context.reader(), columnName);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/operation/reference/doc/lucene/LuceneCollectorExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/doc/lucene/LuceneCollectorExpression.java
@@ -25,6 +25,8 @@ import io.crate.operation.Input;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.Scorer;
 
+import java.io.IOException;
+
 /**
  * An expression which gets evaluated in the collect phase
  */
@@ -43,7 +45,7 @@ public abstract class LuceneCollectorExpression<ReturnType> implements Input<Ret
     public void setNextDocId(int doc) {
     }
 
-    public void setNextReader(LeafReaderContext context) {
+    public void setNextReader(LeafReaderContext context) throws IOException {
     }
 
     public void setScorer(Scorer scorer) {

--- a/sql/src/main/java/io/crate/operation/reference/doc/lucene/ShortColumnReference.java
+++ b/sql/src/main/java/io/crate/operation/reference/doc/lucene/ShortColumnReference.java
@@ -22,11 +22,13 @@
 package io.crate.operation.reference.doc.lucene;
 
 import io.crate.exceptions.GroupByOnArrayUnsupportedException;
+import org.apache.lucene.index.DocValues;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedNumericDocValues;
-import org.elasticsearch.index.fielddata.IndexNumericFieldData;
 
-public class ShortColumnReference extends FieldCacheExpression<IndexNumericFieldData, Short> {
+import java.io.IOException;
+
+public class ShortColumnReference extends LuceneCollectorExpression<Short> {
 
     private SortedNumericDocValues values;
     private Short value;
@@ -57,9 +59,9 @@ public class ShortColumnReference extends FieldCacheExpression<IndexNumericField
     }
 
     @Override
-    public void setNextReader(LeafReaderContext context) {
+    public void setNextReader(LeafReaderContext context) throws IOException {
         super.setNextReader(context);
-        values = indexFieldData.load(context).getLongValues();
+        values = DocValues.getSortedNumeric(context.reader(), columnName);
     }
 
     @Override

--- a/sql/src/test/java/io/crate/operation/reference/doc/BooleanColumnReferenceTest.java
+++ b/sql/src/test/java/io/crate/operation/reference/doc/BooleanColumnReferenceTest.java
@@ -24,13 +24,13 @@ package io.crate.operation.reference.doc;
 import io.crate.operation.reference.doc.lucene.BooleanColumnReference;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
+import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
-import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.index.fielddata.FieldDataType;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.junit.Test;
@@ -39,16 +39,12 @@ import static org.hamcrest.core.Is.is;
 
 public class BooleanColumnReferenceTest extends DocLevelExpressionsTest {
 
-    private static final BytesRef TRUE = new BytesRef("1");
-    private static final BytesRef FALSE = new BytesRef("0");
-
     @Override
     protected void insertValues(IndexWriter writer) throws Exception {
         for (int i = 0; i < 10; i++) {
             Document doc = new Document();
             doc.add(new StringField("_id", Integer.toString(i), Field.Store.NO));
-            doc.add(new StringField(fieldName().indexName(),
-                (i % 2 == 0 ? TRUE : FALSE).utf8ToString(), Field.Store.NO));
+            doc.add(new NumericDocValuesField(fieldName().indexName(), i % 2 == 0 ? 1 : 0));
             writer.addDocument(doc);
         }
     }
@@ -67,7 +63,7 @@ public class BooleanColumnReferenceTest extends DocLevelExpressionsTest {
     }
 
     @Test
-    public void testFieldCacheExpression() throws Exception {
+    public void testBooleanExpression() throws Exception {
         BooleanColumnReference booleanColumn = new BooleanColumnReference(fieldName().indexName());
         booleanColumn.startCollect(ctx);
         booleanColumn.setNextReader(readerContext);

--- a/sql/src/test/java/io/crate/operation/reference/doc/ByteColumnReferenceTest.java
+++ b/sql/src/test/java/io/crate/operation/reference/doc/ByteColumnReferenceTest.java
@@ -24,7 +24,7 @@ package io.crate.operation.reference.doc;
 import io.crate.operation.reference.doc.lucene.ByteColumnReference;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
-import org.apache.lucene.document.IntField;
+import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.search.IndexSearcher;
@@ -43,7 +43,7 @@ public class ByteColumnReferenceTest extends DocLevelExpressionsTest {
         for (byte b = -10; b < 10; b++) {
             Document doc = new Document();
             doc.add(new StringField("_id", Byte.toString(b), Field.Store.NO));
-            doc.add(new IntField(fieldName().indexName(), b, Field.Store.NO));
+            doc.add(new NumericDocValuesField(fieldName().indexName(), b));
             writer.addDocument(doc);
         }
     }
@@ -59,7 +59,7 @@ public class ByteColumnReferenceTest extends DocLevelExpressionsTest {
     }
 
     @Test
-    public void testFieldCacheExpression() throws Exception {
+    public void testByteExpression() throws Exception {
         ByteColumnReference byteColumn = new ByteColumnReference(fieldName().indexName());
         byteColumn.startCollect(ctx);
         byteColumn.setNextReader(readerContext);

--- a/sql/src/test/java/io/crate/operation/reference/doc/IntegerColumnReferenceTest.java
+++ b/sql/src/test/java/io/crate/operation/reference/doc/IntegerColumnReferenceTest.java
@@ -24,7 +24,7 @@ package io.crate.operation.reference.doc;
 import io.crate.operation.reference.doc.lucene.IntegerColumnReference;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
-import org.apache.lucene.document.IntField;
+import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.search.IndexSearcher;
@@ -44,7 +44,7 @@ public class IntegerColumnReferenceTest extends DocLevelExpressionsTest {
         for (int i = -10; i < 10; i++) {
             Document doc = new Document();
             doc.add(new StringField("_id", Integer.toString(i), Field.Store.NO));
-            doc.add(new IntField(fieldName().indexName(), i, Field.Store.NO));
+            doc.add(new NumericDocValuesField(fieldName().indexName(), i));
             writer.addDocument(doc);
         }
     }
@@ -60,7 +60,7 @@ public class IntegerColumnReferenceTest extends DocLevelExpressionsTest {
     }
 
     @Test
-    public void testFieldCacheExpression() throws Exception {
+    public void testIntegerExpression() throws Exception {
         IntegerColumnReference integerColumn = new IntegerColumnReference(fieldName().indexName());
         integerColumn.startCollect(ctx);
         integerColumn.setNextReader(readerContext);

--- a/sql/src/test/java/io/crate/operation/reference/doc/LongColumnReferenceTest.java
+++ b/sql/src/test/java/io/crate/operation/reference/doc/LongColumnReferenceTest.java
@@ -24,7 +24,7 @@ package io.crate.operation.reference.doc;
 import io.crate.operation.reference.doc.lucene.LongColumnReference;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
-import org.apache.lucene.document.LongField;
+import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.search.IndexSearcher;
@@ -43,7 +43,7 @@ public class LongColumnReferenceTest extends DocLevelExpressionsTest {
         for (long l = Long.MIN_VALUE; l < Long.MIN_VALUE + 10; l++) {
             Document doc = new Document();
             doc.add(new StringField("_id", Long.toString(l), Field.Store.NO));
-            doc.add(new LongField(fieldName().indexName(), l, Field.Store.NO));
+            doc.add(new NumericDocValuesField(fieldName().indexName(), l));
             writer.addDocument(doc);
         }
     }
@@ -59,7 +59,7 @@ public class LongColumnReferenceTest extends DocLevelExpressionsTest {
     }
 
     @Test
-    public void testFieldCacheExpression() throws Exception {
+    public void testLongExpression() throws Exception {
         LongColumnReference longColumn = new LongColumnReference(fieldName().indexName());
         longColumn.startCollect(ctx);
         longColumn.setNextReader(readerContext);

--- a/sql/src/test/java/io/crate/operation/reference/doc/ShortColumnReferenceTest.java
+++ b/sql/src/test/java/io/crate/operation/reference/doc/ShortColumnReferenceTest.java
@@ -24,7 +24,7 @@ package io.crate.operation.reference.doc;
 import io.crate.operation.reference.doc.lucene.ShortColumnReference;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
-import org.apache.lucene.document.IntField;
+import org.apache.lucene.document.SortedNumericDocValuesField;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.search.IndexSearcher;
@@ -43,7 +43,7 @@ public class ShortColumnReferenceTest extends DocLevelExpressionsTest {
         for (short i = -10; i < 10; i++) {
             Document doc = new Document();
             doc.add(new StringField("_id", Short.toString(i), Field.Store.NO));
-            doc.add(new IntField(fieldName().indexName(), i, Field.Store.NO));
+            doc.add(new SortedNumericDocValuesField(fieldName().indexName(), i));
             writer.addDocument(doc);
         }
     }
@@ -59,7 +59,7 @@ public class ShortColumnReferenceTest extends DocLevelExpressionsTest {
     }
 
     @Test
-    public void testFieldCacheExpression() throws Exception {
+    public void testShortExpression() throws Exception {
         ShortColumnReference shortColumn = new ShortColumnReference(fieldName().indexName());
         shortColumn.startCollect(ctx);
         shortColumn.setNextReader(readerContext);


### PR DESCRIPTION
We default to docValues for most types, for those it is not necessary to
go over the indexFieldData abstraction layer.
Doing so only causes unnecessary AtomicNumericFieldData allocations.

This doesn't change all expression implementations because in some cases
the abstraction still does useful work (see
`BinaryAsSortedNumericFloatValues` as an example).