### PR TITLE
Expose additional fields on information_schema so that it conforms to the SQL-99 standard

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -18,6 +18,9 @@ Breaking Changes
 Changes
 =======
 
+ - Expose fields for ``information_schema.columns`` and
+   ``information_schema.tables`` so that it conforms to SQL-99 standard.
+
  - Improved the resiliency of the retrieval of large results via HTTP. Queries
    are now aborted and result in an error if they consume too much memory.
 

--- a/blackbox/docs/sql/information_schema.txt
+++ b/blackbox/docs/sql/information_schema.txt
@@ -84,6 +84,46 @@ columns::
     +-------------------+--------------+----------------+--------...-+
     SELECT 5 rows in set (... sec)
 
+Tables Specification
+--------------------
+
++----------------------------------+------------------------------------------------------------------------------------+-------------+
+| Name                             | Description                                                                        | Data Type   |
++==================================+====================================================================================+=============+
+| ``blobs_path``                   | The data path of the blob table                                                    | ``String``  |
++----------------------------------+------------------------------------------------------------------------------------+-------------+
+| ``closed``                       | The state of the table                                                             | ``Boolean`` |
++----------------------------------+------------------------------------------------------------------------------------+-------------+
+| ``clustered_by``                 | The routing column used to cluster the table                                       | ``String``  |
++----------------------------------+------------------------------------------------------------------------------------+-------------+
+| ``column_policy``                | Defines whether the table uses a ``STRICT`` or a ``DYNAMIC`` :ref:`column_policy`  | ``String``  |
++----------------------------------+------------------------------------------------------------------------------------+-------------+
+| ``number_of_replicas``           | The number of replicas the table currently has                                     | ``Integer`` |
++----------------------------------+------------------------------------------------------------------------------------+-------------+
+| ``number_of_shards``             | The number of shards the table is currently distributed across                     | ``Integer`` |
++----------------------------------+------------------------------------------------------------------------------------+-------------+
+| ``partitioned_by``               | The column used to partition the table                                             | ``String``  |
++----------------------------------+------------------------------------------------------------------------------------+-------------+
+| ``reference_generation``         | Specifies how values in the self-referencing column are generated                  | ``String``  |
++----------------------------------+------------------------------------------------------------------------------------+-------------+
+| ``routing_hash_function``        | The hash function used for internal routing                                        | ``String``  |
++----------------------------------+------------------------------------------------------------------------------------+-------------+
+| ``self_referencing_column_name`` | The name of the column that uniquely identifies each row (always ``_id``)          | ``String``  |
++----------------------------------+------------------------------------------------------------------------------------+-------------+
+| ``settings``                     | :ref:`conf_table_settings`                                                         | ``Object``  |
++----------------------------------+------------------------------------------------------------------------------------+-------------+
+| ``table_catalog``                | Refers to the ``table_schema``                                                     | ``String``  |
++----------------------------------+------------------------------------------------------------------------------------+-------------+
+| ``table_name``                   | The name of the table                                                              | ``String``  |
++----------------------------------+------------------------------------------------------------------------------------+-------------+
+| ``table_schema``                 | The name of the schema the table belongs to                                        | ``String``  |
++----------------------------------+------------------------------------------------------------------------------------+-------------+
+| ``table_type``                   | The type of the table (always ``BASE TABLE``)                                      | ``String``  |
++----------------------------------+------------------------------------------------------------------------------------+-------------+
+| ``version``                      | A collection of version numbers relevent to the table                              | ``Object``  |
++----------------------------------+------------------------------------------------------------------------------------+-------------+
+
+
 Columns
 =======
 
@@ -126,25 +166,141 @@ You can even query this tables' own columns (attention: this might lead to infin
     ... from information_schema.columns
     ... where table_schema = 'information_schema'
     ... and table_name = 'columns' order by ordinal_position asc;
-    +-----------------------+-----------+------------------+
-    | column_name           | data_type | ordinal_position |
-    +-----------------------+-----------+------------------+
-    | column_name           | string    |                1 |
-    | data_type             | string    |                2 |
-    | generation_expression | string    |                3 |
-    | is_generated          | boolean   |                4 |
-    | is_nullable           | boolean   |                5 |
-    | ordinal_position      | short     |                6 |
-    | table_name            | string    |                7 |
-    | table_schema          | string    |                8 |
-    +-----------------------+-----------+------------------+
-    SELECT 8 rows in set (... sec)
+    +---------------------------+-----------+------------------+
+    | column_name               | data_type | ordinal_position |
+    +---------------------------+-----------+------------------+
+    | character_maximum_length  | integer   |                1 |
+    | character_octet_length    | integer   |                2 |
+    | character_set_catalog     | string    |                3 |
+    | character_set_name        | string    |                4 |
+    | character_set_schema      | string    |                5 |
+    | check_action              | integer   |                6 |
+    | check_references          | string    |                7 |
+    | collation_catalog         | string    |                8 |
+    | collation_name            | string    |                9 |
+    | collation_schema          | string    |               10 |
+    | column_default            | string    |               11 |
+    | column_name               | string    |               12 |
+    | data_type                 | string    |               13 |
+    | datetime_precision        | integer   |               14 |
+    | domain_catalog            | string    |               15 |
+    | domain_name               | string    |               16 |
+    | domain_schema             | string    |               17 |
+    | generation_expression     | string    |               18 |
+    | interval_precision        | integer   |               19 |
+    | interval_type             | string    |               20 |
+    | is_generated              | boolean   |               21 |
+    | is_nullable               | boolean   |               22 |
+    | numeric_precision         | integer   |               23 |
+    | numeric_precision_radix   | integer   |               24 |
+    | numeric_scale             | integer   |               25 |
+    | ordinal_position          | short     |               26 |
+    | table_catalog             | string    |               27 |
+    | table_name                | string    |               28 |
+    | table_schema              | string    |               29 |
+    | user_defined_type_catalog | string    |               30 |
+    | user_defined_type_name    | string    |               31 |
+    | user_defined_type_schema  | string    |               32 |
+    +---------------------------+-----------+------------------+
+    SELECT 32 rows in set (... sec)
 
 .. note::
 
   Columns are always sorted alphabetically in ascending order regardless of the order
   they were defined on table creation. Thus the ``ordinal_position`` reflects the alphabetical
   position.
