### PR TITLE
Decouple AuthenticationMethod from protocol implementation

### DIFF
--- a/sql/src/main/java/io/crate/operation/auth/AuthenticationMethod.java
+++ b/sql/src/main/java/io/crate/operation/auth/AuthenticationMethod.java
@@ -23,34 +23,20 @@
 package io.crate.operation.auth;
 
 import io.crate.operation.user.User;
-import io.netty.channel.Channel;
 
-import java.util.concurrent.CompletableFuture;
+import javax.annotation.Nullable;
 
-/**
- * Common interface for Authentication methods.
- *
- * An auth method must provide a unique name which is exposed via the {@link #name()} method.
- *
- * It is also responsible for authentication for the Postgres Wire Protocol,
- * {@link #pgAuthenticate(Channel channel, String userName)},
- */
 public interface AuthenticationMethod {
     /**
-     * Authenticates the Postgres Wire Protocol client,
-     * sends AuthenticationOK if authentication is successful
-     * If authentication fails a throwable is passed to the future
-     * @param channel request channel
      * @param userName the userName sent with the startup message
-     * @return Future with authenticated user or null
-     *
+     * @return the user or null; null should be handled as if it's a "guest" user
+     * @throws RuntimeException if the authentication failed
      */
-    CompletableFuture<User> pgAuthenticate(Channel channel, String userName);
+    @Nullable
+    User authenticate(String userName);
 
     /**
-     * @return name of the authentication method
+     * @return unique name of the authentication method
      */
     String name();
-
-    CompletableFuture<User> httpAuthentication(String userName);
 }

--- a/sql/src/main/java/io/crate/operation/auth/AuthenticationProvider.java
+++ b/sql/src/main/java/io/crate/operation/auth/AuthenticationProvider.java
@@ -26,10 +26,8 @@ import com.google.common.annotations.VisibleForTesting;
 import io.crate.operation.user.User;
 import io.crate.operation.user.UserManagerProvider;
 import io.crate.plugin.PipelineRegistry;
-import io.crate.protocols.postgres.Messages;
 import io.crate.settings.CrateSetting;
 import io.crate.types.DataTypes;
-import io.netty.channel.Channel;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Provider;
 import org.elasticsearch.common.inject.Singleton;
@@ -37,7 +35,6 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 
 import java.net.InetAddress;
-import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
 
