### PR TITLE
tests: Rewrite testFailingUpdateBulkOperation to avoid flakyness

### DIFF
--- a/sql/src/test/java/io/crate/integrationtests/ThreadPoolsExhaustedIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ThreadPoolsExhaustedIntegrationTest.java
@@ -48,29 +48,7 @@ public class ThreadPoolsExhaustedIntegrationTest extends SQLTransportIntegration
             .put(super.nodeSettings(nodeOrdinal))
             .put("threadpool.search.size", 2)
             .put("threadpool.search.queue_size", 2)
-            .put("threadpool.bulk.size", 2)
-            .put("threadpool.bulk.queue_size", 2)
             .build();
-    }
-
-    @Test
-    public void testFailingUpdateBulkOperation() throws Exception {
-        execute("create table t (x int) with (number_of_replicas = 0)");
-        ensureYellow();
-        bulkInsert(2);
-        // fails because of too small bulk size / queue_size
-        SQLBulkResponse resp = execute("update t set x = ? where x = ?", new Object[][]{
-            new Object[]{1, 1},
-            new Object[]{2, 2},
-            new Object[]{3, 3},
-            new Object[]{4, 4},
-            new Object[]{5, 5},
-            new Object[]{6, 6},
-        });
-        assertThat(resp.results().length, is(6));
-        for (SQLBulkResponse.Result result : resp.results()) {
-            assertThat(result.rowCount(), is(-2L));
-        }
     }
 
     @Test


### PR DESCRIPTION
Test no longer depends on on the operation failing due to a overflowing
threadpool (RejectedExecution) but instead uses a query which causes a
failure.