+
+
+Columns Specification
+---------------------
+
++-------------------------------+-----------------------------------------------+---------------+
+|            Name               |                Description                    |   Data Type   |
++===============================+===============================================+===============+
+| ``table_catalog``             | Refers to the ``table_schema``                | ``String``    |
++-------------------------------+-----------------------------------------------+---------------+
+| ``table_schema``              | Schema name containing the table              | ``String``    |
++-------------------------------+-----------------------------------------------+---------------+
+| ``table_name``                | Table Name                                    | ``String``    |
++-------------------------------+-----------------------------------------------+---------------+
+| ``column_name``               | Column Name                                   | ``String``    |
++-------------------------------+-----------------------------------------------+---------------+
+| ``ordinal_position``          | The position of the column within the         | ``Integer``   |
+|                               | table                                         |               |
++-------------------------------+-----------------------------------------------+---------------+
+| ``is_nullable``               | Whether the column is nullable                | ``Boolean``   |
++-------------------------------+-----------------------------------------------+---------------+
+| ``data_type``                 | The data type of the column                   | ``String``    |
+|                               |                                               |               |
+|                               | For further information see                   |               |
+|                               | :doc:`/sql/data_types`                        |               |
++-------------------------------+-----------------------------------------------+---------------+
+| ``column_default``            | Not implemented                               | ``String``    |
++-------------------------------+-----------------------------------------------+---------------+
+| ``character_maximum_length``  | Not implemented                               | ``Integer``   |
+|                               |                                               |               |
+|                               | Please refer to :ref:`data-type-string` type  |               |
++-------------------------------+-----------------------------------------------+---------------+
+| ``character_octet_length``    | Not implemented                               | ``Integer``   |
+|                               |                                               |               |
+|                               | Please refer to :ref:`data-type-string` type  |               |
++-------------------------------+-----------------------------------------------+---------------+
+| ``numeric_precision``         | Indicates the number of significant digits    | ``Integer``   |
+|                               | for a numeric ``data_type``. For all other    |               |
+|                               | data types this column is ``null``.           |               |
++-------------------------------+-----------------------------------------------+---------------+
+| ``numeric_precision_radix``   | Indicates in which base the value in the      | ``Integer``   |
+|                               | column ``numeric_precision`` for a numeric    |               |
+|                               | ``data_type`` is exposed. This can either be  |               |
+|                               | 2 (binary) or 10 (decimal). For all other     |               |
+|                               | data types this column is ``null``.           |               |
++-------------------------------+-----------------------------------------------+---------------+
+| ``numeric_scale``             | Not implemented                               | ``Integer``   |
++-------------------------------+-----------------------------------------------+---------------+
+| ``datetime_precision``        | Contains the fractional seconds precision for | ``Integer``   |
+|                               | a ``timestamp`` ``data_type``. For all other  |               |
+|                               | data types this column is ``null``.           |               |
++-------------------------------+-----------------------------------------------+---------------+
+| ``interval_type``             | Not implemented                               | ``String``    |
++-------------------------------+-----------------------------------------------+---------------+
+| ``interval_precision``        | Not implemented                               | ``Integer``   |
++-------------------------------+-----------------------------------------------+---------------+
+| ``character_set_catalog``     | Not implemented                               | ``String``    |
++-------------------------------+-----------------------------------------------+---------------+
+| ``character_set_schema``      | Not implemented                               | ``String``    |
++-------------------------------+-----------------------------------------------+---------------+
+| ``character_set_name``        | Not implemented                               | ``String``    |
++-------------------------------+-----------------------------------------------+---------------+
+| ``collation_catalog``         | Not implemented                               | ``String``    |
++-------------------------------+-----------------------------------------------+---------------+
+| ``collation_schema``          | Not implemented                               | ``String``    |
++-------------------------------+-----------------------------------------------+---------------+
+| ``collation_name``            | Not implemented                               | ``String``    |
++-------------------------------+-----------------------------------------------+---------------+
+| ``domain_catalog``            | Not implemented                               | ``String``    |
++-------------------------------+-----------------------------------------------+---------------+
+| ``domain_schema``             | Not implemented                               | ``String``    |
++-------------------------------+-----------------------------------------------+---------------+
+| ``domain_name``               | Not implemented                               | ``String``    |
++-------------------------------+-----------------------------------------------+---------------+
+| ``user_defined_type_catalog`` | Not implemented                               | ``String``    |
++-------------------------------+-----------------------------------------------+---------------+
+| ``user_defined_type_schema``  | Not implemented                               | ``String``    |
++-------------------------------+-----------------------------------------------+---------------+
+| ``user_defined_type_name``    | Not implemented                               | ``String``    |
++-------------------------------+-----------------------------------------------+---------------+
+| ``check_references``          | Not implemented                               | ``String``    |
++-------------------------------+-----------------------------------------------+---------------+
+| ``check_action``              | Not implemented                               | ``Integer``   |
++-------------------------------+-----------------------------------------------+---------------+
+| ``generation_expression``     | The expression used to generate ad column.    | ``String``    |
+|                               | If the column is not generated ``null`` is    |               |
+|                               | returned.                                     |               |
++-------------------------------+-----------------------------------------------+---------------+
+| ``is_generated``              | Returns ``true`` or ``false`` wether the      | ``Boolean``   |
+|                               | column is generated or not                    |               |
++-------------------------------+-----------------------------------------------+---------------+
+
 
 Table Constraints
 =================

