### PR TITLE
Ensure output is extended for join conditions

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -41,3 +41,10 @@ Fixes
 
  - Fixed an issue that caused ``cluster.name`` setting in ``crate.yml`` file
    to be overridden by default name ``crate``.
+
+ - Fixed a NPE when using explicit join conditions with fields which
+   were not contained in the select list. For example::
+
+     SELECT t3.z FROM t1
+     JOIN t2 ON t1.a = t2.b
+     JOIN t3 ON t2.b = t3.c

--- a/sql/src/test/java/io/crate/planner/consumer/ManyTableConsumerTest.java
+++ b/sql/src/test/java/io/crate/planner/consumer/ManyTableConsumerTest.java
@@ -127,6 +127,20 @@ public class ManyTableConsumerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(root.left().querySpec().orderBy().get().orderBySymbols(), isSQL("add(doc.t1.x, doc.t1.x)"));
     }
 
+    /**
+     * Tests that we can resolve a field from the last joined table.
+     */
+    @Test
+    public void testOutputExtension() throws Exception {
+        MultiSourceSelect mss = analyze("select t3.z from t1 " +
+                                        "join t2 on t1.a = t2.b " +
+                                        "join t3 on t2.b = t3.c");
+        TwoTableJoin root = ManyTableConsumer.buildTwoTableJoinTree(mss);
+
+        assertThat(root.fields().size(), is(1));
+        assertThat(root.fields().get(0).path().outputName(), is("doc.t3['z']"));
+    }
+
     @Test
     public void testGetNamesFromOrderBy() {
         JoinPair pair1 = JoinPair.crossJoin(T3.T1, T3.T2);


### PR DESCRIPTION
Selecting fields from a nested `TwoTableJoin` was not possible if the field was part of a table used in a join condition. 