### PR TITLE
transfer ingestion rules on table rename

### DIFF
--- a/sql/src/main/java/io/crate/metadata/MetaDataModule.java
+++ b/sql/src/main/java/io/crate/metadata/MetaDataModule.java
@@ -22,6 +22,7 @@
 package io.crate.metadata;
 
 import io.crate.metadata.cluster.DDLClusterStateService;
+import io.crate.metadata.rule.ingest.IngestionService;
 import io.crate.metadata.table.SchemaInfo;
 import io.crate.metadata.tablefunctions.TableFunctionImplementation;
 import org.elasticsearch.common.inject.AbstractModule;
@@ -40,6 +41,7 @@ public class MetaDataModule extends AbstractModule {
         bindSchemas();
 
         bind(DDLClusterStateService.class).asEagerSingleton();
+        bind(IngestionService.class).asEagerSingleton();
     }
 
     protected void bindReferences() {

--- a/sql/src/main/java/io/crate/metadata/rule/ingest/IngestRule.java
+++ b/sql/src/main/java/io/crate/metadata/rule/ingest/IngestRule.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 
 import java.io.IOException;
+import java.util.Objects;
 
 public class IngestRule implements Writeable {
 
@@ -62,14 +63,15 @@ public class IngestRule implements Writeable {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-
-        IngestRule that = (IngestRule) o;
-        return name.equals(that.name);
+        IngestRule rule = (IngestRule) o;
+        return Objects.equals(name, rule.name) &&
+               Objects.equals(targetTable, rule.targetTable) &&
+               Objects.equals(condition, rule.condition);
     }
 
     @Override
     public int hashCode() {
-        return name.hashCode();
+        return Objects.hash(name, targetTable, condition);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/metadata/rule/ingest/IngestionDDLClusterStateModifier.java
+++ b/sql/src/main/java/io/crate/metadata/rule/ingest/IngestionDDLClusterStateModifier.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.rule.ingest;
+
+import io.crate.metadata.TableIdent;
+import io.crate.metadata.cluster.DDLClusterStateModifier;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.MetaData;
+
+public class IngestionDDLClusterStateModifier implements DDLClusterStateModifier {
+
+    @Override
+    public ClusterState onRenameTable(ClusterState currentState,
+                                      TableIdent sourceTableIdent,
+                                      TableIdent targetTableIdent,
+                                      boolean isPartitionedTable) {
+        MetaData currentMetaData = currentState.metaData();
+        MetaData.Builder mdBuilder = MetaData.builder(currentMetaData);
+        if (transferIngestionRules(mdBuilder, sourceTableIdent, targetTableIdent)) {
+            return ClusterState.builder(currentState).metaData(mdBuilder).build();
+        }
+        return currentState;
+    }
+
+    private static boolean transferIngestionRules(MetaData.Builder mdBuilder,
+                                                  TableIdent sourceTableIdent,
+                                                  TableIdent targetTableIdent) {
+        IngestRulesMetaData oldMetaData = (IngestRulesMetaData) mdBuilder.getCustom(IngestRulesMetaData.TYPE);
+        if (oldMetaData == null) {
+            return false;
+        }
+
+        // create a new instance of the metadata if rules were changed, to guarantee the cluster changed action.
+        IngestRulesMetaData newMetaData = IngestRulesMetaData.maybeCopyAndReplaceTargetTableIdents(
+            oldMetaData, sourceTableIdent.fqn(), targetTableIdent.fqn());
+
+        if (newMetaData != null) {
+            mdBuilder.putCustom(IngestRulesMetaData.TYPE, newMetaData);
+            return true;
+        }
+        return false;
+    }
+}

--- a/sql/src/test/java/io/crate/metadata/rule/ingest/IngestRulesMetaDataTest.java
+++ b/sql/src/test/java/io/crate/metadata/rule/ingest/IngestRulesMetaDataTest.java
@@ -139,14 +139,4 @@ public class IngestRulesMetaDataTest extends CrateUnitTest {
         IngestRulesMetaData copyOfMetaData = IngestRulesMetaData.copyOf(inputMetaData);
         assertNotSame(copyOfMetaData, inputMetaData);
     }
-
-    @Test
-    public void testGetAllRulesForTargetTable() {
-        IngestRule newIngestRule = new IngestRule("newRule", "mqtt_table", "topic = 'test'");
-        inputMetaData.createIngestRule("newSource", newIngestRule);
-
-        Set<IngestRule> allRules = inputMetaData.getAllRulesForTargetTable("mqtt_table");
-        assertThat(allRules.size(), is(1));
-        assertThat(allRules.iterator().next(), is(newIngestRule));
-    }
 }

--- a/sql/src/test/java/io/crate/metadata/rule/ingest/IngestionServiceTest.java
+++ b/sql/src/test/java/io/crate/metadata/rule/ingest/IngestionServiceTest.java
@@ -24,6 +24,7 @@ package io.crate.metadata.rule.ingest;
 
 import io.crate.metadata.Schemas;
 import io.crate.metadata.TableIdent;
+import io.crate.metadata.cluster.DDLClusterStateService;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
@@ -59,7 +60,7 @@ public class IngestionServiceTest extends CrateDummyClusterServiceUnitTest {
     @Before
     public void setupIngestionServiceAndIngestRulesMetaData() {
         schemas = mock(Schemas.class);
-        ingestionService = new IngestionService(schemas, clusterService);
+        ingestionService = new IngestionService(schemas, clusterService, new DDLClusterStateService());
         ImmutableOpenMap.Builder<String, MetaData.Custom> customsBuilder = ImmutableOpenMap.builder();
         ingestRulesMetaData = new IngestRulesMetaData(new HashMap<>());
         customsBuilder.put(IngestRulesMetaData.TYPE, ingestRulesMetaData);


### PR DESCRIPTION
equals() and hashCode() of the IngestRule must at least contain the 
target_table otherwise no cluster state change will be triggered if only
the target_table of some rules are changed.