### PR TITLE
use crate user in session of system queries

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -22,6 +22,9 @@ Changes
 
 Fixes
 =====
+ 
+ - Internal system queries are now executed under the "crate" superuser if
+   user management is enabled.
 
  - ``!= ANY()`` could not operate on arrays with more than 1024 elements. This
    limit has been increased by default to 8192. A new node setting:

--- a/enterprise/users/src/test/java/io/crate/integrationtests/BaseUsersIntegrationTest.java
+++ b/enterprise/users/src/test/java/io/crate/integrationtests/BaseUsersIntegrationTest.java
@@ -51,6 +51,11 @@ public abstract class BaseUsersIntegrationTest extends SQLTransportIntegrationTe
         return sqlOperations.createSession(null, new User("normal", ImmutableSet.of(), ImmutableSet.of()), Option.NONE, DEFAULT_SOFT_LIMIT);
     }
 
+    SQLOperations.Session createNullUserSession(String node) {
+        SQLOperations sqlOperations = internalCluster().getInstance(SQLOperations.class, node);
+        return sqlOperations.createSession(null, null, Option.NONE, DEFAULT_SOFT_LIMIT);
+    }
+
     @Before
     public void setUpSessions() {
         createSessions();

--- a/enterprise/users/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
+++ b/enterprise/users/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
@@ -145,12 +145,12 @@ public class PrivilegesIntegrationTest extends BaseUsersIntegrationTest {
 
     @Test
     public void testQuerySysShardsReturnsOnlyRowsRegardingTablesUserHasAccessOn() throws Exception {
-        execute("create table t1 (x int) partitioned by (x) clustered into 1 shards with (number_of_replicas = 0)");
-        execute("insert into t1 values (1)");
-        execute("insert into t1 values (2)");
-        execute("insert into t1 values (3)");
-        execute("create table doc.t2 (x int) clustered into 1 shards with (number_of_replicas = 0)");
-        execute("create table t3 (x int) clustered into 1 shards with (number_of_replicas = 0)");
+        executeAsSuperuser("create table t1 (x int) partitioned by (x) clustered into 1 shards with (number_of_replicas = 0)");
+        executeAsSuperuser("insert into t1 values (1)");
+        executeAsSuperuser("insert into t1 values (2)");
+        executeAsSuperuser("insert into t1 values (3)");
+        executeAsSuperuser("create table doc.t2 (x int) clustered into 1 shards with (number_of_replicas = 0)");
+        executeAsSuperuser("create table t3 (x int) clustered into 1 shards with (number_of_replicas = 0)");
 
         executeAsSuperuser("grant dql on table t1 to " + TEST_USERNAME);
         executeAsSuperuser("grant dml on table t2 to " + TEST_USERNAME);
@@ -166,15 +166,15 @@ public class PrivilegesIntegrationTest extends BaseUsersIntegrationTest {
 
     @Test
     public void testQueryInformationSchemaShowsOnlyRowsRegardingTablesUserHasAccessOn() throws Exception {
-        execute("create table t1 (x int) partitioned by (x) clustered into 1 shards with (number_of_replicas = 0)");
-        execute("insert into t1 values (1)");
-        execute("insert into t1 values (2)");
-        execute("create table my_schema.t2 (x int) clustered into 1 shards with (number_of_replicas = 0)");
-        execute("create table other_schema.t3 (x int) clustered into 1 shards with (number_of_replicas = 0)");
+        executeAsSuperuser("create table t1 (x int) partitioned by (x) clustered into 1 shards with (number_of_replicas = 0)");
+        executeAsSuperuser("insert into t1 values (1)");
+        executeAsSuperuser("insert into t1 values (2)");
+        executeAsSuperuser("create table my_schema.t2 (x int) clustered into 1 shards with (number_of_replicas = 0)");
+        executeAsSuperuser("create table other_schema.t3 (x int) clustered into 1 shards with (number_of_replicas = 0)");
 
-        execute("create function my_schema.foo(long)" +
+        executeAsSuperuser("create function my_schema.foo(long)" +
                 " returns string language dummy_lang as 'function foo(x) { return \"1\"; }'");
-        execute("create function other_func(long)" +
+        executeAsSuperuser("create function other_func(long)" +
                 " returns string language dummy_lang as 'function foo(x) { return \"1\"; }'");
 
         executeAsSuperuser("grant dql on table t1 to " + TEST_USERNAME);
@@ -200,7 +200,7 @@ public class PrivilegesIntegrationTest extends BaseUsersIntegrationTest {
 
     @Test
     public void testRenameTableTransfersPrivilegesToNewTable() {
-        execute("create table doc.t1 (x int) clustered into 1 shards with (number_of_replicas = 0)");
+        executeAsSuperuser("create table doc.t1 (x int) clustered into 1 shards with (number_of_replicas = 0)");
         executeAsSuperuser("grant dql on table t1 to "+ TEST_USERNAME);
 
         executeAsSuperuser("alter table doc.t1 rename to t1_renamed");

--- a/enterprise/users/src/test/java/io/crate/integrationtests/UserSessionIntegrationTest.java
+++ b/enterprise/users/src/test/java/io/crate/integrationtests/UserSessionIntegrationTest.java
@@ -1,0 +1,55 @@
+/*
+ * This file is part of a module with proprietary Enterprise Features.
+ *
+ * Licensed to Crate.io Inc. ("Crate.io") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ *
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ *
+ * To use this file, Crate.io must have given you permission to enable and
+ * use such Enterprise Features and you must have a valid Enterprise or
+ * Subscription Agreement with Crate.io.  If you enable or use the Enterprise
+ * Features, you represent and warrant that you have a valid Enterprise or
+ * Subscription Agreement with Crate.io.  Your use of the Enterprise Features
+ * if governed by the terms and conditions of your Enterprise or Subscription
+ * Agreement with Crate.io.
+ */
+
+package io.crate.integrationtests;
+
+import io.crate.operation.collect.stats.JobsLogService;
+import io.crate.settings.SharedSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+
+public class UserSessionIntegrationTest extends BaseUsersIntegrationTest {
+
+    private String nodeEnterpriseEnabled;
+    private String nodeEnterpriseDisabled;
+
+    @Before
+    public void setUpNodesUsersAndPrivileges() throws Exception {
+        nodeEnterpriseEnabled = internalCluster().startNode(Settings.builder()
+            .put(JobsLogService.STATS_ENABLED_SETTING.getKey(), true));
+        nodeEnterpriseDisabled = internalCluster().startNode(Settings.builder()
+            .put(SharedSettings.ENTERPRISE_LICENSE_SETTING.getKey(), false)
+            .put(JobsLogService.STATS_ENABLED_SETTING.getKey(), true));
+        super.createSessions();
+    }
+
+    @Test
+    public void testSystemExecutorUsesSuperuserSession() {
+        systemExecute("select username from sys.jobs", "sys", nodeEnterpriseEnabled);
+        assertThat(response.rows()[0][0], is("crate"));
+    }
+
+    @Test
+    public void testSystemExecutorNullUser() {
+        systemExecute("select username from sys.jobs", "sys", nodeEnterpriseDisabled);
+        assertNull(response.rows()[0][0]);
+    }
+}

--- a/enterprise/users/src/test/java/io/crate/integrationtests/UserSessionIntegrationTest.java
+++ b/enterprise/users/src/test/java/io/crate/integrationtests/UserSessionIntegrationTest.java
@@ -18,6 +18,7 @@
 
 package io.crate.integrationtests;
 
+import io.crate.action.sql.SQLActionException;
 import io.crate.operation.collect.stats.JobsLogService;
 import io.crate.settings.SharedSettings;
 import org.elasticsearch.common.settings.Settings;
@@ -51,5 +52,12 @@ public class UserSessionIntegrationTest extends BaseUsersIntegrationTest {
     public void testSystemExecutorNullUser() {
         systemExecute("select username from sys.jobs", "sys", nodeEnterpriseDisabled);
         assertNull(response.rows()[0][0]);
+    }
+
+    @Test
+    public void testQueryWithNullUserAndEnabledUserManagement() {
+        expectedException.expect(SQLActionException.class);
+        expectedException.expectMessage("MissingPrivilegeException: Missing privilege for user 'User `null` is not authorized to execute statement'");
+        execute("select username from sys.jobs", null, createNullUserSession(nodeEnterpriseEnabled));
     }
 }

--- a/enterprise/users/src/test/java/io/crate/operation/user/StatementPrivilegeValidatorTest.java
+++ b/enterprise/users/src/test/java/io/crate/operation/user/StatementPrivilegeValidatorTest.java
@@ -130,9 +130,10 @@ public class StatementPrivilegeValidatorTest extends CrateDummyClusterServiceUni
     }
 
     @Test
-    public void testNoUserByPassesValidation() throws Exception {
+    public void testSelectStatementNotAllowedAsNullUser() throws Exception {
+        expectedException.expect(UnauthorizedException.class);
+        expectedException.expectMessage("User `null` is not authorized to execute statement");
         analyze("select * from sys.cluster", null);
-        assertThat(validationCallArguments.size(), is(0));
     }
 
     @Test

--- a/enterprise/users/src/test/java/io/crate/operation/user/UserManagerServiceTest.java
+++ b/enterprise/users/src/test/java/io/crate/operation/user/UserManagerServiceTest.java
@@ -29,9 +29,7 @@ import org.junit.Test;
 
 import java.util.Set;
 
-import static io.crate.operation.user.UserManagerService.CRATE_USER;
-import static io.crate.operation.user.UserManagerService.NOOP_EXCEPTION_VALIDATOR;
-import static io.crate.operation.user.UserManagerService.NOOP_STATEMENT_VALIDATOR;
+import static io.crate.operation.user.UserManagerService.*;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
@@ -65,7 +63,7 @@ public class UserManagerServiceTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testGetNoopStatementValidatorForNullUser() throws Exception {
         StatementAuthorizedValidator validator = userManagerService.getStatementValidator(null);
-        assertThat(validator, is(NOOP_STATEMENT_VALIDATOR));
+        assertThat(validator, is(ALWAYS_FAIL_STATEMENT_VALIDATOR));
     }
 
     @Test
@@ -77,7 +75,7 @@ public class UserManagerServiceTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testGetNoopExceptionValidatorForNullUser() throws Exception {
         ExceptionAuthorizedValidator validator = userManagerService.getExceptionValidator(null);
-        assertThat(validator, is(NOOP_EXCEPTION_VALIDATOR));
+        assertThat(validator, is(ALWAYS_FAIL_EXCEPTION_VALIDATOR));
     }
 
     @Test

--- a/sql/src/main/java/io/crate/executor/transport/AlterTableOperation.java
+++ b/sql/src/main/java/io/crate/executor/transport/AlterTableOperation.java
@@ -145,7 +145,7 @@ public class AlterTableOperation {
             String stmt =
                 String.format(Locale.ENGLISH, "SELECT COUNT(*) FROM \"%s\".\"%s\"", ident.schema(), ident.name());
 
-            SQLOperations.SQLDirectExecutor sqlDirectExecutor = sqlOperations.createSQLDirectExecutor(
+            SQLOperations.SQLDirectExecutor sqlDirectExecutor = sqlOperations.createSystemExecutor(
                 null,
                 SQLOperations.Session.UNNAMED,
                 stmt,

--- a/sql/src/main/java/io/crate/operation/reference/sys/check/cluster/TablesNeedUpgradeSysCheck.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/check/cluster/TablesNeedUpgradeSysCheck.java
@@ -92,7 +92,7 @@ public class TablesNeedUpgradeSysCheck extends AbstractSysCheck {
 
     private SQLOperations.SQLDirectExecutor directExecutor() {
         if (sqlDirectExecutor == null) {
-            sqlDirectExecutor = sqlOperationsProvider.get().createSQLDirectExecutor(
+            sqlDirectExecutor = sqlOperationsProvider.get().createSystemExecutor(
                 "sys", PREP_STMT_NAME, STMT, LIMIT);
         }
         return sqlDirectExecutor;

--- a/sql/src/main/java/io/crate/planner/TableStatsService.java
+++ b/sql/src/main/java/io/crate/planner/TableStatsService.java
@@ -82,7 +82,7 @@ public class TableStatsService extends AbstractComponent implements Runnable {
         resultReceiver = new TableStatsResultReceiver(tableStats::updateTableStats);
         refreshInterval = STATS_SERVICE_REFRESH_INTERVAL_SETTING.setting().get(settings);
         refreshScheduledTask = scheduleRefresh(refreshInterval);
-        sqlDirectExecutor = sqlOperations.createSQLDirectExecutor("sys", TABLE_STATS, STMT, DEFAULT_SOFT_LIMIT);
+        sqlDirectExecutor = sqlOperations.createSystemExecutor("sys", TABLE_STATS, STMT, DEFAULT_SOFT_LIMIT);
 
         clusterService.getClusterSettings().addSettingsUpdateConsumer(
             STATS_SERVICE_REFRESH_INTERVAL_SETTING.setting(), this::setRefreshInterval);

--- a/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
@@ -267,6 +267,22 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
     }
 
     /**
+     * Execute a SQL statement as system query on a specific node in the cluster
+     *
+     * @param stmt      the SQL statement
+     * @param schema    the schema that should be used for this statement
+     *                  schema is nullable, which means the default schema ("doc") is used
+     * @param node      the name of the node on which the stmt is executed
+     * @return          the SQL Response
+     */
+    public SQLResponse systemExecute(String stmt, @Nullable String schema, String node) {
+        SQLOperations sqlOperations = internalCluster().getInstance(SQLOperations.class, node);
+        SQLOperations.SQLDirectExecutor directExecutor = sqlOperations.createSystemExecutor(schema, "system_query", stmt, 10_000);
+        response = SQLTransportExecutor.systemExecute(stmt, directExecutor).actionGet(SQLTransportExecutor.REQUEST_TIMEOUT);
+        return response;
+    }
+
+    /**
      * Execute an SQL Statement on a random node of the cluster
      *
      * @param stmt the SQL Statement

--- a/sql/src/test/java/io/crate/planner/TableStatsServiceTest.java
+++ b/sql/src/test/java/io/crate/planner/TableStatsServiceTest.java
@@ -129,7 +129,7 @@ public class TableStatsServiceTest extends CrateDummyClusterServiceUnitTest {
     public void testStatsQueriesCorrectly() throws Throwable {
         final SQLOperations sqlOperations = mock(SQLOperations.class);
         SQLOperations.SQLDirectExecutor sqlDirectExecutor = mock(SQLOperations.SQLDirectExecutor.class);
-        when(sqlOperations.createSQLDirectExecutor(
+        when(sqlOperations.createSystemExecutor(
             eq("sys"),
             eq(TableStatsService.TABLE_STATS),
             eq(TableStatsService.STMT),

--- a/sql/src/test/java/io/crate/testing/SQLTransportExecutor.java
+++ b/sql/src/test/java/io/crate/testing/SQLTransportExecutor.java
@@ -173,6 +173,26 @@ public class SQLTransportExecutor {
         return clientProvider.pgUrl();
     }
 
+    /**
+     * Executes the stmt on directly on the system using {@link SQLOperations.SQLDirectExecutor}
+     *
+     * @param stmt      the SQL stmt
+     * @param executor  an instance of {@link SQLOperations.SQLDirectExecutor}
+     * @return          an {@link ActionFuture} containing the SQL response
+     */
+    public static ActionFuture<SQLResponse> systemExecute(String stmt, SQLOperations.SQLDirectExecutor executor) {
+        final AdapterActionFuture<SQLResponse, SQLResponse> actionFuture = new PlainActionFuture<>();
+        executor.getSession().parse(UNNAMED, stmt, Collections.emptyList());
+        executor.getSession().bind(UNNAMED, UNNAMED, Collections.emptyList(), null);
+        List<Field> outputFields = executor.getSession().describe('P', UNNAMED);
+        try {
+            executor.execute(new ResultSetReceiver(actionFuture, executor.getSession().sessionContext(), outputFields), Collections.emptyList());
+        } catch (Throwable t) {
+            actionFuture.onFailure(SQLExceptions.createSQLActionException(t, executor.getSession().sessionContext()));
+        }
+        return actionFuture;
+    }
+
     public ActionFuture<SQLResponse> execute(String stmt, @Nullable Object[] args) {
         return execute(stmt, args, clientProvider.sqlOperations().createSession(
             null,


### PR DESCRIPTION
This fix prevents from query execution using a `NULL` user session if the user mangement module is enabled.
 - [x] system queries using `SqlDirectExecutor` use now a session with superuser `crate` 
 - [x] all other queries are now rejected if they use a `NULL` user session.