### PR TITLE
Fixed error in joins used in a nested select

### DIFF
--- a/sql/src/main/java/io/crate/analyze/MultiSourceSelect.java
+++ b/sql/src/main/java/io/crate/analyze/MultiSourceSelect.java
@@ -30,6 +30,7 @@ import io.crate.sql.tree.QualifiedName;
 
 import javax.annotation.Nonnull;
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class MultiSourceSelect implements QueriedRelation {
 
@@ -55,6 +56,17 @@ public class MultiSourceSelect implements QueriedRelation {
         for (Path path : outputNames) {
             fields.add(path, new Field(this, path, outputsIterator.next().valueType()));
         }
+    }
+
+    public MultiSourceSelect(MultiSourceSelect mss, QuerySpec querySpec) {
+        this.sources = mss.sources;
+        this.joinPairs = mss.joinPairs;
+        this.splitter = new RelationSplitter(
+            querySpec,
+            sources.values().stream().map(rs -> rs.relation()).collect(Collectors.toList()),
+            joinPairs);
+        this.querySpec = querySpec;
+        this.fields = mss.fields;
     }
 
     public Set<Symbol> requiredForQuery() {

--- a/sql/src/main/java/io/crate/analyze/relations/RelationNormalizer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationNormalizer.java
@@ -22,7 +22,6 @@
 
 package io.crate.analyze.relations;
 
-import com.google.common.collect.Maps;
 import io.crate.analyze.*;
 import io.crate.metadata.Functions;
 import io.crate.metadata.ReplaceMode;
@@ -87,11 +86,7 @@ final class RelationNormalizer {
             QuerySpec querySpec = mss.querySpec();
             querySpec.normalize(normalizer, context);
             // must create a new MultiSourceSelect because paths and query spec changed
-            mss = new MultiSourceSelect(
-                Maps.transformValues(mss.sources(), RelationSource::relation),
-                mss.fields(),
-                querySpec,
-                mss.joinPairs());
+            mss = new MultiSourceSelect(mss, querySpec);
             mss.pushDownQuerySpecs();
             if (mss.sources().size() == 2) {
                 Iterator<RelationSource> it = mss.sources().values().iterator();


### PR DESCRIPTION
Wrongly createdOrderedTopNProjection (outputs where Fields instead of InputColumns) caused
by wrong copy of the Fields of MultiSourceSelect in RelationNormalizer.