### PR TITLE
Change JMX stats to deliver per node values & fix calculation errors

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -20,8 +20,19 @@ Changes
 
  - Added support for joins on virtual tables.
 
+ - Changed the ``QueryStats`` JMX MBean to deliver node-based values instead of
+   cluster-based values.
+   This makes it possible to spot performance discrepancies between nodes more
+   easily.
+
 Fixes
 =====
+
+ - Optimized the JMX ``QueryStats`` MBean to prevent it from putting too much
+   load on the cluster.
+
+ - Fixed the calculation of the ``OverallQueryAverageDuration`` ``QueryStats``
+   MBean.
 
  - The internal ``fetchSize`` now has an upper bound to prevent ``OutOfMemory``
    errors if a postgres client retrieves a large result set without setting a

--- a/jmx-monitoring/src/main/java/io/crate/beans/QueryStats.java
+++ b/jmx-monitoring/src/main/java/io/crate/beans/QueryStats.java
@@ -18,187 +18,175 @@
 
 package io.crate.beans;
 
-import com.google.common.annotations.VisibleForTesting;
-import io.crate.action.sql.Option;
-import io.crate.action.sql.ResultReceiver;
-import io.crate.action.sql.SQLOperations;
-import io.crate.data.Row;
-import io.crate.exceptions.SQLExceptions;
-import org.apache.logging.log4j.Logger;
-import org.elasticsearch.common.logging.Loggers;
-import org.elasticsearch.common.lucene.BytesRefs;
-import org.elasticsearch.common.settings.Settings;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import io.crate.operation.collect.stats.JobsLogs;
+import io.crate.operation.reference.sys.job.JobContextLog;
 
