### PR TITLE
always return the user that has been provided on connect

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -26,11 +26,14 @@ Changes
 
 Fixes
 =====
-
+ 
+ - Fixed an issue where the user that gets provided by the client on connect is
+   not always used as current user if host based authentication is disabled.
+ 
  - Corrected the documentation of the ``version`` column of the ``sys.snapshots``
    table. It was described as the CrateDB version wereas it's an internal
    version instead.
-
+ 
  - Dropping an empty partitioned table did not drop related table privileges.
 
  - Implemented ``NOT NULL`` constraint validation for nested object columns,

--- a/blackbox/docs/administration/hba.txt
+++ b/blackbox/docs/administration/hba.txt
@@ -43,6 +43,9 @@ For HTTP connections the ``X-REAL-IP`` request header has priority over the
 actual client IP address in order to allow proxied clients to authenticate.
 
 If ``auth.host_based`` is not set, the host based authentication is disabled.
+In this case CrateDB **trusts all connections** and accepts the user provided by
+the client given that this user exists.
+
 If the setting ``auth.host_based`` is present and the configurations list does
 not contain any entry, then no client can authenticate.
 

--- a/enterprise/ssl-impl/src/test/java/io/crate/protocols/postgres/SslReqHandlerTest.java
+++ b/enterprise/ssl-impl/src/test/java/io/crate/protocols/postgres/SslReqHandlerTest.java
@@ -19,7 +19,7 @@
 package io.crate.protocols.postgres;
 
 import io.crate.action.sql.SQLOperations;
