### PR TITLE
Add more details to projections in Explain output

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -18,6 +18,8 @@ Breaking Changes
 Changes
 =======
 
+ - Extended the output of the  ``EXPLAIN`` statement.
+
  - Added support for joins on virtual tables.
 
  - Changed the ``QueryStats`` JMX MBean to deliver node-based values instead of

--- a/sql/src/main/java/io/crate/analyze/OrderBy.java
+++ b/sql/src/main/java/io/crate/analyze/OrderBy.java
@@ -27,6 +27,7 @@ import io.crate.analyze.symbol.Symbols;
 import io.crate.collections.Lists2;
 import io.crate.exceptions.AmbiguousOrderByException;
 import io.crate.metadata.TransactionContext;
+import io.crate.planner.ExplainLeaf;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -195,9 +196,17 @@ public class OrderBy implements Writeable {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder("OrderBy{");
-        for (int i = 0; i < orderBySymbols.size(); i++) {
-            Symbol symbol = orderBySymbols.get(i);
-            sb.append(symbol);
+        explainRepresentation(sb, orderBySymbols, reverseFlags, nullsFirst);
+        return sb.toString();
+    }
+
+    public static StringBuilder explainRepresentation(StringBuilder sb,
+                                                      List<? extends ExplainLeaf> leaves,
+                                                      boolean[] reverseFlags,
+                                                      Boolean[] nullsFirst) {
+        for (int i = 0; i < leaves.size(); i++) {
+            ExplainLeaf leaf = leaves.get(i);
+            sb.append(leaf.representation());
             sb.append(" ");
             if (reverseFlags[i]) {
                 sb.append("ASC");
@@ -209,10 +218,10 @@ public class OrderBy implements Writeable {
                 sb.append(" ");
                 sb.append(nullFirst ? "NULLS FIRST" : "NULLS LAST");
             }
-            if (i + 1 < orderBySymbols.size()) {
+            if (i + 1 < leaves.size()) {
                 sb.append(" ");
             }
         }
-        return sb.toString();
+        return sb;
     }
 }

--- a/sql/src/main/java/io/crate/analyze/symbol/Aggregation.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/Aggregation.java
@@ -24,6 +24,7 @@ package io.crate.analyze.symbol;
 import com.google.common.base.Preconditions;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
+import io.crate.planner.ExplainLeaf;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -31,7 +32,6 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class Aggregation extends Symbol {
 
@@ -88,7 +88,12 @@ public class Aggregation extends Symbol {
 
     @Override
     public String toString() {
+        return representation();
+    }
+
+    @Override
+    public String representation() {
         return "Aggregation{" + functionInfo.ident().name() +
-               ", args=[" + inputs.stream().map(Symbol::toString).collect(Collectors.joining(", ")) + "]}";
+               ", args=[" + ExplainLeaf.printList(inputs) + "]}";
     }
 }

--- a/sql/src/main/java/io/crate/analyze/symbol/FetchReference.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/FetchReference.java
@@ -73,9 +73,11 @@ public class FetchReference extends Symbol {
 
     @Override
     public String toString() {
-        return "FetchReference{" +
-               "fetchId=" + fetchId +
-               ", ref=" + ref +
-               '}';
+        return representation();
+    }
+
+    @Override
+    public String representation() {
+        return "Fetch{" + fetchId.representation() + ", " + ref.representation() + '}';
     }
 }

--- a/sql/src/main/java/io/crate/analyze/symbol/Field.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/Field.java
@@ -101,6 +101,11 @@ public class Field extends Symbol implements Path {
 
     @Override
     public String toString() {
+        return representation();
+    }
+
+    @Override
+    public String representation() {
         return "Field{" + relation + "." + path +
                ", type=" + valueType +
                '}';

--- a/sql/src/main/java/io/crate/analyze/symbol/Function.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/Function.java
@@ -1,9 +1,9 @@
 package io.crate.analyze.symbol;
 
-import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import io.crate.metadata.FunctionInfo;
+import io.crate.planner.ExplainLeaf;
 import io.crate.types.DataType;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -69,8 +69,14 @@ public class Function extends Symbol implements Cloneable {
     }
 
     @Override
-    public String toString() {
-        return String.format(Locale.ENGLISH, "%s(%s)", info.ident().name(), Joiner.on(",").join(arguments()));
+    public String representation() {
+        String name = info.ident().name();
+        if (name.startsWith("op_") && arguments.size() == 2) {
+            return arguments.get(0).representation()
+                   + " " + name.substring(3).toUpperCase(Locale.ENGLISH)
+                   + " " + arguments.get(1).representation();
+        }
+        return name + '(' + ExplainLeaf.printList(arguments) + ')';
     }
 
     @Override

--- a/sql/src/main/java/io/crate/analyze/symbol/InputColumn.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/InputColumn.java
@@ -106,6 +106,11 @@ public class InputColumn extends Symbol implements Comparable<InputColumn> {
 
     @Override
     public String toString() {
+        return representation();
+    }
+
+    @Override
+    public String representation() {
         return "IC{" + index + ", " + dataType + '}';
     }
 

--- a/sql/src/main/java/io/crate/analyze/symbol/Literal.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/Literal.java
@@ -11,7 +11,6 @@ import io.crate.types.DataTypes;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.lucene.BytesRefs;
 
 import java.io.IOException;
 import java.util.*;
@@ -159,7 +158,10 @@ public class Literal<ReturnType> extends Symbol implements Input<ReturnType>, Co
         if (value.getClass().isArray()) {
             return '[' + Stream.of((Object[]) value).map(Literal::stringRepresentation).collect(Collectors.joining(", ")) + ']';
         }
-        return BytesRefs.toString(value);
+        if (value instanceof BytesRef) {
+            return "'" + ((BytesRef) value).utf8ToString() + "'";
+        }
+        return value.toString();
     }
 
     @Override
@@ -248,4 +250,8 @@ public class Literal<ReturnType> extends Symbol implements Input<ReturnType>, Co
         }
     }
 
+    @Override
+    public String representation() {
+        return stringRepresentation(value);
+    }
 }

--- a/sql/src/main/java/io/crate/analyze/symbol/MatchPredicate.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/MatchPredicate.java
@@ -21,12 +21,14 @@
 
 package io.crate.analyze.symbol;
 
+import io.crate.planner.ExplainLeaf;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class MatchPredicate extends Symbol {
 
@@ -80,5 +82,13 @@ public class MatchPredicate extends Symbol {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         throw new UnsupportedOperationException("Cannot stream MatchPredicate");
+    }
+
+    @Override
+    public String representation() {
+        return "MATCH{" + identBoostMap.keySet()
+            .stream()
+            .map(ExplainLeaf::representation)
+            .collect(Collectors.joining(", ")) + '}';
     }
 }

--- a/sql/src/main/java/io/crate/analyze/symbol/ParameterSymbol.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/ParameterSymbol.java
@@ -67,10 +67,15 @@ public class ParameterSymbol extends Symbol {
 
     @Override
     public String toString() {
-        return "$" + Integer.toString(index + 1);
+        return representation();
     }
 
     public int index() {
         return index;
+    }
+
+    @Override
+    public String representation() {
+        return "$" + Integer.toString(index + 1);
     }
 }

--- a/sql/src/main/java/io/crate/analyze/symbol/SelectSymbol.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/SelectSymbol.java
@@ -69,4 +69,9 @@ public class SelectSymbol extends Symbol {
     public String toString() {
         return "SelectSymbol{" + type.toString() + "}";
     }
+
+    @Override
+    public String representation() {
+        return "SubQuery{" + relation.getQualifiedName() + '}';
+    }
 }

--- a/sql/src/main/java/io/crate/analyze/symbol/Symbol.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/Symbol.java
@@ -21,10 +21,11 @@
 
 package io.crate.analyze.symbol;
 
+import io.crate.planner.ExplainLeaf;
 import io.crate.types.DataType;
 import org.elasticsearch.common.io.stream.Writeable;
 
-public abstract class Symbol implements Writeable {
+public abstract class Symbol implements Writeable, ExplainLeaf {
 
     public static boolean isLiteral(Symbol symbol, DataType expectedType) {
         return symbol.symbolType() == SymbolType.LITERAL
@@ -36,4 +37,9 @@ public abstract class Symbol implements Writeable {
     public abstract <C, R> R accept(SymbolVisitor<C, R> visitor, C context);
 
     public abstract DataType valueType();
+
+    @Override
+    public String toString() {
+        return representation();
+    }
 }

--- a/sql/src/main/java/io/crate/analyze/symbol/Value.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/Value.java
@@ -78,8 +78,11 @@ public class Value extends Symbol {
 
     @Override
     public String toString() {
-        return "Value{" +
-               "type=" + type +
-               '}';
+        return representation();
+    }
+
+    @Override
+    public String representation() {
+        return "Value{" + type + '}';
     }
 }

--- a/sql/src/main/java/io/crate/analyze/where/EqualityExtractor.java
+++ b/sql/src/main/java/io/crate/analyze/where/EqualityExtractor.java
@@ -264,6 +264,11 @@ class EqualityExtractor {
 
         @Override
         public String toString() {
+            return representation();
+        }
+
+        @Override
+        public String representation() {
             return "EqProxy{" + forDisplay() + "}";
         }
     }

--- a/sql/src/main/java/io/crate/metadata/Reference.java
+++ b/sql/src/main/java/io/crate/metadata/Reference.java
@@ -179,6 +179,11 @@ public class Reference extends Symbol {
     }
 
     @Override
+    public String representation() {
+        return "Ref{" + ident.tableIdent() + '.' + ident.columnIdent() + ", " + type + '}';
+    }
+
+    @Override
     public String toString() {
         MoreObjects.ToStringHelper helper = MoreObjects.toStringHelper(this)
             .add("ident", ident)

--- a/sql/src/main/java/io/crate/planner/ExplainLeaf.java
+++ b/sql/src/main/java/io/crate/planner/ExplainLeaf.java
@@ -20,29 +20,25 @@
  * agreement.
  */
 
-package io.crate.planner.projection;
+package io.crate.planner;
 
-import com.google.common.collect.Collections2;
-import io.crate.metadata.RowGranularity;
+import java.util.List;
+import java.util.stream.Collectors;
 
-import java.util.Collection;
+/**
+ * A leaf of a {@link ExplainNode} - part of the output of a EXPLAIN statement.
+ */
+public interface ExplainLeaf {
 
-public class Projections {
+    /**
+     * @return Human readable representation of the component
+     */
+    String representation();
 
-    public static Collection<? extends Projection> shardProjections(Collection<? extends Projection> projections) {
-        return Collections2.filter(projections, Projection.IS_SHARD_PROJECTION::test);
-    }
 
-    public static Collection<? extends Projection> nodeProjections(Collection<? extends Projection> projections) {
-        return Collections2.filter(projections, Projection.IS_NODE_PROJECTION::test);
-    }
-
-    public static boolean hasAnyShardProjections(Iterable<? extends Projection> projections) {
-        for (Projection projection : projections) {
-            if (projection.requiredGranularity() == RowGranularity.SHARD) {
-                return true;
-            }
-        }
-        return false;
+    static String printList(List<? extends ExplainLeaf> leaves) {
+        return leaves.stream()
+            .map(ExplainLeaf::representation)
+            .collect(Collectors.joining(", "));
     }
 }

--- a/sql/src/main/java/io/crate/planner/ExplainNode.java
+++ b/sql/src/main/java/io/crate/planner/ExplainNode.java
@@ -20,29 +20,22 @@
  * agreement.
  */
 
-package io.crate.planner.projection;
+package io.crate.planner;
 
-import com.google.common.collect.Collections2;
-import io.crate.metadata.RowGranularity;
+import org.elasticsearch.common.io.stream.StreamOutput;
 
-import java.util.Collection;
+import java.util.Map;
 
-public class Projections {
+/**
+ * A component of a Plan(or a Plan) that should be part of the output of the EXPLAIN statement.
+ */
+public interface ExplainNode {
 
-    public static Collection<? extends Projection> shardProjections(Collection<? extends Projection> projections) {
-        return Collections2.filter(projections, Projection.IS_SHARD_PROJECTION::test);
-    }
-
-    public static Collection<? extends Projection> nodeProjections(Collection<? extends Projection> projections) {
-        return Collections2.filter(projections, Projection.IS_NODE_PROJECTION::test);
-    }
-
-    public static boolean hasAnyShardProjections(Iterable<? extends Projection> projections) {
-        for (Projection projection : projections) {
-            if (projection.requiredGranularity() == RowGranularity.SHARD) {
-                return true;
-            }
-        }
-        return false;
-    }
+    /**
+     * @return Representation of the component as Map used for EXPLAIN
+     * <p>
+     * The result must be streamable using {@link io.crate.types.ObjectType#writeValueTo(StreamOutput, Object)}
+     * </p>
+     */
+    Map<String, Object> mapRepresentation();
 }

--- a/sql/src/main/java/io/crate/planner/projection/AggregationProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/AggregationProjection.java
@@ -22,17 +22,20 @@
 package io.crate.planner.projection;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.crate.analyze.symbol.AggregateMode;
 import io.crate.analyze.symbol.Aggregation;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.Symbols;
 import io.crate.metadata.RowGranularity;
+import io.crate.planner.ExplainLeaf;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 
 /**
@@ -110,5 +113,13 @@ public class AggregationProjection extends Projection {
 
     public AggregateMode mode() {
         return mode;
+    }
+
+    @Override
+    public Map<String, Object> mapRepresentation() {
+        return ImmutableMap.of(
+            "type", "HashAggregation",
+            "aggregations", ExplainLeaf.printList(aggregations)
+        );
     }
 }

--- a/sql/src/main/java/io/crate/planner/projection/EvalProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/EvalProjection.java
@@ -22,15 +22,18 @@
 
 package io.crate.planner.projection;
 
+import com.google.common.collect.ImmutableMap;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.SymbolVisitors;
 import io.crate.analyze.symbol.Symbols;
 import io.crate.collections.Lists2;
+import io.crate.planner.ExplainLeaf;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 
 /**
@@ -90,5 +93,13 @@ public class EvalProjection extends Projection {
         int result = super.hashCode();
         result = 31 * result + outputs.hashCode();
         return result;
+    }
+
+    @Override
+    public Map<String, Object> mapRepresentation() {
+        return ImmutableMap.of(
+            "type", "Eval",
+            "outputs", ExplainLeaf.printList(outputs)
+        );
     }
 }

--- a/sql/src/main/java/io/crate/planner/projection/FetchProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/FetchProjection.java
@@ -22,10 +22,12 @@
 package io.crate.planner.projection;
 
 import com.carrotsearch.hppc.IntSet;
+import com.google.common.collect.ImmutableMap;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.collections.Lists2;
 import io.crate.metadata.TableIdent;
 import io.crate.operation.Paging;
+import io.crate.planner.ExplainLeaf;
 import io.crate.planner.node.fetch.FetchSource;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -126,5 +128,13 @@ public class FetchProjection extends Projection {
     public void writeTo(StreamOutput out) throws IOException {
         throw new UnsupportedOperationException("writeTo is not supported for " +
                                                 FetchProjection.class.getSimpleName());
+    }
+
+    @Override
+    public Map<String, Object> mapRepresentation() {
+        return ImmutableMap.of(
+            "type", "Fetch",
+            "outputs", ExplainLeaf.printList(outputSymbols)
+        );
     }
 }

--- a/sql/src/main/java/io/crate/planner/projection/FilterProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/FilterProjection.java
@@ -22,6 +22,7 @@
 package io.crate.planner.projection;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.SymbolVisitors;
 import io.crate.analyze.symbol.Symbols;
@@ -32,6 +33,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 
@@ -109,5 +111,13 @@ public class FilterProjection extends Projection {
     public int hashCode() {
         int result = super.hashCode();
         return 31 * result + (query != null ? query.hashCode() : 0);
+    }
+
+    @Override
+    public Map<String, Object> mapRepresentation() {
+        return ImmutableMap.of(
+            "type", "Filter",
+            "filter", query.representation()
+        );
     }
 }

--- a/sql/src/main/java/io/crate/planner/projection/GroupProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/GroupProjection.java
@@ -21,18 +21,21 @@
 
 package io.crate.planner.projection;
 
+import com.google.common.collect.ImmutableMap;
 import io.crate.analyze.symbol.AggregateMode;
 import io.crate.analyze.symbol.Aggregation;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.Symbols;
 import io.crate.collections.Lists2;
 import io.crate.metadata.RowGranularity;
+import io.crate.planner.ExplainLeaf;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 
 public class GroupProjection extends Projection {
@@ -131,5 +134,14 @@ public class GroupProjection extends Projection {
 
     public AggregateMode mode() {
         return mode;
+    }
+
+    @Override
+    public Map<String, Object> mapRepresentation() {
+        return ImmutableMap.of(
+            "type", "HashAggregation",
+            "keys", ExplainLeaf.printList(keys),
+            "aggregations", ExplainLeaf.printList(values)
+        );
     }
 }

--- a/sql/src/main/java/io/crate/planner/projection/MergeCountProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/MergeCountProjection.java
@@ -54,7 +54,6 @@ public class MergeCountProjection extends Projection {
         return this == o;
     }
 
-
     @Override
     public void writeTo(StreamOutput out) throws IOException {
     }

--- a/sql/src/main/java/io/crate/planner/projection/OrderedTopNProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/OrderedTopNProjection.java
@@ -22,18 +22,18 @@
 
 package io.crate.planner.projection;
 
+import com.google.common.collect.ImmutableMap;
+import io.crate.analyze.OrderBy;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.SymbolVisitors;
 import io.crate.analyze.symbol.Symbols;
 import io.crate.collections.Lists2;
+import io.crate.planner.ExplainLeaf;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 import java.util.function.Function;
 
 public class OrderedTopNProjection extends Projection {
@@ -167,5 +167,17 @@ public class OrderedTopNProjection extends Projection {
         result = 31 * result + Arrays.hashCode(reverseFlags);
         result = 31 * result + Arrays.hashCode(nullsFirst);
         return result;
+    }
+
+    @Override
+    public Map<String, Object> mapRepresentation() {
+        return ImmutableMap.of(
+            "type", "OrderByTopN",
+            "limit", limit,
+            "offset", offset,
+            "outputs", ExplainLeaf.printList(outputs),
+            "orderBy", OrderBy.explainRepresentation(
+                new StringBuilder("["), orderBy, reverseFlags, nullsFirst).append("]").toString()
+        );
     }
 }

--- a/sql/src/main/java/io/crate/planner/projection/Projection.java
+++ b/sql/src/main/java/io/crate/planner/projection/Projection.java
@@ -21,27 +21,23 @@
 
 package io.crate.planner.projection;
 
-import com.google.common.base.Predicate;
-import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableMap;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.RowGranularity;
+import io.crate.planner.ExplainNode;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
-public abstract class Projection {
+public abstract class Projection implements ExplainNode {
 
-    public static final Predicate<Projection> IS_SHARD_PROJECTION = new Predicate<Projection>() {
-        @Override
-        public boolean apply(@Nullable Projection projection) {
-            return projection != null && projection.requiredGranularity() == RowGranularity.SHARD;
-        }
-    };
-    public static final Predicate<Projection> IS_NODE_PROJECTION = Predicates.not(IS_SHARD_PROJECTION);
+    static final Predicate<Projection> IS_SHARD_PROJECTION = p -> p.requiredGranularity() == RowGranularity.SHARD;
+    static final Predicate<Projection> IS_NODE_PROJECTION = IS_SHARD_PROJECTION.negate();
 
     /**
      * The granularity required to run this projection
@@ -87,5 +83,9 @@ public abstract class Projection {
     @Override
     public int hashCode() {
         return projectionType().hashCode();
+    }
+
+    public Map<String, Object> mapRepresentation() {
+        return ImmutableMap.of("type", projectionType().toString());
     }
 }

--- a/sql/src/main/java/io/crate/planner/projection/TopNProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/TopNProjection.java
@@ -21,16 +21,19 @@
 
 package io.crate.planner.projection;
 
+import com.google.common.collect.ImmutableMap;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.SymbolVisitors;
 import io.crate.analyze.symbol.Symbols;
 import io.crate.collections.Lists2;
 import io.crate.operation.projectors.TopN;
+import io.crate.planner.ExplainLeaf;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 
 public class TopNProjection extends Projection {
@@ -109,6 +112,16 @@ public class TopNProjection extends Projection {
         result = 31 * result + offset;
         result = 31 * result + outputs.hashCode();
         return result;
+    }
+
+    @Override
+    public Map<String, Object> mapRepresentation() {
+        return ImmutableMap.of(
+            "type", "TopN",
+            "limit", limit,
+            "offset", offset,
+            "outputs", ExplainLeaf.printList(outputs)
+        );
     }
 
     @Override

--- a/sql/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -142,7 +142,7 @@ public class ExpressionAnalyzerTest extends CrateUnitTest {
                 new LongLiteral("1")));
 
         Function function = (Function) expressionAnalyzer.convert(subscriptFunctionCall, expressionAnalysisContext);
-        assertEquals("subscript(_array(Literal{obj, type=string}),Literal{1, type=integer})", function.toString());
+        assertEquals("subscript(_array('obj'), 1)", function.toString());
     }
 
     @Test


### PR DESCRIPTION
I'm not sure if this is too much. On one hand it would be great to have this information as it would allow us to get more insight into what could be wrong if a user has a statement that runs into an error. On the other hand this will expose more implementation detail.

It's also using two different ways to represent symbols - I choose this based on what I thought would be better depending on the projection, but it's not really nice to have this inconsistency (`INPUT(0)` vs, `IC(0, type)`)

The reason for switching from a Visitor approach to having a method on the Projection was to encourage implementation of this functionallity, otherwise if a new Projection is added one has to remember that there is a separate Visitor that deals with explain. But I don't really have a strong opinion on that.


For example:

    SELECT count(*), x FROM t1 GROUP BY x HAVING x > 10 ORDER BY x LIMIT 10 OFFSET 3

    "projections": [
	{
	    "type": "HashAggregation",
	    "keys": "IC{0, integer}",
	    "aggregations": "Aggregation{count, args=[IC{1, long}]}"
	},
	{
	    "type": "Filter",
	    "filter": "(INPUT(0) > 10)"
	},
	{
	    "type": "TopN",
	    "limit": 10,
	    "offset": 3,
	    "outputs": "IC{1, long}, IC{0, integer}",
	    "orderBy": "[IC{0, integer} DESC]"
	}
    ]

    SELECT * FROM t1 LIMIT 10 OFFSET 5

    "projections": [
        {
            "type": "TopN",
            "limit": 15,
            "offset": 0,
            "outputs": "IC{0, long}"
        },
        {
            "type": "TopN",
            "limit": 10,
            "offset": 5,
            "outputs": "IC{0, long}"
        },
        {
            "type": "Fetch",
            "outputs": "FETCH(INPUT(0), _doc['x'])"
        }
    ]