### PR TITLE
improve release notes organisation, clarity

### DIFF
--- a/blackbox/docs/release_notes/1/0/2.txt
+++ b/blackbox/docs/release_notes/1/0/2.txt
@@ -7,7 +7,7 @@ Released on 2017/01/09.
 Changelog
 =========
 
- - Updated crate-admin to ``1.0.3`` which includes the following change:
+ - Updated crate-admin to 1.0.3 which includes the following change:
 
     - Added compatibility with future crate versions which will serve the
       admin-ui from ``/admin/`` instead of ``/_plugins/crate-admin/``.

--- a/blackbox/docs/release_notes/1/0/3.txt
+++ b/blackbox/docs/release_notes/1/0/3.txt
@@ -7,6 +7,9 @@ Released on 2017/02/10.
 Changelog
 =========
 
+ - DEPRECATED: multicast discovery has been deprecated in this release, and will
+   be removed in the 1.1 release. Multicast discovery is disabled by default.
+
  - Fix: Allow scalar functions on the `HAVING` clause if the scalar function is
    used as a `GROUP BY` symbol.
 

--- a/blackbox/docs/release_notes/1/0/4.txt
+++ b/blackbox/docs/release_notes/1/0/4.txt
@@ -17,7 +17,7 @@ Changelog
  - Fix: Index columns based on string arrays are correctly populated with
    values.
 
- - Updated crate-admin to ``1.0.5`` which includes the following change:
+ - Updated crate-admin to 1.0.5 which includes the following change:
 
     - Fixed a console results issue that caused the results table not to be
       displayed after horizontal scrolling.

--- a/blackbox/docs/release_notes/1/0/5.txt
+++ b/blackbox/docs/release_notes/1/0/5.txt
@@ -15,5 +15,5 @@ Changelog
    concurrently.
 
  - Fixed an issue that caused joins on ``information_schema.columns`` to
-   produce a wrong result if ``information_schema.columns`` was used as the right
-   table.
+   produce a wrong result if ``information_schema.columns`` was used as the
+   right table.

--- a/blackbox/docs/release_notes/1/1/0.txt
+++ b/blackbox/docs/release_notes/1/1/0.txt
@@ -4,103 +4,67 @@ Version 1.1.0
 
 Released on 2017/03/21.
 
+.. WARNING::
+
+   Do not use this version. This release introduced a bug which caused all
+   partitioned tables to become unusable. The bug will be fixed in the next
+   release.
+
+   This version was removed from all release channels. This changelog is kept
+   for information purposes only.
+
 Changelog
 =========
 
+ - BREAKING: Removed multicast discovery.
+
+ - BREAKING: The ``ordinal`` column at the ``information_schema.columns``
+   will return ``NULL`` now for all sub-columns (all non top-level
+   columns) as the order of object columns is not guarateed.
+
+ - BREAKING: The ``TableFunctionImplementation`` interface was streamlined
+   with other function implementation semantics. This requires function
+   implementation plugins to be adapted to the new interface.
+
+ - BREAKING: Removed deprecated setting ``indices.fielddata.breaker`` that have
+   been used as an alias for ``indices.breaker.fielddata``.
+
+ - Serve admin UI from ``/``. Previously used URIs will direct to ``/``.
+
  - Added the subscript function support for object literals.
-
- - Updated crate-admin to ``1.2.0`` which includes the following changes:
-
-    - Added monitoring plugin (enterprise)
-
-    - Added Lazy loading of the stylesheet and plugins depending
-       on the enterprise settings.
-
-    - Added buttons to collapse and expand all schemas in the tables view.
-
-    - The console now expands vertically to show the whole query if its size
-       is larger than the standard size of the console.
-
-    - SQL console keywords are now CrateDB specific.
-
-    - Improved formatted results of the `geo_area` datatype to include an external
-       link to a visualisation of that geo_area.
-
-    - Keywords in the SQL console are capitalised.
-
-    - Added node number to the status bar.
-
-    - Fixed issue that caused `Cluster Offline` message to not be displayed.
-
-    - Fixed a console results issue that caused the results table not to be
-       visible after horizontal scrolling.
-
-    - Fixed styling issue that caused the last element in the side bar
-       list to be hidden.
-
-    - Fixed an issue that caused the notification date to be `null` in safari.
-
-    - Fixed a console results issue that caused the results table not to be
-       displayed after horizontal scrolling.
-
-    - Fixed an issue that caused the admin-ui to load only one plugin.
-
-    - Display warning in the console view when the query result contains
-       an unsafe integer.
-
-    - Relocated the help resources section to be underneath the tweet
-       import tutorial.
-
-    - Show loading indicator when `Execute Query` is in progress.
-
-    - Improved console results table, including data type based colorization,
-       alternating row colorization, structured object/array formatting,
-       human-readable timestamps, Google Maps link on geo-point
-       results & lazy loading on result sets larger than 100 rows.
 
  - Fixed an issue that prevent a node from starting on Windows if the
    sigar-plugin is removed.
 
- - BREAKING: The `ordinal` column at the `information_schema.columns`
-   will return `NULL` now for all sub-columns (all non top-level
-   columns) as the order of object columns is not guarateed.
+ - Added cluster checks that warn if some tables need to be recreated or
+   upgraded for compatibility with future versions of CrateDB.
 
