### PR TITLE
Fix false decrement of reference counted messages

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -36,6 +36,8 @@ Breaking Changes (Packaging only)
 Changes
 =======
 
+ - Added SSL/TLS support for HTTP endpoints.
+
  - Added new HBA setting ``ssl`` which allows to control whether
    users have to connect with ssl enabled or disabled.
 

--- a/users/src/main/java/io/crate/protocols/http/HttpAuthUpstreamHandler.java
+++ b/users/src/main/java/io/crate/protocols/http/HttpAuthUpstreamHandler.java
@@ -58,7 +58,8 @@ public class HttpAuthUpstreamHandler extends SimpleChannelInboundHandler<Object>
     private boolean authorized;
 
     public HttpAuthUpstreamHandler(Settings settings, Authentication authService) {
-        super();
+        // do not auto-release reference counted messages which are just in transit here
+        super(false);
         this.settings = settings;
         this.authService = authService;
     }
@@ -105,6 +106,8 @@ public class HttpAuthUpstreamHandler extends SimpleChannelInboundHandler<Object>
         if (authorized) {
             ctx.fireChannelRead(msg);
         } else {
+            // We won't forward the message downstream, thus we have to release
+            msg.release();
             sendUnauthorized(ctx.channel(), null);
         }
     }


### PR DESCRIPTION
The HttpAuthUpstreamHandler grants permission for messages in the
Netty pipeline. It uses the SimpleChannelInboundHandler which, by
default, releases reference counted messages after calling the channel's
read method. This leads to an unwanted decrement of messages and results
in downstream errors like the following:
io.netty.util.IllegalReferenceCountException: refCnt: 0, decrement: 1

This disables automatic releasing and releases the reference counted
message manually only in case it is not forwarded to the downstream
handler.