### PR TITLE
Offer only enabled SSL ciphers

### DIFF
--- a/enterprise/ssl-impl/src/main/java/io/crate/protocols/ssl/SslConfiguration.java
+++ b/enterprise/ssl-impl/src/main/java/io/crate/protocols/ssl/SslConfiguration.java
@@ -93,7 +93,7 @@ public final class SslConfiguration {
             sslContext.init(keyStoreSettings.keyManagers, trustManagers, null);
             SSLContext.setDefault(sslContext);
 
-            List<String> supportedCiphers = Arrays.asList(sslContext.createSSLEngine().getSupportedCipherSuites());
+            List<String> enabledCiphers = Arrays.asList(sslContext.createSSLEngine().getEnabledCipherSuites());
 
             final X509Certificate[] keystoreCerts = keyStoreSettings.exportServerCertChain();
             final PrivateKey privateKey = keyStoreSettings.exportDecryptedKey();
@@ -106,7 +106,7 @@ public final class SslConfiguration {
             final SslContextBuilder sslContextBuilder =
                 SslContextBuilder
                     .forServer(privateKey, keystoreCerts)
-                    .ciphers(supportedCiphers)
+                    .ciphers(enabledCiphers)
                     .applicationProtocolConfig(ApplicationProtocolConfig.DISABLED)
                     .clientAuth(ClientAuth.OPTIONAL)
                     .sessionCacheSize(0)

--- a/enterprise/ssl-impl/src/test/java/io/crate/protocols/ssl/SslConfigurationTest.java
+++ b/enterprise/ssl-impl/src/test/java/io/crate/protocols/ssl/SslConfigurationTest.java
@@ -35,6 +35,7 @@ import java.security.cert.X509Certificate;
 
 import static io.crate.protocols.ssl.SslConfiguration.KeyStoreSettings;
 import static io.crate.protocols.ssl.SslConfiguration.TrustStoreSettings;
+import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
@@ -71,6 +72,8 @@ public class SslConfigurationTest extends CrateUnitTest {
         SslContext sslContext = SslConfiguration.buildSslContext(settings);
         assertThat(sslContext.isServer(), is(true));
         assertThat(sslContext.cipherSuites(), not(empty()));
+        // check that we don't offer NULL ciphers which do not encrypt
+        assertThat(sslContext.cipherSuites(), not(hasItem(containsString("NULL"))));
     }
 
     @Test


### PR DESCRIPTION
Java supports a whole range of ciphers which are not particularly
secure. Among them are NULL ciphers which do not encrypt. We should only
use the enabled ciphers which can be configured and are set to a sane
default.