### PR TITLE
added possible data type conversion to timestamp array.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -14,6 +14,9 @@ the appropriate section of the docs.
 
 Changelog
 =========
+ 
+ - Added possible data type conversion to a timestamp array.
+   e.g. ``cast(['2017-01-01','2017-12-31'] as array(timestamp))``
 
  - Fixed bug introduced in 1.1.0 which caused all partitioned tables to
    become unusable.

--- a/sql/src/main/java/io/crate/operation/scalar/cast/CastFunctionResolver.java
+++ b/sql/src/main/java/io/crate/operation/scalar/cast/CastFunctionResolver.java
@@ -64,6 +64,7 @@ public class CastFunctionResolver {
         public static final String TO_FLOAT_ARRAY = "to_float_array";
         public static final String TO_SHORT_ARRAY = "to_short_array";
         public static final String TO_IP_ARRAY = "to_ip_array";
+        public static final String TO_TIMESTAMP_ARRAY = "to_timestamp_array";
         public static final String TO_GEO_POINT = "to_geo_point";
         public static final String TO_GEO_SHAPE = "to_geo_shape";
 
@@ -106,6 +107,7 @@ public class CastFunctionResolver {
         .put(new ArrayType(DataTypes.FLOAT), FunctionNames.TO_FLOAT_ARRAY)
         .put(new ArrayType(DataTypes.SHORT), FunctionNames.TO_SHORT_ARRAY)
         .put(new ArrayType(DataTypes.IP), FunctionNames.TO_IP_ARRAY)
+        .put(new ArrayType(DataTypes.TIMESTAMP), FunctionNames.TO_TIMESTAMP_ARRAY)
         .build();
 
     private static final ImmutableMap<DataType, String> SET_FUNCTION_MAP = new ImmutableMap.Builder<DataType, String>()

--- a/sql/src/test/java/io/crate/operation/scalar/cast/CastFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/cast/CastFunctionTest.java
@@ -53,6 +53,7 @@ public class CastFunctionTest extends AbstractScalarFunctionsTest {
         assertEvaluate("'{\"x\": 10}'::object", object);
 
         assertEvaluate("cast(name as object)", object, Literal.of("{\"x\": 10}"));
+        assertEvaluate("cast(['2017-01-01','2017-12-31'] as array(timestamp))", new Long[] {1483228800000L, 1514678400000L});
     }
 
     @Test


### PR DESCRIPTION
e.g. ``select cast(['2017-01-01','2017-12-31'] as array(timestamp))``