-import io.crate.operation.auth.AlwaysOKAuthentication;
+import io.crate.operation.auth.AlwaysOKNullAuthentication;
 import io.crate.test.integration.CrateUnitTest;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -53,7 +53,7 @@ public class SslReqHandlerTest extends CrateUnitTest {
         PostgresWireProtocol ctx =
             new PostgresWireProtocol(
                 mock(SQLOperations.class),
-                new AlwaysOKAuthentication(),
+                new AlwaysOKNullAuthentication(),
                 // use a simple ssl context
                 getSelfSignedSslContext());
 

--- a/enterprise/users/src/main/java/io/crate/operation/auth/AlwaysOKAuthentication.java
+++ b/enterprise/users/src/main/java/io/crate/operation/auth/AlwaysOKAuthentication.java
@@ -20,18 +20,27 @@
  * agreement.
  */
 
-package io.crate.user;
+package io.crate.operation.auth;
 
-import io.crate.operation.auth.AlwaysOKNullAuthentication;
-import io.crate.operation.auth.Authentication;
-import io.crate.operation.user.UserManager;
-import org.elasticsearch.common.inject.AbstractModule;
+import io.crate.operation.user.UserLookup;
+import io.crate.protocols.postgres.ConnectionProperties;
+import org.elasticsearch.common.inject.Inject;
 
-public class UserFallbackModule extends AbstractModule {
+/**
+ * Fallback if host-based authentication is disabled
+ * and the user management is enabled
+ */
+public class AlwaysOKAuthentication implements Authentication {
+
+    private final UserLookup userLookup;
+
+    @Inject
+    public AlwaysOKAuthentication(UserLookup userLookup) {
+        this.userLookup = userLookup;
+    }
 
     @Override
-    protected void configure() {
-        bind(UserManager.class).to(StubUserManager.class);
-        bind(Authentication.class).to(AlwaysOKNullAuthentication.class);
+    public AuthenticationMethod resolveAuthenticationType(String user, ConnectionProperties connectionProperties) {
+        return new TrustAuthenticationMethod(userLookup);
     }
 }

--- a/enterprise/users/src/main/java/io/crate/operation/auth/HostBasedAuthentication.java
+++ b/enterprise/users/src/main/java/io/crate/operation/auth/HostBasedAuthentication.java
@@ -76,7 +76,7 @@ public class HostBasedAuthentication implements Authentication {
     @Inject
     public HostBasedAuthentication(Settings settings, UserLookup userLookup) {
         hbaConf = convertHbaSettingsToHbaConf(AuthSettings.AUTH_HOST_BASED_CONFIG_SETTING.setting().get(settings));
-        authMethodRegistry.put(TrustAuthentication.NAME, () -> new TrustAuthentication(userLookup));
+        authMethodRegistry.put(TrustAuthenticationMethod.NAME, () -> new TrustAuthenticationMethod(userLookup));
         authMethodRegistry.put(ClientCertAuth.NAME, () -> new ClientCertAuth(userLookup));
     }
 

--- a/enterprise/users/src/main/java/io/crate/operation/auth/TrustAuthenticationMethod.java
+++ b/enterprise/users/src/main/java/io/crate/operation/auth/TrustAuthenticationMethod.java
@@ -23,12 +23,12 @@ import io.crate.operation.user.UserLookup;
 import io.crate.protocols.postgres.ConnectionProperties;
 
 
-public class TrustAuthentication implements AuthenticationMethod {
+public class TrustAuthenticationMethod implements AuthenticationMethod {
 
     static final String NAME = "trust";
     private final UserLookup userLookup;
 
-    public TrustAuthentication(UserLookup userLookup) {
+    public TrustAuthenticationMethod(UserLookup userLookup) {
         this.userLookup = userLookup;
     }
 

--- a/enterprise/users/src/main/java/io/crate/plugin/AuthenticationModule.java
+++ b/enterprise/users/src/main/java/io/crate/plugin/AuthenticationModule.java
@@ -41,9 +41,9 @@ public class AuthenticationModule extends AbstractModule {
     protected void configure() {
         if (AuthSettings.AUTH_HOST_BASED_ENABLED_SETTING.setting().get(settings)) {
             bind(Authentication.class).to(HostBasedAuthentication.class);
-            bind(AuthenticationHttpAuthHandlerRegistry.class).asEagerSingleton();
         } else {
             bind(Authentication.class).to(AlwaysOKAuthentication.class);
         }
+        bind(AuthenticationHttpAuthHandlerRegistry.class).asEagerSingleton();
     }
 }

--- a/enterprise/users/src/test/java/io/crate/operation/auth/HostBasedAuthenticationTest.java
+++ b/enterprise/users/src/test/java/io/crate/operation/auth/HostBasedAuthenticationTest.java
@@ -127,7 +127,7 @@ public class HostBasedAuthenticationTest extends CrateUnitTest {
         authService.updateHbaConfig(createHbaConf(HBA_1));
         AuthenticationMethod method =
             authService.resolveAuthenticationType("crate", new ConnectionProperties(LOCALHOST, Protocol.POSTGRES, null));
-        assertThat(method, instanceOf(TrustAuthentication.class));
+        assertThat(method, instanceOf(TrustAuthenticationMethod.class));
     }
 
     @Test

--- a/enterprise/users/src/test/java/io/crate/operation/auth/UserAuthenticationMethodTest.java
+++ b/enterprise/users/src/test/java/io/crate/operation/auth/UserAuthenticationMethodTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.operation.auth;
+
+import io.crate.operation.user.User;
+import io.crate.test.integration.CrateUnitTest;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.hamcrest.core.Is.is;
+
+public class UserAuthenticationMethodTest extends CrateUnitTest {
+
+    @Test
+    public void testTrustAuthentication() throws Exception {
+        TrustAuthenticationMethod trustAuth = new TrustAuthenticationMethod(userName -> {
+            if (userName.equals("crate")) {
+                return new User("crate", Collections.emptySet(), Collections.emptySet());
+            }
+            return null;
+        });
+        assertThat(trustAuth.name(), is("trust"));
+
+        assertThat(trustAuth.authenticate("crate", null).name(), is("crate"));
+
+        expectedException.expectMessage("trust authentication failed for user \"cr8\"");
+        trustAuth.authenticate("cr8", null);
+    }
+
+    @Test
+    public void testAlwaysOKAuthentication() throws Exception {
+        AlwaysOKAuthentication alwaysOkAuth = new AlwaysOKAuthentication(userName -> {
+            if (userName.equals("crate")) {
+                return new User("crate", Collections.emptySet(), Collections.emptySet());
+            }
+            return null;
+        });
+
+        AuthenticationMethod alwaysOkAuthMethod = alwaysOkAuth.resolveAuthenticationType("crate", null);
+
+        assertThat(alwaysOkAuthMethod.name(), is("trust"));
+        assertThat(alwaysOkAuthMethod.authenticate("crate", null).name(), is("crate"));
+
+        expectedException.expectMessage("authentication failed for user \"cr8\"");
+        alwaysOkAuthMethod.authenticate("cr8", null);
+    }
+}

--- a/sql/src/main/java/io/crate/operation/auth/AlwaysOKNullAuthentication.java
+++ b/sql/src/main/java/io/crate/operation/auth/AlwaysOKNullAuthentication.java
@@ -25,9 +25,9 @@ package io.crate.operation.auth;
 import io.crate.operation.user.User;
 import io.crate.protocols.postgres.ConnectionProperties;
 
-public class AlwaysOKAuthentication implements Authentication {
+public class AlwaysOKNullAuthentication implements Authentication {
 
-    private final AuthenticationMethod alwaysOk = new AuthenticationMethod() {
+    private final AuthenticationMethod alwaysOkNull = new AuthenticationMethod() {
         @Override
         public User authenticate(String userName, ConnectionProperties connectionProperties) {
             return null;
@@ -35,12 +35,12 @@ public class AlwaysOKAuthentication implements Authentication {
 
         @Override
         public String name() {
-            return "alwaysOk";
+            return "alwaysOkNull";
         }
     };
 
     @Override
     public AuthenticationMethod resolveAuthenticationType(String user, ConnectionProperties connectionProperties) {
-        return alwaysOk;
+        return alwaysOkNull;
     }
 }

--- a/sql/src/test/java/io/crate/operation/auth/AuthenticationMethodTest.java
+++ b/sql/src/test/java/io/crate/operation/auth/AuthenticationMethodTest.java
@@ -22,31 +22,20 @@
 
 package io.crate.operation.auth;
 
-import io.crate.operation.user.User;
-import io.crate.protocols.postgres.ConnectionProperties;
 import io.crate.test.integration.CrateUnitTest;
 import org.junit.Test;
-
-import java.util.Collections;
 
 import static org.hamcrest.core.Is.is;
 
 public class AuthenticationMethodTest extends CrateUnitTest {
 
     @Test
-    public void testTrustAuthentication() throws Exception {
-        TrustAuthentication trustAuth = new TrustAuthentication(userName -> {
-            if (userName.equals("crate")) {
-                return new User("crate", Collections.emptySet(), Collections.emptySet());
-            }
-            return null;
-        });
-        assertThat(trustAuth.name(), is("trust"));
+    public void testAlwaysOKNullAuthentication() throws Exception {
+        AlwaysOKNullAuthentication alwaysOkNullAuth = new AlwaysOKNullAuthentication();
 
-        ConnectionProperties connectionProperties = new ConnectionProperties(null, Protocol.POSTGRES, null);
-        assertThat(trustAuth.authenticate("crate", connectionProperties).name(), is("crate"));
+        AuthenticationMethod alwaysOkNullAuthMethod = alwaysOkNullAuth.resolveAuthenticationType("crate", null);
 
-        expectedException.expectMessage("trust authentication failed for user \"cr8\"");
-        trustAuth.authenticate("cr8", connectionProperties);
+        assertThat(alwaysOkNullAuthMethod.name(), is("alwaysOkNull"));
+        assertNull(alwaysOkNullAuthMethod.authenticate("crate", null));
     }
 }

--- a/sql/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
+++ b/sql/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
@@ -24,7 +24,7 @@ package io.crate.protocols.postgres;
 
 import io.crate.action.sql.SQLOperations;
 import io.crate.executor.Executor;
-import io.crate.operation.auth.AlwaysOKAuthentication;
+import io.crate.operation.auth.AlwaysOKNullAuthentication;
 import io.crate.operation.collect.stats.JobsLogs;
 import io.crate.operation.user.User;
 import io.crate.operation.user.UserManager;
@@ -99,7 +99,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
         PostgresWireProtocol ctx =
             new PostgresWireProtocol(
                 mock(SQLOperations.class),
-                new AlwaysOKAuthentication(),
+                new AlwaysOKNullAuthentication(),
                 null);
         EmbeddedChannel channel = new EmbeddedChannel(ctx.decoder, ctx.handler);
 
@@ -128,7 +128,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
         PostgresWireProtocol ctx =
             new PostgresWireProtocol(
                 sqlOperations,
-                new AlwaysOKAuthentication(),
+                new AlwaysOKNullAuthentication(),
                 null);
         EmbeddedChannel channel = new EmbeddedChannel(ctx.decoder, ctx.handler);
 
@@ -147,7 +147,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
         PostgresWireProtocol ctx =
             new PostgresWireProtocol(
                 sqlOperations,
-                new AlwaysOKAuthentication(),
+                new AlwaysOKNullAuthentication(),
                 null);
         EmbeddedChannel channel = new EmbeddedChannel(ctx.decoder, ctx.handler);
 
@@ -170,7 +170,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
         PostgresWireProtocol ctx =
             new PostgresWireProtocol(
                 mock(SQLOperations.class),
-                new AlwaysOKAuthentication(),
+                new AlwaysOKNullAuthentication(),
                 null);
 
         channel = new EmbeddedChannel(ctx.decoder, ctx.handler);


### PR DESCRIPTION
This fix always returns the user that has been provided on connect if
host-based authentication is disabled and the user management is
enabled. Since 88f02de132eceb5502ddd6557a2c079a8bebb4e3 `null` user sessions
are prevented from querying the cluster if the user management is enabled.