### PR TITLE
use _id instead of _uid expression in dml projector to prevent unneeded

### DIFF
--- a/sql/src/main/java/io/crate/planner/statement/DeleteStatementPlanner.java
+++ b/sql/src/main/java/io/crate/planner/statement/DeleteStatementPlanner.java
@@ -27,12 +27,10 @@ import io.crate.analyze.DeleteAnalyzedStatement;
 import io.crate.analyze.WhereClause;
 import io.crate.analyze.relations.DocTableRelation;
 import io.crate.analyze.symbol.InputColumn;
-import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.where.DocKeys;
 import io.crate.metadata.Reference;
-import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.Routing;
-import io.crate.metadata.RowGranularity;
+import io.crate.metadata.doc.DocSysColumns;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.TableInfo;
 import io.crate.operation.projectors.TopN;
@@ -48,7 +46,6 @@ import io.crate.planner.node.dql.Collect;
 import io.crate.planner.node.dql.RoutedCollectPhase;
 import io.crate.planner.projection.DeleteProjection;
 import io.crate.planner.projection.MergeCountProjection;
-import io.crate.planner.projection.Projection;
 import io.crate.types.DataTypes;
 import org.elasticsearch.cluster.routing.Preference;
 
@@ -126,8 +123,7 @@ public final class DeleteStatementPlanner {
                                              WhereClause whereClause,
                                              Planner.Context plannerContext) {
         // for delete, we always need to collect the `_uid`
-        Reference uidReference = new Reference(
-            new ReferenceIdent(tableInfo.ident(), "_uid"), RowGranularity.DOC, DataTypes.STRING);
+        Reference idReference = tableInfo.getReference(DocSysColumns.ID);
 
         DeleteProjection deleteProjection = new DeleteProjection(
             new InputColumn(0, DataTypes.STRING));
@@ -139,8 +135,8 @@ public final class DeleteStatementPlanner {
             "collect",
             routing,
             tableInfo.rowGranularity(),
-            ImmutableList.<Symbol>of(uidReference),
-            ImmutableList.<Projection>of(deleteProjection),
+            ImmutableList.of(idReference),
+            ImmutableList.of(deleteProjection),
             whereClause,
             DistributionInfo.DEFAULT_BROADCAST
         );

--- a/sql/src/test/java/io/crate/planner/UpdatePlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/UpdatePlannerTest.java
@@ -72,7 +72,7 @@ public class UpdatePlannerTest extends CrateUnitTest {
         assertThat(collectPhase.projections().get(0), instanceOf(UpdateProjection.class));
         assertThat(collectPhase.toCollect().size(), is(1));
         assertThat(collectPhase.toCollect().get(0), instanceOf(Reference.class));
-        assertThat(((Reference) collectPhase.toCollect().get(0)).ident().columnIdent().fqn(), is("_uid"));
+        assertThat(((Reference) collectPhase.toCollect().get(0)).ident().columnIdent().fqn(), is("_id"));
 
         UpdateProjection updateProjection = (UpdateProjection) collectPhase.projections().get(0);
         assertThat(updateProjection.uidSymbol(), instanceOf(InputColumn.class));


### PR DESCRIPTION
string copying in dml projectors