### PR TITLE
Convert ShardingShardRequestAccumulator to BatchConsumer

### DIFF
--- a/sql/src/main/java/io/crate/executor/transport/task/UpsertByIdTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/UpsertByIdTask.java
@@ -35,7 +35,7 @@ import io.crate.executor.transport.ShardResponse;
 import io.crate.executor.transport.ShardUpsertRequest;
 import io.crate.metadata.PartitionName;
 import io.crate.operation.projectors.RetryListener;
-import io.crate.operation.projectors.ShardingShardRequestAccumulator;
+import io.crate.operation.projectors.ShardingUpsertExecutor;
 import io.crate.planner.node.dml.UpsertById;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
@@ -102,7 +102,7 @@ public class UpsertByIdTask extends JobTask {
         this.isDebugEnabled = LOGGER.isDebugEnabled();
 
         reqBuilder = new ShardUpsertRequest.Builder(
-            ShardingShardRequestAccumulator.BULK_REQUEST_TIMEOUT_SETTING.setting().get(settings),
+            ShardingUpsertExecutor.BULK_REQUEST_TIMEOUT_SETTING.setting().get(settings),
             false,
             upsertById.numBulkResponses() > 0 || items.size() > 1,
             upsertById.updateColumns(),

--- a/sql/src/main/java/io/crate/metadata/settings/CrateSettings.java
+++ b/sql/src/main/java/io/crate/metadata/settings/CrateSettings.java
@@ -27,7 +27,7 @@ import io.crate.breaker.CrateCircuitBreakerService;
 import io.crate.cluster.gracefulstop.DecommissioningService;
 import io.crate.metadata.ReferenceImplementation;
 import io.crate.operation.collect.stats.JobsLogService;
-import io.crate.operation.projectors.ShardingShardRequestAccumulator;
+import io.crate.operation.projectors.ShardingUpsertExecutor;
 import io.crate.operation.reference.NestedObjectExpression;
 import io.crate.planner.TableStatsService;
 import io.crate.protocols.postgres.PostgresNetty;
@@ -82,7 +82,7 @@ public class CrateSettings implements ClusterStateListener {
             CrateCircuitBreakerService.QUERY_CIRCUIT_BREAKER_OVERHEAD_SETTING,
 
             // BULK
-            ShardingShardRequestAccumulator.BULK_REQUEST_TIMEOUT_SETTING,
+            ShardingUpsertExecutor.BULK_REQUEST_TIMEOUT_SETTING,
 
             // GRACEFUL STOP
             DecommissioningService.DECOMMISSION_INTERNAL_SETTING_GROUP,

--- a/sql/src/main/java/io/crate/operation/projectors/ProjectionToProjectorVisitor.java
+++ b/sql/src/main/java/io/crate/operation/projectors/ProjectionToProjectorVisitor.java
@@ -354,7 +354,7 @@ public class ProjectionToProjectorVisitor
     public Projector visitUpdateProjection(final UpdateProjection projection, Context context) {
         checkShardLevel("Update projection can only be executed on a shard");
         ShardUpsertRequest.Builder builder = new ShardUpsertRequest.Builder(
-            ShardingShardRequestAccumulator.BULK_REQUEST_TIMEOUT_SETTING.setting().get(settings),
+            ShardingUpsertExecutor.BULK_REQUEST_TIMEOUT_SETTING.setting().get(settings),
             false,
             false,
             projection.assignmentsColumns(),
@@ -379,7 +379,7 @@ public class ProjectionToProjectorVisitor
     public Projector visitDeleteProjection(DeleteProjection projection, Context context) {
         checkShardLevel("Delete projection can only be executed on a shard");
         ShardDeleteRequest.Builder builder = new ShardDeleteRequest.Builder(
-            ShardingShardRequestAccumulator.BULK_REQUEST_TIMEOUT_SETTING.setting().get(settings),
+            ShardingUpsertExecutor.BULK_REQUEST_TIMEOUT_SETTING.setting().get(settings),
             context.jobId
         );
 

--- a/sql/src/test/java/io/crate/integrationtests/SysClusterSettingsTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysClusterSettingsTest.java
@@ -24,7 +24,7 @@ package io.crate.integrationtests;
 import com.google.common.base.Splitter;
 import io.crate.breaker.CrateCircuitBreakerService;
 import io.crate.operation.collect.stats.JobsLogService;
-import io.crate.operation.projectors.ShardingShardRequestAccumulator;
+import io.crate.operation.projectors.ShardingUpsertExecutor;
 import io.crate.settings.CrateSetting;
 import io.crate.settings.SharedSettings;
 import io.crate.testing.UseJdbc;
@@ -51,7 +51,7 @@ public class SysClusterSettingsTest extends SQLTransportIntegrationTest {
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {
         Settings.Builder builder = Settings.builder().put(super.nodeSettings(nodeOrdinal));
-        builder.put(ShardingShardRequestAccumulator.BULK_REQUEST_TIMEOUT_SETTING.getKey(), "42s");
+        builder.put(ShardingUpsertExecutor.BULK_REQUEST_TIMEOUT_SETTING.getKey(), "42s");
         return builder.build();
     }
 


### PR DESCRIPTION
This is an initial migration from the AsyncOperationBatchIterator and BatchAccumulator pattern to a pattern using CollectingBatchIterator and a BatchConsumer. 
Having the ShardingShardRequestAccumulator as a BatchConsumer will give us access to the batch iterator that's collecting data, so we'll be able to stop collecting when the nodes will have too many 
concurrent requests in progress.