- - Added cluster checks that warn if some tables need to be recreated
-   or upgraded for compatibility with future versions of CrateDB.
-
- - Added functionality to monitor query runtime statistics via JMX.
-   This feature can only be used with an enterprise license.
+ - Added functionality to monitor query runtime statistics via JMX. This feature
+   can only be used with an enterprise license.
 
  - Added a new parameter ``upgrade_segments`` to the ``OPTIMIZE`` statement
    which enables the upgrade of tables and tables partitions to the current
    version of the storage engine.
 
- - Added new column ``min_lucene_version`` to ``sys.shards`` table,
-   which shows the oldest lucene segment version used in the shard.
+ - Added new column ``min_lucene_version`` to ``sys.shards`` table, which shows
+   the oldest lucene segment version used in the shard.
 
  - Remove restriction to run ``OPTIMIZE`` on blob tables.
 
- - UDC: add the ``enterprise`` field to the ``UDC`` ping.
-   The field identifies whether a user uses the enterprise version.
+ - UDC: add the ``enterprise`` field to the ``UDC`` ping. The field identifies
+   whether a user uses the enterprise version.
 
  - Added the ``licence.enterprise`` setting to the cluster settings.
 
  - Fixed validation of known configuration file settings. The settings are also
    validated upon start-up.
 
- - BREAKING: The TableFunctionImplementation interface was streamlined
-   with other function implementation semantics. This requires
-   function implementation plugins to be adapted to the new interface.
-
  - It is now supported to order and group by predicate functions in general
-   with the exception of the `match` predicate.
+   with the exception of the ``match`` predicate.
 
  - Selecting ``os['timestamp'] from ``sys.nodes`` returns the actual timestamp
    of each node clock at the time of collecting the metric instead of the
    timestamp on the handler node.
-
- - BREAKING: Removed deprecated setting ``indices.fielddata.breaker`` that have
-   been used as an alias for ``indices.breaker.fielddata``.
 
  - Added scalar function ``geohash`` that returns a GeoHash representation of
    a ``geo_point``
@@ -109,23 +73,64 @@ Changelog
 
  - The array comparison no longer requires extra parentheses for subselects.
    Now it's possible to use `` = ANY (SELECT ...)`` instead of
-   `` = ANY ((SELECT ...))``
+   `` = ANY ((SELECT ...))``.
 
- - DEPRECATED: multicast discovery has been deprecated in this release, and will be
-   removed in the 1.1 release.
-   Multicast discovery is disabled by default.
-
- - BREAKING: Serve admin ui from ``/``
-   Admin UI is not accessible via ``_plugin/crate-admin`` anymore. Only via
-   ``/admin`` or ``/``.
-
- - Allow semi-colon (;) in the end of simple SQL statements.
+ - Allow semi-colon (``;``) in the end of simple SQL statements.
 
  - Enhanced performance optimisation of full joins by rewriting them to left,
    right or inner joins when conditions in ``WHERE`` exclude null values.
 
  - Added support for filtering and ordering on ``ignored`` object columns.
 
- - Added support for the double colon (::) cast operator.
+ - Added support for the double colon (``::``) cast operator.
 
  - Upgraded the parser from ANTLR3 to ANTLR4.
+
+ - Updated crate-admin to 1.2.0 which includes the following changes:
+
+    - Added monitoring plugin for the Enterprise edition.
+
+    - Added Lazy loading of the stylesheet and plugins depending on the
+      enterprise settings.
+
+    - Added buttons to collapse and expand all schemas in the tables view.
+
+    - The console now expands vertically to show the whole query if its size is
+      larger than the standard size of the console.
+
+    - SQL console keywords are now CrateDB specific.
+
+    - Improved formatted results of the ``geo_area`` datatype to include an
+      external link to a visualisation of that ``geo_area``.
+
+    - Keywords in the SQL console are capitalised.
+
+    - Added node number to the status bar.
+
+    - Fixed issue that caused ``Cluster Offline`` message to not be displayed.
+
+    - Fixed a console results issue that caused the results table not to be
+      visible after horizontal scrolling.
+
+    - Fixed styling issue that caused the last element in the side bar list to
+      be hidden.
+
+    - Fixed an issue that caused the notification date to be ``null`` in Safari.
+
+    - Fixed a console results issue that caused the results table not to be
+      displayed after horizontal scrolling.
+
+    - Fixed an issue that caused the admin UI to load only one plugin.
+
+    - Display warning in the console view when the query result contains an
+      unsafe integer.
+
+    - Relocated the help resources section to be underneath the tweet import
+      tutorial.
+
+    - Show loading indicator when ``Execute Query`` is in progress.
+
+    - Improved console results table, including data type based colorization,
+      alternating row colorization, structured object/array formatting,
+      human-readable timestamps, Google Maps link on geo-point results & lazy
+      loading on result sets larger than 100 rows.


### PR DESCRIPTION
some basic formatting fixes

also, in the most recent release, bubbled BREAKING and DEPRECATED up to the top, and pushed bundled crate-admin changes to the bottom