### PR TITLE
Add NotSerializableExceptionWrapper to exceptions to unwrap

### DIFF
--- a/sql/src/main/java/io/crate/exceptions/Exceptions.java
+++ b/sql/src/main/java/io/crate/exceptions/Exceptions.java
@@ -27,6 +27,7 @@ import io.crate.action.sql.SQLActionException;
 import io.crate.metadata.PartitionName;
 import io.crate.sql.parser.ParsingException;
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.io.stream.NotSerializableExceptionWrapper;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.util.concurrent.UncategorizedExecutionException;
@@ -57,6 +58,7 @@ public class Exceptions {
         throwable instanceof TransportException ||
         throwable instanceof UncheckedExecutionException ||
         throwable instanceof UncategorizedExecutionException ||
+        throwable instanceof NotSerializableExceptionWrapper ||
         throwable instanceof ExecutionException;
 
     public static Throwable unwrap(@Nonnull Throwable t, @Nullable Predicate<Throwable> additionalUnwrapCondition) {


### PR DESCRIPTION
If a `ShardNotFoundException` was wrapped into a
`NotSerializableExceptionWrapper` it didn't recognize it as
shard-failure and therefore the "retry-on-shard-failure" logic didn't
trigger.

This could cause tests like `testFetchPartitionedTable` to fail because
there is no additional `ensureYellow` guard to prevent shard failures.
(This happened very rarely).