### PR TITLE
Fix SplitPoints leaves creation & clarify SplitPoints contents

### DIFF
--- a/sql/src/main/java/io/crate/analyze/symbol/DefaultTraversalSymbolVisitor.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/DefaultTraversalSymbolVisitor.java
@@ -23,19 +23,25 @@ package io.crate.analyze.symbol;
 
 public abstract class DefaultTraversalSymbolVisitor<C, R> extends SymbolVisitor<C, R> {
 
+    /*
+     * These methods don't call into super to enable subclasses to use overwrite `visitSymbol` to visit all leaves.
+     * If we called super.visitXY here,
+     * it would cause visitSymbol to be called for Function, FetchReference and MatchPredicate as well.
+     */
+
     @Override
     public R visitFunction(Function symbol, C context) {
         for (Symbol arg : symbol.arguments()) {
             process(arg, context);
         }
-        return super.visitFunction(symbol, context);
+        return null;
     }
 
     @Override
     public R visitFetchReference(FetchReference fetchReference, C context) {
         process(fetchReference.fetchId(), context);
         process(fetchReference.ref(), context);
-        return super.visitFetchReference(fetchReference, context);
+        return null;
     }
 
     @Override
@@ -43,6 +49,6 @@ public abstract class DefaultTraversalSymbolVisitor<C, R> extends SymbolVisitor<
         for (Field field : matchPredicate.identBoostMap().keySet()) {
             process(field, context);
         }
-        return super.visitMatchPredicate(matchPredicate, context);
+        return null;
     }
 }

--- a/sql/src/main/java/io/crate/planner/projection/builder/SplitPoints.java
+++ b/sql/src/main/java/io/crate/planner/projection/builder/SplitPoints.java
@@ -31,6 +31,17 @@ import java.util.ArrayList;
 /**
  * SplitPoints contain a separated representation of aggregations, leaves and toCollect (aggregation sources).
  * They can be created from a QuerySpec which contains aggregations.
+ * <pre>
+ *     Example:
+ *
+ *     Input QuerySpec:
+ *       outputs: [add(sum(coalesce(x, 10)), 10)]
+ *
+ *     SplitPoints:
+ *       aggregations:  [sum(coalesce(x, 10))]
+ *       toCollect:     [coalesce(x, 10)]
+ *       leaves:        [x, 10]
+ * </pre>
  */
 public class SplitPoints {
 

--- a/sql/src/test/java/io/crate/planner/projection/builder/SplitPointsTest.java
+++ b/sql/src/test/java/io/crate/planner/projection/builder/SplitPointsTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.projection.builder;
+
+import io.crate.analyze.AnalyzedStatement;
+import io.crate.analyze.SelectAnalyzedStatement;
+import io.crate.analyze.relations.QueriedRelation;
+import io.crate.testing.SQLExecutor;
+import io.crate.testing.T3;
+import org.elasticsearch.test.cluster.NoopClusterService;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import static io.crate.testing.SymbolMatchers.*;
+import static org.junit.Assert.assertThat;
+
+public class SplitPointsTest {
+
+    @Test
+    public void testSplitPointsCreationWithFunctionInAggregation() throws Exception {
+        SQLExecutor e = SQLExecutor.builder(new NoopClusterService()).addDocTable(T3.T1_INFO).build();
+
+        AnalyzedStatement analyze = e.analyze("select sum(coalesce(x, 0::integer)) + 10 from t1");
+        QueriedRelation relation = ((SelectAnalyzedStatement) analyze).relation();
+
+        SplitPoints splitPoints = SplitPoints.create(relation.querySpec());
+
+        //noinspection unchecked
+        assertThat(splitPoints.leaves(), Matchers.contains(isReference("x"), isLiteral(0)));
+        assertThat(splitPoints.toCollect(), Matchers.contains(isFunction("coalesce")));
+        assertThat(splitPoints.aggregates(), Matchers.contains(isFunction("sum")));
+    }
+}


### PR DESCRIPTION
The `leaves` in the SplitPoints also included the parent function of the
leaves.
For example in `sum(coalesce(x, 10))` the leaves included all three:
coalesce, x and 10, instead of only x and 10.