### PR TITLE
Skip paging orderby optimization for system columns

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -50,3 +50,5 @@ Fixes
    ``fetchSize`` which is too large.
 
  - Log failed authentication attempts at log level ``WARN``
+
+ - Fix NPE when ordering by system columns

--- a/sql/src/test/java/io/crate/operation/collect/collectors/LuceneOrderedDocCollectorTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/collectors/LuceneOrderedDocCollectorTest.java
@@ -30,6 +30,7 @@ import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.TableIdent;
+import io.crate.metadata.doc.DocSysColumns;
 import io.crate.operation.reference.doc.lucene.LuceneMissingValue;
 import io.crate.types.DataTypes;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
@@ -56,6 +57,7 @@ import java.util.Collections;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertNull;
 
 public class LuceneOrderedDocCollectorTest extends RandomizedTest {
 
@@ -214,5 +216,28 @@ public class LuceneOrderedDocCollectorTest extends RandomizedTest {
         assertThat(result, is(new Long[]{null, null, 2L, 1L}));
 
         reader.close();
+    }
+
+
+    @Test
+    public void testSearchAfterWithSystemColumn() throws Exception {
+        Reference sysColReference =
+            new Reference(
+                new ReferenceIdent(
+                    new TableIdent(null, "table"),
+                    DocSysColumns.SCORE),
+                RowGranularity.DOC, DataTypes.FLOAT);
+
+        OrderBy orderBy = new OrderBy(ImmutableList.of(sysColReference, REFERENCE),
+            new boolean[]{false, false},
+            new Boolean[]{false, false});
+
+        FieldDoc lastCollected = new FieldDoc(0, 0, new Object[]{2L});
+
+        Query nextPageQuery = LuceneOrderedDocCollector.nextPageQuery(
+            lastCollected, orderBy, new Object[]{}, name -> valueFieldType);
+
+        // returns null which leads to reuse of old query without paging optimization
+        assertNull(nextPageQuery);
     }
 }


### PR DESCRIPTION
During the paging query optimization, LuceneOrderedDocCollector.nextPageQuery
would run into a NPE because it can't find the _score field in the field
type map. The solution is to skip this optimization in the presence of
system columns.

This fixes #5601.