### PR TITLE
Upgrade jacoco to latest version (0.7.9)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ allprojects {
     }
 
     jacoco {
-        toolVersion = "0.7.1.201405082137"
+        toolVersion = "0.7.9"
     }
 
     group = 'io.crate'


### PR DESCRIPTION
I sometimes have odd jacoco instrumentation errors like

    INTERNAL_SERVER_ERROR 5000 NullPointerException in
    org.apache.lucene.search.ConstantScoreWeight.$jacocoInit(ConstantScoreWeight.java)

Not sure if those are fixed, but there are other fixes:

    https://github.com/jacoco/jacoco/releases