### PR TITLE
Disable log4j2's shutdown hook.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -24,4 +24,7 @@ Changes
 Fixes
 =====
 
+ - Fix: Log4j would yield a "No log4j2 configuration file found" error when 
+   shutting down crate ungracefully (via kill signal)
+
  - Fix: Restoring empty partitioned tables wasn't possible

--- a/app/src/bin/crate.in.sh
+++ b/app/src/bin/crate.in.sh
@@ -81,3 +81,6 @@ JAVA_OPTS="$JAVA_OPTS -Dfile.encoding=UTF-8"
 
 # Use our provided JNA always versus the system one
 JAVA_OPTS="$JAVA_OPTS -Djna.nosys=true"
+
+# log4j options
+JAVA_OPTS="$JAVA_OPTS -Dlog4j.shutdownHookEnabled=false -Dlog4j2.disable.jmx=true -Dlog4j.skipJansi=true"


### PR DESCRIPTION
Log4j2 introduced a shutdown hook to handle the logging infrastructure
terminationation.
We have our own shutdown hooks which require the logging system. 
Since the log4j hook would run before (or in parallel with) ours, when our 
services began the shutdown process and attempt to log this, we'll get 
"No log4j2 configuration found" error.
This commit disables log4j's shutdown hook as we shut it down ourselves.