### PR TITLE
fixes flaky blob test, flakiness is ES 5 related only

### DIFF
--- a/blob/src/test/java/io/crate/integrationtests/BlobSslEnabledITest.java
+++ b/blob/src/test/java/io/crate/integrationtests/BlobSslEnabledITest.java
@@ -36,7 +36,6 @@ import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -93,15 +92,15 @@ public class BlobSslEnabledITest extends BlobHttpIntegrationTest {
 
         CloseableHttpClient client = HttpClients.custom().disableRedirectHandling().build();
         List<String> redirectLocations = getRedirectLocations(client, blobUri, address);
-        InetSocketAddress correctAddress;
+        String redirectUri;
         if (redirectLocations.isEmpty()) {
-            correctAddress = address;
+            redirectUri = String.format(Locale.ENGLISH,
+                "http://%s:%s/_blobs/%s", address.getHostName(), address.getPort(), blobUri);
         } else {
-            correctAddress = address2;
+            redirectUri = redirectLocations.get(0).replace("https", "http");
         }
 
-        HttpGet httpGet = new HttpGet(String.format(Locale.ENGLISH,
-            "http://%s:%s/_blobs/%s", correctAddress.getHostName(), correctAddress.getPort(), blobUri));
+        HttpGet httpGet = new HttpGet(redirectUri);
 
         CloseableHttpResponse response = client.execute(httpGet);
         assertEquals(1500, response.getEntity().getContentLength());


### PR DESCRIPTION
previously, the test assumed that only 2 non-client nodes are running,
but since ES5, random # of dedicated master nodes are started in 
addition to random # of data nodes.
this fix makes the test more reliable despite how many nodes are started.