### PR TITLE
Remove qualifiedName from RelationSource

### DIFF
--- a/sql/src/main/java/io/crate/analyze/MultiSourceSelect.java
+++ b/sql/src/main/java/io/crate/analyze/MultiSourceSelect.java
@@ -121,7 +121,8 @@ public class MultiSourceSelect implements QueriedRelation {
     private static HashMap<QualifiedName, RelationSource> initializeSources(Map<QualifiedName, AnalyzedRelation> originalSources) {
         HashMap<QualifiedName, RelationSource> sources = new LinkedHashMap<>(originalSources.size());
         for (Map.Entry<QualifiedName, AnalyzedRelation> entry : originalSources.entrySet()) {
-            RelationSource source = new RelationSource(entry.getKey(), entry.getValue());
+            entry.getValue().setQualifiedName(entry.getKey());
+            RelationSource source = new RelationSource(entry.getValue());
             sources.put(entry.getKey(), source);
         }
         return sources;

--- a/sql/src/main/java/io/crate/analyze/RelationSource.java
+++ b/sql/src/main/java/io/crate/analyze/RelationSource.java
@@ -23,26 +23,19 @@
 package io.crate.analyze;
 
 import io.crate.analyze.relations.AnalyzedRelation;
-import io.crate.sql.tree.QualifiedName;
 
 public class RelationSource {
 
-    private final QualifiedName qualifiedName;
     private final AnalyzedRelation relation;
     private QuerySpec querySpec;
 
-    public RelationSource(QualifiedName qualifiedName, AnalyzedRelation relation) {
-        this(qualifiedName, relation, null);
+    public RelationSource(AnalyzedRelation relation) {
+        this(relation, null);
     }
 
-    public RelationSource(QualifiedName qualifiedName, AnalyzedRelation relation, QuerySpec querySpec) {
-        this.qualifiedName = qualifiedName;
+    public RelationSource(AnalyzedRelation relation, QuerySpec querySpec) {
         this.relation = relation;
         this.querySpec = querySpec;
-    }
-
-    public QualifiedName qualifiedName() {
-        return qualifiedName;
     }
 
     public QuerySpec querySpec() {
@@ -60,7 +53,6 @@ public class RelationSource {
     @Override
     public String toString() {
         return "Source{" +
-               "qName=" + qualifiedName +
                ", rel=" + relation +
                ", qs=" + querySpec +
                '}';

--- a/sql/src/main/java/io/crate/analyze/TwoTableJoin.java
+++ b/sql/src/main/java/io/crate/analyze/TwoTableJoin.java
@@ -55,7 +55,10 @@ public class TwoTableJoin implements QueriedRelation {
         this.querySpec = querySpec;
         this.left = left;
         this.right = right;
-        this.name = QualifiedName.of("join", left.qualifiedName().toString(), right.qualifiedName().toString());
+        this.name = QualifiedName.of(
+            "join",
+            left.relation().getQualifiedName().toString(),
+            right.relation().getQualifiedName().toString());
         this.remainingOrderBy = remainingOrderBy;
         this.joinPair = joinPair;
         fields = new ArrayList<>(querySpec.outputs().size());
@@ -111,11 +114,11 @@ public class TwoTableJoin implements QueriedRelation {
     }
 
     public QualifiedName leftName() {
-        return left.qualifiedName();
+        return left.relation().getQualifiedName();
     }
 
     public QualifiedName rightName() {
-        return right.qualifiedName();
+        return right.relation().getQualifiedName();
     }
 
     @Override

--- a/sql/src/main/java/io/crate/analyze/relations/RelationNormalizer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationNormalizer.java
@@ -92,8 +92,8 @@ final class RelationNormalizer {
                 Iterator<RelationSource> it = mss.sources().values().iterator();
                 RelationSource leftSource = it.next();
                 RelationSource rightSource = it.next();
-                QualifiedName left = leftSource.qualifiedName();
-                QualifiedName right = rightSource.qualifiedName();
+                QualifiedName left = leftSource.relation().getQualifiedName();
+                QualifiedName right = rightSource.relation().getQualifiedName();
                 Rewriter.tryRewriteOuterToInnerJoin(
                     normalizer,
                     JoinPairs.ofRelationsWithMergedConditions(left, right, mss.joinPairs(), false),

--- a/sql/src/main/java/io/crate/planner/consumer/ManyTableConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/ManyTableConsumer.java
@@ -236,7 +236,7 @@ public class ManyTableConsumer implements Consumer {
             // NestedLoop will add NULL rows - so order by needs to be applied after the NestedLoop
             TwoTableJoin join = new TwoTableJoin(
                 newQuerySpec,
-                new RelationSource(leftName, leftRelation, leftQuerySpec),
+                new RelationSource(leftRelation, leftQuerySpec),
                 rightSource,
                 remainingOrderByToApply,
                 joinPair

--- a/sql/src/test/java/io/crate/planner/consumer/ManyTableConsumerTest.java
+++ b/sql/src/test/java/io/crate/planner/consumer/ManyTableConsumerTest.java
@@ -200,6 +200,6 @@ public class ManyTableConsumerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(root.toString(), is("join.join.doc.t1.doc.t3.doc.t2"));
         TwoTableJoin t1Andt3 = ((TwoTableJoin) root.left().relation());
         assertThat(t1Andt3.toString(), is("join.doc.t1.doc.t3"));
-        assertThat(root.right().qualifiedName().toString(), is("doc.t2"));
+        assertThat(root.right().relation().getQualifiedName().toString(), is("doc.t2"));
     }
 }


### PR DESCRIPTION
The AnalyzedRelation has a qualifiedName which can be used instead.