### PR TITLE
removed deprecated throwables.propagate

### DIFF
--- a/blob/src/main/java/io/crate/blob/BlobContainer.java
+++ b/blob/src/main/java/io/crate/blob/BlobContainer.java
@@ -21,7 +21,6 @@
 
 package io.crate.blob;
 
-import com.google.common.base.Throwables;
 import io.crate.blob.exceptions.DigestNotFoundException;
 import io.crate.common.Hex;
 import org.apache.logging.log4j.Logger;
@@ -68,14 +67,14 @@ public class BlobContainer {
             createSubDirectories(this.varDirectory);
         } catch (IOException e) {
             logger.error("Could not create 'var' path {}", this.varDirectory);
-            Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
 
         try {
             Files.createDirectories(this.tmpDirectory);
         } catch (IOException e) {
             logger.error("Could not create 'tmp' path {}", this.tmpDirectory);
-            Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/blob/src/main/java/io/crate/blob/v2/BlobShard.java
+++ b/blob/src/main/java/io/crate/blob/v2/BlobShard.java
@@ -21,7 +21,6 @@
 
 package io.crate.blob.v2;
 
-import com.google.common.base.Throwables;
 import io.crate.blob.BlobContainer;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.IOUtils;
@@ -74,7 +73,7 @@ public class BlobShard {
             });
         } catch (IOException e) {
             logger.error("Unable to compute initial blob shard size and count", e);
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -103,7 +102,7 @@ public class BlobShard {
             }
             return deleted;
         } catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/blob/src/test/java/io/crate/integrationtests/BlobHttpIntegrationTest.java
+++ b/blob/src/test/java/io/crate/integrationtests/BlobHttpIntegrationTest.java
@@ -21,8 +21,6 @@
 
 package io.crate.integrationtests;
 
-
-import com.google.common.base.Throwables;
 import io.crate.blob.BlobTransferStatus;
 import io.crate.blob.BlobTransferTarget;
 import io.crate.blob.v2.BlobAdminClient;
@@ -109,7 +107,7 @@ public abstract class BlobHttpIntegrationTest extends BlobIntegrationTestBase {
                     activeTransfers = (Map<UUID, BlobTransferStatus>) activeTransfersField.get(transferTarget);
                     assertThat(activeTransfers.keySet(), empty());
                 } catch (IllegalAccessException e) {
-                    throw Throwables.propagate(e);
+                    throw new RuntimeException(e);
                 }
             }
         });

--- a/blob/src/test/java/io/crate/integrationtests/BlobIntegrationTestBase.java
+++ b/blob/src/test/java/io/crate/integrationtests/BlobIntegrationTestBase.java
@@ -22,7 +22,6 @@
 
 package io.crate.integrationtests;
 
-import com.google.common.base.Throwables;
 import io.crate.blob.v2.BlobIndex;
 import io.crate.blob.v2.BlobIndicesService;
 import io.crate.blob.v2.BlobShard;
@@ -94,7 +93,7 @@ public abstract class BlobIntegrationTestBase extends ESIntegTestCase {
                         }
                     }
                 } catch (IOException | IllegalAccessException e) {
-                    throw Throwables.propagate(e);
+                    throw new RuntimeException(e);
                 }
             }
         }));
@@ -110,7 +109,7 @@ public abstract class BlobIntegrationTestBase extends ESIntegTestCase {
                 Map<String, BlobIndex> indices = (Map<String, BlobIndex>) indicesField.get(blobIndicesService);
                 consumer.accept(indices);
             } catch (IllegalAccessException e) {
-                throw Throwables.propagate(e);
+                throw new RuntimeException(e);
             }
         }
     }

--- a/sql/src/main/java/io/crate/action/sql/query/FieldsVisitorInputFieldComparator.java
+++ b/sql/src/main/java/io/crate/action/sql/query/FieldsVisitorInputFieldComparator.java
@@ -21,7 +21,6 @@
 
 package io.crate.action.sql.query;
 
