### PR TITLE
IngestionService and IngestionImplementation

### DIFF
--- a/sql/src/main/java/io/crate/metadata/rule/ingest/IngestionImplementation.java
+++ b/sql/src/main/java/io/crate/metadata/rule/ingest/IngestionImplementation.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.rule.ingest;
+
+import java.util.Set;
+
+/**
+ * Ingestion implementation that usually facilitate the data flow into the system based on the configured ingestion
+ * rules.
+ */
+public interface IngestionImplementation {
+
+    /**
+     * Provides a way for the IngestionImplementation to receive the configured ingestion rules after it registered
+     * with the {@link IngestionService}.
+     * The {@link IngestionService} listens for changes (eg. rules created/dropped, target tables dropped, etc),
+     * processes the ingestion rules and feeds them to the IngestionImplementations using this callback.
+     * The implementation will receive all rules belonging to its source and should update its ingestion data flow to
+     * obey the received rules.
+     */
+    void applyRules(Set<IngestRule> rules);
+}

--- a/sql/src/main/java/io/crate/metadata/rule/ingest/IngestionService.java
+++ b/sql/src/main/java/io/crate/metadata/rule/ingest/IngestionService.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.rule.ingest;
+
+import io.crate.metadata.Schemas;
+import io.crate.metadata.TableIdent;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterStateListener;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Singleton
+public class IngestionService implements ClusterStateListener {
+
+    private final ClusterService clusterService;
+    private final Map<String, List<IngestionImplementation>> implementations = new HashMap<>();
+    private final Schemas schemas;
+
+    @Inject
+    public IngestionService(Schemas schemas,
+                            ClusterService clusterService) {
+        this.schemas = schemas;
+        this.clusterService = clusterService;
+    }
+
+    /**
+     * Register the provided @param implementation for ingest rule changes belonging to the provided @param sourceIdent.
+     *
+     * @return a set containing the current ingest rules for the @param sourceIdent
+     */
+    public void registerImplementation(String sourceIdent, IngestionImplementation implementation) {
+        List<IngestionImplementation> implementationsForSource = implementations.get(sourceIdent);
+        if (implementationsForSource == null) {
+            implementationsForSource = new ArrayList<>();
+            implementations.put(sourceIdent, implementationsForSource);
+        }
+        implementationsForSource.add(implementation);
+        implementation.applyRules(getIngestionRules(clusterService.state().metaData()).get(sourceIdent));
+    }
+
+    @Override
+    public void clusterChanged(ClusterChangedEvent event) {
+        if (event.metaDataChanged() == false) {
+            return;
+        }
+
+        Map<String, Set<IngestRule>> ingestionRules = getIngestionRules(event.state().metaData());
+        filterOutInvalidRules(ingestionRules);
+        for (Map.Entry<String, List<IngestionImplementation>> entry : implementations.entrySet()) {
+            String sourceIdent = entry.getKey();
+            Set<IngestRule> rulesForSource = ingestionRules.get(sourceIdent);
+            for (IngestionImplementation ingestionImplementation : entry.getValue()) {
+                ingestionImplementation.applyRules(rulesForSource);
+            }
+        }
+    }
+
+    private void filterOutInvalidRules(Map<String, Set<IngestRule>> ingestionRules) {
+        for (Set<IngestRule> sourceIngestRules : ingestionRules.values()) {
+            Iterator<IngestRule> rulesIterator = sourceIngestRules.iterator();
+            while (rulesIterator.hasNext()) {
+                IngestRule ingestRule = rulesIterator.next();
+                if (schemas.tableExists(TableIdent.fromIndexName(ingestRule.getTargetTable())) == false) {
+                    rulesIterator.remove();
+                }
+            }
+        }
+    }
+
+    private Map<String, Set<IngestRule>> getIngestionRules(MetaData metaData) {
+        IngestRulesMetaData ingestRulesMetaData =
+            (IngestRulesMetaData) metaData.customs().get(IngestRulesMetaData.TYPE);
+
+        if (ingestRulesMetaData != null) {
+            return ingestRulesMetaData.getIngestRules();
+        } else {
+            return Collections.emptyMap();
+        }
+    }
+}

