### PR TITLE
fixes global aggregation symbol used twice on join queries

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -21,6 +21,9 @@ Changes
 Fixes
 =====
 
+ - Fixed an issue which resulted in an exception when using the same global
+   aggregation symbol twice as a select item on a join query.
+
  - Provide comprehensive error message when using  ``NULL`` literal in
     ``GROUP BY``.
 

--- a/sql/src/main/java/io/crate/planner/consumer/MultiSourceAggregationConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/MultiSourceAggregationConsumer.java
@@ -104,6 +104,7 @@ class MultiSourceAggregationConsumer implements Consumer {
         Iterator<Function> outputsIt = splitPoints.aggregates().iterator();
         while (fieldsIt.hasNext()) {
             Field field = fieldsIt.next();
+            assert outputsIt.hasNext() : "too less collected aggregations, size must equal the outputs size";
             Symbol output = outputsIt.next();
             fieldsIt.set(new Field(field.relation(), field.path(), output.valueType()));
         }

--- a/sql/src/main/java/io/crate/planner/projection/builder/SplitPointVisitor.java
+++ b/sql/src/main/java/io/crate/planner/projection/builder/SplitPointVisitor.java
@@ -39,6 +39,7 @@ final class SplitPointVisitor extends DefaultTraversalSymbolVisitor<SplitPointVi
         final ArrayList<Symbol> toCollect;
         final ArrayList<Function> aggregates;
         boolean aggregateSeen;
+        boolean collectingOutputs = true;
 
         Context(ArrayList<Symbol> toCollect, ArrayList<Function> aggregates) {
             this.toCollect = toCollect;
@@ -52,7 +53,8 @@ final class SplitPointVisitor extends DefaultTraversalSymbolVisitor<SplitPointVi
         }
 
         void allocateAggregate(Function aggregate) {
-            if (!aggregates.contains(aggregate)) {
+            // while processing outputs aggregates must be added always, otherwise outputs and aggregates differs
+            if (collectingOutputs || aggregates.contains(aggregate) == false) {
                 aggregates.add(aggregate);
             }
         }
@@ -72,6 +74,7 @@ final class SplitPointVisitor extends DefaultTraversalSymbolVisitor<SplitPointVi
     static void addAggregatesAndToCollectSymbols(QuerySpec querySpec, SplitPoints splitContext) {
         Context context = new Context(splitContext.toCollect(), splitContext.aggregates());
         INSTANCE.process(querySpec.outputs(), context);
+        context.collectingOutputs = false;
         if (querySpec.orderBy().isPresent()) {
             INSTANCE.process(querySpec.orderBy().get().orderBySymbols(), context);
         }


### PR DESCRIPTION
a same aggregation symbol was only collected once on join queries and so
the field rewrite on the multi source select resulted in an exception