### PR TITLE
Remove dubious FilterProjection constructor

### DIFF
--- a/sql/src/main/java/io/crate/analyze/symbol/InputColumn.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/InputColumn.java
@@ -30,6 +30,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -48,10 +49,12 @@ public class InputColumn extends Symbol implements Comparable<InputColumn> {
         return inputColumns;
     }
 
-    public static List<Symbol> fromSymbols(List<? extends Symbol> symbols) {
+    public static List<Symbol> fromSymbols(Collection<? extends Symbol> symbols) {
         List<Symbol> inputColumns = new ArrayList<>(symbols.size());
-        for (int i = 0; i < symbols.size(); i++) {
-            inputColumns.add(new InputColumn(i, symbols.get(i).valueType()));
+        int idx = 0;
+        for (Symbol symbol : symbols) {
+            inputColumns.add(new InputColumn(idx, symbol.valueType()));
+            idx++;
         }
         return inputColumns;
     }

--- a/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
@@ -36,7 +36,6 @@ import io.crate.planner.node.dql.MergePhase;
 import io.crate.planner.node.dql.join.JoinType;
 import io.crate.planner.node.dql.join.NestedLoop;
 import io.crate.planner.node.dql.join.NestedLoopPhase;
-import io.crate.planner.projection.FilterProjection;
 import io.crate.planner.projection.Projection;
 import io.crate.planner.projection.builder.InputCreatingVisitor;
 import io.crate.planner.projection.builder.ProjectionBuilder;
@@ -242,10 +241,7 @@ class NestedLoopConsumer implements Consumer {
             List<Projection> projections = new ArrayList<>();
 
             if (filterNeeded) {
-                InputCreatingVisitor.Context inputVisitorContext = new InputCreatingVisitor.Context(nlOutputs);
-                Symbol filterSymbol = InputCreatingVisitor.INSTANCE.process(where.query(), inputVisitorContext);
-                assert filterSymbol instanceof Function : "Only function symbols are allowed for filtering";
-                projections.add(new FilterProjection(filterSymbol));
+                projections.add(ProjectionBuilder.filterProjection(nlOutputs, where));
             }
             if (joinCondition != null) {
                 InputCreatingVisitor.Context inputVisitorContext = new InputCreatingVisitor.Context(nlOutputs);

--- a/sql/src/main/java/io/crate/planner/projection/FilterProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/FilterProjection.java
@@ -40,6 +40,17 @@ public class FilterProjection extends Projection {
     private List<Symbol> outputs = ImmutableList.of();
     private RowGranularity requiredGranularity = RowGranularity.CLUSTER;
 
+    public FilterProjection(Symbol query, List<Symbol> outputs) {
+        this.query = query;
+        this.outputs = outputs;
+    }
+
+    public FilterProjection(StreamInput in) throws IOException {
+        query = Symbols.fromStream(in);
+        outputs = Symbols.listFromStream(in);
+        requiredGranularity = RowGranularity.fromStream(in);
+    }
+
     @Override
     public RowGranularity requiredGranularity() {
         return requiredGranularity;
@@ -53,21 +64,6 @@ public class FilterProjection extends Projection {
 
     public void requiredGranularity(RowGranularity requiredRowGranularity) {
         this.requiredGranularity = requiredRowGranularity;
-    }
-
-    public FilterProjection(Symbol query) {
-        this.query = query;
-    }
-
-    public FilterProjection(Symbol query, List<Symbol> outputs) {
-        this(query);
-        this.outputs = outputs;
-    }
-
-    public FilterProjection(StreamInput in) throws IOException {
-        query = Symbols.fromStream(in);
-        outputs = Symbols.listFromStream(in);
-        requiredGranularity = RowGranularity.fromStream(in);
     }
 
     public Symbol query() {

--- a/sql/src/main/java/io/crate/planner/projection/builder/ProjectionBuilder.java
+++ b/sql/src/main/java/io/crate/planner/projection/builder/ProjectionBuilder.java
@@ -113,8 +113,8 @@ public class ProjectionBuilder {
         } else {
             query = Literal.BOOLEAN_TRUE;
         }
-        List<Symbol> outputs = inputVisitor.process(inputs, context);
-        return new FilterProjection(query, outputs);
+        // FilterProjection can only pass-through rows as is; create inputColumns which preserve the type:
+        return new FilterProjection(query, InputColumn.fromSymbols(inputs));
     }
 
     /**


### PR DESCRIPTION
We allowed the creation of a FilterProjection without specifying outputs
and used that in the NL-Plan creation. It didn't matter there because we
never looked at these outputs but it isn't correct.

A FilterProjection (or any projection) should always have outputs. Even
if there would be a valid reason for them to be empty, this should be explicit.