### PR TITLE
Rename docId to fetchId and add a FetchId class

### DIFF
--- a/sql/src/main/java/io/crate/analyze/fetch/FetchFieldExtractor.java
+++ b/sql/src/main/java/io/crate/analyze/fetch/FetchFieldExtractor.java
@@ -89,7 +89,7 @@ public class FetchFieldExtractor {
     private static class IsFetchableVisitor extends AnalyzedRelationVisitor<Field, Boolean> {
 
         private static final IsFetchableVisitor INSTANCE = new IsFetchableVisitor();
-        private static final Set<Path> NOT_FETCHABLE = ImmutableSet.<Path>of(DocSysColumns.SCORE, DocSysColumns.DOCID);
+        private static final Set<Path> NOT_FETCHABLE = ImmutableSet.<Path>of(DocSysColumns.SCORE, DocSysColumns.FETCHID);
 
         public static Boolean isFetchable(Field field) {
             return INSTANCE.process(field.relation(), field);

--- a/sql/src/main/java/io/crate/analyze/relations/DocTableRelation.java
+++ b/sql/src/main/java/io/crate/analyze/relations/DocTableRelation.java
@@ -41,7 +41,7 @@ import java.util.Optional;
 
 public class DocTableRelation extends AbstractTableRelation<DocTableInfo> {
 
-    private static final ImmutableSet<ColumnIdent> HIDDEN_COLUMNS = ImmutableSet.of(DocSysColumns.DOCID);
+    private static final ImmutableSet<ColumnIdent> HIDDEN_COLUMNS = ImmutableSet.of(DocSysColumns.FETCHID);
     private final static SortValidator SORT_VALIDATOR = new SortValidator();
 
     private static class SortValidator extends SymbolVisitor<DocTableRelation, Void> {

--- a/sql/src/main/java/io/crate/analyze/symbol/DefaultTraversalSymbolVisitor.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/DefaultTraversalSymbolVisitor.java
@@ -33,7 +33,7 @@ public abstract class DefaultTraversalSymbolVisitor<C, R> extends SymbolVisitor<
 
     @Override
     public R visitFetchReference(FetchReference fetchReference, C context) {
-        process(fetchReference.docId(), context);
+        process(fetchReference.fetchId(), context);
         process(fetchReference.ref(), context);
         return super.visitFetchReference(fetchReference, context);
     }

--- a/sql/src/main/java/io/crate/analyze/symbol/FetchReference.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/FetchReference.java
@@ -31,11 +31,11 @@ import java.io.IOException;
 
 public class FetchReference extends Symbol {
 
-    private final Symbol docId;
+    private final Symbol fetchId;
     private final Reference ref;
 
-    public FetchReference(Symbol docId, Reference ref) {
-        this.docId = docId;
+    public FetchReference(Symbol fetchId, Reference ref) {
+        this.fetchId = fetchId;
         this.ref = ref;
     }
 
@@ -54,8 +54,8 @@ public class FetchReference extends Symbol {
         return ref.valueType();
     }
 
-    public Symbol docId() {
-        return docId;
+    public Symbol fetchId() {
+        return fetchId;
     }
 
     public Reference ref() {

--- a/sql/src/main/java/io/crate/analyze/symbol/SymbolVisitors.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/SymbolVisitors.java
@@ -50,7 +50,7 @@ public class SymbolVisitors {
         @Override
         public Boolean visitFetchReference(FetchReference fetchReference, Predicate<? super Symbol> symbolPredicate) {
             return symbolPredicate.apply(fetchReference)
-                   || fetchReference.docId().accept(this, symbolPredicate)
+                   || fetchReference.fetchId().accept(this, symbolPredicate)
                    || fetchReference.ref().accept(this, symbolPredicate);
         }
 

--- a/sql/src/main/java/io/crate/analyze/symbol/Symbols.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/Symbols.java
@@ -128,7 +128,7 @@ public class Symbols {
 
         @Override
         public Boolean visitFetchReference(FetchReference fetchReference, ColumnIdent context) {
-            if (process(fetchReference.docId(), context)) {
+            if (process(fetchReference.fetchId(), context)) {
                 return true;
             }
             return process(fetchReference.ref(), context);

--- a/sql/src/main/java/io/crate/analyze/symbol/format/SymbolPrinter.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/format/SymbolPrinter.java
@@ -303,7 +303,7 @@ public class SymbolPrinter {
             }
 
             context.builder.append("FETCH(");
-            process(fetchReference.docId(), context);
+            process(fetchReference.fetchId(), context);
             context.builder.append(", ");
             process(fetchReference.ref(), context);
             context.builder.append(")");

--- a/sql/src/main/java/io/crate/metadata/doc/DocSysColumns.java
+++ b/sql/src/main/java/io/crate/metadata/doc/DocSysColumns.java
@@ -18,7 +18,12 @@ public class DocSysColumns {
         public static final String UID = "_uid";
         public static final String DOC = "_doc";
         public static final String RAW = "_raw";
-        public static final String DOCID = "_docid";
+
+        /**
+         * Column that contains the lucene docId + a readerId.
+         * See {@link io.crate.operation.projectors.fetch.FetchId}
+         */
+        public static final String FETCHID = "_fetchid";
     }
 
     public static final ColumnIdent ID = new ColumnIdent(Names.ID);
@@ -27,7 +32,11 @@ public class DocSysColumns {
     public static final ColumnIdent UID = new ColumnIdent(Names.UID);
     public static final ColumnIdent DOC = new ColumnIdent(Names.DOC);
     public static final ColumnIdent RAW = new ColumnIdent(Names.RAW);
-    public static final ColumnIdent DOCID = new ColumnIdent(Names.DOCID);
+
+    /**
+     * See {@link Names#FETCHID}
+     */
+    public static final ColumnIdent FETCHID = new ColumnIdent(Names.FETCHID);
 
     public static final ImmutableMap<ColumnIdent, DataType> COLUMN_IDENTS = ImmutableMap.<ColumnIdent, DataType>builder()
         .put(ID, DataTypes.STRING)
@@ -36,7 +45,7 @@ public class DocSysColumns {
         .put(UID, DataTypes.STRING)
         .put(DOC, DataTypes.OBJECT)
         .put(RAW, DataTypes.STRING)
-        .put(DOCID, DataTypes.LONG)
+        .put(FETCHID, DataTypes.LONG)
         .build();
 
     private static final ImmutableMap<ColumnIdent, String> LUCENE_COLUMN_NAMES = ImmutableMap.<ColumnIdent, String>builder()

--- a/sql/src/main/java/io/crate/operation/collect/sources/ShardCollectSource.java
+++ b/sql/src/main/java/io/crate/operation/collect/sources/ShardCollectSource.java
@@ -380,7 +380,7 @@ public class ShardCollectSource extends AbstractComponent implements CollectSour
                     // If toCollect contains a docId it means that this is a QueryThenFetch operation.
                     // In such a case RemoteCollect cannot be used because on that node the FetchContext is missing
                     // and the reader required in the fetchPhase would be missing.
-                    if (Symbols.containsColumn(collectPhase.toCollect(), DocSysColumns.DOCID)) {
+                    if (Symbols.containsColumn(collectPhase.toCollect(), DocSysColumns.FETCHID)) {
                         throw e;
                     }
                     crateCollectors.add(remoteCollectorFactory.createCollector(

--- a/sql/src/main/java/io/crate/operation/fetch/FetchRowInputSymbolVisitor.java
+++ b/sql/src/main/java/io/crate/operation/fetch/FetchRowInputSymbolVisitor.java
@@ -24,13 +24,13 @@ package io.crate.operation.fetch;
 import io.crate.analyze.symbol.FetchReference;
 import io.crate.analyze.symbol.Field;
 import io.crate.analyze.symbol.InputColumn;
+import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.TableIdent;
 import io.crate.operation.BaseImplementationSymbolVisitor;
-import io.crate.data.Input;
 import io.crate.operation.projectors.fetch.FetchProjector;
 import io.crate.planner.node.fetch.FetchSource;
 
@@ -45,28 +45,28 @@ public class FetchRowInputSymbolVisitor extends BaseImplementationSymbolVisitor<
 
         private Map<TableIdent, FetchSource> fetchSources;
         private final FetchProjector.ArrayBackedRow inputRow = new FetchProjector.ArrayBackedRow();
-        private final int[] docIdPositions;
+        private final int[] fetchIdPositions;
         private final Object[][] nullCells;
 
         public Context(Map<TableIdent, FetchSource> fetchSources) {
             assert !fetchSources.isEmpty() : "fetchSources must not be empty";
             this.fetchSources = fetchSources;
 
-            int numDocIds = 0;
+            int numFetchIds = 0;
             for (FetchSource fetchSource : fetchSources.values()) {
-                numDocIds += fetchSource.docIdCols().size();
+                numFetchIds += fetchSource.fetchIdCols().size();
             }
 
-            this.fetchRows = new FetchProjector.ArrayBackedRow[numDocIds];
-            this.docIdPositions = new int[numDocIds];
-            this.partitionRows = new FetchProjector.ArrayBackedRow[numDocIds];
-            nullCells = new Object[numDocIds][];
+            this.fetchRows = new FetchProjector.ArrayBackedRow[numFetchIds];
+            this.fetchIdPositions = new int[numFetchIds];
+            this.partitionRows = new FetchProjector.ArrayBackedRow[numFetchIds];
+            nullCells = new Object[numFetchIds][];
 
             int idx = 0;
             for (FetchSource fetchSource : fetchSources.values()) {
-                for (InputColumn col : fetchSource.docIdCols()) {
+                for (InputColumn col : fetchSource.fetchIdCols()) {
                     fetchRows[idx] = new FetchProjector.ArrayBackedRow();
-                    docIdPositions[idx] = col.index();
+                    fetchIdPositions[idx] = col.index();
                     if (!fetchSource.partitionedByColumns().isEmpty()) {
                         partitionRows[idx] = new FetchProjector.ArrayBackedRow();
                     }
@@ -77,10 +77,10 @@ public class FetchRowInputSymbolVisitor extends BaseImplementationSymbolVisitor<
         }
 
         /**
-         * @return an array with the positions of the docIds in the input
+         * @return an array with the positions of the fetchIds in the input
          */
-        public int[] docIdPositions() {
-            return docIdPositions;
+        public int[] fetchIdPositions() {
+            return fetchIdPositions;
         }
 
         public FetchProjector.ArrayBackedRow[] fetchRows() {
@@ -110,8 +110,8 @@ public class FetchRowInputSymbolVisitor extends BaseImplementationSymbolVisitor<
             for (FetchSource fetchSource : fetchSources.values()) {
                 idx = fetchSource.partitionedByColumns().indexOf(fetchReference.ref());
                 if (idx >= 0) {
-                    for (InputColumn col : fetchSource.docIdCols()) {
-                        if (col.equals(fetchReference.docId())) {
+                    for (InputColumn col : fetchSource.fetchIdCols()) {
+                        if (col.equals(fetchReference.fetchId())) {
                             fs = fetchSource;
                             break;
                         }
@@ -140,15 +140,15 @@ public class FetchRowInputSymbolVisitor extends BaseImplementationSymbolVisitor<
             for (Map.Entry<TableIdent, FetchSource> entry : fetchSources.entrySet()) {
                 if (entry.getKey().equals(fetchReference.ref().ident().tableIdent())) {
                     fs = entry.getValue();
-                    for (InputColumn col : fs.docIdCols()) {
-                        if (col.equals(fetchReference.docId())) {
+                    for (InputColumn col : fs.fetchIdCols()) {
+                        if (col.equals(fetchReference.fetchId())) {
                             break;
                         }
                         fetchIdx++;
                     }
                     break;
                 } else {
-                    fetchIdx += entry.getValue().docIdCols().size();
+                    fetchIdx += entry.getValue().fetchIdCols().size();
                 }
             }
             assert fs != null : "fs must not be null";

--- a/sql/src/main/java/io/crate/operation/projectors/fetch/FetchId.java
+++ b/sql/src/main/java/io/crate/operation/projectors/fetch/FetchId.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.operation.projectors.fetch;
+
+/**
+ * Utility class to pack/unpack a fetchId.
+ * <p>
+ *  A fetchId is a long which contains a readerId and a docId.
+ *
+ * readerIds are generated in the planner-phase. They're used to identify a shard/indexReader.
+ * docIds are part of the lucene api, where they're used to identify documents within an IndexReader.
+ * </p>
+ *
+ * <pre>
+ *      4 bytes     |  4 bytes
+ *         |             |
+ *       readerId      docId
+ * </pre>
+ */
+public final class FetchId {
+
+
+    static int decodeReaderId(long fetchId) {
+        return (int) (fetchId >> 32);
+    }
+
+    static int decodeDocId(long fetchId) {
+        return (int) fetchId;
+    }
+
+    public static long encode(int readerId, int docId) {
+        return ((long) readerId << 32) | (docId & 0xfffL);
+    }
+}

--- a/sql/src/main/java/io/crate/operation/projectors/fetch/FetchProjectorContext.java
+++ b/sql/src/main/java/io/crate/operation/projectors/fetch/FetchProjectorContext.java
@@ -66,9 +66,9 @@ public class FetchProjectorContext {
         return readerBuckets.get(readerId);
     }
 
-    ReaderBucket require(long doc) {
-        int readerId = (int) (doc >> 32);
-        int docId = (int) doc;
+    ReaderBucket require(long fetchId) {
+        int readerId = FetchId.decodeReaderId(fetchId);
+        int docId = FetchId.decodeDocId(fetchId);
         ReaderBucket readerBucket = readerBuckets.get(readerId);
         if (readerBucket == null) {
             readerBucket = createReaderBucket(readerId);

--- a/sql/src/main/java/io/crate/operation/reference/doc/lucene/LuceneReferenceResolver.java
+++ b/sql/src/main/java/io/crate/operation/reference/doc/lucene/LuceneReferenceResolver.java
@@ -63,8 +63,8 @@ public class LuceneReferenceResolver implements ReferenceResolver<LuceneCollecto
             return new IdCollectorExpression();
         } else if (DocCollectorExpression.COLUMN_NAME.equals(name)) {
             return DocCollectorExpression.create(refInfo);
-        } else if (DocIdCollectorExpression.COLUMN_NAME.equals(name)) {
-            return new DocIdCollectorExpression();
+        } else if (FetchIdCollectorExpression.COLUMN_NAME.equals(name)) {
+            return new FetchIdCollectorExpression();
         } else if (ScoreCollectorExpression.COLUMN_NAME.equals(name)) {
             return new ScoreCollectorExpression();
         }

--- a/sql/src/main/java/io/crate/planner/fetch/MultiSourceFetchPushDown.java
+++ b/sql/src/main/java/io/crate/planner/fetch/MultiSourceFetchPushDown.java
@@ -83,14 +83,14 @@ class MultiSourceFetchPushDown {
             DocTableRelation rel = (DocTableRelation) source.relation();
             HashSet<Field> canBeFetched = filterByRelation(statement.canBeFetched(), rel);
             if (!canBeFetched.isEmpty()) {
-                RelationColumn docIdColumn = new RelationColumn(entry.getKey(), 0, DataTypes.LONG);
-                mssOutputs.add(docIdColumn);
-                InputColumn docIdInput = new InputColumn(mssOutputs.size() - 1);
+                RelationColumn fetchIdColumn = new RelationColumn(entry.getKey(), 0, DataTypes.LONG);
+                mssOutputs.add(fetchIdColumn);
+                InputColumn fetchIdInput = new InputColumn(mssOutputs.size() - 1);
 
                 ArrayList<Symbol> qtOutputs = new ArrayList<>(
                     source.querySpec().outputs().size() - canBeFetched.size() + 1);
-                Reference docId = rel.tableInfo().getReference(DocSysColumns.DOCID);
-                qtOutputs.add(docId);
+                Reference fetchId = rel.tableInfo().getReference(DocSysColumns.FETCHID);
+                qtOutputs.add(fetchId);
 
                 for (Symbol output : source.querySpec().outputs()) {
                     if (!canBeFetched.contains(output)) {
@@ -104,7 +104,7 @@ class MultiSourceFetchPushDown {
                 }
                 for (Field field : canBeFetched) {
                     FetchReference fr = new FetchReference(
-                        docIdInput, DocReferenceConverter.toSourceLookup(rel.resolveField(field)));
+                        fetchIdInput, DocReferenceConverter.toSourceLookup(rel.resolveField(field)));
                     allocateFetchedReference(fr, rel);
                     topLevelOutputMap.put(field, fr);
                 }
@@ -143,7 +143,7 @@ class MultiSourceFetchPushDown {
             fs = new FetchSource(rel.tableInfo().partitionedByColumns());
             fetchSources.put(fr.ref().ident().tableIdent(), fs);
         }
-        fs.docIdCols().add((InputColumn) fr.docId());
+        fs.fetchIdCols().add((InputColumn) fr.fetchId());
         if (fr.ref().granularity() == RowGranularity.DOC) {
             fs.references().add(fr.ref());
         }

--- a/sql/src/main/java/io/crate/planner/fetch/QueriedDocTableFetchPushDown.java
+++ b/sql/src/main/java/io/crate/planner/fetch/QueriedDocTableFetchPushDown.java
@@ -111,7 +111,7 @@ class QueriedDocTableFetchPushDown {
 
         // build the subquery
         QuerySpec sub = new QuerySpec();
-        Reference docIdReference = DocSysColumns.forTable(tableRelation.tableInfo().ident(), DocSysColumns.DOCID);
+        Reference docIdReference = DocSysColumns.forTable(tableRelation.tableInfo().ident(), DocSysColumns.FETCHID);
 
         List<Symbol> outputs = new ArrayList<>();
         if (orderBy.isPresent()) {

--- a/sql/src/main/java/io/crate/planner/node/fetch/FetchSource.java
+++ b/sql/src/main/java/io/crate/planner/node/fetch/FetchSource.java
@@ -32,23 +32,23 @@ import java.util.List;
 public class FetchSource {
 
     private final List<Reference> partitionedByColumns;
-    private final Collection<InputColumn> docIdCols;
+    private final Collection<InputColumn> fetchIdCols;
     private final Collection<Reference> references;
 
     public FetchSource(List<Reference> partitionedByColumns) {
-        this(partitionedByColumns, new LinkedHashSet<InputColumn>(), new LinkedHashSet<Reference>());
+        this(partitionedByColumns, new LinkedHashSet<>(), new LinkedHashSet<>());
     }
 
     public FetchSource(List<Reference> partitionedByColumns,
-                       Collection<InputColumn> docIdCols,
+                       Collection<InputColumn> fetchIdCols,
                        Collection<Reference> references) {
         this.partitionedByColumns = partitionedByColumns;
-        this.docIdCols = docIdCols;
+        this.fetchIdCols = fetchIdCols;
         this.references = references;
     }
 
-    public Collection<InputColumn> docIdCols() {
-        return docIdCols;
+    public Collection<InputColumn> fetchIdCols() {
+        return fetchIdCols;
     }
 
     public List<Reference> partitionedByColumns() {

--- a/sql/src/test/java/io/crate/metadata/doc/DocIndexMetaDataTest.java
+++ b/sql/src/test/java/io/crate/metadata/doc/DocIndexMetaDataTest.java
@@ -271,7 +271,7 @@ public class DocIndexMetaDataTest extends CrateUnitTest {
         });
 
         assertThat(fqns, Matchers.<List<String>>is(
-            ImmutableList.of("_doc", "_docid", "_id", "_raw", "_score", "_uid", "_version", "content", "datum", "id", "nested", "nested.inner_nested",
+            ImmutableList.of("_doc", "_fetchid", "_id", "_raw", "_score", "_uid", "_version", "content", "datum", "id", "nested", "nested.inner_nested",
                 "person", "person.birthday", "person.first_name", "title")));
 
     }

--- a/sql/src/test/java/io/crate/operation/projectors/fetch/FetchIdTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/fetch/FetchIdTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.operation.projectors.fetch;
+
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class FetchIdTest {
+
+    @Test
+    public void testEncodeAndDecode() throws Exception {
+        long fetchId = FetchId.encode(10, 3248);
+
+        assertThat(FetchId.decodeDocId(fetchId), is(3248));
+        assertThat(FetchId.decodeReaderId(fetchId), is(10));
+    }
+}

--- a/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -537,7 +537,7 @@ public class SelectPlannerTest extends CrateUnitTest {
 
         // doesn't contain "name" because whereClause is pushed down,
         // but still contains "id" because it is in the joinCondition
-        assertThat(rightCM.collectPhase().toCollect(), contains(isReference("_docid"), isReference("id")));
+        assertThat(rightCM.collectPhase().toCollect(), contains(isReference("_fetchid"), isReference("id")));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/planner/fetch/MultiSourceFetchPushDownTest.java
+++ b/sql/src/test/java/io/crate/planner/fetch/MultiSourceFetchPushDownTest.java
@@ -59,8 +59,8 @@ public class MultiSourceFetchPushDownTest extends CrateUnitTest {
         pushDown("select a, b from t1, t2");
         assertThat(pd.remainingOutputs(), isSQL("FETCH(INPUT(0), doc.t1._doc['a']), FETCH(INPUT(1), doc.t2._doc['b'])"));
         assertThat(mss.querySpec(), isSQL("SELECT RELCOL(doc.t1, 0), RELCOL(doc.t2, 0)"));
-        assertThat(srcSpec("t1"), isSQL("SELECT doc.t1._docid"));
-        assertThat(srcSpec("t2"), isSQL("SELECT doc.t2._docid"));
+        assertThat(srcSpec("t1"), isSQL("SELECT doc.t1._fetchid"));
+        assertThat(srcSpec("t2"), isSQL("SELECT doc.t2._fetchid"));
 
         assertThat(pd.fetchSources().size(), is(2));
 
@@ -71,7 +71,7 @@ public class MultiSourceFetchPushDownTest extends CrateUnitTest {
         pushDown("select a, b from t1, t2 order by b");
         assertThat(pd.remainingOutputs(), isSQL("FETCH(INPUT(0), doc.t1._doc['a']), INPUT(1)"));
         assertThat(mss.querySpec(), isSQL("SELECT RELCOL(doc.t1, 0), RELCOL(doc.t2, 0) ORDER BY RELCOL(doc.t2, 0)"));
-        assertThat(srcSpec("t1"), isSQL("SELECT doc.t1._docid"));
+        assertThat(srcSpec("t1"), isSQL("SELECT doc.t1._fetchid"));
         assertThat(srcSpec("t2"), isSQL("SELECT doc.t2.b ORDER BY doc.t2.b"));
     }
 

--- a/sql/src/test/java/io/crate/planner/fetch/QueriedDocTableFetchPushDownTest.java
+++ b/sql/src/test/java/io/crate/planner/fetch/QueriedDocTableFetchPushDownTest.java
@@ -101,7 +101,7 @@ public class QueriedDocTableFetchPushDownTest {
         QueriedDocTableFetchPushDown pd = new QueriedDocTableFetchPushDown(new QueriedDocTable(TABLE_REL, qs));
         QueriedDocTable sub = pd.pushDown();
         assertThat(qs, isSQL("SELECT FETCH(INPUT(0), s.t._doc['a']), FETCH(INPUT(0), s.t._doc['i'])"));
-        assertThat(sub.querySpec(), isSQL("SELECT s.t._docid"));
+        assertThat(sub.querySpec(), isSQL("SELECT s.t._fetchid"));
     }
 
     @Test
@@ -112,7 +112,7 @@ public class QueriedDocTableFetchPushDownTest {
         QueriedDocTableFetchPushDown pd = new QueriedDocTableFetchPushDown(new QueriedDocTable(TABLE_REL, qs));
         QueriedDocTable sub = pd.pushDown();
         assertThat(qs, isSQL("SELECT FETCH(INPUT(0), s.t._doc['a']), INPUT(1) ORDER BY INPUT(1) DESC NULLS LAST"));
-        assertThat(sub.querySpec(), isSQL("SELECT s.t._docid, s.t.i ORDER BY s.t.i DESC NULLS LAST"));
+        assertThat(sub.querySpec(), isSQL("SELECT s.t._fetchid, s.t.i ORDER BY s.t.i DESC NULLS LAST"));
     }
 
     @Test
@@ -124,7 +124,7 @@ public class QueriedDocTableFetchPushDownTest {
         QueriedDocTableFetchPushDown pd = new QueriedDocTableFetchPushDown(new QueriedDocTable(TABLE_REL, qs));
         QueriedDocTable sub = pd.pushDown();
         assertThat(qs, isSQL("SELECT FETCH(INPUT(0), s.t._doc['a']), FETCH(INPUT(0), s.t._doc['i']) ORDER BY INPUT(1) DESC NULLS LAST"));
-        assertThat(sub.querySpec(), isSQL("SELECT s.t._docid, abs(s.t.i) ORDER BY abs(s.t.i) DESC NULLS LAST"));
+        assertThat(sub.querySpec(), isSQL("SELECT s.t._fetchid, abs(s.t.i) ORDER BY abs(s.t.i) DESC NULLS LAST"));
     }
 
     @Test
@@ -138,7 +138,7 @@ public class QueriedDocTableFetchPushDownTest {
         QueriedDocTableFetchPushDown pd = new QueriedDocTableFetchPushDown(new QueriedDocTable(TABLE_REL, qs));
         QueriedDocTable sub = pd.pushDown();
         assertThat(qs, isSQL("SELECT FETCH(INPUT(0), s.t._doc['a']), FETCH(INPUT(0), s.t._doc['i']), INPUT(1) ORDER BY INPUT(1) DESC NULLS LAST"));
-        assertThat(sub.querySpec(), isSQL("SELECT s.t._docid, abs(s.t.i) ORDER BY abs(s.t.i) DESC NULLS LAST"));
+        assertThat(sub.querySpec(), isSQL("SELECT s.t._fetchid, abs(s.t.i) ORDER BY abs(s.t.i) DESC NULLS LAST"));
     }
 
     @Test
@@ -151,7 +151,7 @@ public class QueriedDocTableFetchPushDownTest {
         QueriedDocTableFetchPushDown pd = new QueriedDocTableFetchPushDown(new QueriedDocTable(TABLE_REL, qs));
         QueriedDocTable sub = pd.pushDown();
         assertThat(qs, isSQL("SELECT FETCH(INPUT(0), s.t._doc['a']), INPUT(1), abs(INPUT(1)) ORDER BY INPUT(1) DESC NULLS LAST"));
-        assertThat(sub.querySpec(), isSQL("SELECT s.t._docid, s.t.i ORDER BY s.t.i DESC NULLS LAST"));
+        assertThat(sub.querySpec(), isSQL("SELECT s.t._fetchid, s.t.i ORDER BY s.t.i DESC NULLS LAST"));
     }
 
     @Test
@@ -181,7 +181,7 @@ public class QueriedDocTableFetchPushDownTest {
         QueriedDocTableFetchPushDown pd = new QueriedDocTableFetchPushDown(new QueriedDocTable(TABLE_REL, qs));
         QueriedDocTable sub = pd.pushDown();
         assertThat(qs, isSQL("SELECT FETCH(INPUT(0), s.t._doc['a']), INPUT(1), INPUT(2) ORDER BY INPUT(1) DESC NULLS LAST"));
-        assertThat(sub.querySpec(), isSQL("SELECT s.t._docid, s.t.i, s.t._score ORDER BY s.t.i DESC NULLS LAST"));
+        assertThat(sub.querySpec(), isSQL("SELECT s.t._fetchid, s.t.i, s.t._score ORDER BY s.t.i DESC NULLS LAST"));
     }
 
     private Function abs(Symbol symbol) {

--- a/sql/src/test/java/io/crate/testing/SymbolMatchers.java
+++ b/sql/src/test/java/io/crate/testing/SymbolMatchers.java
@@ -110,7 +110,7 @@ public class SymbolMatchers {
         ) {
             @Override
             protected Symbol featureValueOf(Symbol actual) {
-                return ((FetchReference) actual).docId();
+                return ((FetchReference) actual).fetchId();
             }
         };
 


### PR DESCRIPTION
The term `docId` was used for two different things. This renames one
usage to `fetchId` to avoid confusion.