### PR TITLE
Add support for non-rewritable simple subselects

### DIFF
--- a/sql/src/main/java/io/crate/planner/consumer/QueryAndFetchConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/QueryAndFetchConsumer.java
@@ -21,10 +21,7 @@
 
 package io.crate.planner.consumer;
 
-import io.crate.analyze.OrderBy;
-import io.crate.analyze.QueriedTable;
-import io.crate.analyze.QueriedTableRelation;
-import io.crate.analyze.QuerySpec;
+import io.crate.analyze.*;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.QueriedDocTable;
 import io.crate.analyze.symbol.Function;
@@ -40,8 +37,10 @@ import io.crate.planner.fetch.FetchPushDown;
 import io.crate.planner.node.dql.Collect;
 import io.crate.planner.node.dql.QueryThenFetch;
 import io.crate.planner.node.dql.RoutedCollectPhase;
+import io.crate.planner.projection.FilterProjection;
 import io.crate.planner.projection.Projection;
 import io.crate.planner.projection.TopNProjection;
+import io.crate.planner.projection.builder.ProjectionBuilder;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
@@ -99,6 +98,37 @@ public class QueryAndFetchConsumer implements Consumer {
                 NoPredicateVisitor.ensureNoMatchPredicate(querySpec.where().query());
             }
             return normalSelect(table, context);
+        }
+
+        @Override
+        public Plan visitQueriedSelectRelation(QueriedSelectRelation relation, ConsumerContext context) {
+            QuerySpec qs = relation.querySpec();
+            if (qs.hasAggregates() || qs.groupBy().isPresent()) {
+                return null;
+            }
+            Planner.Context plannerContext = context.plannerContext();
+            Plan plan = Merge.ensureOnHandler(
+                plannerContext.planSubRelation(relation.subRelation(), context), plannerContext);
+
+            Limits limits = plannerContext.getLimits(qs);
+            maybeAddFilterProjection(relation, plan);
+            Projection topN = ProjectionBuilder.topNOrEval(
+                relation.subRelation().fields(),
+                qs.orderBy().orElse(null),
+                limits.offset(),
+                limits.finalLimit(),
+                qs.outputs()
+            );
+            plan.addProjection(topN, null, null, qs.outputs().size(), null);
+            return plan;
+        }
+    }
+
+    private static void maybeAddFilterProjection(QueriedSelectRelation relation, Plan plan) {
+        WhereClause whereClause = relation.querySpec().where();
+        if (whereClause.hasQuery() || whereClause.noMatch()) {
+            FilterProjection filterProjection = ProjectionBuilder.filterProjection(relation.subRelation().fields(), whereClause);
+            plan.addProjection(filterProjection, null, null, null, null);
         }
     }
 

--- a/sql/src/test/java/io/crate/planner/SubQueryPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/SubQueryPlannerTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner;
+
+import io.crate.planner.node.dql.Collect;
+import io.crate.planner.node.dql.QueryThenFetch;
+import io.crate.planner.projection.*;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+import io.crate.testing.T3;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.instanceOf;
+
+
+public class SubQueryPlannerTest extends CrateDummyClusterServiceUnitTest {
+
+    private SQLExecutor e;
+
+    @Before
+    public void setUpExecutor() throws Exception {
+         e = SQLExecutor.builder(clusterService).addDocTable(T3.T1_INFO).build();
+    }
+
+    @Test
+    public void testNestedSimpleSelectUsesFetch() throws Exception {
+        QueryThenFetch qtf = e.plan(
+            "select x, i from (select x, i from t1 order by x asc limit 10) ti order by x desc limit 3");
+        Collect collect = (Collect) qtf.subPlan();
+        assertThat(collect.collectPhase().projections(), Matchers.contains(
+            instanceOf(TopNProjection.class),
+            instanceOf(TopNProjection.class),
+            // TODO: We can optimize this to delay fetch until after the OrderedTopNProjection
+            instanceOf(FetchProjection.class),
+            instanceOf(OrderedTopNProjection.class)
+        ));
+    }
+
+    @Test
+    public void testNestedSimpleSelectContainsFilterProjectionForWhereClause() throws Exception {
+        QueryThenFetch qtf = e.plan("select x, i from " +
+                                    "   (select x, i from t1 order by x asc limit 10) ti " +
+                                    "where ti.x = 10 " +
+                                    "order by x desc limit 3");
+        List<Projection> projections = ((Collect) qtf.subPlan()).collectPhase().projections();
+        assertThat(projections, Matchers.hasItem(instanceOf(FilterProjection.class)));
+    }
+}


### PR DESCRIPTION
This adds initial support for non-rewritable simple subselects.

Query-then-fetch execution is always only used for the inner-most
relation. It would be possible to generate more efficient execution
plans but that will be done in a separate PR.