### PR TITLE
creating or dropping a user is now an acknowledged cluster operation

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -40,5 +40,8 @@ Changes
 Fixes
 =====
 
+ - ``CREATE USER`` and ``DROP USER`` statements will now only respond after all
+   nodes in the cluster processed the change.
+
  - Fixed an issue that caused an exception to be thrown when using ``unnest``
    with 10 or more columns.

--- a/users/src/main/java/io/crate/metadata/UsersMetaData.java
+++ b/users/src/main/java/io/crate/metadata/UsersMetaData.java
@@ -16,7 +16,7 @@
  * Agreement with Crate.io.
  */
 
-package io.crate.operation.user;
+package io.crate.metadata;
 
 import org.elasticsearch.cluster.AbstractDiffable;
 import org.elasticsearch.cluster.metadata.MetaData;
@@ -32,15 +32,15 @@ public class UsersMetaData extends AbstractDiffable<MetaData.Custom> implements 
 
     public static String TYPE = "users";
 
-    static final UsersMetaData PROTO = new UsersMetaData();
+    public static final UsersMetaData PROTO = new UsersMetaData();
 
     private final List<String> users;
 
-    UsersMetaData() {
+    public UsersMetaData() {
         this.users = new ArrayList<>();
     }
 
-    UsersMetaData(List<String> users) {
+    public UsersMetaData(List<String> users) {
         this.users = users;
     }
 

--- a/users/src/main/java/io/crate/metadata/sys/SysUsersTableInfo.java
+++ b/users/src/main/java/io/crate/metadata/sys/SysUsersTableInfo.java
@@ -16,7 +16,7 @@
  * Agreement with Crate.io.
  */
 
-package io.crate.operation.user;
+package io.crate.metadata.sys;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -24,9 +24,9 @@ import com.google.common.collect.ImmutableSet;
 import io.crate.analyze.WhereClause;
 import io.crate.metadata.*;
 import io.crate.metadata.expressions.RowCollectExpressionFactory;
-import io.crate.metadata.sys.SysSchemaInfo;
 import io.crate.metadata.table.ColumnRegistrar;
 import io.crate.metadata.table.StaticTableInfo;
+import io.crate.operation.user.User;
 import io.crate.types.DataTypes;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.cluster.service.ClusterService;

--- a/users/src/main/java/io/crate/operation/auth/UserServiceFactoryImpl.java
+++ b/users/src/main/java/io/crate/operation/auth/UserServiceFactoryImpl.java
@@ -23,6 +23,7 @@
 package io.crate.operation.auth;
 
 import io.crate.http.netty.HttpAuthUpstreamHandler;
+import io.crate.metadata.sys.SysUsersTableInfo;
 import io.crate.operation.collect.sources.SysTableRegistry;
 import io.crate.operation.user.*;
 import io.crate.plugin.PipelineRegistry;

--- a/users/src/main/java/io/crate/operation/user/CreateUserRequest.java
+++ b/users/src/main/java/io/crate/operation/user/CreateUserRequest.java
@@ -20,13 +20,13 @@ package io.crate.operation.user;
 
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ValidateActions;
-import org.elasticsearch.action.support.master.MasterNodeRequest;
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 
-public class CreateUserRequest extends MasterNodeRequest<CreateUserRequest> {
+public class CreateUserRequest extends AcknowledgedRequest<CreateUserRequest> {
 
     private String userName;
 

--- a/users/src/main/java/io/crate/operation/user/DropUserRequest.java
+++ b/users/src/main/java/io/crate/operation/user/DropUserRequest.java
@@ -20,30 +20,30 @@ package io.crate.operation.user;
 
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ValidateActions;
-import org.elasticsearch.action.support.master.MasterNodeRequest;
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 
-public class DropUserRequest extends MasterNodeRequest<DropUserRequest> {
+public class DropUserRequest extends AcknowledgedRequest<DropUserRequest> {
 
     private String userName;
     private boolean ifExists;
 
-    public DropUserRequest() {
+    DropUserRequest() {
     }
 
-    public DropUserRequest(String userName, boolean ifExists) {
+    DropUserRequest(String userName, boolean ifExists) {
         this.userName = userName;
         this.ifExists = ifExists;
     }
 
-    public String userName() {
+    String userName() {
         return userName;
     }
 
-    public boolean ifExists() {
+    boolean ifExists() {
         return ifExists;
     }
 

--- a/users/src/main/java/io/crate/operation/user/TransportCreateUserAction.java
+++ b/users/src/main/java/io/crate/operation/user/TransportCreateUserAction.java
@@ -20,6 +20,7 @@ package io.crate.operation.user;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.crate.exceptions.ConflictException;
+import io.crate.metadata.UsersMetaData;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.TransportMasterNodeAction;

--- a/users/src/main/java/io/crate/operation/user/TransportDropUserAction.java
+++ b/users/src/main/java/io/crate/operation/user/TransportDropUserAction.java
@@ -19,6 +19,7 @@
 package io.crate.operation.user;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.crate.metadata.UsersMetaData;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;

--- a/users/src/main/java/io/crate/operation/user/UserManagerService.java
+++ b/users/src/main/java/io/crate/operation/user/UserManagerService.java
@@ -20,6 +20,7 @@ package io.crate.operation.user;
 
 import com.google.common.collect.ImmutableSet;
 import io.crate.action.FutureActionListener;
+import io.crate.metadata.UsersMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
 import io.crate.action.sql.SessionContext;
 import io.crate.analyze.AnalyzedStatement;
@@ -37,12 +38,12 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
-import static io.crate.operation.user.UsersMetaData.PROTO;
-import static io.crate.operation.user.UsersMetaData.TYPE;
+import static io.crate.metadata.UsersMetaData.PROTO;
+import static io.crate.metadata.UsersMetaData.TYPE;
 
 public class UserManagerService implements UserManager, ClusterStateListener {
 
-    static User CRATE_USER = new User("crate", EnumSet.of(User.Role.SUPERUSER));
+    public static User CRATE_USER = new User("crate", EnumSet.of(User.Role.SUPERUSER));
 
     private static final PermissionVisitor PERMISSION_VISITOR = new PermissionVisitor();
 

--- a/users/src/test/java/io/crate/integrationtests/UserManagementIntegrationTest.java
+++ b/users/src/test/java/io/crate/integrationtests/UserManagementIntegrationTest.java
@@ -16,13 +16,14 @@
  * Agreement with Crate.io.
  */
 
-package io.crate.operation.user;
+package io.crate.integrationtests;
 
 import com.google.common.collect.ImmutableSet;
 import io.crate.action.sql.Option;
 import io.crate.action.sql.SQLActionException;
 import io.crate.action.sql.SQLOperations;
-import io.crate.integrationtests.SQLTransportIntegrationTest;
+import io.crate.operation.user.User;
+import io.crate.operation.user.UserManagerService;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.TestingHelpers;
 import org.elasticsearch.test.ESIntegTestCase;

--- a/users/src/test/java/io/crate/metadata/UsersMetaDataTest.java
+++ b/users/src/test/java/io/crate/metadata/UsersMetaDataTest.java
@@ -16,7 +16,7 @@
  * Agreement with Crate.io.
  */
 
-package io.crate.operation.user;
+package io.crate.metadata;
 
 import com.google.common.collect.ImmutableList;
 import io.crate.test.integration.CrateUnitTest;

--- a/users/src/test/java/io/crate/operation/user/TransportUserActionTest.java
+++ b/users/src/test/java/io/crate/operation/user/TransportUserActionTest.java
@@ -20,6 +20,7 @@ package io.crate.operation.user;
 
 import com.google.common.collect.ImmutableList;
 import io.crate.exceptions.ConflictException;
+import io.crate.metadata.UsersMetaData;
 import io.crate.test.integration.CrateUnitTest;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.cluster.metadata.MetaData;

--- a/users/src/test/java/io/crate/operation/user/UserManagerServiceTest.java
+++ b/users/src/test/java/io/crate/operation/user/UserManagerServiceTest.java
@@ -25,6 +25,7 @@ import io.crate.action.sql.SessionContext;
 import io.crate.analyze.CreateUserAnalyzedStatement;
 import io.crate.analyze.DropUserAnalyzedStatement;
 import io.crate.exceptions.UnauthorizedException;
+import io.crate.metadata.UsersMetaData;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import org.junit.Test;
 


### PR DESCRIPTION
so the statement will only respond if all nodes in the cluster processed the cluster state change

also fixes the package names of some user module classes in a separate commit