### PR TITLE
Handle pause correctly in RowReceiver upstreams

### DIFF
--- a/sql/src/main/java/io/crate/action/sql/ResultReceiver.java
+++ b/sql/src/main/java/io/crate/action/sql/ResultReceiver.java
@@ -37,11 +37,35 @@ import javax.annotation.Nonnull;
  */
 public interface ResultReceiver extends CompletionListenable {
 
+    /**
+     * Feed the downstream with the next input row. Note thate the row might be a mutable shared object
+     * it is only guaranteed to stay valid as long this method does not return.
+     *
+     * @param row the row handle to be processed
+     *
+     */
     void setNextRow(Row row);
 
+    /**
+     * Called from the upstream in order to notify the receiver that a batch of data has finished. It is the responsibility
+     * of the upstream to eventually call {@link #allFinished()} once it is getting resumed. How this resume is working
+     * is up to the implementation and not part of this interface.
+     */
     void batchFinished();
 
+    /**
+     * Called by an upstream to notify that there will be no more data to process. After calling this method it is no
+     * longer valid to call any method on this interface.
+     */
     void allFinished();
 
-    void fail(@Nonnull Throwable t);
+    /**
+     * Is called from the upstream in case of an upstream failure to indicate that it aborts emitting data due to
+     * a failure. After calling this method it is no longer valid to call any method on this interface.
+     *
+     * @param throwable the cause of the failure
+     *                  <p>
+     *                  NOTE: This method must not throw any exceptions!
+     */
+    void fail(@Nonnull Throwable throwable);
 }

--- a/sql/src/main/java/io/crate/executor/task/ExplainTask.java
+++ b/sql/src/main/java/io/crate/executor/task/ExplainTask.java
@@ -26,8 +26,8 @@ import com.google.common.util.concurrent.ListenableFuture;
 import io.crate.core.collections.Row;
 import io.crate.core.collections.Row1;
 import io.crate.executor.Task;
-import io.crate.operation.projectors.RepeatHandle;
 import io.crate.operation.projectors.RowReceiver;
+import io.crate.operation.projectors.RowReceivers;
 import io.crate.planner.PlanPrinter;
 import io.crate.planner.node.management.ExplainPlan;
 
