### PR TITLE
Replace ListenableRowReceiver future with CompletableFuture

### DIFF
--- a/sql/src/main/java/io/crate/operation/projectors/ListenableRowReceiver.java
+++ b/sql/src/main/java/io/crate/operation/projectors/ListenableRowReceiver.java
@@ -22,9 +22,9 @@
 
 package io.crate.operation.projectors;
 
-import com.google.common.util.concurrent.ListenableFuture;
+import java.util.concurrent.CompletableFuture;
 
 public interface ListenableRowReceiver extends RowReceiver {
 
-    ListenableFuture<Void> finishFuture();
+    CompletableFuture<?> finishFuture();
 }

--- a/sql/src/main/java/io/crate/operation/projectors/RowReceivers.java
+++ b/sql/src/main/java/io/crate/operation/projectors/RowReceivers.java
@@ -22,11 +22,10 @@
 
 package io.crate.operation.projectors;
 
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.SettableFuture;
 import io.crate.data.Row;
 
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.concurrent.CompletableFuture;
 
 public class RowReceivers {
 
@@ -40,7 +39,7 @@ public class RowReceivers {
     @ParametersAreNonnullByDefault
     private static class SettableFutureRowReceiver extends ForwardingRowReceiver implements ListenableRowReceiver {
 
-        private final SettableFuture<Void> finishedFuture = SettableFuture.create();
+        private final CompletableFuture<Void> finishedFuture = new CompletableFuture<>();
 
         SettableFutureRowReceiver(RowReceiver rowReceiver) {
             super(rowReceiver);
@@ -49,17 +48,17 @@ public class RowReceivers {
         @Override
         public void finish(RepeatHandle repeatHandle) {
             super.finish(repeatHandle);
-            finishedFuture.set(null);
+            finishedFuture.complete(null);
         }
 
         @Override
         public void fail(Throwable throwable) {
             super.fail(throwable);
-            finishedFuture.setException(throwable);
+            finishedFuture.completeExceptionally(throwable);
         }
 
         @Override
-        public ListenableFuture<Void> finishFuture() {
+        public CompletableFuture<?> finishFuture() {
             return finishedFuture;
         }
     }


### PR DESCRIPTION
It will make it easier to introduce a closeCallback for rowReceiver's if
we use the same kind of future in all relevant places.