### PR TITLE
Drop batching of pending indices for bulk operations

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -21,6 +21,10 @@ Changes
 Fixes
 =====
 
+ - Fixed an issue that can hang the nodes when running an insert from query 
+   statement for a large dataset when the target table is an empty 
+   partitioned table.
+
  - Fixed an issue that prevents CrateDB from bootstrap on Windows hosts.
 
  - Fixed a race condition which could cause ``UPDATE`` or ``DELETE`` statements

--- a/sql/src/main/java/io/crate/operation/projectors/BatchIteratorBackpressureExecutor.java
+++ b/sql/src/main/java/io/crate/operation/projectors/BatchIteratorBackpressureExecutor.java
@@ -38,7 +38,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
-import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * Consumes a BatchIterator in bulks based on the configured {@link #bulkSize}. When a bulk is complete, it checks
@@ -52,7 +52,7 @@ import java.util.function.Function;
 public class BatchIteratorBackpressureExecutor<R> {
 
     private final BatchIterator batchIterator;
-    private final Function<Boolean, CompletableFuture<R>> executeFunction;
+    private final Supplier<CompletableFuture<R>> executeFunction;
     private final Consumer<Row> onRowConsumer;
     private final ScheduledExecutorService scheduler;
     private final AtomicBoolean collectingEnabled = new AtomicBoolean(false);
@@ -73,7 +73,7 @@ public class BatchIteratorBackpressureExecutor<R> {
     public BatchIteratorBackpressureExecutor(BatchIterator batchIterator,
                                              ScheduledExecutorService scheduler,
                                              Consumer<Row> onRowConsumer,
-                                             Function<Boolean, CompletableFuture<R>> executeFunction,
+                                             Supplier<CompletableFuture<R>> executeFunction,
                                              BooleanSupplier backPressureTrigger,
                                              int bulkSize,
                                              BackoffPolicy backoffPolicy) {
@@ -167,7 +167,7 @@ public class BatchIteratorBackpressureExecutor<R> {
             if (batchIterator.allLoaded()) {
                 lastBulkScheduledToExecute = true;
                 inFlightExecutions.incrementAndGet();
-                executeFunction.apply(true).whenComplete(bulkExecutionCompleteListener);
+                executeFunction.get().whenComplete(bulkExecutionCompleteListener);
             } else {
                 batchIterator.loadNextBatch().whenComplete(loadNextBatchCompleteListener);
             }
@@ -186,7 +186,7 @@ public class BatchIteratorBackpressureExecutor<R> {
         if (backPressureTrigger.getAsBoolean() == false) {
             indexInBulk = 0;
             inFlightExecutions.incrementAndGet();
-            CompletableFuture<R> bulkExecutionFuture = executeFunction.apply(false);
+            CompletableFuture<R> bulkExecutionFuture = executeFunction.get();
             bulkExecutionFuture.whenComplete(bulkExecutionCompleteListener);
             return true;
         }

--- a/sql/src/main/java/io/crate/operation/projectors/ShardDMLExecutor.java
+++ b/sql/src/main/java/io/crate/operation/projectors/ShardDMLExecutor.java
@@ -58,7 +58,7 @@ public class ShardDMLExecutor<TReq extends ShardRequest<TReq, TItem>, TItem exte
     private static final Logger LOGGER = Loggers.getLogger(ShardDMLExecutor.class);
 
     private static final BackoffPolicy BACKOFF_POLICY = LimitedExponentialBackoff.limitedExponential(1000);
-    public static final int DEFAULT_BULK_SIZE = 10_000;
+    static final int DEFAULT_BULK_SIZE = 10_000;
 
     private final int bulkSize;
     private final ScheduledExecutorService scheduler;
@@ -75,14 +75,14 @@ public class ShardDMLExecutor<TReq extends ShardRequest<TReq, TItem>, TItem exte
     private TReq currentRequest;
     private int numItems = -1;
 
-    public ShardDMLExecutor(int bulkSize,
-                            ScheduledExecutorService scheduler,
-                            CollectExpression<Row, ?> uidExpression,
-                            ClusterService clusterService,
-                            NodeJobsCounter nodeJobsCounter,
-                            Supplier<TReq> requestFactory,
-                            Function<String, TItem> itemFactory,
-                            BiConsumer<TReq, ActionListener<ShardResponse>> transportAction) {
+    ShardDMLExecutor(int bulkSize,
+                     ScheduledExecutorService scheduler,
+                     CollectExpression<Row, ?> uidExpression,
+                     ClusterService clusterService,
+                     NodeJobsCounter nodeJobsCounter,
+                     Supplier<TReq> requestFactory,
+                     Function<String, TItem> itemFactory,
+                     BiConsumer<TReq, ActionListener<ShardResponse>> transportAction) {
         this.bulkSize = bulkSize;
         this.scheduler = scheduler;
         this.uidExpression = uidExpression;
@@ -105,7 +105,7 @@ public class ShardDMLExecutor<TReq extends ShardRequest<TReq, TItem>, TItem exte
         currentRequest.add(numItems, itemFactory.apply(((BytesRef) uidExpression.value()).utf8ToString()));
     }
 
-    private CompletableFuture<BitSet> executeBatch(boolean isLastBatch) {
+    private CompletableFuture<BitSet> executeBatch() {
         /* This optimizes cases like "update t set x = ? where part_of_pk = ?"
          * This runs the collect on *all* shards but only a small subset has any matches
          * So this case can happen often.


### PR DESCRIPTION
For insert from query statements we used to batch the creation of indices 
(to 100) and the corresponding requests. 
For tables with fewer than 100 partitions, this means that all the data that had 
to be inserted was batched in memory, potentially leading to OOM for large 
datasets. 