### PR TITLE
Fixed: Reordering optimization of join pairs

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -36,6 +36,13 @@ Changes
 Fixes
 =====
 
+ - Fixed an issue with algorithm that tries to reorder the joined tables using
+   the optimum ordering. The issue caused an exception to be thrown when join
+   conditions contain table(s) which are not part of the adjacent joined tables.
+   E.g.::
+
+    SELECT * FROM t1 JOIN t2 JOIN t3 JOIN t4 ON t4.id = t2.id
+
  - Fixed an issue that could cause ``sys.operations`` entries to remain even
    after the operation has finished.
 

--- a/sql/src/main/java/io/crate/analyze/TwoTableJoin.java
+++ b/sql/src/main/java/io/crate/analyze/TwoTableJoin.java
@@ -66,7 +66,7 @@ public class TwoTableJoin implements QueriedRelation {
         fields = new Fields(querySpec.outputs().size());
         for (int i = 0; i < querySpec.outputs().size(); i++) {
             Symbol output = querySpec.outputs().get(i);
-            String name = SymbolPrinter.INSTANCE.printSimple(output);
+            String name = SymbolPrinter.INSTANCE.printSimple(output).replace("\"", "");
             Path fqPath;
             // prefix paths with origin relationName to keep them unique
             if (output instanceof Field) {

--- a/sql/src/main/java/io/crate/analyze/relations/JoinPair.java
+++ b/sql/src/main/java/io/crate/analyze/relations/JoinPair.java
@@ -119,4 +119,8 @@ public class JoinPair {
     public void joinType(JoinType joinType) {
         this.joinType = joinType;
     }
+
+    public boolean containsRelation(QualifiedName relation) {
+        return this.left.equals(relation) ||  this.right.equals(relation);
+    }
 }

--- a/sql/src/main/java/io/crate/analyze/relations/JoinPairs.java
+++ b/sql/src/main/java/io/crate/analyze/relations/JoinPairs.java
@@ -170,4 +170,43 @@ public final class JoinPairs {
         }
         return outputs;
     }
+
+    public enum RelationInclusion {
+        /**
+         * join condition of the join pair actually includes both relations
+         */
+        BOTH_INCLUDED,
+
+        /**
+         * join condition of the join pair doesn't include both relations
+         */
+        FOREIGN_INCLUDED,
+
+        /**
+         * join condition of the join pair includes relations not already part of the join tree
+         */
+        NOT_INCLUDED
+    }
+
+    /**
+     * See {@link RelationInclusion} for result description
+     */
+    public static RelationInclusion determineRelationInclusion(List<JoinPair> currentPermutationJoinPairs,
+                                                               JoinPair joinPair,
+                                                               QualifiedName rel1,
+                                                               QualifiedName rel2) {
+        for (Field f : JoinPairs.extractFieldsFromJoinConditions(Collections.singletonList(joinPair))) {
+            QualifiedName relationName = f.relation().getQualifiedName();
+
+            // Join condition contains relations not included in existing join pairs
+            if (currentPermutationJoinPairs.stream().noneMatch(jp -> jp.containsRelation(relationName))) {
+                return RelationInclusion.FOREIGN_INCLUDED;
+            }
+
+            if (relationName.equals(rel1) && relationName.equals(rel2)) {
+                return RelationInclusion.BOTH_INCLUDED;
+            }
+        }
+        return RelationInclusion.NOT_INCLUDED;
+    }
 }

--- a/sql/src/main/java/io/crate/planner/consumer/ManyTableConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/ManyTableConsumer.java
@@ -35,6 +35,7 @@ import io.crate.planner.Plan;
 import io.crate.planner.Planner;
 import io.crate.planner.fetch.FetchPushDown;
 import io.crate.planner.node.dql.QueryThenFetch;
+import io.crate.planner.node.dql.join.JoinType;
 import io.crate.sql.tree.QualifiedName;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.logging.Loggers;
@@ -88,11 +89,13 @@ public class ManyTableConsumer implements Consumer {
         Set<QualifiedName> outerJoinRelations = JoinPairs.outerJoinRelations(joinPairs);
         Collection<QualifiedName> bestOrder = null;
         int best = -1;
+        List<JoinPair> currentPermutationJoinPairs = new ArrayList<>(joinPairs.size());
         outerloop:
         for (List<QualifiedName> permutation : Collections2.permutations(relations)) {
             if (!preSorted.equals(permutation.subList(0, preSorted.size()))) {
                 continue;
             }
+            currentPermutationJoinPairs.clear();
             int joinPushDowns = 0;
             for (int i = 0; i < permutation.size() - 1; i++) {
                 QualifiedName a = permutation.get(i);
@@ -109,11 +112,18 @@ public class ManyTableConsumer implements Consumer {
                         pair.add(a);
                         pair.add(b);
                         joinPushDowns += implicitJoinedRelations.contains(pair) ? 1 : 0;
+                        currentPermutationJoinPairs.add(new JoinPair(a, b, JoinType.CROSS));
                     }
                 } else {
-                    if (includesBothRelations(joinPair, a, b)) {
-                        // relations are directly joined
-                        joinPushDowns += 1;
+                    switch (JoinPairs.determineRelationInclusion(currentPermutationJoinPairs, joinPair, a, b)) {
+                        case BOTH_INCLUDED:
+                            // relations are directly joined
+                            joinPushDowns += 1;
+                            currentPermutationJoinPairs.add(new JoinPair(a, b, JoinType.CROSS));
+                            break;
+                        case FOREIGN_INCLUDED:
+                            // join condition includes a relation that is not part of the current join tree permutation
+                            continue outerloop;
                     }
                 }
             }
@@ -131,18 +141,6 @@ public class ManyTableConsumer implements Consumer {
         return bestOrder;
     }
 
-    /*
-     * Returns true if the join condition of the join pair actually includes both relations
-     */
-    private static boolean includesBothRelations(JoinPair joinPair, QualifiedName rel1, QualifiedName rel2) {
-        for (Field f : JoinPairs.extractFieldsFromJoinConditions(Collections.singletonList(joinPair))) {
-            QualifiedName relationName = f.relation().getQualifiedName();
-            if (relationName.equals(rel1) && relationName.equals(rel2)) {
-                return true;
-            }
-        }
-        return false;
-    }
     private static Collection<QualifiedName> getNamesFromOrderBy(OrderBy orderBy) {
         Set<QualifiedName> orderByOrder = new LinkedHashSet<>();
         Set<QualifiedName> names = new HashSet<>();

--- a/sql/src/main/java/io/crate/planner/consumer/ManyTableConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/ManyTableConsumer.java
@@ -111,8 +111,10 @@ public class ManyTableConsumer implements Consumer {
                         joinPushDowns += implicitJoinedRelations.contains(pair) ? 1 : 0;
                     }
                 } else {
-                    // relations are directly joined
-                    joinPushDowns += 1;
+                    if (includesBothRelations(joinPair, a, b)) {
+                        // relations are directly joined
+                        joinPushDowns += 1;
+                    }
                 }
             }
             if (joinPushDowns == relations.size() - 1) {
@@ -129,6 +131,18 @@ public class ManyTableConsumer implements Consumer {
         return bestOrder;
     }
 
+    /*
+     * Returns true if the join condition of the join pair actually includes both relations
+     */
+    private static boolean includesBothRelations(JoinPair joinPair, QualifiedName rel1, QualifiedName rel2) {
+        for (Field f : JoinPairs.extractFieldsFromJoinConditions(Collections.singletonList(joinPair))) {
+            QualifiedName relationName = f.relation().getQualifiedName();
+            if (relationName.equals(rel1) && relationName.equals(rel2)) {
+                return true;
+            }
+        }
+        return false;
+    }
     private static Collection<QualifiedName> getNamesFromOrderBy(OrderBy orderBy) {
         Set<QualifiedName> orderByOrder = new LinkedHashSet<>();
         Set<QualifiedName> names = new HashSet<>();

--- a/sql/src/test/java/io/crate/planner/consumer/ManyTableConsumerTest.java
+++ b/sql/src/test/java/io/crate/planner/consumer/ManyTableConsumerTest.java
@@ -23,25 +23,28 @@
 package io.crate.planner.consumer;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.crate.action.sql.SessionContext;
 import io.crate.analyze.*;
+import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.JoinPair;
 import io.crate.planner.node.dql.join.JoinType;
 import io.crate.sql.parser.SqlParser;
 import io.crate.sql.tree.QualifiedName;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
+import io.crate.testing.SqlExpressions;
 import io.crate.testing.T3;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Set;
+import java.util.*;
 
 import static io.crate.testing.TestingHelpers.isSQL;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 
 public class ManyTableConsumerTest extends CrateDummyClusterServiceUnitTest {
@@ -120,7 +123,7 @@ public class ManyTableConsumerTest extends CrateDummyClusterServiceUnitTest {
             ImmutableList.of(pair1, pair2),
             ImmutableList.<QualifiedName>of());
 
-        assertThat(qualifiedNames, Matchers.contains(T3.T1, T3.T2, T3.T3));
+        assertThat(qualifiedNames, contains(T3.T1, T3.T2, T3.T3));
     }
 
     @Test
@@ -131,7 +134,7 @@ public class ManyTableConsumerTest extends CrateDummyClusterServiceUnitTest {
             ImmutableList.<JoinPair>of(),
             ImmutableList.of(T3.T2));
 
-        assertThat(qualifiedNames, Matchers.contains(T3.T2, T3.T1, T3.T3));
+        assertThat(qualifiedNames, contains(T3.T2, T3.T1, T3.T3));
     }
 
     @Test
@@ -145,7 +148,7 @@ public class ManyTableConsumerTest extends CrateDummyClusterServiceUnitTest {
             ImmutableList.of(pair1, pair2),
             ImmutableList.of(T3.T3, T3.T2));
 
-        assertThat(qualifiedNames, Matchers.contains(T3.T1, T3.T2, T3.T3));
+        assertThat(qualifiedNames, contains(T3.T1, T3.T2, T3.T3));
     }
 
     @Test
@@ -196,5 +199,59 @@ public class ManyTableConsumerTest extends CrateDummyClusterServiceUnitTest {
         TwoTableJoin t1Andt3 = (TwoTableJoin) root.left();
         assertThat(t1Andt3.toString(), is("join.doc.t1.doc.t3"));
         assertThat(root.right().getQualifiedName().toString(), is("doc.t2"));
+    }
+
+    private static final Map<QualifiedName, AnalyzedRelation> sources = ImmutableMap.of(
+        new QualifiedName(T3.T1_INFO.ident().name()), T3.TR_1,
+        new QualifiedName(T3.T2_INFO.ident().name()), T3.TR_2,
+        new QualifiedName(T3.T3_INFO.ident().name()), T3.TR_3,
+        new QualifiedName(T3.T4_INFO.ident().name()), T3.TR_4);
+
+    private static final SqlExpressions expressions = new SqlExpressions(sources);
+
+    @Test
+    public void testReordering4TableSortOnWhereAndJoinConditionsThatDontMatchThePair() throws Exception {
+        List<QualifiedName> relations = ImmutableList.of(
+            T3.T1,
+            T3.T2,
+            T3.T3,
+            T3.T4);
+        List<JoinPair> joinPairs = ImmutableList.of(
+            new JoinPair(T3.T1, T3.T2, JoinType.INNER, expressions.asSymbol("t1.a=t2.b")),
+            new JoinPair(T3.T2, T3.T3, JoinType.INNER, expressions.asSymbol("t2.b=t1.a")),
+            new JoinPair(T3.T4, T3.T3, JoinType.INNER, expressions.asSymbol("t4.id=t3.c")));
+        assertThat(ManyTableConsumer.orderByJoinConditions(
+            relations,
+            Collections.emptySet(),
+            joinPairs,
+            ImmutableList.of(T3.T4)), contains(T3.T4, T3.T3, T3.T1, T3.T2));
+    }
+
+    @Test
+    public void test4TableSortOnWhereAndJoinConditionsThatDontMatchThePair() throws Exception {
+        MultiSourceSelect mss = analyze("select *" +
+                                        " from t1" +
+                                        " join t2 on t1.a=t2.b" +
+                                        " join t3 on t2.b=t3.c" +
+                                        " join users on t1.i=users.id" +
+                                        " join users_multi_pk on t3.z=users_multi_pk.id" +
+                                        " order by t3.c");
+        TwoTableJoin root = ManyTableConsumer.buildTwoTableJoinTree(mss);
+        assertThat(root.toString(), is("join.join.join.join.doc.t3.doc.t1.doc.t2.doc.users.doc.users_multi_pk"));
+        assertThat(root.joinPair().condition(),
+                   isSQL("(join.join.join.doc.t3.doc.t1.doc.t2.doc.users.\"join.join.doc.t3.doc.t1.doc.t2\"['join.doc" +
+                         ".t3.doc.t1['doc.t3['z']']'] = to_int(doc.users_multi_pk.id))"));
+        TwoTableJoin tt1 = (TwoTableJoin) root.left();
+        assertThat(tt1.toString(), is("join.join.join.doc.t3.doc.t1.doc.t2.doc.users"));
+        assertThat(tt1.joinPair().condition(),
+                   isSQL("(join.join.doc.t3.doc.t1.doc.t2.\"join.doc.t3.doc.t1\"['doc.t1['i']'] = to_int(doc.users.id))"));
+        TwoTableJoin tt2 = (TwoTableJoin) tt1.left();
+        assertThat(tt2.toString(), is("join.join.doc.t3.doc.t1.doc.t2"));
+        assertThat(tt2.joinPair().condition(),
+                   isSQL("((join.doc.t3.doc.t1.doc.t1['a'] = doc.t2.b) AND (doc.t2.b = join.doc.t3.doc.t1.doc.t3['c']))"));
+
+        TwoTableJoin tt3 = (TwoTableJoin) tt2.left();
+        assertThat(tt3.toString(), is("join.doc.t3.doc.t1"));
+        assertThat(tt3.joinPair().condition(), nullValue());
     }
 }

--- a/sql/src/test/java/io/crate/testing/T3.java
+++ b/sql/src/test/java/io/crate/testing/T3.java
@@ -86,15 +86,17 @@ public class T3 {
         .add("obj_array", new ArrayType(DataTypes.OBJECT))
         .add("obj_array", DataTypes.INTEGER, ImmutableList.of("i"))
         .build();
+    public static final TableRelation TR_4 = new TableRelation(T4_INFO);
 
     public static final QualifiedName T1 = new QualifiedName(Arrays.asList(Schemas.DEFAULT_SCHEMA_NAME, "t1"));
     public static final QualifiedName T2 = new QualifiedName(Arrays.asList(Schemas.DEFAULT_SCHEMA_NAME, "t2"));
     public static final QualifiedName T3 = new QualifiedName(Arrays.asList(Schemas.DEFAULT_SCHEMA_NAME, "t3"));
+    public static final QualifiedName T4 = new QualifiedName(Arrays.asList(Schemas.DEFAULT_SCHEMA_NAME, "t4"));
 
-    public static final ImmutableList<AnalyzedRelation> RELATIONS = ImmutableList.<AnalyzedRelation>of(TR_1, TR_2, TR_3);
-    public static final Map<QualifiedName, AnalyzedRelation> SOURCES = ImmutableMap.<QualifiedName, AnalyzedRelation>of(
+    public static final ImmutableList<AnalyzedRelation> RELATIONS = ImmutableList.of(TR_1, TR_2, TR_3, TR_4);
+    public static final Map<QualifiedName, AnalyzedRelation> SOURCES = ImmutableMap.of(
         T1, TR_1,
         T2, TR_2,
-        T3, TR_3
-    );
+        T3, TR_3,
+        T4, TR_4);
 }


### PR DESCRIPTION
If there are join conditions that don't directly join the adjacent relations
then don't count them as direct joins when trying to find the best order.

When trying to find the optimum order of join pairs exclude
those orderings that use join conditions which include relations
that are not already part of the join tree.
e.g:

JoinPair1: (t3,t4, t3.id=t4.id)
JoinPair2: (t4,t2, t4.id=t1.id)
...
