### PR TITLE
Fix insert error handling & fix testDeletePartitionWhileBulkInsertingData

### DIFF
--- a/sql/src/main/java/io/crate/executor/transport/task/UpsertByIdTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/UpsertByIdTask.java
@@ -56,12 +56,20 @@ import org.elasticsearch.index.engine.DocumentMissingException;
 import org.elasticsearch.index.engine.VersionConflictEngineException;
 import org.elasticsearch.index.shard.ShardId;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static io.crate.concurrent.CompletableFutures.failedFuture;
 import static java.util.Collections.singletonList;
 
 public class UpsertByIdTask extends JobTask {
@@ -194,7 +202,12 @@ public class UpsertByIdTask extends JobTask {
     }
 
     private CompletableFuture<BitSet> createAndSendRequests() {
-        Map<ShardId, ShardUpsertRequest> requestsByShard = groupRequests();
+        Map<ShardId, ShardUpsertRequest> requestsByShard;
+        try {
+            requestsByShard = groupRequests();
+        } catch (Throwable t) {
+            return failedFuture(t);
+        }
         if (requestsByShard.isEmpty()) {
             return CompletableFuture.completedFuture(new BitSet(0));
         }

--- a/sql/src/main/java/io/crate/operation/projectors/RetryListener.java
+++ b/sql/src/main/java/io/crate/operation/projectors/RetryListener.java
@@ -32,7 +32,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
-public class RetryListener<TReq, TResp> implements ActionListener<TResp> {
+public class RetryListener<TResp> implements ActionListener<TResp> {
 
     private final ScheduledExecutorService scheduler;
     private final ActionListener<TResp> delegate;

--- a/sql/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
@@ -44,7 +44,11 @@ import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.After;
 import org.junit.Test;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -230,11 +234,11 @@ public class PartitionedTableConcurrentIntegrationTest extends SQLTransportInteg
 
     private void deletePartitionWhileInsertingData(final boolean useBulk) throws Exception {
         execute("create table parted (id int, name string) " +
+                "clustered into 1 shards " +
                 "partitioned by (id) " +
                 "with (number_of_replicas = 0)");
-        ensureYellow();
 
-        int numberOfDocs = 1000;
+        int numberOfDocs = 100;
         final Object[][] bulkArgs = new Object[numberOfDocs][];
         for (int i = 0; i < numberOfDocs; i++) {
             bulkArgs[i] = new Object[]{i % 2, randomAsciiOfLength(10)};


### PR DESCRIPTION
A IndexNotFoundException in the UpsertByIdTask could be swallowed.

In addition this commit changes the tests in
`PartitionedTableConcurrentIntegrationTest` to be less resource intense.
There was a chance that the first requests would run into a timeout when
creating the index + waiting for the shards to become active.

This could even lead to a "shard leak" because the test could finish
with the request still being active.

(No changes entry because this didn't occur in 2.0.0, but would be introduced as bug in 2.0.1 without this fix)