### PR TITLE
exclude blob indices from snapshot when using ALL

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -21,6 +21,11 @@ Changes
 Fixes
 =====
 
+ - Do not include Lucene indices (metadata) of ``BLOB`` tables in snapshot
+   when using ``CREATE SNAPSHOT`` with ``ALL``, because the actual binary
+   files of ``BLOB`` tables cannot be backed up using ``SNAPSHOT/RESTORE``
+   functionality.
+
  - Fixed rename table operation for empty partitioned tables.
 
  - Fixed an issue which caused unrelated table privileges to be lost after a

--- a/sandbox/crate/config/crate.yml
+++ b/sandbox/crate/config/crate.yml
@@ -11,3 +11,5 @@ ssl.http.enabled: false
 ssl.keystore_filepath: ./enterprise/ssl-impl/src/test/resources/keystore.jks
 ssl.keystore_password: keystorePassword
 ssl.keystore_key_password: serverKeyPassword
+
+path.repo: ./sandbox/crate/repo

--- a/sql/src/main/java/io/crate/analyze/CreateSnapshotAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/CreateSnapshotAnalyzedStatement.java
@@ -23,7 +23,6 @@
 package io.crate.analyze;
 
 import com.google.common.collect.ImmutableList;
-import io.crate.blob.v2.BlobIndex;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.snapshots.Snapshot;
 

--- a/sql/src/main/java/io/crate/analyze/CreateSnapshotAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/CreateSnapshotAnalyzedStatement.java
@@ -23,6 +23,7 @@
 package io.crate.analyze;
 
 import com.google.common.collect.ImmutableList;
+import io.crate.blob.v2.BlobIndex;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.snapshots.Snapshot;
 
@@ -30,7 +31,7 @@ import java.util.List;
 
 public class CreateSnapshotAnalyzedStatement implements DDLStatement {
 
-    public static final List<String> ALL_INDICES = ImmutableList.of("_all");
+    static final List<String> ALL_INDICES = ImmutableList.of("*", "-.blob_*");
 
     private final Snapshot snapshot;
     private final Settings snapshotSettings;

--- a/sql/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
@@ -187,6 +187,18 @@ public class SnapshotRestoreIntegrationTest extends SQLTransportIntegrationTest 
     }
 
     @Test
+    public void testCreateSnapshotAllBlobsExcluded() throws Exception {
+        execute("CREATE TABLE t1 (id INTEGER, name STRING)");
+        execute("CREATE BLOB TABLE b1");
+        ensureYellow();
+        execute("CREATE SNAPSHOT " + snapshotName() + " ALL WITH (wait_for_completion=true)");
+        assertThat(response.rowCount(), is(1L));
+
+        execute("select concrete_indices from sys.snapshots");
+        assertThat(response.rows()[0][0], is(new String[]{"t1"}));
+    }
+
+    @Test
     public void testCreateExistingSnapshot() throws Exception {
         createTable("backmeup", randomBoolean());
 


### PR DESCRIPTION
`BLOB` tables appeared in the `concrete_indices` column in the `sys.snapshots` table when performing a snapshot using `ALL`. See https://github.com/crate/crate/issues/5939