### PR TITLE
Pushdown NO_MATCH of WHERE clause to the relations of a JOIN.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -21,6 +21,12 @@ Changes
 Fixes
 =====
 
+ - Fixed an issue that caused wrong results to be returned for global
+    aggregation on ``JOINS`` when literal expression in ``WHERE`` clause is
+    evaluated to false. E.g.::
+
+      SELECT COUNT(*) FROM t1, t2 WHERE 1=2
+
  - Fixed an issue which resulted in an exception when using the same global
    aggregation symbol twice as a select item on a join query.
 

--- a/sql/src/main/java/io/crate/analyze/relations/RelationSplitter.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationSplitter.java
@@ -189,9 +189,18 @@ public final class RelationSplitter {
     }
 
     private void processWhere() {
+        // Push down NO_MATCH to all relations
+        if (querySpec.where().noMatch()) {
+            for (QuerySpec querySpec : specs.values()) {
+                querySpec.where(WhereClause.NO_MATCH);
+            }
+            return;
+        }
+
         if (!querySpec.where().hasQuery()) {
             return;
         }
+
         Symbol query = querySpec.where().query();
         assert query != null : "query must not be null";
         QuerySplittingVisitor.Context context = QuerySplittingVisitor.INSTANCE.process(querySpec.where().query(), joinPairs);

--- a/sql/src/main/java/io/crate/planner/SelectStatementPlanner.java
+++ b/sql/src/main/java/io/crate/planner/SelectStatementPlanner.java
@@ -101,9 +101,6 @@ class SelectStatementPlanner {
         public Plan visitMultiSourceSelect(MultiSourceSelect mss, Planner.Context context) {
             QuerySpec querySpec = mss.querySpec();
             context.applySoftLimit(querySpec);
-            if (!querySpec.hasAggregates() && querySpec.where().noMatch()) {
-                return new NoopPlan(context.jobId());
-            }
             return invokeConsumingPlanner(mss, context);
         }
     }

--- a/sql/src/test/java/io/crate/analyze/relations/RelationSplitterTest.java
+++ b/sql/src/test/java/io/crate/analyze/relations/RelationSplitterTest.java
@@ -320,4 +320,14 @@ public class RelationSplitterTest extends CrateUnitTest {
         assertThat("remainingOrderBy must be false if it's safe to remove after pushDown",
             splitter.remainingOrderBy().isPresent(), is(false));
     }
+
+    @Test
+    public void testNoMatchPushedDownToAllRelations() throws Exception {
+        QuerySpec qs = new QuerySpec()
+            .outputs(Arrays.asList(asSymbol("t1.a"), asSymbol("t2.b")))
+            .where(WhereClause.NO_MATCH);
+        RelationSplitter splitter = split(qs);
+        assertThat(splitter.getSpec(T3.TR_1).where().noMatch(), is(true));
+        assertThat(splitter.getSpec(T3.TR_2).where().noMatch(), is(true));
+    }
 }

--- a/sql/src/test/java/io/crate/planner/consumer/NestedLoopConsumerTest.java
+++ b/sql/src/test/java/io/crate/planner/consumer/NestedLoopConsumerTest.java
@@ -39,7 +39,6 @@ import io.crate.metadata.doc.DocSchemaInfo;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.TestingTableInfo;
 import io.crate.planner.Merge;
-import io.crate.planner.NoopPlan;
 import io.crate.planner.Plan;
 import io.crate.planner.Planner;
 import io.crate.planner.PositionalOrderBy;
@@ -126,12 +125,6 @@ public class NestedLoopConsumerTest extends CrateDummyClusterServiceUnitTest {
 
     public <T extends Plan> T plan(String statement) {
         return e.plan(statement, UUID.randomUUID(), 0, 0);
-    }
-
-    @Test
-    public void testWhereWithNoMatchShouldReturnNoopPlan() throws Exception {
-        Plan plan = plan("select u1.name, u2.name from users u1, users u2 where 1 = 2");
-        assertThat(plan, instanceOf(NoopPlan.class));
     }
 
     @Test


### PR DESCRIPTION
In case of global aggregations the JOIN is normally planned even if WHERE
clause evaluates to NO_MATCH. So to avoid incorrect results we push down
the NO_MATCH to the qSpecs of the left and right relations of the join pair.