### PR TITLE
fixes page downstream context failure handling

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed some memory leaks which could happen on error handling of
+   distributed queries like e.g. `GROUP BY`.
+
  - Added a new parameter ``upgrade_segments`` to the ``OPTIMIZE`` statement
    which enables the upgrade of tables and tables partitions to the current
    version of the storage engine.


### PR DESCRIPTION
listeners of successful upstreams were not called 
and so no response was sent if an upstream failed