-import com.google.common.base.Throwables;
 import io.crate.data.Input;
 import io.crate.operation.collect.collectors.CollectorFieldsVisitor;
 import io.crate.operation.reference.doc.lucene.LuceneCollectorExpression;
@@ -77,7 +76,7 @@ class FieldsVisitorInputFieldComparator extends InputFieldComparator {
         try {
             currentReader.document(doc, fieldsVisitor);
         } catch (IOException e) {
-            Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/sql/src/main/java/io/crate/analyze/Id.java
+++ b/sql/src/main/java/io/crate/analyze/Id.java
@@ -21,7 +21,6 @@
 
 package io.crate.analyze;
 
-import com.google.common.base.Throwables;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.doc.DocSysColumns;
 import org.apache.lucene.util.BytesRef;
@@ -124,7 +123,7 @@ public class Id {
             }
             return Base64.getEncoder().encodeToString(BytesReference.toBytes(out.bytes()));
         } catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/sql/src/main/java/io/crate/executor/transport/AlterTableOperation.java
+++ b/sql/src/main/java/io/crate/executor/transport/AlterTableOperation.java
@@ -621,8 +621,8 @@ public class AlterTableOperation {
                     return false;
                 }
                 lastMapping = mapping;
-            } catch (Throwable t) {
-                Throwables.propagate(t);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
             }
         }
         return true;

--- a/sql/src/main/java/io/crate/executor/transport/StreamBucket.java
+++ b/sql/src/main/java/io/crate/executor/transport/StreamBucket.java
@@ -22,7 +22,6 @@
 package io.crate.executor.transport;
 
 import com.google.common.base.Predicates;
-import com.google.common.base.Throwables;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Iterables;
 import io.crate.Streamer;
@@ -163,7 +162,7 @@ public class StreamBucket implements Bucket, Streamable {
                 try {
                     current[c] = streamers[c].readValueFrom(input);
                 } catch (IOException e) {
-                    Throwables.propagate(e);
+                    throw new RuntimeException(e);
                 }
             }
             pos++;
@@ -184,7 +183,7 @@ public class StreamBucket implements Bucket, Streamable {
         try {
             return new RowIterator(bytes.streamInput(), streamers, size);
         } catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/sql/src/main/java/io/crate/executor/transport/distributed/BroadcastingBucketBuilder.java
+++ b/sql/src/main/java/io/crate/executor/transport/distributed/BroadcastingBucketBuilder.java
@@ -21,7 +21,6 @@
 
 package io.crate.executor.transport.distributed;
 
-import com.google.common.base.Throwables;
 import io.crate.Streamer;
 import io.crate.data.Bucket;
 import io.crate.data.Row;
@@ -52,7 +51,7 @@ public class BroadcastingBucketBuilder implements MultiBucketBuilder {
                 size++;
             }
         } catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -69,7 +68,7 @@ public class BroadcastingBucketBuilder implements MultiBucketBuilder {
             bucket = bucketBuilder.build();
             bucketBuilder.reset();
         } catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
         for (int i = 0; i < numBuckets; i++) {
             buckets[i] = bucket;

--- a/sql/src/main/java/io/crate/executor/transport/distributed/ModuloBucketBuilder.java
+++ b/sql/src/main/java/io/crate/executor/transport/distributed/ModuloBucketBuilder.java
@@ -21,7 +21,6 @@
 
 package io.crate.executor.transport.distributed;
 
-import com.google.common.base.Throwables;
 import io.crate.Streamer;
 import io.crate.data.Bucket;
 import io.crate.data.Row;
@@ -63,7 +62,7 @@ public class ModuloBucketBuilder implements MultiBucketBuilder {
                 size++;
             }
         } catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -81,7 +80,7 @@ public class ModuloBucketBuilder implements MultiBucketBuilder {
                 buckets[i] = builder.build();
                 builder.reset();
             } catch (IOException e) {
-                throw Throwables.propagate(e);
+                throw new RuntimeException(e);
             }
         }
         size = 0;

