### PR TITLE
Add support for casting JSON strings to objects

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,8 @@ Unreleased
  - Added scalar function ``geohash`` that returns a GeoHash representation of
    a ``geo_point``
 
+ - Added support for casting JSON strings to object columns.
+
  - Queries with ``_doc`` reference comparison (e.g. ``_doc['name'] = 'foo'``)
    in the ``WHERE`` clause return the correct results instead of empty result.
 

--- a/core/src/main/java/io/crate/types/DataTypes.java
+++ b/core/src/main/java/io/crate/types/DataTypes.java
@@ -162,6 +162,7 @@ public final class DataTypes {
             .add(GEO_SHAPE)
             .add(GEO_POINT)
             .add(BOOLEAN)
+            .add(OBJECT)
             .build())
         .put(IP.id(), ImmutableSet.<DataType>of(STRING))
         .put(TIMESTAMP.id(), ImmutableSet.<DataType>of(LONG))

--- a/sql/src/main/java/io/crate/operation/scalar/cast/CastFunctionResolver.java
+++ b/sql/src/main/java/io/crate/operation/scalar/cast/CastFunctionResolver.java
@@ -53,6 +53,7 @@ public class CastFunctionResolver {
         public static final String TO_BYTE = "to_byte";
         public static final String TO_SHORT = "to_short";
         public static final String TO_IP = "to_ip";
+        public static final String TO_OBJECT = "to_object";
 
         public static final String TO_STRING_ARRAY = "to_string_array";
         public static final String TO_LONG_ARRAY = "to_long_array";
@@ -124,6 +125,7 @@ public class CastFunctionResolver {
         .putAll(GEO_FUNCTION_MAP)
         .putAll(ARRAY_FUNCTION_MAP)
         .putAll(SET_FUNCTION_MAP)
+        .put(DataTypes.OBJECT, FunctionNames.TO_OBJECT)
         .build();
 
     public static Symbol generateCastFunction(Symbol sourceSymbol, DataType targetType, boolean tryCast) {

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -1604,14 +1604,14 @@ public class SelectStatementAnalyzerTest extends CrateUnitTest {
     public void testInvalidTryCastExpression() {
         expectedException.expect(Exception.class);
         expectedException.expectMessage("No cast function found for return type object");
-        analyze("select try_cast(name as object) from users");
+        analyze("select try_cast(name as array(object)) from users");
     }
 
     @Test
     public void testInvalidCastExpression() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("No cast function found for return type object");
-        analyze("select cast(name as object) from users");
+        analyze("select cast(name as array(object)) from users");
     }
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/CastIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/CastIntegrationTest.java
@@ -77,6 +77,6 @@ public class CastIntegrationTest extends SQLTransportIntegrationTest {
     public void testInvalidCastExpression() throws Exception {
         expectedException.expect(Exception.class);
         expectedException.expectMessage("No cast function found for return type object");
-        execute("select try_cast(name as object) from sys.cluster");
+        execute("select try_cast(name as array(object)) from sys.cluster");
     }
 }

--- a/sql/src/test/java/io/crate/operation/scalar/cast/CastFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/cast/CastFunctionTest.java
@@ -22,9 +22,13 @@
 
 package io.crate.operation.scalar.cast;
 
+import io.crate.analyze.symbol.Literal;
 import io.crate.operation.scalar.AbstractScalarFunctionsTest;
 import org.apache.lucene.util.BytesRef;
 import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import static io.crate.testing.SymbolMatchers.isFunction;
 
@@ -44,6 +48,11 @@ public class CastFunctionTest extends AbstractScalarFunctionsTest {
         assertEvaluate("cast(null as string)", null);
         assertEvaluate("cast(10.4 as long)", 10L);
         assertEvaluate("to_long_array([10.2, 12.3])", new Long[] { 10L, 12L });
+        Map<String, Object> object = new HashMap<>();
+        object.put("x", 10);
+        assertEvaluate("'{\"x\": 10}'::object", object);
+
+        assertEvaluate("cast(name as object)", object, Literal.of("{\"x\": 10}"));
     }
 
     @Test


### PR DESCRIPTION
This can be useful for postgres clients where it's not possible to
provide the correct type info (JSON) and which default to text
serialization.