### PR TITLE
Fix masterNode check in DefaultTemplateService

### DIFF
--- a/sql/src/main/java/io/crate/metadata/DefaultTemplateService.java
+++ b/sql/src/main/java/io/crate/metadata/DefaultTemplateService.java
@@ -30,6 +30,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.settings.Settings;
@@ -59,7 +60,8 @@ public class DefaultTemplateService extends AbstractComponent {
     }
 
     public void createIfNotExists(ClusterState state) {
-        if (clusterService.localNode().isMasterNode() == false) {
+        DiscoveryNodes nodes = state.nodes();
+        if (nodes.getMasterNodeId().equals(nodes.getLocalNodeId()) == false) {
             return;
         }
         if (state.getMetaData().getTemplates().containsKey(TEMPLATE_NAME) == false) {


### PR DESCRIPTION
`isMasterNode` is true if a node is eligible to become master, it
doesn't indicate if it's the *current* master.