-import javax.annotation.Nonnull;
-import java.util.*;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
-import static io.crate.action.sql.SQLOperations.Session.UNNAMED;
-import static io.crate.beans.QueryStats.MetricType.AVERAGE_DURATION;
-import static io.crate.beans.QueryStats.MetricType.FREQUENCY;
 
 public class QueryStats implements QueryStatsMBean {
 
-    private final Logger logger;
+    static class Commands {
+        static final String TOTAL = "total";
+        static final String UNCLASSIFIED = "unclassified";
 
-    enum MetricType {
-        FREQUENCY,
-        AVERAGE_DURATION
+        static final String SELECT = "select";
+        static final String INSERT = "insert";
+        static final String UPDATE = "update";
+        static final String DELETE = "delete";
+    }
+
+    static class Metric {
+
+        private final long elapsedSinceUpdateInMs;
+
+        private long count;
+        private long sumOfDurations;
+
+        Metric(long duration, long elapsedSinceUpdateInMs) {
+            this.elapsedSinceUpdateInMs = elapsedSinceUpdateInMs;
+            sumOfDurations = duration;
+            count = 1;
+        }
+
+        void inc(long duration) {
+            sumOfDurations += duration;
+            count++;
+        }
+
+        double statementsPerSec() {
+            return count / (elapsedSinceUpdateInMs / 1000.0);
+        }
+
+        double avgDurationInMs() {
+            return sumOfDurations / count;
+        }
     }
 
     public static final String NAME = "io.crate.monitoring:type=QueryStats";
+    private static final Pattern COMMAND_PATTERN = Pattern.compile("^\\s*(select|insert|update|delete).*");
+    private static final Metric DEFAULT_METRIC = new Metric(0, 0) {
 
-    private static final String QUERY_PATTERN = "^\\s*(%s).*";
-    private static final String STMT = "SELECT COUNT(*) / ((CURRENT_TIMESTAMP - ?) / 1000.0), " +
-        "AVG(ended - started), REGEXP_MATCHES(LOWER(stmt), ?)[1] " +
-        "FROM sys.jobs_log " +
-        "WHERE started BETWEEN ? AND CURRENT_TIMESTAMP " +
-        "  AND REGEXP_MATCHES(LOWER(stmt), ?)[1] IS NOT NULL " +
-        "GROUP BY 3";
+        @Override
+        void inc(long duration) {
+            throw new AssertionError("inc must not be called on default metric - it's immutable");
+        }
 
-    private final ConcurrentMap<String, Double> metrics;
-    private final SQLOperations.Session session;
-    @VisibleForTesting
-    final ConcurrentMap<String, Long> lastQueried;
+        @Override
+        double statementsPerSec() {
+            return 0.0;
+        }
 
-    public QueryStats(SQLOperations sqlOperations, Settings settings) {
-        logger = Loggers.getLogger(QueryStats.class, settings);
-        session = sqlOperations.createSession("sys", null, Option.NONE, 10000);
-        session.parse(NAME, STMT, Collections.emptyList());
+        @Override
+        double avgDurationInMs() {
+            return 0.0;
+        }
+    };
 
-        lastQueried = new ConcurrentHashMap<>();
-        metrics = new ConcurrentHashMap<>();
+    private final Supplier<Map<String, Metric>> metricByCommand;
+
+    private volatile long lastUpdateTsInMillis = System.currentTimeMillis();
+
+    public QueryStats(JobsLogs jobsLogs) {
+        metricByCommand = Suppliers.memoizeWithExpiration(
+            () -> {
+                long currentTs = System.currentTimeMillis();
+                Map<String, Metric> metricByCommand = createMetricsMap(jobsLogs.jobsLog(), currentTs, lastUpdateTsInMillis);
+                lastUpdateTsInMillis = currentTs;
+                return metricByCommand;
+            },
+            1,
+            TimeUnit.SECONDS
+        );
+    }
+
+    static Map<String, Metric> createMetricsMap(Iterable<JobContextLog> logEntries, long currentTs, long lastUpdateTs) {
+        Map<String, Metric> metricsByCommand = new HashMap<>();
+        long elapsedSinceLastUpdateInMs = currentTs - lastUpdateTs;
+
+        Metric total = new Metric(0, elapsedSinceLastUpdateInMs);
+        for (JobContextLog logEntry : logEntries) {
+            if (logEntry.started() < lastUpdateTs || logEntry.started() > currentTs) {
+                continue;
+            }
+            String command = getCommand(logEntry.statement());
+            long duration = logEntry.ended() - logEntry.started();
+            total.inc(duration);
+            metricsByCommand.compute(command, (key, oldMetric) -> {
+                if (oldMetric == null) {
+                    return new Metric(duration, elapsedSinceLastUpdateInMs);
+                }
+                oldMetric.inc(duration);
+                return oldMetric;
+            });
+        }
+        metricsByCommand.put(Commands.TOTAL, total);
+        return metricsByCommand;
+    }
+
+    private static String getCommand(String statement) {
+        Matcher matcher = COMMAND_PATTERN.matcher(statement.toLowerCase(Locale.ENGLISH));
+        if (matcher.find()) {
+            return matcher.group(1);
+        } else {
+            return Commands.UNCLASSIFIED;
+        }
     }
 
     @Override
     public double getSelectQueryFrequency() {
-        return updateAndGetLastSingleMetricValue("select", FREQUENCY);
+        return metricByCommand.get().getOrDefault(Commands.SELECT, DEFAULT_METRIC).statementsPerSec();
     }
 
     @Override
     public double getInsertQueryFrequency() {
-        return updateAndGetLastSingleMetricValue("insert", FREQUENCY);
+        return metricByCommand.get().getOrDefault(Commands.INSERT, DEFAULT_METRIC).statementsPerSec();
     }
 
     @Override
     public double getUpdateQueryFrequency() {
-        return updateAndGetLastSingleMetricValue("update", FREQUENCY);
+        return metricByCommand.get().getOrDefault(Commands.UPDATE, DEFAULT_METRIC).statementsPerSec();
     }
 
     @Override
     public double getDeleteQueryFrequency() {
-        return updateAndGetLastSingleMetricValue("delete", FREQUENCY);
+        return metricByCommand.get().getOrDefault(Commands.DELETE, DEFAULT_METRIC).statementsPerSec();
     }
 
     @Override
     public double getSelectQueryAverageDuration() {
-        return updateAndGetLastSingleMetricValue("select", AVERAGE_DURATION);
+        return metricByCommand.get().getOrDefault(Commands.SELECT, DEFAULT_METRIC).avgDurationInMs();
     }
 
     @Override
     public double getInsertQueryAverageDuration() {
-        return updateAndGetLastSingleMetricValue("insert", AVERAGE_DURATION);
+        return metricByCommand.get().getOrDefault(Commands.INSERT, DEFAULT_METRIC).avgDurationInMs();
     }
 
     @Override
     public double getUpdateQueryAverageDuration() {
-        return updateAndGetLastSingleMetricValue("update", AVERAGE_DURATION);
+        return metricByCommand.get().getOrDefault(Commands.UPDATE, DEFAULT_METRIC).avgDurationInMs();
     }
 
     @Override
     public double getDeleteQueryAverageDuration() {
-        return updateAndGetLastSingleMetricValue("delete", AVERAGE_DURATION);
+        return metricByCommand.get().getOrDefault(Commands.DELETE, DEFAULT_METRIC).avgDurationInMs();
     }
 
     @Override
     public double getOverallQueryFrequency() {
-        return updateAndGetLastOverallMetricValue("select|insert|delete|update", FREQUENCY);
+        return metricByCommand.get().getOrDefault(Commands.TOTAL, DEFAULT_METRIC).statementsPerSec();
     }
 
     @Override
     public double getOverallQueryAverageDuration() {
-        return updateAndGetLastOverallMetricValue("select|insert|delete|update", AVERAGE_DURATION);
-    }
-
-    private double updateAndGetLastOverallMetricValue(String query, MetricType type) {
-        return updateAndLastGetMetricValue(query, type, true);
-    }
-
-    private double updateAndGetLastSingleMetricValue(String query, MetricType type) {
-        return updateAndLastGetMetricValue(query, type, false);
-    }
-
-    private double updateAndLastGetMetricValue(String query, MetricType type, boolean overall) {
-        try {
-            String queryUID = query + type;
-            String queryPattern = String.format(Locale.ENGLISH, QUERY_PATTERN, query);
-            long lastTs = updateAndGetLastExecutedTsFor(queryUID);
-
-            session.bind(UNNAMED, NAME, Arrays.asList(lastTs, queryPattern, lastTs, queryPattern), null);
-            session.execute(UNNAMED, 0, new ResultReceiver() {
-
-                private final CompletableFuture<Boolean> completionFuture = new CompletableFuture<>();
-                private final List<Row> rows = new ArrayList<>();
-
-                @Override
-                public void setNextRow(Row row) {
-                    rows.add(row);
-                }
-
-                @Override
-                public void allFinished(boolean interrupted) {
-                    double value = overall ?
-                        getTotalMetricValue(rows, type.ordinal()) :
-                        getMetricValue(rows, query, type.ordinal());
-                    metrics.put(queryUID, value);
-                    completionFuture.complete(interrupted);
-                }
-
-                @Override
-                public void fail(@Nonnull Throwable t) {
-                    logger.error("Failed to process metric results!", t);
-                    completionFuture.completeExceptionally(t);
-                }
-
-                @Override
-                public CompletableFuture<?> completionFuture() {
-                    return completionFuture;
-                }
-
-                @Override
-                public void batchFinished() {
-                }
-            });
-            session.sync();
-            return metrics.getOrDefault(queryUID, .0);
-        } catch (Throwable t) {
-            throw SQLExceptions.createSQLActionException(t);
-        }
-    }
-
-    @VisibleForTesting
-    double getMetricValue(List<Row> rows, String query, int metricIdx) {
-        return rows.stream()
-            .filter(row -> query.equalsIgnoreCase(BytesRefs.toString(row.get(2))))
-            .mapToDouble(row -> (double) row.get(metricIdx))
-            .findAny().orElse(.0);
-    }
-
-    @VisibleForTesting
-    double getTotalMetricValue(List<Row> rows, int metricIdx) {
-        return rows.stream()
-            .mapToDouble(row -> (double) row.get(metricIdx))
-            .sum();
-    }
-
-    @VisibleForTesting
-    long updateAndGetLastExecutedTsFor(String queryUID) {
-        long currentTs = System.currentTimeMillis();
-        long lastTs = lastQueried.getOrDefault(queryUID, currentTs);
-
-        lastQueried.put(queryUID, currentTs);
-        return lastTs;
+        return metricByCommand.get().getOrDefault(Commands.TOTAL, DEFAULT_METRIC).avgDurationInMs();
     }
 }

--- a/jmx-monitoring/src/main/java/io/crate/plugin/CrateMonitor.java
+++ b/jmx-monitoring/src/main/java/io/crate/plugin/CrateMonitor.java
@@ -18,8 +18,8 @@
 
 package io.crate.plugin;
 
-import io.crate.action.sql.SQLOperations;
 import io.crate.beans.QueryStats;
+import io.crate.operation.collect.stats.JobsLogs;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.logging.Loggers;
@@ -34,9 +34,9 @@ public class CrateMonitor {
     private final MBeanServer mbeanServer = ManagementFactory.getPlatformMBeanServer();
 
     @Inject
-    public CrateMonitor(SQLOperations sqlOperations, Settings settings) {
+    public CrateMonitor(JobsLogs jobsLogs, Settings settings) {
         logger = Loggers.getLogger(CrateMonitor.class, settings);
-        registerMBean(QueryStats.NAME, new QueryStats(sqlOperations, settings));
+        registerMBean(QueryStats.NAME, new QueryStats(jobsLogs));
     }
 
     private void registerMBean(String name, Object bean) {

--- a/jmx-monitoring/src/test/java/io/crate/beans/QueryStatsTest.java
+++ b/jmx-monitoring/src/test/java/io/crate/beans/QueryStatsTest.java
@@ -19,106 +19,58 @@
 package io.crate.beans;
 
 import com.google.common.collect.ImmutableList;
-import io.crate.action.sql.BaseResultReceiver;
-import io.crate.action.sql.SQLOperations;
-import io.crate.data.Row;
-import io.crate.data.RowN;
-import io.crate.types.DataType;
-import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.settings.Settings;
-import org.junit.BeforeClass;
+import io.crate.operation.collect.stats.JobsLogs;
+import io.crate.operation.reference.sys.job.JobContext;
+import io.crate.operation.reference.sys.job.JobContextLog;
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
-import static io.crate.action.sql.SQLOperations.Session.UNNAMED;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.hamcrest.core.Is.is;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyListOf;
-import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.eq;
 
 public class QueryStatsTest {
 
-    private static final List<Row> ROWS = ImmutableList.of(
-        new RowN(new Object[]{1.0, 1.1, new BytesRef("select")}),
-        new RowN(new Object[]{2.0, 2.1, new BytesRef("update")}),
-        new RowN(new Object[]{3.0, 3.1, new BytesRef("insert")}),
-        new RowN(new Object[]{4.0, 4.1, new BytesRef("delete")})
+    private final List<JobContextLog> log = ImmutableList.of(
+        new JobContextLog(new JobContext(UUID.randomUUID(), "select name", 100L), null, 150L),
+        new JobContextLog(new JobContext(UUID.randomUUID(), "select name", 300L), null, 320L),
+        new JobContextLog(new JobContext(UUID.randomUUID(), "update t1 set x = 10", 400L), null, 420L),
+        new JobContextLog(new JobContext(UUID.randomUUID(), "insert into t1 (x) values (20)", 111L), null, 130L),
+        new JobContextLog(new JobContext(UUID.randomUUID(), "delete from t1", 410L), null, 415L),
+        new JobContextLog(new JobContext(UUID.randomUUID(), "delete from t1", 110L), null, 120L),
+        new JobContextLog(new JobContext(UUID.randomUUID(), "create table t1 (x int)", 105L), null, 106L)
     );
 
-    private static QueryStats queryStats;
-    private static SQLOperations.Session session = mock(SQLOperations.Session.class);
+    @Test
+    public void testCreateMetricsMap() throws Exception {
+        Map<String, QueryStats.Metric> metricsByCommand = QueryStats.createMetricsMap(log, 2000, 0L);
+        assertThat(metricsByCommand.size(), is(6));
 
-    @BeforeClass
-    public static void beforeClass() {
-        SQLOperations sqlOperations = mock(SQLOperations.class);
+        assertThat(metricsByCommand.get(QueryStats.Commands.SELECT).avgDurationInMs(), is(35.0));
+        assertThat(metricsByCommand.get(QueryStats.Commands.SELECT).statementsPerSec(), is(1.0));
 
-        when(sqlOperations.createSession(anyString(), anyObject(), anyObject(), anyInt())).thenReturn(session);
-        doNothing().when(session).parse(anyString(), anyString(), anyListOf(DataType.class));
+        assertThat(metricsByCommand.get(QueryStats.Commands.INSERT).avgDurationInMs(), is(19.0));
+        assertThat(metricsByCommand.get(QueryStats.Commands.INSERT).statementsPerSec(), is(0.5));
 
-        queryStats = spy(new QueryStats(sqlOperations, Settings.EMPTY));
+        assertThat(metricsByCommand.get(QueryStats.Commands.UPDATE).avgDurationInMs(), is(20.0));
+        assertThat(metricsByCommand.get(QueryStats.Commands.UPDATE).statementsPerSec(), is(0.5));
+
+        assertThat(metricsByCommand.get(QueryStats.Commands.DELETE).avgDurationInMs(), is(7.0));
+        assertThat(metricsByCommand.get(QueryStats.Commands.DELETE).statementsPerSec(), is(1.0));
+
+        assertThat(metricsByCommand.get(QueryStats.Commands.UNCLASSIFIED).avgDurationInMs(), is(1.0));
+        assertThat(metricsByCommand.get(QueryStats.Commands.UNCLASSIFIED).statementsPerSec(), is(0.5));
+
+        assertThat(metricsByCommand.get(QueryStats.Commands.TOTAL).avgDurationInMs(), is(15.0));
+        assertThat(metricsByCommand.get(QueryStats.Commands.TOTAL).statementsPerSec(), is(4.0));
     }
 
     @Test
-    public void testUpdateAndGetLastQueryExecutionTimestamp() throws InterruptedException {
-        // If a query for a metric was executed for the first time, then the last executed ts will
-        // be updated with the current timestamp and this value will be returned.
-        long firstAvg = queryStats.updateAndGetLastExecutedTsFor("select" + QueryStats.MetricType.AVERAGE_DURATION);
-        long firstQps = queryStats.updateAndGetLastExecutedTsFor("select" + QueryStats.MetricType.FREQUENCY);
-
-        // The second call for the same metrics must return the last executed ts
-        // (assigned to firstQps, firstAvg) and update them with a current timestamp.
-        long lastAvg = queryStats.updateAndGetLastExecutedTsFor("select" + QueryStats.MetricType.AVERAGE_DURATION);
-        long lastQps = queryStats.updateAndGetLastExecutedTsFor("select" + QueryStats.MetricType.FREQUENCY);
-        assertThat(firstQps, is(lastQps));
-        assertThat(firstAvg, is(lastAvg));
-
-        // All the further invocation of the updateAndGetLastExecutedTsFor must return later ts.
-        assertThat(lastAvg,
-            lessThanOrEqualTo(queryStats.updateAndGetLastExecutedTsFor("select" + QueryStats.MetricType.AVERAGE_DURATION)));
-        assertThat(lastQps,
-            lessThanOrEqualTo(queryStats.updateAndGetLastExecutedTsFor("select" + QueryStats.MetricType.FREQUENCY)));
-    }
-
-    @Test
-    public void testFrequencyMetricExtractedCorrectlyFromResponse() {
-        assertThat(queryStats.getMetricValue(ROWS, "select", QueryStats.MetricType.FREQUENCY.ordinal()), is(1.0));
-        assertThat(queryStats.getMetricValue(ROWS, "update", QueryStats.MetricType.FREQUENCY.ordinal()), is(2.0));
-        assertThat(queryStats.getMetricValue(ROWS, "insert", QueryStats.MetricType.FREQUENCY.ordinal()), is(3.0));
-        assertThat(queryStats.getMetricValue(ROWS, "delete", QueryStats.MetricType.FREQUENCY.ordinal()), is(4.0));
-        assertThat(queryStats.getTotalMetricValue(ROWS, QueryStats.MetricType.FREQUENCY.ordinal()), is(10.0));
-    }
-
-    @Test
-    public void testAverageDurationMetricExtractedCorrectlyFromResponse() {
-        assertThat(queryStats.getMetricValue(ROWS, "select", QueryStats.MetricType.AVERAGE_DURATION.ordinal()), is(1.1));
-        assertThat(queryStats.getMetricValue(ROWS, "update", QueryStats.MetricType.AVERAGE_DURATION.ordinal()), is(2.1));
-        assertThat(queryStats.getMetricValue(ROWS, "insert", QueryStats.MetricType.AVERAGE_DURATION.ordinal()), is(3.1));
-        assertThat(queryStats.getMetricValue(ROWS, "delete", QueryStats.MetricType.AVERAGE_DURATION.ordinal()), is(4.1));
-        assertThat(queryStats.getTotalMetricValue(ROWS, QueryStats.MetricType.AVERAGE_DURATION.ordinal()), is(10.4));
-    }
-
-    @Test
-    public void testGetMetricResultInCorrectSessionCalls() {
-        queryStats.getDeleteQueryFrequency();
-        String queryUID = "delete" + QueryStats.MetricType.FREQUENCY;
-        verify(session, times(1)).bind(
-            eq(UNNAMED),
-            eq(QueryStats.NAME),
-            eq(Arrays.asList(
-                queryStats.lastQueried.get(queryUID), "^\\s*(delete).*",
-                queryStats.lastQueried.get(queryUID), "^\\s*(delete).*"
-            )),
-            eq(null)
-        );
-        verify(session, times(1)).execute(eq(""), eq(0), any(BaseResultReceiver.class));
-        verify(session, times(1)).sync();
+    public void testDefaultValue() throws Exception {
+        QueryStats queryStats = new QueryStats(new JobsLogs(() -> true));
+        assertThat(queryStats.getSelectQueryFrequency(), is(0.0));
+        assertThat(queryStats.getSelectQueryAverageDuration(), is(0.0));
     }
 }

--- a/sql/src/main/java/io/crate/operation/collect/sources/SystemCollectSource.java
+++ b/sql/src/main/java/io/crate/operation/collect/sources/SystemCollectSource.java
@@ -116,13 +116,13 @@ public class SystemCollectSource implements CollectSource {
         iterableGetters.put(InformationSqlFeaturesTableInfo.IDENT.fqn(),
            () -> completedFuture(informationSchemaIterables.features()));
         iterableGetters.put(SysJobsTableInfo.IDENT.fqn(),
-           () -> completedFuture(jobsLogs.jobsGetter()));
+           () -> completedFuture(jobsLogs.activeJobs()));
         iterableGetters.put(SysJobsLogTableInfo.IDENT.fqn(),
-           () -> completedFuture(jobsLogs.jobsLogGetter()));
+           () -> completedFuture(jobsLogs.jobsLog()));
         iterableGetters.put(SysOperationsTableInfo.IDENT.fqn(),
-           () -> completedFuture(jobsLogs.operationsGetter()));
+           () -> completedFuture(jobsLogs.activeOperations()));
         iterableGetters.put(SysOperationsLogTableInfo.IDENT.fqn(),
-           () -> completedFuture(jobsLogs.operationsLogGetter()));
+           () -> completedFuture(jobsLogs.operationsLog()));
 
         SysChecker<SysCheck> sysChecker = new SysChecker<>(sysChecks);
         iterableGetters.put(SysChecksTableInfo.IDENT.fqn(), sysChecker::computeResultAndGet);

--- a/sql/src/main/java/io/crate/operation/collect/stats/JobsLogs.java
+++ b/sql/src/main/java/io/crate/operation/collect/stats/JobsLogs.java
@@ -41,6 +41,18 @@ import java.util.function.BooleanSupplier;
  * JobsLogs is responsible for adding jobs and operations of that node.
  * It also provides the functionality to expose that data for system tables,
  * such as sys.jobs, sys.jobs_log, sys.operations and sys.operations_log;
+ * <p>
+ * The data is exposed via the properties
+ *
+ *   - {@link #activeJobs()}
+ *   - {@link #jobsLog()} ()}
+ *   - {@link #activeOperations()} ()}
+ *   - {@link #operationsLog()} ()}
+ *
+ * Note that on configuration updates (E.g.: resizing of jobs-log size, etc.) the Iterable instances previously returned
+ * from the properties may become obsolete.
+ * So the Iterable instances shouldn't be hold onto.
+ * Instead the Iterable should be re-retrieved each time the data is processed.
  */
 @ThreadSafe
 public class JobsLogs {
@@ -138,19 +150,19 @@ public class JobsLogs {
         operationContextLogs.add(new OperationContextLog(operationContext, errorMessage));
     }
 
-    public Iterable<JobContext> jobsGetter() {
+    public Iterable<JobContext> activeJobs() {
         return jobsTable.values();
     }
 
-    public Iterable<?> jobsLogGetter() {
+    public Iterable<JobContextLog> jobsLog() {
         return jobsLog.get();
     }
 
-    public Iterable<OperationContext> operationsGetter() {
+    public Iterable<OperationContext> activeOperations() {
         return operationsTable.values();
     }
 
-    public Iterable<?> operationsLogGetter() {
+    public Iterable<OperationContextLog> operationsLog() {
         return operationsLog.get();
     }
 


### PR DESCRIPTION
Previously on each individual access of a property, a query was
triggered to retrieve the values required for the calculation of the
property.

There were several problems with the implementation:

  - it was very in-efficient and could lead to overloading of the
  threadpool
  - it resulted in cluster based metrics which is not ideal for monitoring
  - it had bugs in the calculation of the properties

This is a total rewrite of the calculation. It now utilizes a local
in-memory structure to calculate the metric.