### PR TITLE
support empty hba

### DIFF
--- a/blackbox/docs/administration/hba.txt
+++ b/blackbox/docs/administration/hba.txt
@@ -3,18 +3,20 @@
 ===============================
 Host Based Authentication (HBA)
 ===============================
+
 .. NOTE::
 
    *Host Based Authentication* (HBA) is an Enterprise Edition feature.
 
 This section explains how to configure CrateDB client connection and authentication.
 
-By default, the optional setting ``auth.host_based`` is absent and therefore host based
-authentication is disabled. In this instance, the CrateDB cluster allows any
-unauthenticated connections.
+By default, the boolean setting ``auth.host_based.enabled`` is ``false`` and
+therefore host based authentication is disabled. In this instance,
+the CrateDB cluster allows any unauthenticated connections.
 
-To allow authenticated access to CrateDB from specific hosts, you need to configure
-the ``auth.host_based`` setting in the ``crate.yml`` file.
+To allow authenticated access to CrateDB from specific hosts, you need to set
+the ``auth.host_based.enabled`` setting in the ``crate.yml`` to ``true`` and
+specify HBA entries in the ``auth.host_based.config`` group setting.
 
 See: :ref:`applying-cluster-settings`.
 
@@ -25,17 +27,15 @@ Allowing Authentication to CrateDB
 
    This feature only concerns connections over :ref:`postgres_wire_protocol`.
 
-
-Client access and authentication is configured by the ``auth.host_based``
+Client access and authentication is configured by the ``auth.host_based.config``
 setting in the ``crate.yml`` file.
 
-The general format of the ``auth.host_based`` setting is a map of remote client
+The general format of the ``auth.host_based.config`` setting is a map of remote client
 access entries, where the key of the map defines the order in which the entries
 are used, which permit authentication to CrateDB. Each entry may contain no, one,
 or multiple fields. Allowed fields are ``user``, ``ip`` or ``cidr``, and
 ``method``. The description of these fields can be found in
 :ref:`host_based_auth`.
-
 
 When a client sends an authentication request, CrateDB matches the provided
 username and IP address against these entries to determine which authentication
@@ -46,33 +46,34 @@ If ``auth.host_based`` is not set, the host based authentication is disabled.
 If the setting ``auth.host_based`` is present and the configurations list
 does not contain any entry, then no client can authenticate.
 
-For example, a host based configuration can look like this::
+For example, a host based configuration can look like this:
+
+.. code-block:: yaml
 
     auth:
       host_based:
-        "1":
+        enabled: true
+        config:
+          0:
             user: mike
             address: 32.0.0.0/8
             method: trust
-
-        "2":
+          a:
             user: barb
             address: 172.16.0.0
-
-        "3":
+          b:
             user: crate
             address: 32.0.0.0/8
             method: trust
-
-        "4":
+          y:
             user: eleven
-
-        "5":
+          z:
             method: trust
 
 .. NOTE::
 
-   In the ``auth.host_based`` setting, the order of entries is relevant.
+   In the ``auth.host_based.config`` setting, the order of the entries is
+   defined by the natural order of the group keys of the setting.
    The authentication method of the first entry that matches the client
    user and address will be used. If the authentication attempt fails,
    subsequent entries will not be considered. The entry look-up order is
@@ -80,11 +81,11 @@ For example, a host based configuration can look like this::
 
 In the example above:
 
-``{user: mike, address:  32.0.0.0/8, method:trust}`` means that the user ``mike``
+``{user: mike, address: 32.0.0.0/8, method: trust}`` means that the user ``mike``
 can authenticate to CrateDB from any IP address ranging from ``32.0.0.0`` to
 ``32.255.255.255``, using the ``trust`` authentication method.
 
-``{user: crate, address:  32.0.0.0/8, method:trust}`` means that the superuser
+``{user: crate, address: 32.0.0.0/8, method: trust}`` means that the superuser
 ``crate`` can authenticate to CrateDB from any IP address ranging from
 ``32.0.0.0`` to ``32.255.255.255``, using the ``trust`` authentication method.
 
@@ -108,10 +109,16 @@ When CrateDB is started, the cluster contains one predefined superuser. This use
 is called ``crate``.
 
 To authenticate as the superuser from a specific IP address, ``crate`` should be
-specified in the the ``auth.host_based`` setting, like this::
+specified in the the ``auth.host_based`` setting, like this:
+
+.. code-block:: yaml
 
     auth:
       host_based:
-        - {user: crate, address: 172.16.0.0, method: trust}
-
+        enabled: true
+        config:
+          0:
+            user: crate
+            address: 172.16.0.0
+            method: trust
 

--- a/blackbox/docs/configuration.txt
+++ b/blackbox/docs/configuration.txt
@@ -1918,39 +1918,67 @@ Authentication
 Host Based Authentication
 -------------------------
 
