### PR TITLE
revert ulimit of nr of processes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ notifications:
   email: false
 
 before_install:
-  - ulimit -u 2048
+  - ulimit -u 65535
   - ulimit -n 65536
 
 script:


### PR DESCRIPTION
this will revert 5f80c9c5c7fa7ff951946462e2b9281d515230c6 which
introduced an OOM error during TravisCI tests.