### PR TITLE
makes opening/closing a partitioned table atomic

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -27,6 +27,8 @@ Changes
 Fixes
 =====
 
+ - Opening or closing a complete partitioned table is an atomic operation now.
+
  - Improved user privileges matching to constant time complexity.
 
  - Improved the error message if an invalid table column reference is used in

--- a/sql/src/main/java/io/crate/executor/transport/TransportExecutorModule.java
+++ b/sql/src/main/java/io/crate/executor/transport/TransportExecutorModule.java
@@ -24,6 +24,7 @@ package io.crate.executor.transport;
 import io.crate.action.job.ContextPreparer;
 import io.crate.action.job.TransportJobAction;
 import io.crate.executor.Executor;
+import io.crate.executor.transport.ddl.TransportOpenCloseTableOrPartitionAction;
 import io.crate.executor.transport.ddl.TransportRenameTableAction;
 import io.crate.executor.transport.distributed.TransportDistributedResultAction;
 import io.crate.executor.transport.kill.TransportKillAllNodeAction;
@@ -49,5 +50,6 @@ public class TransportExecutorModule extends AbstractModule {
         bind(TransportKillJobsNodeAction.class).asEagerSingleton();
         bind(TransportNodeStatsAction.class).asEagerSingleton();
         bind(TransportRenameTableAction.class).asEagerSingleton();
+        bind(TransportOpenCloseTableOrPartitionAction.class).asEagerSingleton();
     }
 }

--- a/sql/src/main/java/io/crate/executor/transport/ddl/OpenCloseTableOrPartitionRequest.java
+++ b/sql/src/main/java/io/crate/executor/transport/ddl/OpenCloseTableOrPartitionRequest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.executor.transport.ddl;
+
+import io.crate.metadata.TableIdent;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+
+import static org.elasticsearch.action.ValidateActions.addValidationError;
+
+public class OpenCloseTableOrPartitionRequest extends AcknowledgedRequest<OpenCloseTableOrPartitionRequest> {
+
+    private TableIdent tableIdent;
+    @Nullable
+    private String partitionIndexName;
+    private boolean openTable = false;
+
+    OpenCloseTableOrPartitionRequest() {
+    }
+
+    public OpenCloseTableOrPartitionRequest(TableIdent tableIdent,
+                                            @Nullable String partitionIndexName,
+                                            boolean openTable) {
+        this.tableIdent = tableIdent;
+        this.partitionIndexName = partitionIndexName;
+        this.openTable = openTable;
+    }
+
+    public TableIdent tableIdent() {
+        return tableIdent;
+    }
+
+    @Nullable
+    public String partitionIndexName() {
+        return partitionIndexName;
+    }
+
+    boolean isOpenTable() {
+        return openTable;
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        ActionRequestValidationException validationException = null;
+        if (tableIdent == null) {
+            validationException = addValidationError("table ident must not be null", null);
+        }
+        return validationException;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        readTimeout(in);
+        tableIdent = new TableIdent(in);
+        partitionIndexName = in.readOptionalString();
+        openTable = in.readBoolean();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        writeTimeout(out);
+        tableIdent.writeTo(out);
+        out.writeOptionalString(partitionIndexName);
+        out.writeBoolean(openTable);
+    }
+}

