### PR TITLE
Fixed issue where settings are not changeable at runtime

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,10 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed an issue where ``indices.fielddata.breaker`` settings are not
+   changeable during runtime. Their usage is deprecated but still supported
+   as an alias to the new setting ``indices.breaker.fielddata``.
+ 
  - Fix: Closing a connection via the Postgres Wire Protocol correctly closes the
    internal resources.
 

--- a/blackbox/docs/best_practice/systables.txt
+++ b/blackbox/docs/best_practice/systables.txt
@@ -91,7 +91,7 @@ available data, run::
     +--------------------------------------------------------------------------------...+-----------...+
     ...
     +--------------------------------------------------------------------------------...+-----------...+
-    SHOW 104 rows in set (... sec)
+    SHOW 103 rows in set (... sec)
 
 While **sys.cluster** contains information about the cluster as a whole,
 **sys.nodes** maintains more detailed information about each Crate

--- a/blackbox/docs/configuration.txt
+++ b/blackbox/docs/configuration.txt
@@ -1587,13 +1587,19 @@ The field data circuit breaker allows estimation of needed heap memory
 required for loading field data into memory. If a certain limit
 is reached an exception is raised.
 
-**indices.fielddata.breaker.limit**
+.. warning::
+
+    The settings **indices.fielddata.breaker.limit** and
+    **indices.fielddata.breaker.overhead** are deprecated. If used the settings
+    are exposed as follows in the ``sys.cluster`` table.
+
+**indices.breaker.fielddata.limit**
   | *Default:*   ``60%``
   | *Runtime:*  ``yes``
 
   Specifies the JVM heap limit for the fielddata breaker.
 
-**indices.fielddata.breaker.overhead**
+**indices.breaker.fielddata.overhead**
   | *Default:*   ``1.03``
   | *Runtime:*  ``yes``
 

--- a/blackbox/docs/sql/system.txt
+++ b/blackbox/docs/sql/system.txt
@@ -142,16 +142,15 @@ currently applied cluster settings.
     | settings['gateway']['recover_after_time']                                         | string       |
     | settings['indices']                                                               | object       |
     | settings['indices']['breaker']                                                    | object       |
+    | settings['indices']['breaker']['fielddata']                                       | object       |
+    | settings['indices']['breaker']['fielddata']['limit']                              | string       |
+    | settings['indices']['breaker']['fielddata']['overhead']                           | double       |
     | settings['indices']['breaker']['query']                                           | object       |
     | settings['indices']['breaker']['query']['limit']                                  | string       |
     | settings['indices']['breaker']['query']['overhead']                               | double       |
     | settings['indices']['breaker']['request']                                         | object       |
     | settings['indices']['breaker']['request']['limit']                                | string       |
     | settings['indices']['breaker']['request']['overhead']                             | double       |
-    | settings['indices']['fielddata']                                                  | object       |
-    | settings['indices']['fielddata']['breaker']                                       | object       |
-    | settings['indices']['fielddata']['breaker']['limit']                              | string       |
-    | settings['indices']['fielddata']['breaker']['overhead']                           | double       |
     | settings['indices']['recovery']                                                   | object       |
     | settings['indices']['recovery']['activity_timeout']                               | string       |
     | settings['indices']['recovery']['compress']                                       | boolean      |

