### PR TITLE
Change Symbol to implement Writeable

### DIFF
--- a/sql/src/main/java/io/crate/analyze/symbol/Field.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/Field.java
@@ -26,7 +26,6 @@ import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.metadata.ColumnIndex;
 import io.crate.metadata.Path;
 import io.crate.types.DataType;
-import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
@@ -36,10 +35,6 @@ public class Field extends Symbol implements Path {
     private AnalyzedRelation relation;
     private Path path;
     private DataType valueType;
-
-    public Field(StreamInput in) {
-        throw new UnsupportedOperationException("Field is not streamable");
-    }
 
     public Field(AnalyzedRelation relation, Path path, DataType valueType) {
         this.relation = relation;

--- a/sql/src/main/java/io/crate/analyze/symbol/SelectSymbol.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/SelectSymbol.java
@@ -24,7 +24,6 @@ package io.crate.analyze.symbol;
 
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.types.DataType;
-import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
@@ -44,10 +43,6 @@ public class SelectSymbol extends Symbol {
 
     public AnalyzedRelation relation() {
         return relation;
-    }
-
-    public SelectSymbol(StreamInput in) throws IOException {
-        throw new UnsupportedOperationException("Cannot stream SelectSymbol");
     }
 
     @Override

--- a/sql/src/main/java/io/crate/analyze/symbol/Symbol.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/Symbol.java
@@ -22,20 +22,13 @@
 package io.crate.analyze.symbol;
 
 import io.crate.types.DataType;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
 
-import java.io.IOException;
-
-public abstract class Symbol {
+public abstract class Symbol implements Writeable {
 
     public static boolean isLiteral(Symbol symbol, DataType expectedType) {
         return symbol.symbolType() == SymbolType.LITERAL
                && symbol.valueType().equals(expectedType);
-    }
-
-    public interface SymbolFactory<T extends Symbol> {
-        T newInstance(StreamInput in) throws IOException;
     }
 
     public abstract SymbolType symbolType();
@@ -43,6 +36,4 @@ public abstract class Symbol {
     public abstract <C, R> R accept(SymbolVisitor<C, R> visitor, C context);
 
     public abstract DataType valueType();
-
-    public abstract void writeTo(StreamOutput out) throws IOException;
 }

--- a/sql/src/main/java/io/crate/analyze/symbol/SymbolType.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/SymbolType.java
@@ -27,6 +27,7 @@ import io.crate.metadata.GeoReference;
 import io.crate.metadata.IndexReference;
 import io.crate.metadata.Reference;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.Writeable;
 
 import java.io.IOException;
 import java.util.List;
@@ -35,7 +36,7 @@ public enum SymbolType {
 
     AGGREGATION(Aggregation::new),
     REFERENCE(Reference::new),
-    RELATION_OUTPUT(Field::new),
+    RELATION_OUTPUT(in -> { throw new UnsupportedOperationException("Field is not streamable"); }),
     FUNCTION(Function::new),
     LITERAL(Literal::new),
     INPUT_COLUMN(InputColumn::new),
@@ -48,18 +49,18 @@ public enum SymbolType {
     GEO_REFERENCE(GeoReference::new),
     GENERATED_REFERENCE(GeneratedReference::new),
     PARAMETER(ParameterSymbol::new),
-    SELECT_SYMBOL(SelectSymbol::new);
+    SELECT_SYMBOL(in -> { throw new UnsupportedOperationException("SelectSymbol is not streamable"); });
 
     public static final List<SymbolType> VALUES = ImmutableList.copyOf(values());
 
-    private final Symbol.SymbolFactory factory;
+    private final Writeable.Reader<Symbol> reader;
 
-    SymbolType(Symbol.SymbolFactory factory) {
-        this.factory = factory;
+    SymbolType(Writeable.Reader<Symbol> reader) {
+        this.reader = reader;
     }
 
     public Symbol newInstance(StreamInput in) throws IOException {
-        return factory.newInstance(in);
+        return reader.read(in);
     }
 
     public boolean isValueSymbol() {

--- a/sql/src/main/java/io/crate/analyze/symbol/Symbols.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/Symbols.java
@@ -30,7 +30,9 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
-import java.util.*;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
 import java.util.function.Predicate;
 
 public class Symbols {
@@ -91,15 +93,7 @@ public class Symbols {
     }
 
     public static List<Symbol> listFromStream(StreamInput in) throws IOException {
-        int numSymbols = in.readVInt();
-        if (numSymbols == 0) {
-            return Collections.emptyList();
-        }
-        List<Symbol> symbols = new ArrayList<>(numSymbols);
-        for (int i = 0; i < numSymbols; i++) {
-            symbols.add(fromStream(in));
-        }
-        return symbols;
+        return in.readList(Symbols::fromStream);
     }
 
     public static Symbol fromStream(StreamInput in) throws IOException {


### PR DESCRIPTION
Using Writeable makes it clear that classes are "streamable" and allows
us to use the latest additions to StreamOutput & StreamInput while still
enabling us to have final attributes.