### PR TITLE
fixup! sets a random crate node name if none is defined

### DIFF
--- a/sql/src/main/java/io/crate/operation/collect/files/SummitsIterable.java
+++ b/sql/src/main/java/io/crate/operation/collect/files/SummitsIterable.java
@@ -27,7 +27,6 @@ import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.primitives.Ints;
 import io.crate.types.DataTypes;
-import org.elasticsearch.node.internal.InternalSettingsPreparer;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -53,7 +52,7 @@ public class SummitsIterable implements Iterable<SummitsContext> {
 
     private List<SummitsContext> fetchSummits() {
         List<SummitsContext> summits = new ArrayList<>();
-        try (InputStream input = InternalSettingsPreparer.class.getResourceAsStream("/config/names.txt")) {
+        try (InputStream input = SummitsIterable.class.getResourceAsStream("/config/names.txt")) {
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8))) {
                 String line;
                 while ((line = reader.readLine()) != null) {

--- a/sql/src/main/resources/config/names.txt
+++ b/sql/src/main/resources/config/names.txt
@@ -1,0 +1,1605 @@
+Mont Blanc	4808	4695	POINT(6.86444 45.8325)	Mont Blanc massif	I/B-07.V-B	U-Savoy/Aosta	FR/IT	1786
+Monte Rosa	4634	2165	POINT(7.86694 45.93694)	Monte Rosa Alps	I/B-09.III-A	Valais	CH	1855
+Dom	4545	1046	POINT(7.85889 46.09389)	Mischabel	I/B-09.V-A	Valais	CH	1858
+Liskamm	4527	376	POINT(7.83556 45.92222)	Monte Rosa Alps	I/B-09.III-A	Valais/Aosta	CH/IT	1861
+Weisshorn	4506	1235	POINT(7.71583 46.10139)	Weisshorn-Matterhorn	I/B-09.II-D	Valais	CH	1861
+Matterhorn	4478	1042	POINT(7.65861 45.97639)	Weisshorn-Matterhorn	I/B-09.II-A	Valais/Aosta	CH/IT	1865
+Dent Blanche	4357	915	POINT(7.61194 46.03417)	Weisshorn-Matterhorn	I/B-09.II-C	Valais	CH	1862
+Grand Combin	4314	1517	POINT(7.29917 45.9375)	Grand Combin Alps	I/B-09.I-B	Valais	CH	1859
+Finsteraarhorn	4274	2280	POINT(8.12611 46.53722)	Bernese Alps	I/B-12.II-A	Bern/Valais	CH	1829
+Zinalrothorn	4221	490	POINT(7.69028 46.065)	Weisshorn-Matterhorn	I/B-09.II-D	Valais	CH	1864
+Grandes Jorasses	4208	843	POINT(6.98833 45.86917)	Mont Blanc massif	I/B-07.V-B	U-Savoy/Aosta	FR/IT	1868
+Alphubel	4206	359	POINT(7.86389 46.06306)	Mischabel	I/B-09.V-A	Valais	CH	1860
+Rimpfischhorn	4199	642	POINT(7.88417 46.02333)	Mischabel	I/B-09.V-A	Valais	CH	1859
+Aletschhorn	4193	1029	POINT(7.99389 46.465)	Bernese Alps	I/B-12.II-E	Valais	CH	1859
+Strahlhorn	4190	401	POINT(7.90167 46.01333)	Mischabel	I/B-09.V-A	Valais	CH	1854
+Dent d'Hérens	4174	701	POINT(7.60528 45.97)	Weisshorn-Matterhorn	I/B-09.II-A	Valais/Aosta	CH/IT	1863
+Breithorn	4164	439	POINT(7.74889 45.94111)	Monte Rosa Alps	I/B-09.III-A	Valais/Aosta	CH/IT	1813
+Jungfrau	4158	687	POINT(7.9625 46.53667)	Bernese Alps	I/B-12.II-B	Bern/Valais	CH	1811
+Aiguille Verte	4122	689	POINT(6.97028 45.93472)	Mont Blanc massif	I/B-07.V-B	Upper Savoy	FR	1865
+Mönch	4107	584	POINT(7.99722 46.55833)	Bernese Alps	I/B-12.II-B	Bern/Valais	CH	1857
+Barre des Écrins	4102	2045	POINT(6.36 44.9225)	Massif des Écrins	I/A-05.III-A	Hautes-Alpes	FR	1864
+Schreckhorn	4078	792	POINT(8.11806 46.59)	Bernese Alps	I/B-12.II-C	Bern	CH	1861
+Ober Gabelhorn	4063	536	POINT(7.66806 46.03861)	Weisshorn-Matterhorn	I/B-09.II-D	Valais	CH	1865
+Gran Paradiso	4061	1888	POINT(7.26722 45.51806)	Gran Paradiso Alps	I/B-07.IV-A	Aosta Valley	IT	1860
+Piz Bernina	4049	2234	POINT(9.90806 46.38222)	Bernina Range	II/A-15.III-A	Graubünden	CH	1850
+Gross Fiescherhorn	4049	398	POINT(8.06139 46.55139)	Bernese Alps	I/B-12.II-B	Bern/Valais	CH	1862
+Gross Grünhorn	4044	305	POINT(8.07778 46.53194)	Bernese Alps	I/B-12.II-B	Valais	CH	1865
+Weissmies	4017	1186	POINT(8.01222 46.12778)	Weissmies Alps	I/B-09.V-C	Valais	CH	1855
+Lagginhorn	4010	511	POINT(8.00306 46.15722)	Weissmies Alps	I/B-09.V-C	Valais	CH	1856
+Piz Zupò	3996	405	POINT(9.93139 46.36833)	Bernina Range	II/A-15.III-A	Graub./Sondrio	CH/IT	1863
+Fletschhorn	3985	297	POINT(8.00333 46.16806)	Weissmies Alps	I/B-09.V-C	Valais	CH	1854
+Gletscherhorn	3983	346	POINT(7.96778 46.51278)	Bernese Alps	I/B-12.II-D	Bern/Valais	CH	1867
+Meije	3982	824	POINT(6.30861 45.00472)	Massif des Écrins	I/A-05.III-B	Isère/H-Alpes	FR	1877
+Eiger	3970	356	POINT(8.00528 46.5775)	Bernese Alps	I/B-12.II-B	Bern	CH	1858
+Grivola	3969	714	POINT(7.2575 45.59583)	Gran Paradiso Alps	I/B-07.IV-A	Aosta Valley	IT	1859
+Grand Cornier	3962	431	POINT(7.61139 46.05194)	Weisshorn-Matterhorn	I/B-09.II-C	Valais	CH	1865
+Ailefroide	3954	762	POINT(6.35639 44.885)	Massif des Écrins	I/A-05.III-C	Isère/H-Alpes	FR	1870
+Mont Pelvoux	3943	465	POINT(6.39667 44.8975)	Massif des Écrins	I/A-05.III-C	Hautes-Alpes	FR	1828
+Piz Roseg	3937	415	POINT(9.88306 46.37361)	Bernina Range	II/A-15.III-A	Graubünden	CH	1865
+Bietschhorn	3934	806	POINT(7.85083 46.39167)	Bernese Alps	I/B-12.II-E	Valais	CH	1859
+Trugberg	3933	306	POINT(8.01528 46.54667)	Bernese Alps	I/B-12.II-B	Valais	CH	1871
+Aiguille de Tré la Tête	3930	588	POINT(6.815 45.79472)	Mont Blanc massif	I/B-07.V-A	Aosta Valley	IT	1864
+Pic Sans Nom	3913	340	POINT(6.38389 44.89333)	Massif des Écrins	I/A-05.III-C	Hautes-Alpes	FR	1877
+Gross Wannenhorn	3906	626	POINT(8.09694 46.49389)	Bernese Alps	I/B-12.II-B	Valais	CH	1864
+Ortler	3905	1953	POINT(10.54472 46.50889)	Ortler Alps	II/C-28.I-A	South Tyrol	IT	1804
+Aiguille d'Argentière	3901	473	POINT(7.02 45.96)	Mont Blanc massif	I/B-07.V-C	Valais/U-Savoy	CH/FR	1864
+Ruinette	3875	851	POINT(7.40028 45.97917)	Grand Combin Alps	I/B-09.I-D	Valais	CH	1865
+Aiguille de Triolet	3870	301	POINT(7.02444 45.91667)	Mont Blanc massif	I/B-07.V-B	U-Savoy/Aosta	FR/IT	1874
+Grande Casse	3855	1305	POINT(6.82778 45.40528)	Vanoise massif	I/B-07.II-B	Savoy	FR	1860
+Königspitze	3851	424	POINT(10.56833 46.47861)	Ortler Alps	II/C-28.I-A	S-Tyrol/Sondrio	IT	1854
+Aiguille du Midi	3842	310	POINT(6.8875 45.87861)	Mont Blanc massif	I/B-07.V-B	Upper Savoy	FR	1856
+Monviso	3841	2062	POINT(7.09083 44.6675)	Southern Cottian Alps	I/A-04.I-C	Cuneo	IT	1861
+Bouquetins	3838	490	POINT(7.54528 45.98222)	Weisshorn-Matterhorn	I/B-09.II-A	Valais/Aosta	CH/IT	1871
+Tour Noir	3837	302	POINT(7.0375 45.94889)	Mont Blanc massif	I/B-07.V-C	Valais/U-Savoy	CH/FR	1876
+Brunegghorn	3833	293	POINT(7.74556 46.12583)	Weisshorn-Matterhorn	I/B-09.II-D	Valais	CH	1865
+Aiguille du Chardonnet	3824	503	POINT(7.00111 45.96889)	Mont Blanc massif	I/B-07.V-C	Upper Savoy	FR	1865
+Nesthorn	3821	636	POINT(7.92611 46.41333)	Bernese Alps	I/B-12.II-E	Valais	CH	1865
+Mont Dolent	3820	330	POINT(7.04611 45.9225)	Mont Blanc massif	I/B-07.V-C	Valais/Aosta	CH/IT	1864
+Aiguille des Glaciers	3816	301	POINT(6.8025 45.77861)	Mont Blanc massif	I/B-07.V-A	Aosta/U-Savoy	FR/IT	1878
+Le Râteau	3809	452	POINT(6.28306 45.00083)	Massif des Écrins	I/A-05.III-B	Isère/H-Alpes	FR	1873
+Großglockner	3798	2428	POINT(12.69444 47.07417)	Glockner Group	II/A-17.II-C	Carinthia/E-Tyrol	AT	1800
+Schinhorn	3797	422	POINT(7.94667 46.45167)	Bernese Alps	I/B-12.II-E	Valais	CH	1869
+Pointe de Zinal	3789	301	POINT(7.63056 46.02694)	Weisshorn-Matterhorn	I/B-09.II-C	Valais	CH	1870
+Lauterbrunnen Breithorn	3780	443	POINT(7.87667 46.47861)	Bernese Alps	I/B-12.II-D	Bern/Valais	CH	1865
+Mont Pourri	3779	1127	POINT(6.86028 45.52806)	Vanoise massif	I/B-07.II-C	Savoy	FR	1861
+Aiguille Noire de Peuterey	3772	343	POINT(6.89306 45.81528)	Mont Blanc massif	I/B-07.V-B	Aosta Valley	IT	1877
+Wildspitze	3770	2263	POINT(10.86722 46.88528)	Ötztal Alps	II/A-16.I-A	North Tyrol	AT	1848
+Monte Cevedale	3769	531	POINT(10.61667 46.44389)	Ortler Alps	II/C-28.I-A	Sondrio/Trentino	IT	1865
+Grande Ruine	3765	496	POINT(6.32972 44.96778)	Massif des Écrins	I/A-05.III-A	Isère/H-Alpes	FR	1873
+Aiguille de Leschaux	3759	309	POINT(7.00694 45.8875)	Mont Blanc massif	I/B-07.V-B	Upper Savoy	FR/IT	1872
+Pointe de Charbonnel	3752	997	POINT(7.055 45.28028)	Graian Alps - SE	I/B-07.I-A	Savoy	FR	1862
+Piz Morteratsch	3751	324	POINT(9.90167 46.40278)	Bernina Range	II/A-15.III-A	Graubünden	CH	1858
+Aiguille de la Grande Sassière	3747	792	POINT(7.0 45.505)	Graian Alps - Central	I/B-07.III-A	Savoy/Aosta	FR/IT	1808
+Weißkugel	3739	569	POINT(10.72639 46.79778)	Ötztal Alps	II/A-16.I-A	N-Tyrol/S-Tyrol	AT/IT	1845
+Roche Faurio	3730	363	POINT(6.35806 44.94194)	Massif des Écrins	I/A-05.III-A	Isère	FR	1873
+Mont Vélan	3726	620	POINT(7.25167 45.89167)	Grand Combin Alps	I/B-09.I-B	Valais/Aosta	CH/IT	1779
+Evêque	3716	647	POINT(7.50278 45.96444)	Grand Combin Alps	I/B-09.I-C	Valais	CH	1867
+Combin de Corbassière	3716	312	POINT(7.28056 45.97806)	Grand Combin Alps	I/B-09.I-B	Valais	CH	1851
+La Singla	3714	452	POINT(7.47194 45.94583)	Grand Combin Alps	I/B-09.I-C	Valais/Aosta	CH/IT	1867
+Wetterhörner	3704	579	POINT(8.12472 46.63528)	Bernese Alps	I/B-12.II-C	Bern	CH	1845
+Le Pleureur	3704	467	POINT(7.36917 46.01639)	Grand Combin Alps	I/B-09.I-D	Valais	CH	1867
+Balmhorn	3698	1022	POINT(7.69361 46.425)	Bernese Alps	I/B-12.II-D	Bern/Valais	CH	1864
+Dent Parrachée	3697	1180	POINT(6.75639 45.28917)	Vanoise massif	I/B-07.II-D	Savoy	FR	1862
+Torre del Gran San Pietro	3692	377	POINT(7.35889 45.52583)	Gran Paradiso Alps	I/B-07.IV-A	Aosta/Turin	IT	1867
+Monte Disgrazia	3678	1116	POINT(9.74944 46.26917)	Bregaglia Range	II/A-15.III-B	Sondrio	IT	1862
+Punta San Matteo	3678	369	POINT(10.56722 46.37778)	Ortler Alps	II/C-28.I-A	Sondrio/Trentino	IT	1865
+Uia di Ciamarella	3676	664	POINT(7.14528 45.32861)	Graian Alps - SE	I/B-07.I-B	Turin	IT	1857
+Dent de Perroc	3676	408	POINT(7.52306 46.03944)	Weisshorn-Matterhorn	I/B-09.II-A	Valais	CH	1871
+Dômes de Miage	3673	324	POINT(6.80028 45.81556)	Mont Blanc massif	I/B-07.V-A	Savoy/U-Savoy	FR	1858
+Les Bans	3669	386	POINT(6.33667 44.84861)	Massif des Écrins	I/A-05.III-C	Isère/H-Alpes	FR	1878
+Großvenediger	3666	1185	POINT(12.34639 47.10917)	Venediger Group	II/A-17.II-A	E-Tyrol/Salzburg	AT	1841
+Montagne des Agneaux	3664	460	POINT(6.43056 44.95028)	Massif des Écrins	I/A-05.III-A	Hautes-Alpes	FR	1873
+Blüemlisalphorn	3661	874	POINT(7.7725 46.48889)	Bernese Alps	I/B-12.II-D	Bern	CH	1860
+Portjengrat: Pizzo d'Andolla	3654	411	POINT(8.03472 46.10083)	Weissmies Alps	I/B-09.V-B	Valais/V-C-O	CH/IT	1871
+Grande Motte	3653	401	POINT(6.87028 45.41139)	Vanoise massif	I/B-07.II-B	Savoy	FR	1864
+Thurwieserspitze	3652	299	POINT(10.52528 46.49528)	Ortler Alps	II/C-28.I-A	S-Tyrol/Sondrio	IT	1869
+Aiguilles Rouges d'Arolla	3644	789	POINT(7.43361 46.05528)	Grand Combin Alps	I/B-09.I-D	Valais	CH	1870
+Ciarforon	3643	349	POINT(7.24722 45.49333)	Gran Paradiso Alps	I/B-07.IV-A	Aosta/Turin	IT	1871
+Doldenhorn	3638	654	POINT(7.73472 46.46889)	Bernese Alps	I/B-12.II-D	Bern	CH	1862
+Albaron	3637	327	POINT(7.10278 45.3325)	Graian Alps - SE	I/B-07.I-B	Savoy	FR	1866
+Dammastock	3630	1466	POINT(8.42111 46.64333)	Urner Alps	I/B-12.I-A	Uri/Valais	CH	1864
+Hintere Schwärze	3628	835	POINT(10.91472 46.77333)	Ötztal Alps	II/A-16.I-A	N-Tyrol/S-Tyrol	AT/IT	1867
+Levanna Centrale	3619	525	POINT(7.17194 45.41028)	Graian Alps - SE	I/B-07.I-C	Savoy/Turin	FR/IT	1875
+Tödi	3614	1570	POINT(8.91472 46.81111)	Glarus Alps	I/B-13.II-A	Glarus/Graub.	CH	1824
+Pointe de Ronce	3612	500	POINT(6.97861 45.26444)	Graian Alps - SE	I/B-07.I-A	Savoy	FR	1784
+Les Diablons	3609	379	POINT(7.67111 46.1425)	Weisshorn-Matterhorn	I/B-09.II-D	Valais	CH	1863
+Grande Rousse	3607	525	POINT(7.08444 45.56333)	Graian Alps - Central	I/B-07.III-A	Aosta Valley	IT	1874
+Tsanteleina	3602	490	POINT(7.04611 45.47944)	Graian Alps - Central	I/B-07.III-A	Savoy/Aosta	FR/IT	1865
+Aiguille du Plat de la Selle	3596	423	POINT(6.22333 44.96444)	Massif des Écrins	I/A-05.III-B	Isère	FR	1876
+Piz Glüschaint	3594	341	POINT(9.84 46.3625)	Bernina Range	II/A-15.III-A	Graub./Sondrio	CH/IT	1863
+Bessanèse	3592	386	POINT(7.11944 45.30222)	Graian Alps - SE	I/B-07.I-B	Savoy/Turin	FR/IT	1857
+Les Rouies	3589	506	POINT(6.25861 44.86444)	Massif des Écrins	I/A-05.III-D	Isère	FR	1873
+Grand Roc Noir	3582	818	POINT(6.89194 45.33028)	Vanoise massif	I/B-07.II-A	Savoy	FR	
+Mont Brulé	3578	365	POINT(7.53833 45.955)	Weisshorn-Matterhorn	I/B-09.II-A	Valais/Aosta	CH/IT	1876
+Croix Rousse	3571	499	POINT(7.13472 45.26056)	Graian Alps - SE	I/B-07.I-B	Savoy/Turin	FR/IT	1857
+Olan	3564	552	POINT(6.19722 44.85944)	Massif des Écrins	I/A-05.III-D	Isère/H-Alpes	FR	1875
+Großes Wiesbachhorn	3564	481	POINT(12.75528 47.15639)	Glockner Group	II/A-17.II-C	Salzburg	AT	1795
+Plaret	3563	362	POINT(6.26 44.96861)	Massif des Écrins	I/A-05.III-B	Isère	FR	1877
+Cime de Clot Châtel	3563	320	POINT(6.28028 44.8975)	Massif des Écrins	I/A-05.III-D	Isère	FR	1877
+Ouille d'Arbéron	3563	294	POINT(7.12806 45.27167)	Graian Alps - SE	I/B-07.I-B	Savoy/Turin	FR/IT	1873
+Aiguille de Péclet	3562	766	POINT(6.62444 45.28139)	Vanoise massif	I/B-07.II-E	Savoy	FR	1878
+Tschingelhorn	3562	388	POINT(7.84861 46.47861)	Bernese Alps	I/B-12.II-D	Bern/Valais	CH	1865
+Monte Emilius	3559	733	POINT(7.38472 45.67889)	Gran Paradiso Alps	I/B-07.IV-C	Aosta Valley	IT	1826
+Tête de l'Étret	3559	310	POINT(6.24528 44.89)	Massif des Écrins	I/A-05.III-D	Isère	FR	1876
+Presanella	3558	1676	POINT(10.66389 46.22)	Adamello-Presanella	II/C-28.III-B	Trentino	IT	1864
+Aouille Tseuque	3554	345	POINT(7.44306 45.93028)	Grand Combin Alps	I/B-09.I-C	Valais/Aosta	CH/IT	
+Monte Leone	3553	1144	POINT(8.11 46.24944)	Leone-Gotthard Alps	I/B-10.I-A	Valais/V-C-O	CH/IT	1859
+Großer Ramolkogel	3550	380	POINT(10.95889 46.84667)	Ötztal Alps	II/A-16.I-A	North Tyrol	AT	1862
+Vertainspitze	3545	422	POINT(10.63556 46.53722)	Ortler Alps	II/C-28.I-A	South Tyrol	IT	1865
+Schalfkogel	3540	351	POINT(10.95917 46.80167)	Ötztal Alps	II/A-16.I-A	North Tyrol	AT	1830
+Adamello	3539	664	POINT(10.49611 46.15583)	Adamello-Presanella	II/C-28.III-A	Brescia	IT	1864
+Rocciamelone	3538	310	POINT(7.07694 45.20389)	Graian Alps - SE	I/B-07.I-A	Turin	IT	1358
+Hochvernagtspitze	3535	299	POINT(10.79611 46.88139)	Ötztal Alps	II/A-16.I-A	North Tyrol	AT	1865
+Watzespitze	3533	489	POINT(10.79556 46.98944)	Ötztal Alps	II/A-16.I-C	North Tyrol	AT	1869
+Bec d'Epicoune	3531	298	POINT(7.4225 45.91472)	Grand Combin Alps	I/B-09.I-C	Valais/Aosta	CH/IT	1866
+Mont Gelé	3518	619	POINT(7.36611 45.90417)	Grand Combin Alps	I/B-09.I-C	Valais/Aosta	CH/IT	1861
+Weißseespitze	3518	345	POINT(10.71722 46.84667)	Ötztal Alps	II/A-16.I-A	N-Tyrol/S-Tyrol	AT/IT	1870
+Aiguille Méridionale d'Arves	3514	1433	POINT(6.33694 45.12722)	Dauphiné Alps	I/A-05.I-A	H-Alpes/Savoy	FR	1878
+Fineilspitze	3514	504	POINT(10.83194 46.78028)	Ötztal Alps	II/A-16.I-A	N-Tyrol/S-Tyrol	AT/IT	1865
+Punta Tersiva	3512	596	POINT(7.47611 45.62056)	Gran Paradiso Alps	I/B-07.IV-C	Aosta Valley	IT	1842
+Hochfeiler	3509	981	POINT(11.72778 46.97222)	Zillertal Alps	II/A-17.I-B	N-Tyrol/S-Tyrol	AT/IT	1865
+Zuckerhütl	3507	1033	POINT(11.15389 46.96444)	Stubai Alps	II/A-16.II-A	North Tyrol	AT	1863
+Aiguille de Scolette	3506	1069	POINT(6.76861 45.16)	Northern Cottian Alps	I/A-04.III-B	Savoy/Turin	FR/IT	1875
+Galmihorn	3505	293	POINT(8.185 46.50667)	Bernese Alps	I/B-12.II-A	Valais	CH	1884
+Becca di Luseney	3504	646	POINT(7.49111 45.87056)	Weisshorn-Matterhorn	I/B-09.II-B	Aosta Valley	IT	1866
+Sustenhorn	3503	414	POINT(8.45528 46.69889)	Urner Alps	I/B-12.I-A	Bern/Uri	CH	1841
+Dreiherrnspitze	3499	581	POINT(12.24083 47.06917)	Venediger Group	II/A-17.II-A	E-Tyr/Salz/S-Tyr	AT/IT	1866
+Schrankogel	3497	545	POINT(11.09917 47.04389)	Stubai Alps	II/A-16.II-B	North Tyrol	AT	1840
+Rötspitze	3496	653	POINT(12.20528 47.02694)	Venediger Group	II/A-17.II-A	E-Tyrol/S-Tyrol	AT/IT	1854
+Grande Traversière	3496	342	POINT(7.05583 45.52306)	Graian Alps - Central	I/B-07.III-A	Aosta Valley	IT	1885
+M. Morion Sud	3489	345	POINT(7.36528 45.87806)	Grand Combin Alps	I/B-09.I-C	Aosta Valley	IT	
+Grand Nomenon	3488	389	POINT(7.23611 45.61194)	Gran Paradiso Alps	I/B-07.IV-A	Aosta Valley	IT	1877
+Sonnighorn	3487	340	POINT(8.02222 46.07417)	Weissmies Alps	I/B-09.V-B	Valais/V-C-O	CH/IT	1879
+Testa del Rutor	3486	850	POINT(7.01444 45.63083)	Graian Alps - Central	I/B-07.III-B	Aosta Valley	IT	1858
+Grande Aiguille Rousse	3482	390	POINT(7.10972 45.43306)	Graian Alps - SE	I/B-07.I-C	Savoy	FR	1878
+Pic de Bonvoisin	3481	397	POINT(6.34694 44.82361)	Massif des Écrins	I/A-05.III-C	Hautes-Alpes	FR	1879
+Großer Möseler	3480	455	POINT(11.78194 46.9925)	Zillertal Alps	II/A-17.I-B	N-Tyrol/S-Tyrol	AT/IT	1865
+Hochwilde	3480	353	POINT(11.02222 46.76556)	Ötztal Alps	II/A-16.I-A	N-Tyrol/S-Tyrol	AT/IT	1852
+Olperer	3476	1231	POINT(11.65889 47.05306)	Zillertal Alps	II/A-17.I-A	North Tyrol	AT	1867
+Ruderhofspitze	3474	370	POINT(11.14333 47.03944)	Stubai Alps	II/A-16.II-B	North Tyrol	AT	1864
+Hinterer Seelenkogel	3472	441	POINT(11.04444 46.80167)	Ötztal Alps	II/A-16.I-B	N-Tyrol/S-Tyrol	AT/IT	1871
+Grande Rousse S	3465	1175	POINT(6.13583 45.13778)	Dauphiné Alps	I/A-05.I-B	Isère	FR	1874
+Roche de la Muzelle	3465	529	POINT(6.10667 44.93111)	Massif des Écrins	I/A-05.III-E	Isère	FR	1875
+Pic de l'Étendard	3464	170	POINT(6.14389 45.15444)	Dauphiné Alps	I/A-05.I-B	Isère/Savoy	FR	1863
+Carè Alto	3463	481	POINT(10.59611 46.10806)	Adamello-Presanella	II/C-28.III-A	Trentino	IT	1865
+Vordere Ölgrubenspitze	3456	390	POINT(10.77333 46.90833)	Ötztal Alps	II/A-16.I-C	North Tyrol	AT	1876
+Bliggspitze	3453	390	POINT(10.78611 46.91806)	Ötztal Alps	II/A-16.I-C	North Tyrol	AT	1874
+Johannisberg	3453	293	POINT(12.67278 47.10944)	Glockner Group	II/A-17.II-C	Carinth/Salzburg	AT	1844
+Piz Corvatsch	3451	383	POINT(9.81611 46.40833)	Bernina Range	II/A-15.III-A	Graubünden	CH	1850
+Rinderhorn	3448	412	POINT(7.65417 46.41361)	Bernese Alps	I/B-12.II-D	Valais	CH	1854
+Punta Garin	3448	294	POINT(7.37778 45.65583)	Gran Paradiso Alps	I/B-07.IV-C	Aosta Valley	IT	1856
+Wasenhorn	3447	303	POINT(8.16583 46.49806)	Bernese Alps	I/B-12.II-E	Valais	CH	1885
+Hintere Eggenspitze	3443	478	POINT(10.77056 46.47778)	Ortler Alps	II/C-28.I-A	S-Tyrol/Trentino	IT	1868
+Roc du Mulinet	3442	342	POINT(7.16278 45.38083)	Graian Alps - SE	I/B-07.I-B	Savoy/Turin	FR/IT	1878
+Sirac	3441	357	POINT(6.30694 44.78972)	Massif des Écrins	I/A-05.III-C	Hautes-Alpes	FR	1877
+Piz Tremoggia	3441	349	POINT(9.82194 46.35194)	Bernina Range	II/A-15.III-A	Graub./Sondrio	CH/IT	1859
+Dosson di Genova	3441	313	POINT(10.55361 46.14861)	Adamello-Presanella	II/C-28.III-A	Brescia/Trentino	IT	1882
+Cima de' Piazzi	3439	1202	POINT(10.285 46.41667)	Livigno Alps	II/A-15.IV-B	Sondrio	IT	1867
+Lagaunspitze	3439	422	POINT(10.73917 46.73917)	Ötztal Alps	II/A-16.I-A	South Tyrol	IT	1876
+Zufrittspitze	3439	309	POINT(10.78222 46.50194)	Ortler Alps	II/C-28.I-A	South Tyrol	IT	1868
+Taou Blanc	3438	415	POINT(7.14806 45.52222)	Graian Alps - Central	I/B-07.III-A	Aosta Valley	IT	1880
+Hochgall	3436	1148	POINT(12.13972 46.91083)	Rieserferner Group	II/A-17.III-A	South Tyrol	IT	1854
+Gspaltenhorn	3436	599	POINT(7.8275 46.51167)	Bernese Alps	I/B-12.II-D	Bern	CH	1869
+Stellihorn	3436	598	POINT(8.00083 46.03639)	Weissmies Alps	I/B-09.V-B	Valais	CH	
+Pointe de la Sana	3436	525	POINT(6.91806 45.385)	Vanoise massif	I/B-07.II-A	Savoy	FR	1877
+Punta Bianca di Bioula	3427	463	POINT(7.16667 45.58667)	Graian Alps - Central	I/B-07.III-A	Aosta Valley	IT	
+Verpeilspitze	3425	415	POINT(10.805 47.00333)	Ötztal Alps	II/A-16.I-C	North Tyrol	AT	1886
+Pointe de l'Échelle	3422	537	POINT(6.68528 45.26917)	Vanoise massif	I/B-07.II-D	Savoy	FR	
+Goléon	3422	330	POINT(6.32639 45.10361)	Dauphiné Alps	I/A-05.I-A	Hautes-Alpes	FR	
+Aiguille de l'Épéna	3421	330	POINT(6.81722 45.41472)	Vanoise massif	I/B-07.II-B	Savoy	FR	1900
+Pics du Says	3420	298	POINT(6.30583 44.87389)	Massif des Écrins	I/A-05.III-D	Isère/H-Alpes	FR	1879
+Bifertenstock	3419	383	POINT(8.9575 46.80444)	Glarus Alps	I/B-13.II-A	Glarus/Graub.	CH	1863
+Piz Kesch	3418	1503	POINT(9.87278 46.62139)	Albula Alps	II/A-15.II-B	Graubünden	CH	1846
+Sommet de Bellecôte	3417	808	POINT(6.7825 45.4925)	Vanoise massif	I/B-07.II-B	Savoy	FR	1866
+Fleckistock	3416	760	POINT(8.4975 46.7075)	Urner Alps	I/B-12.I-A	Uri	CH	1864
+Pointe du Bouchet	3416	321	POINT(6.60417 45.25417)	Vanoise massif	I/B-07.II-E	Savoy	FR	
+Aiguille de Chambeyron	3412	771	POINT(6.85667 44.54778)	Southern Cottian Alps	I/A-04.I-A	A-d-H-Provence	FR	1879
+Piz Linard	3411	1028	POINT(10.07167 46.79889)	Silvretta	II/A-15.VI-A	Graubünden	CH	1835
+Schrammacher	3410	451	POINT(11.64306 47.02694)	Zillertal Alps	II/A-17.I-A	North Tyrol	AT	1847
+Hochfirst	3403	401	POINT(11.08111 46.82667)	Ötztal Alps	II/A-16.I-A	N-Tyrol/S-Tyrol	AT/IT	1870
+Rheinwaldhorn	3402	1337	POINT(9.04028 46.49361)	Adula Alps	I/B-10.III-B	Graub./Ticino	CH	1789
+Aiguille des Arias	3402	432	POINT(6.17417 44.89556)	Massif des Écrins	I/A-05.III-E	Isère	FR	1876
+Fluchthorn	3399	647	POINT(10.2275 46.89083)	Silvretta	II/A-15.VI-A	N-Tyrol/Graub.	AT/CH	1861
+Piz Calderas	3397	1085	POINT(9.69583 46.53639)	Albula Alps	II/A-15.II-A	Graubünden	CH	1857
+Großer Bärenkopf	3396	302	POINT(12.73167 47.13083)	Glockner Group	II/A-17.II-C	Salzburg	AT	1869
+Hohe Geige	3395	458	POINT(10.90861 47.00472)	Ötztal Alps	II/A-16.I-C	North Tyrol	AT	1853
+Piz Platta	3392	1108	POINT(9.56167 46.48722)	Oberhalbstein Range	II/A-15.I-B	Graubünden	CH	1866
+Brec de Chambeyron	3389	462	POINT(6.85333 44.52806)	Southern Cottian Alps	I/A-04.I-A	AdHP/Cuneo	FR/IT	1878
+Diechterhorn	3389	308	POINT(8.36056 46.64861)	Urner Alps	I/B-12.I-A	Bern	CH	1864
+Veneziaspitze	3386	354	POINT(10.68917 46.45389)	Ortler Alps	II/C-28.I-A	S-Tyrol/Trentino	IT	1867
+Pic Nord de la Font Sancte	3385	724	POINT(6.80028 44.605)	Southern Cottian Alps	I/A-04.I-B	AdHP/H-Alpes	FR	1879
+Punta Sulè	3384	311	POINT(7.1375 45.23139)	Graian Alps - SE	I/B-07.I-B	Turin	IT	
+Rognosa d'Etiache	3383	584	POINT(6.83389 45.13472)	Northern Cottian Alps	I/A-04.III-B	Savoy/Turin	FR/IT	1875
+Piz Güglia	3380	489	POINT(9.75972 46.49111)	Albula Alps	II/A-15.II-A	Graubünden	CH	1859
+Grand Tournalin	3379	551	POINT(7.68806 45.87167)	Monte Rosa Alps	I/B-09.III-B	Aosta Valley	IT	1863
+Güferhorn	3379	400	POINT(9.06306 46.5125)	Adula Alps	I/B-10.III-B	Graubünden	CH	1806
+Cima di Castello	3379	388	POINT(9.67694 46.30306)	Bregaglia Range	II/A-15.III-B	Graub./Sondrio	CH/IT	1866
+Großer Löffler	3379	368	POINT(11.91583 47.0325)	Zillertal Alps	II/A-17.I-B	N-Tyrol/S-Tyrol	AT/IT	1843
+Mont d'Ambin	3378	501	POINT(6.88444 45.15667)	Northern Cottian Alps	I/A-04.III-B	Savoy/Turin	FR/IT	1823
+Punta di Fontanella	3378	333	POINT(7.55583 45.90611)	Weisshorn-Matterhorn	I/B-09.II-A	Aosta Valley	IT	1864
+Cima Viola	3374	1073	POINT(10.19639 46.38361)	Livigno Alps	II/A-15.IV-B	Sondrio	IT	1875
+Blinnenhorn	3374	945	POINT(8.30778 46.42583)	Leone-Gotthard Alps	I/B-10.I-A	Valais/V-C-O	CH/IT	1866
+Hoher Eichham	3371	329	POINT(12.40667 47.05389)	Venediger Group	II/A-17.II-A	East Tyrol	AT	1854
+Monte Confinale	3370	376	POINT(10.50444 46.44944)	Ortler Alps	II/C-28.I-A	Sondrio	IT	1864
+Pizzo Cengalo	3369	620	POINT(9.60194 46.295)	Bregaglia Range	II/A-15.III-B	Graub./Sondrio	CH/IT	1866
+Schwarzenstein	3369	342	POINT(11.87417 47.01)	Zillertal Alps	II/A-17.I-B	N-Tyrol/S-Tyrol	AT/IT	1852
+Hoher Tenn	3368	337	POINT(12.75944 47.17972)	Glockner Group	II/A-17.II-C	Salzburg	AT	1840
+Malhamspitze	3368	321	POINT(12.25944 47.04917)	Venediger Group	II/A-17.II-A	East Tyrol	AT	1873
+Egginer	3367	378	POINT(7.93 46.07528)	Mischabel	I/B-09.V-A	Valais	CH	
+Innere Schwarze Schneid	3367	293	POINT(10.92139 46.92417)	Ötztal Alps	II/A-16.I-A	North Tyrol	AT	1874
+Piz Fora	3363	432	POINT(9.78472 46.34083)	Bernina Range	II/A-15.III-A	Graub./Sondrio	CH/IT	1875
+Hochalmspitze	3360	946	POINT(13.32111 47.015)	Ankogel Group	II/A-17.II-F	Carinthia	AT	1855
+Corno dei Tre Signori	3360	361	POINT(10.51556 46.34306)	Ortler Alps	II/C-28.I-A	Bresc/Sond/Trent	IT	1876
+Großer Geiger	3360	293	POINT(12.30889 47.09306)	Venediger Group	II/A-17.II-A	E-Tyrol/Salzburg	AT	1871
+Wilde Leck	3359	309	POINT(11.0625 47.00278)	Stubai Alps	II/A-16.II-A	North Tyrol	AT	1865
+Schneebiger Nock	3358	544	POINT(12.08417 46.90528)	Rieserferner Group	II/A-17.III-A	South Tyrol	IT	1866
+Grande Roise	3357	321	POINT(7.42306 45.67528)	Gran Paradiso Alps	I/B-07.IV-C	Aosta Valley	IT	1875
+Rofelewand	3353	528	POINT(10.81833 47.0325)	Ötztal Alps	II/A-16.I-C	North Tyrol	AT	1873
+Glockturm	3353	415	POINT(10.66556 46.89333)	Ötztal Alps	II/A-16.I-A	North Tyrol	AT	1853
+Puitkogel	3345	392	POINT(10.90139 46.98139)	Ötztal Alps	II/A-16.I-C	North Tyrol	AT	1894
+Marmolada	3343	2134	POINT(11.85083 46.43472)	Dolomites - NW	II/C-31.III-B	Belluno/Trentino	IT	1864
+Bric de Rubren	3340	685	POINT(6.94972 44.62)	Southern Cottian Alps	I/A-04.I-A	AdHP/Cuneo	FR/IT	1823
+Piz Ela	3339	515	POINT(9.7075 46.60194)	Albula Alps	II/A-15.II-A	Graubünden	CH	1865
+Roteck	3337	483	POINT(10.98417 46.72361)	Ötztal Alps	II/A-16.I-B	South Tyrol	IT	1872
+Punta Sommeiller	3332	339	POINT(6.8525 45.12833)	Northern Cottian Alps	I/A-04.III-B	U-Savoy/Turin	FR/IT	1871
+Fuscherkarkopf	3331	490	POINT(12.74556 47.09889)	Glockner Group	II/A-17.II-C	Carinth/Salzburg	AT	1845
+Corno Baitone	3330	483	POINT(10.44111 46.17306)	Adamello-Presanella	II/C-28.III-A	Brescia	IT	1890
+Mont Fort	3329	408	POINT(7.31861 46.08111)	Grand Combin Alps	I/B-09.I-D	Valais	CH	1866
+Oberalpstock	3328	703	POINT(8.76944 46.74278)	Glarus Alps	I/B-13.I-A	Graubünden/Uri	CH	1793
+Grande Rochère	3326	836	POINT(7.06139 45.81361)	Grand Combin Alps	I/B-09.I-A	Aosta Valley	IT	1832
+Busazza	3326	304	POINT(10.61111 46.22389)	Adamello-Presanella	II/C-28.III-B	Trentino	IT	1889
+Tête de Lauranoure	3325	385	POINT(6.15194 44.92639)	Massif des Écrins	I/A-05.III-E	Isère	FR	1879
+Pizzo Scalino	3323	859	POINT(9.97361 46.27861)	Bernina Range	II/A-15.III-A	Sondrio	IT	1830
+Pic de Rochebrune	3320	1019	POINT(6.78778 44.8225)	Central Cottian Alps	I/A-04.II-B	Hautes-Alpes	FR	1819
+Corno Bianco	3320	446	POINT(7.87889 45.82278)	Monte Rosa Alps	I/B-09.III-C	Aosta/Vercelli	IT	1831
+Testa Grigia	3315	643	POINT(7.78667 45.83083)	Monte Rosa Alps	I/B-09.III-B	Aosta Valley	IT	1858
+Mont Giusalet	3312	835	POINT(6.93 45.18056)	Northern Cottian Alps	I/A-04.III-B	Savoy	FR	1871
+Piz Buin	3312	544	POINT(10.11861 46.84417)	Silvretta	II/A-15.VI-A	Vorarlb/Graub.	AT/CH	1865
+Mont Pelve	3312	335	POINT(6.77667 45.35611)	Vanoise massif	I/B-07.II-D	Savoy	FR	
+Torre di Lavina	3308	475	POINT(7.44861 45.55556)	Gran Paradiso Alps	I/B-07.IV-A	Aosta/Turin	IT	1856
+Pointe de l'Aiglière	3307	546	POINT(6.41472 44.81028)	Massif des Écrins	I/A-05.III-C	Hautes-Alpes	FR	
+Laaser Spitze	3305	318	POINT(10.71778 46.56194)	Ortler Alps	II/C-28.I-A	South Tyrol	IT	1855
+Reichenspitze	3303	683	POINT(12.11083 47.13944)	Zillertal Alps	II/A-17.I-D	N-Tyrol/Salzburg	AT	1856
+Piz Paradisin	3302	875	POINT(10.11722 46.42611)	Livigno Alps	II/A-15.IV-B	Graub./Sondrio	CH/IT	
+Punta Ramiere	3302	673	POINT(6.93167 44.86417)	Central Cottian Alps	I/A-04.II-B	H-Alpes/Turin	FR/IT	1877
+Becca di Tos	3301	461	POINT(7.10667 45.63028)	Graian Alps - Central	I/B-07.III-A	Aosta Valley	IT	
+Verstanclahorn	3298	375	POINT(10.0725 46.835)	Silvretta	II/A-15.VI-A	Graubünden	CH	1866
+Cima Sud Argentera	3297	1306	POINT(7.30583 44.17806)	Maritime Alps	I/A-02.I-B	Cuneo	IT	1879
+Monte Sobretta	3296	835	POINT(10.43694 46.3975)	Ortler Alps	II/C-28.I-B	Sondrio	IT	
+Strahlkogel	3295	513	POINT(11.01944 47.10917)	Stubai Alps	II/A-16.II-B	North Tyrol	AT	1833
+Gross Schärhorn	3294	513	POINT(8.82917 46.82722)	Glarus Alps	I/B-13.I-A	Uri	CH	1842
+Muttler	3293	703	POINT(10.37861 46.90056)	Samnaun Alps	II/A-15.VI-B	Graubünden	CH	1859
+Grand Glaiza	3293	496	POINT(6.88194 44.85)	Central Cottian Alps	I/A-04.II-B	H-Alpes/Turin	FR/IT	1835
+Hockenhorn	3293	348	POINT(7.74417 46.42833)	Bernese Alps	I/B-12.II-D	Bern/Valais	CH	1840
+Keeskogel	3291	374	POINT(12.31194 47.13639)	Venediger Group	II/A-17.II-A	Salzburg	AT	1840
+Schlieferspitze	3290	514	POINT(12.24333 47.1225)	Venediger Group	II/A-17.II-A	Salzburg	AT	1871
+M. Aiguillette	3287	472	POINT(7.02667 44.69139)	Southern Cottian Alps	I/A-04.I-C	H-Alpes/Cuneo	FR/IT	
+Petzeck	3283	799	POINT(12.80472 46.94806)	Schober Group	II/A-17.II-D	Carinthia	AT	1844
+Punta di Pietra Rossa	3283	662	POINT(10.4375 46.32472)	Ortler Alps	II/C-28.I-B	Brescia	IT	
+Ritzlihorn	3282	330	POINT(8.25889 46.63222)	Bernese Alps	I/B-12.II-C	Bern	CH	1816
+Roter Knopf	3281	549	POINT(12.73944 46.97861)	Schober Group	II/A-17.II-D	Carinthia/E-Tyrol	AT	1872
+Piz Fliana	3281	406	POINT(10.10861 46.82722)	Silvretta	II/A-15.VI-A	Graubünden	CH	1869
+Rognosa di Sestriere	3280	575	POINT(6.93111 44.93472)	Central Cottian Alps	I/A-04.II-A	Turin	IT	1836
+Pizzo Dosdè	3280	308	POINT(10.22583 46.41)	Livigno Alps	II/A-15.IV-B	Sondrio	IT	1879
+Pizzo Tambo	3279	1164	POINT(9.28333 46.49694)	Adula Alps	I/B-10.III-D	Graub./Sondrio	CH/IT	1828
+Hohe Weiße	3279	384	POINT(11.03722 46.74556)	Ötztal Alps	II/A-16.I-B	South Tyrol	IT	1871
+Habicht	3277	540	POINT(11.28972 47.04361)	Stubai Alps	II/A-16.II-A	North Tyrol	AT	1836
+Gsallkopf	3277	295	POINT(10.805 47.03778)	Ötztal Alps	II/A-16.I-C	North Tyrol	AT	1894
+Basòdino	3272	959	POINT(8.46861 46.41139)	Ticino Alps	I/B-10.II-A	Ticino/V-C-O	CH/IT	1863
+Helsenhorn	3272	586	POINT(8.19167 46.30472)	Leone-Gotthard Alps	I/B-10.I-A	Valais	CH	1863
+Pointe d'Archeboc	3272	439	POINT(6.98028 45.58361)	Graian Alps - Central	I/B-07.III-A	Savoy/Aosta	FR/IT	
+Östliche Feuerstein	3268	428	POINT(11.24444 46.97167)	Stubai Alps	II/A-16.II-A	N-Tyrol/S-Tyrol	AT/IT	1854
+Clariden	3267	413	POINT(8.87139 46.84194)	Glarus Alps	I/B-13.I-A	Glarus/Uri	CH	1863
+Piz Üertsch	3267	396	POINT(9.83639 46.59639)	Albula Alps	II/A-15.II-B	Graubünden	CH	1847
+Antelao	3264	1735	POINT(12.26056 46.4525)	Dolomites - NE	II/C-31.I-E	Belluno	IT	1863
+Scima da Saoseo	3264	440	POINT(10.15806 46.38556)	Livigno Alps	II/A-15.IV-B	Graub./Sondrio	CH/IT	1894
+Piz Languard	3262	947	POINT(9.95639 46.48833)	Livigno Alps	II/A-15.IV-A	Graubünden	CH	1846
+Piz Forbesch	3262	601	POINT(9.55917 46.52028)	Oberhalbstein Range	II/A-15.I-B	Graubünden	CH	1893
+Dents du Midi: Haute Cime	3257	1796	POINT(6.92333 46.16111)	Chablais Alps	I/B-08.II-A	Valais	CH	1784
+Hasenöhrl	3257	375	POINT(10.85861 46.54444)	Ortler Alps	II/C-28.I-A	South Tyrol	IT	1895
+Gross Düssi	3256	429	POINT(8.8275 46.79167)	Glarus Alps	I/B-13.I-A	Graubünden/Uri	CH	1841
+Hocharn	3254	678	POINT(12.93722 47.07611)	Goldberg Group	II/A-17.II-E	Carinth/Salzburg	AT	1827
+Piz Tschütta	3254	406	POINT(10.34306 46.90361)	Samnaun Alps	II/A-15.VI-B	Graubünden	CH	1884
+Sasseneire	3254	386	POINT(7.52528 46.13861)	Weisshorn-Matterhorn	I/B-09.II-C	Valais	CH	1835
+Penne Blanche	3254	349	POINT(7.42694 45.61889)	Gran Paradiso Alps	I/B-07.IV-C	Aosta Valley	IT	
+Berio Blanc	3252	736	POINT(6.89778 45.75306)	Mont Blanc massif	I/B-07.III-B	Aosta Valley	IT	
+Ankogel	3252	578	POINT(13.24917 47.05111)	Ankogel Group	II/A-17.II-F	Carinth/Salzburg	AT	1762
+Cavistrau	3252	448	POINT(8.97389 46.78444)	Glarus Alps	I/B-13.II-A	Graubünden	CH	1865
+Rauhkofel	3251	593	POINT(12.09194 47.07611)	Zillertal Alps	II/A-17.I-B	N-Tyrol/S-Tyrol	AT/IT	1853
+Großer Hornkopf	3251	455	POINT(12.77889 46.96722)	Schober Group	II/A-17.II-D	Carinthia	AT	1890
+Wildhorn	3248	978	POINT(7.36222 46.35583)	Bernese Alps	I/B-12.II-F	Bern/Valais	CH	1843
+Ringelspitz	3247	843	POINT(9.34306 46.89833)	Glarus Alps	I/B-13.II-B	Graub./StGallen	CH	1865
+Piz Ot	3246	631	POINT(9.81028 46.54333)	Albula Alps	II/A-15.II-A	Graubünden	CH	1830
+Wasenhorn	3246	476	POINT(8.08556 46.26639)	Leone-Gotthard Alps	I/B-10.I-A	Valais/V-C-O	CH/IT	1844
+Punta Painale	3246	413	POINT(9.97389 46.25667)	Bernina Range	II/A-15.III-A	Sondrio	IT	1885
+Platthorn	3246	361	POINT(7.86111 46.16639)	Mischabel	I/B-09.V-A	Valais	CH	
+Tofana di Mezzo	3244	1369	POINT(12.06556 46.55111)	Dolomites - NE	II/C-31.I-D	Belluno	IT	1863
+Hohe Fürleg	3244	410	POINT(12.36278 47.14167)	Venediger Group	II/A-17.II-A	E-Tyrol/Salzburg	AT	1894
+Piz Bacun	3244	306	POINT(9.68222 46.34222)	Bregaglia Range	II/A-15.III-B	Graubünden	CH	1883
+Wildstrubel	3243	815	POINT(7.52861 46.40028)	Bernese Alps	I/B-12.II-F	Bern/Valais	CH	1855
+Tête de Soulaure	3243	508	POINT(6.415 44.7625)	Massif des Écrins	I/A-05.III-C	Hautes-Alpes	FR	
+Hochschober	3242	433	POINT(12.69833 46.9425)	Schober Group	II/A-17.II-D	East Tyrol	AT	1852
+Titlis	3238	978	POINT(8.43778 46.77194)	Urner Alps	I/B-12.I-B	Bern/Obwalden	CH	1739
+Grand Golliat	3238	313	POINT(7.10167 45.85917)	Grand Combin Alps	I/B-09.I-A	Valais/Aosta	CH/IT	1879
+Hoher Seeblaskogel	3235	370	POINT(11.07472 47.09556)	Stubai Alps	II/A-16.II-B	North Tyrol	AT	1881
+Pic des Houerts	3235	364	POINT(6.76722 44.58778)	Southern Cottian Alps	I/A-04.I-B	AdHP/H-Alpes	FR	
+Ofenhorn	3235	334	POINT(8.31861 46.38667)	Leone-Gotthard Alps	I/B-10.I-A	Valais/V-C-O	CH/IT	1864
+Becca del Merlo	3234	331	POINT(7.47056 45.84389)	Weisshorn-Matterhorn	I/B-09.II-B	Aosta Valley	IT	
+Großer Muntanitz	3232	717	POINT(12.58917 47.07361)	Granatspitze Group	II/A-17.II-B	East Tyrol	AT	1871
+Le Péouvou	3232	488	POINT(6.88361 44.63028)	Southern Cottian Alps	I/A-04.I-A	AdHP/H-Alpes	FR	1888
+Corno di Dosdè	3232	302	POINT(10.16972 46.40778)	Livigno Alps	II/A-15.IV-B	Sondrio	IT	1866
+Hoher Riffler	3231	321	POINT(11.70444 47.08111)	Zillertal Alps	II/A-17.I-A	North Tyrol	AT	1853
+Augstenberg	3230	432	POINT(10.20389 46.86444)	Silvretta	II/A-15.VI-A	N-Tyrol/Graub.	AT/CH	1881
+Piz Vadret	3229	660	POINT(9.96278 46.68694)	Albula Alps	II/A-15.II-B	Graubünden	CH	1867
+Grand Galibier	3228	635	POINT(6.43417 45.06389)	Massif des Cerces	I/A-04.III-A	H-Alpes/Savoy	FR	1877
+Tofana di Rozes	3225	664	POINT(12.05111 46.53694)	Dolomites - NE	II/C-31.I-D	Belluno	IT	1864
+Hintere Stangenspitze	3225	465	POINT(11.97611 47.05722)	Zillertal Alps	II/A-17.I-B	North Tyrol	AT	1891
+Monte Gavia	3223	309	POINT(10.4725 46.35417)	Ortler Alps	II/C-28.I-B	Brescia/Sondrio	IT	1891
+Rocca Bernauda	3222	682	POINT(6.6275 45.10139)	Massif des Cerces	I/A-04.III-A	H-Alpes/Turin	FR/IT	1882
+Monte Cristallo	3221	1416	POINT(12.20056 46.57528)	Dolomites - NE	II/C-31.I-D	Belluno	IT	1865
+Monte Civetta	3220	1454	POINT(12.05333 46.38)	Dolomites - SE	II/C-31.II-A	Belluno	IT	1860
+Tour Sallière	3220	726	POINT(6.92472 46.12694)	Chablais Alps	I/B-08.II-A	Valais	CH	1858
+Vorderes Plattenhorn: Ostgipfel	3220	300	POINT(10.03306 46.81)	Silvretta	II/A-15.VI-A	Graubünden	CH	1868
+Vogelberg	3218	303	POINT(9.06528 46.47833)	Adula Alps	I/B-10.III-B	Graub./Ticino	CH	1864
+Monte del Forno	3214	446	POINT(9.72472 46.33833)	Bregaglia Range	II/A-15.III-B	Graub./Sondrio	CH/IT	1876
+Bec de l'Ane	3213	372	POINT(6.98389 45.61556)	Graian Alps - Central	I/B-07.III-B	Savoy	FR	
+Le Métailler	3213	302	POINT(7.36028 46.10389)	Grand Combin Alps	I/B-09.I-D	Valais	CH	
+Piz Medel	3211	952	POINT(8.91111 46.61833)	Adula Alps	I/B-10.III-A	Graub./Ticino	CH	1865
+Scherbadung	3211	716	POINT(8.22306 46.32417)	Leone-Gotthard Alps	I/B-10.I-A	Valais/V-C-O	CH/IT	1886
+Diablerets	3210	968	POINT(7.18889 46.30389)	Vaud Alps	I/B-12.III-A	Valais/Vaud	CH	1850
+Gran Vernel	3210	314	POINT(11.83222 46.4425)	Dolomites - NW	II/C-31.III-B	Trentino	IT	1879
+Piz Timun	3209	823	POINT(9.40944 46.46694)	Oberhalbstein Range	II/A-15.I-A	Graub./Sondrio	CH/IT	1884
+Piz Cambrialas	3208	364	POINT(8.85194 46.78944)	Glarus Alps	I/B-13.I-A	Graubünden	CH	1905
+Pic du Thabor	3207	711	POINT(6.56222 45.11861)	Massif des Cerces	I/A-04.III-A	Savoy	FR	1878
+Hocheiser	3206	567	POINT(12.67333 47.15639)	Glockner Group	II/A-17.II-C	Salzburg	AT	1871
+Glödis	3206	376	POINT(12.72611 46.96111)	Schober Group	II/A-17.II-D	East Tyrol	AT	1871
+Pointe Haute de Mary	3206	326	POINT(6.89472 44.57556)	Southern Cottian Alps	I/A-04.I-A	A-d-H-Provence	FR	1879
+Punta Sorapiss	3205	1085	POINT(12.21167 46.50694)	Dolomites - NE	II/C-31.I-D	Belluno	IT	1864
+Piz Sesvenna	3204	1055	POINT(10.40278 46.70583)	Sesvenna Range	II/A-15.V-B	Graubünden	CH	
+Kitzsteinhorn	3203	436	POINT(12.68778 47.18806)	Glockner Group	II/A-17.II-C	Salzburg	AT	1828
+Schwarzhorn	3201	308	POINT(7.75667 46.21667)	Weisshorn-Matterhorn	I/B-09.II-D	Valais	CH	
+Mastaunspitze	3200	455	POINT(10.8025 46.69361)	Ötztal Alps	II/A-16.I-A	South Tyrol	IT	1854
+Piz Vadret	3199	308	POINT(9.95083 46.50889)	Livigno Alps	II/A-15.IV-A	Graubünden	CH	
+Gross Spannort	3198	616	POINT(8.52444 46.78667)	Urner Alps	I/B-12.I-B	Uri	CH	1867
+Dreiländerspitze	3197	306	POINT(10.14472 46.85083)	Silvretta	II/A-15.VI-A	N-Tyr/Vor/Graub.	AT/CH	1853
+Pointes de Pierre Brune	3196	354	POINT(6.85694 45.37806)	Vanoise massif	I/B-07.II-A	Savoy	FR	
+Mont Tondu	3196	301	POINT(6.75556 45.76389)	Mont Blanc massif	I/B-07.V-A	Savoy	FR	
+Bortelhorn	3193	430	POINT(8.12528 46.29472)	Leone-Gotthard Alps	I/B-10.I-A	Valais/V-C-O	CH/IT	1869
+Rocca Blancia	3193	328	POINT(6.86472 44.49917)	Southern Cottian Alps	I/A-04.I-A	AdHP/Cuneo	FR/IT	
+Cima Vezzana	3192	1273	POINT(11.83028 46.28972)	Dolomites - S	II/C-31.IV-A	Belluno/Trentino	IT	1872
+Pizzo Rotondo	3192	752	POINT(8.46611 46.5175)	Leone-Gotthard Alps	I/B-10.I-B	Ticino/Valais	CH	1869
+Hübschhorn I	3192	325	POINT(8.05528 46.23694)	Leone-Gotthard Alps	I/B-10.I-A	Valais	CH	
+Scopi	3190	792	POINT(8.83 46.57167)	Adula Alps	I/B-10.III-A	Graub./Ticino	CH	1782
+Löffelspitze	3190	303	POINT(12.16444 47.0175)	Venediger Group	II/A-17.II-A	East Tyrol	AT	1877
+Spechhorn	3189	355	POINT(8.00111 46.01222)	Weissmies Alps	I/B-09.V-B	Valais/V-C-O	CH/IT	
+Gleirscher Fernerkogel	3189	321	POINT(11.06361 47.11417)	Stubai Alps	II/A-16.II-B	North Tyrol	AT	1883
+Piz Surlej	3188	433	POINT(9.84306 46.45333)	Bernina Range	II/A-15.III-A	Graubünden	CH	1846
+Gross Windgällen	3187	552	POINT(8.73222 46.80722)	Glarus Alps	I/B-13.I-A	Uri	CH	1848
+Mont Glacier	3186	355	POINT(7.53972 45.63139)	Gran Paradiso Alps	I/B-07.IV-C	Aosta Valley	IT	
+Becca di Tey	3186	301	POINT(7.09472 45.58611)	Graian Alps - Central	I/B-07.III-A	Aosta Valley	IT	
+Langkofel	3181	1124	POINT(11.73528 46.525)	Dolomites - NW	II/C-31.III-A	South Tyrol	IT	1869
+Piz Murtaröl	3180	679	POINT(10.2875 46.57028)	Ortler Alps	II/A-15.V-A	Graub./Sondrio	CH/IT	1893
+Piz Tasna	3179	371	POINT(10.25222 46.85917)	Silvretta	II/A-15.VI-A	Graubünden	CH	1849
+Piz Pisoc	3173	922	POINT(10.27944 46.74444)	Sesvenna Range	II/A-15.V-B	Graubünden	CH	1865
+Corn da Tinizong	3173	474	POINT(9.67111 46.61167)	Albula Alps	II/A-15.II-A	Graubünden	CH	1866
+Pte de Paumont	3171	378	POINT(6.72833 45.13944)	Northern Cottian Alps	I/A-04.III-B	Savoy/Turin	FR/IT	
+Fensterlekofel	3171	373	POINT(12.04306 46.89222)	Rieserferner Group	II/A-17.III-A	South Tyrol	IT	1877
+Pic du Clapier du Peyron	3169	556	POINT(6.07694 44.93722)	Massif des Écrins	I/A-05.III-E	Isère	FR	1886
+Hoher Riffler	3168	1341	POINT(10.37083 47.11611)	Verwall	II/A-15.VI-C	North Tyrol	AT	1864
+Monte Pelmo	3168	1191	POINT(12.135 46.41944)	Dolomites - SE	II/C-31.II-A	Belluno	IT	1857
+Piz Tavrü	3168	851	POINT(10.29611 46.67917)	Sesvenna Range	II/A-15.V-B	Graubünden	CH	1893
+Piz Vial	3168	465	POINT(8.96917 46.63194)	Adula Alps	I/B-10.III-A	Graubünden	CH	1873
+Piz Plavna Dadaint	3167	490	POINT(10.22361 46.70861)	Sesvenna Range	II/A-15.V-B	Graubünden	CH	1891
+Piz Albris	3166	318	POINT(9.96333 46.46417)	Livigno Alps	II/A-15.IV-A	Ticino/Sondrio	CH/IT	
+Piz Lagrev	3165	855	POINT(9.72278 46.44583)	Albula Alps	II/A-15.II-A	Graubünden	CH	1875
+Piz Quattervals	3165	471	POINT(10.095 46.62722)	Livigno Alps	II/A-15.IV-A	Graubünden	CH	1848
+Tête de Sautron	3165	300	POINT(6.8775 44.48667)	Southern Cottian Alps	I/A-04.I-A	AdHP/Cuneo	FR/IT	1877
+Rosa dei Banchi	3164	314	POINT(7.5325 45.57722)	Gran Paradiso Alps	I/B-07.IV-B	Aosta/Turin	IT	
+Vieux Chaillol	3163	678	POINT(6.19056 44.73611)	Massif des Écrins	I/A-05.V-A	Hautes-Alpes	FR	
+Pizzo Stella	3163	597	POINT(9.42139 46.38167)	Oberhalbstein Range	II/A-15.I-A	Sondrio	IT	1859
+Pointe Clairy	3162	979	POINT(6.87306 45.24417)	Northern Cottian Alps	I/A-04.III-B	Savoy	FR	
+Piz Mitgel	3159	445	POINT(9.64667 46.61417)	Albula Alps	II/A-15.II-A	Graubünden	CH	1867
+Hausstock	3158	655	POINT(9.06556 46.87444)	Glarus Alps	I/B-13.II-A	Glarus/Graub.	CH	1832
+Monte Vallecetta	3156	493	POINT(10.40028 46.41194)	Ortler Alps	II/C-28.I-B	Sondrio	IT	1867
+Tête de Vautisse	3156	434	POINT(6.48583 44.70139)	Massif des Écrins	I/A-05.III-C	Hautes-Alpes	FR	1887
+Pic Ouest de Combeynot	3155	815	POINT(6.41111 45.01222)	Massif des Écrins	I/A-05.III-A	Hautes-Alpes	FR	
+Piz Prüna	3153	317	POINT(9.98722 46.48722)	Livigno Alps	II/A-15.IV-A	Graubünden	CH	
+Piz Boè	3152	939	POINT(11.82806 46.50889)	Dolomites - NW	II/C-31.III-A	Bell/S-Tyr/Tren	IT	1864
+Piz Popena	3152	344	POINT(12.2075 46.57639)	Dolomites - NE	II/C-31.I-D	Belluno	IT	1870
+Cima Brenta	3151	1499	POINT(10.89972 46.17944)	Brenta Dolomites	II/C-28.IV-A	Trentino	IT	1871
+Piz Terri	3149	390	POINT(9.03417 46.6)	Adula Alps	I/B-10.III-A	Graub./Ticino	CH	1802
+Becs de Bosson	3149	362	POINT(7.51806 46.16778)	Weisshorn-Matterhorn	I/B-09.II-C	Valais	CH	
+Kuchenspitze	3148	575	POINT(10.23 47.04861)	Verwall	II/A-15.VI-C	North Tyrol	AT	1884
+Zillerplattenspitze	3148	300	POINT(12.12972 47.10417)	Zillertal Alps	II/A-17.I-D	N-Tyrol/Salzburg	AT	1877
+Pfroslkopf	3148	298	POINT(10.68917 46.97778)	Ötztal Alps	II/A-16.I-A	North Tyrol	AT	1887
+Croda Rossa	3146	1133	POINT(12.14361 46.63472)	Dolomites - NE	II/C-31.I-B	Belluno/S-Tyrol	IT	1870
+Flüela Schwarzhorn	3146	609	POINT(9.94167 46.73583)	Albula Alps	II/A-15.II-B	Graubünden	CH	1835
+Monte Rafray	3146	343	POINT(7.51083 45.64778)	Gran Paradiso Alps	I/B-07.IV-C	Aosta Valley	IT	
+Piz Mundin	3146	342	POINT(10.43083 46.92528)	Samnaun Alps	II/A-15.VI-B	Graubünden	CH	1849
+Dreischusterspitze	3145	1393	POINT(12.31722 46.66889)	Sexten Dolomites	II/C-31.I-A	South Tyrol	IT	1869
+Napfspitze	3144	587	POINT(12.03972 47.06)	Zillertal Alps	II/A-17.I-B	N-Tyrol/S-Tyrol	AT/IT	1880
+Piz Tea Fondada	3144	319	POINT(10.30806 46.54944)	Ortler Alps	II/A-15.V-A	Graub./Sondrio	CH/IT	1883
+Cime du Gélas	3143	669	POINT(7.38472 44.12306)	Maritime Alps	I/A-02.I-A	A-Marit/Cuneo	FR/IT	1864
+Jochköpfl	3143	297	POINT(11.10778 46.9275)	Stubai Alps	II/A-16.II-A	North Tyrol	AT	
+Monte Cassa del Ferro	3140	849	POINT(10.20167 46.57861)	Livigno Alps	II/A-15.IV-A	Sondrio	IT	1883
+Cima Tosa	3140	587	POINT(10.87056 46.15528)	Brenta Dolomites	II/C-28.IV-A	Trentino	IT	1865
+Cime Redasco	3139	377	POINT(10.30778 46.36944)	Livigno Alps	II/A-15.IV-B	Sondrio	IT	1896
+Gross Ruchen	3138	397	POINT(8.77472 46.81028)	Glarus Alps	I/B-13.I-A	Uri	CH	1864
+Durreck	3135	618	POINT(12.02889 46.96111)	Venediger Group	II/A-17.II-A	South Tyrol	IT	1877
+Wilde Kreuzspitze	3135	567	POINT(11.59333 46.9125)	Zillertal Alps	II/A-17.I-C	South Tyrol	IT	1852
+Großer Friedrichskopf	3134	370	POINT(12.82861 46.95778)	Schober Group	II/A-17.II-D	Carinthia	AT	1872
+Hinter Schloss	3133	506	POINT(8.52694 46.8025)	Urner Alps	I/B-12.I-B	Uri	CH	1863
+Pizzo Filone	3133	332	POINT(10.16333 46.4575)	Livigno Alps	II/A-15.IV-B	Sondrio	IT	
+Oldenhorn	3132	295	POINT(7.22167 46.32917)	Vaud Alps	I/B-12.III-A	Bern/Val./Vaud	CH	1835
+Mont Chaberton	3131	1281	POINT(6.75167 44.96472)	Massif des Cerces	I/A-04.III-A	Hautes-Alpes	FR	1822
+Piz Duan	3131	482	POINT(9.58333 46.37528)	Oberhalbstein Range	II/A-15.I-A	Graubünden	CH	1859
+Pointe Léchaud	3128	525	POINT(6.81417 45.73361)	Mont Blanc massif	I/B-07.III-B	Savoy/Aosta	FR/IT	
+Grohmannspitze	3126	445	POINT(11.73361 46.51056)	Dolomites - NW	II/C-31.III-A	S-Tyrol/Trentino	IT	1880
+Piz Schumbraida	3125	315	POINT(10.33833 46.54278)	Ortler Alps	II/A-15.V-A	Graub./Sondrio	CH/IT	1883
+Fanellhorn	3124	301	POINT(9.13056 46.54778)	Adula Alps	I/B-10.III-B	Graubünden	CH	1859
+Piz Nuna	3123	535	POINT(10.15444 46.72333)	Sesvenna Range	II/A-15.V-B	Graubünden	CH	1886
+Schareck	3123	427	POINT(13.0175 47.04139)	Goldberg Group	II/A-17.II-E	Carinth/Salzburg	AT	1832
+Groß Seehorn	3122	434	POINT(10.0325 46.88778)	Silvretta	II/A-15.VI-A	Vorarlb/Graub.	AT/CH	1869
+Piz Aul	3121	395	POINT(9.125 46.62278)	Adula Alps	I/B-10.III-A	Graubünden	CH	1801
+Piz da l'Acqua	3118	310	POINT(10.13889 46.61111)	Livigno Alps	II/A-15.IV-A	Graub./Sondrio	CH/IT	1888
+Grand Pinier	3117	335	POINT(6.40167 44.72361)	Massif des Écrins	I/A-05.III-C	Hautes-Alpes	FR	
+Schermerspitze	3116	308	POINT(11.08444 46.88778)	Ötztal Alps	II/A-16.I-A	North Tyrol	AT	
+Grand Queyras	3114	308	POINT(6.95194 44.71556)	Southern Cottian Alps	I/A-04.I-C	Hautes-Alpes	FR	
+Luibiskogel	3110	473	POINT(10.90417 47.04972)	Ötztal Alps	II/A-16.I-C	North Tyrol	AT	1894
+Monte Servin	3108	333	POINT(7.19972 45.26472)	Graian Alps - SE	I/B-07.I-C	Turin	IT	
+Krönten	3108	330	POINT(8.56944 46.78222)	Urner Alps	I/B-12.I-B	Uri	CH	1868
+Gletscherhorn	3107	413	POINT(9.56056 46.3875)	Oberhalbstein Range	II/A-15.I-A	Graubünden	CH	1849
+Pizz Gallagiun	3107	413	POINT(9.48778 46.36694)	Oberhalbstein Range	II/A-15.I-A	Graub./Sondrio	CH/IT	1861
+Ochsner	3107	300	POINT(11.81556 47.04389)	Zillertal Alps	II/A-17.I-B	North Tyrol	AT	1880
+Tête de Moïse	3104	562	POINT(6.935 44.44056)	Southern Cottian Alps	I/A-04.I-A	AdHP/Cuneo	FR/IT	1883
+Piz la Stretta	3104	314	POINT(10.04472 46.47667)	Livigno Alps	II/A-15.IV-A	Graub./Sondrio	CH	
+Große Ohrenspitze	3101	369	POINT(12.1775 46.90694)	Rieserferner Group	II/A-17.III-A	E-Tyrol/S-Tyrol	AT/IT	1878
+Piz Segnas	3099	607	POINT(9.23972 46.90778)	Glarus Alps	I/B-13.II-B	Glarus/Graub.	CH	1861
+Monte Ouille	3099	362	POINT(6.86639 45.73167)	Mont Blanc massif	I/B-07.III-B	Aosta Valley	IT	
+Lasörling	3098	490	POINT(12.35528 46.97583)	Venediger Group	II/A-17.II-A	East Tyrol	AT	1854
+Pointe des Cerces	3098	485	POINT(6.48833 45.06556)	Massif des Cerces	I/A-04.III-A	H-Alpes/Savoy	FR	1891
+Pic des Souffles	3098	419	POINT(6.13333 44.865)	Massif des Écrins	I/A-05.III-D	Isère/H-Alpes	FR	1890
+Monte Matto	3097	577	POINT(7.25639 44.225)	Maritime Alps	I/A-02.I-B	Cuneo	IT	1879
+Pflerscher Tribulaun	3097	498	POINT(11.33917 46.98528)	Stubai Alps	II/A-16.II-A	N-Tyrol/S-Tyrol	AT/IT	1874
+Blockkogel	3097	295	POINT(10.88056 47.08528)	Ötztal Alps	II/A-16.I-C	North Tyrol	AT	
+Piz Giuv	3096	749	POINT(8.6925 46.70194)	Glarus Alps	I/B-13.I-A	Graubünden/Uri	CH	1804
+Mont Buet	3096	612	POINT(6.85278 46.02472)	Chablais Alps	I/B-08.II-A	Upper Savoy	FR	1770
+Zwölferkofel	3094	713	POINT(12.35972 46.61917)	Sexten Dolomites	II/C-31.I-A	Belluno/S-Tyrol	IT	1874
+Elferkofel	3092	661	POINT(12.37833 46.63639)	Sexten Dolomites	II/C-31.I-A	Belluno/S-Tyrol	IT	1878
+Racherin	3092	429	POINT(12.79444 47.08111)	Glockner Group	II/A-17.II-C	Carinthia	AT	1848
+Mont Fallère	3090	607	POINT(7.19417 45.77556)	Grand Combin Alps	I/B-09.I-B	Aosta Valley	IT	
+Tête de la Courbe	3089	565	POINT(6.82333 44.49778)	Southern Cottian Alps	I/A-04.I-A	A-d-H-Provence	FR	
+Vesulspitze	3089	550	POINT(10.34917 47.00167)	Samnaun Alps	II/A-15.VI-B	North Tyrol	AT	1866
+Monte Forcellina	3087	473	POINT(10.19861 46.46639)	Livigno Alps	II/A-15.IV-B	Sondrio	IT	
+Hohe Villerspitze	3087	293	POINT(11.16556 47.10667)	Stubai Alps	II/A-16.II-B	North Tyrol	AT	1878
+Flüela Wisshorn	3085	632	POINT(9.96667 46.76222)	Silvretta	II/A-15.VI-A	Graubünden	CH	1880
+Cima da Lägh	3083	422	POINT(9.46111 46.37639)	Oberhalbstein Range	II/A-15.I-A	Graub./Sondrio	CH/IT	
+Zwieselbacher Rosskogel	3081	330	POINT(11.04806 47.16333)	Stubai Alps	II/A-16.II-B	North Tyrol	AT	1881
+Fundusfeiler	3079	295	POINT(10.87028 47.11222)	Ötztal Alps	II/A-16.I-C	North Tyrol	AT	
+Chüealphorn	3078	472	POINT(9.90528 46.68528)	Albula Alps	II/A-15.II-B	Graubünden	CH	1877
+Mont Néry	3076	906	POINT(7.82 45.71583)	Monte Rosa Alps	I/B-09.III-B	Aosta Valley	IT	1873
+Großer Hafner	3076	824	POINT(13.40083 47.07)	Ankogel Group	II/A-17.II-F	Carinth/Salzburg	AT	1825
+Pic de Parières	3076	469	POINT(6.24083 44.77944)	Massif des Écrins	I/A-05.III-C	Hautes-Alpes	FR	
+Piz Starlex	3075	779	POINT(10.3925 46.66278)	Sesvenna Range	II/A-15.V-B	Graub./S-Tyrol	CH/IT	
+Piz Sena	3075	344	POINT(10.11 46.35306)	Livigno Alps	II/A-15.IV-B	Graub./Sondrio	CH/IT	1901
+Bristen	3073	567	POINT(8.68111 46.73694)	Glarus Alps	I/B-13.I-A	Uri	CH	1823
+Wildkarspitze	3073	384	POINT(12.13917 47.1725)	Zillertal Alps	II/A-17.I-D	Salzburg	AT	1892
+Pizzo Campo Tencia	3072	754	POINT(8.72611 46.42972)	Ticino Alps	I/B-10.II-D	Ticino	CH	1867
+Chüebodenhorn	3070	316	POINT(8.45306 46.50806)	Leone-Gotthard Alps	I/B-10.I-B	Ticino/Valais	CH	
+Tête de la Cassille	3069	299	POINT(6.49944 45.04389)	Massif des Cerces	I/A-04.III-A	Hautes-Alpes	FR	
+La Meyna	3067	375	POINT(6.85861 44.48111)	Southern Cottian Alps	I/A-04.I-A	A-d-H-Provence	FR	
+Geltenhorn	3065	312	POINT(7.33444 46.34639)	Bernese Alps	I/B-12.II-F	Bern/Valais	CH	
+Cunturines	3064	913	POINT(11.97778 46.57583)	Dolomites - NE	II/C-31.I-C	South Tyrol	IT	1881
+Hoher Prijakt	3064	473	POINT(12.71278 46.91556)	Schober Group	II/A-17.II-D	East Tyrol	AT	1890
+Pointe des Rochers Charniers	3063	389	POINT(6.73556 44.98778)	Massif des Cerces	I/A-04.III-A	Hautes-Alpes	FR	
+Hoch Ducan	3063	324	POINT(9.85139 46.68944)	Albula Alps	II/A-15.II-B	Graubünden	CH	1845
+Pizzo Gallina	3061	378	POINT(8.39194 46.49472)	Leone-Gotthard Alps	I/B-10.I-B	Ticino/Valais	CH	
+Seeköpfe	3061	330	POINT(10.2675 47.04444)	Verwall	II/A-15.VI-C	North Tyrol	AT	1886
+Piz Grisch	3060	544	POINT(9.47278 46.53111)	Oberhalbstein Range	II/A-15.I-B	Graubünden	CH	1861
+Grand Queyron	3060	295	POINT(7.00167 44.84278)	Central Cottian Alps	I/A-04.II-A	H-Alpes/Turin	FR/IT	
+Grabspitze	3059	415	POINT(11.61444 46.93861)	Zillertal Alps	II/A-17.I-C	South Tyrol	IT	1852
+Monte Vago	3059	388	POINT(10.07889 46.44083)	Livigno Alps	II/A-15.IV-B	Sondrio	IT	
+Sasso Vernale	3058	356	POINT(11.84056 46.41889)	Dolomites - NW	II/C-31.III-B	Belluno/Trentino	IT	
+Bruschghorn	3056	577	POINT(9.30667 46.63111)	Adula Alps	I/B-10.III-C	Graubünden	CH	
+Patteriol	3056	465	POINT(10.1875 47.04417)	Verwall	II/A-15.VI-C	North Tyrol	AT	1860
+Aiguille des Corneillets	3055	325	POINT(6.66139 45.3225)	Vanoise massif	I/B-07.II-E	Savoy	FR	
+Innere Wetterspitze	3053	293	POINT(11.24639 46.99639)	Stubai Alps	II/A-16.II-A	North Tyrol	AT	1874
+Piz Forun	3052	458	POINT(9.865 46.65528)	Albula Alps	II/A-15.II-B	Graubünden	CH	1847
+Grand Muveran	3051	1013	POINT(7.12611 46.23722)	Vaud Alps	I/B-12.III-A	Valais/Vaud	CH	
+Mont Pelat	3051	770	POINT(6.70583 44.265)	Maritime Alps	I/A-02.I-E	A-d-H-Provence	FR	
+Pizzo Coca	3050	1878	POINT(10.01139 46.07167)	Bergamo Alps	II/C-29.I-A	Bergamo/Sondrio	IT	1877
+Piz Minor	3049	584	POINT(10.02833 46.45111)	Livigno Alps	II/A-15.IV-A	Graubünden	CH	
+Gross Lohner	3049	560	POINT(7.6 46.46194)	Bernese Alps	I/B-12.II-F	Bern	CH	1875
+Le Rochail	3049	558	POINT(6.0325 44.97528)	Massif des Écrins	I/A-05.III-E	Isère	FR	
+Rosenspitze	3049	418	POINT(12.25444 46.98833)	Venediger Group	II/A-17.II-A	East Tyrol	AT	1894
+Aiguille du Fruit	3048	519	POINT(6.63139 45.35556)	Vanoise massif	I/B-07.II-E	Savoy	FR	
+Grand Bérard	3046	938	POINT(6.65972 44.44944)	Southern Cottian Alps	I/A-04.I-B	A-d-H-Provence	FR	1820
+Grand Argentier	3046	505	POINT(6.65861 45.12222)	Northern Cottian Alps	I/A-04.III-B	Savoy/Turin	FR/IT	
+Piz Murtera	3044	449	POINT(10.04028 46.77528)	Silvretta	II/A-15.VI-A	Graubünden	CH	
+Gross Wendenstock	3042	346	POINT(8.38028 46.76167)	Urner Alps	I/B-12.I-B	Bern	CH	1873
+Monte Albergian	3041	428	POINT(6.99278 45.0075)	Central Cottian Alps	I/A-04.II-A	Turin	IT	1822
+Piz Gannaretsch	3040	934	POINT(8.78667 46.61194)	Leone-Gotthard Alps	I/B-10.I-B	Graubünden	CH	
+Alperschällihorn	3039	425	POINT(9.30667 46.58667)	Adula Alps	I/B-10.III-C	Graub./Ticino	CH	1893
+Punta Scais	3039	393	POINT(9.98444 46.06861)	Bergamo Alps	II/C-29.I-A	Bergamo/Sondrio	IT	1881
+Bric Ghinivert	3037	347	POINT(6.99111 44.95139)	Central Cottian Alps	I/A-04.II-A	Turin	IT	
+Parseierspitze	3036	1243	POINT(10.47833 47.17444)	Lechtal Alps	II/B-21.I-A	North Tyrol	AT	1869
+Hexenkopf	3035	371	POINT(10.46944 47.02111)	Samnaun Alps	II/A-15.VI-B	North Tyrol	AT	1853
+Piz Umbrail	3033	294	POINT(10.41444 46.55083)	Ortler Alps	II/A-15.V-A	Graub./Sondrio	CH/IT	1865
+Tête de Siguret	3032	706	POINT(6.78833 44.44167)	Maritime Alps	I/A-02.I-C	A-d-H-Provence	FR	
+Pizzo Ligoncio	3032	506	POINT(9.54778 46.23889)	Bregaglia Range	II/A-15.III-B	Sondrio	IT	
+Becca di Vlou	3032	483	POINT(7.79222 45.69167)	Monte Rosa Alps	I/B-09.III-B	Aosta Valley	IT	
+Piz S-chalembert	3031	722	POINT(10.41333 46.80083)	Sesvenna Range	II/A-15.V-B	Graubünden	CH	
+Mont Ténibre	3031	525	POINT(6.97222 44.28389)	Maritime Alps	I/A-02.I-C	A-Marit/Cuneo	FR/IT	1836
+Piz Cotschen	3031	296	POINT(10.17694 46.81306)	Silvretta	II/A-15.VI-A	Graubünden	CH	
+Bric Rosso	3030	317	POINT(7.01861 44.99111)	Central Cottian Alps	I/A-04.II-A	Turin	IT	
+Piz Por	3028	733	POINT(9.38417 46.50944)	Oberhalbstein Range	II/A-15.I-A	Graubünden	CH	1894
+Bündner Vorab	3028	408	POINT(9.15667 46.87389)	Glarus Alps	I/B-13.II-B	Glarus/Graub.	CH	1842
+Corno di Ban	3028	311	POINT(8.36111 46.41778)	Leone-Gotthard Alps	I/B-10.I-A	V-C-O	IT	
+Zehner	3026	493	POINT(11.96056 46.62222)	Dolomites - NE	II/C-31.I-C	South Tyrol	IT	1887
+Furchetta	3025	904	POINT(11.77333 46.61222)	Dolomites - NW	II/C-31.III-A	South Tyrol	IT	1878
+Sas Rigais	3025	904	POINT(11.76667 46.60917)	Dolomites - NW	II/C-31.III-A	South Tyrol	IT	1878
+Piz Corbet	3025	672	POINT(9.28028 46.37972)	Adula Alps	I/B-10.III-D	Graub./Sondrio	CH/IT	1892
+Corno Bussola	3024	356	POINT(7.73611 45.79556)	Monte Rosa Alps	I/B-09.III-B	Aosta Valley	IT	
+Wendenhorn	3023	311	POINT(8.44361 46.75389)	Urner Alps	I/B-12.I-B	Bern/Uri	CH	1884
+Wurmaulspitze	3022	414	POINT(11.63778 46.91389)	Zillertal Alps	II/A-17.I-C	South Tyrol	IT	
+Pointe de la Vallaisonnay	3020	400	POINT(6.81778 45.45806)	Vanoise massif	I/B-07.II-B	Savoy	FR	
+Pic du Mas de la Grave	3020	364	POINT(6.24611 45.12083)	Dauphiné Alps	I/A-05.I-A	H-Alpes/Savoy	FR	
+Le Cimet	3020	342	POINT(6.705 44.29)	Maritime Alps	I/A-02.I-E	A-d-H-Provence	FR	
+Viso Mozzo	3019	361	POINT(7.11 44.67472)	Southern Cottian Alps	I/A-04.I-C	Cuneo	IT	
+Piz Blas	3019	312	POINT(8.72806 46.57722)	Leone-Gotthard Alps	I/B-10.I-B	Graub./Ticino	CH	1871
+Gamspleisspitze	3015	328	POINT(10.24194 46.93167)	Silvretta	II/A-15.VI-A	N-Tyrol/Graub.	AT/CH	1853
+Hochreichkopf	3010	367	POINT(10.96972 47.17028)	Stubai Alps	II/A-16.II-B	North Tyrol	AT	1890
+Cima dell'Uomo	3010	327	POINT(11.80833 46.40611)	Dolomites - NW	II/C-31.III-B	Trentino	IT	
+Monte Giove	3009	516	POINT(8.38806 46.36139)	Leone-Gotthard Alps	I/B-10.I-A	V-C-O	IT	
+Acherkogel	3008	365	POINT(10.95667 47.18917)	Stubai Alps	II/A-16.II-B	North Tyrol	AT	1881
+Älplihorn	3006	426	POINT(9.82583 46.71083)	Albula Alps	II/A-15.II-B	Graubünden	CH	
+Monte Avic	3006	392	POINT(7.55472 45.67694)	Gran Paradiso Alps	I/B-07.IV-C	Aosta Valley	IT	
+Ritterkopf	3006	349	POINT(12.94944 47.1025)	Goldberg Group	II/A-17.II-E	Salzburg	AT	1885
+Furgler	3004	319	POINT(10.51222 47.04028)	Samnaun Alps	II/A-15.VI-B	North Tyrol	AT	
+Kesselkogel	3002	814	POINT(11.64361 46.47444)	Dolomites - NW	II/C-31.III-B	S-Tyrol/Trentino	IT	1872
+Pizzas d'Anarosa	3002	366	POINT(9.31583 46.59889)	Adula Alps	I/B-10.III-C	Graub./Ticino	CH	1894
+Gigalitz	3001	300	POINT(11.89111 47.05778)	Zillertal Alps	II/A-17.I-B	North Tyrol	AT	1884
+Große Zinne	2999	545	POINT(12.30278 46.61889)	Sexten Dolomites	II/C-31.I-A	Belluno/S-Tyrol	IT	1869
+Pizzo Centrale	2999	451	POINT(8.615 46.57806)	Leone-Gotthard Alps	I/B-10.I-B	Ticino/Uri	CH	
+Cima Falkner	2999	343	POINT(10.90472 46.19333)	Brenta Dolomites	II/C-28.IV-A	Trentino	IT	1882
+Piz Beverin	2998	396	POINT(9.35778 46.6525)	Adula Alps	I/B-10.III-C	Graubünden	CH	1707
+Pic d'Artsinol	2998	296	POINT(7.42694 46.115)	Grand Combin Alps	I/B-09.I-D	Valais	CH	
+Bric Bouchet	2997	338	POINT(7.02389 44.82194)	Central Cottian Alps	I/A-04.II-A	H-Alpes/Turin	FR/IT	1876
+Hoher Dachstein	2995	2136	POINT(13.60556 47.47528)	Dachstein Mountains	II/B-25.I-B	Styria/U-Austria	AT	1832
+Roignais	2995	1028	POINT(6.68889 45.64306)	Beaufortain Massif	I/B-07.VI-A	Savoy	FR	
+Rote Säule	2994	304	POINT(12.44389 47.14667)	Venediger Group	II/A-17.II-A	E-Tyrol/Salzburg	AT	1865
+Le Mourre Froid	2993	411	POINT(6.40028 44.63833)	Massif des Écrins	I/A-05.III-C	Hautes-Alpes	FR	
+Grand Parpaillon	2990	335	POINT(6.65194 44.49389)	Southern Cottian Alps	I/A-04.I-B	A-d-H-Provence	FR	
+Mittler Fanis	2989	658	POINT(12.01417 46.55139)	Dolomites - NE	II/C-31.I-C	Belluno/S-Tyrol	IT	1898
+Felber Tauernkogel	2988	377	POINT(12.48389 47.15778)	Venediger Group	II/A-17.II-A	E-Tyrol/Salzburg	AT	1854
+Piz de la Lumbreida	2983	564	POINT(9.22528 46.48111)	Adula Alps	I/B-10.III-D	Graubünden	CH	
+Cima Bagni	2983	455	POINT(12.41028 46.61528)	Sexten Dolomites	II/C-31.I-A	Belluno	IT	
+Pala di San Martino	2982	410	POINT(11.85083 46.25361)	Dolomites - S	II/C-31.IV-A	Trentino	IT	1878
+Rosengartenspitze	2981	425	POINT(11.62083 46.45472)	Dolomites - NW	II/C-31.III-B	S-Tyrol/Trentino	IT	1874
+Aroser Rothorn	2980	1349	POINT(9.61389 46.73778)	Plessur Alps	II/A-15.VII-B	Graubünden	CH	
+Ròthòre	2979	499	POINT(7.88028 45.76694)	Monte Rosa Alps	I/B-09.III-C	Aosta/Vercelli	IT	
+La Tsavre	2978	305	POINT(7.12944 45.91556)	Grand Combin Alps	I/B-09.I-A	Valais	CH	
+Grand Pic de Belledonne	2977	1053	POINT(5.99167 45.17083)	Belledonne	I/A-05.II-B	Isère	FR	1859
+Pic de Colle Blanche	2975	335	POINT(6.1725 44.75333)	Massif des Écrins	I/A-05.V-A	Hautes-Alpes	FR	
+Monte Redival	2973	356	POINT(10.61417 46.30861)	Ortler Alps	II/C-28.I-A	Trentino	IT	1878
+Cima Ovest	2973	306	POINT(12.29722 46.61861)	Sexten Dolomites	II/C-31.I-A	Belluno/S-Tyrol	IT	1879
+Piz Curvér	2972	456	POINT(9.49722 46.60333)	Oberhalbstein Range	II/A-15.I-B	Graubünden	CH	1843
+Wildgrat	2971	461	POINT(10.82667 47.14056)	Ötztal Alps	II/A-16.I-C	North Tyrol	AT	
+Tsaat a l'Etsena	2971	326	POINT(7.4 45.80139)	Weisshorn-Matterhorn	I/B-09.II-B	Aosta Valley	IT	
+Schilthorn	2970	358	POINT(7.83472 46.5575)	Bernese Prealps	I/B-14.II-B	Bern	CH	
+Haut de Cry	2969	525	POINT(7.195 46.24028)	Vaud Alps	I/B-12.III-A	Valais	CH	
+Grieshorn	2969	509	POINT(8.39306 46.45139)	Leone-Gotthard Alps	I/B-10.I-A	Ticino/V-C-O	CH/IT	
+Dent de Morcles	2969	465	POINT(7.07556 46.19917)	Vaud Alps	I/B-12.III-A	Valais	CH	1787
+Piz Daint	2968	734	POINT(10.29083 46.61861)	Ortler Alps	II/A-15.V-A	Graubünden	CH	
+Neuner	2968	301	POINT(11.98111 46.63028)	Dolomites - NE	II/C-31.I-C	South Tyrol	IT	
+Cima del Duca	2968	293	POINT(9.79611 46.28778)	Bregaglia Range	II/A-15.III-B	Sondrio	IT	
+Serottini	2967	425	POINT(10.34778 46.29083)	Ortler Alps	II/C-28.I-B	Brescia/Sondrio	IT	
+Schober	2967	380	POINT(13.46833 47.03444)	Ankogel Group	II/A-17.II-F	Carinthia	AT	
+Haunold	2966	677	POINT(12.2775 46.68861)	Sexten Dolomites	II/C-31.I-A	South Tyrol	IT	1878
+Schesaplana	2965	828	POINT(9.7075 47.05361)	Rätikon	II/A-15.VIII-A	Vorarlb/Graub.	AT/CH	1735
+Aiguille du Belvédère	2965	505	POINT(6.87361 45.98778)	Chablais Alps	I/B-08.II-A	Upper Savoy	FR	
+Reißeck	2965	300	POINT(13.36444 46.94722)	Ankogel Group	II/A-17.II-F	Carinthia	AT	
+Monte Tagliaferro	2964	640	POINT(7.97083 45.8725)	Monte Rosa Alps	I/B-09.III-C	Vercelli	IT	
+Piz Turettas	2963	400	POINT(10.33472 46.58694)	Ortler Alps	II/A-15.V-A	Graubünden	CH	
+Pizzo Lucendro	2963	350	POINT(8.51944 46.53889)	Leone-Gotthard Alps	I/B-10.I-B	Ticino/Uri	CH	1871
+Zugspitze	2962	1746	POINT(10.98528 47.42111)	Wetterstein	II/B-21.III-B	N-Tyrol/Bavaria	AT/DE	1820
+Weiße Spitze	2962	910	POINT(12.35778 46.87194)	Villgraten Mountains	II/A-17.III-B	East Tyrol	AT	1894
+Rienzenstock	2962	479	POINT(8.635 46.68306)	Glarus Alps	I/B-13.I-A	Uri	CH	
+Marchhorn	2962	327	POINT(8.4625 46.44861)	Ticino Alps	I/B-10.II-A	Ticino/V-C-O	CH/IT	
+Tête de l'Estrop	2961	712	POINT(6.50583 44.28667)	Provence Alps	I/A-03.1-A	A-d-H-Provence	FR	
+Cima Brenta Alta	2961	341	POINT(10.89639 46.16028)	Brenta Dolomites	II/C-28.IV-A	Trentino	IT	1880
+Piz Lagalb	2959	524	POINT(10.02361 46.43167)	Livigno Alps	II/A-15.IV-A	Graubünden	CH	
+Cima Giner	2957	340	POINT(10.7325 46.23722)	Adamello-Presanella	II/C-28.III-B	Trentino	IT	
+Piz Miez	2956	445	POINT(8.91667 46.65472)	Adula Alps	I/B-10.III-A	Graubünden	CH	
+Tête de L'Enchastraye	2954	310	POINT(6.88833 44.3675)	Maritime Alps	I/A-02.I-C	AdHP/Cuneo	FR/IT	
+Torent	2952	835	POINT(9.07111 46.34361)	Adula Alps	I/B-10.III-B	Graub./Ticino	CH	1882
+Brunnistock	2952	661	POINT(8.55 46.84778)	Urner Alps	I/B-12.I-B	Uri	CH	
+Crasta Mora	2952	486	POINT(9.86806 46.57139)	Albula Alps	II/A-15.II-A	Graubünden	CH	
+Bättlihorn	2951	388	POINT(8.09389 46.3325)	Leone-Gotthard Alps	I/B-10.I-A	Valais	CH	
+Corni di Nefelgiú	2951	368	POINT(8.37944 46.39556)	Leone-Gotthard Alps	I/B-10.I-A	V-C-O	IT	
+Hochgrabe	2951	296	POINT(12.42167 46.84889)	Villgraten Mountains	II/A-17.III-B	East Tyrol	AT	
+Crête de Lacha	2950	425	POINT(6.45944 45.09722)	Massif des Cerces	I/A-04.III-A	Savoy	FR	
+Asta Soprana	2950	424	POINT(7.31333 44.20333)	Maritime Alps	I/A-02.I-B	Cuneo	IT	
+Piz Tomül	2946	534	POINT(9.22833 46.62333)	Adula Alps	I/B-10.III-C	Graubünden	CH	1807
+Piz Cavel	2946	518	POINT(9.01972 46.65583)	Adula Alps	I/B-10.III-A	Graubünden	CH	
+Einshorn	2944	571	POINT(9.23028 46.51611)	Adula Alps	I/B-10.III-D	Graubünden	CH	
+Gölbner	2943	382	POINT(12.505 46.82417)	Villgraten Mountains	II/A-17.III-B	East Tyrol	AT	
+Hochkönig	2941	2181	POINT(13.0625 47.42028)	Berchtesgaden Alps	II/B-24.III-A	Salzburg	AT	1826
+Cime de la Condamine	2940	515	POINT(6.51972 44.8925)	Massif des Écrins	I/A-05.III-A	Hautes-Alpes	FR	
+Gross Schinhorn	2939	465	POINT(8.26083 46.36111)	Leone-Gotthard Alps	I/B-10.I-A	Valais/V-C-O	CH/IT	
+Pointe de la Louïe Blanche	2939	372	POINT(6.91472 45.66111)	Graian Alps - Central	I/B-07.III-B	Savoy/Aosta	FR/IT	
+Pizzo del Ramulazz S	2939	324	POINT(9.09278 46.39667)	Adula Alps	I/B-10.III-B	Graub./Ticino	CH	
+Monte Unghiasse	2939	298	POINT(7.295 45.41611)	Graian Alps - SE	I/B-07.I-C	Turin	IT	
+Pic de Chabrières	2938	435	POINT(6.62361 44.57056)	Southern Cottian Alps	I/A-04.I-B	A-d-H-Provence	FR	
+Mont Malinvern	2938	403	POINT(7.18944 44.19889)	Maritime Alps	I/A-02.I-B	A-Marit/Cuneo	FR/IT	1878
+Cime di Plator	2937	654	POINT(10.27056 46.515)	Livigno Alps	II/A-15.IV-A	Sondrio	IT	
+Pietra Grande	2937	496	POINT(10.89583 46.23139)	Brenta Dolomites	II/C-28.IV-A	Trentino	IT	1883
+Monte Gruf	2936	446	POINT(9.50583 46.28611)	Bregaglia Range	II/A-15.III-B	Sondrio	IT	
+Mont du Grand Capelet	2935	298	POINT(7.4275 44.07833)	Maritime Alps	I/A-02.I-A	Alpes Maritimes	FR	
+Cimon del Froppa	2932	677	POINT(12.34056 46.50722)	Dolomites - NE	II/C-31.I-E	Belluno	IT	1872
+Monte Pettini	2932	640	POINT(10.2275 46.53611)	Livigno Alps	II/A-15.IV-B	Sondrio	IT	
+Bärenhorn	2929	449	POINT(9.23194 46.57556)	Adula Alps	I/B-10.III-C	Graubünden	CH	
+Tête du Pelvas	2929	400	POINT(6.99972 44.79)	Central Cottian Alps	I/A-04.II-A	H-Alpes/Turin	FR/IT	
+Rosställispitz	2929	368	POINT(9.99361 46.78917)	Silvretta	II/A-15.VI-A	Graubünden	CH	
+Schwarzhorn	2928	966	POINT(8.07556 46.68611)	Bernese Prealps	I/B-14.II-B	Bern	CH	
+Rocher Blanc	2928	939	POINT(6.10722 45.24167)	Belledonne	I/A-05.II-A	Isère	FR	
+Badus	2928	529	POINT(8.66361 46.6225)	Leone-Gotthard Alps	I/B-10.I-B	Graubünden/Uri	CH	1785
+Tête des Lauzières	2928	339	POINT(6.52833 44.87417)	Massif des Écrins	I/A-05.III-A	Hautes-Alpes	FR	
+Vollandspitze	2928	295	POINT(10.17667 47.01861)	Verwall	II/A-15.VI-C	North Tyrol	AT	1886
+Eggishorn	2927	563	POINT(8.09417 46.43139)	Bernese Alps	I/B-12.II-B	Valais	CH	
+Cima Bastioni Sud	2926	554	POINT(12.26778 46.48528)	Dolomites - NE	II/C-31.I-E	Belluno	IT	1890
+Pizzo del Diavolo della Malgina	2926	330	POINT(10.04667 46.08472)	Bergamo Alps	II/C-29.I-A	Bergamo/Sondrio	IT	
+Edlenkopf	2923	441	POINT(12.92639 47.13639)	Goldberg Group	II/A-17.II-E	Salzburg	AT	
+Mährenhorn	2923	355	POINT(8.31083 46.69167)	Urner Alps	I/B-12.I-A	Bern	CH	
+Birkenkofel	2922	385	POINT(12.25667 46.68083)	Sexten Dolomites	II/C-31.I-A	South Tyrol	IT	1880
+Monte Ruvi	2922	333	POINT(7.56444 45.68917)	Gran Paradiso Alps	I/B-07.IV-C	Aosta Valley	IT	
+Hochgasser	2922	311	POINT(12.52194 47.15056)	Granatspitze Group	II/A-17.II-B	E-Tyrol/Salzburg	AT	
+Aiguille du Grand Fond	2920	298	POINT(6.67083 45.66639)	Beaufortain Massif	I/B-07.VI-A	Savoy	FR	
+Monte Ciorneva	2918	483	POINT(7.26028 45.26833)	Graian Alps - SE	I/B-07.I-C	Turin	IT	
+Mulleter Seichenkopf	2918	389	POINT(12.83139 46.91528)	Schober Group	II/A-17.II-D	Carinthia/E-Tyrol	AT	1890
+Corno di Flavona	2918	305	POINT(10.89694 46.24556)	Brenta Dolomites	II/C-28.IV-A	Trentino	IT	1881
+Cima Bel Pra	2917	431	POINT(12.24111 46.48444)	Dolomites - NE	II/C-31.I-E	Belluno	IT	1880
+Dent Favre	2917	315	POINT(7.10389 46.21028)	Vaud Alps	I/B-12.III-A	Valais/Vaud	CH	
+Pizzo del Diavolo di Tenda	2916	506	POINT(9.90806 46.04528)	Bergamo Alps	II/C-29.I-A	Bergamo/Sondrio	IT	1870
+Pointe Côte de l'Âne	2916	472	POINT(6.80472 44.24444)	Maritime Alps	I/A-02.I-D	Alpes Maritimes	FR	
+Maresenspitz	2916	324	POINT(13.23028 47.00417)	Ankogel Group	II/A-17.II-F	Carinthia	AT	
+L'Aupillon	2916	303	POINT(6.57861 44.44889)	Southern Cottian Alps	I/A-04.I-B	A-d-H-Provence	FR	
+Glärnisch	2915	967	POINT(8.99528 46.995)	Schwyz Alps	I/B-13.I-B	Glarus	CH	
+Pflunspitze	2912	977	POINT(10.13278 47.07944)	Verwall	II/A-15.VI-C	N-Tyrol/Vorarlb.	AT	1886
+Cristallina	2912	344	POINT(8.53694 46.46472)	Ticino Alps	I/B-10.II-A	Ticino	CH	
+Beco Alto del Piz	2912	312	POINT(6.98083 44.29889)	Maritime Alps	I/A-02.I-C	Cuneo	IT	
+Monte Torena	2911	299	POINT(10.10306 46.08833)	Bergamo Alps	II/C-29.I-A	Bergamo/Sondrio	IT	
+Pic du Béal Traversier	2910	550	POINT(6.68944 44.75694)	Central Cottian Alps	I/A-04.II-B	Hautes-Alpes	FR	
+Aiguille de Cédéra	2909	458	POINT(6.28472 44.73861)	Massif des Écrins	I/A-05.III-C	Hautes-Alpes	FR	
+Grande Séolane	2909	385	POINT(6.54639 44.33778)	Provence Alps	I/A-03.1-A	A-d-H-Provence	FR	
+Puy Gris	2908	379	POINT(6.14611 45.29583)	Belledonne	I/A-05.II-A	Savoy	FR	
+Pizzo Diei	2906	623	POINT(8.23806 46.26472)	Leone-Gotthard Alps	I/B-10.I-A	V-C-O	IT	
+Les Grandes Aiguilles	2905	293	POINT(6.785 45.70556)	Mont Blanc massif	I/B-07.III-B	Savoy	FR	
+Signal du Lauvitel E	2904	306	POINT(6.0475 44.93889)	Massif des Écrins	I/A-05.III-E	Isère	FR	
+Pic de Peyre Eyraute	2903	400	POINT(6.63056 44.82278)	Central Cottian Alps	I/A-04.II-B	Hautes-Alpes	FR	
+Piz Combul	2901	313	POINT(10.04389 46.22972)	Bernina Range	II/A-15.III-A	Graub./Sondrio	CH/IT	
+Grand Chavalard	2899	446	POINT(7.11306 46.17861)	Vaud Alps	I/B-12.III-A	Valais	CH	
+Becca di Nona	2898	374	POINT(7.41611 45.83972)	Weisshorn-Matterhorn	I/B-09.II-B	Aosta Valley	IT	1832
+Le Pouzenc	2898	374	POINT(6.51694 44.45917)	Southern Cottian Alps	I/A-04.I-B	A-d-H-Provence	FR	
+Monte Frisozzo	2897	609	POINT(10.44917 46.02444)	Adamello-Presanella	II/C-28.III-A	Brescia	IT	1854
+Holzgauer Wetterspitze	2895	592	POINT(10.36944 47.20639)	Lechtal Alps	II/B-21.I-A	North Tyrol	AT	1832
+Reinhart	2891	318	POINT(12.17972 47.04222)	Venediger Group	II/A-17.II-A	South Tyrol	IT	1893
+Regenstein	2891	316	POINT(12.49056 46.86056)	Villgraten Mountains	II/A-17.III-B	East Tyrol	AT	
+Monte Orsiera	2890	859	POINT(7.10722 45.06389)	Central Cottian Alps	I/A-04.II-A	Turin	IT	
+Schwarzhorn	2890	355	POINT(9.02278 46.6775)	Adula Alps	I/B-10.III-A	Graubünden	CH	
+Monte Re di Castello	2889	312	POINT(10.48333 46.02167)	Adamello-Presanella	II/C-28.III-A	Brescia/Trentino	IT	1854
+Vorderseespitze	2889	310	POINT(10.36694 47.18472)	Lechtal Alps	II/B-21.I-A	North Tyrol	AT	1855
+Napfspitze	2888	343	POINT(11.73944 46.93694)	Zillertal Alps	II/A-17.I-C	South Tyrol	IT	
+Schildflue	2887	333	POINT(9.95639 46.88056)	Silvretta	II/A-15.VI-A	Graubünden	CH	
+Wissigstock	2887	329	POINT(8.50667 46.84556)	Urner Alps	I/B-12.I-B	Obwalden/Uri	CH	
+Lizumer Reckner	2886	548	POINT(11.63083 47.14389)	Tux Alps	II/B-23.I-A	North Tyrol	AT	
+Guggernüll	2886	377	POINT(9.27139 46.52389)	Adula Alps	I/B-10.III-D	Graubünden	CH	
+Le Chevalier	2886	373	POINT(6.75917 44.33056)	Maritime Alps	I/A-02.I-C	Alpes Maritimes	FR	
+Pizzo Recastello	2886	373	POINT(10.07556 46.05694)	Bergamo Alps	II/C-29.I-A	Bergamo	IT	1876
+Rietzer Grießkogel	2884	867	POINT(11.05944 47.24583)	Stubai Alps	II/A-16.II-B	North Tyrol	AT	1829
+Monteaviolo	2881	561	POINT(10.39861 46.18528)	Adamello-Presanella	II/C-28.III-A	Brescia	IT	
+Pointe de la Terrasse	2881	405	POINT(6.72472 45.67083)	Beaufortain Massif	I/B-07.VI-A	Savoy	FR	
+Piz Fess	2880	501	POINT(9.28861 46.7275)	Adula Alps	I/B-10.III-C	Graubünden	CH	1895
+Cima della Sasse	2878	402	POINT(12.06444 46.35694)	Dolomites - SE	II/C-31.II-A	Belluno	IT	
+Moiazza Sud	2878	402	POINT(12.05806 46.33833)	Dolomites - SE	II/C-31.II-A	Belluno	IT	1895
+Pointe de Cloutzau	2878	329	POINT(6.7475 45.00722)	Massif des Cerces	I/A-04.III-A	H-Alpes/Turin	FR/IT	
+Peitlerkofel	2875	638	POINT(11.82 46.65889)	Dolomites - NW	II/C-31.III-A	South Tyrol	IT	1885
+Eisentälispitze	2875	386	POINT(9.9625 46.91333)	Silvretta	II/A-15.VI-A	Vorarlb/Graub.	AT/CH	1892
+Schwalbenkofel	2873	328	POINT(12.27028 46.65222)	Sexten Dolomites	II/C-31.I-A	South Tyrol	IT	
+Monte Carbonè	2873	309	POINT(7.43056 44.16028)	Maritime Alps	I/A-02.I-A	Cuneo	IT	
+Monte Agnèr	2872	542	POINT(11.95278 46.27639)	Dolomites - S	II/C-31.IV-A	Belluno	IT	1875
+Mont Bégo	2872	323	POINT(7.45083 44.07389)	Maritime Alps	I/A-02.I-A	Alpes Maritimes	FR	
+Tête des Vieux	2872	302	POINT(6.935 45.75889)	Mont Blanc massif	I/B-07.III-B	Aosta Valley	IT	
+Grand Aréa	2869	442	POINT(6.57333 44.98)	Massif des Cerces	I/A-04.III-A	Hautes-Alpes	FR	
+Kolbenspitze	2868	367	POINT(11.14778 46.77278)	Ötztal Alps	II/A-16.I-B	South Tyrol	IT	
+Punta Cornour	2867	417	POINT(7.09306 44.85056)	Central Cottian Alps	I/A-04.II-A	Turin	IT	1836
+Tête de Gaulent	2867	350	POINT(6.52556 44.71889)	Massif des Écrins	I/A-05.III-C	Hautes-Alpes	FR	
+Nufenenstock	2866	381	POINT(8.38833 46.46694)	Leone-Gotthard Alps	I/B-10.I-A	Ticino/Valais	CH	
+Rocher de Plassa	2865	409	POINT(6.68917 45.37306)	Vanoise massif	I/B-07.II-E	Savoy	FR	
+Triglav	2864	2048	POINT(13.83694 46.37806)	Julian Alps	II/C-34.I-E	West Slovenia	SI	1778
+Pala di Meduce	2864	304	POINT(12.2975 46.50194)	Dolomites - NE	II/C-31.I-E	Belluno	IT	1890
+Poncione di Braga	2864	301	POINT(8.54278 46.43417)	Ticino Alps	I/B-10.II-A	Ticino	CH	
+Wandfluhhorn	2863	452	POINT(8.46417 46.34472)	Ticino Alps	I/B-10.II-A	Ticino/V-C-O	CH/IT	
+Hochgolling	2862	1124	POINT(13.76111 47.26611)	Niedere Tauern	II/A-18.II-A	Salzburg/Styria	AT	1791
+Cima de Barna	2862	314	POINT(9.26361 46.42056)	Adula Alps	I/B-10.III-D	Graub./Sondrio	CH/IT	
+Le Taillefer	2857	1490	POINT(5.92444 45.03972)	Taillefer Massif	I/A-05.IV-A	Isère	FR	
+Gstellihorn	2855	366	POINT(8.17472 46.66222)	Vaud Alps	I/B-12.III-A	Bern	CH	1836
+Piz di Sassiglion	2855	313	POINT(10.1125 46.32278)	Livigno Alps	II/A-15.IV-B	Graub./Sondrio	CH/IT	
+Petite Séolane	2854	317	POINT(6.53 44.3575)	Provence Alps	I/A-03.1-A	A-d-H-Provence	FR	
+Cima Ciantiplagna	2849	673	POINT(7.01333 45.07222)	Central Cottian Alps	I/A-04.II-A	Turin	IT	
+Croda Granda	2849	492	POINT(11.92861 46.24861)	Dolomites - S	II/C-31.IV-A	Belluno	IT	1883
+Cima d'Asta	2847	939	POINT(11.60528 46.17667)	Fiemme Alps	II/C-31.V-B	Trentino	IT	1816
+Punta Nera	2847	431	POINT(12.19167 46.51639)	Dolomites - NE	II/C-31.I-D	Belluno	IT	1876
+Cima del Desenigo	2845	369	POINT(9.56167 46.20167)	Bregaglia Range	II/A-15.III-B	Sondrio	IT	
+Pizol	2844	457	POINT(9.38667 46.95917)	Glarus Alps	I/B-13.II-A	St. Gallen	CH	1864
+Sommet du Charra	2844	363	POINT(6.71028 45.02139)	Massif des Cerces	I/A-04.III-A	H-Alpes/Turin	FR/IT	
+Weissfluh	2843	497	POINT(9.79528 46.835)	Plessur Alps	II/A-15.VII-A	Graubünden	CH	
+Pic de Beaudouis	2843	366	POINT(6.69444 44.83639)	Central Cottian Alps	I/A-04.II-B	Hautes-Alpes	FR	
+Schneekarkopf	2843	307	POINT(12.03556 47.14111)	Zillertal Alps	II/A-17.I-D	North Tyrol	AT	
+Cornone di Blumone	2843	295	POINT(10.45583 45.95472)	Adamello-Presanella	II/C-28.III-A	Brescia	IT	1878
+Latemar	2842	1097	POINT(11.57528 46.38111)	Fiemme Alps	II/C-31.V-A	S-Tyrol/Trentino	IT	1885
+Cima di Gana Bianca	2842	410	POINT(8.99222 46.47139)	Adula Alps	I/B-10.III-B	Ticino	CH	
+Kirchdachspitze	2840	470	POINT(11.34194 47.06722)	Stubai Alps	II/A-16.II-A	North Tyrol	AT	
+Dürrenstein	2839	880	POINT(12.18528 46.6725)	Dolomites - NE	II/C-31.I-B	South Tyrol	IT	
+Cima Cadin di San Lucano	2839	663	POINT(12.28806 46.5775)	Sexten Dolomites	II/C-31.I-A	Belluno	IT	
+Grand Cheval de Bois	2838	424	POINT(6.63389 44.2925)	Maritime Alps	I/A-02.I-E	A-d-H-Provence	FR	
+Kärlskopf	2836	631	POINT(12.23611 46.88861)	Villgraten Mountains	II/A-17.III-B	E-Tyrol/S-Tyrol	AT/IT	
+Tête du Clotonnet	2835	335	POINT(6.10111 44.84278)	Massif des Écrins	I/A-05.III-D	Isère/H-Alpes	FR	
+Gamskarlspitz	2833	374	POINT(13.1625 47.03694)	Ankogel Group	II/A-17.II-F	Carinth/Salzburg	AT	
+Cheval Noir	2832	507	POINT(6.41389 45.42194)	Vanoise massif	I/B-07.II-E	Savoy	FR	
+Rocca la Meja	2831	437	POINT(7.06889 44.39833)	Southern Cottian Alps	I/A-04.I-A	Cuneo	IT	
+Drei Türme	2830	628	POINT(9.81 47.02472)	Rätikon	II/A-15.VIII-A	Vorarlberg	AT	
+Aiguille de Venosc	2830	299	POINT(6.08722 44.96806)	Massif des Écrins	I/A-05.III-E	Isère	FR	
+Grand Pic de la Lauzière	2829	836	POINT(6.36667 45.45917)	Vanoise massif	I/B-07.II-F	Savoy	FR	
+Pirchkogel	2828	300	POINT(10.99917 47.23194)	Stubai Alps	II/A-16.II-B	North Tyrol	AT	
+Große Schlenkerspitze	2827	445	POINT(10.61528 47.24889)	Lechtal Alps	II/B-21.I-A	North Tyrol	AT	1882
+Graunock	2827	419	POINT(11.78889 46.88611)	Zillertal Alps	II/A-17.I-B	South Tyrol	IT	
+Cime de Bolofré	2827	308	POINT(6.83528 44.22306)	Maritime Alps	I/A-02.I-D	Alpes Maritimes	FR	
+Madrisahorn	2826	600	POINT(9.87222 46.93111)	Rätikon	II/A-15.VIII-A	Graubünden	CH	
+Kalkwand	2826	342	POINT(11.66167 47.15389)	Tux Alps	II/B-23.I-B	North Tyrol	AT	
+Grand Perron des Encombres	2824	442	POINT(6.45028 45.29778)	Vanoise massif	I/B-07.II-E	Savoy	FR	
+Tête de l'Hivernet	2824	330	POINT(6.45306 44.62)	Massif des Écrins	I/A-05.III-C	Hautes-Alpes	FR	
+Hoher Herd	2824	313	POINT(12.45 47.19944)	Venediger Group	II/A-17.II-A	Salzburg	AT	
+Hochmaderer	2823	318	POINT(10.02861 46.92861)	Silvretta	II/A-15.VI-A	Vorarlberg	AT	1853
+Le Bellachat	2822	351	POINT(6.39694 45.37972)	Vanoise massif	I/B-07.II-E	Savoy	FR	
+Riedbock	2822	297	POINT(13.35667 46.92861)	Ankogel Group	II/A-17.II-F	Carinthia	AT	
+Monfandì	2820	405	POINT(7.61944 45.52194)	Gran Paradiso Alps	I/B-07.IV-B	Turin	IT	
+Sulzfluh	2818	475	POINT(9.83972 47.0125)	Rätikon	II/A-15.VIII-A	Vorarlb/Graub.	AT/CH	1782
+Mont Mounier	2817	613	POINT(6.9725 44.15472)	Maritime Alps	I/A-02.I-D	Alpes Maritimes	FR	
+Dosso Resaccio	2814	519	POINT(10.22 46.50111)	Livigno Alps	II/A-15.IV-B	Sondrio	IT	
+Sass Maòr	2814	371	POINT(11.84806 46.2325)	Dolomites - S	II/C-31.IV-A	Trentino	IT	1875
+Vallüla	2813	776	POINT(10.1125 46.9375)	Silvretta	II/A-15.VI-A	N-Tyrol/Vorarlb.	AT	1866
+Cima delle Lose	2813	352	POINT(6.925 44.37222)	Maritime Alps	I/A-02.I-C	Cuneo	IT	
+Frate della Meia	2812	387	POINT(7.92417 45.75889)	Monte Rosa Alps	I/B-09.III-C	Vercelli	IT	
+Seekofel	2810	478	POINT(12.0725 46.675)	Dolomites - NE	II/C-31.I-B	Belluno/S-Tyrol	IT	
+Valluga	2809	572	POINT(10.21306 47.1575)	Lechtal Alps	II/B-21.I-A	N-Tyrol/Vorarlb.	AT	1877
+Monte Campellio	2809	315	POINT(10.47722 46.05139)	Adamello-Presanella	II/C-28.III-A	Brescia/Trentino	IT	
+Peiderspitze	2808	408	POINT(11.12167 47.21972)	Stubai Alps	II/A-16.II-B	North Tyrol	AT	1888
+Seejoch	2808	408	POINT(11.10306 47.22444)	Stubai Alps	II/A-16.II-B	North Tyrol	AT	1888
+Pizzo Castello	2808	385	POINT(8.56528 46.41556)	Ticino Alps	I/B-10.II-A	Ticino	CH	
+Pic du Frêne	2807	521	POINT(6.19833 45.3525)	Belledonne	I/A-05.II-A	Isère/Savoy	FR	
+Haldensteiner Calanda	2805	1460	POINT(9.4675 46.9)	Glarus Alps	I/B-13.II-B	Graub./StGallen	CH	1559
+Cima de Gagela	2805	723	POINT(9.17472 46.38417)	Adula Alps	I/B-10.III-B	Graubünden	CH	
+Tête à l'Âne	2804	540	POINT(6.77972 45.98722)	Chablais Alps	I/B-08.II-A	Upper Savoy	FR	
+Corona di Redorta	2804	481	POINT(8.73222 46.37556)	Ticino Alps	I/B-10.II-D	Ticino	CH	
+Schlicker Seespitze	2804	327	POINT(11.27333 47.14556)	Stubai Alps	II/A-16.II-B	North Tyrol	AT	1879
+Bös Fulen	2802	367	POINT(8.94583 46.96722)	Schwyz Alps	I/B-13.I-B	Glarus/Schwyz	CH	
+Cima di Ball	2802	352	POINT(11.84444 46.24306)	Dolomites - S	II/C-31.IV-A	Trentino	IT	1869
+Corno Mud	2802	317	POINT(7.96389 45.88444)	Monte Rosa Alps	I/B-09.III-C	Vercelli	IT	
+Rollspitze	2800	588	POINT(11.50778 46.94639)	Zillertal Alps	II/A-17.I-A	South Tyrol	IT	
+Rosenjoch	2796	466	POINT(11.54333 47.18)	Tux Alps	II/B-23.I-A	North Tyrol	AT	
+Col Bechei	2794	622	POINT(12.04444 46.60778)	Dolomites - NE	II/C-31.I-C	Belluno/S-Tyrol	IT	
+Kärpf	2794	533	POINT(9.09333 46.91667)	Glarus Alps	I/B-13.II-A	Glarus	CH	
+Drättehorn	2794	340	POINT(7.82389 46.58222)	Bernese Prealps	I/B-14.II-B	Bern	CH	
+Pizzo Quadro	2793	470	POINT(8.41806 46.29861)	Ticino Alps	I/B-10.II-A	Ticino/V-C-O	CH/IT	
+Grand Armet	2792	920	POINT(5.93444 44.98194)	Taillefer Massif	I/A-05.IV-A	Isère	FR	
+Punta Ciamberline	2792	325	POINT(7.35806 44.16556)	Maritime Alps	I/A-02.I-B	Cuneo	IT	
+Grande Tête de l'Obiou	2790	1542	POINT(5.83972 44.77472)	Dauphiné Prealps	I/A-06.I-B	Isère	FR	
+Pizzo Marumo	2790	435	POINT(8.95944 46.59833)	Adula Alps	I/B-10.III-A	Ticino	CH	
+Muntejela de Senes	2787	456	POINT(12.01833 46.67167)	Dolomites - NE	II/C-31.I-B	South Tyrol	IT	
+Le Luisin	2786	324	POINT(6.97 46.12083)	Chablais Alps	I/B-08.II-A	Valais	CH	
+Polinik	2784	1575	POINT(13.15806 46.895)	Kreuzeck Group	II/A-17.IV-A	Carinthia	AT	
+Schrotkopf	2784	430	POINT(12.54056 47.20889)	Granatspitze Group	II/A-17.II-B	Salzburg	AT	
+Grande Autane	2782	379	POINT(6.28778 44.64917)	Massif des Écrins	I/A-05.III-C	Hautes-Alpes	FR	
+Hirzer	2781	751	POINT(11.27667 46.73722)	Sarntal Alps	II/A-16.III-A	South Tyrol	IT	
+Tiejer Flue	2781	345	POINT(9.73444 46.78083)	Plessur Alps	II/A-15.VII-B	Graubünden	CH	
+Hohe Warte	2780	1144	POINT(12.88306 46.60694)	Carnic Alps	II/C-33.I-A	Carinthia/Udine	AT/IT	1865
+Monte dei Corni	2779	315	POINT(7.63583 45.57083)	Gran Paradiso Alps	I/B-07.IV-B	Aosta/Turin	IT	
+Monte Cassorso	2776	339	POINT(7.01806 44.41778)	Southern Cottian Alps	I/A-04.I-A	Cuneo	IT	
+Grun de Saint-Maurice	2775	323	POINT(6.05722 44.81611)	Massif des Écrins	I/A-05.III-D	Isère/H-Alpes	FR	
+Imster Muttekopf	2774	300	POINT(10.65167 47.26722)	Lechtal Alps	II/B-21.I-A	North Tyrol	AT	
+Pizzo del Sole	2773	555	POINT(8.76778 46.525)	Leone-Gotthard Alps	I/B-10.I-B	Ticino	CH	
+Punta Lunella	2772	471	POINT(7.21639 45.19722)	Graian Alps - SE	I/B-07.I-A	Turin	IT	
+Große Sandspitze	2770	1245	POINT(12.81194 46.76639)	Gailtal Alps	II/C-33.II-B	East Tyrol	AT	1866
+Madererspitze	2769	495	POINT(10.06972 47.025)	Verwall	II/A-15.VI-C	Vorarlberg	AT	1865
+Fallesinspitze	2769	465	POINT(10.30028 47.18139)	Lechtal Alps	II/B-21.I-A	North Tyrol	AT	
+Hochsteinflache	2769	294	POINT(11.99778 47.15889)	Zillertal Alps	II/A-17.I-D	North Tyrol	AT	
+Hochplattig	2768	1189	POINT(10.98861 47.35306)	Mieminger Chain	II/B-21.III-A	North Tyrol	AT	1873
+Il Madone	2768	330	POINT(8.56694 46.49194)	Ticino Alps	I/B-10.II-A	Ticino	CH	
+Dristner	2767	313	POINT(11.83944 47.11333)	Zillertal Alps	II/A-17.I-B	North Tyrol	AT	1843
+Schwarzkopf	2765	365	POINT(12.86083 47.16694)	Glockner Group	II/A-17.II-C	Salzburg	AT	
+Schächentaler Windgällen	2764	691	POINT(8.79167 46.88806)	Schwyz Alps	I/B-14.IV-A	Uri	CH	
+Schwarzberg	2764	343	POINT(8.67778 46.60944)	Leone-Gotthard Alps	I/B-10.I-B	Graubünden/Uri	CH	
+Albristhorn	2763	823	POINT(7.48778 46.49806)	Bernese Prealps	I/B-14.II-A	Bern	CH	
+Rotenkogel	2762	555	POINT(12.59889 46.98)	Granatspitze Group	II/A-17.II-B	East Tyrol	AT	
+Rastkogel	2762	470	POINT(11.75111 47.20417)	Tux Alps	II/B-23.I-B	North Tyrol	AT	
+Pizzo Massari	2760	424	POINT(8.68333 46.47583)	Ticino Alps	I/B-10.II-A	Ticino	CH	
+Dent de Barme	2759	364	POINT(6.84194 46.13194)	Chablais Alps	I/B-08.II-A	Valais/U-Savoy	CH/FR	
+Grand Ferrand	2758	523	POINT(5.81611 44.7225)	Dauphiné Prealps	I/A-06.I-B	Isère/H-Alpes	FR	1873
+Reeti	2757	341	POINT(8.01167 46.665)	Bernese Prealps	I/B-14.II-B	Bern	CH	
+Ehrenspitze	2756	347	POINT(11.07778 46.76389)	Ötztal Alps	II/A-16.I-B	South Tyrol	IT	
+Roche de l'Abisse	2755	492	POINT(7.505 44.14361)	Maritime Alps	I/A-02.I-A	A-Marit/Cuneo	FR/IT	1832
+Cima di Cece	2754	736	POINT(11.68389 46.26083)	Fiemme Alps	II/C-31.V-B	Trentino	IT	
+Monte Telenek	2754	440	POINT(10.17917 46.0925)	Bergamo Alps	II/C-29.I-A	Sondrio	IT	
+Jôf dal Montâs	2753	1597	POINT(13.43361 46.43583)	Julian Alps	II/C-34.I-A	Udine	IT	1877
+Untere Wildgrubenspitze	2753	980	POINT(10.12639 47.165)	Lechtal Alps	II/B-21.I-A	Vorarlberg	AT	
+Östliche Eisentalerspitze	2753	358	POINT(10.1 47.07972)	Verwall	II/A-15.VI-C	Vorarlberg	AT	
+Pic de Valsenestre	2752	484	POINT(6.0675 44.88667)	Massif des Écrins	I/A-05.III-E	Isère	FR	
+Cima di Quaira	2752	303	POINT(10.61417 46.30861)	Ortler Alps	II/C-28.I-A	S-Tyrol/Trentino	IT	
+Pointe Percée	2750	1643	POINT(6.55611 45.95556)	Aravis Range	I/B-08.IV-A	Upper Savoy	FR	1865
+Birkkarspitze	2749	1564	POINT(11.43778 47.41111)	Karwendel	II/B-21.IV-A	North Tyrol	AT	1870
+Alplerspitz	2748	321	POINT(11.30111 46.76167)	Sarntal Alps	II/A-16.III-A	South Tyrol	IT	
+Sommet de La Frema	2747	702	POINT(6.69861 44.15194)	Maritime Alps	I/A-02.I-E	A-d-H-Provence	FR	
+Hochwildstelle	2747	480	POINT(13.83083 47.335)	Niedere Tauern	II/A-18.II-A	Styria	AT	1801
+Corno del Lago	2747	409	POINT(7.78306 45.67083)	Monte Rosa Alps	I/B-09.III-B	Aosta Valley	IT	
+Hochwart	2746	308	POINT(11.31889 46.79083)	Sarntal Alps	II/A-16.III-A	South Tyrol	IT	
+Cima Bocche	2745	714	POINT(11.75222 46.35417)	Dolomites - NW	II/C-31.III-B	Trentino	IT	
+Jakobsspitze	2745	531	POINT(11.49167 46.76306)	Sarntal Alps	II/A-16.III-A	South Tyrol	IT	
+Sadnig	2745	385	POINT(12.98917 46.94111)	Goldberg Group	II/A-17.II-E	Carinthia	AT	
+Hochwanner	2744	699	POINT(11.05583 47.39611)	Wetterstein	II/B-21.III-B	N-Tyrol/Bavaria	AT/DE	1870
+Roteck	2742	444	POINT(13.85056 47.23)	Niedere Tauern	II/A-18.II-A	Salzburg/Styria	AT	
+Ärmighore	2742	332	POINT(7.71361 46.54167)	Bernese Prealps	I/B-14.II-B	Bern	CH	
+Madom Gröss	2741	630	POINT(8.83111 46.36667)	Ticino Alps	I/B-10.II-D	Ticino	CH	
+Cima Carnera	2741	319	POINT(7.97028 45.855)	Monte Rosa Alps	I/B-09.III-C	Vercelli	IT	
+Škrlatica	2740	972	POINT(13.82111 46.43278)	Julian Alps	II/C-34.I-E	West Slovenia	SI	1880
+Kasereck	2740	425	POINT(13.77167 47.2375)	Niedere Tauern	II/A-18.II-A	Salzburg	AT	
+Schenadüi	2738	375	POINT(8.74861 46.5525)	Leone-Gotthard Alps	I/B-10.I-B	Ticino	CH	
+Spitzhorli	2737	320	POINT(7.98056 46.26444)	Weissmies Alps	I/B-09.V-C	Valais	CH	
+Monte Zucchero	2735	554	POINT(8.71417 46.35417)	Ticino Alps	I/B-10.II-D	Ticino	CH	
+Kaltwasserkarspitze	2733	320	POINT(11.45056 47.40306)	Karwendel	II/B-21.IV-A	North Tyrol	AT	1870
+Dremelspitze	2733	307	POINT(10.59583 47.235)	Lechtal Alps	II/B-21.I-A	North Tyrol	AT	1896
+Pic des Cabottes	2732	548	POINT(6.06389 45.24194)	Belledonne	I/A-05.II-A	Isère	FR	
+Clot de la Cime	2732	312	POINT(6.72194 44.81667)	Central Cottian Alps	I/A-04.II-B	Hautes-Alpes	FR	
+Monte Borga	2731	325	POINT(10.20833 46.09306)	Bergamo Alps	II/C-29.I-A	Sondrio	IT	
+Le Grand Coin	2729	328	POINT(6.40222 45.34611)	Vanoise massif	I/B-07.II-E	Savoy	FR	
+Kesselspitze	2728	323	POINT(11.36472 47.10056)	Stubai Alps	II/A-16.II-A	North Tyrol	AT	
+Bergwerkskopf	2728	310	POINT(10.60917 47.225)	Lechtal Alps	II/B-21.I-A	North Tyrol	AT	1885
+Sas de Mezdi	2727	488	POINT(11.8775 46.47194)	Dolomites - NW	II/C-31.III-B	Belluno/Trentino	IT	
+Pizzo di Claro	2727	361	POINT(9.05556 46.29583)	Adula Alps	I/B-10.III-B	Graub./Ticino	CH/IT	
+Pizzo di Prata	2727	352	POINT(9.45556 46.2775)	Bregaglia Range	II/A-15.III-B	Sondrio	IT	
+Großer Bettelwurf	2726	814	POINT(11.52 47.34417)	Karwendel	II/B-21.IV-A	North Tyrol	AT	1855
+Hirzer	2725	339	POINT(11.66306 47.21778)	Tux Alps	II/B-23.I-B	North Tyrol	AT	
+Schmalzkopf	2724	327	POINT(10.53583 46.93139)	Ötztal Alps	II/A-16.I-A	North Tyrol	AT	
+Weiße Wand	2722	315	POINT(11.81361 46.94583)	Zillertal Alps	II/A-17.I-C	South Tyrol	IT	
+Mont Dzerbion	2720	306	POINT(7.66389 45.78833)	Monte Rosa Alps	I/B-09.III-B	Aosta Valley	IT	
+Hochwand	2719	402	POINT(11.01583 47.35861)	Mieminger Chain	II/B-21.III-A	North Tyrol	AT	1873
+Spitzkofel	2717	457	POINT(12.74333 46.77222)	Gailtal Alps	II/C-33.II-B	East Tyrol	AT	1855
+Serles	2717	333	POINT(11.38111 47.12389)	Stubai Alps	II/A-16.II-A	North Tyrol	AT	1579
+Ortstock	2716	538	POINT(8.94806 46.92528)	Schwyz Alps	I/B-13.I-A	Glarus/Schwyz	CH	
+Valisera	2716	293	POINT(9.95583 46.96083)	Silvretta	II/A-15.VI-A	Vorarlberg	AT	
+Cima Ambrizzola	2715	610	POINT(12.09806 46.47917)	Dolomites - NE	II/C-31.I-D	Belluno	IT	1884
+Colàc	2715	377	POINT(11.7825 46.44139)	Dolomites - NW	II/C-31.III-B	Trentino	IT	
+Watzmann	2713	953	POINT(12.92306 47.555)	Berchtesgaden Alps	II/B-24.III-C	Bavaria	DE	1800
+Pizzo Straciugo	2713	335	POINT(8.12083 46.13222)	Weissmies Alps	I/B-09.V-B	Valais/V-C-O	CH/IT	
+Croda da Campo	2712	365	POINT(12.43417 46.58944)	Sexten Dolomites	II/C-31.I-A	Belluno	IT	
+Weißeck	2711	451	POINT(13.39417 47.1625)	Niedere Tauern	II/A-18.I-A	Salzburg	AT	
+Mont Saint-Sauveur	2711	369	POINT(7.13556 44.16472)	Maritime Alps	I/A-02.I-B	Alpes Maritimes	FR	
+Mont Gond	2710	395	POINT(7.26361 46.28556)	Vaud Alps	I/B-12.III-A	Valais	CH	
+Pic de Bure	2709	1267	POINT(5.935 44.62667)	Dauphiné Prealps	I/A-06.I-A	Hautes-Alpes	FR	
+Hochkreuz	2709	300	POINT(13.07417 46.815)	Kreuzeck Group	II/A-17.IV-A	Carinthia	AT	
+Gsür	2708	372	POINT(7.51972 46.51083)	Bernese Prealps	I/B-14.II-A	Bern	CH	
+Coston di Slavaci	2708	315	POINT(11.71694 46.26222)	Fiemme Alps	II/C-31.V-B	Trentino	IT	
+Cima dei Preti	2706	1420	POINT(12.42083 46.3425)	Carnic Prealps	II/C-33.III-A	Bell./Pordenone	IT	1874
+Penser Weißhorn	2705	458	POINT(11.39556 46.80194)	Sarntal Alps	II/A-16.III-A	South Tyrol	IT	1822
+Pizzo Montalto	2705	395	POINT(8.13306 46.0975)	Weissmies Alps	I/B-09.V-B	V-C-O	IT	
+Rote Wand	2704	877	POINT(9.985 47.18639)	Lechquellen Mts	II/B-21.II-A	Vorarlberg	AT	1867
+Monte Fraiteve	2702	403	POINT(6.86139 44.97722)	Central Cottian Alps	I/A-04.II-A	Turin	IT	
+Waldhorn	2702	392	POINT(13.8175 47.29611)	Niedere Tauern	II/A-18.II-A	Salzburg/Styria	AT	1878
+Rotsandnollen	2700	493	POINT(8.34389 46.80056)	Urner Alps	I/B-14.III-B	Nidwalden/Obw.	CH	
+Cima Iuribrutto	2697	316	POINT(11.76528 46.35917)	Dolomites - NW	II/C-31.III-B	Trentino	IT	
+Großer Lafatscher	2696	615	POINT(11.45278 47.34556)	Karwendel	II/B-21.IV-A	North Tyrol	AT	1867
+Monte Peralba	2694	725	POINT(12.71944 46.62944)	Carnic Alps	II/C-33.I-A	Belluno	IT	1854
+Piz de Groven	2694	433	POINT(9.15917 46.31833)	Adula Alps	I/B-10.III-B	Graubünden	CH	
+Grand Coyer	2693	421	POINT(6.69028 44.10056)	Maritime Alps	I/A-02.I-E	A-d-H-Provence	FR	
+Tête du Colonney	2692	521	POINT(6.69083 45.97167)	Chablais Alps	I/B-08.II-B	Upper Savoy	FR	
+Ilmspitze	2692	300	POINT(11.33028 47.05722)	Stubai Alps	II/A-16.II-A	North Tyrol	AT	1891
+Große Kinigat	2689	595	POINT(12.52444 46.67528)	Carnic Alps	II/C-33.I-A	E-Tyrol/Belluno	AT/IT	1898
+Piz Pian Grand	2689	528	POINT(9.15556 46.4175)	Adula Alps	I/B-10.III-B	Graubünden	CH	
+Aiguilles de la Pennaz	2688	359	POINT(6.69944 45.745)	Beaufortain Massif	I/B-07.VI-B	Savoy/U-Savoy	FR	
+Hochfeind	2687	572	POINT(13.495 47.18722)	Niedere Tauern	II/A-18.I-A	Salzburg	AT	
+Schwabenalpenkopf	2687	296	POINT(12.28667 46.64528)	Sexten Dolomites	II/C-31.I-A	South Tyrol	IT	
+Grand Mont	2686	577	POINT(6.53722 45.63194)	Beaufortain Massif	I/B-07.VI-A	Savoy	FR	
+Cima del Serraglio	2685	350	POINT(10.24222 46.59278)	Ortler Alps	II/A-15.V-A	Graub./Sondrio	CH/IT	
+Deichselspitze	2684	385	POINT(13.82222 47.27028)	Niedere Tauern	II/A-18.II-A	Salzburg/Styria	AT	
+Chapeau de Gendarme	2682	368	POINT(6.66583 44.33833)	Maritime Alps	I/A-02.I-C	Alpes Maritimes	FR	
+Leutascher Dreitorspitze	2682	346	POINT(11.12444 47.40056)	Wetterstein	II/B-21.III-B	N-Tyrol/Bavaria	AT/DE	1871
+Hochstadel	2681	386	POINT(12.85722 46.76)	Gailtal Alps	II/C-33.II-B	Carinthia/E-Tyrol	AT	
+Mosermandl	2680	555	POINT(13.39611 47.20611)	Niedere Tauern	II/A-18.I-A	Salzburg	AT	
+Mangart	2679	1067	POINT(13.65472 46.43944)	Julian Alps	II/C-34.I-C	Udine/Slovenia	IT/SI	1794
+Spullerschafberg	2679	670	POINT(10.07583 47.17389)	Lechquellen Mts	II/B-21.II-A	Vorarlberg	AT	
+Punta Tempesta	2679	309	POINT(7.13833 44.42194)	Southern Cottian Alps	I/A-04.I-A	Cuneo	IT	
+Cima di Santa Maria	2678	436	POINT(10.95083 46.21278)	Brenta Dolomites	II/C-28.IV-A	Trentino	IT	
+Gaflunakopf	2676	351	POINT(10.13472 47.06389)	Verwall	II/A-15.VI-C	N-Tyrol/Vorarlb.	AT	
+Piz della Forcola	2675	449	POINT(9.29333 46.31639)	Adula Alps	I/B-10.III-D	Graub./Sondrio	CH/IT	
+Mont Pépoiri	2674	643	POINT(7.20278 44.11083)	Maritime Alps	I/A-02.I-B	Alpes Maritimes	FR	
+Mont Rougnous	2673	465	POINT(6.87389 44.18417)	Maritime Alps	I/A-02.I-D	Alpes Maritimes	FR	
+Elendberg	2672	346	POINT(13.74694 47.28389)	Niedere Tauern	II/A-18.II-A	Styria	AT	
+Ballunspitze	2671	400	POINT(10.135 46.95528)	Silvretta	II/A-15.VI-A	N-Tyrol/Vorarlb.	AT	1861
+Stübele	2671	384	POINT(10.93667 46.46778)	Ortler Alps	II/C-28.I-A	S-Tyrol/Trentino	IT	
+Sas Ciampac	2671	305	POINT(11.83528 46.56306)	Dolomites - NW	II/C-31.III-A	South Tyrol	IT	
+Le Grand Miceau	2669	300	POINT(6.21222 45.37111)	Belledonne	I/A-05.II-A	Savoy	FR	
+Monte Duranno	2668	510	POINT(12.40278 46.32889)	Carnic Prealps	II/C-33.III-A	Bell./Pordenone	IT	1874
+Südliche Sonnenspitze	2668	325	POINT(11.47778 47.38667)	Karwendel	II/B-21.IV-A	North Tyrol	AT	1870
+Jôf Fuart	2666	528	POINT(13.49139 46.43056)	Julian Alps	II/C-34.I-A	Udine	IT	
+Les Avoudrues	2666	385	POINT(6.81306 46.10111)	Chablais Alps	I/B-08.II-B	Upper Savoy	FR	
+Monte Bruffione	2665	350	POINT(10.49139 45.94222)	Adamello-Presanella	II/C-28.III-A	Brescia/Trentino	IT	
+Monte Cernera	2664	304	POINT(12.05833 46.46889)	Dolomites - NE	II/C-31.I-D	Belluno	IT	
+Toblacher Pfannhorn	2663	337	POINT(12.28417 46.78389)	Villgraten Mountains	II/A-17.III-B	E-Tyrol/S-Tyrol	AT/IT	
+Hohe Munde	2662	603	POINT(11.07194 47.34778)	Mieminger Chain	II/B-21.III-A	North Tyrol	AT	
+Grünstein	2661	389	POINT(10.92139 47.34889)	Mieminger Chain	II/B-21.III-A	North Tyrol	AT	
+Pointe Rousse des Chambres	2660	322	POINT(6.82028 46.11278)	Chablais Alps	I/B-08.II-B	Upper Savoy	FR	
+Pizzo Giezza	2658	555	POINT(8.19667 46.17917)	Weissmies Alps	I/B-09.V-B	V-C-O	IT	
+Piz Toissa	2657	310	POINT(9.525 46.61861)	Oberhalbstein Range	II/A-15.I-B	Graubünden	CH	
+Großer Krottenkopf	2656	996	POINT(10.35583 47.31167)	Allgäu Alps	II/B-22.II-C	North Tyrol	AT	1864
+Ilmenspitze	2656	312	POINT(10.96389 46.48194)	Ortler Alps	II/C-28.I-A	S-Tyrol/Trentino	IT	
+Selbhorn	2655	409	POINT(12.96361 47.44694)	Berchtesgaden Alps	II/B-24.III-A	Salzburg	AT	
+Sommet du Guiau	2654	442	POINT(6.67361 45.02)	Massif des Cerces	I/A-04.III-A	H-Alpes/Turin	FR/IT	
+Faulkogel	2654	350	POINT(13.3725 47.21611)	Niedere Tauern	II/A-18.I-A	Salzburg	AT	
+Schönfeldspitze	2653	384	POINT(12.9375 47.45806)	Berchtesgaden Alps	II/B-24.III-A	Salzburg	AT	
+Tullen	2653	296	POINT(11.775 46.65361)	Dolomites - NW	II/C-31.III-A	South Tyrol	IT	
+Männliflue	2652	374	POINT(7.54639 46.55139)	Bernese Prealps	I/B-14.II-A	Bern	CH	
+Hohes Licht	2651	678	POINT(10.27611 47.28028)	Allgäu Alps	II/B-22.II-C	North Tyrol	AT	1854
+Punta Marguareis	2650	779	POINT(7.68444 44.17389)	Ligurian Alps	I/A-01.II-B	A-Marit/Cuneo	FR/IT	
+Le Chenaillet	2650	496	POINT(6.74056 44.90222)	Central Cottian Alps	I/A-04.II-B	Hautes-Alpes	FR	
+Braunarlspitze	2649	612	POINT(10.06444 47.22944)	Lechquellen Mts	II/B-21.II-A	Vorarlberg	AT	
+Averau	2649	413	POINT(12.03694 46.50083)	Dolomites - NE	II/C-31.I-D	Belluno	IT	1874
+Jalovec	2645	511	POINT(13.67972 46.42167)	Julian Alps	II/C-34.I-C	West Slovenia	SI	1875
+Crête des Crousas	2645	422	POINT(6.66056 44.72306)	Central Cottian Alps	I/A-04.II-B	Hautes-Alpes	FR	
+Zimba	2643	578	POINT(9.78889 47.09139)	Rätikon	II/A-15.VIII-A	Vorarlberg	AT	1848
+Heiterwand	2639	745	POINT(10.73444 47.31444)	Lechtal Alps	II/B-21.I-B	North Tyrol	AT	1890
+Hocheck	2638	401	POINT(13.72417 47.23611)	Niedere Tauern	II/A-18.II-A	Salzburg	AT	
+Kleiner Solstein	2637	516	POINT(11.32444 47.3025)	Karwendel	II/B-21.IV-A	North Tyrol	AT	1867
+Birnhorn	2634	1665	POINT(12.73389 47.47472)	Leoganger Steinberge	II/B-24.I-C	Salzburg	AT	1831
+Crêt du Rey	2633	514	POINT(6.59944 45.60139)	Beaufortain Massif	I/B-07.VI-A	Savoy	FR	
+Urbeleskarspitze	2632	375	POINT(10.46861 47.33667)	Allgäu Alps	II/B-22.II-C	North Tyrol	AT	1869
+Großstein	2632	351	POINT(10.49444 47.23778)	Lechtal Alps	II/B-21.I-A	North Tyrol	AT	
+Rüfispitze	2632	342	POINT(10.18222 47.19111)	Lechtal Alps	II/B-21.I-A	Vorarlberg	AT	
+Monte Mongioie	2630	459	POINT(7.78556 44.175)	Ligurian Alps	I/A-01.II-B	Cuneo	IT	
+Munt Buffalora	2630	351	POINT(10.25 46.62694)	Ortler Alps	II/A-15.V-A	Graubünden	CH	
+Ultner Hochwart	2627	440	POINT(10.99972 46.51167)	Ortler Alps	II/C-28.I-A	South Tyrol	IT	
+Blutspitze	2626	430	POINT(13.68583 47.24972)	Niedere Tauern	II/A-18.II-A	Salzburg/Styria	AT	
+Monte Pradella	2626	348	POINT(9.85056 45.99222)	Bergamo Alps	II/C-29.I-A	Bergamo	IT	
+Cima d'Auta Orientale	2624	312	POINT(11.88611 46.40056)	Dolomites - NW	II/C-31.III-B	Belluno	IT	
+Valschavielberge	2624	304	POINT(10.12667 47.00944)	Verwall	II/A-15.VI-C	Vorarlberg	AT	
+Le Rissiou	2622	522	POINT(6.06806 45.18361)	Dauphiné Alps	I/A-05.I-B	Isère	FR	
+Greifenberg	2618	335	POINT(13.78972 47.28917)	Niedere Tauern	II/A-18.II-A	Salzburg/Styria	AT	
+Monte Stelle delle Sute	2616	550	POINT(11.53333 46.21083)	Fiemme Alps	II/C-31.V-B	Trentino	IT	
+Grande Balmaz	2616	305	POINT(6.49667 45.89333)	Aravis Range	I/B-08.IV-A	Savoy/U-Savoy	FR	
+Piz Cavradi	2614	351	POINT(8.69556 46.6325)	Ticino Alps	I/B-10.II-A	Graubünden	CH	
+Pizzo dell'Alpe Gelato	2613	357	POINT(8.44417 46.24972)	Ticino Alps	I/B-10.II-A	Ticino/V-C-O	CH/IT	
+Le Gros Têt	2613	342	POINT(6.23972 45.07528)	Dauphiné Alps	I/A-05.I-A	Savoy	FR	
+Cima Bianca	2612	309	POINT(8.8125 46.38778)	Ticino Alps	I/B-10.II-D	Ticino	CH	
+Monte le Stelière	2612	301	POINT(7.10722 44.26583)	Maritime Alps	I/A-02.I-C	Cuneo	IT	
+Foostock	2611	388	POINT(9.24472 46.95667)	Glarus Alps	I/B-13.II-B	Glarus/StGallen	CH	
+Monte Legnone	2609	624	POINT(9.41472 46.09472)	Bergamo Alps	II/C-29.I-B	Lecco/Sondrio	IT	
+Sommet d'Assan	2609	358	POINT(6.73611 44.68556)	Southern Cottian Alps	I/A-04.I-A	Hautes-Alpes	FR	
+Mittlere Jägerkarspitze	2608	323	POINT(11.37583 47.35361)	Karwendel	II/B-21.IV-A	North Tyrol	AT	1859
+Hochkalter	2607	663	POINT(12.86667 47.56944)	Berchtesgaden Alps	II/B-24.III-C	Bavaria	DE	1830
+Cima del Rouss	2604	381	POINT(7.0 44.32111)	Maritime Alps	I/A-02.I-C	Cuneo	IT	
+Campanile Ciastelin	2602	395	POINT(12.37722 46.51083)	Dolomites - NE	II/C-31.I-E	Belluno	IT	1890
+Becco di Mezzodì	2602	325	POINT(12.11444 46.46667)	Dolomites - NE	II/C-31.I-D	Belluno	IT	1872
+Schafseitenspitze	2602	305	POINT(11.55444 47.10278)	Tux Alps	II/B-23.I-A	North Tyrol	AT	
+Razor	2601	332	POINT(13.79194 46.41194)	Julian Alps	II/C-34.I-E	West Slovenia	SI	1842
+Monte Cabianca	2601	312	POINT(9.86694 46.01)	Bergamo Alps	II/C-29.I-A	Bergamo	IT	
+Monte Mars	2600	409	POINT(7.91528 45.63333)	Biellese Alps	I/B-09.IV-A	Aosta/Biella	IT	
+Silberpfennig	2600	374	POINT(13.04167 47.08917)	Goldberg Group	II/A-17.II-E	Salzburg	AT	
+Großer Knallstein	2599	548	POINT(13.97694 47.32)	Niedere Tauern	II/A-18.II-A	Styria	AT	
+Vorder Grauspitz	2599	353	POINT(9.58111 47.05278)	Rätikon	II/A-15.VIII-A	Graub./Liecht	CH/LI	
+Biberkopf	2599	337	POINT(10.23278 47.27056)	Allgäu Alps	II/B-22.II-C	N-Tyrol/Bavaria	AT/DE	1853
+Le Catogne	2598	1100	POINT(7.11083 46.05417)	Mont Blanc massif	I/B-07.V-C	Valais	CH	
+Zellinkopf	2597	445	POINT(12.95139 46.89417)	Goldberg Group	II/A-17.II-E	Carinthia	AT	
+Großer Hundstod	2594	475	POINT(12.88667 47.5125)	Berchtesgaden Alps	II/B-24.III-A	Salzburg/Bavaria	AT/DE	1825
+Roc du Bécoin	2594	328	POINT(6.66389 45.49278)	Vanoise massif	I/B-07.II-B	Savoy	FR	
+Gametzalpenkopf	2594	306	POINT(12.10889 46.68917)	Dolomites - NE	II/C-31.I-B	South Tyrol	IT	
+Pizzo Paglia	2593	498	POINT(9.21917 46.23167)	Adula Alps	I/B-10.III-D	Graubünden	CH	
+Monte Forno	2593	339	POINT(8.32361 46.29528)	Leone-Gotthard Alps	I/B-10.I-A	V-C-O	IT	
+Hochvogel	2592	572	POINT(10.43694 47.37972)	Allgäu Alps	II/B-22.II-C	N-Tyrol/Bavaria	AT/DE	1832
+Zwölferspitz	2592	360	POINT(12.72833 46.66167)	Carnic Alps	II/C-33.I-A	Carinthia	AT	1896
+Eggenkofel	2591	714	POINT(12.67806 46.73861)	Gailtal Alps	II/C-33.II-A	East Tyrol	AT	
+Rupprechtseck	2591	417	POINT(14.00139 47.23944)	Niedere Tauern	II/A-18.II-A	Salzburg/Styria	AT	
+Kanin	2587	1397	POINT(13.43833 46.36)	Julian Alps	II/C-34.I-B	Udine/Slovenia	IT/SI	
+Monte Terza Grande	2586	1277	POINT(12.62139 46.52694)	Carnic Alps	II/C-33.I-C	Belluno	IT	
+Monte Cridola	2581	538	POINT(12.48667 46.42639)	Carnic Prealps	II/C-33.III-A	Belluno	IT	1884
+Hochspitz	2581	303	POINT(12.66861 46.65722)	Carnic Alps	II/C-33.I-A	E-Tyrol/Belluno	AT/IT	
+Ruitelspitze	2580	322	POINT(10.44611 47.25556)	Lechtal Alps	II/B-21.I-A	North Tyrol	AT	
+Mont Triboulet	2578	336	POINT(6.86583 44.20611)	Maritime Alps	I/A-02.I-D	Alpes Maritimes	FR	
+Türchlwand	2577	475	POINT(13.0325 47.15083)	Goldberg Group	II/A-17.II-E	Salzburg	AT	
+Plose	2576	713	POINT(11.76306 46.68972)	Dolomites - NW	II/C-31.III-A	South Tyrol	IT	
+Stätzerhorn	2575	1028	POINT(9.51222 46.75583)	Plessur Alps	II/A-15.VII-C	Graubünden	CH	
+Cima delle Buse	2574	318	POINT(11.49806 46.18611)	Fiemme Alps	II/C-31.V-B	Trentino	IT	
+Pfannenstock	2573	373	POINT(8.91139 46.96167)	Schwyz Alps	I/B-13.I-B	Schwyz	CH	
+Westlicher Johanneskopf	2573	328	POINT(10.0225 47.21028)	Lechquellen Mts	II/B-21.II-A	Vorarlberg	AT	
+Torrione dei Longerin	2571	536	POINT(12.56139 46.62917)	Carnic Alps	II/C-33.I-A	Belluno	IT	
+Setsas	2571	403	POINT(11.9575 46.51944)	Dolomites - NE	II/C-31.I-C	Belluno	IT	
+Kanjavec	2569	405	POINT(13.80972 46.36028)	Julian Alps	II/C-34.I-E	West Slovenia	SI	1877
+Tête du Collier	2567	903	POINT(5.96417 44.71722)	Dauphiné Prealps	I/A-06.I-A	Hautes-Alpes	FR	
+Maurerkopf	2567	352	POINT(12.03389 46.71278)	Dolomites - NE	II/C-31.I-B	South Tyrol	IT	
+Schiara	2565	964	POINT(12.18222 46.23)	Dolomites - SE	II/C-31.II-B	Belluno	IT	
+Hinter Planitzer	2562	317	POINT(12.63694 47.21778)	Glockner Group	II/A-17.II-C	Salzburg	AT	
+Grand Galbert	2561	487	POINT(5.95972 45.09056)	Taillefer Massif	I/A-05.IV-A	Isère	FR	
+Grintovec	2558	1706	POINT(14.53611 46.35694)	Kamnik Alps	II/C-35.II-B	East Slovenia	SI	1759
+Kreuzjoch	2558	1051	POINT(11.98278 47.25139)	Kitzbühel Alps	II/B-23.II-A	North Tyrol	AT	
+Monte Bo	2556	616	POINT(7.99889 45.71417)	Biellese Alps	I/B-09.IV-A	Biella	IT	
+Wolayer Seekopf	2554	585	POINT(12.86083 46.60611)	Carnic Alps	II/C-33.I-A	Carinthia/Udine	AT/IT	
+Pizzo Tre Signori	2554	462	POINT(9.52833 46.01194)	Bergamo Alps	II/C-29.I-B	Berg/Lecc/Sond	IT	
+Modeon del Buinz	2554	313	POINT(13.47111 46.41667)	Julian Alps	II/C-34.I-A	Udine	IT	
+Namloser Wetterspitze	2553	722	POINT(10.64167 47.32306)	Lechtal Alps	II/B-21.I-B	North Tyrol	AT	1876
+Kirchlispitzen	2552	313	POINT(9.76944 47.03889)	Rätikon	II/A-15.VIII-A	Vorarlb/Graub.	AT/CH	1891
+Tàmer Piccolo	2550	846	POINT(12.12194 46.31056)	Dolomites - SE	II/C-31.II-B	Belluno	IT	1892
+Concarena	2549	721	POINT(10.28 46.01083)	Bergamasque Prealps	II/C-29.II-C	Bergamo	IT	
+Monte Brentoni	2548	1017	POINT(12.56583 46.51278)	Carnic Alps	II/C-33.I-C	Belluno	IT	
+Le Tarent	2548	1002	POINT(7.1475 46.38222)	Vaud Alps	I/B-14.I-A	Vaud	CH	
+Monfalcon di Montanaia	2548	499	POINT(12.48611 46.40444)	Carnic Prealps	II/C-33.III-A	Bell./Pordenone	IT	
+Sass de Mura	2547	1178	POINT(11.92528 46.16361)	Dolomites - S	II/C-31.IV-B	Belluno/Trentino	IT	1881
+Rosso di Ribia	2547	569	POINT(8.52972 46.26111)	Ticino Alps	I/B-10.II-A	Ticino	CH	
+Prisojnik	2547	551	POINT(13.77 46.42528)	Julian Alps	II/C-34.I-E	West Slovenia	SI	
+Hochnissl	2547	360	POINT(11.61806 47.36722)	Karwendel	II/B-21.IV-A	North Tyrol	AT	
+Les Aiguillettes	2547	313	POINT(6.125 45.18389)	Dauphiné Alps	I/A-05.I-B	Isère	FR	
+Monte Cresto	2546	327	POINT(7.91 45.68083)	Biellese Alps	I/B-09.IV-A	Aosta/Biella	IT	
+L'Aiguille Rouge	2545	351	POINT(6.64444 45.04611)	Massif des Cerces	I/A-04.III-A	Hautes-Alpes	FR	
+Predigstuhl	2543	385	POINT(13.91139 47.26194)	Niedere Tauern	II/A-18.II-A	Styria	AT	
+Monte Talvena	2542	602	POINT(12.15583 46.26611)	Dolomites - SE	II/C-31.II-B	Belluno	IT	
+Giferspitz	2542	556	POINT(7.35333 46.45111)	Bernese Prealps	I/B-14.II-A	Bern	CH	
+Mohnenfluh	2542	387	POINT(10.10222 47.23222)	Lechquellen Mts	II/B-21.II-A	Vorarlberg	AT	
+Pöngertlekopf & Pfaffeneck	2539	632	POINT(10.03444 47.17417)	Lechquellen Mts	II/B-21.II-A	Vorarlberg	AT	
+Östliche Karwendelspitze	2537	734	POINT(11.42194 47.445)	Karwendel	II/B-21.IV-A	N-Tyrol/Bavaria	AT/DE	1870
+Pizzo Cavregasco	2535	334	POINT(9.27639 46.23944)	Adula Alps	I/B-10.III-D	Como/Sondrio	IT	
+Glogghüs	2534	554	POINT(8.2625 46.76056)	Urner Alps	I/B-14.III-B	Bern/Obwalden	CH	
+Hochwang	2534	417	POINT(9.63306 46.87417)	Plessur Alps	II/A-15.VII-A	Graubünden	CH	
+Pointe de Comborsier	2534	403	POINT(6.51556 45.61028)	Beaufortain Massif	I/B-07.VI-A	Savoy	FR	
+Großer Widderstein	2533	845	POINT(10.12917 47.28472)	Allgäu Alps	II/B-22.II-C	Vorarlberg	AT	1669
+Cima Quarazza	2530	413	POINT(11.57 46.12972)	Fiemme Alps	II/C-31.V-B	Trentino	IT	
+Cima Coltorondo	2530	350	POINT(11.63806 46.25583)	Fiemme Alps	II/C-31.V-B	Trentino	IT	
+Gurpitscheck	2526	660	POINT(13.61472 47.21083)	Niedere Tauern	II/A-18.II-A	Salzburg	AT	
+Gamskofel	2526	467	POINT(12.90083 46.63083)	Carnic Alps	II/C-33.I-A	Carinthia	AT	
+Mont Joly	2525	536	POINT(6.69306 45.82611)	Beaufortain Massif	I/B-07.VI-B	Upper Savoy	FR	
+Magerrain	2524	357	POINT(9.22 47.03306)	Glarus Alps	I/B-13.II-A	Glarus/StGallen	CH	
+Hocheisspitze	2523	410	POINT(12.84333 47.54694)	Berchtesgaden Alps	II/B-24.III-C	Salzburg/Bavaria	AT/DE	1868
+Hoher Göll	2522	789	POINT(13.06778 47.59417)	Berchtesgaden Alps	II/B-24.III-B	Salzburg/Bavaria	AT/DE	1800
+Presolana	2521	725	POINT(10.05528 45.95667)	Bergamasque Prealps	II/C-29.II-C	Bergamo	IT	1870
+Monte delle Scale	2521	580	POINT(10.32667 46.5025)	Livigno Alps	II/A-15.IV-A	Sondrio	IT	
+Tschuggen	2521	460	POINT(7.94972 46.60028)	Bernese Prealps	I/B-14.II-B	Bern	CH	
+Hochjoch	2520	547	POINT(9.98806 47.06611)	Verwall	II/A-15.VI-C	Vorarlberg	AT	
+Dreispitz	2520	523	POINT(7.75972 46.59278)	Bernese Prealps	I/B-14.II-B	Bern	CH	
+Steinwand	2520	509	POINT(12.79222 46.64278)	Carnic Alps	II/C-33.I-A	Carinthia/Udine	AT/IT	
+Cima di Bri	2520	313	POINT(8.88417 46.30528)	Ticino Alps	I/B-10.II-D	Ticino	CH	
+Monte Seleron	2519	458	POINT(9.72889 46.1)	Bergamo Alps	II/C-29.I-A	Sondrio	IT	
+Großer Priel	2515	1710	POINT(14.06333 47.71694)	Totes Gebirge	II/B-25.III-A	Upper Austria	AT	1817
+Chaiserstock	2515	470	POINT(8.72861 46.92833)	Schwyz Alps	I/B-14.IV-A	Schwyz/Uri	CH	
+Cima Busa Alta	2513	331	POINT(11.60944 46.24972)	Fiemme Alps	II/C-31.V-B	Trentino	IT	
+Glanderspitze	2512	971	POINT(10.66167 47.14833)	Ötztal Alps	II/A-16.I-C	North Tyrol	AT	
+Pizzo Arera	2512	691	POINT(9.81583 45.93472)	Bergamasque Prealps	II/C-29.II-B	Bergamo	IT	
+Pizzo Alto	2512	320	POINT(9.45667 46.0775)	Bergamo Alps	II/C-29.I-B	Lecco/Sondrio	IT	
+Großes Ochsenhorn	2511	1309	POINT(12.66083 47.53833)	Loferer Steinberge	II/B-24.I-A	Salzburg	AT	
+Villanderer Berg	2509	426	POINT(11.41889 46.65861)	Sarntal Alps	II/A-16.III-A	South Tyrol	IT	
+Mitterhorn	2506	335	POINT(12.62861 47.54944)	Loferer Steinberge	II/B-24.I-A	Salzburg	AT	
+Dormillouse	2505	392	POINT(6.38694 44.40972)	Provence Alps	I/A-03.1-A	A-d-H-Provence	FR	
+Breithorn	2504	327	POINT(12.90278 47.45694)	Berchtesgaden Alps	II/B-24.III-A	Salzburg	AT	
+Cima di Pape	2503	696	POINT(11.92806 46.33444)	Dolomites - S	II/C-31.IV-A	Belluno	IT	
+Piz Ledu	2503	375	POINT(9.32167 46.2325)	Adula Alps	I/B-10.III-D	Como/Sondrio	IT	
+Säntis	2502	2015	POINT(9.34333 47.24944)	Appenzell Alps	I/B-14.V-B	App/StG	CH	1680
+Großer Pleißlingkeil	2501	410	POINT(13.49139 47.22722)	Niedere Tauern	II/A-18.I-A	Salzburg	AT	
+Marchkopf	2499	372	POINT(11.80611 47.25111)	Tux Alps	II/B-23.I-B	North Tyrol	AT	
+Castello di Moschesin	2499	314	POINT(12.13278 46.29722)	Dolomites - SE	II/C-31.II-B	Belluno	IT	
+Monte Croce	2496	533	POINT(11.39222 46.16944)	Fiemme Mountains	II/C-31.V-B	Trentino	IT	
+Mittlere Kreuzspitze	2496	456	POINT(10.59278 47.33611)	Lechtal Alps	II/B-21.I-B	North Tyrol	AT	
+Les Grands Moulins	2495	307	POINT(6.19833 45.40722)	Belledonne	I/A-05.II.B	Savoy	FR	
+Wannig	2493	704	POINT(10.86222 47.33694)	Mieminger Chain	II/B-21.III-A	North Tyrol	AT	
+Pizzo Camino	2491	525	POINT(10.1775 45.98167)	Bergamasque Prealps	II/C-29.II-C	Bergamo / Brescia	IT	
+Fulen	2491	311	POINT(8.71472 46.91861)	Schwyz Alps	I/B-14.IV-A	Schwyz / Uri	CH	
+Viezzena	2490	435	POINT(11.67556 46.3375)	Dolomites - NW	II/C-31.III-B	South Tyrol	IT	
+Zanggen	2488	498	POINT(11.51194 46.34583)	Fiemme Mountains	II/C-31.V-A	South Tyrol / Trentino	IT	
+Creton di Clap Grant	2487	518	POINT(12.67056 46.52917)	Carnic Alps	II/C-33.I-C	Belluno	IT	
+Cima di Pinadee	2486	455	POINT(8.97694 46.51333)	Adula Alps	I/B-10.III-B	Ticino	CH	
+Grand Arc	2484	693	POINT(6.36472 45.56667)	Lauzière massif	I/B-07.II-F	Savoy	FR	
+Étale	2483	997	POINT(6.44778 45.85)	Aravis Range	I/B-08.IV-A	Upper Savoy / Savoy	FR	
+Monte Bertrand	2483	385	POINT(7.67528 44.11778)	Ligurian Alps	I/A-01.II-A	Alpes-Maritimes / Cuneo	FR/IT	
+Rammelstein	2483	304	POINT(12.05306 46.83444)	Rieserferner Group	II/A-17.III-A	South Tyrol	IT	
+Hochkarspitze	2482	662	POINT(11.35056 47.4475)	Karwendel	II/B-21.IV-A	North Tyrol / Bavaria	AT/DE	
+Rauchberg	2480	483	POINT(10.75889 47.30417)	Lechtal Alps	II/B-21.I-B	North Tyrol	AT	
+Monte Pramaggiore	2478	550	POINT(12.55333 46.365)	Carnic Prealps	II/C-33.III-A	Pordenone / Udine	IT	
+Monte Ziolera	2478	345	POINT(11.455 46.17194)	Fiemme Mountains	II/C-31.V-B	Trentino	IT	
+Spillgerte	2476	453	POINT(7.44667 46.53667)	Bernese Alps	I/B-14.II-A	Bern	CH	
+Rettelkirchspitze	2475	687	POINT(14.12778 47.25972)	Wölz Tauern	II/A-18.III-A	Styria	AT	
+Bivare	2474	696	POINT(12.64194 46.44139)	Carnic Alps	II/C-33.I-C	Udine	IT	
+Greim	2474	686	POINT(14.15167 47.24778)	Wölz Tauern	II/A-18.III-A	Styria	AT	
+Monte Rinaldo	2473	675	POINT(12.65806 46.59889)	Carnic Alps	II/C-33.I-A	Belluno	IT	
+Pierre Avoi	2473	300	POINT(7.20028 46.11806)	Pennine Alps	I/B-09.I-D	Valais	CH	
+Špik	2473	291	POINT(13.81444 46.44861)	Julian Alps	II/C-34.I-D	Slovenia	SI	
+Rappenspitze	2472	305	POINT(10.1975 47.23667)	Lechtal Alps	II/B-21.I-A	North Tyrol / Vorarlberg	AT	
+Col Nudo	2471	1644	POINT(12.40278 46.2275)	Venetian Prealps	II/C-32.II-B	Belluno / Pordenone	IT	
+Loreakopf	2471	907	POINT(10.77167 47.35417)	Lechtal Alps	II/B-21.I-B	North Tyrol	AT	
+Cime de l'Aspre	2471	468	POINT(6.80972 44.17556)	Maritime Alps	I/A-02.I-D	Alpes-Maritimes	FR	
+Lungauer Kalkspitze	2471	412	POINT(13.62528 47.27222)	Schladming Tauern	II/A-18.II-A	Salzburg	AT	
+Ochsenkopf	2470	352	POINT(12.07889 47.27528)	Kitzbühel Alps	II/B-23.II-A	North Tyrol / Salzburg	AT	
+Salzachgeier	2470	352	POINT(12.10361 47.29361)	Kitzbühel Alps	II/B-23.II-A	North Tyrol / Salzburg	AT	
+Sasso di Bosconero	2468	938	POINT(12.26861 46.33639)	Dolomites - SE	II/C-31.II-A	Belluno	IT	
+Cima Scanaiol	2467	479	POINT(11.76583 46.215)	Fiemme Mountains	II/C-31.V-B	Trentino	IT	
+Gamskarkogel	2467	376	POINT(13.15861 47.16111)	Ankogel Group	II/A-17.II-F	Salzburg	AT	
+Hauts-Forts	2466	546	POINT(6.7775 46.16861)	Chablais Alps	I/B-08.III-A	Upper Savoy	FR	
+Pizzo la Scheggia	2466	339	POINT(8.41528 46.18417)	Ticino Alps	I/B-10.II-B	V-C-O	IT	
+Creta Forata	2462	857	POINT(12.73583 46.5425)	Carnic Alps	II/C-33.I-C	Belluno / Udine	IT	
+Silberspitze	2461	349	POINT(10.57278 47.18417)	Lechtal Alps	II/B-21.I-A	North Tyrol	AT	
+Mont Mirantin	2460	571	POINT(6.49944 45.68417)	Beaufortain Massif	I/B-07.VI-A	Savoy	FR	
+Pointe de la Grande Journée	2460	571	POINT(6.50111 45.6675)	Beaufortain Massif	I/B-07.VI-A	Savoy	FR	
+Rauchkofel	2460	322	POINT(12.88333 46.61944)	Carnic Alps	II/C-33.I-A	Carinthia	AT	
+Cima dei Lasteri	2459	295	POINT(10.94833 46.17694)	Brenta Dolomites	II/C-28.IV-A	Trentino	IT	
+Große Bischofsmütze	2458	612	POINT(13.51111 47.49389)	Dachstein Mts	II/B-25.I-A	Salzburg	AT	
+Gummfluh	2458	574	POINT(7.195 46.44056)	Vaud Alps	I/B-14.I-A	Bern / Vaud	CH	
+Sonnjoch	2457	625	POINT(11.605 47.41222)	Karwendel	II/B-21.IV-A	North Tyrol	AT	
+Hohniesen	2454	371	POINT(7.58333 46.57722)	Bernese Alps	I/B-14.II-A	Bern	CH	
+Rumer Spitze	2454	296	POINT(11.42583 47.32028)	Karwendel	II/B-21.IV-A	North Tyrol	AT	
+Rocher Rond	2453	365	POINT(5.82944 44.6975)	Dévoluy Mountains	I/A-06.I-B	Drôme / Hautes-Alpes	FR	
+Gamsjoch	2452	658	POINT(11.54889 47.41833)	Karwendel	II/B-21.IV-A	North Tyrol	AT	
+Monte Bussaia	2451	300	POINT(7.46806 44.21806)	Maritime Alps	I/A-02.I-A	Cuneo	IT	
+Pomagagnon	2450	370	POINT(12.14028 46.57389)	Dolomites - NE	II/C-31.I-D	Belluno	IT	
+Cima Cadi	2449	589	POINT(10.29444 46.22361)	Ortler Alps	II/C-28.I-B	Brescia / Sondrio	IT	
+Großer Bösenstein	2448	634	POINT(14.40444 47.44333)	Rottenmann Tauern	II/A-18.III-B	Styria	AT	
+Spitzmauer	2446	516	POINT(14.06222 47.69528)	Totes Gebirge	II/B-25.III-A	Upper Austria	AT	
+Monte Spondone	2445	306	POINT(9.79472 45.98056)	Bergamasque Prealps	II/C-29.II-B	Bergamo	IT	
+Kröndlhorn	2444	461	POINT(12.16472 47.29889)	Kitzbühel Alps	II/B-23.II-A	North Tyrol / Salzburg	AT	
+Monte Siera	2443	344	POINT(12.71083 46.54917)	Carnic Alps	II/C-33.I-C	Belluno / Udine	IT	
+Eisenhut	2441	800	POINT(13.92889 46.95194)	Nock Mountains	II/A-19.I-A	Styria	AT	
+Mürtschenstock	2441	601	POINT(9.14417 47.07)	Glarus Alps	I/B-13.II-C	Glarus	CH	
+Großer Rosennock	2440	657	POINT(13.7125 46.8775)	Nock Mountains	II/A-19.I-A	Carinthia	AT	
+Schwarzhorn	2439	637	POINT(11.45472 46.33472)	Fiemme Mountains	II/C-31.V-A	South Tyrol	IT	
+Pointe Blanche	2438	825	POINT(6.45972 45.99944)	Bornes Massif	I/B-08.IV-B	Upper Savoy	FR	
+Gufelstock	2436	423	POINT(9.14667 47.025)	Glarus Alps	I/B-13.II-A	Glarus	CH	
+Kraxenkogel	2436	296	POINT(13.35722 47.25389)	Radstadt Tauern	II/A-18.I-A	Salzburg	AT	
+Altmann	2435	313	POINT(9.37167 47.23944)	Appenzell Alps	I/B-14.V-B	Appenzell / St. Gallen	CH	
+Laugenspitze	2434	636	POINT(11.08611 46.53472)	Nonsberg Group	II/C-28.II-A	South Tyrol	IT	
+Seehorn	2434	567	POINT(8.11556 46.1825)	Pennine Alps	I/B-09.V-C	Valais	CH	
+Deneck	2433	359	POINT(14.05 47.29111)	Schladming Tauern	II/A-18.II-A	Styria	AT	
+Cornettes de Bise	2432	1061	POINT(6.78472 46.3325)	Chablais Alps	I/B-08.III-B	Valais / Upper Savoy	CH/FR	
+Mont de Grange	2432	768	POINT(6.78083 46.2625)	Chablais Alps	I/B-08.III-A	Upper Savoy	FR	
+Raz de Bec	2431	535	POINT(5.98806 44.66806)	Dévoluy Mountains	I/A-06.I-A	Hautes-Alpes	FR	
+L'Ouillon	2431	367	POINT(6.215 45.24)	Dauphiné Alps	I/A-05.I-B	Isère	FR	
+Monte Azzarini	2431	331	POINT(9.6425 46.05972)	Bergamo Alps	II/C-29.I-A	Bergamo / Sondrio	IT	
+Raucheck	2430	1463	POINT(13.22667 47.49917)	Tennen Mountains	II/B-24.IV-A	Salzburg	AT	
+Laliderer Falk	2427	654	POINT(11.51917 47.435)	Karwendel	II/B-21.IV-A	North Tyrol	AT	
+Monte Ferrante	2427	357	POINT(10.02861 45.97472)	Bergamasque Prealps	II/C-29.II-C	Bergamo	IT	
+Sforniòi di Mezzo	2425	362	POINT(12.26722 46.34861)	Dolomites - SE	II/C-31.II-A	Belluno	IT	
+Großer Galtenberg	2424	513	POINT(11.97639 47.33667)	Kitzbühel Alps	II/B-23.II-A	North Tyrol	AT	
+Col della Croce	2423	376	POINT(11.63861 46.16528)	Fiemme Mountains	II/C-31.V-B	Trentino	IT	
+Oberwölzer Schoberspitze	2423	333	POINT(14.16111 47.28917)	Wölz Tauern	II/A-18.III-A	Styria	AT	
+L'Argentine	2422	393	POINT(7.13083 46.27333)	Vaud Alps	I/B-12.III-A	Vaud	CH	
+Monte Cimon	2422	374	POINT(12.76306 46.55139)	Carnic Alps	II/C-33.I-C	Udine	IT	
+Cima di Capezzone	2421	603	POINT(8.20889 45.945)	Monte Rosa Alps	I/B-09.III-C	V-C-O / Vercelli	IT	
+Geierhaupt	2417	1172	POINT(14.63639 47.37472)	Seckau Tauern	II/A-18.IV-A	Styria	AT	
+Monte Alto di Pelsa	2417	455	POINT(11.99972 46.35583)	Dolomites - SE	II/C-31.II-A	Belluno	IT	
+Ehrwalder Sonnenspitze	2417	417	POINT(10.92194 47.3675)	Mieminger Chain	II/B-21.III-A	North Tyrol	AT	
+Pizzo Erra	2417	301	POINT(8.89083 46.44111)	Saint-Gotthard Massif	I/B-10.I-B	Ticino	CH	
+Karhorn	2416	706	POINT(10.15111 47.24806)	Lechquellen Mts	II/B-21.II-A	Vorarlberg	AT	
+Hochreichart	2416	336	POINT(14.68194 47.36333)	Seckau Tauern	II/A-18.IV-B	Styria	AT	
+Hoh Brisen	2413	489	POINT(8.46583 46.8975)	Uri Alps	I/B-12.I-B	Nidwalden / Uri	CH	
+Crodon di Tiarfin	2413	446	POINT(12.59167 46.46583)	Carnic Alps	II/C-33.I-C	Udine	IT	
+Schafberg	2413	403	POINT(9.95139 47.16917)	Lechquellen Mts	II/B-21.II-A	Vorarlberg	AT	
+Sassolungo di Cibiana	2413	335	POINT(12.28278 46.35889)	Dolomites - SE	II/C-31.II-A	Belluno	IT	
+Bleikogel	2411	334	POINT(13.29833 47.51417)	Tennen Mountains	II/B-24.IV-A	Salzburg	AT	
+Grignone	2409	1686	POINT(9.3875 45.95333)	Bergamasque Prealps	II/C-29.II-A	Lecco	IT	
+Cima di Pramper	2409	540	POINT(12.16694 46.29667)	Dolomites - SE	II/C-31.II-B	Belluno	IT	
+Mont Charvin	2409	449	POINT(6.42 45.8025)	Aravis Range	I/B-08.IV-A	Upper Savoy / Savoy	FR	
+Kilnprein	2408	450	POINT(13.84278 46.98528)	Nock Mountains	II/A-19.I-A	Salzburg / Styria	AT	
+Monte Pezza	2408	364	POINT(11.92056 46.40583)	Dolomites - NW	II/C-31.III-B	Belluno	IT	
+Sasso Bianco	2407	386	POINT(11.95944 46.4125)	Dolomites - NW	II/C-31.III-B	Belluno	IT	
+Zirmebenjoch	2407	310	POINT(10.53833 47.29389)	Lechtal Alps	II/B-21.I-A	North Tyrol	AT	
+Monte San Lucano	2406	411	POINT(11.96 46.31083)	Dolomites - S	II/C-31.IV-A	Belluno	IT	
+Erlspitze	2405	607	POINT(11.28556 47.32)	Karwendel	II/B-21.IV-A	North Tyrol	AT	
+Cresta di Enghe	2405	324	POINT(12.63444 46.52083)	Carnic Alps	II/C-33.I-C	Belluno	IT	
+Saile	2404	412	POINT(11.32528 47.19194)	Stubai Alps	II/A-16.II-B	North Tyrol	AT	
+Bric Costa Rossa	2404	345	POINT(7.6 44.25083)	Ligurian Alps	I/A-01.II-B	Cuneo	IT	
+Zitterklapfen	2403	573	POINT(9.97111 47.26806)	Lechquellen Mts	II/B-21.II-A	Vorarlberg	AT	
+Lopa	2402	335	POINT(13.49417 46.37028)	Julian Alps	II/C-34.I-B	Udine / Slovenia	IT/SI	
+Fundelkopf	2401	375	POINT(9.67639 47.11)	Rätikon	II/A-15.VIII-A	Vorarlberg	AT	
+Monte Susino	2397	301	POINT(10.18667 45.99056)	Bergamasque Prealps	II/C-29.II-C	Bergamo / Brescia	IT	
+Seckauer Zinken	2397	377	POINT(14.73611 47.33917)	Seckau Tauern	II/A-18.IV-B	Styria	AT	
+Hochkünzelspitze	2397	352	POINT(10.03028 47.27194)	Lechquellen Mts	II/B-21.II-A	Vorarlberg	AT	
+Cima d'Oltro	2397	311	POINT(11.90694 46.22056)	Dolomites - S	II/C-31.IV-A	Trentino	IT	
+Zirbitzkogel	2396	1502	POINT(14.56722 47.06361)	Lavanttal Alps	II/A-19.II-A	Styria	AT	
+Veliko Špičje	2396	333	POINT(13.76667 46.34361)	Julian Alps	II/C-34.I-E	Slovenia	SI	
+Cima di Sette Selle	2396	325	POINT(11.39833 46.12833)	Fiemme Mountains	II/C-31.V-B	Trentino	IT	
+Planjava	2394	491	POINT(14.61 46.35667)	Kamnik Alps	II/C-35.II-A	Slovenia	SI	
+Croda di Mezzodi	2394	346	POINT(12.57778 46.53278)	Carnic Alps	II/C-33.I-C	Belluno	IT	
+Montagne de Boules	2391	357	POINT(6.50056 44.17389)	Provence Alps	I/A-03.II-A	Alpes-de-Haute-Provence	FR	
+Kampspitze	2390	438	POINT(13.64278 47.29389)	Schladming Tauern	II/A-18.II-A	Styria	AT	
+Vanil Noir	2389	1120	POINT(7.14833 46.52861)	Fribourg Prealps	I/B-14.I-B	Fribourg / Vaud	CH	
+Le Tabor	2389	1022	POINT(5.85583 44.97722)	Taillefer Massif	I/A-05.IV-A	Isère	FR	
+Großer Hochkasten	2389	342	POINT(14.0475 47.67361)	Totes Gebirge	II/B-25.III-A	Styria	AT	
+Warscheneck	2388	655	POINT(14.24139 47.6525)	Totes Gebirge	II/B-25.III-B	Upper Austria	AT	
+Elferkopf	2387	451	POINT(10.17778 47.30222)	Allgäu Alps	II/B-22.II-A	Vorarlberg	AT	
+Gamskögel	2386	522	POINT(14.54833 47.36583)	Seckau Tauern	II/A-18.IV-A	Styria	AT	
+Gamsberg	2385	1358	POINT(9.37611 47.13556)	Appenzell Alps	I/B-14.V-A	St. Gallen	CH	
+Roc de Garnesier	2383	393	POINT(5.7925 44.66056)	Dévoluy Mountains	I/A-06.I-B	Drôme / Hautes-Alpes	FR	
+Rudiger	2382	310	POINT(10.70167 47.32917)	Lechtal Alps	II/B-21.I-B	North Tyrol	AT	
+Monte Cimone	2379	399	POINT(13.38528 46.42361)	Julian Alps	II/C-34.I-A	Udine	IT	
+Monte Ponteranica	2378	375	POINT(9.59556 46.02917)	Bergamo Alps	II/C-29.I-B	Bergamo / Sondrio	IT	
+Gartnerwand	2377	434	POINT(10.82111 47.385)	Lechtal Alps	II/B-21.I-B	North Tyrol	AT	
+Knittelkarspitze	2376	1017	POINT(10.65111 47.37556)	Lechtal Alps	II/B-21.I-B	North Tyrol	AT	
+Vilan	2376	416	POINT(9.60306 47.01278)	Rätikon	II/A-15.VIII-A	Graubünden	CH	
+Pizzo di Campel	2376	332	POINT(9.26167 46.33194)	Adula Alps	I/B-10.III-D	Graubünden	CH	
+Hochweberspitze	2375	335	POINT(14.20056 47.30889)	Wölz Tauern	II/A-18.III-A	Styria	AT	
+Reither Spitze	2374	300	POINT(11.23611 47.32306)	Karwendel	II/B-21.IV-A	North Tyrol	AT	
+La Croix de Cassini	2373	371	POINT(6.13417 45.07333)	Dauphiné Alps	I/A-05.I-B	Isère	FR	
+Plenge	2373	303	POINT(12.90028 46.6525)	Carnic Alps	II/C-33.I-A	Carinthia	AT	
+Reißkofel	2371	1390	POINT(13.14722 46.68583)	Gailtal Alps	II/C-33.II-D	Carinthia	AT	
+Tschirgant	2370	1263	POINT(10.79639 47.24167)	Mieminger Chain	II/B-21.III-A	North Tyrol	AT	
+Hohe Pressing	2370	485	POINT(13.69222 46.93778)	Nock Mountains	II/A-19.I-A	Carinthia	AT	
+Hochtor	2369	1520	POINT(14.63278 47.56167)	Ennstal Alps	II/B-26.I-B	Styria	AT	
+Monte Pegherolo	2369	350	POINT(9.71361 46.02472)	Bergamo Alps	II/C-29.I-B	Bergamo	IT	
+Gehrenspitze	2367	319	POINT(11.135 47.38667)	Wetterstein	II/B-21.III-B	North Tyrol	AT	
+Großer Rettenstein	2366	680	POINT(12.29694 47.33278)	Kitzbühel Alps	II/B-23.II-A	North Tyrol / Salzburg	AT	
+Croda de R'Ancona	2366	338	POINT(12.11778 46.61417)	Dolomites - NE	II/C-31.I-B	Belluno	IT	
+Geißstein	2363	1089	POINT(12.49556 47.3375)	Kitzbühel Alps	II/B-23.II-C	North Tyrol / Salzburg	AT	
+Pusterwalder Hohenwart	2363	375	POINT(14.23639 47.32889)	Wölz Tauern	II/A-18.III-A	Styria	AT	
+Niesen	2362	407	POINT(7.6525 46.64611)	Bernese Alps	I/B-14.II-A	Bern	CH	
+Wistätthorn	2362	370	POINT(7.38639 46.45417)	Bernese Alps	I/B-14.II-A	Bern	CH	
+Cima Brica	2362	299	POINT(12.53361 46.38028)	Carnic Prealps	II/C-33.III-A	Udine	IT	
+Großes Teufelshorn	2361	341	POINT(13.03611 47.48917)	Berchtesgaden Alps	II/B-24.III-B	Salzburg / Bavaria	AT/DE	
+Poncione Piancascia	2360	325	POINT(8.73361 46.29861)	Ticino Alps	I/B-10.II-D	Ticino	CH	
+Vigna Soliva	2356	403	POINT(9.98694 46.00694)	Bergamasque Prealps	II/C-29.II-C	Bergamo	IT	
+Großer Rosszahn	2356	317	POINT(10.46889 47.38722)	Allgäu Alps	II/B-22.II-C	North Tyrol	AT	
+Grimming	2351	1518	POINT(14.01694 47.52056)	Dachstein Mts	II/B-25.I-C	Styria	AT	
+La Tournette	2351	1514	POINT(6.28639 45.82722)	Bornes Massif	I/B-08.IV-B	Upper Savoy	FR	
+Brienzer Rothorn	2350	1342	POINT(8.04694 46.78722)	Emmental Alps	I/B-14.II-C	Bern / Lucerne / Obwalden	CH	
+Wittenberghorn	2350	465	POINT(7.21 46.41611)	Vaud Alps	I/B-14.I-A	Bern / Vaud	CH	
+Seekarspitze	2350	324	POINT(13.54389 47.27278)	Schladming Tauern	II/A-18.II-A	Salzburg	AT	
+Kahlersberg	2350	315	POINT(13.03222 47.53139)	Berchtesgaden Alps	II/B-24.III-B	Salzburg / Bavaria	AT/DE	
+Cima di Canogia	2350	315	POINT(8.41361 46.20806)	Ticino Alps	I/B-10.II-B	V-C-O	IT	
+Bavški Grintavec	2347	357	POINT(13.67083 46.36889)	Julian Alps	II/C-34.I-C	Slovenia	SI	
+Pletzen	2345	448	POINT(14.61722 47.33306)	Seckau Tauern	II/A-18.IV-A	Styria	AT	
+Cimon del Teverone	2345	417	POINT(12.40278 46.20917)	Venetian Prealps	II/C-32.II-B	Belluno / Pordenone	IT	
+Ellmauer Halt	2344	1551	POINT(12.30306 47.56222)	Kaiser Mountains	II/B-21.VI-A	North Tyrol	AT	
+Kellerjoch	2344	669	POINT(11.77083 47.31889)	Tux Alps	II/B-23.I-B	North Tyrol	AT	
+Steinfeldspitze	2344	542	POINT(13.45194 47.26611)	Radstadt Tauern	II/A-18.I-A	Salzburg	AT	
+Monte Chétif	2343	387	POINT(6.94889 45.79972)	Graian Alps	I/B-07.III-B	Aosta Valley	IT	
+Briceljk	2343	363	POINT(13.63194 46.39472)	Julian Alps	II/C-34.I-C	Slovenia	SI	
+Grand Veymont	2341	1165	POINT(5.52667 44.87)	Vercors Massif	I/A-06.III-A	Isère	FR	
+Thaneller	2341	992	POINT(10.72472 47.42639)	Lechtal Alps	II/B-21.I-B	North Tyrol	AT	
+Crève Tête	2341	363	POINT(6.46778 45.45111)	Vanoise massif	I/B-07.II-E	Savoy	FR	
+Wasserbergfirst	2341	325	POINT(8.78917 46.93944)	Schwyz Alps	I/B-14.IV-A	Schwyz	CH	
+Elsighore	2341	296	POINT(7.63972 46.53472)	Bernese Alps	I/B-14.II-A	Bern	CH	
+Daniel	2340	1233	POINT(10.88028 47.43278)	Ammergau Alps	II/B-22.III-A	North Tyrol	AT	
+Pied Moutet	2339	681	POINT(6.09611 45.00722)	Massif des Écrins	I/A-05.III-B	Isère	FR	
+Aserlespitze	2337	329	POINT(10.7575 47.34056)	Lechtal Alps	II/B-21.I-B	North Tyrol	AT	
+Großer Grießstein	2337	328	POINT(14.54 47.39083)	Seckau Tauern	II/A-18.IV-A	Styria	AT	
+Cima Dodici	2336	1874	POINT(11.46806 45.9975)	Vicentine Alps	II/C-32.I-A	Vicenza / Trentino	IT	
+Hochmölbing	2336	339	POINT(14.17806 47.63417)	Totes Gebirge	II/B-25.III-B	Styria	AT	
+Monte Pavione	2335	597	POINT(11.82111 46.10472)	Dolomites - S	II/C-31.IV-B	Belluno	IT	
+Pizzo del Moro	2335	516	POINT(8.12472 45.93028)	Monte Rosa Alps	I/B-09.III-C	V-C-O / Vercelli	IT	
+Monte Mucrone	2335	309	POINT(7.94472 45.62028)	Biellese Alps	I/B-09.IV-A	Biella	IT	
+Monte Terza Piccola	2334	660	POINT(12.62472 46.56)	Carnic Alps	II/C-33.I-C	Udine	IT	
+Rinsennock	2334	435	POINT(13.85139 46.90889)	Nock Mountains	II/A-19.I-A	Carinthia	AT	
+Gailtaler Polinik	2332	975	POINT(12.98222 46.62722)	Carnic Alps	II/C-33.I-B	Carinthia	AT	
+Maurerberg	2332	469	POINT(11.82139 46.70417)	Dolomites - NW	II/C-31.III-A	South Tyrol	IT	
+Tour d'Aï	2331	886	POINT(7.00194 46.37222)	Vaud Alps	I/B-14.I-A	Vaud	CH	
+Klomnock	2331	360	POINT(13.78806 46.88083)	Nock Mountains	II/A-19.I-A	Carinthia	AT	
+Ackerlspitze	2329	359	POINT(12.3475 47.55917)	Kaiser Mountains	II/B-21.VI-A	North Tyrol	AT	
+Bernkogel	2325	330	POINT(13.04333 47.24861)	Goldberg Group	II/A-17.II-E	Salzburg	AT	
+Monte Piana	2324	450	POINT(12.2425 46.61528)	Sexten Dolomites	II/C-31.I-A	Belluno / South Tyrol	IT	
+Cavallazza	2324	349	POINT(11.77639 46.27889)	Fiemme Mountains	II/C-31.V-B	Trentino	IT	
+Cornaget	2323	619	POINT(12.58444 46.31194)	Carnic Prealps	II/C-33.III-B	Pordenone	IT	
+Montagne du Cheval Blanc	2323	450	POINT(6.42417 44.12722)	Provence Alps	I/A-03.II-A	Alpes-de-Haute-Provence	FR	
+Pointe Noire de Pormenaz	2323	373	POINT(6.80139 45.95889)	Aiguilles Rouges	I/B-08.I-A	Upper Savoy	FR	
+Cima del Fop	2322	325	POINT(9.86389 45.93306)	Bergamasque Prealps	II/C-29.II-B	Bergamo	IT	
+Pizzo Cramalina	2322	297	POINT(8.62389 46.25528)	Ticino Alps	I/B-10.II-B	Ticino	CH	
+Seehorn	2321	300	POINT(12.85306 47.51667)	Berchtesgaden Alps	II/B-24.III-A	Salzburg	AT	
+Creta di Mimoias	2320	330	POINT(12.62472 46.51056)	Carnic Alps	II/C-33.I-C	Belluno	IT	
+Golzentipp	2317	364	POINT(12.60389 46.73444)	Gailtal Alps	II/C-33.II-A	East Tyrol	AT	
+Weißhorn	2317	328	POINT(11.44472 46.35361)	Fiemme Mountains	II/C-31.V-A	South Tyrol	IT	
+Marmontana	2316	343	POINT(9.17028 46.17194)	Adula Alps	I/B-10.III-D	Graubünden / Como	CH/IT	
+Großhansl	2315	304	POINT(14.26583 47.31861)	Wölz Tauern	II/A-18.III-A	Styria	AT	
+Nabois Grande	2313	339	POINT(13.48833 46.43917)	Julian Alps	II/C-34.I-A	Udine	IT	
+Monte Turlon	2312	482	POINT(12.50528 46.32194)	Carnic Prealps	II/C-33.III-A	Pordenone	IT	
+Cima dei Vieres	2310	504	POINT(12.48472 46.30972)	Carnic Prealps	II/C-33.III-A	Pordenone	IT	
+Großer Beil	2309	311	POINT(12.02722 47.34139)	Kitzbühel Alps	II/B-23.II-A	North Tyrol	AT	
+Hinterrugg	2306	470	POINT(9.30472 47.15361)	Appenzell Alps	I/B-14.V-A	St. Gallen	CH	
+Caserine Alte	2306	382	POINT(12.63167 46.31472)	Carnic Prealps	II/C-33.III-B	Pordenone	IT	
+Schaufelspitze	2306	312	POINT(11.60778 47.42306)	Karwendel	II/B-21.IV-A	North Tyrol	AT	
+Monte Civrari	2302	404	POINT(7.32722 45.19194)	Graian Alps	I/B-07.I-A	Turin	IT	
+Monte Togano	2301	1473	POINT(8.39417 46.08972)	Ticino Alps	I/B-10.II-C	V-C-O	IT	
+Cima di Menna	2300	449	POINT(9.76 45.92972)	Bergamasque Prealps	II/C-29.II-B	Bergamo	IT	
+Hochiss	2299	1359	POINT(11.765 47.45833)	Brandenberg Alps	II/B-21.V-A	North Tyrol	AT	
+Bruderkogel	2299	475	POINT(14.42222 47.38778)	Rottenmann Tauern	II/A-18.III-B	Styria	AT	
+Steinkogel	2299	325	POINT(12.23639 47.29861)	Kitzbühel Alps	II/B-23.II-A	Salzburg	AT	
+Mutteristock	2294	744	POINT(8.94306 47.04833)	Schwyz Alps	I/B-14.IV-C	Glarus / Schwyz	CH	
+Lastìa de Framónt	2294	361	POINT(12.03528 46.31417)	Dolomites - SE	II/C-31.II-A	Belluno	IT	
+Höllwand	2287	494	POINT(13.16389 47.2825)	Ankogel Group	II/A-17.II-F	Salzburg	AT	
+Lumkofel	2287	340	POINT(12.84222 46.72111)	Gailtal Alps	II/C-33.II-B	Carinthia	AT	
+Stadelhorn	2286	1121	POINT(12.79583 47.59278)	Berchtesgaden Alps	II/B-24.III-D	Salzburg / Bavaria	AT/DE	
+Montagne de Coste Longue	2286	382	POINT(6.48528 44.13389)	Provence Alps	I/A-03.II-A	Alpes-de-Haute-Provence	FR	
+Ochsenkopf	2286	341	POINT(9.62472 47.11472)	Rätikon	II/A-15.VIII-A	Vorarlberg / Liechtenstein	AT/LI	
+Grande Moucherolle	2284	454	POINT(5.56583 45.00556)	Vercors Massif	I/A-06.III-A	Isère	FR	
+Rautispitz	2283	465	POINT(9.02833 47.07111)	Schwyz Alps	I/B-14.IV-C	Glarus	CH	
+Druesberg	2282	709	POINT(8.83361 47.00417)	Schwyz Alps	I/B-14.IV-A	Schwyz	CH	
+Trogkofel	2280	736	POINT(13.21694 46.57056)	Carnic Alps	II/C-33.I-B	Carinthia / Udine	AT/IT	
+Großer Daumen	2280	354	POINT(10.37556 47.44139)	Allgäu Alps	II/B-22.II-C	Bavaria	DE	
+Brisi	2279	325	POINT(9.27667 47.15333)	Appenzell Alps	I/B-14.V-A	St. Gallen	CH	
+Rauer Knöll	2278	330	POINT(11.62333 47.38694)	Karwendel	II/B-21.IV-A	North Tyrol	AT	
+Hochschwab	2277	1045	POINT(15.14222 47.61833)	Hochschwab	II/B-26.II-A	Styria	AT	
+Jauken	2276	661	POINT(13.07667 46.70194)	Gailtal Alps	II/C-33.II-D	Carinthia	AT	
+Kronplatz	2275	513	POINT(11.95806 46.73889)	Dolomites - NE	II/C-31.I-B	South Tyrol	IT	
+Leilachspitze	2274	423	POINT(10.54611 47.43861)	Allgäu Alps	II/B-22.II-C	North Tyrol	AT	
+Tosc	2273	300	POINT(13.86833 46.35667)	Julian Alps	II/C-34.I-E	Slovenia	SI	
+Rotgschirr	2270	376	POINT(13.99639 47.70167)	Totes Gebirge	II/B-25.III-A	Styria / Upper Austria	AT	
+Monte Chiadin	2269	540	POINT(12.73833 46.59722)	Carnic Alps	II/C-33.I-A	Belluno / Udine	IT	
+Monte Vacalizza	2266	326	POINT(12.47667 46.305)	Carnic Prealps	II/C-33.III-A	Pordenone	IT	
+Hochschottwies	2262	344	POINT(13.12472 47.51417)	Berchtesgaden Alps	II/B-24.III-B	Salzburg	AT	
+Cima Carega	2259	1185	POINT(11.13 45.72417)	Venetian Prealps	II/C-32.II-B	Trentino	IT	
+Höfats	2259	478	POINT(10.34972 47.36694)	Allgäu Alps	II/B-22.II-C	Bavaria	DE	
+Croix de Rougny	2259	305	POINT(5.99944 44.85917)	Massif des Écrins	I/A-05.III-D	Isère	FR	
+Soiernspitze	2257	833	POINT(11.3575 47.48167)	Karwendel	II/B-21.IV-B	Bavaria	DE	
+Monte Cadria	2254	1434	POINT(10.69806 45.93861)	Garda Prealps	II/C-30.II-A	Trentino	IT	
+Dent de Savigny	2252	853	POINT(7.22667 46.54972)	Fribourg Prealps	I/B-14.I-B	Fribourg / Vaud	CH	
+Hirschkopf	2252	305	POINT(12.9425 47.2325)	Goldberg Group	II/A-17.II-E	Salzburg	AT	
+Admonter Reichenstein	2251	812	POINT(14.54417 47.54917)	Ennstal Alps	II/B-26.I-B	Styria	AT	
+Cimon del Cavallo	2251	380	POINT(12.49639 46.13333)	Venetian Prealps	II/C-32.II-B	Belluno / Pordenone	IT	
+Punta Setteventi	2250	358	POINT(10.39278 45.86028)	Brescia Prealps	II/C-30.I-A	Brescia	IT	
+Morgenberghorn	2249	370	POINT(7.79361 46.62222)	Bernese Alps	I/B-14.II-B	Bern	CH	
+Hochkogel	2249	311	POINT(12.61694 47.32833)	Kitzbühel Alps	II/B-23.II-C	Salzburg	AT	
+Rötelstein	2247	424	POINT(13.55528 47.45722)	Dachstein Mts	II/B-25.I-B	Salzburg	AT	
+Gaishorn	2247	388	POINT(10.47694 47.47)	Allgäu Alps	II/B-22.II-C	North Tyrol	AT	
+Sparafeld	2247	361	POINT(14.53028 47.54944)	Ennstal Alps	II/B-26.I-B	Styria	AT	
+Pizzo di Gino	2245	367	POINT(9.145 46.12361)	Lugano Prealps	I/B-11.I-A	Como	IT	
+Großer Pyhrgas	2244	1290	POINT(14.39806 47.6525)	Ennstal Alps	II/B-26.I-A	Styria / Upper Austria	AT	
+Roc d'Enfer	2244	1081	POINT(6.61194 46.18972)	Chablais Alps	I/B-08.III-C	Upper Savoy	FR	
+Krn	2244	609	POINT(13.65833 46.26611)	Julian Alps	II/C-34.I-F	Slovenia	SI	
+Piz di Mezzodì	2240	1248	POINT(12.03611 46.21889)	Dolomites - SE	II/C-31.II-B	Belluno	IT	
+Rosskofel	2239	297	POINT(13.24028 46.55056)	Carnic Alps	II/C-33.I-B	Carinthia / Udine	AT/IT	
+Köllenspitze	2238	1088	POINT(10.63028 47.49889)	Allgäu Alps	II/B-22.II-E	North Tyrol	AT	
+Hochstuhl	2237	1021	POINT(14.17472 46.43361)	Karawanks	II/C-35.I-A	Carinthia / Slovenia	AT/SI	
+Monte Larone	2237	415	POINT(8.36278 46.21917)	Ticino Alps	I/B-10.II-A	V-C-O	IT	
+Latschur	2236	1268	POINT(13.39667 46.73833)	Gailtal Alps	II/C-33.II-E	Carinthia	AT	
+Croise Baulet	2236	435	POINT(6.55278 45.89889)	Aravis Range	I/B-08.IV-A	Upper Savoy	FR	
+Schafberg	2235	726	POINT(7.31639 46.63694)	Fribourg Prealps	I/B-14.I-B	Bern / Fribourg	CH	
+Pasubio	2232	1070	POINT(11.17639 45.79222)	Vicentine Alps	II/C-32.I-B	Trentino	IT	
+Pointe d'Almet	2232	511	POINT(6.52194 45.98139)	Bornes Massif	I/B-08.IV-B	Upper Savoy	FR	
+Geierkogel	2231	326	POINT(14.49972 47.39972)	Seckau Tauern	II/A-18.IV-A	Styria	AT	
+Hoher Ifen	2230	478	POINT(10.1 47.35444)	Allgäu Alps	II/B-22.II-A	Vorarlberg / Bavaria	AT/DE	
+Monte Messer	2230	328	POINT(12.455 46.17528)	Venetian Prealps	II/C-32.II-B	Belluno / Pordenone	IT	
+Monte Lavanech	2229	336	POINT(10.54333 45.95139)	Adamello-Presanella Alps	II/C-28.III-A	Trentino	IT	
+Monte Borga	2228	438	POINT(12.34944 46.29361)	Carnic Prealps	II/C-33.III-A	Belluno / Pordenone	IT	
+Gumpeneck	2226	356	POINT(14.01472 47.39722)	Wölz Tauern	II/A-18.III-A	Styria	AT	
+Großer Buchstein	2224	1363	POINT(14.60417 47.60889)	Ennstal Alps	II/B-26.I-B	Styria	AT	
+Kalški Greben	2224	431	POINT(14.53806 46.33139)	Kamnik Alps	II/C-35.II-B	Slovenia	SI	
+Rappenspitze	2223	323	POINT(11.64583 47.40222)	Karwendel	II/B-21.IV-A	North Tyrol	AT	
+Sosto	2221	524	POINT(8.95194 46.54833)	Adula Alps	I/B-10.III-B	Ticino	CH	
+Dent d'Oche	2221	306	POINT(6.73111 46.35333)	Chablais Alps	I/B-08.III-B	Upper Savoy	FR	
+Hochrettelstein	2220	341	POINT(14.23278 47.42472)	Wölz Tauern	II/A-18.III-A	Styria	AT	
+Hochkarfelderkopf	2219	320	POINT(13.35556 47.51917)	Tennen Mountains	II/B-24.IV-A	Salzburg	AT	
+Cima Valdritta	2218	1950	POINT(10.84389 45.72639)	Garda Mountains	II/C-30.II-C	Verona / Trentino	IT	
+Pointe d'Arcalod	2217	1713	POINT(6.22833 45.68167)	Bauges	I/B-08.V-A	Savoy	FR	
+Lugauer	2217	659	POINT(14.72278 47.55361)	Ennstal Alps	II/B-26.I-B	Styria	AT	
+Kleiner Rettenstein	2216	503	POINT(12.34167 47.33639)	Kitzbühel Alps	II/B-23.II-A	North Tyrol	AT	
+Les Jumelles	2215	365	POINT(6.81222 46.35194)	Chablais Alps	I/B-08.III-B	Valais	CH	
+Steinbergstein	2215	313	POINT(12.19028 47.34139)	Kitzbühel Alps	II/B-23.II-A	North Tyrol	AT	
+Gößeck	2214	832	POINT(14.89972 47.44806)	Ennstal Alps	II/B-26.I-C	Styria	AT	
+Schwarzwand	2214	480	POINT(13.69306 47.0075)	Nock Mountains	II/A-19.I-A	Carinthia / Salzburg	AT	
+Aineck	2210	515	POINT(13.63833 47.05556)	Nock Mountains	II/A-19.I-A	Carinthia / Salzburg	AT	
+Würflinghöhe	2210	460	POINT(13.95167 47.0075)	Nock Mountains	II/A-19.I-A	Styria	AT	
+Monte La Palazza	2210	417	POINT(12.35583 46.31056)	Carnic Prealps	II/C-33.III-A	Belluno / Pordenone	IT	
+Rombon	2208	310	POINT(13.55389 46.36722)	Julian Alps	II/C-34.I-B	Slovenia	SI	
+Mont Charvin	2207	457	POINT(6.285 45.2175)	Dauphiné Alps	I/A-05.I-A	Savoy	FR	
+Hoher Trieb	2199	415	POINT(13.06167 46.59694)	Carnic Alps	II/C-33.I-B	Carinthia / Udine	AT/IT	
+Pointe de la Sambuy	2198	466	POINT(6.26556 45.69167)	Bauges	I/B-08.V-A	Upper Savoy	FR	
+Galinakopf	2198	357	POINT(9.62083 47.15167)	Rätikon	II/A-15.VIII-A	Vorarlberg / Liechtenstein	AT/LI	
+Cima di Vanerle	2198	306	POINT(10.28139 46.05139)	Bergamasque Prealps	II/C-29.II-C	Brescia	IT	
+Pécloz	2197	679	POINT(6.23056 45.63194)	Bauges	I/B-08.V-A	Savoy	FR	
+Hohgant	2197	636	POINT(7.90167 46.78806)	Emmental Alps	I/B-14.II-C	Bern	CH	
+Scheiblingstein	2197	323	POINT(14.42389 47.65333)	Ennstal Alps	II/B-26.I-A	Styria / Upper Austria	AT	
+Große Arnspitze	2196	993	POINT(11.22278 47.3975)	Wetterstein	II/B-21.III-B	North Tyrol / Bavaria	AT/DE	
+Chrüz	2196	589	POINT(9.775 46.955)	Rätikon	II/A-15.VIII-A	Graubünden	CH	
+Hochschwung	2196	342	POINT(14.33944 47.40722)	Rottenmann Tauern	II/A-18.III-B	Styria	AT	
+Zuc dal Bôr	2195	1112	POINT(13.25861 46.44944)	Carnic Alps	II/C-33.I-D	Udine	IT	
+Gartnerkofel	2195	665	POINT(13.30417 46.57139)	Carnic Alps	II/C-33.I-B	Carinthia	AT	
+Hochwipfel	2195	412	POINT(13.17667 46.59444)	Carnic Alps	II/C-33.I-B	Carinthia	AT	
+Guffert	2194	1143	POINT(11.78917 47.54611)	Brandenberg Alps	II/B-21.V-A	North Tyrol	AT	
+Cima della Laurasca	2193	371	POINT(8.47611 46.05806)	Ticino Alps	I/B-10.II-C	V-C-O	IT	
+Hochzinödl	2191	495	POINT(14.66639 47.56583)	Ennstal Alps	II/B-26.I-B	Styria	AT	
+Stockhorn	2190	399	POINT(7.5375 46.69389)	Bernese Alps	I/B-14.II-A	Bern	CH	
+Hinterer Geißstein	2190	351	POINT(13.53861 47.30667)	Schladming Tauern	II/A-18.II-A	Salzburg	AT	
+Blayeul	2189	949	POINT(6.31222 44.24722)	Provence Alps	I/A-03.I-A	Alpes-de-Haute-Provence	FR	
+Gros Van	2189	528	POINT(7.06917 46.39639)	Vaud Alps	I/B-14.I-A	Vaud	CH	
+Gridone	2188	1231	POINT(8.64806 46.12361)	Ticino Alps	I/B-10.II-C	V-C-O / Ticino	CH/IT	
+Ochsen	2188	384	POINT(7.41861 46.69889)	Bernese Alps	I/B-14.II-A	Bern	CH	
+Ameringkogel	2187	1232	POINT(14.80806 47.07333)	Lavanttal Alps	II/A-20.I-A	Styria	AT	
+Monte Sernio	2187	941	POINT(13.1375 46.475)	Carnic Alps	II/C-33.I-D	Udine	IT	
+Pizzocco	2187	324	POINT(12.00944 46.14)	Dolomites - S	II/C-31.IV-B	Belluno	IT	
+Kreuzspitze	2185	1182	POINT(10.91833 47.52667)	Ammergau Alps	II/B-22.III-A	Bavaria	DE	
+Monte Misa	2184	389	POINT(10.44417 45.90111)	Adamello-Presanella Alps	II/C-28.III-A	Brescia	IT	
+Monte Rite	2183	618	POINT(12.25806 46.38444)	Dolomites - SE	II/C-31.II-A	Belluno	IT	
+Pizzo Stagno	2183	342	POINT(8.45917 46.07722)	Ticino Alps	I/B-10.II-C	V-C-O	IT	
+Trélod	2181	686	POINT(6.19639 45.69278)	Bauges	I/B-08.V-A	Savoy / Upper Savoy	FR	
+Monte Bondone	2180	1679	POINT(11.03139 45.98806)	Garda Mountains	II/C-30.II-C	Trentino	IT	
+Vertatscha	2180	340	POINT(14.2125 46.43972)	Karawanks	II/C-35.I-A	Carinthia / Slovenia	AT/SI	
+Lüschgrat	2178	332	POINT(9.34472 46.70167)	Adula Alps	I/B-10.III-C	Graubünden	CH	
+Grignetta	2177	377	POINT(9.39028 45.92167)	Bergamasque Prealps	II/C-29.II-A	Lecco	IT	
+Pointe d'entre Deux Pertuis	2176	398	POINT(6.73111 46.23417)	Chablais Alps	I/B-08.III-A	Upper Savoy	FR	
+Signal de l'Homme	2176	361	POINT(6.08556 45.06694)	Dauphiné Alps	I/A-05.I-B	Isère	FR	
+Bulacia	2174	329	POINT(11.615 46.56389)	Dolomites - NW	II/C-31.III-A	South Tyrol	IT	
+Hexenturm	2172	358	POINT(14.48111 47.64583)	Ennstal Alps	II/B-26.I-A	Styria	AT	
+Goldachnock	2171	787	POINT(14.0575 47.03472)	Gurktal Alps	II/A-19.I-B	Styria	AT	
+Monte Crot	2169	364	POINT(12.09972 46.42722)	Dolomites - SE	II/C-31.II-A	Belluno	IT	
+Monte Chiarescons	2168	332	POINT(12.62639 46.34778)	Carnic Prealps	II/C-33.III-B	Pordenone / Udine	IT	
+Dobratsch	2166	1233	POINT(13.67111 46.60333)	Gailtal Alps	II/C-33.II-F	Carinthia	AT	
+Col Rosa	2166	432	POINT(12.0975 46.58611)	Dolomites - NE	II/C-31.I-D	Belluno	IT	
+Eisenerzer Reichenstein	2165	660	POINT(14.93444 47.5025)	Ennstal Alps	II/B-26.I-C	Styria	AT	
+Gehrenspitze	2163	305	POINT(10.65528 47.50028)	Allgäu Alps	II/B-22.II-E	North Tyrol	AT	
+Geierköpfe	2161	495	POINT(10.875 47.51972)	Ammergau Alps	II/B-22.III-A	North Tyrol	AT	
+Monte Massone	2161	411	POINT(8.33806 45.94694)	Monte Rosa Alps	I/B-09.III-C	V-C-O	IT	
+Pic de Gleize	2161	362	POINT(6.04389 44.63444)	Dévoluy Mountains	I/A-06.I-A	Hautes-Alpes	FR	
+Zuccone Campelli	2159	507	POINT(9.51694 45.95333)	Bergamasque Prealps	II/C-29.II-A	Lecco	IT	
+Monte Zeda	2156	348	POINT(8.53528 46.04556)	Ticino Alps	I/B-10.II-C	V-C-O	IT	
+Dosso della Torta	2156	305	POINT(10.76389 45.96667)	Garda Prealps	II/C-30.II-A	Trentino	IT	
+Frudiger	2153	431	POINT(10.57944 46.96889)	Ötztal Alps	II/A-16.I-C	North Tyrol	AT	
+Monte Padrio	2153	309	POINT(10.2275 46.18667)	Ortler Alps	II/C-28.I-B	Brescia / Sondrio	IT	
+Hochmatt	2152	428	POINT(7.22 46.57583)	Fribourg Prealps	I/B-14.I-B	Fribourg	CH	
+Becco di Filadonna	2150	943	POINT(11.19306 45.96361)	Vicentine Alps	II/C-32.I-A	Trentino	IT	
+Cresta Le Coraie	2149	474	POINT(12.0775 46.20972)	Dolomites - S	II/C-31.IV-A	Belluno	IT	
+Pizzo Camino	2148	323	POINT(8.23444 45.9775)	Monte Rosa Alps	I/B-09.III-C	V-C-O	IT	
+Wöllaner Nock	2145	1042	POINT(13.82972 46.77667)	Gurktal Alps	II/A-19.I-C	Carinthia	AT	
+Mittagskogel	2143	705	POINT(13.95278 46.50667)	Karawanks	II/C-35.I-A	Carinthia / Slovenia	AT/SI	
+Monte Zermula	2143	591	POINT(13.15139 46.56139)	Carnic Alps	II/C-33.I-B	Udine	IT	
+Goldeck	2142	417	POINT(13.45944 46.75861)	Gailtal Alps	II/C-33.II-E	Carinthia	AT	
+Großer Speikkogel	2140	971	POINT(14.97167 46.7875)	Lavanttal Alps	II/A-20.I-B	Carinthia	AT	
+Gstoder	2140	906	POINT(13.9925 47.1425)	Schladming Tauern	II/A-18.II-B	Salzburg / Styria	AT	
+Hochobir	2139	1071	POINT(14.48778 46.50583)	Karawanks	II/C-35.I-B	Carinthia	AT	
+Kammspitz	2139	658	POINT(13.885 47.47611)	Dachstein Mts	II/B-25.I-C	Styria	AT	
+Strimskogel	2139	400	POINT(13.47083 47.31194)	Radstadt Tauern	II/A-18.I-A	Salzburg	AT	
+Koschutnikturm	2136	767	POINT(14.41056 46.44611)	Karawanks	II/C-35.I-A	Carinthia / Slovenia	AT/SI	
+Dôme de Barrot	2136	456	POINT(6.91722 44.03694)	Maritime Alps	I/A-02.I-D	Alpes-Maritimes	FR	
+Cime de Marta	2135	535	POINT(7.65694 44.01833)	Ligurian Alps	I/A-01.II-A	Alpes-Maritimes	FR	
+Monte Colli	2135	319	POINT(10.20139 46.03194)	Bergamasque Prealps	II/C-29.II-C	Bergamo	IT	
+Glatthorn	2134	648	POINT(9.87972 47.26528)	Bregenz Forest Mts	II/B-22.I-A	Vorarlberg	AT	
+Monte Serva	2133	478	POINT(12.23278 46.20028)	Dolomites - SE	II/C-31.II-B	Belluno	IT	
+Storžič	2132	667	POINT(14.40528 46.35)	Kamnik Alps	II/C-35.II-A	Slovenia	SI	
+Monte Birrone	2131	436	POINT(7.25222 44.5425)	Cottian Alps	I/A-04.I-A	Cuneo	IT	
+Pilatus	2128	585	POINT(8.24111 46.97389)	Emmental Alps	I/B-14.III-A	Nidwalden / Obwalden	CH	
+Elm	2128	388	POINT(13.96306 47.67361)	Totes Gebirge	II/B-25.III-A	Styria	AT	
+Kordeschkopf	2126	882	POINT(14.78056 46.5)	Karawanks	II/C-35.I-C	Carinthia / Slovenia	AT/SI	
+Jerebica	2126	425	POINT(13.565 46.39806)	Julian Alps	II/C-34.I-B	Udine / Slovenia	IT/SI	
+Paganella	2124	1099	POINT(11.0375 46.14333)	Brenta Dolomites	II/C-28.IV-A	Trentino	IT	
+Kuhgrat	2123	681	POINT(9.56083 47.16667)	Rätikon	II/A-15.VIII-A	Liechtenstein	LI	
+Montagne du Carton	2123	362	POINT(6.46083 44.18139)	Provence Alps	I/A-03.II-A	Alpes-de-Haute-Provence	FR	
+Ebenstein	2123	348	POINT(15.02833 47.60583)	Hochschwab	II/B-26.II-A	Styria	AT	
+Zeiritzkampel	2120	559	POINT(14.72611 47.49139)	Ennstal Alps	II/B-26.I-C	Styria	AT	
+Monte Tinisa	2120	298	POINT(12.71861 46.41361)	Carnic Alps	II/C-33.I-C	Udine	IT	
+Spitzegel	2119	1045	POINT(13.41056 46.655)	Gailtal Alps	II/C-33.II-D	Carinthia	AT	
+Wildseeloder	2119	338	POINT(12.53194 47.43194)	Kitzbühel Alps	II/B-23.II-C	North Tyrol	AT	
+Hundstein	2117	827	POINT(12.91139 47.33806)	Salzburg Slate Alps	II/B-24.II-A	Salzburg	AT	
+Roen	2116	753	POINT(11.19194 46.36056)	Nonsberg Group	II/C-28.II-A	South Tyrol / Trentino	IT	
+Almkogel	2116	375	POINT(14.09306 47.61944)	Totes Gebirge	II/B-25.III-B	Styria / Upper Austria	AT	
+Gsuchmauer	2116	295	POINT(14.6675 47.54889)	Ennstal Alps	II/B-26.I-B	Styria	AT	
+Les Monges	2115	769	POINT(6.19472 44.26306)	Provence Alps	I/A-03.II-B	Hautes-Alpes	FR	
+Montagne de Cordœil	2114	955	POINT(6.53 44.06833)	Provence Alps	I/A-03.I-A	Alpes-de-Haute-Provence	FR	
+Pointe de Chalune	2113	295	POINT(6.58333 46.18028)	Chablais Alps	I/B-08.III-C	Upper Savoy	FR	
+Sommet de Clot Ginoux	2112	754	POINT(6.21278 44.29639)	Provence Alps	I/A-03.II-B	Hautes-Alpes	FR	
+Le Chamossaire	2112	377	POINT(7.06139 46.32667)	Vaud Alps	I/B-14.I-A	Vaud	CH	
+Mirnock	2110	1343	POINT(13.71556 46.75889)	Gurktal Alps	II/A-19.I-C	Carinthia	AT	
+Trentski Pelc	2109	313	POINT(13.70944 46.38583)	Julian Alps	II/C-34.I-C	Slovenia	SI	
+Millstätter Alpe	2108	443	POINT(13.57833 46.85722)	Nock Mountains	II/A-19.I-A	Carinthia	AT	
+Testa di Comagna	2106	466	POINT(7.72194 45.745)	Monte Rosa Alps	I/B-09.III-B	Aosta Valley	IT	
+Mondscheinspitze	2106	457	POINT(11.61361 47.46667)	Karwendel	II/B-21.IV-B	North Tyrol	AT	
+Les Cluots	2106	425	POINT(7.00472 44.04694)	Maritime Alps	I/A-02.I-D	Alpes-Maritimes	FR	
+Schluchberg	2106	364	POINT(8.33389 46.86667)	Uri Alps	I/B-12.I-B	Nidwalden / Obwalden	CH	
+Hochkogel	2105	800	POINT(14.81528 47.53889)	Ennstal Alps	II/B-26.I-C	Styria	AT	
+Schopfenspitz	2104	537	POINT(7.25056 46.6225)	Fribourg Prealps	I/B-14.I-B	Fribourg	CH	
+Schönberg	2104	318	POINT(9.59306 47.13028)	Rätikon	II/A-15.VIII-A	Liechtenstein	LI	
+Mont Chalancha	2102	598	POINT(7.21278 44.035)	Maritime Alps	I/A-02.I-B	Alpes-Maritimes	FR	
+Schafreuter	2102	562	POINT(11.4875 47.50917)	Karwendel	II/B-21.IV-B	North Tyrol / Bavaria	AT/DE	
+Pizzo Proman	2099	371	POINT(8.39472 46.02417)	Ticino Alps	I/B-10.II-C	V-C-O	IT	
+Zwölferkogel	2099	354	POINT(13.9525 47.70944)	Totes Gebirge	II/B-25.III-A	Styria / Upper Austria	AT	
+Simmering	2096	315	POINT(10.86694 47.27806)	Mieminger Chain	II/B-21.III-A	North Tyrol	AT	
+Himmeleck	2096	302	POINT(14.60306 47.42667)	Seckau Tauern	II/A-18.IV-A	Styria	AT	
+Damülser Mittagsspitze	2095	609	POINT(9.88389 47.31028)	Bregenz Forest Mts	II/B-22.I-A	Vorarlberg	AT	
+Schönberg	2093	495	POINT(13.79361 47.7125)	Totes Gebirge	II/B-25.III-A	Styria	AT	
+Mont Chauffé	2093	399	POINT(6.76056 46.30917)	Chablais Alps	I/B-08.III-B	Upper Savoy	FR	
+Schrattenfluh	2092	776	POINT(7.95778 46.83417)	Emmental Alps	I/B-14.III-A	Lucerne	CH	
+Schatzbichl	2090	536	POINT(12.91194 46.72417)	Gailtal Alps	II/C-33.II-C	Carinthia	AT	
+Il Palone	2090	529	POINT(11.05861 46.02694)	Garda Mountains	II/C-30.II-C	Trentino	IT	
+Pointe d'Angolon	2090	430	POINT(6.73083 46.13806)	Chablais Alps	I/B-08.III-A	Upper Savoy	FR	
+Diedamskopf	2090	303	POINT(10.02556 47.34639)	Allgäu Alps	II/B-22.II-A	Vorarlberg	AT	
+Itonskopf	2089	610	POINT(9.93333 47.11611)	Verwall Alps	II/A-15.VI-C	Vorarlberg	AT	
+Jôf di Miezegnot	2087	695	POINT(13.45333 46.47667)	Julian Alps	II/C-34.I-A	Udine	IT	
+Pic Grillon	2087	407	POINT(5.91778 44.75139)	Dévoluy Mountains	I/A-06.I-A	Hautes-Alpes / Isère	FR	
+Krottenkopf	2086	1156	POINT(11.19333 47.545)	Bavarian Prealps	II/B-22.IV-A	Bavaria	DE	
+Montagne Durbonas	2086	393	POINT(5.75944 44.61111)	Dévoluy Mountains	I/A-06.I-B	Hautes-Alpes	FR	
+Mont de l'Arpille	2085	557	POINT(7.00667 46.07722)	Mont Blanc massif	I/B-07.V-C	Valais	CH	
+Seebergspitze	2085	529	POINT(11.67972 47.46611)	Karwendel	II/B-21.IV-B	North Tyrol	AT	
+Mont Aiguille	2085	465	POINT(5.5525 44.84194)	Vercors Massif	I/A-06.III-A	Isère	FR	
+Monte Zelo	2083	532	POINT(12.0925 46.26333)	Dolomites - SE	II/C-31.II-B	Belluno	IT	
+Zadnjiški Ozebnik	2083	450	POINT(13.78222 46.36944)	Julian Alps	II/C-34.I-E	Slovenia	SI	
+Krofička	2083	291	POINT(14.64583 46.37444)	Kamnik Alps	II/C-35.II-B	Slovenia	SI	
+Chamechaude	2082	1771	POINT(5.79 45.28806)	Chartreuse Mts	I/B-08.VI-B	Isère	FR	
+Hochplatte	2082	967	POINT(10.8425 47.55222)	Ammergau Alps	II/B-22.III-B	Bavaria	DE	
+Trenchtling	2081	515	POINT(15.00806 47.53444)	Hochschwab	II/B-26.II-A	Styria	AT	
+Breithorn	2081	375	POINT(9.91417 47.21139)	Lechquellen Mts	II/B-21.II-A	Vorarlberg	AT	
+Monte Altissimo di Nago	2079	653	POINT(10.88889 45.81028)	Garda Mountains	II/C-30.II-C	Trentino	IT	
+Ladinger Spitz	2079	435	POINT(14.65083 46.85333)	Lavanttal Alps	II/A-19.II-C	Carinthia	AT	
+Rinderberg	2079	371	POINT(7.35694 46.50528)	Bernese Alps	I/B-14.II-A	Bern	CH	
+Turnen	2079	343	POINT(7.4925 46.62778)	Bernese Alps	I/B-14.II-A	Bern	CH	
+Vorderunnütz	2078	591	POINT(11.73889 47.51472)	Brandenberg Alps	II/B-21.V-A	North Tyrol	AT	
+Klosterwappen	2076	1348	POINT(15.805 47.76722)	Rax-Schneeberg Group	II/B-26.II-C	Lower Austria	AT	
+Cima del Cacciatore	2071	595	POINT(13.52806 46.46472)	Julian Alps	II/C-34.I-A	Udine	IT	
+Stadelstein	2070	418	POINT(14.85694 47.48972)	Ennstal Alps	II/B-26.I-C	Styria	AT	
+Monte Coppolo	2069	449	POINT(11.71083 46.08278)	Fiemme Mountains	II/C-31.V-B	Trentino	IT	
+Hirscheck	2068	313	POINT(14.12306 47.6275)	Totes Gebirge	II/B-25.III-B	Styria / Upper Austria	AT	
+Monte Resettum	2067	635	POINT(12.57722 46.23972)	Carnic Prealps	II/C-33.III-B	Pordenone	IT	
+Col Gentile	2067	340	POINT(12.80556 46.46611)	Carnic Alps	II/C-33.I-C	Udine	IT	
+Padauner Kogel	2066	475	POINT(11.5075 47.04278)	Zillertal Alps	II/A-17.I-A	North Tyrol	AT	
+Dosso Alto	2065	411	POINT(10.41694 45.81333)	Brescia Prealps	II/C-30.I-B	Brescia	IT	
+Creta Grauzaria	2065	375	POINT(13.1625 46.4675)	Carnic Alps	II/C-33.I-D	Udine	IT	
+Großer Woising	2064	312	POINT(13.90389 47.71611)	Totes Gebirge	II/B-25.III-A	Styria / Upper Austria	AT	
+Chateau Lebrun	2064	301	POINT(6.53 44.80222)	Massif des Écrins	I/A-05.III-C	Hautes-Alpes	FR	
+Burgfeldstand	2063	508	POINT(7.79472 46.72222)	Emmental Alps	I/B-14.II-C	Bern	CH	
+Dent de Cons	2062	1155	POINT(6.35167 45.72972)	Bauges	I/B-08.V-A	Savoy / Upper Savoy	FR	
+Raduha	2062	803	POINT(14.73833 46.40972)	Kamnik Alps	II/C-35.II-C	Slovenia	SI	
+Dent de Crolles	2062	690	POINT(5.85694 45.30833)	Chartreuse Mts	I/B-08.VI-A	Isère	FR	
+Monte Dosaip	2062	562	POINT(12.63694 46.28389)	Carnic Prealps	II/C-33.III-B	Pordenone	IT	
+Monte Agaro	2062	452	POINT(11.65778 46.09361)	Fiemme Mountains	II/C-31.V-B	Trentino	IT	
+Pic Melette	2062	392	POINT(6.01472 44.62694)	Dévoluy Mountains	I/A-06.I-A	Hautes-Alpes	FR	
+Begunjščica	2060	518	POINT(14.22917 46.42139)	Karawanks	II/C-35.I-A	Slovenia	SI	
+Monte Stivo	2059	489	POINT(10.96361 45.92056)	Garda Mountains	II/C-30.II-C	Trentino	IT	
+Monte Toff	2058	481	POINT(10.78833 46.10667)	Brenta Dolomites	II/C-28.IV-A	Trentino	IT	
+Oisternig	2052	620	POINT(13.5 46.56556)	Carnic Alps	II/C-33.I-B	Carinthia / Udine	AT/IT	
+Mont Jocou	2051	594	POINT(5.6475 44.72417)	Vercors Massif	I/A-06.III-A	Isère / Drôme	FR	
+Sigriswiler Rothorn	2051	372	POINT(7.77056 46.73056)	Emmental Alps	I/B-14.II-C	Bern	CH	
+Mont Lachat de Chatillon	2050	322	POINT(6.47667 45.95972)	Bornes Massif	I/B-08.IV-B	Upper Savoy	FR	
+Roc Cornafion	2049	420	POINT(5.6025 45.06333)	Vercors Massif	I/A-06.III-A	Isère	FR	
+Stoderzinken	2048	318	POINT(13.82889 47.45944)	Dachstein Mts	II/B-25.I-C	Styria	AT	
+Säuling	2047	695	POINT(10.75583 47.535)	Ammergau Alps	II/B-22.III-B	North Tyrol / Bavaria	AT/DE	
+Hundsrügg	2047	414	POINT(7.30528 46.55667)	Fribourg Prealps	I/B-14.I-B	Bern	CH	
+Mont Colombier	2045	1095	POINT(6.11972 45.64417)	Bauges	I/B-08.V-B	Savoy	FR	
+Spielberghorn	2044	725	POINT(12.63278 47.43222)	Kitzbühel Alps	II/B-23.II-C	North Tyrol / Salzburg	AT	
+Monte Barone	2044	602	POINT(8.155 45.735)	Biellese Alps	I/B-09.IV-A	Biella	IT	
+Kanisfluh	2044	410	POINT(9.92694 47.33167)	Bregenz Forest Mts	II/B-22.I-A	Vorarlberg	AT	
+Güpfi	2043	381	POINT(8.19528 46.79611)	Uri Alps	I/B-12.I-B	Obwalden	CH	
+Rochers de Naye	2042	590	POINT(6.97611 46.43194)	Vaud Alps	I/B-14.I-A	Vaud	CH	
+Pointe de Bellevue	2042	355	POINT(6.8875 46.2575)	Chablais Alps	I/B-08.III-B	Valais	CH	
+Le Glandasse	2041	403	POINT(5.47139 44.73722)	Vercors Massif	I/A-06.III-A	Drôme	FR	
+Fürstein	2040	481	POINT(8.06972 46.89556)	Emmental Alps	I/B-14.III-A	Lucerne / Obwalden	CH	
+Saldeiner Spitze	2036	340	POINT(10.53222 47.39889)	Allgäu Alps	II/B-22.II-C	North Tyrol	AT	
+Leobner	2036	297	POINT(14.65 47.49417)	Ennstal Alps	II/B-26.I-C	Styria	AT	
+Tamischbachturm	2035	584	POINT(14.69917 47.61472)	Ennstal Alps	II/B-26.I-B	Styria	AT	
+Monte Curie	2035	468	POINT(12.61361 46.59556)	Carnic Alps	II/C-33.I-A	Belluno	IT	
+Griesmauerkogel	2034	357	POINT(14.98361 47.55111)	Hochschwab	II/B-26.II-A	Styria	AT	
+Tête Grosse	2032	330	POINT(6.27389 44.33139)	Provence Alps	I/A-03.II-B	Alpes-de-Haute-Provence	FR	
+Gamsfeld	2027	1070	POINT(13.48111 47.62306)	Salzkammergut Mts	II/B-25.II-A	Salzburg	AT	
+Grand Som	2026	887	POINT(5.81306 45.37111)	Chartreuse Mts	I/B-08.VI-A	Isère	FR	
+Fleischbank	2026	472	POINT(11.51944 47.47889)	Karwendel	II/B-21.IV-B	North Tyrol	AT	
+Pointe d'Aveneyre	2026	405	POINT(7.00472 46.41722)	Vaud Alps	I/B-14.I-A	Vaud	CH	
+Raut	2025	524	POINT(12.64944 46.22222)	Carnic Prealps	II/C-33.III-B	Pordenone	IT	
+Kosiak	2024	310	POINT(14.18167 46.45306)	Karawanks	II/C-35.I-A	Carinthia	AT	
+Mont Lachat	2023	1064	POINT(6.35111 45.92722)	Bornes Massif	I/B-08.IV-B	Upper Savoy	FR	
+Schreckenspitze	2022	342	POINT(11.64944 47.5)	Karwendel	II/B-21.IV-B	North Tyrol	AT	
+Monte Alben	2019	781	POINT(9.78194 45.86222)	Bergamasque Prealps	II/C-29.II-B	Bergamo	IT	
+Céüse	2016	1040	POINT(5.96194 44.50889)	Bochaine	I/A-06.II-A	Hautes-Alpes	FR	
+Monte Verena	2015	595	POINT(11.41361 45.93111)	Vicentine Alps	II/C-32.I-A	Vicenza	IT	
+Dent de Lys	2014	505	POINT(7.00306 46.50778)	Fribourg Prealps	I/B-14.I-B	Fribourg	CH	
+Montagne de l'Ubac	2010	448	POINT(6.41389 44.26111)	Provence Alps	I/A-03.I-A	Alpes-de-Haute-Provence	FR	
+Bäderhorn	2009	404	POINT(7.3275 46.61333)	Fribourg Prealps	I/B-14.I-B	Bern	CH	
+Heukuppe	2007	992	POINT(15.68778 47.68944)	Rax-Schneeberg Group	II/B-26.II-C	Lower Austria / Styria	AT	
+Corna Blacca	2006	327	POINT(10.38056 45.79139)	Brescia Prealps	II/C-30.I-B	Brescia	IT	
+Dristenkopf	2005	361	POINT(11.66417 47.42056)	Karwendel	II/B-21.IV-A	North Tyrol	AT	
+Montagne de Sous Dine	2004	579	POINT(6.32861 46.00389)	Bornes Massif	I/B-08.IV-B	Upper Savoy	FR	
+Golz	2004	443	POINT(13.36583 46.67139)	Gailtal Alps	II/C-33.II-E	Salzburg	AT	
+Pizzo Ruscada	2004	330	POINT(8.59278 46.1775)	Ticino Alps	I/B-10.II-B	Ticino	CH	
+Brandstein	2003	446	POINT(14.98278 47.60083)	Hochschwab	II/B-26.II-A	Styria	AT	
+Moléson	2002	512	POINT(7.01722 46.54889)	Fribourg Prealps	I/B-14.I-B	Fribourg	CH	
+Vordere Kesselschneid	2001	603	POINT(12.2775 47.60667)	Kaiser Mountains	II/B-21.VI-B	North Tyrol	AT	
+Poludnig	1999	529	POINT(13.41028 46.57194)	Carnic Alps	II/C-33.I-B	Carinthia / Udine	AT/IT	
+Monte Venturosa	1999	471	POINT(9.61583 45.92972)	Bergamo Alps	II/C-29.I-B	Bergamo	IT	
+Pointe de Marcelly	1999	440	POINT(6.57556 46.12861)	Chablais Alps	I/B-08.III-C	Upper Savoy	FR	
+Monte Scinauz	1999	369	POINT(13.36389 46.53222)	Carnic Alps	II/C-33.I-B	Udine	IT	
+Puy de Rent	1996	556	POINT(6.59083 44.02139)	Maritime Alps	I/A-02.I-E	Alpes-de-Haute-Provence	FR	
+Kitzbüheler Horn	1996	516	POINT(12.43 47.47611)	Kitzbühel Alps	II/B-23.II-C	North Tyrol	AT	


### PR DESCRIPTION
adds names.txt to sql resources, so queries against `sys.summits` will work again