### PR TITLE
Format expressions of type ArrayComparisonExpression properly

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -41,6 +41,9 @@ Changes
 Fixes
 =====
 
+ - Fixed an issue which caused an exception if ``EXPLAIN`` is used on a
+   statement that uses the ``ANY (array_expression)`` operator.
+
  - Allow support of conditional expression with different return types that can
    be converted to a single return type.
 

--- a/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
+++ b/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
@@ -64,6 +64,18 @@ public final class ExpressionFormatter {
         }
 
         @Override
+        public String visitArrayComparisonExpression(ArrayComparisonExpression node, Void context) {
+            StringBuilder builder = new StringBuilder();
+
+            String array = node.getRight().toString();
+            String left = node.getLeft().toString();
+            String type = node.getType().getValue();
+
+            builder.append(left + " " + type + " ANY(" + array + ")");
+            return builder.toString();
+        }
+
+        @Override
         protected String visitCurrentTime(CurrentTime node, Void context) {
             StringBuilder builder = new StringBuilder();
             switch (node.getType()) {

--- a/sql/src/test/java/io/crate/analyze/ExplainAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/ExplainAnalyzerTest.java
@@ -49,6 +49,14 @@ public class ExplainAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
+    public void testExplainArrayComparison() throws Exception {
+        ExplainAnalyzedStatement stmt = e.analyze("explain SELECT id from sys.cluster where id = any([1,2,3])");
+        assertNotNull(stmt.statement());
+        assertThat(stmt.statement(), instanceOf(SelectAnalyzedStatement.class));
+        assertThat(stmt.fields(), Matchers.contains(isField("EXPLAIN SELECT \"id\"\nFROM \"sys\".\"cluster\"\nWHERE \"id\" = ANY([1,2,3])\n")));
+    }
+
+    @Test
     public void testExplainCopyFrom() throws Exception {
         ExplainAnalyzedStatement stmt = e.analyze("explain copy users from '/tmp/*' WITH (shared=True)");
         assertThat(stmt.statement(), instanceOf(CopyFromAnalyzedStatement.class));


### PR DESCRIPTION
ArrayComparisonExpression

```sql
x = ANY ([1,2,3])
```