### PR TITLE
Add fetch propagation logic to simple subquery planner

### DIFF
--- a/sql/src/main/java/io/crate/analyze/symbol/RefVisitor.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/RefVisitor.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.analyze.symbol;
+
+import io.crate.metadata.Reference;
+
+import java.util.function.Consumer;
+
+public final class RefVisitor extends DefaultTraversalSymbolVisitor<Consumer<? super Reference>, Void> {
+
+    private static final RefVisitor VISITOR = new RefVisitor();
+
+    private RefVisitor() {
+    }
+
+    public static void visitRefs(Symbol tree, Consumer<? super Reference> consumer) {
+        VISITOR.process(tree, consumer);
+    }
+
+    @Override
+    public Void visitReference(Reference ref, Consumer<? super Reference> consumer) {
+        consumer.accept(ref);
+        return null;
+    }
+}

--- a/sql/src/main/java/io/crate/planner/ResultDescription.java
+++ b/sql/src/main/java/io/crate/planner/ResultDescription.java
@@ -22,6 +22,7 @@
 
 package io.crate.planner;
 
+import io.crate.planner.fetch.FetchRewriter;
 import io.crate.types.DataType;
 
 import javax.annotation.Nullable;
@@ -84,4 +85,8 @@ public interface ResultDescription {
      * sorting
      */
     List<DataType> streamOutputs();
+
+    default FetchRewriter.FetchDescription fetchDescription() {
+        return null;
+    }
 }

