### PR TITLE
Change order of syschecks

### DIFF
--- a/blackbox/docs/sql/system.txt
+++ b/blackbox/docs/sql/system.txt
@@ -1132,8 +1132,8 @@ Example query::
   +----+--------------------------------------------------------------...-+
   |  1 | The setting 'discovery.zen.minimum_master_nodes' must not be ... |
   |  2 | The total number of partitions of one or more partitioned tab... |
-  |  3 | The following tables need to be recreated for compatibility w... |
-  |  4 | The following tables need to be upgraded for compatibility wi... |
+  |  3 | The following tables need to be upgraded for compatibility wi... |
+  |  4 | The following tables need to be recreated for compatibility w... |
   +----+--------------------------------------------------------------...-+
   SELECT 4 rows in set (... sec)
 
@@ -1165,16 +1165,16 @@ This check warns if any :ref:`partitioned table <partitioned_tables>` has more
 than 1000 partitions to detect the usage of a high cardinality field for
 partitioning.
 
-Tables need to be recreated
-...........................
-This check warns if there are tables that need to be recreated for compatibility with
-future versions of CrateDB.
-
 Tables need to be upgraded
 ..........................
 This check warns if there are tables that need to be upgraded for compatibility with
 future versions of CrateDB. For help upgrading these tables,
-see :ref:`optimize_segments_upgrade`. 
+see :ref:`optimize_segments_upgrade`.
+
+Tables need to be recreated
+...........................
+This check warns if there are tables that need to be recreated for compatibility with
+future versions of CrateDB.
 
 .. _sys-repositories:
 

--- a/sql/src/main/java/io/crate/operation/reference/sys/check/cluster/TablesNeedRecreationSysCheck.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/check/cluster/TablesNeedRecreationSysCheck.java
@@ -33,7 +33,7 @@ import java.util.Collection;
 @Singleton
 public class TablesNeedRecreationSysCheck extends AbstractSysCheck {
 
-    public static final int ID = 3;
+    public static final int ID = 4;
     public static final String DESCRIPTION =
         "The following tables need to be recreated for compatibility with future versions of CrateDB: ";
 

--- a/sql/src/main/java/io/crate/operation/reference/sys/check/cluster/TablesNeedUpgradeSysCheck.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/check/cluster/TablesNeedUpgradeSysCheck.java
@@ -43,7 +43,7 @@ import java.util.concurrent.CompletableFuture;
 @Singleton
 public class TablesNeedUpgradeSysCheck extends AbstractSysCheck {
 
-    public static final int ID = 4;
+    public static final int ID = 3;
     public static final String DESCRIPTION =
         "The following tables need to be upgraded for compatibility with future versions of CrateDB: ";
 
@@ -53,7 +53,7 @@ public class TablesNeedUpgradeSysCheck extends AbstractSysCheck {
                                        "AND (NOT schema_name || '.' || table_name = ANY (?)) " +
                                        "order by 1";
     private static final int LIMIT = 50_000;
-    private static final String PREP_STMT_NAME = "tables_need_recrate_syscheck";
+    private static final String PREP_STMT_NAME = "tables_need_upgrade_syscheck";
 
     private final ESLogger logger;
     private final ClusterService clusterService;

--- a/sql/src/test/java/io/crate/integrationtests/TableCompatibilitySysChecksTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TableCompatibilitySysChecksTest.java
@@ -84,18 +84,18 @@ public class TableCompatibilitySysChecksTest extends SQLTransportIntegrationTest
         startUpNodeWithDataDir("/indices/data_home/cratedata_upgrade_and_recreate_required.zip");
         execute("select * from sys.checks where passed = false order by id");
         assertThat(response.rowCount(), is(2L));
-        assertThat(response.rows()[0][1], is(TablesNeedRecreationSysCheck.ID));
+        assertThat(response.rows()[0][1], is(TablesNeedUpgradeSysCheck.ID));
         assertThat(response.rows()[0][3], is(SysCheck.Severity.MEDIUM.value()));
         assertThat(response.rows()[0][0],
-            is(TablesNeedRecreationSysCheck.DESCRIPTION +
-               "[doc.test_recreation_required, doc.test_recreation_required_parted] " +
-               LINK_PATTERN + TablesNeedRecreationSysCheck.ID));
-        assertThat(response.rows()[1][1], is(TablesNeedUpgradeSysCheck.ID));
-        assertThat(response.rows()[1][3], is(SysCheck.Severity.MEDIUM.value()));
-        assertThat(response.rows()[1][0],
             is(TablesNeedUpgradeSysCheck.DESCRIPTION +
                "[doc.test_upgrade_required, doc.test_upgrade_required_parted] " +
                LINK_PATTERN + TablesNeedUpgradeSysCheck.ID));
+        assertThat(response.rows()[1][1], is(TablesNeedRecreationSysCheck.ID));
+        assertThat(response.rows()[1][3], is(SysCheck.Severity.MEDIUM.value()));
+        assertThat(response.rows()[1][0],
+            is(TablesNeedRecreationSysCheck.DESCRIPTION +
+               "[doc.test_recreation_required, doc.test_recreation_required_parted] " +
+               LINK_PATTERN + TablesNeedRecreationSysCheck.ID));
     }
 
     @Test


### PR DESCRIPTION
The latter (ID: 4 recreation required) will be removed easily in future CrateDB version with ES 5.