### PR TITLE
Integrate circuit breaker into fetch-operation

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -44,8 +44,9 @@ Fixes
  - Fixed the calculation of the ``OverallQueryAverageDuration`` ``QueryStats``
    MBean.
 
- - The internal ``fetchSize`` now has an upper bound to prevent ``OutOfMemory``
-   errors if a postgres client retrieves a large result set without setting a
-   ``fetchSize``, or setting a ``fetchSize`` which is too large.
+ - The internal ``fetchSize`` is now dynamic based on configured heap and has
+   an upper bound to prevent ``OutOfMemory`` errors if a postgres client
+   retrieves a large result set without setting a ``fetchSize``, or setting a
+   ``fetchSize`` which is too large.
 
  - Log failed authentication attempts at log level ``WARN``

--- a/sql/src/main/java/io/crate/breaker/RamAccountingContext.java
+++ b/sql/src/main/java/io/crate/breaker/RamAccountingContext.java
@@ -27,9 +27,11 @@ import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
 import org.elasticsearch.common.logging.Loggers;
 
+import javax.annotation.concurrent.ThreadSafe;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicLong;
 
+@ThreadSafe
 public class RamAccountingContext {
 
     // Flush every 2mb

--- a/sql/src/main/java/io/crate/executor/transport/StreamBucketCollector.java
+++ b/sql/src/main/java/io/crate/executor/transport/StreamBucketCollector.java
@@ -48,7 +48,7 @@ public class StreamBucketCollector implements Collector<Row, StreamBucket.Builde
 
     @Override
     public Supplier<StreamBucket.Builder> supplier() {
-        return () -> new StreamBucket.Builder(streamers);
+        return () -> new StreamBucket.Builder(streamers, null);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/executor/transport/distributed/BroadcastingBucketBuilder.java
+++ b/sql/src/main/java/io/crate/executor/transport/distributed/BroadcastingBucketBuilder.java
@@ -41,7 +41,7 @@ public class BroadcastingBucketBuilder implements MultiBucketBuilder {
 
     public BroadcastingBucketBuilder(Streamer<?>[] streamers, int numBuckets) {
         this.numBuckets = numBuckets;
-        this.bucketBuilder = new StreamBucket.Builder(streamers);
+        this.bucketBuilder = new StreamBucket.Builder(streamers, null);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/executor/transport/distributed/ModuloBucketBuilder.java
+++ b/sql/src/main/java/io/crate/executor/transport/distributed/ModuloBucketBuilder.java
@@ -50,7 +50,7 @@ public class ModuloBucketBuilder implements MultiBucketBuilder {
         this.distributedByColumnIdx = distributedByColumnIdx;
         this.bucketBuilders = new ArrayList<>(numBuckets);
         for (int i = 0; i < numBuckets; i++) {
-            bucketBuilders.add(new StreamBucket.Builder(streamers));
+            bucketBuilders.add(new StreamBucket.Builder(streamers, null));
         }
     }
 

--- a/sql/src/main/java/io/crate/operation/projectors/ProjectionToProjectorVisitor.java
+++ b/sql/src/main/java/io/crate/operation/projectors/ProjectionToProjectorVisitor.java
@@ -436,7 +436,8 @@ public class ProjectionToProjectorVisitor
                 transportActionProvider.transportFetchNodeAction(),
                 projectorContext.nodeIdsToStreamers(),
                 context.jobId,
-                projection.collectPhaseId()
+                projection.collectPhaseId(),
+                context.ramAccountingContext
             ),
             functions,
             projection.outputSymbols(),

--- a/sql/src/main/java/io/crate/operation/projectors/fetch/TransportFetchOperation.java
+++ b/sql/src/main/java/io/crate/operation/projectors/fetch/TransportFetchOperation.java
@@ -26,6 +26,7 @@ import com.carrotsearch.hppc.IntContainer;
 import com.carrotsearch.hppc.IntObjectMap;
 import io.crate.Streamer;
 import io.crate.action.FutureActionListener;
+import io.crate.breaker.RamAccountingContext;
 import io.crate.data.Bucket;
 import io.crate.executor.transport.NodeFetchRequest;
 import io.crate.executor.transport.NodeFetchResponse;
@@ -43,15 +44,18 @@ public class TransportFetchOperation implements FetchOperation {
     private final Map<String, ? extends IntObjectMap<Streamer[]>> nodeIdToReaderIdToStreamers;
     private final UUID jobId;
     private final int executionPhaseId;
+    private final RamAccountingContext ramAccountingContext;
 
     public TransportFetchOperation(TransportFetchNodeAction transportFetchNodeAction,
                                    Map<String, ? extends IntObjectMap<Streamer[]>> nodeIdToReaderIdToStreamers,
                                    UUID jobId,
-                                   int executionPhaseId) {
+                                   int executionPhaseId,
+                                   RamAccountingContext ramAccountingContext) {
         this.transportFetchNodeAction = transportFetchNodeAction;
         this.nodeIdToReaderIdToStreamers = nodeIdToReaderIdToStreamers;
         this.jobId = jobId;
         this.executionPhaseId = executionPhaseId;
+        this.ramAccountingContext = ramAccountingContext;
     }
 
     @Override
@@ -63,6 +67,7 @@ public class TransportFetchOperation implements FetchOperation {
             nodeId,
             nodeIdToReaderIdToStreamers.get(nodeId),
             new NodeFetchRequest(jobId, executionPhaseId, closeContext, toFetch),
+            ramAccountingContext,
             listener);
         return listener;
     }

--- a/sql/src/main/java/io/crate/planner/projection/FetchProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/FetchProjection.java
@@ -22,6 +22,7 @@
 package io.crate.planner.projection;
 
 import com.carrotsearch.hppc.IntSet;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.collections.Lists2;
@@ -30,6 +31,7 @@ import io.crate.operation.Paging;
 import io.crate.planner.ExplainLeaf;
 import io.crate.planner.node.fetch.FetchSource;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.monitor.jvm.JvmInfo;
 
 import java.io.IOException;
 import java.util.List;
@@ -38,6 +40,9 @@ import java.util.TreeMap;
 import java.util.function.Function;
 
 public class FetchProjection extends Projection {
+
+    private static final int HEAP_IN_MB = (int) JvmInfo.jvmInfo().getConfiguredMaxHeapSize() / (1024 * 1024);
+    private static final int MAX_FETCH_SIZE = maxFetchSize(HEAP_IN_MB);
 
     private final int collectPhaseId;
     private final int fetchSize;
@@ -48,19 +53,47 @@ public class FetchProjection extends Projection {
     private final Map<String, TableIdent> indicesToIdents;
 
     public FetchProjection(int collectPhaseId,
-                           int fetchSize,
+                           int suppliedFetchSize,
                            Map<TableIdent, FetchSource> fetchSources,
                            List<Symbol> outputSymbols,
                            Map<String, IntSet> nodeReaders,
                            TreeMap<Integer, String> readerIndices,
                            Map<String, TableIdent> indicesToIdents) {
         this.collectPhaseId = collectPhaseId;
-        this.fetchSize = fetchSize == 0 ? Paging.PAGE_SIZE : Math.min(fetchSize, Paging.PAGE_SIZE);
         this.fetchSources = fetchSources;
         this.outputSymbols = outputSymbols;
         this.nodeReaders = nodeReaders;
         this.readerIndices = readerIndices;
         this.indicesToIdents = indicesToIdents;
+        this.fetchSize = boundedFetchSize(suppliedFetchSize, MAX_FETCH_SIZE);
+    }
+
+    @VisibleForTesting
+    static int maxFetchSize(int maxHeapInMb) {
+        /* These values were chosen after some manuel testing with a single node started with
+         * different heap configurations:  56mb, 256mb and 2048mb
+         *
+         * This should result in fetchSizes that err on the safe-side to prevent out of memory issues.
+         * And yet they get large quickly enough that  on a decently sized cluster it's on the maximum
+         * (4gb heap already has a fetchSize of 500000)
+         *
+         * The returned maxFetchSize may still be too large in case of very large result payloads,
+         * but there's still a circuit-breaker which should prevent OOM errors.
+         */
+        int x0 = 56;
+        int y0 = 2000;
+        int x1 = 256;
+        int y1 = 30000;
+        // linear interpolation formula.
+        return Math.min(y0 + (maxHeapInMb - x0) * ((y1 - y0) / (x1 - x0)), Paging.PAGE_SIZE);
+    }
+
+    @VisibleForTesting
+    static int boundedFetchSize(int suppliedFetchSize, int maxSize) {
+        if (suppliedFetchSize == 0) {
+            return maxSize;
+        }
+        return Math.min(suppliedFetchSize, maxSize);
     }
 
     public int collectPhaseId() {
@@ -134,7 +167,8 @@ public class FetchProjection extends Projection {
     public Map<String, Object> mapRepresentation() {
         return ImmutableMap.of(
             "type", "Fetch",
-            "outputs", ExplainLeaf.printList(outputSymbols)
+            "outputs", ExplainLeaf.printList(outputSymbols),
+            "fetchSize", fetchSize
         );
     }
 }

--- a/sql/src/test/java/io/crate/executor/transport/NodeFetchResponseTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/NodeFetchResponseTest.java
@@ -28,45 +28,83 @@ import com.carrotsearch.hppc.IntObjectHashMap;
 import com.carrotsearch.hppc.IntObjectMap;
 import com.google.common.collect.Iterables;
 import io.crate.Streamer;
+import io.crate.breaker.RamAccountingContext;
 import io.crate.data.Row;
 import io.crate.data.RowN;
+import io.crate.test.integration.CrateUnitTest;
 import io.crate.types.DataTypes;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.breaker.MemoryCircuitBreaker;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import static io.crate.testing.TestingHelpers.isRow;
-import static org.junit.Assert.assertThat;
 
-public class NodeFetchResponseTest {
+public class NodeFetchResponseTest extends CrateUnitTest {
 
-    @Test
-    public void testStreaming() throws Exception {
+    private IntObjectMap<Streamer[]> streamers;
+    private IntObjectMap<StreamBucket> fetched;
+    private long originalFlushBufferSize = RamAccountingContext.FLUSH_BUFFER_SIZE;
+    private RamAccountingContext ramAccountingContext = new RamAccountingContext("dummy", new NoopCircuitBreaker("dummy"));
+
+    @Before
+    public void setUpStreamBucketsAndStreamer() throws Exception {
+        originalFlushBufferSize = RamAccountingContext.FLUSH_BUFFER_SIZE;
+        RamAccountingContext.FLUSH_BUFFER_SIZE = 2;
+        streamers = new IntObjectHashMap<>(1);
+        streamers.put(1, new Streamer[]{DataTypes.BOOLEAN.streamer()});
 
         IntObjectHashMap<IntContainer> toFetch = new IntObjectHashMap<>();
         IntHashSet docIds = new IntHashSet(3);
         toFetch.put(1, docIds);
-
-        IntObjectMap<Streamer[]> streamers = new IntObjectHashMap<>(1);
-        streamers.put(1, new Streamer[]{DataTypes.BOOLEAN.streamer()});
-
-        StreamBucket.Builder builder = new StreamBucket.Builder(streamers.get(1));
+        StreamBucket.Builder builder = new StreamBucket.Builder(streamers.get(1), ramAccountingContext);
         builder.add(new RowN(new Object[]{true}));
-        IntObjectHashMap<StreamBucket> fetched = new IntObjectHashMap<>(1);
+        fetched = new IntObjectHashMap<>(1);
         fetched.put(1, builder.build());
+    }
 
+    @After
+    public void reset() throws Exception {
+        RamAccountingContext.FLUSH_BUFFER_SIZE = originalFlushBufferSize;
+    }
+
+    @Test
+    public void testStreaming() throws Exception {
         NodeFetchResponse orig = NodeFetchResponse.forSending(fetched);
 
         BytesStreamOutput out = new BytesStreamOutput();
         orig.writeTo(out);
 
-
         StreamInput in = out.bytes().streamInput();
 
         // receiving side is required to set the streamers
-        NodeFetchResponse streamed = NodeFetchResponse.forReceiveing(streamers);
+        NodeFetchResponse streamed = NodeFetchResponse.forReceiveing(streamers, ramAccountingContext);
         streamed.readFrom(in);
 
         assertThat((Row) Iterables.getOnlyElement(streamed.fetched().get(1)), isRow(true));
+    }
+
+    @Test
+    public void testResponseCircuitBreaker() throws Exception {
+        NodeFetchResponse orig = NodeFetchResponse.forSending(fetched);
+        BytesStreamOutput out = new BytesStreamOutput();
+        orig.writeTo(out);
+        StreamInput in = out.bytes().streamInput();
+
+        NodeFetchResponse nodeFetchResponse = NodeFetchResponse.forReceiveing(
+            streamers,
+            new RamAccountingContext("test",
+                new MemoryCircuitBreaker(
+                    new ByteSizeValue(2, ByteSizeUnit.BYTES), 1.0, Loggers.getLogger(NodeFetchResponseTest.class))));
+
+        expectedException.expect(CircuitBreakingException.class);
+        nodeFetchResponse.readFrom(in);
     }
 }

--- a/sql/src/test/java/io/crate/operation/fetch/NodeFetchOperationTest.java
+++ b/sql/src/test/java/io/crate/operation/fetch/NodeFetchOperationTest.java
@@ -27,6 +27,7 @@ import com.google.common.util.concurrent.MoreExecutors;
 import io.crate.jobs.JobContextService;
 import io.crate.operation.collect.stats.JobsLogs;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.settings.Settings;
 import org.junit.Test;
 
@@ -43,7 +44,8 @@ public class NodeFetchOperationTest extends CrateDummyClusterServiceUnitTest {
         NodeFetchOperation fetchOperation = new NodeFetchOperation(
             MoreExecutors.directExecutor(),
             jobsLogs,
-            new JobContextService(Settings.EMPTY, clusterService, jobsLogs));
+            new JobContextService(Settings.EMPTY, clusterService, jobsLogs),
+            new NoopCircuitBreaker("dummy"));
 
         fetchOperation.fetch(UUID.randomUUID(), 1, null, true).get(5, TimeUnit.SECONDS);
 

--- a/sql/src/test/java/io/crate/planner/projection/FetchProjectionTest.java
+++ b/sql/src/test/java/io/crate/planner/projection/FetchProjectionTest.java
@@ -22,11 +22,7 @@
 
 package io.crate.planner.projection;
 
-import io.crate.operation.Paging;
 import org.junit.Test;
-
-import java.util.Collections;
-import java.util.TreeMap;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -34,22 +30,17 @@ import static org.junit.Assert.assertThat;
 public class FetchProjectionTest {
 
     @Test
-    public void testFetchSizeHasUpperBound() throws Exception {
-        assertThat(getFetchProjection(0).getFetchSize(), is(Paging.PAGE_SIZE));
-
-        assertThat(getFetchProjection(Integer.MAX_VALUE).getFetchSize(), is(Paging.PAGE_SIZE));
+    public void testMaxFetchSize() throws Exception {
+        assertThat(FetchProjection.maxFetchSize(56), is(2_000));
+        assertThat(FetchProjection.maxFetchSize(256), is(30_000));
+        assertThat(FetchProjection.maxFetchSize(512), is(65_840));
+        assertThat(FetchProjection.maxFetchSize(1024), is(137_520));
+        assertThat(FetchProjection.maxFetchSize(2048), is(280_880));
+        assertThat(FetchProjection.maxFetchSize(4096), is(500_000));
     }
 
-
-    private static FetchProjection getFetchProjection(int fetchSize) {
-        return new FetchProjection(
-                1,
-                fetchSize,
-                Collections.emptyMap(),
-                Collections.emptyList(),
-                Collections.emptyMap(),
-                new TreeMap<>(),
-                Collections.emptyMap()
-            );
+    @Test
+    public void testBoundedFetchSize() throws Exception {
+        assertThat(FetchProjection.boundedFetchSize(0, 65_840), is(65_840));
     }
 }


### PR DESCRIPTION
This integrates the circuit breaker into the fetch-operation and also
adds some logic to choose the (max) fetchSize based on configured heap instead
of having a fixed value.

The dynamic fetchSize limits are mostly relevant for low-heap nodes (<
2GB)

Depending on the number of concurrent requests it's still possible that
a node can run out-of-memory. But this commit should reduce the chance
of that happening.