### PR TITLE
fixes users privileges cluster state distribution

### DIFF
--- a/users/src/main/java/io/crate/operation/user/PrivilegesRequest.java
+++ b/users/src/main/java/io/crate/operation/user/PrivilegesRequest.java
@@ -25,7 +25,7 @@ package io.crate.operation.user;
 import io.crate.analyze.user.Privilege;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ValidateActions;
-import org.elasticsearch.action.support.master.MasterNodeRequest;
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -33,7 +33,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 
-public class PrivilegesRequest extends MasterNodeRequest<PrivilegesRequest> {
+public class PrivilegesRequest extends AcknowledgedRequest<PrivilegesRequest> {
 
     private Collection<String> userNames;
     private Collection<Privilege> privileges;

--- a/users/src/main/java/io/crate/operation/user/UsersPrivilegesMetaData.java
+++ b/users/src/main/java/io/crate/operation/user/UsersPrivilegesMetaData.java
@@ -50,7 +50,12 @@ public class UsersPrivilegesMetaData extends AbstractDiffable<MetaData.Custom> i
         if (oldMetaData == null) {
             return new UsersPrivilegesMetaData();
         }
-        return new UsersPrivilegesMetaData(new HashMap<>(oldMetaData.usersPrivileges));
+
+        Map<String, Set<Privilege>> userPrivileges = new HashMap<>(oldMetaData.usersPrivileges.size());
+        for (Map.Entry<String, Set<Privilege>> entry : oldMetaData.usersPrivileges.entrySet()) {
+            userPrivileges.put(entry.getKey(), new HashSet<>(entry.getValue()));
+        }
+        return new UsersPrivilegesMetaData(userPrivileges);
     }
 
     private final Map<String, Set<Privilege>> usersPrivileges;


### PR DESCRIPTION
the transport action will wait now until the new cluster state is
proccessed on all nodes before responding.
privileges changes should be visible immediately on all nodes.
also fixes UsersPrivilegesMetaData.copyOf() to do a deep copy,
otherwise the old and new cluster state is equal and won't be published