### PR TITLE
added node.max_local_storage_nodes to sandbox config

### DIFF
--- a/sandbox/crate/config/crate.yml
+++ b/sandbox/crate/config/crate.yml
@@ -1,7 +1,7 @@
-
 cluster.name: dev
 stats.service.interval: 0
 stats.enabled: true
 # bind to localhost, mainly to prevent the node from dying due to bootstrap checks (HEAP checks)
 network.host: _local_
 license.enterprise: true
+node.max_local_storage_nodes: 3


### PR DESCRIPTION
this allows to start up to 3 nodes from within intellij