### PR TITLE
adds `node.max_local_storage_nodes` default value change to breaking changes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -15,6 +15,15 @@ the appropriate section of the docs.
 Breaking Changes
 ================
 
+ - The default value of the ``node.max_local_storage_nodes`` node setting has
+   been changed to ``1`` to prevent running multiple nodes on the same data path
+   by default. Previous versions of CrateDB defaulted to allowing up to ``50``
+   nodes running on the same data path. This was confusing where users
+   accidentally started multiple nodes and ended up thinking they have lost data
+   because the 2nd node will start with an empty directory. Running multiple
+   nodes on the same data path tends to be an exception, so defaulting towards
+   safer out-of-the-box settings is reasonable.
+
  - Parsing support of time values has been changed:
 
    - The unit ``w`` representing weeks is no longer supported.

--- a/app/src/main/dist/config/crate.yml
+++ b/app/src/main/dist/config/crate.yml
@@ -156,8 +156,8 @@
 #
 #node.rack: rack314
 
-# By default, multiple nodes are allowed to start from the same installation
-# location to disable it, set the following:
+# By default, multiple nodes are not allowed to start from the same installation
+# location. To allow it, set the following to a higher value:
 #node.max_local_storage_nodes: 1
 
 #################################### Table ####################################

--- a/blackbox/docs/configuration.txt
+++ b/blackbox/docs/configuration.txt
@@ -207,6 +207,13 @@ Node Specific Settings
 
    Node names must be unique in a CrateDB cluster.
 
+**node.max_local_storage_nodes**
+  | *Default:*    ``1``
+  | *Runtime:*   ``no``
+
+  Defines how many nodes are allowed to be started on the same machine using the
+  same configured data path defined via `path.data`_.
+
 Node Types
 ----------
 
@@ -405,6 +412,8 @@ Paths
 
   Filesystem path to the directory containing the configuration files ``crate.yml``
   and ``log4j2.properties``.
+
+.. _path.data:
 
 **path.data**
   | *Runtime:* ``no``


### PR DESCRIPTION
also adjusts the description at the `crate.yml` and adds documentation
about this setting to node settings documentation section.