### PR TITLE
Prepare CrateNettyHttpServerTransport to be de-guiced

### DIFF
--- a/http/src/main/java/io/crate/plugin/PipelineRegistry.java
+++ b/http/src/main/java/io/crate/plugin/PipelineRegistry.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.plugin;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelPipeline;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+public final class PipelineRegistry {
+
+
+    /**
+     * A data structure for items that can be added to the channel pipeline of the HTTP transport.
+     */
+    public static class ChannelPipelineItem {
+
+        final String base;
+        final String name;
+        final Supplier<ChannelHandler> handlerFactory;
+
+        /**
+         * @param base              the name of the existing handler in the pipeline before/after which the new handler should be added
+         * @param name              the name of the new handler that should be added to the pipeline
+         * @param handlerFactory    a supplier that provides a new instance of the handler
+         */
+        public ChannelPipelineItem(String base, String name, Supplier<ChannelHandler> handlerFactory) {
+            this.base = base;
+            this.name = name;
+            this.handlerFactory = handlerFactory;
+        }
+
+        @Override
+        public String toString() {
+            return "ChannelPipelineItem{" +
+                   "base='" + base + '\'' +
+                   ", name='" + name + '\'' +
+                   '}';
+        }
+    }
+
+    private final List<ChannelPipelineItem> addBeforeList = new ArrayList<>();
+
+    public void addBefore(ChannelPipelineItem item) {
+        synchronized (addBeforeList) {
+            addSorted(addBeforeList, item);
+        }
+    }
+
+    public void registerItems(ChannelPipeline pipeline) {
+        for (PipelineRegistry.ChannelPipelineItem item : addBeforeList) {
+            pipeline.addBefore(item.base, item.name, item.handlerFactory.get());
+        }
+    }
+
+    List<ChannelPipelineItem> addBeforeList() {
+        return addBeforeList;
+    }
+
+    /**
+     * Add a new {@link ChannelPipelineItem} to an existing list.
+     * An item has base on which it depends on and after which it must be added to the pipeline.
+     * Since items may be added at different times and from different places the dependencies of items may not be present
+     * when they are added.
+     * The sorting works as follows:
+     *   * first, add new item to existing list
+     *   * create a copy on which we can iterate because we may need to modify the order of items of the existing list
+     *   * iterate over items and check if an item already exists which depends on the iterated item - add new item after
+     *   * iterate over items and check if an item already exists on which the iterated item depends on - add new item before
+     *   * if non of the previous predicates apply, add the iterated item at the end of the list
+     *
+     * @param pipelineItems   list to add newItem to
+     * @param newItem         new pipeline item to be added
+     */
+    private void addSorted(List<ChannelPipelineItem> pipelineItems, ChannelPipelineItem newItem) {
+        pipelineItems.add(newItem);
+
+        if (pipelineItems.size() < 2) {
+            return;
+        }
+
+        ArrayList<ChannelPipelineItem> copy = new ArrayList<>(pipelineItems.size());
+        copy.addAll(pipelineItems);
+
+        for (ChannelPipelineItem item : copy) {
+            pipelineItems.remove(item);
+
+            boolean prev = false;
+            int prevIdx = 0;
+            for (ChannelPipelineItem o : pipelineItems) {
+                if (o.name.equals(item.base)) {
+                    prev = true;
+                    break;
+                }
+                prevIdx++;
+            }
+            if (prev) {
+                pipelineItems.add(prevIdx + 1, item);
+                continue;
+            }
+
+            boolean next = false;
+            int nextIdx = 0;
+            for (ChannelPipelineItem o : pipelineItems) {
+                if (o.base.equals(item.name)) {
+                    next = true;
+                    break;
+                }
+                nextIdx++;
+            }
+            if (next) {
+                pipelineItems.add(nextIdx, item);
+                continue;
+            }
+
+            pipelineItems.add(item);
+        }
+    }
+}

--- a/http/src/test/java/io/crate/plugin/PipelineRegistryTest.java
+++ b/http/src/test/java/io/crate/plugin/PipelineRegistryTest.java
@@ -20,24 +20,19 @@
  * agreement.
  */
 
-package io.crate.http.netty;
+package io.crate.plugin;
 
-import io.crate.test.integration.CrateUnitTest;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
-import org.elasticsearch.common.network.NetworkService;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.Test;
 