--- a/sql/src/main/java/io/crate/planner/consumer/ConsumerContext.java
+++ b/sql/src/main/java/io/crate/planner/consumer/ConsumerContext.java
@@ -31,7 +31,7 @@ public class ConsumerContext {
     private final Planner.Context plannerContext;
 
     private ValidationException validationException;
-    private FetchDecider fetchDecider = FetchDecider.ALWAYS;
+    private FetchMode fetchMode = FetchMode.NO_PROPAGATION;
     private Integer requiredPageSize;
 
     public ConsumerContext(Planner.Context plannerContext) {
@@ -51,12 +51,12 @@ public class ConsumerContext {
         return plannerContext;
     }
 
-    public void setFetchDecider(FetchDecider fetchDecider) {
-        this.fetchDecider = fetchDecider;
+    public void setFetchMode(FetchMode fetchMode) {
+        this.fetchMode = fetchMode;
     }
 
-    FetchDecider fetchDecider() {
-        return fetchDecider;
+    FetchMode fetchMode() {
+        return fetchMode;
     }
 
     void requiredPageSize(Integer requiredPageSize) {

--- a/sql/src/main/java/io/crate/planner/consumer/FetchDecider.java
+++ b/sql/src/main/java/io/crate/planner/consumer/FetchDecider.java
@@ -34,10 +34,25 @@ public interface FetchDecider {
 
     FetchDecider NEVER = () -> false;
     FetchDecider ALWAYS = () -> true;
+    FetchDecider NO_FINALIZE = new FetchDecider() {
+        @Override
+        public boolean tryFetchRewrite() {
+            return true;
+        }
+
+        @Override
+        public boolean finalizeFetch() {
+            return false;
+        }
+    };
 
     /**
      * Verify if it makes sense to attempt doing a fetch-rewrite.
      * This is an approximation, if it returns true it may not be possible to really fetch anything.
      */
     boolean tryFetchRewrite();
+
+    default boolean finalizeFetch() {
+        return true;
+    }
 }

--- a/sql/src/main/java/io/crate/planner/consumer/FetchMode.java
+++ b/sql/src/main/java/io/crate/planner/consumer/FetchMode.java
@@ -26,33 +26,12 @@ package io.crate.planner.consumer;
  * Component to help make decisions in the planner on how/if fetch-phases should be planned.
  *
  * This is mostly relevant for nested-relations where the plan being created will also contain one or more sub-plans.
- * A planner component for a parent-relation can set a FetchDecider on the {@link ConsumerContext} to influence the planning of
+ * A planner component for a parent-relation can set a FetchMode on the {@link ConsumerContext} to influence the planning of
  * child-relations.
  */
-@FunctionalInterface
-public interface FetchDecider {
+public enum FetchMode {
 
-    FetchDecider NEVER = () -> false;
-    FetchDecider ALWAYS = () -> true;
-    FetchDecider NO_FINALIZE = new FetchDecider() {
-        @Override
-        public boolean tryFetchRewrite() {
-            return true;
-        }
-
-        @Override
-        public boolean finalizeFetch() {
-            return false;
-        }
-    };
-
-    /**
-     * Verify if it makes sense to attempt doing a fetch-rewrite.
-     * This is an approximation, if it returns true it may not be possible to really fetch anything.
-     */
-    boolean tryFetchRewrite();
-
-    default boolean finalizeFetch() {
-        return true;
-    }
+    NEVER,
+    NO_PROPAGATION,
+    WITH_PROPAGATION
 }

--- a/sql/src/main/java/io/crate/planner/consumer/InsertFromSubQueryPlanner.java
+++ b/sql/src/main/java/io/crate/planner/consumer/InsertFromSubQueryPlanner.java
@@ -75,7 +75,7 @@ public final class InsertFromSubQueryPlanner {
                                                   "supported on insert using a sub-query");
         }
         SOURCE_LOOKUP_CONVERTER.process(subRelation, null);
-        context.setFetchDecider(FetchDecider.NEVER);
+        context.setFetchMode(FetchMode.NEVER);
         Plan plannedSubQuery = plannerContext.planSubRelation(subRelation, context);
         if (plannedSubQuery == null) {
             return null;

--- a/sql/src/main/java/io/crate/planner/consumer/ManyTableConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/ManyTableConsumer.java
@@ -355,11 +355,11 @@ public class ManyTableConsumer implements Consumer {
         public Plan visitMultiSourceSelect(MultiSourceSelect mss, ConsumerContext context) {
             if (isUnsupportedStatement(mss, context)) return null;
 
-            if (mss.canBeFetched().isEmpty() || context.fetchDecider().tryFetchRewrite() == false) {
+            if (mss.canBeFetched().isEmpty() || context.fetchMode() == FetchMode.NEVER) {
                 return getPlan(mss, context);
             }
 
-            context.setFetchDecider(FetchDecider.NEVER);
+            context.setFetchMode(FetchMode.NEVER);
             FetchPushDown.Builder<MultiSourceSelect> builder = FetchPushDown.pushDown(mss);
             if (builder == null) {
                 return getPlan(mss, context);

--- a/sql/src/main/java/io/crate/planner/consumer/MultiSourceAggregationConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/MultiSourceAggregationConsumer.java
@@ -74,7 +74,7 @@ class MultiSourceAggregationConsumer implements Consumer {
             SplitPoints splitPoints = SplitPoints.create(qs);
             removeAggregationsAndLimitsFromMSS(multiSourceSelect, splitPoints);
             Planner.Context plannerContext = context.plannerContext();
-            context.setFetchDecider(FetchDecider.NEVER);
+            context.setFetchMode(FetchMode.NEVER);
             Plan plan = plannerContext.planSubRelation(multiSourceSelect, context);
 
             // whereClause is already handled within the plan, no need to add additional FilterProjection via addAggregations

--- a/sql/src/main/java/io/crate/planner/consumer/MultiSourceGroupByConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/MultiSourceGroupByConsumer.java
@@ -100,7 +100,7 @@ public class MultiSourceGroupByConsumer implements Consumer {
 
             removePostGroupingActionsFromQuerySpec(multiSourceSelect, splitPoints);
 
-            context.setFetchDecider(FetchDecider.NEVER);
+            context.setFetchMode(FetchMode.NEVER);
             Plan plan = context.plannerContext().planSubRelation(multiSourceSelect, context);
 
             if (isExecutedOnHandler(context, plan)) {

--- a/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
@@ -158,7 +158,7 @@ class NestedLoopConsumer implements Consumer {
                     functions, context.plannerContext().transactionContext());
             }
 
-            context.setFetchDecider(FetchDecider.NEVER);
+            context.setFetchMode(FetchMode.NEVER);
             Plan leftPlan = context.plannerContext().planSubRelation(left, context);
             Plan rightPlan = context.plannerContext().planSubRelation(right, context);
             context.requiredPageSize(null);

--- a/sql/src/main/java/io/crate/planner/node/dql/PlanWithFetchDescription.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/PlanWithFetchDescription.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.node.dql;
+
+import io.crate.planner.Plan;
+import io.crate.planner.PlanVisitor;
+import io.crate.planner.PositionalOrderBy;
+import io.crate.planner.ResultDescription;
+import io.crate.planner.distribution.DistributionInfo;
+import io.crate.planner.fetch.FetchRewriter;
+import io.crate.planner.projection.Projection;
+import io.crate.types.DataType;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+
+public class PlanWithFetchDescription implements Plan, ResultDescription {
+
+    private final Plan subPlan;
+    private final FetchRewriter.FetchDescription fetchDescription;
+
+    public PlanWithFetchDescription(Plan subPlan, FetchRewriter.FetchDescription fetchDescription) {
+        this.subPlan = subPlan;
+        this.fetchDescription = fetchDescription;
+    }
+
+    @Override
+    public <C, R> R accept(PlanVisitor<C, R> visitor, C context) {
+        return subPlan.accept(visitor, context);
+    }
+
+    @Override
+    public UUID jobId() {
+        return subPlan.jobId();
+    }
+
+    @Override
+    public void addProjection(Projection projection,
+                              @Nullable Integer newLimit,
+                              @Nullable Integer newOffset,
+                              @Nullable PositionalOrderBy newOrderBy) {
+        subPlan.addProjection(projection, newLimit, newOffset, newOrderBy);
+    }
+
+    @Override
+    public ResultDescription resultDescription() {
+        return this;
+    }
+
+    @Override
+    public void setDistributionInfo(DistributionInfo distributionInfo) {
+        subPlan.setDistributionInfo(distributionInfo);
+    }
+
+    @Override
+    public Collection<String> nodeIds() {
+        return subPlan.resultDescription().nodeIds();
+    }
+
+    @Nullable
+    @Override
+    public PositionalOrderBy orderBy() {
+        return subPlan.resultDescription().orderBy();
+    }
+
+    @Override
+    public int limit() {
+        return subPlan.resultDescription().limit();
+    }
+
+    @Override
+    public int maxRowsPerNode() {
+        return subPlan.resultDescription().maxRowsPerNode();
+    }
+
+    @Override
+    public int offset() {
+        return subPlan.resultDescription().offset();
+    }
+
+    @Override
+    public int numOutputs() {
+        return subPlan.resultDescription().numOutputs();
+    }
+
+    @Override
+    public List<DataType> streamOutputs() {
+        return subPlan.resultDescription().streamOutputs();
+    }
+
+    @Override
+    public FetchRewriter.FetchDescription fetchDescription() {
+        return fetchDescription;
+    }
+
+    public Plan subPlan() {
+        return subPlan;
+    }
+}

--- a/sql/src/main/java/io/crate/planner/projection/builder/ProjectionBuilder.java
+++ b/sql/src/main/java/io/crate/planner/projection/builder/ProjectionBuilder.java
@@ -25,7 +25,10 @@ import com.google.common.collect.ImmutableList;
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.QueryClause;
 import io.crate.analyze.symbol.*;
-import io.crate.metadata.*;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.Functions;
+import io.crate.metadata.RowGranularity;
 import io.crate.operation.aggregation.AggregationFunction;
 import io.crate.operation.projectors.TopN;
 import io.crate.planner.projection.*;
@@ -125,7 +128,7 @@ public class ProjectionBuilder {
                                         @Nullable OrderBy orderBy,
                                         int offset,
                                         int limit,
-                                        @Nullable Collection<Symbol> outputs) {
+                                        @Nullable Collection<? extends Symbol> outputs) {
 
         InputColumns.Context context = new InputColumns.Context(inputs);
         List<Symbol> inputsProcessed = InputColumns.create(inputs, context);

--- a/sql/src/main/java/io/crate/planner/statement/CopyStatementPlanner.java
+++ b/sql/src/main/java/io/crate/planner/statement/CopyStatementPlanner.java
@@ -39,7 +39,7 @@ import io.crate.planner.Merge;
 import io.crate.planner.Plan;
 import io.crate.planner.Planner;
 import io.crate.planner.consumer.ConsumerContext;
-import io.crate.planner.consumer.FetchDecider;
+import io.crate.planner.consumer.FetchMode;
 import io.crate.planner.node.dql.Collect;
 import io.crate.planner.node.dql.FileUriCollectPhase;
 import io.crate.planner.projection.MergeCountProjection;
@@ -191,7 +191,7 @@ public class CopyStatementPlanner {
             outputFormat);
 
         ConsumerContext consumerContext = new ConsumerContext(context);
-        consumerContext.setFetchDecider(FetchDecider.NEVER);
+        consumerContext.setFetchMode(FetchMode.NEVER);
         Plan plan = context.planSubRelation(statement.subQueryRelation(), consumerContext);
         if (plan == null) {
             return null;

--- a/sql/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
@@ -24,13 +24,13 @@ package io.crate.integrationtests;
 
 import io.crate.action.sql.SQLActionException;
 import io.crate.operation.projectors.sorting.OrderingByPosition;
-import io.crate.testing.TestingHelpers;
 import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static io.crate.testing.TestingHelpers.printedTable;
 import static org.hamcrest.Matchers.is;
 
 public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
@@ -42,7 +42,7 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
         setup.setUpCharacters();
 
         execute("select i, name from (select id as i, name from characters order by name) as ch order by i desc");
-        assertThat(TestingHelpers.printedTable(response.rows()),
+        assertThat(printedTable(response.rows()),
             is("4| Arthur\n" +
                "3| Trillian\n" +
                "2| Ford\n" +
@@ -56,7 +56,7 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
         execute("select id, name " +
                 "from (select * from characters where female = true) as ch " +
                 "where name like 'Arthur'");
-        assertThat(TestingHelpers.printedTable(response.rows()),
+        assertThat(printedTable(response.rows()),
             is("4| Arthur\n"));
     }
 
@@ -67,7 +67,7 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
         execute("select id, name " +
                 "from (select * from characters where female = true) as ch " +
                 "where id = 4");
-        assertThat(TestingHelpers.printedTable(response.rows()),
+        assertThat(printedTable(response.rows()),
             is("4| Arthur\n"));
     }
 
@@ -79,7 +79,7 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
         execute("select name " +
                 "from (select * from locations order by name limit 10 offset 5) as l " +
                 "limit 5 offset 4");
-        assertThat(TestingHelpers.printedTable(response.rows()),
+        assertThat(printedTable(response.rows()),
             is("End of the Galaxy\n" +
                "Galactic Sector QQ7 Active J Gamma\n" +
                "North West Ripple\n" +
@@ -99,7 +99,7 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
                 " from (select a, i, (x + x) as xx from t1) as t) as tt " +
                 "order by aa");
 
-        assertThat(TestingHelpers.printedTable(response.rows()),
+        assertThat(printedTable(response.rows()),
             is("aa| 9\n" +
                "bb| 14\n" +
                "cc| 20\n" +
@@ -114,7 +114,7 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
                 "  select gender, min(age) as minAge from characters group by gender" +
                 ") as ch " +
                 "where gender = 'male'");
-        assertThat(TestingHelpers.printedTable(response.rows()),
+        assertThat(printedTable(response.rows()),
             is("male| 34\n"));
     }
 
@@ -125,7 +125,7 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
                 "  select gender, min(age) as minAge from characters group by gender" +
                 ") as ch " +
                 "where (minAge * 2) < 120 order by gender");
-        assertThat(TestingHelpers.printedTable(response.rows()),
+        assertThat(printedTable(response.rows()),
             is("female| 32\n" +
                "male| 34\n"));
     }
@@ -151,7 +151,7 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
 
         List<Object[]> rows = Arrays.asList(response.rows());
         Collections.sort(rows, OrderingByPosition.arrayOrdering(0, true, null));
-        assertThat(TestingHelpers.printedTable(rows.toArray(new Object[0][])),
+        assertThat(printedTable(rows.toArray(new Object[0][])),
             is("Android| NULL\n" +
                "Human| 73.0\n" +
                "Vogon| NULL\n"));
@@ -172,7 +172,7 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
                 "  from t1, t2 where t2.y > 60) as t " +
                 "where col1 = 'a' order by col3");
 
-        assertThat(TestingHelpers.printedTable(response.rows()),
+        assertThat(printedTable(response.rows()),
             is("a| 55\n" +
                "a| 77\n"));
     }
@@ -193,7 +193,7 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
                 "    from t1, t2 where t1.a='a' or t2.a='aa') as t) as tt " +
                 "order by aa, xyi");
 
-        assertThat(TestingHelpers.printedTable(response.rows()),
+        assertThat(printedTable(response.rows()),
             is("aaa| 58\n" +
                "abb| 91\n" +
                "acc| 135\n" +
@@ -219,7 +219,7 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
                 "    from t1 left join t2 on t1.a = t2.a where t1.a='a') as t) as tt " +
                 "order by aa, xyi");
 
-        assertThat(TestingHelpers.printedTable(response.rows()),
+        assertThat(printedTable(response.rows()),
             is("aa| 58\n"));
 
         execute("select aa, xyi from (" +
@@ -228,7 +228,7 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
                 "    from t1 right join t2 on t1.a = t2.a where t1.a='a' or t2.a in ('aa', 'bb')) as t) as tt " +
                 "order by aa, xyi");
 
-        assertThat(TestingHelpers.printedTable(response.rows()),
+        assertThat(printedTable(response.rows()),
             is("aa| 58\n" +
                "bb| NULL\n"));
 
@@ -238,7 +238,7 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
                 "    from t1 full join t2 on t1.a = t2.a where t1.a='a' or t2.a in ('aa', 'bb')) as t) as tt " +
                 "order by aa, xyi");
 
-        assertThat(TestingHelpers.printedTable(response.rows()),
+        assertThat(printedTable(response.rows()),
             is("aa| 58\n" +
                "bb| NULL\n"));
     }
@@ -258,7 +258,7 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
         execute("refresh table t1, t2");
 
         execute("select * from t1 where x = (select y from t2)");
-        assertThat(TestingHelpers.printedTable(response.rows()), is("2\n"));
+        assertThat(printedTable(response.rows()), is("2\n"));
     }
 
     @Test
@@ -273,7 +273,7 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
         execute("refresh table t1, t2, t3");
 
         execute("select * from t1 where x = (select y from t2 where y = (select z from t3))");
-        assertThat(TestingHelpers.printedTable(response.rows()), is("2\n"));
+        assertThat(printedTable(response.rows()), is("2\n"));
     }
 
     @Test
@@ -284,7 +284,7 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
         execute("refresh table t1");
 
         execute("select sum(x) from t1 where x = (select 1)");
-        assertThat(TestingHelpers.printedTable(response.rows()), is("1.0\n"));
+        assertThat(printedTable(response.rows()), is("1.0\n"));
     }
 
     @Test
@@ -295,7 +295,7 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
         execute("refresh table t1");
 
         execute("select sum(x), x from t1 where x = (select 1) group by x");
-        assertThat(TestingHelpers.printedTable(response.rows()), is("1.0| 1\n"));
+        assertThat(printedTable(response.rows()), is("1.0| 1\n"));
     }
 
     @Test
@@ -317,7 +317,7 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
         execute("refresh table t1");
 
         execute("select x, (select 'foo') from t1 where x = (select 1)");
-        assertThat(TestingHelpers.printedTable(response.rows()), is("1| foo\n"));
+        assertThat(printedTable(response.rows()), is("1| foo\n"));
     }
 
     @Test
@@ -328,7 +328,7 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
         execute("refresh table t");
 
         execute("select * from t as t1, t as t2 where t1.x = (select 1) order by t2.x");
-        assertThat(TestingHelpers.printedTable(response.rows()), is("1| 1\n1| 2\n"));
+        assertThat(printedTable(response.rows()), is("1| 1\n1| 2\n"));
     }
 
     @Test
@@ -343,7 +343,7 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
     @Test
     public void testScalarSubqueryCanBeUsedInGroupByAndHaving() throws Exception {
         execute("select (select 'foo'), count(*) from unnest([1, 2]) group by 1 having count(*) = (select 2)");
-        assertThat(TestingHelpers.printedTable(response.rows()), is("foo| 2\n"));
+        assertThat(printedTable(response.rows()), is("foo| 2\n"));
     }
 
     @Test
@@ -365,7 +365,7 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
 
         // orderBy and limit in subQuery to prevent rewrite to non-subquery
         execute("select sum(x) from (select x from t order by x limit 1) as t");
-        assertThat(TestingHelpers.printedTable(response.rows()), is("1.0\n"));
+        assertThat(printedTable(response.rows()), is("1.0\n"));
     }
 
     @Test
@@ -376,7 +376,7 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
         execute("refresh table t");
 
         execute("select sum(x) from (select min(x) as x from (select max(x) as x from t) as t) as t");
-        assertThat(TestingHelpers.printedTable(response.rows()), is("2.0\n"));
+        assertThat(printedTable(response.rows()), is("2.0\n"));
     }
 
     @Test
@@ -386,13 +386,13 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
                 "       where t1.col1 = (select 1) " +
                 "       order by x limit 3" +
                 ") t");
-        assertThat(TestingHelpers.printedTable(response.rows()), is("3.0\n"));
+        assertThat(printedTable(response.rows()), is("3.0\n"));
     }
 
     @Test
     public void testGlobalAggOnSubQueryWithWhereOnOuterRelation() throws Exception {
         execute("select sum(x) from (select min(col1) as x from unnest([1])) as t where x = 2");
-        assertThat(TestingHelpers.printedTable(response.rows()), is("NULL\n"));
+        assertThat(printedTable(response.rows()), is("NULL\n"));
     }
 
     @Test
@@ -403,7 +403,7 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
         execute("refresh table t");
 
         execute("select (select 2), x from t");
-        assertThat(TestingHelpers.printedTable(response.rows()),
+        assertThat(printedTable(response.rows()),
             is("2| 1\n" +
                "2| 1\n"));
     }
@@ -413,7 +413,7 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
         execute("select col1 from (" +
                 "   select col1 from unnest([1, 2, 3, 4]) order by col1 asc limit 3" +
                 ") t order by col1 desc limit 1");
-        assertThat(TestingHelpers.printedTable(response.rows()), is("3\n"));
+        assertThat(printedTable(response.rows()), is("3\n"));
     }
 
     @Test
@@ -426,7 +426,7 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
         execute("select x, y from (" +
                 "   select x, y from t order by x limit 2) t " +
                 "order by y desc limit 1");
-        assertThat(TestingHelpers.printedTable(response.rows()), is("30| 40\n"));
+        assertThat(printedTable(response.rows()), is("30| 40\n"));
     }
 
     @Test
@@ -439,6 +439,46 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
         execute("select x, y from (" +
                 "   select x, y from t order by x limit 3) t " +
                 "where x = 30 order by y desc limit 2");
-        assertThat(TestingHelpers.printedTable(response.rows()), is("30| 40\n"));
+        assertThat(printedTable(response.rows()), is("30| 40\n"));
+    }
+
+    @Test
+    public void testNestedSimpleSubSelectWhichWhereFetchPropagationIsPossible() throws Exception {
+        execute("create table t (x int, y int)");
+        ensureYellow();
+        execute("insert into t (x, y) values (1, 10), (2, 20), (3, 30), (4, 40), (5, 50)");
+        execute("refresh table t");
+
+        // this re-orders columns and contains scalar functions to handle a more-complex case
+        execute("select xx, yy from (" +
+                "   select y + y as yy, x + x as xx from (" +
+                "       select x, y from t order by x asc limit 4" +
+                "   ) tt " +
+                "   order by tt.x desc limit 3" +
+                ") ttt " +
+                "where ttt.xx = 4 or ttt.xx = 6 order by ttt.xx asc limit 2");
+        assertThat(printedTable(response.rows()),
+            is("4| 40\n" +
+               "6| 60\n"));
+    }
+
+    @Test
+    public void testNestedSimpleSubSelectNoFetchPropagationAsWhereIsOnNonQuerySymbol() throws Exception {
+        execute("create table t (x int, y int)");
+        ensureYellow();
+        execute("insert into t (x, y) values (1, 10), (2, 20), (3, 30), (4, 40), (5, 50)");
+        execute("refresh table t");
+
+        // this re-orders columns and contains scalar functions to handle a more-complex case
+        execute("select xx, yy from (" +
+                "   select y + y as yy, x + x as xx from (" +
+                "       select x, y from t order by x asc limit 4" +
+                "   ) tt " +
+                "   order by tt.x desc limit 3" +
+                ") ttt " +
+                "where ttt.yy = 40 or ttt.yy = 60 order by ttt.xx asc limit 2");
+        assertThat(printedTable(response.rows()),
+            is("4| 40\n" +
+               "6| 60\n"));
     }
 }

--- a/sql/src/test/java/io/crate/planner/SubQueryPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/SubQueryPlannerTest.java
@@ -23,6 +23,7 @@
 package io.crate.planner;
 
 import io.crate.planner.node.dql.Collect;
+import io.crate.planner.node.dql.PlanWithFetchDescription;
 import io.crate.planner.node.dql.QueryThenFetch;
 import io.crate.planner.node.dql.join.NestedLoop;
 import io.crate.planner.projection.*;
@@ -51,7 +52,9 @@ public class SubQueryPlannerTest extends CrateDummyClusterServiceUnitTest {
     public void testNestedSimpleSelectUsesFetch() throws Exception {
         QueryThenFetch qtf = e.plan(
             "select x, i from (select x, i from t1 order by x asc limit 10) ti order by x desc limit 3");
-        List<Projection> projections = ((Collect) qtf.subPlan()).collectPhase().projections();
+        PlanWithFetchDescription planWithFetchDescription = (PlanWithFetchDescription) qtf.subPlan();
+        Collect collect = (Collect) planWithFetchDescription.subPlan();
+        List<Projection> projections = collect.collectPhase().projections();
         assertThat(projections, Matchers.contains(
             instanceOf(TopNProjection.class),
             instanceOf(TopNProjection.class),
@@ -69,7 +72,9 @@ public class SubQueryPlannerTest extends CrateDummyClusterServiceUnitTest {
                                     "   (select x, i from t1 order by x asc limit 10) ti " +
                                     "where ti.x = 10 " +
                                     "order by x desc limit 3");
-        List<Projection> projections = ((Collect) qtf.subPlan()).collectPhase().projections();
+        PlanWithFetchDescription planWithFetchDescription = (PlanWithFetchDescription) qtf.subPlan();
+        Collect collect = (Collect) planWithFetchDescription.subPlan();
+        List<Projection> projections = collect.collectPhase().projections();
         assertThat(projections, Matchers.hasItem(instanceOf(FilterProjection.class)));
     }
 

--- a/sql/src/test/java/io/crate/planner/fetch/FetchRewriterTest.java
+++ b/sql/src/test/java/io/crate/planner/fetch/FetchRewriterTest.java
@@ -184,7 +184,7 @@ public class FetchRewriterTest extends CrateDummyClusterServiceUnitTest {
         QueriedDocTable docTable = (QueriedDocTable) stmt.relation();
         FetchRewriter.FetchDescription fetchDescription = FetchRewriter.rewrite(docTable);
 
-        assertThat(fetchDescription.preFetchOutputs, contains(isReference("_fetchid"), isFunction("add")));
+        assertThat(fetchDescription.preFetchOutputs(), contains(isReference("_fetchid"), isFunction("add")));
         assertThat(fetchDescription.postFetchOutputs, contains(isFunction("add"), isReference("_doc['a']")));
 
         List<Symbol> fetchOutputs = FetchRewriter.generateFetchOutputs(fetchDescription);


### PR DESCRIPTION
This optimizes the execution for simple subqueries where the fetch-phase
can be deferred. Queries like:

    select x, y from
        (select x, y from t order by x asc limit 100)  tt
    order by x desc limit 50

Were executed as:

    Collect [_fetchId, x]
        orderBy x asc
        limit 100
        fetch _fetchId -> y
        order by x desc
        limit 50

Now they're executed as:

    Collect [_fetchId, x]
        orderBy x asc
        limit 100
        order by x desc
        limit 50
        fetch _fetchId -> y

Note that this fetch-propagation is all-or-nothing. There are no partial
intermediate fetches (yet).