### PR TITLE
fixup! rename table/partitioned table, blocks were not updated

### DIFF
--- a/sql/src/main/java/io/crate/executor/transport/ddl/TransportRenameTableAction.java
+++ b/sql/src/main/java/io/crate/executor/transport/ddl/TransportRenameTableAction.java
@@ -120,10 +120,14 @@ public class TransportRenameTableAction extends TransportMasterNodeAction<Rename
                         .blocks(currentState.blocks());
 
                     for (int i = 0; i < concreteIndices.length; i++) {
-                        IndexMetaData indexMetaData = currentState.metaData().getIndexSafe(concreteIndices[i]);
-                        mdBuilder.remove(concreteIndices[i].getName());
-                        IndexMetaData.Builder builder = IndexMetaData.builder(indexMetaData).index(targetIndexNames[i]);
-                        mdBuilder.put(builder);
+                        Index index = concreteIndices[i];
+                        IndexMetaData indexMetaData = currentState.metaData().getIndexSafe(index);
+                        IndexMetaData targetIndexMetadata = IndexMetaData.builder(indexMetaData)
+                            .index(targetIndexNames[i]).build();
+                        mdBuilder.remove(index.getName());
+                        mdBuilder.put(targetIndexMetadata, true);
+                        blocksBuilder.removeIndexBlocks(index.getName());
+                        blocksBuilder.addBlocks(targetIndexMetadata);
                     }
 
                     return ClusterState.builder(currentState).metaData(mdBuilder).blocks(blocksBuilder).build();

--- a/sql/src/test/java/io/crate/integrationtests/RenameTableIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/RenameTableIntegrationTest.java
@@ -51,6 +51,21 @@ public class RenameTableIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    public void testRenameTableEnsureOldTableNameCanBeUsed() {
+        execute("create table t1 (id int) with (number_of_replicas = 0)");
+        execute("insert into t1 (id) values (1), (2)");
+        refresh();
+        execute("alter table t1 rename to t2");
+        ensureYellow();
+
+        // creating a new table using the old name must succeed
+        execute("create table t1 (id int) with (number_of_replicas = 0)");
+        ensureYellow();
+        // also inserting must work (no old blocks traces)
+        execute("insert into t1 (id) values (1), (2)");
+    }
+
+    @Test
     public void testRenamePartitionedTable() {
         execute("create table tp1 (id int, id2 integer) partitioned by (id) with (number_of_replicas = 0)");
         execute("insert into tp1 (id, id2) values (1, 1), (2, 2)");
@@ -69,5 +84,20 @@ public class RenameTableIntegrationTest extends SQLTransportIntegrationTest {
 
         execute("select * from information_schema.tables where table_name = 'tp1'");
         assertThat(response.rowCount(), is(0L));
+    }
+
+    @Test
+    public void testRenamePartitionedTableEnsureOldTableNameCanBeUsed() {
+        execute("create table tp1 (id int, id2 integer) partitioned by (id) with (number_of_replicas = 0)");
+        execute("insert into tp1 (id, id2) values (1, 1), (2, 2)");
+        refresh();
+        execute("alter table tp1 rename to tp2");
+        ensureYellow();
+
+        // creating a new table using the old name must succeed
+        execute("create table tp1 (id int, id2 integer) partitioned by (id) with (number_of_replicas = 0)");
+        ensureYellow();
+        // also inserting must work (no old blocks traces)
+        execute("insert into tp1 (id, id2) values (1, 1), (2, 2)");
     }
 }


### PR DESCRIPTION
cluster blocks must be removed for the old name and added by using
the new table/partition name.
otherwise cluster blocks still has blocks registered for the old names
and so prevents using the old name again