### PR TITLE
documentation: default size of "search" threadpool

### DIFF
--- a/blackbox/docs/configuration.txt
+++ b/blackbox/docs/configuration.txt
@@ -1647,13 +1647,10 @@ optional settings.
 .. _threadpool.<threadpool>.size:
 
 **threadpool.<threadpool>.size**
-  | *Default index:*  ``<number-of-cores>``
-  | *Default search:*  ``<number-of-cores> * 3``
-  | *Default get:*  ``<number-of-cores>``
-  | *Default bulk:*  ``<number-of-cores>``
   | *Runtime:*  ``no``
 
-  Number of threads.
+  Number of threads. The default size of the different thread pools depend on
+  the number of available CPU cores.
 
 .. _threadpool.<threadpool>.queue_size:
 


### PR DESCRIPTION
```
cr> select os_info['available_processors'], thread_pools['name'], thread_pools['threads'] from sys.nodes;
+---------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------+
| os_info['available_processors'] | thread_pools['name']                                                                                                                                                                                 | thread_pools['threads']                             |
+---------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------+
|                              16 | ["force_merge", "percolate", "fetch_shard_started", "listener", "index", "refresh", "suggest", "generic", "warmer", "search", "flush", "fetch_shard_store", "management", "get", "bulk", "snapshot"] | [0, 16, 1, 0, 0, 1, 16, 2, 1, 25, 1, 1, 2, 0, 0, 0] |
|                              16 | ["force_merge", "percolate", "fetch_shard_started", "listener", "index", "refresh", "suggest", "generic", "warmer", "search", "flush", "fetch_shard_store", "management", "get", "bulk", "snapshot"] | [0, 16, 0, 0, 0, 1, 16, 1, 1, 25, 1, 1, 2, 0, 0, 0] |
|                              16 | ["force_merge", "percolate", "fetch_shard_started", "listener", "index", "refresh", "suggest", "generic", "warmer", "search", "flush", "fetch_shard_store", "management", "get", "bulk", "snapshot"] | [0, 16, 1, 0, 0, 1, 16, 1, 1, 25, 1, 1, 3, 0, 0, 0] |
|                              16 | ["force_merge", "percolate", "fetch_shard_started", "listener", "index", "refresh", "suggest", "generic", "warmer", "search", "flush", "fetch_shard_store", "management", "get", "bulk", "snapshot"] | [0, 16, 1, 0, 0, 1, 16, 1, 1, 25, 1, 1, 2, 0, 0, 0] |
|                              16 | ["force_merge", "percolate", "fetch_shard_started", "listener", "index", "refresh", "suggest", "generic", "warmer", "search", "flush", "fetch_shard_store", "management", "get", "bulk", "snapshot"] | [0, 16, 1, 0, 0, 1, 16, 1, 1, 25, 1, 1, 2, 0, 0, 0] |
+---------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------+
SELECT 5 rows in set (0.002 sec)
```

`size = 16 * 3 / 2 + 1 = 25`
