### PR TITLE
fixes decision when to auto-create indices at the bulk shard processor

### DIFF
--- a/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -756,7 +756,6 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
                     "(2, 'content42'), " +
                     "(1, 'content2'), " +
                     "(3, 'content6')");
-
         } catch (SQLActionException e) {
             assertThat(e.getMessage(), containsString("blocked by: [FORBIDDEN/8/index write (api)];"));
         }

--- a/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -756,6 +756,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
                     "(2, 'content42'), " +
                     "(1, 'content2'), " +
                     "(3, 'content6')");
+            fail("expected to throw an \"blocked\" exception");
         } catch (SQLActionException e) {
             assertThat(e.getMessage(), containsString("blocked by: [FORBIDDEN/8/index write (api)];"));
         }


### PR DESCRIPTION
the method to create pending indices will also execute all write item 
requests once its done. so either this method is called, or if no pending
indices to create exists, execute write item request.
don’t do both sequentially, otherwise it could happen that the index is
not fully started (shard not started) while executing writes.