### PR TITLE
Fix Literal hashCode implementation

### DIFF
--- a/sql/src/test/java/io/crate/analyze/symbol/LiteralTest.java
+++ b/sql/src/test/java/io/crate/analyze/symbol/LiteralTest.java
@@ -54,4 +54,11 @@ public class LiteralTest extends CrateUnitTest {
             assertThat(nestedLiteral.value(), is(nestedValue));
         }
     }
+
+    @Test
+    public void testHashCodeIsEqualOnArrayValues() throws Exception {
+        Literal<Object[]> l1 = Literal.of(new Double[]{10.0, 20.2}, DataTypes.GEO_POINT);
+        Literal<Object[]> l2 = Literal.of(new Double[]{10.0, 20.2}, DataTypes.GEO_POINT);
+        assertThat(l1.hashCode(), is(l2.hashCode()));
+    }
 }

--- a/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -1327,7 +1327,7 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
         Double result2 = (Double) response.rows()[1][0];
 
         assertThat(result1, is(0.0d));
-        assertThat(result2, is(152354.3209044634));
+        assertThat(result2, is(152354.32308347954));
 
         String stmtOrderBy = "SELECT id " +
                              "FROM t " +


### PR DESCRIPTION
Equal array-literals had different hashCode values.

Fixing this causes queries like

    `select distance(p, 'POINT (11 21)') from t order by 1`

to return a slightly different result because now it won't use
query-then-fetch anymore.