### PR TITLE
Improve suspended portal close handling

### DIFF
--- a/sql/src/main/java/io/crate/action/sql/BatchConsumerToResultReceiver.java
+++ b/sql/src/main/java/io/crate/action/sql/BatchConsumerToResultReceiver.java
@@ -26,7 +26,6 @@ import io.crate.data.BatchConsumer;
 import io.crate.data.BatchIterator;
 import io.crate.data.Row;
 import io.crate.data.RowBridging;
-import io.crate.exceptions.JobKilledException;
 import io.crate.exceptions.SQLExceptions;
 
 import javax.annotation.Nullable;
@@ -88,10 +87,14 @@ public class BatchConsumerToResultReceiver implements BatchConsumer {
         }
     }
 
-    public void interruptIfResumable() {
+    /**
+     * If this consumer suspended itself (due to {@code maxRows} being > 0, it will close the BatchIterator
+     * and finish the ResultReceiver with interrupted=true.
+     */
+    public void closeAndFinishIfSuspended() {
         if (activeIt != null) {
-            activeIt.kill(new InterruptedException(JobKilledException.MESSAGE));
             activeIt.close();
+            resultReceiver.allFinished(true);
         }
     }
 

--- a/sql/src/main/java/io/crate/protocols/postgres/SimplePortal.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/SimplePortal.java
@@ -192,7 +192,7 @@ public class SimplePortal extends AbstractPortal {
     @Override
     public void close() {
         if (consumer != null) {
-            consumer.interruptIfResumable();
+            consumer.closeAndFinishIfSuspended();
         }
     }
 


### PR DESCRIPTION
This changes `interruptIfResumable` to `closeAndFinishIfSuspended` as it
wasn't interrupting an active operation, but instead it's closing a
previosly suspended operation.

This fixes
`testCloseConnectionWithUnfinishedResultSetDoesNotLeaveAnyPendingOperations`

The change in SimplePortal/BatchConsumerToResultReceiver reduced the
flakyness from ~10 failures in 100 runs to 1 failure in 1000 runs. The
`assertBusy` addition should prevent it from failing at all.