### PR TITLE
fixes flaky GeoJSONUtil test by not randomizing it

### DIFF
--- a/core/src/test/java/io/crate/geo/GeoJSONUtilsTest.java
+++ b/core/src/test/java/io/crate/geo/GeoJSONUtilsTest.java
@@ -31,16 +31,21 @@ import com.spatial4j.core.shape.jts.JtsGeometry;
 import com.spatial4j.core.shape.jts.JtsPoint;
 import com.vividsolutions.jts.geom.*;
 import com.vividsolutions.jts.geom.impl.CoordinateArraySequenceFactory;
-import io.crate.test.integration.CrateUnitTest;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.util.List;
 import java.util.Map;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.hamcrest.core.Is.is;
 
-public class GeoJSONUtilsTest extends CrateUnitTest {
+public class GeoJSONUtilsTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
 
     static {
         ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);


### PR DESCRIPTION
Otherwise the default locale changes randomly and will break expected
results. Geometry uses DecimalFormat at its toString methods which uses
always the current set locale.

Follow up commit of 71640ee7f5aa956f9c49d21150357246082627d3.