### PR TITLE
change api of the fucntion class

### DIFF
--- a/sql/src/benchmarks/java/io/crate/operation/projectors/GroupingProjectorBenchmark.java
+++ b/sql/src/benchmarks/java/io/crate/operation/projectors/GroupingProjectorBenchmark.java
@@ -93,7 +93,8 @@ public class GroupingProjectorBenchmark {
         FunctionIdent minStringFuncIdent = new FunctionIdent(MinimumAggregation.NAME,
             Arrays.<DataType>asList(DataTypes.STRING));
         FunctionInfo minStringFuncInfo = new FunctionInfo(minStringFuncIdent, DataTypes.STRING, FunctionInfo.Type.AGGREGATE);
-        AggregationFunction minAgg = (AggregationFunction) functions.get(minStringFuncIdent);
+        AggregationFunction minAgg = (AggregationFunction) functions
+            .get(minStringFuncIdent.schema(), minStringFuncIdent.name(), minStringFuncIdent.argumentTypes());
         Aggregation aggregation = Aggregation.finalAggregation(minStringFuncInfo,
             Arrays.<Symbol>asList(new InputColumn(0)), Aggregation.Step.ITER);
         AggregationContext aggregationContext = new AggregationContext(minAgg, aggregation);
@@ -131,7 +132,8 @@ public class GroupingProjectorBenchmark {
         FunctionIdent functionIdent = new FunctionIdent(SumAggregation.NAME,
             Arrays.<DataType>asList(DataTypes.INTEGER));
         FunctionInfo functionInfo = new FunctionInfo(functionIdent, DataTypes.INTEGER, FunctionInfo.Type.AGGREGATE);
-        AggregationFunction minAgg = (AggregationFunction) functions.get(functionIdent);
+        AggregationFunction minAgg = (AggregationFunction) functions
+            .get(functionIdent.schema(), functionIdent.name(), functionIdent.argumentTypes());
         Aggregation aggregation = Aggregation.finalAggregation(functionInfo,
             Arrays.<Symbol>asList(new InputColumn(0)), Aggregation.Step.ITER);
         AggregationContext aggregationContext = new AggregationContext(minAgg, aggregation);

--- a/sql/src/main/java/io/crate/analyze/EvaluatingNormalizer.java
+++ b/sql/src/main/java/io/crate/analyze/EvaluatingNormalizer.java
@@ -144,7 +144,8 @@ public class EvaluatingNormalizer {
 
         @SuppressWarnings("unchecked")
         Symbol normalizeFunctionSymbol(Function function, Context context) {
-            FunctionImplementation impl = functions.get(function.info().ident());
+            FunctionIdent ident = function.info().ident();
+            FunctionImplementation impl = functions.get(ident.schema(), ident.name(), ident.argumentTypes());
             if (impl != null) {
                 return impl.normalizeSymbol(function, context.transactionContext);
             }

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -39,10 +39,7 @@ import io.crate.analyze.symbol.format.SymbolFormatter;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.exceptions.ConversionException;
 import io.crate.exceptions.UnsupportedFeatureException;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.Functions;
-import io.crate.metadata.Reference;
+import io.crate.metadata.*;
 import io.crate.metadata.table.Operation;
 import io.crate.operation.aggregation.impl.CollectSetAggregation;
 import io.crate.operation.operator.*;
@@ -139,8 +136,12 @@ public class ExpressionAnalyzer {
         }
     }
 
-    private FunctionInfo getFunctionInfo(FunctionIdent ident) {
-        return functions.getSafe(ident).info();
+    private FunctionInfo getBuiltInFunctionInfo(String name, List<DataType> arguments) {
+        return getFunctionInfo(null, name, arguments);
+    }
+
+    private FunctionInfo getFunctionInfo(String schema, String name, List<DataType> arguments) {
+        return functions.getSafe(schema, name, arguments).info();
     }
 
     protected Symbol convertFunctionCall(FunctionCall node, ExpressionAnalysisContext context) {
@@ -152,6 +153,11 @@ public class ExpressionAnalyzer {
             argumentTypes.add(argSymbol.valueType());
             arguments.add(argSymbol);
         }
+        List<String> fName = node.getName().getParts();
+        assert fName.size() <= 2 : "must be compliant with \"[schema.] function\" format";
+        if (fName.size() == 1) {
+            fName = Arrays.asList(null, fName.get(0));
+        }
 
         FunctionInfo functionInfo;
         if (node.isDistinct()) {
@@ -160,27 +166,25 @@ public class ExpressionAnalyzer {
                     "%s(DISTINCT x) does not accept more than one argument", node.getName()));
             }
             // define the inner function. use the arguments/argumentTypes from above
-            FunctionIdent innerIdent = new FunctionIdent(CollectSetAggregation.NAME, argumentTypes);
-            FunctionInfo innerInfo = getFunctionInfo(innerIdent);
-            Symbol innerFunction = context.allocateFunction(innerInfo, arguments);
+            Symbol innerFunction = context.allocateFunction(
+                getBuiltInFunctionInfo(CollectSetAggregation.NAME, argumentTypes),
+                arguments
+            );
 
             // define the outer function which contains the inner function as argument.
-            String nodeName = "collection_" + node.getName().toString();
-            List<Symbol> outerArguments = Arrays.<Symbol>asList(innerFunction);
-            ImmutableList<DataType> outerArgumentTypes =
-                ImmutableList.<DataType>of(new SetType(argumentTypes.get(0)));
+            String nodeName = "collection_" + fName.get(1);
+            List<Symbol> outerArguments = Arrays.asList(innerFunction);
+            ImmutableList<DataType> outerArgumentTypes = ImmutableList.of(new SetType(argumentTypes.get(0)));
 
-            FunctionIdent ident = new FunctionIdent(nodeName, outerArgumentTypes);
             try {
-                functionInfo = getFunctionInfo(ident);
+                functionInfo = getFunctionInfo(fName.get(0), nodeName, outerArgumentTypes);
             } catch (UnsupportedOperationException ex) {
                 throw new UnsupportedOperationException(String.format(Locale.ENGLISH,
                     "unknown function %s(DISTINCT %s)", node.getName(), argumentTypes.get(0)), ex);
             }
             arguments = outerArguments;
         } else {
-            FunctionIdent ident = new FunctionIdent(node.getName().toString(), argumentTypes);
-            functionInfo = getFunctionInfo(ident);
+            functionInfo = getFunctionInfo(fName.get(0), fName.get(1), argumentTypes);
         }
         return context.allocateFunction(functionInfo, arguments);
     }
@@ -254,7 +258,7 @@ public class ExpressionAnalyzer {
             if (!node.getType().equals(CurrentTime.Type.TIMESTAMP)) {
                 visitExpression(node, context);
             }
-            List<Symbol> args = Lists.<Symbol>newArrayList(
+            List<Symbol> args = Lists.newArrayList(
                 Literal.of(node.getPrecision().or(CurrentTimestampFunction.DEFAULT_PRECISION))
             );
             return context.allocateFunction(CurrentTimestampFunction.INFO, args);
@@ -416,13 +420,13 @@ public class ExpressionAnalyzer {
         protected Symbol visitIsNotNullPredicate(IsNotNullPredicate node, ExpressionAnalysisContext context) {
             Symbol argument = process(node.getValue(), context);
 
-            FunctionIdent isNullIdent =
-                new FunctionIdent(io.crate.operation.predicate.IsNullPredicate.NAME, ImmutableList.of(argument.valueType()));
-            FunctionInfo isNullInfo = getFunctionInfo(isNullIdent);
+            FunctionInfo isNullInfo = getBuiltInFunctionInfo(
+                io.crate.operation.predicate.IsNullPredicate.NAME, ImmutableList.of(argument.valueType()));
 
             return context.allocateFunction(
                 NotPredicate.INFO,
-                Arrays.<Symbol>asList(context.allocateFunction(isNullInfo, Arrays.asList(argument))));
+                Arrays.asList(context.allocateFunction(isNullInfo, Arrays.asList(argument)))
+            );
         }
 
         @Override
@@ -442,17 +446,17 @@ public class ExpressionAnalyzer {
                 subscriptSymbol = subscriptExpression.accept(this, context);
             } else {
                 throw new UnsupportedOperationException("Only references, function calls or array literals " +
-                                                        "are valid subscript symbols");
+                    "are valid subscript symbols");
             }
             assert subscriptSymbol != null : "subscriptSymbol must not be null";
             Expression index = subscriptContext.index();
             if (index != null) {
                 Symbol indexSymbol = index.accept(this, context);
                 // rewrite array access to subscript scalar
-                FunctionIdent functionIdent = new FunctionIdent(SubscriptFunction.NAME,
-                    ImmutableList.of(subscriptSymbol.valueType(), indexSymbol.valueType()));
-                return context.allocateFunction(getFunctionInfo(functionIdent),
-                    Arrays.asList(subscriptSymbol, indexSymbol));
+                return context.allocateFunction(
+                    getBuiltInFunctionInfo(SubscriptFunction.NAME, ImmutableList.of(subscriptSymbol.valueType(), indexSymbol.valueType())),
+                    Arrays.asList(subscriptSymbol, indexSymbol)
+                );
             }
             return subscriptSymbol;
         }
@@ -481,8 +485,10 @@ public class ExpressionAnalyzer {
         protected Symbol visitNotExpression(NotExpression node, ExpressionAnalysisContext context) {
             Symbol argument = process(node.getValue(), context);
 
-            FunctionIdent functionIdent = new FunctionIdent(NotPredicate.NAME, Arrays.asList(argument.valueType()));
-            return context.allocateFunction(getFunctionInfo(functionIdent), Arrays.asList(argument));
+            return context.allocateFunction(
+                getBuiltInFunctionInfo(NotPredicate.NAME, Arrays.asList(argument.valueType())),
+                Arrays.asList(argument)
+            );
         }
 
         @Override
@@ -492,8 +498,8 @@ public class ExpressionAnalyzer {
 
             Comparison comparison = new Comparison(node.getType(), left, right);
             comparison.normalize(context);
-            FunctionInfo info = getFunctionInfo(comparison.toFunctionIdent());
-            return context.allocateFunction(info, comparison.arguments());
+            FunctionIdent ident = comparison.toFunctionIdent();
+            return context.allocateFunction(getBuiltInFunctionInfo(ident.name(), ident.argumentTypes()), comparison.arguments());
         }
 
         @Override
@@ -528,11 +534,12 @@ public class ExpressionAnalyzer {
             }
 
             ComparisonExpression.Type operationType = node.getType();
-            String operatorName;
-            operatorName = AnyOperator.OPERATOR_PREFIX + operationType.getValue();
-            FunctionIdent functionIdent = new FunctionIdent(operatorName, Arrays.asList(leftSymbol.valueType(), arraySymbol.valueType()));
-            FunctionInfo functionInfo = getFunctionInfo(functionIdent);
-            return context.allocateFunction(functionInfo, Arrays.asList(leftSymbol, arraySymbol));
+            String operatorName = AnyOperator.OPERATOR_PREFIX + operationType.getValue();
+
+            return context.allocateFunction(
+                getBuiltInFunctionInfo(operatorName, Arrays.asList(leftSymbol.valueType(), arraySymbol.valueType())),
+                Arrays.asList(leftSymbol, arraySymbol)
+            );
         }
 
         @Override
@@ -551,9 +558,10 @@ public class ExpressionAnalyzer {
             rightSymbol = castIfNeededOrFail(rightSymbol, new ArrayType(DataTypes.STRING));
             String operatorName = node.inverse() ? AnyNotLikeOperator.NAME : AnyLikeOperator.NAME;
 
-            FunctionIdent functionIdent = new FunctionIdent(operatorName, Arrays.asList(leftSymbol.valueType(), rightSymbol.valueType()));
-            FunctionInfo functionInfo = getFunctionInfo(functionIdent);
-            return context.allocateFunction(functionInfo, Arrays.asList(leftSymbol, rightSymbol));
+            return context.allocateFunction(
+                getBuiltInFunctionInfo(operatorName, Arrays.asList(leftSymbol.valueType(), rightSymbol.valueType())),
+                Arrays.asList(leftSymbol, rightSymbol)
+            );
         }
 
         @Override
@@ -564,18 +572,20 @@ public class ExpressionAnalyzer {
             Symbol expression = process(node.getValue(), context);
             expression = castIfNeededOrFail(expression, DataTypes.STRING);
             Symbol pattern = castIfNeededOrFail(process(node.getPattern(), context), DataTypes.STRING);
-            FunctionIdent functionIdent = FunctionIdent.of(LikeOperator.NAME, expression.valueType(), pattern.valueType());
-            return context.allocateFunction(getFunctionInfo(functionIdent), Arrays.asList(expression, pattern));
+            return context.allocateFunction(
+                getBuiltInFunctionInfo(LikeOperator.NAME, ImmutableList.of(expression.valueType(), pattern.valueType())),
+                Arrays.asList(expression, pattern)
+            );
         }
 
         @Override
         protected Symbol visitIsNullPredicate(IsNullPredicate node, ExpressionAnalysisContext context) {
             Symbol value = process(node.getValue(), context);
 
-            FunctionIdent functionIdent =
-                new FunctionIdent(io.crate.operation.predicate.IsNullPredicate.NAME, ImmutableList.of(value.valueType()));
-            FunctionInfo functionInfo = getFunctionInfo(functionIdent);
-            return context.allocateFunction(functionInfo, Arrays.asList(value));
+            return context.allocateFunction(
+                getBuiltInFunctionInfo(io.crate.operation.predicate.IsNullPredicate.NAME, ImmutableList.of(value.valueType())),
+                Arrays.asList(value)
+            );
         }
 
         @Override
@@ -591,11 +601,10 @@ public class ExpressionAnalyzer {
             Symbol left = process(node.getLeft(), context);
             Symbol right = process(node.getRight(), context);
 
-            FunctionIdent functionIdent = new FunctionIdent(
-                node.getType().name().toLowerCase(Locale.ENGLISH),
-                Arrays.asList(left.valueType(), right.valueType())
+            return context.allocateFunction(
+                getBuiltInFunctionInfo(node.getType().name().toLowerCase(Locale.ENGLISH), Arrays.asList(left.valueType(), right.valueType())),
+                Arrays.asList(left, right)
             );
-            return context.allocateFunction(getFunctionInfo(functionIdent), Arrays.asList(left, right));
         }
 
         @Override
@@ -651,8 +660,7 @@ public class ExpressionAnalyzer {
                 for (Expression value : values) {
                     arguments.add(process(value, context));
                 }
-                FunctionIdent functionIdent = new FunctionIdent(ArrayFunction.NAME, Symbols.extractTypes(arguments));
-                return context.allocateFunction(getFunctionInfo(functionIdent), arguments);
+                return context.allocateFunction(getBuiltInFunctionInfo(ArrayFunction.NAME, Symbols.extractTypes(arguments)), arguments);
             }
         }
 
@@ -667,8 +675,7 @@ public class ExpressionAnalyzer {
                 arguments.add(Literal.of(entry.getKey()));
                 arguments.add(process(entry.getValue(), context));
             }
-            FunctionIdent functionIdent = new FunctionIdent(MapFunction.NAME, Symbols.extractTypes(arguments));
-            return context.allocateFunction(getFunctionInfo(functionIdent), arguments);
+            return context.allocateFunction(getBuiltInFunctionInfo(MapFunction.NAME, Symbols.extractTypes(arguments)), arguments);
         }
 
         @Override
@@ -685,12 +692,14 @@ public class ExpressionAnalyzer {
             Symbol max = process(node.getMax(), context);
 
             Comparison gte = new Comparison(ComparisonExpression.Type.GREATER_THAN_OR_EQUAL, value, min);
+            FunctionIdent gteIdent = gte.normalize(context).toFunctionIdent();
             Function gteFunc = context.allocateFunction(
-                getFunctionInfo(gte.normalize(context).toFunctionIdent()), gte.arguments());
+                getBuiltInFunctionInfo(gteIdent.name(), gteIdent.argumentTypes()), gte.arguments());
 
             Comparison lte = new Comparison(ComparisonExpression.Type.LESS_THAN_OR_EQUAL, value, max);
+            FunctionIdent lteIdent = lte.normalize(context).toFunctionIdent();
             Function lteFunc = context.allocateFunction(
-                getFunctionInfo(lte.normalize(context).toFunctionIdent()), lte.arguments());
+                getBuiltInFunctionInfo(lteIdent.name(), lteIdent.argumentTypes()), lte.arguments());
 
             return AndOperator.of(gteFunc, lteFunc);
         }

