### PR TITLE
Fixed weird log message coming from the parser.

### DIFF
--- a/sql/src/main/java/io/crate/analyze/TwoTableJoin.java
+++ b/sql/src/main/java/io/crate/analyze/TwoTableJoin.java
@@ -27,7 +27,7 @@ import io.crate.analyze.relations.JoinPair;
 import io.crate.analyze.relations.QueriedRelation;
 import io.crate.analyze.symbol.Field;
 import io.crate.analyze.symbol.Symbol;
-import io.crate.analyze.symbol.format.SymbolPrinter;
+import io.crate.analyze.symbol.Symbols;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.OutputName;
@@ -66,7 +66,7 @@ public class TwoTableJoin implements QueriedRelation {
         fields = new Fields(querySpec.outputs().size());
         for (int i = 0; i < querySpec.outputs().size(); i++) {
             Symbol output = querySpec.outputs().get(i);
-            String name = SymbolPrinter.INSTANCE.printSimple(output).replace("\"", "");
+            String name = Symbols.pathFromSymbol(output).outputName();
             Path fqPath;
             // prefix paths with origin relationName to keep them unique
             if (output instanceof Field) {


### PR DESCRIPTION
SymbolPrinter was used directly to build paths for Fields of TwoTableJoin.
This caused the parser to recognize keyword "join" used in the (QualifiedNames
of the joins) and log a message "line 1:0 no viable alternative at input 'join'".
Replacing direct usage of SymbolPrinter with Symbols.pathFromSymbol() solves the issue
as it avoids calling the SymbolPrinter if the symbol is a Field.