### PR TITLE
Fixed TableInfo creation for unnest().

### DIFF
--- a/sql/src/main/java/io/crate/metadata/table/ColumnRegistrar.java
+++ b/sql/src/main/java/io/crate/metadata/table/ColumnRegistrar.java
@@ -24,11 +24,14 @@ package io.crate.metadata.table;
 
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
-import io.crate.metadata.*;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.Reference;
+import io.crate.metadata.ReferenceIdent;
+import io.crate.metadata.RowGranularity;
+import io.crate.metadata.TableIdent;
 import io.crate.types.DataType;
 
 import javax.annotation.Nullable;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -45,16 +48,6 @@ public class ColumnRegistrar {
         this.rowGranularity = rowGranularity;
         this.infosBuilder = ImmutableSortedMap.naturalOrder();
         this.columnsBuilder = ImmutableSortedSet.orderedBy(Reference.COMPARE_BY_COLUMN_IDENT);
-    }
-
-    public ColumnRegistrar(TableIdent tableIdent,
-                           RowGranularity rowGranularity,
-                           Comparator<ColumnIdent> infosComparator,
-                           Comparator<Reference> columnComparator) {
-        this.tableIdent = tableIdent;
-        this.rowGranularity = rowGranularity;
-        this.infosBuilder = ImmutableSortedMap.orderedBy(infosComparator);
-        this.columnsBuilder = ImmutableSortedSet.orderedBy(columnComparator);
     }
 
     public ColumnRegistrar register(String column, DataType type, @Nullable List<String> path) {

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -2142,4 +2142,11 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         assertThat(stmt.relation().querySpec().outputs(), isSQL(sqlFields));
         assertThat(stmt.relation().fields(), isSQL(sqlFields));
     }
+
+    @Test
+    public void testUnnestWithObjectColumn() {
+        expectedException.expect(ColumnUnknownException.class);
+        expectedException.expectMessage("Column col1['x'] unknown");
+        analyze("select col1['x'] from unnest([{x=1}])");
+    }
 }


### PR DESCRIPTION
The comparator for sorting the columns numericly and not lexically is also used when issuing
get() on the ImmutableSortedMap/Set so it should be implemented with more complex logic.

Instead of that we skip ColumnRegistrar and we create the Map and Set
of columns presorted as we need.

This is a followup of commit: e1a76e1