### PR TITLE
Move decision for directResponse into NodeOperationTreeGenerator

### DIFF
--- a/sql/src/main/java/io/crate/executor/transport/executionphases/ExecutionPhasesTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/executionphases/ExecutionPhasesTask.java
@@ -41,9 +41,9 @@ import io.crate.operation.NodeOperationTree;
 import io.crate.planner.node.ExecutionPhase;
 import io.crate.planner.node.ExecutionPhases;
 import io.crate.planner.node.NodeOperationGrouper;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.collect.Tuple;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.indices.IndicesService;
 
@@ -206,6 +206,7 @@ public class ExecutionPhasesTask extends JobTask {
          * Seed: CC456FF5004F35D3 - testFailureOfJoinDownstream
          */
         if (!localNodeOperations.isEmpty() && !directResponseFutures.isEmpty()) {
+            assert directResponseFutures.size() == pageBucketReceivers.size() : "directResponses size must match pageBucketReceivers";
             CompletableFutures.allAsList(directResponseFutures)
                 .whenComplete(new SetBucketCallback(pageBucketReceivers, bucketIdx, initializationTracker));
             bucketIdx++;

--- a/sql/src/main/java/io/crate/planner/consumer/CountConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/CountConsumer.java
@@ -96,7 +96,7 @@ public class CountConsumer implements Consumer {
                 plannerContext.nextExecutionPhaseId(),
                 "count-merge",
                 countPhase.nodeIds().size(),
-                Collections.emptyList(),
+                Collections.singletonList(plannerContext.handlerNode()),
                 Collections.singletonList(DataTypes.LONG),
                 projections,
                 DistributionInfo.DEFAULT_SAME_NODE,

--- a/sql/src/main/java/io/crate/planner/consumer/NonDistributedGroupByConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/NonDistributedGroupByConsumer.java
@@ -175,7 +175,7 @@ class NonDistributedGroupByConsumer implements Consumer {
                 plannerContext.nextExecutionPhaseId(),
                 "mergeOnHandler",
                 collect.resultDescription().nodeIds().size(),
-                Collections.emptyList(),
+                Collections.singletonList(plannerContext.handlerNode()),
                 collect.resultDescription().streamOutputs(),
                 mergeProjections,
                 DistributionInfo.DEFAULT_SAME_NODE,

--- a/sql/src/main/java/io/crate/planner/node/ExecutionPhase.java
+++ b/sql/src/main/java/io/crate/planner/node/ExecutionPhase.java
@@ -21,16 +21,22 @@
 
 package io.crate.planner.node;
 
-import io.crate.planner.node.dql.*;
+import io.crate.planner.node.dql.CountPhase;
+import io.crate.planner.node.dql.FileUriCollectPhase;
+import io.crate.planner.node.dql.MergePhase;
+import io.crate.planner.node.dql.RoutedCollectPhase;
 import io.crate.planner.node.dql.join.NestedLoopPhase;
 import io.crate.planner.node.fetch.FetchPhase;
 import org.elasticsearch.common.io.stream.Streamable;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 public interface ExecutionPhase extends Streamable {
 
-    String DIRECT_RETURN_DOWNSTREAM_NODE = "_response";
+    String DIRECT_RESPONSE = "_response";
+    List<String> DIRECT_RESPONSE_LIST = Collections.singletonList("_response");
 
     int NO_EXECUTION_PHASE = Integer.MAX_VALUE;
 

--- a/sql/src/main/java/io/crate/planner/node/ExecutionPhases.java
+++ b/sql/src/main/java/io/crate/planner/node/ExecutionPhases.java
@@ -61,7 +61,7 @@ public class ExecutionPhases {
 
     public static boolean hasDirectResponseDownstream(Collection<String> downstreamNodes) {
         for (String nodeId : downstreamNodes) {
-            if (nodeId.equals(ExecutionPhase.DIRECT_RETURN_DOWNSTREAM_NODE)) {
+            if (nodeId.equals(ExecutionPhase.DIRECT_RESPONSE)) {
                 return true;
             }
         }

--- a/sql/src/test/groovy/io/crate/action/job/NodeOperationCtxTest.groovy
+++ b/sql/src/test/groovy/io/crate/action/job/NodeOperationCtxTest.groovy
@@ -37,8 +37,8 @@ class NodeOperationCtxTest {
         def p3 = StubPhases.newPhase(2, "n2")
 
         def opCtx = new ContextPreparer.NodeOperationCtx("n1", [
-                NodeOperation.withDownstream(p1, p2, (byte)0, "n2"),
-                NodeOperation.withDownstream(p2, p3, (byte)0, "n2")])
+                NodeOperation.withDownstream(p1, p2, (byte)0),
+                NodeOperation.withDownstream(p2, p3, (byte)0)])
 
         def expected = new IntArrayList()
         expected.add(2)
@@ -49,7 +49,7 @@ class NodeOperationCtxTest {
     @Test
     void testFindLeafWithNodeOperationsThatHaveNoLeaf() {
         def p1 = StubPhases.newPhase(0, "n1");
-        def opCtx = new ContextPreparer.NodeOperationCtx("n1", [NodeOperation.withDownstream(p1, p1, (byte)0, "n1")])
+        def opCtx = new ContextPreparer.NodeOperationCtx("n1", [NodeOperation.withDownstream(p1, p1, (byte)0)])
 
         opCtx.findLeafs().size() == 0;
     }
@@ -58,7 +58,7 @@ class NodeOperationCtxTest {
     void testIsUpstreamOnSameNodeWithSameNodeOptimization() throws Exception {
         def p1 = StubPhases.newUpstreamPhase(0, DistributionInfo.DEFAULT_BROADCAST, "n1")
         def p2 = StubPhases.newPhase(1, "n1")
-        def opCtx = new ContextPreparer.NodeOperationCtx("n1", [NodeOperation.withDownstream(p1, p2, (byte)0, "n2")])
+        def opCtx = new ContextPreparer.NodeOperationCtx("n1", [NodeOperation.withDownstream(p1, p2, (byte)0)])
 
         // withDownstream set DistributionInfo to SAME_NODE because both phases are on n1
         assert opCtx.upstreamsAreOnSameNode(1)
@@ -68,7 +68,7 @@ class NodeOperationCtxTest {
     void testIsUpstreamOnSameNodeWithUpstreamOnOtherNode() throws Exception {
         def p1 = StubPhases.newUpstreamPhase(0, DistributionInfo.DEFAULT_BROADCAST, "n2")
         def p2 = StubPhases.newPhase(1, "n1")
-        def opCtx = new ContextPreparer.NodeOperationCtx("n1", [NodeOperation.withDownstream(p1, p2, (byte)0, "n1")])
+        def opCtx = new ContextPreparer.NodeOperationCtx("n1", [NodeOperation.withDownstream(p1, p2, (byte)0)])
 
         assert !opCtx.upstreamsAreOnSameNode(1)
     }
@@ -80,8 +80,8 @@ class NodeOperationCtxTest {
         def p3 = StubPhases.newPhase(3, "n2")
 
         def opCtx = new ContextPreparer.NodeOperationCtx("n1",[
-                NodeOperation.withDownstream(p1, p3, (byte)0, "n1"),
-                NodeOperation.withDownstream(p2, p3, (byte)0, "n1")])
+                NodeOperation.withDownstream(p1, p3, (byte)0),
+                NodeOperation.withDownstream(p2, p3, (byte)0)])
 
 
         assert opCtx.upstreamsAreOnSameNode(3)

--- a/sql/src/test/java/io/crate/executor/transport/ExecutionPhasesTaskTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/ExecutionPhasesTaskTest.java
@@ -92,9 +92,9 @@ public class ExecutionPhasesTaskTest {
 
 
         String localNodeId = "node1";
-        NodeOperation n1 = NodeOperation.withDownstream(c1, m1, (byte) 0, localNodeId);
-        NodeOperation n2 = NodeOperation.withDownstream(m1, m2, (byte) 0, localNodeId);
-        NodeOperation n3 = NodeOperation.withDownstream(m2, mock(ExecutionPhase.class), (byte) 0, localNodeId);
+        NodeOperation n1 = NodeOperation.withDownstream(c1, m1, (byte) 0);
+        NodeOperation n2 = NodeOperation.withDownstream(m1, m2, (byte) 0);
+        NodeOperation n3 = NodeOperation.withDownstream(m2, mock(ExecutionPhase.class), (byte) 0);
 
         Map<String, Collection<NodeOperation>> groupByServer = NodeOperationGrouper.groupByServer(ImmutableList.of(n1, n2, n3));
 

--- a/sql/src/test/java/io/crate/executor/transport/distributed/DistributingDownstreamFactoryTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/distributed/DistributingDownstreamFactoryTest.java
@@ -88,7 +88,7 @@ public class DistributingDownstreamFactoryTest extends CrateDummyClusterServiceU
             null
         );
         mergePhase.executionNodes(downstreamExecutionNodes);
-        NodeOperation nodeOperation = NodeOperation.withDownstream(collectPhase, mergePhase, (byte) 0, "nodeName");
+        NodeOperation nodeOperation = NodeOperation.withDownstream(collectPhase, mergePhase, (byte) 0);
         return rowDownstreamFactory.create(nodeOperation, collectPhase.distributionInfo(), jobId, Paging.PAGE_SIZE);
     }
 

--- a/sql/src/test/java/io/crate/operation/collect/DocLevelCollectTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/DocLevelCollectTest.java
@@ -211,7 +211,7 @@ public class DocLevelCollectTest extends SQLTransportIntegrationTest {
         JobContextService contextService = internalCluster().getDataNodeInstance(JobContextService.class);
         SharedShardContexts sharedShardContexts = new SharedShardContexts(internalCluster().getDataNodeInstance(IndicesService.class));
         JobExecutionContext.Builder builder = contextService.newBuilder(collectNode.jobId());
-        NodeOperation nodeOperation = NodeOperation.withDownstream(collectNode, mock(ExecutionPhase.class), (byte) 0,
+        NodeOperation nodeOperation = NodeOperation.withDirectResponse(collectNode, mock(ExecutionPhase.class), (byte) 0,
             "remoteNode");
 
         List<CompletableFuture<Bucket>> results = contextPreparer.prepareOnRemote(


### PR DESCRIPTION
Part of the decision to use direct-response execution was still made in
the Planner. This would cause issues once we want to support joins on
virtual tables because there would be intermediate Merge components without
executionNodes used as subPlans for a join. That messes up both, the
join-planner and the executor.

This commit moves the directResponse logic into the
NodeOperationTreeGenerator.