### PR TITLE
WIP: Add NestedLoopBatchIterator

### DIFF
--- a/dex/src/main/java/io/crate/data/CompositeBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/CompositeBatchIterator.java
@@ -167,13 +167,4 @@ public class CompositeBatchIterator implements BatchIterator {
         }
     }
 
-    private static class ProxyInput implements Input {
-
-        Input<?> input;
-
-        @Override
-        public Object value() {
-            return input.value();
-        }
-    }
 }

--- a/dex/src/main/java/io/crate/data/NestedLoopBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/NestedLoopBatchIterator.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.data;
+
+import java.util.concurrent.CompletionStage;
+
+public class NestedLoopBatchIterator implements BatchIterator {
+
+    private final BatchIterator left;
+    private final BatchIterator right;
+    private final CombinedColumn rowData;
+
+    private BatchIterator activeIt;
+
+    public NestedLoopBatchIterator(BatchIterator left, BatchIterator right) {
+        this.left = left;
+        this.right = right;
+        this.activeIt = left;
+        this.rowData = new CombinedColumn(left.rowData(), right.rowData());
+    }
+
+    @Override
+    public Columns rowData() {
+        return rowData;
+    }
+
+    @Override
+    public void moveToStart() {
+        left.moveToStart();
+        right.moveToStart();
+    }
+
+    @Override
+    public boolean moveNext() {
+        if (activeIt == left) {
+            return tryAdvanceLeftAndRight();
+        } else {
+            return tryAdvanceRight();
+        }
+    }
+
+    private boolean tryAdvanceRight() {
+        if (right.moveNext()) {
+            return true;
+        }
+        if (right.allLoaded() == false) {
+            return false;
+        }
+
+        // new outer loop iteration
+        right.moveToStart();
+        if (left.moveNext()) {
+            return right.moveNext();
+        }
+        activeIt = left; // left is either out of rows or needs to load more data - whatever the case,
+                         // next moveNext must operate on left
+        return false;
+    }
+
+    private boolean tryAdvanceLeftAndRight() {
+        while (left.moveNext()) {
+            activeIt = right;
+            if (right.moveNext()) {
+                return true;
+            }
+            if (right.allLoaded() == false) {
+                return false;
+            }
+            right.moveToStart();
+        }
+        return false;
+    }
+
+    @Override
+    public void close() {
+        left.close();
+        right.close();
+    }
+
+    @Override
+    public CompletionStage<?> loadNextBatch() {
+        return activeIt.loadNextBatch();
+    }
+
+    @Override
+    public boolean allLoaded() {
+        return left.allLoaded() && right.allLoaded();
+    }
+
+    private static class CombinedColumn implements Columns {
+        private final int numColumns;
+        private final Columns left;
+        private final Columns right;
+
+        CombinedColumn(Columns left, Columns right) {
+            this.left = left;
+            this.right = right;
+            numColumns = left.size() + right.size();
+        }
+
+        @Override
+        public Input<?> get(int index) {
+            if (index >= left.size()) {
+                return right.get(index - left.size());
+            }
+            return left.get(index);
+        }
+
+        @Override
+        public int size() {
+            return numColumns;
+        }
+    }
+}

