### PR TITLE
 Added column `user` to `sys.jobs` and `sys.jobs_log`

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -41,6 +41,9 @@ Breaking Changes (Packaging only)
 
 Changes
 =======
+ 
+ - Added column ``username`` to ``sys.jobs`` and ``sys.jobs_log`` that contains
+   the username under which the job was invoked.
 
  - Upgraded the Admin UI to 1.3.3
 

--- a/blackbox/docs/sql/system.txt
+++ b/blackbox/docs/sql/system.txt
@@ -996,14 +996,14 @@ Jobs
 ----
 
 The ``sys.jobs`` table is a constantly updated view of all jobs that are
-currently being executed in the cluster::
+currently being executed by a user in the cluster::
 
-    cr> select stmt, started from sys.jobs where stmt like 'sel% from %jobs%';
-    +-----------------------------------------------------------------------+-...-----+
-    | stmt                                                                  | started |
-    +-----------------------------------------------------------------------+-...-----+
-    | select stmt, started from sys.jobs where stmt like 'sel% from %jobs%' | ...     |
-    +-----------------------------------------------------------------------+-...-----+
+    cr> select stmt, username, started from sys.jobs where stmt like 'sel% from %jobs%';
+    +---------------------------------------------------------------------------------+----------+-...-----+
+    | stmt                                                                            | username | started |
+    +---------------------------------------------------------------------------------+----------+-...-----+
+    | select stmt, username, started from sys.jobs where stmt like 'sel% from %jobs%' | crate    | ...     |
+    +---------------------------------------------------------------------------------+----------+-...-----+
     SELECT 1 row in set (... sec)
 
 Every request that queries data or manipulates data is considered a "job" if it
@@ -1048,14 +1048,14 @@ The ``sys.jobs`` and ``sys.operations`` tables have corresponding log tables:
 After a job or operation finishes, the corresponding entry will be moved into
 the corresponding log table::
 
-    cr> select id, stmt, started, ended, error
+    cr> select id, stmt, username, started, ended, error
     ... from sys.jobs_log order by ended desc limit 2;
-    +-...+------------------------------------...-+-...-----+-...---+-------+
-    | id | stmt                                   | started | ended | error |
-    +-...+------------------------------------...-+-...-----+-...---+-------+
-    | ...| select _node['name'], ...              | ...     | ...   |  NULL |
-    | ...| select stmt, started from sys.jobs ... | ...     | ...   |  NULL |
-    +-...+------------------------------------...-+-...-----+-...---+-------+
+    +-...+----------------------------------------------...-+----------+-...-----+-...---+-------+
+    | id | stmt                                             | username | started | ended | error |
+    +-...+----------------------------------------------...-+----------+-...-----+-...---+-------+
+    | ...| select _node['name'], ...                        | crate    | ...     | ...   |  NULL |
+    | ...| select stmt, username, started from sys.jobs ... | crate    | ...     | ...   |  NULL |
+    +-...+----------------------------------------------...-+----------+-...-----+-...---+-------+
     SELECT 2 rows in set (... sec)
 
 Invalid queries are also logged in the ``sys.jobs_log`` table, i.e. queries

