### PR TITLE
prevents sys.nodes itest from running on a client node

### DIFF
--- a/sql/src/test/java/io/crate/integrationtests/SysNodesITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysNodesITest.java
@@ -24,11 +24,13 @@ package io.crate.integrationtests;
 
 import io.crate.action.sql.SQLActionException;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 
+@ESIntegTestCase.ClusterScope(numClientNodes = 0)
 public class SysNodesITest extends SQLTransportIntegrationTest {
 
     @Override


### PR DESCRIPTION
follow up commit of ddc17dc996d4ae744549e65f6216a85ef766ce61