### PR TITLE
Prefer user in client cert over trust-auth setting

### DIFF
--- a/ssl-impl/src/test/java/io/crate/protocols/http/CrateHttpTransportIntegrationTest.java
+++ b/ssl-impl/src/test/java/io/crate/protocols/http/CrateHttpTransportIntegrationTest.java
@@ -111,5 +111,4 @@ public class CrateHttpTransportIntegrationTest extends SQLHttpIntegrationTest {
             execute("drop table if exists test");
         }
     }
-
 }

--- a/users/src/main/java/io/crate/operation/auth/ClientCertAuth.java
+++ b/users/src/main/java/io/crate/operation/auth/ClientCertAuth.java
@@ -51,6 +51,9 @@ public class ClientCertAuth implements AuthenticationMethod {
                 if (user != null) {
                     return user;
                 }
+            } else {
+                throw new RuntimeException(
+                    "Common name \"" + commonName + "\" in client certificate doesn't match username \"" + userName + "\"");
             }
         }
         throw new RuntimeException("Client certificate authentication failed for user \"" + userName + "\"");

--- a/users/src/test/java/io/crate/operation/auth/ClientCertAuthTest.java
+++ b/users/src/test/java/io/crate/operation/auth/ClientCertAuthTest.java
@@ -91,15 +91,6 @@ public class ClientCertAuthTest extends CrateUnitTest {
     }
 
     @Test
-    public void testHttpUsesCNAsUserNameIfNoUsernamePresentFromHeaders() throws Exception {
-        ClientCertAuth clientCertAuth = new ClientCertAuth(userName -> exampleUser);
-        ConnectionProperties conn = new ConnectionProperties(InetAddresses.forString("127.0.0.1"), Protocol.HTTP, sslSession);
-
-        assertThat(clientCertAuth.authenticate("", conn), is(exampleUser));
-        assertThat(clientCertAuth.authenticate(null, conn), is(exampleUser));
-    }
-
-    @Test
     public void testHttpClientCertAuthFailsOnUserMissMatchWithCN() throws Exception {
         ClientCertAuth clientCertAuth = new ClientCertAuth(userName -> exampleUser);
         ConnectionProperties conn = new ConnectionProperties(InetAddresses.forString("127.0.0.1"), Protocol.HTTP, sslSession);

--- a/users/src/test/java/io/crate/operation/auth/ClientCertAuthTest.java
+++ b/users/src/test/java/io/crate/operation/auth/ClientCertAuthTest.java
@@ -66,7 +66,7 @@ public class ClientCertAuthTest extends CrateUnitTest {
     public void testLookupValidUserWithCertWithDifferentCN() throws Exception {
         ClientCertAuth clientCertAuth = new ClientCertAuth(userName -> new User("arthur", Collections.emptySet()));
 
-        expectedException.expectMessage("Client certificate authentication failed for user \"arthur\"");
+        expectedException.expectMessage("Common name \"example.com\" in client certificate doesn't match username \"arthur\"");
         clientCertAuth.authenticate("arthur", sslConnWithCert);
     }
 
@@ -95,7 +95,7 @@ public class ClientCertAuthTest extends CrateUnitTest {
         ClientCertAuth clientCertAuth = new ClientCertAuth(userName -> exampleUser);
         ConnectionProperties conn = new ConnectionProperties(InetAddresses.forString("127.0.0.1"), Protocol.HTTP, sslSession);
 
-        expectedException.expectMessage("Client certificate authentication failed for user \"arthur_is_wrong\"");
+        expectedException.expectMessage("Common name \"example.com\" in client certificate doesn't match username \"arthur_is_wrong\"");
         clientCertAuth.authenticate("arthur_is_wrong", conn);
     }
 }


### PR DESCRIPTION
This commit changes the precedence to infer the userName from HTTP requests:

 - Use `X-USER` if present
 - Use commonName from client certificate if present
 - Fallback to `auth.trust.http_default_user` setting or `crate` if not
 available

Without this change client certificate authentication via HTTP didn't
work without using the `X-USER` header.