--- a/sql/src/main/java/io/crate/executor/transport/ddl/OpenCloseTableOrPartitionResponse.java
+++ b/sql/src/main/java/io/crate/executor/transport/ddl/OpenCloseTableOrPartitionResponse.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.executor.transport.ddl;
+
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+public class OpenCloseTableOrPartitionResponse extends AcknowledgedResponse {
+
+    OpenCloseTableOrPartitionResponse() {
+    }
+
+    OpenCloseTableOrPartitionResponse(boolean acknowledged) {
+        super(acknowledged);
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        readAcknowledged(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        writeAcknowledged(out);
+    }
+}

--- a/sql/src/main/java/io/crate/executor/transport/ddl/TransportOpenCloseTableOrPartitionAction.java
+++ b/sql/src/main/java/io/crate/executor/transport/ddl/TransportOpenCloseTableOrPartitionAction.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.executor.transport.ddl;
+
+import io.crate.metadata.cluster.ClusterStateTableOperations;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
+import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+@Singleton
+public class TransportOpenCloseTableOrPartitionAction extends TransportMasterNodeAction<OpenCloseTableOrPartitionRequest, OpenCloseTableOrPartitionResponse> {
+
+    private static final IndicesOptions STRICT_INDICES_OPTIONS = IndicesOptions.fromOptions(false, false, false, false);
+    private static final String ACTION_NAME = "crate/sql/table_or_partition/open_close";
+
+    private final ClusterStateTableOperations tableOperations;
+
+    @Inject
+    public TransportOpenCloseTableOrPartitionAction(Settings settings,
+                                                    TransportService transportService,
+                                                    ClusterService clusterService,
+                                                    ThreadPool threadPool,
+                                                    ActionFilters actionFilters,
+                                                    IndexNameExpressionResolver indexNameExpressionResolver,
+                                                    ClusterStateTableOperations tableOperations) {
+        super(settings, ACTION_NAME, transportService, clusterService, threadPool, actionFilters,
+            indexNameExpressionResolver, OpenCloseTableOrPartitionRequest::new);
+        this.tableOperations = tableOperations;
+    }
+
+
+    @Override
+    protected String executor() {
+        // no need to use a thread pool, we go async right away
+        return ThreadPool.Names.SAME;
+    }
+
+    @Override
+    protected OpenCloseTableOrPartitionResponse newResponse() {
+        return new OpenCloseTableOrPartitionResponse();
+    }
+
+    @Override
+    protected void masterOperation(OpenCloseTableOrPartitionRequest request,
+                                   ClusterState state,
+                                   ActionListener<OpenCloseTableOrPartitionResponse> listener) throws Exception {
+        String source = "open-close-table-or-partition " + request.tableIdent() + ", open: " + request.isOpenTable();
+        clusterService.submitStateUpdateTask(source,
+            new AckedClusterStateUpdateTask<OpenCloseTableOrPartitionResponse>(Priority.URGENT, request, listener) {
+                @Override
+                protected OpenCloseTableOrPartitionResponse newResponse(boolean acknowledged) {
+                    return new OpenCloseTableOrPartitionResponse(acknowledged);
+                }
+
+                @Override
+                public ClusterState execute(ClusterState currentState) throws Exception {
+                    if (request.isOpenTable()) {
+                        return tableOperations.openTableOrPartition(currentState, request.tableIdent(),
+                            request.partitionIndexName());
+                    }
+                    return tableOperations.closeTableOrPartition(currentState, request.tableIdent(),
+                        request.partitionIndexName());
+                }
+            });
+    }
+
+    @Override
+    protected ClusterBlockException checkBlock(OpenCloseTableOrPartitionRequest request, ClusterState state) {
+        return state.blocks().indicesBlockedException(ClusterBlockLevel.METADATA_WRITE,
+            indexNameExpressionResolver.concreteIndexNames(state, STRICT_INDICES_OPTIONS, request.tableIdent().indexName()));
+    }
+}

--- a/sql/src/main/java/io/crate/metadata/TableIdent.java
+++ b/sql/src/main/java/io/crate/metadata/TableIdent.java
@@ -33,13 +33,14 @@ import io.crate.sql.tree.QualifiedName;
 import io.crate.sql.tree.Table;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 
-public class TableIdent {
+public class TableIdent implements Writeable {
 
     private static final Set<String> INVALID_TABLE_NAME_CHARACTERS = ImmutableSet.of(".");
     private static final Splitter SPLITTER = Splitter.on(".").limit(6);
@@ -173,6 +174,7 @@ public class TableIdent {
         return fqn();
     }
 
+    @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(schema);
         out.writeString(name);

--- a/sql/src/main/java/io/crate/metadata/cluster/ClusterStateTableOperations.java
+++ b/sql/src/main/java/io/crate/metadata/cluster/ClusterStateTableOperations.java
@@ -1,0 +1,267 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.cluster;
+
+import io.crate.Constants;
+import io.crate.executor.transport.AlterTableOperation;
+import io.crate.metadata.PartitionName;
+import io.crate.metadata.TableIdent;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlocks;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.cluster.metadata.MetaDataIndexUpgradeService;
+import org.elasticsearch.cluster.routing.RoutingTable;
+import org.elasticsearch.cluster.routing.allocation.AllocationService;
+import org.elasticsearch.common.collect.MapBuilder;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.snapshots.RestoreService;
+import org.elasticsearch.snapshots.SnapshotsService;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.elasticsearch.cluster.metadata.MetaDataIndexStateService.INDEX_CLOSED_BLOCK;
+
+@Singleton
+public class ClusterStateTableOperations {
+
+    private final Logger logger;
+    private final AllocationService allocationService;
+    private final MetaDataIndexUpgradeService metaDataIndexUpgradeService;
+    private final IndicesService indicesService;
+    private final IndexNameExpressionResolver indexNameExpressionResolver;
+
+    @Inject
+    public ClusterStateTableOperations(Settings settings,
+                                       AllocationService allocationService,
+                                       MetaDataIndexUpgradeService metaDataIndexUpgradeService,
+                                       IndicesService indexServices,
+                                       IndexNameExpressionResolver indexNameExpressionResolver) {
+        this.allocationService = allocationService;
+        this.metaDataIndexUpgradeService = metaDataIndexUpgradeService;
+        this.indicesService = indexServices;
+        this.indexNameExpressionResolver = indexNameExpressionResolver;
+        logger = Loggers.getLogger(getClass(), settings);
+    }
+
+    public ClusterState closeTableOrPartition(ClusterState currentState,
+                                              TableIdent tableIdent,
+                                              @Nullable String partitionIndexName) {
+        MetaData metaData = currentState.metaData();
+        String indexToResolve = partitionIndexName != null ? partitionIndexName : tableIdent.indexName();
+        String[] concreteIndices = indexNameExpressionResolver.concreteIndexNames(
+            currentState, IndicesOptions.lenientExpandOpen(), indexToResolve);
+        Set<IndexMetaData> indicesToClose = indexMetaDataSetFromIndexNames(metaData, concreteIndices, IndexMetaData.State.CLOSE);
+        IndexTemplateMetaData indexTemplateMetaData = null;
+        if (partitionIndexName == null) {
+            indexTemplateMetaData = templateMetaData(metaData, tableIdent);
+        }
+
+        if (indicesToClose.isEmpty() && indexTemplateMetaData == null) {
+            return currentState;
+        }
+
+        RestoreService.checkIndexClosing(currentState, indicesToClose);
+        // Check if index closing conflicts with any running snapshots
+        SnapshotsService.checkIndexClosing(currentState, indicesToClose);
+
+        if (logger.isInfoEnabled()) {
+            if (partitionIndexName != null) {
+                logger.info("closing partition [{}] of table [{}]", partitionIndexName, tableIdent.fqn());
+            } else if (concreteIndices.length > 1) {
+                logger.info("closing partitioned table [{}] including all partitions", tableIdent.fqn());
+            } else {
+                logger.info("closing table [{}]", tableIdent.fqn());
+            }
+        }
+
+        MetaData.Builder mdBuilder = MetaData.builder(currentState.metaData());
+        ClusterBlocks.Builder blocksBuilder = ClusterBlocks.builder()
+            .blocks(currentState.blocks());
+        for (IndexMetaData openIndexMetadata : indicesToClose) {
+            final String indexName = openIndexMetadata.getIndex().getName();
+            mdBuilder.put(IndexMetaData.builder(openIndexMetadata).state(IndexMetaData.State.CLOSE));
+            blocksBuilder.addIndexBlock(indexName, INDEX_CLOSED_BLOCK);
+        }
+
+        // update possible partitioned table template
+        if (indexTemplateMetaData != null) {
+            mdBuilder.put(updateOpenCloseOnPartitionTemplate(indexTemplateMetaData, false));
+        }
+
+        ClusterState updatedState = ClusterState.builder(currentState).metaData(mdBuilder).blocks(blocksBuilder).build();
+
+        RoutingTable.Builder rtBuilder = RoutingTable.builder(currentState.routingTable());
+        for (IndexMetaData index : indicesToClose) {
+            rtBuilder.remove(index.getIndex().getName());
+        }
+
+        //no explicit wait for other nodes needed as we use AckedClusterStateUpdateTask
+        return allocationService.reroute(
+            ClusterState.builder(updatedState).routingTable(rtBuilder.build()).build(),
+            "indices closed " + indicesToClose);
+    }
+
+    public ClusterState openTableOrPartition(ClusterState currentState,
+                                             TableIdent tableIdent,
+                                             @Nullable String partitionIndexName) {
+        MetaData metaData = currentState.metaData();
+        String indexToResolve = partitionIndexName != null ? partitionIndexName : tableIdent.indexName();
+        String[] concreteIndices = indexNameExpressionResolver.concreteIndexNames(
+            currentState, IndicesOptions.lenientExpandOpen(), indexToResolve);
+        Set<IndexMetaData> indicesToOpen = indexMetaDataSetFromIndexNames(metaData, concreteIndices, IndexMetaData.State.OPEN);
+        IndexTemplateMetaData indexTemplateMetaData = null;
+        if (partitionIndexName == null) {
+            indexTemplateMetaData = templateMetaData(metaData, tableIdent);
+        }
+
+        if (indicesToOpen.isEmpty() && indexTemplateMetaData == null) {
+            return currentState;
+        }
+
+        if (logger.isInfoEnabled()) {
+            if (partitionIndexName != null) {
+                logger.info("opening partition [{}] of table [{}]", partitionIndexName, tableIdent.fqn());
+            } else if (concreteIndices.length > 1) {
+                logger.info("opening partitioned table [{}] including all partitions", tableIdent.fqn());
+            } else {
+                logger.info("opening table [{}]", tableIdent.fqn());
+            }
+        }
+
+        MetaData.Builder mdBuilder = MetaData.builder(currentState.metaData());
+        ClusterBlocks.Builder blocksBuilder = ClusterBlocks.builder()
+            .blocks(currentState.blocks());
+        final Version minIndexCompatibilityVersion = currentState.getNodes().getMaxNodeVersion()
+            .minimumIndexCompatibilityVersion();
+        for (IndexMetaData closedMetaData : indicesToOpen) {
+            final String indexName = closedMetaData.getIndex().getName();
+            IndexMetaData indexMetaData = IndexMetaData.builder(closedMetaData).state(IndexMetaData.State.OPEN).build();
+            // The index might be closed because we couldn't import it due to old incompatible version
+            // We need to check that this index can be upgraded to the current version
+            indexMetaData = metaDataIndexUpgradeService.upgradeIndexMetaData(indexMetaData, minIndexCompatibilityVersion);
+            try {
+                indicesService.verifyIndexMetadata(indexMetaData, indexMetaData);
+            } catch (Exception e) {
+                throw new ElasticsearchException("Failed to verify index " + indexMetaData.getIndex(), e);
+            }
+
+            mdBuilder.put(indexMetaData, true);
+            blocksBuilder.removeIndexBlock(indexName, INDEX_CLOSED_BLOCK);
+        }
+
+        // update possible partitioned table template
+        if (indexTemplateMetaData != null) {
+            mdBuilder.put(updateOpenCloseOnPartitionTemplate(indexTemplateMetaData, true));
+        }
+
+        ClusterState updatedState = ClusterState.builder(currentState).metaData(mdBuilder).blocks(blocksBuilder).build();
+
+        RoutingTable.Builder rtBuilder = RoutingTable.builder(updatedState.routingTable());
+        for (IndexMetaData index : indicesToOpen) {
+            rtBuilder.addAsFromCloseToOpen(updatedState.metaData().getIndexSafe(index.getIndex()));
+        }
+
+        //no explicit wait for other nodes needed as we use AckedClusterStateUpdateTask
+        return allocationService.reroute(
+            ClusterState.builder(updatedState).routingTable(rtBuilder.build()).build(),
+            "indices opened " + indicesToOpen);
+    }
+
+    private static IndexTemplateMetaData updateOpenCloseOnPartitionTemplate(IndexTemplateMetaData indexTemplateMetaData,
+                                                                            boolean openTable) {
+        Map<String, Object> metaMap = Collections.singletonMap("_meta", Collections.singletonMap("closed", true));
+        if (openTable) {
+            //Remove the mapping from the template.
+            return updateTemplate(indexTemplateMetaData, Collections.emptyMap(), metaMap, Settings.EMPTY);
+        } else {
+            //Otherwise, add the mapping to the template.
+            return updateTemplate(indexTemplateMetaData, metaMap, Collections.emptyMap(), Settings.EMPTY);
+        }
+    }
+
+    private static IndexTemplateMetaData updateTemplate(IndexTemplateMetaData indexTemplateMetaData,
+                                                        Map<String, Object> newMappings,
+                                                        Map<String, Object> mappingsToRemove,
+                                                        Settings newSettings) {
+
+        // merge mappings
+        Map<String, Object> mapping = AlterTableOperation.mergeTemplateMapping(indexTemplateMetaData, newMappings);
+
+        // remove mappings
+        mapping = AlterTableOperation.removeFromMapping(mapping, mappingsToRemove);
+
+        // merge settings
+        Settings.Builder settingsBuilder = Settings.builder();
+        settingsBuilder.put(indexTemplateMetaData.settings());
+        settingsBuilder.put(newSettings);
+
+        // wrap it in a type map if its not
+        if (mapping.size() != 1 || mapping.containsKey(Constants.DEFAULT_MAPPING_TYPE) == false) {
+            mapping = MapBuilder.<String, Object>newMapBuilder().put(Constants.DEFAULT_MAPPING_TYPE, mapping).map();
+        }
+        try {
+            return new IndexTemplateMetaData.Builder(indexTemplateMetaData)
+                .settings(settingsBuilder)
+                .putMapping(Constants.DEFAULT_MAPPING_TYPE, XContentFactory.jsonBuilder().map(mapping).string())
+                .build();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Set<IndexMetaData> indexMetaDataSetFromIndexNames(MetaData metaData,
+                                                                     String[] indices,
+                                                                     IndexMetaData.State state) {
+        Set<IndexMetaData> indicesMetaData = new HashSet<>();
+        for (String indexName : indices) {
+            IndexMetaData indexMetaData = metaData.index(indexName);
+            if (indexMetaData != null && indexMetaData.getState() != state) {
+                indicesMetaData.add(indexMetaData);
+            }
+        }
+        return indicesMetaData;
+    }
+
+    @Nullable
+    private static IndexTemplateMetaData templateMetaData(MetaData metaData, TableIdent tableIdent) {
+        String templateName = PartitionName.templateName(tableIdent.schema(), tableIdent.name());
+        return metaData.templates().get(templateName);
+    }
+}


### PR DESCRIPTION
Opening/Closing a complete partitioned table results in:
- opening/closing all partitions
- adding a flag at the partitioned table template so prevent write ops
This was done by using two separate actions and so it wasn’t atomic.
Now both cluster state changes are done at once making the while
operation atomic.