### PR TITLE
Fix: Limit not applied in subselects of a join.

### DIFF
--- a/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
@@ -45,7 +45,10 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.logging.Loggers;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 
 class NestedLoopConsumer implements Consumer {
 
@@ -105,13 +108,6 @@ class NestedLoopConsumer implements Consumer {
             boolean hasDocTables = left instanceof QueriedDocTable || right instanceof QueriedDocTable;
             boolean isDistributed = hasDocTables && filterNeeded && !joinType.isOuter();
             Limits limits = context.plannerContext().getLimits(querySpec);
-
-            if (filterNeeded || joinCondition != null || statement.remainingOrderBy().isPresent()) {
-                left.querySpec().limit(Optional.empty());
-                right.querySpec().limit(Optional.empty());
-                left.querySpec().offset(Optional.empty());
-                right.querySpec().offset(Optional.empty());
-            }
 
             if (!filterNeeded && joinCondition == null && querySpec.limit().isPresent()) {
                 context.requiredPageSize(limits.limitAndOffset());

--- a/sql/src/test/java/io/crate/analyze/SubSelectAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SubSelectAnalyzerTest.java
@@ -117,15 +117,21 @@ public class SubSelectAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testJoinOnSubSelects() throws Exception {
         SelectAnalyzedStatement statement = analyze("select * from " +
-                                                    " (select a, i from t1) t1 " +
+                                                    " (select a, i from t1 order by a limit 5) t1 " +
                                                     "left join" +
                                                     " (select b, i from t2 where b > 10) t2 " +
-                                                    "on t1.i = t2.i where t1.a > 50 and t2.b > 100");
+                                                    "on t1.i = t2.i where t1.a > 50 and t2.b > 100 " +
+                                                    "limit 10");
         MultiSourceSelect relation = (MultiSourceSelect) statement.relation();
-        assertThat(relation.querySpec(), isSQL("SELECT doc.t1.a, doc.t1.i, doc.t2.b, doc.t2.i"));
-        assertThat(relation.joinPairs().get(0).condition(), isSQL("(doc.t1.i = doc.t2.i)"));
+        assertThat(relation.querySpec(),
+                   isSQL("SELECT io.crate.analyze.QueriedSelectRelation.a, " +
+                         "io.crate.analyze.QueriedSelectRelation.i, doc.t2.b, doc.t2.i LIMIT 10"));
+        assertThat(relation.joinPairs().get(0).condition(),
+                   isSQL("(io.crate.analyze.QueriedSelectRelation.i = doc.t2.i)"));
         assertThat(((QueriedRelation)relation.sources().get(new QualifiedName("t1"))).querySpec(),
                    isSQL("SELECT doc.t1.i, doc.t1.a WHERE (doc.t1.a > '50')"));
+        assertThat(((QueriedSelectRelation)relation.sources().get(new QualifiedName("t1"))).subRelation().querySpec(),
+                   isSQL("SELECT doc.t1.a, doc.t1.i ORDER BY doc.t1.a LIMIT 5"));
         assertThat(((QueriedRelation)relation.sources().get(new QualifiedName("t2"))).querySpec(),
                    isSQL("SELECT doc.t2.b, doc.t2.i WHERE ((doc.t2.b > '10') AND (doc.t2.b > '100'))"));
     }

--- a/sql/src/test/java/io/crate/analyze/relations/RelationSplitterTest.java
+++ b/sql/src/test/java/io/crate/analyze/relations/RelationSplitterTest.java
@@ -179,9 +179,9 @@ public class RelationSplitterTest extends CrateUnitTest {
 
         assertThat(querySpec, isSQL("SELECT doc.t1.x, doc.t2.y ORDER BY doc.t1.x, doc.t2.y, doc.t3.z LIMIT 20"));
 
-        assertThat(splitter.getSpec(T3.TR_1), isSQL("SELECT doc.t1.x WHERE (doc.t1.x = 1) ORDER BY doc.t1.x LIMIT 20"));
-        assertThat(splitter.getSpec(T3.TR_2), isSQL("SELECT doc.t2.y WHERE (true AND (doc.t2.y = 2)) ORDER BY doc.t2.y LIMIT 20"));
-        assertThat(splitter.getSpec(T3.TR_3), isSQL("SELECT doc.t3.z WHERE (true AND (doc.t3.z = 3)) ORDER BY doc.t3.z LIMIT 20"));
+        assertThat(splitter.getSpec(T3.TR_1), isSQL("SELECT doc.t1.x WHERE (doc.t1.x = 1) ORDER BY doc.t1.x"));
+        assertThat(splitter.getSpec(T3.TR_2), isSQL("SELECT doc.t2.y WHERE (true AND (doc.t2.y = 2)) ORDER BY doc.t2.y"));
+        assertThat(splitter.getSpec(T3.TR_3), isSQL("SELECT doc.t3.z WHERE (true AND (doc.t3.z = 3)) ORDER BY doc.t3.z"));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -756,33 +756,34 @@ public class JoinIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testJoinOnVirtualTableWithQTF() throws Exception {
-        execute("create table customers (\n" +
-                "id long,\n" +
-                "name string,\n" +
-                "country string,\n" +
-                "company_id long\n" +
+        execute("create table customers (" +
+                "id long," +
+                "name string," +
+                "country string," +
+                "company_id long" +
                 ")");
         ensureYellow();
         execute("insert into customers (id, name, country, company_id) values(1, 'Marios', 'Greece', 1) ");
         execute("refresh table customers");
 
-        execute("create table orders (\n" +
-                "id long,\n" +
-                "customer_id long,\n" +
-                "price float\n" +
+        execute("create table orders (" +
+                "id long," +
+                "customer_id long," +
+                "price float" +
                 ")");
         ensureYellow();
-        execute("insert into orders(id, customer_id, price) values (1, 1, 10.0), (2,1,20.0)");
+        execute("insert into orders(id, customer_id, price) values (1,1,20.0), (2,1,10.0), (3,1,30.0), (4,1,40.0), (5,1,50.0)");
         execute("refresh table orders");
 
-        String stmt = "SELECT * FROM \n" +
-                      "     (SELECT * FROM (SELECT * from customers order by name limit 4) t ORDER BY country LiMit 3) t1,\n" +
-                      "     orders t2\n" +
+        String stmt = "SELECT * FROM" +
+                      "  customers t1, " +
+                      "  (SELECT * FROM (SELECT * from orders order by price desc limit 4) t ORDER BY price limit 3) t2 " +
                       "WHERE t2.customer_id = t1.id " +
-                      "order by price";
+                      "order by price limit 3 offset 1";
+
         execute(stmt);
         assertThat(printedTable(response.rows()),
-            is("1| Greece| 1| Marios| 1| 1| 10.0\n" +
-               "1| Greece| 1| Marios| 1| 2| 20.0\n"));
+            is("1| Greece| 1| Marios| 1| 3| 30.0\n" +
+               "1| Greece| 1| Marios| 1| 4| 40.0\n"));
     }
 }


### PR DESCRIPTION
Limit was pushed down early in RelationSplitter without checking
any preconditions and was later on removed in NestedLoopConsumer.
Now that subrelations of MSS can be subselects can have their own
limit which was wrongly removed in NestedLoopConsumer.
To fix this we move the precondition checks for pushing down the limit to
RelationSplitter.