### PR TITLE
Stop bulk operations when killed (propagate InterruptedException signal)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -44,6 +44,9 @@ Changes
 Fixes
 =====
 
+ - Fixed issue where bulk operations like `insert from dynamic queries` and 
+   ``COPY FROM`` did not stop after being killed.    
+
  - ``CREATE USER`` and ``DROP USER`` statements will now only respond after all
    nodes in the cluster processed the change.
 

--- a/sql/src/main/java/io/crate/operation/projectors/BatchIteratorBackpressureExecutor.java
+++ b/sql/src/main/java/io/crate/operation/projectors/BatchIteratorBackpressureExecutor.java
@@ -147,6 +147,10 @@ public class BatchIteratorBackpressureExecutor<R> {
      * !! THIS SHOULD ONLY BE CALLED BY THE loadNextBatch COMPLETE LISTENER !!
      */
     private void unsafeConsumeIterator(BatchIterator batchIterator) {
+        if(executionFuture.isDone()) {
+            // if the execution future was completed (most likely failed or killed) we stop consuming
+            return;
+        }
         Row row = RowBridging.toRow(batchIterator.rowData());
         try {
             while (true) {


### PR DESCRIPTION
Insert from query and copy from operations failures are generally
counted in the "affected rows" report. That's usually fine, except
for when the operation is killed, in which case we need to stop and
fail the operation, propagating InterruptedException.