### PR TITLE
apply new mapping on index only if mapping gets changed

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -76,6 +76,9 @@ Changes
 
 Fixes
 =====
+ 
+ - Fixed an issue that caused an exception if a column gets added to a table
+   that has been created with CrateDB version <= 1.1.
 
  - Fixed a regression that caused queries with a ``GROUP BY`` on array-columns,
    which are wrapped in a scalar function, to fail.


### PR DESCRIPTION
If the mapping gets changed, apply the new mapping only without merging the old.

will get backported to 2.0