### PR TITLE
upgrade Crash to 0.22.1

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -27,12 +27,10 @@ Breaking Changes
 Changes
 =======
 
- - Update Crash to ``0.22.0`` which includes the following changes:
+ - Update Crash to ``0.22.1`` which includes the following changes:
 
     - Added a status toolbar that prints the current session info.
 
-    - Added support for multiline table headers in the tabular output format.
- 
     - Start autocompletion for non-command keys at the 3rd character.
 
  - Change semantics of ``IN`` operator to behave like ``= ANY``. The argument

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -300,7 +300,7 @@ installDist {
 
 ext {
     downloadDir = new File(buildDir, 'downloads')
-    crash_version = '0.22.0'
+    crash_version = '0.22.1'
     adminui_version = '1.4.2'
 }
 

--- a/blackbox/requirements.txt
+++ b/blackbox/requirements.txt
@@ -3,7 +3,7 @@ appdirs==1.4.3
 argh==0.26.2
 Babel==2.4.0
 colorama==0.3.9
-crash==0.22.0
+crash==0.22.1
 crate==0.20.1
 crate-docs-theme==0.5.24
 docutils==0.13.1


### PR DESCRIPTION
revert multiline table header support in Crash

Causing `itest` to fail