### PR TITLE
Move UDF instance construction into UDFService

### DIFF
--- a/enterprise/lang-js/src/test/java/io/crate/operation/language/JavascriptUserDefinedFunctionTest.java
+++ b/enterprise/lang-js/src/test/java/io/crate/operation/language/JavascriptUserDefinedFunctionTest.java
@@ -63,7 +63,7 @@ public class JavascriptUserDefinedFunctionTest extends AbstractScalarFunctionsTe
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        udfService = new UserDefinedFunctionService(mock(ClusterService.class));
+        udfService = new UserDefinedFunctionService(mock(ClusterService.class), functions);
         udfService.registerLanguage(new JavaScriptLanguage(udfService));
     }
 

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -37,6 +37,7 @@ import io.crate.exceptions.ColumnUnknownException;
 import io.crate.exceptions.RelationUnknownException;
 import io.crate.exceptions.UnsupportedFeatureException;
 import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.Functions;
 import io.crate.metadata.TableIdent;
 import io.crate.metadata.doc.DocSchemaInfo;
 import io.crate.metadata.doc.DocTableInfo;
@@ -117,10 +118,11 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
             .build();
         DocTableInfoFactory fooTableFactory = new TestingDocTableInfoFactory(
             ImmutableMap.of(fooUserTableInfo.ident(), fooUserTableInfo));
-        UserDefinedFunctionService udfService = new UserDefinedFunctionService(clusterService);
+        Functions functions = getFunctions();
+        UserDefinedFunctionService udfService = new UserDefinedFunctionService(clusterService, functions);
         sqlExecutor = SQLExecutor.builder(clusterService)
             .enableDefaultTables()
-            .addSchema(new DocSchemaInfo("foo", clusterService, getFunctions(), udfService, fooTableFactory))
+            .addSchema(new DocSchemaInfo("foo", clusterService, functions, udfService, fooTableFactory))
             .build();
     }
 

--- a/sql/src/test/java/io/crate/analyze/relations/SubselectRewriterTest.java
+++ b/sql/src/test/java/io/crate/analyze/relations/SubselectRewriterTest.java
@@ -60,7 +60,7 @@ public class SubselectRewriterTest extends CrateDummyClusterServiceUnitTest {
     @Before
     public void setupAnalyzer() throws Exception {
         Functions functions = getFunctions();
-        UserDefinedFunctionService udfService = new UserDefinedFunctionService(clusterService);
+        UserDefinedFunctionService udfService = new UserDefinedFunctionService(clusterService, functions);
         TestingDocTableInfoFactory docTableInfoFactory = new TestingDocTableInfoFactory(
             ImmutableMap.of(
                 T3.T1_INFO.ident(), T3.T1_INFO,

--- a/sql/src/test/java/io/crate/metadata/doc/DocIndexMetaDataTest.java
+++ b/sql/src/test/java/io/crate/metadata/doc/DocIndexMetaDataTest.java
@@ -109,7 +109,7 @@ public class DocIndexMetaDataTest extends CrateDummyClusterServiceUnitTest {
     @Before
     public void setupUdfService() throws Exception {
         functions = getFunctions();
-        udfService = new UserDefinedFunctionService(clusterService);
+        udfService = new UserDefinedFunctionService(clusterService, functions);
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/reference/sys/SysShardsExpressionsTest.java
+++ b/sql/src/test/java/io/crate/operation/reference/sys/SysShardsExpressionsTest.java
@@ -86,14 +86,12 @@ public class SysShardsExpressionsTest extends CrateDummyClusterServiceUnitTest {
     private IndexShard indexShard;
     private Schemas schemas;
     private String indexUUID;
-    private Functions functions;
-    private UserDefinedFunctionService udfService;
 
     @Before
     public void prepare()  {
         indexShard = mockIndexShard();
-        functions = getFunctions();
-        udfService = new UserDefinedFunctionService(clusterService);
+        Functions functions = getFunctions();
+        UserDefinedFunctionService udfService = new UserDefinedFunctionService(clusterService, functions);
         schemas = new Schemas(
             Settings.EMPTY,
             ImmutableMap.of("sys", new SysSchemaInfo(clusterService)),

--- a/sql/src/test/java/io/crate/operation/udf/UdfUnitTest.java
+++ b/sql/src/test/java/io/crate/operation/udf/UdfUnitTest.java
@@ -23,18 +23,21 @@
 package io.crate.operation.udf;
 
 import io.crate.data.Input;
-import io.crate.metadata.*;
+import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.Scalar;
 import io.crate.test.integration.CrateUnitTest;
 import org.elasticsearch.cluster.service.ClusterService;
 
 import javax.annotation.Nullable;
 import javax.script.ScriptException;
 
+import static io.crate.testing.TestingHelpers.getFunctions;
 import static org.mockito.Mockito.mock;
 
 public abstract class UdfUnitTest extends CrateUnitTest {
 
-    UserDefinedFunctionService udfService = new UserDefinedFunctionService(mock(ClusterService.class));
+    UserDefinedFunctionService udfService = new UserDefinedFunctionService(mock(ClusterService.class), getFunctions());
 
     static final UDFLanguage DUMMY_LANG = new UDFLanguage() {
         @Override

--- a/sql/src/test/java/io/crate/testing/SQLExecutor.java
+++ b/sql/src/test/java/io/crate/testing/SQLExecutor.java
@@ -151,7 +151,7 @@ public class SQLExecutor {
         }
 
         public SQLExecutor build() {
-            UserDefinedFunctionService udfService = new UserDefinedFunctionService(clusterService);
+            UserDefinedFunctionService udfService = new UserDefinedFunctionService(clusterService, functions);
             schemas.put(Schemas.DEFAULT_SCHEMA_NAME, new DocSchemaInfo(Schemas.DEFAULT_SCHEMA_NAME, clusterService, functions, udfService, new TestingDocTableInfoFactory(docTables)));
             if (!blobTables.isEmpty()) {
                 schemas.put(BlobSchemaInfo.NAME, new BlobSchemaInfo(clusterService, new TestingBlobTableInfoFactory(blobTables)));


### PR DESCRIPTION
DocSchemaInfo is now only responsible for triggering an update event.
The UserDefinedFunctionService will take care of handling the scalar
instance creation and registering them in the Functions registry.