### PR TITLE
Added deprecation note for the use of cluster name in path.data

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -27,6 +27,8 @@ Breaking Changes
 Changes
 =======
 
+ - Added node cluster check for cluster-name folder in data path directory.
+
  - Update Crash to ``0.22.1`` which includes the following changes:
 
     - Added a status toolbar that prints the current session info.

--- a/blackbox/docs/release_notes/2.0.0.txt
+++ b/blackbox/docs/release_notes/2.0.0.txt
@@ -138,6 +138,9 @@ Breaking Changes
  - Thread pool settings prefix have been changed from ``threadpool`` to
    ``thread_pool``. E.g.: ``thread_pool.<name>.type``.
 
+ - The ``cluster name`` is not part of the effective path where data is stored
+   anymore.
+
 Changes
 -------
 
@@ -301,3 +304,17 @@ sets both the minimum and maximum memory to allocate, and should be set to
 whatever your previous ``CRATE_MAX_MEM`` was set to.
 
 .. _enterprise edition: https://crate.io/enterprise-edition/
+
+Cluster name in path data
+-------------------------
+
+The computation of the effective data directory path has changed in a way that
+the cluster name is not part of the path anymore. In previous versions it was
+``$PATH_DATA_DIR/$CLUSTER_NAME/nodes/`` and now it is
+``$PATH_DATA_DIR/nodes/``. There's a fallback that still accepts the old data
+structure, which will be removed in future versions of CrateDB.
+It will be required that the data directory is either moved to the new location
+or the ``path.data`` setting gets changed to point to the old location by
+appending the clustername to it (e.g ``/data/`` becomes
+``/data/yourclustername``). Therefore it's not possible anymore for multiple
+clusters to share the exact same ``path.data`` directory.

--- a/blackbox/docs/sql/system.txt
+++ b/blackbox/docs/sql/system.txt
@@ -604,16 +604,17 @@ The table schema is the following:
 Example query::
 
   cr> select id, node_id, description from sys.node_checks order by id, node_id;
-  +----+---------...-+--------------------------------------------------------------...-+
-  | id | node_id     | description                                                      |
-  +----+---------...-+--------------------------------------------------------------...-+
-  |  1 | ...         | The value of the cluster setting 'gateway.expected_nodes' mus... |
-  |  2 | ...         | The value of the cluster setting 'gateway.recover_after_nodes... |
-  |  3 | ...         | If any of the "expected nodes" recovery settings are set, the... |
-  |  5 | ...         | The high disk watermark is exceeded on the node. The cluster ... |
-  |  6 | ...         | The low disk watermark is exceeded on the node. The cluster w... |
-  +----+---------...-+--------------------------------------------------------------...-+
-  SELECT 5 rows in set (... sec)
+  +-...-+---------...-+--------------------------------------------------------------...-+
+  |  id | node_id     | description                                                      |
+  +-...-+---------...-+--------------------------------------------------------------...-+
+  |   1 | ...         | The value of the cluster setting 'gateway.expected_nodes' mus... |
+  |   2 | ...         | The value of the cluster setting 'gateway.recover_after_nodes... |
+  |   3 | ...         | If any of the "expected nodes" recovery settings are set, the... |
+  |   5 | ...         | The high disk watermark is exceeded on the node. The cluster ... |
+  |   6 | ...         | The low disk watermark is exceeded on the node. The cluster w... |
+  ...
+  +-...-+---------...-+--------------------------------------------------------------...-+
+  SELECT ... rows in set (... sec)
 
 .. _sys-node-checks-ack:
 