-import static org.hamcrest.core.Is.is;
-import static org.mockito.Mockito.mock;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 
-public class CrateNettyHttpServerTransportTest extends CrateUnitTest {
+public class PipelineRegistryTest {
 
-    private static CrateNettyHttpServerTransport.ChannelPipelineItem channelPipelineItem(String base, String name) {
-        return new CrateNettyHttpServerTransport.ChannelPipelineItem(base, name, () -> new ChannelHandler() {
+    private static PipelineRegistry.ChannelPipelineItem channelPipelineItem(String base, String name) {
+        return new PipelineRegistry.ChannelPipelineItem(base, name, () -> new ChannelHandler() {
             @Override
             public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
 
@@ -57,24 +52,20 @@ public class CrateNettyHttpServerTransportTest extends CrateUnitTest {
 
     @Test
     public void testAddSortedToPipline() throws Exception {
-        CrateNettyHttpServerTransport httpTransport = new CrateNettyHttpServerTransport(Settings.EMPTY,
-            mock(NetworkService.class),
-            mock(BigArrays.class),
-            mock(ThreadPool.class));
+        PipelineRegistry pipelineRegistry = new PipelineRegistry();
 
-        httpTransport.addBefore(channelPipelineItem("c", "d"));
-        httpTransport.addBefore(channelPipelineItem("a", "b"));
-        httpTransport.addBefore(channelPipelineItem("d", "e"));
-        httpTransport.addBefore(channelPipelineItem("b", "c"));
+        pipelineRegistry.addBefore(channelPipelineItem("c", "d"));
+        pipelineRegistry.addBefore(channelPipelineItem("a", "b"));
+        pipelineRegistry.addBefore(channelPipelineItem("d", "e"));
+        pipelineRegistry.addBefore(channelPipelineItem("b", "c"));
 
-        int size = httpTransport.addBefore().size();
+        int size = pipelineRegistry.addBeforeList().size();
         assertThat(size, is(4));
 
-        String[] names = new String[httpTransport.addBefore().size()];
+        String[] names = new String[pipelineRegistry.addBeforeList().size()];
         for (int i = 0; i < size; i++) {
-            names[i] = httpTransport.addBefore().get(i).name;
+            names[i] = pipelineRegistry.addBeforeList().get(i).name;
         }
         assertThat(names, is(new String[]{"b", "c", "d", "e"}));
     }
-
 }

--- a/sql/src/main/java/io/crate/operation/auth/AuthenticationProvider.java
+++ b/sql/src/main/java/io/crate/operation/auth/AuthenticationProvider.java
@@ -23,9 +23,9 @@
 package io.crate.operation.auth;
 
 import com.google.common.annotations.VisibleForTesting;
-import io.crate.http.netty.CrateNettyHttpServerTransport;
 import io.crate.operation.user.User;
 import io.crate.operation.user.UserManagerProvider;
+import io.crate.plugin.PipelineRegistry;
 import io.crate.protocols.postgres.Messages;
 import io.crate.settings.CrateSetting;
 import io.crate.types.DataTypes;
@@ -97,12 +97,12 @@ public class AuthenticationProvider implements Provider<Authentication> {
     };
 
     @Inject
-    public AuthenticationProvider(Settings settings, UserManagerProvider userManagerProvider, CrateNettyHttpServerTransport httpTransport) {
+    public AuthenticationProvider(Settings settings, UserManagerProvider userManagerProvider, PipelineRegistry pipelineRegistry) {
             UserServiceFactory serviceFactory = UserServiceFactoryLoader.load(settings);
             if (serviceFactory != null) {
                 authService = serviceFactory.authService(settings, userManagerProvider.get());
                 if (authService.enabled()) {
-                    serviceFactory.registerHttpAuthHandler(settings, httpTransport, authService);
+                    serviceFactory.registerHttpAuthHandler(settings, pipelineRegistry, authService);
                 }
             } else {
                 authService = NOOP_AUTH;

--- a/sql/src/main/java/io/crate/operation/auth/UserServiceFactory.java
+++ b/sql/src/main/java/io/crate/operation/auth/UserServiceFactory.java
@@ -24,10 +24,10 @@ package io.crate.operation.auth;
 
 import io.crate.operation.collect.sources.SysTableRegistry;
 import io.crate.operation.user.UserManager;
+import io.crate.plugin.PipelineRegistry;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
-import io.crate.http.netty.CrateNettyHttpServerTransport;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -57,6 +57,6 @@ public interface UserServiceFactory {
                                  SysTableRegistry sysTableRegistry);
 
     void registerHttpAuthHandler(Settings settings,
-                                 CrateNettyHttpServerTransport httpTransport,
+                                 PipelineRegistry pipelineRegistry,
                                  Authentication authService);
 }

--- a/users/src/main/java/io/crate/operation/auth/UserServiceFactoryImpl.java
+++ b/users/src/main/java/io/crate/operation/auth/UserServiceFactoryImpl.java
@@ -22,13 +22,13 @@
 
 package io.crate.operation.auth;
 
+import io.crate.http.netty.HttpAuthUpstreamHandler;
 import io.crate.operation.collect.sources.SysTableRegistry;
 import io.crate.operation.user.*;
+import io.crate.plugin.PipelineRegistry;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
-import io.crate.http.netty.CrateNettyHttpServerTransport;
-import io.crate.http.netty.HttpAuthUpstreamHandler;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -66,12 +66,12 @@ public class UserServiceFactoryImpl implements UserServiceFactory {
     }
 
     @Override
-    public void registerHttpAuthHandler(Settings settings, CrateNettyHttpServerTransport httpTransport, Authentication authService) {
-        CrateNettyHttpServerTransport.ChannelPipelineItem pipelineItem = new CrateNettyHttpServerTransport.ChannelPipelineItem(
+    public void registerHttpAuthHandler(Settings settings, PipelineRegistry pipelineRegistry, Authentication authService) {
+        PipelineRegistry.ChannelPipelineItem pipelineItem = new PipelineRegistry.ChannelPipelineItem(
             "blob_handler",
             "auth_handler",
             () -> new HttpAuthUpstreamHandler(settings, authService)
         );
-        httpTransport.addBefore(pipelineItem);
+        pipelineRegistry.addBefore(pipelineItem);
     }
 }


### PR DESCRIPTION
This extracts a `PipelineRegistry` from the
`CrateNettyHttpServerTransport` in order to prepare it for the ES 5.1
update.

In ES 5.1 `onModule` has been removed. To register a different http
transport there is a new `NetworkPlugin` interface which contains a
method as follows:

     Map<String, Supplier<HttpServerTransport>> getHttpTransports(...)

This can be used to create and register the
`CrateNettyHttpServerTransport`, but as a side effect it won't be bound
to guice anymore - which means it's no longer a global singleton. This
breaks the pipeline logic.

To work around that there is a new `PipelineRegistry` which can be
created earlier and be made available within guice.