### PR TITLE
Make sure joins work on sources using RowsBatchIterator.empty()

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -27,6 +27,9 @@ Changes
 Fixes
 =====
 
+ - Fixed a regression that lead to `ArrayIndexOutOfBoundsException` if a JOIN
+   query was made with a WHERE clause on partitioned columns.
+
  - Fixed a NullPointerException which could occur if an attempt was made to use
    `match` on two different relations within an explicit join condition.
    This now raises a proper error stating that it's not supported.

--- a/dex/src/main/java/io/crate/data/RowsBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/RowsBatchIterator.java
@@ -40,8 +40,8 @@ public class RowsBatchIterator implements BatchIterator {
 
     private Iterator<? extends Row> it;
 
-    public static BatchIterator empty() {
-        return newInstance(Collections.emptyList(), 0);
+    public static BatchIterator empty(int numCols) {
+        return newInstance(Collections.emptyList(), numCols);
     }
 
     public static BatchIterator newInstance(Row row) {

--- a/dex/src/test/java/io/crate/data/NestedLoopBatchIteratorTest.java
+++ b/dex/src/test/java/io/crate/data/NestedLoopBatchIteratorTest.java
@@ -115,8 +115,8 @@ public class NestedLoopBatchIteratorTest {
     @Test
     public void testNestedLoopLeftAndRightEmpty() throws Exception {
         BatchIterator iterator = NestedLoopBatchIterator.crossJoin(
-            RowsBatchIterator.empty(),
-            RowsBatchIterator.empty()
+            RowsBatchIterator.empty(1),
+            RowsBatchIterator.empty(1)
         );
         TestingBatchConsumer consumer = new TestingBatchConsumer();
         consumer.accept(iterator, null);
@@ -126,7 +126,7 @@ public class NestedLoopBatchIteratorTest {
     @Test
     public void testNestedLoopLeftEmpty() throws Exception {
         BatchIterator iterator = NestedLoopBatchIterator.crossJoin(
-            RowsBatchIterator.empty(),
+            RowsBatchIterator.empty(1),
             TestingBatchIterators.range(0, 5)
         );
         TestingBatchConsumer consumer = new TestingBatchConsumer();
@@ -138,7 +138,7 @@ public class NestedLoopBatchIteratorTest {
     public void testNestedLoopRightEmpty() throws Exception {
         BatchIterator iterator = NestedLoopBatchIterator.crossJoin(
             TestingBatchIterators.range(0, 5),
-            RowsBatchIterator.empty()
+            RowsBatchIterator.empty(1)
         );
         TestingBatchConsumer consumer = new TestingBatchConsumer();
         consumer.accept(iterator, null);

--- a/sql/src/main/java/io/crate/executor/task/NoopTask.java
+++ b/sql/src/main/java/io/crate/executor/task/NoopTask.java
@@ -39,7 +39,7 @@ public class NoopTask implements Task {
 
     @Override
     public void execute(BatchConsumer consumer, Row parameters) {
-        consumer.accept(RowsBatchIterator.empty(), null);
+        consumer.accept(RowsBatchIterator.empty(0), null);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/executor/task/SetSessionTask.java
+++ b/sql/src/main/java/io/crate/executor/task/SetSessionTask.java
@@ -64,7 +64,7 @@ public class SetSessionTask extends JobTask {
                 LOGGER.warn("SET SESSION STATEMENT WILL BE IGNORED: {}", setting);
             }
         }
-        consumer.accept(RowsBatchIterator.empty(), null);
+        consumer.accept(RowsBatchIterator.empty(0), null);
     }
 }
 

--- a/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/ESGetTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/ESGetTask.java
@@ -107,7 +107,7 @@ public class ESGetTask extends JobTask {
         protected void innerStart() {
             if (request == null) {
                 // request can be null if id is null -> since primary keys cannot be null this is a no-match
-                consumer.accept(RowsBatchIterator.empty(), null);
+                consumer.accept(RowsBatchIterator.empty(task.inputRow.numColumns()), null);
                 close();
             } else {
                 transportAction.execute(request, this);
@@ -258,7 +258,7 @@ public class ESGetTask extends JobTask {
                 }
                 consumer.accept(RowsBatchIterator.newInstance(task.inputRow), null);
             } else {
-                consumer.accept(RowsBatchIterator.empty(), null);
+                consumer.accept(RowsBatchIterator.empty(task.inputRow.numColumns()), null);
             }
             close();
         }
@@ -267,7 +267,7 @@ public class ESGetTask extends JobTask {
         public void onFailure(Exception e) {
             if (task.esGet.tableInfo().isPartitioned() && e instanceof IndexNotFoundException) {
                 // this means we have no matching document
-                consumer.accept(RowsBatchIterator.empty(), null);
+                consumer.accept(RowsBatchIterator.empty(task.inputRow.numColumns()), null);
                 close();
             } else {
                 consumer.accept(null, e);

--- a/sql/src/main/java/io/crate/operation/collect/InputCollectExpression.java
+++ b/sql/src/main/java/io/crate/operation/collect/InputCollectExpression.java
@@ -62,4 +62,9 @@ public class InputCollectExpression implements CollectExpression<Row, Object> {
         result = 31 * result + (value != null ? value.hashCode() : 0);
         return result;
     }
+
+    @Override
+    public String toString() {
+        return "Input{pos=" + position + '}';
+    }
 }

--- a/sql/src/main/java/io/crate/operation/collect/RowsCollector.java
+++ b/sql/src/main/java/io/crate/operation/collect/RowsCollector.java
@@ -29,8 +29,8 @@ import java.util.Collections;
 
 public final class RowsCollector {
 
-    public static CrateCollector empty(BatchConsumer consumer) {
-        return BatchIteratorCollectorBridge.newInstance(RowsBatchIterator.empty(), consumer);
+    public static CrateCollector empty(BatchConsumer consumer, int numColumns) {
+        return BatchIteratorCollectorBridge.newInstance(RowsBatchIterator.empty(numColumns), consumer);
     }
 
     public static CrateCollector single(Row row, BatchConsumer consumer) {
@@ -44,8 +44,8 @@ public final class RowsCollector {
         return BatchIteratorCollectorBridge.newInstance(RowsBatchIterator.newInstance(rows, numCols), consumer);
     }
 
-    static CrateCollector.Builder emptyBuilder() {
-        return consumer -> BatchIteratorCollectorBridge.newInstance(RowsBatchIterator.empty(), consumer);
+    static CrateCollector.Builder emptyBuilder(int numColumns) {
+        return consumer -> BatchIteratorCollectorBridge.newInstance(RowsBatchIterator.empty(numColumns), consumer);
     }
 
     public static CrateCollector.Builder builder(final Iterable<Row> rows, int numCols) {

--- a/sql/src/main/java/io/crate/operation/collect/ShardCollectorProvider.java
+++ b/sql/src/main/java/io/crate/operation/collect/ShardCollectorProvider.java
@@ -42,8 +42,8 @@ import io.crate.planner.node.dql.RoutedCollectPhase;
 import io.crate.planner.projection.Projection;
 import io.crate.planner.projection.Projections;
 import org.elasticsearch.action.bulk.BulkRetryCoordinatorPool;
-import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -128,7 +128,7 @@ public abstract class ShardCollectorProvider {
 
         final CrateCollector.Builder builder;
         if (normalizedCollectNode.whereClause().noMatch()) {
-            builder = RowsCollector.emptyBuilder();
+            builder = RowsCollector.emptyBuilder(collectPhase.toCollect().size());
         } else {
             assert normalizedCollectNode.maxRowGranularity() == RowGranularity.DOC : "granularity must be DOC";
             builder = getBuilder(normalizedCollectNode, requiresScroll, jobCollectContext);

--- a/sql/src/main/java/io/crate/operation/collect/sources/CollectSourceResolver.java
+++ b/sql/src/main/java/io/crate/operation/collect/sources/CollectSourceResolver.java
@@ -186,7 +186,7 @@ public class CollectSourceResolver {
 
         @Override
         public CrateCollector getCollector(CollectPhase collectPhase, BatchConsumer consumer, JobCollectContext jobCollectContext) {
-            return RowsCollector.empty(consumer);
+            return RowsCollector.empty(consumer, collectPhase.toCollect().size());
         }
     }
 }

--- a/sql/src/main/java/io/crate/operation/collect/sources/NodeStatsCollectSource.java
+++ b/sql/src/main/java/io/crate/operation/collect/sources/NodeStatsCollectSource.java
@@ -41,8 +41,8 @@ import io.crate.operation.collect.collectors.NodeStatsIterator;
 import io.crate.operation.reference.sys.node.NodeStatsContext;
 import io.crate.planner.node.dql.CollectPhase;
 import io.crate.planner.node.dql.RoutedCollectPhase;
-import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
@@ -73,13 +73,13 @@ public class NodeStatsCollectSource implements CollectSource {
     public CrateCollector getCollector(CollectPhase phase, BatchConsumer consumer, JobCollectContext jobCollectContext) {
         RoutedCollectPhase collectPhase = (RoutedCollectPhase) phase;
         if (collectPhase.whereClause().noMatch()) {
-            return RowsCollector.empty(consumer);
+            return RowsCollector.empty(consumer, phase.toCollect().size());
         }
         Collection<DiscoveryNode> nodes = nodeIds(collectPhase.whereClause(),
             Lists.newArrayList(clusterService.state().getNodes().iterator()),
             functions);
         if (nodes.isEmpty()) {
-            return RowsCollector.empty(consumer);
+            return RowsCollector.empty(consumer, phase.toCollect().size());
         }
         BatchIterator nodeStatsIterator = NodeStatsIterator.newInstance(
             nodeStatsAction,

--- a/sql/src/main/java/io/crate/operation/collect/sources/ShardCollectSource.java
+++ b/sql/src/main/java/io/crate/operation/collect/sources/ShardCollectSource.java
@@ -313,7 +313,7 @@ public class ShardCollectSource extends AbstractComponent implements CollectSour
 
         switch (builders.size()) {
             case 0:
-                return RowsCollector.empty(firstConsumer);
+                return RowsCollector.empty(firstConsumer, phase.toCollect().size());
             case 1:
                 CrateCollector.Builder collectorBuilder = builders.iterator().next();
                 return collectorBuilder.build(collectorBuilder.applyProjections(firstConsumer));

--- a/sql/src/main/java/io/crate/operation/collect/sources/SingleRowSource.java
+++ b/sql/src/main/java/io/crate/operation/collect/sources/SingleRowSource.java
@@ -57,7 +57,7 @@ public class SingleRowSource implements CollectSource {
         RoutedCollectPhase collectPhase = (RoutedCollectPhase) phase;
         collectPhase = collectPhase.normalize(clusterNormalizer, null);
         if (collectPhase.whereClause().noMatch()) {
-            return RowsCollector.empty(consumer);
+            return RowsCollector.empty(consumer, phase.toCollect().size());
         }
         assert !collectPhase.whereClause().hasQuery()
             : "WhereClause should have been normalized to either MATCH_ALL or NO_MATCH";

--- a/sql/src/main/java/io/crate/operation/collect/sources/TableFunctionCollectSource.java
+++ b/sql/src/main/java/io/crate/operation/collect/sources/TableFunctionCollectSource.java
@@ -64,7 +64,7 @@ public class TableFunctionCollectSource implements CollectSource {
         TableFunctionCollectPhase phase = (TableFunctionCollectPhase) collectPhase;
         WhereClause whereClause = phase.whereClause();
         if (whereClause.noMatch()) {
-            return RowsCollector.empty(consumer);
+            return RowsCollector.empty(consumer, collectPhase.toCollect().size());
         }
 
         TableFunctionImplementation functionImplementation = phase.relation().functionImplementation();

--- a/sql/src/main/java/io/crate/operation/join/NestedLoopOperation.java
+++ b/sql/src/main/java/io/crate/operation/join/NestedLoopOperation.java
@@ -25,6 +25,7 @@ import io.crate.concurrent.CompletionListenable;
 import io.crate.data.*;
 import io.crate.data.join.NestedLoopBatchIterator;
 import io.crate.planner.node.dql.join.JoinType;
+
 import javax.annotation.Nullable;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BooleanSupplier;
@@ -58,10 +59,10 @@ public class NestedLoopOperation implements CompletionListenable {
             });
     }
 
-    private BatchIterator createNestedLoopIterator(BatchIterator left,
-                                                   BatchIterator right,
-                                                   JoinType joinType,
-                                                   Predicate<Row> joinCondition) {
+    private static BatchIterator createNestedLoopIterator(BatchIterator left,
+                                                          BatchIterator right,
+                                                          JoinType joinType,
+                                                          Predicate<Row> joinCondition) {
         switch (joinType) {
             case CROSS:
                 return NestedLoopBatchIterator.crossJoin(left, right);
@@ -82,7 +83,7 @@ public class NestedLoopOperation implements CompletionListenable {
         throw new AssertionError("Invalid joinType: " + joinType);
     }
 
-    private Function<Columns, BooleanSupplier> getJoinCondition(Predicate<Row> joinCondition) {
+    private static Function<Columns, BooleanSupplier> getJoinCondition(Predicate<Row> joinCondition) {
         return columns -> {
             final Row row = RowBridging.toRow(columns);
             return () -> joinCondition.test(row);

--- a/sql/src/test/java/io/crate/operation/collect/collectors/MultiConsumerTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/collectors/MultiConsumerTest.java
@@ -61,7 +61,7 @@ public class MultiConsumerTest extends CrateUnitTest {
         TestingBatchConsumer batchConsumer = new TestingBatchConsumer();
         BatchConsumer consumer = new CompositeCollector.MultiConsumer(2, batchConsumer, CompositeBatchIterator::new);
         consumer.accept(null, new IllegalStateException("dummy"));
-        consumer.accept(RowsBatchIterator.empty(), null);
+        consumer.accept(RowsBatchIterator.empty(1), null);
 
         expectedException.expect(IllegalStateException.class);
         expectedException.expectMessage("dummy");

--- a/sql/src/test/java/io/crate/operation/projectors/ProjectingBatchConsumerTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/ProjectingBatchConsumerTest.java
@@ -188,7 +188,7 @@ public class ProjectingBatchConsumerTest extends CrateUnitTest {
             projectorFactory
         );
 
-        batchConsumer.accept(RowsBatchIterator.empty(), null);
+        batchConsumer.accept(RowsBatchIterator.empty(1), null);
 
         expectedException.expect(UnhandledServerException.class);
         expectedException.expectMessage("Failed to open output");

--- a/sql/src/test/java/io/crate/operation/projectors/SimpleTopNProjectorTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/SimpleTopNProjectorTest.java
@@ -99,7 +99,7 @@ public class SimpleTopNProjectorTest extends CrateUnitTest {
     @Test
     public void testProjectLimitOnly0() throws Throwable {
         Projector projector = prepareProjector(10, TopN.NO_OFFSET);
-        consumer.accept(projector.apply(RowsBatchIterator.empty()), null);
+        consumer.accept(projector.apply(RowsBatchIterator.empty(1)), null);
 
         Bucket projected = consumer.getBucket();
         assertThat(projected, emptyIterable());
@@ -193,7 +193,7 @@ public class SimpleTopNProjectorTest extends CrateUnitTest {
     @Test
     public void testProjectLimitOnly0UpStream() throws Throwable {
         Projector projector = prepareProjector(10, TopN.NO_OFFSET);
-        consumer.accept(projector.apply(RowsBatchIterator.empty()), null);
+        consumer.accept(projector.apply(RowsBatchIterator.empty(1)), null);
         Bucket projected = consumer.getBucket();
         assertThat(projected, emptyIterable());
     }


### PR DESCRIPTION
The data of multiple partitions is exposed via a CompositeBatchIterator.
If the first instance of the underlying BatchIterators happened to be a
`RowsBatchIterator.empty()` then the number of columns was initialized
as 0 - leading to ArrayOutOfBoundsExceptions.