### PR TITLE
Fix pageResultListener leak

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,8 @@ Changes for Crate
 
 Unreleased
 ==========
+
+ - Fixed a race condition in `KILL` statements which lead to a memory leak.
  
  - Fixed an issue that prevent a node from starting on Windows if the
    sigar-plugin is removed.


### PR DESCRIPTION
A PageDownstreamContext that is being killed may still receive
`setBucket` calls because the context is still accessible until the kill
operation is completed.

The response listeners that happened between this "kill already in
progress" and "context is removed" window where never released.