### PR TITLE
Don't bind HBA if it's disabled

### DIFF
--- a/enterprise/users/src/main/java/io/crate/operation/auth/HostBasedAuthentication.java
+++ b/enterprise/users/src/main/java/io/crate/operation/auth/HostBasedAuthentication.java
@@ -70,13 +70,11 @@ public class HostBasedAuthentication implements Authentication {
      }
      */
     private Map<String, Map<String, String>> hbaConf;
-    private boolean enabled;
 
     private final Map<String, Supplier<AuthenticationMethod>> authMethodRegistry = new HashMap<>();
 
     @Inject
     public HostBasedAuthentication(Settings settings, UserLookup userLookup) {
-        enabled = AuthSettings.AUTH_HOST_BASED_ENABLED_SETTING.setting().get(settings);
         hbaConf = convertHbaSettingsToHbaConf(AuthSettings.AUTH_HOST_BASED_CONFIG_SETTING.setting().get(settings));
         authMethodRegistry.put(TrustAuthentication.NAME, () -> new TrustAuthentication(userLookup));
         authMethodRegistry.put(ClientCertAuth.NAME, () -> new ClientCertAuth(userLookup));
@@ -96,11 +94,6 @@ public class HostBasedAuthentication implements Authentication {
             hostBasedConf.put(entry.getKey(), entry.getValue().getAsMap());
         }
         return hostBasedConf.build();
-    }
-
-    @Override
-    public boolean enabled() {
-        return enabled;
     }
 
     @Override

--- a/enterprise/users/src/main/java/io/crate/plugin/AuthenticationHttpAuthHandlerRegistry.java
+++ b/enterprise/users/src/main/java/io/crate/plugin/AuthenticationHttpAuthHandlerRegistry.java
@@ -28,6 +28,9 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.settings.Settings;
 
