### PR TITLE
Make WhereClause#replace semantics consistent with new WhereClause instances

### DIFF
--- a/sql/src/main/java/io/crate/analyze/QueryClause.java
+++ b/sql/src/main/java/io/crate/analyze/QueryClause.java
@@ -78,7 +78,12 @@ public abstract class QueryClause {
         if (hasQuery()) {
             Symbol newQuery = replaceFunction.apply(query);
             if (query != newQuery) {
-                query = newQuery;
+                if (newQuery instanceof Input) {
+                    noMatch = !canMatch(newQuery);
+                    query = null;
+                } else {
+                    query = newQuery;
+                }
             }
         }
     }

--- a/sql/src/test/java/io/crate/analyze/WhereClauseTest.java
+++ b/sql/src/test/java/io/crate/analyze/WhereClauseTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.analyze;
+
+import io.crate.analyze.symbol.Literal;
+import io.crate.analyze.symbol.Symbol;
+import io.crate.testing.SqlExpressions;
+import io.crate.testing.T3;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class WhereClauseTest {
+
+    private SqlExpressions sqlExpressions = new SqlExpressions(T3.SOURCES);
+
+    @Test
+    public void testReplaceWithLiteralTrueSemantics() throws Exception {
+        Symbol query = sqlExpressions.asSymbol("x = 10");
+
+        WhereClause whereReplaced = new WhereClause(query);
+        whereReplaced.replace(s -> Literal.BOOLEAN_TRUE);
+        WhereClause whereLiteralTrue = new WhereClause(Literal.BOOLEAN_TRUE);
+
+        assertThat(whereLiteralTrue.hasQuery(), is(whereReplaced.hasQuery()));
+        assertThat(whereLiteralTrue.noMatch(), is(whereReplaced.noMatch()));
+        assertThat(whereLiteralTrue.query(), is(whereReplaced.query()));
+    }
+
+    @Test
+    public void testReplaceWithLiteralFalseSemantics() throws Exception {
+        Symbol query = sqlExpressions.asSymbol("x = 10");
+
+        WhereClause whereReplaced = new WhereClause(query);
+        whereReplaced.replace(s -> Literal.BOOLEAN_FALSE);
+        WhereClause whereLiteralFalse = new WhereClause(Literal.BOOLEAN_FALSE);
+
+        assertThat(whereLiteralFalse.hasQuery(), is(whereReplaced.hasQuery()));
+        assertThat(whereLiteralFalse.noMatch(), is(whereReplaced.noMatch()));
+        assertThat(whereLiteralFalse.query(), is(whereReplaced.query()));
+    }
+}


### PR DESCRIPTION
Before:

    new WhereClause(Literal.BOOLEAN_TRUE)          -> hasQuery=false, noMatch=false
    whereClause.replace(s -> Literal.BOOLEAN_TRUE) -> hasQuery=true,  noMatch=false

Now:

    new WhereClause(Literal.BOOLEAN_TRUE)          -> hasQuery=false, noMatch=false
    whereClause.replace(s -> Literal.BOOLEAN_TRUE) -> hasQuery=false, noMatch=false