### PR TITLE
Fixed output column name when select list contains subqueries.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -39,6 +39,12 @@ Changes
 Fixes
 =====
 
+ - Fixed column name in output by removing new lines when select list contains
+   subquery. E.g.::
+
+     SELECT 1 =
+         (SELECT 1)
+
  - Fixed an issue that prevents CrateDB from bootstrap on Windows hosts.
 
  - Fixed an issue that caused queries with ``IS NULL`` or ``IS NOT NULL` on

--- a/sql/src/main/java/io/crate/analyze/OutputNameFormatter.java
+++ b/sql/src/main/java/io/crate/analyze/OutputNameFormatter.java
@@ -25,6 +25,7 @@ import io.crate.sql.ExpressionFormatter;
 import io.crate.sql.tree.ArrayComparisonExpression;
 import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.QualifiedNameReference;
+import io.crate.sql.tree.SubqueryExpression;
 import io.crate.sql.tree.SubscriptExpression;
 
 import java.util.List;
@@ -59,6 +60,11 @@ public class OutputNameFormatter {
                    node.getType().getValue() + ' ' +
                    node.quantifier().name() + '(' +
                    process(node.getRight(), null) + ')';
+        }
+
+        @Override
+        protected String visitSubqueryExpression(SubqueryExpression node, Void context) {
+            return super.visitSubqueryExpression(node, context).replace("\n", "");
         }
     }
 }

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -1880,4 +1880,10 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         expectedException.expectMessage("Cannot use relation \"grandparent\" in subquery. Correlated subqueries are not supported");
         analyze("select (select (select 1 from t1 where grandparent.x = t1.x) from t1 as parent) from t1 as grandparent");
     }
+
+    @Test
+    public void testColumnOutputWithSingleRowSubselect() {
+        SelectAnalyzedStatement statement = analyze("select 1 = \n (select \n 2\n)\n");
+        assertThat(statement.relation().fields(), isSQL("doc.empty_row.(1 = (SELECT 2))"));
+    }
 }


### PR DESCRIPTION
Remove new lines (inserted by the user or automatically by SqlFormatter)
from output column name.