### PR TITLE
ConcurrentModificationException when executing `delete from`

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -44,6 +44,9 @@ Changes
 Fixes
 =====
 
+ - Fixed an issue that could cause ``DELETE`` by query  and ``UPDATE`` 
+   statements to fail on datasets larger than 10_000 rows.
+
  - Improved the resiliency of queries on `sys.nodes`: If a node disconnects
    during the execution of a query it will no longer fail.
 

--- a/sql/src/main/java/io/crate/executor/transport/ShardRequest.java
+++ b/sql/src/main/java/io/crate/executor/transport/ShardRequest.java
@@ -155,6 +155,16 @@ public abstract class ShardRequest<T extends ShardRequest<T, I>, I extends Shard
                '}';
     }
 
+    /**
+     * The description is used when creating transport, replication and search tasks and it defaults to `toString`.
+     * Overriding here to return the parent `toString` to avoid using the local, expensive (printing all items)
+     * `toString`.
+     */
+    @Override
+    public String getDescription() {
+        return super.toString();
+    }
+
     protected abstract I readItem(StreamInput input) throws IOException;
 
     /**

--- a/sql/src/main/java/io/crate/operation/projectors/ShardDMLExecutor.java
+++ b/sql/src/main/java/io/crate/operation/projectors/ShardDMLExecutor.java
@@ -111,7 +111,6 @@ public class ShardDMLExecutor<TReq extends ShardRequest<TReq, TItem>, TItem exte
             nodeJobsCounter.increment(localNodeId);
 
             Function<ShardResponse, BitSet> transformResponseFunction = response -> {
-                currentRequest = requestFactory.get();
                 nodeJobsCounter.decrement(localNodeId);
                 processShardResponse(response);
                 return responses;
@@ -137,6 +136,9 @@ public class ShardDMLExecutor<TReq extends ShardRequest<TReq, TItem>, TItem exte
                     BACKOFF_POLICY
                 )
             );
+            // The current bulk was submitted to the transport action for execution, so we'll continue to collect and
+            // accumulate data for the next bulk in a new request object
+            currentRequest = requestFactory.get();
             return listener;
         };
     }


### PR DESCRIPTION
ConcurrentModificationException was raised due to the same ShardRequest object being when executing the _current bulk_ for the operation, which at some point called `ShardRequest.toString` which iterates over the `items` in the request, and collecting more rows for the next bulk (these new rows were accumulated in the same `items` collection in the request)