### PR TITLE
fix lost alias on single-row subquery with virtual tables join

### DIFF
--- a/sql/src/main/java/io/crate/analyze/relations/SubselectRewriter.java
+++ b/sql/src/main/java/io/crate/analyze/relations/SubselectRewriter.java
@@ -24,9 +24,7 @@ package io.crate.analyze.relations;
 
 import com.google.common.collect.ImmutableList;
 import io.crate.analyze.*;
-import io.crate.analyze.symbol.Aggregations;
-import io.crate.analyze.symbol.Field;
-import io.crate.analyze.symbol.Symbol;
+import io.crate.analyze.symbol.*;
 import io.crate.analyze.symbol.format.SymbolPrinter;
 import io.crate.metadata.OutputName;
 import io.crate.metadata.Path;
@@ -62,13 +60,13 @@ public final class SubselectRewriter {
             boolean mergedWithParent = false;
             QuerySpec currentQS = relation.querySpec();
             if (parent != null) {
-                FieldReplacer fieldReplacer = new FieldReplacer(currentQS.outputs());
+                FieldReplacer fieldReplacer = new FieldReplacer(currentQS.outputs(), parent);
                 QuerySpec parentQS = parent.querySpec().copyAndReplace(fieldReplacer);
                 if (canBeMerged(currentQS, parentQS)) {
                     QuerySpec currentWithParentMerged = mergeQuerySpec(currentQS, parentQS);
                     relation = new QueriedSelectRelation(
                         relation.subRelation(),
-                        namesFromOutputs(currentWithParentMerged.outputs(), fieldReplacer.replacedFieldsByNewOutput),
+                        namesFromOutputs(currentWithParentMerged.outputs(), fieldReplacer.fieldByQSOutputSymbol),
                         currentWithParentMerged
                     );
                     mergedWithParent = true;
@@ -82,7 +80,7 @@ public final class SubselectRewriter {
             }
             if (!mergedWithParent && parent != null) {
                 parent.subRelation(subRelation);
-                FieldReplacer fieldReplacer = new FieldReplacer(subRelation.fields());
+                FieldReplacer fieldReplacer = new FieldReplacer(subRelation.fields(), parent);
                 parent.querySpec().replace(fieldReplacer);
             }
             if (relation.subRelation() != origSubRelation) {
@@ -98,13 +96,13 @@ public final class SubselectRewriter {
                 return table;
             }
             QuerySpec currentQS = table.querySpec();
-            FieldReplacer fieldReplacer = new FieldReplacer(currentQS.outputs());
+            FieldReplacer fieldReplacer = new FieldReplacer(currentQS.outputs(), parent);
             QuerySpec parentQS = parent.querySpec().copyAndReplace(fieldReplacer);
             if (canBeMerged(currentQS, parentQS)) {
                 QuerySpec currentWithParentMerged = mergeQuerySpec(currentQS, parentQS);
                 return new QueriedTable(
                     table.tableRelation(),
-                    namesFromOutputs(currentWithParentMerged.outputs(), fieldReplacer.replacedFieldsByNewOutput),
+                    namesFromOutputs(currentWithParentMerged.outputs(), fieldReplacer.fieldByQSOutputSymbol),
                     currentWithParentMerged
                 );
             }
@@ -117,13 +115,13 @@ public final class SubselectRewriter {
                 return table;
             }
             QuerySpec currentQS = table.querySpec();
-            FieldReplacer fieldReplacer = new FieldReplacer(currentQS.outputs());
+            FieldReplacer fieldReplacer = new FieldReplacer(currentQS.outputs(), parent);
             QuerySpec parentQS = parent.querySpec().copyAndReplace(fieldReplacer);
             if (canBeMerged(currentQS, parentQS)) {
                 QuerySpec currentWithParentMerged = mergeQuerySpec(currentQS, parentQS);
                 return new QueriedDocTable(
                     table.tableRelation(),
-                    namesFromOutputs(currentWithParentMerged.outputs(), fieldReplacer.replacedFieldsByNewOutput),
+                    namesFromOutputs(currentWithParentMerged.outputs(), fieldReplacer.fieldByQSOutputSymbol),
                     currentWithParentMerged
                 );
             }
@@ -136,13 +134,13 @@ public final class SubselectRewriter {
                 return multiSourceSelect;
             }
             QuerySpec currentQS = multiSourceSelect.querySpec();
-            FieldReplacer fieldReplacer = new FieldReplacer(currentQS.outputs());
+            FieldReplacer fieldReplacer = new FieldReplacer(currentQS.outputs(), parent);
             QuerySpec parentQS = parent.querySpec().copyAndReplace(fieldReplacer);
             if (canBeMerged(currentQS, parentQS)) {
                 QuerySpec currentWithParentMerged = mergeQuerySpec(currentQS, parentQS);
                 return new MultiSourceSelect(
                     multiSourceSelect.sources(),
-                    namesFromOutputs(currentWithParentMerged.outputs(), fieldReplacer.replacedFieldsByNewOutput),
+                    namesFromOutputs(currentWithParentMerged.outputs(), fieldReplacer.fieldByQSOutputSymbol),
                     currentWithParentMerged,
                     multiSourceSelect.joinPairs()
                 );
@@ -280,17 +278,21 @@ public final class SubselectRewriter {
     private final static class FieldReplacer extends ReplacingSymbolVisitor<Void> implements Function<Symbol, Symbol> {
 
         private final List<? extends Symbol> outputs;
-        final HashMap<Symbol, Field> replacedFieldsByNewOutput = new HashMap<>();
+        final Map<Symbol, Field> fieldByQSOutputSymbol = new HashMap<>();
 
-        FieldReplacer(List<? extends Symbol> outputs) {
+        FieldReplacer(List<? extends Symbol> outputs, QueriedRelation relation) {
             super(ReplaceMode.COPY);
+            // Store the fields of a relation mapped to its output symbol so they will not get lost (e.g. alias preserve)
+            for (Field field : relation.fields()) {
+                fieldByQSOutputSymbol.put(relation.querySpec().outputs().get(field.index()), field);
+            }
             this.outputs = outputs;
         }
 
         @Override
         public Symbol visitField(Field field, Void context) {
             Symbol newOutput = outputs.get(field.index());
-            replacedFieldsByNewOutput.put(newOutput, field);
+            fieldByQSOutputSymbol.put(newOutput, field);
             return newOutput;
         }
 

--- a/sql/src/test/java/io/crate/analyze/SubSelectAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SubSelectAnalyzerTest.java
@@ -152,4 +152,18 @@ public class SubSelectAnalyzerTest extends CrateDummyClusterServiceUnitTest {
                    isSQL("SELECT max(doc.t2.b), doc.t2.i GROUP BY doc.t2.i " +
                          "HAVING ((doc.t2.i > 10) AND (max(doc.t2.b) > '100'))"));
     }
+
+    @Test
+    public void testPreserveAliasOnSingleRowSubSelectWithVirtualTableJoin() throws Exception {
+        SelectAnalyzedStatement statement = analyze("SELECT " +
+                                                    "   (select min(t1.x) from t1) as min_col," +
+                                                    "   (select 10) + (select 20) as add_subquery "+
+                                                    "FROM (select * from t1) tt1");
+        QueriedDocTable relation = (QueriedDocTable) statement.relation();
+        assertThat(relation.fields().size(), is(2));
+        assertThat(relation.fields().get(0), isField("min_col"));
+        assertThat(relation.fields().get(1), isField("add_subquery"));
+        assertThat(relation.tableRelation().tableInfo(), is(T1_INFO));
+    }
+
 }


### PR DESCRIPTION
Previously a Single-Row Subselect with a virtual table join resulted into an insufficient columname caused of a lost alias.

```sql
SELECT
        (select min(t1.x) from t1) as min_col1
FROM
        (select * from t1) tt1;
+--------------------+
| SelectSymbol{long} |
+--------------------+
|                  1 |
+--------------------+
```