### PR TITLE
Updated .travis.yml for using Fully-virtualized istead of Container-based machine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 jdk:
   - oraclejdk8
 
-sudo: false
+sudo: required
 env:
   global:
     - secure: "LLqhKxqgRMp/C/TzZWv8YuhpmEm1twggm76NBUAQfZmOPLCkQSpAO8hoBM3qaIlDPSKPgoYj9f0TBuNi0iIFghQf0Xc4pXPCV0AnoGpXwRGiJATTAXfnG7RBa/hXRRBeAKlGmAI9GLtIoCQbUKYhq8gqwbzQVQXq+90rhsMH4zo="


### PR DESCRIPTION
It seems that the travis host is killing jobs sometimes (sigkill with error 137) due to reaching some system limits. Switching to fully-virtualized should help to make the test runs more stable.
