### PR TITLE
validate user names at the transport handler

### DIFF
--- a/blackbox/docs/sql/administration/privileges.txt
+++ b/blackbox/docs/sql/administration/privileges.txt
@@ -129,12 +129,12 @@ CrateDB exposes privileges ``sys.privileges`` system table.
 By querying the ``sys.privileges`` table you can get all
 information regarding the existing privileges. E.g.::
 
-    cr> SELECT * FROM sys.privileges;
+    cr> SELECT * FROM sys.privileges order by type;
     +---------+---------+---------+-------+-------+------+
     | class   | grantee | grantor | ident | state | type |
     +---------+---------+---------+-------+-------+------+
-    | CLUSTER | will    | crate   |  NULL | GRANT | DQL  |
     | CLUSTER | will    | crate   |  NULL | GRANT | DML  |
+    | CLUSTER | will    | crate   |  NULL | GRANT | DQL  |
     +---------+---------+---------+-------+-------+------+
     SELECT 2 rows in set (... sec)
 

--- a/sql/src/main/java/io/crate/exceptions/UserUnknownException.java
+++ b/sql/src/main/java/io/crate/exceptions/UserUnknownException.java
@@ -22,17 +22,31 @@
 
 package io.crate.exceptions;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 
 public class UserUnknownException extends ResourceUnknownException implements UnscopedException {
 
     public UserUnknownException(String userName) {
-        super(String.format(
-            Locale.ENGLISH, "User '%s' does not exist", userName));
+        super(getMessage(Collections.singletonList(userName)));
+    }
+
+    public UserUnknownException(List<String> userNames) {
+        super(getMessage(userNames));
     }
 
     @Override
     public int errorCode() {
         return 36370;  // <-- will be added to 4040, results in 40410
+    }
+
+    private static String getMessage(List<String> userNames) {
+        //noinspection PointlessBooleanExpression
+        assert userNames.isEmpty() == false : "At least one username must be provided";
+        if (userNames.size() == 1) {
+            return String.format(Locale.ENGLISH, "User '%s' does not exist", userNames.get(0));
+        }
+        return String.format(Locale.ENGLISH, "Users '%s' do not exist", String.join(", ", userNames));
     }
 }

