### PR TITLE
Add initial semi-join rewrite for `op ANY sub-select`

### DIFF
--- a/sql-parser/src/main/java/io/crate/sql/tree/QualifiedName.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/QualifiedName.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -103,5 +104,12 @@ public class QualifiedName {
     @Override
     public int hashCode() {
         return parts.hashCode();
+    }
+
+    public QualifiedName withPrefix(String prefix) {
+        ArrayList<String> newParts = new ArrayList<>(parts.size() + 1);
+        newParts.add(prefix);
+        newParts.addAll(parts);
+        return new QualifiedName(newParts);
     }
 }

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -33,8 +33,8 @@ import io.crate.analyze.DataTypeAnalyzer;
 import io.crate.analyze.NegativeLiteralVisitor;
 import io.crate.analyze.SubscriptContext;
 import io.crate.analyze.SubscriptValidator;
-import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.FieldProvider;
+import io.crate.analyze.relations.QueriedRelation;
 import io.crate.analyze.symbol.Field;
 import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Literal;
@@ -56,6 +56,7 @@ import io.crate.operation.aggregation.impl.CollectSetAggregation;
 import io.crate.operation.operator.AndOperator;
 import io.crate.operation.operator.EqOperator;
 import io.crate.operation.operator.LikeOperator;
+import io.crate.operation.operator.Operator;
 import io.crate.operation.operator.OrOperator;
 import io.crate.operation.operator.RegexpMatchCaseInsensitiveOperator;
 import io.crate.operation.operator.RegexpMatchOperator;
