### PR TITLE
LoadNextBatch future isDone return a value consistent with iterator isLoading

### DIFF
--- a/sql/src/test/java/io/crate/operation/merge/BatchPagingIteratorTest.java
+++ b/sql/src/test/java/io/crate/operation/merge/BatchPagingIteratorTest.java
@@ -34,7 +34,6 @@ import java.util.stream.StreamSupport;
 
 public class BatchPagingIteratorTest {
 
-
     @Test
     public void testBatchPagingIterator() throws Exception {
         Iterable<Row> rows = RowGenerator.range(0, 3);


### PR DESCRIPTION
The loadNextBatch future isDone method is used to identify when the next batch is loaded in the BatchIteratorTester. We do this in order to issue concurrent moveNext calls *as long* as the batch is loading, in order to test the correct exception is thrown. 
This means that if the future is *not done*, the iterator isLoading should return true.

In order to identify a batch loading is in progress we used flags (ie bool loading) which we'd set to false when the loadNextBatch future is complete. The resulting completion stage is what we generally returned to the outside world ( eg a loadNextBatch call would look like : return internalFuture.whenComplete( (r, t) -> loading = false)) ). The problem with this approach is that there is an extra computational step between setting the loading flag to false and completing the future. Due to this extra step, the iterator would internally read the loading flag as false, but the outside world asking the future isDone would still see it as false, and act as if the iterator is still loading (so internally the iterator sees that it is *not* loading and the outside world asking the returned future if it is done would see the future as *not done*, as if the iterator still *is* loading).

To prevent this we now return the internalFuture completion stage to the outside world, store it internally in a container and internally, add a whenComplete callback to the internalFuture. In this callback we just clear the container (ie whenComplete((r, t) -> loadingStatus[0] = null)).
If the iterator, internally, wants to check if it's loading it will look for a future in the internal container. If one is there and *is not done*, then the iterator is still loading.
This works now because: 
-  if the future we returned to the outside world *is completed* but our internal callback clearing the container didn't run, the iterator status container will have not been cleared and we will see the future inside the container with the status of done and isLoading will return false (this means future.isDone is true, loading is false - a consistent state). 
- If our iterator's internal future.whencomplete callback ran, we emptied the container and our internal loading status is false. Since this callback ran, that means the future we returned to the outside world is complete and whoever is interested in it will see it as complete. 