### PR TITLE
Fix regexp_replace compile to use the correct flags parameter

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -31,6 +31,9 @@ Changes
 Fixes
 =====
 
+ - Fixed an issue with `regexp_replace`: In some cases it used the third
+   argument as flags parameter instead of the fourth argument.
+
  - Fixed an issue which lead to brief unavailability of already registered
    functions after a function was created or dropped in the same schema.
 

--- a/sql/src/main/java/io/crate/operation/scalar/regex/RegexMatcher.java
+++ b/sql/src/main/java/io/crate/operation/scalar/regex/RegexMatcher.java
@@ -24,6 +24,7 @@ package io.crate.operation.scalar.regex;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.CharsRef;
 import org.apache.lucene.util.UnicodeUtil;
+import org.elasticsearch.common.lucene.BytesRefs;
 
 import javax.annotation.Nullable;
 import java.util.regex.Matcher;
@@ -42,6 +43,10 @@ public class RegexMatcher {
     }
 
     public RegexMatcher(String regex, @Nullable BytesRef flags) {
+        this(regex, parseFlags(BytesRefs.toString(flags)), isGlobal(BytesRefs.toString(flags)));
+    }
+
+    public RegexMatcher(String regex, @Nullable String flags) {
         this(regex, parseFlags(flags), isGlobal(flags));
     }
 
@@ -84,21 +89,21 @@ public class RegexMatcher {
         return null;
     }
 
