### PR TITLE
Add symbol type assertion to projections

### DIFF
--- a/sql/src/main/java/io/crate/analyze/symbol/Symbols.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/Symbols.java
@@ -35,6 +35,8 @@ import java.util.function.Predicate;
 
 public class Symbols {
 
+    public static final Predicate<Symbol> IS_COLUMN = s -> s instanceof Field || s instanceof Reference;
+
     private static final HasColumnVisitor HAS_COLUMN_VISITOR = new HasColumnVisitor();
 
     public static final Predicate<Symbol> IS_GENERATED_COLUMN = input -> input instanceof GeneratedReference;

--- a/sql/src/main/java/io/crate/planner/projection/EvalProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/EvalProjection.java
@@ -23,6 +23,7 @@
 package io.crate.planner.projection;
 
 import io.crate.analyze.symbol.Symbol;
+import io.crate.analyze.symbol.SymbolVisitors;
 import io.crate.analyze.symbol.Symbols;
 import io.crate.collections.Lists2;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -40,6 +41,8 @@ public class EvalProjection extends Projection {
     private final List<Symbol> outputs;
 
     public EvalProjection(List<Symbol> outputs) {
+        assert outputs.stream().noneMatch(s -> SymbolVisitors.any(Symbols.IS_COLUMN, s))
+            : "EvalProjection doesn't support Field or Reference symbols";
         this.outputs = outputs;
     }
 

--- a/sql/src/main/java/io/crate/planner/projection/FilterProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/FilterProjection.java
@@ -23,6 +23,7 @@ package io.crate.planner.projection;
 
 import com.google.common.collect.ImmutableList;
 import io.crate.analyze.symbol.Symbol;
+import io.crate.analyze.symbol.SymbolVisitors;
 import io.crate.analyze.symbol.Symbols;
 import io.crate.collections.Lists2;
 import io.crate.metadata.RowGranularity;
@@ -41,6 +42,8 @@ public class FilterProjection extends Projection {
     private RowGranularity requiredGranularity = RowGranularity.CLUSTER;
 
     public FilterProjection(Symbol query, List<Symbol> outputs) {
+        assert !SymbolVisitors.any(Symbols.IS_COLUMN, query)
+            : "FilterProjection cannot operate on Reference or Field symbols";
         this.query = query;
         this.outputs = outputs;
     }

--- a/sql/src/main/java/io/crate/planner/projection/OrderedTopNProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/OrderedTopNProjection.java
@@ -23,6 +23,7 @@
 package io.crate.planner.projection;
 
 import io.crate.analyze.symbol.Symbol;
+import io.crate.analyze.symbol.SymbolVisitors;
 import io.crate.analyze.symbol.Symbols;
 import io.crate.collections.Lists2;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -50,6 +51,10 @@ public class OrderedTopNProjection extends Projection {
                                  List<Symbol> orderBy,
                                  boolean[] reverseFlags,
                                  Boolean[] nullsFirst) {
+        assert outputs.stream().noneMatch(s -> SymbolVisitors.any(Symbols.IS_COLUMN, s))
+            : "OrderedTopNProjection outputs cannot contain Field or Reference symbols";
+        assert orderBy.stream().noneMatch(s -> SymbolVisitors.any(Symbols.IS_COLUMN, s))
+            : "OrderedTopNProjection orderBy cannot contain Field or Reference symbols";
         assert orderBy.size() == reverseFlags.length : "reverse flags length does not match orderBy items count";
         assert orderBy.size() == nullsFirst.length : "nullsFirst length does not match orderBy items count";
 

--- a/sql/src/main/java/io/crate/planner/projection/TopNProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/TopNProjection.java
@@ -22,6 +22,7 @@
 package io.crate.planner.projection;
 
 import io.crate.analyze.symbol.Symbol;
+import io.crate.analyze.symbol.SymbolVisitors;
 import io.crate.analyze.symbol.Symbols;
 import io.crate.collections.Lists2;
 import io.crate.operation.projectors.TopN;
@@ -39,6 +40,8 @@ public class TopNProjection extends Projection {
     private final List<Symbol> outputs;
 
     public TopNProjection(int limit, int offset, List<Symbol> outputs) {
+        assert outputs.stream().noneMatch(s -> SymbolVisitors.any(Symbols.IS_COLUMN, s))
+            : "TopNProjection doesn't support Field or Reference symbols";
         assert limit > TopN.NO_LIMIT : "limit of TopNProjection must not be negative/unlimited";
 
         this.limit = limit;

--- a/sql/src/test/java/io/crate/planner/projection/FilterProjectionTest.java
+++ b/sql/src/test/java/io/crate/planner/projection/FilterProjectionTest.java
@@ -21,25 +21,24 @@
 
 package io.crate.planner.projection;
 
-import com.google.common.collect.ImmutableList;
 import io.crate.analyze.symbol.InputColumn;
 import io.crate.metadata.RowGranularity;
+import io.crate.operation.operator.EqOperator;
 import io.crate.test.integration.CrateUnitTest;
-import io.crate.testing.SqlExpressions;
-import io.crate.testing.T3;
+import io.crate.types.DataTypes;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.junit.Test;
+
+import java.util.Collections;
 
 public class FilterProjectionTest extends CrateUnitTest {
 
     @Test
     public void testStreaming() throws Exception {
-        SqlExpressions sqlExpressions = new SqlExpressions(T3.SOURCES, T3.TR_1);
-
         FilterProjection p = new FilterProjection(
-            sqlExpressions.normalize(sqlExpressions.asSymbol("a = 'foo'")),
-            ImmutableList.of(new InputColumn(1))
+            EqOperator.createFunction(new InputColumn(0, DataTypes.INTEGER), new InputColumn(1, DataTypes.INTEGER)),
+            Collections.singletonList(new InputColumn(0))
         );
         p.requiredGranularity(RowGranularity.SHARD);
 


### PR DESCRIPTION
This should make it easier to debug planner bugs as errors are raised
closer to their occurrence. (So far, having an invalid symbol in a
projection raised an error in the ContextPreparer)