### PR TITLE
Prevent repeated finish calls in SetSessionTask

### DIFF
--- a/sql/src/main/java/io/crate/executor/task/SetSessionTask.java
+++ b/sql/src/main/java/io/crate/executor/task/SetSessionTask.java
@@ -63,8 +63,8 @@ public class SetSessionTask extends JobTask {
             } else {
                 LOGGER.warn("SET SESSION STATEMENT WILL BE IGNORED: {}", setting);
             }
-            rowReceiver.finish(RepeatHandle.UNSUPPORTED);
         }
+        rowReceiver.finish(RepeatHandle.UNSUPPORTED);
     }
 }
 


### PR DESCRIPTION
`finish` was called per setting. That's a violation of the RowReceiver
contract.