### PR TITLE
Tests: Change dynamic column template update test to use less resources

### DIFF
--- a/sql/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
@@ -331,8 +331,8 @@ public class PartitionedTableConcurrentIntegrationTest extends SQLTransportInteg
                 "with (number_of_replicas = 0)");
         ensureYellow();
 
-        int bulkSize = 100;
-        int numCols = 100;
+        int bulkSize = 10;
+        int numCols = 5;
         String[] buckets = new String[]{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"};
         final CountDownLatch countDownLatch = new CountDownLatch(buckets.length);
         for (String bucket : buckets) {


### PR DESCRIPTION
The insert statement would sometimes run into a timeout causing the test
to fail.

Reducing the bulkSize & numCols still causes the test to fail without
the fix applied in bd4dba27cb6c1cdb659698dd37ce2bcf3f5c03e7