### PR TITLE
Fix NPE in due to MultiConsumer failure handling

### DIFF
--- a/dex/src/main/java/io/crate/data/ListenableBatchConsumer.java
+++ b/dex/src/main/java/io/crate/data/ListenableBatchConsumer.java
@@ -36,7 +36,12 @@ public class ListenableBatchConsumer implements BatchConsumer {
 
     @Override
     public void accept(BatchIterator iterator, @Nullable Throwable failure) {
-        delegate.accept(new ListenableBatchIterator(iterator, completionFuture), failure);
+        if (failure == null) {
+            delegate.accept(new ListenableBatchIterator(iterator, completionFuture), null);
+        } else {
+            delegate.accept(null, failure);
+            completionFuture.completeExceptionally(failure);
+        }
     }
 
     @Override

--- a/dex/src/test/java/io/crate/data/ListenableBatchConsumerTest.java
+++ b/dex/src/test/java/io/crate/data/ListenableBatchConsumerTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.data;
+
+import io.crate.testing.TestingBatchConsumer;
+import org.junit.Test;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.fail;
+
+public class ListenableBatchConsumerTest {
+
+    @Test
+    public void testErrorCaseHandling() throws Exception {
+        TestingBatchConsumer consumer = new TestingBatchConsumer();
+        ListenableBatchConsumer listenableBatchConsumer = new ListenableBatchConsumer(consumer);
+
+        listenableBatchConsumer.accept(null, new IllegalStateException("dummy"));
+
+
+        // both the delegate consumer must receive the error and also the listenableBatchConsumers future must trigger
+        try {
+            consumer.getResult();
+            fail("should have raised an exception");
+        } catch (IllegalStateException e) {
+            // expected
+        }
+
+        try {
+            listenableBatchConsumer.completionFuture().get(10, TimeUnit.SECONDS);
+            fail("should have raised an exception");
+        } catch (ExecutionException e) {
+            // expected
+        }
+    }
+}

--- a/dex/src/test/java/io/crate/testing/TestingBatchConsumer.java
+++ b/dex/src/test/java/io/crate/testing/TestingBatchConsumer.java
@@ -54,6 +54,9 @@ public class TestingBatchConsumer implements BatchConsumer, Killable {
                     it.close();
                 });
         } else {
+            if (it != null) {
+                it.close();
+            }
             result.completeExceptionally(failure);
         }
     }

--- a/sql/src/main/java/io/crate/operation/collect/collectors/CompositeCollector.java
+++ b/sql/src/main/java/io/crate/operation/collect/collectors/CompositeCollector.java
@@ -113,7 +113,12 @@ public class CompositeCollector implements CrateCollector {
                 iterators[remaining] = iterator;
             }
             if (remaining == 0) {
-                consumer.accept(compositeBatchIteratorFactory.apply(iterators), lastFailure);
+                // null checks to avoid using the factory with potential null-entries within the iterators
+                if (lastFailure == null) {
+                    consumer.accept(compositeBatchIteratorFactory.apply(iterators), null);
+                } else {
+                    consumer.accept(null, lastFailure);
+                }
             }
         }
 


### PR DESCRIPTION
If the first `accept` call didn't receive a BatchIterator but a failure
this led to a NPE in the CompositeColumns constructor as the first
iterator is used to retrieve the number of columns.

The CompositeBatchIterators are generally not expecting nulled
iterators, so this changes the MultiConsumer to not create a
CompositeBatchIterator if there was a failure.