### PR TITLE
Tests: Force SQLExecutor initialization with a valid clusterService

### DIFF
--- a/sql/src/test/java/io/crate/analyze/CreateFunctionAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateFunctionAnalyzerTest.java
@@ -35,6 +35,7 @@ import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.types.ArrayType;
 import io.crate.types.DataTypes;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -44,7 +45,12 @@ import static org.hamcrest.Matchers.is;
 
 public class CreateFunctionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
-    private SQLExecutor e = SQLExecutor.builder(clusterService).build();
+    private SQLExecutor e;
+
+    @Before
+    public void initExecutor() throws Exception {
+        e = SQLExecutor.builder(clusterService).build();
+    }
 
     @Test
     public void testCreateFunctionSimple() {

--- a/sql/src/test/java/io/crate/analyze/DropFunctionAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/DropFunctionAnalyzerTest.java
@@ -33,6 +33,7 @@ import io.crate.sql.parser.SqlParser;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.types.DataTypes;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -42,7 +43,12 @@ import static org.hamcrest.Matchers.is;
 
 public class DropFunctionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
-    private SQLExecutor e = SQLExecutor.builder(clusterService).build();
+    private SQLExecutor e;
+
+    @Before
+    public void initExecutor() throws Exception {
+        e = SQLExecutor.builder(clusterService).build();
+    }
 
     @Test
     public void testDropFunctionSimple() throws Exception {

--- a/sql/src/test/java/io/crate/analyze/UserDDLAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/UserDDLAnalyzerTest.java
@@ -24,13 +24,19 @@ package io.crate.analyze;
 
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
+import org.junit.Before;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 
 public class UserDDLAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
-    private SQLExecutor e = SQLExecutor.builder(clusterService).build();
+    private SQLExecutor e;
+
+    @Before
+    public void initExecutor() throws Exception {
+        e = SQLExecutor.builder(clusterService).build();
+    }
 
     @Test
     public void testCreateUserSimple() {

--- a/sql/src/test/java/io/crate/testing/SQLExecutor.java
+++ b/sql/src/test/java/io/crate/testing/SQLExecutor.java
@@ -81,6 +81,7 @@ import static io.crate.analyze.TableDefinitions.USER_TABLE_INFO_CLUSTERED_BY_ONL
 import static io.crate.analyze.TableDefinitions.USER_TABLE_INFO_MULTI_PK;
 import static io.crate.analyze.TableDefinitions.USER_TABLE_INFO_REFRESH_INTERVAL_BY_ONLY;
 import static io.crate.testing.TestingHelpers.getFunctions;
+import static java.util.Objects.requireNonNull;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -226,7 +227,7 @@ public class SQLExecutor {
     }
 
     public static Builder builder(ClusterService clusterService) {
-        return new Builder(clusterService);
+        return new Builder(requireNonNull(clusterService, "clusterService is required for SQLExecutor"));
     }
 
     private SQLExecutor(Functions functions, Analyzer analyzer, Planner planner) {


### PR DESCRIPTION
This adds a check to the SQLExecutor to make sure the clusterService is
never null. Otherwise it will lead to strange NPEs in tests that's that *do*
use the clusterService.