### PR TITLE
Rename ConnectionContext -> PostgresWireProtocol

### DIFF
--- a/sql/src/main/java/io/crate/protocols/postgres/PostgresNetty.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/PostgresNetty.java
@@ -137,10 +137,10 @@ public class PostgresNetty extends AbstractLifecycleComponent {
                 @Override
                 protected void initChannel(Channel ch) throws Exception {
                     ChannelPipeline pipeline = ch.pipeline();
-                    ConnectionContext connectionContext =
-                        new ConnectionContext(sslReqHandler, sqlOperations, authentication);
-                    pipeline.addLast("frame-decoder", connectionContext.decoder);
-                    pipeline.addLast("handler", connectionContext.handler);
+                    PostgresWireProtocol postgresWireProtocol =
+                        new PostgresWireProtocol(sslReqHandler, sqlOperations, authentication);
+                    pipeline.addLast("frame-decoder", postgresWireProtocol.decoder);
+                    pipeline.addLast("handler", postgresWireProtocol.handler);
                 }
             });
 

--- a/sql/src/test/java/io/crate/protocols/postgres/ClientMessages.java
+++ b/sql/src/test/java/io/crate/protocols/postgres/ClientMessages.java
@@ -33,7 +33,7 @@ import java.util.List;
 /**
  * Class to encode postgres client messages and write them onto a buffer.
  *
- * For more information about the messages see {@link Messages} and {@link ConnectionContext} or refer to
+ * For more information about the messages see {@link Messages} and {@link PostgresWireProtocol} or refer to
  * the PostgreSQL protocol documentation.
  */
 class ClientMessages {

--- a/sql/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
+++ b/sql/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
@@ -56,7 +56,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isOneOf;
 import static org.mockito.Mockito.*;
 
-public class ConnectionContextTest extends CrateDummyClusterServiceUnitTest {
+public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
 
     private SQLOperations sqlOperations;
     private List<SQLOperations.Session> sessions = new ArrayList<>();
@@ -92,8 +92,8 @@ public class ConnectionContextTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testHandleEmptySimpleQuery() throws Exception {
-        ConnectionContext ctx =
-            new ConnectionContext(
+        PostgresWireProtocol ctx =
+            new PostgresWireProtocol(
                 new SslReqRejectingHandler(Settings.EMPTY),
                 mock(SQLOperations.class),
                 AuthenticationProvider.NOOP_AUTH);
@@ -121,8 +121,8 @@ public class ConnectionContextTest extends CrateDummyClusterServiceUnitTest {
         SQLOperations sqlOperations = mock(SQLOperations.class);
         SQLOperations.Session session = mock(SQLOperations.Session.class);
         when(sqlOperations.createSession(any(SessionContext.class))).thenReturn(session);
-        ConnectionContext ctx =
-            new ConnectionContext(
+        PostgresWireProtocol ctx =
+            new PostgresWireProtocol(
                 new SslReqRejectingHandler(Settings.EMPTY),
                 sqlOperations,
                 new TestAuthentication(null));
@@ -140,8 +140,8 @@ public class ConnectionContextTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testBindMessageCanBeReadIfTypeForParamsIsUnknown() throws Exception {
-        ConnectionContext ctx =
-            new ConnectionContext(
+        PostgresWireProtocol ctx =
+            new PostgresWireProtocol(
                 new SslReqRejectingHandler(Settings.EMPTY),
                 sqlOperations,
                 new TestAuthentication(null));
@@ -193,8 +193,8 @@ public class ConnectionContextTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testSslReqRejectingHandler() {
-        ConnectionContext ctx =
-            new ConnectionContext(
+        PostgresWireProtocol ctx =
+            new PostgresWireProtocol(
                 new SslReqRejectingHandler(Settings.EMPTY),
                 mock(SQLOperations.class),
                 AuthenticationProvider.NOOP_AUTH);

--- a/ssl-impl/src/test/java/io/crate/protocols/postgres/SslReqHandlerTest.java
+++ b/ssl-impl/src/test/java/io/crate/protocols/postgres/SslReqHandlerTest.java
@@ -72,8 +72,8 @@ public class SslReqHandlerTest extends CrateUnitTest {
 
     @Test
     public void testSslReqConfiguringHandler() {
-        ConnectionContext ctx =
-            new ConnectionContext(
+        PostgresWireProtocol ctx =
+            new PostgresWireProtocol(
                 new SslReqConfiguringHandler(
                     Settings.EMPTY,
                     // use a simple ssl context


### PR DESCRIPTION
`ConnectionContext` sounds like it contains some properties that
describe the aspect of a connection. But the class is actually the full
implementation of the wire protocol.