### PR TITLE
allow negate undefined data type

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -41,6 +41,8 @@ Changes
 Fixes
 =====
 
+ - Fixed support for negate on null in conditional expression.
+
  - Fixed support for setting ``write.wait_for_active_shards`` on a partitioned
    table.
 

--- a/sql/src/main/java/io/crate/operation/scalar/arithmetic/NegateFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/arithmetic/NegateFunction.java
@@ -96,6 +96,9 @@ public abstract class NegateFunction<TOut, TIn> extends Scalar<TOut, TIn> {
             case LongType.ID:
                 info = NegateLong.INFO;
                 break;
+            case UndefinedType.ID:
+                info = NegateLong.INFO;
+                break;
             default:
                 throw new IllegalArgumentException("Cannot negate values of type " + argument.valueType().getName());
         }

--- a/sql/src/test/java/io/crate/operation/scalar/arithmetic/NegateFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/arithmetic/NegateFunctionTest.java
@@ -55,4 +55,9 @@ public class NegateFunctionTest extends AbstractScalarFunctionsTest {
     public void testNegateDouble() throws Exception {
         assertEvaluate("- cast(age as double)", -4.2d, Literal.of(4.2d));
     }
+
+    @Test
+    public void testNegateUndefinedType() throws Exception {
+        assertEvaluate("- - (case 3 when 1 then 1 else Null end) + 1 ", null);
+    }
 }


### PR DESCRIPTION
negate fails for null in a conditional expression because it's returned as an undefinedType