### PR TITLE
added logger warning when inserting to unavailable shards using bulk inserts

### DIFF
--- a/sql/src/main/java/org/elasticsearch/action/bulk/BulkShardProcessor.java
+++ b/sql/src/main/java/org/elasticsearch/action/bulk/BulkShardProcessor.java
@@ -225,6 +225,7 @@ public class BulkShardProcessor<Request extends ShardRequest> {
                 routing
             ).shardId();
         } catch (IndexNotFoundException e) {
+            LOGGER.warn(String.format(Locale.ENGLISH, "Trying to insert value into unavailable partition: %s", indexName));
             if (!autoCreateIndices) {
                 throw e;
             }


### PR DESCRIPTION
This extends 6b5dd0af6bd3226d9f9973477c84bab1c764dc80 and will result in a warning when bulk inserts or an insert-from-query is used.