### PR TITLE
Copy from computes generated columns when used as partition key and pk.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -31,6 +31,9 @@ Changes
 Fixes
 =====
 
+ - Fixed `copy from` to be able to copy data into a partitioned table with a 
+   generated column as both the primary key and the partitioned column.
+
  - NullPointerException thrown when selecting ``routing_hash_function``
    or ``version`` columns from sys.shards for blob tables.
 

--- a/sql/src/main/java/io/crate/planner/statement/CopyStatementPlanner.java
+++ b/sql/src/main/java/io/crate/planner/statement/CopyStatementPlanner.java
@@ -52,7 +52,12 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.function.Predicate;
 
 public class CopyStatementPlanner {
@@ -116,15 +121,21 @@ public class CopyStatementPlanner {
             table.isPartitioned() // autoCreateIndices
         );
         List<Projection> projections = Collections.singletonList(sourceIndexWriterProjection);
-        partitionedByNames.removeAll(Lists.transform(table.primaryKey(), ColumnIdent::fqn));
-        int referencesSize = table.primaryKey().size() + partitionedByNames.size() + 1;
-        referencesSize = clusteredByPrimaryKeyIdx == -1 ? referencesSize + 1 : referencesSize;
 
-        List<Symbol> toCollect = new ArrayList<>(referencesSize);
+        List<ColumnIdent> primaryKeys = new ArrayList<>(table.primaryKey().size());
+        List<Symbol> toCollect = new ArrayList<>();
         // add primaryKey columns
         for (ColumnIdent primaryKey : table.primaryKey()) {
-            toCollect.add(table.getReference(primaryKey));
+            Reference reference = table.getReference(primaryKey);
+            if (reference instanceof GeneratedReference && table.partitionedByColumns().contains(reference)) {
+                // will track this reference in the partitioned by list (so we can extract its references and
+                // the function expression
+                continue;
+            }
+            toCollect.add(reference);
+            primaryKeys.add(primaryKey);
         }
+        partitionedByNames.removeAll(Lists.transform(primaryKeys, ColumnIdent::fqn));
 
         // add partitioned columns (if not part of primaryKey)
         Set<Reference> referencedReferences = new HashSet<>();


### PR DESCRIPTION
A generated column was not taken into account as a partition key if it
was also a primary key. This resulted in the generated column not being
computed when copying data from a source, and the import would fail as the
rows would have a null primary key.