### PR TITLE
Introduced ExpressionToColumnIdentVisitor in order to fix wrong behaviour at alter table column add.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -48,6 +48,10 @@ Changes
 Fixes
 =====
 
+ - Fixed an issue when using dots in an identifier for column creation in alter
+   table, where they were interpreted as sub-fields of an object. The usage of
+   dots as part of a column name is prohibited.
+
  - Fixed an issue that prevented CrateDB from starting when ``path.home`` was
    set via command line argument.
 

--- a/sql/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
@@ -21,6 +21,7 @@
 
 package io.crate.analyze;
 
+import io.crate.analyze.expressions.ExpressionToColumnIdentVisitor;
 import io.crate.analyze.expressions.ExpressionToStringVisitor;
 import io.crate.data.Row;
 import io.crate.metadata.ColumnIdent;
@@ -109,8 +110,7 @@ public class TableElementsAnalyzer {
 
         @Override
         public Void visitAddColumnDefinition(AddColumnDefinition node, ColumnDefinitionContext context) {
-            String columnName = ExpressionToStringVisitor.convert(node.name(), context.parameters);
-            ColumnIdent ident = ColumnIdent.fromPath(columnName);
+            ColumnIdent ident = ExpressionToColumnIdentVisitor.convert(node.name());
             context.analyzedColumnDefinition.name(ident.name(), context.tableIdent);
 
             // nested columns can only be added using alter table so no other columns exist.

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionToColumnIdentVisitor.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionToColumnIdentVisitor.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.analyze.expressions;
+
+import io.crate.metadata.ColumnIdent;
+import io.crate.sql.tree.AstVisitor;
+import io.crate.sql.tree.Node;
+import io.crate.sql.tree.QualifiedNameReference;
+import io.crate.sql.tree.StringLiteral;
+import io.crate.sql.tree.SubscriptExpression;
+import org.elasticsearch.common.inject.internal.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+public class ExpressionToColumnIdentVisitor extends AstVisitor<ColumnIdent, List<String>> {
+
+    private final static ExpressionToColumnIdentVisitor INSTANCE = new ExpressionToColumnIdentVisitor();
+
+    private ExpressionToColumnIdentVisitor() {
+    }
+
+    public static ColumnIdent convert(Node node) {
+        return INSTANCE.process(node, null);
+    }
+
+    @Override
+    protected ColumnIdent visitQualifiedNameReference(QualifiedNameReference node, @Nullable List<String> context) {
+        if (node.getName().getParts().size() > 1) {
+            throw new IllegalArgumentException(String.format(
+                Locale.ENGLISH,
+                "Qualified name references are not allowed to contain paths ('%s')",
+                node.getName().toString()
+            ));
+        }
+        if (context != null) {
+            return new ColumnIdent(node.getName().toString(), context);
+        }
+        return new ColumnIdent(node.getName().toString());
+    }
+
+    @Override
+    protected ColumnIdent visitStringLiteral(StringLiteral node, List<String> context) {
+        if (context == null) {
+            // TopLevel doesn't allow string literals.
+            throw new IllegalArgumentException(String.format(
+                Locale.ENGLISH,
+                "String literal '%s' is not allowed as column identifier",
+                node.getValue()
+            ));
+        }
+
+        context.add(node.getValue());
+        return null;
+    }
+
+    @Override
+    protected ColumnIdent visitSubscriptExpression(SubscriptExpression node, List<String> context) {
+        if (node.index() instanceof QualifiedNameReference) {
+            throw new IllegalArgumentException(
+                String.format(Locale.ENGLISH, "Key of subscript must not be a reference")
+            );
+        }
+        if (context == null) {
+            context = new ArrayList<>();
+        }
+        ColumnIdent colIdent = process(node.name(), context);
+        process(node.index(), context);
+
+
+        return colIdent;
+    }
+
+    @Override
+    protected ColumnIdent visitNode(Node node, List<String> context) {
+        throw new UnsupportedOperationException(String.format(Locale.ENGLISH, "Can't handle %s.", node));
+    }
+}

--- a/sql/src/test/java/io/crate/analyze/expressions/ExpressionToColumnIdentVisitorTest.java
+++ b/sql/src/test/java/io/crate/analyze/expressions/ExpressionToColumnIdentVisitorTest.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.analyze.expressions;
+
+import io.crate.metadata.ColumnIdent;
+import io.crate.sql.parser.SqlParser;
+import io.crate.sql.tree.Expression;
+import io.crate.test.integration.CrateUnitTest;
+import org.junit.Test;
+
+public class ExpressionToColumnIdentVisitorTest extends CrateUnitTest {
+
+    @Test
+    public void testConvertWithSimpleStringLiteral() throws Exception {
+        assertIllegalArgumentExceptionOnConvert("'a'", "String literal");
+    }
+
+    @Test
+    public void testConvertWithArithmeticStringLiteral() throws Exception {
+        assertIllegalArgumentExceptionOnConvert("'1+1'", "String literal");
+    }
+
+    @Test
+    public void testConvertWithDotStringLiteral() throws Exception {
+        assertIllegalArgumentExceptionOnConvert("'a.b'", "String literal");
+    }
+
+    @Test
+    public void testConvertWithSubscriptStringLiteral() throws Exception {
+        assertIllegalArgumentExceptionOnConvert("'a[b]'", "String literal");
+    }
+
+    @Test
+    public void testConvertWithQualifiedNameReferenceContainingDot() throws Exception {
+        assertIllegalArgumentExceptionOnConvert(
+            "a.b",
+            "Qualified name references are not allowed to contain paths"
+        );
+    }
+
+    @Test
+    public void testConvertWithQualifiedNameReferenceContainingDots() throws Exception {
+        assertIllegalArgumentExceptionOnConvert(
+            "a.b.c",
+            "Qualified name references are not allowed to contain paths"
+        );
+    }
+
+    @Test
+    public void testConvertWithQualifiedNameReference() throws Exception {
+        assertColumnIdent("a", new ColumnIdent("a"));
+        assertColumnIdent("ab", new ColumnIdent("ab"));
+        assertColumnIdent("a_b", new ColumnIdent("a_b"));
+    }
+
+    @Test
+    public void testConvertWithSubscripts() throws Exception {
+        assertColumnIdent("a['b']", new ColumnIdent("a", "b"));
+        assertColumnIdent("a['b']['c']", ColumnIdent.fromPath("a.b.c"));
+
+        // We allow dot here in the string literal, since the column name check
+        // will throw an error when index contains a dot.
+        assertColumnIdent("a['b.c']", new ColumnIdent("a", "b.c"));
+
+        assertIllegalArgumentExceptionOnConvert("a[b.c]", "Key of subscript must not be a reference");
+    }
+
+    @Test
+    public void testConvertWithUnsupportedSubscript() throws Exception {
+        assertExceptionOnUnsupportedConvert("a[0]");
+    }
+
+    @Test
+    public void testConvertWithUnsupportedArithmetic() throws Exception {
+        assertExceptionOnUnsupportedConvert("1+1");
+    }
+
+    @Test
+    public void testConvertWithUnsupportedLong() throws Exception {
+        assertExceptionOnUnsupportedConvert("1");
+    }
+
+    private void assertColumnIdent(String stringValue, ColumnIdent expecedIdent) {
+        assertEquals(createIdentFromString(stringValue), expecedIdent);
+    }
+
+    private ColumnIdent createIdentFromString(String stringValue) {
+        Expression expression = SqlParser.createExpression(stringValue);
+        return ExpressionToColumnIdentVisitor.convert(expression);
+    }
+
+    private void assertIllegalArgumentExceptionOnConvert(String stringValue, String exceptionMessage) {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage(exceptionMessage);
+        createIdentFromString(stringValue);
+    }
+
+    private void assertExceptionOnUnsupportedConvert(String stringValue) {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("Can't handle");
+        createIdentFromString(stringValue);
+    }
+}


### PR DESCRIPTION
Fixes wrong use of identifiers, especially when containing a dot.
Column name identifiers that **worked before, but do not work anymore**:

* a.b
* a['b.c']
* a[0]
* a[b]
