### PR TITLE
[backport] Skip paging orderby optimization for system columns

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -50,6 +50,8 @@ Fixes
  - Fixed a race condition that could lead to ``KILL (ALL)`` causing queries to
    get stuck instead of interrupting them.
 
+ - Fix NPE when ordering by system columns
+
  - Fixed validation so that ``SELECT DISTINCT`` can be used only if there
    is no ``GROUP BY`` present or if the set of ``GROUP BY`` expressions is
    the same as the set ``SELECT`` expressions.


### PR DESCRIPTION
During the paging query optimization, LuceneOrderedDocCollector.nextPageQuery
would run into a NPE because it can't find the _score field in the field
type map. The solution is to skip this optimization in the presence of
system columns.

This fixes #5601.