### PR TITLE
Tests: Fix flaky testUpdateWithExpressionAndRelocatedShard

### DIFF
--- a/sql/src/test/java/io/crate/integrationtests/RemoteCollectorIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/RemoteCollectorIntegrationTest.java
@@ -72,7 +72,7 @@ public class RemoteCollectorIntegrationTest extends SQLTransportIntegrationTest 
 
         client().admin().cluster().prepareHealth("t")
             .setWaitForEvents(Priority.LANGUID)
-            .setWaitForNoRelocatingShards(false)
+            .setWaitForNoRelocatingShards(true)
             .setTimeout(TimeValue.timeValueSeconds(5)).execute().actionGet();
 
         execute(plan).getResult();


### PR DESCRIPTION
It didn't wait for relocation, so it didn't test the RemoteCollector and
was flaky because it could hit a stale relocating-replica.