### PR TITLE
Remove Context class from FieldCollectingVisitor

### DIFF
--- a/sql/src/main/java/io/crate/analyze/relations/FieldCollectingVisitor.java
+++ b/sql/src/main/java/io/crate/analyze/relations/FieldCollectingVisitor.java
@@ -22,70 +22,33 @@
 
 package io.crate.analyze.relations;
 
-import com.google.common.base.Predicate;
-import com.google.common.base.Predicates;
-import com.google.common.base.Supplier;
 import com.google.common.collect.Multimap;
-import com.google.common.collect.Multimaps;
 import io.crate.analyze.symbol.DefaultTraversalSymbolVisitor;
 import io.crate.analyze.symbol.Field;
 import io.crate.analyze.symbol.Symbol;
 
-import javax.annotation.Nullable;
-import java.util.Collection;
-import java.util.IdentityHashMap;
-import java.util.LinkedHashSet;
-import java.util.Set;
+final class FieldCollectingVisitor extends DefaultTraversalSymbolVisitor<Multimap<AnalyzedRelation, ? super Field>, Void> {
 
-class FieldCollectingVisitor extends DefaultTraversalSymbolVisitor<FieldCollectingVisitor.Context, Void> {
-
-    private static final Supplier<Set<Symbol>> FIELD_SET_SUPPLIER = new Supplier<Set<Symbol>>() {
-        @Override
-        public Set<Symbol> get() {
-            // a LinkedHashSet is required for deterministic output order
-            return new LinkedHashSet<>();
-        }
-    };
-
-    public static class Context {
-        final Multimap<AnalyzedRelation, Symbol> fields;
-        final Predicate<Symbol> skipIf;
-
-        public Context(int expectedNumRelations, Predicate<Symbol> skipIf) {
-            fields = Multimaps.newSetMultimap(
-                new IdentityHashMap<AnalyzedRelation, Collection<Symbol>>(expectedNumRelations),
-                FIELD_SET_SUPPLIER);
-            this.skipIf = skipIf;
-        }
-
-        public Context(int expectedNumRelations) {
-            this(expectedNumRelations, Predicates.<Symbol>alwaysFalse());
-        }
-    }
+    private static final FieldCollectingVisitor INSTANCE = new FieldCollectingVisitor();
 
     private FieldCollectingVisitor() {
     }
 
-    public static final FieldCollectingVisitor INSTANCE = new FieldCollectingVisitor();
-
-    @Override
-    public Void process(Symbol symbol, @Nullable Context context) {
-        assert context != null : "context must not be null";
-        if (!context.skipIf.apply(symbol)) {
-            super.process(symbol, context);
-        }
-        return null;
+    public static void collectFields(Symbol symbol,
+                                     Multimap<AnalyzedRelation, ? super Field> fieldsByRelation) {
+        INSTANCE.process(symbol, fieldsByRelation);
     }
 
-    public void process(Iterable<? extends Symbol> symbols, FieldCollectingVisitor.Context context) {
+    public static void collectFields(Iterable<? extends Symbol> symbols,
+                                     Multimap<AnalyzedRelation, ? super Field> fieldsByRelation) {
         for (Symbol symbol : symbols) {
-            process(symbol, context);
+            INSTANCE.process(symbol, fieldsByRelation);
         }
     }
 
     @Override
-    public Void visitField(Field field, FieldCollectingVisitor.Context context) {
-        context.fields.put(field.relation(), field);
+    public Void visitField(Field field, Multimap<AnalyzedRelation, ? super Field> fieldsByRelation) {
+        fieldsByRelation.put(field.relation(), field);
         return null;
     }
 }


### PR DESCRIPTION
skipIf was always `s -> false` so it was possible to remove it - and
once removed the Context class became unnecessary.