### PR TITLE
LongType: Improve BytesRef -> long conversion error msg

### DIFF
--- a/core/src/main/java/io/crate/types/LongType.java
+++ b/core/src/main/java/io/crate/types/LongType.java
@@ -87,7 +87,7 @@ LongType extends DataType<Long> implements FixedWidthType, Streamer<Long>, DataT
         int digit;
 
         if (len <= 0) {
-            throw new NumberFormatException(value.utf8ToString());
+            throw raiseNumberFormatException(value);
         }
 
         char firstChar = (char) bytes[i];
@@ -96,11 +96,11 @@ LongType extends DataType<Long> implements FixedWidthType, Streamer<Long>, DataT
                 negative = true;
                 limit = Long.MIN_VALUE;
             } else if (firstChar != '+') {
-                throw new NumberFormatException(value.utf8ToString());
+                throw raiseNumberFormatException(value);
             }
 
             if (len == 1) { // lone '+' or '-'
-                throw new NumberFormatException(value.utf8ToString());
+                throw raiseNumberFormatException(value);
             }
             i++;
         }
@@ -109,18 +109,22 @@ LongType extends DataType<Long> implements FixedWidthType, Streamer<Long>, DataT
             digit = Character.digit((char) bytes[i], radix);
             i++;
             if (digit < 0) {
-                throw new NumberFormatException(value.utf8ToString());
+                throw raiseNumberFormatException(value);
             }
             if (result < multmin) {
-                throw new NumberFormatException(value.utf8ToString());
+                throw raiseNumberFormatException(value);
             }
             result *= radix;
             if (result < limit + digit) {
-                throw new NumberFormatException(value.utf8ToString());
+                throw raiseNumberFormatException(value);
             }
             result -= digit;
         }
         return negative ? result : -result;
+    }
+
+    private NumberFormatException raiseNumberFormatException(BytesRef value) {
+        throw new NumberFormatException('"' + value.utf8ToString() + "\" cannot be converted to type long");
     }
 
     @Override

--- a/core/src/test/java/io/crate/types/LongTypeTest.java
+++ b/core/src/test/java/io/crate/types/LongTypeTest.java
@@ -61,6 +61,7 @@ public class LongTypeTest extends CrateUnitTest {
     @Test
     public void testOnlyPlusSign() throws Exception {
         expectedException.expect(NumberFormatException.class);
+        expectedException.expectMessage("\"+\" cannot be converted to type long");
         assertBytesRefParsing("+", 1L);
     }
 


### PR DESCRIPTION
The error message of a failed BytesRef -> long conversion only contained
the value of the string that couldn't be converted.

This wasn't an issue in most cases as we wrap a `NumberFormatException`
into a a different exception with a good error message if it's part of a
cast. So something like `select 'foo'::long` raised a meaningful error,
but some other cases miss this conversion