### PR TITLE
Do not stack MultiExceptions

### DIFF
--- a/sql/src/main/java/io/crate/executor/transport/ChainableActions.java
+++ b/sql/src/main/java/io/crate/executor/transport/ChainableActions.java
@@ -115,7 +115,7 @@ public class ChainableActions {
             }
             if (t != null) {
                 if (error != null) {
-                    error = new MultiException(ImmutableList.of(error, t));
+                    error = MultiException.of(error, t);
                     // if an error was already set, current error must resulted due to on undo operation
                     errorOnUndo = true;
                 } else {


### PR DESCRIPTION
MultiExceptions get flattened instead of stacking them. This should
be more memory efficient.