### PR TITLE
Removed path to sigar lib in crate.bat for Windows

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for Crate
 Unreleased
 ==========
 
+ - Fixed an issue that prevent a node from starting on Windows if the
+   sigar-plugin is removed.
+
  - Fix: Case sensivity of aliases wasn't handled correctly.
    Aliases are now fully case sensitive.
 

--- a/app/src/bin/crate.bat
+++ b/app/src/bin/crate.bat
@@ -57,7 +57,7 @@ REM Ensure UTF-8 encoding by default (e.g. filenames)
 set JAVA_OPTS=%JAVA_OPTS% -Dfile.encoding=UTF-8
 
 if "%CRATE_CLASSPATH%" == "" (
-    set CRATE_CLASSPATH=%CRATE_HOME%/lib/crate-app-@version@.jar;%CRATE_HOME%/lib/*;%CRATE_HOME%/plugins/sigar/lib/*
+    set CRATE_CLASSPATH=%CRATE_HOME%/lib/crate-app-@version@.jar;%CRATE_HOME%/lib/*
 ) else (
     ECHO Error: Don't modify the classpath with CRATE_CLASSPATH. 1>&2
     ECHO Add plugins and their dependencies into the plugins/ folder instead. 1>&2


### PR DESCRIPTION
Automatic plugin load mechanism does not require the path to sigar lib anymore. This fixed a bug that prevent CrateDB from starting if the sigar-plugin is removed.