### PR TITLE
Fix subselect rewrite

### DIFF
--- a/sql/src/main/java/io/crate/analyze/relations/SubselectRewriter.java
+++ b/sql/src/main/java/io/crate/analyze/relations/SubselectRewriter.java
@@ -28,7 +28,6 @@ import io.crate.analyze.*;
 import io.crate.analyze.symbol.Aggregations;
 import io.crate.analyze.symbol.Field;
 import io.crate.analyze.symbol.Symbol;
-import io.crate.analyze.symbol.SymbolVisitor;
 import io.crate.metadata.ReplaceMode;
 import io.crate.metadata.ReplacingSymbolVisitor;
 import io.crate.operation.operator.AndOperator;
@@ -75,12 +74,15 @@ final class SubselectRewriter {
         public AnalyzedRelation visitQueriedSelectRelation(QueriedSelectRelation relation, Context context) {
             QuerySpec querySpec = relation.querySpec();
             // Try to merge with parent query spec
+            if (context.currentParentQSpec != null) {
+                context.currentParentQSpec.replace(new FieldReplacer(querySpec.outputs()));
+            }
             if (canBeMerged(querySpec, context.currentParentQSpec)) {
                 querySpec = mergeQuerySpec(querySpec, context.currentParentQSpec);
             }
 
             // Try to push down to the child
-            context.currentParentQSpec = querySpec.copyAndReplace(i -> i);
+            context.currentParentQSpec = querySpec.copyAndReplace(Function.identity());
             AnalyzedRelation processedChildRelation = process(relation.subRelation(), context);
 
             // If cannot be pushed down replace qSpec with possibly merged qSpec from context
@@ -98,7 +100,7 @@ final class SubselectRewriter {
                 return table;
             }
             QuerySpec querySpec = table.querySpec();
-            context.currentParentQSpec.replace(FieldReferenceResolver.INSTANCE);
+            context.currentParentQSpec.replace(new FieldReplacer(querySpec.outputs()));
             if (!canBeMerged(querySpec, context.currentParentQSpec)) {
                 return null;
             }
@@ -113,7 +115,7 @@ final class SubselectRewriter {
                 return table;
             }
             QuerySpec querySpec = table.querySpec();
-            context.currentParentQSpec.replace(FieldReferenceResolver.INSTANCE);
+            context.currentParentQSpec.replace(new FieldReplacer(table.querySpec().outputs()));
             if (!canBeMerged(querySpec, context.currentParentQSpec)) {
                 return null;
             }
@@ -127,7 +129,7 @@ final class SubselectRewriter {
             if (context.currentParentQSpec == null) {
                 return multiSourceSelect;
             }
-            context.currentParentQSpec.replace(FieldReferenceResolver.INSTANCE);
+            context.currentParentQSpec.replace(new FieldReplacer(multiSourceSelect.querySpec().outputs()));
             QuerySpec querySpec = multiSourceSelect.querySpec();
             if (!canBeMerged(querySpec, context.currentParentQSpec)) {
                 return null;
@@ -141,6 +143,7 @@ final class SubselectRewriter {
                 querySpec,
                 multiSourceSelect.joinPairs());
         }
+
     }
 
     private static QuerySpec mergeQuerySpec(QuerySpec childQSpec, @Nullable QuerySpec parentQSpec) {
@@ -253,86 +256,23 @@ final class SubselectRewriter {
         return true;
     }
 
-    /**
-     * Function to replace Fields with the Reference from the output of the relation the Field is pointing to.
-     * E.g.
-     *
-     * <pre>
-     * select t.x from (select x from t1) t
-     *         |         |
-     *       Field       \                  ____ Reference that is used as replacement.
-     *          relation: t                /
-     *                    +-- QS.outputs: [x]
-     *                                     ^
-     *                                     |
-     *          index: 0 ------------------+
-     *
-     * </pre>
-     */
-    private static class FieldReferenceResolver extends ReplacingSymbolVisitor<Void> implements Function<Symbol, Symbol> {
+    private final static class FieldReplacer extends ReplacingSymbolVisitor<Void> implements Function<Symbol, Symbol> {
 
-        public static final FieldReferenceResolver INSTANCE = new FieldReferenceResolver(ReplaceMode.MUTATE);
-        private static final FieldRelationVisitor<Symbol> FIELD_RELATION_VISITOR = new FieldRelationVisitor<>(INSTANCE);
+        private final List<Symbol> outputs;
 
-        private FieldReferenceResolver(ReplaceMode mode) {
-            super(mode);
+        FieldReplacer(List<Symbol> outputs) {
+            super(ReplaceMode.COPY);
+            this.outputs = outputs;
         }
 
         @Override
         public Symbol visitField(Field field, Void context) {
-            Symbol output = FIELD_RELATION_VISITOR.process(field.relation(), field);
-            return output != null ? output : field;
-        }
-
-        @Nullable
-        @Override
-        public Symbol apply(@Nullable Symbol input) {
-            if (input == null) {
-                return null;
-            }
-            return process(input, null);
-        }
-    }
-
-    /**
-     * Visits an output symbol in a queried relation using the provided field index.
-     */
-    private static class FieldRelationVisitor<R> extends AnalyzedRelationVisitor<Field, R> {
-
-        private final SymbolVisitor<?, R> symbolVisitor;
-
-        FieldRelationVisitor(SymbolVisitor<?, R> symbolVisitor) {
-            this.symbolVisitor = symbolVisitor;
+            return outputs.get(field.index());
         }
 
         @Override
-        protected R visitAnalyzedRelation(AnalyzedRelation relation, Field context) {
-            return null;
-        }
-
-        @Override
-        public R visitQueriedTable(QueriedTable relation, Field field) {
-            return visitQueriedRelation(relation, field);
-        }
-
-        @Override
-        public R visitQueriedDocTable(QueriedDocTable relation, Field field) {
-            return visitQueriedRelation(relation, field);
-        }
-
-        @Override
-        public R visitMultiSourceSelect(MultiSourceSelect relation, Field field) {
-            return visitQueriedRelation(relation, field);
-        }
-
-        @Override
-        public R visitQueriedSelectRelation(QueriedSelectRelation relation, Field field) {
-            return visitQueriedRelation(relation, field);
-        }
-
-        private R visitQueriedRelation(QueriedRelation relation, Field field) {
-            Symbol output = relation.querySpec().outputs().get(field.index());
-            return symbolVisitor.process(output, null);
+        public Symbol apply(Symbol symbol) {
+            return process(symbol, null);
         }
     }
 }

--- a/sql/src/test/java/io/crate/analyze/relations/RelationNormalizerTest.java
+++ b/sql/src/test/java/io/crate/analyze/relations/RelationNormalizerTest.java
@@ -26,6 +26,7 @@ import io.crate.analyze.MultiSourceSelect;
 import io.crate.analyze.QueriedSelectRelation;
 import io.crate.analyze.RelationSource;
 import io.crate.analyze.SelectAnalyzedStatement;
+import io.crate.analyze.symbol.Field;
 import io.crate.planner.node.dql.join.JoinType;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
@@ -86,9 +87,8 @@ public class RelationNormalizerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(relation, instanceOf(QueriedSelectRelation.class));
         QueriedSelectRelation outerRelation = (QueriedSelectRelation) relation;
         assertThat(outerRelation.querySpec(),
-            isSQL("SELECT io.crate.analyze.QueriedSelectRelation.a, " +
-                  "io.crate.analyze.QueriedSelectRelation.x, " +
-                  "io.crate.analyze.QueriedSelectRelation.i ORDER BY io.crate.analyze.QueriedSelectRelation.x"));
+            isSQL("SELECT doc.t1.a, doc.t1.x, doc.t1.i ORDER BY doc.t1.x"));
+        assertThat(((Field) outerRelation.querySpec().outputs().get(0)).relation(), sameInstance(outerRelation.subRelation()));
         assertThat(outerRelation.subRelation(), instanceOf(QueriedDocTable.class));
         assertThat(outerRelation.subRelation().querySpec(),
             isSQL("SELECT doc.t1.a, doc.t1.x, doc.t1.i ORDER BY doc.t1.a LIMIT 10"));
@@ -116,10 +116,8 @@ public class RelationNormalizerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(relation, instanceOf(QueriedSelectRelation.class));
         QueriedSelectRelation outerRelation = (QueriedSelectRelation) relation;
         assertThat(outerRelation.querySpec(),
-            isSQL("SELECT io.crate.analyze.QueriedSelectRelation.a, " +
-                  "io.crate.analyze.QueriedSelectRelation.x, " +
-                  "io.crate.analyze.QueriedSelectRelation.i " +
-                  "ORDER BY io.crate.analyze.QueriedSelectRelation.a DESC LIMIT 5"));
+            isSQL("SELECT doc.t1.a, doc.t1.x, doc.t1.i ORDER BY doc.t1.a DESC LIMIT 5"));
+        assertThat(((Field) outerRelation.querySpec().outputs().get(0)).relation(), sameInstance(outerRelation.subRelation()));
         assertThat(outerRelation.subRelation(), instanceOf(QueriedDocTable.class));
         assertThat(outerRelation.subRelation().querySpec(),
             isSQL("SELECT doc.t1.a, doc.t1.x, doc.t1.i ORDER BY doc.t1.a LIMIT 10 OFFSET 5"));


### PR DESCRIPTION
The SubselectRewriter messed up Fields in queries that cannot be
re-written to a single select.

This doesn't cause any issues so far on master as those kind of queries
result in an unsupported error later on.