### PR TITLE
Remove locks from SharedShardContext(s)

### DIFF
--- a/sql/src/main/java/io/crate/action/job/ContextPreparer.java
+++ b/sql/src/main/java/io/crate/action/job/ContextPreparer.java
@@ -382,21 +382,20 @@ public class ContextPreparer extends AbstractComponent {
         private final LongObjectMap<BatchConsumer> consumersByPhaseInputId = new LongObjectHashMap<>();
         private final IntObjectMap<BatchConsumer> handlerConsumersByPhaseId = new IntObjectHashMap<>();
 
-        @Nullable
         private final SharedShardContexts sharedShardContexts;
 
         private final List<CompletableFuture<Bucket>> directResponseFutures = new ArrayList<>();
         private final NodeOperationCtx opCtx;
         private final JobExecutionContext.Builder contextBuilder;
         private final ESLogger logger;
-        private List<ExecutionPhase> leafs = new ArrayList<>();
+        private final List<ExecutionPhase> leafs = new ArrayList<>();
 
         PreparerContext(String localNodeId,
                         JobExecutionContext.Builder contextBuilder,
                         ESLogger logger,
                         DistributingDownstreamFactory distributingDownstreamFactory,
                         Collection<? extends NodeOperation> nodeOperations,
-                        @Nullable SharedShardContexts sharedShardContexts) {
+                        SharedShardContexts sharedShardContexts) {
             this.contextBuilder = contextBuilder;
             this.logger = logger;
             this.opCtx = new NodeOperationCtx(localNodeId, nodeOperations);

--- a/sql/src/main/java/io/crate/action/job/SharedShardContexts.java
+++ b/sql/src/main/java/io/crate/action/job/SharedShardContexts.java
@@ -24,9 +24,11 @@ package io.crate.action.job;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
 
+import javax.annotation.concurrent.NotThreadSafe;
 import java.util.HashMap;
 import java.util.Map;
 
+@NotThreadSafe
 public class SharedShardContexts {
 
     private final IndicesService indicesService;
@@ -48,15 +50,9 @@ public class SharedShardContexts {
     public SharedShardContext getOrCreateContext(ShardId shardId) {
         SharedShardContext sharedShardContext = allocatedShards.get(shardId);
         if (sharedShardContext == null) {
-            synchronized (this) {
-                sharedShardContext = allocatedShards.get(shardId);
-                if (sharedShardContext == null) {
-                    sharedShardContext = new SharedShardContext(indicesService, shardId, readerId);
-                    allocatedShards.put(shardId, sharedShardContext);
-                    readerId++;
-                }
-                return sharedShardContext;
-            }
+            sharedShardContext = new SharedShardContext(indicesService, shardId, readerId);
+            allocatedShards.put(shardId, sharedShardContext);
+            readerId++;
         }
         return sharedShardContext;
     }


### PR DESCRIPTION
The prepare phase runs in a single thread so there is no need for
synchronization in SharedShardContext/SharedShardContexts.