### PR TITLE
Prevent `KILL` or `KILL ALL` from killing the whole node

### DIFF
--- a/dex/src/main/java/io/crate/data/BatchRowVisitor.java
+++ b/dex/src/main/java/io/crate/data/BatchRowVisitor.java
@@ -44,16 +44,18 @@ public class BatchRowVisitor {
                                                         CompletableFuture<R> resultFuture) {
         BiConsumer<A, Row> accumulator = collector.accumulator();
         Row row = RowBridging.toRow(it.rowData());
+        boolean allLoaded;
         try {
             while (it.moveNext()) {
                 accumulator.accept(state, row);
             }
+            allLoaded = it.allLoaded();
         } catch (Throwable t) {
             resultFuture.completeExceptionally(t);
             return resultFuture;
         }
 
-        if (it.allLoaded()) {
+        if (allLoaded) {
             resultFuture.complete(collector.finisher().apply(state));
         } else {
             it.loadNextBatch().whenComplete((r, t) -> {

--- a/dex/src/test/java/io/crate/data/BatchRowVisitorTest.java
+++ b/dex/src/test/java/io/crate/data/BatchRowVisitorTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.data;
+
+import io.crate.testing.FailingBatchIterator;
+import org.junit.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class BatchRowVisitorTest {
+
+    @Test
+    public void testExceptionOnAllLoadedIsSetOntoFuture() throws Exception {
+        CompletableFuture<Long> future = BatchRowVisitor.visitRows(
+            FailingBatchIterator.failOnAllLoaded(), Collectors.counting());
+        assertThat(future.isCompletedExceptionally(), is(true));
+    }
+}

--- a/dex/src/test/java/io/crate/testing/FailingBatchIterator.java
+++ b/dex/src/test/java/io/crate/testing/FailingBatchIterator.java
@@ -24,12 +24,30 @@ package io.crate.testing;
 
 import io.crate.data.BatchIterator;
 import io.crate.data.ForwardingBatchIterator;
+import io.crate.data.RowsBatchIterator;
+import io.crate.exceptions.Exceptions;
 
 public class FailingBatchIterator extends ForwardingBatchIterator {
 
     private final BatchIterator delegate;
     private final int failAfter;
     private int moveNextCalls = 0;
+
+    public static BatchIterator failOnAllLoaded() {
+        BatchIterator delegate = RowsBatchIterator.empty(1);
+        return new ForwardingBatchIterator() {
+            @Override
+            protected BatchIterator delegate() {
+                return delegate;
+            }
+
+            @Override
+            public boolean allLoaded() {
+                Exceptions.rethrowUnchecked(new InterruptedException("Job killed"));
+                return true;
+            }
+        };
+    }
 
     public FailingBatchIterator(BatchIterator delegate, int failAfter) {
         this.delegate = delegate;

--- a/sql/src/main/java/io/crate/action/sql/BatchConsumerToResultReceiver.java
+++ b/sql/src/main/java/io/crate/action/sql/BatchConsumerToResultReceiver.java
@@ -56,6 +56,7 @@ public class BatchConsumerToResultReceiver implements BatchConsumer {
 
     private void consumeIt(BatchIterator iterator) {
         Row row = RowBridging.toRow(iterator.rowData());
+        boolean allLoaded;
         try {
             while (iterator.moveNext()) {
                 rowCount++;
@@ -67,12 +68,13 @@ public class BatchConsumerToResultReceiver implements BatchConsumer {
                     return; // resumed via postgres protocol, close is done later
                 }
             }
+            allLoaded = iterator.allLoaded();
         } catch (Throwable t) {
             iterator.close();
             resultReceiver.fail(t);
             return;
         }
-        if (iterator.allLoaded()) {
+        if (allLoaded) {
             iterator.close();
             resultReceiver.allFinished(false);
         } else {

--- a/sql/src/main/java/io/crate/executor/transport/distributed/DistributingConsumer.java
+++ b/sql/src/main/java/io/crate/executor/transport/distributed/DistributingConsumer.java
@@ -107,6 +107,7 @@ public class DistributingConsumer implements BatchConsumer {
 
     private void consumeIt(BatchIterator it) {
         Row row = RowBridging.toRow(it.rowData());
+        boolean allLoaded;
         try {
             while (it.moveNext()) {
                 multiBucketBuilder.add(row);
@@ -115,11 +116,12 @@ public class DistributingConsumer implements BatchConsumer {
                     return;
                 }
             }
+            allLoaded = it.allLoaded();
         } catch (Throwable t) {
             forwardFailure(it, t);
             return;
         }
-        if (it.allLoaded()) {
+        if (allLoaded) {
             forwardResults(it, true);
         } else {
             it.loadNextBatch().whenComplete((r, t) -> {

--- a/sql/src/test/java/io/crate/action/sql/BatchConsumerToResultReceiverTest.java
+++ b/sql/src/test/java/io/crate/action/sql/BatchConsumerToResultReceiverTest.java
@@ -24,6 +24,7 @@ package io.crate.action.sql;
 
 import io.crate.data.Row;
 import io.crate.testing.BatchSimulatingIterator;
+import io.crate.testing.FailingBatchIterator;
 import io.crate.testing.TestingBatchIterators;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -67,5 +68,14 @@ public class BatchConsumerToResultReceiverTest {
 
         assertThat(collectedRows.size(), is(10));
         assertThat(collectedRows, Matchers.contains(expectedResult.toArray(new Object[0])));
+    }
+
+    @Test
+    public void testExceptionOnAllLoadedCallIsForwardedToResultReceiver() throws Exception {
+        BaseResultReceiver resultReceiver = new BaseResultReceiver();
+        BatchConsumerToResultReceiver consumer = new BatchConsumerToResultReceiver(resultReceiver, 0);
+
+        consumer.accept(FailingBatchIterator.failOnAllLoaded(), null);
+        assertThat(resultReceiver.completionFuture().isCompletedExceptionally(), is(true));
     }
 }


### PR DESCRIPTION
This fixes a nasty race condition which lead to the termination of a
node.

Since ES5 there is an uncaught exception handler which terminates the
node if an uncaught exception is encountered which is not a
RuntimeException. (That's a good thing)

With the BatchIterator introduction we've added consumers which had a
bug: They didn't handle exceptions on `batchIterator.allLoaded` calls -
these were simply uncaught and could lead to a query getting stuck.

Now the only cases where `allLoaded` thows an exception is due to a
kill: Either internal or user provoked with the `KILL (ALL)` statement.

**Review Info**: I'll add different changes entries for 1.1 / 2.0 because the node-termination is 2.0 only; In 1.1 queries could get stuck. So changes are not part of this PR