### PR TITLE
Prepare BulkProcessor result handling for cursor close handling

### DIFF
--- a/sql/src/main/java/io/crate/exceptions/Exceptions.java
+++ b/sql/src/main/java/io/crate/exceptions/Exceptions.java
@@ -47,6 +47,7 @@ import org.elasticsearch.transport.TransportException;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Locale;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Predicate;
 
@@ -57,6 +58,7 @@ public class Exceptions {
         throwable instanceof TransportException ||
         throwable instanceof UncheckedExecutionException ||
         throwable instanceof UncategorizedExecutionException ||
+        throwable instanceof CompletionException ||
         throwable instanceof ExecutionException;
 
     public static Throwable unwrap(@Nonnull Throwable t, @Nullable Predicate<Throwable> additionalUnwrapCondition) {

--- a/sql/src/main/java/org/elasticsearch/action/bulk/BulkShardProcessor.java
+++ b/sql/src/main/java/org/elasticsearch/action/bulk/BulkShardProcessor.java
@@ -380,7 +380,10 @@ public class BulkShardProcessor<Request extends ShardRequest> {
 
     public void kill(@Nullable Throwable throwable) {
         failure.compareAndSet(null, throwable);
-        result.completeExceptionally(new InterruptedException(JobKilledException.MESSAGE));
+        if (throwable == null) {
+            throwable = new InterruptedException(JobKilledException.MESSAGE);
+        }
+        result.completeExceptionally(throwable);
     }
 
     private void setFailure(Throwable e) {


### PR DESCRIPTION
This commit introduces a upstreamFinishedFuture to projectors using the
BulkShardProcessor. The downstream rowReceiver will only receive it's
result once both, the upstreamFinishedFuture and the BulkShardProcessor
future has completed.

This is done so we can later add a `close` method to the RepeatHandle or
extend `finish` to contain a `CloseCallback`.
That is necessary to be able to slowly migrate to a cursor/pull based
execution pipeline because the consumers/downstreams will need to invoke
a `close` method for the upstream to be able to release its resources.