--- a/sql/src/main/java/io/crate/metadata/settings/CrateSettings.java
+++ b/sql/src/main/java/io/crate/metadata/settings/CrateSettings.java
@@ -852,7 +852,7 @@ public class CrateSettings {
 
         @Override
         public List<Setting> children() {
-            return ImmutableList.<Setting>of(INDICES_RECOVERY, INDICES_STORE, INDICES_FIELDDATA, INDICES_BREAKER);
+            return ImmutableList.<Setting>of(INDICES_RECOVERY, INDICES_STORE, INDICES_BREAKER);
         }
 
         @Override
@@ -1091,6 +1091,8 @@ public class CrateSettings {
     public static final ByteSizeSetting INDICES_STORE_THROTTLE_MAX_BYTES_PER_SEC = new ByteSizeSetting(
         "max_bytes_per_sec", new ByteSizeValue(20, ByteSizeUnit.MB), true, INDICES_STORE_THROTTLE);
 
+
+    @Deprecated
     public static final NestedSetting INDICES_FIELDDATA = new NestedSetting() {
         @Override
         public String name() {
@@ -1113,6 +1115,7 @@ public class CrateSettings {
         }
     };
 
+    @Deprecated
     public static final NestedSetting INDICES_FIELDDATA_BREAKER = new NestedSetting() {
         @Override
         public String name() {
@@ -1138,9 +1141,11 @@ public class CrateSettings {
         }
     };
 
+    @Deprecated
     public static final MemorySetting INDICES_FIELDDATA_BREAKER_LIMIT = new MemorySetting(
         "limit", HierarchyCircuitBreakerService.DEFAULT_FIELDDATA_BREAKER_LIMIT, true, INDICES_FIELDDATA_BREAKER);
 
+    @Deprecated
     public static final DoubleSetting INDICES_FIELDDATA_BREAKER_OVERHEAD = new DoubleSetting() {
         @Override
         public String name() {
@@ -1163,6 +1168,7 @@ public class CrateSettings {
         }
     };
 
+
     public static final NestedSetting INDICES_BREAKER = new NestedSetting() {
         @Override
         public String name() {
@@ -1173,7 +1179,8 @@ public class CrateSettings {
         public List<Setting> children() {
             return ImmutableList.<Setting>of(
                 INDICES_BREAKER_QUERY,
-                INDICES_BREAKER_REQUEST
+                INDICES_BREAKER_REQUEST,
+                INDICES_BREAKER_FIELDDATA
             );
         }
 
@@ -1280,6 +1287,56 @@ public class CrateSettings {
         @Override
         public Setting parent() {
             return INDICES_BREAKER_REQUEST;
+        }
+
+        @Override
+        public boolean isRuntime() {
+            return true;
+        }
+    };
+
+    public static final NestedSetting INDICES_BREAKER_FIELDDATA = new NestedSetting() {
+        @Override
+        public String name() {
+            return "fielddata";
+        }
+
+        @Override
+        public List<Setting> children() {
+            return ImmutableList.<Setting>of(
+                INDICES_BREAKER_FIELDDATA_LIMIT,
+                INDICES_BREAKER_FIELDDATA_OVERHEAD
+            );
+        }
+
+        @Override
+        public Setting parent() {
+            return INDICES_BREAKER;
+        }
+
+        @Override
+        public boolean isRuntime() {
+            return true;
+        }
+    };
+
+    public static final MemorySetting INDICES_BREAKER_FIELDDATA_LIMIT = new MemorySetting(
+        "limit", HierarchyCircuitBreakerService.DEFAULT_FIELDDATA_BREAKER_LIMIT, true, INDICES_BREAKER_FIELDDATA);
+
+    public static final DoubleSetting INDICES_BREAKER_FIELDDATA_OVERHEAD = new DoubleSetting() {
+        @Override
+        public String name() {
+            return "overhead";
+        }
+
+        @Override
+        public Double defaultValue() {
+            return 1.03;
+        }
+
+        @Override
+        public Setting parent() {
+            return INDICES_BREAKER_FIELDDATA;
         }
 
         @Override
@@ -1695,14 +1752,6 @@ public class CrateSettings {
             new SettingsAppliers.StringSettingsApplier(CrateSettings.INDICES_STORE_THROTTLE_TYPE))
         .put(CrateSettings.INDICES_STORE_THROTTLE_MAX_BYTES_PER_SEC.settingName(),
             new SettingsAppliers.ByteSizeSettingsApplier(CrateSettings.INDICES_STORE_THROTTLE_MAX_BYTES_PER_SEC))
-        .put(CrateSettings.INDICES_FIELDDATA.settingName(),
-            new SettingsAppliers.ObjectSettingsApplier(CrateSettings.INDICES_FIELDDATA))
-        .put(CrateSettings.INDICES_FIELDDATA_BREAKER.settingName(),
-            new SettingsAppliers.ObjectSettingsApplier(CrateSettings.INDICES_FIELDDATA_BREAKER))
-        .put(CrateSettings.INDICES_FIELDDATA_BREAKER_LIMIT.settingName(),
-            new SettingsAppliers.MemoryValueSettingsApplier(CrateSettings.INDICES_FIELDDATA_BREAKER_LIMIT))
-        .put(CrateSettings.INDICES_FIELDDATA_BREAKER_OVERHEAD.settingName(),
-            new SettingsAppliers.DoubleSettingsApplier(CrateSettings.INDICES_FIELDDATA_BREAKER_OVERHEAD))
         .put(CrateSettings.INDICES_BREAKER.settingName(),
             new SettingsAppliers.ObjectSettingsApplier(CrateSettings.INDICES_BREAKER))
         .put(CrateSettings.INDICES_BREAKER_REQUEST.settingName(),
@@ -1717,6 +1766,12 @@ public class CrateSettings {
             new SettingsAppliers.MemoryValueSettingsApplier(CrateSettings.INDICES_BREAKER_QUERY_LIMIT))
         .put(CrateSettings.INDICES_BREAKER_QUERY_OVERHEAD.settingName(),
             new SettingsAppliers.DoubleSettingsApplier(CrateSettings.INDICES_BREAKER_QUERY_OVERHEAD))
+        .put(CrateSettings.INDICES_BREAKER_FIELDDATA.settingName(),
+            new SettingsAppliers.ObjectSettingsApplier(CrateSettings.INDICES_BREAKER_FIELDDATA))
+        .put(CrateSettings.INDICES_BREAKER_FIELDDATA_LIMIT.settingName(),
+            new SettingsAppliers.MemoryValueSettingsApplier(CrateSettings.INDICES_BREAKER_FIELDDATA_LIMIT))
+        .put(CrateSettings.INDICES_BREAKER_FIELDDATA_OVERHEAD.settingName(),
+            new SettingsAppliers.DoubleSettingsApplier(CrateSettings.INDICES_BREAKER_FIELDDATA_OVERHEAD))
         .put(CrateSettings.CLUSTER_INFO.settingName(),
             new SettingsAppliers.ObjectSettingsApplier(CrateSettings.CLUSTER_INFO))
         .put(CrateSettings.CLUSTER_INFO_UPDATE.settingName(),

--- a/sql/src/main/java/io/crate/metadata/settings/SettingsAppliers.java
+++ b/sql/src/main/java/io/crate/metadata/settings/SettingsAppliers.java
@@ -145,6 +145,15 @@ public class SettingsAppliers {
                         setting.getValue());
                 }
             } else {
+                 // Rewrites old settings to new settings
+                 // This will be removed in CrateDB v1.1
+                if (key.equals(CrateSettings.INDICES_FIELDDATA_BREAKER_LIMIT.settingName())) {
+                    key = CrateSettings.INDICES_BREAKER_FIELDDATA_LIMIT.settingName();
+                }
+                if (key.equals(CrateSettings.INDICES_FIELDDATA_BREAKER_OVERHEAD.settingName())) {
+                    key = CrateSettings.INDICES_BREAKER_FIELDDATA_OVERHEAD.settingName();
+                }
+
                 SettingsApplier settingsApplier = CrateSettings.getSettingsApplier(key);
                 settingsApplier.applyValue(settingsBuilder, value);
             }

--- a/sql/src/main/java/io/crate/metadata/sys/SysClusterTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysClusterTableInfo.java
@@ -323,20 +323,6 @@ public class SysClusterTableInfo extends StaticTableInfo {
                     CrateSettings.INDICES_STORE_THROTTLE_MAX_BYTES_PER_SEC.name()))
 
                 .register(ClusterSettingsExpression.NAME, DataTypes.OBJECT, ImmutableList.of(CrateSettings.INDICES.name(),
-                    CrateSettings.INDICES_FIELDDATA.name()))
-                .register(ClusterSettingsExpression.NAME, DataTypes.OBJECT, ImmutableList.of(CrateSettings.INDICES.name(),
-                    CrateSettings.INDICES_FIELDDATA.name(),
-                    CrateSettings.INDICES_FIELDDATA_BREAKER.name()))
-                .register(ClusterSettingsExpression.NAME, DataTypes.STRING, ImmutableList.of(CrateSettings.INDICES.name(),
-                    CrateSettings.INDICES_FIELDDATA.name(),
-                    CrateSettings.INDICES_FIELDDATA_BREAKER.name(),
-                    CrateSettings.INDICES_FIELDDATA_BREAKER_LIMIT.name()))
-                .register(ClusterSettingsExpression.NAME, DataTypes.DOUBLE, ImmutableList.of(CrateSettings.INDICES.name(),
-                    CrateSettings.INDICES_FIELDDATA.name(),
-                    CrateSettings.INDICES_FIELDDATA_BREAKER.name(),
-                    CrateSettings.INDICES_FIELDDATA_BREAKER_OVERHEAD.name()))
-
-                .register(ClusterSettingsExpression.NAME, DataTypes.OBJECT, ImmutableList.of(CrateSettings.INDICES.name(),
                     CrateSettings.INDICES_BREAKER.name()))
                 .register(ClusterSettingsExpression.NAME, DataTypes.OBJECT, ImmutableList.of(CrateSettings.INDICES.name(),
                     CrateSettings.INDICES_BREAKER.name(),
@@ -360,6 +346,17 @@ public class SysClusterTableInfo extends StaticTableInfo {
                     CrateSettings.INDICES_BREAKER.name(),
                     CrateSettings.INDICES_BREAKER_REQUEST.name(),
                     CrateSettings.INDICES_BREAKER_REQUEST_OVERHEAD.name()))
+                .register(ClusterSettingsExpression.NAME, DataTypes.OBJECT, ImmutableList.of(CrateSettings.INDICES.name(),
+                    CrateSettings.INDICES_BREAKER.name(),
+                    CrateSettings.INDICES_BREAKER_FIELDDATA.name()))
+                .register(ClusterSettingsExpression.NAME, DataTypes.STRING, ImmutableList.of(CrateSettings.INDICES.name(),
+                    CrateSettings.INDICES_BREAKER.name(),
+                    CrateSettings.INDICES_BREAKER_FIELDDATA.name(),
+                    CrateSettings.INDICES_BREAKER_FIELDDATA_LIMIT.name()))
+                .register(ClusterSettingsExpression.NAME, DataTypes.DOUBLE, ImmutableList.of(CrateSettings.INDICES.name(),
+                    CrateSettings.INDICES_BREAKER.name(),
+                    CrateSettings.INDICES_BREAKER_FIELDDATA.name(),
+                    CrateSettings.INDICES_BREAKER_FIELDDATA_OVERHEAD.name()))
 
                 .register(ClusterSettingsExpression.NAME, DataTypes.OBJECT, ImmutableList.of(CrateSettings.CLUSTER.name(),
                     CrateSettings.CLUSTER_INFO.name()))

--- a/sql/src/main/java/io/crate/operation/reference/sys/cluster/ClusterSettingsExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/cluster/ClusterSettingsExpression.java
@@ -95,6 +95,10 @@ public class ClusterSettingsExpression extends NestedObjectExpression {
             this.values = values;
             this.initialSettings = initialSettings;
             applySettings(CrateSettings.SETTINGS, initialSettings);
+            applyNewSettingIfDeprecated(CrateSettings.INDICES_FIELDDATA_BREAKER_LIMIT,
+                CrateSettings.INDICES_BREAKER_FIELDDATA_LIMIT, initialSettings);
+            applyNewSettingIfDeprecated(CrateSettings.INDICES_FIELDDATA_BREAKER_OVERHEAD,
+                CrateSettings.INDICES_BREAKER_FIELDDATA_OVERHEAD, initialSettings);
         }
 
         @Override
@@ -112,7 +116,6 @@ public class ClusterSettingsExpression extends NestedObjectExpression {
          */
         private void applySettings(List<Setting> clusterSettings, Settings newSettings) {
             for (Setting<?, ?> setting : clusterSettings) {
-
                 String name = setting.settingName();
                 Object newValue = setting.extract(newSettings);
                 if (newSettings.get(name) == null) {
@@ -123,6 +126,28 @@ public class ClusterSettingsExpression extends NestedObjectExpression {
                         logger.info("updating [{}] from [{}] to [{}]", name, values.get(name), newValue);
                     }
                     values.put(name, newValue);
+                }
+            }
+        }
+
+        /**
+         * apply the new setting if a deprecated setting is provided
+         * if a the new setting is provided the deprecated setting will be ignored
+         *
+         * This will be removed in CrateDB v1.1
+         */
+        @Deprecated
+        private void applyNewSettingIfDeprecated(Setting deprecatedSetting, Setting newSetting, Settings providedSettings) {
+            if (providedSettings.get(deprecatedSetting.settingName()) != null &&
+                providedSettings.get(newSetting.settingName()) == null) {
+
+                Object newValue = deprecatedSetting.extract(providedSettings);
+                if (!newValue.equals(values.get(newSetting.settingName()))) {
+                    logger.info("updating [{}] from [{}] to [{}]",
+                        newSetting.settingName(),
+                        values.get(newSetting.settingName()),
+                        newValue);
+                    values.put(newSetting.settingName(), newValue);
                 }
             }
         }

--- a/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -441,7 +441,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultColumns() throws Exception {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(369, response.rowCount());
+        assertEquals(368, response.rowCount());
     }
 
     @Test
@@ -569,7 +569,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
         execute("select max(ordinal_position) from information_schema.columns");
         assertEquals(1, response.rowCount());
 
-        short max_ordinal = 104;
+        short max_ordinal = 103;
         assertEquals(max_ordinal, response.rows()[0][0]);
 
         execute("create table t1 (id integer, col1 string)");


### PR DESCRIPTION
Settings in ``indices.fielddata.breaker`` are now rewritten and exposed to
``indices.breaker.fielddata``

```sql
cr> SELECT settings['indices']['breaker'] FROM sys.cluster;
settings['indices']['breaker'] | {
                               |  "fielddata": {
                               |    "limit": "500mb",
                               |    "overhead": 1.03
                               |  },
                               |  "query": {
                               |    "limit": "2.1gb",
                               |    "overhead": 1.09
                               |  },
                               |  "request": {
                               |    "limit": "1.4gb",
                               |    "overhead": 1.0
                               |  }
                               | }
------------------------------------------------------------------------------------
```

Old setting `indices.fielddata.breaker` is not exposed anymore and marked as deprecated.