### PR TITLE
RecoverySetting will not be guiced anymore starting with es 5.3 

### DIFF
--- a/blob/src/main/java/io/crate/blob/recovery/BlobRecoveryHandler.java
+++ b/blob/src/main/java/io/crate/blob/recovery/BlobRecoveryHandler.java
@@ -68,12 +68,12 @@ public class BlobRecoveryHandler extends RecoverySourceHandler {
                                StartRecoveryRequest request,
                                Supplier<Long> currentClusterStateVersionSupplier,
                                Function<String, Releasable> delayNewRecoveries,
-                               RecoverySettings recoverySettings,
+                               int fileChunkSizeInBytes,
                                Logger logger,
                                final TransportService transportService,
                                BlobTransferTarget blobTransferTarget,
                                BlobIndicesService blobIndicesService) {
-        super(shard, recoveryTarget, request, currentClusterStateVersionSupplier, delayNewRecoveries, recoverySettings.getChunkSize().bytesAsInt(), logger);
+        super(shard, recoveryTarget, request, currentClusterStateVersionSupplier, delayNewRecoveries, fileChunkSizeInBytes, logger);
         assert BlobIndex.isBlobIndex(shard.shardId().getIndexName()) : "Shard must belong to a blob index";
         this.blobShard = blobIndicesService.blobShardSafe(request.shardId());
         this.request = request;


### PR DESCRIPTION
This commit drops the need to inject RecoverySettings and uses PeerRecoverySourceService which now encapsulates the recovery source resource providers