### PR TITLE
Fix RecoveryAfterTimeSysCheck

### DIFF
--- a/sql/src/main/java/io/crate/operation/reference/sys/check/node/RecoveryAfterTimeSysCheck.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/check/node/RecoveryAfterTimeSysCheck.java
@@ -56,6 +56,6 @@ public class RecoveryAfterTimeSysCheck extends AbstractSysNodeCheck {
     protected boolean validate(TimeValue recoverAfterTime, int recoveryAfterNodes, int expectedNodes) {
         return recoveryAfterNodes <= expectedNodes &&
                (expectedNodes == GatewayService.EXPECTED_NODES_SETTING.getDefault(Settings.EMPTY) ||
-                recoverAfterTime.getSeconds() >= 0L);
+                recoverAfterTime.getMillis() > 0L);
     }
 }

--- a/sql/src/test/java/io/crate/operation/reference/sys/check/node/SysNodeChecksTest.java
+++ b/sql/src/test/java/io/crate/operation/reference/sys/check/node/SysNodeChecksTest.java
@@ -158,7 +158,7 @@ public class SysNodeChecksTest extends CrateDummyClusterServiceUnitTest {
 
         RecoveryAfterTimeSysCheck recoveryAfterNodesCheck = new RecoveryAfterTimeSysCheck(clusterService, settings);
 
-        assertThat(recoveryAfterNodesCheck.validate(), is(true));
+        assertThat(recoveryAfterNodesCheck.validate(), is(false));
     }
 
     @Test


### PR DESCRIPTION
This is a follow up to d7d37e031097b6e47bdc68ad1f227a379da0b47d


Noticed this during backport to 2.0. (Already applied this fix in the 2.0-cherry-pick c997564fdf7e04ba94247731289410c4f2cec2ef)