### PR TITLE
fixed value comparison of data type array

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -41,6 +41,9 @@ Changes
 
 Fixes
 =====
+ 
+ - Fixed an issue that leads to an exception if the statement evaluates on
+   arrays that are provided in an aggregation function.
 
  - Fixed a performance regression that could cause JOIN queries to execute
    slower than they used to.

--- a/core/src/main/java/io/crate/types/ArrayType.java
+++ b/core/src/main/java/io/crate/types/ArrayType.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -102,7 +103,13 @@ public class ArrayType extends DataType implements CollectionType, Streamer<Obje
 
         int size1 = val1 instanceof List ? ((List) val1).size() : ((Object[]) val1).length;
         int size2 = val2 instanceof List ? ((List) val2).size() : ((Object[]) val2).length;
-        return Integer.compare(size1, size2);
+
+        int compResult = Integer.compare(size1, size2);
+        if (compResult == 0) {
+            return Arrays.deepEquals((Object[]) val1, (Object[]) val2) ? 0 : 1;
+        } else {
+            return compResult;
+        }
     }
 
     @Override

--- a/sql/src/test/java/io/crate/analyze/symbol/LiteralTest.java
+++ b/sql/src/test/java/io/crate/analyze/symbol/LiteralTest.java
@@ -61,4 +61,46 @@ public class LiteralTest extends CrateUnitTest {
         Literal<Object[]> l2 = Literal.of(new Double[]{10.0, 20.2}, DataTypes.GEO_POINT);
         assertThat(l1.hashCode(), is(l2.hashCode()));
     }
+
+    @Test
+    public void testCompareArrayValues() throws Exception {
+        DataType intTypeArr = new ArrayType(DataTypes.INTEGER);
+
+        Literal val1 = Literal.of(intTypeArr, new Object[] {1,2,3});
+        Literal val2 = Literal.of(intTypeArr, new Object[] {4,5,6});
+        assertThat(val1.equals(val2), is(false));
+
+        val1 = Literal.of(intTypeArr, new Object[] {1,2,3});
+        val2 = Literal.of(intTypeArr, new Object[] {1,2,3});
+        assertThat(val1.equals(val2), is(true));
+
+        val1 = Literal.of(intTypeArr, new Object[] {3,2,1});
+        val2 = Literal.of(intTypeArr, new Object[] {1,2,3});
+        assertThat(val1.equals(val2), is(false));
+
+        val1 = Literal.of(intTypeArr, new Object[] {1,2,3,4,5});
+        val2 = Literal.of(intTypeArr, new Object[] {1,2,3});
+        assertThat(val1.equals(val2), is(false));
+    }
+
+    @Test
+    public void testCompareNestedArrayValues() throws Exception {
+        DataType intTypeNestedArr = new ArrayType(new ArrayType(DataTypes.INTEGER));
+
+        Literal val1 = Literal.of(intTypeNestedArr, new Object[][] {new Object[] {1,2,3}});
+        Literal val2 = Literal.of(intTypeNestedArr, new Object[][] {new Object[] {4,5,6}});
+        assertThat(val1.equals(val2), is(false));
+
+        val1 = Literal.of(intTypeNestedArr, new Object[][] {new Object[] {1,2,3}});
+        val2 = Literal.of(intTypeNestedArr, new Object[][] {new Object[] {1,2,3}});
+        assertThat(val1.equals(val2), is(true));
+
+        val1 = Literal.of(intTypeNestedArr, new Object[][] {new Object[] {3,2,1}});
+        val2 = Literal.of(intTypeNestedArr, new Object[][] {new Object[] {1,2,3}});
+        assertThat(val1.equals(val2), is(false));
+
+        val1 = Literal.of(intTypeNestedArr, new Object[][] {new Object[] {1,2,3,4,5}});
+        val2 = Literal.of(intTypeNestedArr, new Object[][] {new Object[] {1,2,3}});
+        assertThat(val1.equals(val2), is(false));
+    }
 }


### PR DESCRIPTION
In this case the aggregation function gets only added once to the context instead of twice. This is caused by an insufficient value comparison inside the `contains` check of the provided array in the (in this case) `any` operator.

```java
// check if aggregate function is already added to the context
if (!aggregates.contains(aggregate)) {
      aggregates.add(aggregate);
}
```

```sql
SELECT
       SUM(
           CASE
               WHEN EXTRACT(MONTH FROM ts)=ANY([1,2,3])
               THEN value
               ELSE 0.0
           END
       ) AS "q1",
       SUM(
           CASE
               WHEN EXTRACT(MONTH FROM ts)=ANY([4,5,6])
               THEN value
               ELSE 0.0
           END
       ) AS "q2"
FROM    xyz;
```

lead into: 

```
SQLActionException: BAD_REQUEST 4000 SQLParseException: Couldn't create executionContexts from
NodeOperations: [0=>NodeOp{ phase{id=0/collect, nodes=[XZgMd4QJR0ivZbL3m9PpVw], dist=BROADCAST}, downstreamNodes=[], downstreamPhase=1, downstreamInputId=0}]
Leafs: [MergePhase{executionPhaseId=1, name=mergeOnHandler, projections=[io.crate.planner.projection.AggregationProjection@41880d07, TopNProjection{outputs=[IC{0, double}, sum(if(any_=(extract_MONTH(Reference{ident=<RefIdent: doc.xyz->ts>, granularity=DOC, type=timestamp, index type=NOT_ANALYZED, nullable=true}),Literal{[4, 5, 6], type=integer_array}),Reference{ident=<RefIdent: doc.xyz->value>, granularity=DOC, type=double, index type=NOT_ANALYZED, nullable=true},Literal{0.0, type=double}))], limit=100, offset=0}], outputTypes=[double, double], jobId=fe488074-51a2-47c1-b4a7-59c16ee0c41a, numUpstreams=1, nodeOperations=[XZgMd4QJR0ivZbL3m9PpVw], inputTypes=[double], orderBy=null}]
target-sources: [1=>[0]]
original-error: UnsupportedFeatureException: Function sum(double) is not a scalar function.
```