--- a/sql/src/main/java/io/crate/metadata/information/InformationColumnsTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/information/InformationColumnsTableInfo.java
@@ -37,23 +37,71 @@ public class InformationColumnsTableInfo extends InformationTableInfo {
     public static class Columns {
         public static final ColumnIdent TABLE_SCHEMA = new ColumnIdent("table_schema");
         public static final ColumnIdent TABLE_NAME = new ColumnIdent("table_name");
+        public static final ColumnIdent TABLE_CATALOG = new ColumnIdent("table_catalog");
         public static final ColumnIdent COLUMN_NAME = new ColumnIdent("column_name");
         public static final ColumnIdent ORDINAL_POSITION = new ColumnIdent("ordinal_position");
         public static final ColumnIdent DATA_TYPE = new ColumnIdent("data_type");
         public static final ColumnIdent IS_GENERATED = new ColumnIdent("is_generated");
         public static final ColumnIdent IS_NULLABLE = new ColumnIdent("is_nullable");
         public static final ColumnIdent GENERATION_EXPRESSION = new ColumnIdent("generation_expression");
+        public static final ColumnIdent COLUMN_DEFAULT = new ColumnIdent("column_default");
+        public static final ColumnIdent CHARACTER_MAXIMUM_LENGTH = new ColumnIdent("character_maximum_length");
+        public static final ColumnIdent CHARACTER_OCTET_LENGTH = new ColumnIdent("character_octet_length");
+        public static final ColumnIdent NUMERIC_PRECISION = new ColumnIdent("numeric_precision");
+        public static final ColumnIdent NUMERIC_PRECISION_RADIX = new ColumnIdent("numeric_precision_radix");
+        public static final ColumnIdent NUMERIC_SCALE = new ColumnIdent("numeric_scale");
+        public static final ColumnIdent DATETIME_PRECISION = new ColumnIdent("datetime_precision");
+        public static final ColumnIdent INTERVAL_TYPE = new ColumnIdent("interval_type");
+        public static final ColumnIdent INTERVAL_PRECISION = new ColumnIdent("interval_precision");
+        public static final ColumnIdent CHARACTER_SET_CATALOG = new ColumnIdent("character_set_catalog");
+        public static final ColumnIdent CHARACTER_SET_SCHEMA = new ColumnIdent("character_set_schema");
+        public static final ColumnIdent CHARACTER_SET_NAME = new ColumnIdent("character_set_name");
+        public static final ColumnIdent COLLATION_CATALOG = new ColumnIdent("collation_catalog");
+        public static final ColumnIdent COLLATION_SCHEMA = new ColumnIdent("collation_schema");
+        public static final ColumnIdent COLLATION_NAME = new ColumnIdent("collation_name");
+        public static final ColumnIdent DOMAIN_CATALOG = new ColumnIdent("domain_catalog");
+        public static final ColumnIdent DOMAIN_SCHEMA = new ColumnIdent("domain_schema");
+        public static final ColumnIdent DOMAIN_NAME = new ColumnIdent("domain_name");
+        public static final ColumnIdent USER_DEFINED_TYPE_CATALOG = new ColumnIdent("user_defined_type_catalog");
+        public static final ColumnIdent USER_DEFINED_TYPE_SCHEMA = new ColumnIdent("user_defined_type_schema");
+        public static final ColumnIdent USER_DEFINED_TYPE_NAME = new ColumnIdent("user_defined_type_name");
+        public static final ColumnIdent CHECK_REFERENCES = new ColumnIdent("check_references");
+        public static final ColumnIdent CHECK_ACTION = new ColumnIdent("check_action");
     }
 
     public static class References {
         public static final Reference TABLE_SCHEMA = info(Columns.TABLE_SCHEMA, DataTypes.STRING, false);
         public static final Reference TABLE_NAME = info(Columns.TABLE_NAME, DataTypes.STRING, false);
+        public static final Reference TABLE_CATALOG = info(Columns.TABLE_CATALOG, DataTypes.STRING, false);
         public static final Reference COLUMN_NAME = info(Columns.COLUMN_NAME, DataTypes.STRING, false);
         public static final Reference ORDINAL_POSITION = info(Columns.ORDINAL_POSITION, DataTypes.SHORT, false);
         public static final Reference DATA_TYPE = info(Columns.DATA_TYPE, DataTypes.STRING, false);
         public static final Reference IS_GENERATED = info(Columns.IS_GENERATED, DataTypes.BOOLEAN, false);
         public static final Reference IS_NULLABLE = info(Columns.IS_NULLABLE, DataTypes.BOOLEAN, false);
         public static final Reference GENERATION_EXPRESSION = info(Columns.GENERATION_EXPRESSION, DataTypes.STRING, true);
+        public static final Reference COLUMN_DEFAULT = info(Columns.COLUMN_DEFAULT, DataTypes.STRING, true);
+        public static final Reference CHARACTER_MAXIMUM_LENGTH = info(Columns.CHARACTER_MAXIMUM_LENGTH, DataTypes.INTEGER, true);
+        public static final Reference CHARACTER_OCTET_LENGTH = info(Columns.CHARACTER_OCTET_LENGTH, DataTypes.INTEGER, true);
+        public static final Reference NUMERIC_PRECISION = info(Columns.NUMERIC_PRECISION, DataTypes.INTEGER, true);
+        public static final Reference NUMERIC_PRECISION_RADIX = info(Columns.NUMERIC_PRECISION_RADIX, DataTypes.INTEGER, true);
+        public static final Reference NUMERIC_SCALE = info(Columns.NUMERIC_SCALE, DataTypes.INTEGER, true);
+        public static final Reference DATETIME_PRECISION = info(Columns.DATETIME_PRECISION, DataTypes.INTEGER, true);
+        public static final Reference INTERVAL_TYPE = info(Columns.INTERVAL_TYPE, DataTypes.STRING, true);
+        public static final Reference INTERVAL_PRECISION = info(Columns.INTERVAL_PRECISION, DataTypes.INTEGER, true);
+        public static final Reference CHARACTER_SET_CATALOG = info(Columns.CHARACTER_SET_CATALOG, DataTypes.STRING, true);
+        public static final Reference CHARACTER_SET_SCHEMA = info(Columns.CHARACTER_SET_SCHEMA, DataTypes.STRING, true);
+        public static final Reference CHARACTER_SET_NAME = info(Columns.CHARACTER_SET_NAME, DataTypes.STRING, true);
+        public static final Reference COLLATION_CATALOG = info(Columns.COLLATION_CATALOG, DataTypes.STRING, true);
+        public static final Reference COLLATION_SCHEMA = info(Columns.COLLATION_SCHEMA, DataTypes.STRING, true);
+        public static final Reference COLLATION_NAME = info(Columns.COLLATION_NAME, DataTypes.STRING, true);
+        public static final Reference DOMAIN_CATALOG = info(Columns.DOMAIN_CATALOG, DataTypes.STRING, true);
+        public static final Reference DOMAIN_SCHEMA = info(Columns.DOMAIN_SCHEMA, DataTypes.STRING, true);
+        public static final Reference DOMAIN_NAME = info(Columns.DOMAIN_NAME, DataTypes.STRING, true);
+        public static final Reference USER_DEFINED_TYPE_CATALOG = info(Columns.USER_DEFINED_TYPE_CATALOG, DataTypes.STRING, true);
+        public static final Reference USER_DEFINED_TYPE_SCHEMA = info(Columns.USER_DEFINED_TYPE_SCHEMA, DataTypes.STRING, true);
+        public static final Reference USER_DEFINED_TYPE_NAME = info(Columns.USER_DEFINED_TYPE_NAME, DataTypes.STRING, true);
+        public static final Reference CHECK_REFERENCES = info(Columns.CHECK_REFERENCES, DataTypes.STRING, true);
+        public static final Reference CHECK_ACTION = info(Columns.CHECK_ACTION, DataTypes.INTEGER, true);
     }
 
     private static Reference info(ColumnIdent columnIdent, DataType dataType, Boolean nullable) {
@@ -67,12 +115,36 @@ public class InformationColumnsTableInfo extends InformationTableInfo {
             ImmutableSortedMap.<ColumnIdent, Reference>naturalOrder()
                 .put(Columns.TABLE_SCHEMA, References.TABLE_SCHEMA)
                 .put(Columns.TABLE_NAME, References.TABLE_NAME)
+                .put(Columns.TABLE_CATALOG, References.TABLE_CATALOG)
                 .put(Columns.COLUMN_NAME, References.COLUMN_NAME)
                 .put(Columns.ORDINAL_POSITION, References.ORDINAL_POSITION)
                 .put(Columns.DATA_TYPE, References.DATA_TYPE)
                 .put(Columns.IS_GENERATED, References.IS_GENERATED)
                 .put(Columns.IS_NULLABLE, References.IS_NULLABLE)
                 .put(Columns.GENERATION_EXPRESSION, References.GENERATION_EXPRESSION)
+                .put(Columns.COLUMN_DEFAULT, References.COLUMN_DEFAULT)
+                .put(Columns.CHARACTER_MAXIMUM_LENGTH, References.CHARACTER_MAXIMUM_LENGTH)
+                .put(Columns.CHARACTER_OCTET_LENGTH, References.CHARACTER_OCTET_LENGTH)
+                .put(Columns.NUMERIC_PRECISION, References.NUMERIC_PRECISION)
+                .put(Columns.NUMERIC_PRECISION_RADIX, References.NUMERIC_PRECISION_RADIX)
+                .put(Columns.NUMERIC_SCALE, References.NUMERIC_SCALE)
+                .put(Columns.DATETIME_PRECISION, References.DATETIME_PRECISION)
+                .put(Columns.INTERVAL_TYPE, References.INTERVAL_TYPE)
+                .put(Columns.INTERVAL_PRECISION, References.INTERVAL_PRECISION)
+                .put(Columns.CHARACTER_SET_CATALOG, References.CHARACTER_SET_CATALOG)
+                .put(Columns.CHARACTER_SET_SCHEMA, References.CHARACTER_SET_SCHEMA)
+                .put(Columns.CHARACTER_SET_NAME, References.CHARACTER_SET_NAME)
+                .put(Columns.COLLATION_CATALOG, References.COLLATION_CATALOG)
+                .put(Columns.COLLATION_SCHEMA, References.COLLATION_SCHEMA)
+                .put(Columns.COLLATION_NAME, References.COLLATION_NAME)
+                .put(Columns.DOMAIN_CATALOG, References.DOMAIN_CATALOG)
+                .put(Columns.DOMAIN_SCHEMA, References.DOMAIN_SCHEMA)
+                .put(Columns.DOMAIN_NAME, References.DOMAIN_NAME)
+                .put(Columns.USER_DEFINED_TYPE_CATALOG, References.USER_DEFINED_TYPE_CATALOG)
+                .put(Columns.USER_DEFINED_TYPE_SCHEMA, References.USER_DEFINED_TYPE_SCHEMA)
+                .put(Columns.USER_DEFINED_TYPE_NAME, References.USER_DEFINED_TYPE_NAME)
+                .put(Columns.CHECK_REFERENCES, References.CHECK_REFERENCES)
+                .put(Columns.CHECK_ACTION, References.CHECK_ACTION)
                 .build()
         );
     }

--- a/sql/src/main/java/io/crate/metadata/information/InformationTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/information/InformationTableInfo.java
@@ -38,6 +38,8 @@ public class InformationTableInfo extends StaticTableInfo {
     public static class Columns {
         public static final ColumnIdent TABLE_NAME = new ColumnIdent("table_name");
         public static final ColumnIdent TABLE_SCHEMA = new ColumnIdent("table_schema");
+        public static final ColumnIdent TABLE_CATALOG = new ColumnIdent("table_catalog");
+        public static final ColumnIdent TABLE_TYPE = new ColumnIdent("table_type");
         public static final ColumnIdent PARTITION_IDENT = new ColumnIdent("partition_ident");
         public static final ColumnIdent VALUES = new ColumnIdent("values");
         public static final ColumnIdent NUMBER_OF_SHARDS = new ColumnIdent("number_of_shards");
@@ -61,6 +63,8 @@ public class InformationTableInfo extends StaticTableInfo {
         public static final ColumnIdent TABLE_VERSION_UPGRADED_ES = new ColumnIdent("version",
             ImmutableList.of(Version.Property.UPGRADED.toString(), Version.ES_VERSION_KEY));
         public static final ColumnIdent CLOSED = new ColumnIdent("closed");
+        public static final ColumnIdent REFERENCE_GENERATION = new ColumnIdent("reference_generation");
+        public static final ColumnIdent SELF_REFERENCING_COLUMN_NAME = new ColumnIdent("self_referencing_column_name");
         public static final ColumnIdent TABLE_SETTINGS = new ColumnIdent("settings");
         public static final ColumnIdent TABLE_SETTINGS_BLOCKS = new ColumnIdent("settings",
             ImmutableList.of("blocks"));

--- a/sql/src/main/java/io/crate/metadata/information/InformationTablesTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/information/InformationTablesTableInfo.java
@@ -37,6 +37,8 @@ public class InformationTablesTableInfo extends InformationTableInfo {
     public static class References {
         public static final Reference TABLE_SCHEMA = createRef(Columns.TABLE_SCHEMA, DataTypes.STRING);
         public static final Reference TABLE_NAME = createRef(Columns.TABLE_NAME, DataTypes.STRING);
+        public static final Reference TABLE_CATALOG = createRef(Columns.TABLE_CATALOG, DataTypes.STRING);
+        public static final Reference TABLE_TYPE = createRef(Columns.TABLE_TYPE, DataTypes.STRING);
         public static final Reference NUMBER_OF_SHARDS = createRef(Columns.NUMBER_OF_SHARDS, DataTypes.INTEGER);
         public static final Reference NUMBER_OF_REPLICAS = createRef(Columns.NUMBER_OF_REPLICAS, DataTypes.STRING);
         public static final Reference CLUSTERED_BY = createRef(Columns.CLUSTERED_BY, DataTypes.STRING);
@@ -58,6 +60,9 @@ public class InformationTablesTableInfo extends InformationTableInfo {
         public static final Reference TABLE_VERSION_UPGRADED_ES = createRef(
             Columns.TABLE_VERSION_UPGRADED_ES, DataTypes.OBJECT);
         public static final Reference CLOSED = createRef(Columns.CLOSED, DataTypes.BOOLEAN);
+        public static final Reference REFERENCE_GENERATION = createRef(Columns.REFERENCE_GENERATION, DataTypes.STRING);
+        public static final Reference SELF_REFERENCING_COLUMN_NAME = createRef(Columns.SELF_REFERENCING_COLUMN_NAME,
+            DataTypes.STRING);
 
         public static final Reference TABLE_SETTINGS = createRef(Columns.TABLE_SETTINGS, DataTypes.OBJECT);
 
@@ -120,6 +125,8 @@ public class InformationTablesTableInfo extends InformationTableInfo {
             ImmutableSortedMap.<ColumnIdent, Reference>naturalOrder()
                 .put(Columns.TABLE_SCHEMA, References.TABLE_SCHEMA)
                 .put(Columns.TABLE_NAME, References.TABLE_NAME)
+                .put(Columns.TABLE_CATALOG, References.TABLE_CATALOG)
+                .put(Columns.TABLE_TYPE, References.TABLE_TYPE)
                 .put(Columns.NUMBER_OF_SHARDS, References.NUMBER_OF_SHARDS)
                 .put(Columns.NUMBER_OF_REPLICAS, References.NUMBER_OF_REPLICAS)
                 .put(Columns.CLUSTERED_BY, References.CLUSTERED_BY)
@@ -135,6 +142,8 @@ public class InformationTablesTableInfo extends InformationTableInfo {
                 .put(Columns.TABLE_VERSION_UPGRADED_CRATEDB, References.TABLE_VERSION_UPGRADED_CRATEDB)
                 .put(Columns.TABLE_VERSION_UPGRADED_ES, References.TABLE_VERSION_UPGRADED_ES)
                 .put(Columns.CLOSED, References.CLOSED)
+                .put(Columns.REFERENCE_GENERATION, References.REFERENCE_GENERATION)
+                .put(Columns.SELF_REFERENCING_COLUMN_NAME, References.SELF_REFERENCING_COLUMN_NAME)
                 .put(Columns.TABLE_SETTINGS, References.TABLE_SETTINGS)
                 .put(Columns.TABLE_SETTINGS_BLOCKS, References.TABLE_SETTINGS_BLOCKS)
                 .put(Columns.TABLE_SETTINGS_BLOCKS_READ_ONLY, References.TABLE_SETTINGS_BLOCKS_READ_ONLY)
@@ -165,10 +174,14 @@ public class InformationTablesTableInfo extends InformationTableInfo {
                 References.NUMBER_OF_REPLICAS,
                 References.NUMBER_OF_SHARDS,
                 References.PARTITIONED_BY,
+                References.REFERENCE_GENERATION,
                 References.ROUTING_HASH_FUNCTION,
+                References.SELF_REFERENCING_COLUMN_NAME,
                 References.TABLE_SETTINGS,
+                References.TABLE_CATALOG,
                 References.TABLE_NAME,
                 References.TABLE_SCHEMA,
+                References.TABLE_TYPE,
                 References.TABLE_VERSION
             )
         );

--- a/sql/src/main/java/io/crate/operation/reference/information/InformationSchemaExpressionFactories.java
+++ b/sql/src/main/java/io/crate/operation/reference/information/InformationSchemaExpressionFactories.java
@@ -81,6 +81,10 @@ public class InformationSchemaExpressionFactories {
                 InformationTablePartitionsExpression.PartitionsTableNameExpression::new)
             .put(InformationPartitionsTableInfo.PartitionsTableColumns.SCHEMA_NAME,
                 InformationTablePartitionsExpression.PartitionsSchemaNameExpression::new)
+            .put(InformationPartitionsTableInfo.Columns.TABLE_CATALOG,
+                InformationTablePartitionsExpression.PartitionsTableCatalogExpression::new)
+            .put(InformationPartitionsTableInfo.Columns.TABLE_TYPE,
+                InformationTablePartitionsExpression.PartitionsTableTypeExpression::new)
             .put(InformationPartitionsTableInfo.Columns.PARTITION_IDENT,
                 InformationTablePartitionsExpression.PartitionsPartitionIdentExpression::new)
             .put(InformationPartitionsTableInfo.Columns.VALUES,
@@ -93,16 +97,44 @@ public class InformationSchemaExpressionFactories {
                 InformationTablePartitionsExpression.PartitionsRoutingHashFunctionExpression::new)
             .put(InformationPartitionsTableInfo.Columns.CLOSED, InformationTablePartitionsExpression.ClosedExpression::new)
             .put(InformationPartitionsTableInfo.Columns.TABLE_VERSION, PartitionsVersionExpression::new)
-            .put(InformationPartitionsTableInfo.Columns.TABLE_SETTINGS, PartitionsSettingsExpression::new).build();
+            .put(InformationPartitionsTableInfo.Columns.TABLE_SETTINGS, PartitionsSettingsExpression::new)
+            .put(InformationPartitionsTableInfo.Columns.SELF_REFERENCING_COLUMN_NAME,
+                InformationTablePartitionsExpression.PartitionsSelfReferencingColumnNameExpression::new)
+            .put(InformationPartitionsTableInfo.Columns.REFERENCE_GENERATION,
+                InformationTablePartitionsExpression.PartitionsReferenceGenerationExpression::new).build();
     }
 
     public static Map<ColumnIdent, RowCollectExpressionFactory<ColumnContext>> columnsFactories() {
         return ImmutableMap.<ColumnIdent, RowCollectExpressionFactory<ColumnContext>>builder()
             .put(InformationColumnsTableInfo.Columns.TABLE_SCHEMA, InformationColumnsExpression.ColumnsSchemaNameExpression::new)
             .put(InformationColumnsTableInfo.Columns.TABLE_NAME, InformationColumnsExpression.ColumnsTableNameExpression::new)
+            .put(InformationColumnsTableInfo.Columns.TABLE_CATALOG, InformationColumnsExpression.ColumnsSchemaNameExpression::new)
             .put(InformationColumnsTableInfo.Columns.COLUMN_NAME, InformationColumnsExpression.ColumnsColumnNameExpression::new)
             .put(InformationColumnsTableInfo.Columns.ORDINAL_POSITION, InformationColumnsExpression.ColumnsOrdinalExpression::new)
             .put(InformationColumnsTableInfo.Columns.DATA_TYPE, InformationColumnsExpression.ColumnsDataTypeExpression::new)
+            .put(InformationColumnsTableInfo.Columns.COLUMN_DEFAULT, InformationColumnsExpression.ColumnsNullExpression::new)
+            .put(InformationColumnsTableInfo.Columns.CHARACTER_MAXIMUM_LENGTH, InformationColumnsExpression.ColumnsNullExpression::new)
+            .put(InformationColumnsTableInfo.Columns.CHARACTER_OCTET_LENGTH, InformationColumnsExpression.ColumnsNullExpression::new)
+            .put(InformationColumnsTableInfo.Columns.NUMERIC_PRECISION, InformationColumnsExpression.ColumnsNumericPrecisionExpression::new)
+            .put(InformationColumnsTableInfo.Columns.NUMERIC_PRECISION_RADIX, InformationColumnsExpression.ColumnsNumericPrecisionRadixExpression::new)
+            .put(InformationColumnsTableInfo.Columns.NUMERIC_SCALE, InformationColumnsExpression.ColumnsNullExpression::new)
+            .put(InformationColumnsTableInfo.Columns.DATETIME_PRECISION, InformationColumnsExpression.ColumnsDatetimePrecisionExpression::new)
+            .put(InformationColumnsTableInfo.Columns.INTERVAL_TYPE, InformationColumnsExpression.ColumnsNullExpression::new)
+            .put(InformationColumnsTableInfo.Columns.INTERVAL_PRECISION, InformationColumnsExpression.ColumnsNullExpression::new)
+            .put(InformationColumnsTableInfo.Columns.CHARACTER_SET_CATALOG, InformationColumnsExpression.ColumnsNullExpression::new)
+            .put(InformationColumnsTableInfo.Columns.CHARACTER_SET_SCHEMA, InformationColumnsExpression.ColumnsNullExpression::new)
+            .put(InformationColumnsTableInfo.Columns.CHARACTER_SET_NAME, InformationColumnsExpression.ColumnsNullExpression::new)
+            .put(InformationColumnsTableInfo.Columns.COLLATION_CATALOG, InformationColumnsExpression.ColumnsNullExpression::new)
+            .put(InformationColumnsTableInfo.Columns.COLLATION_SCHEMA, InformationColumnsExpression.ColumnsNullExpression::new)
+            .put(InformationColumnsTableInfo.Columns.COLLATION_NAME, InformationColumnsExpression.ColumnsNullExpression::new)
+            .put(InformationColumnsTableInfo.Columns.DOMAIN_CATALOG, InformationColumnsExpression.ColumnsNullExpression::new)
+            .put(InformationColumnsTableInfo.Columns.DOMAIN_SCHEMA, InformationColumnsExpression.ColumnsNullExpression::new)
+            .put(InformationColumnsTableInfo.Columns.DOMAIN_NAME, InformationColumnsExpression.ColumnsNullExpression::new)
+            .put(InformationColumnsTableInfo.Columns.USER_DEFINED_TYPE_CATALOG, InformationColumnsExpression.ColumnsNullExpression::new)
+            .put(InformationColumnsTableInfo.Columns.USER_DEFINED_TYPE_SCHEMA, InformationColumnsExpression.ColumnsNullExpression::new)
+            .put(InformationColumnsTableInfo.Columns.USER_DEFINED_TYPE_NAME, InformationColumnsExpression.ColumnsNullExpression::new)
+            .put(InformationColumnsTableInfo.Columns.CHECK_REFERENCES, InformationColumnsExpression.ColumnsNullExpression::new)
+            .put(InformationColumnsTableInfo.Columns.CHECK_ACTION, InformationColumnsExpression.ColumnsNullExpression::new)
             .put(InformationColumnsTableInfo.Columns.IS_GENERATED, () -> new InformationColumnsExpression<Boolean>() {
                 @Override
                 public Boolean value() {
@@ -135,6 +167,20 @@ public class InformationSchemaExpressionFactories {
                 @Override
                 public BytesRef value() {
                     return new BytesRef(row.ident().name());
+                }
+            })
+            .put(InformationTablesTableInfo.Columns.TABLE_CATALOG, () -> new RowContextCollectorExpression<TableInfo, BytesRef>() {
+
+                @Override
+                public BytesRef value() {
+                    return new BytesRef(row.ident().schema());
+                }
+            })
+            .put(InformationTablesTableInfo.Columns.TABLE_TYPE, () -> new RowContextCollectorExpression<TableInfo, BytesRef>() {
+
+                @Override
+                public BytesRef value() {
+                    return InformationTablePartitionsExpression.TABLE_TYPE;
                 }
             })
             .put(InformationTablesTableInfo.Columns.NUMBER_OF_SHARDS, () -> new RowContextCollectorExpression<TableInfo, Integer>() {
@@ -235,6 +281,20 @@ public class InformationSchemaExpressionFactories {
                         return null;
                     }
                 })
+            .put(InformationTablesTableInfo.Columns.SELF_REFERENCING_COLUMN_NAME, () -> new RowContextCollectorExpression<TableInfo, BytesRef>() {
+
+                @Override
+                public BytesRef value() {
+                    return InformationTablePartitionsExpression.SELF_REFERENCING_COLUMN_NAME;
+                }
+            })
+            .put(InformationTablesTableInfo.Columns.REFERENCE_GENERATION, () -> new RowContextCollectorExpression<TableInfo, BytesRef>() {
+
+                @Override
+                public BytesRef value() {
+                    return InformationTablePartitionsExpression.REFERENCE_GENERATION;
+                }
+            })
             .put(InformationTablesTableInfo.Columns.TABLE_VERSION, TablesVersionExpression::new)
             .put(InformationTablesTableInfo.Columns.TABLE_SETTINGS, TablesSettingsExpression::new
             ).build();

--- a/sql/src/main/java/io/crate/operation/reference/information/InformationTablePartitionsExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/information/InformationTablePartitionsExpression.java
@@ -30,6 +30,10 @@ import java.util.Map;
 abstract class InformationTablePartitionsExpression<T>
     extends RowContextCollectorExpression<PartitionInfo, T> {
 
+    public static final BytesRef TABLE_TYPE = new BytesRef("BASE TABLE");
+    public static final BytesRef SELF_REFERENCING_COLUMN_NAME = new BytesRef("_id");
+    public static final BytesRef REFERENCE_GENERATION = new BytesRef("SYSTEM GENERATED");
+
     public static class PartitionsTableNameExpression extends InformationTablePartitionsExpression<BytesRef> {
         @Override
         public BytesRef value() {
@@ -42,6 +46,22 @@ abstract class InformationTablePartitionsExpression<T>
         @Override
         public BytesRef value() {
             return new BytesRef(row.name().tableIdent().schema());
+        }
+    }
+
+    public static class PartitionsTableCatalogExpression extends InformationTablePartitionsExpression<BytesRef> {
+
+        @Override
+        public BytesRef value() {
+            return new BytesRef(row.name().tableIdent().schema());
+        }
+    }
+
+    public static class PartitionsTableTypeExpression extends InformationTablePartitionsExpression<BytesRef> {
+
+        @Override
+        public BytesRef value() {
+            return TABLE_TYPE;
         }
     }
 
@@ -86,6 +106,20 @@ abstract class InformationTablePartitionsExpression<T>
         @Override
         public Boolean value() {
             return row.isClosed();
+        }
+    }
+
+    public static class PartitionsSelfReferencingColumnNameExpression extends InformationTablePartitionsExpression<BytesRef> {
+        @Override
+        public BytesRef value() {
+            return SELF_REFERENCING_COLUMN_NAME;
+        }
+    }
+
+    public static class PartitionsReferenceGenerationExpression extends InformationTablePartitionsExpression<BytesRef> {
+        @Override
+        public BytesRef value() {
+            return REFERENCE_GENERATION;
         }
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -460,7 +460,7 @@ public class DDLIntegrationTest extends SQLTransportIntegrationTest {
             // column o exists already
             assertThat(e.getMessage(), containsString("The table doc.t already has a column named o"));
         }
-        execute("select * from information_schema.columns where " +
+        execute("select column_name from information_schema.columns where " +
                 "table_name = 't' and table_schema='doc'" +
                 "order by column_name asc");
         assertThat(response.rowCount(), is(3L));

--- a/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -23,14 +23,12 @@ package io.crate.integrationtests;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
-import io.crate.metadata.IndexMappings;
 import io.crate.Version;
 import io.crate.action.sql.SQLActionException;
+import io.crate.metadata.IndexMappings;
 import io.crate.testing.TestingHelpers;
 import io.crate.testing.UseJdbc;
-import org.elasticsearch.action.admin.indices.close.CloseIndexRequest;
 import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
-import org.elasticsearch.action.admin.indices.open.OpenIndexRequest;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.hamcrest.Matchers;
@@ -66,26 +64,27 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
         assertEquals(20L, response.rowCount());
 
         assertThat(TestingHelpers.printedTable(response.rows()), is(
-            "NULL| NULL| NULL| strict| 0| 1| NULL| NULL| NULL| columns| information_schema| NULL\n" +
-            "NULL| NULL| NULL| strict| 0| 1| NULL| NULL| NULL| routines| information_schema| NULL\n" +
-            "NULL| NULL| NULL| strict| 0| 1| NULL| NULL| NULL| schemata| information_schema| NULL\n" +
-            "NULL| NULL| NULL| strict| 0| 1| NULL| NULL| NULL| sql_features| information_schema| NULL\n" +
-            "NULL| NULL| NULL| strict| 0| 1| NULL| NULL| NULL| table_constraints| information_schema| NULL\n" +
-            "NULL| NULL| NULL| strict| 0| 1| NULL| NULL| NULL| table_partitions| information_schema| NULL\n" +
-            "NULL| NULL| NULL| strict| 0| 1| NULL| NULL| NULL| tables| information_schema| NULL\n" +
-            "NULL| NULL| NULL| strict| 0| 1| NULL| NULL| NULL| pg_type| pg_catalog| NULL\n" +
-            "NULL| NULL| NULL| strict| 0| 1| NULL| NULL| NULL| checks| sys| NULL\n" +
-            "NULL| NULL| NULL| strict| 0| 1| NULL| NULL| NULL| cluster| sys| NULL\n" +
-            "NULL| NULL| NULL| strict| 0| 1| NULL| NULL| NULL| jobs| sys| NULL\n" +
-            "NULL| NULL| NULL| strict| 0| 1| NULL| NULL| NULL| jobs_log| sys| NULL\n" +
-            "NULL| NULL| NULL| strict| 0| 1| NULL| NULL| NULL| node_checks| sys| NULL\n" +
-            "NULL| NULL| NULL| strict| 0| 1| NULL| NULL| NULL| nodes| sys| NULL\n" +
-            "NULL| NULL| NULL| strict| 0| 1| NULL| NULL| NULL| operations| sys| NULL\n" +
-            "NULL| NULL| NULL| strict| 0| 1| NULL| NULL| NULL| operations_log| sys| NULL\n" +
-            "NULL| NULL| NULL| strict| 0| 1| NULL| NULL| NULL| repositories| sys| NULL\n" +
-            "NULL| NULL| NULL| strict| 0| 1| NULL| NULL| NULL| shards| sys| NULL\n" +
-            "NULL| NULL| NULL| strict| 0| 1| NULL| NULL| NULL| snapshots| sys| NULL\n" +
-            "NULL| NULL| NULL| strict| 0| 1| NULL| NULL| NULL| summits| sys| NULL\n"));
+            "NULL| NULL| NULL| strict| 0| 1| NULL| SYSTEM GENERATED| NULL| _id| NULL| information_schema| columns| information_schema| BASE TABLE| NULL\n" +
+            "NULL| NULL| NULL| strict| 0| 1| NULL| SYSTEM GENERATED| NULL| _id| NULL| information_schema| routines| information_schema| BASE TABLE| NULL\n" +
+            "NULL| NULL| NULL| strict| 0| 1| NULL| SYSTEM GENERATED| NULL| _id| NULL| information_schema| schemata| information_schema| BASE TABLE| NULL\n" +
+            "NULL| NULL| NULL| strict| 0| 1| NULL| SYSTEM GENERATED| NULL| _id| NULL| information_schema| sql_features| information_schema| BASE TABLE| NULL\n" +
+            "NULL| NULL| NULL| strict| 0| 1| NULL| SYSTEM GENERATED| NULL| _id| NULL| information_schema| table_constraints| information_schema| BASE TABLE| NULL\n" +
+            "NULL| NULL| NULL| strict| 0| 1| NULL| SYSTEM GENERATED| NULL| _id| NULL| information_schema| table_partitions| information_schema| BASE TABLE| NULL\n" +
+            "NULL| NULL| NULL| strict| 0| 1| NULL| SYSTEM GENERATED| NULL| _id| NULL| information_schema| tables| information_schema| BASE TABLE| NULL\n" +
+            "NULL| NULL| NULL| strict| 0| 1| NULL| SYSTEM GENERATED| NULL| _id| NULL| pg_catalog| pg_type| pg_catalog| BASE TABLE| NULL\n" +
+            "NULL| NULL| NULL| strict| 0| 1| NULL| SYSTEM GENERATED| NULL| _id| NULL| sys| checks| sys| BASE TABLE| NULL\n" +
+            "NULL| NULL| NULL| strict| 0| 1| NULL| SYSTEM GENERATED| NULL| _id| NULL| sys| cluster| sys| BASE TABLE| NULL\n" +
+            "NULL| NULL| NULL| strict| 0| 1| NULL| SYSTEM GENERATED| NULL| _id| NULL| sys| jobs| sys| BASE TABLE| NULL\n" +
+            "NULL| NULL| NULL| strict| 0| 1| NULL| SYSTEM GENERATED| NULL| _id| NULL| sys| jobs_log| sys| BASE TABLE| NULL\n" +
+            "NULL| NULL| NULL| strict| 0| 1| NULL| SYSTEM GENERATED| NULL| _id| NULL| sys| node_checks| sys| BASE TABLE| NULL\n" +
+            "NULL| NULL| NULL| strict| 0| 1| NULL| SYSTEM GENERATED| NULL| _id| NULL| sys| nodes| sys| BASE TABLE| NULL\n" +
+            "NULL| NULL| NULL| strict| 0| 1| NULL| SYSTEM GENERATED| NULL| _id| NULL| sys| operations| sys| BASE TABLE| NULL\n" +
+            "NULL| NULL| NULL| strict| 0| 1| NULL| SYSTEM GENERATED| NULL| _id| NULL| sys| operations_log| sys| BASE TABLE| NULL\n" +
+            "NULL| NULL| NULL| strict| 0| 1| NULL| SYSTEM GENERATED| NULL| _id| NULL| sys| repositories| sys| BASE TABLE| NULL\n" +
+            "NULL| NULL| NULL| strict| 0| 1| NULL| SYSTEM GENERATED| NULL| _id| NULL| sys| shards| sys| BASE TABLE| NULL\n" +
+            "NULL| NULL| NULL| strict| 0| 1| NULL| SYSTEM GENERATED| NULL| _id| NULL| sys| snapshots| sys| BASE TABLE| NULL\n" +
+            "NULL| NULL| NULL| strict| 0| 1| NULL| SYSTEM GENERATED| NULL| _id| NULL| sys| summits| sys| BASE TABLE| NULL\n")
+        );
     }
 
     @Test
@@ -139,19 +138,23 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
         execute("select * from INFORMATION_SCHEMA.Tables where table_schema='doc' order by table_name asc");
         assertThat(response.rowCount(), is(2L));
 
-        TestingHelpers.assertCrateVersion(response.rows()[0][11], Version.CURRENT, null);
-        assertThat(response.rows()[0][10], is("doc"));
-        assertThat(response.rows()[0][9], is("foo"));
-        assertThat(response.rows()[0][7], is(IndexMappings.DEFAULT_ROUTING_HASH_FUNCTION_PRETTY_NAME));
+        TestingHelpers.assertCrateVersion(response.rows()[0][15], Version.CURRENT, null);
+        assertThat(response.rows()[0][13], is("doc"));
+        assertThat(response.rows()[0][12], is("foo"));
+        assertThat(response.rows()[0][11], is("doc"));
+        assertThat(response.rows()[0][14], is("BASE TABLE"));
+        assertThat(response.rows()[0][8], is(IndexMappings.DEFAULT_ROUTING_HASH_FUNCTION_PRETTY_NAME));
         assertThat(response.rows()[0][5], is(3));
         assertThat(response.rows()[0][4], is("1"));
         assertThat(response.rows()[0][2], is("col1"));
         assertThat(response.rows()[0][1], is(false));
 
-        TestingHelpers.assertCrateVersion(response.rows()[0][11], Version.CURRENT, null);
-        assertThat(response.rows()[1][10], is("doc"));
-        assertThat(response.rows()[1][9], is("test"));
-        assertThat(response.rows()[1][7], is(IndexMappings.DEFAULT_ROUTING_HASH_FUNCTION_PRETTY_NAME));
+        TestingHelpers.assertCrateVersion(response.rows()[0][15], Version.CURRENT, null);
+        assertThat(response.rows()[1][13], is("doc"));
+        assertThat(response.rows()[1][12], is("test"));
+        assertThat(response.rows()[1][11], is("doc"));
+        assertThat(response.rows()[1][14], is("BASE TABLE"));
+        assertThat(response.rows()[1][8], is(IndexMappings.DEFAULT_ROUTING_HASH_FUNCTION_PRETTY_NAME));
         assertThat(response.rows()[1][5], is(5));
         assertThat(response.rows()[1][4], is("1"));
         assertThat(response.rows()[1][2], is("col1"));
@@ -196,10 +199,12 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
         execute("select * from INFORMATION_SCHEMA.Tables where table_schema='doc' order by table_name asc limit 1 offset 1");
         assertThat(response.rowCount(), is(1L));
 
-        TestingHelpers.assertCrateVersion(response.rows()[0][11], Version.CURRENT, null); // version
-        assertThat(response.rows()[0][10], is("doc")); // table_schema
-        assertThat(response.rows()[0][9], is("test"));  // table_name
-        assertThat(response.rows()[0][7], is(IndexMappings.DEFAULT_ROUTING_HASH_FUNCTION_PRETTY_NAME)); // routing_hash_function
+        TestingHelpers.assertCrateVersion(response.rows()[0][15], Version.CURRENT, null); // version
+        assertThat(response.rows()[0][13], is("doc")); // table_schema
+        assertThat(response.rows()[0][12], is("test"));  // table_name
+        assertThat(response.rows()[0][11], is("doc")); // table_catalog
+        assertThat(response.rows()[0][14], is("BASE TABLE")); // table_type
+        assertThat(response.rows()[0][8], is(IndexMappings.DEFAULT_ROUTING_HASH_FUNCTION_PRETTY_NAME)); // routing_hash_function
         assertThat(response.rows()[0][5], is(5)); // number_of_shards
         assertThat(response.rows()[0][4], is("1")); // number_of_replicas
         assertThat(response.rows()[0][2], is("col1")); // primary key
@@ -271,10 +276,12 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
         execute("select * from INFORMATION_SCHEMA.Tables where table_schema='doc'");
         assertThat(response.rowCount(), is(1L));
 
-        TestingHelpers.assertCrateVersion(response.rows()[0][11], Version.CURRENT, null);
-        assertThat(response.rows()[0][10], is("doc"));
-        assertThat(response.rows()[0][9], is("test"));
-        assertThat(response.rows()[0][7], is(IndexMappings.DEFAULT_ROUTING_HASH_FUNCTION_PRETTY_NAME));
+        TestingHelpers.assertCrateVersion(response.rows()[0][15], Version.CURRENT, null);
+        assertThat(response.rows()[0][13], is("doc"));
+        assertThat(response.rows()[0][12], is("test"));
+        assertThat(response.rows()[0][11], is("doc"));
+        assertThat(response.rows()[0][14], is("BASE TABLE"));
+        assertThat(response.rows()[0][8], is(IndexMappings.DEFAULT_ROUTING_HASH_FUNCTION_PRETTY_NAME));
         assertThat(response.rows()[0][5], is(5));
         assertThat(response.rows()[0][4], is("1"));
         assertThat(response.rows()[0][2], is("_id"));
@@ -462,45 +469,90 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultColumns() throws Exception {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(386, response.rowCount());
+        assertEquals(414, response.rowCount());
     }
 
     @Test
     public void testColumnsColumns() throws Exception {
         execute("select * from information_schema.columns where table_schema='information_schema' and table_name='columns' order by ordinal_position asc");
-        assertThat(response.rowCount(), is(8L));
+        assertThat(response.rowCount(), is(32L));
         assertThat(TestingHelpers.printedTable(response.rows()), is(
-            "column_name| string| NULL| false| false| 1| columns| information_schema\n" +
-            "data_type| string| NULL| false| false| 2| columns| information_schema\n" +
-            "generation_expression| string| NULL| false| true| 3| columns| information_schema\n" +
-            "is_generated| boolean| NULL| false| false| 4| columns| information_schema\n" +
-            "is_nullable| boolean| NULL| false| false| 5| columns| information_schema\n" +
-            "ordinal_position| short| NULL| false| false| 6| columns| information_schema\n" +
-            "table_name| string| NULL| false| false| 7| columns| information_schema\n" +
-            "table_schema| string| NULL| false| false| 8| columns| information_schema\n"));
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| character_maximum_length| integer| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| 32| 2| NULL| 1| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| character_octet_length| integer| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| 32| 2| NULL| 2| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| character_set_catalog| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| 3| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| character_set_name| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| 4| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| character_set_schema| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| 5| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| check_action| integer| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| 32| 2| NULL| 6| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| check_references| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| 7| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| collation_catalog| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| 8| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| collation_name| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| 9| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| collation_schema| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| 10| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| column_default| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| 11| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| column_name| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| false| NULL| NULL| NULL| 12| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| data_type| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| false| NULL| NULL| NULL| 13| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| datetime_precision| integer| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| 32| 2| NULL| 14| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| domain_catalog| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| 15| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| domain_name| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| 16| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| domain_schema| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| 17| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| generation_expression| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| 18| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| interval_precision| integer| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| 32| 2| NULL| 19| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| interval_type| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| 20| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| is_generated| boolean| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| false| NULL| NULL| NULL| 21| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| is_nullable| boolean| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| false| NULL| NULL| NULL| 22| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| numeric_precision| integer| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| 32| 2| NULL| 23| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| numeric_precision_radix| integer| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| 32| 2| NULL| 24| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| numeric_scale| integer| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| 32| 2| NULL| 25| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| ordinal_position| short| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| false| 16| 2| NULL| 26| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| table_catalog| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| false| NULL| NULL| NULL| 27| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| table_name| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| false| NULL| NULL| NULL| 28| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| table_schema| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| false| NULL| NULL| NULL| 29| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| user_defined_type_catalog| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| 30| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| user_defined_type_name| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| 31| information_schema| columns| information_schema| NULL| NULL| NULL\n" +
+            "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| user_defined_type_schema| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| 32| information_schema| columns| information_schema| NULL| NULL| NULL\n")
+        );
     }
 
     @Test
     public void testSelectFromTableColumns() throws Exception {
-        execute("create table test (col1 integer primary key, col2 string index off, age integer not null)");
+        execute("create table test ( " +
+                "col1 integer primary key, " +
+                "col2 string index off, " +
+                "age integer not null, " +
+                "b byte, " +
+                "s short, " +
+                "d double, " +
+                "f float)");
+
         ensureGreen();
         execute("select * from INFORMATION_SCHEMA.Columns where table_schema='doc'");
-        assertEquals(3L, response.rowCount());
-        assertEquals("age", response.rows()[0][0]);
-        assertEquals("integer", response.rows()[0][1]);
-        assertEquals(null, response.rows()[0][2]);
-        assertEquals(false, response.rows()[0][3]);
-        assertEquals(false, response.rows()[0][4]);
+        assertEquals(7L, response.rowCount());
+        assertEquals("age", response.rows()[0][11]); // column_name
+        assertEquals("integer", response.rows()[0][12]); // data_type
+        assertEquals(null, response.rows()[0][13]); // datetime_precision
+        assertEquals(false, response.rows()[0][20]); // is_generated
+        assertEquals(false, response.rows()[0][21]); // is_nullable
+        assertEquals(32, response.rows()[0][22]); // numeric_precision
+        assertEquals(2, response.rows()[0][23]); // numeric_precision_radix
 
-        assertEquals((short) 1, response.rows()[0][5]);
-        assertEquals("test", response.rows()[0][6]);
-        assertEquals("doc", response.rows()[0][7]);
+        assertEquals((short) 1, response.rows()[0][25]); // ordinal_position
+        assertEquals("doc", response.rows()[0][26]); // table_catalog
+        assertEquals("test", response.rows()[0][27]); // table_name
+        assertEquals("doc", response.rows()[0][28]); // table_schema
 
-        assertEquals("col1", response.rows()[1][0]);
-        assertEquals(false, response.rows()[1][4]);
+        assertEquals("col1", response.rows()[2][11]);
+        assertEquals(false, response.rows()[2][21]);
 
-        assertEquals("col2", response.rows()[2][0]);
-        assertEquals(true, response.rows()[2][4]);
+        assertEquals("col2", response.rows()[3][11]);
+        assertEquals(true, response.rows()[3][21]);
+
+        assertEquals("b", response.rows()[1][11]);
+        assertEquals(8, response.rows()[1][22]);
+        assertEquals("s", response.rows()[6][11]);
+        assertEquals(16, response.rows()[6][22]);
+        assertEquals("d", response.rows()[4][11]);
+        assertEquals(53, response.rows()[4][22]);
+        assertEquals("f", response.rows()[5][11]);
+        assertEquals(24, response.rows()[5][22]);
     }
 
     @Test
@@ -551,7 +603,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
         execute("select max(ordinal_position) from information_schema.columns");
         assertEquals(1, response.rowCount());
 
-        short max_ordinal = 15;
+        short max_ordinal = 32;
         assertEquals(max_ordinal, response.rows()[0][0]);
 
         execute("create table t1 (id integer, col1 string)");

--- a/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -246,15 +246,15 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
 
         execute("select * from information_schema.tables where table_schema='doc' order by table_name");
         assertThat(response.rowCount(), is(1L));
-        assertThat(response.rows()[0][9], is("quotes"));
-        assertThat(response.rows()[0][7], is(IndexMappings.DEFAULT_ROUTING_HASH_FUNCTION_PRETTY_NAME));
+        assertThat(response.rows()[0][12], is("quotes"));
+        assertThat(response.rows()[0][8], is(IndexMappings.DEFAULT_ROUTING_HASH_FUNCTION_PRETTY_NAME));
         assertThat(response.rows()[0][1], is(false));
-        TestingHelpers.assertCrateVersion(response.rows()[0][11], Version.CURRENT, null);
+        TestingHelpers.assertCrateVersion(response.rows()[0][15], Version.CURRENT, null);
         execute("select * from information_schema.columns where table_name='quotes' order by ordinal_position");
         assertThat(response.rowCount(), is(3L));
-        assertThat(response.rows()[0][0], is("id"));
-        assertThat(response.rows()[1][0], is("quote"));
-        assertThat(response.rows()[2][0], is("timestamp"));
+        assertThat(response.rows()[0][11], is("id"));
+        assertThat(response.rows()[1][11], is("quote"));
+        assertThat(response.rows()[2][11], is("timestamp"));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/collect/HandlerSideLevelCollectTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/HandlerSideLevelCollectTest.java
@@ -116,7 +116,7 @@ public class HandlerSideLevelCollectTest extends SQLTransportIntegrationTest {
         for (Reference reference : tablesTableInfo.columns()) {
             toCollect.add(reference);
         }
-        Symbol tableNameRef = toCollect.get(9);
+        Symbol tableNameRef = toCollect.get(12);
 
         FunctionImplementation eqImpl
             = functions.getBuiltin(EqOperator.NAME, ImmutableList.of(DataTypes.STRING, DataTypes.STRING));
@@ -126,7 +126,7 @@ public class HandlerSideLevelCollectTest extends SQLTransportIntegrationTest {
         RoutedCollectPhase collectNode = collectNode(routing, toCollect, RowGranularity.DOC, new WhereClause(whereClause));
         Bucket result = collect(collectNode);
         assertThat(TestingHelpers.printedTable(result),
-            is("NULL| NULL| NULL| strict| 0| 1| NULL| NULL| NULL| shards| sys| NULL\n"));
+            is("NULL| NULL| NULL| strict| 0| 1| NULL| SYSTEM GENERATED| NULL| _id| NULL| sys| shards| sys| BASE TABLE| NULL\n"));
     }
 
     @Test
@@ -142,10 +142,10 @@ public class HandlerSideLevelCollectTest extends SQLTransportIntegrationTest {
         RoutedCollectPhase collectNode = collectNode(routing, toCollect, RowGranularity.DOC);
         Bucket result = collect(collectNode);
 
-        String expected = "id| string| NULL| false| true| 1| cluster| sys\n" +
-                          "master_node| string| NULL| false| true| 2| cluster| sys\n" +
-                          "name| string| NULL| false| true| 3| cluster| sys\n" +
-                          "settings| object| NULL| false| true| 4| cluster| sys\n";
+        String expected = "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| id| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| 1| sys| cluster| sys| NULL| NULL| NULL\n" +
+                          "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| master_node| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| 2| sys| cluster| sys| NULL| NULL| NULL\n" +
+                          "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| name| string| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| 3| sys| cluster| sys| NULL| NULL| NULL\n" +
+                          "NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| NULL| settings| object| NULL| NULL| NULL| NULL| NULL| NULL| NULL| false| true| NULL| NULL| NULL| 4| sys| cluster| sys| NULL| NULL| NULL\n";
 
 
         assertThat(TestingHelpers.printedTable(result), Matchers.containsString(expected));


### PR DESCRIPTION
This extends the ``information_schema.tables`` as well as the ``information_schema.columns`` so that are all fields are exposed that are defined in the SQL-99 standard.