### PR TITLE
Improve correlation detection in sub-queries

### DIFF
--- a/sql/src/main/java/io/crate/analyze/relations/ParentRelations.java
+++ b/sql/src/main/java/io/crate/analyze/relations/ParentRelations.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.analyze.relations;
+
+import io.crate.sql.tree.QualifiedName;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class ParentRelations {
+
+    public static final ParentRelations NO_PARENTS = new ParentRelations();
+
+    private final List<Map<QualifiedName, AnalyzedRelation>> sourcesTree;
+
+    private ParentRelations() {
+        sourcesTree = Collections.emptyList();
+    }
+
+    private ParentRelations(ArrayList<Map<QualifiedName, AnalyzedRelation>> sourcesTree) {
+        this.sourcesTree = sourcesTree;
+    }
+
+    public ParentRelations newLevel(Map<QualifiedName, AnalyzedRelation> sources) {
+        ArrayList<Map<QualifiedName, AnalyzedRelation>> newSourcesTree = new ArrayList<>(sourcesTree);
+        newSourcesTree.add(sources);
+        return new ParentRelations(newSourcesTree);
+    }
+
+    public boolean containsRelation(QualifiedName qualifiedName) {
+        for (int i = sourcesTree.size() - 1; i >= 0; i--) {
+            if (sourcesTree.get(i).containsKey(qualifiedName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalysisContext.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalysisContext.java
@@ -41,7 +41,7 @@ public class RelationAnalysisContext {
 
     private final ExpressionAnalysisContext expressionAnalysisContext;
     private final boolean aliasedRelation;
-    private final Map<QualifiedName, AnalyzedRelation> parentSources;
+    private final ParentRelations parents;
     // keep order of sources.
     //  e.g. something like:  select * from t1, t2 must not become select t2.*, t1.*
     private final Map<QualifiedName, AnalyzedRelation> sources = new LinkedHashMap<>();
@@ -49,9 +49,9 @@ public class RelationAnalysisContext {
     @Nullable
     private List<JoinPair> joinPairs;
 
-    RelationAnalysisContext(boolean aliasedRelation, Map<QualifiedName, AnalyzedRelation> parentSources) {
+    RelationAnalysisContext(boolean aliasedRelation, ParentRelations parents) {
         this.aliasedRelation = aliasedRelation;
-        this.parentSources = parentSources;
+        this.parents = parents;
         expressionAnalysisContext = new ExpressionAnalysisContext();
     }
 
@@ -119,7 +119,7 @@ public class RelationAnalysisContext {
         return expressionAnalysisContext;
     }
 
-    public Map<QualifiedName,AnalyzedRelation> parentSources() {
-        return parentSources;
+    public ParentRelations parentSources() {
+        return parents;
     }
 }

--- a/sql/src/main/java/io/crate/analyze/relations/StatementAnalysisContext.java
+++ b/sql/src/main/java/io/crate/analyze/relations/StatementAnalysisContext.java
@@ -26,12 +26,9 @@ import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.ParameterExpression;
-import io.crate.sql.tree.QualifiedName;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Function;
 
 public class StatementAnalysisContext {
@@ -65,13 +62,14 @@ public class StatementAnalysisContext {
     }
 
     RelationAnalysisContext startRelation(boolean aliasedRelation) {
-        Map<QualifiedName, AnalyzedRelation> parentSources;
+        ParentRelations parentRelations;
         if (lastRelationContextQueue.isEmpty()) {
-            parentSources = Collections.emptyMap();
+            parentRelations = ParentRelations.NO_PARENTS;
         } else {
-            parentSources = lastRelationContextQueue.get(lastRelationContextQueue.size() - 1).sources();
+            RelationAnalysisContext parentCtx = lastRelationContextQueue.get(lastRelationContextQueue.size() - 1);
+            parentRelations = parentCtx.parentSources().newLevel(parentCtx.sources());
         }
-        RelationAnalysisContext currentRelationContext = new RelationAnalysisContext(aliasedRelation, parentSources);
+        RelationAnalysisContext currentRelationContext = new RelationAnalysisContext(aliasedRelation, parentRelations);
         lastRelationContextQueue.add(currentRelationContext);
         return currentRelationContext;
     }

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -2206,9 +2206,23 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     }
 
     @Test
-    public void testSubSelectWithAcessToParentRelationThrowsUnsupportedFeature() throws Exception {
+    public void testSubSelectWithAccessToParentRelationThrowsUnsupportedFeature() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
         expectedException.expectMessage("Cannot use relation \"doc.t1\" in subquery. Correlated subqueries are not supported");
         analyze("select (select 1 from t1 as ti where ti.x = t1.x) from t1");
+    }
+
+    @Test
+    public void testSubSelectWithAccessToParentRelationAliasThrowsUnsupportedFeature() throws Exception {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("Cannot use relation \"tparent\" in subquery. Correlated subqueries are not supported");
+        analyze("select (select 1 from t1 where t1.x = tparent.x) from t1 as tparent");
+    }
+
+    @Test
+    public void testSubSelectWithAccessToGrandParentRelation() throws Exception {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("Cannot use relation \"grandparent\" in subquery. Correlated subqueries are not supported");
+        analyze("select (select (select 1 from t1 where grandparent.x = t1.x) from t1 as parent) from t1 as grandparent");
     }
 }

--- a/sql/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -29,6 +29,7 @@ import io.crate.action.sql.SessionContext;
 import io.crate.analyze.ParamTypeHints;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.FullQualifiedNameFieldProvider;
+import io.crate.analyze.relations.ParentRelations;
 import io.crate.analyze.relations.TableRelation;
 import io.crate.analyze.symbol.Field;
 import io.crate.analyze.symbol.Function;
@@ -98,7 +99,7 @@ public class ExpressionAnalyzerTest extends CrateUnitTest {
         expectedException.expectMessage("Unsupported expression current_time");
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
             functions, SessionContext.SYSTEM_SESSION, paramTypeHints,
-            new FullQualifiedNameFieldProvider(dummySources, Collections.emptyMap()),
+            new FullQualifiedNameFieldProvider(dummySources, ParentRelations.NO_PARENTS),
             null);
         ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext();
 
@@ -111,7 +112,7 @@ public class ExpressionAnalyzerTest extends CrateUnitTest {
             functions,
             new SessionContext(0, EnumSet.of(Option.ALLOW_QUOTED_SUBSCRIPT), null, null, s -> {}, t -> {}),
             paramTypeHints,
-            new FullQualifiedNameFieldProvider(dummySources, Collections.emptyMap()),
+            new FullQualifiedNameFieldProvider(dummySources, ParentRelations.NO_PARENTS),
             null);
         ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext();
 
@@ -149,7 +150,7 @@ public class ExpressionAnalyzerTest extends CrateUnitTest {
             functions,
             new SessionContext(0, EnumSet.of(Option.ALLOW_QUOTED_SUBSCRIPT), null, null, s -> {}, t -> {}),
             paramTypeHints,
-            new FullQualifiedNameFieldProvider(dummySources, Collections.emptyMap()),
+            new FullQualifiedNameFieldProvider(dummySources, ParentRelations.NO_PARENTS),
             null);
         ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext();
         FunctionCall subscriptFunctionCall = new FunctionCall(
@@ -179,7 +180,7 @@ public class ExpressionAnalyzerTest extends CrateUnitTest {
             functions,
             SessionContext.SYSTEM_SESSION,
             paramTypeHints,
-            new FullQualifiedNameFieldProvider(sources, Collections.emptyMap()),
+            new FullQualifiedNameFieldProvider(sources, ParentRelations.NO_PARENTS),
             null
         );
         Function andFunction = (Function) expressionAnalyzer.convert(

--- a/sql/src/test/java/io/crate/analyze/relations/FieldProviderTest.java
+++ b/sql/src/test/java/io/crate/analyze/relations/FieldProviderTest.java
@@ -33,7 +33,6 @@ import io.crate.testing.DummyRelation;
 import org.junit.Test;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -51,7 +50,7 @@ public class FieldProviderTest extends CrateUnitTest {
     }
 
     private static FullQualifiedNameFieldProvider newFQFieldProvider(Map<QualifiedName, AnalyzedRelation> sources) {
-        return new FullQualifiedNameFieldProvider(sources, Collections.emptyMap());
+        return new FullQualifiedNameFieldProvider(sources, ParentRelations.NO_PARENTS);
     }
 
     @Test

--- a/sql/src/test/java/io/crate/testing/SqlExpressions.java
+++ b/sql/src/test/java/io/crate/testing/SqlExpressions.java
@@ -31,6 +31,7 @@ import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.FieldResolver;
 import io.crate.analyze.relations.FullQualifiedNameFieldProvider;
+import io.crate.analyze.relations.ParentRelations;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.data.Row;
 import io.crate.data.RowN;
@@ -104,7 +105,7 @@ public class SqlExpressions {
             parameters == null
                 ? ParamTypeHints.EMPTY
                 : new ParameterContext(new RowN(parameters), Collections.<Row>emptyList()),
-            new FullQualifiedNameFieldProvider(sources, Collections.emptyMap()),
+            new FullQualifiedNameFieldProvider(sources, ParentRelations.NO_PARENTS),
             null
         );
         normalizer = new EvaluatingNormalizer(


### PR DESCRIPTION
If a sub-query contained an alias of a parent relation, or if it
contained an ancestor further away than just one level, the "correlated
sub-query" detection didn't work and a user would get a "unknown
relation" error instead of the more accurate "correlated sub-queries are
not supported" error.