### PR TITLE
Tune pageSize calculation for small limits

### DIFF
--- a/sql/src/test/java/io/crate/operation/PagingTest.java
+++ b/sql/src/test/java/io/crate/operation/PagingTest.java
@@ -40,4 +40,9 @@ public class PagingTest {
         int pageSize = Paging.getWeightedPageSize(10, 1.0 / 20.0);
         assertThat(pageSize, is(10));
     }
+
+    @Test
+    public void testSmallLimitIsUnchanged() throws Exception {
+        assertThat(Paging.getWeightedPageSize(10, 1.0d / 4), is(10));
+    }
 }

--- a/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -498,11 +498,11 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testShardQueueSizeCalculation() throws Exception {
-        Merge merge = e.plan("select name from users order by name limit 100");
+        Merge merge = e.plan("select name from users order by name limit 500");
         Collect collect = (Collect) merge.subPlan();
         int shardQueueSize = ((RoutedCollectPhase) collect.collectPhase()).shardQueueSize(
             collect.collectPhase().nodeIds().iterator().next());
-        assertThat(shardQueueSize, is(75));
+        assertThat(shardQueueSize, is(375));
     }
 
     @Test


### PR DESCRIPTION
This disables the "pageSize adaption" for small limits, as the overhead
of a `searchMore` is bigger than to sort a couple of extra records.

2 shards:

![2shards](https://user-images.githubusercontent.com/38700/28269150-4a3a41da-6b01-11e7-8251-a0bbd6c89f5f.png)

4 shards:
![4shards](https://user-images.githubusercontent.com/38700/28269151-4a3ba82c-6b01-11e7-9512-31000c71c6e6.png)

8 shards:
![8shards](https://user-images.githubusercontent.com/38700/28269152-4a3e6d0a-6b01-11e7-8491-01dfdbc3718c.png)
