### PR TITLE
made error message for both bin/crate and java code consistent

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -27,6 +27,10 @@ Breaking Changes
 Changes
 =======
 
+ - Made the help messages of ``bin/crate`` and the Java code consistent. This
+   change also removes the undocumented ``-E`` command line option which makes
+   ``-C`` the only valid option for passing settings to CrateDB.
+
  - Changed the Enterprise License missing check message, as well as lowering
    the severity from HIGH to LOW.
 

--- a/app/src/main/dist/bin/crate
+++ b/app/src/main/dist/bin/crate
@@ -113,10 +113,10 @@ launch_service()
     pidpath=$1
     daemonized=$2
     javaProperties=$3
-    props="-Epath.home=$CRATE_HOME $4"
+    props="-Cpath.home=$CRATE_HOME $4"
 
     if [ "x$pidpath" != "x" ]; then
-        props="-Epidfile=$pidpath $props"
+        props="-Cpidfile=$pidpath $props"
     fi
 
     if [ "x$daemonized" = "x" ]; then
@@ -160,16 +160,17 @@ while true; do
             shift
         ;;
         -h)
-            echo "Crate is a shared nothing, fully searchable document oriented cluster datastore."
+            echo "CrateDB is a shared nothing, fully searchable document oriented cluster datastore."
             echo ""
             echo "  Usage: $(basename $0) [OPTION]..."
-            echo "         starts a new Crate database instance"
+            echo "         starts a new CrateDB instance"
             echo ""
             echo "General options:"
             echo "  -d            start the daemon in the background"
             echo "  -h            print usage information"
             echo "  -p <pidfile>  log the pid to a file"
             echo "  -v            print version information"
+            echo "  -C            set a CrateDB setting"
             echo "  -D            set a java system property value"
             echo "  -X            set a nonstandard java option"
             exit 0
@@ -179,7 +180,7 @@ while true; do
             shift 2
         ;;
         -C)
-            properties="$properties -E$2"
+            properties="$properties -C$2"
             shift 2
         ;;
         -X)

--- a/app/src/main/java/io/crate/bootstrap/CrateDB.java
+++ b/app/src/main/java/io/crate/bootstrap/CrateDB.java
@@ -53,7 +53,7 @@ public class CrateDB extends EnvironmentAwareCommand {
     private final OptionSpecBuilder quietOption;
 
     private CrateDB() {
-        super("starts CrateDB");
+        super("starts CrateDB", "C");
         versionOption = parser.acceptsAll(Arrays.asList("V", "version"),
             "Prints CrateDB version information and exits");
         daemonizeOption = parser.acceptsAll(Arrays.asList("d", "daemonize"),


### PR DESCRIPTION
removed rewrite from -C command line option to `-E`
but instead pass the option name to EnvironmentAwareCommand super class

see https://github.com/crate/elasticsearch/pull/127