### PR TITLE
Hanging sys.snapshots queries.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -31,6 +31,9 @@ Changes
 Fixes
 =====
 
+ - Fix: `sys.snapshot` queries hung instead of throwing an error if something
+   went wrong.
+
  - Fixed an issue with `regexp_replace`: In some cases it used the third
    argument as flags parameter instead of the fourth argument.
 


### PR DESCRIPTION
`sys.snapshot` queries hung instead of throwing an error if any kind of error occured while using the elasticsearch API.

There will be another fix for the actual error.