### PR TITLE
Stop using the future.isDone() in batchiterator tester

### DIFF
--- a/dex/src/main/java/io/crate/data/AsyncCompositeBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/AsyncCompositeBatchIterator.java
@@ -133,9 +133,7 @@ public class AsyncCompositeBatchIterator implements BatchIterator {
             (List<CompletableFuture<?>> loadNextBatchFutures) ->
                 // Future that'll wait for all loadNextBatch futures to complete
                 CompletableFuture.allOf(loadNextBatchFutures.toArray(new CompletableFuture[0]))
-                    // loading is complete when all loadNextBatch futures are complete
-                    .whenComplete((r, t) -> loading = false)
-        );
+        ).whenComplete((r, t) -> loading = false);
     }
 
     @Override


### PR DESCRIPTION
In order to test the moveNext is throwing exception whilst an iterator is loading, we use 
the loadNextBatchFuture.isDone flag to determine that an iterator has actually completed 
loading.
isDone can return false even though certain implementation signaled internally that they 
have completed loading and this contradiction makes BatchIteratorTester.testIllegalStateIsRaisedIfMoveIsCalledWhileLoadingNextBatch flaky

This PR relaxes the test semantics to what we actually intended testing: that the iterators 
throw exceptions when moveNext is invoked whilst the iterator is loading.