--- a/sql/src/main/java/io/crate/operation/reference/sys/check/node/ClusterNameInPathDataNodesSysCheck.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/check/node/ClusterNameInPathDataNodesSysCheck.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.operation.reference.sys.check.node;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.crate.operation.reference.sys.check.AbstractSysCheck;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.env.NodeEnvironment;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+@Singleton
+// TODO-ES6: REMOVE THIS CHECK ONCE CrateDB IS UPDATED TO ES >= 6.0
+public class ClusterNameInPathDataNodesSysCheck extends AbstractSysNodeCheck {
+
+    private final NodeEnvironment nodeEnvironment;
+    private final Settings settings;
+
+    static final int ID = 1000;
+    private static final String DESCRIPTION = "The path.data directories [%s] appear to have an old structure, which " +
+                                              "will not be supported in future versions of CrateDB. %s%d";
+    private final List<String> clusterNamePaths;
+
+    @Inject
+    public ClusterNameInPathDataNodesSysCheck(ClusterService clusterService,
+                                              Settings settings,
+                                              NodeEnvironment nodeEnvironment) {
+        super(ID, DESCRIPTION, Severity.MEDIUM, clusterService);
+        this.nodeEnvironment = nodeEnvironment;
+        this.settings = settings;
+
+        // Find all paths that contain the cluster name.
+        this.clusterNamePaths = getClusterNamePaths();
+    }
+
+    @Override
+    public boolean validate() {
+        return clusterNamePaths.size() == 0;
+    }
+
+    @Override
+    public BytesRef description() {
+        String linkedDescriptionBuilder = String.format(
+            Locale.ENGLISH,
+            DESCRIPTION,
+            String.join(",", clusterNamePaths),
+            AbstractSysCheck.LINK_PATTERN,
+            ID);
+        return new BytesRef(linkedDescriptionBuilder);
+    }
+
+    /**
+     * Returns all path.data paths that still use cluster name folder.
+     *
+     * @return list of all paths that contain the cluster name as folder
+     */
+    private List<String> getClusterNamePaths() {
+        String clusterName = ClusterName.CLUSTER_NAME_SETTING.get(settings).value();
+        List<String> pathData = Environment.PATH_DATA_SETTING.get(settings);
+
+        return comparePathDataWithNodeDataPaths(clusterName, pathData, nodeEnvironment.nodeDataPaths());
+    }
+
+    /**
+     * Checks if pathData paths do contain cluster name as a folder. This is
+     * done by matching against the NodeEnvironment paths, since this is the
+     * only hint, that the fallback procedure is operating.
+     *
+     * @param clusterName         current cluster name
+     * @param configuredDataPaths all paths specified in path.data
+     * @param resolvedDataPaths   all paths specified in NodeEnvironment
+     * @return list of all paths that contain the cluster name as folder
+     */
+    @VisibleForTesting
+    static List<String> comparePathDataWithNodeDataPaths(String clusterName,
+                                                         List<String> configuredDataPaths,
+                                                         Path[] resolvedDataPaths) {
+        List<String> resolvedDataPathList = trimNodeSuffix(resolvedDataPaths);
+        List<String> result = new ArrayList<>();
+        int index;
+        String path;
+        for (String pathDataPath : configuredDataPaths) {
+            path = Paths.get(pathDataPath, clusterName).toString();
+            index = resolvedDataPathList.indexOf(path);
+
+            if (index != -1) {
+                result.add(pathDataPath);
+                resolvedDataPathList.remove(index);
+                continue;
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * Creates list of strings from NodeEnvironment paths and cuts off nodes folder.
+     *
+     * @return list of node data paths without nodes suffix
+     */
+    private static List<String> trimNodeSuffix(Path[] paths) {
+        List<String> nodeDataPaths = new ArrayList<>();
+        String pathString;
+        for (Path path : paths) {
+            pathString = path.toString();
+            // Cut string ending "/nodes/0"
+            nodeDataPaths.add(pathString.substring(0, pathString.indexOf(NodeEnvironment.NODES_FOLDER) - 1));
+        }
+
+        return nodeDataPaths;
+    }
+}

--- a/sql/src/main/java/io/crate/operation/reference/sys/check/node/SysNodeChecksModule.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/check/node/SysNodeChecksModule.java
@@ -33,10 +33,14 @@ public class SysNodeChecksModule extends AbstractModule {
 
         MapBinder<Integer, SysNodeCheck> b = MapBinder.newMapBinder(binder(), Integer.class, SysNodeCheck.class);
 
-        b.addBinding(HighDiskWatermarkNodesSysCheck.ID).to(HighDiskWatermarkNodesSysCheck.class);
-        b.addBinding(LowDiskWatermarkNodesSysCheck.ID).to(LowDiskWatermarkNodesSysCheck.class);
+        // Node checks ordered by ID. New ID must be max ID + 1 and must not be reused.
+        b.addBinding(RecoveryExpectedNodesSysCheck.ID).to(RecoveryExpectedNodesSysCheck.class);
         b.addBinding(RecoveryAfterNodesSysCheck.ID).to(RecoveryAfterNodesSysCheck.class);
         b.addBinding(RecoveryAfterTimeSysCheck.ID).to(RecoveryAfterTimeSysCheck.class);
-        b.addBinding(RecoveryExpectedNodesSysCheck.ID).to(RecoveryExpectedNodesSysCheck.class);
+        b.addBinding(HighDiskWatermarkNodesSysCheck.ID).to(HighDiskWatermarkNodesSysCheck.class);
+        b.addBinding(LowDiskWatermarkNodesSysCheck.ID).to(LowDiskWatermarkNodesSysCheck.class);
+
+        // Checks that are intentionally declared as temporary should have an ID > 999.
+        b.addBinding(ClusterNameInPathDataNodesSysCheck.ID).to(ClusterNameInPathDataNodesSysCheck.class);
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/SysNodeCheckerIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysNodeCheckerIntegrationTest.java
@@ -25,9 +25,20 @@ package io.crate.integrationtests;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.TestingHelpers;
 import io.crate.testing.UseJdbc;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Test;
 
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
@@ -36,10 +47,28 @@ import static org.hamcrest.Matchers.is;
 @UseJdbc
 public class SysNodeCheckerIntegrationTest extends SQLTransportIntegrationTest {
 
+    private static List<String> dirs = new ArrayList<>();
+
+    @Override
+    // TODO-ES6: This is for testing the ClusterNameInPathDataNodesSysCheck and
+    // should be removed once we migrate to ES >= 6.0
+    protected Settings nodeSettings(int nodeOrdinal) {
+        String clusterName = internalCluster().getClusterName();
+        Path tmpDir = createTempDir();
+        dirs.add(tmpDir.toString());
+        Path nodesPath = Paths.get(tmpDir.toString(), clusterName, NodeEnvironment.NODES_FOLDER);
+        new File(nodesPath.toString()).mkdirs();
+
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put(Environment.PATH_DATA_SETTING.getKey(), tmpDir.toString())
+            .build();
+    }
+
     @Test
     public void testChecksPresenceAndSeverityLevels() throws Exception {
         SQLResponse response = execute("select id, severity, passed from sys.node_checks order by id, node_id asc");
-        assertThat(response.rowCount(), equalTo(10L));
+        assertThat(response.rowCount(), equalTo(12L));
         assertThat(TestingHelpers.printedTable(response.rows()),
             is("1| 3| false\n" +  // 1 = recoveryExpectedNodesCheck
                "1| 3| false\n" +
@@ -50,7 +79,9 @@ public class SysNodeCheckerIntegrationTest extends SQLTransportIntegrationTest {
                "5| 3| true\n" +   // 5 = HighDiskWatermark
                "5| 3| true\n" +
                "6| 3| true\n" +   // 6 = LowDiskWatermark
-               "6| 3| true\n"));
+               "6| 3| true\n" +
+               "1000| 2| false\n" +   // 1000 = Cluster name in path.data
+               "1000| 2| false\n"));
     }
 
     @Test
@@ -77,5 +108,21 @@ public class SysNodeCheckerIntegrationTest extends SQLTransportIntegrationTest {
         assertThat(rc, greaterThan(0L));
         execute("update sys.node_checks set acknowledged = not passed where passed = false");
         assertThat(response.rowCount(), is(rc));
+    }
+
+    /**
+     * Check if cluster name check is raising a warning, when path.data
+     * contains cluster name folder.
+     * <p>
+     * TODO-ES6: Remove this when ES >= 6.0
+     */
+    @Test
+    public void testClusterNameInPathDataNodesSysCheck() throws Exception {
+        execute("select description, passed from sys.node_checks where not passed and id=1000");
+        assertThat(response.rowCount(), is(2L));
+        String description = (String) response.rows()[0][0];
+        assertThat(description, anyOf(containsString(dirs.get(0)), containsString(dirs.get(1))));
+        description = (String) response.rows()[1][0];
+        assertThat(description, anyOf(containsString(dirs.get(0)), containsString(dirs.get(1))));
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/SysNodeResiliencyIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysNodeResiliencyIntegrationTest.java
@@ -45,7 +45,6 @@ public class SysNodeResiliencyIntegrationTest extends SQLTransportIntegrationTes
         return nodePlugins;
     }
 
-
     /**
      * Test that basic information from cluster state is used if a sys node
      * request is timing out
@@ -76,5 +75,17 @@ public class SysNodeResiliencyIntegrationTest extends SQLTransportIntegrationTes
             internalCluster().clearDisruptionScheme(true);
             waitNoPendingTasksOnAll();
         }
+    }
+
+    /**
+     * Test cluster name check, when path.data does not contain cluster
+     * name as a folder.
+     * <p>
+     * TODO-ES6: Remove this when ES >= 6.0
+     */
+    @Test
+    public void testClusterNameInPathCheckDoesNotFailWithDefaultConfig() throws Exception {
+        execute("select description, passed from sys.node_checks where not passed and id=1000");
+        assertThat(response.rowCount(), is(0L));
     }
 }

--- a/sql/src/test/java/io/crate/operation/reference/sys/check/node/ClusterNameInPathDataNodesSysCheckTest.java
+++ b/sql/src/test/java/io/crate/operation/reference/sys/check/node/ClusterNameInPathDataNodesSysCheckTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.operation.reference.sys.check.node;
+
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import org.elasticsearch.common.inject.internal.Nullable;
+import org.elasticsearch.env.NodeEnvironment;
+import org.junit.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.is;
+
+public class ClusterNameInPathDataNodesSysCheckTest extends CrateDummyClusterServiceUnitTest {
+    @Test
+    public void validatePathsWithoutClusterNameFolder() throws Exception {
+        List<String> paths = new ArrayList<>();
+        paths.add("/absolute/path");
+        paths.add("./relative-path");
+
+        List<String> clusterNamePaths = ClusterNameInPathDataNodesSysCheck.comparePathDataWithNodeDataPaths(
+            "testcluster",
+            paths,
+            convertToNodeEnvironmentPaths(paths, null));
+
+        assertThat(clusterNamePaths.size(), is(0));
+    }
+
+    @Test
+    public void validatePathsWithClusterNameFolder() throws Exception {
+        List<String> paths = new ArrayList<>();
+        paths.add("/absolute/path");
+        paths.add("./relative-path");
+
+        List<String> clusterNamePaths = ClusterNameInPathDataNodesSysCheck.comparePathDataWithNodeDataPaths(
+            "testcluster",
+            paths,
+            convertToNodeEnvironmentPaths(paths, "testcluster"));
+
+        assertThat(clusterNamePaths.size(), is(2));
+    }
+
+    /**
+     * Converts a list of path strings to a Path array. If a clusterName is
+     * set the path is going to look like $path/$clustername/nodes/0 such as
+     * they are created in NodeEnvironment.
+     *
+     * @param paths       list of path strings
+     * @param clusterName name of the cluster to add to path
+     * @return array of paths
+     */
+    private Path[] convertToNodeEnvironmentPaths(List<String> paths, @Nullable String clusterName) {
+        if (clusterName == null) {
+            clusterName = "";
+        }
+
+        Path[] result = new Path[paths.size()];
+        int index = 0;
+
+        for (String path : paths) {
+            result[index++] = Paths.get(path, clusterName, NodeEnvironment.NODES_FOLDER, "0");
+        }
+
+        return result;
+    }
+}


### PR DESCRIPTION
This PR adds **release notes** for 2.0.0, where the effective data storage path was changed and adds a **cluster node check** for that, since this is going to be a breaking change in future versions of CrateDB. Currently there's a fallback which still accepts the old path structure.

This needs to be backported