### PR TITLE
fixup! Adds support for renaming a table and partitioned tables

### DIFF
--- a/sql/src/main/java/io/crate/executor/transport/TransportActionProvider.java
+++ b/sql/src/main/java/io/crate/executor/transport/TransportActionProvider.java
@@ -22,7 +22,6 @@
 package io.crate.executor.transport;
 
 import io.crate.action.job.TransportJobAction;
-import io.crate.executor.transport.ddl.TransportRenameTableAction;
 import io.crate.executor.transport.kill.TransportKillAllNodeAction;
 import io.crate.executor.transport.kill.TransportKillJobsNodeAction;
 import org.elasticsearch.action.admin.cluster.settings.TransportClusterUpdateSettingsAction;
@@ -30,7 +29,6 @@ import org.elasticsearch.action.admin.cluster.snapshots.create.TransportCreateSn
 import org.elasticsearch.action.admin.cluster.snapshots.delete.TransportDeleteSnapshotAction;
 import org.elasticsearch.action.admin.cluster.snapshots.get.TransportGetSnapshotsAction;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.TransportRestoreSnapshotAction;
-import org.elasticsearch.action.admin.indices.alias.TransportIndicesAliasesAction;
 import org.elasticsearch.action.admin.indices.close.TransportCloseIndexAction;
 import org.elasticsearch.action.admin.indices.create.TransportBulkCreateIndicesAction;
 import org.elasticsearch.action.admin.indices.create.TransportCreateIndexAction;
@@ -57,8 +55,6 @@ public class TransportActionProvider {
     private final Provider<TransportClusterUpdateSettingsAction> transportClusterUpdateSettingsActionProvider;
     private final Provider<TransportShardDeleteAction> transportShardDeleteActionProvider;
     private final Provider<TransportDeleteAction> transportDeleteActionProvider;
-    private final Provider<TransportRenameTableAction> transportRenameTableActionProvider;
-    private final Provider<TransportIndicesAliasesAction> transportIndicesAliasesActionProvider;
 
     private final Provider<TransportGetAction> transportGetActionProvider;
     private final Provider<TransportMultiGetAction> transportMultiGetActionProvider;
@@ -85,8 +81,6 @@ public class TransportActionProvider {
                                    Provider<TransportClusterUpdateSettingsAction> transportClusterUpdateSettingsActionProvider,
                                    Provider<TransportShardDeleteAction> transportShardDeleteActionProvider,
                                    Provider<TransportDeleteAction> transportDeleteActionProvider,
-                                   Provider<TransportRenameTableAction> transportRenameTableActionProvider,
-                                   Provider<TransportIndicesAliasesAction> transportIndicesAliasesActionProvider,
                                    Provider<TransportGetAction> transportGetActionProvider,
                                    Provider<TransportMultiGetAction> transportMultiGetActionProvider,
                                    Provider<TransportShardUpsertAction> transportShardUpsertActionProvider,
@@ -109,8 +103,6 @@ public class TransportActionProvider {
         this.transportClusterUpdateSettingsActionProvider = transportClusterUpdateSettingsActionProvider;
         this.transportShardDeleteActionProvider = transportShardDeleteActionProvider;
         this.transportDeleteActionProvider = transportDeleteActionProvider;
-        this.transportRenameTableActionProvider = transportRenameTableActionProvider;
-        this.transportIndicesAliasesActionProvider = transportIndicesAliasesActionProvider;
         this.transportGetActionProvider = transportGetActionProvider;
         this.transportMultiGetActionProvider = transportMultiGetActionProvider;
         this.transportShardUpsertActionProvider = transportShardUpsertActionProvider;
@@ -153,14 +145,6 @@ public class TransportActionProvider {
 
     public TransportDeleteAction transportDeleteAction() {
         return transportDeleteActionProvider.get();
-    }
-
-    TransportRenameTableAction transportRenameTableAction() {
-        return transportRenameTableActionProvider.get();
-    }
-
-    TransportIndicesAliasesAction transportIndicesAliasesAction() {
-        return transportIndicesAliasesActionProvider.get();
     }
 
     public TransportGetAction transportGetAction() {


### PR DESCRIPTION
inject required transport actions directly into the AlterTableOperation
instead of using the transport povider