@@ -826,7 +827,7 @@ public class ExpressionAnalyzer {
             /* note: This does not support analysis columns in the subquery which belong to the parent relation
              * this would require {@link StatementAnalysisContext#startRelation} to somehow inherit the parent context
              */
-            AnalyzedRelation relation = subQueryAnalyzer.analyze(node.getQuery());
+            QueriedRelation relation = subQueryAnalyzer.analyze(node.getQuery());
             List<Field> fields = relation.fields();
             if (fields.size() > 1) {
                 throw new UnsupportedOperationException("Subqueries with more than 1 column are not supported.");
@@ -879,7 +880,7 @@ public class ExpressionAnalyzer {
         private Comparison(ComparisonExpression.Type comparisonExpressionType,
                            Symbol left,
                            Symbol right) {
-            this.operatorName = "op_" + comparisonExpressionType.getValue();
+            this.operatorName = Operator.PREFIX + comparisonExpressionType.getValue();
             this.comparisonExpressionType = comparisonExpressionType;
             this.left = left;
             this.right = right;
@@ -908,7 +909,7 @@ public class ExpressionAnalyzer {
             ComparisonExpression.Type type = SWAP_OPERATOR_TABLE.get(comparisonExpressionType);
             if (type != null) {
                 comparisonExpressionType = type;
-                operatorName = "op_" + type.getValue();
+                operatorName = Operator.PREFIX + type.getValue();
             }
             Symbol tmp = left;
             DataType tmpType = leftType;

--- a/sql/src/main/java/io/crate/analyze/expressions/SubqueryAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/SubqueryAnalyzer.java
@@ -22,7 +22,7 @@
 
 package io.crate.analyze.expressions;
 
-import io.crate.analyze.relations.AnalyzedRelation;
+import io.crate.analyze.relations.QueriedRelation;
 import io.crate.analyze.relations.RelationAnalyzer;
 import io.crate.analyze.relations.StatementAnalysisContext;
 import io.crate.sql.tree.Query;
@@ -37,7 +37,8 @@ public class SubqueryAnalyzer {
         this.statementAnalysisContext = statementAnalysisContext;
     }
 
-    public AnalyzedRelation analyze(Query query) {
-        return relationAnalyzer.analyze(query, statementAnalysisContext);
+    public QueriedRelation analyze(Query query) {
+        // The only non-queried relations are base tables - which cannot occur as part of a subquery. so this cast is safe.
+        return (QueriedRelation) relationAnalyzer.analyze(query, statementAnalysisContext);
     }
 }

--- a/sql/src/main/java/io/crate/analyze/relations/JoinPair.java
+++ b/sql/src/main/java/io/crate/analyze/relations/JoinPair.java
@@ -78,6 +78,11 @@ public class JoinPair {
     }
 
     @Override
+    public String toString() {
+        return "Join{" + joinType + " " + left + " ⇔ " + right + '}';
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;

--- a/sql/src/main/java/io/crate/analyze/relations/JoinPairs.java
+++ b/sql/src/main/java/io/crate/analyze/relations/JoinPairs.java
@@ -90,7 +90,7 @@ public final class JoinPairs {
         // check if relations were switched due to some optimization
         if (checkReversePair) {
             for (JoinPair joinPair : joinPairs) {
-                if (joinPair.equalsNames(right, left)) {
+                if (joinPair.joinType() != JoinType.SEMI && joinPair.equalsNames(right, left)) {
                     JoinPair reverseJoinPair = JoinPair.of(
                         joinPair.right(),
                         joinPair.left(),

--- a/sql/src/main/java/io/crate/analyze/relations/RelationNormalizer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationNormalizer.java
@@ -42,7 +42,7 @@ public final class RelationNormalizer {
 
     private final NormalizerVisitor visitor;
 
-    RelationNormalizer(Functions functions) {
+    public RelationNormalizer(Functions functions) {
         visitor =  new NormalizerVisitor(functions);
     }
 

--- a/sql/src/main/java/io/crate/analyze/symbol/FuncSymbols.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/FuncSymbols.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.analyze.symbol;
+
+public final class FuncSymbols {
+
+
+    /**
+     * @return a function that applies the mapper to all "nodes" (=functions) in a symbol
+     */
+    public static java.util.function.Function<? super Symbol, ? extends Symbol> mapNodes(java.util.function.Function<? super Function, ? extends Symbol> mapper) {
+        return st -> mapNodes(st, mapper);
+    }
+
+    /**
+     * Apply the mapper function on all nodes in a symbolTree.
+     */
+    public static Symbol mapNodes(Symbol st, java.util.function.Function<? super Function, ? extends Symbol> mapper) {
+        return Visitor.INSTANCE.process(st, mapper);
+    }
+
+    private static class Visitor extends FunctionCopyVisitor<java.util.function.Function<? super Function, ? extends Symbol>> {
+
+        private static final Visitor INSTANCE = new Visitor();
+
+        @Override
+        public Symbol visitFunction(Function func, java.util.function.Function<? super Function, ? extends Symbol> mapper) {
+            return mapper.apply(processAndMaybeCopy(func, mapper));
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/analyze/symbol/SelectSymbol.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/SelectSymbol.java
@@ -22,7 +22,7 @@
 
 package io.crate.analyze.symbol;
 
-import io.crate.analyze.relations.AnalyzedRelation;
+import io.crate.analyze.relations.QueriedRelation;
 import io.crate.types.DataType;
 import io.crate.types.SingleColumnTableType;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -34,24 +34,23 @@ import java.io.IOException;
  */
 public class SelectSymbol extends Symbol {
 
-    private final AnalyzedRelation relation;
+    private final QueriedRelation relation;
     private final SingleColumnTableType dataType;
     private final ResultType resultType;
-
-    private boolean isPlanned = false;
+    private boolean isPlanned;
 
     public enum ResultType {
         SINGLE_COLUMN_SINGLE_VALUE,
         SINGLE_COLUMN_MULTIPLE_VALUES
     }
 
-    public SelectSymbol(AnalyzedRelation relation, SingleColumnTableType dataType, ResultType resultType) {
+    public SelectSymbol(QueriedRelation relation, SingleColumnTableType dataType, ResultType resultType) {
         this.relation = relation;
         this.dataType = dataType;
         this.resultType = resultType;
     }
 
-    public AnalyzedRelation relation() {
+    public QueriedRelation relation() {
         return relation;
     }
 

--- a/sql/src/main/java/io/crate/operation/operator/Operator.java
+++ b/sql/src/main/java/io/crate/operation/operator/Operator.java
@@ -17,6 +17,7 @@ import java.util.Locale;
 public abstract class Operator<I> extends Scalar<Boolean, I> implements OperatorFormatSpec {
 
     public static final io.crate.types.DataType RETURN_TYPE = DataTypes.BOOLEAN;
+    public static final String PREFIX = "op_";
 
     @Override
     public String operator(Function function) {

--- a/sql/src/main/java/io/crate/operation/operator/any/AnyOperator.java
+++ b/sql/src/main/java/io/crate/operation/operator/any/AnyOperator.java
@@ -48,6 +48,15 @@ public abstract class AnyOperator extends Operator<Object> {
 
     public static final String OPERATOR_PREFIX = "any_";
 
+    /*
+     * Rewrite `op ANY` to `op` using the actual function names.
+     *
+     * E.g. `any_=` becomes `op_=`
+     */
+    public static String nameToNonAny(String functionName) {
+        return Operator.PREFIX + functionName.substring(OPERATOR_PREFIX.length());
+    }
+
     /**
      * called inside {@link #normalizeSymbol(Function, TransactionContext)}
      * in order to interpret the result of compareTo

--- a/sql/src/main/java/io/crate/operation/scalar/cast/CastFunctionResolver.java
+++ b/sql/src/main/java/io/crate/operation/scalar/cast/CastFunctionResolver.java
@@ -42,6 +42,8 @@ public class CastFunctionResolver {
 
     public static final String TRY_CAST_PREFIX = "try_";
 
+    private static final String TO_PREFIX = "to_";
+
     public static class FunctionNames {
         public static final String TO_STRING = "to_string";
         public static final String TO_INTEGER = "to_int";
@@ -147,6 +149,11 @@ public class CastFunctionResolver {
         DataType sourceType = sourceSymbol.valueType();
         FunctionInfo functionInfo = functionInfo(sourceType, targetType, tryCast);
         return new io.crate.analyze.symbol.Function(functionInfo, ImmutableList.of(sourceSymbol));
+    }
+
+    public static boolean isCastFunction(Symbol symbol) {
+        return symbol instanceof io.crate.analyze.symbol.Function
+               && ((io.crate.analyze.symbol.Function) symbol).info().ident().name().startsWith(TO_PREFIX);
     }
 
     /**

--- a/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/NestedLoopConsumer.java
@@ -136,7 +136,7 @@ class NestedLoopConsumer implements Consumer {
                             (!leftResultDesc.nodeIds().isEmpty() && !rightResultDesc.nodeIds().isEmpty());
             boolean broadcastLeftTable = false;
             if (isDistributed) {
-                broadcastLeftTable = isLeftSmallerThanRight(left, right);
+                broadcastLeftTable = joinType != JoinType.SEMI && isLeftSmallerThanRight(left, right);
                 if (broadcastLeftTable) {
                     Plan tmpPlan = leftPlan;
                     leftPlan = rightPlan;

--- a/sql/src/main/java/io/crate/planner/consumer/OptimizingRewriter.java
+++ b/sql/src/main/java/io/crate/planner/consumer/OptimizingRewriter.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.consumer;
+
+import io.crate.analyze.QueriedTable;
+import io.crate.analyze.relations.AnalyzedRelation;
+import io.crate.analyze.relations.AnalyzedRelationVisitor;
+import io.crate.analyze.relations.QueriedDocTable;
+import io.crate.analyze.relations.QueriedRelation;
+import io.crate.metadata.Functions;
+import io.crate.metadata.TransactionContext;
+
+final class OptimizingRewriter {
+
+    private final Functions functions;
+
+    OptimizingRewriter(Functions functions) {
+        this.functions = functions;
+    }
+
+    /*
+         * Return the relation as is or a re-written relation
+         */
+    public AnalyzedRelation optimize(AnalyzedRelation relation, TransactionContext transactionContext) {
+        return new Visitor(new SemiJoins(functions), transactionContext).process(relation, null);
+    }
+
+    private static class Visitor extends AnalyzedRelationVisitor<Void, AnalyzedRelation> {
+
+        private final SemiJoins semiJoins;
+        private final TransactionContext transactionContext;
+
+        public Visitor(SemiJoins semiJoins, TransactionContext transactionContext) {
+            this.semiJoins = semiJoins;
+            this.transactionContext = transactionContext;
+        }
+
+        @Override
+        protected AnalyzedRelation visitAnalyzedRelation(AnalyzedRelation relation, Void context) {
+            return relation;
+        }
+
+        @Override
+        public AnalyzedRelation visitQueriedTable(QueriedTable table, Void context) {
+            return super.visitQueriedTable(table, context);
+        }
+
+        @Override
+        public AnalyzedRelation visitQueriedDocTable(QueriedDocTable table, Void context) {
+            QueriedRelation rewrite = semiJoins.tryRewrite(table, transactionContext);
+            if (rewrite != null) {
+                return rewrite;
+            }
+            return super.visitQueriedDocTable(table, context);
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/planner/consumer/SemiJoins.java
+++ b/sql/src/main/java/io/crate/planner/consumer/SemiJoins.java
@@ -1,0 +1,257 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.consumer;
+
+import com.google.common.collect.ImmutableList;
+import io.crate.analyze.MultiSourceSelect;
+import io.crate.analyze.QueriedTableRelation;
+import io.crate.analyze.QuerySpec;
+import io.crate.analyze.WhereClause;
+import io.crate.analyze.relations.AnalyzedRelation;
+import io.crate.analyze.relations.JoinPair;
+import io.crate.analyze.relations.QueriedRelation;
+import io.crate.analyze.relations.RelationNormalizer;
+import io.crate.analyze.symbol.FuncSymbols;
+import io.crate.analyze.symbol.Function;
+import io.crate.analyze.symbol.Literal;
+import io.crate.analyze.symbol.RefReplacer;
+import io.crate.analyze.symbol.SelectSymbol;
+import io.crate.analyze.symbol.Symbol;
+import io.crate.analyze.symbol.SymbolVisitor;
+import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.Functions;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.table.Operation;
+import io.crate.operation.operator.OrOperator;
+import io.crate.operation.operator.any.AnyNeqOperator;
+import io.crate.operation.operator.any.AnyOperator;
+import io.crate.operation.predicate.NotPredicate;
+import io.crate.planner.node.dql.join.JoinType;
+import io.crate.sql.tree.QualifiedName;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+import static io.crate.analyze.expressions.ExpressionAnalyzer.castIfNeededOrFail;
+import static io.crate.operation.operator.Operators.LOGICAL_OPERATORS;
+import static io.crate.operation.scalar.cast.CastFunctionResolver.isCastFunction;
+
+final class SemiJoins {
+
+    private final RelationNormalizer relationNormalizer;
+
+    public SemiJoins(Functions functions) {
+        relationNormalizer = new RelationNormalizer(functions);
+    }
+
+    /**
+     * Try to rewrite a QueriedRelation into a SemiJoin:
+     *
+     * <pre>
+     *
+     *     select x from t1 where x in (select id from t2)
+     *               |
+     *               v
+     *     select t1.x from t1 SEMI JOIN (select id from t2) t2 on t1.x = t2.id
+     * </pre>
+     *
+     * (Note that it's not possible to write a SemiJoin directly using SQL. But the example above is semantically close.)
+     *
+     * This rewrite isn't always possible - certain conditions need to be met for the semi-join to have the same
+     * semantics as the subquery.
+     *
+     * @return the rewritten relation or null if a rewrite wasn't possible.
+     */
+    @Nullable
+    QueriedRelation tryRewrite(QueriedRelation rel, TransactionContext transactionCtx) {
+        WhereClause where = rel.querySpec().where();
+        if (!where.hasQuery()) {
+            return null;
+        }
+        List<Function> rewriteCandidates = gatherRewriteCandidates(where.query());
+        if (rewriteCandidates.isEmpty()) {
+            return null;
+        }
+        if (rewriteCandidates.size() > 1) {
+            return null;  // TODO: support this as well
+        }
+        Function rewriteCandidate = rewriteCandidates.get(0);
+        SelectSymbol selectSymbol = getSubqueryOrNull(rewriteCandidate.arguments().get(1));
+        assert selectSymbol != null : "rewriteCandidate must contain a selectSymbol";
+
+        AnalyzedRelation sourceRel = getSource(rel);
+        if (sourceRel == null) {
+            return null;
+        }
+
+        // Turn Ref(x) back into Field(rel, x); it's required for the MultiSourceSelect structure;
+        // (a lot of logic that follows in the Planner after the rewrite is based on Fields)
+        java.util.function.Function<? super Symbol, ? extends Symbol> refsToFields =
+            RefReplacer.replaceRefs(r -> sourceRel.getField(r.ident().columnIdent(), Operation.READ));
+        Symbol joinCondition = makeJoinCondition(rewriteCandidate, sourceRel, selectSymbol.relation());
+
+        removeRewriteCandidatesFromWhere(rel, rewriteCandidate);
+        QuerySpec newQS = rel.querySpec().copyAndReplace(refsToFields);
+
+        // Avoid name clashes if the subquery is on the same relation; e.g.: select * from t1 where x in (select * from t1)
+        QualifiedName subQueryName = selectSymbol.relation().getQualifiedName().withPrefix("S");
+
+        // Using MSS instead of TwoTableJoin so that the "fetch-pushdown" logic in the Planner is also applied
+        HashMap<QualifiedName, AnalyzedRelation> sources = new HashMap<>(2);
+        sources.put(rel.getQualifiedName(), sourceRel);
+        sources.put(subQueryName, selectSymbol.relation());
+
+        // normalize is done to rewrite  SELECT * from t1, t2 to SELECT * from (select ... t1) t1, (select ... t2) t2
+        // because planner logic expects QueriedRelation in the sources
+        return (QueriedRelation) relationNormalizer.normalize(new MultiSourceSelect(
+            sources,
+            rel.fields(),
+            newQS,
+            new ArrayList<>(Collections.singletonList(
+                JoinPair.of(
+                    rel.getQualifiedName(),
+                    subQueryName,
+                    JoinType.SEMI,
+                    joinCondition
+                )))
+        ), transactionCtx);
+    }
+
+    @Nullable
+    private static AnalyzedRelation getSource(QueriedRelation rel) {
+        if (rel instanceof QueriedTableRelation) {
+            return ((QueriedTableRelation) rel).tableRelation();
+        }
+        // TODO: support other cases as well
+        return null;
+    }
+
+    private static void removeRewriteCandidatesFromWhere(QueriedRelation rel, Function rewriteCandidate) {
+        rel.querySpec().where().replace(FuncSymbols.mapNodes(f -> {
+            if (f == rewriteCandidate) {
+                return Literal.BOOLEAN_TRUE;
+            }
+            return f;
+        }));
+    }
+
+    static List<Function> gatherRewriteCandidates(Symbol query) {
+        ArrayList<Function> candidates = new ArrayList<>();
+        RewriteCandidateGatherer.INSTANCE.process(query, candidates);
+        return candidates;
+    }
+
+    @Nullable
+    static SelectSymbol getSubqueryOrNull(Symbol symbol) {
+        symbol = unwrapCast(symbol);
+        if (symbol instanceof SelectSymbol) {
+            return ((SelectSymbol) symbol);
+        }
+        return null;
+    }
+
+    private static Symbol unwrapCast(Symbol symbol) {
+        while (isCastFunction(symbol)) {
+            symbol = ((Function) symbol).arguments().get(0);
+        }
+        return symbol;
+    }
+
+    /**
+     * t1.x IN (select y from t2)  --> SEMI JOIN t1 on t1.x = t2.y
+     */
+    static Symbol makeJoinCondition(Function rewriteCandidate, AnalyzedRelation sourceRel, QueriedRelation subRel) {
+        assert getSubqueryOrNull(rewriteCandidate.arguments().get(1)).relation() == subRel
+            : "subRel argument must match selectSymbol relation";
+
+        rewriteCandidate = RefReplacer.replaceRefs(
+            rewriteCandidate,
+            r -> sourceRel.getField(r.ident().columnIdent(), Operation.READ));
+        String name = rewriteCandidate.info().ident().name();
+        assert name.startsWith(AnyOperator.OPERATOR_PREFIX) : "Can only create a join condition from any_";
+
+        List<Symbol> args = rewriteCandidate.arguments();
+        Symbol firstArg = args.get(0);
+        List<DataType> newArgTypes = ImmutableList.of(firstArg.valueType(), firstArg.valueType());
+
+        FunctionIdent joinCondIdent = new FunctionIdent(AnyOperator.nameToNonAny(name), newArgTypes);
+        return new Function(
+            new FunctionInfo(joinCondIdent, DataTypes.BOOLEAN),
+            ImmutableList.of(firstArg, castIfNeededOrFail(subRel.fields().get(0), firstArg.valueType()))
+        );
+    }
+
+    private static class RewriteCandidateGatherer extends SymbolVisitor<List<Function>, Boolean> {
+
+        static final RewriteCandidateGatherer INSTANCE = new RewriteCandidateGatherer();
+
+        @Override
+        protected Boolean visitSymbol(Symbol symbol, List<Function> context) {
+            return true;
+        }
+
+        @Override
+        public Boolean visitFunction(Function func, List<Function> candidates) {
+            String funcName = func.info().ident().name();
+
+            /* Cannot rewrite a `op ANY subquery` expression into a semi-join if it's beneath a OR because
+             * `op ANY subquery` has different semantics in case of NULL values than a semi-join would have
+             */
+            if (funcName.equals(OrOperator.NAME) || funcName.equals(NotPredicate.NAME) || funcName.equals(AnyNeqOperator.NAME)) {
+                candidates.clear();
+                return false;
+            }
+
+            if (LOGICAL_OPERATORS.contains(funcName)) {
+                for (Symbol arg : func.arguments()) {
+                    Boolean continueTraversal = process(arg, candidates);
+                    if (!continueTraversal) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+
+            if (funcName.startsWith(AnyOperator.OPERATOR_PREFIX)) {
+                maybeAddSubQueryAsCandidate(func, candidates);
+            }
+            return true;
+        }
+
+        private static void maybeAddSubQueryAsCandidate(Function func, List<Function> candidates) {
+            SelectSymbol subQuery = getSubqueryOrNull(func.arguments().get(1));
+            if (subQuery == null) {
+                return;
+            }
+            if (subQuery.getResultType() == SelectSymbol.ResultType.SINGLE_COLUMN_MULTIPLE_VALUES) {
+                candidates.add(func);
+            }
+        }
+    }
+}

--- a/sql/src/test/java/io/crate/planner/consumer/SemiJoinsTest.java
+++ b/sql/src/test/java/io/crate/planner/consumer/SemiJoinsTest.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.consumer;
+
+import io.crate.action.sql.SessionContext;
+import io.crate.analyze.MultiSourceSelect;
+import io.crate.analyze.QueriedTableRelation;
+import io.crate.analyze.SelectAnalyzedStatement;
+import io.crate.analyze.relations.QueriedRelation;
+import io.crate.analyze.symbol.Function;
+import io.crate.analyze.symbol.SelectSymbol;
+import io.crate.analyze.symbol.Symbol;
+import io.crate.metadata.TransactionContext;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+import io.crate.testing.T3;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static io.crate.testing.TestingHelpers.getFunctions;
+import static io.crate.testing.TestingHelpers.isSQL;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+public class SemiJoinsTest extends CrateDummyClusterServiceUnitTest {
+
+    private SQLExecutor executor;
+    private SemiJoins semiJoins = new SemiJoins(getFunctions());
+
+    @Before
+    public void initExecutor() throws Exception {
+        executor = SQLExecutor.builder(clusterService)
+            .addDocTable(T3.T1_INFO)
+            .addDocTable(T3.T2_INFO)
+            .addDocTable(T3.T3_INFO)
+            .build();
+    }
+
+    private <T extends Symbol> T asSymbol(String expression) {
+        //noinspection unchecked - for tests it's okay to do nasty casts
+        return (T) executor.asSymbol(T3.SOURCES, expression);
+    }
+
+    @Test
+    public void testGatherRewriteCandidatesSingle() throws Exception {
+        Symbol query = asSymbol("a in (select 'foo')");
+        assertThat(SemiJoins.gatherRewriteCandidates(query).size(), is(1));
+    }
+
+    @Test
+    public void testGatherRewriteCandidatesTwo() throws Exception {
+        Symbol query = asSymbol("a in (select 'foo') and a = 'foo' and x in (select 1)");
+        List<Function> candidates = SemiJoins.gatherRewriteCandidates(query);
+        assertThat(candidates.size(), is(2));
+
+        for (Function candidate : candidates) {
+            assertThat(candidate.info().ident().name(), is("any_="));
+        }
+    }
+
+    @Test
+    public void testMakeJoinConditionWith() throws Exception {
+        SelectAnalyzedStatement stmt = executor.analyze("select * from t1 where a in (select 'foo')");
+        QueriedTableRelation rel = ((QueriedTableRelation) stmt.relation());
+        Function query = (Function) rel.querySpec().where().query();
+
+        SelectSymbol subquery = SemiJoins.getSubqueryOrNull(query.arguments().get(1));
+        Symbol joinCondition = SemiJoins.makeJoinCondition(query, rel.tableRelation(), subquery.relation());
+
+        assertThat(joinCondition, isSQL("(doc.t1.a = doc.empty_row.'foo')"));
+    }
+
+    @Test
+    public void testRewriteOfWhereClause() throws Exception {
+        SelectAnalyzedStatement stmt = executor.analyze("select * from t1 where a in (select 'foo') and x = 10");
+        QueriedRelation rel = stmt.relation();
+        MultiSourceSelect semiJoin = (MultiSourceSelect) semiJoins.tryRewrite(rel, new TransactionContext(SessionContext.create()));
+
+        assertThat(
+            semiJoin.querySpec().where(),
+            isSQL("WhereClause{MATCH_ALL=true}"));
+
+        assertThat(semiJoin.joinPairs().get(0).condition(), isSQL("(doc.t1.a = doc.empty_row.'foo')"));
+    }
+
+    @Test
+    public void testNotInIsNotRewritten() throws Exception {
+        SelectAnalyzedStatement stmt = executor.analyze("select * from t1 where a not in (select 'foo')");
+        QueriedRelation rel = stmt.relation();
+        QueriedRelation semiJoin = semiJoins.tryRewrite(rel, new TransactionContext(SessionContext.create()));
+
+        assertThat(semiJoin, nullValue());
+    }
+
+    @Test
+    public void testQueryWithOrIsNotRewritten() throws Exception {
+        SelectAnalyzedStatement stmt = executor.analyze("select * from t1 where a in (select 'foo') or a = '10'");
+        QueriedRelation rel = stmt.relation();
+        QueriedRelation semiJoin = semiJoins.tryRewrite(rel, new TransactionContext(SessionContext.create()));
+
+        assertThat(semiJoin, nullValue());
+    }
+}


### PR DESCRIPTION
For now this is a bit limited. The rewrite is only done if:

 - The root relation is a simple select from a single table
 - Only one ANY or IN expression is in the WHERE clause
 - The column used in the ANY or IN expression must also appear in the
 select list of the root relation

Furthermore, the performance will actually decrease significantly for a
lot of cases. The rewrite is only results in a better execution
strategy if the subquery resultset is huge and would lead to memory
issues with a two-phase execution.