### PR TITLE
Replace RelationSource with Analyzed-/QueriedRelation

### DIFF
--- a/sql/src/main/java/io/crate/analyze/OrderBy.java
+++ b/sql/src/main/java/io/crate/analyze/OrderBy.java
@@ -79,7 +79,7 @@ public class OrderBy implements Streamable {
         boolean[] reverseFlags = new boolean[positions.size()];
         int pos = 0;
         for (Integer i : positions) {
-            orderBySymbols.add(this.orderBySymbols.get(i));
+            orderBySymbols.add(Symbols.DEEP_COPY.apply(this.orderBySymbols.get(i)));
             nullsFirst[pos] = this.nullsFirst[i];
             reverseFlags[pos] = this.reverseFlags[i];
             pos++;

--- a/sql/src/main/java/io/crate/analyze/Relations.java
+++ b/sql/src/main/java/io/crate/analyze/Relations.java
@@ -23,9 +23,12 @@
 package io.crate.analyze;
 
 import com.google.common.collect.Lists;
+import io.crate.analyze.relations.*;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.Symbols;
+import io.crate.metadata.Functions;
 import io.crate.metadata.Path;
+import io.crate.metadata.TransactionContext;
 
 import java.util.Collection;
 import java.util.List;
@@ -34,5 +37,37 @@ class Relations {
 
     static Collection<? extends Path> namesFromOutputs(List<Symbol> outputs) {
         return Lists.transform(outputs, Symbols::pathFromSymbol);
+    }
+
+    /**
+     * Promotes the relation to a QueriedRelation by applying the QuerySpec.
+     *
+     * <pre>
+     * TableRelation -> QueriedTable
+     * QueriedTable  -> QueriedSelect
+     * QueriedSelect -> nested QueriedSelect
+     * </pre>
+     *
+     * If the result is a QueriedTable it is also normalized.
+     */
+    static QueriedRelation applyQSToRelation(Functions functions,
+                                             TransactionContext transactionContext,
+                                             AnalyzedRelation relation,
+                                             QuerySpec querySpec) {
+        QueriedRelation newRelation;
+        if (relation instanceof DocTableRelation) {
+            QueriedDocTable queriedDocTable = new QueriedDocTable((DocTableRelation) relation, querySpec);
+            queriedDocTable.normalize(functions, transactionContext);
+            newRelation = queriedDocTable;
+        } else if (relation instanceof TableRelation) {
+            QueriedTable queriedTable = new QueriedTable((TableRelation) relation, querySpec);
+            queriedTable.normalize(functions, transactionContext);
+            newRelation = queriedTable;
+        } else {
+            newRelation = new QueriedSelectRelation(
+                ((QueriedRelation) relation), namesFromOutputs(querySpec.outputs()), querySpec);
+        }
+        newRelation.setQualifiedName(relation.getQualifiedName());
+        return newRelation;
     }
 }

--- a/sql/src/main/java/io/crate/analyze/relations/AbstractTableRelation.java
+++ b/sql/src/main/java/io/crate/analyze/relations/AbstractTableRelation.java
@@ -209,7 +209,7 @@ public abstract class AbstractTableRelation<T extends TableInfo> implements Anal
     @Override
     @Nullable
     public Reference resolveField(Field field) {
-        if (field.relation() == this) {
+        if (field.relation().equals(this)) {
             return allocatedFields.get(field.path());
         }
         return null;

--- a/sql/src/main/java/io/crate/analyze/relations/QuerySplittingVisitor.java
+++ b/sql/src/main/java/io/crate/analyze/relations/QuerySplittingVisitor.java
@@ -175,7 +175,7 @@ class QuerySplittingVisitor extends ReplacingSymbolVisitor<QuerySplittingVisitor
         for (Field field : matchPredicate.identBoostMap().keySet()) {
             if (relation == null) {
                 relation = field.relation();
-            } else if (relation != field.relation()) {
+            } else if (!relation.equals(field.relation())) {
                 throw new IllegalArgumentException("Must not use columns from more than 1 relation inside the MATCH predicate");
             }
         }

--- a/sql/src/main/java/io/crate/analyze/relations/RelationNormalizer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationNormalizer.java
@@ -68,7 +68,7 @@ final class RelationNormalizer {
             relation.subRelation(normalizedSubRelation);
             if (subRelation != normalizedSubRelation) {
                 relation.querySpec().replace(FieldReplacer.bind(f -> {
-                    if (f.relation() == subRelation) {
+                    if (f.relation().equals(subRelation)) {
                         return normalizedSubRelation.getField(f.path(), Operation.READ);
                     }
                     return f;
@@ -95,7 +95,7 @@ final class RelationNormalizer {
             QuerySpec querySpec = mss.querySpec();
             querySpec.normalize(normalizer, context);
             // must create a new MultiSourceSelect because paths and query spec changed
-            mss = MultiSourceSelect.createWithPushDown(mss, querySpec);
+            mss = MultiSourceSelect.createWithPushDown(functions, context, mss, querySpec);
             Rewriter.tryRewriteOuterToInnerJoin(normalizer, mss);
             return mss;
         }

--- a/sql/src/main/java/io/crate/analyze/relations/SubselectRewriter.java
+++ b/sql/src/main/java/io/crate/analyze/relations/SubselectRewriter.java
@@ -23,7 +23,6 @@
 package io.crate.analyze.relations;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Maps;
 import io.crate.analyze.*;
 import io.crate.analyze.symbol.Aggregations;
 import io.crate.analyze.symbol.Field;
@@ -142,7 +141,7 @@ final class SubselectRewriter {
             if (canBeMerged(currentQS, parentQS)) {
                 QuerySpec currentWithParentMerged = mergeQuerySpec(currentQS, parentQS);
                 return new MultiSourceSelect(
-                    Maps.transformValues(multiSourceSelect.sources(), RelationSource::relation),
+                    multiSourceSelect.sources(),
                     namesFromOutputs(currentWithParentMerged.outputs(), fieldReplacer.replacedFieldsByNewOutput),
                     currentWithParentMerged,
                     multiSourceSelect.joinPairs()

--- a/sql/src/main/java/io/crate/collections/Sets2.java
+++ b/sql/src/main/java/io/crate/collections/Sets2.java
@@ -20,41 +20,19 @@
  * agreement.
  */
 
-package io.crate.analyze;
+package io.crate.collections;
 
-import io.crate.analyze.relations.AnalyzedRelation;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Function;
 
-public class RelationSource {
+public class Sets2 {
 
-    private final AnalyzedRelation relation;
-    private QuerySpec querySpec;
-
-    public RelationSource(AnalyzedRelation relation) {
-        this(relation, null);
-    }
-
-    public RelationSource(AnalyzedRelation relation, QuerySpec querySpec) {
-        this.relation = relation;
-        this.querySpec = querySpec;
-    }
-
-    public QuerySpec querySpec() {
-        return querySpec;
-    }
-
-    public void querySpec(QuerySpec querySpec) {
-        this.querySpec = querySpec;
-    }
-
-    public AnalyzedRelation relation() {
-        return relation;
-    }
-
-    @Override
-    public String toString() {
-        return "Source{" +
-               ", rel=" + relation +
-               ", qs=" + querySpec +
-               '}';
+    public static <I, R> Set<R> transformedCopy(Set<? extends I> input, Function<? super I, ? extends R> func) {
+        HashSet<R> result = new HashSet<>(input.size());
+        for (I i : input) {
+            result.add(func.apply(i));
+        }
+        return result;
     }
 }

--- a/sql/src/main/java/io/crate/planner/consumer/MultiSourceAggregationConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/MultiSourceAggregationConsumer.java
@@ -24,10 +24,10 @@ package io.crate.planner.consumer;
 
 import io.crate.analyze.MultiSourceSelect;
 import io.crate.analyze.QuerySpec;
-import io.crate.analyze.RelationSource;
 import io.crate.analyze.WhereClause;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.JoinPairs;
+import io.crate.analyze.relations.QueriedRelation;
 import io.crate.analyze.symbol.Field;
 import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Symbol;
@@ -94,8 +94,8 @@ class MultiSourceAggregationConsumer implements Consumer {
         // OrderBy can be ignored because it's also applied after aggregation but there is always only 1 row so it
         // wouldn't have any effect.
         removeLimitOffsetAndOrder(querySpec);
-        for (RelationSource relationSource : mss.sources().values()) {
-            removeLimitOffsetAndOrder(relationSource.querySpec());
+        for (AnalyzedRelation relation : mss.sources().values()) {
+            removeLimitOffsetAndOrder(((QueriedRelation) relation).querySpec());
         }
 
         // need to change the types on the fields of the MSS to match the new outputs

--- a/sql/src/main/java/io/crate/planner/consumer/MultiSourceGroupByConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/MultiSourceGroupByConsumer.java
@@ -24,9 +24,9 @@ package io.crate.planner.consumer;
 
 import io.crate.analyze.MultiSourceSelect;
 import io.crate.analyze.QuerySpec;
-import io.crate.analyze.RelationSource;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.JoinPairs;
+import io.crate.analyze.relations.QueriedRelation;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.Symbols;
 import io.crate.collections.Lists2;
@@ -107,8 +107,8 @@ public class MultiSourceGroupByConsumer implements Consumer {
             querySpec.hasAggregates(false);
             removePostGroupingActions(querySpec);
 
-            for (RelationSource relationSource : mss.sources().values()) {
-                removePostGroupingActions(relationSource.querySpec());
+            for (AnalyzedRelation relation : mss.sources().values()) {
+                removePostGroupingActions(((QueriedRelation) relation).querySpec());
             }
         }
 

--- a/sql/src/main/java/io/crate/planner/fetch/MultiSourceFetchPushDown.java
+++ b/sql/src/main/java/io/crate/planner/fetch/MultiSourceFetchPushDown.java
@@ -23,17 +23,25 @@
 package io.crate.planner.fetch;
 
 import io.crate.analyze.MultiSourceSelect;
-import io.crate.analyze.RelationSource;
+import io.crate.analyze.QuerySpec;
+import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.DocTableRelation;
+import io.crate.analyze.relations.QueriedDocTable;
+import io.crate.analyze.relations.QueriedRelation;
 import io.crate.analyze.symbol.*;
 import io.crate.metadata.DocReferences;
+import io.crate.metadata.Reference;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.TableIdent;
 import io.crate.metadata.doc.DocSysColumns;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.metadata.table.Operation;
 import io.crate.planner.node.fetch.FetchSource;
 import io.crate.sql.tree.QualifiedName;
+import org.elasticsearch.common.collect.Tuple;
 
 import java.util.*;
+import java.util.function.Function;
 
 class MultiSourceFetchPushDown {
 
@@ -55,48 +63,86 @@ class MultiSourceFetchPushDown {
         return remainingOutputs;
     }
 
+    /**
+     * Re-write the MSS to utilize fetch.
+     *
+     * Example:
+     * <pre>
+     *     select t1.x, t1.y, t2.x from
+     *       (select x, y from t1) t1,
+     *       (select x from t2) t2
+     *
+     *  Becomes:
+     *
+     *     select t1._fetchId, t2._fetchId from
+     *       (select _fetchId from t1) t1,
+     *       (select _fetchId from t2) t2
+     *
+     *     remainingOutputs: [
+     *        FetchReference(IC(0), Reference(_doc[x])),
+     *        FetchReference(IC(0), Reference(_doc[y])),
+     *        FetchReference(IC(1), Reference(_doc[x])),
+     *     ]
+     * </pre>
+     */
     void process() {
         remainingOutputs = statement.querySpec().outputs();
-        statement.querySpec().outputs(new ArrayList<>());
 
-        HashMap<Symbol, FetchReference> fetchRefByOriginalSymbol = new HashMap<>();
+        Map<Symbol, FetchReference> fetchRefByOriginalSymbol = new IdentityHashMap<>();
         ArrayList<Symbol> mssOutputs = new ArrayList<>(
             statement.sources().size() + statement.requiredForQuery().size());
 
-        for (Map.Entry<QualifiedName, RelationSource> entry : statement.sources().entrySet()) {
-            RelationSource source = entry.getValue();
-            if (!(source.relation() instanceof DocTableRelation)) {
-                mssOutputs.addAll(source.querySpec().outputs());
+        for (Map.Entry<QualifiedName, AnalyzedRelation> entry : statement.sources().entrySet()) {
+            QueriedRelation relation = (QueriedRelation) entry.getValue();
+            if (!(relation instanceof QueriedDocTable)) {
+                mssOutputs.addAll(relation.fields());
                 continue;
             }
 
-            DocTableRelation rel = (DocTableRelation) source.relation();
-            HashSet<Field> canBeFetched = filterByRelation(statement.canBeFetched(), rel);
+            DocTableRelation rel = ((QueriedDocTable) relation).tableRelation();
+            DocTableInfo tableInfo = rel.tableInfo();
+            FetchFields canBeFetched = filterByRelation(statement.canBeFetched(), relation, rel);
             if (!canBeFetched.isEmpty()) {
 
                 Field fetchIdColumn = rel.getField(DocSysColumns.FETCHID);
+                assert fetchIdColumn != null: "_fetchId must be accessible";
                 mssOutputs.add(fetchIdColumn);
-                InputColumn fetchIdInput = new InputColumn(mssOutputs.size() - 1);
+                InputColumn fetchIdInput = new InputColumn(mssOutputs.size() - 1, fetchIdColumn.valueType());
 
                 ArrayList<Symbol> qtOutputs = new ArrayList<>(
-                    source.querySpec().outputs().size() - canBeFetched.size() + 1);
+                    relation.querySpec().outputs().size() - canBeFetched.size() + 1);
                 qtOutputs.add(fetchIdColumn);
 
-                for (Symbol output : source.querySpec().outputs()) {
+                for (int i = 0; i < relation.querySpec().outputs().size(); i++) {
+                    Symbol output = relation.querySpec().outputs().get(i);
                     if (!canBeFetched.contains(output)) {
                         qtOutputs.add(output);
-                        mssOutputs.add(output);
+                        mssOutputs.add(relation.fields().get(i));
                     }
                 }
-                for (Field field : canBeFetched) {
-                    FetchReference fr = new FetchReference(
-                        fetchIdInput, DocReferences.toSourceLookup(rel.resolveField(field)));
-                    allocateFetchedReference(fr, rel);
-                    fetchRefByOriginalSymbol.put(field, fr);
+                /*
+                 *         Parent (as Field)
+                 *          |
+                 *  select t1.x from
+                 *      (select x from t1)
+                 *              |
+                 *              Child (as Reference)
+                 */
+                for (Tuple<Field, Reference> parentAndChild : canBeFetched.parentAndChildren()) {
+                    Field parent = parentAndChild.v1();
+                    Reference child = parentAndChild.v2();
+                    FetchReference fr = new FetchReference(fetchIdInput, DocReferences.toSourceLookup(child));
+                    allocateFetchedReference(fr, tableInfo.partitionedByColumns());
+                    fetchRefByOriginalSymbol.put(parent, fr);
                 }
-                source.querySpec().outputs(qtOutputs);
+                QuerySpec querySpec = relation.querySpec().copyAndReplace(Function.identity());
+                querySpec.outputs(qtOutputs);
+                // create a new relation instead of only mutating the querySpec so that the fields are correct as well
+                QueriedDocTable newRelation = new QueriedDocTable(rel, querySpec);
+                entry.setValue(newRelation);
+                mssOutputs.set(fetchIdInput.index(), newRelation.getField(DocSysColumns.FETCHID, Operation.READ));
             } else {
-                mssOutputs.addAll(source.querySpec().outputs());
+                mssOutputs.addAll(relation.fields());
             }
         }
 
@@ -107,25 +153,78 @@ class MultiSourceFetchPushDown {
         }
     }
 
-    private static HashSet<Field> filterByRelation(Set<Field> fields, DocTableRelation rel) {
-        HashSet<Field> filteredFields = new HashSet<>();
+    private static FetchFields filterByRelation(Set<Field> fields, AnalyzedRelation rel, DocTableRelation tableRelation) {
+        FetchFields fetchFields = new FetchFields(tableRelation);
         for (Field field : fields) {
-            if (field.relation() == rel) {
-                filteredFields.add(field);
+            if (field.relation().equals(rel)) {
+                fetchFields.add(field);
             }
         }
-        return filteredFields;
+        return fetchFields;
     }
 
-    private void allocateFetchedReference(FetchReference fr, DocTableRelation rel) {
+    private void allocateFetchedReference(FetchReference fr, List<Reference> partitionedByColumns) {
         FetchSource fs = fetchSources.get(fr.ref().ident().tableIdent());
         if (fs == null) {
-            fs = new FetchSource(rel.tableInfo().partitionedByColumns());
+            fs = new FetchSource(partitionedByColumns);
             fetchSources.put(fr.ref().ident().tableIdent(), fs);
         }
         fs.fetchIdCols().add(fr.fetchId());
         if (fr.ref().granularity() == RowGranularity.DOC) {
             fs.references().add(fr.ref());
+        }
+    }
+
+    private final static class FetchFields {
+
+        private final DocTableRelation tableRelation;
+        private Set<Field> canBeFetchedParent = new LinkedHashSet<>();
+        private Set<Reference> canBeFetchedChild = new LinkedHashSet<>();
+
+        FetchFields(DocTableRelation tableRelation) {
+            this.tableRelation = tableRelation;
+        }
+
+        void add(Field field) {
+            canBeFetchedParent.add(field);
+            Reference reference = tableRelation.resolveField(tableRelation.getField(field.path()));
+            canBeFetchedChild.add(reference);
+        }
+
+        boolean isEmpty() {
+            return canBeFetchedChild.isEmpty();
+        }
+
+        int size() {
+            return canBeFetchedChild.size();
+        }
+
+        boolean contains(Symbol output) {
+            return canBeFetchedChild.contains(output);
+        }
+
+        Iterable<Tuple<Field, Reference>> parentAndChildren() {
+            return () -> new Iterator<Tuple<Field, Reference>>() {
+
+                private final Iterator<Reference> children = canBeFetchedChild.iterator();
+                private final Iterator<Field> parents = canBeFetchedParent.iterator();
+
+                @Override
+                public boolean hasNext() {
+                    return children.hasNext();
+                }
+
+                @Override
+                public Tuple<Field, Reference> next() {
+                    if (!children.hasNext()) {
+                        throw new NoSuchElementException("Iterator is exhausted");
+                    }
+                    Reference child = children.next();
+                    Field parent = parents.next();
+
+                    return new Tuple<>(parent, child);
+                }
+            };
         }
     }
 }

--- a/sql/src/main/java/io/crate/planner/node/dql/join/NestedLoop.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/join/NestedLoop.java
@@ -103,6 +103,7 @@ public class NestedLoop implements Plan, ResultDescription {
                       int limit,
                       int offset,
                       int maxRowsPerNode,
+                      int numOutputs,
                       @Nullable PositionalOrderBy orderBy) {
         this.jobId = nestedLoopPhase.jobId();
         this.left = left;
@@ -112,7 +113,7 @@ public class NestedLoop implements Plan, ResultDescription {
         this.offset = offset;
         this.maxRowsPerNode = maxRowsPerNode;
         this.orderBy = orderBy;
-        this.numOutputs = nestedLoopPhase.outputTypes().size();
+        this.numOutputs = numOutputs;
     }
 
     public Plan left() {

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -882,8 +882,8 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
 
         // make sure that where clause was pushed down and didn't disappear somehow
         assertThat(relation.querySpec().where().query(), isSQL("null"));
-        RelationSource users =
-            ((MultiSourceSelect) analysis.relation()).sources().get(QualifiedName.of("doc", "users"));
+        QueriedRelation users =
+            ((QueriedRelation) ((MultiSourceSelect) analysis.relation()).sources().get(QualifiedName.of("doc", "users")));
         assertThat(users.querySpec().where().query(), isSQL("(doc.users.name = 'Arthur')"));
     }
 
@@ -894,11 +894,11 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         assertThat(analysis.relation().querySpec().where(), is(WhereClause.MATCH_ALL));
         assertThat(analysis.relation(), instanceOf(MultiSourceSelect.class));
 
-        RelationSource source1 = ((MultiSourceSelect) analysis.relation()).sources().get(QualifiedName.of("t1"));
-        RelationSource source2 = ((MultiSourceSelect) analysis.relation()).sources().get(QualifiedName.of("t2"));
+        QueriedRelation subRel1 = (QueriedRelation) ((MultiSourceSelect) analysis.relation()).sources().get(QualifiedName.of("t1"));
+        QueriedRelation subRel2 = (QueriedRelation) ((MultiSourceSelect) analysis.relation()).sources().get(QualifiedName.of("t2"));
 
-        assertThat(source1.querySpec().where().query(), isSQL("(doc.users.name = 'foo')"));
-        assertThat(source2.querySpec().where().query(), isSQL("(true AND (doc.users.name = 'bar'))"));
+        assertThat(subRel1.querySpec().where().query(), isSQL("(doc.users.name = 'foo')"));
+        assertThat(subRel2.querySpec().where().query(), isSQL("(doc.users.name = 'bar')"));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/analyze/relations/SubselectRewriterTest.java
+++ b/sql/src/test/java/io/crate/analyze/relations/SubselectRewriterTest.java
@@ -353,10 +353,10 @@ public class SubselectRewriterTest extends CrateDummyClusterServiceUnitTest {
             "SELECT doc.t1.a, doc.t2.i ORDER BY doc.t2.y"));
 
         // make sure that where clause was pushed down and didn't disappear somehow
-        RelationSource t1 = ((MultiSourceSelect) relation).sources().get(T3.T1);
+        QueriedRelation t1 = ((QueriedRelation) ((MultiSourceSelect) relation).sources().get(T3.T1));
         assertThat(t1.querySpec().where().query(), isSQL("(doc.t1.a = 'a')"));
-        RelationSource t2 = ((MultiSourceSelect) relation).sources().get(T3.T2);
-        assertThat(t2.querySpec().where().query(), isSQL("(true AND (doc.t2.y > 60))"));
+        QueriedRelation t2 = ((QueriedRelation) ((MultiSourceSelect) relation).sources().get(T3.T2));
+        assertThat(t2.querySpec().where().query(), isSQL("(doc.t2.y > 60)"));
     }
 
     @Test
@@ -374,9 +374,9 @@ public class SubselectRewriterTest extends CrateDummyClusterServiceUnitTest {
         assertThat(mss.joinPairs().get(0).condition(), isSQL("(doc.t1.a = doc.t2.b)"));
 
         // make sure that where clause was pushed down and didn't disappear somehow
-        RelationSource t1 = mss.sources().get(T3.T1);
+        QueriedRelation t1 = ((QueriedRelation) mss.sources().get(T3.T1));
         assertThat(t1.querySpec().where().query(), isSQL("(doc.t1.a = 'a')"));
-        RelationSource t2 = mss.sources().get(T3.T2);
+        QueriedRelation t2 = ((QueriedRelation) mss.sources().get(T3.T2));
         assertThat(t2.querySpec().where().query(), isSQL("(doc.t2.y > 60)"));
     }
 
@@ -395,9 +395,9 @@ public class SubselectRewriterTest extends CrateDummyClusterServiceUnitTest {
         assertThat(mss.joinPairs().get(0).condition(), isSQL("(doc.t1.a = doc.t2.b)"));
 
         // make sure that where clause was pushed down and didn't disappear somehow
-        RelationSource t1 = mss.sources().get(T3.T1);
+        QueriedRelation t1 = ((QueriedRelation) mss.sources().get(T3.T1));
         assertThat(t1.querySpec().where().query(), isSQL("(doc.t1.x > 60)"));
-        RelationSource t2 = mss.sources().get(T3.T2);
+        QueriedRelation t2 = ((QueriedRelation) mss.sources().get(T3.T2));
         assertThat(t2.querySpec().where().query(), isSQL("(doc.t2.i = 10)"));
     }
 
@@ -427,9 +427,9 @@ public class SubselectRewriterTest extends CrateDummyClusterServiceUnitTest {
         assertThat(mss.joinPairs().get(0).condition(), isSQL("(doc.t1.a = doc.t2.b)"));
 
         // make sure that the conditions of where clause were pushed down to the relations
-        RelationSource t1 = mss.sources().get(T3.T1);
+        QueriedRelation t1 = ((QueriedRelation) mss.sources().get(T3.T1));
         assertThat(t1.querySpec().where().query(), isSQL("(doc.t1.a = 'a')"));
-        RelationSource t2 = mss.sources().get(T3.T2);
+        QueriedRelation t2 = ((QueriedRelation) mss.sources().get(T3.T2));
         assertThat(t2.querySpec().where().query(), isSQL("(NOT (ISNULL doc.t2.y))"));
     }
 
@@ -450,9 +450,9 @@ public class SubselectRewriterTest extends CrateDummyClusterServiceUnitTest {
         assertThat(mss.joinPairs().get(0).condition(), isSQL("(doc.t1.a = doc.t2.b)"));
 
         // make sure that where clause for t1 wasn't pushed down since but be applied after the FULL join
-        RelationSource t1 = mss.sources().get(T3.T1);
+        QueriedRelation t1 = ((QueriedRelation) mss.sources().get(T3.T1));
         assertThat(t1.querySpec().where().query(), isSQL("(doc.t1.a = 'a')"));
-        RelationSource t2 = mss.sources().get(T3.T2);
+        QueriedRelation t2 = ((QueriedRelation) mss.sources().get(T3.T2));
         assertThat(t2.querySpec().where().query(), is(nullValue()));
     }
 
@@ -473,9 +473,9 @@ public class SubselectRewriterTest extends CrateDummyClusterServiceUnitTest {
         assertThat(mss.joinPairs().get(0).condition(), isSQL("(doc.t1.a = doc.t2.b)"));
 
         // make sure that where clause for t2 wasn't pushed down since but be applied after the FULL join
-        RelationSource t1 = mss.sources().get(T3.T1);
+        QueriedRelation t1 = ((QueriedRelation) mss.sources().get(T3.T1));
         assertThat(t1.querySpec().where().query(), is(nullValue()));
-        RelationSource t2 = mss.sources().get(T3.T2);
+        QueriedRelation t2 = ((QueriedRelation) mss.sources().get(T3.T2));
         assertThat(t2.querySpec().where().query(), isSQL("(doc.t2.b = 'b')"));
     }
 
@@ -496,9 +496,9 @@ public class SubselectRewriterTest extends CrateDummyClusterServiceUnitTest {
         assertThat(mss.joinPairs().get(0).condition(), isSQL("(doc.t1.a = doc.t2.b)"));
 
         // make sure that where clause wasn't pushed down since but be applied after the FULL join
-        RelationSource t1 = mss.sources().get(T3.T1);
+        QueriedRelation t1 = ((QueriedRelation) mss.sources().get(T3.T1));
         assertThat(t1.querySpec().where().query(), is(nullValue()));
-        RelationSource t2 = mss.sources().get(T3.T2);
+        QueriedRelation t2 = ((QueriedRelation) mss.sources().get(T3.T2));
         assertThat(t2.querySpec().where().query(), is(nullValue()));
     }
 

--- a/sql/src/test/java/io/crate/planner/consumer/ManyTableConsumerTest.java
+++ b/sql/src/test/java/io/crate/planner/consumer/ManyTableConsumerTest.java
@@ -66,7 +66,7 @@ public class ManyTableConsumerTest extends CrateDummyClusterServiceUnitTest {
                                         "join t3 on t2.b = t3.c " +
                                         "order by t1.a, t2.b, t3.c");
         TwoTableJoin root = ManyTableConsumer.buildTwoTableJoinTree(mss);
-        TwoTableJoin t1AndT2 = ((TwoTableJoin) root.left().relation());
+        TwoTableJoin t1AndT2 = (TwoTableJoin) root.left();
 
         assertThat(t1AndT2.joinPair().condition(), isSQL("(doc.t1.a = doc.t2.b)"));
         assertThat(root.joinPair().condition(), isSQL("(join.doc.t1.doc.t2.doc.t2['b'] = doc.t3.c)"));
@@ -78,7 +78,7 @@ public class ManyTableConsumerTest extends CrateDummyClusterServiceUnitTest {
                                         "where t3.c = t2.b " +
                                         "order by t3.c");
         TwoTableJoin root = ManyTableConsumer.buildTwoTableJoinTree(mss);
-        TwoTableJoin left = (TwoTableJoin) root.left().relation();
+        TwoTableJoin left = (TwoTableJoin) root.left();
 
         assertThat(left.querySpec().where().query(), isSQL("(doc.t3.c = doc.t2.b)"));
     }
@@ -90,7 +90,7 @@ public class ManyTableConsumerTest extends CrateDummyClusterServiceUnitTest {
                                         "join t3 on t2.b = t3.c " +
                                         "order by t3.c, t1.a, t2.b");
         TwoTableJoin root = ManyTableConsumer.buildTwoTableJoinTree(mss);
-        TwoTableJoin t3AndT1 = ((TwoTableJoin) root.left().relation());
+        TwoTableJoin t3AndT1 = (TwoTableJoin) root.left();
 
         assertThat(t3AndT1.querySpec().where().query(), isSQL("null"));
 
@@ -166,7 +166,7 @@ public class ManyTableConsumerTest extends CrateDummyClusterServiceUnitTest {
                                         "left join t3 on t2.b = t3.c " +
                                         "order by t2.b, t3.c");
         TwoTableJoin root = ManyTableConsumer.buildTwoTableJoinTree(mss);
-        TwoTableJoin t1AndT2 = ((TwoTableJoin) root.left().relation());
+        TwoTableJoin t1AndT2 = (TwoTableJoin) root.left();
 
         assertThat(t1AndT2.right().querySpec().orderBy().isPresent(), is(false));
         assertThat(t1AndT2.querySpec().orderBy().get(), isSQL("doc.t2.b"));
@@ -193,8 +193,8 @@ public class ManyTableConsumerTest extends CrateDummyClusterServiceUnitTest {
                                         "where t1.a=t3.c");
         TwoTableJoin root = ManyTableConsumer.buildTwoTableJoinTree(mss);
         assertThat(root.toString(), is("join.join.doc.t1.doc.t3.doc.t2"));
-        TwoTableJoin t1Andt3 = ((TwoTableJoin) root.left().relation());
+        TwoTableJoin t1Andt3 = (TwoTableJoin) root.left();
         assertThat(t1Andt3.toString(), is("join.doc.t1.doc.t3"));
-        assertThat(root.right().relation().getQualifiedName().toString(), is("doc.t2"));
+        assertThat(root.right().getQualifiedName().toString(), is("doc.t2"));
     }
 }

--- a/sql/src/test/java/io/crate/planner/fetch/MultiSourceFetchPushDownTest.java
+++ b/sql/src/test/java/io/crate/planner/fetch/MultiSourceFetchPushDownTest.java
@@ -25,6 +25,7 @@ package io.crate.planner.fetch;
 import io.crate.analyze.MultiSourceSelect;
 import io.crate.analyze.QuerySpec;
 import io.crate.analyze.SelectAnalyzedStatement;
+import io.crate.analyze.relations.QueriedRelation;
 import io.crate.sql.tree.QualifiedName;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
@@ -56,7 +57,7 @@ public class MultiSourceFetchPushDownTest extends CrateDummyClusterServiceUnitTe
     }
 
     private QuerySpec srcSpec(String tableName) {
-        return mss.sources().get(QualifiedName.of("doc", tableName)).querySpec();
+        return ((QueriedRelation) mss.sources().get(QualifiedName.of("doc", tableName))).querySpec();
     }
 
     @Test


### PR DESCRIPTION
In order to do a "query push-down" we used a custom data structure to
represent a query with a JOIN.

For example

    select t1.x, t2.x from t1, t2 where t1.x = 10

Was represented as:

    select t1.x, t2.x from t1, t2

    t1 querySpec:
        outputs: [x]
        where: x = 10

    t2 querySpec:
        outputs: [x]

This commit changes the internal representation so that the sub-query
data structures are used. The above example now looks like this:

    select t1.x, t2.x from
        (select x from t1 where x = 1) t1,
        (select x from t2) t2

This should make it easier to support joined virtual tables since the
internal representation is already the same.