### PR TITLE
Make ANY and IN expressions behave consistently

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -26,8 +26,21 @@ Breaking Changes
 
 Changes
 =======
- 
- - Introduce support for single column subselects in `ANY` and `IN`, e.g.::
+
+ - Change semantics of ``IN`` operator to behave like ``= ANY``. The argument
+   list for ``IN`` now has to be comprised of the same type. For example,
+   this is now an illegal ``IN`` query because the list mixes integer and
+   double type::
+
+     Select * from t1 where id IN (1, 1.2, 2)
+
+   This would get translated into the following and throw an error::
+
+     Select * from t1 where id = ANY([1, 1.2, 3])
+
+ - Support single column subselects within the `IN` operator, e.g.::
+
+- Introduce support for single column subselects in `ANY` and `IN`, e.g.::
 
     select id from t where id IN (select id from t2)
 

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -456,29 +456,29 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
 
     @Test
     public void testWhereInSelectValueIsNull() throws Exception {
-        SelectAnalyzedStatement analysis = analyze("select 'found' from users where null in (1.2, 2)");
+        SelectAnalyzedStatement analysis = analyze("select 'found' from users where null in (1, 2)");
         assertThat(analysis.relation().querySpec().where().hasQuery(), is(false));
         assertThat(analysis.relation().querySpec().where().noMatch(), is(true));
     }
 
     @Test
     public void testWhereInSelectDifferentDataTypeList() throws Exception {
-        SelectAnalyzedStatement analysis = analyze("select 'found' from users where 1 in (1.2, 2)");
-        assertThat(analysis.relation().querySpec().where().hasQuery(), is(false)); // already normalized from 1 in (1, 2) --> true
-        assertThat(analysis.relation().querySpec().where().noMatch(), is(false));
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("unknown function: _array(double, long)");
+        analyze("select 'found' from users where 1 in (1.2, 2)");
     }
 
     @Test
     public void testWhereInSelectDifferentDataTypeValue() throws Exception {
         SelectAnalyzedStatement analysis = analyze("select 'found' from users where 1.2 in (1, 2)");
         assertThat(analysis.relation().querySpec().where().hasQuery(), is(false)); // already normalized from 1.2 in (1.0, 2.0) --> false
-        assertThat(analysis.relation().querySpec().where().noMatch(), is(true));
+        assertThat(analysis.relation().querySpec().where().noMatch(), is(false));
     }
 
     @Test
-    public void testWhereInSelectDifferentDataTypeValueUncompatibleDataTypes() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Cannot cast 'foo' to type long");
+    public void testWhereInSelectDifferentDataTypeValueIncompatibleDataTypes() throws Exception {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("unknown function: _array(long, string, long)");
         analyze("select 'found' from users where 1 in (1, 'foo', 2)");
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
@@ -201,7 +201,7 @@ public class SQLTypeMappingTest extends SQLTransportIntegrationTest {
     @Test
     public void testInvalidWhereInWhereClause() throws Exception {
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("Cannot cast 'a' to type byte");
+        expectedException.expectMessage("Cannot cast ['a'] to type byte_array");
 
         setUpSimple();
         execute("update t1 set byte_field=0 where byte_field in ('a')");

--- a/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -885,7 +885,7 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
     @Test
     public void selectWhereNonExistingColumnWhereIn() throws Exception {
         nonExistingColumnSetup();
-        execute("select * from quotes where o['something'] IN(1,2,3)");
+        execute("select * from quotes where o['something'] IN (1,2,3)");
         assertEquals(0L, response.rowCount());
     }
 

--- a/sql/src/test/java/io/crate/operation/operator/InOperatorTest.java
+++ b/sql/src/test/java/io/crate/operation/operator/InOperatorTest.java
@@ -43,7 +43,7 @@ public class InOperatorTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testNormalizeSymbolSetLiteralDifferentDataTypeValue() {
-        assertNormalize("2.3 in (1, 2, 4, 8)", isLiteral(false));
+        assertNormalize("2.3 in (1, 2, 4, 8)", isLiteral(true));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/operator/any/AnyEqOperatorTest.java
+++ b/sql/src/test/java/io/crate/operation/operator/any/AnyEqOperatorTest.java
@@ -106,7 +106,7 @@ public class AnyEqOperatorTest extends AbstractScalarFunctionsTest {
     }
 
     @Test
-    public void testArgumentIsNotAnArrayExpression() throws Exception {
+    public void testExceptionForwardingForIllegalInput() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("cannot cast bar to Iterable");
         anyEq(1, "bar");


### PR DESCRIPTION
This gets rid of the subtle differences between ANY and IN
operators. Expressions of the form `expression IN (expression1, expression2, ...)`
now have the same result as `expression = ANY([expression1, expression2, ...])`.