### PR TITLE
fixed race condition in concurrent template update of partitioned table

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,10 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed a race condition that could have caused that not all columns were
+   written to the metadata when a lot of new dynamic columns were generated
+   concurrently.
+
  - Fixed an issue that caused joins on `information_schema.columns` to produce
    a wrong result if `information_schema.columns` was used as the right table.
 

--- a/sql/src/main/java/io/crate/metadata/doc/DocIndexMetaData.java
+++ b/sql/src/main/java/io/crate/metadata/doc/DocIndexMetaData.java
@@ -553,24 +553,16 @@ public class DocIndexMetaData {
         if (schemaEquals(other)) {
             return this;
         } else if (thisIsCreatedFromTemplate) {
-            if (this.references.size() < other.references.size()) {
-                // this is older, update template and return other
-                // settings in template are always authoritative for table information about
-                // number_of_shards and number_of_replicas
-                updateTemplate(other, transportPutIndexTemplateAction, this.metaData.getSettings());
-                // merge the new mapping with the template settings
-                return new DocIndexMetaData(
-                    functions,
-                    IndexMetaData.builder(other.metaData).settings(this.metaData.getSettings()).build(),
-                    other.ident).build();
-            } else if (references().size() == other.references().size() &&
-                       !references().keySet().equals(other.references().keySet())) {
-                XContentHelper.update(defaultMappingMap, other.defaultMappingMap, false);
-                // update the template with new information
-                updateTemplate(this, transportPutIndexTemplateAction, this.metaData.getSettings());
-                return this;
+            boolean mappingChanged = XContentHelper.update(this.defaultMappingMap, other.defaultMappingMap, true);
+            if (mappingChanged) {
+                IndexMetaData indexMetaData = IndexMetaData.builder(other.metaData)
+                    .putMapping(new MappingMetaData(Constants.DEFAULT_MAPPING_TYPE, defaultMappingMap))
+                    .settings(this.metaData.getSettings())
+                    .build();
+                DocIndexMetaData ret = new DocIndexMetaData(functions, indexMetaData, other.ident).build();
+                updateTemplate(ret, transportPutIndexTemplateAction, this.metaData.getSettings());
+                return ret;
             }
-            // other is older, just return this
             return this;
         } else {
             throw new TableAliasSchemaException(other.ident.name());

--- a/sql/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
@@ -315,4 +315,45 @@ public class PartitionedTableConcurrentIntegrationTest extends SQLTransportInteg
     public void testDeletePartitionWhileBulkInsertingData() throws Exception {
         deletePartitionWhileInsertingData(true);
     }
+
+    private static Map createColumnMap(int numCols, String prefix) {
+        Map<String, Object> map = new HashMap<>(numCols);
+        for (int i = 0; i < numCols; i++) {
+            map.put(String.format("%s_col_%d", prefix, i), i);
+        }
+        return map;
+    }
+
+
+    @Test
+    public void testInsertIntoDynamicObjectColumnAddsAllColumnsToTemplate() throws Exception {
+        // regression test for issue that caused columns not being added to metadata/tableinfo of partitioned table
+        // when inserting a lot of new dynamic columns to various partitions of a table
+        execute("create table dyn_parted (id int, bucket string, data object(dynamic), primary key (id, bucket)) " +
+                "partitioned by (bucket) " +
+                "with (number_of_replicas = 0)");
+        ensureYellow();
+
+        int bulkSize = 100;
+        int numCols = 100;
+        String[] buckets = new String[]{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"};
+        final CountDownLatch countDownLatch = new CountDownLatch(buckets.length);
+        for (String bucket : buckets) {
+            Object[][] bulkArgs = new Object[bulkSize][];
+            for (int i = 0; i < bulkSize; i++) {
+                bulkArgs[i] = new Object[]{i, bucket, createColumnMap(numCols, bucket)};
+            }
+            new Thread(() -> {
+                try {
+                    execute("insert into dyn_parted (id, bucket, data) values (?, ?, ?)", bulkArgs, TimeValue.timeValueSeconds(10));
+                } finally {
+                    countDownLatch.countDown();
+                }
+            }).start();
+        }
+
+        countDownLatch.await();
+        execute("select count(*) from information_schema.columns where table_name = 'dyn_parted'");
+        assertThat(response.rows()[0][0], is(3L + numCols * buckets.length));
+    }
 }


### PR DESCRIPTION
the race condition could have caused that not all columns were written to the
metadata when a lot of new dynamic columns were generated concurrently on a
partitioned table.