--- a/sql/src/main/java/io/crate/metadata/DefaultTemplateService.java
+++ b/sql/src/main/java/io/crate/metadata/DefaultTemplateService.java
@@ -23,7 +23,6 @@
 package io.crate.metadata;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Throwables;
 import io.crate.Constants;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
@@ -129,7 +128,7 @@ public class DefaultTemplateService extends AbstractComponent {
 
             return builder.bytes().utf8ToString();
         } catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/sql/src/main/java/io/crate/metadata/FulltextAnalyzerResolver.java
+++ b/sql/src/main/java/io/crate/metadata/FulltextAnalyzerResolver.java
@@ -21,7 +21,6 @@
 
 package io.crate.metadata;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
 import io.crate.exceptions.AnalyzerInvalidException;
 import io.crate.exceptions.AnalyzerUnknownException;
@@ -215,7 +214,7 @@ public class FulltextAnalyzerResolver {
             return bso.bytes();
         } catch (IOException e) {
             // this is a memory stream so no real I/O happens and a IOException can't really happen at runtime
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/sql/src/main/java/io/crate/metadata/PartitionName.java
+++ b/sql/src/main/java/io/crate/metadata/PartitionName.java
@@ -23,7 +23,6 @@ package io.crate.metadata;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import io.crate.types.StringType;
 import org.apache.commons.codec.binary.Base32;
@@ -108,7 +107,7 @@ public class PartitionName {
                 StringType.INSTANCE.streamer().writeValueTo(streamOutput, value);
             }
         } catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
         byte[] bytes = BytesReference.toBytes(streamOutput.bytes());
         String identBase32 = BASE32.encodeAsString(bytes).toLowerCase(Locale.ROOT);

--- a/sql/src/main/java/io/crate/operation/collect/collectors/ScoreDocRowFunction.java
+++ b/sql/src/main/java/io/crate/operation/collect/collectors/ScoreDocRowFunction.java
@@ -23,7 +23,6 @@
 package io.crate.operation.collect.collectors;
 
 import com.google.common.base.Function;
-import com.google.common.base.Throwables;
 import io.crate.data.Row;
 import io.crate.data.Input;
 import io.crate.operation.InputRow;
@@ -88,7 +87,7 @@ class ScoreDocRowFunction implements Function<ScoreDoc, Row> {
             try {
                 expression.setNextReader(subReaderContext);
             } catch (IOException e) {
-                throw Throwables.propagate(e);
+                throw new RuntimeException(e);
             }
             expression.setNextDocId(subDoc);
         }

--- a/sql/src/main/java/io/crate/operation/collect/sources/ShardCollectSource.java
+++ b/sql/src/main/java/io/crate/operation/collect/sources/ShardCollectSource.java
@@ -22,7 +22,6 @@
 package io.crate.operation.collect.sources;
 
 import com.google.common.base.Suppliers;
-import com.google.common.base.Throwables;
 import com.google.common.collect.Iterables;
 import io.crate.action.job.SharedShardContext;
 import io.crate.action.job.SharedShardContexts;
@@ -469,9 +468,9 @@ public class ShardCollectSource extends AbstractComponent implements CollectSour
                     crateCollectors.add(remoteCollectorFactory.createCollector(
                         indexName, shardId.id(), collectPhase, jobCollectContext.queryPhaseRamAccountingContext()));
                 } catch (InterruptedException e) {
-                    throw Throwables.propagate(e);
-                } catch (Throwable t) {
-                    throw new UnhandledServerException(t);
+                    throw new RuntimeException(e);
+                } catch (Exception e) {
+                    throw new UnhandledServerException(e);
                 }
             }
         }

