### PR TITLE
Sometimes on startup it happens that a cluster changed event contains…

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -27,6 +27,8 @@ Changes
 Fixes
 =====
 
+ - Fix: Appereance of NPE during startup of crate
+
  - ``ORDER BY`` on joins caused incorrect order of values when having multiple
    non-distinct values on the left part of the join. Now ``ORDER BY`` is
    correctly applied.

--- a/sql/src/main/java/io/crate/metadata/doc/DocSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/doc/DocSchemaInfo.java
@@ -241,7 +241,7 @@ public class DocSchemaInfo implements SchemaInfo {
         // search for aliases of deleted and created indices, they must be invalidated also
         MetaData prevMetaData = event.previousState().metaData();
         for (Index index : event.indicesDeleted()) {
-            invalidateAliases(prevMetaData.index(index).getAliases());
+            invalidateFromIndex(index, prevMetaData);
         }
         MetaData newMetaData = event.state().metaData();
         for (String index : event.indicesCreated()) {
@@ -321,6 +321,18 @@ public class DocSchemaInfo implements SchemaInfo {
             }
         }
         return udfFunctions;
+    }
+
+    /**
+     * checks if metaData contains a particular index and
+     * invalidates its aliases if so
+     */
+    @VisibleForTesting
+    void invalidateFromIndex(Index index, MetaData metaData) {
+        IndexMetaData indexMetaData = metaData.index(index);
+        if (indexMetaData != null) {
+            invalidateAliases(indexMetaData.getAliases());
+        }
     }
 
     private String getIndexName(String tableName) {

--- a/sql/src/test/java/io/crate/metadata/doc/DocSchemaInfoTest.java
+++ b/sql/src/test/java/io/crate/metadata/doc/DocSchemaInfoTest.java
@@ -24,7 +24,6 @@ package io.crate.metadata.doc;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import io.crate.analyze.CreateFunctionAnalyzedStatement;
 import io.crate.data.Input;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
@@ -36,7 +35,8 @@ import io.crate.operation.udf.UserDefinedFunctionService;
 import io.crate.operation.udf.UserDefinedFunctionsMetaData;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.types.DataTypes;
-import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.index.Index;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -110,6 +110,14 @@ public class DocSchemaInfoTest extends CrateDummyClusterServiceUnitTest {
         assertThat(functionImpl.size(), is(1));
         // the valid functions will be registered
         assertThat(functionImpl.entrySet().iterator().next().getKey().name(), is("valid"));
+    }
+
+    @Test
+    public void testNoNPEIfDeletedIndicesNotInPreviousClusterState() throws Exception {
+        // sometimes on startup it occurs that a ClusterChangedEvent contains deleted indices
+        // which are not in the previousState.
+        MetaData metaData = new MetaData.Builder().build();
+        docSchemaInfo.invalidateFromIndex(new Index("my_index", "asdf"), metaData);
     }
 
 }


### PR DESCRIPTION
… deleted indices which are not included in the previous state