### PR TITLE
Added tests and implementation for new column naming rules

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -27,6 +27,8 @@ Breaking Changes
 Changes
 =======
 
+ - Relaxed column naming restrictions.
+
  - Made the help messages of ``bin/crate`` and the Java code consistent. This
    change also removes the undocumented ``-E`` command line option which makes
    ``-C`` the only valid option for passing settings to CrateDB.

--- a/blackbox/docs/protocols/http.txt
+++ b/blackbox/docs/protocols/http.txt
@@ -73,7 +73,7 @@ expected under the ``args`` key::
 
 .. WARNING::
 
-    Parameter substition must not be used within subscript notation.
+    Parameter substitution must not be used within subscript notation.
 
     For example, ``column[?]`` is not allowed.
 

--- a/blackbox/docs/sql/administration/system_columns.txt
+++ b/blackbox/docs/sql/administration/system_columns.txt
@@ -6,7 +6,8 @@ System Columns
 
 On every table CrateDB implements several implicitly defined system columns.
 Their names are reserved and cannot be used as user-defined column names. All
-system columns are prefixed with an underscore.
+system columns are prefixed with an underscore, consist of lowercase letters
+and might contain underscores in between.
 
 .. _sql_administration_system_column_version:
 

--- a/blackbox/docs/sql/ddl/basics.txt
+++ b/blackbox/docs/sql/ddl/basics.txt
@@ -118,41 +118,15 @@ length. They:
   - should not exceed 255 bytes when encoded with ``utf-8`` (this
     limit applies on the optionally schema-qualified table name)
 
-Column names are restricted in terms of characters.
+Column names are restricted in terms of patterns:
 
-  - Columns that *start* with an underscore (``_``) followed by a lowercase
-    letter, followed by a sequence of lower case letters or underscores and
-    ending with a lower case letter are not allowed (equivalent to
-    ``^_[a-z][_a-z]*[a-z]$``).
-    Such fields are reserved for virtual system columns.
+  - Columns are not allowed to contain a dot (``.``), since this conflicts
+    with internal path definitions.
 
-    Examples:
-
-    +--------------+--------------+
-    | allowed      | not allowed  |
-    +==============+==============+
-    | _foo_        | _foo         |
-    +--------------+--------------+
-    | _Foo         | _foo_bar     |
-    +--------------+--------------+
-    | _fo1o        |              |
-    +--------------+--------------+
-    | __foo        |              |
-    +--------------+--------------+
+  - Columns that conflict with the naming scheme of
+    :ref:`virtual system columns <sql_administration_system_columns>` are
+    restricted.
 
   - Character sequences that conform to the
     :ref:`subscript notation <sql_dql_object_arrays>` (e.g. ``col['id']``) are
