### PR TITLE
Fix issue with JOIN on >=4 tables with ORDER BY.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -44,13 +44,16 @@ Changes
 Fixes
 =====
 
+ - Fixed an issue that caused an Exception to be thrown on ``JOIN`` queries
+   with 4 or more tables when an ``ORDER BY`` is also applied.
+
  - Fixed an issue that resulted in rows could not be queried by primary keys
    when the order of the primary key columns on insert differs from the order of
    the primary keys on the table definition.
    Note: If records are already inserted by using a different primary key column
    order, they must be re-inserted, otherwise queries will still fail.
 
- - Fixed an issue that could cause ``DELETE`` by query  and ``UPDATE`` 
+ - Fixed an issue that could cause ``DELETE`` by query  and ``UPDATE``
    statements to fail on datasets larger than 10_000 rows.
 
  - Improved the resiliency of queries on `sys.nodes`: If a node disconnects

--- a/sql/src/main/java/io/crate/analyze/relations/JoinPairs.java
+++ b/sql/src/main/java/io/crate/analyze/relations/JoinPairs.java
@@ -176,42 +176,34 @@ public final class JoinPairs {
         return outputs;
     }
 
-    public enum RelationInclusion {
-        /**
-         * join condition of the join pair actually includes both relations
-         */
-        BOTH_INCLUDED,
-
-        /**
-         * join condition of the join pair doesn't include both relations
-         */
-        FOREIGN_INCLUDED,
-
-        /**
-         * join condition of the join pair includes relations not already part of the join tree
-         */
-        NOT_INCLUDED
-    }
 
     /**
-     * See {@link RelationInclusion} for result description
+     * Returns true if join condition contains both relations of the join pair and also
+     * doesn't contain any relation that's not already part of the join tree.
      */
