### PR TITLE
Set maxRows to 0 for DML operations

### DIFF
--- a/sql/src/main/java/io/crate/executor/transport/AlterTableOperation.java
+++ b/sql/src/main/java/io/crate/executor/transport/AlterTableOperation.java
@@ -99,7 +99,7 @@ public class AlterTableOperation {
             try {
                 session.parse(SQLOperations.Session.UNNAMED, stmt, Collections.<DataType>emptyList());
                 session.bind(SQLOperations.Session.UNNAMED, SQLOperations.Session.UNNAMED, Collections.emptyList(), null);
-                session.execute(SQLOperations.Session.UNNAMED, 1, new ResultSetReceiver(analysis, result));
+                session.execute(SQLOperations.Session.UNNAMED, 0, new ResultSetReceiver(analysis, result));
                 session.sync();
             } catch (Throwable t) {
                 result.completeExceptionally(t);

--- a/sql/src/main/java/io/crate/protocols/postgres/BulkPortal.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/BulkPortal.java
@@ -31,7 +31,6 @@ import io.crate.data.Row;
 import io.crate.data.RowN;
 import io.crate.data.Rows;
 import io.crate.exceptions.Exceptions;
-import io.crate.exceptions.UnsupportedFeatureException;
 import io.crate.executor.Executor;
 import io.crate.operation.collect.stats.JobsLogs;
 import io.crate.planner.Plan;
@@ -107,9 +106,6 @@ class BulkPortal extends AbstractPortal {
 
     @Override
     public void execute(ResultReceiver resultReceiver, int maxRows) {
-        if (maxRows != 1) {
-            throw new UnsupportedFeatureException("bulk operations don't support fetch size");
-        }
         this.resultReceivers.add(resultReceiver);
         this.maxRows = maxRows;
     }

--- a/sql/src/main/java/io/crate/rest/action/RestSQLAction.java
+++ b/sql/src/main/java/io/crate/rest/action/RestSQLAction.java
@@ -113,7 +113,7 @@ public class RestSQLAction extends BaseRestHandler {
             if (outputFields == null) {
                 ResultReceiver resultReceiver
                     = new RestRowCountReceiver(channel, startTime, request.paramAsBoolean("types", false));
-                session.execute(UNNAMED, 1, resultReceiver);
+                session.execute(UNNAMED, 0, resultReceiver);
             } else {
                 ResultReceiver resultReceiver =
                     new RestResultSetReceiver(channel, outputFields, startTime, request.paramAsBoolean("types", false));
@@ -137,12 +137,12 @@ public class RestSQLAction extends BaseRestHandler {
             final RestBulkRowCountReceiver.Result[] results = new RestBulkRowCountReceiver.Result[bulkArgs.length];
             if (results.length == 0) {
                 session.bind(UNNAMED, UNNAMED, Collections.emptyList(), null);
-                session.execute(UNNAMED, 1, new BaseResultReceiver());
+                session.execute(UNNAMED, 0, new BaseResultReceiver());
             } else {
                 for (int i = 0; i < bulkArgs.length; i++) {
                     session.bind(UNNAMED, UNNAMED, Arrays.asList(bulkArgs[i]), null);
                     ResultReceiver resultReceiver = new RestBulkRowCountReceiver(results, i);
-                    session.execute(UNNAMED, 1, resultReceiver);
+                    session.execute(UNNAMED, 0, resultReceiver);
                 }
             }
             List<Field> outputColumns = session.describe('P', UNNAMED);

--- a/sql/src/test/java/io/crate/testing/SQLTransportExecutor.java
+++ b/sql/src/test/java/io/crate/testing/SQLTransportExecutor.java
@@ -173,7 +173,7 @@ public class SQLTransportExecutor {
             List<Field> outputFields = session.describe('P', UNNAMED);
             if (outputFields == null) {
                 ResultReceiver resultReceiver = new RowCountReceiver(listener);
-                session.execute(UNNAMED, 1, resultReceiver);
+                session.execute(UNNAMED, 0, resultReceiver);
             } else {
                 ResultReceiver resultReceiver = new ResultSetReceiver(listener, outputFields);
                 session.execute(UNNAMED, 0, resultReceiver);
@@ -198,12 +198,12 @@ public class SQLTransportExecutor {
             final SQLBulkResponse.Result[] results = new SQLBulkResponse.Result[bulkArgs.length];
             if (results.length == 0) {
                 session.bind(UNNAMED, UNNAMED, Collections.emptyList(), null);
-                session.execute(UNNAMED, 1, new BaseResultReceiver());
+                session.execute(UNNAMED, 0, new BaseResultReceiver());
             } else {
                 for (int i = 0; i < bulkArgs.length; i++) {
                     session.bind(UNNAMED, UNNAMED, Arrays.asList(bulkArgs[i]), null);
                     ResultReceiver resultReceiver = new BulkRowCountReceiver(results, i);
-                    session.execute(UNNAMED, 1, resultReceiver);
+                    session.execute(UNNAMED, 0, resultReceiver);
                 }
             }
             List<Field> outputColumns = session.describe('P', UNNAMED);


### PR DESCRIPTION
Setting maxRows to 1 causes `RowReceiverToResultReceiver` to return
PAUSE on the first row.
This isn't currently an issue in master because all components that emit
one row ignore the `setNextRow` result but it's a problem in the
`batch-iterator` branch.