### PR TITLE
Improve sys.nodes resiliency

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -44,6 +44,9 @@ Changes
 Fixes
 =====
 
+ - Improved the resiliency of queries on `sys.nodes`: If a node disconnects
+   during the execution of a query it will no longer fail.
+
  - Added proper handling when memory requirements of a ``JOIN`` query exceeds
    the available memory. Instead of having OutOfMemoryException thrown which
    led to killed nodes in the cluster, the issue is detected and the query is

--- a/sql/src/main/java/io/crate/operation/collect/collectors/NodeStatsIterator.java
+++ b/sql/src/main/java/io/crate/operation/collect/collectors/NodeStatsIterator.java
@@ -25,7 +25,12 @@ package io.crate.operation.collect.collectors;
 import io.crate.analyze.symbol.DefaultTraversalSymbolVisitor;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.concurrent.CompletableFutures;
-import io.crate.data.*;
+import io.crate.data.BatchIterator;
+import io.crate.data.CloseAssertingBatchIterator;
+import io.crate.data.Columns;
+import io.crate.data.Row;
+import io.crate.data.RowColumns;
+import io.crate.exceptions.SQLExceptions;
 import io.crate.executor.transport.NodeStatsRequest;
 import io.crate.executor.transport.NodeStatsResponse;
 import io.crate.executor.transport.TransportNodeStatsAction;
@@ -40,10 +45,17 @@ import io.crate.planner.node.dql.RoutedCollectPhase;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.transport.ConnectTransportException;
 import org.elasticsearch.transport.ReceiveTimeoutTransportException;
 
 import javax.annotation.Nonnull;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -138,8 +150,9 @@ public class NodeStatsIterator implements BatchIterator {
                 }
 
                 @Override
-                public void onFailure(Exception t) {
-                    if (t instanceof ReceiveTimeoutTransportException) {
+                public void onFailure(Exception e) {
+                    Throwable t = SQLExceptions.unwrap(e);
+                    if (isTimeoutOrNodeNotReachable(t)) {
                         rows.add(new NodeStatsContext(nodeId, node.getName()));
                         if (remainingNodesToCollect.decrementAndGet() == 0) {
                             nodeStatsContextsFuture.complete(rows);
@@ -151,6 +164,11 @@ public class NodeStatsIterator implements BatchIterator {
             }, TimeValue.timeValueMillis(3000L));
         }
         return nodeStatsContextsFuture;
+    }
+
+    private static boolean isTimeoutOrNodeNotReachable(Throwable t) {
+        return t instanceof ReceiveTimeoutTransportException
+            || t instanceof ConnectTransportException;
     }
 
     @Override


### PR DESCRIPTION
`NodeDisconnectedException` is now handled the same as a
`ReceiveTimeoutTransportException`: The exception no longer causes a
failure but results in a `nulled` (+ node name + id) row.