### PR TITLE
fix function registration/deregistration in new and dying schemas

### DIFF
--- a/sql/src/main/java/io/crate/metadata/Schemas.java
+++ b/sql/src/main/java/io/crate/metadata/Schemas.java
@@ -162,13 +162,13 @@ public class Schemas extends AbstractLifecycleComponent implements Iterable<Sche
                 }
             }
 
+            for (String addedSchema : added) {
+                schemas.put(addedSchema, getCustomSchemaInfo(addedSchema));
+            }
+
             // update all existing schemas
             for (SchemaInfo schemaInfo : this) {
                 schemaInfo.update(event);
-            }
-
-            for (String addedSchema : added) {
-                schemas.put(addedSchema, getCustomSchemaInfo(addedSchema));
             }
         }
     }

--- a/sql/src/main/java/io/crate/metadata/doc/DocSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/doc/DocSchemaInfo.java
@@ -353,5 +353,6 @@ public class DocSchemaInfo implements SchemaInfo {
 
     @Override
     public void close() throws Exception {
+        functions.deregisterSchemaFunctions(schemaName);
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
@@ -409,37 +409,30 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
         }, 20L, TimeUnit.SECONDS);
     }
 
-    public void waitForFunctionCreatedOnAll(String schema, String name, List<DataType> types) throws Exception {
-        awaitBusy(() -> {
-            int count = 0;
-            int expected = 0;
+    public void assertFunctionIsCreatedOnAll(String schema, String name, List<DataType> types) throws Exception {
+        assertBusy(() -> {
             Iterable<Functions> functions = internalCluster().getInstances(Functions.class);
             for (Functions function : functions) {
-                expected += 1;
                 try {
                     function.getUserDefined(schema, name, types);
-                    count += 1;
                 } catch (UnsupportedOperationException e) {
-                    // pass
+                    assertFalse("function not found", true);
                 }
             }
-            return count == expected;
         });
     }
 
-    public void waitForFunctionDeleted(String schema, String name, List<DataType> types) throws Exception {
-        awaitBusy(() -> {
-            int count = 0;
+    public void assertFunctionIsDeletedOnAll(String schema, String name, List<DataType> types) throws Exception {
+        assertBusy(() -> {
             Iterable<Functions> functions = internalCluster().getInstances(Functions.class);
             for (Functions function : functions) {
                 try {
                     function.getUserDefined(schema, name, types);
-                    count += 1;
+                    assertFalse("function should be deleted", true);
                 } catch (UnsupportedOperationException e) {
                     // pass
                 }
             }
-            return count == 0;
         });
     }
 


### PR DESCRIPTION
- Functions with a new schema weren’t registered
- Functions weren’t deregistered on schema deletion