### PR TITLE
saves routing hash function to the metadata of existing (upgrade) and new tables

### DIFF
--- a/core/src/main/java/io/crate/Version.java
+++ b/core/src/main/java/io/crate/Version.java
@@ -23,11 +23,13 @@ package io.crate;
 
 
 import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.monitor.jvm.JvmInfo;
 
 import java.io.IOException;
+import java.util.Map;
 
 public class Version {
 
@@ -129,5 +131,23 @@ public class Version {
         out.writeVInt(version.id);
         out.writeBoolean(version.snapshot);
         org.elasticsearch.Version.writeVersion(version.esVersion, out);
+    }
+
+    public static Map<String, String> toMap(Version version) {
+        return MapBuilder.<String, String>newMapBuilder()
+            .put("crate", String.valueOf(version.id))
+            .put("elasticsearch", String.valueOf(version.esVersion.id))
+            .map();
+    }
+
+    @Nullable
+    public static Version fromMap(Map<String, String> versionMap) {
+        if (versionMap == null || versionMap.isEmpty()) {
+            return null;
+        }
+        return new Version(
+            Integer.parseInt(versionMap.get("crate")),
+            null, // snapshot info is not saved
+            org.elasticsearch.Version.fromId(Integer.parseInt(versionMap.get("elasticsearch"))));
     }
 }

--- a/sql/src/main/java/io/crate/analyze/CreateTableAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/CreateTableAnalyzedStatement.java
@@ -26,6 +26,7 @@ import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.TableIdent;
+import io.crate.metadata.doc.DocIndexMetaData;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
@@ -126,6 +127,10 @@ public class CreateTableAnalyzedStatement extends AbstractDDLAnalyzedStatement {
             if (routingColumn != null) {
                 ((Map) mapping.get("_meta")).put("routing", routingColumn.fqn());
             }
+            // set the default routing hash function type
+            ((Map) mapping.get("_meta")).put(DocIndexMetaData.SETTING_ROUTING_HASH_FUNCTION,
+                DocIndexMetaData.DEFAULT_ROUTING_HASH_FUNCTION);
+
             // merge in user defined mapping parameter
             mapping.putAll(tableParameter.mappings());
         }

--- a/sql/src/main/java/io/crate/analyze/CreateTableAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/CreateTableAnalyzedStatement.java
@@ -21,6 +21,7 @@
 
 package io.crate.analyze;
 
+import io.crate.Version;
 import io.crate.exceptions.TableAlreadyExistsException;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.PartitionName;