--- a/dex/src/main/java/io/crate/data/NestedLoopBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/NestedLoopBatchIterator.java
@@ -27,7 +27,49 @@ import java.util.concurrent.CompletionStage;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 
+/**
+ * NestedLoop BatchIterator implementations
+ *
+ * - {@link #crossJoin(BatchIterator, BatchIterator)}
+ * - {@link #leftJoin(BatchIterator, BatchIterator, Function)}
+ * - {@link #rightJoin(BatchIterator, BatchIterator, Function)}
+ * - {@link #fullOuterJoin(BatchIterator, BatchIterator, Function)}
+ */
 public class NestedLoopBatchIterator implements BatchIterator {
+
+    /**
+     * Create a BatchIterator that creates a full-outer-join of {@code left} and {@code right}.
+     */
+    public static BatchIterator fullOuterJoin(BatchIterator left,
+                                              BatchIterator right,
+                                              Function<Columns, BooleanSupplier> joinCondition) {
+        return new FullOuterJoinBatchIterator(left, right, joinCondition);
+    }
+
+    /**
+     * Create a BatchIterator that creates a cross-join of {@code left} and {@code right}.
+     */
+    public static BatchIterator crossJoin(BatchIterator left, BatchIterator right) {
+        return new NestedLoopBatchIterator(left, right);
+    }
+
+    /**
+     * Create a BatchIterator that creates the left-outer-join result of {@code left} and {@code right}.
+     */
+    public static BatchIterator leftJoin(BatchIterator left,
+                                         BatchIterator right,
+                                         Function<Columns, BooleanSupplier> joinCondition) {
+        return new LeftJoinBatchIterator(left, right, joinCondition);
+    }
+
+    /**
+     * Create a BatchIterator that creates the right-outer-join result of {@code left} and {@code right}.
+     */
+    public static BatchIterator rightJoin(BatchIterator left,
+                                          BatchIterator right,
+                                          Function<Columns, BooleanSupplier> joinCondition) {
+        return new RightJoinBatchIterator(left, right, joinCondition);
+    }
 
     final CombinedColumn rowData;
     final BatchIterator left;
@@ -37,28 +79,6 @@ public class NestedLoopBatchIterator implements BatchIterator {
      * points to the batchIterator which will be used on the next {@link #moveNext()} call
      */
     BatchIterator activeIt;
-
-    public static BatchIterator fullOuterJoin(BatchIterator left,
-                                              BatchIterator right,
-                                              Function<Columns, BooleanSupplier> joinCondition) {
-        return new FullOuterJoinBatchIterator(left, right, joinCondition);
-    }
-
-    public static BatchIterator crossJoin(BatchIterator left, BatchIterator right) {
-        return new NestedLoopBatchIterator(left, right);
-    }
-
-    public static BatchIterator leftJoin(BatchIterator left,
-                                         BatchIterator right,
-                                         Function<Columns, BooleanSupplier> joinCondition) {
-        return new LeftJoinBatchIterator(left, right, joinCondition);
-    }
-
-    public static BatchIterator rightJoin(BatchIterator left,
-                                          BatchIterator right,
-                                          Function<Columns, BooleanSupplier> joinCondition) {
-        return new RightJoinBatchIterator(left, right, joinCondition);
-    }
 
     NestedLoopBatchIterator(BatchIterator left, BatchIterator right) {
         this.left = left;

--- a/dex/src/main/java/io/crate/data/ProxyInput.java
+++ b/dex/src/main/java/io/crate/data/ProxyInput.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.data;
+
+class ProxyInput implements Input {
+
+    Input<?> input;
+
+    @Override
+    public Object value() {
+        return input.value();
+    }
+}

--- a/dex/src/test/java/io/crate/data/NestedLoopBatchIteratorTest.java
+++ b/dex/src/test/java/io/crate/data/NestedLoopBatchIteratorTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.data;
+
+import io.crate.testing.BatchIteratorTester;
+import io.crate.testing.CollectingBatchConsumer;
+import io.crate.testing.TestingBatchIterators;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertThat;
+
+public class NestedLoopBatchIteratorTest {
+
+    @Test
+    public void testNestedLoopBatchIterator() throws Exception {
+        List<Object[]> expectedResult = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            for (int j = 0; j < 3; j++) {
+                expectedResult.add(new Object[] { i, j });
+            }
+        }
+        BatchIteratorTester tester = new BatchIteratorTester(
+            () -> new NestedLoopBatchIterator(
+                TestingBatchIterators.range(0, 3),
+                TestingBatchIterators.range(0, 3)
+            ),
+            expectedResult
+        );
+        tester.run();
+    }
+
+    @Test
+    public void testNestedLoopLeftAndRightEmpty() throws Exception {
+        NestedLoopBatchIterator iterator = new NestedLoopBatchIterator(
+            RowsBatchIterator.empty(),
+            RowsBatchIterator.empty()
+        );
+        CollectingBatchConsumer consumer = new CollectingBatchConsumer();
+        consumer.accept(iterator, null);
+        assertThat(consumer.getResult(), Matchers.empty());
+    }
+
+    @Test
+    public void testNestedLoopLeftEmpty() throws Exception {
+        NestedLoopBatchIterator iterator = new NestedLoopBatchIterator(
+            RowsBatchIterator.empty(),
+            TestingBatchIterators.range(0, 5)
+        );
+        CollectingBatchConsumer consumer = new CollectingBatchConsumer();
+        consumer.accept(iterator, null);
+        assertThat(consumer.getResult(), Matchers.empty());
+    }
+
+    @Test
+    public void testNestedLoopRightEmpty() throws Exception {
+        NestedLoopBatchIterator iterator = new NestedLoopBatchIterator(
+            TestingBatchIterators.range(0, 5),
+            RowsBatchIterator.empty()
+        );
+        CollectingBatchConsumer consumer = new CollectingBatchConsumer();
+        consumer.accept(iterator, null);
+        assertThat(consumer.getResult(), Matchers.empty());
+    }
+
+}

--- a/dex/src/test/java/io/crate/data/NestedLoopBatchIteratorTest.java
+++ b/dex/src/test/java/io/crate/data/NestedLoopBatchIteratorTest.java
@@ -23,39 +23,90 @@
 package io.crate.data;
 
 import io.crate.testing.BatchIteratorTester;
+import io.crate.testing.BatchSimulatingIterator;
 import io.crate.testing.CollectingBatchConsumer;
 import io.crate.testing.TestingBatchIterators;
 import org.hamcrest.Matchers;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
-import java.util.List;
+import java.util.Objects;
+import java.util.function.BooleanSupplier;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 import static org.junit.Assert.assertThat;
 
 public class NestedLoopBatchIteratorTest {
 
-    @Test
-    public void testNestedLoopBatchIterator() throws Exception {
-        List<Object[]> expectedResult = new ArrayList<>();
+    private ArrayList<Object[]> threeXThreeRows;
+    private ArrayList<Object[]> leftJoinResult;
+
+    private Function<Columns, BooleanSupplier> getCol0EqCol1JoinCondition() {
+        return columns -> new BooleanSupplier() {
+
+            Input<?> col1 = columns.get(0);
+            Input<?> col2 = columns.get(1);
+
+            @Override
+            public boolean getAsBoolean() {
+                return Objects.equals(col1.value(), col2.value());
+            }
+        };
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        threeXThreeRows = new ArrayList<>();
         for (int i = 0; i < 3; i++) {
             for (int j = 0; j < 3; j++) {
-                expectedResult.add(new Object[] { i, j });
+                threeXThreeRows.add(new Object[] { i, j });
             }
         }
+
+        leftJoinResult = new ArrayList<>();
+        for (int i = 0; i < 4; i++) {
+            boolean matched = false;
+            for (int j = 2; j < 6 ; j++) {
+                if (Integer.compare(i, j) == 0) {
+                    matched = true;
+                    leftJoinResult.add(new Object[] { i, j });
+                }
+            }
+            if (!matched) {
+                leftJoinResult.add(new Object[] { i, null });
+            }
+        }
+    }
+
+    @Test
+    public void testNestedLoopBatchIterator() throws Exception {
         BatchIteratorTester tester = new BatchIteratorTester(
-            () -> new NestedLoopBatchIterator(
+            () -> NestedLoopBatchIterator.crossJoin(
                 TestingBatchIterators.range(0, 3),
                 TestingBatchIterators.range(0, 3)
             ),
-            expectedResult
+            threeXThreeRows
+        );
+        tester.run();
+    }
+
+    @Test
+    public void testNestedLoopWithBatchedSource() throws Exception {
+        BatchIteratorTester tester = new BatchIteratorTester(
+            () -> NestedLoopBatchIterator.crossJoin(
+                new BatchSimulatingIterator(TestingBatchIterators.range(0, 3), 2, 2, null),
+                new BatchSimulatingIterator(TestingBatchIterators.range(0, 3), 2, 2, null)
+            ),
+            threeXThreeRows
         );
         tester.run();
     }
 
     @Test
     public void testNestedLoopLeftAndRightEmpty() throws Exception {
-        NestedLoopBatchIterator iterator = new NestedLoopBatchIterator(
+        BatchIterator iterator = NestedLoopBatchIterator.crossJoin(
             RowsBatchIterator.empty(),
             RowsBatchIterator.empty()
         );
@@ -66,7 +117,7 @@ public class NestedLoopBatchIteratorTest {
 
     @Test
     public void testNestedLoopLeftEmpty() throws Exception {
-        NestedLoopBatchIterator iterator = new NestedLoopBatchIterator(
+        BatchIterator iterator = NestedLoopBatchIterator.crossJoin(
             RowsBatchIterator.empty(),
             TestingBatchIterators.range(0, 5)
         );
@@ -77,13 +128,36 @@ public class NestedLoopBatchIteratorTest {
 
     @Test
     public void testNestedLoopRightEmpty() throws Exception {
-        NestedLoopBatchIterator iterator = new NestedLoopBatchIterator(
+        BatchIterator iterator = NestedLoopBatchIterator.crossJoin(
             TestingBatchIterators.range(0, 5),
             RowsBatchIterator.empty()
         );
         CollectingBatchConsumer consumer = new CollectingBatchConsumer();
         consumer.accept(iterator, null);
         assertThat(consumer.getResult(), Matchers.empty());
+    }
+
+
+    @Test
+    public void testLeftJoin() throws Exception {
+        Supplier<BatchIterator> batchIteratorSupplier = () -> NestedLoopBatchIterator.leftJoin(
+            TestingBatchIterators.range(0, 4),
+            TestingBatchIterators.range(2, 6),
+            getCol0EqCol1JoinCondition()
+        );
+        BatchIteratorTester tester = new BatchIteratorTester(batchIteratorSupplier, leftJoinResult);
+        tester.run();
+    }
+
+    @Test
+    public void testLeftJoinBatchedSource() throws Exception {
+        Supplier<BatchIterator> batchIteratorSupplier = () -> NestedLoopBatchIterator.leftJoin(
+            new BatchSimulatingIterator(TestingBatchIterators.range(0, 4), 2, 2, null),
+            new BatchSimulatingIterator(TestingBatchIterators.range(2, 6), 2, 2, null),
+            getCol0EqCol1JoinCondition()
+        );
+        BatchIteratorTester tester = new BatchIteratorTester(batchIteratorSupplier, leftJoinResult);
+        tester.run();
     }
 
 }

--- a/dex/src/test/java/io/crate/testing/SingleColumnBatchIterator.java
+++ b/dex/src/test/java/io/crate/testing/SingleColumnBatchIterator.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.testing;
+
+import io.crate.concurrent.CompletableFutures;
+import io.crate.data.BatchIterator;
+import io.crate.data.CloseAssertingBatchIterator;
+import io.crate.data.Columns;
+
+import java.util.Iterator;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+
+/**
+ * A batch iterator with a single column.
+ *
+ * @param <T> the type of the column values
+ */
+public class SingleColumnBatchIterator<T> implements BatchIterator {
+
+    private final Iterable<T> iterable;
+    private final Columns inputs;
+    private T value;
+    private Iterator<T> currentIterator;
+
+    /**
+     * Returns a batch iterator getting its data from an iterable representing the values for each row.
+     *
+     * @param iterable the value iterable
+     * @param <T>      the type of the values
+     * @return a new batch currentIterator
+     */
+    public static <T> BatchIterator fromIterable(Iterable<T> iterable) {
+        return new CloseAssertingBatchIterator(new SingleColumnBatchIterator<>(iterable));
+    }
+
+    /**
+     * Returns a batch iterator containing a range of integers.
+     */
+    public static BatchIterator range(int startInclusive, int endExclusive) {
+        return fromIterable(() -> IntStream.range(startInclusive, endExclusive).iterator());
+    }
+
+    /**
+     * Returns a batch iterator containing a range of longs.
+     */
+    public static BatchIterator range(long startInclusive, long endExclusive) {
+        return fromIterable(() -> LongStream.range(startInclusive, endExclusive).iterator());
+    }
+
+    private SingleColumnBatchIterator(Iterable<T> iterable) {
+        this.iterable = iterable;
+        this.inputs = Columns.singleCol(() -> value);
+        moveToStart();
+    }
+
+    @Override
+    public Columns rowData() {
+        return inputs;
+    }
+
+    @Override
+    public void moveToStart() {
+        currentIterator = iterable.iterator();
+        value = null;
+    }
+
+    @Override
+    public boolean moveNext() {
+        if (currentIterator.hasNext()) {
+            value = currentIterator.next();
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public CompletionStage<?> loadNextBatch() {
+        return CompletableFutures.failedFuture(new IllegalStateException("loadNextBatch with allLoaded"));
+    }
+
+    @Override
+    public boolean allLoaded() {
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "SingleColumnBatchIt{" +
+               "val=" + value +
+               '}';
+    }
+}


### PR DESCRIPTION
This is not yet integrated, but I want to get some feedback before I continue with integration.

The left/right/full-outer join implementations right now don't really share much code. It looks like a lot of duplication but I wasn't able to extract a good abstraction without increasing complexity even more. 

I had also tried to extract the `moveNext` logic altogether to enable a composition pattern, but that would require a Tuple as result (to change the BatchIterator pointer) and so I discarded that for performance reasons.

Some of the code would probably be also easier to read using recursion, but I also wanted to avoid that to prevent stackoverflows.