### PR TITLE
Fix ArrayIndexOutOfBoundsException on sys.shards group by queries

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -30,6 +30,9 @@ Changes
 Fixes
 =====
 
+ - Fixed an issue that led to ``ArrayIndexOutOfBoundsException`` on
+   ``DISTINCT`` or ``GROUP BY`` queries on the ``sys.shards`` table.
+
  - Fixed an issue that could cause ``sys.operations`` entries to remain even
    after the operation has finished.
 

--- a/sql/src/main/java/io/crate/operation/collect/sources/ShardCollectSource.java
+++ b/sql/src/main/java/io/crate/operation/collect/sources/ShardCollectSource.java
@@ -490,7 +490,7 @@ public class ShardCollectSource extends AbstractComponent implements CollectSour
         }
         return BatchIteratorCollectorBridge.newInstance(
             RowsBatchIterator.newInstance(
-                Iterables.transform(rows, Buckets.arrayToRowFunction()), collectPhase.outputTypes().size()),
+                Iterables.transform(rows, Buckets.arrayToRowFunction()), collectPhase.toCollect().size()),
             consumer
         );
     }

--- a/sql/src/test/java/io/crate/integrationtests/SysShardsTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysShardsTest.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static io.crate.testing.TestingHelpers.printedTable;
 import static io.crate.testing.TestingHelpers.resolveCanonicalString;
 import static org.hamcrest.Matchers.*;
 
@@ -400,5 +401,14 @@ public class SysShardsTest extends SQLTransportIntegrationTest {
         expectedException.expect(SQLActionException.class);
         expectedException.expectMessage(" / by zero");
         execute("select 1/0 from sys.shards");
+    }
+
+    @Test
+    public void testDistinctConcat() throws Exception {
+        execute("SELECT distinct concat(schema_name, '.', table_name) as t FROM sys.shards order by 1");
+        assertThat(printedTable(response.rows()),
+            is("blob.blobs\n" +
+               "doc.characters\n" +
+               "doc.quotes\n"));
     }
 }


### PR DESCRIPTION
`numColumns` of the BatchIterator was set incorrectly.


master / 2.0 is not affected (at least not with this particular query, because the planner generates a slightly different plan)