### PR TITLE
Optimize guessType for arrays

### DIFF
--- a/core/src/main/java/io/crate/types/DataTypes.java
+++ b/core/src/main/java/io/crate/types/DataTypes.java
@@ -221,10 +221,6 @@ public final class DataTypes {
     }
 
     private static DataType valueFromList(List<Object> value) {
-        List<DataType> innerTypes = new ArrayList<>(value.size());
-        if (value.isEmpty()) {
-            return new ArrayType(UNDEFINED);
-        }
         DataType previous = null;
         DataType current = null;
         for (Object o : value) {
@@ -235,15 +231,12 @@ public final class DataTypes {
             if (previous != null && !current.equals(previous)) {
                 throw new IllegalArgumentException("Mixed dataTypes inside a list are not supported");
             }
-            innerTypes.add(current);
             previous = current;
         }
-
-        if (innerTypes.isEmpty() || (innerTypes.size() > 0 && current == null)) {
+        if (current == null) {
             return new ArrayType(UNDEFINED);
-        } else {
-            return new ArrayType(current);
         }
+        return new ArrayType(current);
     }
 
     private static final ImmutableMap<String, DataType> staticTypesNameMap = ImmutableMap.<String, DataType>builder()


### PR DESCRIPTION
```
Benchmark     Mode  Cnt    Score   Error  Units
guessTypeNew  avgt  200  275.621 ± 4.898  ns/op
guessTypeOld  avgt  200  304.432 ± 4.513  ns/op

```