### PR TITLE
Improve some toString implementations

### DIFF
--- a/sql/src/main/java/io/crate/analyze/OrderBy.java
+++ b/sql/src/main/java/io/crate/analyze/OrderBy.java
@@ -205,4 +205,28 @@ public class OrderBy implements Streamable {
     public int hashCode() {
         return Objects.hash(orderBySymbols, reverseFlags, nullsFirst);
     }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder("OrderBy{");
+        for (int i = 0; i < orderBySymbols.size(); i++) {
+            Symbol symbol = orderBySymbols.get(i);
+            sb.append(symbol);
+            sb.append(" ");
+            if (reverseFlags[i]) {
+                sb.append("ASC");
+            } else {
+                sb.append("DESC");
+            }
+            Boolean nullFirst = nullsFirst[i];
+            if (nullFirst != null) {
+                sb.append(" ");
+                sb.append(nullFirst ? "NULLS FIRST" : "NULLS LAST");
+            }
+            if (i + 1 < orderBySymbols.size()) {
+                sb.append(" ");
+            }
+        }
+        return sb.toString();
+    }
 }

--- a/sql/src/main/java/io/crate/analyze/QueriedTableRelation.java
+++ b/sql/src/main/java/io/crate/analyze/QueriedTableRelation.java
@@ -98,4 +98,9 @@ public abstract class QueriedTableRelation<TR extends AbstractTableRelation> imp
     public void setQualifiedName(@Nonnull QualifiedName qualifiedName) {
         tableRelation.setQualifiedName(qualifiedName);
     }
+
+    @Override
+    public String toString() {
+        return "QueriedTable{" + tableRelation + '}';
+    }
 }

--- a/sql/src/main/java/io/crate/analyze/relations/AbstractTableRelation.java
+++ b/sql/src/main/java/io/crate/analyze/relations/AbstractTableRelation.java
@@ -21,7 +21,6 @@
 
 package io.crate.analyze.relations;
 
-import com.google.common.base.MoreObjects;
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.symbol.Field;
 import io.crate.metadata.ColumnIdent;
@@ -177,7 +176,7 @@ public abstract class AbstractTableRelation<T extends TableInfo> implements Anal
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this).add("table", tableInfo.ident()).toString();
+        return getClass().getSimpleName() + '{' + tableInfo.ident() + '}';
     }
 
 

--- a/sql/src/main/java/io/crate/analyze/symbol/Field.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/Field.java
@@ -21,7 +21,6 @@
 
 package io.crate.analyze.symbol;
 
-import com.google.common.base.MoreObjects;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.metadata.ColumnIndex;
 import io.crate.metadata.Path;
@@ -72,10 +71,9 @@ public class Field extends Symbol implements Path {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(Field.class)
-            .add("path", path)
-            .add("valueType", valueType)
-            .add("relation", relation).toString();
+        return "Field{" + relation + "." + path +
+               ", type=" + valueType +
+               '}';
     }
 
     @Override


### PR DESCRIPTION
More compact representations without losing valueable information.
Should make debugging a bit easier. Example:

    Optional[OrderBy{
        Field{DocTableRelation{doc.colors}.name, type=string} DESC
        Field{DocTableRelation{doc.sizes}.name, type=string} DESC
    ]