### PR TITLE
bump version to 2.1.1-SNAPSHOT

### DIFF
--- a/core/src/main/java/io/crate/Version.java
+++ b/core/src/main/java/io/crate/Version.java
@@ -41,7 +41,7 @@ public class Version {
 
 
     public static final boolean SNAPSHOT = true;
-    public static final Version CURRENT = new Version(2020099, SNAPSHOT, org.elasticsearch.Version.V_5_2_2_UNRELEASED);
+    public static final Version CURRENT = new Version(2010199, SNAPSHOT, org.elasticsearch.Version.V_5_2_2_UNRELEASED);
 
     static {
         // safe-guard that we don't release a version with DEBUG_MODE set to true


### PR DESCRIPTION
This commit reflects the recent change to the release process. We
started introducing a period (feature freeze) in which no new features
or changes that could effect stability are merged into master. In this
time new releases are "stabilised" directly on master instead of on the
release branch. Also, tags for releases in this period are done directly
on master.
After bumping the version, setting the snapshot flag to false and
creating the release version tag, the version must be increased to the
next greater patch release and the snapshot flag reset to true again in
order to reflect the upcoming release.
Only after the feature freeze period a new version branch for the release is
created.