### PR TITLE
Disable gradle daemon on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
     - secure: "LLqhKxqgRMp/C/TzZWv8YuhpmEm1twggm76NBUAQfZmOPLCkQSpAO8hoBM3qaIlDPSKPgoYj9f0TBuNi0iIFghQf0Xc4pXPCV0AnoGpXwRGiJATTAXfnG7RBa/hXRRBeAKlGmAI9GLtIoCQbUKYhq8gqwbzQVQXq+90rhsMH4zo="
     - CRATE_TESTS_SQL_REQUEST_TIMEOUT="20"
     - _JAVA_OPTIONS="-Xms1g -Xmx1g"
+    - GRADLE_OPTS="-Dorg.gradle.daemon=false"
 
 
 before_cache:


### PR DESCRIPTION
For CI environments it's recommended to disable the daemon.

See https://docs.gradle.org/current/userguide/gradle_daemon.html#when_should_i_not_use_the_gradle_daemon