### PR TITLE
change the signature of the get method in the functions class

### DIFF
--- a/sql/src/jmh/java/io/crate/operation/projectors/GroupingBytesRefCollectorBenchmark.java
+++ b/sql/src/jmh/java/io/crate/operation/projectors/GroupingBytesRefCollectorBenchmark.java
@@ -25,7 +25,6 @@ package io.crate.operation.projectors;
 import io.crate.analyze.symbol.AggregateMode;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.data.*;
-import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.Functions;
 import io.crate.operation.aggregation.AggregationFunction;
 import io.crate.operation.aggregation.impl.AggregationImplModule;
@@ -81,9 +80,8 @@ public class GroupingBytesRefCollectorBenchmark {
         List<Input<?>> keyInputs = Collections.singletonList(keyInput);
         CollectExpression[] collectExpressions = new CollectExpression[]{keyInput};
 
-        FunctionIdent minBytesRefFuncIdent = new FunctionIdent(MinimumAggregation.NAME,
-            Collections.singletonList(DataTypes.STRING));
-        AggregationFunction minAgg = (AggregationFunction) functions.get(minBytesRefFuncIdent);
+        AggregationFunction minAgg =
+            (AggregationFunction) functions.get(MinimumAggregation.NAME, Collections.singletonList(DataTypes.STRING));
 
         return GroupingCollector.singleKey(
             collectExpressions,

--- a/sql/src/jmh/java/io/crate/operation/projectors/GroupingIntegerCollectorBenchmark.java
+++ b/sql/src/jmh/java/io/crate/operation/projectors/GroupingIntegerCollectorBenchmark.java
@@ -25,7 +25,6 @@ package io.crate.operation.projectors;
 import io.crate.analyze.symbol.AggregateMode;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.data.*;
-import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.Functions;
 import io.crate.operation.aggregation.AggregationFunction;
 import io.crate.operation.aggregation.impl.AggregationImplModule;
@@ -73,8 +72,8 @@ public class GroupingIntegerCollectorBenchmark {
         List<Input<?>> keyInputs = Arrays.<Input<?>>asList(keyInput);
         CollectExpression[] collectExpressions = new CollectExpression[]{keyInput};
 
-        FunctionIdent functionIdent = new FunctionIdent(SumAggregation.NAME, Arrays.asList(DataTypes.INTEGER));
-        AggregationFunction sumAgg = (AggregationFunction) functions.get(functionIdent);
+        AggregationFunction sumAgg =
+            (AggregationFunction) functions.get(SumAggregation.NAME, Arrays.asList(DataTypes.INTEGER));
 
         return GroupingCollector.singleKey(
             collectExpressions,

--- a/sql/src/main/java/io/crate/analyze/EvaluatingNormalizer.java
+++ b/sql/src/main/java/io/crate/analyze/EvaluatingNormalizer.java
@@ -144,7 +144,8 @@ public class EvaluatingNormalizer {
 
         @SuppressWarnings("unchecked")
         Symbol normalizeFunctionSymbol(Function function, Context context) {
-            FunctionImplementation impl = functions.get(function.info().ident());
+            FunctionIdent ident = function.info().ident();
+            FunctionImplementation impl = functions.get(ident.name(), ident.argumentTypes());
             if (impl != null) {
                 return impl.normalizeSymbol(function, context.transactionContext);
             }

--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -463,7 +463,8 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
         );
 
         Function function = (Function) expressionAnalyzer.convert(node.functionCall(), context.expressionAnalysisContext());
-        FunctionImplementation functionImplementation = functions.getSafe(function.info().ident());
+        FunctionIdent ident = function.info().ident();
+        FunctionImplementation functionImplementation = functions.getSafe(ident.name(), ident.argumentTypes());
         if (functionImplementation.info().type() != FunctionInfo.Type.TABLE) {
             throw new UnsupportedFeatureException(
                 "Non table function " + function.info().ident().name() + " is not supported in from clause");

--- a/sql/src/main/java/io/crate/analyze/symbol/format/SymbolPrinter.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/format/SymbolPrinter.java
@@ -24,10 +24,7 @@ package io.crate.analyze.symbol.format;
 
 import io.crate.analyze.relations.RelationPrinter;
 import io.crate.analyze.symbol.*;
-import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.FunctionImplementation;
-import io.crate.metadata.Functions;
-import io.crate.metadata.Reference;
+import io.crate.metadata.*;
 import io.crate.operation.operator.any.AnyOperator;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
@@ -186,7 +183,8 @@ public class SymbolPrinter {
             OperatorFormatSpec operatorFormatSpec = null;
 
             if (functions != null) {
-                FunctionImplementation impl = functions.get(function.info().ident());
+                FunctionIdent ident = function.info().ident();
+                FunctionImplementation impl = functions.get(ident.name(), ident.argumentTypes());
                 if (impl instanceof FunctionFormatSpec) {
                     functionFormatSpec = (FunctionFormatSpec) impl;
                 } else if (impl instanceof OperatorFormatSpec) {

--- a/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/SymbolToFieldExtractor.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/SymbolToFieldExtractor.java
@@ -25,6 +25,7 @@ import com.google.common.base.Function;
 import com.google.common.base.Functions;
 import io.crate.analyze.symbol.*;
 import io.crate.analyze.symbol.format.SymbolFormatter;
+import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.Reference;
 import io.crate.metadata.Scalar;
 
@@ -99,7 +100,9 @@ public class SymbolToFieldExtractor<T> {
             for (Symbol argument : symbol.arguments()) {
                 subExtractors.add(process(argument, context));
             }
-            return new FunctionExtractor<>((Scalar) context.functions.getSafe(symbol.info().ident()), subExtractors);
+            FunctionIdent functionIdent = symbol.info().ident();
+            return new FunctionExtractor<>((Scalar) context.functions
+                .getSafe(functionIdent.name(), functionIdent.argumentTypes()), subExtractors);
         }
 
         @Override

--- a/sql/src/main/java/io/crate/metadata/Functions.java
+++ b/sql/src/main/java/io/crate/metadata/Functions.java
@@ -54,19 +54,19 @@ public class Functions {
     }
 
     /**
-     * <p>
-     * returns the functionImplementation for the given ident.
-     * </p>
-     * <p>
-     * same as {@link #get(FunctionIdent)} but will throw an UnsupportedOperationException
-     * if no implementation is found.
+     * Returns the function implementation for the given function name and arguments.
+     *
+     * @param name           The function name.
+     * @param argumentsTypes The function argument types.
+     * @return The function implementation..
+     * @throws UnsupportedOperationException if an implementation is not found.
      */
-    public FunctionImplementation getSafe(FunctionIdent ident)
+    public FunctionImplementation getSafe(String name, List<DataType> argumentsTypes)
         throws IllegalArgumentException, UnsupportedOperationException {
         FunctionImplementation implementation = null;
         String exceptionMessage = null;
         try {
-            implementation = get(ident);
+            implementation = get(name, argumentsTypes);
         } catch (IllegalArgumentException e) {
             if (e.getMessage() != null && !e.getMessage().isEmpty()) {
                 exceptionMessage = e.getMessage();
@@ -74,8 +74,8 @@ public class Functions {
         }
         if (implementation == null) {
             if (exceptionMessage == null) {
-                exceptionMessage = String.format(Locale.ENGLISH, "unknown function: %s(%s)", ident.name(),
-                    Joiner.on(", ").join(ident.argumentTypes()));
+                exceptionMessage = String.format(Locale.ENGLISH, "unknown function: %s(%s)", name,
+                    Joiner.on(", ").join(argumentsTypes));
             }
             throw new UnsupportedOperationException(exceptionMessage);
         }
@@ -83,15 +83,17 @@ public class Functions {
     }
 
     /**
-     * returns the functionImplementation for the given ident
-     * or null if nothing was found
+     * Returns the function implementation for the given function name and arguments.
+     *
+     * @param name           The function name.
+     * @param argumentsTypes The function argument types.
+     * @return a function implementation or null if it was not found.
      */
     @Nullable
-    public FunctionImplementation get(FunctionIdent ident) throws IllegalArgumentException {
-        FunctionResolver dynamicResolver = functionResolvers.get(ident.name());
+    public FunctionImplementation get(String name, List<DataType> argumentsTypes) throws IllegalArgumentException {
+        FunctionResolver dynamicResolver = functionResolvers.get(name);
         if (dynamicResolver != null) {
-            List<DataType> argumentTypes = ident.argumentTypes();
-            List<DataType> signature = dynamicResolver.getSignature(argumentTypes);
+            List<DataType> signature = dynamicResolver.getSignature(argumentsTypes);
             if (signature != null) {
                 return dynamicResolver.getForTypes(signature);
             }

--- a/sql/src/main/java/io/crate/operation/BaseImplementationSymbolVisitor.java
+++ b/sql/src/main/java/io/crate/operation/BaseImplementationSymbolVisitor.java
@@ -25,6 +25,7 @@ package io.crate.operation;
 import io.crate.analyze.symbol.*;
 import io.crate.analyze.symbol.format.SymbolFormatter;
 import io.crate.data.Input;
+import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
@@ -42,7 +43,8 @@ public class BaseImplementationSymbolVisitor<C> extends SymbolVisitor<C, Input<?
 
     @Override
     public Input<?> visitFunction(Function function, C context) {
-        final FunctionImplementation functionImplementation = functions.get(function.info().ident());
+        FunctionIdent ident = function.info().ident();
+        final FunctionImplementation functionImplementation = functions.get(ident.name(), ident.argumentTypes());
         if (functionImplementation instanceof Scalar<?, ?>) {
             List<Symbol> arguments = function.arguments();
             Scalar<?, ?> scalarImpl = ((Scalar) functionImplementation).compile(arguments);

--- a/sql/src/main/java/io/crate/operation/InputFactory.java
+++ b/sql/src/main/java/io/crate/operation/InputFactory.java
@@ -31,6 +31,7 @@ import io.crate.analyze.symbol.SymbolVisitor;
 import io.crate.analyze.symbol.format.SymbolFormatter;
 import io.crate.data.Input;
 import io.crate.data.Row;
+import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
@@ -192,7 +193,8 @@ public class InputFactory {
 
         @Override
         public Input<?> visitAggregation(Aggregation symbol, Void context) {
-            FunctionImplementation impl = functions.get(symbol.functionIdent());
+            FunctionIdent ident = symbol.functionIdent();
+            FunctionImplementation impl = functions.get(ident.name(), ident.argumentTypes());
             if (impl == null) {
                 throw new UnsupportedOperationException(
                     SymbolFormatter.format("Can't load aggregation impl for symbol %s", symbol));

--- a/sql/src/main/java/io/crate/planner/projection/builder/ProjectionBuilder.java
+++ b/sql/src/main/java/io/crate/planner/projection/builder/ProjectionBuilder.java
@@ -26,10 +26,7 @@ import io.crate.analyze.OrderBy;
 import io.crate.analyze.QueryClause;
 import io.crate.analyze.QuerySpec;
 import io.crate.analyze.symbol.*;
-import io.crate.metadata.ColumnIdent;
-import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.Functions;
-import io.crate.metadata.RowGranularity;
+import io.crate.metadata.*;
 import io.crate.operation.aggregation.AggregationFunction;
 import io.crate.operation.projectors.TopN;
 import io.crate.planner.projection.*;
@@ -107,10 +104,10 @@ public class ProjectionBuilder {
                 default:
                     throw new AssertionError("Invalid mode: " + mode.name());
             }
-
+            FunctionIdent ident = function.info().ident();
             Aggregation aggregation = new Aggregation(
                 function.info(),
-                mode.returnType(((AggregationFunction) this.functions.get(function.info().ident()))),
+                mode.returnType(((AggregationFunction) this.functions.get(ident.name(), ident.argumentTypes()))),
                 aggregationInputs
             );
             aggregations.add(aggregation);

--- a/sql/src/test/java/io/crate/analyze/EvaluatingNormalizerTest.java
+++ b/sql/src/test/java/io/crate/analyze/EvaluatingNormalizerTest.java
@@ -116,7 +116,7 @@ public class EvaluatingNormalizerTest extends CrateUnitTest {
         } else {
             dataTypes = ImmutableList.of(dataType, dataType);
         }
-        return functions.get(new FunctionIdent(name, dataTypes)).info();
+        return functions.get(name, dataTypes).info();
     }
 
     private FunctionInfo functionInfo(String name, DataType dataType) {

--- a/sql/src/test/java/io/crate/operation/InputFactoryTest.java
+++ b/sql/src/test/java/io/crate/operation/InputFactoryTest.java
@@ -26,6 +26,7 @@ import io.crate.analyze.symbol.*;
 import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.data.RowN;
+import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.operation.aggregation.FunctionExpression;
 import io.crate.operation.collect.CollectExpression;
@@ -158,7 +159,8 @@ public class InputFactoryTest extends CrateUnitTest {
         FunctionImplementation impl = (FunctionImplementation) f.get(expression);
         assertThat(impl.info(), is(function.info()));
 
-        FunctionImplementation uncompiled = expressions.functions().get(function.info().ident());
+        FunctionIdent ident = function.info().ident();
+        FunctionImplementation uncompiled = expressions.functions().get(ident.name(), ident.argumentTypes());
         assertThat(uncompiled, not(sameInstance(impl)));
     }
 }

--- a/sql/src/test/java/io/crate/operation/aggregation/AggregationTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/AggregationTest.java
@@ -77,7 +77,7 @@ public abstract class AggregationTest extends CrateUnitTest {
             fi = new FunctionIdent(name, ImmutableList.<DataType>of());
             inputs = new InputCollectExpression[0];
         }
-        AggregationFunction impl = (AggregationFunction) functions.get(fi);
+        AggregationFunction impl = (AggregationFunction) functions.get(fi.name(), fi.argumentTypes());
         Object state = impl.newState(ramAccountingContext);
 
         ArrayBucket bucket = new ArrayBucket(data);
@@ -103,7 +103,7 @@ public abstract class AggregationTest extends CrateUnitTest {
             argTypes[i] = args[i].valueType();
         }
         AggregationFunction function =
-            (AggregationFunction) functions.get(new FunctionIdent(functionName, Arrays.asList(argTypes)));
+            (AggregationFunction) functions.get(functionName, Arrays.asList(argTypes));
         return function.normalizeSymbol(new Function(function.info(), Arrays.asList(args)), new TransactionContext(SessionContext.SYSTEM_SESSION));
     }
 }

--- a/sql/src/test/java/io/crate/operation/aggregation/impl/ArbitraryAggregationTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/impl/ArbitraryAggregationTest.java
@@ -22,7 +22,6 @@
 package io.crate.operation.aggregation.impl;
 
 import com.google.common.collect.ImmutableList;
-import io.crate.metadata.FunctionIdent;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -39,8 +38,7 @@ public class ArbitraryAggregationTest extends AggregationTest {
 
     @Test
     public void testReturnType() throws Exception {
-        FunctionIdent fi = new FunctionIdent("arbitrary", ImmutableList.<DataType>of(DataTypes.INTEGER));
-        assertEquals(DataTypes.INTEGER, functions.get(fi).info().returnType());
+        assertEquals(DataTypes.INTEGER, functions.get("arbitrary", ImmutableList.of(DataTypes.INTEGER)).info().returnType());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/aggregation/impl/AverageAggregationTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/impl/AverageAggregationTest.java
@@ -22,7 +22,6 @@
 package io.crate.operation.aggregation.impl;
 
 import com.google.common.collect.ImmutableList;
-import io.crate.metadata.FunctionIdent;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -36,12 +35,9 @@ public class AverageAggregationTest extends AggregationTest {
 
     @Test
     public void testReturnType() throws Exception {
-        FunctionIdent fi = new FunctionIdent("avg", ImmutableList.<DataType>of(DataTypes.INTEGER));
         // Return type is fixed to Double
-        assertEquals(DataTypes.DOUBLE, functions.get(fi).info().returnType());
-
-        FunctionIdent meanFi = new FunctionIdent("mean", ImmutableList.<DataType>of(DataTypes.INTEGER));
-        assertEquals(DataTypes.DOUBLE, functions.get(meanFi).info().returnType());
+        assertEquals(DataTypes.DOUBLE, functions.get("avg", ImmutableList.of(DataTypes.INTEGER)).info().returnType());
+        assertEquals(DataTypes.DOUBLE, functions.get("mean", ImmutableList.of(DataTypes.INTEGER)).info().returnType());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/aggregation/impl/CollectSetAggregationTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/impl/CollectSetAggregationTest.java
@@ -22,7 +22,6 @@
 package io.crate.operation.aggregation.impl;
 
 import com.google.common.collect.ImmutableList;
-import io.crate.metadata.FunctionIdent;
 import io.crate.operation.aggregation.AggregationFunction;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
@@ -45,8 +44,8 @@ public class CollectSetAggregationTest extends AggregationTest {
 
     @Test
     public void testReturnType() throws Exception {
-        FunctionIdent fi = new FunctionIdent("collect_set", ImmutableList.<DataType>of(DataTypes.INTEGER));
-        assertEquals(new SetType(DataTypes.INTEGER), functions.get(fi).info().returnType());
+        assertEquals(new SetType(DataTypes.INTEGER),
+            functions.get("collect_set", ImmutableList.of(DataTypes.INTEGER)).info().returnType());
     }
 
     @Test
@@ -60,8 +59,7 @@ public class CollectSetAggregationTest extends AggregationTest {
 
     @Test
     public void testLongSerialization() throws Exception {
-        FunctionIdent fi = new FunctionIdent("collect_set", ImmutableList.<DataType>of(DataTypes.LONG));
-        AggregationFunction impl = (AggregationFunction) functions.get(fi);
+        AggregationFunction impl = (AggregationFunction) functions.get("collect_set", ImmutableList.of(DataTypes.LONG));
 
         Object state = impl.newState(ramAccountingContext);
 

--- a/sql/src/test/java/io/crate/operation/aggregation/impl/CountAggregationTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/impl/CountAggregationTest.java
@@ -23,7 +23,6 @@ package io.crate.operation.aggregation.impl;
 
 import com.google.common.collect.ImmutableList;
 import io.crate.Streamer;
-import io.crate.metadata.FunctionIdent;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -42,9 +41,8 @@ public class CountAggregationTest extends AggregationTest {
 
     @Test
     public void testReturnType() throws Exception {
-        FunctionIdent fi = new FunctionIdent("count", ImmutableList.<DataType>of(DataTypes.INTEGER));
         // Return type is fixed to Long
-        assertEquals(DataTypes.LONG, functions.get(fi).info().returnType());
+        assertEquals(DataTypes.LONG, functions.get("count", ImmutableList.of(DataTypes.INTEGER)).info().returnType());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/aggregation/impl/GeometricMeanAggregationtest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/impl/GeometricMeanAggregationtest.java
@@ -23,7 +23,6 @@ package io.crate.operation.aggregation.impl;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import io.crate.metadata.FunctionIdent;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -40,9 +39,8 @@ public class GeometricMeanAggregationtest extends AggregationTest {
     @Test
     public void testReturnType() throws Exception {
         for (DataType<?> type : Iterables.concat(DataTypes.NUMERIC_PRIMITIVE_TYPES, Arrays.asList(DataTypes.TIMESTAMP))) {
-            FunctionIdent fi = new FunctionIdent("geometric_mean", ImmutableList.<DataType>of(type));
             // Return type is fixed to Double
-            assertEquals(DataTypes.DOUBLE, functions.get(fi).info().returnType());
+            assertEquals(DataTypes.DOUBLE, functions.get("geometric_mean", ImmutableList.of(type)).info().returnType());
         }
     }
 

--- a/sql/src/test/java/io/crate/operation/aggregation/impl/MaximumAggregationTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/impl/MaximumAggregationTest.java
@@ -22,7 +22,6 @@
 package io.crate.operation.aggregation.impl;
 
 import com.google.common.collect.ImmutableList;
-import io.crate.metadata.FunctionIdent;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -37,8 +36,7 @@ public class MaximumAggregationTest extends AggregationTest {
 
     @Test
     public void testReturnType() throws Exception {
-        FunctionIdent fi = new FunctionIdent("max", ImmutableList.<DataType>of(DataTypes.INTEGER));
-        assertEquals(DataTypes.INTEGER, functions.get(fi).info().returnType());
+        assertEquals(DataTypes.INTEGER, functions.get("max", ImmutableList.of(DataTypes.INTEGER)).info().returnType());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/aggregation/impl/MinimumAggregationTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/impl/MinimumAggregationTest.java
@@ -22,7 +22,6 @@
 package io.crate.operation.aggregation.impl;
 
 import com.google.common.collect.ImmutableList;
-import io.crate.metadata.FunctionIdent;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -37,8 +36,7 @@ public class MinimumAggregationTest extends AggregationTest {
 
     @Test
     public void testReturnType() throws Exception {
-        FunctionIdent fi = new FunctionIdent("min", ImmutableList.<DataType>of(DataTypes.INTEGER));
-        assertEquals(DataTypes.INTEGER, functions.get(fi).info().returnType());
+        assertEquals(DataTypes.INTEGER, functions.get("min", ImmutableList.of(DataTypes.INTEGER)).info().returnType());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/aggregation/impl/PercentileAggregationTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/impl/PercentileAggregationTest.java
@@ -23,7 +23,6 @@ package io.crate.operation.aggregation.impl;
 
 import com.google.common.collect.ImmutableList;
 import io.crate.analyze.symbol.Literal;
-import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.ArrayType;
@@ -47,11 +46,10 @@ public class PercentileAggregationTest extends AggregationTest {
 
     @Test
     public void testReturnTypes() throws Exception {
-        FunctionIdent synopsis1 = new FunctionIdent(NAME, ImmutableList.<DataType>of(DataTypes.DOUBLE, DataTypes.DOUBLE));
-        assertEquals(DataTypes.DOUBLE, functions.get(synopsis1).info().returnType());
-
-        FunctionIdent synopsis2 = new FunctionIdent(NAME, ImmutableList.<DataType>of(DataTypes.DOUBLE, new ArrayType(DataTypes.DOUBLE)));
-        assertEquals(new ArrayType(DataTypes.DOUBLE), functions.get(synopsis2).info().returnType());
+        assertEquals(DataTypes.DOUBLE,
+            functions.get(NAME, ImmutableList.of(DataTypes.DOUBLE, DataTypes.DOUBLE)).info().returnType());
+        assertEquals(new ArrayType(DataTypes.DOUBLE),
+            functions.get(NAME, ImmutableList.of(DataTypes.DOUBLE, new ArrayType(DataTypes.DOUBLE))).info().returnType());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/aggregation/impl/StdDevAggregationTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/impl/StdDevAggregationTest.java
@@ -23,7 +23,6 @@ package io.crate.operation.aggregation.impl;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import io.crate.metadata.FunctionIdent;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -40,9 +39,8 @@ public class StdDevAggregationTest extends AggregationTest {
     @Test
     public void testReturnType() throws Exception {
         for (DataType<?> type : Iterables.concat(DataTypes.NUMERIC_PRIMITIVE_TYPES, Arrays.asList(DataTypes.TIMESTAMP))) {
-            FunctionIdent fi = new FunctionIdent("stddev", ImmutableList.<DataType>of(type));
             // Return type is fixed to Double
-            assertEquals(DataTypes.DOUBLE, functions.get(fi).info().returnType());
+            assertEquals(DataTypes.DOUBLE, functions.get("stddev", ImmutableList.of(type)).info().returnType());
         }
     }
 

--- a/sql/src/test/java/io/crate/operation/aggregation/impl/SumAggregationTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/impl/SumAggregationTest.java
@@ -22,7 +22,6 @@
 package io.crate.operation.aggregation.impl;
 
 import com.google.common.collect.ImmutableList;
-import io.crate.metadata.FunctionIdent;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -36,9 +35,8 @@ public class SumAggregationTest extends AggregationTest {
 
     @Test
     public void testReturnType() throws Exception {
-        FunctionIdent fi = new FunctionIdent("sum", ImmutableList.<DataType>of(DataTypes.INTEGER));
         // Return type is fixed to Double
-        assertEquals(DataTypes.DOUBLE, functions.get(fi).info().returnType());
+        assertEquals(DataTypes.DOUBLE, functions.get("sum", ImmutableList.of(DataTypes.INTEGER)).info().returnType());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/aggregation/impl/VarianceAggregationTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/impl/VarianceAggregationTest.java
@@ -23,7 +23,6 @@ package io.crate.operation.aggregation.impl;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import io.crate.metadata.FunctionIdent;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -40,9 +39,8 @@ public class VarianceAggregationTest extends AggregationTest {
     @Test
     public void testReturnType() throws Exception {
         for (DataType<?> type : Iterables.concat(DataTypes.NUMERIC_PRIMITIVE_TYPES, Arrays.asList(DataTypes.TIMESTAMP))) {
-            FunctionIdent fi = new FunctionIdent("variance", ImmutableList.<DataType>of(type));
             // Return type is fixed to Double
-            assertEquals(DataTypes.DOUBLE, functions.get(fi).info().returnType());
+            assertEquals(DataTypes.DOUBLE, functions.get("variance", ImmutableList.of(type)).info().returnType());
         }
     }
 

--- a/sql/src/test/java/io/crate/operation/collect/DocLevelCollectTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/DocLevelCollectTest.java
@@ -40,7 +40,6 @@ import io.crate.planner.distribution.DistributionInfo;
 import io.crate.planner.node.ExecutionPhase;
 import io.crate.planner.node.dql.RoutedCollectPhase;
 import io.crate.planner.projection.Projection;
-import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.indices.IndicesService;
@@ -150,8 +149,7 @@ public class DocLevelCollectTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testCollectDocLevelWhereClause() throws Throwable {
-        EqOperator op = (EqOperator) functions.get(new FunctionIdent(EqOperator.NAME,
-            ImmutableList.<DataType>of(DataTypes.INTEGER, DataTypes.INTEGER)));
+        EqOperator op = (EqOperator) functions.get(EqOperator.NAME, ImmutableList.of(DataTypes.INTEGER, DataTypes.INTEGER));
         List<Symbol> toCollect = Collections.<Symbol>singletonList(testDocLevelReference);
         WhereClause whereClause = new WhereClause(new Function(
             op.info(),

--- a/sql/src/test/java/io/crate/operation/collect/HandlerSideLevelCollectTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/HandlerSideLevelCollectTest.java
@@ -118,8 +118,8 @@ public class HandlerSideLevelCollectTest extends SQLTransportIntegrationTest {
         }
         Symbol tableNameRef = toCollect.get(8);
 
-        FunctionImplementation eqImpl = functions.get(new FunctionIdent(EqOperator.NAME,
-            ImmutableList.of(DataTypes.STRING, DataTypes.STRING)));
+        FunctionImplementation eqImpl = functions.get(EqOperator.NAME,
+            ImmutableList.of(DataTypes.STRING, DataTypes.STRING));
         Function whereClause = new Function(eqImpl.info(),
             Arrays.asList(tableNameRef, Literal.of("shards")));
 

--- a/sql/src/test/java/io/crate/operation/projectors/ProjectingBatchConsumerTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/ProjectingBatchConsumerTest.java
@@ -34,7 +34,6 @@ import io.crate.data.BatchIterator;
 import io.crate.data.RowsBatchIterator;
 import io.crate.exceptions.UnhandledServerException;
 import io.crate.executor.transport.TransportActionProvider;
-import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.Functions;
 import io.crate.metadata.ReplaceMode;
 import io.crate.metadata.RowGranularity;
@@ -130,8 +129,7 @@ public class ProjectingBatchConsumerTest extends CrateUnitTest {
 
     @Test
     public void testConsumerRequiresScrollAndProjectorsDontSupportScrolling() throws Exception {
-        EqOperator op = (EqOperator) functions.get(
-            new FunctionIdent(EqOperator.NAME, ImmutableList.of(DataTypes.INTEGER, DataTypes.INTEGER)));
+        EqOperator op = (EqOperator) functions.get(EqOperator.NAME, ImmutableList.of(DataTypes.INTEGER, DataTypes.INTEGER));
         Function function = new Function(op.info(), Arrays.asList(Literal.of(2), new InputColumn(1)));
         FilterProjection filterProjection = new FilterProjection(function,
             Arrays.asList(new InputColumn(0), new InputColumn(1)));

--- a/sql/src/test/java/io/crate/operation/projectors/ProjectionToProjectorVisitorTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/ProjectionToProjectorVisitorTest.java
@@ -234,8 +234,7 @@ public class ProjectionToProjectorVisitorTest extends CrateUnitTest {
 
     @Test
     public void testFilterProjection() throws Exception {
-        EqOperator op = (EqOperator) functions.get(
-            new FunctionIdent(EqOperator.NAME, ImmutableList.of(DataTypes.INTEGER, DataTypes.INTEGER)));
+        EqOperator op = (EqOperator) functions.get(EqOperator.NAME, ImmutableList.of(DataTypes.INTEGER, DataTypes.INTEGER));
         Function function = new Function(
             op.info(), Arrays.asList(Literal.of(2), new InputColumn(1)));
         FilterProjection projection = new FilterProjection(function,

--- a/sql/src/test/java/io/crate/operation/projectors/SimpleTopNProjectorTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/SimpleTopNProjectorTest.java
@@ -24,7 +24,6 @@ package io.crate.operation.projectors;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import io.crate.data.*;
-import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.Scalar;
 import io.crate.operation.aggregation.FunctionExpression;
 import io.crate.operation.collect.CollectExpression;
@@ -34,7 +33,6 @@ import io.crate.testing.RowGenerator;
 import io.crate.testing.TestingBatchConsumer;
 import io.crate.testing.TestingBatchIterators;
 import io.crate.testing.TestingHelpers;
-import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.junit.Test;
 
@@ -152,8 +150,7 @@ public class SimpleTopNProjectorTest extends CrateUnitTest {
 
     @Test
     public void testFunctionExpression() throws Throwable {
-        Scalar floor = (Scalar) TestingHelpers.getFunctions().get(
-            new FunctionIdent("floor", Collections.<DataType>singletonList(DataTypes.DOUBLE)));
+        Scalar floor = (Scalar) TestingHelpers.getFunctions().get("floor", Collections.singletonList(DataTypes.DOUBLE));
         FunctionExpression<Number, ?> funcExpr = new FunctionExpression<>(floor, new Input[]{input});
         Projector projector = new SimpleTopNProjector(ImmutableList.<Input<?>>of(funcExpr), COLLECT_EXPRESSIONS, 10, TopN.NO_OFFSET);
 

--- a/sql/src/test/java/io/crate/operation/scalar/AbstractScalarFunctionsTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/AbstractScalarFunctionsTest.java
@@ -110,7 +110,8 @@ public abstract class AbstractScalarFunctionsTest extends CrateUnitTest {
             return;
         }
         Function function = (Function) functionSymbol;
-        FunctionImplementation impl = functions.get(function.info().ident());
+        FunctionIdent ident = function.info().ident();
+        FunctionImplementation impl = functions.get(ident.name(), ident.argumentTypes());
         assertThat(impl, Matchers.notNullValue());
 
         Symbol normalized = sqlExpressions.normalize(function);
@@ -155,7 +156,8 @@ public abstract class AbstractScalarFunctionsTest extends CrateUnitTest {
             return;
         }
         Function function = (Function) functionSymbol;
-        Scalar scalar = (Scalar) functions.getSafe(function.info().ident());
+        FunctionIdent ident = function.info().ident();
+        Scalar scalar = (Scalar) functions.getSafe(ident.name(), ident.argumentTypes());
 
         InputApplierContext inputApplierContext = new InputApplierContext(inputs, sqlExpressions);
         AssertingInput[] arguments = new AssertingInput[function.arguments().size()];
@@ -180,7 +182,8 @@ public abstract class AbstractScalarFunctionsTest extends CrateUnitTest {
         functionSymbol = sqlExpressions.normalize(functionSymbol);
         assertThat("function expression was normalized, compile would not be hit", functionSymbol, not(instanceOf(Literal.class)));
         Function function = (Function) functionSymbol;
-        Scalar scalar = (Scalar) functions.get(function.info().ident());
+        FunctionIdent ident = function.info().ident();
+        Scalar scalar = (Scalar) functions.getSafe(ident.name(), ident.argumentTypes());
         assert scalar != null : "function must be registered";
 
         Scalar compiled = scalar.compile(function.arguments());
@@ -204,7 +207,8 @@ public abstract class AbstractScalarFunctionsTest extends CrateUnitTest {
 
     @SuppressWarnings("unchecked")
     protected <T extends FunctionImplementation> T getFunction(String functionName, List<DataType> argTypes) {
-        return (T) functions.get(new FunctionIdent(functionName, argTypes));
+
+        return (T) functions.get(functionName, argTypes);
     }
 
     protected Symbol normalize(String functionName, Object value, DataType type) {
@@ -307,7 +311,8 @@ public abstract class AbstractScalarFunctionsTest extends CrateUnitTest {
             try {
                 return (Input) context.sqlExpressions.normalize(function);
             } catch (Exception e) {
-                Scalar scalar = (Scalar) context.sqlExpressions.functions().get(function.info().ident());
+                FunctionIdent ident = function.info().ident();
+                Scalar scalar = (Scalar) context.sqlExpressions.functions().get(ident.name(), ident.argumentTypes());
                 return new FunctionExpression<>(scalar, argInputs);
             }
         }

--- a/sql/src/test/java/io/crate/operation/scalar/SubscriptFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/SubscriptFunctionTest.java
@@ -21,8 +21,6 @@
 
 package io.crate.operation.scalar;
 
-import io.crate.metadata.FunctionIdent;
-import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.SetType;
 import org.junit.Test;
@@ -54,9 +52,7 @@ public class SubscriptFunctionTest extends AbstractScalarFunctionsTest {
     public void testNotRegisteredForSets() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
         expectedException.expectMessage("unknown function: subscript(integer_set, integer)");
-        FunctionIdent functionIdent = new FunctionIdent(SubscriptFunction.NAME,
-            Arrays.<DataType>asList(new SetType(DataTypes.INTEGER), DataTypes.INTEGER));
-        functions.getSafe(functionIdent);
+        functions.getSafe(SubscriptFunction.NAME, Arrays.asList(new SetType(DataTypes.INTEGER), DataTypes.INTEGER));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/scalar/arithmetic/AddFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/arithmetic/AddFunctionTest.java
@@ -21,9 +21,7 @@
 
 package io.crate.operation.scalar.arithmetic;
 
-import io.crate.metadata.FunctionIdent;
 import io.crate.operation.scalar.AbstractScalarFunctionsTest;
-import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.junit.Test;
 
@@ -33,7 +31,6 @@ public class AddFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testTimestampTypeValidation() throws Exception {
-        functions.get(new FunctionIdent(AddFunction.NAME,
-            Arrays.<DataType>asList(DataTypes.TIMESTAMP, DataTypes.TIMESTAMP)));
+        functions.get(AddFunction.NAME, Arrays.asList(DataTypes.TIMESTAMP, DataTypes.TIMESTAMP));
     }
 }

--- a/sql/src/test/java/io/crate/operation/scalar/arithmetic/LogFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/arithmetic/LogFunctionTest.java
@@ -25,10 +25,9 @@ import io.crate.action.sql.SessionContext;
 import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
-import io.crate.metadata.FunctionIdent;
+import io.crate.data.Input;
 import io.crate.metadata.Reference;
 import io.crate.metadata.TransactionContext;
-import io.crate.data.Input;
 import io.crate.operation.scalar.AbstractScalarFunctionsTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -47,11 +46,11 @@ public class LogFunctionTest extends AbstractScalarFunctionsTest {
     private TransactionContext transactionContext = new TransactionContext(SessionContext.SYSTEM_SESSION);
 
     private LogFunction getFunction(String name, DataType value) {
-        return (LogFunction) functions.get(new FunctionIdent(name, Arrays.asList(value)));
+        return (LogFunction) functions.get(name, Arrays.asList(value));
     }
 
     private LogFunction getFunction(String name, DataType value, DataType base) {
-        return (LogFunction) functions.get(new FunctionIdent(name, Arrays.asList(value, base)));
+        return (LogFunction) functions.get(name, Arrays.asList(value, base));
     }
 
     private Symbol normalizeLog(Number value, DataType valueType) {

--- a/sql/src/test/java/io/crate/operation/scalar/arithmetic/RandomFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/arithmetic/RandomFunctionTest.java
@@ -24,11 +24,9 @@ package io.crate.operation.scalar.arithmetic;
 import io.crate.action.sql.SessionContext;
 import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Symbol;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.TransactionContext;
 import io.crate.data.Input;
+import io.crate.metadata.TransactionContext;
 import io.crate.operation.scalar.AbstractScalarFunctionsTest;
-import io.crate.types.DataType;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -44,7 +42,7 @@ public class RandomFunctionTest extends AbstractScalarFunctionsTest {
 
     @Before
     public void prepareRandom() {
-        random = (RandomFunction) functions.get(new FunctionIdent(RandomFunction.NAME, Collections.<DataType>emptyList()));
+        random = (RandomFunction) functions.get(RandomFunction.NAME, Collections.emptyList());
 
     }
 

--- a/sql/src/test/java/io/crate/operation/tablefunctions/UnnestFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/tablefunctions/UnnestFunctionTest.java
@@ -27,6 +27,7 @@ import io.crate.analyze.relations.DocTableRelation;
 import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.data.Bucket;
+import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.Functions;
 import io.crate.metadata.tablefunctions.TableFunctionImplementation;
 import io.crate.data.Input;
@@ -57,7 +58,9 @@ public class UnnestFunctionTest extends CrateUnitTest {
         Symbol functionSymbol = sqlExpressions.asSymbol(expr);
         functionSymbol = sqlExpressions.normalize(functionSymbol);
         Function function = (Function) functionSymbol;
-        TableFunctionImplementation tableFunction = (TableFunctionImplementation) functions.getSafe(function.info().ident());
+        FunctionIdent ident = function.info().ident();
+        TableFunctionImplementation tableFunction = (TableFunctionImplementation)
+            functions.getSafe(ident.name(), ident.argumentTypes());
         return tableFunction.execute(function.arguments().stream().map(a -> (Input) a).collect(Collectors.toList()));
     }
 


### PR DESCRIPTION
The signature of the ``get`` method does not require a
function ident as an argument any longer. The new signature:

    get(functionName, argumentTypes)

The new signature will prevent from instantiating a
function ident object upon the getting an implementation
of a fucntion.