--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -463,7 +463,8 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
         );
 
         Function function = (Function) expressionAnalyzer.convert(node.functionCall(), context.expressionAnalysisContext());
-        FunctionImplementation functionImplementation = functions.getSafe(function.info().ident());
+        FunctionIdent ident = function.info().ident();
+        FunctionImplementation functionImplementation = functions.getSafe(ident.schema(), ident.name(), ident.argumentTypes());
         if (functionImplementation.info().type() != FunctionInfo.Type.TABLE) {
             throw new UnsupportedFeatureException(
                 "Non table function " + function.info().ident().name() + " is not supported in from clause");

--- a/sql/src/main/java/io/crate/analyze/symbol/format/SymbolPrinter.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/format/SymbolPrinter.java
@@ -24,10 +24,7 @@ package io.crate.analyze.symbol.format;
 
 import io.crate.analyze.relations.RelationPrinter;
 import io.crate.analyze.symbol.*;
-import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.FunctionImplementation;
-import io.crate.metadata.Functions;
-import io.crate.metadata.Reference;
+import io.crate.metadata.*;
 import io.crate.operation.operator.any.AnyOperator;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
@@ -186,7 +183,8 @@ public class SymbolPrinter {
             OperatorFormatSpec operatorFormatSpec = null;
 
             if (functions != null) {
-                FunctionImplementation impl = functions.get(function.info().ident());
+                FunctionIdent ident = function.info().ident();
+                FunctionImplementation impl = functions.get(ident.schema(), ident.name(), ident.argumentTypes());
                 if (impl instanceof FunctionFormatSpec) {
                     functionFormatSpec = (FunctionFormatSpec) impl;
                 } else if (impl instanceof OperatorFormatSpec) {

--- a/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/SymbolToFieldExtractor.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/SymbolToFieldExtractor.java
@@ -25,6 +25,7 @@ import com.google.common.base.Function;
 import com.google.common.base.Functions;
 import io.crate.analyze.symbol.*;
 import io.crate.analyze.symbol.format.SymbolFormatter;
+import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.Reference;
 import io.crate.metadata.Scalar;
 
@@ -99,7 +100,9 @@ public class SymbolToFieldExtractor<T> {
             for (Symbol argument : symbol.arguments()) {
                 subExtractors.add(process(argument, context));
             }
-            return new FunctionExtractor<>((Scalar) context.functions.getSafe(symbol.info().ident()), subExtractors);
+            FunctionIdent ident = symbol.info().ident();
+            return new FunctionExtractor<>(
+                (Scalar) context.functions.getSafe(ident.schema(), ident.name(), ident.argumentTypes()), subExtractors);
         }
 
         @Override

--- a/sql/src/main/java/io/crate/metadata/FunctionIdent.java
+++ b/sql/src/main/java/io/crate/metadata/FunctionIdent.java
@@ -21,10 +21,8 @@
 
 package io.crate.metadata;
 
-import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.collect.ComparisonChain;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Ordering;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -38,28 +36,39 @@ import java.util.List;
 
 public class FunctionIdent implements Comparable<FunctionIdent>, Streamable {
 
+    private String schema;
     private String name;
     private List<DataType> argumentTypes;
 
     public FunctionIdent() {
-
     }
 
-    public static FunctionIdent of(String name, DataType type1, DataType type2) {
-        return new FunctionIdent(name, ImmutableList.of(type1, type2));
-    }
-
-    public FunctionIdent(String name, List<DataType> argumentTypes) {
+    public FunctionIdent(String schema, String name, List<DataType> argumentTypes) {
+        this.schema = schema;
         this.name = name;
         this.argumentTypes = argumentTypes;
     }
 
-    public List<DataType> argumentTypes() {
-        return argumentTypes;
+    /**
+     * Creates a function ident without a schema.
+     *
+     * @param name          The function name.
+     * @param argumentTypes The list of argument types.
+     */
+    public FunctionIdent(String name, List<DataType> argumentTypes) {
+        this(null, name, argumentTypes);
+    }
+
+    public String schema() {
+        return schema;
     }
 
     public String name() {
         return name;
+    }
+
+    public List<DataType> argumentTypes() {
+        return argumentTypes;
     }
 
     @Override
@@ -72,34 +81,37 @@ public class FunctionIdent implements Comparable<FunctionIdent>, Streamable {
         }
 
         FunctionIdent o = (FunctionIdent) obj;
-        return name.equalsIgnoreCase(o.name) &&
-               Objects.equal(argumentTypes, o.argumentTypes);
+        return Objects.equal(schema, o.schema) &&
+            Objects.equal(name, o.name) &&
+            Objects.equal(argumentTypes, o.argumentTypes);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(name, argumentTypes);
+        return Objects.hashCode(schema, name, argumentTypes);
     }
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("name", name)
-            .add("argumentTypes", argumentTypes)
-            .toString();
+        return "FunctionIdent{" +
+            "schema='" + schema + '\'' +
+            ", name='" + name + '\'' +
+            ", argumentTypes=" + argumentTypes +
+            '}';
     }
 
     @Override
     public int compareTo(FunctionIdent o) {
         return ComparisonChain.start()
             .compare(name, o.name)
+            .compare(schema, o.schema)
             .compare(argumentTypes, o.argumentTypes, Ordering.<DataType>natural().lexicographical())
             .result();
     }
 
-
     @Override
     public void readFrom(StreamInput in) throws IOException {
+        schema = in.readOptionalString();
         name = in.readString();
         int numTypes = in.readVInt();
         argumentTypes = new ArrayList<>(numTypes);
@@ -111,6 +123,7 @@ public class FunctionIdent implements Comparable<FunctionIdent>, Streamable {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
+        out.writeOptionalString(schema);
         out.writeString(name);
         out.writeVInt(argumentTypes.size());
 

--- a/sql/src/main/java/io/crate/operation/BaseImplementationSymbolVisitor.java
+++ b/sql/src/main/java/io/crate/operation/BaseImplementationSymbolVisitor.java
@@ -25,6 +25,7 @@ package io.crate.operation;
 import io.crate.analyze.symbol.*;
 import io.crate.analyze.symbol.format.SymbolFormatter;
 import io.crate.data.Input;
+import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
@@ -42,7 +43,9 @@ public class BaseImplementationSymbolVisitor<C> extends SymbolVisitor<C, Input<?
 
     @Override
     public Input<?> visitFunction(Function function, C context) {
-        final FunctionImplementation functionImplementation = functions.get(function.info().ident());
+        FunctionIdent ident = function.info().ident();
+        final FunctionImplementation functionImplementation =
+            functions.get(ident.schema(), ident.name(), ident.argumentTypes());
         if (functionImplementation instanceof Scalar<?, ?>) {
             List<Symbol> arguments = function.arguments();
             Scalar<?, ?> scalarImpl = ((Scalar) functionImplementation).compile(arguments);

--- a/sql/src/main/java/io/crate/operation/InputFactory.java
+++ b/sql/src/main/java/io/crate/operation/InputFactory.java
@@ -31,6 +31,7 @@ import io.crate.analyze.symbol.SymbolVisitor;
 import io.crate.analyze.symbol.format.SymbolFormatter;
 import io.crate.data.Input;
 import io.crate.data.Row;
+import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
@@ -192,7 +193,8 @@ public class InputFactory {
 
         @Override
         public Input<?> visitAggregation(Aggregation symbol, Void context) {
-            FunctionImplementation impl = functions.get(symbol.functionIdent());
+            FunctionIdent ident = symbol.functionIdent();
+            FunctionImplementation impl = functions.get(ident.schema(), ident.name(), ident.argumentTypes());
             if (impl == null) {
                 throw new UnsupportedOperationException(
                     SymbolFormatter.format("Can't load aggregation impl for symbol %s", symbol));

--- a/sql/src/main/java/io/crate/operation/scalar/arithmetic/FloorFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/arithmetic/FloorFunction.java
@@ -97,6 +97,9 @@ public abstract class FloorFunction extends Scalar<Number, Number> {
 
         @Override
         public Number evaluate(Input<Number>[] args) {
+            if (args == null) {
+                return null;
+            }
             return args[0].value();
         }
 

--- a/sql/src/main/java/io/crate/planner/projection/builder/ProjectionBuilder.java
+++ b/sql/src/main/java/io/crate/planner/projection/builder/ProjectionBuilder.java
@@ -26,10 +26,7 @@ import io.crate.analyze.OrderBy;
 import io.crate.analyze.QueryClause;
 import io.crate.analyze.QuerySpec;
 import io.crate.analyze.symbol.*;
-import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.Functions;
-import io.crate.metadata.RowGranularity;
+import io.crate.metadata.*;
 import io.crate.operation.aggregation.AggregationFunction;
 import io.crate.operation.projectors.TopN;
 import io.crate.planner.projection.*;
@@ -104,9 +101,10 @@ public class ProjectionBuilder {
             }
 
             if (toStep == Aggregation.Step.PARTIAL) {
+                FunctionIdent ident = function.info().ident();
                 aggregation = Aggregation.partialAggregation(
                     function.info(),
-                    ((AggregationFunction) this.functions.get(function.info().ident())).partialType(),
+                    ((AggregationFunction) this.functions.get(ident.schema(), ident.name(), ident.argumentTypes())).partialType(),
                     aggregationInputs
                 );
             } else {

--- a/sql/src/test/java/io/crate/analyze/EvaluatingNormalizerTest.java
+++ b/sql/src/test/java/io/crate/analyze/EvaluatingNormalizerTest.java
@@ -110,13 +110,13 @@ public class EvaluatingNormalizerTest extends CrateUnitTest {
     }
 
     private FunctionInfo functionInfo(String name, DataType dataType, boolean isPredicate) {
-        ImmutableList dataTypes = null;
+        ImmutableList dataTypes;
         if (isPredicate) {
             dataTypes = ImmutableList.of(dataType);
         } else {
             dataTypes = ImmutableList.of(dataType, dataType);
         }
-        return functions.get(new FunctionIdent(name, dataTypes)).info();
+        return functions.get(null, name, dataTypes).info();
     }
 
     private FunctionInfo functionInfo(String name, DataType dataType) {

--- a/sql/src/test/java/io/crate/integrationtests/PostgresITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PostgresITest.java
@@ -633,6 +633,18 @@ public class PostgresITest extends SQLTransportIntegrationTest {
         }
     }
 
+    @Test
+    public void testUseBuiltInFunctionWithSetSchemaOnSession() throws Exception {
+        try (Connection conn = DriverManager.getConnection(JDBC_CRATE_URL, properties)) {
+            conn.setAutoCommit(true);
+
+            conn.createStatement().execute("set session search_path to bar");
+            ResultSet resultSet = conn.createStatement().executeQuery("select concat('foo', 'bar')");
+            assertThat(resultSet.next(), is(true));
+            assertThat(resultSet.getString(1), is("foobar"));
+        }
+    }
+
     private void assertSelectNameFromSysClusterWorks(Connection conn) throws SQLException {
         PreparedStatement stmt;// verify that queries can be made after an error occurred
         stmt = conn.prepareStatement("select name from sys.cluster");

--- a/sql/src/test/java/io/crate/operation/InputFactoryTest.java
+++ b/sql/src/test/java/io/crate/operation/InputFactoryTest.java
@@ -26,6 +26,7 @@ import io.crate.analyze.symbol.*;
 import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.data.RowN;
+import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.operation.aggregation.FunctionExpression;
 import io.crate.operation.collect.CollectExpression;
@@ -158,7 +159,9 @@ public class InputFactoryTest extends CrateUnitTest {
         FunctionImplementation impl = (FunctionImplementation) f.get(expression);
         assertThat(impl.info(), is(function.info()));
 
-        FunctionImplementation uncompiled = expressions.functions().get(function.info().ident());
+        FunctionIdent ident = function.info().ident();
+        FunctionImplementation uncompiled =
+            expressions.functions().get(ident.schema(), ident.name(), ident.argumentTypes());
         assertThat(uncompiled, not(sameInstance(impl)));
     }
 }

--- a/sql/src/test/java/io/crate/operation/aggregation/AggregatorTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/AggregatorTest.java
@@ -25,19 +25,16 @@ import io.crate.analyze.symbol.Aggregation;
 import io.crate.analyze.symbol.InputColumn;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.breaker.RamAccountingContext;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.Functions;
 import io.crate.data.Input;
+import io.crate.metadata.Functions;
 import io.crate.operation.aggregation.impl.CountAggregation;
 import io.crate.test.integration.CrateUnitTest;
-import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.util.Collections;
 
 import static io.crate.testing.TestingHelpers.getFunctions;
@@ -53,8 +50,8 @@ public class AggregatorTest extends CrateUnitTest {
     @Before
     public void setUpFunctions() {
         Functions functions = getFunctions();
-        FunctionIdent countAggIdent = new FunctionIdent(CountAggregation.NAME, Arrays.<DataType>asList(DataTypes.STRING));
-        countImpl = (AggregationFunction) functions.get(countAggIdent);
+        countImpl = (AggregationFunction) functions
+            .get(null, CountAggregation.NAME, Collections.singletonList(DataTypes.STRING));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/aggregation/impl/ArbitraryAggregationTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/impl/ArbitraryAggregationTest.java
@@ -22,7 +22,6 @@
 package io.crate.operation.aggregation.impl;
 
 import com.google.common.collect.ImmutableList;
-import io.crate.metadata.FunctionIdent;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -39,8 +38,8 @@ public class ArbitraryAggregationTest extends AggregationTest {
 
     @Test
     public void testReturnType() throws Exception {
-        FunctionIdent fi = new FunctionIdent("arbitrary", ImmutableList.<DataType>of(DataTypes.INTEGER));
-        assertEquals(DataTypes.INTEGER, functions.get(fi).info().returnType());
+        assertEquals(DataTypes.INTEGER,
+            getFunction("arbitrary", ImmutableList.of(DataTypes.INTEGER)).info().returnType());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/aggregation/impl/AverageAggregationTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/impl/AverageAggregationTest.java
@@ -22,7 +22,6 @@
 package io.crate.operation.aggregation.impl;
 
 import com.google.common.collect.ImmutableList;
-import io.crate.metadata.FunctionIdent;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -36,12 +35,12 @@ public class AverageAggregationTest extends AggregationTest {
 
     @Test
     public void testReturnType() throws Exception {
-        FunctionIdent fi = new FunctionIdent("avg", ImmutableList.<DataType>of(DataTypes.INTEGER));
         // Return type is fixed to Double
-        assertEquals(DataTypes.DOUBLE, functions.get(fi).info().returnType());
+        assertEquals(DataTypes.DOUBLE,
+            getFunction("avg", ImmutableList.<DataType>of(DataTypes.INTEGER)).info().returnType());
 
-        FunctionIdent meanFi = new FunctionIdent("mean", ImmutableList.<DataType>of(DataTypes.INTEGER));
-        assertEquals(DataTypes.DOUBLE, functions.get(meanFi).info().returnType());
+        assertEquals(DataTypes.DOUBLE,
+            getFunction("mean", ImmutableList.of(DataTypes.INTEGER)).info().returnType());
     }
 
     @Test
@@ -81,6 +80,6 @@ public class AverageAggregationTest extends AggregationTest {
 
     @Test(expected = NullPointerException.class)
     public void testUnsupportedType() throws Exception {
-        Object[][] result = executeAggregation(DataTypes.STRING, new Object[][]{{"Youri"}, {"Ruben"}});
+        executeAggregation(DataTypes.STRING, new Object[][]{{"Youri"}, {"Ruben"}});
     }
 }

--- a/sql/src/test/java/io/crate/operation/aggregation/impl/CollectSetAggregationTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/impl/CollectSetAggregationTest.java
@@ -22,11 +22,11 @@
 package io.crate.operation.aggregation.impl;
 
 import com.google.common.collect.ImmutableList;
-import io.crate.metadata.FunctionIdent;
 import io.crate.operation.aggregation.AggregationFunction;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+import io.crate.types.IntegerType;
 import io.crate.types.SetType;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
@@ -45,8 +45,8 @@ public class CollectSetAggregationTest extends AggregationTest {
 
     @Test
     public void testReturnType() throws Exception {
-        FunctionIdent fi = new FunctionIdent("collect_set", ImmutableList.<DataType>of(DataTypes.INTEGER));
-        assertEquals(new SetType(DataTypes.INTEGER), functions.get(fi).info().returnType());
+        assertEquals(new SetType(DataTypes.INTEGER),
+            getFunction("collect_set", ImmutableList.of(DataTypes.INTEGER)).info().returnType());
     }
 
     @Test
@@ -60,8 +60,8 @@ public class CollectSetAggregationTest extends AggregationTest {
 
     @Test
     public void testLongSerialization() throws Exception {
-        FunctionIdent fi = new FunctionIdent("collect_set", ImmutableList.<DataType>of(DataTypes.LONG));
-        AggregationFunction impl = (AggregationFunction) functions.get(fi);
+        AggregationFunction impl =
+            (AggregationFunction) functions.get(null, "collect_set", ImmutableList.of(DataTypes.LONG));
 
         Object state = impl.newState(ramAccountingContext);
 

--- a/sql/src/test/java/io/crate/operation/aggregation/impl/CountAggregationTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/impl/CountAggregationTest.java
@@ -23,7 +23,6 @@ package io.crate.operation.aggregation.impl;
 
 import com.google.common.collect.ImmutableList;
 import io.crate.Streamer;
-import io.crate.metadata.FunctionIdent;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -42,9 +41,9 @@ public class CountAggregationTest extends AggregationTest {
 
     @Test
     public void testReturnType() throws Exception {
-        FunctionIdent fi = new FunctionIdent("count", ImmutableList.<DataType>of(DataTypes.INTEGER));
         // Return type is fixed to Long
-        assertEquals(DataTypes.LONG, functions.get(fi).info().returnType());
+        assertEquals(DataTypes.LONG,
+            getFunction("count", ImmutableList.of(DataTypes.INTEGER)).info().returnType());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/aggregation/impl/GeometricMeanAggregationtest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/impl/GeometricMeanAggregationtest.java
@@ -23,7 +23,6 @@ package io.crate.operation.aggregation.impl;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import io.crate.metadata.FunctionIdent;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -40,9 +39,8 @@ public class GeometricMeanAggregationtest extends AggregationTest {
     @Test
     public void testReturnType() throws Exception {
         for (DataType<?> type : Iterables.concat(DataTypes.NUMERIC_PRIMITIVE_TYPES, Arrays.asList(DataTypes.TIMESTAMP))) {
-            FunctionIdent fi = new FunctionIdent("geometric_mean", ImmutableList.<DataType>of(type));
             // Return type is fixed to Double
-            assertEquals(DataTypes.DOUBLE, functions.get(fi).info().returnType());
+            assertEquals(DataTypes.DOUBLE, getFunction("geometric_mean", ImmutableList.of(type)).info().returnType());
         }
     }
 
@@ -96,6 +94,6 @@ public class GeometricMeanAggregationtest extends AggregationTest {
 
     @Test(expected = NullPointerException.class)
     public void testUnsupportedType() throws Exception {
-        Object[][] result = executeAggregation(DataTypes.BOOLEAN, new Object[][]{{true}, {false}});
+        executeAggregation(DataTypes.BOOLEAN, new Object[][]{{true}, {false}});
     }
 }

--- a/sql/src/test/java/io/crate/operation/aggregation/impl/MaximumAggregationTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/impl/MaximumAggregationTest.java
@@ -22,7 +22,6 @@
 package io.crate.operation.aggregation.impl;
 
 import com.google.common.collect.ImmutableList;
-import io.crate.metadata.FunctionIdent;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -37,8 +36,7 @@ public class MaximumAggregationTest extends AggregationTest {
 
     @Test
     public void testReturnType() throws Exception {
-        FunctionIdent fi = new FunctionIdent("max", ImmutableList.<DataType>of(DataTypes.INTEGER));
-        assertEquals(DataTypes.INTEGER, functions.get(fi).info().returnType());
+        assertEquals(DataTypes.INTEGER, getFunction("max", ImmutableList.of(DataTypes.INTEGER)).info().returnType());
     }
 
     @Test
@@ -86,6 +84,6 @@ public class MaximumAggregationTest extends AggregationTest {
 
     @Test(expected = NullPointerException.class)
     public void testUnsupportedType() throws Exception {
-        Object[][] result = executeAggregation(DataTypes.OBJECT, new Object[][]{{new Object()}});
+        executeAggregation(DataTypes.OBJECT, new Object[][]{{new Object()}});
     }
 }

--- a/sql/src/test/java/io/crate/operation/aggregation/impl/MinimumAggregationTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/impl/MinimumAggregationTest.java
@@ -22,7 +22,6 @@
 package io.crate.operation.aggregation.impl;
 
 import com.google.common.collect.ImmutableList;
-import io.crate.metadata.FunctionIdent;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -37,8 +36,7 @@ public class MinimumAggregationTest extends AggregationTest {
 
     @Test
     public void testReturnType() throws Exception {
-        FunctionIdent fi = new FunctionIdent("min", ImmutableList.<DataType>of(DataTypes.INTEGER));
-        assertEquals(DataTypes.INTEGER, functions.get(fi).info().returnType());
+        assertEquals(DataTypes.INTEGER, getFunction("min", ImmutableList.of(DataTypes.INTEGER)).info().returnType());
     }
 
     @Test
@@ -86,6 +84,6 @@ public class MinimumAggregationTest extends AggregationTest {
 
     @Test(expected = NullPointerException.class)
     public void testUnsupportedType() throws Exception {
-        Object[][] result = executeAggregation(DataTypes.OBJECT, new Object[][]{{new Object()}});
+        executeAggregation(DataTypes.OBJECT, new Object[][]{{new Object()}});
     }
 }

--- a/sql/src/test/java/io/crate/operation/aggregation/impl/PercentileAggregationTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/impl/PercentileAggregationTest.java
@@ -23,7 +23,6 @@ package io.crate.operation.aggregation.impl;
 
 import com.google.common.collect.ImmutableList;
 import io.crate.analyze.symbol.Literal;
-import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.ArrayType;
@@ -47,11 +46,12 @@ public class PercentileAggregationTest extends AggregationTest {
 
     @Test
     public void testReturnTypes() throws Exception {
-        FunctionIdent synopsis1 = new FunctionIdent(NAME, ImmutableList.<DataType>of(DataTypes.DOUBLE, DataTypes.DOUBLE));
-        assertEquals(DataTypes.DOUBLE, functions.get(synopsis1).info().returnType());
-
-        FunctionIdent synopsis2 = new FunctionIdent(NAME, ImmutableList.<DataType>of(DataTypes.DOUBLE, new ArrayType(DataTypes.DOUBLE)));
-        assertEquals(new ArrayType(DataTypes.DOUBLE), functions.get(synopsis2).info().returnType());
+        assertEquals(DataTypes.DOUBLE,
+            getFunction(NAME, ImmutableList.of(DataTypes.DOUBLE, DataTypes.DOUBLE)).info().returnType()
+        );
+        assertEquals(
+            new ArrayType(DataTypes.DOUBLE),
+            getFunction(NAME, ImmutableList.of(DataTypes.DOUBLE, new ArrayType(DataTypes.DOUBLE))).info().returnType());
     }
 
     @Test
@@ -90,7 +90,7 @@ public class PercentileAggregationTest extends AggregationTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testEmptyPercentile() throws Exception {
-        Object[][] result = executeAggregation(DataTypes.INTEGER, new Object[][]{
+        executeAggregation(DataTypes.INTEGER, new Object[][]{
             {1, new Object[]{}},
             {10, new Object[]{}}
         });
@@ -99,7 +99,7 @@ public class PercentileAggregationTest extends AggregationTest {
     @Test(expected = IllegalArgumentException.class)
     public void testNullMultiplePercentiles() throws Exception {
         Double[] fractions = new Double[]{0.25, null};
-        Object[][] result = executeAggregation(DataTypes.INTEGER, new Object[][]{
+        executeAggregation(DataTypes.INTEGER, new Object[][]{
             {1, fractions},
             {10, fractions}
         });
@@ -107,7 +107,7 @@ public class PercentileAggregationTest extends AggregationTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testNegativePercentile() throws Exception {
-        Object[][] result = executeAggregation(DataTypes.INTEGER, new Object[][]{
+        executeAggregation(DataTypes.INTEGER, new Object[][]{
             {1, -1.2},
             {10, -1.2}
         });
@@ -115,7 +115,7 @@ public class PercentileAggregationTest extends AggregationTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testTooLargePercentile() throws Exception {
-        Object[][] result = executeAggregation(DataTypes.INTEGER, new Object[][]{
+        executeAggregation(DataTypes.INTEGER, new Object[][]{
             {1, 1.5},
             {10, 1.5}
         });
@@ -123,7 +123,7 @@ public class PercentileAggregationTest extends AggregationTest {
 
     @Test(expected = NullPointerException.class)
     public void testUnsupportedType() throws Exception {
-        Object[][] result = executeAggregation(DataTypes.STRING, new Object[][]{
+        executeAggregation(DataTypes.STRING, new Object[][]{
             {"Akira", 0.5},
             {"Tetsuo", 0.5}
         });

--- a/sql/src/test/java/io/crate/operation/aggregation/impl/StdDevAggregationTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/impl/StdDevAggregationTest.java
@@ -40,9 +40,10 @@ public class StdDevAggregationTest extends AggregationTest {
     @Test
     public void testReturnType() throws Exception {
         for (DataType<?> type : Iterables.concat(DataTypes.NUMERIC_PRIMITIVE_TYPES, Arrays.asList(DataTypes.TIMESTAMP))) {
-            FunctionIdent fi = new FunctionIdent("stddev", ImmutableList.<DataType>of(type));
+            FunctionIdent fi = new FunctionIdent();
             // Return type is fixed to Double
-            assertEquals(DataTypes.DOUBLE, functions.get(fi).info().returnType());
+            assertEquals(DataTypes.DOUBLE,
+                getFunction("stddev", ImmutableList.of(type)).info().returnType());
         }
     }
 
@@ -102,7 +103,6 @@ public class StdDevAggregationTest extends AggregationTest {
 
     @Test(expected = NullPointerException.class)
     public void testUnsupportedType() throws Exception {
-        Object[][] result = executeAggregation(DataTypes.STRING, new Object[][]{{"Youri"}, {"Ruben"}});
+        executeAggregation(DataTypes.STRING, new Object[][]{{"Youri"}, {"Ruben"}});
     }
-
 }

--- a/sql/src/test/java/io/crate/operation/aggregation/impl/SumAggregationTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/impl/SumAggregationTest.java
@@ -22,7 +22,6 @@
 package io.crate.operation.aggregation.impl;
 
 import com.google.common.collect.ImmutableList;
-import io.crate.metadata.FunctionIdent;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -36,9 +35,9 @@ public class SumAggregationTest extends AggregationTest {
 
     @Test
     public void testReturnType() throws Exception {
-        FunctionIdent fi = new FunctionIdent("sum", ImmutableList.<DataType>of(DataTypes.INTEGER));
         // Return type is fixed to Double
-        assertEquals(DataTypes.DOUBLE, functions.get(fi).info().returnType());
+        assertEquals(DataTypes.DOUBLE,
+            getFunction("sum", ImmutableList.of(DataTypes.INTEGER)).info().returnType());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/aggregation/impl/VarianceAggregationTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/impl/VarianceAggregationTest.java
@@ -23,7 +23,6 @@ package io.crate.operation.aggregation.impl;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import io.crate.metadata.FunctionIdent;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -40,9 +39,8 @@ public class VarianceAggregationTest extends AggregationTest {
     @Test
     public void testReturnType() throws Exception {
         for (DataType<?> type : Iterables.concat(DataTypes.NUMERIC_PRIMITIVE_TYPES, Arrays.asList(DataTypes.TIMESTAMP))) {
-            FunctionIdent fi = new FunctionIdent("variance", ImmutableList.<DataType>of(type));
             // Return type is fixed to Double
-            assertEquals(DataTypes.DOUBLE, functions.get(fi).info().returnType());
+            assertEquals(DataTypes.DOUBLE, getFunction("variance", ImmutableList.of(type)).info().returnType());
         }
     }
 
@@ -96,6 +94,6 @@ public class VarianceAggregationTest extends AggregationTest {
 
     @Test(expected = NullPointerException.class)
     public void testUnsupportedType() throws Exception {
-        Object[][] result = executeAggregation(DataTypes.STRING, new Object[][]{{"Youri"}, {"Ruben"}});
+        executeAggregation(DataTypes.STRING, new Object[][]{{"Youri"}, {"Ruben"}});
     }
 }

--- a/sql/src/test/java/io/crate/operation/collect/DocLevelCollectTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/DocLevelCollectTest.java
@@ -40,7 +40,6 @@ import io.crate.planner.distribution.DistributionInfo;
 import io.crate.planner.node.ExecutionPhase;
 import io.crate.planner.node.dql.RoutedCollectPhase;
 import io.crate.planner.projection.Projection;
-import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.indices.IndicesService;
@@ -150,8 +149,8 @@ public class DocLevelCollectTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testCollectDocLevelWhereClause() throws Throwable {
-        EqOperator op = (EqOperator) functions.get(new FunctionIdent(EqOperator.NAME,
-            ImmutableList.<DataType>of(DataTypes.INTEGER, DataTypes.INTEGER)));
+        EqOperator op = (EqOperator) functions
+            .get(null, EqOperator.NAME, ImmutableList.of(DataTypes.INTEGER, DataTypes.INTEGER));
         List<Symbol> toCollect = Collections.<Symbol>singletonList(testDocLevelReference);
         WhereClause whereClause = new WhereClause(new Function(
             op.info(),

--- a/sql/src/test/java/io/crate/operation/collect/HandlerSideLevelCollectTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/HandlerSideLevelCollectTest.java
@@ -114,8 +114,7 @@ public class HandlerSideLevelCollectTest extends SQLTransportIntegrationTest {
         }
         Symbol tableNameRef = toCollect.get(8);
 
-        FunctionImplementation eqImpl = functions.get(new FunctionIdent(EqOperator.NAME,
-            ImmutableList.of(DataTypes.STRING, DataTypes.STRING)));
+        FunctionImplementation eqImpl = functions.get(null, EqOperator.NAME, ImmutableList.of(DataTypes.STRING, DataTypes.STRING));
         Function whereClause = new Function(eqImpl.info(),
             Arrays.asList(tableNameRef, Literal.of("shards")));
 

--- a/sql/src/test/java/io/crate/operation/projectors/GroupingProjectorTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/GroupingProjectorTest.java
@@ -2,22 +2,20 @@ package io.crate.operation.projectors;
 
 import com.google.common.collect.ImmutableList;
 import io.crate.analyze.symbol.Aggregation;
-import io.crate.analyze.symbol.Symbol;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.data.Bucket;
+import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.data.RowN;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Functions;
 import io.crate.operation.AggregationContext;
-import io.crate.data.Input;
 import io.crate.operation.aggregation.AggregationFunction;
 import io.crate.operation.aggregation.impl.CountAggregation;
 import io.crate.operation.collect.CollectExpression;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.testing.CollectingRowReceiver;
-import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.breaker.CircuitBreaker;
@@ -45,18 +43,18 @@ public class GroupingProjectorTest extends CrateUnitTest {
     @Test
     public void testAggregationToPartial() throws Exception {
 
-        ImmutableList<Input<?>> keys = ImmutableList.<Input<?>>of(
+        ImmutableList<Input<?>> keys = ImmutableList.of(
             new DummyInput(new BytesRef("one"), new BytesRef("one"), new BytesRef("three")));
 
 
-        FunctionInfo countInfo = new FunctionInfo(new FunctionIdent("count", ImmutableList.<DataType>of()), DataTypes.LONG);
+        FunctionInfo countInfo = new FunctionInfo(new FunctionIdent("count", ImmutableList.of()), DataTypes.LONG);
         Aggregation countAggregation =
-            Aggregation.partialAggregation(countInfo, DataTypes.LONG, ImmutableList.<Symbol>of());
+            Aggregation.partialAggregation(countInfo, DataTypes.LONG, ImmutableList.of());
 
         Functions functions = getFunctions();
-
+        FunctionIdent ident = countInfo.ident();
         AggregationContext aggregationContext = new AggregationContext(
-            (AggregationFunction) functions.get(countInfo.ident()),
+            (AggregationFunction) functions.get(ident.schema(), ident.name(), ident.argumentTypes()),
             countAggregation);
 
         AggregationContext[] aggregations = new AggregationContext[]{aggregationContext};

--- a/sql/src/test/java/io/crate/operation/projectors/ProjectionToProjectorVisitorTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/ProjectionToProjectorVisitorTest.java
@@ -240,8 +240,8 @@ public class ProjectionToProjectorVisitorTest extends CrateUnitTest {
 
     @Test
     public void testFilterProjection() throws Exception {
-        EqOperator op = (EqOperator) functions.get(
-            new FunctionIdent(EqOperator.NAME, ImmutableList.of(DataTypes.INTEGER, DataTypes.INTEGER)));
+        EqOperator op = (EqOperator) functions
+            .get(null, EqOperator.NAME, ImmutableList.of(DataTypes.INTEGER, DataTypes.INTEGER));
         Function function = new Function(
             op.info(), Arrays.asList(Literal.of(2), new InputColumn(1)));
         FilterProjection projection = new FilterProjection(function,

--- a/sql/src/test/java/io/crate/operation/projectors/SimpleTopNProjectorTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/SimpleTopNProjectorTest.java
@@ -24,11 +24,10 @@ package io.crate.operation.projectors;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import io.crate.data.Bucket;
+import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.data.Row1;
-import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.Scalar;
-import io.crate.data.Input;
 import io.crate.operation.aggregation.FunctionExpression;
 import io.crate.operation.collect.CollectExpression;
 import io.crate.operation.collect.InputCollectExpression;
@@ -36,7 +35,6 @@ import io.crate.test.integration.CrateUnitTest;
 import io.crate.testing.CollectingRowReceiver;
 import io.crate.testing.RowSender;
 import io.crate.testing.TestingHelpers;
-import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.junit.Test;
 
@@ -155,8 +153,8 @@ public class SimpleTopNProjectorTest extends CrateUnitTest {
 
     @Test
     public void testFunctionExpression() throws Throwable {
-        Scalar floor = (Scalar) TestingHelpers.getFunctions().get(
-            new FunctionIdent("floor", Collections.<DataType>singletonList(DataTypes.DOUBLE)));
+        Scalar floor = (Scalar) TestingHelpers.getFunctions()
+            .get(null, "floor", Collections.singletonList(DataTypes.DOUBLE));
         FunctionExpression<Number, ?> funcExpr = new FunctionExpression<>(floor, new Input[]{input});
         CollectingRowReceiver rowReceiver = new CollectingRowReceiver();
         Projector pipe = new SimpleTopNProjector(ImmutableList.<Input<?>>of(funcExpr), COLLECT_EXPRESSIONS, 10, TopN.NO_OFFSET);

--- a/sql/src/test/java/io/crate/operation/scalar/AbstractScalarFunctionsTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/AbstractScalarFunctionsTest.java
@@ -110,7 +110,8 @@ public abstract class AbstractScalarFunctionsTest extends CrateUnitTest {
             return;
         }
         Function function = (Function) functionSymbol;
-        FunctionImplementation impl = functions.get(function.info().ident());
+        FunctionIdent ident = function.info().ident();
+        FunctionImplementation impl = functions.get(ident.schema(), ident.name(), ident.argumentTypes());
         assertThat(impl, Matchers.notNullValue());
 
         Symbol normalized = sqlExpressions.normalize(function);
@@ -155,7 +156,8 @@ public abstract class AbstractScalarFunctionsTest extends CrateUnitTest {
             return;
         }
         Function function = (Function) functionSymbol;
-        Scalar scalar = (Scalar) functions.getSafe(function.info().ident());
+        FunctionIdent ident = function.info().ident();
+        Scalar scalar = (Scalar) functions.get(ident.schema(), ident.name(), ident.argumentTypes());
 
         InputApplierContext inputApplierContext = new InputApplierContext(inputs, sqlExpressions);
         AssertingInput[] arguments = new AssertingInput[function.arguments().size()];
@@ -167,7 +169,7 @@ public abstract class AbstractScalarFunctionsTest extends CrateUnitTest {
                 arguments[i] = new AssertingInput(INPUT_APPLIER.process(arg, inputApplierContext));
             }
         }
-        assertThat(scalar.compile(function.arguments()).evaluate((Input[] )arguments), is(expectedValue));
+        assertThat(scalar.compile(function.arguments()).evaluate((Input[]) arguments), is(expectedValue));
         for (AssertingInput argument : arguments) {
             argument.calls = 0;
         }
@@ -180,7 +182,8 @@ public abstract class AbstractScalarFunctionsTest extends CrateUnitTest {
         functionSymbol = sqlExpressions.normalize(functionSymbol);
         assertThat("function expression was normalized, compile would not be hit", functionSymbol, not(instanceOf(Literal.class)));
         Function function = (Function) functionSymbol;
-        Scalar scalar = (Scalar) functions.get(function.info().ident());
+        FunctionIdent ident = function.info().ident();
+        Scalar scalar = (Scalar) functions.get(ident.schema(), ident.name(), ident.argumentTypes());
         assert scalar != null : "function must be registered";
 
         Scalar compiled = scalar.compile(function.arguments());
@@ -204,7 +207,12 @@ public abstract class AbstractScalarFunctionsTest extends CrateUnitTest {
 
     @SuppressWarnings("unchecked")
     protected <T extends FunctionImplementation> T getFunction(String functionName, List<DataType> argTypes) {
-        return (T) functions.get(new FunctionIdent(functionName, argTypes));
+        return getFunction(null, functionName, argTypes);
+    }
+
+    @SuppressWarnings("unchecked")
+    protected <T extends FunctionImplementation> T getFunction(String schema, String functionName, List<DataType> argTypes) {
+        return (T) functions.get(schema, functionName, argTypes);
     }
 
     protected Symbol normalize(String functionName, Object value, DataType type) {
@@ -307,7 +315,8 @@ public abstract class AbstractScalarFunctionsTest extends CrateUnitTest {
             try {
                 return (Input) context.sqlExpressions.normalize(function);
             } catch (Exception e) {
-                Scalar scalar = (Scalar) context.sqlExpressions.functions().get(function.info().ident());
+                FunctionIdent ident = function.info().ident();
+                Scalar scalar = (Scalar) context.sqlExpressions.functions().get(ident.schema(), ident.name(), ident.argumentTypes());
                 return new FunctionExpression<>(scalar, argInputs);
             }
         }

--- a/sql/src/test/java/io/crate/operation/scalar/SubscriptFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/SubscriptFunctionTest.java
@@ -21,8 +21,6 @@
 
 package io.crate.operation.scalar;
 
-import io.crate.metadata.FunctionIdent;
-import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.SetType;
 import org.junit.Test;
@@ -54,9 +52,11 @@ public class SubscriptFunctionTest extends AbstractScalarFunctionsTest {
     public void testNotRegisteredForSets() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
         expectedException.expectMessage("unknown function: subscript(integer_set, integer)");
-        FunctionIdent functionIdent = new FunctionIdent(SubscriptFunction.NAME,
-            Arrays.<DataType>asList(new SetType(DataTypes.INTEGER), DataTypes.INTEGER));
-        functions.getSafe(functionIdent);
+        functions.getSafe(
+            null,
+            SubscriptFunction.NAME,
+            Arrays.asList(new SetType(DataTypes.INTEGER), DataTypes.INTEGER)
+        );
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/scalar/arithmetic/AddFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/arithmetic/AddFunctionTest.java
@@ -21,9 +21,7 @@
 
 package io.crate.operation.scalar.arithmetic;
 
-import io.crate.metadata.FunctionIdent;
 import io.crate.operation.scalar.AbstractScalarFunctionsTest;
-import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.junit.Test;
 
@@ -33,7 +31,6 @@ public class AddFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testTimestampTypeValidation() throws Exception {
-        functions.get(new FunctionIdent(AddFunction.NAME,
-            Arrays.<DataType>asList(DataTypes.TIMESTAMP, DataTypes.TIMESTAMP)));
+        functions.get(null, AddFunction.NAME, Arrays.asList(DataTypes.TIMESTAMP, DataTypes.TIMESTAMP));
     }
 }

--- a/sql/src/test/java/io/crate/operation/scalar/arithmetic/LogFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/arithmetic/LogFunctionTest.java
@@ -25,10 +25,9 @@ import io.crate.action.sql.SessionContext;
 import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
-import io.crate.metadata.FunctionIdent;
+import io.crate.data.Input;
 import io.crate.metadata.Reference;
 import io.crate.metadata.TransactionContext;
-import io.crate.data.Input;
 import io.crate.operation.scalar.AbstractScalarFunctionsTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -47,11 +46,11 @@ public class LogFunctionTest extends AbstractScalarFunctionsTest {
     private TransactionContext transactionContext = new TransactionContext(SessionContext.SYSTEM_SESSION);
 
     private LogFunction getFunction(String name, DataType value) {
-        return (LogFunction) functions.get(new FunctionIdent(name, Arrays.asList(value)));
+        return (LogFunction) getFunction(name, Arrays.asList(value));
     }
 
     private LogFunction getFunction(String name, DataType value, DataType base) {
-        return (LogFunction) functions.get(new FunctionIdent(name, Arrays.asList(value, base)));
+        return (LogFunction) getFunction(name, Arrays.asList(value, base));
     }
 
     private Symbol normalizeLog(Number value, DataType valueType) {
@@ -213,5 +212,4 @@ public class LogFunctionTest extends AbstractScalarFunctionsTest {
 
         assertThat(evaluateLn(null, DataTypes.DOUBLE), nullValue());
     }
-
 }

--- a/sql/src/test/java/io/crate/operation/scalar/arithmetic/RandomFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/arithmetic/RandomFunctionTest.java
@@ -23,12 +23,9 @@ package io.crate.operation.scalar.arithmetic;
 
 import io.crate.action.sql.SessionContext;
 import io.crate.analyze.symbol.Function;
-import io.crate.analyze.symbol.Symbol;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.TransactionContext;
 import io.crate.data.Input;
+import io.crate.metadata.TransactionContext;
 import io.crate.operation.scalar.AbstractScalarFunctionsTest;
-import io.crate.types.DataType;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -44,8 +41,7 @@ public class RandomFunctionTest extends AbstractScalarFunctionsTest {
 
     @Before
     public void prepareRandom() {
-        random = (RandomFunction) functions.get(new FunctionIdent(RandomFunction.NAME, Collections.<DataType>emptyList()));
-
+        random = (RandomFunction) functions.get(null, RandomFunction.NAME, Collections.emptyList());
     }
 
     @Test
@@ -56,9 +52,8 @@ public class RandomFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void normalizeReference() {
-        Function function = new Function(random.info(), Collections.<Symbol>emptyList());
+        Function function = new Function(random.info(), Collections.emptyList());
         Function normalized = (Function) random.normalizeSymbol(function, new TransactionContext(SessionContext.SYSTEM_SESSION));
         assertThat(normalized, sameInstance(function));
     }
-
 }

--- a/sql/src/test/java/io/crate/operation/tablefunctions/UnnestFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/tablefunctions/UnnestFunctionTest.java
@@ -27,6 +27,7 @@ import io.crate.analyze.relations.DocTableRelation;
 import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.data.Bucket;
+import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.Functions;
 import io.crate.metadata.tablefunctions.TableFunctionImplementation;
 import io.crate.data.Input;
@@ -57,7 +58,9 @@ public class UnnestFunctionTest extends CrateUnitTest {
         Symbol functionSymbol = sqlExpressions.asSymbol(expr);
         functionSymbol = sqlExpressions.normalize(functionSymbol);
         Function function = (Function) functionSymbol;
-        TableFunctionImplementation tableFunction = (TableFunctionImplementation) functions.getSafe(function.info().ident());
+        FunctionIdent ident = function.info().ident();
+        TableFunctionImplementation tableFunction =
+            (TableFunctionImplementation) functions.getSafe(ident.schema(), ident.name(), ident.argumentTypes());
         return tableFunction.execute(function.arguments().stream().map(a -> (Input) a).collect(Collectors.toList()));
     }
 


### PR DESCRIPTION
The signature of the ``get`` method does not require a function ident any longer.

    get(schema, functionName, argumentTypes)

The new signature will prevent us from initializing the function ident upon Functions.get calls.