### PR TITLE
ec2 discovery: set current region if no endpoint available

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -31,6 +31,10 @@ Changes
 Fixes
 =====
 
+ - Use the region of the EC2 instance for EC2 discovery when neither
+   ``cloud.aws.ec2.endpoint`` nor ``cloud.aws.region`` are specified or do not
+   resolve in a valid service endpoint.
+
  - Use crate favicon instead of elasticsearch.
 
  - Fixed issue which lead to an object's column policy being changed to 


### PR DESCRIPTION
The AwsEc2ServiceImpl instantiates a client and sets the endpoint which
can be specified explicitly by the ``ENDPOINT_SETTING`` or the
``REGION_SETTING``. If none of these settings are provided the client
would fall back to the endpoint of the ``us-east-1`` region.
This change however sets the client's region based on the region of the
running EC2 instance which can be obtained by an API call to the
instance metadata.

This behaviour was already patched in version 2.4.x of the Crate fork of
Elasticsearch and was accidentially removed with the ES5 upgrade.

See also: https://github.com/crate/elasticsearch/pull/117