### PR TITLE
Added more CrateDB startup configuration tests.

### DIFF
--- a/app/src/test/resources/org/elasticsearch/node/internal/config/crate.yml
+++ b/app/src/test/resources/org/elasticsearch/node/internal/config/crate.yml
@@ -1,0 +1,2 @@
+stats.enabled: false
+psql.enabled: false

--- a/app/src/test/resources/org/elasticsearch/node/internal/config_invalid/crate.yml
+++ b/app/src/test/resources/org/elasticsearch/node/internal/config_invalid/crate.yml
@@ -1,0 +1,2 @@
+stats.enabled: false
+stats.enabled: true


### PR DESCRIPTION
 - Test that command line args override settings from crate.yml
 - Test no duplicate settings can be define in crate.yml