### PR TITLE
docs/sphinx: Treat warnings as error in sphinx-autobuild

### DIFF
--- a/blackbox/bin/sphinx
+++ b/blackbox/bin/sphinx
@@ -3,7 +3,7 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 PATH=$DIR/.venv/bin:$PATH
 if test "$1" == "dev"; then
-    sphinx-autobuild $DIR/docs $DIR/docs/out/html
+    sphinx-autobuild -W $DIR/docs $DIR/docs/out/html
 else
     declare -i RESULT=0
     printf "\033[1mCleaning output folder ...\033[0m\n"


### PR DESCRIPTION
We've had it a couple of times that the docs contained broken links
because `bin/sphinx dev` was used which didn't treat warnings as errors
and we didn't wait for travis to finish.