### PR TITLE
Fixed wrong default translog.flush_threshold_size

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -28,6 +28,10 @@ Changes
 Fixes
 =====
 
+ - Reflect internally used default size for ``translog.flush_threshold_size``
+   also in documentation and expose the correct default value in table
+   settings.
+
  - Added missing table setting ``translog.durability`` which is required and
    and must be set accordingly so that ``translog.sync_interval`` takes effect.
 

--- a/app/src/main/dist/config/crate.yml
+++ b/app/src/main/dist/config/crate.yml
@@ -199,7 +199,7 @@
 
 # Sets size of transaction log prior to flushing.
 #
-#index.translog.flush_threshold_size: 200mb
+#index.translog.flush_threshold_size: 512mb
 
 # Sets period of no flushing after which force flush occurs.
 #

--- a/blackbox/docs/sql/administration/show_create_table.txt
+++ b/blackbox/docs/sql/administration/show_create_table.txt
@@ -44,7 +44,7 @@ already existing user-created doc tables in the cluster::
     |    "routing.allocation.enable" = 'all',             |
     |    "routing.allocation.total_shards_per_node" = -1, |
     |    "translog.durability" = 'REQUEST',               |
-    |    "translog.flush_threshold_size" = 209715200,     |
+    |    "translog.flush_threshold_size" = 536870912,     |
     |    "translog.sync_interval" = 5000,                 |
     |    "unassigned.node_left.delayed_timeout" = 60000,  |
     |    "warmer.enabled" = true                          |

--- a/sql/src/main/java/io/crate/metadata/settings/CrateTableSettings.java
+++ b/sql/src/main/java/io/crate/metadata/settings/CrateTableSettings.java
@@ -25,10 +25,11 @@ package io.crate.metadata.settings;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import io.crate.analyze.TableParameterInfo;
-import org.elasticsearch.common.unit.ByteSizeUnit;
-import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.translog.Translog;
+
+import static org.elasticsearch.index.IndexSettings.INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING;
 
 public class CrateTableSettings {
 
@@ -57,7 +58,7 @@ public class CrateTableSettings {
 
 
     public static final ByteSizeSetting FLUSH_THRESHOLD_SIZE = new ByteSizeSetting(
-        TableParameterInfo.FLUSH_THRESHOLD_SIZE, new ByteSizeValue(200, ByteSizeUnit.MB));
+        TableParameterInfo.FLUSH_THRESHOLD_SIZE, INDEX_TRANSLOG_FLUSH_THRESHOLD_SIZE_SETTING.getDefault(Settings.EMPTY));
 
     public static final BoolSetting WARMER_ENABLED = new BoolSetting(TableParameterInfo.WARMER_ENABLED, true);
 


### PR DESCRIPTION
Reflect internally used default size for ``translog.flush_threshold_size`` also in documentation and expose the correct default value in table settings.
