### PR TITLE
Wait for bulkShardProcessor to finish at the end of the test

### DIFF
--- a/sql/src/test/java/io/crate/operation/projectors/IndexWriterCountBatchIteratorTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/IndexWriterCountBatchIteratorTest.java
@@ -53,6 +53,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
 
@@ -86,6 +87,12 @@ public class IndexWriterCountBatchIteratorTest extends SQLTransportIntegrationTe
             IndexWriterCountBatchIterator.newIndexInstance(sourceSupplier.get(), indexNameResolver,
                 collectExpressions, rowShardResolver, bulkShardProcessor, updateItemSupplier));
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
+
+        try {
+            bulkShardProcessor.result().get(10, TimeUnit.SECONDS);
+        } finally {
+            bulkShardProcessor.close();
+        }
     }
 
     private RowShardResolver getRowShardResolver() {


### PR DESCRIPTION
The bulkShardProcessor needs to finish before the @after layers of the test kick in