### PR TITLE
testing: upgrades crate-python to 0.19.4

### DIFF
--- a/blackbox/requirements.txt
+++ b/blackbox/requirements.txt
@@ -3,7 +3,7 @@ appdirs==1.4.0
 Babel==2.3.4
 colorama==0.3.7
 crash==0.20.0
-crate==0.19.2
+crate==0.19.4
 crate-docs-theme
 sphinx-csv-filter
 docutils==0.12


### PR DESCRIPTION
this version includes a crate testing layer fix which bug was causing the tests to stall if port binding failed