### PR TITLE
Move fetch planning logic into Consumers

### DIFF
--- a/sql/src/main/java/io/crate/planner/consumer/ConsumerContext.java
+++ b/sql/src/main/java/io/crate/planner/consumer/ConsumerContext.java
@@ -31,7 +31,7 @@ public class ConsumerContext {
     private final Planner.Context plannerContext;
 
     private ValidationException validationException;
-
+    private FetchDecider fetchDecider = FetchDecider.ALWAYS;
     private Integer requiredPageSize;
 
     public ConsumerContext(Planner.Context plannerContext) {
@@ -51,14 +51,22 @@ public class ConsumerContext {
         return plannerContext;
     }
 
-    public void requiredPageSize(Integer requiredPageSize) {
+    public void setFetchDecider(FetchDecider fetchDecider) {
+        this.fetchDecider = fetchDecider;
+    }
+
+    FetchDecider fetchDecider() {
+        return fetchDecider;
+    }
+
+    void requiredPageSize(Integer requiredPageSize) {
         this.requiredPageSize = requiredPageSize;
     }
 
     /**
      * required pageSize that a parent relation might have specified.
      */
-    public Integer requiredPageSize() {
+    Integer requiredPageSize() {
         return requiredPageSize;
     }
 }

--- a/sql/src/main/java/io/crate/planner/consumer/FetchDecider.java
+++ b/sql/src/main/java/io/crate/planner/consumer/FetchDecider.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.consumer;
+
+/**
+ * Component to help make decisions in the planner on how/if fetch-phases should be planned.
+ *
+ * This is mostly relevant for nested-relations where the plan being created will also contain one or more sub-plans.
+ * A planner component for a parent-relation can set a FetchDecider on the {@link ConsumerContext} to influence the planning of
+ * child-relations.
+ */
+@FunctionalInterface
+public interface FetchDecider {
+
+    FetchDecider NEVER = () -> false;
+    FetchDecider ALWAYS = () -> true;
+
+    /**
+     * Verify if it makes sense to attempt doing a fetch-rewrite.
+     * This is an approximation, if it returns true it may not be possible to really fetch anything.
+     */
+    boolean tryFetchRewrite();
+}

--- a/sql/src/main/java/io/crate/planner/consumer/InsertFromSubQueryPlanner.java
+++ b/sql/src/main/java/io/crate/planner/consumer/InsertFromSubQueryPlanner.java
@@ -75,6 +75,7 @@ public final class InsertFromSubQueryPlanner {
                                                   "supported on insert using a sub-query");
         }
         SOURCE_LOOKUP_CONVERTER.process(subRelation, null);
+        context.setFetchDecider(FetchDecider.NEVER);
         Plan plannedSubQuery = plannerContext.planSubRelation(subRelation, context);
         if (plannedSubQuery == null) {
             return null;

--- a/sql/src/main/java/io/crate/planner/consumer/MultiSourceAggregationConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/MultiSourceAggregationConsumer.java
@@ -74,6 +74,7 @@ class MultiSourceAggregationConsumer implements Consumer {
             SplitPoints splitPoints = SplitPoints.create(qs);
             removeAggregationsAndLimitsFromMSS(multiSourceSelect, splitPoints);
             Planner.Context plannerContext = context.plannerContext();
+            context.setFetchDecider(FetchDecider.NEVER);
             Plan plan = plannerContext.planSubRelation(multiSourceSelect, context);
 
             // whereClause is already handled within the plan, no need to add additional FilterProjection via addAggregations

--- a/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
@@ -158,6 +158,7 @@ class NestedLoopConsumer implements Consumer {
                     functions, context.plannerContext().transactionContext());
             }
 
+            context.setFetchDecider(FetchDecider.NEVER);
             Plan leftPlan = context.plannerContext().planSubRelation(left, context);
             Plan rightPlan = context.plannerContext().planSubRelation(right, context);
             context.requiredPageSize(null);

--- a/sql/src/main/java/io/crate/planner/statement/CopyStatementPlanner.java
+++ b/sql/src/main/java/io/crate/planner/statement/CopyStatementPlanner.java
@@ -39,6 +39,7 @@ import io.crate.planner.Merge;
 import io.crate.planner.Plan;
 import io.crate.planner.Planner;
 import io.crate.planner.consumer.ConsumerContext;
+import io.crate.planner.consumer.FetchDecider;
 import io.crate.planner.node.dql.Collect;
 import io.crate.planner.node.dql.FileUriCollectPhase;
 import io.crate.planner.projection.MergeCountProjection;
@@ -190,7 +191,9 @@ public class CopyStatementPlanner {
             statement.outputNames(),
             outputFormat);
 
-        Plan plan = context.planSubRelation(statement.subQueryRelation(), new ConsumerContext(context));
+        ConsumerContext consumerContext = new ConsumerContext(context);
+        consumerContext.setFetchDecider(FetchDecider.NEVER);
+        Plan plan = context.planSubRelation(statement.subQueryRelation(), consumerContext);
         if (plan == null) {
             return null;
         }

--- a/sql/src/test/java/io/crate/planner/SingleRowSubselectPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/SingleRowSubselectPlannerTest.java
@@ -45,9 +45,8 @@ public class SingleRowSubselectPlannerTest extends CrateDummyClusterServiceUnitT
 
     @Test
     public void testPlanSimpleSelectWithSingleRowSubSelectInWhereClause() throws Exception {
-        QueryThenFetch qtf = e.plan("select x from t1 where a = (select b from t2)");
-        assertThat(qtf.subPlan(), instanceOf(MultiPhasePlan.class));
-        MultiPhasePlan multiPhasePlan = (MultiPhasePlan) qtf.subPlan();
+        MultiPhasePlan multiPhasePlan = e.plan("select x from t1 where a = (select b from t2)");
+        assertThat(multiPhasePlan.rootPlan(), instanceOf(QueryThenFetch.class));
         assertThat(multiPhasePlan.dependencies().keySet(), contains(instanceOf(QueryThenFetch.class)));
     }
 

--- a/sql/src/test/java/io/crate/planner/consumer/GlobalAggregatePlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/consumer/GlobalAggregatePlannerTest.java
@@ -23,25 +23,46 @@
 package io.crate.planner.consumer;
 
 import io.crate.planner.node.dql.Collect;
-import io.crate.planner.projection.FilterProjection;
-import io.crate.planner.projection.Projection;
+import io.crate.planner.node.dql.QueryThenFetch;
+import io.crate.planner.projection.*;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.testing.T3;
 import org.hamcrest.Matchers;
+import org.junit.Before;
 import org.junit.Test;
+
+import java.util.List;
 
 import static org.hamcrest.Matchers.instanceOf;
 
 public class GlobalAggregatePlannerTest extends CrateDummyClusterServiceUnitTest {
 
+    private SQLExecutor e;
+
+    @Before
+    public void setUpExecutor() throws Exception {
+        e = SQLExecutor.builder(clusterService).addDocTable(T3.T1_INFO).build();
+    }
+
     @Test
     public void testAggregateOnSubQueryHasNoFilterProjectionWithoutWhereAndHaving() throws Exception {
-        SQLExecutor e = SQLExecutor.builder(clusterService).addDocTable(T3.T1_INFO).build();
-
         Collect plan = e.plan("select sum(x) from (select x from t1 order by x limit 10) ti");
         for (Projection projection : plan.collectPhase().projections()) {
             assertThat(projection, Matchers.not(instanceOf(FilterProjection.class)));
         }
+    }
+
+    @Test
+    public void testAggregateOnSubQueryUsesQueryThenFetchIfPossible() throws Exception {
+        QueryThenFetch plan = e.plan("select sum(x) from (select x, i from t1 order by x limit 10) ti");
+        List<Projection> projections = ((Collect) plan.subPlan()).collectPhase().projections();
+        assertThat(projections, Matchers.contains(
+            instanceOf(TopNProjection.class),
+            instanceOf(TopNProjection.class),
+            instanceOf(FetchProjection.class),
+            instanceOf(AggregationProjection.class),
+            instanceOf(EvalProjection.class)
+        ));
     }
 }


### PR DESCRIPTION
So far the fetch rewrite logic was part of the SelectStatementPlanner.
This meant that fetch was only possible as a last step.

By moving the logic from the SelectStatementPlanner into the respective
consumers it is possible to have intermediate fetches.
With this commit this is already the case for non-grouping global
aggregations on subqueries.

In the future this will also allow efficient non-rewritable simple
subqueries.