### PR TITLE
Improve error msg for correlated subqueries

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -41,7 +41,11 @@ Breaking Changes (Packaging only)
 
 Changes
 =======
- 
+
+ - Queries which contain a correlated subquery will now result in an error
+   stating that correlated subqueries are not supported, instead of a more
+   confusing error indicating that a relation is unknown.
+
  - Added column ``username`` to ``sys.jobs`` and ``sys.jobs_log`` that contains
    the username under which the job was invoked.
 

--- a/sql/src/main/java/io/crate/analyze/DeleteAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/DeleteAnalyzer.java
@@ -23,7 +23,12 @@ package io.crate.analyze;
 
 import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
-import io.crate.analyze.relations.*;
+import io.crate.analyze.relations.AnalyzedRelation;
+import io.crate.analyze.relations.DocTableRelation;
+import io.crate.analyze.relations.FullQualifiedNameFieldProvider;
+import io.crate.analyze.relations.RelationAnalysisContext;
+import io.crate.analyze.relations.RelationAnalyzer;
+import io.crate.analyze.relations.StatementAnalysisContext;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.Symbols;
 import io.crate.analyze.where.WhereClauseAnalyzer;
@@ -79,7 +84,7 @@ class DeleteAnalyzer {
             functions,
             analysis.sessionContext(),
             convertParamFunction,
-            new FullQualifedNameFieldProvider(relationAnalysisContext.sources()),
+            new FullQualifiedNameFieldProvider(relationAnalysisContext.sources(), relationAnalysisContext.parentSources()),
             null);
         ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext();
         WhereClauseAnalyzer whereClauseAnalyzer = new WhereClauseAnalyzer(

--- a/sql/src/main/java/io/crate/analyze/UpdateAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/UpdateAnalyzer.java
@@ -25,17 +25,35 @@ import com.google.common.collect.Iterables;
 import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.expressions.ValueNormalizer;
-import io.crate.analyze.relations.*;
+import io.crate.analyze.relations.AbstractTableRelation;
+import io.crate.analyze.relations.AnalyzedRelation;
+import io.crate.analyze.relations.DocTableRelation;
+import io.crate.analyze.relations.FieldProvider;
+import io.crate.analyze.relations.FieldResolver;
+import io.crate.analyze.relations.FullQualifiedNameFieldProvider;
+import io.crate.analyze.relations.NameFieldProvider;
+import io.crate.analyze.relations.RelationAnalysisContext;
+import io.crate.analyze.relations.RelationAnalyzer;
+import io.crate.analyze.relations.StatementAnalysisContext;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.Symbols;
 import io.crate.analyze.where.WhereClauseAnalyzer;
 import io.crate.exceptions.ColumnValidationException;
 import io.crate.exceptions.UnsupportedFeatureException;
-import io.crate.metadata.*;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.Functions;
+import io.crate.metadata.Reference;
+import io.crate.metadata.ReplaceMode;
+import io.crate.metadata.RowGranularity;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocSysColumns;
 import io.crate.metadata.table.Operation;
 import io.crate.metadata.table.TableInfo;
-import io.crate.sql.tree.*;
+import io.crate.sql.tree.Assignment;
+import io.crate.sql.tree.AstVisitor;
+import io.crate.sql.tree.LongLiteral;
+import io.crate.sql.tree.SubscriptExpression;
+import io.crate.sql.tree.Update;
 import io.crate.types.ArrayType;
 import io.crate.types.DataTypes;
 
@@ -98,7 +116,7 @@ public class UpdateAnalyzer {
             functions,
             analysis.sessionContext(),
             analysis.parameterContext(),
-            new FullQualifedNameFieldProvider(currentRelationContext.sources()),
+            new FullQualifiedNameFieldProvider(currentRelationContext.sources(), currentRelationContext.parentSources()),
             null);
         ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext();
 

--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalysisContext.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalysisContext.java
@@ -41,6 +41,7 @@ public class RelationAnalysisContext {
 
     private final ExpressionAnalysisContext expressionAnalysisContext;
     private final boolean aliasedRelation;
+    private final Map<QualifiedName, AnalyzedRelation> parentSources;
     // keep order of sources.
     //  e.g. something like:  select * from t1, t2 must not become select t2.*, t1.*
     private final Map<QualifiedName, AnalyzedRelation> sources = new LinkedHashMap<>();
@@ -48,8 +49,9 @@ public class RelationAnalysisContext {
     @Nullable
     private List<JoinPair> joinPairs;
 
-    RelationAnalysisContext(boolean aliasedRelation) {
+    RelationAnalysisContext(boolean aliasedRelation, Map<QualifiedName, AnalyzedRelation> parentSources) {
         this.aliasedRelation = aliasedRelation;
+        this.parentSources = parentSources;
         expressionAnalysisContext = new ExpressionAnalysisContext();
     }
 
@@ -115,5 +117,9 @@ public class RelationAnalysisContext {
 
     public ExpressionAnalysisContext expressionAnalysisContext() {
         return expressionAnalysisContext;
+    }
+
+    public Map<QualifiedName,AnalyzedRelation> parentSources() {
+        return parentSources;
     }
 }

--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -171,7 +171,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
                     functions,
                     statementContext.sessionContext(),
                     statementContext.convertParamFunction(),
-                    new FullQualifedNameFieldProvider(relationContext.sources()),
+                    new FullQualifiedNameFieldProvider(relationContext.sources(), relationContext.parentSources()),
                     new SubqueryAnalyzer(this, statementContext));
                 try {
                     joinCondition = expressionAnalyzer.convert(
@@ -205,7 +205,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
             functions,
             statementContext.sessionContext(),
             statementContext.convertParamFunction(),
-            new FullQualifedNameFieldProvider(context.sources()),
+            new FullQualifiedNameFieldProvider(context.sources(), context.parentSources()),
             new SubqueryAnalyzer(this, statementContext));
         ExpressionAnalysisContext expressionAnalysisContext = context.expressionAnalysisContext();
         Symbol querySymbol = expressionAnalyzer.generateQuerySymbol(node.getWhere(), expressionAnalysisContext);

--- a/sql/src/main/java/io/crate/analyze/relations/StatementAnalysisContext.java
+++ b/sql/src/main/java/io/crate/analyze/relations/StatementAnalysisContext.java
@@ -26,9 +26,12 @@ import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.ParameterExpression;
+import io.crate.sql.tree.QualifiedName;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 
 public class StatementAnalysisContext {
@@ -62,7 +65,13 @@ public class StatementAnalysisContext {
     }
 
     RelationAnalysisContext startRelation(boolean aliasedRelation) {
-        RelationAnalysisContext currentRelationContext = new RelationAnalysisContext(aliasedRelation);
+        Map<QualifiedName, AnalyzedRelation> parentSources;
+        if (lastRelationContextQueue.isEmpty()) {
+            parentSources = Collections.emptyMap();
+        } else {
+            parentSources = lastRelationContextQueue.get(lastRelationContextQueue.size() - 1).sources();
+        }
+        RelationAnalysisContext currentRelationContext = new RelationAnalysisContext(aliasedRelation, parentSources);
         lastRelationContextQueue.add(currentRelationContext);
         return currentRelationContext;
     }

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -2151,4 +2151,11 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         expectedException.expectMessage("Column col1['x'] unknown");
         analyze("select col1['x'] from unnest([{x=1}])");
     }
+
+    @Test
+    public void testSubSelectWithAcessToParentRelationThrowsUnsupportedFeature() throws Exception {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("Cannot use relation \"doc.t1\" in subquery. Correlated subqueries are not supported");
+        analyze("select (select 1 from t1 as ti where ti.x = t1.x) from t1");
+    }
 }

--- a/sql/src/test/java/io/crate/testing/SqlExpressions.java
+++ b/sql/src/test/java/io/crate/testing/SqlExpressions.java
@@ -30,7 +30,7 @@ import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.FieldResolver;
-import io.crate.analyze.relations.FullQualifedNameFieldProvider;
+import io.crate.analyze.relations.FullQualifiedNameFieldProvider;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.data.Row;
 import io.crate.data.RowN;
@@ -104,7 +104,7 @@ public class SqlExpressions {
             parameters == null
                 ? ParamTypeHints.EMPTY
                 : new ParameterContext(new RowN(parameters), Collections.<Row>emptyList()),
-            new FullQualifedNameFieldProvider(sources),
+            new FullQualifiedNameFieldProvider(sources, Collections.emptyMap()),
             null
         );
         normalizer = new EvaluatingNormalizer(


### PR DESCRIPTION
A query like `select (select 1 from t1 where t1.x = t2.x) from t2`
previously caused a `RelationUnknownException`. Now it recognises that
`t2` exists in the parent-scope and causes a
`UnsupportedOperationException` with a more accurate error message.