### PR TITLE
Fix listener leak in PageDownstreamContext / BatchPagingIterator

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -15,6 +15,8 @@ the appropriate section of the docs.
 Changelog
 =========
 
+ - Fixed a race condition which could cause a memory leak
+
  - Updated documentation to indicate that it's not possible to use
     ``object``, ``geo_point``, ``geo_shape`` or ``array`` in the
     ``ORDER BY`` clause.

--- a/sql/src/main/java/io/crate/operation/merge/BatchPagingIterator.java
+++ b/sql/src/main/java/io/crate/operation/merge/BatchPagingIterator.java
@@ -145,6 +145,14 @@ public class BatchPagingIterator<Key> implements BatchIterator {
     }
 
     public void completeLoad(@Nullable Throwable t) {
+        if (currentlyLoading == null) {
+            if (t == null) {
+                killed = new IllegalStateException("completeLoad called without having called loadNextBatch");
+            } else {
+                killed = t;
+            }
+            return;
+        }
         if (t == null) {
             currentlyLoading.complete(null);
         } else {

--- a/sql/src/test/java/io/crate/operation/merge/BatchPagingIteratorTest.java
+++ b/sql/src/test/java/io/crate/operation/merge/BatchPagingIteratorTest.java
@@ -55,4 +55,19 @@ public class BatchPagingIteratorTest {
         });
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
     }
+
+    @Test
+    public void testCompleteLoadCanBeCalledWithoutHavingCalledLoadNextBatch() throws Exception {
+        PassThroughPagingIterator<Integer, Row> pagingIterator = PassThroughPagingIterator.repeatable();
+        BatchPagingIterator<Integer> iterator = new BatchPagingIterator<>(
+            pagingIterator,
+            exhaustedIt -> false,
+            () -> true,
+            () -> {
+            },
+            1
+        );
+        // must not throw an exception
+        iterator.completeLoad(new IllegalStateException("Dummy"));
+    }
 }


### PR DESCRIPTION
There was a race condition that would cause a NPE in
`BatchPagingIterator#completeLoad` which would prevent the listeners
from being released.

The race condition happened if:

 - There is a kill call on the PageDownstreamContext. This sets
   receivingFirstPage to false and invokes the consumer with a failure.
 - After the kill there is a failure call.
   This failure call leads to a call to `completeLoad` because the kill
   already invoked the consumer - but since the consumer was called with
   a failure the `loadNextBatch` call wasn't made so inside the
   BatchPagingIterator `currentlyLoading` is null.