### PR TITLE
removed the PREDICATE function type

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - It is now supported to order and group by predicate functions in general
+   with the exception of the `match` predicate.
+
  - Removed limitation which didn't allow ordering on partitioned columns in
    GROUP BY query
 

--- a/blackbox/docs/sql/joins.txt
+++ b/blackbox/docs/sql/joins.txt
@@ -192,10 +192,6 @@ Example with ``within`` scalar function::
     +--------------+---------+
     SELECT 2 rows in set (... sec)
 
-.. note::
-
-    :ref:`predicates` are **not** supported as join conditions.
-
 However, there are no specific optimisations for certain join conditions such
 as ``=`` (equals) yet. The JOIN operation is implemented as a generic nested loop
 that invokes the operation on every record of the left table with every record

--- a/blackbox/docs/sql/queries.txt
+++ b/blackbox/docs/sql/queries.txt
@@ -212,40 +212,6 @@ For custom date types, or defined date formats in the object mapping
 the corresponding format should be used for a comparison. Otherwise
 the operation may fail.
 
-.. _predicates:
-
-Predicates
-..........
-
-Predicates are expressions that evaluate to boolean.
-
-While scalar functions that evaluate to boolean can be used in place of a predicate, the
-semantics of a predicate usually differ from function semantics.
-
-e.g. A function is resolved by its name and the type of its arguments.
-A reference can be interchanged with the value it evaluates to (given as a literal)
-in a function argument and the function resolves to the same value.
-Predicates can bear different semantics, e.g. enforce the usage of a column reference.
-
-The following predicates extend the range of possible conditions to use in the where clause.
-
-    ==========================  ===========================================================
-    Predicate                   Description
-    ==========================  ===========================================================
-    :ref:`predicates_not_null`  field is not null and not missing
-    :ref:`predicates_is_null`   field is null or missing
-    :ref:`predicates_match`     Perform a search on an indexed column.
-                                See :ref:`sql_dql_fulltext_search`
-                                or :ref:`sql_dql_geo_search` for usage.
-    ==========================  ===========================================================
-
-.. note::
-
-    Not all predicates can utilize the index efficiently. For example ``is
-    null`` can't use the index at all and will therefor perform worse than
-    other operators.
-
-
 .. _sql_ddl_regexp:
 
 Regular Expressions
@@ -466,7 +432,7 @@ value from a right-hand set equals left-hand operand. Returns ``false`` otherwis
 
 
 
-.. _predicates_is_null:
+.. _sql_dql_is_null:
 
 IS NULL
 -------
@@ -511,7 +477,7 @@ does always return ``NULL`` when comparing ``NULL``.
     SELECT 1 row in set (... sec)
 
 
-.. _predicates_not_null:
+.. _sql_dql_is_not_null:
 
 IS NOT NULL
 -----------
@@ -1137,17 +1103,3 @@ The having clause supports the same operators as the :ref:`sql_dql_where_clause`
     between           ``a BETWEEN x and y``:
                       shortcut for ``a >= x AND a <= y``
     ================  ==================================
-
-Predicates
-~~~~~~~~~~
-
-The having supports almost the same predicates as the :ref:`sql_dql_where_clause`
-excpet the `match` predicate, which is not supported.
-The following :ref:`predicates` are supported:
-
-    ==========================  ===========================================================
-    Predicate                   Description
-    ==========================  ===========================================================
-    :ref:`predicates_not_null`  value is not null and not missing
-    :ref:`predicates_is_null`   value is null or missing
-    ==========================  ===========================================================