@@ -46,8 +46,7 @@ public class ExplainTask implements Task {
     public void execute(RowReceiver rowReceiver, Row parameters) {
         try {
             Map<String, Object> map = PlanPrinter.objectMap(explainPlan.subPlan());
-            rowReceiver.setNextRow(new Row1(map));
-            rowReceiver.finish(RepeatHandle.UNSUPPORTED);
+            RowReceivers.sendOneRow(rowReceiver, new Row1(map));
         } catch (Throwable t) {
             rowReceiver.fail(t);
         }

--- a/sql/src/main/java/io/crate/executor/transport/AlterTableOperation.java
+++ b/sql/src/main/java/io/crate/executor/transport/AlterTableOperation.java
@@ -100,7 +100,7 @@ public class AlterTableOperation {
             try {
                 session.parse(SQLOperations.Session.UNNAMED, stmt, Collections.<DataType>emptyList());
                 session.bind(SQLOperations.Session.UNNAMED, SQLOperations.Session.UNNAMED, Collections.emptyList(), null);
-                session.execute(SQLOperations.Session.UNNAMED, 1, new ResultSetReceiver(analysis, result));
+                session.execute(SQLOperations.Session.UNNAMED, 0, new ResultSetReceiver(analysis, result));
                 session.sync();
             } catch (Throwable t) {
                 result.setException(t);

--- a/sql/src/main/java/io/crate/executor/transport/OneRowActionListener.java
+++ b/sql/src/main/java/io/crate/executor/transport/OneRowActionListener.java
@@ -25,8 +25,8 @@ package io.crate.executor.transport;
 import com.google.common.base.Function;
 import com.google.common.util.concurrent.FutureCallback;
 import io.crate.core.collections.Row;
-import io.crate.operation.projectors.RepeatHandle;
 import io.crate.operation.projectors.RowReceiver;
+import io.crate.operation.projectors.RowReceivers;
 import org.elasticsearch.action.ActionListener;
 
 import javax.annotation.Nonnull;
@@ -44,8 +44,7 @@ public class OneRowActionListener<Response> implements ActionListener<Response>,
 
     @Override
     public void onResponse(Response response) {
-        rowReceiver.setNextRow(toRowFunction.apply(response));
-        rowReceiver.finish(RepeatHandle.UNSUPPORTED);
+        RowReceivers.sendOneRow(rowReceiver, toRowFunction.apply(response));
     }
 
     @Override

--- a/sql/src/main/java/io/crate/executor/transport/task/GenericShowTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/GenericShowTask.java
@@ -27,8 +27,8 @@ import io.crate.analyze.AbstractShowAnalyzedStatement;
 import io.crate.core.collections.Row;
 import io.crate.core.collections.Row1;
 import io.crate.executor.Task;
-import io.crate.operation.projectors.RepeatHandle;
 import io.crate.operation.projectors.RowReceiver;
+import io.crate.operation.projectors.RowReceivers;
 
 import java.util.List;
 import java.util.UUID;
@@ -48,8 +48,7 @@ public class GenericShowTask implements Task {
     @Override
     public void execute(RowReceiver rowReceiver, Row parameters) {
         try {
-            rowReceiver.setNextRow(new Row1(showStatementDispatcher.process(statement, jobId)));
-            rowReceiver.finish(RepeatHandle.UNSUPPORTED);
+            RowReceivers.sendOneRow(rowReceiver, new Row1(showStatementDispatcher.process(statement, jobId)));
         } catch (Throwable t) {
             rowReceiver.fail(t);
         }

--- a/sql/src/main/java/io/crate/executor/transport/task/UpsertByIdTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/UpsertByIdTask.java
@@ -34,8 +34,8 @@ import io.crate.executor.transport.ShardUpsertRequest;
 import io.crate.jobs.*;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.settings.CrateSettings;
-import io.crate.operation.projectors.RepeatHandle;
 import io.crate.operation.projectors.RowReceiver;
+import io.crate.operation.projectors.RowReceivers;
 import io.crate.planner.node.dml.UpsertById;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
@@ -127,8 +127,7 @@ public class UpsertByIdTask extends JobTask {
         Futures.addCallback(result, new FutureCallback<Long>() {
             @Override
             public void onSuccess(@Nullable Long result) {
-                rowReceiver.setNextRow(new Row1(result));
-                rowReceiver.finish(RepeatHandle.UNSUPPORTED);
+                RowReceivers.sendOneRow(rowReceiver, new Row1(result));
             }
 
             @Override

--- a/sql/src/main/java/io/crate/operation/projectors/AggregationPipe.java
+++ b/sql/src/main/java/io/crate/operation/projectors/AggregationPipe.java
@@ -79,7 +79,6 @@ public class AggregationPipe extends AbstractProjector {
         for (int i = 0; i < aggregators.length; i++) {
             cells[i] = aggregators[i].finishCollect(states[i]);
         }
-        downstream.setNextRow(row);
-        downstream.finish(RepeatHandle.UNSUPPORTED);
+        RowReceivers.sendOneRow(downstream, row);
     }
 }

--- a/sql/src/main/java/io/crate/operation/projectors/BulkProcessorFutureCallback.java
+++ b/sql/src/main/java/io/crate/operation/projectors/BulkProcessorFutureCallback.java
@@ -43,8 +43,7 @@ class BulkProcessorFutureCallback implements FutureCallback<BitSet> {
     public void onSuccess(@Nullable BitSet result) {
         if (!failed.get()) {
             long rowCount = result == null ? 0 : result.cardinality();
-            rowReceiver.setNextRow(new Row1(rowCount));
-            rowReceiver.finish(RepeatHandle.UNSUPPORTED);
+            RowReceivers.sendOneRow(rowReceiver, new Row1(rowCount));
         }
     }
 

--- a/sql/src/main/java/io/crate/operation/projectors/RowReceivers.java
+++ b/sql/src/main/java/io/crate/operation/projectors/RowReceivers.java
@@ -64,8 +64,20 @@ public class RowReceivers {
         }
     }
 
+    /**
+     * Sends exactly one row to the given receiver and calls {@link RowReceiver#finish}. The repeatHandle passed to
+     * the receiver does not support repeat.
+     *
+     * Pause is not supported, so if the receiver tries to pause it {@link RowReceiver#fail} will be called immediately.
+     *
+     * @param receiver the downstream receiver to send the row to
+     * @param row the row to be sent to the receiver
+     */
     public static void sendOneRow(RowReceiver receiver, Row row) {
-        receiver.setNextRow(row);
+        RowReceiver.Result result = receiver.setNextRow(row);
+        if (result == RowReceiver.Result.PAUSE){
+            receiver.fail(new UnsupportedOperationException("Pause not supported receiver=" + receiver));
+        }
         receiver.finish(RepeatHandle.UNSUPPORTED);
     }
 }

--- a/sql/src/main/java/io/crate/operation/projectors/SysUpdateProjector.java
+++ b/sql/src/main/java/io/crate/operation/projectors/SysUpdateProjector.java
@@ -77,9 +77,7 @@ class SysUpdateProjector extends AbstractProjector {
 
     @Override
     public void finish(RepeatHandle repeatHandle) {
-        downstream.setNextRow(new Row1(rowCount));
-        downstream.finish(RepeatHandle.UNSUPPORTED);
-        ;
+        RowReceivers.sendOneRow(downstream, new Row1(rowCount));
     }
 
     @Override

--- a/sql/src/main/java/io/crate/operation/projectors/WriterProjector.java
+++ b/sql/src/main/java/io/crate/operation/projectors/WriterProjector.java
@@ -166,9 +166,7 @@ public class WriterProjector extends AbstractProjector {
     @Override
     public void finish(RepeatHandle repeatHandle) {
         if (closeWriterAndOutput()) return;
-
-        downstream.setNextRow(new Row1(counter.get()));
-        downstream.finish(RepeatHandle.UNSUPPORTED);
+        RowReceivers.sendOneRow(downstream, new Row1(counter.get()));
     }
 
     private boolean closeWriterAndOutput() {

--- a/sql/src/main/java/io/crate/protocols/postgres/BatchPortal.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/BatchPortal.java
@@ -140,7 +140,7 @@ class BatchPortal extends AbstractPortal {
             statsTables.logExecutionStart(jobId, stmt);
             Futures.addCallback(resultReceiver.completionFuture(), new StatsTablesUpdateListener(jobId, statsTables));
             Futures.addCallback(resultReceiver.completionFuture(), completionCallback);
-            RowReceiver rowReceiver = new RowReceiverToResultReceiver(resultReceiver, 0);
+            RowReceiver rowReceiver = RowReceiverToResultReceiver.singleRow(resultReceiver);
             portalContext.getExecutor().execute(plan, rowReceiver, new RowN(batchParams.toArray()));
         }
         return completionCallback;

--- a/sql/src/main/java/io/crate/protocols/postgres/BulkPortal.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/BulkPortal.java
@@ -110,7 +110,7 @@ class BulkPortal extends AbstractPortal {
 
     @Override
     public void execute(ResultReceiver resultReceiver, int maxRows) {
-        if (maxRows != 1) {
+        if (maxRows > 1) {
             throw new UnsupportedFeatureException("bulk operations don't support fetch size");
         }
         this.resultReceivers.add(resultReceiver);

--- a/sql/src/main/java/io/crate/protocols/postgres/ConnectionContext.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/ConnectionContext.java
@@ -559,7 +559,7 @@ class ConnectionContext {
             List<Field> fields = session.describe('P', "");
             if (fields == null) {
                 RowCountReceiver rowCountReceiver = new RowCountReceiver(query, channel);
-                session.execute("", 1, rowCountReceiver);
+                session.execute("", 0, rowCountReceiver);
             } else {
                 Messages.sendRowDescription(channel, fields, null);
                 ResultSetReceiver resultSetReceiver = new ResultSetReceiver(query, channel, Symbols.extractTypes(fields), null);

--- a/sql/src/main/java/io/crate/rest/action/RestSQLAction.java
+++ b/sql/src/main/java/io/crate/rest/action/RestSQLAction.java
@@ -117,7 +117,7 @@ public class RestSQLAction extends BaseRestHandler {
             if (outputFields == null) {
                 ResultReceiver resultReceiver
                     = new RestRowCountReceiver(channel, startTime, request.paramAsBoolean("types", false));
-                session.execute(UNNAMED, 1, resultReceiver);
+                session.execute(UNNAMED, 0, resultReceiver);
             } else {
                 ResultReceiver resultReceiver =
                     new RestResultSetReceiver(channel, outputFields, startTime, request.paramAsBoolean("types", false));
@@ -141,12 +141,12 @@ public class RestSQLAction extends BaseRestHandler {
             final RestBulkRowCountReceiver.Result[] results = new RestBulkRowCountReceiver.Result[bulkArgs.length];
             if (results.length == 0) {
                 session.bind(UNNAMED, UNNAMED, Collections.emptyList(), null);
-                session.execute(UNNAMED, 1, new BaseResultReceiver());
+                session.execute(UNNAMED, 0, new BaseResultReceiver());
             } else {
                 for (int i = 0; i < bulkArgs.length; i++) {
                     session.bind(UNNAMED, UNNAMED, Arrays.asList(bulkArgs[i]), null);
                     ResultReceiver resultReceiver = new RestBulkRowCountReceiver(results, i);
-                    session.execute(UNNAMED, 1, resultReceiver);
+                    session.execute(UNNAMED, 0, resultReceiver);
                 }
             }
             List<Field> outputColumns = session.describe('P', UNNAMED);

--- a/sql/src/test/java/io/crate/operation/collect/LuceneDocCollectorTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/LuceneDocCollectorTest.java
@@ -73,7 +73,9 @@ public class LuceneDocCollectorTest extends SQLTransportIntegrationTest {
 
     @After
     public void closeContext() throws Exception {
-        collectorProvider.close();
+        if (collectorProvider != null) {
+            collectorProvider.close();
+        }
     }
 
     public void generateData() throws Exception {

--- a/sql/src/test/java/io/crate/testing/SQLTransportExecutor.java
+++ b/sql/src/test/java/io/crate/testing/SQLTransportExecutor.java
@@ -176,7 +176,7 @@ public class SQLTransportExecutor {
             List<Field> outputFields = session.describe('P', UNNAMED);
             if (outputFields == null) {
                 ResultReceiver resultReceiver = new RowCountReceiver(listener);
-                session.execute(UNNAMED, 1, resultReceiver);
+                session.execute(UNNAMED, 0, resultReceiver);
             } else {
                 ResultReceiver resultReceiver = new ResultSetReceiver(listener, outputFields);
                 session.execute(UNNAMED, 0, resultReceiver);
@@ -201,12 +201,12 @@ public class SQLTransportExecutor {
             final SQLBulkResponse.Result[] results = new SQLBulkResponse.Result[bulkArgs.length];
             if (results.length == 0) {
                 session.bind(UNNAMED, UNNAMED, Collections.emptyList(), null);
-                session.execute(UNNAMED, 1, new BaseResultReceiver());
+                session.execute(UNNAMED, 0, new BaseResultReceiver());
             } else {
                 for (int i = 0; i < bulkArgs.length; i++) {
                     session.bind(UNNAMED, UNNAMED, Arrays.asList(bulkArgs[i]), null);
                     ResultReceiver resultReceiver = new BulkRowCountReceiver(results, i);
-                    session.execute(UNNAMED, 1, resultReceiver);
+                    session.execute(UNNAMED, 0, resultReceiver);
                 }
             }
             List<Field> outputColumns = session.describe('P', UNNAMED);


### PR DESCRIPTION
In various places the PAUSE return value of setNextRow was not respected
when emitting just one single row, this lead to inconsistencies when 
bridging it to ResultReceivers 

It is now asserted that PAUSE is never used when emitting a single row.