### PR TITLE
BatchIterators: Swap close/kill checks

### DIFF
--- a/dex/src/main/java/io/crate/data/AsyncOperationBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/AsyncOperationBatchIterator.java
@@ -196,11 +196,11 @@ public class AsyncOperationBatchIterator implements BatchIterator {
     }
 
     private void raiseIfClosedOrKilled() {
-        if (closed) {
-            throw new IllegalStateException("BatchIterator is closed");
-        }
         if (killed != null) {
             Exceptions.rethrowUnchecked(killed);
+        }
+        if (closed) {
+            throw new IllegalStateException("BatchIterator is closed");
         }
     }
 

--- a/dex/src/main/java/io/crate/data/CloseAssertingBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/CloseAssertingBatchIterator.java
@@ -76,11 +76,11 @@ public class CloseAssertingBatchIterator implements BatchIterator {
     }
 
     private void raiseIfClosedOrKilled() {
-        if (closed) {
-            throw new IllegalStateException("Iterator is closed");
-        }
         if (killed != null) {
             Exceptions.rethrowUnchecked(killed);
+        }
+        if (closed) {
+            throw new IllegalStateException("Iterator is closed");
         }
     }
 

--- a/sql/src/main/java/io/crate/operation/collect/collectors/LuceneBatchIterator.java
+++ b/sql/src/main/java/io/crate/operation/collect/collectors/LuceneBatchIterator.java
@@ -224,11 +224,11 @@ public class LuceneBatchIterator implements BatchIterator {
     }
 
     private void raiseIfClosedOrKilled() {
-        if (closed) {
-            throw new IllegalStateException("BatchIterator is closed");
-        }
         if (killed != null) {
             Exceptions.rethrowUnchecked(killed);
+        }
+        if (closed) {
+            throw new IllegalStateException("BatchIterator is closed");
         }
     }
 

--- a/sql/src/main/java/io/crate/operation/merge/BatchPagingIterator.java
+++ b/sql/src/main/java/io/crate/operation/merge/BatchPagingIterator.java
@@ -156,11 +156,11 @@ public class BatchPagingIterator<Key> implements BatchIterator {
     }
 
     private void raiseIfClosedOrKilled() {
-        if (closed) {
-            throw new IllegalStateException("Iterator is closed");
-        }
         if (killed != null) {
             Exceptions.rethrowUnchecked(killed);
+        }
+        if (closed) {
+            throw new IllegalStateException("Iterator is closed");
         }
     }
 


### PR DESCRIPTION
Kill can cause a BatchIterator to get closed which could lead to the
"BatchIterator is closed" exception instead of the kill-reason to be
raised.

`testKillUpdateByQuery` could fail because of this.