### PR TITLE
Consider SSL as connection property instead of as separate protocol

### DIFF
--- a/sql/src/main/java/io/crate/operation/auth/AuthenticationMethod.java
+++ b/sql/src/main/java/io/crate/operation/auth/AuthenticationMethod.java
@@ -23,17 +23,19 @@
 package io.crate.operation.auth;
 
 import io.crate.operation.user.User;
+import io.crate.protocols.postgres.ConnectionProperties;
 
 import javax.annotation.Nullable;
 
 public interface AuthenticationMethod {
+
     /**
      * @param userName the userName sent with the startup message
      * @return the user or null; null should be handled as if it's a "guest" user
      * @throws RuntimeException if the authentication failed
      */
     @Nullable
-    User authenticate(String userName);
+    User authenticate(String userName, ConnectionProperties connProperties);
 
     /**
      * @return unique name of the authentication method

--- a/sql/src/main/java/io/crate/operation/auth/AuthenticationProvider.java
+++ b/sql/src/main/java/io/crate/operation/auth/AuthenticationProvider.java
@@ -26,6 +26,7 @@ import com.google.common.annotations.VisibleForTesting;
 import io.crate.operation.user.User;
 import io.crate.operation.user.UserManagerProvider;
 import io.crate.plugin.PipelineRegistry;
+import io.crate.protocols.postgres.ConnectionProperties;
 import io.crate.settings.CrateSetting;
 import io.crate.types.DataTypes;
 import org.elasticsearch.common.inject.Inject;
@@ -34,7 +35,6 @@ import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 
-import java.net.InetAddress;
 import java.util.function.Function;
 
 
@@ -64,7 +64,7 @@ public class AuthenticationProvider implements Provider<Authentication> {
 
         private final AuthenticationMethod alwaysOk = new AuthenticationMethod() {
             @Override
-            public User authenticate(String userName) {
+            public User authenticate(String userName, ConnectionProperties connectionProperties) {
                 return null;
             }
 
@@ -80,7 +80,7 @@ public class AuthenticationProvider implements Provider<Authentication> {
         }
 
         @Override
-        public AuthenticationMethod resolveAuthenticationType(String user, InetAddress address, HbaProtocol protocol) {
+        public AuthenticationMethod resolveAuthenticationType(String user, ConnectionProperties connectionProperties) {
             return alwaysOk;
         }
     };

--- a/sql/src/main/java/io/crate/operation/auth/Protocol.java
+++ b/sql/src/main/java/io/crate/operation/auth/Protocol.java
@@ -1,14 +1,13 @@
 package io.crate.operation.auth;
 
-public enum HbaProtocol {
+public enum Protocol {
 
     POSTGRES("pg"),
-    POSTGRES_SSL("pg"),
     HTTP("http");
 
     private final String protocolName;
 
-    HbaProtocol(String protocolName) {
+    Protocol(String protocolName) {
         this.protocolName = protocolName;
     }
 

--- a/sql/src/main/java/io/crate/protocols/postgres/ConnectionProperties.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/ConnectionProperties.java
@@ -20,16 +20,35 @@
  * agreement.
  */
 
-package io.crate.operation.auth;
+package io.crate.protocols.postgres;
 
-import io.crate.protocols.postgres.ConnectionProperties;
+import io.crate.operation.auth.Protocol;
+import io.netty.handler.ssl.SslHandler;
 
 import javax.annotation.Nullable;
+import java.net.InetAddress;
 
-public interface Authentication {
+public class ConnectionProperties {
 
-    boolean enabled();
+    private final InetAddress address;
+    private final Protocol protocol;
+    private final boolean hasSSL;
 
-    @Nullable
-    AuthenticationMethod resolveAuthenticationType(String user, ConnectionProperties connectionProperties);
+    public ConnectionProperties(InetAddress address, Protocol protocol, @Nullable SslHandler sslHandler) {
+        this.address = address;
+        this.protocol = protocol;
+        this.hasSSL = sslHandler != null;
+    }
+
+    public boolean hasSSL() {
+        return hasSSL;
+    }
+
+    public InetAddress address() {
+        return address;
+    }
+
+    public Protocol protocol() {
+        return protocol;
+    }
 }

--- a/sql/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
+++ b/sql/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
@@ -28,7 +28,6 @@ import io.crate.executor.Executor;
 import io.crate.operation.auth.Authentication;
 import io.crate.operation.auth.AuthenticationMethod;
 import io.crate.operation.auth.AuthenticationProvider;
-import io.crate.operation.auth.HbaProtocol;
 import io.crate.operation.collect.stats.JobsLogs;
 import io.crate.operation.user.User;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
@@ -43,7 +42,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import javax.annotation.Nullable;
-import java.net.InetAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -53,7 +51,11 @@ import java.util.Map;
 import static io.netty.util.ReferenceCountUtil.releaseLater;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isOneOf;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
 
@@ -174,11 +176,11 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
         }
 
         @Override
-        public AuthenticationMethod resolveAuthenticationType(String user, InetAddress address, HbaProtocol protocol) {
+        public AuthenticationMethod resolveAuthenticationType(String user, ConnectionProperties connectionProperties) {
             return new AuthenticationMethod() {
                 @Nullable
                 @Override
-                public User authenticate(String userName) {
+                public User authenticate(String userName, ConnectionProperties connectionProperties) {
                     return TestAuthentication.this.user;
                 }
 

--- a/users/src/main/java/io/crate/operation/auth/TrustAuthentication.java
+++ b/users/src/main/java/io/crate/operation/auth/TrustAuthentication.java
@@ -20,6 +20,7 @@ package io.crate.operation.auth;
 
 import io.crate.operation.user.User;
 import io.crate.operation.user.UserLookup;
+import io.crate.protocols.postgres.ConnectionProperties;
 
 
 public class TrustAuthentication implements AuthenticationMethod {
@@ -32,7 +33,7 @@ public class TrustAuthentication implements AuthenticationMethod {
     }
 
     @Override
-    public User authenticate(String userName) {
+    public User authenticate(String userName, ConnectionProperties connectionProperties) {
         User user = userLookup.findUser(userName);
         if (user == null) {
             throw new RuntimeException("trust authentication failed for user \"" + userName + "\"");

--- a/users/src/test/java/io/crate/operation/auth/AuthenticationMethodTest.java
+++ b/users/src/test/java/io/crate/operation/auth/AuthenticationMethodTest.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableList;
 import io.crate.operation.user.User;
 import io.crate.operation.user.UserManager;
 import io.crate.operation.user.UserManagerService;
+import io.crate.protocols.postgres.ConnectionProperties;
 import io.crate.test.integration.CrateUnitTest;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.junit.Test;
@@ -53,9 +54,10 @@ public class AuthenticationMethodTest extends CrateUnitTest {
         TrustAuthentication trustAuth = new TrustAuthentication(fakeUserManager);
         assertThat(trustAuth.name(), is("trust"));
 
-        assertThat(trustAuth.authenticate("crate").name(), is("crate"));
+        ConnectionProperties connectionProperties = new ConnectionProperties(null, Protocol.POSTGRES, null);
+        assertThat(trustAuth.authenticate("crate", connectionProperties).name(), is("crate"));
 
         expectedException.expectMessage("trust authentication failed for user \"cr8\"");
-        trustAuth.authenticate("cr8");
+        trustAuth.authenticate("cr8", connectionProperties);
     }
 }


### PR DESCRIPTION
Main purpose here is to add a `ConnectionProperties` which can later be
used to hold additional information about a connection, like information
about a client certificate.

In addition, these changes here will probably make further HBA / SSL
changes for HTTPS unnecessary.