### PR TITLE
Fix partitioned-by/generated-column COPY FROM IndexOutOfBoundsException

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -36,6 +36,9 @@ Changes
 Fixes
 =====
 
+ - Fixed a ``COPY FROM`` issue that caused imports into tables with certain
+   combinations of PARTITIONED BY, PRIMARY KEY and GENERATED COLUMNS to fail.
+
  - Fixed an issue with algorithm that tries to reorder the joined tables using
    the optimum ordering. The issue caused an exception to be thrown when join
    conditions contain table(s) which are not part of the adjacent joined tables.

--- a/sql/src/main/java/io/crate/planner/projection/AbstractIndexWriterProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/AbstractIndexWriterProjection.java
@@ -40,28 +40,26 @@ import java.util.List;
 
 public abstract class AbstractIndexWriterProjection extends Projection {
 
-    protected final static List<Symbol> OUTPUTS = ImmutableList.<Symbol>of(
-        new Value(DataTypes.LONG)  // number of rows imported
-    );
+    private final static List<Symbol> OUTPUTS = ImmutableList.<Symbol>of(new Value(DataTypes.LONG));  // number of rows imported
 
-    protected final static String BULK_SIZE = "bulk_size";
-    protected final static int BULK_SIZE_DEFAULT = 10000;
+    private final static String BULK_SIZE = "bulk_size";
+    private final static int BULK_SIZE_DEFAULT = 10000;
 
-    protected Integer bulkActions;
+    private Integer bulkActions;
     protected TableIdent tableIdent;
     protected String partitionIdent;
     protected List<ColumnIdent> primaryKeys;
-    protected
-    @Nullable
-    ColumnIdent clusteredByColumn;
 
-    protected List<Symbol> idSymbols;
-    protected List<Symbol> partitionedBySymbols;
-    protected
+    @Nullable
+    private ColumnIdent clusteredByColumn;
+
+    private List<Symbol> idSymbols;
+    List<Symbol> partitionedBySymbols;
+
     @Nullable
     Symbol clusteredBySymbol;
 
-    protected boolean autoCreateIndices;
+    private boolean autoCreateIndices;
 
 
     protected AbstractIndexWriterProjection(TableIdent tableIdent,
@@ -69,12 +67,14 @@ public abstract class AbstractIndexWriterProjection extends Projection {
                                             List<ColumnIdent> primaryKeys,
                                             @Nullable ColumnIdent clusteredByColumn,
                                             Settings settings,
+                                            List<Symbol> idSymbols,
                                             boolean autoCreateIndices) {
         this.tableIdent = tableIdent;
         this.partitionIdent = partitionIdent;
         this.primaryKeys = primaryKeys;
         this.clusteredByColumn = clusteredByColumn;
         this.autoCreateIndices = autoCreateIndices;
+        this.idSymbols = idSymbols;
 
         this.bulkActions = settings.getAsInt(BULK_SIZE, BULK_SIZE_DEFAULT);
         Preconditions.checkArgument(bulkActions > 0, "\"bulk_size\" must be greater than 0.");

--- a/sql/src/main/java/io/crate/planner/projection/ColumnIndexWriterProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/ColumnIndexWriterProjection.java
@@ -56,8 +56,7 @@ public class ColumnIndexWriterProjection extends AbstractIndexWriterProjection {
                                        @Nullable String partitionIdent,
                                        List<ColumnIdent> primaryKeys,
                                        List<Reference> columns,
-                                       @Nullable
-                                           Map<Reference, Symbol> onDuplicateKeyAssignments,
+                                       @Nullable Map<Reference, Symbol> onDuplicateKeyAssignments,
                                        List<Symbol> primaryKeySymbols,
                                        List<ColumnIdent> partitionedByColumns,
                                        List<Symbol> partitionedBySymbols,
@@ -65,8 +64,7 @@ public class ColumnIndexWriterProjection extends AbstractIndexWriterProjection {
                                        @Nullable Symbol clusteredBySymbol,
                                        Settings settings,
                                        boolean autoCreateIndices) {
-        super(tableIdent, partitionIdent, primaryKeys, clusteredByColumn, settings, autoCreateIndices);
-        this.idSymbols = primaryKeySymbols;
+        super(tableIdent, partitionIdent, primaryKeys, clusteredByColumn, settings, primaryKeySymbols, autoCreateIndices);
         this.partitionedBySymbols = partitionedBySymbols;
         this.onDuplicateKeyAssignments = onDuplicateKeyAssignments;
         this.columnReferences = new ArrayList<>(columns);

--- a/sql/src/main/java/io/crate/planner/projection/builder/InputColumns.java
+++ b/sql/src/main/java/io/crate/planner/projection/builder/InputColumns.java
@@ -24,6 +24,8 @@ package io.crate.planner.projection.builder;
 import com.google.common.base.MoreObjects;
 import io.crate.analyze.symbol.*;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.GeneratedReference;
+import io.crate.metadata.Reference;
 import io.crate.types.DataType;
 import org.elasticsearch.common.inject.Singleton;
 
@@ -123,6 +125,14 @@ public final class InputColumns extends DefaultTraversalSymbolVisitor<InputColum
     @Override
     protected Symbol visitSymbol(Symbol symbol, Context context) {
         return MoreObjects.firstNonNull(context.inputs.get(symbol), symbol);
+    }
+
+    @Override
+    public Symbol visitReference(Reference ref, Context context) {
+        if (ref instanceof GeneratedReference) {
+            return visitSymbol(((GeneratedReference) ref).generatedExpression(), context);
+        }
+        return visitSymbol(ref, context);
     }
 
     @Override


### PR DESCRIPTION
The InputColumn index calculation in the creation of the
SourceIndexWriterProjection wasn't correct.

This commit changes the pattern to create the projection from an
imperative to a more declarative approach.

The input-column indices are no longer calculated manually. Instead the
`toCollect` symbols are declared based on primary keys and partitioned by
columns. Then the `InputColumns` API is used to generate the input
columns.

This also eliminates the loose contract that we had, that the
`SourceIndexWriterProjection` constructor expected the `toCollect`
symbols of the `FileUriCollectPhase` to be in a certain order.