### PR TITLE
Allow subqueries in ANY expressions 

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -34,7 +34,7 @@ Changes
  - Changed the Enterprise License missing check message, as well as lowering
    the severity from HIGH to LOW.
    
-  - Introduce support for single row subselects in ANY, e.g.::
+  - Introduce support for single column subselects in ANY, e.g.::
 
       Select id from t where id = ANY(Select id from t2)
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -33,6 +33,10 @@ Changes
 
  - Changed the Enterprise License missing check message, as well as lowering
    the severity from HIGH to LOW.
+   
+  - Introduce support for single row subselects in ANY, e.g.::
+
+      Select id from t where id = ANY(Select id from t2)
 
  - Added a warning message to the log if the Unofficial Elasticsearch HTTP
    REST API is enabled via ``es.api.enabled`` setting.

--- a/core/src/main/java/io/crate/types/CollectionType.java
+++ b/core/src/main/java/io/crate/types/CollectionType.java
@@ -21,6 +21,9 @@
 
 package io.crate.types;
 
+/**
+ * A type which contains elements of another type.
+ */
 public interface CollectionType {
 
     DataType<?> innerType();

--- a/core/src/main/java/io/crate/types/DataTypes.java
+++ b/core/src/main/java/io/crate/types/DataTypes.java
@@ -69,7 +69,6 @@ public final class DataTypes {
     public final static DataType DOUBLE_ARRAY = new ArrayType(DOUBLE);
     public final static DataType OBJECT_ARRAY = new ArrayType(OBJECT);
 
-
     public final static ImmutableList<DataType> PRIMITIVE_TYPES = ImmutableList.of(
         BYTE,
         BOOLEAN,
@@ -112,7 +111,9 @@ public final class DataTypes {
         .put(GeoPointType.ID, GEO_POINT)
         .put(GeoShapeType.ID, GEO_SHAPE)
         .put(ArrayType.ID, ArrayType::new)
-        .put(SetType.ID, SetType::new).map();
+        .put(SetType.ID, SetType::new)
+        .put(TableType.ID, TableType::new)
+        .map();
 
 
     private static final Set<DataType> NUMBER_CONVERSIONS = ImmutableSet.<DataType>builder()
@@ -147,7 +148,7 @@ public final class DataTypes {
         .build();
 
     public static boolean isCollectionType(DataType type) {
-        return type.id() == ArrayType.ID || type.id() == SetType.ID;
+        return type.id() == ArrayType.ID || type.id() == SetType.ID || type.id() == TableType.ID;
     }
 
     public static DataType fromStream(StreamInput in) throws IOException {

--- a/core/src/main/java/io/crate/types/TableType.java
+++ b/core/src/main/java/io/crate/types/TableType.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.types;
+
+import io.crate.Streamer;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A type which represents a table retrieved by a subquery.
+ * May be used in an IN or ANY operation, e.g. select 1 where 1 = ANY(Select 1)
+ */
+public class TableType extends DataType<Collection> implements CollectionType, Streamer<Object> {
+
+    public static final int ID = 102;
+    private DataType<?> valueType;
+
+    public TableType(DataType<?> innerType) {
+        this.valueType = innerType;
+    }
+
+    TableType() {}
+
+    @Override
+    public int id() {
+        return ID;
+    }
+
+    @Override
+    public String getName() {
+        return valueType.getName() + "_table";
+    }
+
+    @Override
+    public Streamer<?> streamer() {
+        return this;
+    }
+
+    @Override
+    public Collection value(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Collection) {
+            return (Collection) value;
+        }
+        return Collections.singleton(valueType.value(value));
+    }
+
+    @Override
+    public boolean isConvertableTo(DataType other) {
+        return this.valueType.isConvertableTo(other) ||
+               (other != null && other instanceof CollectionType &&
+                ((CollectionType) other).innerType().isConvertableTo(this.valueType));
+    }
+
+    @Override
+    public int compareValueTo(Collection val1, Collection val2) {
+        if (val1 == val2 || (val1 != null && val1.equals(val2))) {
+            return 0;
+        }
+        return -1;
+    }
+
+    @Override
+    public int compareTo(Object o) {
+        if (!(o instanceof TableType)) {
+            return -1;
+        }
+        return Integer.compare(valueType.id(), ((TableType) o).valueType.id());
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        valueType = DataTypes.fromStream(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        DataTypes.toStream(valueType, out);
+    }
+
+    @Override
+    public Collection readValueFrom(StreamInput in) throws IOException {
+        if (valueType.id() == SetType.ID || valueType.id() == ArrayType.ID) {
+            return (Collection) valueType.streamer().readValueFrom(in);
+        }
+        int size = in.readVInt();
+        switch (size) {
+            case 0:
+                return Collections.EMPTY_LIST;
+            case 1:
+                return Collections.singletonList(valueType.streamer().readValueFrom(in));
+            default:
+                List<Object> list = new ArrayList<>(size);
+                for (int i = 0; i < size; i++) {
+                    list.add(valueType.streamer().readValueFrom(in));
+                }
+                return list;
+        }
+    }
+
+    @Override
+    public void writeValueTo(StreamOutput out, Object value) throws IOException {
+        if (value == null) {
+            out.writeVInt(0);
+            return;
+        }
+        if (valueType.id() == SetType.ID || valueType.id() == ArrayType.ID) {
+            valueType.streamer().writeValueTo(out, value);
+            return;
+        }
+        Collection collection = ((Collection) value);
+        int size = collection.size();
+        out.writeVInt(size);
+        for (Object obj : collection) {
+            valueType.streamer().writeValueTo(out, obj);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof TableType)) return false;
+        if (!super.equals(o)) return false;
+
+        TableType setType = (TableType) o;
+        return valueType.equals(setType.valueType);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + valueType.hashCode();
+        return result;
+    }
+
+    @Override
+    public DataType<?> innerType() {
+        if (valueType instanceof CollectionType){
+            return ((CollectionType) valueType).innerType();
+        }
+        return valueType;
+    }
+}

--- a/sql-parser/src/main/java/io/crate/sql/tree/SubqueryExpression.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/SubqueryExpression.java
@@ -25,12 +25,25 @@ public class SubqueryExpression
     extends Expression {
     private final Query query;
 
+    private boolean isArrayExpression;
+
     public SubqueryExpression(Query query) {
         this.query = query;
     }
 
     public Query getQuery() {
         return query;
+    }
+
+    /**
+     * Set to true to indicate this expressions will be used in an array operator
+     */
+    public void setArrayExpression() {
+        isArrayExpression = true;
+    }
+
+    public boolean isArrayExpression() {
+        return isArrayExpression;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -118,8 +118,8 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
 
     public AnalyzedRelation analyze(Node node, StatementAnalysisContext statementContext) {
         AnalyzedRelation relation = process(node, statementContext);
-        relation = SubselectRewriter.rewrite(relation);
-        return relationNormalizer.normalize(relation, statementContext.transactionContext());
+        AnalyzedRelation rewrittenRelation = SubselectRewriter.rewrite(relation);
+        return relationNormalizer.normalize(rewrittenRelation, statementContext.transactionContext());
     }
 
     public AnalyzedRelation analyzeUnbound(Query query, SessionContext sessionContext, ParamTypeHints paramTypeHints) {

--- a/sql/src/main/java/io/crate/analyze/symbol/Literal.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/Literal.java
@@ -7,6 +7,7 @@ import io.crate.types.ArrayType;
 import io.crate.types.CollectionType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+import io.crate.types.TableType;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;

--- a/sql/src/main/java/io/crate/executor/transport/SubSelectSymbolReplacer.java
+++ b/sql/src/main/java/io/crate/executor/transport/SubSelectSymbolReplacer.java
@@ -143,7 +143,7 @@ class SubSelectSymbolReplacer implements FutureCallback<Object> {
         @Override
         public Symbol visitSelectSymbol(SelectSymbol selectSymbol, Void context) {
             if (selectSymbol == selectSymbolToReplace) {
-                return Literal.of(selectSymbolToReplace.valueType(), value);
+                return Literal.of(selectSymbolToReplace.valueType(), selectSymbol.valueType().value(value));
             }
             return selectSymbol;
         }

--- a/sql/src/main/java/io/crate/executor/transport/TransportExecutor.java
+++ b/sql/src/main/java/io/crate/executor/transport/TransportExecutor.java
@@ -142,7 +142,7 @@ public class TransportExecutor implements Executor {
         this.indicesService = indicesService;
         this.dclStatementDispatcher = dclStatementDispatcher;
         this.userManager = userManager;
-        plan2TaskVisitor = new TaskCollectingVisitor();
+        this.plan2TaskVisitor = new TaskCollectingVisitor();
         EvaluatingNormalizer normalizer = EvaluatingNormalizer.functionOnlyNormalizer(functions, ReplaceMode.COPY);
         globalProjectionToProjectionVisitor = new ProjectionToProjectorVisitor(
             clusterService,
@@ -338,7 +338,6 @@ public class TransportExecutor implements Executor {
             for (Map.Entry<Plan, SelectSymbol> entry : dependencies.entrySet()) {
                 Plan plan = entry.getKey();
 
-                SubSelectSymbolReplacer replacer = new SubSelectSymbolReplacer(rootPlan, entry.getValue());
                 CollectingBatchConsumer<Object[], Object> consumer = SingleRowSingleValueConsumer.create();
 
                 CompletableFuture<Plan> planFuture = process(plan, context);
@@ -352,6 +351,7 @@ public class TransportExecutor implements Executor {
                         consumer.accept(null, e);
                     }
                 });
+                SubSelectSymbolReplacer replacer = new SubSelectSymbolReplacer(rootPlan, entry.getValue());
                 dependencyFutures.add(consumer.resultFuture().thenAccept(replacer::onSuccess));
             }
             CompletableFuture[] cfs = dependencyFutures.toArray(new CompletableFuture[0]);

--- a/sql/src/main/java/io/crate/operation/operator/any/AnyOperator.java
+++ b/sql/src/main/java/io/crate/operation/operator/any/AnyOperator.java
@@ -103,11 +103,7 @@ public abstract class AnyOperator extends Operator<Object> {
             return null;
         }
         Iterable<?> rightIterable;
-        try {
-            rightIterable = collectionValueToIterable(collectionReference);
-        } catch (IllegalArgumentException e) {
-            return false;
-        }
+        rightIterable = collectionValueToIterable(collectionReference);
         return doEvaluate(value, rightIterable);
     }
 

--- a/sql/src/main/java/io/crate/operation/operator/any/AnyOperator.java
+++ b/sql/src/main/java/io/crate/operation/operator/any/AnyOperator.java
@@ -30,7 +30,12 @@ import io.crate.types.BooleanType;
 import io.crate.types.CollectionType;
 import io.crate.types.DataType;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
 
 import static com.google.common.base.Preconditions.checkArgument;
 

--- a/sql/src/test/java/io/crate/analyze/SingleRowSubselectAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SingleRowSubselectAnalyzerTest.java
@@ -114,5 +114,9 @@ public class SingleRowSubselectAnalyzerTest extends CrateDummyClusterServiceUnit
         SelectAnalyzedStatement stmt = e.analyze("select * from users where (select 'bar') = ANY (tags)");
         assertThat(stmt.relation().querySpec().where().query(),
             isSQL("(SelectSymbol{string} = ANY(doc.users.tags))"));
+
+        stmt = e.analyze("select * from users where 'bar' = ANY (select 'bar')");
+        assertThat(stmt.relation().querySpec().where().query(),
+            isSQL("('bar' = ANY(SelectSymbol{string_table}))"));
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/AnyIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/AnyIntegrationTest.java
@@ -105,6 +105,29 @@ public class AnyIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    public void testAnyWithSubselect() throws Exception {
+        execute("select 2 where 1 = ANY(select 2)");
+        assertThat(response.rowCount(), is(0L));
+
+        execute("select 2 where 1 = ANY(select null)");
+        assertThat(response.rowCount(), is(0L));
+
+        execute("select 2 where 1 = ANY(select 1)");
+        assertThat(response.rowCount(), is(1L));
+        assertThat(response.rows()[0][0], is(2L));
+
+        execute("create table t (id integer) clustered into 1 shards with (number_of_replicas=0)");
+        ensureYellow();
+        execute("insert into t values(1)");
+        execute("insert into t values(2)");
+        execute("refresh table t");
+
+        execute("select id from t where id = ANY(select id from t where id = 1)");
+        assertThat(response.rowCount(), is(1L));
+        assertThat(response.rows()[0][0], is(1));
+    }
+
+    @Test
     public void testAnyOnArrayLiteralWithNullElements() throws Exception {
         execute("create table t (s string)");
         ensureYellow();

--- a/sql/src/test/java/io/crate/operation/operator/any/AnyEqOperatorTest.java
+++ b/sql/src/test/java/io/crate/operation/operator/any/AnyEqOperatorTest.java
@@ -104,4 +104,10 @@ public class AnyEqOperatorTest extends AbstractScalarFunctionsTest {
         assertNormalize("42 = ANY([42])", isLiteral(true));
         assertNormalize("42 = ANY([41, 43, -42])", isLiteral(false));
     }
+
+    @Test
+    public void testExceptionForwarding() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        anyEq(1, "bar");
+    }
 }

--- a/sql/src/test/java/io/crate/operation/operator/any/AnyEqOperatorTest.java
+++ b/sql/src/test/java/io/crate/operation/operator/any/AnyEqOperatorTest.java
@@ -106,7 +106,7 @@ public class AnyEqOperatorTest extends AbstractScalarFunctionsTest {
     }
 
     @Test
-    public void testExceptionForwarding() throws Exception {
+    public void testIncompatibleTypes() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
         anyEq(1, "bar");
     }


### PR DESCRIPTION
This enables queries like the following:

`Select 2 where 1 = ANY(Select 1)` which were not possible beforehand.