### PR TITLE
Improve kill handling in CollectingBatchIterator/AsyncOperationBatchIterator

### DIFF
--- a/dex/src/main/java/io/crate/data/CollectingBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/CollectingBatchIterator.java
@@ -138,7 +138,7 @@ public class CollectingBatchIterator<A> implements BatchIterator {
 
     @Override
     public void kill(@Nonnull Throwable throwable) {
-        resultFuture.cancel(true);
+        source.kill(throwable);
         // rest is handled by CloseAssertingBatchIterator
     }
 }


### PR DESCRIPTION
CollectingBatchIterator now forwards the kill call to its source instead
of cancelling the future, in order to give the source the chance to
handle the kill itself.

AsyncOperationBatchIterator will now check the killed state if
`processBatch` fails and in case it was killed prefer the killed
exception over the `processBatch` failure.

In the fetch-operation case a user invoked kill might remove the
FetchContext which causes `processBatch` to fail with a context not
found exception.
This led to the user getting this context not found exception instead of
the expected "job killed" error.

This doesn't solve the issue completely as there is still a race
condition where the handler-node receives the kill request *after* a
node with a FetchContext has already been killed and led to the error.