@@ -67,21 +64,13 @@ public class AuthenticationProvider implements Provider<Authentication> {
 
         private final AuthenticationMethod alwaysOk = new AuthenticationMethod() {
             @Override
-            public CompletableFuture<User> pgAuthenticate(Channel channel, String userName) {
-                CompletableFuture<User> future = new CompletableFuture<>();
-                Messages.sendAuthenticationOK(channel)
-                    .addListener(f -> future.complete(null));
-                return future;
+            public User authenticate(String userName) {
+                return null;
             }
 
             @Override
             public String name() {
                 return "alwaysOk";
-            }
-
-            @Override
-            public CompletableFuture<User> httpAuthentication(String userName) {
-                return CompletableFuture.completedFuture(null);
             }
         };
 

--- a/users/src/test/java/io/crate/http/netty/HttpAuthUpstreamHandlerTest.java
+++ b/users/src/test/java/io/crate/http/netty/HttpAuthUpstreamHandlerTest.java
@@ -18,7 +18,6 @@
 
 package io.crate.http.netty;
 
-import io.crate.concurrent.CompletableFutures;
 import io.crate.operation.auth.Authentication;
 import io.crate.operation.auth.AuthenticationMethod;
 import io.crate.operation.auth.AuthenticationProvider;
@@ -26,7 +25,6 @@ import io.crate.operation.auth.HbaProtocol;
 import io.crate.operation.user.User;
 import io.crate.test.integration.CrateUnitTest;
 import io.netty.buffer.Unpooled;
-import io.netty.channel.Channel;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.*;
 import org.elasticsearch.common.settings.Settings;
@@ -35,7 +33,6 @@ import org.junit.Test;
 import javax.annotation.Nullable;
 import java.net.InetAddress;
 import java.nio.charset.StandardCharsets;
-import java.util.concurrent.CompletableFuture;
 
 import static org.hamcrest.core.Is.is;
 
@@ -44,18 +41,13 @@ public class HttpAuthUpstreamHandlerTest extends CrateUnitTest {
     private final AuthenticationMethod denyAll = new AuthenticationMethod() {
 
         @Override
-        public CompletableFuture<User> pgAuthenticate(Channel channel, String userName) {
-            return CompletableFutures.failedFuture(new Throwable("denied"));
+        public User authenticate(String userName) {
+            throw new RuntimeException("denied");
         }
 
         @Override
         public String name() {
             return "denyAll";
-        }
-
-        @Override
-        public CompletableFuture<User> httpAuthentication(String userName) {
-            return CompletableFutures.failedFuture(new Throwable("denied"));
         }
     };
 

--- a/users/src/test/java/io/crate/operation/auth/AuthenticationMethodTest.java
+++ b/users/src/test/java/io/crate/operation/auth/AuthenticationMethodTest.java
@@ -27,8 +27,6 @@ import io.crate.operation.user.User;
 import io.crate.operation.user.UserManager;
 import io.crate.operation.user.UserManagerService;
 import io.crate.test.integration.CrateUnitTest;
-import io.netty.channel.Channel;
-import io.netty.channel.embedded.EmbeddedChannel;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.junit.Test;
 
@@ -55,18 +53,9 @@ public class AuthenticationMethodTest extends CrateUnitTest {
         TrustAuthentication trustAuth = new TrustAuthentication(fakeUserManager);
         assertThat(trustAuth.name(), is("trust"));
 
-        Channel ch = new EmbeddedChannel();
+        assertThat(trustAuth.authenticate("crate").name(), is("crate"));
 
-        trustAuth.pgAuthenticate(ch, "crate")
-            .whenComplete((user, throwable) -> {
-                assertThat(user.name(), is("crate"));
-                assertNull(throwable);
-            });
-
-        trustAuth.pgAuthenticate(ch, "cr8")
-            .whenComplete((success, throwable) -> {
-                assertNotNull(throwable);
-            });
-
+        expectedException.expectMessage("trust authentication failed for user \"cr8\"");
+        trustAuth.authenticate("cr8");
     }
 }

--- a/users/src/test/java/io/crate/operation/auth/HostBasedAuthenticationTest.java
+++ b/users/src/test/java/io/crate/operation/auth/HostBasedAuthenticationTest.java
@@ -21,19 +21,18 @@ package io.crate.operation.auth;
 import com.google.common.collect.ImmutableMap;
 import io.crate.operation.user.User;
 import io.crate.test.integration.CrateUnitTest;
-import io.netty.channel.Channel;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.settings.Settings;
 import org.junit.Before;
 import org.junit.Test;
 
+import javax.annotation.Nullable;
 import java.net.InetAddress;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
 import static io.crate.operation.auth.HostBasedAuthentication.Matchers.*;
 import static org.hamcrest.core.Is.is;
@@ -116,19 +115,15 @@ public class HostBasedAuthenticationTest extends CrateUnitTest {
     public void testResolveAuthMethod() throws Exception {
         AuthenticationMethod noopAuthMethod = new AuthenticationMethod() {
 
+            @Nullable
             @Override
-            public CompletableFuture<User> pgAuthenticate(Channel channel, String userName) {
+            public User authenticate(String userName) {
                 return null;
             }
 
             @Override
             public String name() {
                 return "trust";
-            }
-
-            @Override
-            public CompletableFuture<User> httpAuthentication(String userName) {
-                return null;
             }
         };
         authService.registerAuthMethod(noopAuthMethod.name(), () -> noopAuthMethod);


### PR DESCRIPTION
The interface contained separate methods for http and pg - the intention
was to be able to support more complex authentication methods - e.g.
password authentication.

But these will require a more complicated message flow - so we'll have
to re-model the interface and we should try to decouple the state
changes from the protocol implementation.