### PR TITLE
Replace [[]] bash specific syntax with `case` for string contains() implementation

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -38,3 +38,6 @@ Changes
 
 Fixes
 =====
+
+ - Changed ``crate`` unix/linux startup script to use standard ``sh`` syntax
+   instead of ``bash`` specific syntax.

--- a/app/src/main/dist/bin/crate
+++ b/app/src/main/dist/bin/crate
@@ -113,11 +113,13 @@ launch_service()
     pidpath=$1
     daemonized=$2
     javaProperties=$3
-    if [[ $4 == *"-Cpath.home="* ]]; then
-        props="$4"
-    else
-        props="-Cpath.home=$CRATE_HOME $4"
-    fi
+
+    case "$4" in
+        *"-Cpath.home="*)
+            props="$4" ;;
+        *               )
+            props="-Cpath.home=$CRATE_HOME $4" ;;
+    esac
 
     if [ "x$pidpath" != "x" ]; then
         props="-Cpidfile=$pidpath $props"


### PR DESCRIPTION
Fixes: https://github.com/crate/crate/issues/6134