### PR TITLE
Remove redundant argument from Plan#addProjection

### DIFF
--- a/sql/src/main/java/io/crate/planner/Merge.java
+++ b/sql/src/main/java/io/crate/planner/Merge.java
@@ -127,10 +127,10 @@ public class Merge implements Plan, ResultDescription {
         for (Projection projection : projections) {
             assert projection.outputs().size() == resultDescription.numOutputs()
                 : "projection must not affect numOutputs";
-            subPlan.addProjection(projection, null, null, null, null);
+            subPlan.addProjection(projection, null, null, null);
         }
         if (topN != null) {
-            subPlan.addProjection(topN, TopN.NO_LIMIT, 0, resultDescription.numOutputs(), null);
+            subPlan.addProjection(topN, TopN.NO_LIMIT, 0, null);
         }
         // resultDescription.orderBy can be ignored here because it is only relevant to do a sorted merge
         // (of a pre-sorted result)
@@ -184,7 +184,6 @@ public class Merge implements Plan, ResultDescription {
     public void addProjection(Projection projection,
                               @Nullable Integer newLimit,
                               @Nullable Integer newOffset,
-                              @Nullable Integer newNumOutputs,
                               @Nullable PositionalOrderBy newOrderBy) {
         mergePhase.addProjection(projection);
         if (newLimit != null) {
@@ -196,9 +195,7 @@ public class Merge implements Plan, ResultDescription {
         if (newOrderBy != null) {
             orderBy = newOrderBy;
         }
-        if (newNumOutputs != null) {
-            numOutputs = newNumOutputs;
-        }
+        numOutputs = projection.outputs().size();
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/MultiPhasePlan.java
+++ b/sql/src/main/java/io/crate/planner/MultiPhasePlan.java
@@ -82,9 +82,8 @@ public class MultiPhasePlan implements Plan {
     public void addProjection(Projection projection,
                               @Nullable Integer newLimit,
                               @Nullable Integer newOffset,
-                              @Nullable Integer newNumOutputs,
                               @Nullable PositionalOrderBy newOrderBy) {
-        rootPlan.addProjection(projection, newLimit, newOffset, newNumOutputs, newOrderBy);
+        rootPlan.addProjection(projection, newLimit, newOffset, newOrderBy);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/Plan.java
+++ b/sql/src/main/java/io/crate/planner/Plan.java
@@ -40,12 +40,10 @@ public interface Plan {
      * @param newLimit new limit if the projection is affecting the limit.
      * @param newOffset new offset if the projection is affecting the offset.
      * @param newOrderBy new orderBy if the projection is affecting the ordering.
-     * @param newNumOutputs new number of outputs if the projection is affecting it.
      */
     void addProjection(Projection projection,
                        @Nullable Integer newLimit,
                        @Nullable Integer newOffset,
-                       @Nullable Integer newNumOutputs,
                        @Nullable PositionalOrderBy newOrderBy);
 
     ResultDescription resultDescription();

--- a/sql/src/main/java/io/crate/planner/UnnestablePlan.java
+++ b/sql/src/main/java/io/crate/planner/UnnestablePlan.java
@@ -36,7 +36,6 @@ public abstract class UnnestablePlan implements Plan {
     public void addProjection(Projection projection,
                               @Nullable Integer newLimit,
                               @Nullable Integer newOffset,
-                              @Nullable Integer newNumOutputs,
                               @Nullable PositionalOrderBy newOrderBy) {
         throw new UnsupportedOperationException("addProjection() is not supported on: " + getClass().getSimpleName());
     }

--- a/sql/src/main/java/io/crate/planner/consumer/GlobalAggregateConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/GlobalAggregateConsumer.java
@@ -78,7 +78,7 @@ class GlobalAggregateConsumer implements Consumer {
         WhereClause where = qs.where();
         if (where.hasQuery() || where.noMatch()) {
             FilterProjection whereFilter = ProjectionBuilder.filterProjection(splitPoints.toCollect(), where);
-            plan.addProjection(whereFilter, null, null, null, null);
+            plan.addProjection(whereFilter, null, null, null);
         }
         List<Projection> postAggregationProjections = createPostAggregationProjections(qs, splitPoints, plannerContext);
         if (ExecutionPhases.executesOnHandler(plannerContext.handlerNode(), resultDescription.nodeIds())) {
@@ -88,9 +88,9 @@ class GlobalAggregateConsumer implements Consumer {
                 AggregateMode.ITER_FINAL,
                 RowGranularity.CLUSTER
             );
-            plan.addProjection(finalAggregation, null, null, splitPoints.aggregates().size(), null);
+            plan.addProjection(finalAggregation, null, null, null);
             for (Projection postAggregationProjection : postAggregationProjections) {
-                plan.addProjection(postAggregationProjection, null, null, null, null);
+                plan.addProjection(postAggregationProjection, null, null, null);
             }
             return plan;
         } else {
@@ -100,7 +100,7 @@ class GlobalAggregateConsumer implements Consumer {
                 AggregateMode.ITER_PARTIAL,
                 RowGranularity.CLUSTER
             );
-            plan.addProjection(partialAggregation, null, null, splitPoints.aggregates().size(), null);
+            plan.addProjection(partialAggregation, null, null, null);
 
             AggregationProjection finalAggregation = projectionBuilder.aggregationProjection(
                 splitPoints.aggregates(),

--- a/sql/src/main/java/io/crate/planner/consumer/InsertFromSubQueryPlanner.java
+++ b/sql/src/main/java/io/crate/planner/consumer/InsertFromSubQueryPlanner.java
@@ -80,12 +80,12 @@ public final class InsertFromSubQueryPlanner {
         if (plannedSubQuery == null) {
             return null;
         }
-        plannedSubQuery.addProjection(indexWriterProjection, null, null, 1, null);
+        plannedSubQuery.addProjection(indexWriterProjection, null, null, null);
         Plan plan = Merge.ensureOnHandler(plannedSubQuery, plannerContext);
         if (plan == plannedSubQuery) {
             return plan;
         }
-        plan.addProjection(MergeCountProjection.INSTANCE, null, null, 1, null);
+        plan.addProjection(MergeCountProjection.INSTANCE, null, null, null);
         return plan;
     }
 

--- a/sql/src/main/java/io/crate/planner/consumer/ManyTableConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/ManyTableConsumer.java
@@ -372,7 +372,6 @@ public class ManyTableConsumer implements Consumer {
                 phaseAndProjection.projection,
                 null,
                 null,
-                phaseAndProjection.projection.outputs().size(),
                 null
             );
             return new QueryThenFetch(plan,  phaseAndProjection.phase);

--- a/sql/src/main/java/io/crate/planner/consumer/MultiSourceGroupByConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/MultiSourceGroupByConsumer.java
@@ -25,7 +25,10 @@ package io.crate.planner.consumer;
 import io.crate.analyze.*;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.JoinPairs;
-import io.crate.analyze.symbol.*;
+import io.crate.analyze.symbol.AggregateMode;
+import io.crate.analyze.symbol.Field;
+import io.crate.analyze.symbol.FieldsVisitor;
+import io.crate.analyze.symbol.Symbol;
 import io.crate.collections.Lists2;
 import io.crate.metadata.ReplaceMode;
 import io.crate.metadata.ReplacingSymbolVisitor;
@@ -44,7 +47,10 @@ import io.crate.planner.projection.builder.ProjectionBuilder;
 import io.crate.planner.projection.builder.SplitPoints;
 import io.crate.sql.tree.QualifiedName;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 public class MultiSourceGroupByConsumer implements Consumer {
 
@@ -217,7 +223,7 @@ public class MultiSourceGroupByConsumer implements Consumer {
                 limits.finalLimit(),
                 outputs
             );
-            plan.addProjection(postAggregationProjection, null, null, outputs.size(), null);
+            plan.addProjection(postAggregationProjection, null, null, null);
         }
 
         /**
@@ -233,7 +239,7 @@ public class MultiSourceGroupByConsumer implements Consumer {
                 AggregateMode.ITER_FINAL,
                 RowGranularity.CLUSTER
             );
-            plan.addProjection(groupProjection, null, null, groupProjection.outputs().size(), null);
+            plan.addProjection(groupProjection, null, null, null);
         }
 
         /**
@@ -250,7 +256,7 @@ public class MultiSourceGroupByConsumer implements Consumer {
                 RowGranularity.SHARD
             );
             plan.setDistributionInfo(DistributionInfo.DEFAULT_MODULO);
-            plan.addProjection(groupProjection, null, null, groupProjection.outputs().size(), null);
+            plan.addProjection(groupProjection, null, null, null);
         }
 
         /**
@@ -266,7 +272,7 @@ public class MultiSourceGroupByConsumer implements Consumer {
                 postGroupingOutputs.addAll(splitPoints.aggregates());
                 HavingClause having = havingClause.get();
                 FilterProjection filterProjection = ProjectionBuilder.filterProjection(postGroupingOutputs, having);
-                plan.addProjection(filterProjection, null, null, null, null);
+                plan.addProjection(filterProjection, null, null, null);
             }
         }
 

--- a/sql/src/main/java/io/crate/planner/consumer/QueryAndFetchConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/QueryAndFetchConsumer.java
@@ -83,7 +83,6 @@ public class QueryAndFetchConsumer implements Consumer {
                 fetchPhaseAndProjection.projection,
                 null,
                 null,
-                fetchPhaseAndProjection.projection.outputs().size(),
                 null
             );
             return new QueryThenFetch(plan, fetchPhaseAndProjection.phase);

--- a/sql/src/main/java/io/crate/planner/node/dql/Collect.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/Collect.java
@@ -82,7 +82,6 @@ public class Collect implements Plan, ResultDescription {
     public void addProjection(Projection projection,
                               @Nullable Integer newLimit,
                               @Nullable Integer newOffset,
-                              @Nullable Integer newNumOutputs,
                               @Nullable PositionalOrderBy newOrderBy) {
         collectPhase.addProjection(projection);
         if (newLimit != null) {
@@ -94,9 +93,7 @@ public class Collect implements Plan, ResultDescription {
         if (newOrderBy != null) {
             orderBy = newOrderBy;
         }
-        if (newNumOutputs != null) {
-            numOutputs = newNumOutputs;
-        }
+        numOutputs = projection.outputs().size();
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/node/dql/CountPlan.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/CountPlan.java
@@ -69,7 +69,6 @@ public class CountPlan implements Plan, ResultDescription {
     public void addProjection(Projection projection,
                               @Nullable Integer newLimit,
                               @Nullable Integer newOffset,
-                              @Nullable Integer newNumOutputs,
                               @Nullable PositionalOrderBy newOrderBy) {
         mergePhase.addProjection(projection);
     }

--- a/sql/src/main/java/io/crate/planner/node/dql/QueryThenFetch.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/QueryThenFetch.java
@@ -65,9 +65,8 @@ public class QueryThenFetch implements Plan {
     public void addProjection(Projection projection,
                               @Nullable Integer newLimit,
                               @Nullable Integer newOffset,
-                              @Nullable Integer newNumOutputs,
                               @Nullable PositionalOrderBy newOrderBy) {
-        subPlan.addProjection(projection, newLimit, newOffset, newNumOutputs, newOrderBy);
+        subPlan.addProjection(projection, newLimit, newOffset, newOrderBy);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/node/dql/join/NestedLoop.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/join/NestedLoop.java
@@ -151,7 +151,6 @@ public class NestedLoop implements Plan, ResultDescription {
     public void addProjection(Projection projection,
                               @Nullable Integer newLimit,
                               @Nullable Integer newOffset,
-                              @Nullable Integer newNumOutputs,
                               @Nullable PositionalOrderBy newOrderBy) {
         nestedLoopPhase.addProjection(projection);
         if (newLimit != null) {
@@ -163,9 +162,7 @@ public class NestedLoop implements Plan, ResultDescription {
         if (newOrderBy != null) {
             orderBy = newOrderBy;
         }
-        if (newNumOutputs != null) {
-            numOutputs = newNumOutputs;
-        }
+        numOutputs = projection.outputs().size();
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/statement/CopyStatementPlanner.java
+++ b/sql/src/main/java/io/crate/planner/statement/CopyStatementPlanner.java
@@ -196,7 +196,7 @@ public class CopyStatementPlanner {
         if (plan == null) {
             return null;
         }
-        plan.addProjection(projection, null, null, 1, null);
+        plan.addProjection(projection, null, null, null);
         return Merge.ensureOnHandler(plan, context, Collections.singletonList(MergeCountProjection.INSTANCE));
     }
 


### PR DESCRIPTION
This removes the `newNumOutputs` parameter from `Plan#addProjection`.
It can be inferred from the outputs of the projection.