### PR TITLE
start with first implementations of pure BatchIteratorProjectors 

### DIFF
--- a/dex/src/main/java/io/crate/data/CollectingBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/CollectingBatchIterator.java
@@ -29,7 +29,6 @@ import java.util.Iterator;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Collector;
-import java.util.stream.Collectors;
 
 /**
  * A BatchIterator implementation which always fully consumes another BatchIterator before it can generate it's result.
@@ -47,26 +46,6 @@ public class CollectingBatchIterator<A> implements BatchIterator {
     private Row currentRow = RowBridging.OFF_ROW;
     private Iterator<Row> it = Collections.emptyIterator();
     private CompletableFuture<? extends Iterable<Row>> resultFuture;
-
-    /**
-     * Create a BatchIterator which will consume the source, summing up the first column (must be of type long).
-     *
-     * <pre>
-     *     source BatchIterator:
-     *     [ 1, 2, 2, 1 ]
-     *
-     *     output:
-     *     [ 6 ]
-     * </pre>
-     */
-    public static BatchIterator summingLong(BatchIterator source) {
-        return newInstance(
-            source,
-            Collectors.collectingAndThen(
-                Collectors.summingLong((Row r) -> (long) r.get(0)), sum -> Collections.singletonList(new Row1(sum))),
-            1
-        );
-    }
 
     public static <A> BatchIterator newInstance(BatchIterator source, Collector<Row, A, ? extends Iterable<Row>> collector, int numCols) {
         return new CloseAssertingBatchIterator(new CollectingBatchIterator<>(source, collector, numCols));

--- a/dex/src/main/java/io/crate/data/Columns.java
+++ b/dex/src/main/java/io/crate/data/Columns.java
@@ -105,4 +105,8 @@ public interface Columns extends Iterable<Input<?>> {
     static Columns wrap(List<? extends Input<?>> listOfInputs) {
         return new ListBackedColumns(listOfInputs);
     }
+
+    static Columns of(Object[] cells) {
+        return ListBackedColumns.forArray(cells);
+    }
 }

--- a/dex/src/main/java/io/crate/data/InputAtIndex.java
+++ b/dex/src/main/java/io/crate/data/InputAtIndex.java
@@ -22,23 +22,11 @@
 
 package io.crate.data;
 
-import io.crate.testing.BatchIteratorTester;
-import io.crate.testing.SingleColumnBatchIterator;
-import org.junit.Test;
+abstract class InputAtIndex<T> implements Input<T>{
 
-import java.util.Collections;
-import java.util.List;
+    protected final int idx;
 
-public class CollectingBatchIteratorTest {
-
-    private List<Object[]> expectedResult = Collections.singletonList(new Object[] { 45L });
-
-    @Test
-    public void testCollectingBatchIterator() throws Exception {
-        BatchIteratorTester tester = new BatchIteratorTester(
-            () -> CollectingBatchIterator.summingLong(SingleColumnBatchIterator.range(0L, 10L)),
-            expectedResult
-        );
-        tester.run();
+    InputAtIndex(int idx) {
+        this.idx = idx;
     }
 }

--- a/sql/src/main/java/io/crate/operation/projectors/AggregationPipe.java
+++ b/sql/src/main/java/io/crate/operation/projectors/AggregationPipe.java
@@ -23,15 +23,12 @@ package io.crate.operation.projectors;
 
 import io.crate.breaker.RamAccountingContext;
 import io.crate.data.BatchIteratorProjector;
-import io.crate.data.CollectingBatchIterator;
 import io.crate.data.Row;
 import io.crate.data.RowN;
 import io.crate.operation.AggregationContext;
 import io.crate.operation.aggregation.Aggregator;
 import io.crate.operation.collect.CollectExpression;
-
-import java.util.Collections;
-import java.util.stream.Collectors;
+import io.crate.operation.projectors.ng.AggregationBIP;
 
 public class AggregationPipe extends AbstractProjector {
 
@@ -90,10 +87,6 @@ public class AggregationPipe extends AbstractProjector {
 
     @Override
     public BatchIteratorProjector asProjector() {
-        return bi ->  CollectingBatchIterator.newInstance(bi,
-                Collectors.collectingAndThen(
-                    new AggregateCollector(expressions, aggregators),
-                    cells -> Collections.singletonList(new RowN(cells))),
-            aggregators.length);
+        return new AggregationBIP(aggregators, expressions);
     }
 }

--- a/sql/src/main/java/io/crate/operation/projectors/ng/AggregationBIP.java
+++ b/sql/src/main/java/io/crate/operation/projectors/ng/AggregationBIP.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.operation.projectors.ng;
+
+import io.crate.data.*;
+import io.crate.operation.aggregation.Aggregator;
+import io.crate.operation.collect.CollectExpression;
+
+import java.util.Collections;
+
+public class AggregationBIP implements BatchIteratorProjector{
+
+    private final Aggregator[] aggregators;
+    private final Iterable<CollectExpression<Row, ?>> expressions;
+
+    public AggregationBIP(Aggregator[] aggregators, Iterable<CollectExpression<Row, ?>> expressions) {
+        this.aggregators = aggregators;
+        this.expressions = expressions;
+    }
+
+    @Override
+    public BatchIterator apply(BatchIterator batchIterator) {
+        Listener l = new Listener(RowBridging.toRow(batchIterator.rowData()));
+        return CollectingProjectors.collecting(batchIterator, l, Columns.of(l.states));
+    }
+
+    class Listener implements CollectingProjectors.BatchCollectorListener {
+
+        final Object[] states;
+        private final Row row;
+
+        Listener(Row row) {
+            this.row = row;
+            this.states = new Object[aggregators.length];
+        }
+
+        @Override
+        public void pre() {
+            for (int i = 0; i < aggregators.length; i++) {
+                states[i] = aggregators[i].prepareState();
+            }
+        }
+
+        @Override
+        public boolean onRow() {
+            for (CollectExpression<Row, ?> collectExpression : expressions) {
+                collectExpression.setNextRow(row);
+            }
+            for (int i = 0; i < aggregators.length; i++) {
+                Aggregator aggregator = aggregators[i];
+                states[i] = aggregator.processRow(states[i]);
+            }
+            return true;
+        }
+
+        @Override
+        public Iterable<?> post() {
+            for (int i = 0; i < aggregators.length; i++) {
+                states[i] = aggregators[i].finishCollect(states[i]);
+            }
+            return Collections.singletonList(null);
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/operation/projectors/ng/CollectingProjectors.java
+++ b/sql/src/main/java/io/crate/operation/projectors/ng/CollectingProjectors.java
@@ -1,0 +1,251 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.operation.projectors.ng;
+
+import io.crate.concurrent.CompletableFutures;
+import io.crate.data.*;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.BooleanSupplier;
+import java.util.stream.Collector;
+
+public class CollectingProjectors {
+
+    private static final Iterable<?> ONE_ROW_ITERABLE = Collections.singletonList(null);
+
+    public static BatchIterator collecting(BatchIterator source,
+                                           BatchCollectorListener listener,
+                                           Columns rowData) {
+        return new CloseAssertingBatchIterator(new LazyCollectingBatchIterator(source, listener, rowData));
+    }
+
+    /**
+     * A projector which will consume the source, summing up the first column (must be of type long).
+     * and emitting one row with the sum.
+     * <p>
+     * <pre>
+     *     input:
+     *     [ 1, 2, 2, 1 ]
+     *
+     *     output:
+     *     [ 6 ]
+     * </pre>
+     */
+    public static final BatchIteratorProjector SUMMING_LONG = (BatchIterator source) -> {
+        assert source.rowData().size() >= 1 : "summing long requires at least one column";
+        final Input<?> input = source.rowData().get(0);
+        final long[] state = {0L};
+        BatchCollectorListener listener = new BatchCollectorListener() {
+            @Override
+            public boolean onRow() {
+                Object v = input.value();
+                if (v != null) {
+                    assert v instanceof Long : "a long is required";
+                    state[0] += (long) v;
+                }
+                return true;
+            }
+
+            @Override
+            public Iterable<?> post() {
+                return ONE_ROW_ITERABLE;
+            }
+        };
+        return collecting(source, listener, Columns.singleCol(() -> state[0]));
+    };
+
+    /**
+     * The collecting interferface used to collect and aggegate the rows of a batch iterator.
+     *
+     * This does not expose any data handling since this should be done via seperate {@link Columns} objects.
+     */
+    interface BatchCollectorListener {
+
+        /**
+         * Called when on a new valid row position.
+         *
+         * @return true if the iteration should continue
+         */
+        boolean onRow();
+
+        /**
+         * Preperation hook which is called before starting the iteration.
+         */
+        default void pre() {
+
+        }
+
+        /**
+         * Finalization hook which is called once all rows have been visited.
+         *
+         * The iterable returned here is the controller of the projected rows. The row values of this iterator
+         * is not used, however the implementation needs to upate its output {@link Columns} when the iterator
+         * is advanced.
+         *
+         * @return an iterable for controlling the output rows
+         */
+        default Iterable<?> post() {
+            return Collections.emptyList();
+        }
+
+        /**
+         * example to show how a {@link Collector} can be mapped this interface
+         */
+        static <A> BatchCollectorListener fromCollector(Collector<Void, A, ? extends Iterable<?>> collector) {
+            return new BatchCollectorListener() {
+
+                A state;
+
+                @Override
+                public void pre() {
+                    state = collector.supplier().get();
+                }
+
+                @Override
+                public boolean onRow() {
+                    collector.accumulator().accept(state, null);
+                    return true;
+                }
+
+                @Override
+                public Iterable<?> post() {
+                    return collector.finisher().apply(state);
+                }
+            };
+        }
+    }
+
+    /**
+     * A batch iterator which starts collecting a whole source batch iterator lazily when {@link #loadNextBatch()}
+     * is called. This class can be used by projector implementations which require all rows from the upstream.
+     */
+    private static class LazyCollectingBatchIterator implements BatchIterator {
+
+        private final Columns rowData;
+        private CompletableFuture<Void> resultFuture;
+
+
+        private final BatchIterator source;
+        private final BatchCollectorListener listener;
+        private Iterable<?> iterable;
+        private Iterator<?> it;
+
+        public LazyCollectingBatchIterator(BatchIterator source, BatchCollectorListener listener, Columns rowData) {
+            this.source = source;
+            this.listener = listener;
+            this.rowData = rowData;
+        }
+
+        @Override
+        public Columns rowData() {
+            return rowData;
+        }
+
+        @Override
+        public void moveToStart() {
+            raiseIfLoading();
+            if (iterable == null) {
+                throw new IllegalStateException("CollectingBatchIterator can only move to start when all data is loaded");
+            }
+            it = iterable.iterator();
+        }
+
+        @Override
+        public boolean moveNext() {
+            if (it != null) {
+                if (it.hasNext()) {
+                    it.next();
+                    return true;
+                }
+                return false;
+            }
+            raiseIfLoading();
+            return false;
+        }
+
+        @Override
+        public void close() {
+            source.close();
+            it = null;
+        }
+
+        @Override
+        public CompletionStage<?> loadNextBatch() {
+            if (resultFuture == null) {
+                resultFuture = new CompletableFuture<>();
+                listener.pre();
+                consumeBatchIterator(source, listener::onRow, resultFuture);
+                return resultFuture.whenComplete((r, t) -> {
+                    if (t == null) {
+                        iterable = listener.post();
+                        moveToStart();
+                    }
+                    source.close();
+                });
+            }
+            return CompletableFutures.failedFuture(new IllegalStateException("BatchIterator already loaded"));
+        }
+
+        @Override
+        public boolean allLoaded() {
+            return resultFuture != null;
+        }
+
+        private void raiseIfLoading() {
+            if (resultFuture != null && !resultFuture.isDone()) {
+                throw new IllegalStateException("BatchIterator is loading");
+            }
+        }
+    }
+
+    private static void consumeBatchIterator(BatchIterator it,
+                                             BooleanSupplier moveListener,
+                                             CompletableFuture<?> resultFuture) {
+        try {
+            while (it.moveNext()) {
+                if (!moveListener.getAsBoolean()) {
+                    resultFuture.complete(null);
+                    return;
+                }
+            }
+        } catch (Throwable t) {
+            resultFuture.completeExceptionally(t);
+            return;
+        }
+
+        if (it.allLoaded()) {
+            resultFuture.complete(null);
+        } else {
+            it.loadNextBatch().whenComplete((r, t) -> {
+                if (t == null) {
+                    consumeBatchIterator(it, moveListener, resultFuture);
+                } else {
+                    resultFuture.completeExceptionally(t);
+                }
+            });
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/operation/projectors/ng/SortingTopNBIP.java
+++ b/sql/src/main/java/io/crate/operation/projectors/ng/SortingTopNBIP.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.operation.projectors.ng;
+
+import com.google.common.base.Preconditions;
+import io.crate.data.*;
+import io.crate.operation.collect.CollectExpression;
+import io.crate.operation.projectors.sorting.RowPriorityQueue;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Iterator;
+
+
+/**
+ * Collector implementation which collects rows into a priorityQueue in order to sort the rows and apply a limit + offset.
+ * The final result is a sorted bucket with limit and offset applied.
+ */
+public class SortingTopNBIP implements BatchIteratorProjector {
+
+
+    private final Collection<? extends Input<?>> inputs;
+    private final Iterable<? extends CollectExpression<Row, ?>> expressions;
+    private final int numOutputs;
+    private final Comparator<Object[]> comparator;
+    private final int limit;
+    private final int offset;
+
+    private Object[] spare;
+
+    /**
+     * @param inputs      contains output {@link Input}s and orderBy {@link Input}s
+     * @param expressions expressions linked to the inputs
+     * @param numOutputs  number of output columns
+     * @param comparator  used to sort the rows
+     * @param limit       the max number of rows the result should contain
+     * @param offset      the number of rows to skip (after sort)
+     */
+    public SortingTopNBIP(Collection<? extends Input<?>> inputs,
+                          Iterable<? extends CollectExpression<Row, ?>> expressions,
+                          int numOutputs,
+                          Comparator<Object[]> comparator,
+                          int limit,
+                          int offset) {
+        Preconditions.checkArgument(limit > 0, "invalid limit %s, this collector only supports positive limits", limit);
+        Preconditions.checkArgument(offset >= 0, "invalid offset %s", offset);
+
+        this.inputs = inputs;
+        this.expressions = expressions;
+        this.numOutputs = numOutputs;
+        this.comparator = comparator;
+        this.limit = limit;
+        this.offset = offset;
+    }
+
+    public int numOutputs() {
+        return numOutputs;
+    }
+
+    class Listener implements CollectingProjectors.BatchCollectorListener {
+
+        private final Row row;
+        private final RowPriorityQueue<Object[]> pq = new RowPriorityQueue<>(offset + limit, comparator);
+        Object[] current;
+
+        Listener(Row row) {
+            this.row = row;
+        }
+
+        public Object[] current() {
+            return current;
+        }
+
+        @Override
+        public boolean onRow() {
+            for (CollectExpression<Row, ?> expression : expressions) {
+                expression.setNextRow(row);
+            }
+            if (spare == null) {
+                spare = new Object[inputs.size()];
+            }
+            int i = 0;
+            for (Input<?> input : inputs) {
+                spare[i] = input.value();
+                i++;
+            }
+            spare = pq.insertWithOverflow(spare);
+            return true;
+        }
+
+        @Override
+        public Iterable<?> post() {
+            int resultSize = Math.max(pq.size() - offset, 0);
+            Object[][] rows = new Object[resultSize][];
+            for (int i = resultSize - 1; i >= 0; i--) {
+                rows[i] = pq.pop();
+            }
+            return (Iterable<Void>) () -> new Iterator<Void>() {
+                int pos = -1;
+                @Override
+                public boolean hasNext() {
+                    return pos+1 < rows.length;
+                }
+
+                @Override
+                public Void next() {
+                    current = rows[++pos];
+                    return null;
+                }
+            };
+        }
+    }
+
+    @Override
+    public BatchIterator apply(BatchIterator batchIterator) {
+        Listener l = new Listener(RowBridging.toRow(batchIterator.rowData()));
+        return CollectingProjectors.collecting(batchIterator, l,
+            ListBackedColumns.forArraySupplier(numOutputs).apply(l::current));
+    }
+}

--- a/sql/src/test/java/io/crate/operation/projectors/ng/CollectingProjectorsTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/ng/CollectingProjectorsTest.java
@@ -20,37 +20,27 @@
  * agreement.
  */
 
-package io.crate.operation.projectors;
+package io.crate.operation.projectors.ng;
 
-import io.crate.data.BatchIteratorProjector;
-import io.crate.data.Row;
-import io.crate.data.Row1;
-import io.crate.operation.projectors.ng.CollectingProjectors;
+import io.crate.test.integration.CrateUnitTest;
+import io.crate.testing.BatchIteratorTester;
+import io.crate.testing.SingleColumnBatchIterator;
+import org.junit.Test;
 
-public class MergeCountProjector extends AbstractProjector {
+import java.util.Collections;
+import java.util.List;
 
-    private long sum;
+public class CollectingProjectorsTest extends CrateUnitTest {
 
-    @Override
-    public Result setNextRow(Row row) {
-        Long count = (Long) row.get(0);
-        sum += count;
-        return Result.CONTINUE;
+    private List<Object[]> expectedResult = Collections.singletonList(new Object[]{45L});
+
+    @Test
+    public void testSummingLong() throws Exception {
+        BatchIteratorTester tester = new BatchIteratorTester(
+            () -> CollectingProjectors.SUMMING_LONG.apply(SingleColumnBatchIterator.range(0L, 10L)),
+            expectedResult
+        );
+        tester.run();
     }
 
-    @Override
-    public void finish(RepeatHandle repeatHandle) {
-        downstream.setNextRow(new Row1(sum));
-        downstream.finish(RepeatHandle.UNSUPPORTED);
-    }
-
-    @Override
-    public void fail(Throwable throwable) {
-        downstream.fail(throwable);
-    }
-
-    @Override
-    public BatchIteratorProjector asProjector() {
-        return CollectingProjectors.SUMMING_LONG;
-    }
 }

--- a/sql/src/test/java/io/crate/operation/projectors/ng/SortingTopNBIPTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/ng/SortingTopNBIPTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.operation.projectors.ng;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Ordering;
+import io.crate.analyze.symbol.Literal;
+import io.crate.data.BatchIterator;
+import io.crate.data.BatchIteratorProjector;
+import io.crate.data.Input;
+import io.crate.data.Row;
+import io.crate.operation.collect.CollectExpression;
+import io.crate.operation.collect.InputCollectExpression;
+import io.crate.operation.projectors.sorting.OrderingByPosition;
+import io.crate.test.integration.CrateUnitTest;
+import io.crate.testing.BatchIteratorTester;
+import io.crate.testing.SingleColumnBatchIterator;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+
+
+/**
+ * Equivalent copy of {@link io.crate.operation.projectors.SortingTopNProjectorTest}
+ */
+public class SortingTopNBIPTest extends CrateUnitTest {
+
+    private static final InputCollectExpression INPUT = new InputCollectExpression(0);
+    private static final Literal<Boolean> TRUE_LITERAL = Literal.of(true);
+    private static final List<Input<?>> INPUT_LITERAL_LIST = ImmutableList.of(INPUT, TRUE_LITERAL);
+    private static final List<CollectExpression<Row, ?>> COLLECT_EXPRESSIONS = ImmutableList.of(INPUT);
+    private static final Ordering<Object[]> FIRST_CELL_ORDERING = OrderingByPosition.arrayOrdering(0, false, null);
+
+    private BatchIteratorProjector getProjector(int numOutputs, int limit, int offset, Ordering<Object[]> ordering) {
+        return new SortingTopNBIP(INPUT_LITERAL_LIST, COLLECT_EXPRESSIONS, numOutputs, ordering, limit, offset);
+    }
+
+    private BatchIteratorProjector getProjector(int numOutputs, int limit, int offset) {
+        return getProjector(numOutputs, limit, offset, FIRST_CELL_ORDERING);
+    }
+
+    private void assertAndTest(BatchIteratorProjector p, Supplier<BatchIterator> upstream, List<Object[]> expectedResult) throws Exception {
+        BatchIteratorTester tester = new BatchIteratorTester(
+            () -> p.apply(upstream.get()),
+            expectedResult
+        );
+        tester.run();
+    }
+
+    private void assertAndTest(BatchIteratorProjector p, List<Object[]> expectedResult) throws Exception {
+        assertAndTest(p, ()-> SingleColumnBatchIterator.range(0L, 100L), expectedResult);
+    }
+
+    private List<Object[]> rowsOfLongs(LongStream stream){
+        return stream.mapToObj(l -> new Object[]{l}).collect(Collectors.toList());
+    }
+
+    @Test
+    public void testOrderBy() throws Exception {
+        BatchIteratorProjector p = getProjector(1, 3, 5);
+        assertAndTest(p, rowsOfLongs(LongStream.of(5L, 6L, 7L)));
+    }
+
+    @Test
+    public void testOrderByWithoutOffset() throws Exception {
+        BatchIteratorProjector p = getProjector(1, 10, 0);
+        assertAndTest(p, rowsOfLongs(LongStream.range(0L, 10L)));
+    }
+
+    @Test
+    public void testWithHighOffset() throws Exception {
+        BatchIteratorProjector p = getProjector(1, 2, 130);
+        assertAndTest(p, Collections.emptyList());
+    }
+
+    @Test
+    public void testInvalidNegativeLimit() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("invalid limit -1, this collector only supports positive limits");
+        new SortingTopNBIP(INPUT_LITERAL_LIST, COLLECT_EXPRESSIONS, 2, FIRST_CELL_ORDERING, -1, 0);
+    }
+
+    @Test
+    public void testInvalidZeroLimit() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("invalid limit 0, this collector only supports positive limits");
+        new SortingTopNBIP(INPUT_LITERAL_LIST, COLLECT_EXPRESSIONS, 2, FIRST_CELL_ORDERING, 0, 0);
+    }
+
+    @Test
+    public void testInvalidOffset() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("invalid offset -1");
+        new SortingTopNBIP(INPUT_LITERAL_LIST, COLLECT_EXPRESSIONS, 2, FIRST_CELL_ORDERING, 1, -1);
+    }
+}


### PR DESCRIPTION
The new collecting projector should eventually replace the CollectingBatchIterator which passes around row values and not leveraging the fact that there is only one shared row/state. This is only possible for BatchIterator based projectors, since RowReceivers do not have the contract of shared rows.

Projector implementations are tried to be constructed in a way that it easy to replace the equivalent rowreceiver based impls later on. The new projectors are constructed in Projector.asProjector if applicable


