### PR TITLE
Adopt java options for TravisCI build/test process 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
   global:
     - secure: "LLqhKxqgRMp/C/TzZWv8YuhpmEm1twggm76NBUAQfZmOPLCkQSpAO8hoBM3qaIlDPSKPgoYj9f0TBuNi0iIFghQf0Xc4pXPCV0AnoGpXwRGiJATTAXfnG7RBa/hXRRBeAKlGmAI9GLtIoCQbUKYhq8gqwbzQVQXq+90rhsMH4zo="
     - CRATE_TESTS_SQL_REQUEST_TIMEOUT="20"
-    - _JAVA_OPTIONS="-Xmx1g"
+    - _JAVA_OPTIONS="-Xms1g -Xmx1g"
 
 
 before_cache:


### PR DESCRIPTION
This setting will ensure that a job won't get killed during the tests on TravisCI.