### PR TITLE
Change Field equals to not depend on relation identity

### DIFF
--- a/sql/src/main/java/io/crate/analyze/relations/AbstractTableRelation.java
+++ b/sql/src/main/java/io/crate/analyze/relations/AbstractTableRelation.java
@@ -194,13 +194,16 @@ public abstract class AbstractTableRelation<T extends TableInfo> implements Anal
         AbstractTableRelation that = (AbstractTableRelation) o;
 
         if (!tableInfo.equals(that.tableInfo)) return false;
+        if (!qualifiedName.equals(that.qualifiedName)) return false;
 
         return true;
     }
 
     @Override
     public int hashCode() {
-        return tableInfo.hashCode();
+        int result = tableInfo.hashCode();
+        result = 31 * result + qualifiedName.hashCode();
+        return result;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/analyze/symbol/Field.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/Field.java
@@ -28,6 +28,7 @@ import io.crate.types.DataType;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
+import java.util.Objects;
 
 public class Field extends Symbol implements Path {
 
@@ -83,7 +84,7 @@ public class Field extends Symbol implements Path {
 
         Field that = (Field) o;
 
-        if (relation != that.relation) return false;
+        if (!relation.equals(that.relation)) return false;
         if (!path.equals(that.path)) return false;
         if (!valueType.equals(that.valueType)) return false;
 
@@ -92,7 +93,7 @@ public class Field extends Symbol implements Path {
 
     @Override
     public int hashCode() {
-        int result = relation.hashCode();
+        int result = Objects.hashCode(relation.getQualifiedName());
         result = 31 * result + path.hashCode();
         result = 31 * result + valueType.hashCode();
         return result;

--- a/sql/src/test/java/io/crate/analyze/DeleteAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/DeleteAnalyzerTest.java
@@ -92,7 +92,7 @@ public class DeleteAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         DeleteAnalyzedStatement expectedStatement = e.analyze("delete from users where name='Trillian'");
         DeleteAnalyzedStatement actualStatement = e.analyze("delete from users as u where u.name='Trillian'");
 
-        assertThat(actualStatement.analyzedRelation, equalTo(expectedStatement.analyzedRelation()));
+        assertThat(actualStatement.analyzedRelation.tableInfo(), equalTo(expectedStatement.analyzedRelation().tableInfo()));
         assertThat(actualStatement.whereClauses().get(0), equalTo(expectedStatement.whereClauses().get(0)));
     }
 

--- a/sql/src/test/java/io/crate/testing/DummyRelation.java
+++ b/sql/src/test/java/io/crate/testing/DummyRelation.java
@@ -42,6 +42,7 @@ import java.util.Set;
 public class DummyRelation implements AnalyzedRelation {
 
     private final Set<ColumnIdent> columnReferences = new HashSet<>();
+    private QualifiedName name = new QualifiedName("dummy");
 
     public DummyRelation(String... referenceNames) {
         for (String referenceName : referenceNames) {
@@ -69,11 +70,11 @@ public class DummyRelation implements AnalyzedRelation {
 
     @Override
     public QualifiedName getQualifiedName() {
-        throw new UnsupportedOperationException("method not supported");
+        return name;
     }
 
     @Override
     public void setQualifiedName(@Nonnull QualifiedName qualifiedName) {
-        throw new UnsupportedOperationException("method not supported");
+        this.name = qualifiedName;
     }
 }


### PR DESCRIPTION
The `Field.equals` implementation did an identity check on the relation
to distinguish between the same table in the case of a self-join.

This commit changes Field to do a equality check and also changes the
AbstractTableRelation equals/hashCode implementation to include the
qualifiedName. This will allow us to still distinguish tables in a
self-join case, but will also allow us to rewrite/recreate relation
instances and still have Field equality work as expected.