### PR TITLE
idea/codeStyle: Disable wildcard imports

### DIFF
--- a/idea/codeStyle.xml
+++ b/idea/codeStyle.xml
@@ -2,8 +2,8 @@
 <component name="ProjectCodeStyleSettingsManager">
   <option name="PER_PROJECT_SETTINGS">
     <value>
-      <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="5" />
-      <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="3" />
+      <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="9999" />
+      <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="9999" />
       <option name="USE_SINGLE_CLASS_IMPORTS" value="true" />
       <option name="USE_FQ_CLASS_NAMES" value="false" />
       <option name="INSERT_INNER_CLASS_IMPORTS" value="false" />


### PR DESCRIPTION
ES has introduced style checks which cause failures if wildcard imports
are used.

So in order to avoid these failures this commit changes our settings to
prevent wildcard imports.