### PR TITLE
Tests: Adapt T3 Routing to match node-name used in testing clusterService

### DIFF
--- a/integration-testing/src/main/java/io/crate/test/integration/CrateDummyClusterServiceUnitTest.java
+++ b/integration-testing/src/main/java/io/crate/test/integration/CrateDummyClusterServiceUnitTest.java
@@ -47,6 +47,8 @@ import java.util.concurrent.TimeUnit;
 
 public class CrateDummyClusterServiceUnitTest extends CrateUnitTest {
 
+    public static final String NODE_ID = "node";
+
     private static final Set<Setting<?>> EMPTY_CLUSTER_SETTINGS = ImmutableSet.of();
 
     protected static ThreadPool THREAD_POOL;
@@ -84,7 +86,7 @@ public class CrateDummyClusterServiceUnitTest extends CrateUnitTest {
         clusterSettings.addAll(additionalClusterSettings);
         DiscoveryNode discoveryNode = new DiscoveryNode(
             "node-name",
-            "node",
+            NODE_ID,
             LocalTransportAddress.buildUnique(),
             Collections.emptyMap(),
             new HashSet<>(Arrays.asList(DiscoveryNode.Role.values())),

--- a/sql/src/test/java/io/crate/planner/SingleRowSubselectPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/SingleRowSubselectPlannerTest.java
@@ -46,10 +46,8 @@ public class SingleRowSubselectPlannerTest extends CrateDummyClusterServiceUnitT
     @Test
     public void testPlanSimpleSelectWithSingleRowSubSelectInWhereClause() throws Exception {
         QueryThenFetch qtf = e.plan("select x from t1 where a = (select b from t2)");
-        assertThat(qtf.subPlan(), instanceOf(Merge.class));
-
-        Merge merge = (Merge) qtf.subPlan();
-        MultiPhasePlan multiPhasePlan = (MultiPhasePlan) merge.subPlan();
+        assertThat(qtf.subPlan(), instanceOf(MultiPhasePlan.class));
+        MultiPhasePlan multiPhasePlan = (MultiPhasePlan) qtf.subPlan();
         assertThat(multiPhasePlan.dependencies().keySet(), contains(instanceOf(QueryThenFetch.class)));
     }
 
@@ -62,12 +60,11 @@ public class SingleRowSubselectPlannerTest extends CrateDummyClusterServiceUnitT
 
     @Test
     public void testSingleRowSubSelectInSelectList() throws Exception {
-        Merge merge = e.plan("select (select b from t2 limit 1) from t1");
-        MultiPhasePlan plan = (MultiPhasePlan) merge.subPlan();
+        MultiPhasePlan plan = e.plan("select (select b from t2 limit 1) from t1");
 
         assertThat(plan.rootPlan(), instanceOf(Collect.class));
         assertThat(plan.dependencies().keySet(), contains(instanceOf(QueryThenFetch.class)));
-        assertThat(((QueryThenFetch) plan.dependencies().keySet().iterator().next()).subPlan(), instanceOf(Merge.class));
+        assertThat(((QueryThenFetch) plan.dependencies().keySet().iterator().next()).subPlan(), instanceOf(Collect.class));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/testing/T3.java
+++ b/sql/src/test/java/io/crate/testing/T3.java
@@ -33,30 +33,30 @@ import io.crate.metadata.TableIdent;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.TestingTableInfo;
 import io.crate.sql.tree.QualifiedName;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.types.ArrayType;
 import io.crate.types.DataTypes;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 public class T3 {
 
     private static final Routing t1Routing = new Routing(
-        ImmutableMap.<String, Map<String, List<Integer>>>of("noop_id",
+        ImmutableMap.of(CrateDummyClusterServiceUnitTest.NODE_ID,
             ImmutableMap.of("t1", Collections.singletonList(0))));
 
     private static final Routing t2Routing = new Routing(
-        ImmutableMap.<String, Map<String, List<Integer>>>of("noop_id",
+        ImmutableMap.of(CrateDummyClusterServiceUnitTest.NODE_ID,
             ImmutableMap.of("t2", Arrays.asList(0, 1))));
 
     private static final Routing t3Routing = new Routing(
-        ImmutableMap.<String, Map<String, List<Integer>>>of("noop_id",
+        ImmutableMap.of(CrateDummyClusterServiceUnitTest.NODE_ID,
             ImmutableMap.of("t3", Arrays.asList(0, 1, 2))));
 
     private static final Routing t4Routing = new Routing(
-        ImmutableMap.<String, Map<String, List<Integer>>>of("noop_id",
+        ImmutableMap.of(CrateDummyClusterServiceUnitTest.NODE_ID,
             ImmutableMap.of("t4", Collections.singletonList(0))));
 
     public static final DocTableInfo T1_INFO = new TestingTableInfo.Builder(new TableIdent(null, "t1"), t1Routing)


### PR DESCRIPTION
Unittests that use T3 should still result in "single-node"
execution-plans. For that to work the nodeId used in the routing needs
to match the nodeId that is part of the clusterState.

Ideally we'd generate the routing based on the clusterState, but that
takes a bit more effort to do.

(Noticed this as I wanted to rebase https://github.com/crate/crate/pull/5303)