### PR TITLE
Fixed UnsupportedOperationException thrown when

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed and issue that caused ``UPDATE`` statement on an empty partitioned
+   table to throw UnsupportedOperationException.
+
  - The array comparison no longer requires extra parentheses for subselects.
    Now it's possible to use `` = ANY (SELECT ...)`` instead of
    `` = ANY ((SELECT ...))``

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -12,17 +12,18 @@ Unreleased
    Now it's possible to use `` = ANY (SELECT ...)`` instead of
    `` = ANY ((SELECT ...))``
 
- - Fix issue where fulltext search with fuzziness='AUTO' throws
-   NumberFormatException.
+ - Fixed an issue that caused fulltext search with fuzziness='AUTO'
+   to throw NumberFormatException.
 
  - BREAKING: Serve admin ui from ``/``
    Admin UI is not accessible via ``_plugin/crate-admin`` anymore. Only via
    ``/admin`` or ``/``.
 
- - Fix an issue in the ``LIKE`` predicate which prevents using escaped
+ - Fixed an issue in the ``LIKE`` predicate which prevented from using escaped
    backslash before the wildcard.
 
-- Updated crate-admin to ``1.1.0`` which includes the following change:
+ - Updated crate-admin to ``1.1.0`` which includes the following change:
+
      - Improved console results table, including data type based colorization,
        alternating row colorization, structured object/array formatting,
        human-readable timestamps, Google Maps link on geo-point

--- a/sql/src/main/java/io/crate/planner/consumer/UpdateConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/UpdateConsumer.java
@@ -91,6 +91,9 @@ public class UpdateConsumer implements Consumer {
 
             DocTableRelation tableRelation = (DocTableRelation) statement.sourceRelation();
             DocTableInfo tableInfo = tableRelation.tableInfo();
+            if (tableInfo.isPartitioned() && tableInfo.partitions().isEmpty()) {
+                return new NoopPlan(plannerContext.jobId());
+            }
 
             List<Plan> childNodes = new ArrayList<>(statement.nestedStatements().size());
             UpsertById upsertById = null;

--- a/sql/src/test/java/io/crate/analyze/TableDefinitions.java
+++ b/sql/src/test/java/io/crate/analyze/TableDefinitions.java
@@ -142,6 +142,15 @@ public final class TableDefinitions {
                 add(null);
             }}).asIndexName())
         .build();
+    public static final TableIdent TEST_EMPTY_PARTITIONED_TABLE_IDENT =
+        new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "empty_parted");
+    public static final DocTableInfo TEST_EMPTY_PARTITIONED_TABLE_INFO = new TestingTableInfo.Builder(
+        TEST_EMPTY_PARTITIONED_TABLE_IDENT, new Routing(ImmutableMap.of()))
+        .add("id", DataTypes.INTEGER, null)
+        .add("name", DataTypes.STRING, null)
+        .add("date", DataTypes.TIMESTAMP, null, true)
+        .add("obj", DataTypes.OBJECT, null, ColumnPolicy.DYNAMIC)
+        .build();
     public static final TableIdent PARTED_PKS_IDENT = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "parted_pks");
     public static final DocTableInfo PARTED_PKS_TI = new TestingTableInfo.Builder(
         PARTED_PKS_IDENT, PARTED_ROUTING)

--- a/sql/src/test/java/io/crate/planner/UpdatePlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/UpdatePlannerTest.java
@@ -52,6 +52,7 @@ public class UpdatePlannerTest extends CrateUnitTest {
     private SQLExecutor e = SQLExecutor.builder(new NoopClusterService())
         .enableDefaultTables()
         .addDocTable(TableDefinitions.PARTED_PKS_TI)
+        .addDocTable(TableDefinitions.TEST_EMPTY_PARTITIONED_TABLE_INFO)
         .build();
 
 
@@ -132,5 +133,11 @@ public class UpdatePlannerTest extends CrateUnitTest {
         }
         assertThat(ids, containsInAnyOrder("AgEyATA=", "AgEzAzEyMw==")); // multi primary key - values concatenated and base64'ed
         assertThat(partitions, containsInAnyOrder(".partitioned.parted_pks.04130", ".partitioned.parted_pks.04232chj"));
+    }
+
+    @Test
+    public void testUpdateOnEmptyPartitionedTable() throws Exception {
+        Plan plan = e.plan("update empty_parted set name='Vogon lyric fan'");
+        assertThat(plan, instanceOf(NoopPlan.class));
     }
 }


### PR DESCRIPTION
running an update statement on empty partitioned table.