### PR TITLE
Fix stuck bulk operations / NPE in `executeBulk` result handling

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,11 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed an issue that could cause UPDATE or DELETE bulk operations to get
+   stuck if the bulk_size was big.
+   Now the response will contain a list of results where each individual result
+   will contain `-2` as row count do indicate an error.
+
  - Removed limitation which didn't allow ordering on partitioned columns in
    GROUP BY query
 

--- a/sql/src/main/java/io/crate/protocols/postgres/BulkPortal.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/BulkPortal.java
@@ -148,7 +148,8 @@ class BulkPortal extends AbstractPortal {
                     Long[] cells = new Long[1];
                     RowN row = new RowN(cells);
                     for (int i = 0; i < result.size(); i++) {
-                        cells[0] = result.get(i);
+                        Long rowCount = result.get(i);
+                        cells[0] = rowCount == null ? Executor.ROWCOUNT_ERROR : rowCount;
                         ResultReceiver resultReceiver = resultReceivers.get(i);
                         resultReceiver.setNextRow(row);
                         resultReceiver.allFinished(false);


### PR DESCRIPTION
`executeBulk` internally uses `successfulAsList` which results in `null`
entries in the result list, these null entries must be mapped to
row-count-unknown (-2).