--- a/sql/src/main/java/io/crate/operation/reference/doc/lucene/VersionCollectorExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/doc/lucene/VersionCollectorExpression.java
@@ -22,7 +22,6 @@
 
 package io.crate.operation.reference.doc.lucene;
 
-import com.google.common.base.Throwables;
 import io.crate.metadata.doc.DocSysColumns;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NumericDocValues;
@@ -43,7 +42,7 @@ public class VersionCollectorExpression extends LuceneCollectorExpression<Long> 
         try {
             versions = reader.reader().getNumericDocValues(columnName);
         } catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/sql/src/main/java/io/crate/protocols/postgres/types/JsonType.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/JsonType.java
@@ -22,7 +22,6 @@
 
 package io.crate.protocols.postgres.types;
 
-import com.google.common.base.Throwables;
 import io.netty.buffer.ByteBuf;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
@@ -71,7 +70,7 @@ class JsonType extends PGType {
             builder.close();
             return BytesReference.toBytes(builder.bytes());
         } catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -92,7 +91,7 @@ class JsonType extends PGType {
             }
             return parser.map();
         } catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/sql/src/main/java/org/elasticsearch/index/mapper/BuilderFactory.java
+++ b/sql/src/main/java/org/elasticsearch/index/mapper/BuilderFactory.java
@@ -22,7 +22,6 @@
 
 package org.elasticsearch.index.mapper;
 
-import com.google.common.base.Throwables;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.mapper.array.DynamicArrayFieldMapperBuilderFactory;
@@ -58,7 +57,7 @@ public class BuilderFactory implements DynamicArrayFieldMapperBuilderFactory {
                 FieldMapper.MultiFields.empty(),
                 innerMapper);
         } catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
@@ -23,7 +23,6 @@ package io.crate.integrationtests;
 
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.carrotsearch.randomizedtesting.annotations.Listeners;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import io.crate.action.sql.Option;
@@ -191,7 +190,7 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
                             Map<UUID, JobExecutionContext> contexts = (Map<UUID, JobExecutionContext>) activeContexts.get(jobContextService);
                             assertThat(contexts.size(), is(0));
                         } catch (IllegalAccessException e) {
-                            throw Throwables.propagate(e);
+                            throw new RuntimeException(e);
                         }
                     }
                     for (TransportShardUpsertAction action : internalCluster().getInstances(TransportShardUpsertAction.class)) {
@@ -199,7 +198,7 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
                             Multimap<UUID, KillableCallable> operations = (Multimap<UUID, KillableCallable>) activeOperationsSb.get(action);
                             assertThat(operations.size(), is(0));
                         } catch (IllegalAccessException e) {
-                            throw Throwables.propagate(e);
+                            throw new RuntimeException(e);
                         }
                     }
                     for (TransportShardDeleteAction action : internalCluster().getInstances(TransportShardDeleteAction.class)) {
@@ -207,7 +206,7 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
                             Multimap<UUID, KillableCallable> operations = (Multimap<UUID, KillableCallable>) activeOperationsSb.get(action);
                             assertThat(operations.size(), is(0));
                         } catch (IllegalAccessException e) {
-                            throw Throwables.propagate(e);
+                            throw new RuntimeException(e);
                         }
                     }
                 }
@@ -230,7 +229,7 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
                     }
                     contexts.clear();
                 } catch (IllegalAccessException ex) {
-                    throw Throwables.propagate(e);
+                    throw new RuntimeException(ex);
                 }
             }
             throw new AssertionError(errorMessageBuilder.toString(), e);
