### PR TITLE
fixes scalar function usage on the `having` clause

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fix: Allow scalar functions on the `HAVING` clause if the scalar
+   function is used as a `GROUP BY` symbol.
+
  - Return correct affected row count instead of throwing an exception
    when trying to bulk insert values that don't match the column type(s).
 

--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -332,7 +332,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
     }
 
     private HavingClause analyzeHaving(Optional<Expression> having,
-                                       List<Symbol> groupBy,
+                                       @Nullable List<Symbol> groupBy,
                                        ExpressionAnalyzer expressionAnalyzer,
                                        ExpressionAnalysisContext expressionAnalysisContext) {
         if (having.isPresent()) {

--- a/sql/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
@@ -739,6 +739,15 @@ public class GroupByAggregateTest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    public void testHavingGroupByOnScalar() throws Exception {
+        this.setup.groupBySetup("integer");
+        execute("select date_trunc('week', birthdate) from characters group by 1" +
+                " having date_trunc('week', birthdate) > 0" +
+                " order by date_trunc('week', birthdate)");
+        assertEquals(2L, response.rowCount());
+    }
+
+    @Test
     public void testHavingOnSameAggregate() throws Exception {
         this.setup.groupBySetup("integer");
         execute("select avg(birthdate) from characters group by gender\n" +


### PR DESCRIPTION
scalar functions were wrongly forbidden even if
the same function symbol was part of the grouping symbols