### PR TITLE
define sys columns as not nullable

### DIFF
--- a/sql/src/main/java/io/crate/metadata/doc/DocSysColumns.java
+++ b/sql/src/main/java/io/crate/metadata/doc/DocSysColumns.java
@@ -2,6 +2,7 @@ package io.crate.metadata.doc;
 
 import com.google.common.collect.ImmutableMap;
 import io.crate.metadata.*;
+import io.crate.metadata.table.ColumnPolicy;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
@@ -54,7 +55,8 @@ public class DocSysColumns {
         .build();
 
     private static Reference newInfo(TableIdent table, ColumnIdent column, DataType dataType) {
-        return new Reference(new ReferenceIdent(table, column), RowGranularity.DOC, dataType);
+        return new Reference(new ReferenceIdent(table, column), RowGranularity.DOC, dataType, ColumnPolicy.STRICT,
+            Reference.IndexType.NOT_ANALYZED, false);
     }
 
     /**

--- a/sql/src/test/java/io/crate/integrationtests/LuceneQueryBuilderIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/LuceneQueryBuilderIntegrationTest.java
@@ -240,4 +240,16 @@ public class LuceneQueryBuilderIntegrationTest extends SQLTransportIntegrationTe
         assertThat(printedTable(execute("select p from t where x is null").rows()), is("1\n"));
         assertThat(printedTable(execute("select p from t where obj is null").rows()), is("1\n"));
     }
+
+    @Test
+    public void testWhereNotIdInFunction() throws Exception {
+        execute("create table t (dummy string) clustered into 2 shards with (number_of_replicas = 0)");
+        ensureYellow();
+        execute("insert into t (dummy) values ('yalla')");
+        refresh();
+
+        execute("select dummy from t where substr(_id, 1, 1) != '{'");
+        assertThat(response.rowCount(), is(1L));
+        assertThat(response.rows()[0][0], is("yalla"));
+    }
 }

--- a/sql/src/test/java/io/crate/lucene/LuceneQueryBuilderTest.java
+++ b/sql/src/test/java/io/crate/lucene/LuceneQueryBuilderTest.java
@@ -543,6 +543,7 @@ public class LuceneQueryBuilderTest extends CrateUnitTest {
     public void testRangeQueryForId() throws Exception {
         Query query = convert("_id > 'foo'");
         assertThat(query, instanceOf(TermRangeQuery.class));
+        assertThat(query.toString(), is("_uid:{default#foo TO *}"));
     }
 
     @Test


### PR DESCRIPTION
sys columns are never nullable.
this resulted in a bug, using the _id column inside a function
surrounded by NOT resulted in an exception (_id not searchable)