--- a/enterprise/jmx-monitoring/src/test/java/io/crate/beans/QueryStatsTest.java
+++ b/enterprise/jmx-monitoring/src/test/java/io/crate/beans/QueryStatsTest.java
@@ -34,13 +34,13 @@ import static org.junit.Assert.assertThat;
 public class QueryStatsTest {
 
     private final List<JobContextLog> log = ImmutableList.of(
-        new JobContextLog(new JobContext(UUID.randomUUID(), "select name", 100L), null, 150L),
-        new JobContextLog(new JobContext(UUID.randomUUID(), "select name", 300L), null, 320L),
-        new JobContextLog(new JobContext(UUID.randomUUID(), "update t1 set x = 10", 400L), null, 420L),
-        new JobContextLog(new JobContext(UUID.randomUUID(), "insert into t1 (x) values (20)", 111L), null, 130L),
-        new JobContextLog(new JobContext(UUID.randomUUID(), "delete from t1", 410L), null, 415L),
-        new JobContextLog(new JobContext(UUID.randomUUID(), "delete from t1", 110L), null, 120L),
-        new JobContextLog(new JobContext(UUID.randomUUID(), "create table t1 (x int)", 105L), null, 106L)
+        new JobContextLog(new JobContext(UUID.randomUUID(), "select name", 100L, null), null, 150L),
+        new JobContextLog(new JobContext(UUID.randomUUID(), "select name", 300L, null), null, 320L),
+        new JobContextLog(new JobContext(UUID.randomUUID(), "update t1 set x = 10", 400L, null), null, 420L),
+        new JobContextLog(new JobContext(UUID.randomUUID(), "insert into t1 (x) values (20)", 111L, null), null, 130L),
+        new JobContextLog(new JobContext(UUID.randomUUID(), "delete from t1", 410L, null), null, 415L),
+        new JobContextLog(new JobContext(UUID.randomUUID(), "delete from t1", 110L, null), null, 120L),
+        new JobContextLog(new JobContext(UUID.randomUUID(), "create table t1 (x int)", 105L, null), null, 106L)
     );
 
     @Test

--- a/sql/src/main/java/io/crate/action/sql/SQLOperations.java
+++ b/sql/src/main/java/io/crate/action/sql/SQLOperations.java
@@ -221,7 +221,7 @@ public class SQLOperations {
                 if ("".equals(query)) {
                     statement = EMPTY_STMT;
                 } else {
-                    jobsLogs.logPreExecutionFailure(UUID.randomUUID(), query, SQLExceptions.messageOf(t));
+                    jobsLogs.logPreExecutionFailure(UUID.randomUUID(), query, SQLExceptions.messageOf(t), sessionContext.user());
                     throw SQLExceptions.createSQLActionException(t, sessionContext);
                 }
             }
@@ -247,7 +247,7 @@ public class SQLOperations {
                     portal.close();
                 }
             } catch (Throwable t) {
-                jobsLogs.logPreExecutionFailure(UUID.randomUUID(), portal.getLastQuery(), SQLExceptions.messageOf(t));
+                jobsLogs.logPreExecutionFailure(UUID.randomUUID(), portal.getLastQuery(), SQLExceptions.messageOf(t), sessionContext.user());
                 throw SQLExceptions.createSQLActionException(t, sessionContext);
             }
         }

