### PR TITLE
Change ColumnsIterable to be materializable (fix join bug)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed an issue that caused joins on `information_schema.columns` to produce
+   a wrong result if `information_schema.columns` was used as the right table.
+
  - Added cluster checks that warn if some tables need to be recreated
    or upgraded for compatibility with future versions of CrateDB.
 

--- a/sql/src/main/java/io/crate/operation/reference/information/ColumnContext.java
+++ b/sql/src/main/java/io/crate/operation/reference/information/ColumnContext.java
@@ -25,7 +25,14 @@ import io.crate.metadata.Reference;
 import io.crate.metadata.table.TableInfo;
 
 public class ColumnContext {
-    public TableInfo tableInfo;
-    public Reference info;
-    public Short ordinal;
+
+    public final TableInfo tableInfo;
+    public final short ordinal;
+    public final Reference info;
+
+    public ColumnContext(TableInfo tableInfo, short ordinal, Reference ref) {
+        this.tableInfo = tableInfo;
+        this.ordinal = ordinal;
+        this.info = ref;
+    }
 }

--- a/sql/src/test/java/io/crate/operation/collect/sources/ColumnsIterableTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/sources/ColumnsIterableTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.operation.collect.sources;
+
+import com.google.common.collect.ImmutableList;
+import io.crate.operation.reference.information.ColumnContext;
+import io.crate.testing.T3;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertThat;
+
+public class ColumnsIterableTest {
+
+
+    @Test
+    public void testColumnsIteratorCanBeMaterializedToList() throws Exception {
+        InformationSchemaIterables.ColumnsIterable columns = new InformationSchemaIterables.ColumnsIterable(T3.T1_INFO);
+        ImmutableList<ColumnContext> contexts = ImmutableList.copyOf((Iterable<ColumnContext>) columns);
+
+        assertThat(
+            contexts.stream().map(c -> c.info.ident().columnIdent().name()).collect(Collectors.toList()),
+            Matchers.contains("a", "x", "i"));
+    }
+
+    @Test
+    public void testColumnsIterableCanBeConsumedTwice() throws Exception {
+        List<String> names = new ArrayList<>(6);
+        InformationSchemaIterables.ColumnsIterable columns = new InformationSchemaIterables.ColumnsIterable(T3.T1_INFO);
+        for (ColumnContext column : columns) {
+            names.add(column.info.ident().columnIdent().name());
+        }
+        for (ColumnContext column : columns) {
+            names.add(column.info.ident().columnIdent().name());
+        }
+        assertThat(names, Matchers.contains("a", "x", "i", "a", "x", "i"));
+    }
+}


### PR DESCRIPTION
If `information_schema.columns` was used on the right side of a join all
elements contained the values of the last columns because
`ImmutableList.copy(iterable)` is used on the callsite and the
ColumnContext iterable used a shared ColumnContext object.

This commit fixes the Iterable to properly implement the Iterable
interface.