-**auth.host_based**
-  | *Runtime:*     ``no``
-  | *Examples:*
-  |  ``a: {user:crate, address: 172.16.0.0/16}``
-  |  ``b: {method: trust}``
-  |  ``3: {user:crate, address: 172.16.0.0/16, method:trust}``
+**auth.host_based.enabled**
+  | *Runtime:* ``no``
+  | *Default:* ``false``
 
-  The :ref:`administration_hba` setting is a list of predicates that users can
-  specify to restrict or allow access to CrateDB.
+  Setting to enable or disable Host Based Authentication (HBA). It is disabled
+  by default.
 
-  The meaning of the fields are as follows:
+HBA Entries
+...........
 
-  **order:**
-    | An identifier that is used as a natural order key when looking up the
-    | host based configuration entries. For example, an order key of ``a`` will
-    | be looked up before an order key of ``b``. This key guarantees that the entry
-    | lookup order will remain independent from the insertion order of the entries.
+The ``auth.host_based.config.`` setting is a group setting that can have zero,
+one or multiple groups that are defined by their group key (``${order}``) and
+their fields (``user``, ``address``, ``method``).
 
-  **user:**
-    | Specifies an existing CrateDB username, only ``crate`` user (superuser)
-    | is available. If no user is specified in the entry, then
-    | all existing users can have access.
+**${order}:**
+  | An identifier that is used as a natural order key when looking up the
+  | host based configuration entries. For example, an order key of ``a`` will
+  | be looked up before an order key of ``b``. This key guarantees that the entry
+  | lookup order will remain independent from the insertion order of the entries.
 
-  **address:**
-    | The client machine addresses that the client matches, and which are
-    | allowed to authenticate. This field can contain an IP address or a CIDR
-    | mask. For example: ``127.0.0.1`` or ``127.0.0.1/32``. If no address is specified
-    | in the entry, then access to CrateDB is open for all hosts.
+The :ref:`administration_hba` setting is a list of predicates that users can
+specify to restrict or allow access to CrateDB.
 
-  **method:**
-    | The authentication method to use when a connection matches this entry.
-    | At the moment only the ``trust`` method is available. If no method is
-    | specified, the ``trust`` method is used by default.( See :ref:`auth_trust` )
+The meaning of the fields of the are as follows:
+
+**auth.host_based.config.${order}.user**
+  | *Runtime:*  ``no``
+
+  | Specifies an existing CrateDB username, only ``crate`` user (superuser)
+  | is available. If no user is specified in the entry, then
+  | all existing users can have access.
+
+**auth.host_based.config.${order}.address**
+  | *Runtime:* ``no``
+
+  | The client machine addresses that the client matches, and which are
+  | allowed to authenticate. This field can contain an IP address or a CIDR
+  | mask. For example: ``127.0.0.1`` or ``127.0.0.1/32``. If no address is specified
+  | in the entry, then access to CrateDB is open for all hosts.
+
+**auth.host_based.config.${order}.method**
+  | *Runtime:* ``no``
+
+  | The authentication method to use when a connection matches this entry.
+  | At the moment only the ``trust`` method is available. If no method is
+  | specified, the ``trust`` method is used by default (see :ref:`auth_trust`).
+
+**Example of config groups:**
+
+.. code-block:: yaml
+
+    auth.host_based.config:
+      entry_a:
+        user: crate
+        address: 127.16.0.0/16
+      entry_b:
+        method: trust
+      entry_3:
+        user: crate
+        address: 172.16.0.0/16
+        method: trust
 
 
 .. _`same-origin policy`: https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy

--- a/core/src/main/java/io/crate/settings/SharedSettings.java
+++ b/core/src/main/java/io/crate/settings/SharedSettings.java
@@ -29,17 +29,19 @@ import org.elasticsearch.common.settings.Settings;
 public class SharedSettings {
 
     public static final CrateSetting<Boolean> ENTERPRISE_LICENSE_SETTING = CrateSetting.of(Setting.boolSetting(
-        "license.enterprise", true,
-        Setting.Property.NodeScope), DataTypes.BOOLEAN);
+        "license.enterprise", true, Setting.Property.NodeScope),
+        DataTypes.BOOLEAN);
 
     public static final CrateSetting<String> LICENSE_IDENT_SETTING = CrateSetting.of(Setting.simpleString(
-        "license.ident", Setting.Property.NodeScope, Setting.Property.Dynamic), DataTypes.STRING);
+        "license.ident", Setting.Property.NodeScope, Setting.Property.Dynamic),
+        DataTypes.STRING);
 