--- a/sql/src/main/java/io/crate/analyze/symbol/MatchPredicate.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/MatchPredicate.java
@@ -30,10 +30,6 @@ import java.util.Map;
 
 public class MatchPredicate extends Symbol {
 
-    public static final SymbolFactory FACTORY = (SymbolFactory) (in) -> {
-        throw new UnsupportedOperationException("Streaming a MatchPredicate is not supported");
-    };
-
     private final Map<Field, Symbol> identBoostMap;
     private final Symbol queryTerm;
     private final String matchType;

--- a/sql/src/main/java/io/crate/analyze/symbol/SymbolType.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/SymbolType.java
@@ -41,7 +41,7 @@ public enum SymbolType {
     INPUT_COLUMN(InputColumn::new),
     DYNAMIC_REFERENCE(DynamicReference::new),
     VALUE(Value::new),
-    MATCH_PREDICATE(MatchPredicate.FACTORY),
+    MATCH_PREDICATE(null),
     FETCH_REFERENCE(null),
     RELATION_COLUMN(RelationColumn::new),
     INDEX_REFERENCE(IndexReference::new),

--- a/sql/src/main/java/io/crate/analyze/validator/GroupBySymbolValidator.java
+++ b/sql/src/main/java/io/crate/analyze/validator/GroupBySymbolValidator.java
@@ -57,9 +57,6 @@ public class GroupBySymbolValidator {
                     break;
                 case AGGREGATE:
                     throw new IllegalArgumentException("Aggregate functions are not allowed in GROUP BY");
-                case PREDICATE:
-                    throw new UnsupportedOperationException(String.format(Locale.ENGLISH,
-                        "%s predicate cannot be used in a GROUP BY clause", symbol.info().ident().name()));
                 default:
                     throw new UnsupportedOperationException(
                         String.format(Locale.ENGLISH, "FunctionInfo.Type %s not handled", symbol.info().type()));

--- a/sql/src/main/java/io/crate/analyze/validator/SelectSymbolValidator.java
+++ b/sql/src/main/java/io/crate/analyze/validator/SelectSymbolValidator.java
@@ -46,7 +46,6 @@ public class SelectSymbolValidator {
             switch (symbol.info().type()) {
                 case SCALAR:
                 case AGGREGATE:
-                case PREDICATE:
                     break;
                 default:
                     throw new UnsupportedOperationException(String.format(Locale.ENGLISH,

--- a/sql/src/main/java/io/crate/analyze/validator/SemanticSortValidator.java
+++ b/sql/src/main/java/io/crate/analyze/validator/SemanticSortValidator.java
@@ -23,7 +23,6 @@ package io.crate.analyze.validator;
 
 import io.crate.analyze.symbol.*;
 import io.crate.analyze.symbol.format.SymbolPrinter;
-import io.crate.metadata.FunctionInfo;
 import io.crate.types.DataTypes;
 
 import java.util.Locale;
@@ -60,10 +59,6 @@ public class SemanticSortValidator {
                         SymbolPrinter.INSTANCE.printSimple(symbol),
                         symbol.valueType())
                 );
-            }
-            if (symbol.info().type() == FunctionInfo.Type.PREDICATE) {
-                throw new UnsupportedOperationException(String.format(Locale.ENGLISH,
-                    "%s predicate cannot be used in an ORDER BY clause", symbol.info().ident().name()));
             }
             try {
                 context.inFunction = true;

--- a/sql/src/main/java/io/crate/metadata/FunctionInfo.java
+++ b/sql/src/main/java/io/crate/metadata/FunctionInfo.java
@@ -144,8 +144,7 @@ public class FunctionInfo implements Comparable<FunctionInfo>, Streamable {
 
     public enum Type {
         SCALAR,
-        AGGREGATE,
-        PREDICATE
+        AGGREGATE
     }
 
     public enum Feature {

--- a/sql/src/main/java/io/crate/operation/predicate/IsNullPredicate.java
+++ b/sql/src/main/java/io/crate/operation/predicate/IsNullPredicate.java
@@ -44,7 +44,7 @@ public class IsNullPredicate<T> extends Scalar<Boolean, T> implements FunctionFo
     }
 
     public static FunctionInfo generateInfo(List<DataType> types) {
-        return new FunctionInfo(new FunctionIdent(NAME, types), DataTypes.BOOLEAN, FunctionInfo.Type.PREDICATE);
+        return new FunctionInfo(new FunctionIdent(NAME, types), DataTypes.BOOLEAN);
     }
 
     IsNullPredicate(FunctionInfo info) {

--- a/sql/src/main/java/io/crate/operation/predicate/MatchPredicate.java
+++ b/sql/src/main/java/io/crate/operation/predicate/MatchPredicate.java
@@ -44,10 +44,10 @@ import java.util.Set;
  */
 public class MatchPredicate implements FunctionImplementation {
 
-    public static final Set<DataType> SUPPORTED_TYPES = ImmutableSet.<DataType>of(DataTypes.STRING, DataTypes.GEO_SHAPE);
+    public static final Set<DataType> SUPPORTED_TYPES = ImmutableSet.of(DataTypes.STRING, DataTypes.GEO_SHAPE);
 
     private static final String DEFAULT_MATCH_TYPE_STRING = MultiMatchQueryBuilder.Type.BEST_FIELDS.toString().toLowerCase(Locale.ENGLISH);
-    private static final Map<DataType, String> DATA_TYPE_TO_DEFAULT_MATCH_TYPE = ImmutableMap.<DataType, String>of(
+    private static final Map<DataType, String> DATA_TYPE_TO_DEFAULT_MATCH_TYPE = ImmutableMap.of(
         DataTypes.STRING, DEFAULT_MATCH_TYPE_STRING,
         DataTypes.GEO_SHAPE, "intersects"
     );
@@ -56,10 +56,10 @@ public class MatchPredicate implements FunctionImplementation {
     public static final String NAME = "match";
     public static final FunctionIdent IDENT = new FunctionIdent(
         NAME,
-        Arrays.<DataType>asList(DataTypes.OBJECT, DataTypes.STRING, DataTypes.STRING, DataTypes.OBJECT)
+        Arrays.asList(DataTypes.OBJECT, DataTypes.STRING, DataTypes.STRING, DataTypes.OBJECT)
     );
 
-    public static final FunctionInfo INFO = new FunctionInfo(IDENT, DataTypes.BOOLEAN, FunctionInfo.Type.PREDICATE);
+    public static final FunctionInfo INFO = new FunctionInfo(IDENT, DataTypes.BOOLEAN);
 
 
     private static String defaultMatchType(DataType dataType) {
@@ -109,7 +109,7 @@ public class MatchPredicate implements FunctionImplementation {
         module.register(new MatchPredicate());
     }
 
-    public MatchPredicate() {
+    private MatchPredicate() {
     }
 
     @Override

--- a/sql/src/main/java/io/crate/operation/predicate/NotPredicate.java
+++ b/sql/src/main/java/io/crate/operation/predicate/NotPredicate.java
@@ -40,7 +40,7 @@ public class NotPredicate extends Scalar<Boolean, Boolean> implements OperatorFo
     public static final String NAME = "op_not";
     public static final String OPERATOR_ALIAS = "NOT";
     public static final FunctionInfo INFO = new FunctionInfo(
-        new FunctionIdent(NAME, Arrays.<DataType>asList(DataTypes.BOOLEAN)), DataTypes.BOOLEAN, FunctionInfo.Type.PREDICATE);
+        new FunctionIdent(NAME, Arrays.<DataType>asList(DataTypes.BOOLEAN)), DataTypes.BOOLEAN);
 
     public static void register(PredicateModule module) {
         module.register(new NotPredicate());


### PR DESCRIPTION
it was actually only adding an artificial limitation on some scalar
functions so that those could not be used in order by or group by. 
however it is only the match predicate which is not implementing scalar
which is not a function symbol in the analysis anyways.