### PR TITLE
The representation of simple expressions was surrounded by redundant parenthesis eg. (1=1)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -56,6 +56,9 @@ Changes
 Fixes
 =====
 
+ - Fix display of redundant parenthesis around expressions visible in 
+   `SHOW CREATE` and `EXPLAIN` statements.
+
  - Fixed column name in output by removing new lines when select list contains
    subquery. E.g.::
 

--- a/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
+++ b/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
@@ -90,6 +90,7 @@ import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
 import static io.crate.sql.ExpressionFormatter.formatExpression;
+import static io.crate.sql.ExpressionFormatter.formatStandaloneExpression;
 
 public final class SqlFormatter {
 
@@ -146,7 +147,7 @@ public final class SqlFormatter {
 
         @Override
         protected Void visitExpression(Expression node, Integer indent) {
-            builder.append(formatExpression(node));
+            builder.append(formatStandaloneExpression(node));
             return null;
         }
 
@@ -222,20 +223,20 @@ public final class SqlFormatter {
             builder.append('\n');
 
             if (node.getWhere().isPresent()) {
-                append(indent, "WHERE " + formatExpression(node.getWhere().get()))
+                append(indent, "WHERE " + formatStandaloneExpression(node.getWhere().get()))
                     .append('\n');
             }
 
             if (!node.getGroupBy().isEmpty()) {
                 append(indent,
                     "GROUP BY " + node.getGroupBy().stream()
-                        .map(ExpressionFormatter::formatExpression)
+                        .map(ExpressionFormatter::formatStandaloneExpression)
                         .collect(COMMA_JOINER))
                     .append('\n');
             }
 
             if (node.getHaving().isPresent()) {
-                append(indent, "HAVING " + formatExpression(node.getHaving().get()))
+                append(indent, "HAVING " + formatStandaloneExpression(node.getHaving().get()))
                     .append('\n');
             }
 
@@ -287,7 +288,7 @@ public final class SqlFormatter {
 
         @Override
         protected Void visitSingleColumn(SingleColumn node, Integer indent) {
-            builder.append(formatExpression(node.getExpression()));
+            builder.append(formatStandaloneExpression(node.getExpression()));
             if (node.getAlias().isPresent()) {
                 builder.append(' ')
                     .append('"')
@@ -492,7 +493,7 @@ public final class SqlFormatter {
             }
             if (node.expression() != null) {
                 builder.append(" GENERATED ALWAYS AS ")
-                    .append(formatExpression(node.expression()));
+                    .append(formatStandaloneExpression(node.expression()));
             }
 
             if (!node.constraints().isEmpty()) {
@@ -613,7 +614,7 @@ public final class SqlFormatter {
             } else if (criteria instanceof JoinOn) {
                 JoinOn on = (JoinOn) criteria;
                 builder.append(" ON (")
-                    .append(formatExpression(on.getExpression()))
+                    .append(formatStandaloneExpression(on.getExpression()))
                     .append(")");
             } else if (node.getType() != Join.Type.CROSS && !(criteria instanceof NaturalJoin)) {
                 throw new UnsupportedOperationException("unknown join criteria: " + criteria);
@@ -765,7 +766,7 @@ public final class SqlFormatter {
     static Function<SortItem, String> orderByFormatterFunction = input -> {
         StringBuilder builder = new StringBuilder();
 
-        builder.append(formatExpression(input.getSortKey()));
+        builder.append(formatStandaloneExpression(input.getSortKey()));
 
         switch (input.getOrdering()) {
             case ASCENDING:

--- a/sql-parser/src/main/java/io/crate/sql/tree/Expression.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/Expression.java
@@ -31,6 +31,6 @@ public abstract class Expression
     }
 
     public final String toString() {
-        return ExpressionFormatter.formatExpression(this);
+        return ExpressionFormatter.formatStandaloneExpression(this);
     }
 }

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -335,7 +335,7 @@ public class ExpressionAnalyzer {
         @Override
         protected Symbol visitExpression(Expression node, ExpressionAnalysisContext context) {
             throw new UnsupportedOperationException(String.format(Locale.ENGLISH,
-                "Unsupported expression %s", ExpressionFormatter.formatExpression(node)));
+                "Unsupported expression %s", ExpressionFormatter.formatStandaloneExpression(node)));
         }
 
         @Override

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionToStringVisitor.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionToStringVisitor.java
@@ -67,12 +67,12 @@ public class ExpressionToStringVisitor extends AstVisitor<String, Row> {
 
     @Override
     public String visitArrayLiteral(ArrayLiteral node, Row context) {
-        return ExpressionFormatter.formatExpression(node);
+        return ExpressionFormatter.formatStandaloneExpression(node);
     }
 
     @Override
     public String visitObjectLiteral(ObjectLiteral node, Row context) {
-        return ExpressionFormatter.formatExpression(node);
+        return ExpressionFormatter.formatStandaloneExpression(node);
     }
 
     @Override

--- a/sql/src/test/java/io/crate/analyze/SubscriptValidatorTest.java
+++ b/sql/src/test/java/io/crate/analyze/SubscriptValidatorTest.java
@@ -94,7 +94,7 @@ public class SubscriptValidatorTest extends CrateUnitTest {
     public void testVisitSubscriptWithIndexExpression() throws Exception {
         SubscriptContext context = analyzeSubscript("a[1+2]");
         assertThat(context.qName().getSuffix(), is("a"));
-        assertThat(context.index(), isSQL("(1 + 2)"));
+        assertThat(context.index(), isSQL("1 + 2"));
     }
 
     @SuppressWarnings("ConstantConditions")

--- a/sql/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -221,7 +221,7 @@ public class ShowIntegrationTest extends SQLTransportIntegrationTest {
                 ")");
         execute("show create table test_generated_column");
         assertRow("CREATE TABLE IF NOT EXISTS \"doc\".\"test_generated_column\" (\n" +
-                  "   \"col1\" LONG GENERATED ALWAYS AS (\"ts\" + 1),\n" +
+                  "   \"col1\" LONG GENERATED ALWAYS AS \"ts\" + 1,\n" +
                   "   \"col2\" STRING GENERATED ALWAYS AS CAST((\"ts\" + 1) AS string),\n" +
                   "   \"col3\" STRING GENERATED ALWAYS AS CAST((\"ts\" + 1) AS string),\n" +
                   "   \"day1\" TIMESTAMP GENERATED ALWAYS AS date_trunc('day', \"ts\"),\n" +


### PR DESCRIPTION
This commit removes the outer most parenthesis of expressions.