### PR TITLE
Fix fetchId encoding

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -15,6 +15,9 @@ the appropriate section of the docs.
 Changelog
 =========
 
+ - Fixed a regression introduced in 1.1.0 which could cause queries to return
+   wrong values.
+
  - Updated crate-admin to ``1.2.1`` which includes the following changes:
 
    - Removed blog feed from side bar.

--- a/sql/src/main/java/io/crate/operation/projectors/fetch/FetchId.java
+++ b/sql/src/main/java/io/crate/operation/projectors/fetch/FetchId.java
@@ -49,6 +49,6 @@ public final class FetchId {
     }
 
     public static long encode(int readerId, int docId) {
-        return ((long) readerId << 32) | (docId & 0xfffL);
+        return ((long) readerId << 32) | (docId & 0xffffffffL);
     }
 }

--- a/sql/src/test/java/io/crate/operation/projectors/fetch/FetchIdTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/fetch/FetchIdTest.java
@@ -22,18 +22,25 @@
 
 package io.crate.operation.projectors.fetch;
 
+import io.crate.test.integration.CrateUnitTest;
 import org.junit.Test;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import java.util.stream.LongStream;
 
-public class FetchIdTest {
+import static org.hamcrest.core.Is.is;
+
+public class FetchIdTest extends CrateUnitTest {
 
     @Test
     public void testEncodeAndDecode() throws Exception {
-        long fetchId = FetchId.encode(10, 3248);
+        LongStream longs = random().longs(50, 0, Long.MAX_VALUE);
+        longs.forEach(this::assertEncodeDecodeMatches);
+    }
 
-        assertThat(FetchId.decodeDocId(fetchId), is(3248));
-        assertThat(FetchId.decodeReaderId(fetchId), is(10));
+    private void assertEncodeDecodeMatches(long val) {
+        int docId = FetchId.decodeDocId(val);
+        int readerId = FetchId.decodeReaderId(val);
+
+        assertThat(FetchId.encode(readerId, docId), is(val));
     }
 }


### PR DESCRIPTION
f1c0595b2dbe485a6626231f98603782a1bbff48 broke the encoding of fetchId,
causing queries to return wrong values.