### PR TITLE
Remove explicit casts to ArrayType in ExpressionAnalyzer

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -44,11 +44,10 @@ Changes
 
      Select * from t1 where id = ANY([1, 1.2, 3])
 
- - Support single column subselects within the `IN` operator, e.g.::
+ - Introduce support for single column subselects in `ANY` and `IN`, e.g.::
 
-- Introduce support for single column subselects in `ANY` and `IN`, e.g.::
-
-    select id from t where id IN (select id from t2)
+     Select * from t1 where id = ANY(select id from t2)
+     Select * from t1 where id IN (select id from t2)
 
  - Improved resiliency of the table rename operation.
 

--- a/core/src/main/java/io/crate/types/ArrayType.java
+++ b/core/src/main/java/io/crate/types/ArrayType.java
@@ -73,4 +73,9 @@ public class ArrayType extends CollectionType {
         }
         return result;
     }
+
+    @Override
+    public CollectionType newInstance(DataType innerType) {
+        return new ArrayType(innerType);
+    }
 }

--- a/core/src/main/java/io/crate/types/CollectionType.java
+++ b/core/src/main/java/io/crate/types/CollectionType.java
@@ -80,6 +80,12 @@ public abstract class CollectionType extends DataType {
         return innerType;
     }
 
+    /**
+     * Returns a new instance of this CollectionType with a given inner type.
+     * @param innerType The inner type of the new CollectionType.
+     */
+    public abstract CollectionType newInstance(DataType innerType);
+
     @Override
     public int compareTo(Object o) {
         if (!(o instanceof CollectionType)) return -1;

--- a/core/src/main/java/io/crate/types/SetType.java
+++ b/core/src/main/java/io/crate/types/SetType.java
@@ -130,4 +130,9 @@ public class SetType extends CollectionType {
             out.writeBoolean(containsNull);
         }
     }
+
+    @Override
+    public CollectionType newInstance(DataType innerType) {
+        return new SetType(innerType);
+    }
 }

--- a/core/src/main/java/io/crate/types/SingleColumnTableType.java
+++ b/core/src/main/java/io/crate/types/SingleColumnTableType.java
@@ -59,4 +59,9 @@ public class SingleColumnTableType extends CollectionType {
         }
         return (Object[]) value;
     }
+
+    @Override
+    public CollectionType newInstance(DataType innerType) {
+        return new SingleColumnTableType(innerType);
+    }
 }

--- a/sql/src/main/java/io/crate/operation/scalar/cast/CastFunctionResolver.java
+++ b/sql/src/main/java/io/crate/operation/scalar/cast/CastFunctionResolver.java
@@ -33,6 +33,7 @@ import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.SetType;
+import io.crate.types.SingleColumnTableType;
 
 import java.util.Arrays;
 import java.util.Locale;
@@ -122,11 +123,24 @@ public class CastFunctionResolver {
         .put(new SetType(DataTypes.IP), FunctionNames.TO_IP_SET)
         .build();
 
+    private static final ImmutableMap<DataType, String> TABLE_FUNCTION_MAP = new ImmutableMap.Builder<DataType, String>()
+        .put(new SingleColumnTableType(DataTypes.STRING), FunctionNames.TO_STRING_SET)
+        .put(new SingleColumnTableType(DataTypes.LONG), FunctionNames.TO_LONG_SET)
+        .put(new SingleColumnTableType(DataTypes.INTEGER), FunctionNames.TO_INTEGER_SET)
+        .put(new SingleColumnTableType(DataTypes.DOUBLE), FunctionNames.TO_DOUBLE_SET)
+        .put(new SingleColumnTableType(DataTypes.BOOLEAN), FunctionNames.TO_BOOLEAN_SET)
+        .put(new SingleColumnTableType(DataTypes.BYTE), FunctionNames.TO_BYTE_SET)
+        .put(new SingleColumnTableType(DataTypes.FLOAT), FunctionNames.TO_FLOAT_SET)
+        .put(new SingleColumnTableType(DataTypes.SHORT), FunctionNames.TO_SHORT_SET)
+        .put(new SingleColumnTableType(DataTypes.IP), FunctionNames.TO_IP_SET)
+        .build();
+
     static final ImmutableMap<DataType, String> FUNCTION_MAP = new ImmutableMap.Builder<DataType, String>()
         .putAll(PRIMITIVE_FUNCTION_MAP)
         .putAll(GEO_FUNCTION_MAP)
         .putAll(ARRAY_FUNCTION_MAP)
         .putAll(SET_FUNCTION_MAP)
+        .putAll(TABLE_FUNCTION_MAP)
         .put(DataTypes.OBJECT, FunctionNames.TO_OBJECT)
         .build();
 

--- a/sql/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -247,6 +247,6 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testInPredicateWithSubqueryIsRewrittenToAnyEq() {
         Symbol symbol = executor.asSymbol(T3.SOURCES, "t1.x in (select t2.y from t2)");
-        assertThat(symbol, isSQL("(doc.t1.x = ANY(to_int_array(SelectSymbol{integer_table})))"));
+        assertThat(symbol, isSQL("(doc.t1.x = ANY(SelectSymbol{integer_table}))"));
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/LuceneQueryBuilderIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/LuceneQueryBuilderIntegrationTest.java
@@ -37,11 +37,11 @@ import static io.crate.testing.DataTypeTesting.randomType;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static org.hamcrest.core.Is.is;
 
-@ESIntegTestCase.ClusterScope(randomDynamicTemplates = false, transportClientRatio = 0)
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, randomDynamicTemplates = false, transportClientRatio = 0)
 @UseJdbc
 public class LuceneQueryBuilderIntegrationTest extends SQLTransportIntegrationTest {
 
-    private static int NUMBER_OF_BOOLEAN_CLAUSES = 10_000;
+    private static final int NUMBER_OF_BOOLEAN_CLAUSES = 10_000;
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {


### PR DESCRIPTION
Expressions allowing `CollectionType` shouldn't assume `ArrayType` as
input. When casting, they should only cast the inner type but leave the outer
type unchanged.