--- a/sql/src/main/java/io/crate/metadata/sys/SysJobsLogTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysJobsLogTableInfo.java
@@ -45,6 +45,7 @@ public class SysJobsLogTableInfo extends StaticTableInfo {
 
     public static class Columns {
         public static final ColumnIdent ID = new ColumnIdent("id");
+        public static final ColumnIdent USERNAME = new ColumnIdent("username");
         public static final ColumnIdent STMT = new ColumnIdent("stmt");
         public static final ColumnIdent STARTED = new ColumnIdent("started");
         public static final ColumnIdent ENDED = new ColumnIdent("ended");
@@ -57,6 +58,7 @@ public class SysJobsLogTableInfo extends StaticTableInfo {
     public SysJobsLogTableInfo(ClusterService clusterService) {
         super(IDENT, new ColumnRegistrar(IDENT, RowGranularity.DOC)
             .register(Columns.ID, DataTypes.STRING)
+            .register(Columns.USERNAME, DataTypes.STRING)
             .register(Columns.STMT, DataTypes.STRING)
             .register(Columns.STARTED, DataTypes.TIMESTAMP)
             .register(Columns.ENDED, DataTypes.TIMESTAMP)

--- a/sql/src/main/java/io/crate/metadata/sys/SysJobsTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysJobsTableInfo.java
@@ -43,6 +43,7 @@ public class SysJobsTableInfo extends StaticTableInfo {
 
     public static class Columns {
         public static final ColumnIdent ID = new ColumnIdent("id");
+        public static final ColumnIdent USERNAME = new ColumnIdent("username");
         public static final ColumnIdent STMT = new ColumnIdent("stmt");
         public static final ColumnIdent STARTED = new ColumnIdent("started");
     }
@@ -51,6 +52,7 @@ public class SysJobsTableInfo extends StaticTableInfo {
     public SysJobsTableInfo(ClusterService service) {
         super(IDENT, new ColumnRegistrar(IDENT, RowGranularity.DOC)
             .register(Columns.ID, DataTypes.STRING)
+            .register(Columns.USERNAME, DataTypes.STRING)
             .register(Columns.STMT, DataTypes.STRING)
             .register(Columns.STARTED, DataTypes.TIMESTAMP), PRIMARY_KEY);
         this.service = service;

--- a/sql/src/main/java/io/crate/operation/collect/stats/JobsLogs.java
+++ b/sql/src/main/java/io/crate/operation/collect/stats/JobsLogs.java
@@ -26,6 +26,7 @@ import io.crate.operation.reference.sys.job.JobContext;
 import io.crate.operation.reference.sys.job.JobContextLog;
 import io.crate.operation.reference.sys.operation.OperationContext;
 import io.crate.operation.reference.sys.operation.OperationContextLog;
+import io.crate.operation.user.User;
 import org.elasticsearch.common.collect.Tuple;
 
 import javax.annotation.Nullable;
@@ -91,12 +92,12 @@ public class JobsLogs {
      * <p>
      * If {@link #isEnabled()} is false this method won't do anything.
      */
-    public void logExecutionStart(UUID jobId, String statement) {
+    public void logExecutionStart(UUID jobId, String statement, @Nullable User user) {
         activeRequests.increment();
         if (!isEnabled()) {
             return;
         }
-        jobsTable.put(jobId, new JobContext(jobId, statement, System.currentTimeMillis()));
+        jobsTable.put(jobId, new JobContext(jobId, statement, System.currentTimeMillis(), user));
     }
 
     /**
@@ -116,14 +117,14 @@ public class JobsLogs {
 
     /**
      * Create a entry into `sys.jobs_log`
-     * This method can be used instead of {@link #logExecutionEnd(UUID, String)} if there was no {@link #logExecutionStart(UUID, String)}
+     * This method can be used instead of {@link #logExecutionEnd(UUID, String)} if there was no {@link #logExecutionStart(UUID, String, User)}
      * Call because an error happened during parse, analysis or plan.
      * <p>
-     * {@link #logExecutionStart(UUID, String)} is only called after a Plan has been created and execution starts.
+     * {@link #logExecutionStart(UUID, String, User)} is only called after a Plan has been created and execution starts.
      */
-    public void logPreExecutionFailure(UUID jobId, String stmt, String errorMessage) {
+    public void logPreExecutionFailure(UUID jobId, String stmt, String errorMessage, @Nullable User user) {
         LogSink<JobContextLog> jobContextLogs = jobsLog.get();
-        JobContext jobContext = new JobContext(jobId, stmt, System.currentTimeMillis());
+        JobContext jobContext = new JobContext(jobId, stmt, System.currentTimeMillis(), user);
         jobContextLogs.add(new JobContextLog(jobContext, errorMessage));
     }
 

--- a/sql/src/main/java/io/crate/operation/reference/sys/RowContextReferenceResolver.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/RowContextReferenceResolver.java
@@ -163,6 +163,8 @@ public class RowContextReferenceResolver implements ReferenceResolver<RowCollect
         return ImmutableMap.<ColumnIdent, RowCollectExpressionFactory<JobContextLog>>builder()
             .put(SysJobsLogTableInfo.Columns.ID,
                 () -> RowContextCollectorExpression.objToBytesRef(JobContextLog::id))
+            .put(SysJobsTableInfo.Columns.USERNAME,
+                () -> RowContextCollectorExpression.objToBytesRef(JobContextLog::username))
             .put(SysJobsLogTableInfo.Columns.STMT,
                 () -> RowContextCollectorExpression.objToBytesRef(JobContextLog::statement))
             .put(SysJobsLogTableInfo.Columns.STARTED,
@@ -178,6 +180,8 @@ public class RowContextReferenceResolver implements ReferenceResolver<RowCollect
         return ImmutableMap.<ColumnIdent, RowCollectExpressionFactory<JobContext>>builder()
             .put(SysJobsTableInfo.Columns.ID,
                 () -> RowContextCollectorExpression.objToBytesRef(JobContext::id))
+            .put(SysJobsTableInfo.Columns.USERNAME,
+                () -> RowContextCollectorExpression.objToBytesRef(JobContext::username))
             .put(SysJobsTableInfo.Columns.STMT,
                 () -> RowContextCollectorExpression.objToBytesRef(JobContext::stmt))
             .put(SysJobsTableInfo.Columns.STARTED,

--- a/sql/src/main/java/io/crate/operation/reference/sys/job/JobContext.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/job/JobContext.java
@@ -21,18 +21,29 @@
 
 package io.crate.operation.reference.sys.job;
 
+import io.crate.operation.user.User;
+
+import javax.annotation.Nullable;
 import java.util.UUID;
 
 public class JobContext {
 
     public final UUID id;
+    @Nullable
+    public final String username;
     public final String stmt;
     public final long started;
 
-    public JobContext(UUID id, String stmt, long started) {
+    public JobContext(UUID id, String stmt, long started, @Nullable User user) {
         this.id = id;
         this.stmt = stmt;
         this.started = started;
+
+        if (user != null) {
+            this.username = user.name();
+        } else {
+            this.username = null;
+        }
     }
 
     public UUID id() {
@@ -41,6 +52,11 @@ public class JobContext {
 
     public String stmt() {
         return stmt;
+    }
+
+    @Nullable
+    public String username() {
+        return username;
     }
 
     public long started() {

--- a/sql/src/main/java/io/crate/operation/reference/sys/job/JobContextLog.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/job/JobContextLog.java
@@ -52,6 +52,11 @@ public class JobContextLog implements ContextLog {
         return jobContext.id;
     }
 
+    @Nullable
+    public String username() {
+        return jobContext.username();
+    }
+
     public String statement() {
         return jobContext.stmt;
     }

--- a/sql/src/main/java/io/crate/protocols/postgres/BatchPortal.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/BatchPortal.java
@@ -132,11 +132,11 @@ class BatchPortal extends AbstractPortal {
             try {
                 plan = planner.plan(analysis.get(i), jobId, 0, 0);
             } catch (Throwable t) {
-                jobsLogs.logPreExecutionFailure(jobId, stmt, SQLExceptions.messageOf(t));
+                jobsLogs.logPreExecutionFailure(jobId, stmt, SQLExceptions.messageOf(t), sessionContext.user());
                 throw t;
             }
             ResultReceiver resultReceiver = resultReceivers.get(i);
-            jobsLogs.logExecutionStart(jobId, stmt);
+            jobsLogs.logExecutionStart(jobId, stmt, sessionContext.user());
             JobsLogsUpdateListener jobsLogsUpdateListener = new JobsLogsUpdateListener(jobId, jobsLogs);
 
             resultReceiver.completionFuture()

--- a/sql/src/main/java/io/crate/protocols/postgres/BulkPortal.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/BulkPortal.java
@@ -38,7 +38,6 @@ import io.crate.planner.Planner;
 import io.crate.sql.tree.Statement;
 import io.crate.types.DataType;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
@@ -122,10 +121,10 @@ class BulkPortal extends AbstractPortal {
         try {
             plan = planner.plan(analysis, jobId, 0, maxRows);
         } catch (Throwable t) {
-            jobsLogs.logPreExecutionFailure(jobId, query, SQLExceptions.messageOf(t));
+            jobsLogs.logPreExecutionFailure(jobId, query, SQLExceptions.messageOf(t), sessionContext.user());
             throw t;
         }
-        jobsLogs.logExecutionStart(jobId, query);
+        jobsLogs.logExecutionStart(jobId, query, sessionContext.user());
         synced = true;
         return executeBulk(portalContext.getExecutor(), plan, jobId, jobsLogs);
     }

--- a/sql/src/main/java/io/crate/protocols/postgres/SimplePortal.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/SimplePortal.java
@@ -160,7 +160,7 @@ public class SimplePortal extends AbstractPortal {
         try {
             plan = planner.plan(analysis, jobId, defaultLimit, maxRows);
         } catch (Throwable t) {
-            jobsLogs.logPreExecutionFailure(jobId, query, SQLExceptions.messageOf(t));
+            jobsLogs.logPreExecutionFailure(jobId, query, SQLExceptions.messageOf(t), sessionContext.user());
             throw t;
         }
 
@@ -169,7 +169,7 @@ public class SimplePortal extends AbstractPortal {
                 resultReceiver, jobId, newJobId -> retryQuery(planner, newJobId));
         }
 
-        jobsLogs.logExecutionStart(jobId, query);
+        jobsLogs.logExecutionStart(jobId, query, sessionContext.user());
         JobsLogsUpdateListener jobsLogsUpdateListener = new JobsLogsUpdateListener(jobId, jobsLogs);
         CompletableFuture completableFuture = resultReceiver.completionFuture().whenComplete(jobsLogsUpdateListener);
 

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -2003,9 +2003,9 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     public void testFullQualifiedStarPrefix() throws Exception {
         SelectAnalyzedStatement statement = analyze("select sys.jobs.* from sys.jobs");
         List<Symbol> outputs = statement.relation().querySpec().outputs();
-        assertThat(outputs.size(), is(3));
+        assertThat(outputs.size(), is(4));
         //noinspection unchecked
-        assertThat(outputs, Matchers.contains(isReference("id"), isReference("started"), isReference("stmt")));
+        assertThat(outputs, Matchers.contains(isReference("id"), isReference("started"), isReference("stmt"), isReference("username")));
     }
 
     @Test
@@ -2019,9 +2019,9 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     public void testSelectStarWithTableAliasAsPrefix() throws Exception {
         SelectAnalyzedStatement statement = analyze("select t1.* from sys.jobs t1");
         List<Symbol> outputs = statement.relation().querySpec().outputs();
-        assertThat(outputs.size(), is(3));
+        assertThat(outputs.size(), is(4));
         //noinspection unchecked
-        assertThat(outputs, Matchers.contains(isReference("id"), isReference("started"), isReference("stmt")));
+        assertThat(outputs, Matchers.contains(isReference("id"), isReference("started"), isReference("stmt"), isReference("username")));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -460,7 +460,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultColumns() throws Exception {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(416, response.rowCount());
+        assertEquals(418, response.rowCount());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/collect/stats/RamAccountingQueueSinkTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/stats/RamAccountingQueueSinkTest.java
@@ -22,6 +22,7 @@
 
 package io.crate.operation.collect.stats;
 
+import io.crate.action.sql.SessionContext;
 import io.crate.breaker.SizeEstimator;
 import io.crate.core.collections.BlockingEvictingQueue;
 import io.crate.operation.reference.sys.job.ContextLog;
@@ -120,13 +121,12 @@ public class RamAccountingQueueSinkTest extends CrateUnitTest {
     public void testRemoveExpiredLogs() {
         ConcurrentLinkedQueue<JobContextLog> q = new ConcurrentLinkedQueue<>();
         ScheduledFuture<?> task = new TimeExpiring(1_000_000L, 1_000_000L).registerTruncateTask(q, scheduler, TimeValue.timeValueSeconds(1L));
-
         q.add(new JobContextLog(new JobContext(UUID.fromString("067e6162-3b6f-4ae2-a171-2470b63dff01"),
-            "select 1", 1L), null, 2000L));
+            "select 1", 1L, null), null, 2000L));
         q.add(new JobContextLog(new JobContext(UUID.fromString("067e6162-3b6f-4ae2-a171-2470b63dff02"),
-            "select 1", 1L), null, 4000L));
+            "select 1", 1L, null), null, 4000L));
         q.add(new JobContextLog(new JobContext(UUID.fromString("067e6162-3b6f-4ae2-a171-2470b63dff03"),
-            "select 1", 1L), null, 7000L));
+            "select 1", 1L, null), null, 7000L));
 
         TimeExpiring.instance().removeExpiredLogs(q, 10_000L, 5_000L);
         assertThat(q.size(), is(1));


### PR DESCRIPTION
This feature add the column expression `user` to the system tables `sys.jobs` and `sys.jobs_log`. The column shows the username of the session that made the request.

- [x] added username of the current session
- [x] documentation
