### PR TITLE
Update breakings 

### DIFF
--- a/BREAKING.txt
+++ b/BREAKING.txt
@@ -2,6 +2,11 @@
  BREAKING CHANGES due to ES 5.x upgrade
 ========================================
 
+- Tables created with Crate versions older than 0.46.0 will have to be 
+  recreated. This is due to the way numeric docvalues are stored starting with  
+  Crate 0.46.0 (sorted numeric instead of binary) which uses ES 1.4 
+  The backwards compatibility layer for binary docvalues was removed in ES 5.x
+
 - -Des cannot be used anymore, ES 5.0 needs -Eparam=value which is passed as command line argument
   after the main class.
   https://www.elastic.co/guide/en/elasticsearch/reference/5.0/breaking_50_settings_changes.html#_using_system_properties_to_configure_elasticsearch


### PR DESCRIPTION
data older than Crate 0.46.0 will need to be recreated due to numeric data types using sorted_numeric docvalues instead of binary