### PR TITLE
Remove outputSymbols from MultiSourceSelect

### DIFF
--- a/sql/src/main/java/io/crate/analyze/MultiSourceSelect.java
+++ b/sql/src/main/java/io/crate/analyze/MultiSourceSelect.java
@@ -21,7 +21,6 @@
 
 package io.crate.analyze;
 
-import com.google.common.collect.ImmutableList;
 import io.crate.analyze.relations.*;
 import io.crate.analyze.symbol.Field;
 import io.crate.analyze.symbol.Symbol;
@@ -39,15 +38,12 @@ public class MultiSourceSelect implements QueriedRelation {
     private final QuerySpec querySpec;
     private final Fields fields;
     private final List<JoinPair> joinPairs;
-    private final List<Symbol> outputSymbols;
     private QualifiedName qualifiedName;
 
     public MultiSourceSelect(Map<QualifiedName, AnalyzedRelation> sources,
-                             List<Symbol> outputSymbols,
                              Collection<? extends Path> outputNames,
                              QuerySpec querySpec,
                              List<JoinPair> joinPairs) {
-        this.outputSymbols = ImmutableList.copyOf(outputSymbols);
         assert sources.size() > 1 : "MultiSourceSelect requires at least 2 relations";
         this.splitter = new RelationSplitter(querySpec, sources.values(), joinPairs);
         this.sources = initializeSources(sources);
@@ -129,9 +125,5 @@ public class MultiSourceSelect implements QueriedRelation {
 
     public Optional<RemainingOrderBy> remainingOrderBy() {
         return splitter.remainingOrderBy();
-    }
-
-    public List<Symbol> outputSymbols() {
-        return outputSymbols;
     }
 }

--- a/sql/src/main/java/io/crate/analyze/Rewriter.java
+++ b/sql/src/main/java/io/crate/analyze/Rewriter.java
@@ -69,7 +69,6 @@ public class Rewriter {
      */
     public static void tryRewriteOuterToInnerJoin(EvaluatingNormalizer normalizer,
                                                   JoinPair joinPair,
-                                                  List<Symbol> mssOutputSymbols,
                                                   QuerySpec multiSourceQuerySpec,
                                                   QualifiedName left,
                                                   QualifiedName right,
@@ -126,7 +125,6 @@ public class Rewriter {
                 } else {
                     applyOuterJoinRewrite(
                         joinPair,
-                        mssOutputSymbols,
                         multiSourceQuerySpec,
                         outerSpec,
                         outerRelation,
@@ -139,14 +137,13 @@ public class Rewriter {
     }
 
     private static void applyOuterJoinRewrite(JoinPair joinPair,
-                                              List<Symbol> mssOutputSymbols,
                                               QuerySpec multiSourceQuerySpec,
                                               QuerySpec outerSpec,
                                               QualifiedName outerRelation,
                                               Map<Set<QualifiedName>, Symbol> splitQueries,
                                               Symbol outerRelationQuery) {
         RemoveFieldsNotToCollectFunction removeFieldsNotToCollectFunction =
-            new RemoveFieldsNotToCollectFunction(outerRelation, mssOutputSymbols, joinPair.condition());
+            new RemoveFieldsNotToCollectFunction(outerRelation, multiSourceQuerySpec.outputs(), joinPair.condition());
         outerSpec.where(outerSpec.where().add(Symbols.replaceField(
             outerRelationQuery,
             removeFieldsNotToCollectFunction)));

--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -224,7 +224,6 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
         } else {
             relation = new MultiSourceSelect(
                 context.sources(),
-                selectAnalysis.outputSymbols(),
                 selectAnalysis.outputNames(),
                 querySpec,
                 context.joinPairs()

--- a/sql/src/main/java/io/crate/analyze/relations/RelationNormalizer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationNormalizer.java
@@ -362,7 +362,6 @@ final class RelationNormalizer {
             querySpec = mergeQuerySpec(querySpec, context.currentParentQSpec);
             // must create a new MultiSourceSelect because paths and query spec changed
             return new MultiSourceSelect(mapSourceRelations(multiSourceSelect),
-                multiSourceSelect.outputSymbols(),
                 context.paths(),
                 querySpec,
                 multiSourceSelect.joinPairs());
@@ -409,8 +408,10 @@ final class RelationNormalizer {
             QuerySpec querySpec = mss.querySpec();
             querySpec.normalize(context.normalizer, context.transactionContext);
             // must create a new MultiSourceSelect because paths and query spec changed
-            mss = new MultiSourceSelect(mapSourceRelations(mss),
-                mss.outputSymbols(), context.paths(), querySpec,
+            mss = new MultiSourceSelect(
+                mapSourceRelations(mss),
+                context.paths(),
+                querySpec,
                 mss.joinPairs());
             mss.pushDownQuerySpecs();
             if (mss.sources().size() == 2) {
@@ -422,7 +423,6 @@ final class RelationNormalizer {
                 Rewriter.tryRewriteOuterToInnerJoin(
                     context.normalizer,
                     JoinPairs.ofRelationsWithMergedConditions(left, right, mss.joinPairs(), false),
-                    mss.outputSymbols(),
                     mss.querySpec(),
                     left,
                     right,


### PR DESCRIPTION
Having separate outputSymbols is confusing as they were the same thing
as the outputs of the QuerySpec.