-    not allowed as this notation is already used for the identification of
-    fields in object columns and indices of array columns.
-
-    Examples:
-
-    +--------------+--------------+
-    | allowed      | not allowed  |
-    +==============+==============+
-    | ['bar']      | foo['bar']   |
-    +--------------+--------------+
-    | foo]'bar'[   | foo[bar]     |
-    +--------------+--------------+
-    | foo['bar'    | foo[]        |
-    +--------------+--------------+
+    not allowed.

--- a/sql/src/main/java/io/crate/analyze/AbstractInsertAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/AbstractInsertAnalyzer.java
@@ -21,8 +21,6 @@
 
 package io.crate.analyze;
 
-import com.google.common.base.Preconditions;
-import io.crate.exceptions.InvalidColumnNameException;
 import io.crate.metadata.*;
 import io.crate.sql.tree.Insert;
 
@@ -73,7 +71,7 @@ abstract class AbstractInsertAnalyzer {
             }
             context.columns(new ArrayList<Reference>(numColumns));
             for (int i = 0; i < node.columns().size(); i++) {
-                addColumn(new ColumnIdent(node.columns().get(i)), context, i);
+                addColumn(ColumnIdent.fromNameSafe(node.columns().get(i)), context, i);
             }
         }
 
@@ -114,17 +112,12 @@ abstract class AbstractInsertAnalyzer {
     }
 
     /**
-     * validates the column and sets primary key / partitioned by / routing information as well as a
+     * Sets primary key / partitioned by / routing information as well as a
      * column Reference to the context.
      * <p>
      * the created column reference is returned
      */
     private Reference addColumn(ColumnIdent column, AbstractInsertAnalyzedStatement context, int i) {
-        Preconditions.checkArgument(!column.name().startsWith("_"), "Inserting system columns is not allowed");
-        if (ColumnIdent.INVALID_COLUMN_NAME_PREDICATE.apply(column.name())) {
-            throw new InvalidColumnNameException(column.name(), context.tableInfo().ident());
-        }
-
         // set primary key column if found
         for (ColumnIdent pkIdent : context.tableInfo().primaryKey()) {
             if (pkIdent.getRoot().equals(column)) {

--- a/sql/src/main/java/io/crate/analyze/AlterTableAddColumnAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/AlterTableAddColumnAnalyzer.java
@@ -107,7 +107,7 @@ class AlterTableAddColumnAnalyzer {
 
             AnalyzedColumnDefinition pkColumn = new AnalyzedColumnDefinition(null);
             pkColumn.ident(pkIdent);
-            pkColumn.name(pkIdent.name(), tableInfo.ident());
+            pkColumn.name(pkIdent.name());
             pkColumn.setPrimaryKeyConstraint();
 
             assert !(pkInfo.valueType() instanceof CollectionType) : "pk can't be an array";

--- a/sql/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
@@ -23,16 +23,13 @@ package io.crate.analyze;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import io.crate.analyze.ddl.GeoSettingsApplier;
-import io.crate.exceptions.InvalidColumnNameException;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
-import io.crate.metadata.TableIdent;
 import io.crate.sql.tree.Expression;
 import io.crate.types.DataTypes;
 import org.elasticsearch.common.settings.Settings;
@@ -87,24 +84,16 @@ public class AnalyzedColumnDefinition {
     @Nullable
     private Expression generatedExpression;
 
-    public static void validateName(String name, TableIdent tableIdent) {
-        Preconditions.checkArgument(!name.startsWith("_"), "Column name must not start with '_'");
-        if (ColumnIdent.INVALID_COLUMN_NAME_PREDICATE.apply(name)) {
-            throw new InvalidColumnNameException(name, tableIdent);
-        }
-    }
-
     AnalyzedColumnDefinition(@Nullable AnalyzedColumnDefinition parent) {
         this.parent = parent;
     }
 
-    public void name(String name, TableIdent tableIdent) {
-        validateName(name, tableIdent);
+    public void name(String name) {
         this.name = name;
         if (this.parent != null) {
-            this.ident = ColumnIdent.getChild(this.parent.ident, name);
+            this.ident = ColumnIdent.getChildSafe(this.parent.ident, name);
         } else {
-            this.ident = new ColumnIdent(name);
+            this.ident = ColumnIdent.fromNameSafe(name);
         }
     }
 

--- a/sql/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
@@ -95,7 +95,7 @@ public class TableElementsAnalyzer {
 
         @Override
         public Void visitColumnDefinition(ColumnDefinition node, ColumnDefinitionContext context) {
-            context.analyzedColumnDefinition.name(node.ident(), context.tableIdent);
+            context.analyzedColumnDefinition.name(node.ident());
             for (ColumnConstraint columnConstraint : node.constraints()) {
                 process(columnConstraint, context);
             }
@@ -111,7 +111,7 @@ public class TableElementsAnalyzer {
         @Override
         public Void visitAddColumnDefinition(AddColumnDefinition node, ColumnDefinitionContext context) {
             ColumnIdent ident = ExpressionToColumnIdentVisitor.convert(node.name());
-            context.analyzedColumnDefinition.name(ident.name(), context.tableIdent);
+            context.analyzedColumnDefinition.name(ident.name());
 
             // nested columns can only be added using alter table so no other columns exist.
             assert context.analyzedTableElements.columns().size() == 0 :
@@ -138,7 +138,7 @@ public class TableElementsAnalyzer {
                     }
                     parent.markAsParentColumn();
                     leaf = new AnalyzedColumnDefinition(parent);
-                    leaf.name(name, context.tableIdent);
+                    leaf.name(name);
                     parent.addChild(leaf);
                     parent = leaf;
                 }
@@ -257,7 +257,7 @@ public class TableElementsAnalyzer {
         public Void visitIndexDefinition(IndexDefinition node, ColumnDefinitionContext context) {
             context.analyzedColumnDefinition.setAsIndexColumn();
             context.analyzedColumnDefinition.dataType("text");
-            context.analyzedColumnDefinition.name(node.ident(), context.tableIdent);
+            context.analyzedColumnDefinition.name(node.ident());
 
             setAnalyzer(node.properties(), context, node.method());
 

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionToColumnIdentVisitor.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionToColumnIdentVisitor.java
@@ -55,9 +55,9 @@ public class ExpressionToColumnIdentVisitor extends AstVisitor<ColumnIdent, List
             ));
         }
         if (context != null) {
-            return new ColumnIdent(node.getName().toString(), context);
+            return ColumnIdent.fromNameAndPathSafe(node.getName().toString(), context);
         }
-        return new ColumnIdent(node.getName().toString());
+        return ColumnIdent.fromNameSafe(node.getName().toString());
     }
 
     @Override
@@ -71,6 +71,7 @@ public class ExpressionToColumnIdentVisitor extends AstVisitor<ColumnIdent, List
             ));
         }
 
+        ColumnIdent.validateObjectKey(node.getValue());
         context.add(node.getValue());
         return null;
     }

--- a/sql/src/main/java/io/crate/analyze/expressions/ValueNormalizer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ValueNormalizer.java
@@ -23,7 +23,6 @@
 package io.crate.analyze.expressions;
 
 import com.google.common.base.Preconditions;
-import io.crate.analyze.AnalyzedColumnDefinition;
 import io.crate.analyze.symbol.DynamicReference;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
@@ -111,8 +110,7 @@ public class ValueNormalizer {
     @SuppressWarnings("unchecked")
     private void normalizeObjectValue(Map<String, Object> value, Reference info, TableInfo tableInfo) {
         for (Map.Entry<String, Object> entry : value.entrySet()) {
-            AnalyzedColumnDefinition.validateName(entry.getKey(), tableInfo.ident());
-            ColumnIdent nestedIdent = ColumnIdent.getChild(info.ident().columnIdent(), entry.getKey());
+            ColumnIdent nestedIdent = ColumnIdent.getChildSafe(info.ident().columnIdent(), entry.getKey());
             Reference nestedInfo = tableInfo.getReference(nestedIdent);
             if (nestedInfo == null) {
                 if (info.columnPolicy() == ColumnPolicy.IGNORED) {

--- a/sql/src/main/java/io/crate/exceptions/InvalidColumnNameException.java
+++ b/sql/src/main/java/io/crate/exceptions/InvalidColumnNameException.java
@@ -21,27 +21,16 @@
 
 package io.crate.exceptions;
 
-import io.crate.metadata.TableIdent;
-
-import java.util.Collections;
 import java.util.Locale;
 
-public class InvalidColumnNameException extends ValidationException implements TableScopeException {
+public class InvalidColumnNameException extends ValidationException implements ClusterScopeException {
 
-    private final TableIdent tableIdent;
-
-    public InvalidColumnNameException(String columnName, TableIdent tableIdent) {
-        super(String.format(Locale.ENGLISH, "column name \"%s\" is invalid.", columnName));
-        this.tableIdent = tableIdent;
+    public InvalidColumnNameException(String columnName, String message) {
+        super(String.format(Locale.ENGLISH, "\"%s\" %s", columnName, message));
     }
 
     @Override
     public int errorCode() {
         return 2;
-    }
-
-    @Override
-    public Iterable<TableIdent> getTableIdents() {
-        return Collections.singletonList(tableIdent);
     }
 }

--- a/sql/src/test/java/io/crate/analyze/AlterTableAddColumnAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/AlterTableAddColumnAnalyzerTest.java
@@ -156,6 +156,17 @@ public class AlterTableAddColumnAnalyzerTest extends CrateDummyClusterServiceUni
         assertThat((String) inner.get("type"), is("keyword"));
     }
 
+    public void testAddObjectColumnWithUnderscore() throws Exception {
+        AddColumnAnalyzedStatement analysis = e.analyze("alter table users add column foo['_x'] int");
+
+        assertThat(analysis.analyzedTableElements().columns().size(), is(2)); // id pk column is also added
+        AnalyzedColumnDefinition column = analysis.analyzedTableElements().columns().get(0);
+        assertThat(column.ident(), Matchers.equalTo(new ColumnIdent("foo")));
+        assertThat(column.children().size(), is(1));
+        AnalyzedColumnDefinition xColumn = column.children().get(0);
+        assertThat(xColumn.ident(), Matchers.equalTo(new ColumnIdent("foo", Arrays.asList("_x"))));
+    }
+
     @Test
     public void testAddNewNestedObjectColumn() throws Exception {
         AddColumnAnalyzedStatement analysis = e.analyze(

--- a/sql/src/test/java/io/crate/analyze/InsertFromValuesAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/InsertFromValuesAnalyzerTest.java
@@ -457,7 +457,7 @@ public class InsertFromValuesAnalyzerTest extends CrateDummyClusterServiceUnitTe
         assertThat(((Object[]) analysis.sourceMaps().get(0)[1]).length, is(0));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = InvalidColumnNameException.class)
     public void testInsertSystemColumn() throws Exception {
         e.analyze("insert into users (id, _id) values (?, ?)",
             new Object[]{1, "1"});
@@ -854,36 +854,37 @@ public class InsertFromValuesAnalyzerTest extends CrateDummyClusterServiceUnitTe
     @Test
     public void testInvalidColumnName() throws Exception {
         expectedException.expect(InvalidColumnNameException.class);
-        expectedException.expectMessage("column name \"newCol[\" is invalid");
-       e.analyze("insert into users (\"newCol[\") values(test)");
+        expectedException.expectMessage(
+            "\"newCol['a']\" conflicts with subscript pattern");
+        e.analyze("insert into users (\"newCol['a']\") values(test)");
     }
 
     @Test
     public void testInsertIntoTableWithNestedObjectPrimaryKeyAndNullInsert() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Primary key value must not be NULL");
-       e.analyze("insert into nested_pk (o) values (null)");
+        e.analyze("insert into nested_pk (o) values (null)");
     }
 
     @Test
     public void testNestedPrimaryKeyColumnMustNotBeNull() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Primary key value must not be NULL");
-       e.analyze("insert into nested_pk (o) values ({b=null})");
+        e.analyze("insert into nested_pk (o) values ({b=null})");
     }
 
     @Test
     public void testNestedClusteredByColumnMustNotBeNull() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Clustered by value must not be NULL");
-       e.analyze("insert into nested_clustered (o) values ({c=null})");
+        e.analyze("insert into nested_clustered (o) values ({c=null})");
     }
 
     @Test
     public void testNestedClusteredByColumnMustNotBeNullWholeObject() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Clustered by value must not be NULL");
-       e.analyze("insert into nested_clustered (o) values (null)");
+        e.analyze("insert into nested_clustered (o) values (null)");
     }
 
     @Test

--- a/sql/src/test/java/io/crate/analyze/ValueNormalizerTest.java
+++ b/sql/src/test/java/io/crate/analyze/ValueNormalizerTest.java
@@ -28,6 +28,7 @@ import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.exceptions.ColumnValidationException;
+import io.crate.exceptions.InvalidColumnNameException;
 import io.crate.metadata.*;
 import io.crate.metadata.table.ColumnPolicy;
 import io.crate.metadata.table.TableInfo;
@@ -38,6 +39,7 @@ import org.apache.lucene.util.BytesRef;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
+import org.omg.CORBA.DynAnyPackage.Invalid;
 
 import java.util.HashMap;
 import java.util.List;
@@ -162,11 +164,11 @@ public class ValueNormalizerTest extends CrateUnitTest {
 
     @Test
     public void testNormalizeDynamicObjectWithRestrictedAdditionalColumn() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Column name must not start with '_'");
+        expectedException.expect(InvalidColumnNameException.class);
+        expectedException.expectMessage("contains a dot");
         Reference objInfo = userTableInfo.getReference(new ColumnIdent("dyn"));
         Map<String, Object> map = new HashMap<>();
-        map.put("_invalid_column_name", 0);
+        map.put("_invalid.column_name", 0);
         normalizeInputForReference(Literal.of(map), objInfo);
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -453,7 +453,7 @@ public class DDLIntegrationTest extends SQLTransportIntegrationTest {
                 "with (number_of_replicas=0)");
         ensureYellow();
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("InvalidColumnNameException: column name \"o.x\" is invalid");
+        expectedException.expectMessage("\"o.x\" contains a dot");
         execute("alter table t add \"o.x\" int");
     }
 
@@ -464,7 +464,7 @@ public class DDLIntegrationTest extends SQLTransportIntegrationTest {
                 "with (number_of_replicas=0)");
         ensureYellow();
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("InvalidColumnNameException: column name \"o['x.y']\" is invalid");
+        expectedException.expectMessage("\"o['x.y']\" contains a dot");
 
         execute("alter table t add \"o['x.y']\" int");
     }

--- a/sql/src/test/java/io/crate/integrationtests/ObjectColumnTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ObjectColumnTest.java
@@ -304,12 +304,12 @@ public class ObjectColumnTest extends SQLTransportIntegrationTest {
     }
 
     @Test
-    public void testAddRestrictedColumnName() throws Exception {
+    public void testAddUnderscoreColumnNameToObjectAtInsert() throws Exception {
         execute("create table test (foo object)");
         ensureYellow();
         execute("INSERT INTO test (o) (select {\"_w\"= 20})");
         refresh();
         execute("select count(*) from test");
-        assertThat(response.rows()[0][0], is(0L));
+        assertThat(response.rows()[0][0], is(1L));
     }
 }


### PR DESCRIPTION
This PR changes rules for column naming:
* `'` is allowed for column names
* `[` and `]` are allowed if they are not like a subscript expression
* `_` underscore at the beginning is allowed if it doesn't conflict with the system column naming rule (_ + lowercase letter containing _)