### PR TITLE
Disable supportsDedicatedMasters and use getDataNodeInstance()

### DIFF
--- a/sql/src/test/java/io/crate/operation/collect/BlobShardCollectorProviderTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/BlobShardCollectorProviderTest.java
@@ -45,7 +45,7 @@ import java.util.UUID;
 
 import static org.hamcrest.Matchers.is;
 
-@ESIntegTestCase.ClusterScope(numDataNodes = 1, numClientNodes = 0)
+@ESIntegTestCase.ClusterScope(numDataNodes = 1, numClientNodes = 0, supportsDedicatedMasters = false)
 public class BlobShardCollectorProviderTest extends SQLHttpIntegrationTest {
 
     private BlobShardCollectorProvider collectorProvider;
@@ -94,10 +94,10 @@ public class BlobShardCollectorProviderTest extends SQLHttpIntegrationTest {
         @Override
         public void run() {
             try {
-                ClusterService clusterService = internalCluster().getInstance(ClusterService.class);
+                ClusterService clusterService = internalCluster().getDataNodeInstance(ClusterService.class);
                 MetaData metaData = clusterService.state().getMetaData();
                 String indexUUID = metaData.index(".blob_b1").getIndexUUID();
-                BlobIndicesService blobIndicesService = internalCluster().getInstance(BlobIndicesService.class);
+                BlobIndicesService blobIndicesService = internalCluster().getDataNodeInstance(BlobIndicesService.class);
                 BlobShard blobShard = blobIndicesService.blobShard(new ShardId(".blob_b1", indexUUID, 0));
                 assertNotNull(blobShard);
                 collectorProvider = new BlobShardCollectorProvider(blobShard, null, null,

--- a/sql/src/test/java/io/crate/operation/collect/sources/SystemCollectSourceTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/sources/SystemCollectSourceTest.java
@@ -58,12 +58,12 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 
-@ESIntegTestCase.ClusterScope(numDataNodes = 1)
+@ESIntegTestCase.ClusterScope(numDataNodes = 1, supportsDedicatedMasters = false)
 public class SystemCollectSourceTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testOrderBySymbolsDoNotAppearTwiceInRows() throws Exception {
-        SystemCollectSource systemCollectSource = internalCluster().getInstance(SystemCollectSource.class);
+        SystemCollectSource systemCollectSource = internalCluster().getDataNodeInstance(SystemCollectSource.class);
 
         Reference shardId = new Reference(
             new ReferenceIdent(new TableIdent("sys", "shards"), "id"), RowGranularity.SHARD, DataTypes.INTEGER);
@@ -92,7 +92,7 @@ public class SystemCollectSourceTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testReadIsolation() throws Exception {
-        SystemCollectSource systemCollectSource = internalCluster().getInstance(SystemCollectSource.class);
+        SystemCollectSource systemCollectSource = internalCluster().getDataNodeInstance(SystemCollectSource.class);
         RoutedCollectPhase collectPhase = new RoutedCollectPhase(
             UUID.randomUUID(),
             1,


### PR DESCRIPTION
to make sure that the correct instance of the 1 data node is used.