### PR TITLE
Updated documentation about virtual memory limits.

### DIFF
--- a/blackbox/docs/configuration.txt
+++ b/blackbox/docs/configuration.txt
@@ -1851,6 +1851,26 @@ to your config. This will prevent allocating primary and replica
 of the same shard on the same machine even if more than one instances
 running on it.
 
+Other System Configuration
+==========================
+
+Virtual Memory
+--------------
+
+CrateDB uses a hybrid MMap/NIO file system storage directory to store
+its indices. Out-of-memory exceptions and failing bootstrap checks may be
+caused by the operating system's default limit on ``max_map_count`` (the
+maximum number of memory map areas a process may have) being too low.
+
+On Linux, you can increase the limit by running the following command::
+
+    sh$ sudo sysctl -w vm.max_map_count=262144
+
+To set this value permanently, update the ``vm.max_map_count`` setting in
+``/etc/sysctl.conf``. You can then verify this after rebooting by running::
+
+    sh$ sysctl vm.max_map_count
+
 Enterprise Features
 ===================
 


### PR DESCRIPTION
This update is required as part of the bootstrap check failures brought
about by the upgrade to ElasticSearch 5+.

See https://www.elastic.co/guide/en/elasticsearch/reference/current/vm-max-map-count.html

Should this also be cherry-picked into master? Since it is now using ES5+