@@ -124,12 +125,15 @@ public class CreateTableAnalyzedStatement extends AbstractDDLAnalyzedStatement {
     public Map<String, Object> mapping() {
         if (mapping == null) {
             mapping = analyzedTableElements.toMapping();
+            Map<String, Object> metaMap = (Map<String, Object>) mapping.get("_meta");
             if (routingColumn != null) {
-                ((Map) mapping.get("_meta")).put("routing", routingColumn.fqn());
+                metaMap.put("routing", routingColumn.fqn());
             }
             // set the default routing hash function type
-            ((Map) mapping.get("_meta")).put(DocIndexMetaData.SETTING_ROUTING_HASH_FUNCTION,
-                DocIndexMetaData.DEFAULT_ROUTING_HASH_FUNCTION);
+            metaMap.put(DocIndexMetaData.SETTING_ROUTING_HASH_FUNCTION, DocIndexMetaData.DEFAULT_ROUTING_HASH_FUNCTION);
+
+            // set the created version
+            DocIndexMetaData.putVersionToMap(metaMap, "created", Version.CURRENT);
 
             // merge in user defined mapping parameter
             mapping.putAll(tableParameter.mappings());

--- a/sql/src/main/java/io/crate/metadata/MetaDataModule.java
+++ b/sql/src/main/java/io/crate/metadata/MetaDataModule.java
@@ -21,8 +21,10 @@
 
 package io.crate.metadata;
 
+import io.crate.metadata.doc.CrateMetaDataUpgradeService;
 import io.crate.metadata.table.SchemaInfo;
 import io.crate.metadata.tablefunctions.TableFunctionImplementation;
+import org.elasticsearch.cluster.metadata.CustomUpgradeService;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.inject.multibindings.MapBinder;
 
@@ -34,6 +36,8 @@ public class MetaDataModule extends AbstractModule {
 
     @Override
     protected void configure() {
+        bind(CustomUpgradeService.class).to(CrateMetaDataUpgradeService.class).asEagerSingleton();
+
         bindReferences();
         bindFunctions();
         bindSchemas();

--- a/sql/src/main/java/io/crate/metadata/doc/CrateMetaDataUpgradeService.java
+++ b/sql/src/main/java/io/crate/metadata/doc/CrateMetaDataUpgradeService.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.doc;
+
+import io.crate.Constants;
+import io.crate.metadata.PartitionName;
+import org.elasticsearch.cluster.metadata.CustomUpgradeService;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
+import org.elasticsearch.cluster.metadata.MappingMetaData;
+import org.elasticsearch.common.collect.MapBuilder;
+import org.elasticsearch.common.component.AbstractComponent;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.common.settings.Settings;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Crate specific {@link CustomUpgradeService} which hooks in into ES's {@link org.elasticsearch.gateway.GatewayMetaState}.
+ */
+@Singleton
+public class CrateMetaDataUpgradeService extends AbstractComponent implements CustomUpgradeService {
+
+    @Inject
+    public CrateMetaDataUpgradeService(Settings settings) {
+        super(settings);
+    }
+
+    @Override
+    public IndexMetaData upgradeIndexMetaData(IndexMetaData indexMetaData) {
+        try {
+            return upgradeIndexMapping(indexMetaData);
+        } catch (Exception e) {
+            logger.error("index={} could not be upgraded", indexMetaData.getIndex());
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public IndexTemplateMetaData upgradeIndexTemplateMetaData(IndexTemplateMetaData indexTemplateMetaData) {
+        try {
+            return upgradeTemplateMapping(indexTemplateMetaData);
+        } catch (Exception e) {
+            logger.error("template={} could not be upgraded", indexTemplateMetaData.getName());
+            throw new RuntimeException(e);
+        }
+    }
+
+    private IndexMetaData upgradeIndexMapping(IndexMetaData indexMetaData) throws IOException {
+        MappingMetaData mappingMetaData = indexMetaData.mapping(Constants.DEFAULT_MAPPING_TYPE);
+        MappingMetaData newMappingMetaData = saveRoutingHashFunctionToMapping(
+            mappingMetaData,
+            indexMetaData.getSettings().get(IndexMetaData.SETTING_LEGACY_ROUTING_HASH_FUNCTION));
+        if (mappingMetaData != newMappingMetaData) {
+            logger.info("upgraded mapping of index={}", indexMetaData.getIndex());
+            return IndexMetaData.builder(indexMetaData)
+                .removeMapping(Constants.DEFAULT_MAPPING_TYPE)
+                .putMapping(newMappingMetaData)
+                .build();
+        }
+        return indexMetaData;
+    }
+
+    private IndexTemplateMetaData upgradeTemplateMapping(IndexTemplateMetaData indexTemplateMetaData) throws IOException {
+        // we only want to upgrade partition table related templates
+        if (PartitionName.isPartition(indexTemplateMetaData.getTemplate()) == false) {
+            return indexTemplateMetaData;
+        }
+        MappingMetaData mappingMetaData = new MappingMetaData(indexTemplateMetaData.getMappings().get(Constants.DEFAULT_MAPPING_TYPE));
+        MappingMetaData newMappingMetaData = saveRoutingHashFunctionToMapping(
+            mappingMetaData,
+            indexTemplateMetaData.getSettings().get(IndexMetaData.SETTING_LEGACY_ROUTING_HASH_FUNCTION));
+        if (mappingMetaData != newMappingMetaData) {
+            logger.info("upgraded mapping of template={}", indexTemplateMetaData.getName());
+            return new IndexTemplateMetaData.Builder(indexTemplateMetaData)
+                .removeMapping(Constants.DEFAULT_MAPPING_TYPE)
+                .putMapping(Constants.DEFAULT_MAPPING_TYPE, newMappingMetaData.source())
+                .build();
+        }
+        return indexTemplateMetaData;
+    }
+
+    private MappingMetaData saveRoutingHashFunctionToMapping(@Nullable MappingMetaData mappingMetaData,
+                                                             @Nullable String routingHashFunctionType) throws IOException {
+        Map<String, Object> mappingMap = null;
+        if (mappingMetaData != null) {
+            mappingMap = mappingMetaData.sourceAsMap();
+        }
+        String hashFunction = DocIndexMetaData.getRoutingHashFunctionType(mappingMap);
+        if (hashFunction == null) {
+            if (routingHashFunctionType == null) {
+                routingHashFunctionType = DocIndexMetaData.DEFAULT_ROUTING_HASH_FUNCTION;
+            }
+            // create new map, existing one can be immutable
+            Map<String, Object> newMappingMap = mappingMap == null
+                ? new HashMap<>(1)
+                : MapBuilder.newMapBuilder(mappingMap).map();
+
+            Map<String, Object> newMetaMap = (Map<String, Object>) newMappingMap.get("_meta");
+            if (newMetaMap == null) {
+                newMetaMap = new HashMap<>(1);
+                newMappingMap.put("_meta", newMetaMap);
+            }
+            newMetaMap.put(DocIndexMetaData.SETTING_ROUTING_HASH_FUNCTION, routingHashFunctionType);
+
+            Map<String, Object> typeAndMapping = new HashMap<>(1);
+            typeAndMapping.put(Constants.DEFAULT_MAPPING_TYPE, newMappingMap);
+            return new MappingMetaData(typeAndMapping);
+        }
+        return mappingMetaData;
+    }
+}

--- a/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.analyze;
 
+import io.crate.Version;
 import io.crate.action.sql.Option;
 import io.crate.action.sql.SessionContext;
 import io.crate.data.Row;
@@ -33,7 +34,6 @@ import io.crate.metadata.table.ColumnPolicy;
 import io.crate.sql.parser.SqlParser;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.testing.SQLExecutor;
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.MetaData;
@@ -68,9 +68,9 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateUnitTest {
             .build();
         ClusterState state = ClusterState.builder(ClusterName.DEFAULT)
             .nodes(DiscoveryNodes.builder()
-                .put(new DiscoveryNode("n1", DummyTransportAddress.INSTANCE, Version.CURRENT))
-                .put(new DiscoveryNode("n2", DummyTransportAddress.INSTANCE, Version.CURRENT))
-                .put(new DiscoveryNode("n3", DummyTransportAddress.INSTANCE, Version.CURRENT))
+                .put(new DiscoveryNode("n1", DummyTransportAddress.INSTANCE, org.elasticsearch.Version.CURRENT))
+                .put(new DiscoveryNode("n2", DummyTransportAddress.INSTANCE, org.elasticsearch.Version.CURRENT))
+                .put(new DiscoveryNode("n3", DummyTransportAddress.INSTANCE, org.elasticsearch.Version.CURRENT))
                 .localNodeId("n1")
             )
             .metaData(metaData)
@@ -991,5 +991,15 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateUnitTest {
             "create table default_routing_hash_set (id int)");
         Map<String, Object> metaMapping = ((Map) analysis.mapping().get("_meta"));
         assertThat(metaMapping.get(DocIndexMetaData.SETTING_ROUTING_HASH_FUNCTION), is(DocIndexMetaData.DEFAULT_ROUTING_HASH_FUNCTION));
+    }
+
+    @Test
+    public void testCreateTableCreatedVersionSet() throws Exception {
+        CreateTableAnalyzedStatement analysis = e.analyze(
+            "create table created_version_table (id int)");
+        Map<String, Object> metaMapping = ((Map) analysis.mapping().get("_meta"));
+        Map<String, Object> versionMap = (Map) metaMapping.get("version");
+        assertThat(versionMap.get("created"), is(Version.toMap(Version.CURRENT)));
+        assertThat(versionMap.get("upgraded"), nullValue());
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -60,7 +60,7 @@ public class DDLIntegrationTest extends SQLTransportIntegrationTest {
             .actionGet().isExists());
 
         String expectedMapping = "{\"default\":{" +
-                                 "\"dynamic\":\"true\",\"_meta\":{\"primary_keys\":[\"col1\"]}," +
+                                 "\"dynamic\":\"true\",\"_meta\":{\"routing_hash_function\":\"org.elasticsearch.cluster.routing.Murmur3HashFunction\",\"primary_keys\":[\"col1\"]}," +
                                  "\"_all\":{\"enabled\":false}," +
                                  "\"dynamic_templates\":[{\"strings\":{\"mapping\":{\"index\":\"not_analyzed\",\"store\":false,\"type\":\"string\",\"doc_values\":true},\"match_mapping_type\":\"string\"}}]," +
                                  "\"properties\":{" +
@@ -172,7 +172,7 @@ public class DDLIntegrationTest extends SQLTransportIntegrationTest {
             .actionGet().isExists());
 
         String expectedMapping = "{\"default\":{" +
-                                 "\"dynamic\":\"strict\",\"_meta\":{\"primary_keys\":[\"col1\"]},\"_all\":{\"enabled\":false}," +
+                                 "\"dynamic\":\"strict\",\"_meta\":{\"routing_hash_function\":\"org.elasticsearch.cluster.routing.Murmur3HashFunction\",\"primary_keys\":[\"col1\"]},\"_all\":{\"enabled\":false}," +
                                  "\"dynamic_templates\":[{\"strings\":{\"mapping\":{\"index\":\"not_analyzed\",\"store\":false,\"type\":\"string\",\"doc_values\":true},\"match_mapping_type\":\"string\"}}]," +
                                  "\"properties\":{" +
                                  "\"col1\":{\"type\":\"integer\"}," +
@@ -195,7 +195,7 @@ public class DDLIntegrationTest extends SQLTransportIntegrationTest {
         execute("create table test (col1 geo_shape INDEX using QUADTREE with (precision='1m', distance_error_pct='0.25'))");
         ensureYellow();
         String expectedMapping = "{\"default\":{" +
-                                 "\"dynamic\":\"true\"," +
+                                 "\"dynamic\":\"true\",\"_meta\":{\"routing_hash_function\":\"org.elasticsearch.cluster.routing.Murmur3HashFunction\"}," +
                                  "\"_all\":{\"enabled\":false}," +
                                  "\"dynamic_templates\":[{\"strings\":{\"mapping\":{\"index\":\"not_analyzed\",\"store\":false,\"type\":\"string\",\"doc_values\":true},\"match_mapping_type\":\"string\"}}]," +
                                  "\"properties\":{" +
@@ -208,7 +208,7 @@ public class DDLIntegrationTest extends SQLTransportIntegrationTest {
         execute("create table test (col1 geo_shape)");
         ensureYellow();
         String expectedMapping = "{\"default\":{" +
-                                 "\"dynamic\":\"true\"," +
+                                 "\"dynamic\":\"true\",\"_meta\":{\"routing_hash_function\":\"org.elasticsearch.cluster.routing.Murmur3HashFunction\"}," +
                                  "\"_all\":{\"enabled\":false}," +
                                  "\"dynamic_templates\":[{\"strings\":{\"mapping\":{\"index\":\"not_analyzed\",\"store\":false,\"type\":\"string\",\"doc_values\":true},\"match_mapping_type\":\"string\"}}]," +
                                  "\"properties\":{\"col1\":{\"type\":\"geo_shape\"}}}}";
@@ -685,7 +685,7 @@ public class DDLIntegrationTest extends SQLTransportIntegrationTest {
         ensureYellow();
         String expectedMapping = "{\"default\":" +
                                  "{\"dynamic\":\"true\"," +
-                                 "\"_meta\":{\"generated_columns\":{\"day\":\"date_trunc('day', ts)\"}}," +
+                                 "\"_meta\":{\"routing_hash_function\":\"org.elasticsearch.cluster.routing.Murmur3HashFunction\",\"generated_columns\":{\"day\":\"date_trunc('day', ts)\"}}," +
                                  "\"_all\":{\"enabled\":false}," +
                                  "\"dynamic_templates\":[{\"strings\":{\"mapping\":{\"index\":\"not_analyzed\",\"store\":false,\"type\":\"string\",\"doc_values\":true},\"match_mapping_type\":\"string\"}}]," +
                                  "\"properties\":{\"day\":{\"type\":\"date\",\"format\":\"epoch_millis||strict_date_optional_time\"},\"ts\":{\"type\":\"date\",\"format\":\"epoch_millis||strict_date_optional_time\"}}}}";

--- a/sql/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -60,7 +60,8 @@ public class DDLIntegrationTest extends SQLTransportIntegrationTest {
             .actionGet().isExists());
 
         String expectedMapping = "{\"default\":{" +
-                                 "\"dynamic\":\"true\",\"_meta\":{\"routing_hash_function\":\"org.elasticsearch.cluster.routing.Murmur3HashFunction\",\"primary_keys\":[\"col1\"]}," +
+                                 "\"dynamic\":\"true\",\"_meta\":{\"routing_hash_function\":\"org.elasticsearch.cluster.routing.Murmur3HashFunction\",\"primary_keys\":[\"col1\"]," +
+                                 "\"version\":{\"created\":{\"elasticsearch\":\"" + Version.CURRENT.esVersion.id + "\",\"crate\":\"" + Version.CURRENT.id + "\"}}}," +
                                  "\"_all\":{\"enabled\":false}," +
                                  "\"dynamic_templates\":[{\"strings\":{\"mapping\":{\"index\":\"not_analyzed\",\"store\":false,\"type\":\"string\",\"doc_values\":true},\"match_mapping_type\":\"string\"}}]," +
                                  "\"properties\":{" +
@@ -172,7 +173,9 @@ public class DDLIntegrationTest extends SQLTransportIntegrationTest {
             .actionGet().isExists());
 
         String expectedMapping = "{\"default\":{" +
-                                 "\"dynamic\":\"strict\",\"_meta\":{\"routing_hash_function\":\"org.elasticsearch.cluster.routing.Murmur3HashFunction\",\"primary_keys\":[\"col1\"]},\"_all\":{\"enabled\":false}," +
+                                 "\"dynamic\":\"strict\",\"_meta\":{\"routing_hash_function\":\"org.elasticsearch.cluster.routing.Murmur3HashFunction\",\"primary_keys\":[\"col1\"]," +
+                                 "\"version\":{\"created\":{\"elasticsearch\":\"" + Version.CURRENT.esVersion.id + "\",\"crate\":\"" + Version.CURRENT.id + "\"}}}," +
+                                 "\"_all\":{\"enabled\":false}," +
                                  "\"dynamic_templates\":[{\"strings\":{\"mapping\":{\"index\":\"not_analyzed\",\"store\":false,\"type\":\"string\",\"doc_values\":true},\"match_mapping_type\":\"string\"}}]," +
                                  "\"properties\":{" +
                                  "\"col1\":{\"type\":\"integer\"}," +
@@ -195,7 +198,8 @@ public class DDLIntegrationTest extends SQLTransportIntegrationTest {
         execute("create table test (col1 geo_shape INDEX using QUADTREE with (precision='1m', distance_error_pct='0.25'))");
         ensureYellow();
         String expectedMapping = "{\"default\":{" +
-                                 "\"dynamic\":\"true\",\"_meta\":{\"routing_hash_function\":\"org.elasticsearch.cluster.routing.Murmur3HashFunction\"}," +
+                                 "\"dynamic\":\"true\",\"_meta\":{\"routing_hash_function\":\"org.elasticsearch.cluster.routing.Murmur3HashFunction\"," +
+                                 "\"version\":{\"created\":{\"elasticsearch\":\"" + Version.CURRENT.esVersion.id + "\",\"crate\":\"" + Version.CURRENT.id + "\"}}}," +
                                  "\"_all\":{\"enabled\":false}," +
                                  "\"dynamic_templates\":[{\"strings\":{\"mapping\":{\"index\":\"not_analyzed\",\"store\":false,\"type\":\"string\",\"doc_values\":true},\"match_mapping_type\":\"string\"}}]," +
                                  "\"properties\":{" +
@@ -208,7 +212,8 @@ public class DDLIntegrationTest extends SQLTransportIntegrationTest {
         execute("create table test (col1 geo_shape)");
         ensureYellow();
         String expectedMapping = "{\"default\":{" +
-                                 "\"dynamic\":\"true\",\"_meta\":{\"routing_hash_function\":\"org.elasticsearch.cluster.routing.Murmur3HashFunction\"}," +
+                                 "\"dynamic\":\"true\",\"_meta\":{\"routing_hash_function\":\"org.elasticsearch.cluster.routing.Murmur3HashFunction\"," +
+                                 "\"version\":{\"created\":{\"elasticsearch\":\"" + Version.CURRENT.esVersion.id + "\",\"crate\":\"" + Version.CURRENT.id + "\"}}}," +
                                  "\"_all\":{\"enabled\":false}," +
                                  "\"dynamic_templates\":[{\"strings\":{\"mapping\":{\"index\":\"not_analyzed\",\"store\":false,\"type\":\"string\",\"doc_values\":true},\"match_mapping_type\":\"string\"}}]," +
                                  "\"properties\":{\"col1\":{\"type\":\"geo_shape\"}}}}";
@@ -685,7 +690,9 @@ public class DDLIntegrationTest extends SQLTransportIntegrationTest {
         ensureYellow();
         String expectedMapping = "{\"default\":" +
                                  "{\"dynamic\":\"true\"," +
-                                 "\"_meta\":{\"routing_hash_function\":\"org.elasticsearch.cluster.routing.Murmur3HashFunction\",\"generated_columns\":{\"day\":\"date_trunc('day', ts)\"}}," +
+                                 "\"_meta\":{\"routing_hash_function\":\"org.elasticsearch.cluster.routing.Murmur3HashFunction\"," +
+                                 "\"generated_columns\":{\"day\":\"date_trunc('day', ts)\"}," +
+                                 "\"version\":{\"created\":{\"elasticsearch\":\"" + Version.CURRENT.esVersion.id + "\",\"crate\":\"" + Version.CURRENT.id + "\"}}}," +
                                  "\"_all\":{\"enabled\":false}," +
                                  "\"dynamic_templates\":[{\"strings\":{\"mapping\":{\"index\":\"not_analyzed\",\"store\":false,\"type\":\"string\",\"doc_values\":true},\"match_mapping_type\":\"string\"}}]," +
                                  "\"properties\":{\"day\":{\"type\":\"date\",\"format\":\"epoch_millis||strict_date_optional_time\"},\"ts\":{\"type\":\"date\",\"format\":\"epoch_millis||strict_date_optional_time\"}}}}";

--- a/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -1594,13 +1594,15 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
         MappingMetaData partitionMetaData = clusterService().state().metaData().indices()
             .get(new PartitionName("dynamic_table", Collections.singletonList(new BytesRef("10.0"))).asIndexName())
             .getMappings().get(Constants.DEFAULT_MAPPING_TYPE);
-        assertThat(String.valueOf(partitionMetaData.getSourceAsMap().get("_meta")), Matchers.is("{partitioned_by=[[score, double]]}"));
+        Map<String, Object> metaMap = (Map) partitionMetaData.getSourceAsMap().get("_meta");
+        assertThat(String.valueOf(metaMap.get("partitioned_by")), Matchers.is("[[score, double]]"));
         execute("alter table dynamic_table set (column_policy= 'dynamic')");
         waitNoPendingTasksOnAll();
         partitionMetaData = clusterService().state().metaData().indices()
             .get(new PartitionName("dynamic_table", Collections.singletonList(new BytesRef("10.0"))).asIndexName())
             .getMappings().get(Constants.DEFAULT_MAPPING_TYPE);
-        assertThat(String.valueOf(partitionMetaData.getSourceAsMap().get("_meta")), Matchers.is("{partitioned_by=[[score, double]]}"));
+        metaMap = (Map) partitionMetaData.getSourceAsMap().get("_meta");
+        assertThat(String.valueOf(metaMap.get("partitioned_by")), Matchers.is("[[score, double]]"));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/metadata/doc/DocIndexMetaDataTest.java
+++ b/sql/src/test/java/io/crate/metadata/doc/DocIndexMetaDataTest.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import io.crate.Constants;
+import io.crate.Version;
 import io.crate.action.sql.SessionContext;
 import io.crate.analyze.*;
 import io.crate.metadata.*;
@@ -19,7 +20,6 @@ import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.GeoPointType;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.indices.template.put.TransportPutIndexTemplateAction;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.metadata.AliasMetaData;
@@ -71,7 +71,7 @@ public class DocIndexMetaDataTest extends CrateUnitTest {
         Settings.Builder settingsBuilder = Settings.builder()
             .put("index.number_of_shards", 1)
             .put("index.number_of_replicas", 0)
-            .put("index.version.created", Version.CURRENT)
+            .put("index.version.created", org.elasticsearch.Version.CURRENT)
             .put(settings);
 
         IndexMetaData.Builder mdBuilder = IndexMetaData.builder(indexName)
@@ -917,7 +917,7 @@ public class DocIndexMetaDataTest extends CrateUnitTest {
         Settings.Builder settingsBuilder = Settings.builder()
             .put("index.number_of_shards", 1)
             .put("index.number_of_replicas", 0)
-            .put("index.version.created", Version.CURRENT)
+            .put("index.version.created", org.elasticsearch.Version.CURRENT)
             .put(analyzedStatement.tableParameter().settings());
 
         IndexMetaData indexMetaData = IndexMetaData.builder(analyzedStatement.tableIdent().name())
@@ -1329,7 +1329,37 @@ public class DocIndexMetaDataTest extends CrateUnitTest {
         assertThat(md.indices().size(), is(1));
         assertThat(md.indices().keySet().iterator().next(), is(new ColumnIdent("description_ft")));
     }
+
+    @Test
+    public void testVersionsRead() throws Exception {
+        // @formatter:off
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+                .startObject("_meta")
+                    .startObject("version")
+                        .startObject("created")
+                            .field("crate", "560499")
+                            .field("elasticsearch", "2040299")
+                        .endObject()
+                        .startObject("upgraded")
+                            .field("crate", String.valueOf(Version.CURRENT.id))
+                            .field("elasticsearch", String.valueOf(Version.CURRENT.esVersion.id))
+                        .endObject()
+                    .endObject()
+                .endObject()
+            .startObject("properties")
+                .startObject("id")
+                    .field("type", "integer")
+                    .field("index", "not_analyzed")
+                .endObject()
+            .endObject();
+        // @formatter: on
+
+        IndexMetaData metaData = getIndexMetaData("test1", builder, Settings.EMPTY, null);
+        DocIndexMetaData md = newMeta(metaData, "test1");
+
+        assertThat(md.versionCreated().id, is(560499));
+        assertThat(md.versionCreated().esVersion.id, is(2040299));
+        assertThat(md.versionUpgraded(), is(Version.CURRENT));
+    }
 }
-
-
-


### PR DESCRIPTION
requires https://github.com/crate/elasticsearch/pull/100