### PR TITLE
Bump version to 2.2.0-snapshot

### DIFF
--- a/core/src/main/java/io/crate/Version.java
+++ b/core/src/main/java/io/crate/Version.java
@@ -41,7 +41,7 @@ public class Version {
 
 
     public static final boolean SNAPSHOT = true;
-    public static final Version CURRENT = new Version(2010199, SNAPSHOT, org.elasticsearch.Version.V_5_2_2_UNRELEASED);
+    public static final Version CURRENT = new Version(2020099, SNAPSHOT, org.elasticsearch.Version.V_5_2_2_UNRELEASED);
 
     static {
         // safe-guard that we don't release a version with DEBUG_MODE set to true


### PR DESCRIPTION
Release branch 2.1 has been created as well out of the current master: https://github.com/crate/crate/tree/2.1