### PR TITLE
renamed bootstrap.mlockall setting to bootstrap.memory_lock in crate.yml

### DIFF
--- a/app/src/main/dist/config/crate.yml
+++ b/app/src/main/dist/config/crate.yml
@@ -18,7 +18,7 @@
 #   Depending on the OS the best place to do so is
 #   '/etc/default/crate' or '/etc/sysconfig/crate'
 # - disable swapping
-#bootstrap.mlockall: true
+#bootstrap.memory_lock : true
 
 # Name of the Node, e.g. '$(hostname -s)'
 #node.name: "Piz Buin"


### PR DESCRIPTION
```console
$ ./app/build/install/crate/bin/crate -Cboostrap.mlockall=true
[2017-04-24T09:31:34,552][INFO ][o.e.n.Node               ] [Schiara] initializing ...
[2017-04-24T09:31:34,628][INFO ][o.e.e.NodeEnvironment    ] [Schiara] using [1] data paths, mounts [[/ (/dev/disk1)]], net usable_space [44.7gb], net total_space [231.3gb], spins? [unknown], types [hfs]
[2017-04-24T09:31:34,630][INFO ][o.e.e.NodeEnvironment    ] [Schiara] heap size [3.9gb], compressed ordinary object pointers [true]
[2017-04-24T09:31:35,097][INFO ][i.c.plugin               ] [Schiara] plugins loaded: [crate-sigar, jmx-monitoring, lang-js]
[2017-04-24T09:31:36,030][INFO ][o.e.p.PluginsService     ] [Schiara] no modules loaded
[2017-04-24T09:31:36,033][INFO ][o.e.p.PluginsService     ] [Schiara] loaded plugin [crate-admin-ui]
[2017-04-24T09:31:36,033][INFO ][o.e.p.PluginsService     ] [Schiara] loaded plugin [crate-azure-discovery]
[2017-04-24T09:31:36,033][INFO ][o.e.p.PluginsService     ] [Schiara] loaded plugin [es-repository-hdfs]
[2017-04-24T09:31:36,033][INFO ][o.e.p.PluginsService     ] [Schiara] loaded plugin [io.crate.plugin.BlobPlugin]
[2017-04-24T09:31:36,034][INFO ][o.e.p.PluginsService     ] [Schiara] loaded plugin [io.crate.plugin.CrateCorePlugin]
[2017-04-24T09:31:36,034][INFO ][o.e.p.PluginsService     ] [Schiara] loaded plugin [io.crate.plugin.PluginLoaderPlugin]
[2017-04-24T09:31:36,034][INFO ][o.e.p.PluginsService     ] [Schiara] loaded plugin [io.crate.plugin.SrvPlugin]
[2017-04-24T09:31:36,034][INFO ][o.e.p.PluginsService     ] [Schiara] loaded plugin [io.crate.udc.plugin.UDCPlugin]
[2017-04-24T09:31:36,034][INFO ][o.e.p.PluginsService     ] [Schiara] loaded plugin [org.elasticsearch.plugin.discovery.ec2.Ec2DiscoveryPlugin]
[2017-04-24T09:31:36,034][INFO ][o.e.p.PluginsService     ] [Schiara] loaded plugin [org.elasticsearch.plugin.repository.s3.S3RepositoryPlugin]
[2017-04-24T09:31:36,035][INFO ][o.e.p.PluginsService     ] [Schiara] loaded plugin [org.elasticsearch.transport.Netty3Plugin]
[2017-04-24T09:31:36,087][INFO ][o.e.b.BootstrapProxy$1   ] [Schiara] CrateDB version[1.2.0-SNAPSHOT], pid[12656], build[0eabb52/2017-04-24T07:30:02Z], OS[Mac OS X/10.12.3/x86_64], JVM[Oracle Corporation/Java HotSpot(TM) 64-Bit Server VM/1.8.0_40/25.40-b25]
[2017-04-24T09:31:36,639][WARN ][o.e.b.ElasticsearchUncaughtExceptionHandler] [Schiara] uncaught exception in thread [main]
org.elasticsearch.bootstrap.StartupException: java.lang.IllegalArgumentException: unknown setting [boostrap.mlockall] please check that any required plugins are installed, or check the breaking changes documentation for removed settings
	at org.elasticsearch.bootstrap.StartupExceptionProxy.<init>(StartupExceptionProxy.java:31) ~[crate-app-1.2.0-SNAPSHOT-0eabb52ab.jar:1.2.0-SNAPSHOT-0eabb52ab]
	at io.crate.bootstrap.CrateDB.init(CrateDB.java:120) ~[crate-app-1.2.0-SNAPSHOT-0eabb52ab.jar:1.2.0-SNAPSHOT-0eabb52ab]
	at io.crate.bootstrap.CrateDB.execute(CrateDB.java:107) ~[crate-app-1.2.0-SNAPSHOT-0eabb52ab.jar:1.2.0-SNAPSHOT-0eabb52ab]
	at org.elasticsearch.cli.SettingCommand.execute(SettingCommand.java:54) ~[crate-app-1.2.0-SNAPSHOT-0eabb52ab.jar:1.2.0-SNAPSHOT-0eabb52ab]
	at org.elasticsearch.cli.Command.mainWithoutErrorHandling(Command.java:96) ~[crate-app-1.2.0-SNAPSHOT-0eabb52ab.jar:1.2.0-SNAPSHOT-0eabb52ab]
	at org.elasticsearch.cli.Command.main(Command.java:62) ~[crate-app-1.2.0-SNAPSHOT-0eabb52ab.jar:1.2.0-SNAPSHOT-0eabb52ab]
	at io.crate.bootstrap.CrateDB.main(CrateDB.java:84) ~[crate-app-1.2.0-SNAPSHOT-0eabb52ab.jar:1.2.0-SNAPSHOT-0eabb52ab]
	at io.crate.bootstrap.CrateDB.main(CrateDB.java:77) ~[crate-app-1.2.0-SNAPSHOT-0eabb52ab.jar:1.2.0-SNAPSHOT-0eabb52ab]
Caused by: java.lang.IllegalArgumentException: unknown setting [boostrap.mlockall] please check that any required plugins are installed, or check the breaking changes documentation for removed settings
	at org.elasticsearch.common.settings.AbstractScopedSettings.validate(AbstractScopedSettings.java:272) ~[crate-app-1.2.0-SNAPSHOT-0eabb52ab.jar:1.2.0-SNAPSHOT-0eabb52ab]
	at org.elasticsearch.common.settings.AbstractScopedSettings.validate(AbstractScopedSettings.java:240) ~[crate-app-1.2.0-SNAPSHOT-0eabb52ab.jar:1.2.0-SNAPSHOT-0eabb52ab]
	at org.elasticsearch.common.settings.SettingsModule.<init>(SettingsModule.java:138) ~[crate-app-1.2.0-SNAPSHOT-0eabb52ab.jar:1.2.0-SNAPSHOT-0eabb52ab]
	at org.elasticsearch.node.Node.<init>(Node.java:278) ~[crate-app-1.2.0-SNAPSHOT-0eabb52ab.jar:1.2.0-SNAPSHOT-0eabb52ab]
	at io.crate.node.CrateNode.<init>(CrateNode.java:60) ~[crate-app-1.2.0-SNAPSHOT-0eabb52ab.jar:1.2.0-SNAPSHOT-0eabb52ab]
	at org.elasticsearch.bootstrap.BootstrapProxy$1.<init>(BootstrapProxy.java:201) ~[crate-app-1.2.0-SNAPSHOT-0eabb52ab.jar:1.2.0-SNAPSHOT-0eabb52ab]
	at org.elasticsearch.bootstrap.BootstrapProxy.setup(BootstrapProxy.java:201) ~[crate-app-1.2.0-SNAPSHOT-0eabb52ab.jar:1.2.0-SNAPSHOT-0eabb52ab]
	at org.elasticsearch.bootstrap.BootstrapProxy.init(BootstrapProxy.java:297) ~[crate-app-1.2.0-SNAPSHOT-0eabb52ab.jar:1.2.0-SNAPSHOT-0eabb52ab]
	at io.crate.bootstrap.CrateDB.init(CrateDB.java:116) ~[crate-app-1.2.0-SNAPSHOT-0eabb52ab.jar:1.2.0-SNAPSHOT-0eabb52ab]
```