### PR TITLE
Prevent creation of invalid JoinPair instances

### DIFF
--- a/sql/src/main/java/io/crate/analyze/relations/JoinPair.java
+++ b/sql/src/main/java/io/crate/analyze/relations/JoinPair.java
@@ -36,14 +36,20 @@ public class JoinPair {
 
     private QualifiedName left;
     private QualifiedName right;
+
     @Nullable
     private Symbol condition;
 
-    public JoinPair(QualifiedName left, QualifiedName right, JoinType joinType) {
-        this(left, right, joinType, null);
+    public static JoinPair crossJoin(QualifiedName left, QualifiedName right) {
+        return new JoinPair(left, right, JoinType.CROSS, null);
     }
 
-    public JoinPair(QualifiedName left, QualifiedName right, JoinType joinType, @Nullable Symbol condition) {
+    public static JoinPair of(QualifiedName left, QualifiedName right, JoinType joinType, Symbol condition) {
+        assert condition != null || joinType == JoinType.CROSS : "condition must be present unless it's a cross-join";
+        return new JoinPair(left, right, joinType, condition);
+    }
+
+    private JoinPair(QualifiedName left, QualifiedName right, JoinType joinType, @Nullable Symbol condition) {
         this.left = left;
         this.right = right;
         this.joinType = joinType;

--- a/sql/src/main/java/io/crate/analyze/relations/JoinPairs.java
+++ b/sql/src/main/java/io/crate/analyze/relations/JoinPairs.java
@@ -32,7 +32,12 @@ import io.crate.planner.node.dql.join.JoinType;
 import io.crate.sql.tree.QualifiedName;
 
 import javax.annotation.Nullable;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.function.Function;
 
 public final class JoinPairs {
@@ -49,7 +54,7 @@ public final class JoinPairs {
         JoinPair joinPair = ofRelations(left, right, joinPairs, true);
         if (joinPair == null) {
             // default to cross join (or inner, doesn't matter)
-            return new JoinPair(left, right, JoinType.CROSS);
+            return JoinPair.crossJoin(left, right);
         }
         assert !(joinPairs instanceof ImmutableList) : "joinPairs list must be mutable if it contains items";
         // if it's an INNER, lets check for reverse relations and merge conditions
@@ -87,7 +92,7 @@ public final class JoinPairs {
         if (checkReversePair) {
             for (JoinPair joinPair : joinPairs) {
                 if (joinPair.equalsNames(right, left)) {
-                    JoinPair reverseJoinPair = new JoinPair(
+                    JoinPair reverseJoinPair = JoinPair.of(
                         joinPair.right(),
                         joinPair.left(),
                         joinPair.joinType().invert(),

--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalysisContext.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalysisContext.java
@@ -29,7 +29,13 @@ import io.crate.planner.node.dql.join.JoinType;
 import io.crate.sql.tree.QualifiedName;
 
 import javax.annotation.Nullable;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
 public class RelationAnalysisContext {
 
@@ -78,7 +84,7 @@ public class RelationAnalysisContext {
             }
             idx++;
         }
-        addJoinPair(new JoinPair(left, right, joinType, joinCondition));
+        addJoinPair(JoinPair.of(left, right, joinType, joinCondition));
     }
 
     List<JoinPair> joinPairs() {

--- a/sql/src/test/java/io/crate/analyze/relations/RelationSplitterTest.java
+++ b/sql/src/test/java/io/crate/analyze/relations/RelationSplitterTest.java
@@ -279,7 +279,7 @@ public class RelationSplitterTest extends CrateUnitTest {
     @Test
     public void testNoSplitOnOuterJoinRelation() throws Exception {
         QuerySpec querySpec = fromQuery("t2.y < 10");
-        JoinPair joinPair = new JoinPair(T3.T1, T3.T2, JoinType.LEFT, asSymbol("t1.a = t2.b"));
+        JoinPair joinPair = JoinPair.of(T3.T1, T3.T2, JoinType.LEFT, asSymbol("t1.a = t2.b"));
         RelationSplitter splitter = split(querySpec, Collections.singletonList(joinPair));
 
         assertThat(querySpec, isSQL("SELECT true WHERE (doc.t2.y < 10)"));
@@ -313,7 +313,7 @@ public class RelationSplitterTest extends CrateUnitTest {
             .outputs(Arrays.asList(asSymbol("t1.a"), asSymbol("t2.b")))
             .orderBy(new OrderBy(
                 Collections.singletonList(asSymbol("t1.a")), new boolean[]{false}, new Boolean[]{null}));
-        JoinPair t1AndT2InnerJoin = new JoinPair(T3.T1, T3.T2, JoinType.INNER, asSymbol("t1.a = t2.b"));
+        JoinPair t1AndT2InnerJoin = JoinPair.of(T3.T1, T3.T2, JoinType.INNER, asSymbol("t1.a = t2.b"));
 
         RelationSplitter splitter = split(qs, Collections.singletonList(t1AndT2InnerJoin));
         assertThat(splitter.getSpec(T3.TR_1), isSQL("SELECT doc.t1.a ORDER BY doc.t1.a"));


### PR DESCRIPTION
This commit restricts the API so it's impossible to create
INNER/LEFT/RIGHT/FULL JoinPair instances that have no join condition.