### PR TITLE
get rid of getSafe() and raise unknown function error in analyzer

### DIFF
--- a/sql/src/jmh/java/io/crate/operation/projectors/GroupingBytesRefCollectorBenchmark.java
+++ b/sql/src/jmh/java/io/crate/operation/projectors/GroupingBytesRefCollectorBenchmark.java
@@ -81,7 +81,7 @@ public class GroupingBytesRefCollectorBenchmark {
         CollectExpression[] collectExpressions = new CollectExpression[]{keyInput};
 
         AggregationFunction minAgg =
-            (AggregationFunction) functions.get(MinimumAggregation.NAME, Collections.singletonList(DataTypes.STRING));
+            (AggregationFunction) functions.getBuiltin(MinimumAggregation.NAME, Collections.singletonList(DataTypes.STRING));
 
         return GroupingCollector.singleKey(
             collectExpressions,

--- a/sql/src/jmh/java/io/crate/operation/projectors/GroupingIntegerCollectorBenchmark.java
+++ b/sql/src/jmh/java/io/crate/operation/projectors/GroupingIntegerCollectorBenchmark.java
@@ -73,7 +73,7 @@ public class GroupingIntegerCollectorBenchmark {
         CollectExpression[] collectExpressions = new CollectExpression[]{keyInput};
 
         AggregationFunction sumAgg =
-            (AggregationFunction) functions.get(SumAggregation.NAME, Arrays.asList(DataTypes.INTEGER));
+            (AggregationFunction) functions.getBuiltin(SumAggregation.NAME, Arrays.asList(DataTypes.INTEGER));
 
         return GroupingCollector.singleKey(
             collectExpressions,

--- a/sql/src/main/java/io/crate/analyze/EvaluatingNormalizer.java
+++ b/sql/src/main/java/io/crate/analyze/EvaluatingNormalizer.java
@@ -145,7 +145,7 @@ public class EvaluatingNormalizer {
         @SuppressWarnings("unchecked")
         Symbol normalizeFunctionSymbol(Function function, Context context) {
             FunctionIdent ident = function.info().ident();
-            FunctionImplementation impl = functions.get(ident.name(), ident.argumentTypes());
+            FunctionImplementation impl = functions.getBuiltin(ident.name(), ident.argumentTypes());
             if (impl != null) {
                 return impl.normalizeSymbol(function, context.transactionContext);
             }

--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -463,10 +463,10 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
 
         Function function = (Function) expressionAnalyzer.convert(node.functionCall(), context.expressionAnalysisContext());
         FunctionIdent ident = function.info().ident();
-        FunctionImplementation functionImplementation = functions.getSafe(ident.name(), ident.argumentTypes());
+        FunctionImplementation functionImplementation = functions.getQualified(ident);
         if (functionImplementation.info().type() != FunctionInfo.Type.TABLE) {
-            throw new UnsupportedFeatureException(
-                "Non table function " + function.info().ident().name() + " is not supported in from clause");
+            String message = "Non table function " + ident.name() + " is not supported in from clause";
+            throw new UnsupportedFeatureException(message);
         }
         TableFunctionImplementation tableFunction = (TableFunctionImplementation) functionImplementation;
         TableInfo tableInfo = tableFunction.createTableInfo(clusterService);

--- a/sql/src/main/java/io/crate/analyze/symbol/format/SymbolPrinter.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/format/SymbolPrinter.java
@@ -182,15 +182,15 @@ public class SymbolPrinter {
             FunctionFormatSpec functionFormatSpec = null;
             OperatorFormatSpec operatorFormatSpec = null;
 
+            FunctionIdent ident = function.info().ident();
             if (functions != null) {
-                FunctionIdent ident = function.info().ident();
-                FunctionImplementation impl = functions.get(ident.name(), ident.argumentTypes());
+                FunctionImplementation impl = functions.getBuiltin(ident.name(), ident.argumentTypes());
                 if (impl instanceof FunctionFormatSpec) {
                     functionFormatSpec = (FunctionFormatSpec) impl;
                 } else if (impl instanceof OperatorFormatSpec) {
                     operatorFormatSpec = (OperatorFormatSpec) impl;
                 }
-            } else if (function.info().ident().name().startsWith("op_")) {
+            } else if (ident.name().startsWith("op_")) {
                 operatorFormatSpec = SIMPLE_OPERATOR_FORMAT_SPEC;
             }
             if (operatorFormatSpec != null) {

--- a/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/SymbolToFieldExtractor.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/SymbolToFieldExtractor.java
@@ -101,8 +101,7 @@ public class SymbolToFieldExtractor<T> {
                 subExtractors.add(process(argument, context));
             }
             FunctionIdent functionIdent = symbol.info().ident();
-            return new FunctionExtractor<>((Scalar) context.functions
-                .getSafe(functionIdent.name(), functionIdent.argumentTypes()), subExtractors);
+            return new FunctionExtractor<>((Scalar) context.functions.getQualified(functionIdent), subExtractors);
         }
 
         @Override

--- a/sql/src/main/java/io/crate/metadata/Functions.java
+++ b/sql/src/main/java/io/crate/metadata/Functions.java
@@ -54,43 +54,14 @@ public class Functions {
     }
 
     /**
-     * Returns the function implementation for the given function name and arguments.
-     *
-     * @param name           The function name.
-     * @param argumentsTypes The function argument types.
-     * @return The function implementation..
-     * @throws UnsupportedOperationException if an implementation is not found.
-     */
-    public FunctionImplementation getSafe(String name, List<DataType> argumentsTypes)
-        throws IllegalArgumentException, UnsupportedOperationException {
-        FunctionImplementation implementation = null;
-        String exceptionMessage = null;
-        try {
-            implementation = get(name, argumentsTypes);
-        } catch (IllegalArgumentException e) {
-            if (e.getMessage() != null && !e.getMessage().isEmpty()) {
-                exceptionMessage = e.getMessage();
-            }
-        }
-        if (implementation == null) {
-            if (exceptionMessage == null) {
-                exceptionMessage = String.format(Locale.ENGLISH, "unknown function: %s(%s)", name,
-                    Joiner.on(", ").join(argumentsTypes));
-            }
-            throw new UnsupportedOperationException(exceptionMessage);
-        }
-        return implementation;
-    }
-
-    /**
-     * Returns the function implementation for the given function name and arguments.
+     * Returns the built-in function implementation for the given function name and arguments.
      *
      * @param name           The function name.
      * @param argumentsTypes The function argument types.
      * @return a function implementation or null if it was not found.
      */
     @Nullable
-    public FunctionImplementation get(String name, List<DataType> argumentsTypes) throws IllegalArgumentException {
+    public FunctionImplementation getBuiltin(String name, List<DataType> argumentsTypes) throws IllegalArgumentException {
         FunctionResolver dynamicResolver = functionResolvers.get(name);
         if (dynamicResolver != null) {
             List<DataType> signature = dynamicResolver.getSignature(argumentsTypes);
@@ -99,6 +70,28 @@ public class Functions {
             }
         }
         return null;
+    }
+
+    /**
+     * Returns the function implementation for the given function ident.
+     *
+     * @param ident The function ident.
+     * @return The function implementation.
+     * @throws UnsupportedOperationException if an implementation is not found.
+     */
+
+    public FunctionImplementation getQualified(FunctionIdent ident) throws IllegalArgumentException {
+        FunctionImplementation impl = getBuiltin(ident.name(), ident.argumentTypes());
+        if (impl == null) {
+            throw createUnknownFunctionException(ident.name(), ident.argumentTypes());
+        }
+        return impl;
+    }
+
+    public static UnsupportedOperationException createUnknownFunctionException(String name, List<DataType> argumentTypes) {
+        return new UnsupportedOperationException(
+            String.format(Locale.ENGLISH, "unknown function: %s(%s)", name, Joiner.on(", ").join(argumentTypes))
+        );
     }
 
     private static class GeneratedFunctionResolver implements FunctionResolver {

--- a/sql/src/main/java/io/crate/operation/BaseImplementationSymbolVisitor.java
+++ b/sql/src/main/java/io/crate/operation/BaseImplementationSymbolVisitor.java
@@ -44,7 +44,7 @@ public class BaseImplementationSymbolVisitor<C> extends SymbolVisitor<C, Input<?
     @Override
     public Input<?> visitFunction(Function function, C context) {
         FunctionIdent ident = function.info().ident();
-        final FunctionImplementation functionImplementation = functions.get(ident.name(), ident.argumentTypes());
+        final FunctionImplementation functionImplementation = functions.getQualified(ident);
         if (functionImplementation instanceof Scalar<?, ?>) {
             List<Symbol> arguments = function.arguments();
             Scalar<?, ?> scalarImpl = ((Scalar) functionImplementation).compile(arguments);
@@ -55,8 +55,7 @@ public class BaseImplementationSymbolVisitor<C> extends SymbolVisitor<C, Input<?
             }
             return new FunctionExpression<>(scalarImpl, argumentInputs);
         } else {
-            throw new IllegalArgumentException(
-                SymbolFormatter.format("Cannot find implementation for function %s", function));
+            throw Functions.createUnknownFunctionException(ident.name(), ident.argumentTypes());
         }
     }
 

--- a/sql/src/main/java/io/crate/operation/InputFactory.java
+++ b/sql/src/main/java/io/crate/operation/InputFactory.java
@@ -194,11 +194,7 @@ public class InputFactory {
         @Override
         public Input<?> visitAggregation(Aggregation symbol, Void context) {
             FunctionIdent ident = symbol.functionIdent();
-            FunctionImplementation impl = functions.get(ident.name(), ident.argumentTypes());
-            if (impl == null) {
-                throw new UnsupportedOperationException(
-                    SymbolFormatter.format("Can't load aggregation impl for symbol %s", symbol));
-            }
+            FunctionImplementation impl = functions.getQualified(ident);
             AggregationContext aggregationContext = new AggregationContext((AggregationFunction) impl, symbol);
             for (Symbol aggInput : symbol.inputs()) {
                 aggregationContext.addInput(process(aggInput, context));

--- a/sql/src/main/java/io/crate/planner/projection/builder/ProjectionBuilder.java
+++ b/sql/src/main/java/io/crate/planner/projection/builder/ProjectionBuilder.java
@@ -95,7 +95,7 @@ public class ProjectionBuilder {
             FunctionIdent ident = function.info().ident();
             Aggregation aggregation = new Aggregation(
                 function.info(),
-                mode.returnType(((AggregationFunction) this.functions.get(ident.name(), ident.argumentTypes()))),
+                mode.returnType(((AggregationFunction) this.functions.getQualified(ident))),
                 aggregationInputs
             );
             aggregations.add(aggregation);

--- a/sql/src/test/java/io/crate/analyze/EvaluatingNormalizerTest.java
+++ b/sql/src/test/java/io/crate/analyze/EvaluatingNormalizerTest.java
@@ -116,7 +116,7 @@ public class EvaluatingNormalizerTest extends CrateUnitTest {
         } else {
             dataTypes = ImmutableList.of(dataType, dataType);
         }
-        return functions.get(name, dataTypes).info();
+        return functions.getBuiltin(name, dataTypes).info();
     }
 
     private FunctionInfo functionInfo(String name, DataType dataType) {

--- a/sql/src/test/java/io/crate/operation/InputFactoryTest.java
+++ b/sql/src/test/java/io/crate/operation/InputFactoryTest.java
@@ -160,7 +160,7 @@ public class InputFactoryTest extends CrateUnitTest {
         assertThat(impl.info(), is(function.info()));
 
         FunctionIdent ident = function.info().ident();
-        FunctionImplementation uncompiled = expressions.functions().get(ident.name(), ident.argumentTypes());
+        FunctionImplementation uncompiled = expressions.functions().getBuiltin(ident.name(), ident.argumentTypes());
         assertThat(uncompiled, not(sameInstance(impl)));
     }
 }

--- a/sql/src/test/java/io/crate/operation/aggregation/AggregationTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/AggregationTest.java
@@ -77,7 +77,7 @@ public abstract class AggregationTest extends CrateUnitTest {
             fi = new FunctionIdent(name, ImmutableList.<DataType>of());
             inputs = new InputCollectExpression[0];
         }
-        AggregationFunction impl = (AggregationFunction) functions.get(fi.name(), fi.argumentTypes());
+        AggregationFunction impl = (AggregationFunction) functions.getBuiltin(fi.name(), fi.argumentTypes());
         Object state = impl.newState(ramAccountingContext);
 
         ArrayBucket bucket = new ArrayBucket(data);
@@ -103,7 +103,7 @@ public abstract class AggregationTest extends CrateUnitTest {
             argTypes[i] = args[i].valueType();
         }
         AggregationFunction function =
-            (AggregationFunction) functions.get(functionName, Arrays.asList(argTypes));
+            (AggregationFunction) functions.getBuiltin(functionName, Arrays.asList(argTypes));
         return function.normalizeSymbol(new Function(function.info(), Arrays.asList(args)), new TransactionContext(SessionContext.SYSTEM_SESSION));
     }
 }

--- a/sql/src/test/java/io/crate/operation/aggregation/impl/ArbitraryAggregationTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/impl/ArbitraryAggregationTest.java
@@ -38,7 +38,8 @@ public class ArbitraryAggregationTest extends AggregationTest {
 
     @Test
     public void testReturnType() throws Exception {
-        assertEquals(DataTypes.INTEGER, functions.get("arbitrary", ImmutableList.of(DataTypes.INTEGER)).info().returnType());
+        assertEquals(DataTypes.INTEGER,
+            functions.getBuiltin("arbitrary", ImmutableList.of(DataTypes.INTEGER)).info().returnType());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/aggregation/impl/AverageAggregationTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/impl/AverageAggregationTest.java
@@ -36,8 +36,8 @@ public class AverageAggregationTest extends AggregationTest {
     @Test
     public void testReturnType() throws Exception {
         // Return type is fixed to Double
-        assertEquals(DataTypes.DOUBLE, functions.get("avg", ImmutableList.of(DataTypes.INTEGER)).info().returnType());
-        assertEquals(DataTypes.DOUBLE, functions.get("mean", ImmutableList.of(DataTypes.INTEGER)).info().returnType());
+        assertEquals(DataTypes.DOUBLE, functions.getBuiltin("avg", ImmutableList.of(DataTypes.INTEGER)).info().returnType());
+        assertEquals(DataTypes.DOUBLE, functions.getBuiltin("mean", ImmutableList.of(DataTypes.INTEGER)).info().returnType());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/aggregation/impl/CollectSetAggregationTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/impl/CollectSetAggregationTest.java
@@ -45,7 +45,7 @@ public class CollectSetAggregationTest extends AggregationTest {
     @Test
     public void testReturnType() throws Exception {
         assertEquals(new SetType(DataTypes.INTEGER),
-            functions.get("collect_set", ImmutableList.of(DataTypes.INTEGER)).info().returnType());
+            functions.getBuiltin("collect_set", ImmutableList.of(DataTypes.INTEGER)).info().returnType());
     }
 
     @Test
@@ -59,7 +59,8 @@ public class CollectSetAggregationTest extends AggregationTest {
 
     @Test
     public void testLongSerialization() throws Exception {
-        AggregationFunction impl = (AggregationFunction) functions.get("collect_set", ImmutableList.of(DataTypes.LONG));
+        AggregationFunction impl
+            = (AggregationFunction) functions.getBuiltin("collect_set", ImmutableList.of(DataTypes.LONG));
 
         Object state = impl.newState(ramAccountingContext);
 

--- a/sql/src/test/java/io/crate/operation/aggregation/impl/CountAggregationTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/impl/CountAggregationTest.java
@@ -42,7 +42,8 @@ public class CountAggregationTest extends AggregationTest {
     @Test
     public void testReturnType() throws Exception {
         // Return type is fixed to Long
-        assertEquals(DataTypes.LONG, functions.get("count", ImmutableList.of(DataTypes.INTEGER)).info().returnType());
+        assertEquals(DataTypes.LONG,
+            functions.getBuiltin("count", ImmutableList.of(DataTypes.INTEGER)).info().returnType());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/aggregation/impl/GeometricMeanAggregationtest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/impl/GeometricMeanAggregationtest.java
@@ -40,7 +40,8 @@ public class GeometricMeanAggregationtest extends AggregationTest {
     public void testReturnType() throws Exception {
         for (DataType<?> type : Iterables.concat(DataTypes.NUMERIC_PRIMITIVE_TYPES, Arrays.asList(DataTypes.TIMESTAMP))) {
             // Return type is fixed to Double
-            assertEquals(DataTypes.DOUBLE, functions.get("geometric_mean", ImmutableList.of(type)).info().returnType());
+            assertEquals(DataTypes.DOUBLE,
+                functions.getBuiltin("geometric_mean", ImmutableList.of(type)).info().returnType());
         }
     }
 

--- a/sql/src/test/java/io/crate/operation/aggregation/impl/MaximumAggregationTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/impl/MaximumAggregationTest.java
@@ -36,7 +36,7 @@ public class MaximumAggregationTest extends AggregationTest {
 
     @Test
     public void testReturnType() throws Exception {
-        assertEquals(DataTypes.INTEGER, functions.get("max", ImmutableList.of(DataTypes.INTEGER)).info().returnType());
+        assertEquals(DataTypes.INTEGER, functions.getBuiltin("max", ImmutableList.of(DataTypes.INTEGER)).info().returnType());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/aggregation/impl/MinimumAggregationTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/impl/MinimumAggregationTest.java
@@ -36,7 +36,8 @@ public class MinimumAggregationTest extends AggregationTest {
 
     @Test
     public void testReturnType() throws Exception {
-        assertEquals(DataTypes.INTEGER, functions.get("min", ImmutableList.of(DataTypes.INTEGER)).info().returnType());
+        assertEquals(DataTypes.INTEGER,
+            functions.getBuiltin("min", ImmutableList.of(DataTypes.INTEGER)).info().returnType());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/aggregation/impl/PercentileAggregationTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/impl/PercentileAggregationTest.java
@@ -47,9 +47,9 @@ public class PercentileAggregationTest extends AggregationTest {
     @Test
     public void testReturnTypes() throws Exception {
         assertEquals(DataTypes.DOUBLE,
-            functions.get(NAME, ImmutableList.of(DataTypes.DOUBLE, DataTypes.DOUBLE)).info().returnType());
+            functions.getBuiltin(NAME, ImmutableList.of(DataTypes.DOUBLE, DataTypes.DOUBLE)).info().returnType());
         assertEquals(new ArrayType(DataTypes.DOUBLE),
-            functions.get(NAME, ImmutableList.of(DataTypes.DOUBLE, new ArrayType(DataTypes.DOUBLE))).info().returnType());
+            functions.getBuiltin(NAME, ImmutableList.of(DataTypes.DOUBLE, new ArrayType(DataTypes.DOUBLE))).info().returnType());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/aggregation/impl/StdDevAggregationTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/impl/StdDevAggregationTest.java
@@ -40,7 +40,7 @@ public class StdDevAggregationTest extends AggregationTest {
     public void testReturnType() throws Exception {
         for (DataType<?> type : Iterables.concat(DataTypes.NUMERIC_PRIMITIVE_TYPES, Arrays.asList(DataTypes.TIMESTAMP))) {
             // Return type is fixed to Double
-            assertEquals(DataTypes.DOUBLE, functions.get("stddev", ImmutableList.of(type)).info().returnType());
+            assertEquals(DataTypes.DOUBLE, functions.getBuiltin("stddev", ImmutableList.of(type)).info().returnType());
         }
     }
 

--- a/sql/src/test/java/io/crate/operation/aggregation/impl/SumAggregationTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/impl/SumAggregationTest.java
@@ -36,7 +36,7 @@ public class SumAggregationTest extends AggregationTest {
     @Test
     public void testReturnType() throws Exception {
         // Return type is fixed to Double
-        assertEquals(DataTypes.DOUBLE, functions.get("sum", ImmutableList.of(DataTypes.INTEGER)).info().returnType());
+        assertEquals(DataTypes.DOUBLE, functions.getBuiltin("sum", ImmutableList.of(DataTypes.INTEGER)).info().returnType());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/aggregation/impl/VarianceAggregationTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/impl/VarianceAggregationTest.java
@@ -40,7 +40,8 @@ public class VarianceAggregationTest extends AggregationTest {
     public void testReturnType() throws Exception {
         for (DataType<?> type : Iterables.concat(DataTypes.NUMERIC_PRIMITIVE_TYPES, Arrays.asList(DataTypes.TIMESTAMP))) {
             // Return type is fixed to Double
-            assertEquals(DataTypes.DOUBLE, functions.get("variance", ImmutableList.of(type)).info().returnType());
+            assertEquals(DataTypes.DOUBLE,
+                functions.getBuiltin("variance", ImmutableList.of(type)).info().returnType());
         }
     }
 

--- a/sql/src/test/java/io/crate/operation/collect/DocLevelCollectTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/DocLevelCollectTest.java
@@ -149,7 +149,8 @@ public class DocLevelCollectTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testCollectDocLevelWhereClause() throws Throwable {
-        EqOperator op = (EqOperator) functions.get(EqOperator.NAME, ImmutableList.of(DataTypes.INTEGER, DataTypes.INTEGER));
+        EqOperator op =
+            (EqOperator) functions.getBuiltin(EqOperator.NAME, ImmutableList.of(DataTypes.INTEGER, DataTypes.INTEGER));
         List<Symbol> toCollect = Collections.<Symbol>singletonList(testDocLevelReference);
         WhereClause whereClause = new WhereClause(new Function(
             op.info(),

--- a/sql/src/test/java/io/crate/operation/collect/HandlerSideLevelCollectTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/HandlerSideLevelCollectTest.java
@@ -118,8 +118,8 @@ public class HandlerSideLevelCollectTest extends SQLTransportIntegrationTest {
         }
         Symbol tableNameRef = toCollect.get(8);
 
-        FunctionImplementation eqImpl = functions.get(EqOperator.NAME,
-            ImmutableList.of(DataTypes.STRING, DataTypes.STRING));
+        FunctionImplementation eqImpl
+            = functions.getBuiltin(EqOperator.NAME, ImmutableList.of(DataTypes.STRING, DataTypes.STRING));
         Function whereClause = new Function(eqImpl.info(),
             Arrays.asList(tableNameRef, Literal.of("shards")));
 

--- a/sql/src/test/java/io/crate/operation/projectors/ProjectingBatchConsumerTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/ProjectingBatchConsumerTest.java
@@ -129,7 +129,8 @@ public class ProjectingBatchConsumerTest extends CrateUnitTest {
 
     @Test
     public void testConsumerRequiresScrollAndProjectorsDontSupportScrolling() throws Exception {
-        EqOperator op = (EqOperator) functions.get(EqOperator.NAME, ImmutableList.of(DataTypes.INTEGER, DataTypes.INTEGER));
+        EqOperator op =
+            (EqOperator) functions.getBuiltin(EqOperator.NAME, ImmutableList.of(DataTypes.INTEGER, DataTypes.INTEGER));
         Function function = new Function(op.info(), Arrays.asList(Literal.of(2), new InputColumn(1)));
         FilterProjection filterProjection = new FilterProjection(function,
             Arrays.asList(new InputColumn(0), new InputColumn(1)));

--- a/sql/src/test/java/io/crate/operation/projectors/ProjectionToProjectorVisitorTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/ProjectionToProjectorVisitorTest.java
@@ -234,7 +234,8 @@ public class ProjectionToProjectorVisitorTest extends CrateUnitTest {
 
     @Test
     public void testFilterProjection() throws Exception {
-        EqOperator op = (EqOperator) functions.get(EqOperator.NAME, ImmutableList.of(DataTypes.INTEGER, DataTypes.INTEGER));
+        EqOperator op =
+            (EqOperator) functions.getBuiltin(EqOperator.NAME, ImmutableList.of(DataTypes.INTEGER, DataTypes.INTEGER));
         Function function = new Function(
             op.info(), Arrays.asList(Literal.of(2), new InputColumn(1)));
         FilterProjection projection = new FilterProjection(function,

--- a/sql/src/test/java/io/crate/operation/projectors/SimpleTopNProjectorTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/SimpleTopNProjectorTest.java
@@ -150,7 +150,8 @@ public class SimpleTopNProjectorTest extends CrateUnitTest {
 
     @Test
     public void testFunctionExpression() throws Throwable {
-        Scalar floor = (Scalar) TestingHelpers.getFunctions().get("floor", Collections.singletonList(DataTypes.DOUBLE));
+        Scalar floor =
+            (Scalar) TestingHelpers.getFunctions().getBuiltin("floor", Collections.singletonList(DataTypes.DOUBLE));
         FunctionExpression<Number, ?> funcExpr = new FunctionExpression<>(floor, new Input[]{input});
         Projector projector = new SimpleTopNProjector(ImmutableList.<Input<?>>of(funcExpr), COLLECT_EXPRESSIONS, 10, TopN.NO_OFFSET);
 

--- a/sql/src/test/java/io/crate/operation/scalar/AbstractScalarFunctionsTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/AbstractScalarFunctionsTest.java
@@ -111,7 +111,7 @@ public abstract class AbstractScalarFunctionsTest extends CrateUnitTest {
         }
         Function function = (Function) functionSymbol;
         FunctionIdent ident = function.info().ident();
-        FunctionImplementation impl = functions.get(ident.name(), ident.argumentTypes());
+        FunctionImplementation impl = functions.getBuiltin(ident.name(), ident.argumentTypes());
         assertThat(impl, Matchers.notNullValue());
 
         Symbol normalized = sqlExpressions.normalize(function);
@@ -157,7 +157,7 @@ public abstract class AbstractScalarFunctionsTest extends CrateUnitTest {
         }
         Function function = (Function) functionSymbol;
         FunctionIdent ident = function.info().ident();
-        Scalar scalar = (Scalar) functions.getSafe(ident.name(), ident.argumentTypes());
+        Scalar scalar = (Scalar) functions.getBuiltin(ident.name(), ident.argumentTypes());
 
         InputApplierContext inputApplierContext = new InputApplierContext(inputs, sqlExpressions);
         AssertingInput[] arguments = new AssertingInput[function.arguments().size()];
@@ -183,7 +183,7 @@ public abstract class AbstractScalarFunctionsTest extends CrateUnitTest {
         assertThat("function expression was normalized, compile would not be hit", functionSymbol, not(instanceOf(Literal.class)));
         Function function = (Function) functionSymbol;
         FunctionIdent ident = function.info().ident();
-        Scalar scalar = (Scalar) functions.getSafe(ident.name(), ident.argumentTypes());
+        Scalar scalar = (Scalar) functions.getBuiltin(ident.name(), ident.argumentTypes());
         assert scalar != null : "function must be registered";
 
         Scalar compiled = scalar.compile(function.arguments());
@@ -208,7 +208,7 @@ public abstract class AbstractScalarFunctionsTest extends CrateUnitTest {
     @SuppressWarnings("unchecked")
     protected <T extends FunctionImplementation> T getFunction(String functionName, List<DataType> argTypes) {
 
-        return (T) functions.get(functionName, argTypes);
+        return (T) functions.getBuiltin(functionName, argTypes);
     }
 
     protected Symbol normalize(String functionName, Object value, DataType type) {
@@ -312,7 +312,8 @@ public abstract class AbstractScalarFunctionsTest extends CrateUnitTest {
                 return (Input) context.sqlExpressions.normalize(function);
             } catch (Exception e) {
                 FunctionIdent ident = function.info().ident();
-                Scalar scalar = (Scalar) context.sqlExpressions.functions().get(ident.name(), ident.argumentTypes());
+                Scalar scalar =
+                    (Scalar) context.sqlExpressions.functions().getBuiltin(ident.name(), ident.argumentTypes());
                 return new FunctionExpression<>(scalar, argInputs);
             }
         }

--- a/sql/src/test/java/io/crate/operation/scalar/ArrayCatFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/ArrayCatFunctionTest.java
@@ -47,7 +47,7 @@ public class ArrayCatFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testNullArguments() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Argument 2 of the array_cat function cannot be converted to array");
         assertEvaluate("array_cat([1, 2, 3], null)", null);
     }
@@ -114,7 +114,7 @@ public class ArrayCatFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testEmptyArrays() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("One of the arguments of the array_cat function can be of undefined inner type, but not both");
         assertNormalize("array_cat([], [])", null);
     }

--- a/sql/src/test/java/io/crate/operation/scalar/ArrayDifferenceFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/ArrayDifferenceFunctionTest.java
@@ -54,7 +54,7 @@ public class ArrayDifferenceFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testNormalizeNullArguments() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Argument 2 of the array_difference function is not an array type");
         assertNormalize("array_difference([1], null)", null);
     }
@@ -100,7 +100,7 @@ public class ArrayDifferenceFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testEmptyArrays() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("One of the arguments of the array_difference function can be of undefined inner type, but not both");
         assertNormalize("array_difference([], [])", null);
     }

--- a/sql/src/test/java/io/crate/operation/scalar/ArrayUniqueFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/ArrayUniqueFunctionTest.java
@@ -45,7 +45,7 @@ public class ArrayUniqueFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testNullArguments() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Argument 2 of the array_unique function cannot be converted to array");
         assertEvaluate("array_unique([1], null)", null);
     }
@@ -88,7 +88,7 @@ public class ArrayUniqueFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testDifferentUnconvertableInnerTypes() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Second argument's inner type (boolean) of the array_unique function " +
                                         "cannot be converted to the first argument's inner type (geo_point)");
         assertEvaluate("array_unique([geopoint], [true])", null);
@@ -106,7 +106,7 @@ public class ArrayUniqueFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testEmptyArrays() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("One of the arguments of the array_unique function can " +
                                         "be of undefined inner type, but not both");
         assertEvaluate("array_unique([], [])", null);
@@ -114,7 +114,7 @@ public class ArrayUniqueFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testEmptyArray() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage(
             "When used with only one argument, the inner type of the array argument cannot be undefined");
         assertEvaluate("array_unique([])", null);

--- a/sql/src/test/java/io/crate/operation/scalar/ConcatFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/ConcatFunctionTest.java
@@ -40,7 +40,7 @@ public class ConcatFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testArgumentThatHasNoStringRepr() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Argument 2 of the concat function can't be converted to string");
         assertNormalize("concat('foo', [1])", null);
     }
@@ -83,14 +83,14 @@ public class ConcatFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testTwoArraysOfIncompatibleInnerTypes() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Second argument's inner type (long_array) of the array_cat function cannot be converted to the first argument's inner type (long)");
         assertNormalize("concat([1, 2], [[1, 2]])", null);
     }
 
     @Test
     public void testTwoArraysOfUndefinedTypes() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("When concatenating arrays, one of the two arguments can be of undefined inner type, but not both");
         assertNormalize("concat([], [])", null);
     }

--- a/sql/src/test/java/io/crate/operation/scalar/SubscriptFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/SubscriptFunctionTest.java
@@ -21,11 +21,11 @@
 
 package io.crate.operation.scalar;
 
+import com.google.common.collect.ImmutableSet;
+import io.crate.analyze.symbol.Literal;
 import io.crate.types.DataTypes;
 import io.crate.types.SetType;
 import org.junit.Test;
-
-import java.util.Arrays;
 
 import static io.crate.testing.SymbolMatchers.isFunction;
 import static io.crate.testing.SymbolMatchers.isLiteral;
@@ -51,8 +51,11 @@ public class SubscriptFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testNotRegisteredForSets() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: subscript(integer_set, integer)");
-        functions.getSafe(SubscriptFunction.NAME, Arrays.asList(new SetType(DataTypes.INTEGER), DataTypes.INTEGER));
+        expectedException.expectMessage("unknown function: subscript(long_set, integer)");
+        assertEvaluate("subscript(long_set, a)", 3L,
+            Literal.of(ImmutableSet.of(3L, 7L), new SetType(DataTypes.LONG)),
+            Literal.of(DataTypes.INTEGER, 1)
+        );
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/scalar/arithmetic/AddFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/arithmetic/AddFunctionTest.java
@@ -31,6 +31,6 @@ public class AddFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testTimestampTypeValidation() throws Exception {
-        functions.get(AddFunction.NAME, Arrays.asList(DataTypes.TIMESTAMP, DataTypes.TIMESTAMP));
+        functions.getBuiltin(AddFunction.NAME, Arrays.asList(DataTypes.TIMESTAMP, DataTypes.TIMESTAMP));
     }
 }

--- a/sql/src/test/java/io/crate/operation/scalar/arithmetic/LogFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/arithmetic/LogFunctionTest.java
@@ -46,11 +46,11 @@ public class LogFunctionTest extends AbstractScalarFunctionsTest {
     private TransactionContext transactionContext = new TransactionContext(SessionContext.SYSTEM_SESSION);
 
     private LogFunction getFunction(String name, DataType value) {
-        return (LogFunction) functions.get(name, Arrays.asList(value));
+        return (LogFunction) functions.getBuiltin(name, Arrays.asList(value));
     }
 
     private LogFunction getFunction(String name, DataType value, DataType base) {
-        return (LogFunction) functions.get(name, Arrays.asList(value, base));
+        return (LogFunction) functions.getBuiltin(name, Arrays.asList(value, base));
     }
 
     private Symbol normalizeLog(Number value, DataType valueType) {

--- a/sql/src/test/java/io/crate/operation/scalar/arithmetic/RandomFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/arithmetic/RandomFunctionTest.java
@@ -42,7 +42,7 @@ public class RandomFunctionTest extends AbstractScalarFunctionsTest {
 
     @Before
     public void prepareRandom() {
-        random = (RandomFunction) functions.get(RandomFunction.NAME, Collections.emptyList());
+        random = (RandomFunction) functions.getBuiltin(RandomFunction.NAME, Collections.emptyList());
 
     }
 

--- a/sql/src/test/java/io/crate/operation/scalar/systeminformation/CurrentSchemaFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/systeminformation/CurrentSchemaFunctionTest.java
@@ -57,7 +57,7 @@ public class CurrentSchemaFunctionTest extends AbstractScalarFunctionsTest {
         expectedException.expectMessage("Cannot evaluate CURRENT_SCHEMA function.");
         Function function = (Function) sqlExpressions.asSymbol("current_schema()");
         FunctionIdent ident = function.info().ident();
-        Scalar impl = (Scalar) functions.get(ident.name(), ident.argumentTypes());
+        Scalar impl = (Scalar) functions.getBuiltin(ident.name(), ident.argumentTypes());
         impl.evaluate();
     }
 }

--- a/sql/src/test/java/io/crate/operation/tablefunctions/UnnestFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/tablefunctions/UnnestFunctionTest.java
@@ -60,7 +60,7 @@ public class UnnestFunctionTest extends CrateUnitTest {
         Function function = (Function) functionSymbol;
         FunctionIdent ident = function.info().ident();
         TableFunctionImplementation tableFunction = (TableFunctionImplementation)
-            functions.getSafe(ident.name(), ident.argumentTypes());
+            functions.getBuiltin(ident.name(), ident.argumentTypes());
         return tableFunction.execute(function.arguments().stream().map(a -> (Input) a).collect(Collectors.toList()));
     }
 


### PR DESCRIPTION
due to this refactoring calling builtin functions with invalid argument types raises `InvalidArgumentException` correctly (instead of `UnsupportedOperationException`).