### PR TITLE
Tweak JOIN ORDER-BY push-down optimization

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -36,6 +36,9 @@ Changes
 Fixes
 =====
 
+ - Fixed a performance regression that could cause JOIN queries to execute
+   slower than they used to.
+
  - Return proper exception when group by is used on scalar funtions that are
    applied to an aggregation.
 

--- a/sql/src/main/java/io/crate/analyze/relations/RelationSplitter.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationSplitter.java
@@ -22,20 +22,38 @@
 
 package io.crate.analyze.relations;
 
-import com.google.common.collect.*;
+import com.google.common.collect.Multimaps;
+import com.google.common.collect.SetMultimap;
+import com.google.common.collect.Sets;
 import io.crate.analyze.HavingClause;
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.QuerySpec;
 import io.crate.analyze.WhereClause;
 import io.crate.analyze.fetch.FetchFieldExtractor;
-import io.crate.analyze.symbol.*;
+import io.crate.analyze.symbol.Aggregations;
+import io.crate.analyze.symbol.DefaultTraversalSymbolVisitor;
+import io.crate.analyze.symbol.Field;
+import io.crate.analyze.symbol.FieldsVisitor;
+import io.crate.analyze.symbol.Literal;
+import io.crate.analyze.symbol.MatchPredicate;
+import io.crate.analyze.symbol.Symbol;
+import io.crate.analyze.symbol.Symbols;
 import io.crate.operation.operator.AndOperator;
 import io.crate.planner.Limits;
 import io.crate.sql.tree.QualifiedName;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 
 public final class RelationSplitter {
 
@@ -48,8 +66,6 @@ public final class RelationSplitter {
     private final Set<QualifiedName> relationPartOfJoinConditions;
     private Set<Field> canBeFetched;
     private RemainingOrderBy remainingOrderBy;
-
-    private static final Supplier<Set<Integer>> INT_SET_SUPPLIER = HashSet::new;
 
     public RelationSplitter(QuerySpec querySpec,
                             Collection<? extends AnalyzedRelation> relations,
@@ -212,101 +228,68 @@ public final class RelationSplitter {
         }
     }
 
+    /**
+     * Move ORDER BY expressions to the subRelations if it's safe.
+     * Move is safe if all order by expressions refer to the same relation and there is no outer join.
+     *
+     *  - NL with outer-join injects null rows; so it doesn't preserve the ordering
+     *  - Two or more relations in ORDER BY requires a post-join sorting, relying on preserving the pre-ordering doesn't work:
+     *
+     *  Example:
+     *
+     * <pre>
+     *   ORDER BY tx, ty
+     *
+     *   tx = [1, 1, 2, 2]
+     *   ty = [1, 2]
+     *
+     *   for x in tx:
+     *      for y in ty:
+     *
+     *   results in
+     *     1| 1
+     *     1| 2
+     *     1| 1
+     *     1| 2
+     *     ...
+     *
+     *   but should result in
+     *
+     *     1| 1
+     *     1| 1
+     *     1| 2
+     *     1| 2
+     *
+     * </pre>
+     */
     private void processOrderBy() {
-        if (!querySpec.orderBy().isPresent()) {
+        Optional<OrderBy> optOrderBy = querySpec.orderBy();
+        if (!optOrderBy.isPresent()) {
             return;
         }
-        OrderBy orderBy = querySpec.orderBy().get();
-
+        OrderBy orderBy = optOrderBy.get();
         Set<AnalyzedRelation> relations = Collections.newSetFromMap(new IdentityHashMap<AnalyzedRelation, Boolean>());
-        Consumer<Field> relationsConsumer = f -> relations.add(f.relation());
+        Consumer<Field> gatherRelations = f -> relations.add(f.relation());
 
-        // We copy all ORDER BY symbols to remainingOrderBy
-        extractRemainingOrderBy(orderBy, relations, relationsConsumer);
-
-        Multimap<AnalyzedRelation, Integer> splits = extractOrderByForPushDown(orderBy, relations, relationsConsumer);
-
-        // Pushed down the orderBy to subquery specs
-        for (Map.Entry<AnalyzedRelation, Collection<Integer>> entry : splits.asMap().entrySet()) {
-            AnalyzedRelation relation = entry.getKey();
-            OrderBy newOrderBy = orderBy.subset(entry.getValue());
-            QuerySpec spec = getSpec(relation);
-            assert !spec.orderBy().isPresent() : "spec.orderBy() must not be present";
-            spec.orderBy(newOrderBy);
-            requiredForQuery.addAll(newOrderBy.orderBySymbols());
+        if (querySpec.hasAggregates() || querySpec.groupBy().isPresent()) {
+            return;
         }
-    }
-
-    private void extractRemainingOrderBy(OrderBy orderBy, Set<AnalyzedRelation> relations, Consumer<Field> relationsConsumer) {
-        Integer idx = 0;
-        for (Symbol symbol : orderBy.orderBySymbols()) {
-            // If order by is pointing to an aggregation we cannot push it down
-            // because ordering needs to happen AFTER the join
-            if (Aggregations.containsAggregation(symbol)) {
-                continue;
-            }
-            relations.clear();
-            FieldsVisitor.visitFields(symbol, relationsConsumer);
-
-            // instantiate remainingOrderBy really only if needed!
-            // because it is used as a marker
-            if (remainingOrderBy == null) {
-                remainingOrderBy = new RemainingOrderBy();
-            }
-
-            OrderBy newOrderBy = orderBy.subset(Collections.singletonList(idx));
-            for (AnalyzedRelation rel : relations) {
-                remainingOrderBy.addRelation(rel.getQualifiedName());
-            }
-            remainingOrderBy.addOrderBy(newOrderBy);
-            idx++;
+        for (Symbol orderExpr : orderBy.orderBySymbols()) {
+            FieldsVisitor.visitFields(orderExpr, gatherRelations);
         }
-        relations.clear();
-    }
-
-    /**
-     * Extract the ORDER BY symbols which can be pushed down to subqueries.
-     * To extract them, the symbols are processed from left to right in their stated order.
-     * A symbol can only be pushed down if it contains a single relation.
-     * Additionally either the previous symbol (from left to right) contained the same relation,
-     * or that relation of the symbol did not occur yet.
-     * Once a symbols contains more than a single relation no further order by symbols may be pushed down.
-     *
-     * Examples:
-     * ORDER BY t1.a, t1.b, t2.x, t2.y -> t1: a, b, t2: x, y
-     * ORDER BY t1.a, t2.x, t1.b, t2.x -> t1: a, t2: x
-     * ORDER BY t1.a, fn(t1.a, t2.x), t2.x -> t1: a
-     * ORDER BY fn(t1.a, t2.x), t3.z -> none
-     */
-    private Multimap<AnalyzedRelation, Integer> extractOrderByForPushDown(OrderBy orderBy, Set<AnalyzedRelation> relations, Consumer<Field> relationsConsumer) {
-        Multimap<AnalyzedRelation, Integer> splits = Multimaps.newSetMultimap(
-            new IdentityHashMap<AnalyzedRelation, Collection<Integer>>(specs.size()),
-            INT_SET_SUPPLIER::get);
-
-        Integer idx = 0;
-        List<QualifiedName> allRelations = new ArrayList<>();
-        for (Symbol symbol : orderBy.orderBySymbols()) {
-            // If order by is pointing to an aggregation we cannot push it down
-            // because ordering needs to happen AFTER the join
-            if (Aggregations.containsAggregation(symbol)) {
-                continue;
+        if (relations.size() == 1 && joinPairs.stream().noneMatch(p -> p.joinType().isOuter())) {
+            AnalyzedRelation relationInOrderBy = relations.iterator().next();
+            QuerySpec spec = getSpec(relationInOrderBy);
+            orderBy = orderBy.copyAndReplace(Symbols.DEEP_COPY);
+            spec.orderBy(orderBy);
+            requiredForQuery.addAll(orderBy.orderBySymbols());
+        } else {
+            remainingOrderBy = new RemainingOrderBy();
+            for (AnalyzedRelation relation : relations) {
+                remainingOrderBy.addRelation(relation.getQualifiedName());
             }
-            relations.clear();
-            FieldsVisitor.visitFields(symbol, relationsConsumer);
-
-            if (relations.size() == 1) {
-                AnalyzedRelation rel = Iterables.getOnlyElement(relations);
-                if (!allRelations.contains(rel.getQualifiedName()) || allRelations.get(allRelations.size() - 1).equals(rel.getQualifiedName())) {
-                    splits.put(rel, idx);
-                    allRelations.add(rel.getQualifiedName());
-                }
-            } else {
-                break;
-            }
-            idx++;
+            remainingOrderBy.addOrderBy(orderBy);
         }
-        relations.clear();
-        return splits;
     }
 
     private final static class JoinConditionValidator extends DefaultTraversalSymbolVisitor<Void, Symbol> {

--- a/sql/src/test/java/io/crate/analyze/relations/RelationSplitterTest.java
+++ b/sql/src/test/java/io/crate/analyze/relations/RelationSplitterTest.java
@@ -35,12 +35,18 @@ import io.crate.testing.SqlExpressions;
 import io.crate.testing.T3;
 import org.junit.Test;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import static io.crate.testing.SymbolMatchers.isField;
 import static io.crate.testing.SymbolMatchers.isFunction;
 import static io.crate.testing.TestingHelpers.isSQL;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.Is.is;
 
 public class RelationSplitterTest extends CrateUnitTest {
@@ -163,7 +169,7 @@ public class RelationSplitterTest extends CrateUnitTest {
         assertThat(splitter.remainingOrderBy().isPresent(), is(true));
         assertThat(splitter.remainingOrderBy().get().orderBy(), isSQL("doc.t1.a DESC, add(doc.t1.x, doc.t2.y)"));
         assertThat(splitter.requiredForQuery(), isSQL("doc.t1.a, doc.t1.x, doc.t2.y"));
-        assertThat(splitter.getSpec(T3.TR_1), isSQL("SELECT doc.t1.a, doc.t1.x ORDER BY doc.t1.a DESC"));
+        assertThat(splitter.getSpec(T3.TR_1), isSQL("SELECT doc.t1.a, doc.t1.x"));
         assertThat(splitter.getSpec(T3.TR_2), isSQL("SELECT doc.t2.y"));
         assertThat(splitter.canBeFetched(), empty());
     }
@@ -179,9 +185,9 @@ public class RelationSplitterTest extends CrateUnitTest {
 
         assertThat(querySpec, isSQL("SELECT doc.t1.x, doc.t2.y ORDER BY doc.t1.x, doc.t2.y, doc.t3.z LIMIT 20"));
 
-        assertThat(splitter.getSpec(T3.TR_1), isSQL("SELECT doc.t1.x WHERE (doc.t1.x = 1) ORDER BY doc.t1.x"));
-        assertThat(splitter.getSpec(T3.TR_2), isSQL("SELECT doc.t2.y WHERE (true AND (doc.t2.y = 2)) ORDER BY doc.t2.y"));
-        assertThat(splitter.getSpec(T3.TR_3), isSQL("SELECT doc.t3.z WHERE (true AND (doc.t3.z = 3)) ORDER BY doc.t3.z"));
+        assertThat(splitter.getSpec(T3.TR_1), isSQL("SELECT doc.t1.x WHERE (doc.t1.x = 1)"));
+        assertThat(splitter.getSpec(T3.TR_2), isSQL("SELECT doc.t2.y WHERE (true AND (doc.t2.y = 2))"));
+        assertThat(splitter.getSpec(T3.TR_3), isSQL("SELECT doc.t3.z WHERE (true AND (doc.t3.z = 3))"));
     }
 
     @Test
@@ -202,7 +208,7 @@ public class RelationSplitterTest extends CrateUnitTest {
         assertThat(querySpec, isSQL("SELECT doc.t1.a, doc.t2.b " +
                                     "ORDER BY doc.t1.x, add(subtract(doc.t1.x, doc.t2.y), doc.t3.z), " +
                                     "doc.t2.y, add(doc.t1.x, doc.t2.y)"));
-        assertThat(splitter.getSpec(T3.TR_1), isSQL("SELECT doc.t1.x, doc.t1.a ORDER BY doc.t1.x"));
+        assertThat(splitter.getSpec(T3.TR_1), isSQL("SELECT doc.t1.x, doc.t1.a"));
         assertThat(splitter.getSpec(T3.TR_2), isSQL("SELECT doc.t2.y, doc.t2.b"));
         assertThat(splitter.getSpec(T3.TR_3), isSQL("SELECT doc.t3.z"));
 
@@ -298,5 +304,20 @@ public class RelationSplitterTest extends CrateUnitTest {
             .having(new HavingClause(asSymbol("t1.x = 10")));
         RelationSplitter splitter = split(qs);
         assertThat(splitter.getSpec(T3.TR_1), isSQL("SELECT doc.t1.x, doc.t1.a"));
+    }
+
+    @Test
+    public void testOrderByIsFullyPushedDownIfPossible() throws Exception {
+        // select t1.a, t2.b from t1 inner join t2 on t1.a = t2.b order by t1.a
+        QuerySpec qs = new QuerySpec()
+            .outputs(Arrays.asList(asSymbol("t1.a"), asSymbol("t2.b")))
+            .orderBy(new OrderBy(
+                Collections.singletonList(asSymbol("t1.a")), new boolean[]{false}, new Boolean[]{null}));
+        JoinPair t1AndT2InnerJoin = new JoinPair(T3.T1, T3.T2, JoinType.INNER, asSymbol("t1.a = t2.b"));
+
+        RelationSplitter splitter = split(qs, Collections.singletonList(t1AndT2InnerJoin));
+        assertThat(splitter.getSpec(T3.TR_1), isSQL("SELECT doc.t1.a ORDER BY doc.t1.a"));
+        assertThat("remainingOrderBy must be false if it's safe to remove after pushDown",
+            splitter.remainingOrderBy().isPresent(), is(false));
     }
 }

--- a/sql/src/test/java/io/crate/planner/SubQueryPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/SubQueryPlannerTest.java
@@ -28,7 +28,13 @@ import io.crate.planner.node.dql.Collect;
 import io.crate.planner.node.dql.PlanWithFetchDescription;
 import io.crate.planner.node.dql.QueryThenFetch;
 import io.crate.planner.node.dql.join.NestedLoop;
-import io.crate.planner.projection.*;
+import io.crate.planner.projection.EvalProjection;
+import io.crate.planner.projection.FetchProjection;
+import io.crate.planner.projection.FilterProjection;
+import io.crate.planner.projection.GroupProjection;
+import io.crate.planner.projection.OrderedTopNProjection;
+import io.crate.planner.projection.Projection;
+import io.crate.planner.projection.TopNProjection;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.testing.T3;
@@ -146,7 +152,7 @@ public class SubQueryPlannerTest extends CrateDummyClusterServiceUnitTest {
                                     ") t order by t1x desc limit 3");
         List<Projection> projections = ((NestedLoop) qtf.subPlan()).nestedLoopPhase().projections();
         assertThat(projections, Matchers.contains(
-            instanceOf(OrderedTopNProjection.class),
+            instanceOf(TopNProjection.class),
             instanceOf(FetchProjection.class),
             instanceOf(OrderedTopNProjection.class)));
 


### PR DESCRIPTION
Instead of duplicating the ORDER BY expressions onto the sub-relations,
they're now either fully moved or not at all.

This can significantly improve the speed of a query (In one test-case
the runtime decreased from 800sec to 5sec)