### PR TITLE
recompute values of generated expressions on updates

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,10 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fix an issue which prevented generated columns without any referenced
+   columns in it, e.g. when it contanins only ``CURRENT_TIMESTAMP``, from
+   computing a new value on ``UPDATE``.
+
  - Fixed global aggregations on JOINs with 3 or more tables.
 
  - BREAKING: The TableFunctionImplementation interface was streamlined

--- a/sql/src/main/java/io/crate/executor/transport/TransportShardUpsertAction.java
+++ b/sql/src/main/java/io/crate/executor/transport/TransportShardUpsertAction.java
@@ -317,6 +317,9 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
         // Currently the validation is done only for generated columns.
         processGeneratedColumns(tableInfo, pathsToUpdate, updatedGeneratedColumns, true, getResult);
 
+        // compute generated columns which doesn't have any references to other columns
+        processGeneratedColumnsWithoutReferencedRefs(tableInfo.generatedColumns(), pathsToUpdate, updatedGeneratedColumns);
+
         updateSourceByPaths(updatedSourceAsMap, pathsToUpdate);
 
         try {
@@ -325,6 +328,20 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
             return new SourceAndVersion(builder.bytes(), getResult.getVersion());
         } catch (IOException e) {
             throw new ElasticsearchGenerationException("Failed to generate [" + updatedSourceAsMap + "]", e);
+        }
+    }
+
+    private void processGeneratedColumnsWithoutReferencedRefs(List<GeneratedReference> generatedColumns,
+                                                            Map<String, Object> pathsToUpdate,
+                                                            Map<String, Object> updatedGeneratedColumns) {
+        SymbolToFieldExtractorContext ctx = new SymbolToFieldExtractorContext(functions, new Object[]{});
+        for (GeneratedReference reference : generatedColumns) {
+            String columnPath = reference.ident().columnIdent().fqn();
+            if (!updatedGeneratedColumns.containsKey(columnPath) && reference.referencedReferences().isEmpty()) {
+                Object value = SYMBOL_TO_FIELD_EXTRACTOR.convert(reference.generatedExpression(), ctx).apply(null);
+                ConstraintsValidator.validate(value, reference);
+                pathsToUpdate.put(columnPath, value);
+            }
         }
     }
 


### PR DESCRIPTION
Generated expressions which don't have references to any columns
would not recompute their values on update operations. For instance,

    CREATE TABLE test (id LONG, ts TIMESTAMP GENERATED ALWAYS AS current_timestamp)
    INSERT INTO test (id) values (1)
    UPDATE TEST SET id = 2

previously, would have the same timestamp value after insert and update
operations.