### PR TITLE
fix code blocks for consistency

### DIFF
--- a/blackbox/docs/best_practice/crate_ami.txt
+++ b/blackbox/docs/best_practice/crate_ami.txt
@@ -1,4 +1,4 @@
-.. highlight:: yaml
+.. highlight:: sh
 .. _crate_ami:
 
 =============================================
@@ -7,9 +7,9 @@ Launching EC2 Instances with the Crate AMI
 
 Crate provides custom public `AMI`_ s that can be launched by every EC2 user
 by using the AWS Management Console or `AWS CLI`_. The naming convention
-is as follows:
+is as follows::
 
-  ``crate-<VERSION>-<REVISION>-<AMI_REVISION>-<BASE_AMI>``
+    crate-<VERSION>-<REVISION>-<AMI_REVISION>-<BASE_AMI>
 
 ``<VERSION>-<REVISION>`` is the Crate version and its revision in the format
 ``w.x.y-z``, ``<AMI_REVISION>`` is the AMI build revision and ``<BASE_AMI>`` is
@@ -40,9 +40,9 @@ If you are using the `AWS CLI`_ you can find the public Crate AMI by using the
 ``AMI Name``. AMIs are listed in JSON-format and sorted by their creation date.
 The following command lists every available Crate AMI on the AWS platform.
 
-.. code-block:: bash
+::
 
-    $ aws ec2 describe-images --filters "Name=name,Values=crate-0.51.1-*"
+    sh$ aws ec2 describe-images --filters "Name=name,Values=crate-0.51.1-*"
 
 
 Launch the AMI
@@ -54,9 +54,9 @@ You can use the parameters of the command to configure its start-up behavior
 and hardware configuration. A valid key-pair is necessary to connect to the
 instances later.
 
-.. code-block:: bash
+::
 
-    $ aws ec2 run-instances --image-id <AMI-ID> --count <NR-OF-INSTANCES> --iam-instance-profile Name="<IAM-ROLE>" --instance-type <INSTANCE-TYPE> --user-data <USER-DATA>  --key-name <KEY-NAME>
+    sh$ aws ec2 run-instances --image-id <AMI-ID> --count <NR-OF-INSTANCES> --iam-instance-profile Name="<IAM-ROLE>" --instance-type <INSTANCE-TYPE> --user-data <USER-DATA>  --key-name <KEY-NAME>
 
 .. _cloud_init:
 
@@ -106,7 +106,7 @@ shows how to set the ``minimum_master_nodes`` and gateway configuration setting
 which are essential for a `multi node setup`_. This
 configuration is used when a cluster with 3 or more nodes is set up.
 
-.. code-block:: bash
+::
 
     #!/bin/bash
     echo "
@@ -130,9 +130,9 @@ mechanism. The following example shows how to run a single instance of type
 ``m3.medium``. The adapted Crate configuration is passed via ``user-data.sh``
 file.
 
-.. code-block:: bash
+::
 
-    $ aws ec2 run-instances --image-id ami-544c1923 --count 1 --iam-instance-profile Name="crate-ec2" --instance-type m3.medium --user-data $(base64 user-data.sh) --key-name my_key_pair
+    sh$ aws ec2 run-instances --image-id ami-544c1923 --count 1 --iam-instance-profile Name="crate-ec2" --instance-type m3.medium --user-data $(base64 user-data.sh) --key-name my_key_pair
 
 
 .. note::
@@ -165,9 +165,9 @@ In this case ``ephemeral1`` will be added as an instance store volume with the
 device name ``/dev/sdc``. For additional info see
 `device naming on linux instances`_.
 
-.. code-block:: bash
+::
 
-    $ aws ec2 run-instances --image-id ami-544c1923 --count 1 --instance-type m3.medium --block-device-mappings "[{\"DeviceName\": \"/dev/sdc\",\"VirtualName\":\"ephemeral1\"}]"
+    sh$ aws ec2 run-instances --image-id ami-544c1923 --count 1 --instance-type m3.medium --block-device-mappings "[{\"DeviceName\": \"/dev/sdc\",\"VirtualName\":\"ephemeral1\"}]"
 
 .. note::
     Note that the data stored on ephemeral disks is not permanent and only

--- a/blackbox/docs/best_practice/migrating_from_mysql.txt
+++ b/blackbox/docs/best_practice/migrating_from_mysql.txt
@@ -12,18 +12,18 @@ This best practice example shows how to migrate your data without any hassle.
 
 We are assuming we have an existing table ``foo`` in MySQL with the following schema::
 
-  CREATE TABLE foo (
-    id integer primary key,
-    name varchar(255),
-    date datetime,
-    fruits set('apple', 'pear', 'banana')
-  ) CHARACTER SET utf8 COLLATE utf8_unicode_ci;
+  cr> CREATE TABLE foo (
+  ...  id integer primary key,
+  ...  name varchar(255),
+  ...  date datetime,
+  ...  fruits set('apple', 'pear', 'banana')
+  ... ) CHARACTER SET utf8 COLLATE utf8_unicode_ci;
 
 Sampledata::
 