-    public BytesRef replace(BytesRef term, BytesRef replacement) {
+    public BytesRef replace(BytesRef term, String replacement) {
         UTF8toUTF16(term, utf16);
         if (globalFlag) {
-            return new BytesRef(matcher.replaceAll(replacement.utf8ToString()));
+            return new BytesRef(matcher.replaceAll(replacement));
         } else {
-            return new BytesRef(matcher.replaceFirst(replacement.utf8ToString()));
+            return new BytesRef(matcher.replaceFirst(replacement));
         }
     }
 
-    public static int parseFlags(@Nullable BytesRef flagsString) {
+    public static int parseFlags(@Nullable String flagsString) {
         int flags = 0;
         if (flagsString == null) {
             return flags;
         }
-        for (char flag : flagsString.utf8ToString().toCharArray()) {
+        for (char flag : flagsString.toCharArray()) {
             switch (flag) {
                 case 'i':
                     flags = flags | Pattern.CASE_INSENSITIVE;
@@ -129,11 +134,11 @@ public class RegexMatcher {
         return flags;
     }
 
-    public static boolean isGlobal(@Nullable BytesRef flags) {
+    public static boolean isGlobal(@Nullable String flags) {
         if (flags == null) {
             return false;
         }
-        return flags.utf8ToString().indexOf('g') != -1;
+        return flags.indexOf('g') != -1;
     }
 
 

--- a/sql/src/main/java/io/crate/operation/scalar/regex/ReplaceFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/regex/ReplaceFunction.java
@@ -24,13 +24,13 @@ package io.crate.operation.scalar.regex;
 import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
-import io.crate.analyze.symbol.SymbolType;
 import io.crate.data.Input;
 import io.crate.metadata.*;
 import io.crate.operation.scalar.ScalarFunctionModule;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.lucene.BytesRefs;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -63,58 +63,50 @@ public class ReplaceFunction extends Scalar<BytesRef, Object> implements Functio
     }
 
     @Override
-    public Symbol normalizeSymbol(Function symbol, TransactionContext transactionContext) {
-        final int size = symbol.arguments().size();
+    public Symbol normalizeSymbol(Function function, TransactionContext transactionContext) {
+        List<Symbol> arguments = function.arguments();
+        final int size = arguments.size();
         assert size == 3 || size == 4 : "function's number of arguments must be 3 or 4";
 
-        if (anyNonLiterals(symbol.arguments())) {
-            return symbol;
+        if (anyNonLiterals(arguments)) {
+            return function;
         }
 
-        final Symbol input = symbol.arguments().get(0);
-        final Symbol pattern = symbol.arguments().get(1);
-        final Symbol replacement = symbol.arguments().get(2);
-        final Object inputValue = ((Input) input).value();
-        final Object patternValue = ((Input) pattern).value();
-        final Object replacementValue = ((Input) replacement).value();
+        final Input input = (Input) arguments.get(0);
+        final Input pattern = (Input) arguments.get(1);
+        final Input replacement = (Input) arguments.get(2);
+        final Object inputValue = input.value();
+        final Object patternValue = pattern.value();
+        final String replacementValue = BytesRefs.toString(replacement.value());
         if (inputValue == null || patternValue == null || replacementValue == null) {
             return Literal.NULL;
         }
 
-        Input[] args = new Input[size];
-        args[0] = (Input) input;
-        args[1] = (Input) pattern;
-        args[2] = (Input) replacement;
-
+        String flags = null;
         if (size == 4) {
-            args[3] = (Input) symbol.arguments().get(3);
+            flags = BytesRefs.toString(((Input) arguments.get(3)).value());
         }
-        return Literal.of(evaluate(args));
+        return Literal.of(
+            eval(BytesRefs.toBytesRef(inputValue), BytesRefs.toString(patternValue), replacementValue, flags));
     }
 
     @Override
     public Scalar<BytesRef, Object> compile(List<Symbol> arguments) {
         assert arguments.size() >= 3 : "number of arguments muts be > 3";
-        String pattern = null;
-        if (arguments.get(1).symbolType() == SymbolType.LITERAL) {
-            Literal literal = (Literal) arguments.get(1);
-            Object patternVal = literal.value();
-            if (patternVal == null) {
+
+        Symbol patternSymbol = arguments.get(1);
+        if (patternSymbol instanceof Input) {
+            String pattern = BytesRefs.toString(((Input) patternSymbol).value());
+            if (pattern == null) {
                 return this;
             }
-            pattern = ((BytesRef) patternVal).utf8ToString();
-        }
-        BytesRef flags = null;
-        if (arguments.size() == 4) {
-            assert arguments.get(3).symbolType() == SymbolType.LITERAL
-                : "4th argument must be of type " + SymbolType.LITERAL;
-            flags = (BytesRef) ((Literal) arguments.get(3)).value();
-        }
-
-        if (pattern != null) {
-            regexMatcher = new RegexMatcher(pattern, flags);
-        } else {
-            regexMatcher = null;
+            if (arguments.size() == 4) {
+                Symbol flagsSymbol = arguments.get(3);
+                if (flagsSymbol instanceof Input) {
+                    String flags = BytesRefs.toString(((Input) flagsSymbol).value());
+                    regexMatcher = new RegexMatcher(pattern, flags);
+                }
+            }
         }
         return this;
     }
@@ -122,35 +114,23 @@ public class ReplaceFunction extends Scalar<BytesRef, Object> implements Functio
     @Override
     public BytesRef evaluate(Input[] args) {
         assert args.length == 3 || args.length == 4 : "number of args must be 3 or 4";
-        Object val = args[0].value();
-        Object patternValue = args[1].value();
-        Object replacementValue = args[2].value();
-        if (val == null || patternValue == null || replacementValue == null) {
+        BytesRef val = BytesRefs.toBytesRef(args[0].value());
+        String pattern = BytesRefs.toString(args[1].value());
+        String replacement = BytesRefs.toString(args[2].value());
+        if (val == null || pattern == null || replacement == null) {
             return null;
         }
-        // values can be strings if e.g. result is retrieved by ESSearchTask
-        if (val instanceof String) {
-            val = new BytesRef((String) val);
-        }
-        if (replacementValue instanceof String) {
-            replacementValue = new BytesRef((String) replacementValue);
-        }
-        if (patternValue instanceof BytesRef) {
-            patternValue = ((BytesRef) patternValue).utf8ToString();
-        }
-
         RegexMatcher matcher;
         if (regexMatcher == null) {
-            BytesRef flags = null;
+            String flags = null;
             if (args.length == 4) {
-                flags = (BytesRef) args[3].value();
+                flags = BytesRefs.toString(args[3].value());
             }
-            matcher = new RegexMatcher((String) patternValue, flags);
+            matcher = new RegexMatcher(pattern, flags);
         } else {
             matcher = regexMatcher;
         }
-
-        return matcher.replace((BytesRef) val, (BytesRef) replacementValue);
+        return matcher.replace(val, replacement);
     }
 
     @Override
@@ -165,5 +145,10 @@ public class ReplaceFunction extends Scalar<BytesRef, Object> implements Functio
             return null;
         }
         return Signature.SIGNATURES_ALL_OF_SAME.apply(dataTypes);
+    }
+
+    private static BytesRef eval(BytesRef value, String pattern, String replacement, @Nullable String flags) {
+        RegexMatcher regexMatcher = new RegexMatcher(pattern, flags);
+        return regexMatcher.replace(value, replacement);
     }
 }

--- a/sql/src/main/java/io/crate/operation/scalar/regex/ReplaceFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/regex/ReplaceFunction.java
@@ -25,8 +25,8 @@ import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.SymbolType;
-import io.crate.metadata.*;
 import io.crate.data.Input;
+import io.crate.metadata.*;
 import io.crate.operation.scalar.ScalarFunctionModule;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -108,7 +108,7 @@ public class ReplaceFunction extends Scalar<BytesRef, Object> implements Functio
         if (arguments.size() == 4) {
             assert arguments.get(3).symbolType() == SymbolType.LITERAL
                 : "4th argument must be of type " + SymbolType.LITERAL;
-            flags = (BytesRef) ((Literal) arguments.get(2)).value();
+            flags = (BytesRef) ((Literal) arguments.get(3)).value();
         }
 
         if (pattern != null) {

--- a/sql/src/test/java/io/crate/operation/scalar/regex/RegexMatcherTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/regex/RegexMatcherTest.java
@@ -63,7 +63,7 @@ public class RegexMatcherTest extends CrateUnitTest {
     public void testReplaceNoMatch() throws Exception {
         String pattern = "crate";
         BytesRef text = new BytesRef("foobarbequebaz");
-        BytesRef replacement = new BytesRef("crate");
+        String replacement = "crate";
         RegexMatcher regexMatcher = new RegexMatcher(pattern);
         assertEquals(text, regexMatcher.replace(text, replacement));
     }
@@ -72,12 +72,12 @@ public class RegexMatcherTest extends CrateUnitTest {
     public void testReplace() throws Exception {
         String pattern = "ba";
         BytesRef text = new BytesRef("foobarbequebaz");
-        BytesRef replacement = new BytesRef("Crate");
+        String replacement = "Crate";
         RegexMatcher regexMatcher = new RegexMatcher(pattern);
         assertEquals(new BytesRef("fooCraterbequebaz"), regexMatcher.replace(text, replacement));
 
         pattern = "(ba).*(ba)";
-        replacement = new BytesRef("First$1Second$2");
+        replacement = "First$1Second$2";
         regexMatcher = new RegexMatcher(pattern);
         assertEquals(new BytesRef("fooFirstbaSecondbaz"), regexMatcher.replace(text, replacement));
     }
@@ -86,7 +86,7 @@ public class RegexMatcherTest extends CrateUnitTest {
     public void testReplaceGlobal() throws Exception {
         String pattern = "ba";
         BytesRef text = new BytesRef("foobarbequebaz");
-        BytesRef replacement = new BytesRef("Crate");
+        String replacement = "Crate";
         RegexMatcher regexMatcher = new RegexMatcher(pattern, new BytesRef("g"));
         assertEquals(new BytesRef("fooCraterbequeCratez"), regexMatcher.replace(text, replacement));
     }

--- a/sql/src/test/java/io/crate/operation/scalar/regex/ReplaceFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/regex/ReplaceFunctionTest.java
@@ -40,17 +40,15 @@ public class ReplaceFunctionTest extends AbstractScalarFunctionsTest {
     }
 
     @Test
-    public void testEvaluateWithFlags() throws Exception {
-        assertEvaluate(
-            "regexp_replace(name, '(ba)', 'Crate', 'usn g')",
-            "fooCraterbequebaz bar",
-            Literal.of("foobarbequebaz bar"));
-    }
-
-    @Test
     public void testNormalizeSymbol() throws Exception {
         assertNormalize("regexp_replace('foobarbequebaz bar', '(ba)', 'Crate')", isLiteral("fooCraterbequebaz bar"));
         assertNormalize("regexp_replace(name, '(ba)', 'Crate')", isFunction(ReplaceFunction.NAME));
+    }
+
+    @Test
+    public void testEvalWithFlags() throws Exception {
+        assertEvaluate("regexp_replace('st. cloud', '[^a-z]', '', 'g')", "stcloud");
+        assertEvaluate("regexp_replace(name, '[^a-z]', '', 'g')", "stcloud", Literal.of("st. cloud"));
     }
 
     @Test


### PR DESCRIPTION
First commit contains the fix, the second commit is optimization/cleanup.