### PR TITLE
Move `sendErrorResponse` calls out of `exceptionCaught`

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed an issue in the postgres protocol that could cause a StackOverflow
+   exception due to connection errors or malfunctioning clients.
+
  - BREAKING: Removed deprecated setting ``indices.fielddata.breaker`` that have
    been used as an alias for ``indices.breaker.fielddata``.
  

--- a/sql/src/test/java/io/crate/integrationtests/PostgresITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PostgresITest.java
@@ -29,7 +29,6 @@ import io.crate.shade.org.postgresql.util.PSQLException;
 import io.crate.shade.org.postgresql.util.PSQLState;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;


### PR DESCRIPTION
This prevents a possible exceptionCaught recursion leading to a
StackOverflow.

`sendErrorResponse` internally calls `channel.write` which in turn calls
`Channels.fireExceptionCaught` if there is an error.
This then triggered `sendErrorResponse` again.