+/**
+ * Class that if instantiated causes the {@link HttpAuthUpstreamHandler} to be registered in the {@link PipelineRegistry}
+ */
 @Singleton
 public class AuthenticationHttpAuthHandlerRegistry {
 
@@ -35,13 +38,11 @@ public class AuthenticationHttpAuthHandlerRegistry {
     public AuthenticationHttpAuthHandlerRegistry(Settings settings,
                                                  PipelineRegistry pipelineRegistry,
                                                  Authentication authentication) {
-        if (authentication.enabled()) {
-            PipelineRegistry.ChannelPipelineItem pipelineItem = new PipelineRegistry.ChannelPipelineItem(
-                "blob_handler",
-                "auth_handler",
-                () -> new HttpAuthUpstreamHandler(settings, authentication)
-            );
-            pipelineRegistry.addBefore(pipelineItem);
-        }
+        PipelineRegistry.ChannelPipelineItem pipelineItem = new PipelineRegistry.ChannelPipelineItem(
+            "blob_handler",
+            "auth_handler",
+            () -> new HttpAuthUpstreamHandler(settings, authentication)
+        );
+        pipelineRegistry.addBefore(pipelineItem);
     }
 }

--- a/enterprise/users/src/main/java/io/crate/plugin/AuthenticationModule.java
+++ b/enterprise/users/src/main/java/io/crate/plugin/AuthenticationModule.java
@@ -22,15 +22,28 @@
 
 package io.crate.plugin;
 
+import io.crate.operation.auth.AlwaysOKAuthentication;
+import io.crate.operation.auth.AuthSettings;
 import io.crate.operation.auth.Authentication;
 import io.crate.operation.auth.HostBasedAuthentication;
 import org.elasticsearch.common.inject.AbstractModule;
+import org.elasticsearch.common.settings.Settings;
 
 public class AuthenticationModule extends AbstractModule {
 
+    private final Settings settings;
+
+    public AuthenticationModule(Settings settings) {
+        this.settings = settings;
+    }
+
     @Override
     protected void configure() {
-        bind(Authentication.class).to(HostBasedAuthentication.class);
-        bind(AuthenticationHttpAuthHandlerRegistry.class).asEagerSingleton();
+        if (AuthSettings.AUTH_HOST_BASED_ENABLED_SETTING.setting().get(settings)) {
+            bind(Authentication.class).to(HostBasedAuthentication.class);
+            bind(AuthenticationHttpAuthHandlerRegistry.class).asEagerSingleton();
+        } else {
+            bind(Authentication.class).to(AlwaysOKAuthentication.class);
+        }
     }
 }

--- a/enterprise/users/src/main/java/io/crate/plugin/EnterpriseUsersExtension.java
+++ b/enterprise/users/src/main/java/io/crate/plugin/EnterpriseUsersExtension.java
@@ -27,6 +27,7 @@ import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.inject.Module;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 
 import java.util.ArrayList;
@@ -80,10 +81,10 @@ public class EnterpriseUsersExtension implements UserExtension {
     }
 
     @Override
-    public Collection<Module> getModules() {
+    public Collection<Module> getModules(Settings settings) {
         return Arrays.asList(
             new UserManagementModule(),
-            new AuthenticationModule(),
+            new AuthenticationModule(settings),
             new UsersScalarFunctionModule());
     }
 }

--- a/enterprise/users/src/test/java/io/crate/operation/auth/HostBasedAuthenticationTest.java
+++ b/enterprise/users/src/test/java/io/crate/operation/auth/HostBasedAuthenticationTest.java
@@ -105,18 +105,6 @@ public class HostBasedAuthenticationTest extends CrateUnitTest {
     }
 
     @Test
-    public void testEnableAuthentication() throws Exception {
-        Authentication authService = new HostBasedAuthentication(Settings.EMPTY, null);
-        assertFalse(authService.enabled());
-
-        Settings settings = Settings.builder()
-            .put(AuthSettings.AUTH_HOST_BASED_ENABLED_SETTING.getKey(), true)
-            .build();
-        authService = new HostBasedAuthentication(settings, null);
-        assertTrue(authService.enabled());
-    }
-
-    @Test
     public void testMissingUserOrAddress() throws Exception {
         authService.updateHbaConfig(Collections.emptyMap());
         AuthenticationMethod method;

--- a/sql/src/main/java/io/crate/operation/auth/AlwaysOKAuthentication.java
+++ b/sql/src/main/java/io/crate/operation/auth/AlwaysOKAuthentication.java
@@ -40,11 +40,6 @@ public class AlwaysOKAuthentication implements Authentication {
     };
 
     @Override
-    public boolean enabled() {
-        return true;
-    }
-
-    @Override
     public AuthenticationMethod resolveAuthenticationType(String user, ConnectionProperties connectionProperties) {
         return alwaysOk;
     }

--- a/sql/src/main/java/io/crate/operation/auth/Authentication.java
+++ b/sql/src/main/java/io/crate/operation/auth/Authentication.java
@@ -28,8 +28,6 @@ import javax.annotation.Nullable;
 
 public interface Authentication {
 
-    boolean enabled();
-
     @Nullable
     AuthenticationMethod resolveAuthenticationType(String user, ConnectionProperties connectionProperties);
 }

--- a/sql/src/main/java/io/crate/plugin/SQLPlugin.java
+++ b/sql/src/main/java/io/crate/plugin/SQLPlugin.java
@@ -58,8 +58,8 @@ import io.crate.protocols.postgres.PostgresNetty;
 import io.crate.protocols.ssl.SslConfigSettings;
 import io.crate.rest.action.RestSQLAction;
 import io.crate.settings.CrateSetting;
-import io.crate.user.UserFallbackModule;
 import io.crate.user.UserExtension;
+import io.crate.user.UserFallbackModule;
 import org.elasticsearch.action.bulk.BulkModule;
 import org.elasticsearch.cluster.NamedDiff;
 import org.elasticsearch.cluster.metadata.MetaData;
@@ -187,7 +187,7 @@ public class SQLPlugin extends Plugin implements ActionPlugin, MapperPlugin, Clu
         modules.add(new SysNodeChecksModule());
         modules.add(new RepositorySettingsModule());
         if (userExtension != null) {
-            modules.addAll(userExtension.getModules());
+            modules.addAll(userExtension.getModules(settings));
         } else {
             modules.add(new UserFallbackModule());
         }

--- a/sql/src/main/java/io/crate/user/UserExtension.java
+++ b/sql/src/main/java/io/crate/user/UserExtension.java
@@ -24,6 +24,7 @@ package io.crate.user;
 
 import org.elasticsearch.common.inject.Module;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 
 import java.util.Collection;
@@ -34,5 +35,5 @@ public interface UserExtension {
     List<NamedWriteableRegistry.Entry> getNamedWriteables();
     List<NamedXContentRegistry.Entry> getNamedXContent();
 
-    Collection<Module> getModules();
+    Collection<Module> getModules(Settings settings);
 }

--- a/sql/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
+++ b/sql/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
@@ -25,8 +25,6 @@ package io.crate.protocols.postgres;
 import io.crate.action.sql.SQLOperations;
 import io.crate.executor.Executor;
 import io.crate.operation.auth.AlwaysOKAuthentication;
-import io.crate.operation.auth.Authentication;
-import io.crate.operation.auth.AuthenticationMethod;
 import io.crate.operation.collect.stats.JobsLogs;
 import io.crate.operation.user.User;
 import io.crate.operation.user.UserManager;
@@ -130,7 +128,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
         PostgresWireProtocol ctx =
             new PostgresWireProtocol(
                 sqlOperations,
-                new TestAuthentication(null),
+                new AlwaysOKAuthentication(),
                 null);
         EmbeddedChannel channel = new EmbeddedChannel(ctx.decoder, ctx.handler);
 
@@ -149,7 +147,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
         PostgresWireProtocol ctx =
             new PostgresWireProtocol(
                 sqlOperations,
-                new TestAuthentication(null),
+                new AlwaysOKAuthentication(),
                 null);
         EmbeddedChannel channel = new EmbeddedChannel(ctx.decoder, ctx.handler);
 
@@ -165,31 +163,6 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
         SQLOperations.Session session = sessions.get(0);
         // If the query can be retrieved via portalName it means bind worked
         assertThat(session.getQuery("P1"), is("select ?, ?"));
-    }
-
-    private static class TestAuthentication implements Authentication {
-
-        private final User user;
-
-        TestAuthentication(User user) {
-            this.user = user;
-        }
-
-        @Override
-        public AuthenticationMethod resolveAuthenticationType(String user, ConnectionProperties connectionProperties) {
-            return new AuthenticationMethod() {
-                @Nullable
-                @Override
-                public User authenticate(String userName, ConnectionProperties connectionProperties) {
-                    return TestAuthentication.this.user;
-                }
-
-                @Override
-                public String name() {
-                    return null;
-                }
-            };
-        }
     }
 
     @Test

--- a/sql/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
+++ b/sql/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
@@ -176,11 +176,6 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
         }
 
         @Override
-        public boolean enabled() {
-            return true;
-        }
-
-        @Override
         public AuthenticationMethod resolveAuthenticationType(String user, ConnectionProperties connectionProperties) {
             return new AuthenticationMethod() {
                 @Nullable


### PR DESCRIPTION
Follow up to c6cdb244c315ca555817a0cd5c64626de07de0de which broke
sqllogic tests (among others), because for postgres HBA was always
enabled.