-    public static RelationInclusion determineRelationInclusion(List<JoinPair> currentPermutationJoinPairs,
-                                                               JoinPair joinPair,
-                                                               QualifiedName rel1,
-                                                               QualifiedName rel2) {
+    public static boolean joinConditionIncludesRelations(List<JoinPair> currentPermutationJoinPairs,
+                                                         JoinPair joinPair) {
+        boolean rel1Included = false;
+        boolean rel2Included = false;
+
         for (Field f : JoinPairs.extractFieldsFromJoinConditions(Collections.singletonList(joinPair))) {
             QualifiedName relationName = f.relation().getQualifiedName();
+            if (relationName.equals(joinPair.left())) {
+                rel1Included = true;
+            }
+            if (relationName.equals(joinPair.right())) {
+                rel2Included = true;
+            }
 
             // Join condition contains relations not included in existing join pairs
             if (currentPermutationJoinPairs.stream().noneMatch(jp -> jp.containsRelation(relationName))) {
-                return RelationInclusion.FOREIGN_INCLUDED;
+                return false;
             }
 
-            if (relationName.equals(rel1) && relationName.equals(rel2)) {
-                return RelationInclusion.BOTH_INCLUDED;
+            if (rel1Included && rel2Included) {
+                return true;
             }
         }
-        return RelationInclusion.NOT_INCLUDED;
+        return false;
     }
 }

--- a/sql/src/test/java/io/crate/planner/consumer/ManyTableConsumerTest.java
+++ b/sql/src/test/java/io/crate/planner/consumer/ManyTableConsumerTest.java
@@ -23,7 +23,6 @@
 package io.crate.planner.consumer;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.crate.action.sql.SessionContext;
 import io.crate.analyze.Analysis;
@@ -31,8 +30,8 @@ import io.crate.analyze.MultiSourceSelect;
 import io.crate.analyze.ParameterContext;
 import io.crate.analyze.SelectAnalyzedStatement;
 import io.crate.analyze.TwoTableJoin;
-import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.JoinPair;
+import io.crate.analyze.symbol.Symbol;
 import io.crate.planner.node.dql.join.JoinType;
 import io.crate.sql.parser.SqlParser;
 import io.crate.sql.tree.QualifiedName;
@@ -40,7 +39,6 @@ import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.testing.SqlExpressions;
 import io.crate.testing.T3;
-import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -59,13 +57,7 @@ import static org.hamcrest.core.Is.is;
 public class ManyTableConsumerTest extends CrateDummyClusterServiceUnitTest {
 
     private SQLExecutor e;
-    private final Map<QualifiedName, AnalyzedRelation> sources = ImmutableMap.of(
-        new QualifiedName(T3.T1_INFO.ident().name()), T3.TR_1,
-        new QualifiedName(T3.T2_INFO.ident().name()), T3.TR_2,
-        new QualifiedName(T3.T3_INFO.ident().name()), T3.TR_3,
-        new QualifiedName(T3.T4_INFO.ident().name()), T3.TR_4);
-
-    private final SqlExpressions expressions = new SqlExpressions(sources);
+    private final SqlExpressions expressions = new SqlExpressions(T3.SOURCES);
 
     @Before
     public void prepare() {
@@ -113,9 +105,8 @@ public class ManyTableConsumerTest extends CrateDummyClusterServiceUnitTest {
 
         assertThat(t3AndT1.querySpec().where().query(), isSQL("null"));
 
-        assertThat(root.joinPair().condition(), Matchers.anyOf(
-            // order of the AND clauses is not deterministic, but both are okay as they're semantically the same
-            isSQL("((join.doc.t3.doc.t1.doc.t1['a'] = doc.t2.b) AND (doc.t2.b = join.doc.t3.doc.t1.doc.t3['c']))")));
+        assertThat(root.joinPair().condition(),
+            isSQL("((doc.t2.b = join.doc.t3.doc.t1.doc.t3['c']) AND (join.doc.t3.doc.t1.doc.t1['a'] = doc.t2.b))"));
     }
 
     @Test
@@ -232,39 +223,56 @@ public class ManyTableConsumerTest extends CrateDummyClusterServiceUnitTest {
             relations,
             Collections.emptySet(),
             joinPairs,
-            ImmutableList.of(T3.T4)), contains(T3.T4, T3.T1, T3.T3, T3.T2));
+            ImmutableList.of(T3.T4)), contains(T3.T4, T3.T1, T3.T2, T3.T3));
     }
 
     @Test
     public void test4TableSortOnWhereAndJoinConditionsThatDontMatchThePair() throws Exception {
         MultiSourceSelect mss = analyze("select *" +
                                         " from t1" +
-                                        " join t2 on t1.a=t2.b" +
+                                        " join t2 on t1.a=t2.b and (t2.b=10 or t1.a=20) " +
                                         " join t3 on t2.b=t3.c" +
                                         " join users on t1.i=users.id" +
                                         " join users_multi_pk on t3.z=users_multi_pk.id" +
                                         " order by t3.c");
         TwoTableJoin root = ManyTableConsumer.buildTwoTableJoinTree(mss);
-        assertThat(root.toString(), is("join.join.join.join.doc.t3.doc.t1.doc.users_multi_pk.doc.t2.doc.users"));
+        assertThat(root.toString(), is("join.join.join.join.doc.t3.doc.t1.doc.t2.doc.users.doc.users_multi_pk"));
         assertThat(root.joinPair().condition(),
-                   isSQL("((join.join.join.doc.t3.doc.t1.doc.users_multi_pk.doc.t2.\"join.join.doc.t3.doc.t1.doc" +
-                         ".users_multi_pk\"['join.doc.t3.doc.t1['doc.t1['i']']'] = to_int(doc.users.id)) AND (join" +
-                         ".join.join.doc.t3.doc.t1.doc.users_multi_pk.doc.t2.\"join.join.doc.t3.doc.t1.doc" +
-                         ".users_multi_pk\"['join.doc.t3.doc.t1['doc.t3['z']']'] = to_int(join.join.join.doc.t3.doc" +
-                         ".t1.doc.users_multi_pk.doc.t2.\"join.join.doc.t3.doc.t1.doc.users_multi_pk\"['doc" +
-                         ".users_multi_pk['id']'])))"));
+                   isSQL("(join.join.join.doc.t3.doc.t1.doc.t2.doc.users.\"join.join.doc.t3.doc.t1.doc.t2\"" +
+                       "['join.doc.t3.doc.t1['doc.t3['z']']'] = to_int(doc.users_multi_pk.id))"));
         TwoTableJoin tt1 = (TwoTableJoin) root.left();
