### PR TITLE
fixed map comparison that led to cast exception

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed issue that led to casting exception when comparing an object column
+   with an object literal that contains a string value.
+
  - Dynamically added string columns now have exactly the same characteristics
    as string columns created via ``CREATE TABLE`` or ``ALTER TABLE ADD COLUMN``
 

--- a/core/src/main/java/io/crate/core/collections/MapComparator.java
+++ b/core/src/main/java/io/crate/core/collections/MapComparator.java
@@ -62,7 +62,7 @@ public class MapComparator implements Comparator<Map> {
                 }
                 if (!thisValue.getClass().equals(otherValue.getClass())) {
                     DataType leftType = DataTypes.guessType(thisValue);
-                    int cmp = leftType.compareValueTo(thisValue, leftType.value(otherValue));
+                    int cmp = leftType.compareValueTo(leftType.value(thisValue), leftType.value(otherValue));
                     if (cmp == 0) {
                         continue;
                     }

--- a/core/src/test/java/io/crate/core/collections/MapComparatorTest.java
+++ b/core/src/test/java/io/crate/core/collections/MapComparatorTest.java
@@ -23,6 +23,7 @@
 package io.crate.core.collections;
 
 import io.crate.test.integration.CrateUnitTest;
+import org.elasticsearch.common.lucene.BytesRefs;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -95,5 +96,24 @@ public class MapComparatorTest extends CrateUnitTest {
         map1.put("str2", 5.0);
         assertThat(MapComparator.compareMaps(map1, map2), is(1));
         assertThat(MapComparator.compareMaps(map2, map1), is(-1));
+    }
+
+    public void testCompareMapsWithStringAndBytesRef() {
+        /**
+         * this can happen when you compare an object with an object literal
+         * ... WHERE o = {"x" = 'foo'}
+         */
+        Map<String, Object> map1 = new HashMap<String, Object>() {{
+            put("str1", "a");
+            put("str2", "b");
+            put("str3", "3");
+        }};
+        Map<String, Object> map2 = new HashMap<String, Object>() {{
+            put("str1", "a");
+            put("str2", BytesRefs.toBytesRef("b"));
+            put("str3", 3);
+        }};
+        assertThat(MapComparator.compareMaps(map1, map2), is(0));
+        assertThat(MapComparator.compareMaps(map2, map1), is(0));
     }
 }


### PR DESCRIPTION
the issue occured when comparing object column with object literal that contained
a string value, e.g.

```sql
SELECT * FROM t1 WHERE o = {"s" = 'foo'};
```