### PR TITLE
Update bootstrap configration for Windows hosts

### DIFF
--- a/app/src/bin/crate.bat
+++ b/app/src/bin/crate.bat
@@ -53,6 +53,12 @@ REM JAVA_OPTS=%JAVA_OPTS% -XX:+PrintTenuringDistribution
 REM JAVA_OPTS=%JAVA_OPTS% -XX:+PrintGCApplicationStoppedTime
 REM JAVA_OPTS=%JAVA_OPTS% -Xloggc:/var/log/crate/gc.log
 
+REM Disables explicit GC
+set JAVA_OPTS=%JAVA_OPTS% -XX:+DisableExplicitGC
+
+REM Use our provided JNA always versus the system one
+set JAVA_OPTS=%JAVA_OPTS% -Djna.nosys=true
+
 REM Ensure UTF-8 encoding by default (e.g. filenames)
 set JAVA_OPTS=%JAVA_OPTS% -Dfile.encoding=UTF-8
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,6 @@ build_script:
 - cmd: >-
     git submodule update --init -- es/upstream
 
-    gradlew.bat compileJava
+    gradlew.bat --quiet compileJava
 test_script:
 - cmd: gradlew.bat :sql:test

--- a/gradle/version.properties
+++ b/gradle/version.properties
@@ -29,7 +29,7 @@ jackson=2.8.6
 log4j=1.2.7
 log4j2=2.8.2
 slf4j=1.6.2
-jna=4.4.0
+jna=4.2.2
 
 # ES test
 randomizedrunner=2.5.0


### PR DESCRIPTION
- [x] update the JVM parameters of the Windows bat script to reflect the same state than in the unix shell script
- [x] downgraded the version of JNA (Java Native Library) to be compatible with the version installed on Appveyor. The current version of JNA `4.4.0` resulted in a version incompatibility and causes the test process to fail.