### PR TITLE
add subscript support for object literals

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -15,12 +15,14 @@ the appropriate section of the docs.
 Changelog
 =========
 
+  - Added the subscript function support for object literals.
+
   - Updated crate-admin to ``1.2.0`` which includes the following changes:
 
     - Added monitoring plugin (enterprise)
 
     - Added Lazy loading of the stylesheet and plugins depending
-       on the enterprise settings.  
+       on the enterprise settings.
 
     - Added buttons to collapse and expand all schemas in the tables view.
 
@@ -38,7 +40,7 @@ Changelog
 
     - Fixed issue that caused `Cluster Offline` message to not be displayed.
 
-    - Fixed a console results issue that caused the results table not to be 
+    - Fixed a console results issue that caused the results table not to be
        visible after horizontal scrolling.
 
     - Fixed styling issue that caused the last element in the side bar
@@ -46,7 +48,7 @@ Changelog
 
     - Fixed an issue that caused the notification date to be `null` in safari.
 
-    - Fixed a console results issue that caused the results table not to be 
+    - Fixed a console results issue that caused the results table not to be
        displayed after horizontal scrolling.
 
     - Fixed an issue that caused the admin-ui to load only one plugin.
@@ -54,7 +56,7 @@ Changelog
     - Display warning in the console view when the query result contains
        an unsafe integer.
 
-    - Relocated the help resources section to be underneath the tweet 
+    - Relocated the help resources section to be underneath the tweet
        import tutorial.
 
     - Show loading indicator when `Execute Query ` is in progress.

--- a/sql/src/main/java/io/crate/analyze/SubscriptValidator.java
+++ b/sql/src/main/java/io/crate/analyze/SubscriptValidator.java
@@ -64,6 +64,12 @@ public final class SubscriptValidator {
         }
 
         @Override
+        public Void visitObjectLiteral(ObjectLiteral node, SubscriptContext context) {
+            context.expression(node);
+            return null;
+        }
+
+        @Override
         protected Void visitCast(Cast node, SubscriptContext context) {
             context.expression(node);
             return null;

--- a/sql/src/main/java/io/crate/operation/scalar/SubscriptObjectFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/SubscriptObjectFunction.java
@@ -30,6 +30,7 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.lucene.BytesRefs;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 public class SubscriptObjectFunction extends Scalar<Object, Map> {
@@ -71,6 +72,11 @@ public class SubscriptObjectFunction extends Scalar<Object, Map> {
         assert element instanceof Map : "first argument must be of type Map";
         assert key instanceof BytesRef : "second argument must be of type BytesRef";
 
-        return ((Map) element).get(BytesRefs.toString(key));
+        Map m = (Map) element;
+        String k = BytesRefs.toString(key);
+        if (!m.containsKey(k)) {
+            throw new IllegalArgumentException(String.format(Locale.ENGLISH, "The object does not contain [%s] key", k));
+        }
+        return m.get(k);
     }
 }


### PR DESCRIPTION
Expressions like ``{"key"=10}['key']`` can be evaluated now.