### PR TITLE
Tests: Fix test_graceful_stop_none

### DIFF
--- a/blackbox/docs/src/doc_tests/process_test.py
+++ b/blackbox/docs/src/doc_tests/process_test.py
@@ -48,7 +48,8 @@ def retry_sql(client, statement):
         try:
             return client.sql(statement)
         except ProgrammingError as e:
-            if 'not found in cluster state' in e.message:
+            if ('not found in cluster state' in e.message or
+                    'Node not connected' in e.message):
                 time.sleep(0.1)
                 last_error = e
                 retry += 1


### PR DESCRIPTION
Broke with the ES 5.2 upgrade because the error message changed.