### PR TITLE
Make template schema update synchronous

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -27,6 +27,10 @@ Changes
 Fixes
 =====
 
+ - Fixed a race condition which made it possible to create new columns in a
+   partition of a partitioned table that didn't match the type of the same
+   column of sibling partitions.
+
  - Fixed a NPE when running ``select port from sys.nodes`` and
    ``psql.enabled: false`` was set
 

--- a/sql/src/main/java/io/crate/executor/transport/ActionListeners.java
+++ b/sql/src/main/java/io/crate/executor/transport/ActionListeners.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.executor.transport;
+
+import org.elasticsearch.action.ActionListener;
+
+import java.util.function.BiConsumer;
+
+public final class ActionListeners {
+
+    private ActionListeners() {
+    }
+
+
+    public static <T> BiConsumer<? super T, ? super Throwable> asBiConsumer(ActionListener<T> listener) {
+        return (r, f) -> {
+            if (f == null) {
+                listener.onResponse(r);
+            } else {
+                if (f instanceof Exception) {
+                    listener.onFailure(((Exception) f));
+                } else {
+                    listener.onFailure(new RuntimeException(f));
+                }
+            }
+        };
+    }
+}

--- a/sql/src/main/java/io/crate/executor/transport/SchemaUpdateClient.java
+++ b/sql/src/main/java/io/crate/executor/transport/SchemaUpdateClient.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.executor.transport;
+
+import org.elasticsearch.cluster.action.index.MappingUpdatedAction;
+import org.elasticsearch.common.component.AbstractComponent;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.mapper.Mapping;
+
+import java.util.concurrent.TimeoutException;
+
+@Singleton
+public class SchemaUpdateClient extends AbstractComponent {
+
+    private final TransportSchemaUpdateAction schemaUpdateAction;
+    private volatile TimeValue dynamicMappingUpdateTimeout;
+
+    @Inject
+    public SchemaUpdateClient(Settings settings,
+                              ClusterSettings clusterSettings,
+                              TransportSchemaUpdateAction schemaUpdateAction) {
+        super(settings);
+        this.schemaUpdateAction = schemaUpdateAction;
+        this.dynamicMappingUpdateTimeout = MappingUpdatedAction.INDICES_MAPPING_DYNAMIC_TIMEOUT_SETTING.get(settings);
+        clusterSettings.addSettingsUpdateConsumer(
+            MappingUpdatedAction.INDICES_MAPPING_DYNAMIC_TIMEOUT_SETTING, this::setDynamicMappingUpdateTimeout);
+    }
+
+    private void setDynamicMappingUpdateTimeout(TimeValue dynamicMappingUpdateTimeout) {
+        this.dynamicMappingUpdateTimeout = dynamicMappingUpdateTimeout;
+    }
+
+    public void blockingUpdateOnMaster(Index index, Mapping mappingUpdate) throws TimeoutException{
+        TimeValue timeout = this.dynamicMappingUpdateTimeout;
+        SchemaUpdateResponse schemaUpdateResponse = schemaUpdateAction.execute(
+            new SchemaUpdateRequest(index, mappingUpdate.toString())).actionGet();
+        if (!schemaUpdateResponse.isAcknowledged()) {
+            throw new TimeoutException("Failed to acknowledge mapping update within [" + timeout + "]");
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/executor/transport/SchemaUpdateClient.java
+++ b/sql/src/main/java/io/crate/executor/transport/SchemaUpdateClient.java
@@ -55,7 +55,7 @@ public class SchemaUpdateClient extends AbstractComponent {
         this.dynamicMappingUpdateTimeout = dynamicMappingUpdateTimeout;
     }
 
-    public void blockingUpdateOnMaster(Index index, Mapping mappingUpdate) throws TimeoutException{
+    public void blockingUpdateOnMaster(Index index, Mapping mappingUpdate) throws TimeoutException {
         TimeValue timeout = this.dynamicMappingUpdateTimeout;
         SchemaUpdateResponse schemaUpdateResponse = schemaUpdateAction.execute(
             new SchemaUpdateRequest(index, mappingUpdate.toString())).actionGet();

--- a/sql/src/main/java/io/crate/executor/transport/SchemaUpdateRequest.java
+++ b/sql/src/main/java/io/crate/executor/transport/SchemaUpdateRequest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.executor.transport;
+
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.support.master.MasterNodeRequest;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.Index;
+
+import java.io.IOException;
+
+public class SchemaUpdateRequest extends MasterNodeRequest<SchemaUpdateRequest> {
+
+    private Index index;
+    private String mappingSource;
+
+    public SchemaUpdateRequest() {
+    }
+
+    public SchemaUpdateRequest(Index index, String mappingSource) {
+        this.index = index;
+        this.mappingSource = mappingSource;
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        return null;
+    }
+
+    public Index index() {
+        return index;
+    }
+
+    public String mappingSource() {
+        return mappingSource;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        index.writeTo(out);
+        out.writeString(mappingSource);
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        index = new Index(in);
+        mappingSource = in.readString();
+    }
+}

--- a/sql/src/main/java/io/crate/executor/transport/SchemaUpdateResponse.java
+++ b/sql/src/main/java/io/crate/executor/transport/SchemaUpdateResponse.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.executor.transport;
+
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+
+public class SchemaUpdateResponse extends AcknowledgedResponse {
+
+    public SchemaUpdateResponse() {
+        super();
+    }
+
+    public SchemaUpdateResponse(boolean isAcknowledged) {
+        super(isAcknowledged);
+    }
+}

--- a/sql/src/main/java/io/crate/executor/transport/SchemaUpdateResponse.java
+++ b/sql/src/main/java/io/crate/executor/transport/SchemaUpdateResponse.java
@@ -26,10 +26,6 @@ import org.elasticsearch.action.support.master.AcknowledgedResponse;
 
 public class SchemaUpdateResponse extends AcknowledgedResponse {
 
-    public SchemaUpdateResponse() {
-        super();
-    }
-
     public SchemaUpdateResponse(boolean isAcknowledged) {
         super(isAcknowledged);
     }

--- a/sql/src/main/java/io/crate/executor/transport/TransportSchemaUpdateAction.java
+++ b/sql/src/main/java/io/crate/executor/transport/TransportSchemaUpdateAction.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.executor.transport;
+
+import io.crate.Constants;
+import io.crate.action.FutureActionListener;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingAction;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingResponse;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+import java.util.concurrent.CompletableFuture;
+
+@Singleton
+public class TransportSchemaUpdateAction extends TransportMasterNodeAction<SchemaUpdateRequest, SchemaUpdateResponse> {
+
+    private final NodeClient nodeClient;
+
+    @Inject
+    public TransportSchemaUpdateAction(Settings settings,
+                                       TransportService transportService,
+                                       ClusterService clusterService,
+                                       ThreadPool threadPool,
+                                       ActionFilters actionFilters,
+                                       IndexNameExpressionResolver indexNameExpressionResolver,
+                                       NodeClient nodeClient) {
+        super(settings,
+            "crate/sql/ddl/schema_update",
+            transportService,
+            clusterService,
+            threadPool,
+            actionFilters,
+            indexNameExpressionResolver,
+            SchemaUpdateRequest::new);
+        this.nodeClient = nodeClient;
+    }
+
+    @Override
+    protected String executor() {
+        return ThreadPool.Names.GENERIC;
+    }
+
+    @Override
+    protected SchemaUpdateResponse newResponse() {
+        return new SchemaUpdateResponse(true);
+    }
+
+    @Override
+    protected void masterOperation(SchemaUpdateRequest request, ClusterState state, ActionListener<SchemaUpdateResponse> listener) throws Exception {
+        updateMapping(request.index(), request.masterNodeTimeout(), request.mappingSource())
+            .thenApply(r -> new SchemaUpdateResponse(true))
+            .whenComplete(ActionListeners.asBiConsumer(listener));
+    }
+
+    private CompletableFuture<PutMappingResponse> updateMapping(Index index,
+                                                                TimeValue timeout,
+                                                                String mappingSource) {
+        FutureActionListener<PutMappingResponse, PutMappingResponse> putMappingListener = FutureActionListener.newInstance();
+        PutMappingRequest putMappingRequest = new PutMappingRequest()
+            .indices(new String[0])
+            .setConcreteIndex(index)
+            .type(Constants.DEFAULT_MAPPING_TYPE)
+            .source(mappingSource)
+            .timeout(timeout)
+            .masterNodeTimeout(timeout);
+        nodeClient.executeLocally(PutMappingAction.INSTANCE, putMappingRequest, putMappingListener);
+        return putMappingListener;
+    }
+
+    @Override
+    protected ClusterBlockException checkBlock(SchemaUpdateRequest request, ClusterState state) {
+        return null;
+    }
+}

--- a/sql/src/main/java/io/crate/metadata/PartitionName.java
+++ b/sql/src/main/java/io/crate/metadata/PartitionName.java
@@ -72,6 +72,11 @@ public class PartitionName {
         return DOT_JOINER.join(tableIdent.schema(), PARTITIONED_TABLE_PREFIX, tableIdent.name(), ident);
     }
 
+    public static String templateName(String indexName) {
+        TableIdent tableIdent = PartitionName.fromIndexOrTemplate(indexName).tableIdent;
+        return templateName(tableIdent.schema(), tableIdent.name());
+    }
+
     /**
      * decodes an encoded ident into it's values
      */

--- a/sql/src/main/java/io/crate/metadata/doc/InternalDocTableInfoFactory.java
+++ b/sql/src/main/java/io/crate/metadata/doc/InternalDocTableInfoFactory.java
@@ -24,11 +24,9 @@ package io.crate.metadata.doc;
 
 import io.crate.metadata.Functions;
 import io.crate.metadata.TableIdent;
-import org.elasticsearch.action.admin.indices.template.put.TransportPutIndexTemplateAction;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.inject.Provider;
 import org.elasticsearch.common.inject.Singleton;
 
 @Singleton
@@ -36,15 +34,12 @@ public class InternalDocTableInfoFactory implements DocTableInfoFactory {
 
     private final Functions functions;
     private final IndexNameExpressionResolver indexNameExpressionResolver;
-    private final Provider<TransportPutIndexTemplateAction> putIndexTemplateActionProvider;
 
     @Inject
     public InternalDocTableInfoFactory(Functions functions,
-                                       IndexNameExpressionResolver indexNameExpressionResolver,
-                                       Provider<TransportPutIndexTemplateAction> putIndexTemplateActionProvider) {
+                                       IndexNameExpressionResolver indexNameExpressionResolver) {
         this.functions = functions;
         this.indexNameExpressionResolver = indexNameExpressionResolver;
-        this.putIndexTemplateActionProvider = putIndexTemplateActionProvider;
     }
 
     @Override
@@ -55,7 +50,6 @@ public class InternalDocTableInfoFactory implements DocTableInfoFactory {
             ident,
             clusterService,
             indexNameExpressionResolver,
-            putIndexTemplateActionProvider.get(),
             checkAliasSchema
         );
         return builder.build();

--- a/sql/src/main/java/io/crate/plugin/SQLModule.java
+++ b/sql/src/main/java/io/crate/plugin/SQLModule.java
@@ -23,6 +23,7 @@ package io.crate.plugin;
 
 import io.crate.action.sql.DDLStatementDispatcher;
 import io.crate.action.sql.SQLOperations;
+import io.crate.executor.transport.TransportSchemaUpdateAction;
 import io.crate.metadata.FulltextAnalyzerResolver;
 import io.crate.operation.udf.TransportCreateUserDefinedFunctionAction;
 import io.crate.operation.udf.TransportDropUserDefinedFunctionAction;
@@ -49,6 +50,7 @@ public class SQLModule extends AbstractModule {
         bind(UserDefinedFunctionService.class).asEagerSingleton();
         bind(TransportCreateUserDefinedFunctionAction.class).asEagerSingleton();
         bind(TransportDropUserDefinedFunctionAction.class).asEagerSingleton();
+        bind(TransportSchemaUpdateAction.class).asEagerSingleton();
         bind(SslContextProvider.class).asEagerSingleton();
     }
 }

--- a/sql/src/test/java/io/crate/metadata/doc/DocTableInfoBuilderTest.java
+++ b/sql/src/test/java/io/crate/metadata/doc/DocTableInfoBuilderTest.java
@@ -30,7 +30,6 @@ import io.crate.metadata.TableIdent;
 import io.crate.test.integration.CrateUnitTest;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.Version;
-import org.elasticsearch.action.admin.indices.template.put.TransportPutIndexTemplateAction;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
@@ -49,8 +48,6 @@ import org.mockito.Mock;
 import java.util.Collections;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
-
-import static org.mockito.Mockito.mock;
 
 public class DocTableInfoBuilderTest extends CrateUnitTest {
 
@@ -111,7 +108,6 @@ public class DocTableInfoBuilderTest extends CrateUnitTest {
             new TableIdent(schemaName, "test"),
             clusterService,
             new IndexNameExpressionResolver(Settings.EMPTY),
-            mock(TransportPutIndexTemplateAction.class),
             false
         );
 


### PR DESCRIPTION
There was a window in which it was possible to create the same column
with different types in two or more partitons. Selecting from a
partitioned table with such partitions would then no longer be possible
as a column type must be consistent across partitons.

This fixes the race condition by updating the template synchronous on
the dynamic mapping update, similar how the partition/index is updated.

Note that due to serialization changes this can't be backported to 2.0.

This also only works for SQL. Inserts via ES API won't result in those mapping updates; but given that  other functionality (like generated columns) is also missing this should be okay.