### PR TITLE
Narrow locks to improve kill behaviour

### DIFF
--- a/dex/src/main/java/io/crate/data/CloseAssertingBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/CloseAssertingBatchIterator.java
@@ -26,7 +26,6 @@ import io.crate.concurrent.CompletableFutures;
 import io.crate.exceptions.Exceptions;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.concurrent.CompletionStage;
 
 public class CloseAssertingBatchIterator implements BatchIterator {
@@ -92,7 +91,7 @@ public class CloseAssertingBatchIterator implements BatchIterator {
 
     @Override
     public void kill(@Nonnull Throwable throwable) {
-        killed = throwable;
         delegate.kill(throwable);
+        killed = throwable;
     }
 }

--- a/sql/src/main/java/io/crate/action/sql/BatchConsumerToResultReceiver.java
+++ b/sql/src/main/java/io/crate/action/sql/BatchConsumerToResultReceiver.java
@@ -27,6 +27,7 @@ import io.crate.data.BatchIterator;
 import io.crate.data.Row;
 import io.crate.data.RowBridging;
 import io.crate.exceptions.JobKilledException;
+import io.crate.exceptions.SQLExceptions;
 
 import javax.annotation.Nullable;
 
@@ -81,7 +82,7 @@ public class BatchConsumerToResultReceiver implements BatchConsumer {
                     consumeIt(iterator);
                 } else {
                     iterator.close();
-                    resultReceiver.fail(f);
+                    resultReceiver.fail(SQLExceptions.unwrap(f));
                 }
             });
         }

--- a/sql/src/main/java/io/crate/executor/transport/executionphases/SetBucketCallback.java
+++ b/sql/src/main/java/io/crate/executor/transport/executionphases/SetBucketCallback.java
@@ -23,6 +23,7 @@
 package io.crate.executor.transport.executionphases;
 
 import io.crate.data.Bucket;
+import io.crate.exceptions.SQLExceptions;
 import io.crate.jobs.PageBucketReceiver;
 
 import java.util.List;
@@ -39,7 +40,7 @@ class SetBucketCallback extends SetBucketAction implements BiConsumer<List<Bucke
         if (throwable == null) {
             setBuckets(buckets);
         } else {
-            failed(throwable);
+            failed(SQLExceptions.unwrap(throwable));
         }
     }
 }

--- a/sql/src/main/java/io/crate/operation/collect/files/FileReadingIterator.java
+++ b/sql/src/main/java/io/crate/operation/collect/files/FileReadingIterator.java
@@ -81,8 +81,6 @@ public class FileReadingIterator implements BatchIterator {
     private LineContext lineContext;
     private final Columns inputs;
 
-    private volatile Throwable killed;
-
     private FileReadingIterator(Collection<String> fileUris,
                                 List<? extends Input<?>> inputs,
                                 Iterable<LineCollectorExpression<?>> collectorExpressions,


### PR DESCRIPTION
This narrows the locking in BatchIteratorCollectorBridge.
`consumer.accept(...)` can be synchronous. Due to that `kill` didn't
have any effect until the whole consume operation was finished because
both `doCollect` (which calls the consumer) and `kill` were synchronized.

This commit changes the locking so that `consumer.accept(...)` is called
outside of a lock.