### PR TITLE
Fixed an issue that caused ``cluster.name`` from crate.yml to be ignored.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -39,6 +39,9 @@ Changes
 Fixes
 =====
 
+ - Fixed an issue that caused ``cluster.name`` setting in ``crate.yml`` file
+   to be ignored.
+
  - Fixed a single insert only related memory leak.
 
  - Improved displaying of error messages if multiple errors are happening on

--- a/app/src/main/java/org/elasticsearch/node/internal/CrateSettingsPreparer.java
+++ b/app/src/main/java/org/elasticsearch/node/internal/CrateSettingsPreparer.java
@@ -70,14 +70,17 @@ public class CrateSettingsPreparer {
             }
         }
 
+        // we put back settings from command line to override the ones from configuration file
+        builder.put(esEnvironment.settings());
+
+        // we put back the path.logs so we can use it in the logging configuration file
+        builder.put(
+            Environment.PATH_LOGS_SETTING.getKey(),
+            cleanPath(newEnvironment.logsFile().toAbsolutePath().toString()));
+
         validateKnownSettings(builder);
         applyCrateDefaults(builder);
 
-        // we put back the path.logs so we can use it in the logging configuration file
-        builder.put(Environment.PATH_LOGS_SETTING.getKey(), cleanPath(newEnvironment.logsFile().toAbsolutePath().toString()));
-
-        // we put back settings from command line to override the ones from configuration file
-        builder.put(esEnvironment.settings());
         return new Environment(builder.build());
     }
 

--- a/app/src/test/java/org/elasticsearch/node/internal/CrateSettingsPreparerTest.java
+++ b/app/src/test/java/org/elasticsearch/node/internal/CrateSettingsPreparerTest.java
@@ -104,6 +104,38 @@ public class CrateSettingsPreparerTest {
         assertThat(finalSettings.getAsBoolean("stats.enabled", null), is(true));
         // Value kept from crate.yml
         assertThat(finalSettings.getAsBoolean("psql.enabled", null), is(false));
+        assertThat(finalSettings.get("cluster.name", null), is("testCluster"));
+    }
+
+    @Test
+    public void testClusterNameFromCommandLineArgsOverridesSettingFromConfigFile() throws Exception {
+        Settings.Builder builder = Settings.builder();
+        builder.put("path.home", ".");
+        builder.put("path.conf", PathUtils.get(getClass().getResource("config").toURI()));
+        builder.put("cluster.name", "clusterNameOverridden");
+        Environment environment = new Environment(builder.build());
+        Settings finalSettings = CrateSettingsPreparer.prepareEnvironment(Settings.EMPTY, environment).settings();
+        // Overriding value from crate.yml
+        assertThat(finalSettings.get("cluster.name", null), is("clusterNameOverridden"));
+    }
+
+    @Test
+    public void testClusterNameMissingFromConfigFile() throws Exception {
+        Settings.Builder builder = Settings.builder();
+        builder.put("path.home", ".");
+        builder.put("cluster.name", "clusterName");
+        Environment environment = new Environment(builder.build());
+        Settings finalSettings = CrateSettingsPreparer.prepareEnvironment(Settings.EMPTY, environment).settings();
+        assertThat(finalSettings.get("cluster.name", null), is("clusterName"));
+    }
+
+    @Test
+    public void testClusterNameMissingFromBothConfigFileAndCommandLineArgs() throws Exception {
+        Settings.Builder builder = Settings.builder();
+        builder.put("path.home", ".");
+        Environment environment = new Environment(builder.build());
+        Settings finalSettings = CrateSettingsPreparer.prepareEnvironment(Settings.EMPTY, environment).settings();
+        assertThat(finalSettings.get("cluster.name", null), is("crate"));
     }
 
     @Test

--- a/app/src/test/resources/org/elasticsearch/node/internal/config/crate.yml
+++ b/app/src/test/resources/org/elasticsearch/node/internal/config/crate.yml
@@ -1,2 +1,3 @@
+cluster.name: testCluster
 stats.enabled: false
 psql.enabled: false


### PR DESCRIPTION
The issue was introduced by by ES 5.4.3 and the fix: 7c0f96c5e1f2848f8de1db6de3009d048cdb2fa7
to allow cmd line args to override settings fro m crate.yml