### PR TITLE
Unwrap CompletionException before transport serialization

### DIFF
--- a/sql/src/main/java/io/crate/action/job/TransportJobAction.java
+++ b/sql/src/main/java/io/crate/action/job/TransportJobAction.java
@@ -23,6 +23,7 @@ package io.crate.action.job;
 
 import io.crate.concurrent.CompletableFutures;
 import io.crate.data.Bucket;
+import io.crate.exceptions.Exceptions;
 import io.crate.executor.transport.DefaultTransportResponseHandler;
 import io.crate.executor.transport.NodeAction;
 import io.crate.executor.transport.NodeActionRequestHandler;
@@ -99,7 +100,7 @@ public class TransportJobAction implements NodeAction<JobRequest, JobResponse> {
                 if (t == null) {
                     actionListener.onResponse(new JobResponse(buckets));
                 } else {
-                    actionListener.onFailure(t);
+                    actionListener.onFailure(Exceptions.unwrap(t));
                 }
             });
         }

--- a/sql/src/main/java/io/crate/exceptions/Exceptions.java
+++ b/sql/src/main/java/io/crate/exceptions/Exceptions.java
@@ -47,6 +47,7 @@ import org.elasticsearch.transport.TransportException;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Locale;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Predicate;
 
@@ -57,6 +58,7 @@ public class Exceptions {
         throwable instanceof TransportException ||
         throwable instanceof UncheckedExecutionException ||
         throwable instanceof UncategorizedExecutionException ||
+        throwable instanceof CompletionException ||
         throwable instanceof ExecutionException;
 
     public static Throwable unwrap(@Nonnull Throwable t, @Nullable Predicate<Throwable> additionalUnwrapCondition) {


### PR DESCRIPTION
CompletableFuture exceptions are wrapped in a CompletionException which
cannot be serialization - it'll be wrapped in a
NotSerializableExceptionWrapper which causes logic checking the
exception type to fail.