@@ -241,17 +240,13 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
         assertBusy(new Runnable() {
             @Override
             public void run() {
-                try {
-                    Iterable<IndicesService> indexServices = internalCluster().getInstances(IndicesService.class);
-                    for (IndicesService indicesService : indexServices) {
-                        for (IndexService indexService : indicesService) {
-                            for (IndexShard indexShard : indexService) {
-                                assertThat(indexShard.getActiveOperationsCount(), Matchers.equalTo(0));
-                            }
+                Iterable<IndicesService> indexServices = internalCluster().getInstances(IndicesService.class);
+                for (IndicesService indicesService : indexServices) {
+                    for (IndexService indexService : indicesService) {
+                        for (IndexShard indexShard : indexService) {
+                            assertThat(indexShard.getActiveOperationsCount(), Matchers.equalTo(0));
                         }
                     }
-                } catch (Throwable t) {
-                    throw Throwables.propagate(t);
                 }
             }
         }, 5, TimeUnit.SECONDS);

--- a/sql/src/test/java/io/crate/jobs/AbstractExecutionSubContextTest.java
+++ b/sql/src/test/java/io/crate/jobs/AbstractExecutionSubContextTest.java
@@ -22,7 +22,6 @@
 
 package io.crate.jobs;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import io.crate.test.integration.CrateUnitTest;
 import org.apache.logging.log4j.Logger;
@@ -75,7 +74,7 @@ public class AbstractExecutionSubContextTest extends CrateUnitTest {
             try {
                 thread.join(500);
             } catch (InterruptedException e) {
-                Throwables.propagate(e);
+                throw new RuntimeException(e);
             }
         }
     }

--- a/sql/src/test/java/io/crate/operation/collect/ShardCollectorProviderTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/ShardCollectorProviderTest.java
@@ -22,7 +22,6 @@
 
 package io.crate.operation.collect;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import io.crate.exceptions.TableUnknownException;
 import io.crate.integrationtests.SQLTransportIntegrationTest;
@@ -49,7 +48,7 @@ public class ShardCollectorProviderTest extends SQLTransportIntegrationTest {
                 Map<ShardId, ShardCollectorProvider> shardMap = (Map<ShardId, ShardCollectorProvider>) shards.get(shardCollectSource);
                 assertThat(shardMap.size(), is(0));
             } catch (IllegalAccessException e) {
-                Throwables.propagate(e);
+                throw new RuntimeException(e);
             }
         }
     }

--- a/sql/src/test/java/io/crate/testing/SQLTransportExecutor.java
+++ b/sql/src/test/java/io/crate/testing/SQLTransportExecutor.java
@@ -23,7 +23,6 @@ package io.crate.testing;
 
 import com.carrotsearch.randomizedtesting.RandomizedContext;
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Throwables;
 import io.crate.action.sql.BaseResultReceiver;
 import io.crate.action.sql.Option;
 import io.crate.action.sql.ResultReceiver;
@@ -298,7 +297,7 @@ public class SQLTransportExecutor {
             try {
                 return toPGObjectJson(toJsonString(((Map) arg)));
             } catch (SQLException | IOException e) {
-                throw Throwables.propagate(e);
+                throw new RuntimeException(e);
             }
         }
         if (arg.getClass().isArray()) {
@@ -314,7 +313,7 @@ public class SQLTransportExecutor {
                 try {
                     return toPGObjectJson(toJsonString(values));
                 } catch (SQLException | IOException e) {
-                    throw Throwables.propagate(e);
+                    throw new RuntimeException(e);
                 }
             }
             List<Object> convertedValues = new ArrayList<>(values.size());
@@ -333,7 +332,7 @@ public class SQLTransportExecutor {
                  * Set a breakpoint in {@link io.crate.protocols.postgres.Messages#sendErrorResponse(Channel, Throwable)}
                  * to inspect the error
                  */
-                throw Throwables.propagate(e);
+                throw new RuntimeException(e);
             }
         }
         return arg;
@@ -465,7 +464,7 @@ public class SQLTransportExecutor {
                 return null;
             }
         } catch (IOException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
     }
 


### PR DESCRIPTION
the deprecation is documented here: [deprecation-of-throwables-propagate](https://github.com/google/guava/wiki/Why-we-deprecated-Throwables.propagate)