### PR TITLE
!fixup LuceneBatchIterator / fix flaky selectGroupByWithBreaking

### DIFF
--- a/sql/src/main/java/io/crate/exceptions/SQLExceptions.java
+++ b/sql/src/main/java/io/crate/exceptions/SQLExceptions.java
@@ -59,7 +59,6 @@ public class SQLExceptions {
         throwable instanceof UncheckedExecutionException ||
         throwable instanceof CompletionException ||
         throwable instanceof UncategorizedExecutionException ||
-        throwable instanceof CompletionException ||
         throwable instanceof ExecutionException;
 
     public static Throwable unwrap(@Nonnull Throwable t, @Nullable Predicate<Throwable> additionalUnwrapCondition) {

--- a/sql/src/main/java/io/crate/operation/collect/collectors/LuceneBatchIterator.java
+++ b/sql/src/main/java/io/crate/operation/collect/collectors/LuceneBatchIterator.java
@@ -28,7 +28,6 @@ import io.crate.concurrent.CompletableFutures;
 import io.crate.data.BatchIterator;
 import io.crate.data.Input;
 import io.crate.data.Row;
-import io.crate.exceptions.CircuitBreakingException;
 import io.crate.operation.InputRow;
 import io.crate.operation.reference.doc.lucene.CollectorContext;
 import io.crate.operation.reference.doc.lucene.LuceneCollectorExpression;
@@ -36,6 +35,7 @@ import org.apache.lucene.index.LeafReader;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.*;
 import org.apache.lucene.util.Bits;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
 
 import javax.annotation.Nullable;
 import java.io.IOException;

--- a/sql/src/main/java/io/crate/operation/projectors/BatchConsumerToRowReceiver.java
+++ b/sql/src/main/java/io/crate/operation/projectors/BatchConsumerToRowReceiver.java
@@ -24,6 +24,7 @@ package io.crate.operation.projectors;
 
 import io.crate.data.BatchConsumer;
 import io.crate.data.BatchIterator;
+import io.crate.exceptions.SQLExceptions;
 
 import java.util.Objects;
 
@@ -82,7 +83,7 @@ public class BatchConsumerToRowReceiver implements BatchConsumer {
             iterator.loadNextBatch().whenComplete(
                 (r, e) -> {
                     if (e != null) {
-                        rowReceiver.fail(e);
+                        rowReceiver.fail(SQLExceptions.unwrap(e));
                     } else {
                         safeConsumeIterator(iterator);
                     }


### PR DESCRIPTION
selectGroupByWithBreaking was sometimes flaky because the
LuceneBatchIterator throw the wrong CircuitBreakingException which
wasn't serializable.