### PR TITLE
Enterprise first

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -15,6 +15,8 @@ the appropriate section of the docs.
 Breaking Changes
 ================
 
+ - The ``license.enterprise`` setting is set to ``true`` by default.
+
  - Parsing support of time values has been changed:
 
    - The unit ``w`` representing weeks is no longer supported.
@@ -93,6 +95,9 @@ Breaking Changes
 
 Changes
 =======
+
+ - Added ``license.ident`` setting, and a cluster check for unlicensed
+   ``Enterprise Edition``.
 
  - Updated the ``admin-ui`` to ``1.2.3`` which includes the following change:
 

--- a/app/src/main/dist/config/crate.yml
+++ b/app/src/main/dist/config/crate.yml
@@ -46,8 +46,8 @@
 
 ############################# Enterprise Features #############################
 
-# Setting this to `true` enables the Enterprise Edition of CrateDB.
-#license.enterprise: false
+# Setting this to `false` disabled the Enterprise Edition of CrateDB.
+#license.enterprise: true
 
 # To enable or use any of the enterprise features, Crate.io must have given you
 # permission to enable and use the Enterprise Edition of CrateDB (see

--- a/blackbox/docs/best_practice/systables.txt
+++ b/blackbox/docs/best_practice/systables.txt
@@ -91,7 +91,7 @@ available data, run::
     +--------------------------------------------------------------------------------...+-----------...+
     ...
     +--------------------------------------------------------------------------------...+-----------...+
-    SHOW 106 rows in set (... sec)
+    SHOW 107 rows in set (... sec)
 
 While **sys.cluster** contains information about the cluster as a whole,
 **sys.nodes** maintains more detailed information about each Crate

--- a/blackbox/docs/configuration.txt
+++ b/blackbox/docs/configuration.txt
@@ -1857,13 +1857,6 @@ Enterprise License
 
   Setting this to ``false`` disabled the `Enterprise Edition`_ of CrateDB.
 
-**license.ident**
-  | *Default:*  ``null``
-  | *Runtime:*  ``yes``
-
-  Setting this to the licence key delivered to you by Crate.io activates
-  the `Enterprise Edition`_ of CrateDB.
-
 .. NOTE::
 
    To enable or use any of the enterprise features, Crate.io must have given

--- a/blackbox/docs/configuration.txt
+++ b/blackbox/docs/configuration.txt
@@ -1857,6 +1857,13 @@ Enterprise License
 
   Setting this to ``false`` disabled the `Enterprise Edition`_ of CrateDB.
 
+**license.ident**
+  | *Default:*  ``null``
+  | *Runtime:*  ``yes``
+
+  Setting this to the licence key delivered to you by Crate.io activates
+  the `Enterprise Edition`_ of CrateDB.
+
 .. NOTE::
 
    To enable or use any of the enterprise features, Crate.io must have given

--- a/blackbox/docs/configuration.txt
+++ b/blackbox/docs/configuration.txt
@@ -1852,10 +1852,10 @@ Enterprise License
 ------------------
 
 **license.enterprise**
-  | *Default:*  ``false``
+  | *Default:*  ``true``
   | *Runtime:*  ``no``
 
-  Setting this to ``true`` enables the `Enterprise Edition`_ of CrateDB.
+  Setting this to ``false`` disabled the `Enterprise Edition`_ of CrateDB.
 
 .. NOTE::
 

--- a/blackbox/docs/sql/system.txt
+++ b/blackbox/docs/sql/system.txt
@@ -1135,8 +1135,9 @@ Here's an example query::
   |  1 | The setting 'discovery.zen.minimum_master_nodes' must not be ... |
   |  2 | The total number of partitions of one or more partitioned tab... |
   |  3 | The following tables need to be upgraded for compatibility wi... |
+  |  4 | You are currently using the Enterprise Edition, but have not ... |
   +----+--------------------------------------------------------------...-+
-  SELECT 3 rows in set (... sec)
+  SELECT 4 rows in set (... sec)
 
 Cluster checks are also indicated in the CrateDB `admin console`_. When all
 cluster checks (and all :ref:`sys-node-checks`) pass, the *Checks* icon will be

--- a/blackbox/docs/sql/system.txt
+++ b/blackbox/docs/sql/system.txt
@@ -163,6 +163,7 @@ currently applied cluster settings.
     | settings['indices']['store']['throttle']['type']                                  | string       |
     | settings['license']                                                               | object       |
     | settings['license']['enterprise']                                                 | boolean      |