-        assertThat(tt1.toString(), is("join.join.join.doc.t3.doc.t1.doc.users_multi_pk.doc.t2"));
+        assertThat(tt1.toString(), is("join.join.join.doc.t3.doc.t1.doc.t2.doc.users"));
         assertThat(tt1.joinPair().condition(),
-                   isSQL("((join.join.doc.t3.doc.t1.doc.users_multi_pk.\"join.doc.t3.doc.t1\"['doc.t1['a']'] = " +
-                         "doc.t2.b) AND (doc.t2.b = join.join.doc.t3.doc.t1.doc.users_multi_pk.\"join.doc.t3.doc" +
-                         ".t1\"['doc.t3['c']']))"));
+                   isSQL("(join.join.doc.t3.doc.t1.doc.t2.\"join.doc.t3.doc.t1\"['doc.t1['i']'] = " +
+                         "to_int(doc.users.id))"));
         TwoTableJoin tt2 = (TwoTableJoin) tt1.left();
-        assertThat(tt2.toString(), is("join.join.doc.t3.doc.t1.doc.users_multi_pk"));
-        assertThat(tt2.joinPair().condition(), nullValue());
+        assertThat(tt2.toString(), is("join.join.doc.t3.doc.t1.doc.t2"));
+        assertThat(tt2.joinPair().condition(),
+                   isSQL("((doc.t2.b = join.doc.t3.doc.t1.doc.t3['c']) AND " +
+                         "((join.doc.t3.doc.t1.doc.t1['a'] = doc.t2.b) AND " +
+                         "((doc.t2.b = '10') OR (join.doc.t3.doc.t1.doc.t1['a'] = '20'))))"));
 
         TwoTableJoin tt3 = (TwoTableJoin) tt2.left();
         assertThat(tt3.toString(), is("join.doc.t3.doc.t1"));
         assertThat(tt3.joinPair().condition(), nullValue());
+    }
+
+    @Test
+    public void testBuildingOfJoinConditionsMap() {
+        List<JoinPair> joinPairs = ImmutableList.of(
+            JoinPair.of(T3.T1, T3.T2, JoinType.INNER, expressions.asSymbol("t1.a=t2.b")),
+            JoinPair.of(T3.T2, T3.T3, JoinType.INNER, expressions.asSymbol("t2.b=t1.a and t2.b=t3.c")),
+            JoinPair.of(T3.T4, T3.T3, JoinType.INNER,
+                        expressions.asSymbol("t4.id=t3.z and (t2.b=t3.c or t4.id=t1.x)")));
+
+
+        Map<Set<QualifiedName>, Symbol> joinConditions = ManyTableConsumer.buildJoinConditionsMap(joinPairs);
+        assertThat(joinConditions.size(), is(4));
+        assertThat(joinConditions.get(ImmutableSet.of(T3.T1, T3.T2)),
+                   isSQL("((doc.t1.a = doc.t2.b) AND (doc.t2.b = doc.t1.a))"));
+        assertThat(joinConditions.get(ImmutableSet.of(T3.T2, T3.T3)), isSQL("(doc.t2.b = doc.t3.c)"));
+        assertThat(joinConditions.get(ImmutableSet.of(T3.T3, T3.T4)), isSQL("(doc.t4.id = doc.t3.z)"));
+        assertThat(joinConditions.get(ImmutableSet.of(T3.T1, T3.T2, T3.T3, T3.T4)),
+                   isSQL("((doc.t2.b = doc.t3.c) OR (doc.t4.id = doc.t1.x))"));
     }
 }


### PR DESCRIPTION
When building the join tree in the ManyTableConsumer we try to find the optimum order
of relations based also on the ORDER BY. The ORDER BY has the highest priority so we
move the tables that are included in the ORDER BY symbols to the left side of the tree
so that are joined as early as possible. If the join conditions contain relations that
are not immediately adjucent in the original query (eg: ... t2 JOIN t3 on t3.id = t1.d)
the new optimized ordering could lead to a situation that we try to apply a join condition
that contains relations which are not already part of the tree.

To solve this problem a new Map structure is build which holds the join conditions and
helps to apply the following logic:

During the construction of the join tree at the depth that is currently being built with
with the help of the new Map we try to apply all the eligible join conditions for that depth,
so we end up with a join tree where the join conditions are applied as early as possible.

This commit fixes: https://github.com/crate/crate/issues/5747