### PR TITLE
Remove ulimit from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,6 @@ cache:
 notifications:
   email: false
 
-before_install:
-  - ulimit -u 65535
-  - ulimit -n 65536
 
 script:
   - ./gradlew -s :sql:test


### PR DESCRIPTION
Builds started failing with:

    line 57: ulimit: open files: cannot modify limit: Operation not permitted