--- a/sql/src/test/java/io/crate/metadata/rule/ingest/IngestionServiceTest.java
+++ b/sql/src/test/java/io/crate/metadata/rule/ingest/IngestionServiceTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.rule.ingest;
+
+import io.crate.metadata.Schemas;
+import io.crate.metadata.TableIdent;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.common.collect.ImmutableOpenMap;
+import org.elasticsearch.test.ClusterServiceUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class IngestionServiceTest extends CrateDummyClusterServiceUnitTest {
+
+    private static final String UNDER_TEST_SOURCE_IDENT = "mqtt";
+    private static final String UNDER_TEST_RULE_TARGET_TABLE = "temp_data.raw";
+    private static final IngestRule UNDER_TEST_INGEST_RULE =
+        new IngestRule("temperature", UNDER_TEST_RULE_TARGET_TABLE, "(topic like 'temperature/%')");
+    private static final IngestRule HUMIDITY_INGEST_RULE =
+        new IngestRule("humidity", "humidity_data.raw", "(topic like 'humidity/%')");
+
+    private Schemas schemas;
+    private IngestRulesMetaData ingestRulesMetaData;
+    private IngestionService ingestionService;
+
+    @Before
+    public void setupIngestionServiceAndIngestRulesMetaData() {
+        schemas = mock(Schemas.class);
+        ingestionService = new IngestionService(schemas, clusterService);
+        ImmutableOpenMap.Builder<String, MetaData.Custom> customsBuilder = ImmutableOpenMap.builder();
+        ingestRulesMetaData = new IngestRulesMetaData(new HashMap<>());
+        customsBuilder.put(IngestRulesMetaData.TYPE, ingestRulesMetaData);
+        ImmutableOpenMap<String, MetaData.Custom> customs = customsBuilder.build();
+
+        MetaData metaData = MetaData.builder().customs(customs).build();
+        ClusterState clusterState = ClusterState.builder(clusterService.state())
+            .metaData(metaData)
+            .build();
+
+        ClusterServiceUtils.setState(clusterService, clusterState);
+        setupIngestRules();
+    }
+
+    private void setupIngestRules() {
+        ingestRulesMetaData.createIngestRule(UNDER_TEST_SOURCE_IDENT, UNDER_TEST_INGEST_RULE);
+        ingestRulesMetaData.createIngestRule("kafka", HUMIDITY_INGEST_RULE);
+    }
+
+    @Test
+    public void testRegisterImplementationAppliesCurrentRules() {
+        final AtomicReference<Set<IngestRule>> receivedRules = new AtomicReference<>();
+        ingestionService.registerImplementation(UNDER_TEST_SOURCE_IDENT,
+            rules -> receivedRules.set(rules));
+        assertThat(receivedRules.get().size(), is(1));
+        assertThat(receivedRules.get().iterator().next(), is(UNDER_TEST_INGEST_RULE));
+    }
+
+    @Test
+    public void testOnClusterStateChangeRulesAreRevalidatedAndPushedToListener() {
+        when(schemas.tableExists(any())).thenAnswer(invocationOnMock -> {
+            TableIdent tableIdent = (TableIdent) invocationOnMock.getArguments()[0];
+            // simulate target table was dropped
+            if (tableIdent.fqn().equals(UNDER_TEST_RULE_TARGET_TABLE)) {
+                return false;
+            } else {
+                return true;
+            }
+        });
+
+        final AtomicReference<Set<IngestRule>> receivedRules = new AtomicReference<>();
+        ingestionService.registerImplementation(UNDER_TEST_SOURCE_IDENT, rules -> receivedRules.set(rules));
+        ingestionService.clusterChanged(new ClusterChangedEvent("table_dropped", newClusterState(), clusterService.state()));
+        assertThat(receivedRules.get(), notNullValue());
+        assertThat(receivedRules.get().size(), is(0));
+    }
+
+    private ClusterState newClusterState() {
+        MetaData newMetaData = MetaData.builder(clusterService.state().metaData()).build();
+        return ClusterState.builder(clusterService.state())
+            .metaData(newMetaData)
+            .build();
+    }
+}


### PR DESCRIPTION
IngestionService is the central ingestion service against which ingestion implementations can register as IngestionRuleListener. 
The IngestionService listens for cluster events and on each event re-validates the rules and pushes them to the interested listeners (in case the rules are affected)