### PR TITLE
Validate explicit join conditions

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -27,6 +27,10 @@ Changes
 Fixes
 =====
 
+ - Fixed a NullPointerException which could occur if an attempt was made to use
+   `match` on two different relations within an explicit join condition.
+   This now raises a proper error stating that it's not supported.
+
  - Wrong results were returned from queries with more than one level
    of nested subselects.
 

--- a/sql/src/main/java/io/crate/analyze/relations/RelationSplitter.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationSplitter.java
@@ -32,7 +32,6 @@ import io.crate.operation.operator.AndOperator;
 import io.crate.planner.Limits;
 import io.crate.sql.tree.QualifiedName;
 
-import javax.annotation.Nullable;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -64,6 +63,7 @@ public final class RelationSplitter {
         joinConditions = new ArrayList<>(joinPairs.size());
         for (JoinPair joinPair : joinPairs) {
             if (joinPair.condition() != null) {
+                JoinConditionValidator.validate(joinPair.condition());
                 joinConditions.add(joinPair.condition());
             }
         }
@@ -155,7 +155,7 @@ public final class RelationSplitter {
         Symbol query = querySpec.where().query();
         assert query != null : "query must not be null";
         QuerySplittingVisitor.Context context = QuerySplittingVisitor.INSTANCE.process(querySpec.where().query(), joinPairs);
-        JoinConditionValidator.INSTANCE.process(context.query(), null);
+        JoinConditionValidator.validate(context.query());
         querySpec.where(new WhereClause(context.query()));
         for (Map.Entry<QualifiedName, Collection<Symbol>> entry : context.queries().asMap().entrySet()) {
             getSpec(entry.getKey()).where(new WhereClause(AndOperator.join(entry.getValue())));
@@ -263,21 +263,17 @@ public final class RelationSplitter {
         return splits;
     }
 
-    private static class JoinConditionValidator extends SymbolVisitor<Void, Symbol> {
+    private final static class JoinConditionValidator extends DefaultTraversalSymbolVisitor<Void, Symbol> {
 
         private static final JoinConditionValidator INSTANCE = new JoinConditionValidator();
 
-        @Override
-        public Symbol process(Symbol symbol, @Nullable Void context) {
-            return symbol != null ? super.process(symbol, context) : null;
-        }
-
-        @Override
-        public Symbol visitFunction(Function symbol, Void context) {
-            for (Symbol argument : symbol.arguments()) {
-                process(argument, context);
+        /**
+         * @throws IllegalArgumentException thrown if the join condition is not valid
+         */
+        public static void validate(Symbol joinCondition) {
+            if (joinCondition != null) {
+                INSTANCE.process(joinCondition, null);
             }
-            return null;
         }
 
         @Override

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -1999,4 +1999,10 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         expectedException.expectMessage("Non table function abs is not supported in from clause");
         analyze("select * from abs(1)");
     }
+
+    @Test
+    public void testMatchInExplicitJoinConditionIsProhibited() throws Exception {
+        expectedException.expectMessage("Cannot use MATCH predicates on columns of 2 different relations");
+        analyze("select * from users u1 inner join users u2 on match((u1.name, u2.name), 'foo')");
+    }
 }


### PR DESCRIPTION
A statement like

    select * from t1 inner join t2 on match((t1.name,t2.name), 'foo')

failed with a NPE because explicit join conditions were not validated.