+    | settings['license']['ident']                                                      | string       |
     | settings['logger']                                                                | object_array |
     | settings['logger']['level']                                                       | string       |
     | settings['logger']['name']                                                        | string       |

--- a/core/src/main/java/io/crate/module/CrateCoreModule.java
+++ b/core/src/main/java/io/crate/module/CrateCoreModule.java
@@ -25,6 +25,7 @@ package io.crate.module;
 import io.crate.ClusterIdService;
 import io.crate.plugin.IndexEventListenerProxy;
 import io.crate.rest.CrateRestMainAction;
+import io.crate.settings.SharedSettings;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.inject.AbstractModule;
 import org.elasticsearch.common.inject.TypeLiteral;
@@ -46,6 +47,10 @@ public class CrateCoreModule extends AbstractModule {
     public CrateCoreModule(Settings settings, IndexEventListenerProxy indexEventListenerProxy) {
         logger = Loggers.getLogger(getClass().getPackage().getName(), settings);
         this.indexEventListenerProxy = indexEventListenerProxy;
+        if (settings.getAsBoolean("license.enterprise", false) &&
+            "".equals(settings.get("license.ident",""))){
+            logger.warn("You are using an unlicensed version of CrateDB Enterprise Edition");
+        }
     }
 
     @Override

--- a/core/src/main/java/io/crate/settings/SharedSettings.java
+++ b/core/src/main/java/io/crate/settings/SharedSettings.java
@@ -31,4 +31,7 @@ public class SharedSettings {
         "license.enterprise", true,
         Setting.Property.NodeScope), DataTypes.BOOLEAN);
 
+    public static final CrateSetting<String> LICENSE_IDENT_SETTING = CrateSetting.of(Setting.simpleString(
+        "license.ident", Setting.Property.NodeScope, Setting.Property.Dynamic), DataTypes.STRING);
+
 }

--- a/core/src/main/java/io/crate/settings/SharedSettings.java
+++ b/core/src/main/java/io/crate/settings/SharedSettings.java
@@ -28,7 +28,7 @@ import org.elasticsearch.common.settings.Setting;
 public class SharedSettings {
 
     public static final CrateSetting<Boolean> ENTERPRISE_LICENSE_SETTING = CrateSetting.of(Setting.boolSetting(
-        "license.enterprise", false,
+        "license.enterprise", true,
         Setting.Property.NodeScope), DataTypes.BOOLEAN);
 
 }

--- a/sql/src/main/java/io/crate/metadata/settings/CrateSettings.java
+++ b/sql/src/main/java/io/crate/metadata/settings/CrateSettings.java
@@ -102,7 +102,8 @@ public class CrateSettings implements ClusterStateListener {
             PostgresNetty.PSQL_PORT_SETTING,
 
             // ENTERPRISE
-            SharedSettings.ENTERPRISE_LICENSE_SETTING
+            SharedSettings.ENTERPRISE_LICENSE_SETTING,
+            SharedSettings.LICENSE_IDENT_SETTING
         ));
 
     private static final List<CrateSetting> EXPOSED_ES_SETTINGS = Collections.unmodifiableList(

--- a/sql/src/main/java/io/crate/operation/reference/sys/check/SysChecksModule.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/check/SysChecksModule.java
@@ -21,6 +21,7 @@
 
 package io.crate.operation.reference.sys.check;
 
+import io.crate.operation.reference.sys.check.cluster.LicenseEnterpriseChecks;
 import io.crate.operation.reference.sys.check.cluster.MinMasterNodesSysCheck;
 import io.crate.operation.reference.sys.check.cluster.NumberOfPartitionsSysCheck;
 import io.crate.operation.reference.sys.check.cluster.TablesNeedUpgradeSysCheck;
@@ -35,5 +36,6 @@ public class SysChecksModule extends AbstractModule {
         checksBinder.addBinding().to(MinMasterNodesSysCheck.class);
         checksBinder.addBinding().to(NumberOfPartitionsSysCheck.class);
         checksBinder.addBinding().to(TablesNeedUpgradeSysCheck.class);
+        checksBinder.addBinding().to(LicenseEnterpriseChecks.class);
     }
 }

