### PR TITLE
Allow subqueries in ANY expressions

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -29,6 +29,11 @@ Changes
 
  - Improved resiliency of drop, close and open table operations
 
+  - Introduce support for single column subselects in ANY, e.g.::
+
+      Select id from t where id = ANY(Select id from t2)
+
+
 
 Fixes
 =====

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalysisContext.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalysisContext.java
@@ -31,7 +31,7 @@ public class ExpressionAnalysisContext {
 
     public boolean hasAggregates = false;
 
-    public Function allocateFunction(FunctionInfo functionInfo, List<Symbol> arguments) {
+    Function allocateFunction(FunctionInfo functionInfo, List<Symbol> arguments) {
         Function newFunction = new Function(functionInfo, arguments);
         hasAggregates = hasAggregates || functionInfo.type() == FunctionInfo.Type.AGGREGATE;
         return newFunction;

--- a/sql/src/main/java/io/crate/analyze/symbol/SelectSymbol.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/SelectSymbol.java
@@ -28,6 +28,8 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 
+import static io.crate.analyze.symbol.SelectSymbol.ResultType.*;
+
 /**
  * Symbol representing a sub-query
  */
@@ -35,7 +37,15 @@ public class SelectSymbol extends Symbol {
 
     private final AnalyzedRelation relation;
     private final SingleColumnTableType type;
+
     private boolean isPlanned = false;
+
+    private ResultType resultType = SINGLE_COLUMN_MULTIPLE_VALUES;
+
+    public enum ResultType {
+        SINGLE_COLUMN_SINGLE_VALUE,
+        SINGLE_COLUMN_MULTIPLE_VALUES
+    }
 
     public SelectSymbol(AnalyzedRelation relation, SingleColumnTableType type) {
         this.relation = relation;
@@ -82,5 +92,13 @@ public class SelectSymbol extends Symbol {
 
     public void markAsPlanned() {
         isPlanned = true;
+    }
+
+    public void setResultType(ResultType type) {
+        resultType = type;
+    }
+
+    public ResultType getResultType() {
+        return resultType;
     }
 }

--- a/sql/src/main/java/io/crate/metadata/Scalar.java
+++ b/sql/src/main/java/io/crate/metadata/Scalar.java
@@ -26,7 +26,6 @@ import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.format.OperatorFormatSpec;
 import io.crate.data.Input;
-import io.crate.exceptions.UnsupportedFeatureException;
 
 import java.util.Collection;
 import java.util.List;

--- a/sql/src/main/java/io/crate/planner/Planner.java
+++ b/sql/src/main/java/io/crate/planner/Planner.java
@@ -51,6 +51,8 @@ import io.crate.analyze.UpdateAnalyzedStatement;
 import io.crate.analyze.WhereClause;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.symbol.Literal;
+import io.crate.analyze.symbol.SelectSymbol;
+import io.crate.analyze.symbol.SelectSymbol.ResultType;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.data.Input;
 import io.crate.exceptions.UnhandledServerException;
@@ -99,6 +101,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+
+import static io.crate.analyze.symbol.SelectSymbol.ResultType.*;
 
 @Singleton
 public class Planner extends AnalyzedStatementVisitor<Planner.Context, Plan> {
@@ -180,10 +184,17 @@ public class Planner extends AnalyzedStatementVisitor<Planner.Context, Plan> {
             return transactionContext;
         }
 
-        public Plan planSingleRowSubselect(AnalyzedStatement statement) {
+        Plan planSubselect(AnalyzedStatement statement, SelectSymbol selectSymbol) {
             UUID subJobId = UUID.randomUUID();
+            final int softLimit, fetchSize;
+            if (selectSymbol.getResultType() == SINGLE_COLUMN_SINGLE_VALUE) {
+                softLimit = fetchSize = 2;
+            } else {
+                softLimit = this.softLimit;
+                fetchSize = this.fetchSize;
+            }
             return planner.process(statement, new Planner.Context(
-                planner, clusterService, subJobId, consumingPlanner, normalizer, transactionContext, 2, 2));
+                planner, clusterService, subJobId, consumingPlanner, normalizer, transactionContext, softLimit, fetchSize));
         }
 
         void applySoftLimit(QuerySpec querySpec) {

--- a/sql/src/main/java/io/crate/planner/SubqueryPlanner.java
+++ b/sql/src/main/java/io/crate/planner/SubqueryPlanner.java
@@ -48,7 +48,7 @@ public class SubqueryPlanner {
     private void planSubquery(SelectSymbol selectSymbol) {
         AnalyzedRelation relation = selectSymbol.relation();
         SelectAnalyzedStatement selectAnalyzedStatement = new SelectAnalyzedStatement(((QueriedRelation) relation));
-        Plan subPlan = plannerContext.planSingleRowSubselect(selectAnalyzedStatement);
+        Plan subPlan = plannerContext.planSubselect(selectAnalyzedStatement, selectSymbol);
         subQueries.put(subPlan, selectSymbol);
     }
 

--- a/sql/src/test/java/io/crate/analyze/SingleRowSubselectAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SingleRowSubselectAnalyzerTest.java
@@ -114,5 +114,9 @@ public class SingleRowSubselectAnalyzerTest extends CrateDummyClusterServiceUnit
         SelectAnalyzedStatement stmt = e.analyze("select * from users where (select 'bar') = ANY (tags)");
         assertThat(stmt.relation().querySpec().where().query(),
             isSQL("(single_value(SelectSymbol{string_table}) = ANY(doc.users.tags))"));
+
+        stmt = e.analyze("select * from users where 'bar' = ANY (select 'bar')");
+        assertThat(stmt.relation().querySpec().where().query(),
+            isSQL("('bar' = ANY(SelectSymbol{string_table}))"));
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/LuceneQueryBuilderIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/LuceneQueryBuilderIntegrationTest.java
@@ -281,7 +281,7 @@ public class LuceneQueryBuilderIntegrationTest extends SQLTransportIntegrationTe
         execute("insert into t2 (id) values (1)");
         execute("refresh table t1, t2");
 
-        execute("select count(*) from t2 where id != any(select collect_set(id) from t1)");
+        execute("select count(*) from t2 where id != any(select id from t1)");
         assertThat(response.rows()[0][0], is(1L));
     }
 }

--- a/sql/src/test/java/io/crate/operation/operator/any/AnyEqOperatorTest.java
+++ b/sql/src/test/java/io/crate/operation/operator/any/AnyEqOperatorTest.java
@@ -104,4 +104,10 @@ public class AnyEqOperatorTest extends AbstractScalarFunctionsTest {
         assertNormalize("42 = ANY([42])", isLiteral(true));
         assertNormalize("42 = ANY([41, 43, -42])", isLiteral(false));
     }
+
+    @Test
+    public void testExceptionForwarding() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        anyEq(1, "bar");
+    }
 }


### PR DESCRIPTION
This enables queries like the following: `Select id from t1 where 1 = ANY(Select id from t2)`

Follow-up PR to #6086 which introduces a `SingleColumnTableType` for all subqueries. This PR removes the limitation that subqueries can only return a single value in ANY or IN clauses. For Subqueries which only allow a single value, the `singleValue` function enforces that only one value is returned.