### PR TITLE
adopt ulimits on TravisCI to reflect important system settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,8 @@ notifications:
   email: false
 
 before_install:
-  - ulimit -u 65535
+  - ulimit -u 2048
+  - ulimit -n 65536
 
 script:
   - ./gradlew -s test


### PR DESCRIPTION
according to ES 5.0 upgrade it is necessary to increase the limits of
open file descriptors and adapt the number of threads.

https://www.elastic.co/guide/en/elasticsearch/reference/5.4/system-config.html