-    public static final CrateSetting<Settings> AUTH_HOST_BASED_SETTING = CrateSetting.of(
-        Setting.groupSetting("auth.host_based.",
-            Setting.Property.Dynamic,
-            Setting.Property.NodeScope),
-        DataTypes.OBJECT
-    );
+    public static final CrateSetting<Boolean> AUTH_HOST_BASED_ENABLED_SETTING = CrateSetting.of(Setting.boolSetting(
+        "auth.host_based.enabled", false, Setting.Property.NodeScope, Setting.Property.Dynamic),
+        DataTypes.BOOLEAN);
+
+    public static final CrateSetting<Settings> AUTH_HOST_BASED_CONFIG_SETTING = CrateSetting.of(Setting.groupSetting(
+        "auth.host_based.config.", Setting.Property.NodeScope, Setting.Property.Dynamic),
+        DataTypes.OBJECT);
 
 }

--- a/sql/src/main/java/io/crate/metadata/settings/CrateSettings.java
+++ b/sql/src/main/java/io/crate/metadata/settings/CrateSettings.java
@@ -107,7 +107,8 @@ public class CrateSettings implements ClusterStateListener {
             SharedSettings.LICENSE_IDENT_SETTING,
 
             // AUTHENTICATION
-            SharedSettings.AUTH_HOST_BASED_SETTING
+            SharedSettings.AUTH_HOST_BASED_ENABLED_SETTING,
+            SharedSettings.AUTH_HOST_BASED_CONFIG_SETTING
 
         ));
 

--- a/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -452,7 +452,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultColumns() throws Exception {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(389, response.rowCount());
+        assertEquals(391, response.rowCount());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/SysClusterSettingsTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysClusterSettingsTest.java
@@ -179,22 +179,17 @@ public class SysClusterSettingsTest extends SQLTransportIntegrationTest {
     }
 
     @Test
-    public void testDefaultEnterpriseSetting() {
+    public void testDefaultEnterpriseSettings() {
         execute("select settings from sys.cluster");
         assertSettingsDefault(SharedSettings.ENTERPRISE_LICENSE_SETTING);
-    }
-
-
-    @Test
-    public void testDefaultHbaSetting() {
-        execute("select settings from sys.cluster");
-        assertSettingsDefault(SharedSettings.AUTH_HOST_BASED_SETTING);
-    }
-
-    @Test
-    public void testDefaultLicenseIdentSetting() {
-        execute("select settings from sys.cluster");
         assertSettingsDefault(SharedSettings.LICENSE_IDENT_SETTING);
+    }
+
+    @Test
+    public void testDefaultAuthenticationSettings() {
+        execute("select settings from sys.cluster");
+        assertSettingsDefault(SharedSettings.AUTH_HOST_BASED_ENABLED_SETTING);
+        assertSettingsDefault(SharedSettings.AUTH_HOST_BASED_CONFIG_SETTING);
     }
 
     @Test

--- a/users/src/test/java/io/crate/operation/auth/AuthenticationIntegrationTest.java
+++ b/users/src/test/java/io/crate/operation/auth/AuthenticationIntegrationTest.java
@@ -36,21 +36,13 @@ public class AuthenticationIntegrationTest extends SQLTransportIntegrationTest {
         return Settings.builder()
             .put(super.nodeSettings(nodeOrdinal))
             .put("network.host", "127.0.0.1")
-            .put(Settings.builder()
-                .put("auth.host_based.a.user", "crate")
-                .put("auth.host_based.a.method", "trust")
-                .put("auth.host_based.a.address", "127.0.0.1")
-                .build())
-            .put(Settings.builder()
-                .put("auth.host_based.b.user", "cr8")
-                .put("auth.host_based.b.method", "trust")
-                .put("auth.host_based.b.address", "0.0.0.0/0")
-                .build())
-            .put(Settings.builder()
-                .put("auth.host_based.c.user", "foo")
-                .put("auth.host_based.c.method", "fake")
-                .put("auth.host_based.c.address", "127.0.0.1/32")
-                .build())
+            .put("auth.host_based.enabled", true)
+            .put("auth.host_based.config",
+                "a", new String[]{"user", "method", "address"}, new String[]{"crate", "trust", "127.0.0.1"})
+            .put("auth.host_based.config",
+                "b", new String[]{"user", "method", "address"}, new String[]{"cr8", "trust", "0.0.0.0/0"})
+            .put("auth.host_based.config",
+                "c", new String[]{"user", "method", "address"}, new String[]{"foo", "fake", "127.0.0.1/32"})
             .build();
     }
 


### PR DESCRIPTION
to support empty hba config we need to introduce a new
``auth.host_based.enabled`` boolean setting which is ``false`` by
default. the ``auth.host_based.`` is renamed to
``auth.host_based.config.``

Example of full HBA config:

```yaml
auth:
  host_based:
    enabled: true
    config:
      0:
        user: crate
        address: 127.0.0.1
        method: trust
````