### PR TITLE
fix sphinx build

### DIFF
--- a/blackbox/docs/index_html.rst
+++ b/blackbox/docs/index_html.rst
@@ -31,3 +31,4 @@ Contents
    protocols/index
    enterprise/index
    administration/index
+   monitoring/index


### PR DESCRIPTION
all files need to be referenced from within a doctree