### PR TITLE
Allow usage of != ANY() on arrays with size > 1024.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -23,8 +23,13 @@ Changes
 Fixes
 =====
 
+ - ``!= ANY()`` could not operate on arrays with more than 1024 elements. This
+   limit has been increased by default to 8192. A new node setting:
+   ``indices.query.bool.max_clause_count`` has been exposed to allow to
+    configure this limit.
+
  - Added support for conditionals with ``NULL`` arguments.
- 
+
  - Do not include Lucene indices (metadata) of ``BLOB`` tables in snapshot
    when using ``CREATE SNAPSHOT`` with ``ALL``, because the actual binary
    files of ``BLOB`` tables cannot be backed up using ``SNAPSHOT/RESTORE``
@@ -36,10 +41,10 @@ Fixes
    table was renamed.
 
  - Fixed an issue that caused wrong results to be returned for global
-    aggregation on ``JOINS`` when literal expression in ``WHERE`` clause is
-    evaluated to false. E.g.::
+   aggregation on ``JOINS`` when literal expression in ``WHERE`` clause is
+   evaluated to false. E.g.::
 
-      SELECT COUNT(*) FROM t1, t2 WHERE 1=2
+     SELECT COUNT(*) FROM t1, t2 WHERE 1=2
 
  - Fixed an issue which resulted in an exception when using the same global
    aggregation symbol twice as a select item on a join query.

--- a/blackbox/docs/configuration.txt
+++ b/blackbox/docs/configuration.txt
@@ -493,6 +493,25 @@ Repositories are used to :ref:`backup <snapshot-restore>` a CrateDB cluster.
 
 See also the :ref:`path.repo <conf-path-repo>` Setting.
 
+Queries
+-------
+
+.. _conf-indices-query-bool.max_clause_count:
+
+**indices.query.bool.max_clause_count**
+  | *Default:* ``8192``
+  | *Runtime:* ``no``
+
+  This setting defines the maximum number of elements an array can have so
+  that the ``!= ANY()``, ``LIKE ANY()`` and the ``NOT LIKE ANY()`` operators
+  can be applied on it.
+
+  .. NOTE::
+
+    Increasing this value to a large number (e.g. 10M) and applying  those
+    ``ANY`` operators on arrays of that length can lead to heavy memory,
+    consumption which could cause nodes to crash with OutOfMemory exceptions.
+
 .. _conf-cluster-settings:
 
 Cluster Wide Settings
@@ -1847,10 +1866,10 @@ The meaning of the fields of the are as follows:
 **auth.host_based.config.${order}.method**
   | *Runtime:* ``no``
 
-  | The authentication method to use when a connection matches this entry. 
+  | The authentication method to use when a connection matches this entry.
   | Valid values are ``trust`` and ``cert``. If no method is
   | specified, the ``trust`` method is used by default.
-  | See :ref:`auth_trust` and :ref:`auth_cert` for more information about the 
+  | See :ref:`auth_trust` and :ref:`auth_cert` for more information about the
   | methods.
 
 **auth.host_based.config.${order}.protocol**

--- a/blackbox/docs/sql/queries.txt
+++ b/blackbox/docs/sql/queries.txt
@@ -616,6 +616,13 @@ all rows where race['interests'] has at least one element that does not equal
     +----------------+-----------------------------------------+
     SELECT 2 rows in set (... sec)
 
+.. NOTE::
+
+    When using the negated operator ``!= ANY`` by default the maximum size of
+    the array to operate on is ``8192``. To be able to use larger arrays the
+    :ref:`indices.query.bool.max_clause_count <conf-indices-query-bool.max_clause_count>`
+    setting must be changed appropriately on each node.
+
 Negating the ``=`` query from above is totally different. It can be translated
 to *get all rows where race['interests'] has no value that equals 'netball'*::
 
@@ -634,6 +641,13 @@ for operators
  - ``LIKE`` and ``NOT LIKE``
 
  - all other comparison operators (excluding ``IS NULL`` and ``IS NOT NULL``)
+
+.. NOTE::
+
+    When using the operators ``LIKE ANY`` and ``NOT LIKE ANY`` by default the
+    maximum size of the array to operate on is ``8192``. To be able to use
+    larger arrays the :ref:`indices.query.bool.max_clause_count <conf-indices-query-bool.max_clause_count>`
+    setting must be changed appropriately on each node.
 
 Limits
 ------

--- a/sql/src/main/java/io/crate/plugin/SQLPlugin.java
+++ b/sql/src/main/java/io/crate/plugin/SQLPlugin.java
@@ -80,6 +80,7 @@ import org.elasticsearch.plugins.ClusterPlugin;
 import org.elasticsearch.plugins.MapperPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.rest.RestHandler;
+import org.elasticsearch.search.SearchModule;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -113,6 +114,11 @@ public class SQLPlugin extends Plugin implements ActionPlugin, MapperPlugin, Clu
         // partitions explicitly
         settingsBuilder.put("action.auto_create_index", false);
 
+        // Set maxClauses to 8192 for Boolean queries so that we allow the != ANY()
+        // to operate on arrays with more than 1024 elements which is the ES default value for this setting.
+        if (SearchModule.INDICES_MAX_CLAUSE_COUNT_SETTING.exists(settings) == false) {
+            settingsBuilder.put(SearchModule.INDICES_MAX_CLAUSE_COUNT_SETTING.getKey(), 8192);
+        }
         return settingsBuilder.build();
     }
 


### PR DESCRIPTION
Before the != ANY() was implemented by creating array.length() BooleanQueries
and joining them with AND operator. The limit of maxClauses for BooleanQueries
is 1024 which is a static variable and can only be changed globally.
The implementation was replaced by TermsQuery which doesn't have this limitation.