### PR TITLE
Change BatchIterator allLoaded to never raise

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -44,6 +44,9 @@ Changes
 Fixes
 =====
 
+ - Fixed an error handling issue that could lead to the termination of a node
+   in very rare cases. (Usually if a user invoked the `KILL` statement)
+
  - Fixed issue where bulk operations like `insert from dynamic queries` and 
    ``COPY FROM`` did not stop after being killed.    
 

--- a/dex/src/main/java/io/crate/data/AsyncOperationBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/AsyncOperationBatchIterator.java
@@ -179,7 +179,6 @@ public class AsyncOperationBatchIterator implements BatchIterator {
 
     @Override
     public boolean allLoaded() {
-        raiseIfClosedOrKilled();
         return sourceExhausted;
     }
 

--- a/dex/src/main/java/io/crate/data/BatchIterator.java
+++ b/dex/src/main/java/io/crate/data/BatchIterator.java
@@ -124,7 +124,6 @@ public interface BatchIterator extends Killable {
 
     /**
      * @return true if no more batches can be loaded
-     * @throws IllegalStateException if the cursor is closed
      */
     boolean allLoaded();
 }

--- a/dex/src/main/java/io/crate/data/CloseAssertingBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/CloseAssertingBatchIterator.java
@@ -71,7 +71,6 @@ public class CloseAssertingBatchIterator implements BatchIterator {
 
     @Override
     public boolean allLoaded() {
-        raiseIfClosedOrKilled();
         return delegate.allLoaded();
     }
 

--- a/sql/src/main/java/io/crate/operation/collect/collectors/LuceneBatchIterator.java
+++ b/sql/src/main/java/io/crate/operation/collect/collectors/LuceneBatchIterator.java
@@ -195,7 +195,6 @@ public class LuceneBatchIterator implements BatchIterator {
 
     @Override
     public boolean allLoaded() {
-        raiseIfClosedOrKilled();
         return true;
     }
 

--- a/sql/src/main/java/io/crate/operation/merge/BatchPagingIterator.java
+++ b/sql/src/main/java/io/crate/operation/merge/BatchPagingIterator.java
@@ -23,7 +23,11 @@
 package io.crate.operation.merge;
 
 import io.crate.concurrent.CompletableFutures;
-import io.crate.data.*;
+import io.crate.data.BatchIterator;
+import io.crate.data.Columns;
+import io.crate.data.Row;
+import io.crate.data.RowBridging;
+import io.crate.data.RowColumns;
 import io.crate.exceptions.Exceptions;
 
 import javax.annotation.Nonnull;
@@ -140,7 +144,6 @@ public class BatchPagingIterator<Key> implements BatchIterator {
 
     @Override
     public boolean allLoaded() {
-        raiseIfClosedOrKilled();
         return isUpstreamExhausted.getAsBoolean();
     }
 


### PR DESCRIPTION
This fixes some uncaught exceptions that could happen.

We've a couple of BatchIterator implementations which call `allLoaded`
of another BatchIterator from within `loadNextBatch()`.
`loadNextBatch()` should return a failed future instead of raising, but
if `allLoaded` raises an exception it bubbles up.

Instead of adding `try/catch` blocks this commit changes the contract
because `allLoaded` is usually a very cheap check that doesn't require
any other resources.

If a BatchIterator has been killed or is closed the next `moveNext()`
call will fail anyway. This slight delay doesn't matter.