### PR TITLE
Fixed: using `unnest` with 10 or more columns.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -39,3 +39,6 @@ Changes
 
 Fixes
 =====
+
+ - Fixed an issue that caused an exception to be thrown when using ``unnest``
+   with 10 or more columns.

--- a/sql/src/main/java/io/crate/metadata/table/ColumnRegistrar.java
+++ b/sql/src/main/java/io/crate/metadata/table/ColumnRegistrar.java
@@ -28,6 +28,7 @@ import io.crate.metadata.*;
 import io.crate.types.DataType;
 
 import javax.annotation.Nullable;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -44,6 +45,16 @@ public class ColumnRegistrar {
         this.rowGranularity = rowGranularity;
         this.infosBuilder = ImmutableSortedMap.naturalOrder();
         this.columnsBuilder = ImmutableSortedSet.orderedBy(Reference.COMPARE_BY_COLUMN_IDENT);
+    }
+
+    public ColumnRegistrar(TableIdent tableIdent,
+                           RowGranularity rowGranularity,
+                           Comparator<ColumnIdent> infosComparator,
+                           Comparator<Reference> columnComparator) {
+        this.tableIdent = tableIdent;
+        this.rowGranularity = rowGranularity;
+        this.infosBuilder = ImmutableSortedMap.orderedBy(infosComparator);
+        this.columnsBuilder = ImmutableSortedSet.orderedBy(columnComparator);
     }
 
     public ColumnRegistrar register(String column, DataType type, @Nullable List<String> path) {

--- a/sql/src/main/java/io/crate/operation/tablefunctions/UnnestFunction.java
+++ b/sql/src/main/java/io/crate/operation/tablefunctions/UnnestFunction.java
@@ -130,7 +130,12 @@ public class UnnestFunction {
 
         @Override
         public TableInfo createTableInfo(ClusterService clusterService) {
-            ColumnRegistrar columnRegistrar = new ColumnRegistrar(TABLE_IDENT, RowGranularity.DOC);
+            ColumnRegistrar columnRegistrar = new ColumnRegistrar(
+                TABLE_IDENT,
+                RowGranularity.DOC,
+                // Use custom comparators to avoid lexical ordering of the columns (col10 before column 2)
+                Comparator.comparing(o -> Integer.valueOf(o.name().substring(3))),
+                Comparator.comparing(o -> Integer.valueOf(o.ident().columnIdent().name().substring(3))));
             for (int i = 0; i < info.ident().argumentTypes().size(); i++) {
                 columnRegistrar.register(new ColumnIdent(
                     "col" + (i + 1)), ((CollectionType) info.ident().argumentTypes().get(i)).innerType());


### PR DESCRIPTION
When creating the temp TableInfo for the table created by unnest
we were using lexical ordering of the columns which caused an ordering
like this: col1, col10, col11, col2