### PR TITLE
Utilize _field_names for IS NULL and IS NOT NULL

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -39,5 +39,9 @@ Changes
 Fixes
 =====
 
+ - Fixed an issue that caused queries with ``IS NULL`` or ``IS NOT NULL` on
+   columns of type ``geo_point`` to fail.
+
  - Changed ``crate`` unix/linux startup script to use standard ``sh`` syntax
    instead of ``bash`` specific syntax.
+

--- a/sql/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
+++ b/sql/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
@@ -123,6 +123,7 @@ import org.elasticsearch.index.mapper.LatLonPointFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.Uid;
+import org.elasticsearch.index.query.ExistsQueryBuilder;
 import org.elasticsearch.index.query.QueryShardContext;
 import org.elasticsearch.index.query.RegexpFlag;
 import org.elasticsearch.index.search.geo.LegacyInMemoryGeoBoundingBoxQuery;
@@ -607,7 +608,7 @@ public class LuceneQueryBuilder {
                         return null;
                     }
                     if (reference.isNullable()) {
-                        builder.add(fieldType.rangeQuery(null, null, true, true, context.queryShardContext), BooleanClause.Occur.MUST);
+                        builder.add(ExistsQueryBuilder.newFilter(context.queryShardContext, columnName), BooleanClause.Occur.MUST);
                     }
                 }
                 if (ctx.hasStrictThreeValuedLogicFunction) {
@@ -633,18 +634,8 @@ public class LuceneQueryBuilder {
                     return null;
                 }
                 Reference reference = (Reference) arg;
-
                 String columnName = reference.ident().columnIdent().fqn();
-                MappedFieldType fieldType = context.getFieldTypeOrNull(columnName);
-                if (fieldType == null) {
-                    if (CollectionType.unnest(reference.valueType()).equals(DataTypes.OBJECT)) {
-                        // object column has no mappedFieldType, but may exist. Need to use generic fallback
-                        return null;
-                    }
-                    // is null on an unknown column is always true
-                    return Queries.newMatchAllQuery();
-                }
-                return Queries.not(fieldType.rangeQuery(null, null, true, true, context.queryShardContext));
+                return Queries.not(ExistsQueryBuilder.newFilter(context.queryShardContext, columnName));
             }
         }
 

--- a/sql/src/test/java/io/crate/testing/DataTypeTesting.java
+++ b/sql/src/test/java/io/crate/testing/DataTypeTesting.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.testing;
+
+import com.carrotsearch.randomizedtesting.RandomizedContext;
+import com.carrotsearch.randomizedtesting.RandomizedTest;
+import com.carrotsearch.randomizedtesting.generators.BiasedNumbers;
+import com.carrotsearch.randomizedtesting.generators.RandomPicks;
+import com.google.common.collect.ImmutableList;
+import io.crate.types.BooleanType;
+import io.crate.types.ByteType;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+import io.crate.types.DoubleType;
+import io.crate.types.FloatType;
+import io.crate.types.GeoPointType;
+import io.crate.types.GeoShapeType;
+import io.crate.types.IntegerType;
+import io.crate.types.IpType;
+import io.crate.types.LongType;
+import io.crate.types.ObjectType;
+import io.crate.types.ShortType;
+import io.crate.types.StringType;
+import io.crate.types.TimestampType;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Random;
+import java.util.function.Supplier;
+
+public class DataTypeTesting {
+
+    static final List<DataType> ALL_TYPES_EXCEPT_ARRAYS = ImmutableList.<DataType>builder()
+        .addAll(DataTypes.PRIMITIVE_TYPES)
+        .add(DataTypes.GEO_POINT)
+        .add(DataTypes.GEO_SHAPE)
+        .add(DataTypes.OBJECT)
+        .build();
+
+    public static DataType<?> randomType() {
+        return RandomPicks.randomFrom(RandomizedContext.current().getRandom(),ALL_TYPES_EXCEPT_ARRAYS);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> Supplier<T> getDataGenerator(DataType<T> type) {
+        Random random = RandomizedContext.current().getRandom();
+        switch (type.id()) {
+            case ByteType.ID:
+                return () -> (T) (Byte) (byte) random.nextInt(Byte.MAX_VALUE);
+            case BooleanType.ID:
+                return () -> (T) (Boolean) random.nextBoolean();
+
+            case StringType.ID:
+                return () -> (T) RandomizedTest.randomAsciiOfLength(random.nextInt(10));
+
+            case IpType.ID:
+                return () -> (T) (
+                    Integer.toString(RandomizedTest.randomIntBetween(1, 255)) + "." +
+                    Integer.toString(RandomizedTest.randomIntBetween(0, 255)) + "." +
+                    Integer.toString(RandomizedTest.randomIntBetween(0, 255)) + "." +
+                    Integer.toString(RandomizedTest.randomIntBetween(0, 255)));
+
+            case DoubleType.ID:
+                return () -> (T) (Double) random.nextDouble();
+
+            case FloatType.ID:
+                return () -> (T) (Float) random.nextFloat();
+
+            case ShortType.ID:
+                return () -> (T) (Short) (short) random.nextInt(Short.MAX_VALUE);
+
+            case IntegerType.ID:
+                return () -> (T) (Integer) random.nextInt();
+
+            case LongType.ID:
+            case TimestampType.ID:
+                return () -> (T) (Long) random.nextLong();
+
+            case GeoPointType.ID:
+                return () -> (T) new Double[]{
+                    BiasedNumbers.randomDoubleBetween(random, -180, 180),
+                    BiasedNumbers.randomDoubleBetween(random, -90, 90)
+                };
+
+            case GeoShapeType.ID:
+                return () -> (T) GeoShapeType.INSTANCE.value("POINT (10.2 32.2)");
+
+            case ObjectType.ID:
+                Supplier<?> innerValueGenerator = getDataGenerator(randomType());
+                return () -> {
+                    // Can't use immutable Collections.singletonMap; insert-analyzer mutates the map
+                    HashMap<String, Object> map = new HashMap<>();
+                    map.put("x", innerValueGenerator.get());
+                    return (T) map;
+                };
+        }
+
+        throw new AssertionError("No data generator for type " + type.getName());
+    }
+}

--- a/sql/src/test/java/io/crate/testing/DataTypeTestingTest.java
+++ b/sql/src/test/java/io/crate/testing/DataTypeTestingTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.testing;
+
+import io.crate.test.integration.CrateUnitTest;
+import io.crate.types.DataType;
+import org.junit.Test;
+
+public class DataTypeTestingTest extends CrateUnitTest {
+
+    @Test
+    public void testDataGeneratorReturnValidValues() throws Exception {
+        for (DataType type : DataTypeTesting.ALL_TYPES_EXCEPT_ARRAYS) {
+            type.value(DataTypeTesting.getDataGenerator(type).get());
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/crate/crate/issues/6126 and should also improve
performance for IS NULL queries.

(According to https://www.elastic.co/guide/en/elasticsearch/reference/1.7/mapping-field-names-field.html  _field_names is available since ES 1.3 - which would be Crate 0.45) so this should be fine to use also for upgraded tables)