### PR TITLE
fix: udf weren’t persisted

### DIFF
--- a/sql/src/main/java/io/crate/operation/udf/UserDefinedFunctionService.java
+++ b/sql/src/main/java/io/crate/operation/udf/UserDefinedFunctionService.java
@@ -39,10 +39,16 @@ import org.elasticsearch.common.settings.Settings;
 
 import java.util.Map;
 
+import static io.crate.operation.udf.UserDefinedFunctionsMetaData.PROTO;
 import static java.util.stream.Collectors.toMap;
 
 @Singleton
 public class UserDefinedFunctionService extends AbstractLifecycleComponent<UserDefinedFunctionService> implements ClusterStateListener {
+
+    static {
+        // register non plugin custom metadata
+        MetaData.registerPrototype(UserDefinedFunctionsMetaData.TYPE, PROTO);
+    }
 
     private final ClusterService clusterService;
     private final Functions functions;

--- a/sql/src/main/java/io/crate/operation/udf/UserDefinedFunctionsMetaData.java
+++ b/sql/src/main/java/io/crate/operation/udf/UserDefinedFunctionsMetaData.java
@@ -42,11 +42,6 @@ public class UserDefinedFunctionsMetaData extends AbstractDiffable<MetaData.Cust
 
     public static final UserDefinedFunctionsMetaData PROTO = new UserDefinedFunctionsMetaData();
 
-    static {
-        // register non plugin custom metadata
-        MetaData.registerPrototype(TYPE, PROTO);
-    }
-
     private final Map<Integer, UserDefinedFunctionMetaData> functionsBySignatureHash;
 
     private UserDefinedFunctionsMetaData() {
@@ -118,11 +113,13 @@ public class UserDefinedFunctionsMetaData extends AbstractDiffable<MetaData.Cust
     @Override
     public MetaData.Custom fromXContent(XContentParser parser) throws IOException {
         Map<Integer, UserDefinedFunctionMetaData> functions = new HashMap<>();
-        if ((parser.nextToken()) == XContentParser.Token.START_ARRAY) {
-            XContentParser.Token token;
-            while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY && token != null) {
-                UserDefinedFunctionMetaData function = UserDefinedFunctionMetaData.fromXContent(parser);
-                functions.put(function.createMethodSignature(), function);
+        if (parser.nextToken() == XContentParser.Token.FIELD_NAME &&  parser.currentName() == "functions") {
+            if ((parser.nextToken()) == XContentParser.Token.START_ARRAY) {
+                XContentParser.Token token;
+                while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY && token != null) {
+                    UserDefinedFunctionMetaData function = UserDefinedFunctionMetaData.fromXContent(parser);
+                    functions.put(function.createMethodSignature(), function);
+                }
             }
         }
         return new UserDefinedFunctionsMetaData(functions);
@@ -130,7 +127,7 @@ public class UserDefinedFunctionsMetaData extends AbstractDiffable<MetaData.Cust
 
     @Override
     public EnumSet<MetaData.XContentContext> context() {
-        return MetaData.API_AND_SNAPSHOT;
+        return EnumSet.of(MetaData.XContentContext.GATEWAY, MetaData.XContentContext.SNAPSHOT);
     }
 
     @Override

--- a/sql/src/test/java/io/crate/operation/udf/UserDefinedFunctionsMetaDataTest.java
+++ b/sql/src/test/java/io/crate/operation/udf/UserDefinedFunctionsMetaDataTest.java
@@ -81,7 +81,6 @@ public class UserDefinedFunctionsMetaDataTest extends CrateUnitTest {
 
         XContentParser parser = JsonXContent.jsonXContent.createParser(builder.bytes());
         parser.nextToken(); // start object
-        parser.nextToken(); // field name
         UserDefinedFunctionsMetaData functions2 =
             (UserDefinedFunctionsMetaData) UserDefinedFunctionsMetaData.of().fromXContent(parser);
         assertEquals(functions, functions2);


### PR DESCRIPTION
One thing prevented udfs to be persisted:
* XContentContext.GATEWAY was missing

Two things prevented proper reading from cluster state
* MetaData.registerPrototype wasn't called on startup, so the custom udf metadata was unknown and ignored
* Parsing of UserDefinedFunctionsMetaData was wrong
