### PR TITLE
fixes correct releasing of upstream listeners at the PageDownstreamContext

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,9 +11,6 @@ Unreleased
  - Added functionality to monitor query runtime statistics via JMX.
    This feature can only be used with an enterprise license.
 
- - Fixed some memory leaks which could happen on error handling of
-   distributed queries like e.g. `GROUP BY`.
-
  - Added a new parameter ``upgrade_segments`` to the ``OPTIMIZE`` statement
    which enables the upgrade of tables and tables partitions to the current
    version of the storage engine.

--- a/sql/src/main/java/io/crate/jobs/PageDownstreamContext.java
+++ b/sql/src/main/java/io/crate/jobs/PageDownstreamContext.java
@@ -215,14 +215,13 @@ public class PageDownstreamContext extends AbstractExecutionSubContext implement
         // can't trigger failure on pageDownstream immediately as it would remove the context which the other
         // upstreams still require
 
-        setExhaustedUpstreams();
+        exhausted.set(bucketIdx);
         if (bucketsByIdx.size() == numBuckets) {
             rowReceiver.fail(throwable);
             releaseListenersAndCloseContext(throwable);
         } else {
             lastThrowable = throwable;
         }
-        exhausted.set(bucketIdx);
     }
 
     /**


### PR DESCRIPTION
this is a follow up commit of https://github.com/crate/crate/commit/e10dd17445c8b8e8a3c62438727f428651e8b434,
it will avoids memory leaking of still allocated but never released downstream requests.
removes the before added changes entry because the issue was introduced
on master only due to https://github.com/crate/crate/commit/d608c3eff7cfe1c91c6d07cf026c2f2a91fe0953