### PR TITLE
stack futures to avoid that the callbacks get executed in parallel

### DIFF
--- a/sql/src/main/java/io/crate/protocols/postgres/BatchPortal.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/BatchPortal.java
@@ -139,8 +139,9 @@ class BatchPortal extends AbstractPortal {
             statsTables.logExecutionStart(jobId, stmt);
             StatsTablesUpdateListener statsTablesUpdateListener = new StatsTablesUpdateListener(jobId, statsTables);
 
-            resultReceiver.completionFuture().whenComplete(statsTablesUpdateListener);
-            resultReceiver.completionFuture().whenComplete(completionCallback);
+            resultReceiver.completionFuture()
+                .whenComplete(statsTablesUpdateListener)
+                .whenComplete(completionCallback);
 
             RowReceiver rowReceiver = new RowReceiverToResultReceiver(resultReceiver, 0);
             portalContext.getExecutor().execute(plan, rowReceiver, new RowN(batchParams.toArray()));


### PR DESCRIPTION
This fixes the test ``PostgresStatsTablesITest.resetStats()`` that leads to a query response before the job appears in the stats table.