### PR TITLE
Fix single-row subQuery plan creation for joins

### DIFF
--- a/sql/src/main/java/io/crate/analyze/symbol/SelectSymbol.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/SelectSymbol.java
@@ -35,6 +35,7 @@ public class SelectSymbol extends Symbol {
 
     private final AnalyzedRelation relation;
     private final DataType type;
+    private boolean isPlanned = false;
 
     public SelectSymbol(AnalyzedRelation relation, DataType type) {
         this.relation = relation;
@@ -73,5 +74,13 @@ public class SelectSymbol extends Symbol {
     @Override
     public String representation() {
         return "SubQuery{" + relation.getQualifiedName() + '}';
+    }
+
+    public boolean isPlanned() {
+        return isPlanned;
+    }
+
+    public void markAsPlanned() {
+        isPlanned = true;
     }
 }

--- a/sql/src/main/java/io/crate/planner/SubqueryPlanner.java
+++ b/sql/src/main/java/io/crate/planner/SubqueryPlanner.java
@@ -69,7 +69,10 @@ public class SubqueryPlanner {
 
         @Override
         public Void visitSelectSymbol(SelectSymbol selectSymbol, Symbol parent) {
-            planSubquery(selectSymbol);
+            if (!selectSymbol.isPlanned()) {
+                planSubquery(selectSymbol);
+                selectSymbol.markAsPlanned();
+            }
             return null;
         }
 

--- a/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -786,4 +786,18 @@ public class JoinIntegrationTest extends SQLTransportIntegrationTest {
             is("1| Greece| 1| Marios| 1| 3| 30.0\n" +
                "1| Greece| 1| Marios| 1| 4| 40.0\n"));
     }
+
+    @Test
+    public void testJoinOnVirtualTableWithSingleRowSubselect() throws Exception {
+        execute("SELECT\n" +
+                "        (select min(t1.x) from\n" +
+                "            (select col1 as x from unnest([1, 2, 3])) t1,\n" +
+                "            (select * from unnest([1, 2, 3])) t2\n" +
+                "        ) as min_col1,\n" +
+                "        *\n" +
+                "    FROM\n" +
+                "        unnest([1]) tt1," +
+                "        unnest([2]) tt2");
+        assertThat(printedTable(response.rows()), is("1| 1| 2\n"));
+    }
 }


### PR DESCRIPTION
In some cases `SelectSymbol`s were processed twice:

    MSS
    -> ConsumingPlanner (processes SelectSymbol)
    -> ManyTableConsumer creates TwoTableJoin (contains same SelectSymbol)
    -> ConsumingPlanner is called again with TwoTableJoin
    -> SelectSymbol is processed again

Although this occurred for any kind of join, it seems like it only
causes broken plans if there are virtual tables involved as well.