### PR TITLE
Fix failing queries to sys.repositories

### DIFF
--- a/sql/src/main/java/io/crate/metadata/Routing.java
+++ b/sql/src/main/java/io/crate/metadata/Routing.java
@@ -5,6 +5,9 @@ import com.google.common.collect.ImmutableMap;
 import io.crate.core.collections.TreeMapBuilder;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Randomness;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -245,6 +248,25 @@ public class Routing implements Streamable {
             nodesMapBuilder.put(node.getId(), tableMap);
         }
         return new Routing(nodesMapBuilder.map());
+    }
+
+    public static Routing forRandomMasterOrDataNode(TableIdent tableIdent, ClusterService clusterService) {
+        DiscoveryNode localNode = clusterService.localNode();
+        if (localNode.isMasterNode() || localNode.isDataNode()) {
+            return forTableOnSingleNode(tableIdent, localNode.getId());
+        }
+        ImmutableOpenMap<String, DiscoveryNode> masterAndDataNodes = clusterService.state().nodes().getMasterAndDataNodes();
+        int randomIdx = Randomness.get().nextInt(masterAndDataNodes.size());
+        Iterator<DiscoveryNode> it = masterAndDataNodes.valuesIt();
+        int currIdx = 0;
+        while (it.hasNext()) {
+            if (currIdx == randomIdx) {
+                return forTableOnSingleNode(tableIdent, it.next().getId());
+            }
+            currIdx++;
+        }
+        throw new AssertionError(String.format(Locale.ENGLISH,
+            "Cannot find a master or data node with given random index %d", randomIdx));
     }
 
     @Override

--- a/sql/src/main/java/io/crate/metadata/sys/SysRepositoriesTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysRepositoriesTableInfo.java
@@ -63,6 +63,6 @@ public class SysRepositoriesTableInfo extends StaticTableInfo {
 
     @Override
     public Routing getRouting(WhereClause whereClause, @Nullable String preference) {
-        return Routing.forTableOnSingleNode(IDENT, clusterService.localNode().getId());
+        return Routing.forRandomMasterOrDataNode(IDENT, clusterService);
     }
 }


### PR DESCRIPTION
The RepositoriesService maintains the list of
Repositories only on master and data nodes, so
queries to sys.repositories failed on non
data and non master nodes. Changed routing of
table to master and data nodes to fix this problem.