### PR TITLE
fixes flakyness of testInsertBulkDifferentTypesResultsInStreamingFailure

### DIFF
--- a/sql/src/main/java/io/crate/exceptions/Exceptions.java
+++ b/sql/src/main/java/io/crate/exceptions/Exceptions.java
@@ -27,7 +27,6 @@ import io.crate.action.sql.SQLActionException;
 import io.crate.metadata.PartitionName;
 import io.crate.sql.parser.ParsingException;
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.common.io.stream.NotSerializableExceptionWrapper;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.util.concurrent.UncategorizedExecutionException;
@@ -58,7 +57,6 @@ public class Exceptions {
         throwable instanceof TransportException ||
         throwable instanceof UncheckedExecutionException ||
         throwable instanceof UncategorizedExecutionException ||
-        throwable instanceof NotSerializableExceptionWrapper ||
         throwable instanceof ExecutionException;
 
     public static Throwable unwrap(@Nonnull Throwable t, @Nullable Predicate<Throwable> additionalUnwrapCondition) {

--- a/sql/src/main/java/org/elasticsearch/action/bulk/BulkShardProcessor.java
+++ b/sql/src/main/java/org/elasticsearch/action/bulk/BulkShardProcessor.java
@@ -42,6 +42,7 @@ import org.elasticsearch.action.admin.indices.create.TransportBulkCreateIndicesA
 import org.elasticsearch.action.support.AutoCreateIndex;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.common.io.stream.NotSerializableExceptionWrapper;
 import org.elasticsearch.common.logging.ESLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
@@ -265,7 +266,7 @@ public class BulkShardProcessor<Request extends ShardRequest> {
                     @Override
                     public void onFailure(Throwable t) {
                         t = Exceptions.unwrap(t, throwable -> throwable instanceof RuntimeException);
-                        if (t instanceof ClassCastException) {
+                        if (t instanceof ClassCastException || t instanceof NotSerializableExceptionWrapper) {
                             // this is caused by passing mixed argument types into a bulk upsert.
                             // it can happen after an valid request already succeeded and data was written.
                             // so never bubble, but rather mark all items of this request as failed.

--- a/sql/src/test/java/io/crate/integrationtests/BulkInsertOnClientNodeTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/BulkInsertOnClientNodeTest.java
@@ -34,12 +34,15 @@ import java.util.HashMap;
 
 import static org.hamcrest.Matchers.is;
 
-@ESIntegTestCase.ClusterScope(numDataNodes = 2, numClientNodes = 1)
+@ESIntegTestCase.ClusterScope(numDataNodes = 2, numClientNodes = 1, transportClientRatio = 0)
 public class BulkInsertOnClientNodeTest extends SQLTransportIntegrationTest {
 
     public BulkInsertOnClientNodeTest() {
         super(new SQLTransportExecutor(
             new SQLTransportExecutor.ClientProvider() {
+
+                private String nodeName;
+
                 @Override
                 public Client client() {
                     // make sure we use a client node (started with client=true)
@@ -53,9 +56,15 @@ public class BulkInsertOnClientNodeTest extends SQLTransportIntegrationTest {
 
                 @Override
                 public SQLOperations sqlOperations() {
-                    return internalCluster().getInstance(
-                        SQLOperations.class,
-                        internalCluster().clientNodeClient().settings().get("node.name"));
+                    return internalCluster().getInstance(SQLOperations.class, nodeName());
+                }
+
+                private String nodeName() {
+                    if (nodeName == null) {
+                        Client client= client();
+                        nodeName = client.settings().get("name");
+                    }
+                    return nodeName;
                 }
             }
         ));


### PR DESCRIPTION
also reverts https://github.com/crate/crate/commit/3eb3a9bdb740a3c9a68ceb1726c863eb633bbc13, as a `NotSerializableWrapperException` cannot be unwrapped and so the commit won't affect anything.