### PR TITLE
Add SessionContext flag to enable semi joins

### DIFF
--- a/sql/src/main/java/io/crate/action/sql/SessionContext.java
+++ b/sql/src/main/java/io/crate/action/sql/SessionContext.java
@@ -37,11 +37,13 @@ public class SessionContext implements StatementAuthorizedValidator, ExceptionAu
 
     private final int defaultLimit;
     private final Set<Option> options;
-    private String defaultSchema;
     @Nullable
     private final User user;
     private final StatementAuthorizedValidator statementAuthorizedValidator;
     private final ExceptionAuthorizedValidator exceptionAuthorizedValidator;
+
+    private String defaultSchema;
+    private boolean semiJoinsRewriteEnabled;
 
     public SessionContext(@Nullable String defaultSchema,
                           @Nullable User user,
@@ -85,6 +87,14 @@ public class SessionContext implements StatementAuthorizedValidator, ExceptionAu
 
     public void setDefaultSchema(String schema) {
         defaultSchema = Objects.requireNonNull(schema, "Default schema must never be set to null");
+    }
+
+    public void setSemiJoinsRewriteEnabled(boolean flag) {
+        this.semiJoinsRewriteEnabled = flag;
+    }
+
+    public boolean getSemiJoinsRewriteEnabled() {
+        return semiJoinsRewriteEnabled;
     }
 
     @Nullable

--- a/sql/src/main/java/io/crate/planner/consumer/ConsumingPlanner.java
+++ b/sql/src/main/java/io/crate/planner/consumer/ConsumingPlanner.java
@@ -21,6 +21,7 @@
 
 package io.crate.planner.consumer;
 
+import io.crate.action.sql.SessionContext;
 import io.crate.analyze.QuerySpec;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.QueriedRelation;

--- a/sql/src/main/java/io/crate/planner/consumer/OptimizingRewriter.java
+++ b/sql/src/main/java/io/crate/planner/consumer/OptimizingRewriter.java
@@ -67,7 +67,10 @@ final class OptimizingRewriter {
 
         @Override
         public AnalyzedRelation visitQueriedDocTable(QueriedDocTable table, Void context) {
-            QueriedRelation rewrite = semiJoins.tryRewrite(table, transactionContext);
+            QueriedRelation rewrite = null;
+            if (transactionContext.sessionContext().getSemiJoinsRewriteEnabled()) {
+                rewrite = semiJoins.tryRewrite(table, transactionContext);
+            }
             if (rewrite != null) {
                 return rewrite;
             }

--- a/sql/src/test/java/io/crate/metadata/settings/session/SessionSettingRegistryTest.java
+++ b/sql/src/test/java/io/crate/metadata/settings/session/SessionSettingRegistryTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.settings.session;
+
+import io.crate.action.sql.SessionContext;
+import io.crate.data.Row;
+import io.crate.sql.tree.Expression;
+import io.crate.sql.tree.StringLiteral;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.fail;
+
+public class SessionSettingRegistryTest {
+
+    @Test
+    public void testSemiJoinSessionSetting() {
+        SessionContext sessionContext = new SessionContext(null, null, x -> {}, x -> {});
+        SessionSettingApplier applier = SessionSettingRegistry.getApplier(SessionSettingRegistry.SEMI_JOIN_KEY);
+
+        assertThat(sessionContext.getSemiJoinsRewriteEnabled(), is(false));
+        applier.apply(Row.EMPTY, generateInput("true"), sessionContext);
+        assertThat(sessionContext.getSemiJoinsRewriteEnabled(), is(true));
+        applier.apply(Row.EMPTY, generateInput("false"), sessionContext);
+        assertThat(sessionContext.getSemiJoinsRewriteEnabled(), is(false));
+        applier.apply(Row.EMPTY, generateInput("TrUe"), sessionContext);
+        assertThat(sessionContext.getSemiJoinsRewriteEnabled(), is(true));
+        try {
+            applier.apply(Row.EMPTY, generateInput(""), sessionContext);
+            fail("Should have failed to apply setting.");
+        } catch (IllegalArgumentException e) {
+            assertThat(sessionContext.getSemiJoinsRewriteEnabled(), is(true));
+        }
+        try {
+            applier.apply(Row.EMPTY, generateInput("invalid", "input"), sessionContext);
+            fail("Should have failed to apply setting.");
+        } catch (IllegalArgumentException e) {
+            assertThat(sessionContext.getSemiJoinsRewriteEnabled(), is(true));
+        }
+    }
+
+    private static List<Expression> generateInput(String... inputs) {
+        ArrayList<Expression> expressions = new ArrayList<>(inputs.length);
+        for (String input : inputs) {
+            expressions.add(StringLiteral.fromObject(input));
+        }
+        return expressions;
+    }
+}

--- a/sql/src/test/java/io/crate/planner/consumer/SemiJoinsTest.java
+++ b/sql/src/test/java/io/crate/planner/consumer/SemiJoinsTest.java
@@ -31,6 +31,8 @@ import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.SelectSymbol;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.TransactionContext;
+import io.crate.planner.Plan;
+import io.crate.planner.node.dql.join.NestedLoop;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.testing.T3;
@@ -41,7 +43,9 @@ import java.util.List;
 
 import static io.crate.testing.TestingHelpers.getFunctions;
 import static io.crate.testing.TestingHelpers.isSQL;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
 public class SemiJoinsTest extends CrateDummyClusterServiceUnitTest {
@@ -121,5 +125,11 @@ public class SemiJoinsTest extends CrateDummyClusterServiceUnitTest {
         QueriedRelation semiJoin = semiJoins.tryRewrite(rel, new TransactionContext(SessionContext.create()));
 
         assertThat(semiJoin, nullValue());
+    }
+
+    @Test
+    public void testDisabledByDefault() throws Exception {
+        Plan plan = executor.plan("select * from t1 where a in (select 'foo')");
+        assertThat(plan, not(instanceOf(NestedLoop.class)));
     }
 }


### PR DESCRIPTION
This disables semi joins by default and introduces a flag to enable semi joins
on a per-session base.