--- a/users/src/main/java/io/crate/operation/user/PrivilegesRequest.java
+++ b/users/src/main/java/io/crate/operation/user/PrivilegesRequest.java
@@ -34,15 +34,15 @@ public class PrivilegesRequest extends AcknowledgedRequest<PrivilegesRequest> {
     private Collection<String> userNames;
     private Collection<Privilege> privileges;
 
-    public PrivilegesRequest() {
+    PrivilegesRequest() {
     }
 
-    public PrivilegesRequest(Collection<String> userNames, Collection<Privilege> privileges) {
+    PrivilegesRequest(Collection<String> userNames, Collection<Privilege> privileges) {
         this.userNames = userNames;
         this.privileges = privileges;
     }
 
-    public Collection<String> userNames() {
+    Collection<String> userNames() {
         return userNames;
     }
 

--- a/users/src/main/java/io/crate/operation/user/PrivilegesResponse.java
+++ b/users/src/main/java/io/crate/operation/user/PrivilegesResponse.java
@@ -23,22 +23,29 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
+import java.util.List;
 
 public class PrivilegesResponse extends AcknowledgedResponse {
 
     private long affectedRows;
+    private List<String> unknownUserNames;
 
     PrivilegesResponse() {
         affectedRows = 0L;
     }
 
-    PrivilegesResponse(boolean acknowledged, long affectedRows) {
+    PrivilegesResponse(boolean acknowledged, long affectedRows, List<String> unknownUserNames) {
         super(acknowledged);
         this.affectedRows = affectedRows;
+        this.unknownUserNames = unknownUserNames;
     }
 
     long affectedRows() {
         return affectedRows;
+    }
+
+    List<String> unknownUserNames() {
+        return unknownUserNames;
     }
 
     @Override
@@ -46,6 +53,7 @@ public class PrivilegesResponse extends AcknowledgedResponse {
         super.readFrom(in);
         readAcknowledged(in);
         affectedRows = in.readLong();
+        unknownUserNames = in.readList(StreamInput::readString);
     }
 
     @Override
@@ -53,5 +61,6 @@ public class PrivilegesResponse extends AcknowledgedResponse {
         super.writeTo(out);
         writeAcknowledged(out);
         out.writeLong(affectedRows);
+        out.writeStringList(unknownUserNames);
     }
 }

--- a/users/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
+++ b/users/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
@@ -99,4 +99,18 @@ public class PrivilegesIntegrationTest extends BaseUsersIntegrationTest {
                                         superuserName + "'");
         executeAsSuperuser("grant DQL to " + superuserName);
     }
+
+    @Test
+    public void testApplyPrivilegesToUnknownUserThrowsException() throws Exception {
+        expectedException.expect(SQLActionException.class);
+        expectedException.expectMessage("UserUnknownException: User 'unknown_user' does not exist");
+        executeAsSuperuser("grant DQL to unknown_user");
+    }
+
+    @Test
+    public void testApplyPrivilegesToMultipleUnknownUsersThrowsException() throws Exception {
+        expectedException.expect(SQLActionException.class);
+        expectedException.expectMessage("UserUnknownException: Users 'unknown_user, also_unknown' do not exist");
+        executeAsSuperuser("grant DQL to unknown_user, also_unknown");
+    }
 }

--- a/users/src/test/java/io/crate/operation/user/PrivilegesRequestTest.java
+++ b/users/src/test/java/io/crate/operation/user/PrivilegesRequestTest.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of a module with proprietary Enterprise Features.
+ *
+ * Licensed to Crate.io Inc. ("Crate.io") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ *
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ *
+ * To use this file, Crate.io must have given you permission to enable and
+ * use such Enterprise Features and you must have a valid Enterprise or
+ * Subscription Agreement with Crate.io.  If you enable or use the Enterprise
+ * Features, you represent and warrant that you have a valid Enterprise or
+ * Subscription Agreement with Crate.io.  Your use of the Enterprise Features
+ * if governed by the terms and conditions of your Enterprise or Subscription
+ * Agreement with Crate.io.
+ */
+
+package io.crate.operation.user;
+
+import com.google.common.collect.Lists;
+import io.crate.analyze.user.Privilege;
+import io.crate.test.integration.CrateUnitTest;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.is;
+
+public class PrivilegesRequestTest extends CrateUnitTest {
+
+    @Test
+    public void testStreaming() throws Exception {
+        List<String> users = Lists.newArrayList("ford", "arthur");
+        List<Privilege> privileges = Lists.newArrayList(
+            new Privilege(Privilege.State.GRANT, Privilege.Type.DQL, Privilege.Clazz.CLUSTER, null, "crate"),
+            new Privilege(Privilege.State.GRANT, Privilege.Type.DML, Privilege.Clazz.CLUSTER, null, "crate")
+        );
+        PrivilegesRequest r1 = new PrivilegesRequest(users, privileges);
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        r1.writeTo(out);
+
+        PrivilegesRequest r2 = new PrivilegesRequest();
+        r2.readFrom(out.bytes().streamInput());
+
+        assertThat(r2.userNames(), is(users));
+        assertThat(r2.privileges(), is(privileges));
+    }
+}

--- a/users/src/test/java/io/crate/operation/user/PrivilegesResponseTest.java
+++ b/users/src/test/java/io/crate/operation/user/PrivilegesResponseTest.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of a module with proprietary Enterprise Features.
+ *
+ * Licensed to Crate.io Inc. ("Crate.io") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ *
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ *
+ * To use this file, Crate.io must have given you permission to enable and
+ * use such Enterprise Features and you must have a valid Enterprise or
+ * Subscription Agreement with Crate.io.  If you enable or use the Enterprise
+ * Features, you represent and warrant that you have a valid Enterprise or
+ * Subscription Agreement with Crate.io.  Your use of the Enterprise Features
+ * if governed by the terms and conditions of your Enterprise or Subscription
+ * Agreement with Crate.io.
+ */
+
+package io.crate.operation.user;
+
+import com.google.common.collect.Lists;
+import io.crate.test.integration.CrateUnitTest;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.is;
+
+public class PrivilegesResponseTest extends CrateUnitTest {
+
+    @Test
+    public void testStreaming() throws Exception {
+        List<String> unknownUsers = Lists.newArrayList("ford", "arthur");
+        long affectedRows = 1L;
+        PrivilegesResponse r1 = new PrivilegesResponse(true, affectedRows, unknownUsers);
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        r1.writeTo(out);
+
+        PrivilegesResponse r2 = new PrivilegesResponse();
+        r2.readFrom(out.bytes().streamInput());
+
+        assertThat(r2.isAcknowledged(), is(true));
+        assertThat(r2.affectedRows(), is(1L));
+        assertThat(r2.unknownUserNames(), is(unknownUsers));
+    }
+}
+

--- a/users/src/test/java/io/crate/operation/user/UserManagerServiceTest.java
+++ b/users/src/test/java/io/crate/operation/user/UserManagerServiceTest.java
@@ -20,15 +20,12 @@ package io.crate.operation.user;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Lists;
-import io.crate.exceptions.UserUnknownException;
 import io.crate.metadata.UsersMetaData;
 import io.crate.metadata.UsersPrivilegesMetaData;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.Set;
 
 import static io.crate.operation.user.UserManagerService.CRATE_USER;
@@ -85,25 +82,5 @@ public class UserManagerServiceTest extends CrateDummyClusterServiceUnitTest {
     public void testGetNoopExceptionValidatorForSuperUser() throws Exception {
         ExceptionAuthorizedValidator validator = userManagerService.getExceptionValidator(CRATE_USER);
         assertThat(validator, is(NOOP_EXCEPTION_VALIDATOR));
-    }
-
-    @Test
-    public void testValidateExistingUserName() {
-        // must not throw an exception, user is found
-        UserManagerService.validateUsernames(Lists.newArrayList("ford"), s -> new User(s, Collections.emptySet(), Collections.emptySet()));
-    }
-
-    @Test
-    public void testValidateNonExistingUserNameThrowsException() {
-        expectedException.expect(UserUnknownException.class);
-        expectedException.expectMessage("User 'ford' does not exist");
-        UserManagerService.validateUsernames(Lists.newArrayList("ford"), s -> null);
-    }
-
-    @Test
-    public void testValidateSuperUserThrowsException() {
-        expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("Cannot alter privileges for superuser 'crate'");
-        UserManagerService.validateUsernames(Lists.newArrayList(CRATE_USER.name()), s -> CRATE_USER);
     }
 }


### PR DESCRIPTION
we must do this were the cluster state is read and applied,
otherwise we could run into race conditions