### PR TITLE
Adding support for renaming tables and partitioned tables

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -21,6 +21,9 @@ Breaking Changes
 Changes
 =======
 
+ - Added support for renaming tables using the `ALTER ... RENAME TO ...`
+   statement.
+
  - Added support for `CREATE USER` and `DROP USER`
 
  - Added support for opening and closing a table or single partition.

--- a/blackbox/docs/sql/ddl/alter_table.txt
+++ b/blackbox/docs/sql/ddl/alter_table.txt
@@ -75,3 +75,26 @@ A table can be reopened again by using ``ALTER TABLE`` with the ``OPEN`` clause:
     This setting is *not* the same as the :ref:`Blocks Settings <ref-configuration-blocks>`.
     Closing and opening a table will preserve these settings if they are already
     set.
+
+Renaming Tables
+---------------
+
+.. Hidden: CREATE TABLE::
+
+    cr> create table table_a (
+    ... id long
+    ... );
+    CREATE OK, 1 row affected (... sec)
+
+A table can be renamed by using ``ALTER TABLE`` with the ``RENAME TO`` clause::
+
+     cr> alter table table_a rename to table_b;
+     ALTER OK, -1 rows affected (... sec)
+
+During the rename operation the table will be closed, and all operations on the
+table will fail until the rename operation is completed.
+
+.. Hidden: DROP TABLE::
+
+    cr> drop table if exists table_b;
+    DROP OK, 1 row affected (... sec)

--- a/blackbox/docs/sql/reference/alter_table.txt
+++ b/blackbox/docs/sql/reference/alter_table.txt
@@ -19,6 +19,7 @@ Synopsis
         | ADD [ COLUMN ] column_name data_type [ column_constraint [ ... ] ]
         | OPEN
         | CLOSE
+        | RENAME TO table_ident
       }
 
 where ``column_constraint`` is::
@@ -47,6 +48,10 @@ Closing a table prevents all operations, except ``ALTER TABLE ... OPEN``, to
 fail. Operations on closed partitions will not produce an exception, but will have
 no effect. Similarly, like ``SELECT`` and ``INSERT`` on partitioned will exclude
 closed partitions and continue working.
+
+``RENAME TO`` can be used to rename a table, while maintaining its schema and data.
+During this operation the table will be closed, and all operations upon the table
+will fail until the rename operation is completed.
 
 Use the ``BLOB`` keyword in order to alter a blob table (see
 :ref:`blob_support`). Blob tables cannot have custom columns which means that

--- a/sql-parser/src/main/antlr/SqlBase.g4
+++ b/sql-parser/src/main/antlr/SqlBase.g4
@@ -50,6 +50,7 @@ statement
     | ALTER BLOB TABLE alterTableDefinition
         (SET '(' genericProperties ')' | RESET ('(' ident (',' ident)* ')')?)        #alterBlobTableProperties
     | ALTER TABLE alterTableDefinition (OPEN | CLOSE)                                #alterTableOpenClose
+    | ALTER TABLE alterTableDefinition RENAME TO qname                               #alterTableRename
     | RESET GLOBAL primaryExpression (',' primaryExpression)*                        #resetGlobal
     | SET (SESSION | LOCAL)? qname
         (EQ | TO) (DEFAULT | setExpr (',' setExpr)*)                                 #set
@@ -564,7 +565,7 @@ nonReserved
     | SHARDS | SHOW | STRICT | SYSTEM | TABLES | TABLESAMPLE | TEXT | TIME
     | TIMESTAMP | TO | TOKENIZER | TOKEN_FILTERS | TYPE | VALUES | VIEW | YEAR
     | REPOSITORY | SNAPSHOT | RESTORE | GENERATED | ALWAYS | BEGIN
-    | ISOLATION | TRANSACTION | LEVEL | LANGUAGE | OPEN | CLOSE | USER
+    | ISOLATION | TRANSACTION | LEVEL | LANGUAGE | OPEN | CLOSE | RENAME | USER
     ;
 
 SELECT: 'SELECT';
@@ -656,6 +657,8 @@ COLUMN: 'COLUMN';
 
 OPEN: 'OPEN';
 CLOSE: 'CLOSE';
+
+RENAME: 'RENAME';
 
 BOOLEAN: 'BOOLEAN';
 BYTE: 'BYTE';

--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -522,6 +522,14 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     }
 
     @Override
+    public Node visitAlterTableRename(SqlBaseParser.AlterTableRenameContext context) {
+        return new AlterTableRename(
+            (Table) visit(context.alterTableDefinition()),
+            getQualifiedName(context.qname())
+        );
+    }
+
+    @Override
     public Node visitSetGlobalAssignment(SqlBaseParser.SetGlobalAssignmentContext context) {
         return new Assignment((Expression) visit(context.primaryExpression()), (Expression) visit(context.expr()));
     }

--- a/sql-parser/src/main/java/io/crate/sql/tree/AlterTableRename.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AlterTableRename.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.sql.tree;
+
+import com.google.common.base.MoreObjects;
+
+public class AlterTableRename extends Statement {
+
+    private final Table table;
+    private final QualifiedName newName;
+
+    public AlterTableRename(Table table, QualifiedName newName) {
+        this.table = table;
+        this.newName = newName;
+    }
+
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitAlterTableRename(this, context);
+    }
+
+    public Table table() {
+        return table;
+    }
+
+    public QualifiedName newName() {
+        return newName;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+            .add("table", table)
+            .add("new name", newName).toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        AlterTableRename that = (AlterTableRename) o;
+
+        if (!newName.equals(that.newName)) return false;
+        if (!table.equals(that.table)) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = table.hashCode();
+        result = 31 * result + newName.hashCode();
+        return result;
+    }
+}

--- a/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
@@ -417,6 +417,10 @@ public abstract class AstVisitor<R, C> {
         return visitStatement(node, context);
     }
 
+    public R visitAlterTableRename(AlterTableRename node, C context) {
+        return visitStatement(node, context);
+    }
+
     public R visitAlterBlobTable(AlterBlobTable node, C context) {
         return visitStatement(node, context);
     }

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -984,6 +984,11 @@ public class TestStatementBuilder {
     }
 
     @Test
