### PR TITLE
fixed concurrency issue which lead to a temporary unavailability of a…

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -31,6 +31,9 @@ Changes
 Fixes
 =====
 
+ - Fixed an issue which lead to brief unavailability of already registered
+   functions after a function was created or dropped in the same schema.
+
  - Improved error message when trying to update an element of an array. 
 
  - Fixed a regression that lead to `ArrayIndexOutOfBoundsException` if a JOIN

--- a/sql/src/main/java/io/crate/metadata/doc/DocSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/doc/DocSchemaInfo.java
@@ -294,7 +294,6 @@ public class DocSchemaInfo implements SchemaInfo {
         }
 
         // re register UDFs for this schema
-        functions.deregisterUdfResolversForSchema(schemaName);
         UserDefinedFunctionsMetaData udfMetaData = newMetaData.custom(UserDefinedFunctionsMetaData.TYPE);
         if (udfMetaData != null) {
             Stream<UserDefinedFunctionMetaData> udfFunctions = udfMetaData.functionsMetaData().stream()


### PR DESCRIPTION
…lready registered functions after a new function was created or dropped.