### PR TITLE
Remove unnecessary lookup for IndexShard.

### DIFF
--- a/sql/src/main/java/io/crate/executor/transport/TransportShardAction.java
+++ b/sql/src/main/java/io/crate/executor/transport/TransportShardAction.java
@@ -36,7 +36,6 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.shard.IndexShard;
-import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.translog.Translog;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -82,7 +81,7 @@ public abstract class TransportShardAction<Request extends ShardRequest<Request,
         KillableWrapper<WriteResult<ShardResponse>> callable = new KillableWrapper<WriteResult<ShardResponse>>() {
             @Override
             public WriteResult<ShardResponse> call() throws Exception {
-                return processRequestItems(shardRequest.shardId(), shardRequest, killed);
+                return processRequestItems(indexShard, shardRequest, killed);
             }
         };
         return wrapOperationInKillable(shardRequest, callable);
@@ -94,7 +93,7 @@ public abstract class TransportShardAction<Request extends ShardRequest<Request,
         KillableWrapper<Translog.Location> callable = new KillableWrapper<Translog.Location>() {
             @Override
             public Translog.Location call() throws Exception {
-                return processRequestItemsOnReplica(shardRequest.shardId(), shardRequest);
+                return processRequestItemsOnReplica(indexShard, shardRequest);
             }
 
         };
@@ -137,9 +136,9 @@ public abstract class TransportShardAction<Request extends ShardRequest<Request,
         }
     }
 
-    protected abstract WriteResult<ShardResponse> processRequestItems(ShardId shardId, Request request, AtomicBoolean killed) throws InterruptedException;
+    protected abstract WriteResult<ShardResponse> processRequestItems(IndexShard indexShard, Request request, AtomicBoolean killed) throws InterruptedException;
 
-    protected abstract Translog.Location processRequestItemsOnReplica(ShardId shardId, Request request);
+    protected abstract Translog.Location processRequestItemsOnReplica(IndexShard indexShard, Request request);
 
     static abstract class KillableWrapper<WrapperResponse> implements KillableCallable<WrapperResponse> {
 

--- a/sql/src/test/java/io/crate/executor/transport/TransportShardDeleteActionTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/TransportShardDeleteActionTest.java
@@ -87,7 +87,7 @@ public class TransportShardDeleteActionTest extends CrateDummyClusterServiceUnit
         request.add(1, new ShardDeleteRequest.Item("1"));
 
         TransportWriteAction.WriteResult<ShardResponse> result = transportShardDeleteAction.processRequestItems(
-            shardId, request, new AtomicBoolean(true));
+            indexShard, request, new AtomicBoolean(true));
 
         assertThat(result.getResponse().failure(), instanceOf(InterruptedException.class));
         assertThat(request.skipFromLocation(), is(1));
@@ -101,7 +101,7 @@ public class TransportShardDeleteActionTest extends CrateDummyClusterServiceUnit
         request.skipFromLocation(1);
 
         // replica operation must skip all not by primary processed items
-        transportShardDeleteAction.processRequestItemsOnReplica(shardId, request);
+        transportShardDeleteAction.processRequestItemsOnReplica(indexShard, request);
         verify(indexShard, times(0)).delete(any(Engine.Delete.class));
     }
 }

--- a/sql/src/test/java/io/crate/executor/transport/TransportShardUpsertActionTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/TransportShardUpsertActionTest.java
@@ -187,7 +187,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
         request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null));
 
         TransportWriteAction.WriteResult<ShardResponse> result = transportShardUpsertAction.processRequestItems(
-            shardId, request, new AtomicBoolean(false));
+            indexShard, request, new AtomicBoolean(false));
 
         assertThat(result.getResponse().failure(), instanceOf(VersionConflictEngineException.class));
     }
@@ -206,7 +206,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
         request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null));
 
         TransportWriteAction.WriteResult<ShardResponse> result = transportShardUpsertAction.processRequestItems(
-            shardId, request, new AtomicBoolean(false));
+            indexShard, request, new AtomicBoolean(false));
 
         ShardResponse response = result.getResponse();
         assertThat(response.failures().size(), is(1));
@@ -439,7 +439,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
         request.add(1, new ShardUpsertRequest.Item("1", null, new Object[]{1}, null));
 
         TransportWriteAction.WriteResult<ShardResponse> result = transportShardUpsertAction.processRequestItems(
-            shardId, request, new AtomicBoolean(true));
+            indexShard, request, new AtomicBoolean(true));
 
         assertThat(result.getResponse().failure(), instanceOf(InterruptedException.class));
     }
@@ -460,7 +460,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
         reset(indexShard);
 
         // would fail with NPE if not skipped
-        transportShardUpsertAction.processRequestItemsOnReplica(shardId, request);
+        transportShardUpsertAction.processRequestItemsOnReplica(indexShard, request);
         verify(indexShard, times(0)).index(any(Engine.Index.class));
     }
 }


### PR DESCRIPTION
With new API IndexShard is passed as argument in onPrimaryShard/onReplicaShard
so can be used directly without the need of lookup through IndexService.