### PR TITLE
re-enables range query support on the `_id` + `_uid` columns

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -56,6 +56,9 @@ Changes
 Fixes
 =====
 
+ - Throw proper exception when using the ``_raw`` column inside the where clause
+   instead of silently ignoring it.
+
  - Fixed support for range queries on the ``_id`` and ``_uid`` columns, range
    queries on these columns weren't working at all since v2.0.0.
    Issue: https://github.com/crate/crate/issues/5845

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -56,6 +56,10 @@ Changes
 Fixes
 =====
 
+ - Fixed support for range queries on the ``_id`` and ``_uid`` columns, range
+   queries on these columns weren't working at all since v2.0.0.
+   Issue: https://github.com/crate/crate/issues/5845
+
  - Fixed an issue on ``RENAME`` a partitioned table which would result in data
    loss if a new table is created with the old name of the renamed table and
    afterwards dropped. Issue: https://github.com/crate/crate/issues/5823

--- a/sql/src/main/java/io/crate/analyze/where/WhereClauseValidator.java
+++ b/sql/src/main/java/io/crate/analyze/where/WhereClauseValidator.java
@@ -8,6 +8,7 @@ import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.SymbolVisitor;
 import io.crate.metadata.Reference;
+import io.crate.metadata.doc.DocSysColumns;
 import io.crate.operation.operator.EqOperator;
 import io.crate.operation.operator.GteOperator;
 import io.crate.operation.operator.any.AnyEqOperator;
@@ -91,6 +92,8 @@ public abstract class WhereClauseValidator {
                 validateSysReference(context, VERSION_ALLOWED_COMPARISONS, VERSION_ERROR);
             } else if (columnName.equalsIgnoreCase(_SCORE)) {
                 validateSysReference(context, SCORE_ALLOWED_COMPARISONS, SCORE_ERROR);
+            } else if (columnName.equalsIgnoreCase(DocSysColumns.RAW.name())) {
+                throw new UnsupportedOperationException("The _raw column is not searchable and cannot be used inside a query");
             }
         }
 

--- a/sql/src/test/java/io/crate/lucene/LuceneQueryBuilderTest.java
+++ b/sql/src/test/java/io/crate/lucene/LuceneQueryBuilderTest.java
@@ -538,4 +538,23 @@ public class LuceneQueryBuilderTest extends CrateUnitTest {
         expectedException.expectMessage("queryTerm must be a literal");
         convert("match(name, name)");
     }
+
+    @Test
+    public void testRangeQueryForId() throws Exception {
+        Query query = convert("_id > 'foo'");
+        assertThat(query, instanceOf(TermRangeQuery.class));
+    }
+
+    @Test
+    public void testRangeQueryForUid() throws Exception {
+        Query query = convert("_uid > 'foo'");
+        assertThat(query, instanceOf(TermRangeQuery.class));
+    }
+
+    @Test
+    public void testRangeQueryOnDocThrowsException() throws Exception {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("unknown function: op_>(object, object)");
+        convert("_doc > {\"name\"='foo'}");
+    }
 }


### PR DESCRIPTION
also see crate/elasticsearch#123
fixes #5845

also throw exception when using the `_raw` column inside a where clause instead of silently ignoring it.