### PR TITLE
Remove mapperService from CollectorContext

### DIFF
--- a/sql/src/main/java/io/crate/action/sql/query/LuceneSortGenerator.java
+++ b/sql/src/main/java/io/crate/action/sql/query/LuceneSortGenerator.java
@@ -22,6 +22,7 @@
 package io.crate.action.sql.query;
 
 import io.crate.analyze.OrderBy;
+import io.crate.lucene.FieldTypeLookup;
 import io.crate.operation.collect.DocInputFactory;
 import io.crate.operation.reference.doc.lucene.CollectorContext;
 import org.apache.lucene.search.Sort;
@@ -34,11 +35,12 @@ public class LuceneSortGenerator {
     @Nullable
     public static Sort generateLuceneSort(CollectorContext context,
                                           OrderBy orderBy,
-                                          DocInputFactory docInputFactory) {
+                                          DocInputFactory docInputFactory,
+                                          FieldTypeLookup fieldTypeLookup) {
         if (orderBy.orderBySymbols().isEmpty()) {
             return null;
         }
-        SortSymbolVisitor sortSymbolVisitor = new SortSymbolVisitor(docInputFactory);
+        SortSymbolVisitor sortSymbolVisitor = new SortSymbolVisitor(docInputFactory, fieldTypeLookup);
         SortField[] sortFields = sortSymbolVisitor.generateSortFields(
             orderBy.orderBySymbols(),
             context,

--- a/sql/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
+++ b/sql/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
@@ -1293,7 +1293,6 @@ public class LuceneQueryBuilder {
             @SuppressWarnings("unchecked")
             final Collection<? extends LuceneCollectorExpression<?>> expressions = ctx.expressions();
             final CollectorContext collectorContext = new CollectorContext(
-                context.mapperService,
                 context.fieldDataService,
                 new CollectorFieldsVisitor(expressions.size())
             );

--- a/sql/src/main/java/io/crate/operation/collect/collectors/LuceneOrderedDocCollector.java
+++ b/sql/src/main/java/io/crate/operation/collect/collectors/LuceneOrderedDocCollector.java
@@ -57,6 +57,7 @@ public class LuceneOrderedDocCollector extends OrderedDocCollector {
     private final Float minScore;
     private final boolean doDocsScores;
     private final int batchSize;
+    private final FieldTypeLookup fieldTypeLookup;
     private final CollectorContext collectorContext;
     private final OrderBy orderBy;
     private final Sort sort;
@@ -76,6 +77,7 @@ public class LuceneOrderedDocCollector extends OrderedDocCollector {
                                      Float minScore,
                                      boolean doDocsScores,
                                      int batchSize,
+                                     FieldTypeLookup fieldTypeLookup,
                                      CollectorContext collectorContext,
                                      OrderBy orderBy,
                                      Sort sort,
@@ -87,6 +89,7 @@ public class LuceneOrderedDocCollector extends OrderedDocCollector {
         this.minScore = minScore;
         this.doDocsScores = doDocsScores;
         this.batchSize = batchSize;
+        this.fieldTypeLookup = fieldTypeLookup;
         this.collectorContext = collectorContext;
         this.orderBy = orderBy;
         this.sort = sort;
@@ -158,7 +161,7 @@ public class LuceneOrderedDocCollector extends OrderedDocCollector {
     }
 
     private Query query(FieldDoc lastDoc) {
-        Query query = nextPageQuery(lastDoc, orderBy, missingValues, collectorContext.mapperService()::fullName);
+        Query query = nextPageQuery(lastDoc, orderBy, missingValues, fieldTypeLookup);
         if (query == null) {
             return this.query;
         }

--- a/sql/src/main/java/io/crate/operation/fetch/FetchCollector.java
+++ b/sql/src/main/java/io/crate/operation/fetch/FetchCollector.java
@@ -34,7 +34,6 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.ReaderUtil;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.fielddata.IndexFieldDataService;
-import org.elasticsearch.index.mapper.MapperService;
 
 import java.io.IOException;
 import java.util.List;
@@ -50,7 +49,6 @@ class FetchCollector {
 
     FetchCollector(List<LuceneCollectorExpression<?>> collectorExpressions,
                    Streamer<?>[] streamers,
-                   MapperService mapperService,
                    Engine.Searcher searcher,
                    IndexFieldDataService indexFieldDataService,
                    int readerId) {
@@ -59,7 +57,7 @@ class FetchCollector {
         this.streamers = streamers;
         this.readerContexts = searcher.searcher().getIndexReader().leaves();
         this.fieldsVisitor = new CollectorFieldsVisitor(this.collectorExpressions.length);
-        CollectorContext collectorContext = new CollectorContext(mapperService, indexFieldDataService, fieldsVisitor, readerId);
+        CollectorContext collectorContext = new CollectorContext(indexFieldDataService, fieldsVisitor, readerId);
         for (LuceneCollectorExpression<?> collectorExpression : this.collectorExpressions) {
             collectorExpression.startCollect(collectorContext);
         }

--- a/sql/src/main/java/io/crate/operation/fetch/NodeFetchOperation.java
+++ b/sql/src/main/java/io/crate/operation/fetch/NodeFetchOperation.java
@@ -40,7 +40,6 @@ import io.crate.metadata.TableIdent;
 import io.crate.operation.collect.stats.StatsTables;
 import io.crate.operation.reference.doc.lucene.LuceneCollectorExpression;
 import io.crate.operation.reference.doc.lucene.LuceneReferenceResolver;
-import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -74,7 +73,7 @@ public class NodeFetchOperation {
 
         FetchCollector createCollector(int readerId) {
             IndexService indexService = fetchContext.indexService(readerId);
-            LuceneReferenceResolver resolver = new LuceneReferenceResolver(indexService.mapperService());
+            LuceneReferenceResolver resolver = new LuceneReferenceResolver(indexService.mapperService()::smartNameFieldType);
             ArrayList<LuceneCollectorExpression<?>> exprs = new ArrayList<>(refs.size());
             for (Reference reference : refs) {
                 exprs.add(resolver.getImplementation(reference));
@@ -82,7 +81,6 @@ public class NodeFetchOperation {
             return new FetchCollector(
                 exprs,
                 streamers,
-                indexService.mapperService(),
                 fetchContext.searcher(readerId),
                 indexService.fieldData(),
                 readerId

--- a/sql/src/main/java/io/crate/operation/reference/doc/lucene/BytesRefColumnReference.java
+++ b/sql/src/main/java/io/crate/operation/reference/doc/lucene/BytesRefColumnReference.java
@@ -27,6 +27,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.RandomAccessOrds;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.index.fielddata.IndexOrdinalsFieldData;
+import org.elasticsearch.index.mapper.MappedFieldType;
 
 import java.io.IOException;
 
@@ -35,8 +36,8 @@ public class BytesRefColumnReference extends FieldCacheExpression<IndexOrdinalsF
     private RandomAccessOrds values;
     private BytesRef value;
 
-    public BytesRefColumnReference(String columnName) {
-        super(columnName);
+    public BytesRefColumnReference(String columnName, MappedFieldType mappedFieldType) {
+        super(columnName, mappedFieldType);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/operation/reference/doc/lucene/CollectorContext.java
+++ b/sql/src/main/java/io/crate/operation/reference/doc/lucene/CollectorContext.java
@@ -23,29 +23,24 @@ package io.crate.operation.reference.doc.lucene;
 
 import io.crate.operation.collect.collectors.CollectorFieldsVisitor;
 import org.elasticsearch.index.fielddata.IndexFieldDataService;
-import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.search.lookup.SourceLookup;
 
 public class CollectorContext {
 
-    private final MapperService mapperService;
     private final IndexFieldDataService fieldData;
     private final CollectorFieldsVisitor fieldsVisitor;
     private final int jobSearchContextId;
 
     private SourceLookup sourceLookup;
 
-    public CollectorContext(MapperService mapperService,
-                            IndexFieldDataService fieldData,
+    public CollectorContext(IndexFieldDataService fieldData,
                             CollectorFieldsVisitor visitor) {
-        this(mapperService, fieldData, visitor, -1);
+        this(fieldData, visitor, -1);
     }
 
-    public CollectorContext(MapperService mapperService,
-                            IndexFieldDataService fieldData,
+    public CollectorContext(IndexFieldDataService fieldData,
                             CollectorFieldsVisitor visitor,
                             int jobSearchContextId) {
-        this.mapperService = mapperService;
         this.fieldData = fieldData;
         fieldsVisitor = visitor;
         this.jobSearchContextId = jobSearchContextId;
@@ -57,10 +52,6 @@ public class CollectorContext {
 
     public int jobSearchContextId() {
         return jobSearchContextId;
-    }
-
-    public MapperService mapperService() {
-        return mapperService;
     }
 
     public IndexFieldDataService fieldData() {

--- a/sql/src/main/java/io/crate/operation/reference/doc/lucene/DoubleColumnReference.java
+++ b/sql/src/main/java/io/crate/operation/reference/doc/lucene/DoubleColumnReference.java
@@ -25,6 +25,7 @@ import io.crate.exceptions.GroupByOnArrayUnsupportedException;
 import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
+import org.elasticsearch.index.mapper.MappedFieldType;
 
 import java.io.IOException;
 
@@ -33,8 +34,8 @@ public class DoubleColumnReference extends FieldCacheExpression<IndexNumericFiel
     private SortedNumericDoubleValues values;
     private Double value;
 
-    public DoubleColumnReference(String columnName) {
-        super(columnName);
+    public DoubleColumnReference(String columnName, MappedFieldType mappedFieldType) {
+        super(columnName, mappedFieldType);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/operation/reference/doc/lucene/FieldCacheExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/doc/lucene/FieldCacheExpression.java
@@ -21,7 +21,6 @@
 
 package io.crate.operation.reference.doc.lucene;
 
-import io.crate.Constants;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.mapper.MappedFieldType;
 
@@ -29,17 +28,15 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 public abstract class FieldCacheExpression<IFD extends IndexFieldData, ReturnType> extends
     LuceneCollectorExpression<ReturnType> {
 
-    private final static String[] DEFAULT_MAPPING_TYPES = new String[]{
-        Constants.DEFAULT_MAPPING_TYPE};
-
+    private final MappedFieldType fieldType;
     protected IFD indexFieldData;
 
-    public FieldCacheExpression(String columnName) {
+    FieldCacheExpression(String columnName, MappedFieldType fieldType) {
         super(columnName);
+        this.fieldType = fieldType;
     }
 
     public void startCollect(CollectorContext context) {
-        MappedFieldType mapper = context.mapperService().smartNameFieldType(columnName, DEFAULT_MAPPING_TYPES);
-        indexFieldData = context.fieldData().getForField(mapper);
+        indexFieldData = context.fieldData().getForField(fieldType);
     }
 }

--- a/sql/src/main/java/io/crate/operation/reference/doc/lucene/FloatColumnReference.java
+++ b/sql/src/main/java/io/crate/operation/reference/doc/lucene/FloatColumnReference.java
@@ -25,6 +25,7 @@ import io.crate.exceptions.GroupByOnArrayUnsupportedException;
 import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.index.fielddata.IndexNumericFieldData;
 import org.elasticsearch.index.fielddata.SortedNumericDoubleValues;
+import org.elasticsearch.index.mapper.MappedFieldType;
 
 import java.io.IOException;
 
@@ -33,8 +34,8 @@ public class FloatColumnReference extends FieldCacheExpression<IndexNumericField
     private SortedNumericDoubleValues values;
     private Float value;
 
-    public FloatColumnReference(String columnName) {
-        super(columnName);
+    public FloatColumnReference(String columnName, MappedFieldType fieldType) {
+        super(columnName, fieldType);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/operation/reference/doc/lucene/GeoPointColumnReference.java
+++ b/sql/src/main/java/io/crate/operation/reference/doc/lucene/GeoPointColumnReference.java
@@ -26,6 +26,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.index.fielddata.IndexGeoPointFieldData;
 import org.elasticsearch.index.fielddata.MultiGeoPointValues;
+import org.elasticsearch.index.mapper.MappedFieldType;
 
 import java.io.IOException;
 
@@ -34,8 +35,8 @@ public class GeoPointColumnReference extends FieldCacheExpression<IndexGeoPointF
     private MultiGeoPointValues values;
     private Double[] value;
 
-    public GeoPointColumnReference(String columnName) {
-        super(columnName);
+    public GeoPointColumnReference(String columnName, MappedFieldType mappedFieldType) {
+        super(columnName, mappedFieldType);
     }
 
     @Override

--- a/sql/src/test/java/io/crate/operation/reference/doc/BooleanColumnReferenceTest.java
+++ b/sql/src/test/java/io/crate/operation/reference/doc/BooleanColumnReferenceTest.java
@@ -31,40 +31,27 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
-import org.elasticsearch.index.fielddata.FieldDataType;
-import org.elasticsearch.index.mapper.MappedFieldType;
 import org.junit.Test;
 
 import static org.hamcrest.core.Is.is;
 
 public class BooleanColumnReferenceTest extends DocLevelExpressionsTest {
 
+    private String column = "b";
+
     @Override
     protected void insertValues(IndexWriter writer) throws Exception {
         for (int i = 0; i < 10; i++) {
             Document doc = new Document();
             doc.add(new StringField("_id", Integer.toString(i), Field.Store.NO));
-            doc.add(new NumericDocValuesField(fieldName().indexName(), i % 2 == 0 ? 1 : 0));
+            doc.add(new NumericDocValuesField(column, i % 2 == 0 ? 1 : 0));
             writer.addDocument(doc);
         }
     }
 
-    @Override
-    protected MappedFieldType.Names fieldName() {
-        return new MappedFieldType.Names("bool");
-    }
-
-    /**
-     * @see {@link org.elasticsearch.index.mapper.core.BooleanFieldMapper}
-     */
-    @Override
-    protected FieldDataType fieldType() {
-        return new FieldDataType("string");
-    }
-
     @Test
     public void testBooleanExpression() throws Exception {
-        BooleanColumnReference booleanColumn = new BooleanColumnReference(fieldName().indexName());
+        BooleanColumnReference booleanColumn = new BooleanColumnReference(column);
         booleanColumn.startCollect(ctx);
         booleanColumn.setNextReader(readerContext);
         IndexSearcher searcher = new IndexSearcher(readerContext.reader());

--- a/sql/src/test/java/io/crate/operation/reference/doc/ByteColumnReferenceTest.java
+++ b/sql/src/test/java/io/crate/operation/reference/doc/ByteColumnReferenceTest.java
@@ -31,36 +31,27 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
-import org.elasticsearch.index.fielddata.FieldDataType;
-import org.elasticsearch.index.mapper.MappedFieldType;
 import org.junit.Test;
 
 import static org.hamcrest.core.Is.is;
 
 public class ByteColumnReferenceTest extends DocLevelExpressionsTest {
+
+    private String column = "b";
+
     @Override
     protected void insertValues(IndexWriter writer) throws Exception {
         for (byte b = -10; b < 10; b++) {
             Document doc = new Document();
             doc.add(new StringField("_id", Byte.toString(b), Field.Store.NO));
-            doc.add(new NumericDocValuesField(fieldName().indexName(), b));
+            doc.add(new NumericDocValuesField(column, b));
             writer.addDocument(doc);
         }
     }
 
-    @Override
-    protected MappedFieldType.Names fieldName() {
-        return new MappedFieldType.Names("b");
-    }
-
-    @Override
-    protected FieldDataType fieldType() {
-        return new FieldDataType("byte");
-    }
-
     @Test
     public void testByteExpression() throws Exception {
-        ByteColumnReference byteColumn = new ByteColumnReference(fieldName().indexName());
+        ByteColumnReference byteColumn = new ByteColumnReference(column);
         byteColumn.startCollect(ctx);
         byteColumn.setNextReader(readerContext);
         IndexSearcher searcher = new IndexSearcher(readerContext.reader());

--- a/sql/src/test/java/io/crate/operation/reference/doc/BytesRefColumnReferenceTest.java
+++ b/sql/src/test/java/io/crate/operation/reference/doc/BytesRefColumnReferenceTest.java
@@ -30,13 +30,15 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
-import org.elasticsearch.index.fielddata.FieldDataType;
 import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.core.StringFieldMapper;
 import org.junit.Test;
 
 import static org.hamcrest.core.Is.is;
 
 public class BytesRefColumnReferenceTest extends DocLevelExpressionsTest {
+
+    private String column = "b";
 
     @Override
     protected void insertValues(IndexWriter writer) throws Exception {
@@ -45,24 +47,16 @@ public class BytesRefColumnReferenceTest extends DocLevelExpressionsTest {
             builder.append(i);
             Document doc = new Document();
             doc.add(new StringField("_id", Integer.toString(i), Field.Store.NO));
-            doc.add(new StringField(fieldName().indexName(), builder.toString(), Field.Store.NO));
+            doc.add(new StringField(column, builder.toString(), Field.Store.NO));
             writer.addDocument(doc);
         }
     }
 
-    @Override
-    protected MappedFieldType.Names fieldName() {
-        return new MappedFieldType.Names("br");
-    }
-
-    @Override
-    protected FieldDataType fieldType() {
-        return new FieldDataType("string");
-    }
-
     @Test
     public void testFieldCacheExpression() throws Exception {
-        BytesRefColumnReference bytesRefColumn = new BytesRefColumnReference(fieldName().indexName());
+        MappedFieldType fieldType = StringFieldMapper.Defaults.FIELD_TYPE.clone();
+        fieldType.setNames(new MappedFieldType.Names(column));
+        BytesRefColumnReference bytesRefColumn = new BytesRefColumnReference(column, fieldType);
         bytesRefColumn.startCollect(ctx);
         bytesRefColumn.setNextReader(readerContext);
         IndexSearcher searcher = new IndexSearcher(readerContext.reader());

--- a/sql/src/test/java/io/crate/operation/reference/doc/DocLevelExpressionsTest.java
+++ b/sql/src/test/java/io/crate/operation/reference/doc/DocLevelExpressionsTest.java
@@ -28,18 +28,9 @@ import org.apache.lucene.index.*;
 import org.apache.lucene.store.RAMDirectory;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexService;
-import org.elasticsearch.index.fielddata.FieldDataType;
-import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.IndexFieldDataService;
-import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.index.mapper.MapperService;
 import org.junit.After;
 import org.junit.Before;
-import org.mockito.Matchers;
-
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public abstract class DocLevelExpressionsTest extends CrateSingleNodeTest {
 
@@ -53,26 +44,15 @@ public abstract class DocLevelExpressionsTest extends CrateSingleNodeTest {
         Settings settings = Settings.builder().put("index.fielddata.cache", "none").build();
         IndexService indexService = createIndex("test", settings);
         ifd = indexService.fieldData();
-
-        MapperService mapperService = mock(MapperService.class);
-        MappedFieldType fieldMapper = mock(MappedFieldType.class);
-        when(fieldMapper.names()).thenReturn(fieldName());
-        when(fieldMapper.fieldDataType()).thenReturn(fieldType());
-        when(mapperService.smartNameFieldType(anyString(), Matchers.<String[]>any())).thenReturn(fieldMapper);
-
-
-        IndexFieldData<?> fieldData = ifd.getForField(fieldMapper);
         writer = new IndexWriter(new RAMDirectory(),
-            new IndexWriterConfig(new StandardAnalyzer())
-                .setMergePolicy(new LogByteSizeMergePolicy()));
+            new IndexWriterConfig(new StandardAnalyzer()).setMergePolicy(new LogByteSizeMergePolicy()));
 
         insertValues(writer);
 
         DirectoryReader directoryReader = DirectoryReader.open(writer, true);
         readerContext = directoryReader.leaves().get(0);
-        fieldData.load(readerContext);
 
-        ctx = new CollectorContext(mapperService, ifd, null);
+        ctx = new CollectorContext(ifd, null);
     }
 
     @After
@@ -83,8 +63,4 @@ public abstract class DocLevelExpressionsTest extends CrateSingleNodeTest {
     }
 
     protected abstract void insertValues(IndexWriter writer) throws Exception;
-
-    protected abstract MappedFieldType.Names fieldName();
-
-    protected abstract FieldDataType fieldType();
 }

--- a/sql/src/test/java/io/crate/operation/reference/doc/DoubleColumnReferenceTest.java
+++ b/sql/src/test/java/io/crate/operation/reference/doc/DoubleColumnReferenceTest.java
@@ -31,37 +31,31 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
-import org.elasticsearch.index.fielddata.FieldDataType;
 import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.core.DoubleFieldMapper;
 import org.junit.Test;
 
 import static org.hamcrest.core.Is.is;
 
 public class DoubleColumnReferenceTest extends DocLevelExpressionsTest {
 
+    private String column = "d";
+
     @Override
     protected void insertValues(IndexWriter writer) throws Exception {
         for (double d = 0.5; d < 10.0d; d++) {
             Document doc = new Document();
             doc.add(new StringField("_id", Double.toString(d), Field.Store.NO));
-            doc.add(new DoubleField(fieldName().indexName(), d, Field.Store.NO));
+            doc.add(new DoubleField(column, d, Field.Store.NO));
             writer.addDocument(doc);
         }
     }
 
-    @Override
-    protected MappedFieldType.Names fieldName() {
-        return new MappedFieldType.Names("d");
-    }
-
-    @Override
-    protected FieldDataType fieldType() {
-        return new FieldDataType("double");
-    }
-
     @Test
     public void testFieldCacheExpression() throws Exception {
-        DoubleColumnReference doubleColumn = new DoubleColumnReference(fieldName().indexName());
+        MappedFieldType fieldType = DoubleFieldMapper.Defaults.FIELD_TYPE.clone();
+        fieldType.setNames(new MappedFieldType.Names("d"));
+        DoubleColumnReference doubleColumn = new DoubleColumnReference(column, fieldType);
         doubleColumn.startCollect(ctx);
         doubleColumn.setNextReader(readerContext);
         IndexSearcher searcher = new IndexSearcher(readerContext.reader());

--- a/sql/src/test/java/io/crate/operation/reference/doc/FloatColumnReferenceTest.java
+++ b/sql/src/test/java/io/crate/operation/reference/doc/FloatColumnReferenceTest.java
@@ -31,36 +31,31 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
-import org.elasticsearch.index.fielddata.FieldDataType;
 import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.core.FloatFieldMapper;
 import org.junit.Test;
 
 import static org.hamcrest.core.Is.is;
 
 public class FloatColumnReferenceTest extends DocLevelExpressionsTest {
+
+    private String column = "f";
+
     @Override
     protected void insertValues(IndexWriter writer) throws Exception {
         for (float f = -0.5f; f < 10.0f; f++) {
             Document doc = new Document();
             doc.add(new StringField("_id", Float.toString(f), Field.Store.NO));
-            doc.add(new FloatField(fieldName().indexName(), f, Field.Store.NO));
+            doc.add(new FloatField(column, f, Field.Store.NO));
             writer.addDocument(doc);
         }
     }
 
-    @Override
-    protected MappedFieldType.Names fieldName() {
-        return new MappedFieldType.Names("f");
-    }
-
-    @Override
-    protected FieldDataType fieldType() {
-        return new FieldDataType("float");
-    }
-
     @Test
     public void testFieldCacheExpression() throws Exception {
-        FloatColumnReference floatColumn = new FloatColumnReference(fieldName().indexName());
+        MappedFieldType fieldType = FloatFieldMapper.Defaults.FIELD_TYPE.clone();
+        fieldType.setNames(new MappedFieldType.Names(column));
+        FloatColumnReference floatColumn = new FloatColumnReference(column, fieldType);
         floatColumn.startCollect(ctx);
         floatColumn.setNextReader(readerContext);
         IndexSearcher searcher = new IndexSearcher(readerContext.reader());

--- a/sql/src/test/java/io/crate/operation/reference/doc/IntegerColumnReferenceTest.java
+++ b/sql/src/test/java/io/crate/operation/reference/doc/IntegerColumnReferenceTest.java
@@ -31,37 +31,27 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
-import org.elasticsearch.index.fielddata.FieldDataType;
-import org.elasticsearch.index.mapper.MappedFieldType;
 import org.junit.Test;
 
 import static org.hamcrest.core.Is.is;
 
 public class IntegerColumnReferenceTest extends DocLevelExpressionsTest {
 
+   private String column = "i";
+
     @Override
     protected void insertValues(IndexWriter writer) throws Exception {
         for (int i = -10; i < 10; i++) {
             Document doc = new Document();
             doc.add(new StringField("_id", Integer.toString(i), Field.Store.NO));
-            doc.add(new NumericDocValuesField(fieldName().indexName(), i));
+            doc.add(new NumericDocValuesField(column, i));
             writer.addDocument(doc);
         }
     }
 
-    @Override
-    protected MappedFieldType.Names fieldName() {
-        return new MappedFieldType.Names("i");
-    }
-
-    @Override
-    protected FieldDataType fieldType() {
-        return new FieldDataType("int");
-    }
-
     @Test
     public void testIntegerExpression() throws Exception {
-        IntegerColumnReference integerColumn = new IntegerColumnReference(fieldName().indexName());
+        IntegerColumnReference integerColumn = new IntegerColumnReference(column);
         integerColumn.startCollect(ctx);
         integerColumn.setNextReader(readerContext);
         IndexSearcher searcher = new IndexSearcher(readerContext.reader());

--- a/sql/src/test/java/io/crate/operation/reference/doc/LongColumnReferenceTest.java
+++ b/sql/src/test/java/io/crate/operation/reference/doc/LongColumnReferenceTest.java
@@ -31,36 +31,27 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
-import org.elasticsearch.index.fielddata.FieldDataType;
-import org.elasticsearch.index.mapper.MappedFieldType;
 import org.junit.Test;
 
 import static org.hamcrest.core.Is.is;
 
 public class LongColumnReferenceTest extends DocLevelExpressionsTest {
+
+    private String column = "l";
+
     @Override
     protected void insertValues(IndexWriter writer) throws Exception {
         for (long l = Long.MIN_VALUE; l < Long.MIN_VALUE + 10; l++) {
             Document doc = new Document();
             doc.add(new StringField("_id", Long.toString(l), Field.Store.NO));
-            doc.add(new NumericDocValuesField(fieldName().indexName(), l));
+            doc.add(new NumericDocValuesField(column, l));
             writer.addDocument(doc);
         }
     }
 
-    @Override
-    protected MappedFieldType.Names fieldName() {
-        return new MappedFieldType.Names("l");
-    }
-
-    @Override
-    protected FieldDataType fieldType() {
-        return new FieldDataType("long");
-    }
-
     @Test
     public void testLongExpression() throws Exception {
-        LongColumnReference longColumn = new LongColumnReference(fieldName().indexName());
+        LongColumnReference longColumn = new LongColumnReference(column);
         longColumn.startCollect(ctx);
         longColumn.setNextReader(readerContext);
         IndexSearcher searcher = new IndexSearcher(readerContext.reader());

--- a/sql/src/test/java/io/crate/operation/reference/doc/ShortColumnReferenceTest.java
+++ b/sql/src/test/java/io/crate/operation/reference/doc/ShortColumnReferenceTest.java
@@ -31,36 +31,27 @@ import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
-import org.elasticsearch.index.fielddata.FieldDataType;
-import org.elasticsearch.index.mapper.MappedFieldType;
 import org.junit.Test;
 
 import static org.hamcrest.core.Is.is;
 
 public class ShortColumnReferenceTest extends DocLevelExpressionsTest {
+
+    private String column = "s";
+
     @Override
     protected void insertValues(IndexWriter writer) throws Exception {
         for (short i = -10; i < 10; i++) {
             Document doc = new Document();
             doc.add(new StringField("_id", Short.toString(i), Field.Store.NO));
-            doc.add(new SortedNumericDocValuesField(fieldName().indexName(), i));
+            doc.add(new SortedNumericDocValuesField(column, i));
             writer.addDocument(doc);
         }
     }
 
-    @Override
-    protected MappedFieldType.Names fieldName() {
-        return new MappedFieldType.Names("s");
-    }
-
-    @Override
-    protected FieldDataType fieldType() {
-        return new FieldDataType("short");
-    }
-
     @Test
     public void testShortExpression() throws Exception {
-        ShortColumnReference shortColumn = new ShortColumnReference(fieldName().indexName());
+        ShortColumnReference shortColumn = new ShortColumnReference(column);
         shortColumn.startCollect(ctx);
         shortColumn.setNextReader(readerContext);
         IndexSearcher searcher = new IndexSearcher(readerContext.reader());

--- a/sql/src/test/java/io/crate/operation/reference/doc/lucene/LuceneReferenceResolverTest.java
+++ b/sql/src/test/java/io/crate/operation/reference/doc/lucene/LuceneReferenceResolverTest.java
@@ -28,13 +28,14 @@ import io.crate.metadata.RowGranularity;
 import io.crate.metadata.TableIdent;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.types.DataTypes;
+import org.elasticsearch.index.mapper.core.StringFieldMapper;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.instanceOf;
 
 public class LuceneReferenceResolverTest extends CrateUnitTest {
 
-    private LuceneReferenceResolver luceneReferenceResolver = new LuceneReferenceResolver(null);
+    private LuceneReferenceResolver luceneReferenceResolver = new LuceneReferenceResolver(i -> StringFieldMapper.Defaults.FIELD_TYPE);
 
     @Test
     public void testGetImplementationWithColumnsOfTypeCollection() {


### PR DESCRIPTION
Some LuceneCollectorExpressions used the mapperService in startCollect
to retrieve the MappedFieldType. But the MappedFieldType is already
available when the expressions are created so this indirection through
the CollectorContext & startCollect can be removed.