--- a/sql/src/main/java/io/crate/operation/reference/sys/check/cluster/LicenseEnterpriseChecks.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/check/cluster/LicenseEnterpriseChecks.java
@@ -30,7 +30,7 @@ import org.elasticsearch.common.settings.Settings;
 
 @Singleton
 public class LicenseEnterpriseChecks extends AbstractSysCheck {
-    private static final int ID = 5;
+    private static final int ID = 4;
     private static final String DESCRIPTION = "You are currently using the Enterprise Edition, " +
         "but have not configured a licence. Please configure a license or deactivate the Enterprise Edition.";
 

--- a/sql/src/main/java/io/crate/operation/reference/sys/check/cluster/LicenseEnterpriseChecks.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/check/cluster/LicenseEnterpriseChecks.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to Crate.IO GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.operation.reference.sys.check.cluster;
+
+import io.crate.operation.reference.sys.check.AbstractSysCheck;
+import io.crate.settings.SharedSettings;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Settings;
+
+@Singleton
+public class LicenseEnterpriseChecks extends AbstractSysCheck {
+    private static final int ID = 5;
+    private static final String DESCRIPTION = "You are currently using the Enterprise Edition, " +
+        "but have not configured a licence. Please configure a license or deactivate the Enterprise Edition.";
+
+    private final boolean licenseEnterprise;
+    private String licenseIdent;
+
+    @Inject
+    public LicenseEnterpriseChecks(ClusterSettings clusterSettings, Settings settings) {
+        super(ID, DESCRIPTION, Severity.HIGH);
+        licenseIdent = SharedSettings.LICENSE_IDENT_SETTING.setting().get(settings);
+        clusterSettings.addSettingsUpdateConsumer(SharedSettings.LICENSE_IDENT_SETTING.setting(), this::setLicenseIdent);
+        licenseEnterprise = SharedSettings.ENTERPRISE_LICENSE_SETTING.setting().get(settings);
+    }
+
+    public void setLicenseIdent(String licenseIdent) {
+        this.licenseIdent = licenseIdent;
+    }
+
+    @Override
+    public boolean validate() {
+        return licenseEnterprise && (licenseIdent != null && !"".equals(licenseIdent));
+    }
+}

--- a/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -452,7 +452,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultColumns() throws Exception {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(380, response.rowCount());
+        assertEquals(381, response.rowCount());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/SysCheckerIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysCheckerIntegrationTest.java
@@ -80,7 +80,7 @@ public class SysCheckerIntegrationTest extends SQLTransportIntegrationTest {
         Settings settings = Settings.builder().put("license.enterprise", true).build();
         internalCluster().startNode(settings);
         internalCluster().startNode(settings);
-        SQLResponse response = execute("select severity, passed from sys.checks where id=?", new Object[]{5});
+        SQLResponse response = execute("select severity, passed from sys.checks where id=?", new Object[]{4});
         assertThat(TestingHelpers.printedTable(response.rows()), is("3| false\n"));
     }
 
@@ -91,7 +91,7 @@ public class SysCheckerIntegrationTest extends SQLTransportIntegrationTest {
             .put("license.ident", "").build();
         internalCluster().startNode(settings);
         internalCluster().startNode(settings);
-        SQLResponse response = execute("select severity, passed from sys.checks where id=?", new Object[]{5});
+        SQLResponse response = execute("select severity, passed from sys.checks where id=?", new Object[]{4});
         assertThat(TestingHelpers.printedTable(response.rows()), is("3| false\n"));
     }
 
@@ -102,7 +102,7 @@ public class SysCheckerIntegrationTest extends SQLTransportIntegrationTest {
             .put("license.ident", "my-awesome-key").build();
         internalCluster().startNode(settings);
         internalCluster().startNode(settings);
-        SQLResponse response = execute("select severity, passed from sys.checks where id=?", new Object[]{5});
+        SQLResponse response = execute("select severity, passed from sys.checks where id=?", new Object[]{4});
         assertThat(TestingHelpers.printedTable(response.rows()), is("3| true\n"));
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/SysCheckerIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysCheckerIntegrationTest.java
@@ -40,7 +40,7 @@ public class SysCheckerIntegrationTest extends SQLTransportIntegrationTest {
     public void testChecksPresenceAndSeverityLevels() throws Exception {
         internalCluster().startNode();
         SQLResponse response = execute("select severity, passed from sys.checks order by id asc");
-        assertThat(response.rowCount(), equalTo(3L));
+        assertThat(response.rowCount(), equalTo(4L));
         assertThat(response.rows()[0][0], is(Severity.HIGH.value()));
         assertThat(response.rows()[1][0], is(Severity.MEDIUM.value()));
         assertThat(response.rows()[2][0], is(Severity.MEDIUM.value()));
@@ -74,4 +74,36 @@ public class SysCheckerIntegrationTest extends SQLTransportIntegrationTest {
         SQLResponse response = execute("select severity, passed from sys.checks where id=?", new Object[]{2});
         assertThat(TestingHelpers.printedTable(response.rows()), is("2| true\n"));
     }
+
+    @Test
+    public void testUnlicencedEnterpriseCheck() {
+        Settings settings = Settings.builder().put("license.enterprise", true).build();
+        internalCluster().startNode(settings);
+        internalCluster().startNode(settings);
+        SQLResponse response = execute("select severity, passed from sys.checks where id=?", new Object[]{5});
+        assertThat(TestingHelpers.printedTable(response.rows()), is("3| false\n"));
+    }
+
+    @Test
+    public void testUnlicencedEnterpriseCheck2() {
+        Settings settings = Settings.builder()
+            .put("license.enterprise", true)
+            .put("license.ident", "").build();
+        internalCluster().startNode(settings);
+        internalCluster().startNode(settings);
+        SQLResponse response = execute("select severity, passed from sys.checks where id=?", new Object[]{5});
+        assertThat(TestingHelpers.printedTable(response.rows()), is("3| false\n"));
+    }
+
+    @Test
+    public void testLicencedEnterpriseCheck() {
+        Settings settings = Settings.builder()
+            .put("license.enterprise", true)
+            .put("license.ident", "my-awesome-key").build();
+        internalCluster().startNode(settings);
+        internalCluster().startNode(settings);
+        SQLResponse response = execute("select severity, passed from sys.checks where id=?", new Object[]{5});
+        assertThat(TestingHelpers.printedTable(response.rows()), is("3| true\n"));
+    }
+
 }

--- a/sql/src/test/java/io/crate/integrationtests/SysClusterSettingsTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysClusterSettingsTest.java
@@ -184,6 +184,12 @@ public class SysClusterSettingsTest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    public void testDefaultLicenseIdentSetting() {
+        execute("select settings from sys.cluster");
+        assertSettingsDefault(SharedSettings.LICENSE_IDENT_SETTING);
+    }
+
+    @Test
     public void testReadChangedElasticsearchSetting() throws Exception {
         execute("set global transient indices.store.throttle.type = ?",
             new Object[]{StoreRateLimiting.Type.MERGE.toString()});

--- a/sql/src/test/java/io/crate/integrationtests/TableCompatibilitySysChecksTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TableCompatibilitySysChecksTest.java
@@ -55,6 +55,9 @@ public class TableCompatibilitySysChecksTest extends SQLTransportIntegrationTest
     @Test
     public void testUpgradeRequired() throws Exception {
         startUpNodeWithDataDir("/indices/data_home/cratedata_upgrade_required.zip");
+        //add license ident setting to avoid unlicensed enterprise check
+        execute("set global transient 'license.ident' = 'my-awesome-key'");
+
         execute("select * from sys.checks where passed = false");
         assertThat(response.rowCount(), is(1L));
         assertThat(response.rows()[0][1], is(TablesNeedUpgradeSysCheck.ID));
@@ -73,6 +76,8 @@ public class TableCompatibilitySysChecksTest extends SQLTransportIntegrationTest
     @Test
     public void testAlreadyUpgraded() throws Exception {
         startUpNodeWithDataDir("/indices/data_home/cratedata_already_upgraded.zip");
+        //add license ident setting to avoid unlicensed enterprise check
+        execute("set global transient 'license.ident' = 'my-awesome-key'");
         execute("select * from sys.checks where passed = false");
         assertThat(response.rowCount(), is(0L));
     }

--- a/udc/src/test/java/io/crate/udc/ping/PingTaskTest.java
+++ b/udc/src/test/java/io/crate/udc/ping/PingTaskTest.java
@@ -102,16 +102,16 @@ public class PingTaskTest extends CrateUnitTest {
             "http://dummy",
             Settings.EMPTY
         );
-        assertThat(pingTask.isEnterprise(), is("false"));
+        assertThat(pingTask.isEnterprise(), is("true"));
 
         pingTask = new PingTask(
             clusterService,
             clusterIdService,
             extendedNodeInfo,
             "http://dummy",
-            Settings.builder().put(SharedSettings.ENTERPRISE_LICENSE_SETTING.getKey(), true).build()
+            Settings.builder().put(SharedSettings.ENTERPRISE_LICENSE_SETTING.getKey(), false).build()
         );
-        assertThat(pingTask.isEnterprise(), is("true"));
+        assertThat(pingTask.isEnterprise(), is("false"));
     }
 
     @Test


### PR DESCRIPTION
- [x] license.enterprise true by default

- [x] license.ident runtime setting

- [x] add sys check for unlicensed enterprise edition

- [x] add warning for unlicensed enterprise 

- [ ] add redirect for cluster check link
