### PR TITLE
fixed two cases of selects on virtual tables that result into a lost alias

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -36,6 +36,9 @@ Changes
 Fixes
 =====
 
+ - Fixed an issue that causes aliases used in the select list to get lost on
+   subselect queries.
+
  - The correct error messages and codes are now thrown for REST actions.
 
  - Fixed a bug in the memory accounting of the circuit breaker for HTTP

--- a/sql/src/main/java/io/crate/analyze/relations/SubselectRewriter.java
+++ b/sql/src/main/java/io/crate/analyze/relations/SubselectRewriter.java
@@ -283,16 +283,31 @@ public final class SubselectRewriter {
         FieldReplacer(List<? extends Symbol> outputs, QueriedRelation relation) {
             super(ReplaceMode.COPY);
             // Store the fields of a relation mapped to its output symbol so they will not get lost (e.g. alias preserve)
-            for (Field field : relation.fields()) {
-                fieldByQSOutputSymbol.put(relation.querySpec().outputs().get(field.index()), field);
-            }
             this.outputs = outputs;
+
+            /* Create a "backrefs" map to be able to preserve field names/aliases if we merge relations
+             *
+             * currentQS.outputs,  parent-relation
+             *
+             * select aliased_sub.x / aliased_sub.i from (select x, i from t1) as aliased_sub
+             *
+             * parent.fields(): Field[divide..., rel=root]
+             * parent.querySpec.outputs:  divide(Field[x, rel=aliased_sub], Field[i, rel=aliased_sub]
+             * currentQS.outputs: Field[x, rel=t1], Field[i, rel=t1]
+             *
+             * -> fieldByQSOutputSymbol
+             *
+             * divide(Field[x, rel=t1], Field[i, rel=t2]  -> divide(Field[x, rel=aliased_sub], Field[i, rel=aliased_sub])
+             */
+            for (Field field : relation.fields()) {
+                fieldByQSOutputSymbol.put(apply(relation.querySpec().outputs().get(field.index())), field);
+            }
         }
 
         @Override
         public Symbol visitField(Field field, Void context) {
             Symbol newOutput = outputs.get(field.index());
-            fieldByQSOutputSymbol.put(newOutput, field);
+            fieldByQSOutputSymbol.putIfAbsent(newOutput, field);
             return newOutput;
         }
 

--- a/sql/src/test/java/io/crate/analyze/SubSelectAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SubSelectAnalyzerTest.java
@@ -154,7 +154,7 @@ public class SubSelectAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
-    public void testPreserveAliasOnSingleRowSubSelectWithVirtualTableJoin() throws Exception {
+    public void  testPreserveAliasOnSubSelectInSelectList() throws Exception {
         SelectAnalyzedStatement statement = analyze("SELECT " +
                                                     "   (select min(t1.x) from t1) as min_col," +
                                                     "   (select 10) + (select 20) as add_subquery "+

--- a/sql/src/test/java/io/crate/analyze/SubSelectAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SubSelectAnalyzerTest.java
@@ -55,7 +55,7 @@ public class SubSelectAnalyzerTest extends CrateDummyClusterServiceUnitTest {
             "select aliased_sub.x / aliased_sub.i from (select x, i from t1) as aliased_sub");
         QueriedDocTable relation = (QueriedDocTable) statement.relation();
         assertThat(relation.fields().size(), is(1));
-        assertThat(relation.fields().get(0), isField("divide(x, i)"));
+        assertThat(relation.fields().get(0), isField("(x / i)"));
         assertThat(relation.tableRelation().tableInfo(), is(T1_INFO));
     }
 
@@ -83,7 +83,7 @@ public class SubSelectAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         QueriedDocTable relation = (QueriedDocTable) statement.relation();
         assertThat(relation.fields().size(), is(2));
         assertThat(relation.fields().get(0), isField("aa"));
-        assertThat(relation.fields().get(1), isField("add(add(x, i), 1)"));
+        assertThat(relation.fields().get(1), isField("(xi + 1)"));
         assertThat(relation.tableRelation().tableInfo(), is(T1_INFO));
     }
 
@@ -154,7 +154,7 @@ public class SubSelectAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
-    public void  testPreserveAliasOnSubSelectInSelectList() throws Exception {
+    public void testPreserveAliasOnSubSelectInSelectList() throws Exception {
         SelectAnalyzedStatement statement = analyze("SELECT " +
                                                     "   (select min(t1.x) from t1) as min_col," +
                                                     "   (select 10) + (select 20) as add_subquery "+
@@ -166,4 +166,15 @@ public class SubSelectAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(relation.tableRelation().tableInfo(), is(T1_INFO));
     }
 
+    @Test
+    public void testPreserveAliasedOnSubSelect() throws Exception {
+        SelectAnalyzedStatement statement = analyze("SELECT tt1.x as a1, min(tt1.x) as a2 " +
+                                                    "FROM (select * from t1) as tt1 " +
+                                                    "GROUP BY a1");
+        QueriedDocTable relation = (QueriedDocTable) statement.relation();
+        assertThat(relation.fields().size(), is(2));
+        assertThat(relation.fields().get(0), isField("a1"));
+        assertThat(relation.fields().get(1), isField("a2"));
+        assertThat(relation.tableRelation().tableInfo(), is(T1_INFO));
+    }
 }


### PR DESCRIPTION
Previously a Single-Row select with a virtual table join resulted into an insufficient columname caused of a lost alias.