### PR TITLE
fixes a single insert only related memory leak

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -37,6 +37,8 @@ Changes
 Fixes
 =====
 
+ - Fixed a single insert only related memory leak.
+
  - Improved displaying of error messages if multiple errors are happening on
    ``ALTER TABLE`` statements.
 

--- a/sql/src/main/java/io/crate/planner/Planner.java
+++ b/sql/src/main/java/io/crate/planner/Planner.java
@@ -404,14 +404,16 @@ public class Planner extends AnalyzedStatementVisitor<Planner.Context, Plan> {
         if (analysis.onDuplicateKeyAssignmentsColumns().size() > 0) {
             onDuplicateKeyAssignmentsColumns = analysis.onDuplicateKeyAssignmentsColumns().get(0);
         }
+        DocTableInfo tableInfo = analysis.tableInfo();
         UpsertById upsertById = new UpsertById(
             context.jobId(),
             analysis.numBulkResponses(),
+            tableInfo.isPartitioned(),
             analysis.bulkIndices(),
             onDuplicateKeyAssignmentsColumns,
             analysis.columns().toArray(new Reference[analysis.columns().size()])
         );
-        if (analysis.tableInfo().isPartitioned()) {
+        if (tableInfo.isPartitioned()) {
             List<String> partitions = analysis.generatePartitions();
             String[] indices = partitions.toArray(new String[partitions.size()]);
             for (int i = 0; i < indices.length; i++) {
@@ -434,7 +436,7 @@ public class Planner extends AnalyzedStatementVisitor<Planner.Context, Plan> {
                     onDuplicateKeyAssignments = analysis.onDuplicateKeyAssignments().get(i);
                 }
                 upsertById.add(
-                    analysis.tableInfo().ident().indexName(),
+                    tableInfo.ident().indexName(),
                     analysis.ids().get(i),
                     analysis.routingValues().get(i),
                     onDuplicateKeyAssignments,

--- a/sql/src/main/java/io/crate/planner/consumer/UpdatePlanner.java
+++ b/sql/src/main/java/io/crate/planner/consumer/UpdatePlanner.java
@@ -111,7 +111,8 @@ public final class UpdatePlanner {
                             // disable bulk logic for 1 bulk item
                             numBulkResponses = 0;
                         }
-                        upsertById = UpsertById.forUpdate(plannerContext.jobId(), numBulkResponses, assignments.v1());
+                        upsertById = UpsertById.forUpdate(plannerContext.jobId(), numBulkResponses,
+                            tableInfo.isPartitioned(), assignments.v1());
                     }
                     upsertById(nestedAnalysis, tableInfo, whereClause, upsertById, bulkIdx++);
                 } else {

--- a/sql/src/main/java/io/crate/planner/node/dml/UpsertById.java
+++ b/sql/src/main/java/io/crate/planner/node/dml/UpsertById.java
@@ -94,6 +94,7 @@ public class UpsertById extends UnnestablePlan {
 
     private final UUID jobId;
     private final int numBulkResponses;
+    private final boolean isPartitioned;
     private final List<Item> items;
     private final List<Integer> bulkIndices;
 
@@ -104,19 +105,24 @@ public class UpsertById extends UnnestablePlan {
 
     public UpsertById(UUID jobId,
                       int numBulkResponses,
+                      boolean isPartitioned,
                       List<Integer> bulkIndices,
                       @Nullable String[] updateColumns,
                       @Nullable Reference[] insertColumns) {
         this.jobId = jobId;
         this.numBulkResponses = numBulkResponses;
+        this.isPartitioned = isPartitioned;
         this.bulkIndices = bulkIndices;
         this.updateColumns = updateColumns;
         this.insertColumns = insertColumns;
         this.items = new ArrayList<>();
     }
 
-    public static UpsertById forUpdate(UUID jobId, int numBulkResponses, @Nullable String[] updateColumns) {
-        return new UpsertById(jobId, numBulkResponses, new ArrayList<>(), updateColumns, null);
+    public static UpsertById forUpdate(UUID jobId,
+                                       int numBulkResponses,
+                                       boolean isPartitioned,
+                                       @Nullable String[] updateColumns) {
+        return new UpsertById(jobId, numBulkResponses, isPartitioned, new ArrayList<>(), updateColumns, null);
     }
 
     @Nullable
@@ -131,6 +137,10 @@ public class UpsertById extends UnnestablePlan {
 
     public int numBulkResponses() {
         return numBulkResponses;
+    }
+
+    public boolean isPartitioned() {
+        return isPartitioned;
     }
 
     public List<Integer> bulkIndices() {


### PR DESCRIPTION
the AutoCreateIndex class is expected to be used as a singleton, but it 
wasn’t and a new instance was created for every single insert.
the real memory leak was happening due to that this class is registering
itself as a setting update consumer, so every insert registered a new 
instance as a settings update consumer and it was never de-registering.
also usage of AutoCreateIndex was wrong anyway, replace it with own correct logic.