### PR TITLE
fixes reading of the UsersMetaData out of the persisted global state

### DIFF
--- a/users/src/main/java/io/crate/metadata/UsersMetaData.java
+++ b/users/src/main/java/io/crate/metadata/UsersMetaData.java
@@ -18,6 +18,7 @@
 
 package io.crate.metadata;
 
+import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.cluster.AbstractDiffable;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -26,7 +27,10 @@ import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Objects;
 
 public class UsersMetaData extends AbstractDiffable<MetaData.Custom> implements MetaData.Custom {
 
@@ -103,6 +107,11 @@ public class UsersMetaData extends AbstractDiffable<MetaData.Custom> implements 
                 while ((token = parser.nextToken()) != XContentParser.Token.END_ARRAY && token != null) {
                     users.add(parser.text());
                 }
+            }
+            if (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+                // each custom metadata is packed inside an object.
+                // each custom must move the parser to the end otherwise possible following customs won't be read
+                throw new ElasticsearchParseException("failed to parse users, expected an object token at the end");
             }
         }
         return new UsersMetaData(users);

--- a/users/src/test/java/io/crate/metadata/UsersMetaDataTest.java
+++ b/users/src/test/java/io/crate/metadata/UsersMetaDataTest.java
@@ -31,6 +31,8 @@ import org.junit.Test;
 
 import java.io.IOException;
 
+import static org.hamcrest.Matchers.nullValue;
+
 public class UsersMetaDataTest extends CrateUnitTest {
 
     @Test
@@ -40,7 +42,7 @@ public class UsersMetaDataTest extends CrateUnitTest {
         users.writeTo(out);
 
         StreamInput in = out.bytes().streamInput();
-        UsersMetaData users2 = (UsersMetaData)new UsersMetaData().readFrom(in);
+        UsersMetaData users2 = (UsersMetaData) new UsersMetaData().readFrom(in);
         assertEquals(users, users2);
     }
 
@@ -57,7 +59,10 @@ public class UsersMetaDataTest extends CrateUnitTest {
 
         XContentParser parser = JsonXContent.jsonXContent.createParser(builder.bytes());
         parser.nextToken(); // start object
-        UsersMetaData users2 = (UsersMetaData)new UsersMetaData().fromXContent(parser);
+        UsersMetaData users2 = (UsersMetaData) new UsersMetaData().fromXContent(parser);
         assertEquals(users, users2);
+
+        // a metadata custom must consume the surrounded END_OBJECT token, no token must be left
+        assertThat(parser.nextToken(), nullValue());
     }
 }


### PR DESCRIPTION
Each metadata custom must consume the surrounded object token,
otherwise possible following customs are not read.
This bug will only occur if multiple MetaData.Custom implementation are registered, which is currently not the case, so no CHANGES entry is needed.