### PR TITLE
Use the lamdda argument as oppose to the enclosing method argument.

### DIFF
--- a/sql/src/main/java/io/crate/metadata/cluster/DDLClusterStateService.java
+++ b/sql/src/main/java/io/crate/metadata/cluster/DDLClusterStateService.java
@@ -47,27 +47,27 @@ public class DDLClusterStateService {
 
     ClusterState onCloseTable(ClusterState currentState, TableIdent tableIdent) {
         return applyOnAllModifiers(currentState,
-            (modifier, clusterState) -> modifier.onCloseTable(currentState, tableIdent));
+            (modifier, clusterState) -> modifier.onCloseTable(clusterState, tableIdent));
     }
 
     ClusterState onCloseTablePartition(ClusterState currentState, PartitionName partitionName) {
         return applyOnAllModifiers(currentState,
-            (modifier, clusterState) -> modifier.onCloseTablePartition(currentState, partitionName));
+            (modifier, clusterState) -> modifier.onCloseTablePartition(clusterState, partitionName));
     }
 
     ClusterState onOpenTable(ClusterState currentState, TableIdent tableIdent) {
         return applyOnAllModifiers(currentState,
-            (modifier, clusterState) -> modifier.onOpenTable(currentState, tableIdent));
+            (modifier, clusterState) -> modifier.onOpenTable(clusterState, tableIdent));
     }
 
     ClusterState onOpenTablePartition(ClusterState currentState, PartitionName partitionName) {
         return applyOnAllModifiers(currentState,
-            (modifier, clusterState) -> modifier.onOpenTablePartition(currentState, partitionName));
+            (modifier, clusterState) -> modifier.onOpenTablePartition(clusterState, partitionName));
     }
 
     ClusterState onDropTable(ClusterState currentState, TableIdent tableIdent) {
         return applyOnAllModifiers(currentState,
-            (modifier, clusterState) -> modifier.onDropTable(currentState, tableIdent));
+            (modifier, clusterState) -> modifier.onDropTable(clusterState, tableIdent));
     }
 
     ClusterState onRenameTable(ClusterState currentState,
@@ -75,7 +75,7 @@ public class DDLClusterStateService {
                                TableIdent targetTableIdent,
                                boolean isPartitioned) {
         return applyOnAllModifiers(currentState,
-            (modifier, clusterState) -> modifier.onRenameTable(currentState, sourceTableIdent, targetTableIdent, isPartitioned));
+            (modifier, clusterState) -> modifier.onRenameTable(clusterState, sourceTableIdent, targetTableIdent, isPartitioned));
     }
 
     private ClusterState applyOnAllModifiers(ClusterState currentState,


### PR DESCRIPTION
When multiple modifiers are used the lambda function needs to use the `clusterState` argument that's passed into it (as oppose to the enclosing's method `currentState`) because `applyOnAllModifiers` changes the _lambda_ cluster state with every modifier (basically every modifier creates a new `clusterState` which is then passed to the next one).
On master we only have the `UserManagerDDLModifier` so the state modifications accidentally work as there are no others modifiers to chain.