### PR TITLE
HAVING clause is also aware of aliases

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -27,6 +27,9 @@ Changes
 Fixes
 =====
 
+ - Fixed an issue that caused statements with a ``HAVING`` clause to fail for 
+   fields aliased with the name of a real column.
+
  - Dropping an empty partitioned table did not drop related table privileges.
 
  - Implemented ``NOT NULL`` constraint validation for nested object columns,

--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -202,12 +202,13 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
 
         RelationAnalysisContext context = statementContext.currentRelationContext();
         FullQualifiedNameFieldProvider fieldProvider = new FullQualifiedNameFieldProvider(context.sources(), context.parentSources());
+        SubqueryAnalyzer subQueryAnalyzer = new SubqueryAnalyzer(this, statementContext);
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
             functions,
             statementContext.sessionContext(),
             statementContext.convertParamFunction(),
             fieldProvider,
-            new SubqueryAnalyzer(this, statementContext));
+            subQueryAnalyzer);
         ExpressionAnalysisContext expressionAnalysisContext = context.expressionAnalysisContext();
         Symbol querySymbol = expressionAnalyzer.generateQuerySymbol(node.getWhere(), expressionAnalysisContext);
         WhereClause whereClause = new WhereClause(querySymbol);
@@ -220,7 +221,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
             statementContext.sessionContext(),
             statementContext.convertParamFunction(),
             new SelectAnalysisFieldProvider(selectAnalysis, fieldProvider),
-            new SubqueryAnalyzer(this, statementContext));
+            subQueryAnalyzer);
 
         List<Symbol> groupBy = analyzeGroupBy(
             selectAnalysis,

--- a/sql/src/main/java/io/crate/analyze/relations/SelectAnalysisFieldProvider.java
+++ b/sql/src/main/java/io/crate/analyze/relations/SelectAnalysisFieldProvider.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.analyze.relations;
+
+import com.google.common.collect.Iterables;
+import io.crate.analyze.relations.select.SelectAnalysis;
+import io.crate.analyze.symbol.Symbol;
+import io.crate.exceptions.AmbiguousColumnAliasException;
+import io.crate.metadata.table.Operation;
+import io.crate.sql.tree.QualifiedName;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Field provider that takes into account the select analysis output map. If first tries to resolve the symbol given the
+ * provided {@link SelectAnalysis}, in case a symbol is not found it will return the symbol resolved by the delegate
+ * {@link FieldProvider}
+ */
+public class SelectAnalysisFieldProvider implements FieldProvider<Symbol> {
+
+    private final SelectAnalysis selectAnalysis;
+    private final FieldProvider<? extends Symbol> delegate;
+
+    public SelectAnalysisFieldProvider(SelectAnalysis selectAnalysis, FieldProvider<? extends Symbol> delegate) {
+        this.selectAnalysis = selectAnalysis;
+        this.delegate = delegate;
+    }
+
+    public Symbol resolveField(QualifiedName qualifiedName, Operation operation) {
+        return resolveField(qualifiedName, null, operation);
+    }
+
+    public Symbol resolveField(QualifiedName qualifiedName, @Nullable List<String> path, Operation operation) {
+        List<String> parts = qualifiedName.getParts();
+
+        if (parts.size() == 1) {
+            String element = Iterables.getOnlyElement(parts);
+            Collection<Symbol> symbols = selectAnalysis.outputMultiMap().get(element);
+            if (symbols.size() > 1) {
+                throw new AmbiguousColumnAliasException(element, symbols);
+            }
+            if (!symbols.isEmpty()) {
+                return symbols.iterator().next();
+            }
+        }
+
+        return delegate.resolveField(qualifiedName, path, operation);
+    }
+}

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -1569,6 +1569,16 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     }
 
     @Test
+    public void testGroupByHavingAliasForRealColumn() {
+        SelectAnalyzedStatement analysis = analyze(
+            "select id as name from users group by id, name having name != null;");
+
+        Optional<HavingClause> havingClause = analysis.relation().querySpec().having();
+        assertThat(havingClause.isPresent(), is(true));
+        assertThat(havingClause.get().query(), nullValue());
+    }
+
+    @Test
     public void testGroupByHavingByGroupKey() throws Exception {
         SelectAnalyzedStatement analysis = analyze(
             "select sum(floats), name from users group by name having name like 'Slartibart%'");


### PR DESCRIPTION
For fields in the group by statement we replace the aliases with the real column names. 
This fixes the `having` clause to do the same (the fields used in the `having` clause need to be part of the `group by` fields, so the fact that we didn't replace them caused the statements to fail with `Cannot use column x outside of an Aggregation in HAVING clause. Only GROUP BY keys allowed here.`)