### PR TITLE
Change num replicas from 1 to 0 in single-node itests

### DIFF
--- a/blackbox/docs/blob.txt
+++ b/blackbox/docs/blob.txt
@@ -15,7 +15,7 @@ Creating a Table for Blobs
 Before adding blobs a ``blob table`` must be created. Lets use the CrateDB
 shell ``crash`` to issue the SQL statement::
 
-    sh$ crash -c "create blob table myblobs clustered into 3 shards with (number_of_replicas=1)"
+    sh$ crash -c "create blob table myblobs clustered into 3 shards with (number_of_replicas=0)"
     CREATE OK, 1 row affected (... sec)
 
 Now CrateDB is configured to allow blobs to be management under the
@@ -173,7 +173,7 @@ shell here)::
 
 .. Hidden: Re-create the blob table so information_schema will show it::
 
-    sh$ crash -c "create blob table myblobs clustered into 3 shards with (number_of_replicas=1)"
+    sh$ crash -c "create blob table myblobs clustered into 3 shards with (number_of_replicas=0)"
     CREATE OK, 1 row affected (... sec)
 
 .. _`binary large objects`: http://en.wikipedia.org/wiki/Binary_large_object

--- a/blackbox/docs/sql/information_schema.txt
+++ b/blackbox/docs/sql/information_schema.txt
@@ -35,7 +35,7 @@ settings like the ``number of shards`` or ``number of replicas``.
     +--------------------+-------------------+------------------+--------------------+
     | table_schema       | table_name        | number_of_shards | number_of_replicas |
     +--------------------+-------------------+------------------+--------------------+
-    | blob               | myblobs           |                3 | 1                  |
+    | blob               | myblobs           |                3 | 0                  |
     | doc                | documents         |                4 | 0-1                |
     | doc                | locations         |                2 | 0                  |
     | doc                | partitioned_table |                4 | 0-1                |


### PR DESCRIPTION
Made the tests a lot slower because of the wait-for-active shards
timeout.