### PR TITLE
fixes setting `write.wait_for_active_shards` on a parted table

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -41,6 +41,9 @@ Changes
 Fixes
 =====
 
+ - Fixed support for setting ``write.wait_for_active_shards`` on a partitioned
+   table.
+
  - Added missing documentation about the default value of the table setting
    ``write.wait_for_active_shards``.
 

--- a/sql/src/main/java/io/crate/analyze/PartitionedTableParameterInfo.java
+++ b/sql/src/main/java/io/crate/analyze/PartitionedTableParameterInfo.java
@@ -47,6 +47,7 @@ public class PartitionedTableParameterInfo extends TableParameterInfo {
             .add(MAPPING_TOTAL_FIELDS_LIMIT)
             .add(RECOVERY_INITIAL_SHARDS)
             .add(WARMER_ENABLED)
+            .add(SETTING_WAIT_FOR_ACTIVE_SHARDS)
             .build();
 
     private static final TableParameterInfo PARTITION_TABLE_PARAMETER_INFO = new TablePartitionParameterInfo();

--- a/sql/src/test/java/io/crate/analyze/CreateAlterPartitionedTableAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateAlterPartitionedTableAnalyzerTest.java
@@ -333,4 +333,14 @@ public class CreateAlterPartitionedTableAnalyzerTest extends CrateDummyClusterSe
         expectedException.expectMessage("Cannot use column shape of type geo_shape in PARTITIONED BY clause");
         e.analyze("create table shaped (id int, shape geo_shape) partitioned by (shape)");
     }
+
+    @Test
+    public void testAlterTableWithWaitForActiveShards() throws Exception {
+        AlterTableAnalyzedStatement analyzedStatement = e.analyze("ALTER TABLE parted " +
+                                                                  "SET (\"write.wait_for_active_shards\"=1)");
+        assertThat(analyzedStatement.tableParameter().settings().get(TableParameterInfo.SETTING_WAIT_FOR_ACTIVE_SHARDS), is("1"));
+
+        analyzedStatement = e.analyze("ALTER TABLE parted RESET (\"write.wait_for_active_shards\")");
+        assertThat(analyzedStatement.tableParameter().settings().get(TableParameterInfo.SETTING_WAIT_FOR_ACTIVE_SHARDS), is("all"));
+    }
 }


### PR DESCRIPTION
setting was not included in the allowed setting list of partitioned tables
addresses: https://github.com/crate/crate/issues/6038