### PR TITLE
Tests: disable hostname verification for https tests

### DIFF
--- a/sql/src/test/java/io/crate/integrationtests/SQLHttpIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SQLHttpIntegrationTest.java
@@ -28,6 +28,7 @@ import org.apache.http.Header;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -57,7 +58,8 @@ public abstract class SQLHttpIntegrationTest extends SQLTransportIntegrationTest
     }
 
     public SQLHttpIntegrationTest(boolean useSSL) {
-        this.httpClient = HttpClients.createDefault();
+        this.httpClient = HttpClients.custom()
+            .setSSLHostnameVerifier(new NoopHostnameVerifier()).build();
         this.usesSSL = useSSL;
     }
 

--- a/ssl-impl/src/test/java/io/crate/protocols/http/CrateHttpTransportIntegrationTest.java
+++ b/ssl-impl/src/test/java/io/crate/protocols/http/CrateHttpTransportIntegrationTest.java
@@ -68,8 +68,8 @@ public class CrateHttpTransportIntegrationTest extends SQLHttpIntegrationTest {
 
     @AfterClass
     public static void afterIntegrationTest() {
-        System.setProperty("javax.net.ssl.trustStore", "");
-        System.setProperty("javax.net.ssl.trustStorePassword", "");
+        System.clearProperty("javax.net.ssl.trustStore");
+        System.clearProperty("javax.net.ssl.trustStorePassword");
     }
 
     @Override


### PR DESCRIPTION
Otherwise the test fails if run on a machine where the IP to which Crate
binds to resolves to a name other than "localhost".