-  INSERT INTO foo (id, name, date, fruits)
-    VALUES (1, 'foo', '2014-10-31 09:22:56', 'apple,banana'),
-      (2, 'bar', null, 'pear');
+  cr> INSERT INTO foo (id, name, date, fruits)
+  ...  VALUES (1, 'foo', '2014-10-31 09:22:56', 'apple,banana'),
+  ...   (2, 'bar', null, 'pear');
 
 
 Exporting Data from MySQL
@@ -34,18 +34,20 @@ write to a file using the ``csv`` format.
 
 Example::
 
-  SELECT id, name
-    INTO OUTFILE '/tmp/dump.csv'
-      CHARACTER SET utf8
-      FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"'
-      LINES TERMINATED BY '\n'
-    FROM foo;
+  cr> SELECT id, name
+  ...  INTO OUTFILE '/tmp/dump.csv'
+  ...   CHARACTER SET utf8
+  ...   FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"'
+  ...   LINES TERMINATED BY '\n'
+  ...  FROM foo;
 
 Make sure fields are seperated by a comma (``,``), that values are quoted with a pair of ``"`` and that lines are terminated by the newline character ``\n``.
 
 Note that we specify ``utf8`` as encoding for writing into the outfile. This is important because Crate requires ``utf8`` encoding.
 
-You may need to set the character encoding of the client and ``mysqld`` in the ``my.cnf``, too::
+You may need to set the character encoding of the client and ``mysqld`` in the ``my.cnf``, too:
+
+.. code-block:: ini
 
   [client]
   default-character-set=utf8
@@ -66,16 +68,16 @@ The output of this function must be multiplied by ``1000`` (converting ``s`` to 
 
 ::
 
-  SELECT UNIX_TIMESTAMP(datetime_column)*1000 from table_name;
+  cr> SELECT UNIX_TIMESTAMP(datetime_column)*1000 from table_name;
 
 Final export query::
 
-  SELECT id, name, UNIX_TIMESTAMP(date)*1000, fruits
-    INTO OUTFILE '/tmp/dump.csv'
-      CHARACTER SET utf8
-      FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"'
-      LINES TERMINATED BY '\n'
-    FROM foo;
+  cr> SELECT id, name, UNIX_TIMESTAMP(date)*1000, fruits
+  ...  INTO OUTFILE '/tmp/dump.csv'
+  ...    CHARACTER SET utf8
+  ...    FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '"'
+  ...    LINES TERMINATED BY '\n'
+  ...  FROM foo;
 
 Converting CSV to JSON
 ======================
@@ -112,14 +114,14 @@ For our example the usage looks like:
 
 .. code-block:: sh
 
-  $ cat /tmp/dump.csv | python mysql2crate.py - \
-        --columns id:int name:str date:timestamp fruits:array > /tmp/import.json
+  sh$ cat /tmp/dump.csv | python mysql2crate.py - \
+  ...     --columns id:int name:str date:timestamp fruits:array > /tmp/import.json
 
 For help use the ``-h`` option:
 
 .. code-block:: sh
 
-  $ python mysql2crate.py -h
+  sh$ python mysql2crate.py -h
 
 
 Importing Data into Crate
@@ -129,18 +131,18 @@ The column names need to match the names specified by the ``--columns`` argument
 
 ::
 
-  CREATE TABLE foo_imported (
-    id int,
-    name string,
-    date timestamp,
-    fruits array(string)
-  );
+  cr> CREATE TABLE foo_imported (
+  ...  id int,
+  ...  name string,
+  ...  date timestamp,
+  ...  fruits array(string)
+  ... );
 
 Finally use the ``COPY FROM`` statement to import your newly generated json file into Crate.
 
 ::
 
-  COPY foo_imported FROM '/tmp/import.json' WITH (bulk_size=1000);
+  cr> COPY foo_imported FROM '/tmp/import.json' WITH (bulk_size=1000);
 
 
 .. note::
@@ -159,7 +161,7 @@ The simplest way to do so is like this:
 
 .. code-block:: sh
 
-  $ csvsql --db crate://localhost:4200 --insert /tmp/dump.csv
+  sh$ csvsql --db crate://localhost:4200 --insert /tmp/dump.csv
 
 .. note::
 


### PR DESCRIPTION
we had a few code blocks which are not executed as part of our doctests. these code blocks were using `$` for shell prompts and no prompt at all for SQL statements

this pr fixes them to use `sh$` and `cr>`respectively, as well as the multiline `...` syntax, so they are consistent with code blocks that are tested, as the distinction between non tested and tested code blocks is invisible to the end user

this pr also makes a few other minor code block edits