### PR TITLE
REST row count reciever now throws an SQLActionException when it fails

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -28,6 +28,8 @@ Changes
 Fixes
 =====
 
+ - The correct error messages and codes are now thrown for REST actions.
+
  - Fixed a bug in the memory accounting of the circuit breaker for HTTP
    results when querying ``GEO_SHAPE`` columns.
 

--- a/sql/src/main/java/io/crate/rest/action/RestRowCountReceiver.java
+++ b/sql/src/main/java/io/crate/rest/action/RestRowCountReceiver.java
@@ -25,6 +25,7 @@ package io.crate.rest.action;
 import io.crate.action.sql.BaseResultReceiver;
 import io.crate.analyze.symbol.Field;
 import io.crate.data.Row;
+import io.crate.exceptions.SQLExceptions;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -95,7 +96,7 @@ class RestRowCountReceiver extends BaseResultReceiver {
     @Override
     public void fail(@Nonnull Throwable t) {
         try {
-            channel.sendResponse(new CrateThrowableRestResponse(channel, t));
+            channel.sendResponse(new CrateThrowableRestResponse(channel, SQLExceptions.createSQLActionException(t)));
         } catch (Throwable e) {
             LOGGER.error("failed to send failure response", e);
         } finally {

--- a/sql/src/main/java/io/crate/rest/action/RestSQLAction.java
+++ b/sql/src/main/java/io/crate/rest/action/RestSQLAction.java
@@ -32,6 +32,7 @@ import io.crate.analyze.symbol.Symbols;
 import io.crate.breaker.CrateCircuitBreakerService;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.breaker.RowAccounting;
+import io.crate.exceptions.SQLExceptions;
 import io.crate.exceptions.SQLParseException;
 import io.crate.operation.auth.AuthenticationProvider;
 import io.crate.operation.user.User;
@@ -231,7 +232,7 @@ public class RestSQLAction extends BaseRestHandler {
 
     private void errorResponse(RestChannel channel, Throwable t) {
         try {
-            channel.sendResponse(new CrateThrowableRestResponse(channel, t));
+            channel.sendResponse(new CrateThrowableRestResponse(channel, SQLExceptions.createSQLActionException(t)));
         } catch (Throwable e) {
             logger.error("failed to send failure response", e);
         }


### PR DESCRIPTION
Addresses #5681 

 When inserting a duplicate key, an incorrect exception was thrown:

`VersionConflictEngineException[[default][1]: version conflict, document already exists (current version [1])]`

Upon failing, the REST row count receiver will now throw an SQLActionException version of the throwable it receives, resulting in:

`SQLActionException[DuplicateKeyException: A document with the same primary key exists already]`

Which also returns the correct error code. This needs to be backported to 1.1; should it also be backported to 2.0?