### PR TITLE
remove unnecessary test.output.resourcesDir

### DIFF
--- a/lang-js/build.gradle
+++ b/lang-js/build.gradle
@@ -47,5 +47,3 @@ jar {
     }
 }
 jar.dependsOn('getVersion')
-
-sourceSets.test.output.resourcesDir = 'src/test/java'


### PR DESCRIPTION
config from lang.js/build.gradle