### PR TITLE
Fixed push down of `WhereClause` to relations of MSS.

### DIFF
--- a/sql/src/main/java/io/crate/analyze/HavingClause.java
+++ b/sql/src/main/java/io/crate/analyze/HavingClause.java
@@ -23,6 +23,7 @@ package io.crate.analyze;
 
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.TransactionContext;
+import io.crate.operation.operator.AndOperator;
 
 import javax.annotation.Nullable;
 
@@ -41,5 +42,10 @@ public class HavingClause extends QueryClause {
             return this;
         }
         return new HavingClause(normalizedQuery);
+    }
+
+    public HavingClause add(Symbol otherQuery) {
+        this.query = AndOperator.of(this.query, otherQuery);
+        return this;
     }
 }


### PR DESCRIPTION
When `WhereClause` is pushed down to a relation of an MSS it must be translated to having if it contains aggregations.