### PR TITLE
fixed CrateDB-to-PG type mapping for field type `object_array`

### DIFF
--- a/sql/src/main/java/io/crate/protocols/postgres/types/PGTypes.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/PGTypes.java
@@ -60,7 +60,7 @@ public class PGTypes {
         .put(new ArrayType(DataTypes.STRING), PGArray.VARCHAR_ARRAY)
         .put(new ArrayType(DataTypes.GEO_POINT), PGArray.FLOAT8_ARRAY)
         .put(new ArrayType(DataTypes.GEO_SHAPE), PGArray.JSON_ARRAY)
-        .put(new ArrayType(DataTypes.OBJECT), JsonType.INSTANCE)
+        .put(new ArrayType(DataTypes.OBJECT), PGArray.JSON_ARRAY)
         .put(new SetType(DataTypes.BYTE), PGArray.CHAR_ARRAY) // postgres has no Set type, so map it to array
         .put(new SetType(DataTypes.SHORT), PGArray.INT2_ARRAY)
         .put(new SetType(DataTypes.INTEGER), PGArray.INT4_ARRAY)


### PR DESCRIPTION
Fields of type `object_array` have been returned with the `OID = 144` (same as `object`) which should be `OID = 199` (same as for `geo_shape` field type). I'm a bit unsure if this fix will affect a certain edge case for our JDBC driver. This [commit](https://github.com/crate/crate/commit/ab7c278b6a527cbafdc98116c7155fe6c400ac74) added the mapping previously. @mfussenegger what do you mean?

```sql
cr> select * from pg_catalog.pg_type where oid in (199, 114);
+-----+----------+---------+---------+
| oid | typdelim | typelem | typname |
+-----+----------+---------+---------+
| 199 | ,        |     114 | _json   |
| 114 | ,        |       0 | json    |
+-----+----------+---------+---------+
```