### PR TITLE
Fix restoring a partitioned table from a snapshot

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed an issue which caused restoring a whole partitioned table from a
+   snapshot to fail.
+
  - Added the ``licence.enterprise`` setting to the cluster settings.
 
  - Fixed low/high disk-based shard allocation watermark checks. The checks

--- a/sql/src/main/java/io/crate/executor/transport/TransportActionProvider.java
+++ b/sql/src/main/java/io/crate/executor/transport/TransportActionProvider.java
@@ -27,6 +27,7 @@ import io.crate.executor.transport.kill.TransportKillJobsNodeAction;
 import org.elasticsearch.action.admin.cluster.settings.TransportClusterUpdateSettingsAction;
 import org.elasticsearch.action.admin.cluster.snapshots.create.TransportCreateSnapshotAction;
 import org.elasticsearch.action.admin.cluster.snapshots.delete.TransportDeleteSnapshotAction;
+import org.elasticsearch.action.admin.cluster.snapshots.get.TransportGetSnapshotsAction;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.TransportRestoreSnapshotAction;
 import org.elasticsearch.action.admin.indices.create.TransportBulkCreateIndicesAction;
 import org.elasticsearch.action.admin.indices.create.TransportCreateIndexAction;
@@ -71,6 +72,7 @@ public class TransportActionProvider {
     private final Provider<TransportCreateSnapshotAction> transportCreateSnapshotActionProvider;
     private final Provider<TransportDeleteSnapshotAction> transportDeleteSnapshotActionProvider;
     private final Provider<TransportRestoreSnapshotAction> transportRestoreSnapshotActionProvider;
+    private final Provider<TransportGetSnapshotsAction> transportGetSnapshotsActionProvider;
 
     @Inject
     public TransportActionProvider(Provider<TransportFetchNodeAction> transportFetchNodeActionProvider,
@@ -94,7 +96,8 @@ public class TransportActionProvider {
                                    Provider<TransportKillJobsNodeAction> transportKillJobsNodeActionProvider,
                                    Provider<TransportDeleteSnapshotAction> transportDeleteSnapshotActionProvider,
                                    Provider<TransportCreateSnapshotAction> transportCreateSnapshotActionProvider,
-                                   Provider<TransportRestoreSnapshotAction> transportRestoreSnapshotActionProvider) {
+                                   Provider<TransportRestoreSnapshotAction> transportRestoreSnapshotActionProvider,
+                                   Provider<TransportGetSnapshotsAction> transportGetSnapshotsActionPovider) {
         this.transportCreateIndexActionProvider = transportCreateIndexActionProvider;
         this.transportDeleteIndexActionProvider = transportDeleteIndexActionProvider;
         this.transportPutIndexTemplateActionProvider = transportPutIndexTemplateActionProvider;
@@ -117,6 +120,7 @@ public class TransportActionProvider {
         this.transportDeleteSnapshotActionProvider = transportDeleteSnapshotActionProvider;
         this.transportCreateSnapshotActionProvider = transportCreateSnapshotActionProvider;
         this.transportRestoreSnapshotActionProvider = transportRestoreSnapshotActionProvider;
+        this.transportGetSnapshotsActionProvider = transportGetSnapshotsActionPovider;
     }
 
     public TransportCreateIndexAction transportCreateIndexAction() {
@@ -205,5 +209,9 @@ public class TransportActionProvider {
 
     public TransportRestoreSnapshotAction transportRestoreSnapshotAction() {
         return transportRestoreSnapshotActionProvider.get();
+    }
+
+    public TransportGetSnapshotsAction transportGetSnapshotsAction() {
+        return transportGetSnapshotsActionProvider.get();
     }
 }

--- a/sql/src/test/java/io/crate/executor/transport/SnapshotRestoreDDLDispatcherTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/SnapshotRestoreDDLDispatcherTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.executor.transport;
+
+import io.crate.analyze.RestoreSnapshotAnalyzedStatement;
+import io.crate.exceptions.TableUnknownException;
+import io.crate.metadata.PartitionName;
+import io.crate.metadata.TableIdent;
+import io.crate.test.integration.CrateUnitTest;
+import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsResponse;
+import org.elasticsearch.snapshots.Snapshot;
+import org.elasticsearch.snapshots.SnapshotInfo;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SnapshotRestoreDDLDispatcherTest extends CrateUnitTest {
+
+    @Test
+    public void testResolveTableIndexWithIgnoreUnavailable() throws Exception {
+        CompletableFuture<List<String>> f = SnapshotRestoreDDLDispatcher.resolveIndexNames(
+            Collections.singletonList(new RestoreSnapshotAnalyzedStatement.RestoreTableInfo(new TableIdent(null, "my_table"),null)),
+            true, null, "my_repo"
+        );
+        assertThat(f.get(), containsInAnyOrder("my_table", PartitionName.templateName(null, "my_table") + "*"));
+    }
+
+    @Test
+    public void testResolveTableIndexFromSnapshot() throws Exception {
+        String resolvedIndex = SnapshotRestoreDDLDispatcher.ResolveFromSnapshotActionListener.resolveIndexNameFromSnapshot(
+            new TableIdent("custom", "restoreme"),
+            Collections.singletonList(
+                new SnapshotInfo(new Snapshot("snapshot01", Collections.singletonList("custom.restoreme"), 0L))
+            )
+        );
+        assertThat(resolvedIndex, is("custom.restoreme"));
+    }
+
+    @Test
+    public void testResolvePartitionedTableIndexFromSnapshot() throws Exception {
+        String resolvedIndex = SnapshotRestoreDDLDispatcher.ResolveFromSnapshotActionListener.resolveIndexNameFromSnapshot(
+            new TableIdent(null, "restoreme"),
+            Collections.singletonList(
+                new SnapshotInfo(new Snapshot("snapshot01",
+                    Collections.singletonList(".partitioned.restoreme.046jcchm6krj4e1g60o30c0"), 0L))
+            )
+        );
+        String template = PartitionName.templateName(null, "restoreme") + "*";
+        assertThat(resolvedIndex, is(template));
+    }
+
+    @Test
+    public void testResolveMultiTablesIndexNamesFromSnapshot() throws Exception {
+        List<RestoreSnapshotAnalyzedStatement.RestoreTableInfo> tables = Arrays.asList(
+            new RestoreSnapshotAnalyzedStatement.RestoreTableInfo(new TableIdent(null, "my_table"), null),
+            new RestoreSnapshotAnalyzedStatement.RestoreTableInfo(new TableIdent(null, "my_partitioned_table"), null)
+        );
+        List<SnapshotInfo> snapshots = Arrays.asList(
+                new SnapshotInfo(
+                    new Snapshot("snapshot01", Collections.singletonList(".partitioned.my_partitioned_table.046jcchm6krj4e1g60o30c0"), 0)
+                ),
+                new SnapshotInfo(new Snapshot("snapshot03", Collections.singletonList("my_table"), 0))
+            );
+
+        CompletableFuture<List<String>> future = new CompletableFuture<>();
+        SnapshotRestoreDDLDispatcher.ResolveFromSnapshotActionListener actionListener =
+            new SnapshotRestoreDDLDispatcher.ResolveFromSnapshotActionListener(future, tables, new HashSet<>());
+
+        // need to mock here as constructor is not accessible
+        GetSnapshotsResponse response = mock(GetSnapshotsResponse.class);
+        when(response.getSnapshots()).thenReturn(snapshots);
+        actionListener.onResponse(response);
+        assertThat(future.get(), containsInAnyOrder("my_table", PartitionName.templateName(null, "my_partitioned_table") + "*"));
+    }
+
+    @Test
+    public void testResolveUnknownTableFromSnapshot() throws Exception {
+        expectedException.expect(TableUnknownException.class);
+        expectedException.expectMessage("Table 'doc.t1' unknown");
+        SnapshotRestoreDDLDispatcher.ResolveFromSnapshotActionListener.resolveIndexNameFromSnapshot(new TableIdent(null, "t1"), Collections.emptyList());
+    }
+
+}

--- a/sql/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
@@ -378,7 +378,6 @@ public class SnapshotRestoreIntegrationTest extends SQLTransportIntegrationTest 
         execute("drop table my_parted_2");
 
         execute("RESTORE SNAPSHOT " + snapshotName() + " TABLE my_parted_1 with (" +
-                "ignore_unavailable=true, " +
                 "wait_for_completion=true)");
 
         execute("select table_schema || '.' || table_name from information_schema.tables where table_schema='doc'");


### PR DESCRIPTION
When one restored a single table from a snapshot,
crate attempted to restore the table as a normal
table and also as a partitioned table, because
crate didn’t determine if the table is partitioned
or not.

This caused an error if the table was partitioned
as the attempt to restore it as a normal table failed.

Fixed this behaviour by reading the snapshot to
determine if the table is partitioned or not.