### PR TITLE
Integrate HBA with SSL support

### DIFF
--- a/sql/src/main/java/io/crate/operation/auth/HbaProtocol.java
+++ b/sql/src/main/java/io/crate/operation/auth/HbaProtocol.java
@@ -3,6 +3,7 @@ package io.crate.operation.auth;
 public enum HbaProtocol {
 
     POSTGRES("pg"),
+    POSTGRES_SSL("pg"),
     HTTP("http");
 
     private final String protocolName;

--- a/sql/src/main/java/io/crate/protocols/postgres/ConnectionContext.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/ConnectionContext.java
@@ -43,6 +43,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.ByteToMessageDecoder;
+import io.netty.handler.ssl.SslHandler;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.logging.Loggers;
 
@@ -359,7 +360,9 @@ class ConnectionContext {
     private void authenticate(Channel channel, Properties properties) {
         String userName = properties.getProperty("user");
         InetAddress address = CrateNettyHttpServerTransport.getRemoteAddress(channel);
-        AuthenticationMethod authMethod = authService.resolveAuthenticationType(userName, address, HbaProtocol.POSTGRES);
+        boolean usesSSL = channel.pipeline().first() instanceof SslHandler;
+        HbaProtocol hbaProtocol = usesSSL ? HbaProtocol.POSTGRES_SSL : HbaProtocol.POSTGRES;
+        AuthenticationMethod authMethod = authService.resolveAuthenticationType(userName, address, hbaProtocol);
         if (authMethod == null) {
             String errorMessage = String.format(
                 Locale.ENGLISH,

--- a/users/build.gradle
+++ b/users/build.gradle
@@ -7,6 +7,7 @@ description = 'User Management for CrateDB'
 dependencies {
     compile project(':sql')
     testCompile project(':integration-testing')
+    testCompile project(':ssl-impl')
     testCompile project(path: ':sql', configuration: 'testOutput')
     testCompile project(path: ':dex', configuration: 'testOutput')
     testCompile "org.hamcrest:hamcrest-all:${versions.hamcrest}"

--- a/users/src/test/resources/keystore.jks
+++ b/users/src/test/resources/keystore.jks
@@ -1,0 +1,1 @@
+../../../../ssl-impl/src/test/resources/keystore.jks

--- a/users/src/test/resources/truststore.jks
+++ b/users/src/test/resources/truststore.jks
@@ -1,0 +1,1 @@
+../../../../ssl-impl/src/test/resources/truststore.jks


### PR DESCRIPTION
This integrates the new `ssl-impl` module with the `users` module. The HBA config now has an entry `requireSSL` which may be `required`, `optional`, or `never`. There are unit and integration tests in the users module to verify the functionality.

For the tests I had to duplicate the keystore/truststore files used in the ssl-impl module. Probably there is a better way which we can proceed before merging this PR.