+    public void testAlterTableRename() throws Exception {
+        printStatement("alter table t rename to t2");
+    }
+
+    @Test
     public void testSubSelects() throws Exception {
         printStatement("select * from (select * from foo) as f");
         printStatement("select * from (select * from (select * from foo) as f1) as f2");

--- a/sql/src/main/java/io/crate/action/sql/DDLStatementDispatcher.java
+++ b/sql/src/main/java/io/crate/action/sql/DDLStatementDispatcher.java
@@ -127,6 +127,11 @@ public class DDLStatementDispatcher {
         }
 
         @Override
+        public CompletableFuture<Long> visitAlterTableRenameStatement(AlterTableRenameAnalyzedStatement analysis, Row parameters) {
+            return alterTableOperation.executeAlterTableRenameTable(analysis);
+        }
+
+        @Override
         public CompletableFuture<Long> visitOptimizeTableStatement(OptimizeTableAnalyzedStatement analysis, Row parameters) {
             if (analysis.settings().getAsBoolean(OptimizeSettings.UPGRADE_SEGMENTS.name(),
                 OptimizeSettings.UPGRADE_SEGMENTS.defaultValue())) {

--- a/sql/src/main/java/io/crate/analyze/AlterTableRenameAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/AlterTableRenameAnalyzedStatement.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.analyze;
+
+import io.crate.metadata.TableIdent;
+import io.crate.metadata.doc.DocTableInfo;
+
+public class AlterTableRenameAnalyzedStatement implements DDLStatement {
+
+    private final DocTableInfo sourceTableInfo;
+    private final TableIdent targetTableIdent;
+
+    AlterTableRenameAnalyzedStatement(DocTableInfo sourceTableInfo, TableIdent targetTableIdent) {
+        this.sourceTableInfo = sourceTableInfo;
+        this.targetTableIdent = targetTableIdent;
+    }
+
+    public DocTableInfo sourceTableInfo() {
+        return sourceTableInfo;
+    }
+
+    public TableIdent targetTableIdent() {
+        return targetTableIdent;
+    }
+
+    @Override
+    public <C, R> R accept(AnalyzedStatementVisitor<C, R> analyzedStatementVisitor, C context) {
+        return analyzedStatementVisitor.visitAlterTableRenameStatement(this, context);
+    }
+
+    @Override
+    public boolean isWriteOperation() {
+        return false;
+    }
+}

--- a/sql/src/main/java/io/crate/analyze/AnalyzedStatementVisitor.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedStatementVisitor.java
@@ -117,6 +117,10 @@ public class AnalyzedStatementVisitor<C, R> {
         return visitDDLStatement(analysis, context);
     }
 
+    public R visitAlterTableRenameStatement(AlterTableRenameAnalyzedStatement analysis, C context) {
+        return visitDDLStatement(analysis, context);
+    }
+
     public R visitAlterBlobTableStatement(AlterBlobTableAnalyzedStatement analysis, C context) {
         return visitDDLStatement(analysis, context);
     }

--- a/sql/src/main/java/io/crate/analyze/Analyzer.java
+++ b/sql/src/main/java/io/crate/analyze/Analyzer.java
@@ -251,6 +251,11 @@ public class Analyzer {
         }
 
         @Override
+        public AnalyzedStatement visitAlterTableRename(AlterTableRename node, Analysis context) {
+            return alterTableAnalyzer.analyzeRename(node, context.sessionContext());
+        }
+
+        @Override
         public AnalyzedStatement visitAlterTableAddColumnStatement(AlterTableAddColumn node, Analysis context) {
             return alterTableAddColumnAnalyzer.analyze(node, context);
         }

--- a/sql/src/main/java/io/crate/exceptions/MultiException.java
+++ b/sql/src/main/java/io/crate/exceptions/MultiException.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.exceptions;
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
+
+/**
+ * Collects multiple {@code Throwable}s into one exception.
+ */
+public class MultiException extends RuntimeException {
+
+    private final Iterable<? extends Throwable> exceptions;
+
+    public MultiException(Iterable<? extends Throwable> exceptions) {
+        this.exceptions = exceptions;
+    }
+
+    @Override
+    public void printStackTrace() {
+        for (Throwable exception : exceptions) {
+            exception.printStackTrace();
+        }
+    }
+
+    @Override
+    public void printStackTrace(PrintStream s) {
+        for (Throwable exception : exceptions) {
+            exception.printStackTrace(s);
+        }
+    }
+
+    @Override
+    public void printStackTrace(PrintWriter s) {
+        for (Throwable exception : exceptions) {
+            exception.printStackTrace(s);
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/executor/transport/AlterTableOperation.java
+++ b/sql/src/main/java/io/crate/executor/transport/AlterTableOperation.java
@@ -33,11 +33,17 @@ import io.crate.concurrent.CompletableFutures;
 import io.crate.concurrent.MultiBiConsumer;
 import io.crate.data.Row;
 import io.crate.exceptions.AlterTableAliasException;
+import io.crate.executor.transport.ddl.RenameTableRequest;
+import io.crate.executor.transport.ddl.RenameTableResponse;
+import io.crate.executor.transport.ddl.TransportRenameTableAction;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.TableIdent;
 import io.crate.metadata.doc.DocTableInfo;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.admin.indices.alias.Alias;
+import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
+import org.elasticsearch.action.admin.indices.alias.IndicesAliasesResponse;
+import org.elasticsearch.action.admin.indices.alias.TransportIndicesAliasesAction;
 import org.elasticsearch.action.admin.indices.close.CloseIndexRequest;
 import org.elasticsearch.action.admin.indices.close.CloseIndexResponse;
 import org.elasticsearch.action.admin.indices.close.TransportCloseIndexAction;
@@ -50,11 +56,15 @@ import org.elasticsearch.action.admin.indices.open.TransportOpenIndexAction;
 import org.elasticsearch.action.admin.indices.settings.put.TransportUpdateSettingsAction;
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsResponse;
+import org.elasticsearch.action.admin.indices.template.delete.DeleteIndexTemplateRequest;
+import org.elasticsearch.action.admin.indices.template.delete.DeleteIndexTemplateResponse;
+import org.elasticsearch.action.admin.indices.template.delete.TransportDeleteIndexTemplateAction;
 import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest;
 import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateResponse;
 import org.elasticsearch.action.admin.indices.template.put.TransportPutIndexTemplateAction;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.metadata.AliasMetaData;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -79,26 +89,35 @@ public class AlterTableOperation {
 
     private final ClusterService clusterService;
     private final TransportPutIndexTemplateAction transportPutIndexTemplateAction;
+    private final TransportDeleteIndexTemplateAction transportDeleteIndexTemplateAction;
     private final TransportPutMappingAction transportPutMappingAction;
     private final TransportUpdateSettingsAction transportUpdateSettingsAction;
     private final TransportOpenIndexAction transportOpenIndexAction;
     private final TransportCloseIndexAction transportCloseIndexAction;
+    private final TransportRenameTableAction transportRenameTableAction;
+    private final TransportIndicesAliasesAction transportIndicesAliasesAction;
     private final SQLOperations sqlOperations;
 
     @Inject
     public AlterTableOperation(ClusterService clusterService,
                                TransportPutIndexTemplateAction transportPutIndexTemplateAction,
+                               TransportDeleteIndexTemplateAction transportDeleteIndexTemplateAction,
                                TransportPutMappingAction transportPutMappingAction,
                                TransportUpdateSettingsAction transportUpdateSettingsAction,
                                TransportOpenIndexAction transportOpenIndexAction,
                                TransportCloseIndexAction transportCloseIndexAction,
+                               TransportRenameTableAction transportRenameTableAction,
+                               TransportIndicesAliasesAction transportIndicesAliasesAction,
                                SQLOperations sqlOperations) {
         this.clusterService = clusterService;
         this.transportPutIndexTemplateAction = transportPutIndexTemplateAction;
+        this.transportDeleteIndexTemplateAction = transportDeleteIndexTemplateAction;
         this.transportPutMappingAction = transportPutMappingAction;
         this.transportUpdateSettingsAction = transportUpdateSettingsAction;
         this.transportOpenIndexAction = transportOpenIndexAction;
         this.transportCloseIndexAction = transportCloseIndexAction;
+        this.transportRenameTableAction = transportRenameTableAction;
+        this.transportIndicesAliasesAction = transportIndicesAliasesAction;
         this.sqlOperations = sqlOperations;
     }
 
@@ -156,61 +175,17 @@ public class AlterTableOperation {
     }
 
     private CompletableFuture<Long> openTable(String... indices) {
-        FutureActionListener<OpenIndexResponse, Long> listener = new FutureActionListener<>(r -> 0L);
+        FutureActionListener<OpenIndexResponse, Long> listener = new FutureActionListener<>(r -> -1L);
         OpenIndexRequest request = new OpenIndexRequest(indices);
         transportOpenIndexAction.execute(request, listener);
         return listener;
     }
 
     private CompletableFuture<Long> closeTable(String... indices) {
-        FutureActionListener<CloseIndexResponse, Long> listener = new FutureActionListener<>(r -> 0L);
+        FutureActionListener<CloseIndexResponse, Long> listener = new FutureActionListener<>(r -> -1L);
         CloseIndexRequest request = new CloseIndexRequest(indices);
         transportCloseIndexAction.execute(request, listener);
         return listener;
-    }
-
-
-        private class ResultSetReceiver implements ResultReceiver {
-
-        private final AddColumnAnalyzedStatement analysis;
-        private final CompletableFuture<?> result;
-
-        private long count;
-
-        ResultSetReceiver(AddColumnAnalyzedStatement analysis, CompletableFuture<?> result) {
-            this.analysis = analysis;
-            this.result = result;
-        }
-
-        @Override
-        public void setNextRow(Row row) {
-            count = (long) row.get(0);
-        }
-
-        @Override
-        public void batchFinished() {
-        }
-
-        @Override
-        public void allFinished(boolean interrupted) {
-            if (count == 0L) {
-                addColumnToTable(analysis, result);
-            } else {
-                String columnFailure = analysis.newPrimaryKeys() ? "primary key" : "generated";
-                fail(new UnsupportedOperationException(String.format(Locale.ENGLISH,
-                    "Cannot add a %s column to a table that isn't empty", columnFailure)));
-            }
-        }
-
-        @Override
-        public void fail(@Nonnull Throwable t) {
-            result.completeExceptionally(t);
-        }
-
-        @Override
-        public CompletableFuture<?> completionFuture() {
-            return result;
-        }
     }
 
     public CompletableFuture<Long> executeAlterTable(AlterTableAnalyzedStatement analysis) {
@@ -265,6 +240,156 @@ public class AlterTableOperation {
         }
     }
 
+    public CompletableFuture<Long> executeAlterTableRenameTable(AlterTableRenameAnalyzedStatement statement) {
+        DocTableInfo sourceTableInfo = statement.sourceTableInfo();
+        TableIdent sourceTableIdent = sourceTableInfo.ident();
+        TableIdent targetTableIdent = statement.targetTableIdent();
+
+        if (sourceTableInfo.isPartitioned()) {
+            return renamePartitionedTable(sourceTableInfo, targetTableIdent);
+        }
+
+        String[] sourceIndices = new String[]{sourceTableIdent.indexName()};
+        String[] targetIndices = new String[]{targetTableIdent.indexName()};
+
+        List<ChainableAction<Long>> actions = new ArrayList<>(3);
+
+        if (sourceTableInfo.isClosed() == false) {
+            actions.add(new ChainableAction<>(
+                () -> closeTable(sourceIndices),
+                () -> openTable(sourceIndices)
+            ));
+        }
+        actions.add(new ChainableAction<>(
+            () -> renameTable(sourceIndices, targetIndices),
+            () -> renameTable(targetIndices, sourceIndices)
+        ));
+        if (sourceTableInfo.isClosed() == false) {
+            actions.add(new ChainableAction<>(
+                () -> openTable(targetIndices),
+                () -> CompletableFuture.completedFuture(-1L)
+            ));
+        }
+        return ChainableActions.run(actions);
+    }
+
+    private CompletableFuture<Long> renamePartitionedTable(DocTableInfo sourceTableInfo, TableIdent targetTableIdent) {
+        boolean completeTableIsClosed = sourceTableInfo.isClosed();
+        TableIdent sourceTableIdent = sourceTableInfo.ident();
+        String[] sourceIndices = sourceTableInfo.concreteIndices();
+        String[] targetIndices = new String[sourceIndices.length];
+        // only close/open open partitions
+        List<String> sourceIndicesToClose = new ArrayList<>(sourceIndices.length);
+        List<String> targetIndicesToOpen = new ArrayList<>(sourceIndices.length);
+
+        MetaData metaData = clusterService.state().metaData();
+        for (int i = 0; i < sourceIndices.length; i++) {
+            PartitionName partitionName = PartitionName.fromIndexOrTemplate(sourceIndices[i]);
+            String sourceIndexName = partitionName.asIndexName();
+            String targetIndexName = PartitionName.indexName(targetTableIdent, partitionName.ident());
+            targetIndices[i] = targetIndexName;
+            if (metaData.index(sourceIndexName).getState() == IndexMetaData.State.OPEN) {
+                sourceIndicesToClose.add(sourceIndexName);
+                targetIndicesToOpen.add(targetIndexName);
+            }
+        }
+        String[] sourceIndicesToCloseArray = sourceIndicesToClose.toArray(new String[0]);
+        String[] targetIndicesToOpenArray = targetIndicesToOpen.toArray(new String[0]);
+
+        List<ChainableAction<Long>> actions = new ArrayList<>(7);
+
+        if (completeTableIsClosed == false) {
+            actions.add(new ChainableAction<>(
+                () -> updateOpenCloseOnPartitionTemplate(false, sourceTableIdent),
+                () -> updateOpenCloseOnPartitionTemplate(true, sourceTableIdent)
+            ));
+            actions.add(new ChainableAction<>(
+                () -> closeTable(sourceIndicesToCloseArray),
+                () -> openTable(sourceIndicesToCloseArray)
+            ));
+        }
+
+        actions.add(new ChainableAction<>(
+            () -> changeAliases(sourceIndices, sourceTableIdent.indexName(), targetTableIdent.indexName()),
+            () -> changeAliases(targetIndices, targetTableIdent.indexName(), sourceTableIdent.indexName())
+        ));
+        actions.add(new ChainableAction<>(
+            () -> renameTable(sourceIndices, targetIndices),
+            () -> renameTable(targetIndices, sourceIndices)
+        ));
+        actions.add(new ChainableAction<>(
+            () -> renameTemplate(sourceTableIdent, targetTableIdent),
+            () -> renameTemplate(targetTableIdent, sourceTableIdent)
+        ));
+
+        if (completeTableIsClosed == false) {
+            actions.add(new ChainableAction<>(
+                () -> updateOpenCloseOnPartitionTemplate(true, targetTableIdent),
+                () -> updateOpenCloseOnPartitionTemplate(false, targetTableIdent)
+            ));
+            actions.add(new ChainableAction<>(
+                () -> openTable(targetIndicesToOpenArray),
+                () -> CompletableFuture.completedFuture(-1L)
+            ));
+        }
+
+        return ChainableActions.run(actions);
+    }
+
+    private CompletableFuture<Long> renameTable(String[] sourceIndices, String[] targetIndices) {
+        RenameTableRequest request = new RenameTableRequest(sourceIndices, targetIndices);
+        FutureActionListener<RenameTableResponse, Long> listener = new FutureActionListener<>(r -> -1L);
+        transportRenameTableAction.execute(request, listener);
+        return listener;
+    }
+
+    private CompletableFuture<Long> changeAliases(String[] partitions, String oldAlias, String newAlias) {
+        IndicesAliasesRequest changeAliasRequest = new IndicesAliasesRequest();
+        changeAliasRequest.addAliasAction(IndicesAliasesRequest.AliasActions.remove()
+            .alias(oldAlias).indices(partitions));
+        changeAliasRequest.addAliasAction(IndicesAliasesRequest.AliasActions.add()
+            .alias(newAlias).indices(partitions));
+
+        FutureActionListener<IndicesAliasesResponse, Long> listener = new FutureActionListener<>(r -> -1L);
+        transportIndicesAliasesAction.execute(changeAliasRequest, listener);
+        return listener;
+    }
+
+    private CompletableFuture<Long> renameTemplate(TableIdent sourceIdent, TableIdent targetIdent) {
+        String sourceTemplate = PartitionName.templateName(sourceIdent.schema(), sourceIdent.name());
+        String targetTemplate = PartitionName.templateName(targetIdent.schema(), targetIdent.name());
+        IndexTemplateMetaData indexTemplateMetaData =
+            clusterService.state().metaData().templates().get(sourceTemplate);
+        if (indexTemplateMetaData == null) {
+            return CompletableFutures.failedFuture(new RuntimeException("Template for partitioned table is missing"));
+        }
+
+        PutIndexTemplateRequest addRequest = new PutIndexTemplateRequest(targetTemplate)
+            .create(true)
+            .mapping(Constants.DEFAULT_MAPPING_TYPE, mergeTemplateMapping(indexTemplateMetaData, Collections.emptyMap()))
+            .order(indexTemplateMetaData.order())
+            .settings(indexTemplateMetaData.settings())
+            .template(indexTemplateMetaData.template())
+            .alias(new Alias(targetIdent.indexName()));
+        for (ObjectObjectCursor<String, AliasMetaData> container : indexTemplateMetaData.aliases()) {
+            Alias alias = new Alias(container.key);
+            addRequest.alias(alias);
+        }
+        DeleteIndexTemplateRequest deleteRequest = new DeleteIndexTemplateRequest(sourceTemplate);
+
+        List<CompletableFuture<Long>> results = new ArrayList<>(2);
+        FutureActionListener<PutIndexTemplateResponse, Long> addListener = new FutureActionListener<>(r -> -1L);
+        transportPutIndexTemplateAction.execute(addRequest, addListener);
+        results.add(addListener);
+        FutureActionListener<DeleteIndexTemplateResponse, Long> deleteListener = new FutureActionListener<>(r -> -1L);
+        transportDeleteIndexTemplateAction.execute(deleteRequest, deleteListener);
+        results.add(deleteListener);
+
+        final CompletableFuture<Long> result = new CompletableFuture<>();
+        applyMultiFutureCallback(result, results);
+        return result;
+    }
+
     private CompletableFuture<Long> updateTemplate(TableParameter tableParameter, TableIdent tableIdent) {
         return updateTemplate(tableParameter.mappings(), tableParameter.settings(), tableIdent);
     }
@@ -302,8 +427,8 @@ public class AlterTableOperation {
             .mapping(Constants.DEFAULT_MAPPING_TYPE, mapping)
             .order(indexTemplateMetaData.order())
             .settings(settingsBuilder.build())
-            .template(indexTemplateMetaData.template());
-
+            .template(indexTemplateMetaData.template())
+            .alias(new Alias(tableIdent.indexName()));
         for (ObjectObjectCursor<String, AliasMetaData> container : indexTemplateMetaData.aliases()) {
             Alias alias = new Alias(container.key);
             request.alias(alias);
@@ -459,5 +584,48 @@ public class AlterTableOperation {
             }
         }
         return true;
+    }
+
+    private class ResultSetReceiver implements ResultReceiver {
+
+        private final AddColumnAnalyzedStatement analysis;
+        private final CompletableFuture<?> result;
+
+        private long count;
+
+        ResultSetReceiver(AddColumnAnalyzedStatement analysis, CompletableFuture<?> result) {
+            this.analysis = analysis;
+            this.result = result;
+        }
+
+        @Override
+        public void setNextRow(Row row) {
+            count = (long) row.get(0);
+        }
+
+        @Override
+        public void batchFinished() {
+        }
+
+        @Override
+        public void allFinished(boolean interrupted) {
+            if (count == 0L) {
+                addColumnToTable(analysis, result);
+            } else {
+                String columnFailure = analysis.newPrimaryKeys() ? "primary key" : "generated";
+                fail(new UnsupportedOperationException(String.format(Locale.ENGLISH,
+                    "Cannot add a %s column to a table that isn't empty", columnFailure)));
+            }
+        }
+
+        @Override
+        public void fail(@Nonnull Throwable t) {
+            result.completeExceptionally(t);
+        }
+
+        @Override
+        public CompletableFuture<?> completionFuture() {
+            return result;
+        }
     }
 }

--- a/sql/src/main/java/io/crate/executor/transport/ChainableAction.java
+++ b/sql/src/main/java/io/crate/executor/transport/ChainableAction.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.executor.transport;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+
+class ChainableAction<ReturnType> {
+
+    private final Supplier<CompletableFuture<ReturnType>> doSupplier;
+    private final Supplier<CompletableFuture<ReturnType>> undoSupplier;
+
+    ChainableAction(Supplier<CompletableFuture<ReturnType>> doSupplier,
+                    Supplier<CompletableFuture<ReturnType>> undoSupplier) {
+        this.doSupplier = doSupplier;
+        this.undoSupplier = undoSupplier;
+    }
+
+    CompletableFuture<ReturnType> doIt() {
+        return doSupplier.get();
+    }
+
+    CompletableFuture<ReturnType> undo() {
+        return undoSupplier.get();
+    }
+}

--- a/sql/src/main/java/io/crate/executor/transport/ChainableActions.java
+++ b/sql/src/main/java/io/crate/executor/transport/ChainableActions.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.executor.transport;
+
+import com.google.common.collect.ImmutableList;
+import io.crate.concurrent.CompletableFutures;
+import io.crate.exceptions.Exceptions;
+import io.crate.exceptions.MultiException;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+public class ChainableActions {
+
+    /**
+     * Runs the given list of chainable actions sequentially.
+     *
+     * If one fails, all previous actions will be rolled back by calling
+     * the {@link ChainableAction#undo()} callable of each action in reverse order.
+     */
+    public static <R> CompletableFuture<R> run(List<? extends ChainableAction<R>> actions) {
+        assert actions.size() > 0 : "Empty list of ChainableActions";
+
+        List<ChainableAction<R>> previousActions = new ArrayList<>(actions.size());
+        ChainableAction<R> lastAction = actions.get(0);
+        CompletableFuture<R> future = lastAction.doIt();
+
+        Result<R> result = new Result<>(null, null);
+        for (int i = 1; i < actions.size(); i++) {
+            ChainableAction<R> action = actions.get(i);
+            previousActions.add(lastAction);
+            lastAction = action;
+            future = future.handle(result::addResultAndError)
+                .thenCompose(r -> runOrRollbackOnErrors(r, action, ImmutableList.copyOf(previousActions)));
+        }
+        return future.handle(result::addResultAndError)
+            .thenCompose(r -> rollbackOnErrors(r, previousActions));
+    }
+
+    private static <R> CompletableFuture<R> runOrRollbackOnErrors(Result<R> result,
+                                                                  ChainableAction<R> action,
+                                                                  List<ChainableAction<R>> previousActions) {
+        if (result.error != null) {
+            return rollbackOnErrors(result, previousActions);
+        }
+        return action.doIt();
+    }
+
+    private static <R> CompletableFuture<R> rollbackOnErrors(Result<R> result,
+                                                             List<ChainableAction<R>> previousActions) {
+        if (result.error != null) {
+            int previousActionsSize = previousActions.size();
+            CompletableFuture<R> previousActionUndo = previousActions.get(previousActionsSize - 1).undo();
+            for (int i = previousActionsSize - 2; i >= 0; i--) {
+                ChainableAction<R> previousAction = previousActions.get(i);
+                previousActionUndo = previousActionUndo
+                    .handle(result::addResultAndError)
+                    .thenCompose(r -> {
+                        if (r.errorOnUndo) {
+                            // last undo also throws an exception. throw it, will stop execution
+                            // (no further undo actions are executed)
+                            Exceptions.rethrowUnchecked(r.error);
+                        }
+                        return previousAction.undo();
+                    });
+            }
+            return previousActionUndo
+                .handle(result::addResultAndError)
+                .thenCompose(r -> {
+                    Exceptions.rethrowUnchecked(result.error);
+                    return CompletableFutures.failedFuture(result.error);
+                });
+        }
+        return CompletableFuture.completedFuture(result.result);
+    }
+
+    private static class Result<R> {
+
+        @Nullable
+        private R result;
+        @Nullable
+        private Throwable error;
+        private boolean errorOnUndo = false;
+
+        public Result(@Nullable R result, @Nullable Throwable error) {
+            this.result = result;
+            this.error = error;
+        }
+
+        Result<R> addResultAndError(@Nullable R result, @Nullable Throwable t) {
+            if (result != null) {
+                this.result = result;
+            }
+            if (t != null) {
+                if (error != null) {
+                    error = new MultiException(ImmutableList.of(error, t));
+                    // if an error was already set, current error must resulted due to on undo operation
+                    errorOnUndo = true;
+                } else {
+                    error = t;
+                }
+            }
+            return this;
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/executor/transport/TransportExecutorModule.java
+++ b/sql/src/main/java/io/crate/executor/transport/TransportExecutorModule.java
@@ -24,6 +24,7 @@ package io.crate.executor.transport;
 import io.crate.action.job.ContextPreparer;
 import io.crate.action.job.TransportJobAction;
 import io.crate.executor.Executor;
+import io.crate.executor.transport.ddl.TransportRenameTableAction;
 import io.crate.executor.transport.distributed.TransportDistributedResultAction;
 import io.crate.executor.transport.kill.TransportKillAllNodeAction;
 import io.crate.executor.transport.kill.TransportKillJobsNodeAction;
@@ -47,5 +48,6 @@ public class TransportExecutorModule extends AbstractModule {
         bind(TransportKillAllNodeAction.class).asEagerSingleton();
         bind(TransportKillJobsNodeAction.class).asEagerSingleton();
         bind(TransportNodeStatsAction.class).asEagerSingleton();
+        bind(TransportRenameTableAction.class).asEagerSingleton();
     }
 }

--- a/sql/src/main/java/io/crate/executor/transport/ddl/RenameTableRequest.java
+++ b/sql/src/main/java/io/crate/executor/transport/ddl/RenameTableRequest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.executor.transport.ddl;
+
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+import static org.elasticsearch.action.ValidateActions.addValidationError;
+
+public class RenameTableRequest extends AcknowledgedRequest<RenameTableRequest> {
+
+    private String[] sourceIndices;
+    private String[] targetIndices;
+
+    RenameTableRequest() {
+    }
+
+    public RenameTableRequest(String[] sourceIndices, String[] targetIndices) {
+        this.sourceIndices = sourceIndices;
+        this.targetIndices = targetIndices;
+    }
+
+    String[] sourceIndices() {
+        return sourceIndices;
+    }
+
+    String[] targetIndices() {
+        return targetIndices;
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        ActionRequestValidationException validationException = null;
+        if (sourceIndices == null || targetIndices == null) {
+            validationException = addValidationError("source or target table name must not be null", null);
+        }
+        return validationException;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        sourceIndices = in.readStringArray();
+        targetIndices = in.readStringArray();
+        readTimeout(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeStringArray(sourceIndices);
+        out.writeStringArray(targetIndices);
+        writeTimeout(out);
+    }
+}

--- a/sql/src/main/java/io/crate/executor/transport/ddl/RenameTableResponse.java
+++ b/sql/src/main/java/io/crate/executor/transport/ddl/RenameTableResponse.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.executor.transport.ddl;
+
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+public class RenameTableResponse extends AcknowledgedResponse {
+
+    public RenameTableResponse() {
+    }
+
+    public RenameTableResponse(boolean acknowledged) {
+        super(acknowledged);
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        readAcknowledged(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        writeAcknowledged(out);
+    }
+}

--- a/sql/src/main/java/io/crate/executor/transport/ddl/TransportRenameTableAction.java
+++ b/sql/src/main/java/io/crate/executor/transport/ddl/TransportRenameTableAction.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.executor.transport.ddl;
+
+import org.apache.logging.log4j.message.ParameterizedMessage;
+import org.apache.logging.log4j.util.Supplier;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
+import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ack.ClusterStateUpdateResponse;
+import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.block.ClusterBlocks;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+import java.util.Arrays;
+
+@Singleton
+public class TransportRenameTableAction extends TransportMasterNodeAction<RenameTableRequest, RenameTableResponse> {
+
+    private static final String ACTION_NAME = "crate/table/rename";
+    private static final IndicesOptions STRICT_INDICES_OPTIONS = IndicesOptions.fromOptions(false, false, false, false);
+
+    @Inject
+    public TransportRenameTableAction(Settings settings,
+                                      TransportService transportService,
+                                      ClusterService clusterService,
+                                      ThreadPool threadPool,
+                                      ActionFilters actionFilters,
+                                      IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, ACTION_NAME, transportService, clusterService, threadPool, actionFilters,
+            indexNameExpressionResolver, RenameTableRequest::new);
+    }
+
+    @Override
+    protected String executor() {
+        // no need to use a thread pool, we go async right away
+        return ThreadPool.Names.SAME;
+    }
+
+    @Override
+    protected RenameTableResponse newResponse() {
+        return new RenameTableResponse();
+    }
+
+    @Override
+    protected void masterOperation(RenameTableRequest request,
+                                   ClusterState state,
+                                   ActionListener<RenameTableResponse> listener) throws Exception {
+        final Index[] concreteIndices = indexNameExpressionResolver.concreteIndices(state, STRICT_INDICES_OPTIONS,
+            request.sourceIndices());
+        String[] targetIndexNames = request.targetIndices();
+
+        updateClusterState(concreteIndices, targetIndexNames, request, new ActionListener<ClusterStateUpdateResponse>() {
+
+            @Override
+            public void onResponse(ClusterStateUpdateResponse response) {
+                listener.onResponse(new RenameTableResponse(response.isAcknowledged()));
+            }
+
+            @Override
+            public void onFailure(Exception t) {
+                logger.debug((Supplier<?>) () -> new ParameterizedMessage("failed to rename indices [{}]", (Object) concreteIndices), t);
+                listener.onFailure(t);
+            }
+        });
+    }
+
+    private void updateClusterState(Index[] concreteIndices,
+                                    String[] targetIndexNames,
+                                    RenameTableRequest request,
+                                    ActionListener<ClusterStateUpdateResponse> listener) {
+        final String indicesAsString = Arrays.toString(concreteIndices);
+        clusterService.submitStateUpdateTask("rename-indices " + indicesAsString,
+            new AckedClusterStateUpdateTask<ClusterStateUpdateResponse>(Priority.URGENT, request, listener) {
+                @Override
+                protected ClusterStateUpdateResponse newResponse(boolean acknowledged) {
+                    return new ClusterStateUpdateResponse(acknowledged);
+                }
+
+                @Override
+                public ClusterState execute(ClusterState currentState) {
+                    logger.info("renaming indices [{}]", indicesAsString);
+
+                    MetaData.Builder mdBuilder = MetaData.builder(currentState.metaData());
+                    ClusterBlocks.Builder blocksBuilder = ClusterBlocks.builder()
+                        .blocks(currentState.blocks());
+
+                    for (int i = 0; i < concreteIndices.length; i++) {
+                        Index index = concreteIndices[i];
+                        IndexMetaData indexMetaData = currentState.metaData().getIndexSafe(index);
+                        IndexMetaData targetIndexMetadata = IndexMetaData.builder(indexMetaData)
+                            .index(targetIndexNames[i]).build();
+                        mdBuilder.remove(index.getName());
+                        mdBuilder.put(targetIndexMetadata, true);
+                        blocksBuilder.removeIndexBlocks(index.getName());
+                        blocksBuilder.addBlocks(targetIndexMetadata);
+                    }
+
+                    return ClusterState.builder(currentState).metaData(mdBuilder).blocks(blocksBuilder).build();
+                }
+            });
+    }
+
+    @Override
+    protected ClusterBlockException checkBlock(RenameTableRequest request, ClusterState state) {
+        return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_WRITE,
+            indexNameExpressionResolver.concreteIndexNames(state, STRICT_INDICES_OPTIONS, request.sourceIndices()));
+    }
+}

--- a/sql/src/test/java/io/crate/analyze/AlterTableRenameAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/AlterTableRenameAnalyzerTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.analyze;
+
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AlterTableRenameAnalyzerTest extends CrateDummyClusterServiceUnitTest {
+
+    private SQLExecutor e;
+
+    @Before
+    public void prepare() {
+        e = SQLExecutor.builder(clusterService).enableDefaultTables().build();
+    }
+
+    @Test
+    public void testRenamePartitionThrowsException() {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("Renaming a single partition is not supported");
+        e.analyze("alter table t1 partition (i=1) rename to t2");
+    }
+
+    @Test
+    public void testRenameToUsingSchemaThrowsException() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Target table name must not include a schema");
+        e.analyze("alter table t1 rename to my_schema.t1");
+    }
+}

--- a/sql/src/test/java/io/crate/executor/transport/ChainableActionsTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/ChainableActionsTest.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.executor.transport;
+
+import io.crate.concurrent.CompletableFutures;
+import io.crate.exceptions.MultiException;
+import io.crate.exceptions.SQLExceptions;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import static org.hamcrest.Matchers.*;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class ChainableActionsTest {
+
+    private static class TrackedChainableAction extends ChainableAction<Integer> {
+
+        private final Integer idx;
+        private final List<Integer> doCalls;
+        private final List<Integer> undoCalls;
+
+        TrackedChainableAction(Integer idx,
+                               List<Integer> doCalls,
+                               List<Integer> undoCalls,
+                               Supplier<CompletableFuture<Integer>> doSupplier,
+                               Supplier<CompletableFuture<Integer>> undoSupplier) {
+            super(doSupplier, undoSupplier);
+            this.idx = idx;
+            this.doCalls = doCalls;
+            this.undoCalls = undoCalls;
+        }
+
+        @Override
+        CompletableFuture<Integer> doIt() {
+            doCalls.add(idx);
+            return super.doIt();
+        }
+
+        @Override
+        CompletableFuture<Integer> undo() {
+            undoCalls.add(idx);
+            return super.undo();
+        }
+    }
+
+    @Test
+    public void testRun() throws Exception {
+        int numActions = 3;
+        List<TrackedChainableAction> actions = new ArrayList<>(numActions);
+        List<Integer> doCalls = new ArrayList<>(numActions);
+        List<Integer> undoCalls = new ArrayList<>(numActions);
+
+        for (int i = 0; i < numActions; i++) {
+            actions.add(new TrackedChainableAction(
+                i,
+                doCalls,
+                undoCalls,
+                () -> CompletableFuture.completedFuture(0),
+                () -> CompletableFuture.completedFuture(0)));
+        }
+
+        CompletableFuture<Integer> result = ChainableActions.run(actions);
+        assertThat(result.get(1, TimeUnit.SECONDS), is(0));
+
+        assertThat(doCalls, contains(0, 1, 2));
+        assertThat(undoCalls, empty());
+    }
+
+    @Test
+    public void testRollbackOnError() {
+        int numActions = 3;
+        List<TrackedChainableAction> actions = new ArrayList<>(numActions);
+        List<Integer> doCalls = new ArrayList<>(numActions);
+        List<Integer> undoCalls = new ArrayList<>(numActions);
+
+        for (int i = 0; i < numActions - 1; i++) {
+            actions.add(new TrackedChainableAction(
+                i,
+                doCalls,
+                undoCalls,
+                () -> CompletableFuture.completedFuture(0),
+                () -> CompletableFuture.completedFuture(0)));
+        }
+
+        // create last one which will throw an error, undo() on all previous actions must be called in reverse order
+        CompletableFuture<Integer> failingFuture = new CompletableFuture<>();
+        actions.add(new TrackedChainableAction(
+            numActions - 1,
+            doCalls,
+            undoCalls,
+            () -> CompletableFutures.failedFuture(new RuntimeException("do operation failed")),
+            () -> CompletableFuture.completedFuture(0)));
+
+        CompletableFuture<Integer> result = ChainableActions.run(actions);
+
+        assertThat(result.isCompletedExceptionally(), is(true));
+
+        assertThat(doCalls, contains(0, 1, 2));
+        assertThat(undoCalls, contains(1, 0));
+    }
+
+    @Test
+    public void testRollbackErrorsAreChainedToRootCause() {
+        int numActions = 3;
+        List<TrackedChainableAction> actions = new ArrayList<>(numActions);
+        List<Integer> doCalls = new ArrayList<>(numActions);
+        List<Integer> undoCalls = new ArrayList<>(numActions);
+
+        actions.add(new TrackedChainableAction(
+            0,
+            doCalls,
+            undoCalls,
+            () -> CompletableFuture.completedFuture(0),
+            () -> CompletableFuture.completedFuture(0)));
+
+        // 2nd one will throw an error on rollback
+        actions.add(new TrackedChainableAction(
+            1,
+            doCalls,
+            undoCalls,
+            () -> CompletableFuture.completedFuture(0),
+            () -> CompletableFutures.failedFuture(new RuntimeException("undo operation failed"))));
+
+        // last one which will throw an error, undo() on all previous actions must be called in reverse order
+        actions.add(new TrackedChainableAction(
+            numActions - 1,
+            doCalls,
+            undoCalls,
+            () -> CompletableFutures.failedFuture(new RuntimeException("do operation failed")),
+            () -> CompletableFuture.completedFuture(0)));
+
+        CompletableFuture<Integer> result = ChainableActions.run(actions);
+
+        assertThat(result.isCompletedExceptionally(), is(true));
+        assertThat(doCalls, contains(0, 1, 2));
+        // undo was only called on action 1. as it failed, no other action was rolled back
+        assertThat(undoCalls, contains(1));
+
+        try {
+            result.get();
+        } catch (Throwable t) {
+            t = SQLExceptions.unwrap(t);
+            assertThat(t, instanceOf(MultiException.class));
+
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            t.printStackTrace(new PrintStream(out));
+            assertThat(new String(out.toByteArray()), allOf(
+                containsString("do operation failed"),
+                containsString("undo operation failed")));
+        }
+    }
+}

--- a/sql/src/test/java/io/crate/integrationtests/RenameTableIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/RenameTableIntegrationTest.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.integrationtests;
+
+import io.crate.testing.TestingHelpers;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+
+public class RenameTableIntegrationTest extends SQLTransportIntegrationTest {
+
+    @Test
+    public void testRenameTable() {
+        execute("create table t1 (id int) with (number_of_replicas = 0)");
+        execute("insert into t1 (id) values (1), (2)");
+        refresh();
+
+        execute("alter table t1 rename to t2");
+        assertThat(response.rowCount(), is(-1L));
+        ensureYellow();
+
+        execute("select * from t2 order by id");
+        assertThat(TestingHelpers.printedTable(response.rows()), is("1\n" +
+                                                                    "2\n"));
+
+        execute("select * from information_schema.tables where table_name = 't2'");
+        assertThat(response.rowCount(), is(1L));
+
+        execute("select * from information_schema.tables where table_name = 't1'");
+        assertThat(response.rowCount(), is(0L));
+    }
+
+    @Test
+    public void testRenameTableEnsureOldTableNameCanBeUsed() {
+        execute("create table t1 (id int) with (number_of_replicas = 0)");
+        execute("insert into t1 (id) values (1), (2)");
+        refresh();
+        execute("alter table t1 rename to t2");
+        ensureYellow();
+
+        // creating a new table using the old name must succeed
+        execute("create table t1 (id int) with (number_of_replicas = 0)");
+        ensureYellow();
+        // also inserting must work (no old blocks traces)
+        execute("insert into t1 (id) values (1), (2)");
+    }
+
+    @Test
+    public void testRenameClosedTable() {
+        execute("create table t1 (id int) with (number_of_replicas = 0)");
+        execute("insert into t1 (id) values (1), (2)");
+        refresh();
+
+        execute("alter table t1 close");
+
+        execute("alter table t1 rename to t2");
+        assertThat(response.rowCount(), is(-1L));
+        ensureYellow();
+
+        execute("select closed from information_schema.tables where table_name = 't2'");
+        assertThat(response.rows()[0][0], is(true));
+    }
+
+    @Test
+    public void testRenamePartitionedTable() {
+        execute("create table tp1 (id int, id2 integer) partitioned by (id) with (number_of_replicas = 0)");
+        execute("insert into tp1 (id, id2) values (1, 1), (2, 2)");
+        refresh();
+
+        execute("alter table tp1 rename to tp2");
+        assertThat(response.rowCount(), is(-1L));
+        ensureYellow();
+
+        execute("select id from tp2 order by id2");
+        assertThat(TestingHelpers.printedTable(response.rows()), is("1\n" +
+                                                                    "2\n"));
+
+        execute("select * from information_schema.tables where table_name = 'tp2'");
+        assertThat(response.rowCount(), is(1L));
+
+        execute("select * from information_schema.tables where table_name = 'tp1'");
+        assertThat(response.rowCount(), is(0L));
+    }
+
+    @Test
+    public void testRenamePartitionedTableEnsureOldTableNameCanBeUsed() {
+        execute("create table tp1 (id int, id2 integer) partitioned by (id) with (number_of_replicas = 0)");
+        execute("insert into tp1 (id, id2) values (1, 1), (2, 2)");
+        refresh();
+        execute("alter table tp1 rename to tp2");
+        ensureYellow();
+
+        // creating a new table using the old name must succeed
+        execute("create table tp1 (id int, id2 integer) partitioned by (id) with (number_of_replicas = 0)");
+        ensureYellow();
+        // also inserting must work (no old blocks traces)
+        execute("insert into tp1 (id, id2) values (1, 1), (2, 2)");
+    }
+
+    @Test
+    public void testRenamePartitionedTablePartitionStayClosed() {
+        execute("create table tp1 (id int, id2 integer) partitioned by (id) with (number_of_replicas = 0)");
+        execute("insert into tp1 (id, id2) values (1, 1), (2, 2)");
+        refresh();
+
+        execute("alter table tp1 partition (id=1) close");
+
+        execute("alter table tp1 rename to tp2");
+        ensureYellow();
+
+        execute("select closed from information_schema.table_partitions where partition_ident = '04132'");
+        assertThat(response.rows()[0][0], is(true));
+    }
+}


### PR DESCRIPTION
The related table will be closed upfront renaming (if not already closed), same for a partitioned table (close all non-closed partitions) and re-opened afterwards (only re-open if table or partition was open before).