### PR TITLE
removes moquette library dependency

### DIFF
--- a/enterprise/mqtt/build.gradle
+++ b/enterprise/mqtt/build.gradle
@@ -4,35 +4,9 @@ archivesBaseName = 'mqtt'
 group = 'io.crate'
 description = 'MQTT ingestion implementation'
 
-configurations {
-    dependency
-    compile.extendsFrom dependency
-    requiredLibs.transitive = true
-}
-
 dependencies {
     compile project(':sql')
-    compile ('io.moquette:moquette-broker:0.10') {
-        exclude group: 'org.mapdb'
-        exclude group: 'org.hdrhistogram'
-        exclude group: 'com.hazelcast'
-        exclude group: 'commons-codec'
-        exclude group: 'org.slf4j'
-        exclude group: 'com.google.guava'
-        exclude group: 'com.fasterxml.jackson.core'
-        exclude group: 'io.dropwizard.metrics'
-    }
-
-    requiredLibs('io.moquette:moquette-broker:0.10') {
-        exclude group: 'org.mapdb'
-        exclude group: 'org.hdrhistogram'
-        exclude group: 'com.hazelcast'
-        exclude group: 'commons-codec'
-        exclude group: 'org.slf4j'
-        exclude group: 'com.google.guava'
-        exclude group: 'com.fasterxml.jackson.core'
-        exclude group: 'io.dropwizard.metrics'
-    }
+    compile "io.netty:netty-codec-mqtt:${versions.netty4}"
 
     testCompile project(':integration-testing')
     testCompile project(path: ':sql', configuration: 'testOutput')

--- a/enterprise/mqtt/src/main/java/io/crate/mqtt/netty/MqttMessageLogger.java
+++ b/enterprise/mqtt/src/main/java/io/crate/mqtt/netty/MqttMessageLogger.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ *
+ * This code is derived from https://github.com/andsel/moquette/blob/master/broker/src/main/java/io/moquette/server/netty/metrics/MQTTMessageLogger.java
+ */
+
+package io.crate.mqtt.netty;
+
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.mqtt.MqttMessage;
+import io.netty.handler.codec.mqtt.MqttMessageIdVariableHeader;
+import io.netty.handler.codec.mqtt.MqttMessageType;
+import io.netty.handler.codec.mqtt.MqttPublishMessage;
+import io.netty.handler.codec.mqtt.MqttSubAckMessage;
+import io.netty.handler.codec.mqtt.MqttSubscribeMessage;
+import io.netty.handler.codec.mqtt.MqttUnsubscribeMessage;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Settings;
+
+import java.util.List;
+
+@ChannelHandler.Sharable
+public class MqttMessageLogger extends ChannelDuplexHandler {
+
+    private static final String DIRECTION_READ = "C->B";
+    private static final String DIRECTION_WRITE = "C<-B";
+
+    private final Logger logger;
+
+    MqttMessageLogger(Settings settings) {
+        logger = Loggers.getLogger(getClass(), settings);
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object message) {
+        logMQTTMessage(ctx, message, DIRECTION_READ);
+        ctx.fireChannelRead(message);
+    }
+
+    @Override
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        logMQTTMessage(ctx, msg, DIRECTION_WRITE);
+        ctx.write(msg, promise);
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        String clientID = NettyUtils.clientID(ctx.channel());
+        if (logger.isTraceEnabled() && clientID != null && !clientID.isEmpty()) {
+            logger.trace("Channel closed <{}>", clientID);
+        }
+        ctx.fireChannelInactive();
+    }
+
+    private void logMQTTMessage(ChannelHandlerContext ctx, Object message, String direction) {
+        if (logger.isTraceEnabled() && message instanceof MqttMessage) {
+            MqttMessage msg = (MqttMessage) message;
+            String clientID = NettyUtils.clientID(ctx.channel());
+            MqttMessageType messageType = msg.fixedHeader().messageType();
+            switch (messageType) {
+                case CONNECT:
+                case CONNACK:
+                case PINGREQ:
+                case PINGRESP:
+                case DISCONNECT:
+                    logger.trace("{} {} <{}>", direction, messageType, clientID);
+                    break;
+                case SUBSCRIBE:
+                    MqttSubscribeMessage subscribe = (MqttSubscribeMessage) msg;
+                    logger.trace("{} SUBSCRIBE <{}> to topics {}",
+                        direction, clientID, subscribe.payload().topicSubscriptions());
+                    break;
+                case UNSUBSCRIBE:
+                    MqttUnsubscribeMessage unsubscribe = (MqttUnsubscribeMessage) msg;
+                    logger.trace("{} UNSUBSCRIBE <{}> to topics <{}>",
+                        direction, clientID, unsubscribe.payload().topics());
+                    break;
+                case PUBLISH:
+                    MqttPublishMessage publish = (MqttPublishMessage) msg;
+                    logger.trace("{} PUBLISH <{}> to topics <{}>",
+                        direction, clientID, publish.variableHeader().topicName());
+                    break;
+                case PUBREC:
+                case PUBCOMP:
+                case PUBREL:
+                case PUBACK:
+                case UNSUBACK:
+                    logger.trace("{} {} <{}> packetID <{}>",
+                        direction, messageType, clientID, messageId(msg));
+                    break;
+                case SUBACK:
+                    MqttSubAckMessage suback = (MqttSubAckMessage) msg;
+                    List<Integer> grantedQoSLevels = suback.payload().grantedQoSLevels();
+                    logger.trace("{} SUBACK <{}> packetID <{}>, grantedQoses {}",
+                        direction, clientID, messageId(msg), grantedQoSLevels);
+                    break;
+            }
+        }
+    }
+
+    private static int messageId(MqttMessage msg) {
+        return ((MqttMessageIdVariableHeader) msg.variableHeader()).messageId();
+    }
+}

--- a/enterprise/mqtt/src/main/java/io/crate/mqtt/netty/MqttNettyHandler.java
+++ b/enterprise/mqtt/src/main/java/io/crate/mqtt/netty/MqttNettyHandler.java
@@ -23,7 +23,9 @@ import io.crate.mqtt.protocol.MqttProcessor;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
-import io.netty.handler.codec.mqtt.*;
+import io.netty.handler.codec.mqtt.MqttConnectMessage;
+import io.netty.handler.codec.mqtt.MqttMessage;
+import io.netty.handler.codec.mqtt.MqttPublishMessage;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.logging.Loggers;
 

--- a/enterprise/mqtt/src/main/java/io/crate/mqtt/netty/MqttNettyHandler.java
+++ b/enterprise/mqtt/src/main/java/io/crate/mqtt/netty/MqttNettyHandler.java
@@ -38,7 +38,7 @@ public class MqttNettyHandler extends ChannelInboundHandlerAdapter {
     private final Logger LOGGER = Loggers.getLogger(MqttNettyHandler.class);
     private final MqttProcessor processor;
 
-    public MqttNettyHandler(MqttProcessor processor) {
+    MqttNettyHandler(MqttProcessor processor) {
         this.processor = processor;
     }
 

--- a/enterprise/mqtt/src/main/java/io/crate/mqtt/netty/Netty4MqttServerTransport.java
+++ b/enterprise/mqtt/src/main/java/io/crate/mqtt/netty/Netty4MqttServerTransport.java
@@ -27,11 +27,6 @@ import io.crate.protocols.postgres.BindPostgresException;
 import io.crate.settings.CrateSetting;
 import io.crate.settings.SharedSettings;
 import io.crate.types.DataTypes;
-import io.moquette.server.netty.metrics.BytesMetricsCollector;
-import io.moquette.server.netty.metrics.BytesMetricsHandler;
-import io.moquette.server.netty.metrics.MQTTMessageLogger;
-import io.moquette.server.netty.metrics.MessageMetricsCollector;
-import io.moquette.server.netty.metrics.MessageMetricsHandler;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.bootstrap.ServerBootstrapConfig;
 import io.netty.channel.Channel;
@@ -102,9 +97,6 @@ public class Netty4MqttServerTransport extends AbstractLifecycleComponent {
     private final List<Channel> serverChannels = new ArrayList<>();
     private final List<InetSocketTransportAddress> boundAddresses = new ArrayList<>();
 
-    private final BytesMetricsCollector bytesMetricsCollector = new BytesMetricsCollector();
-    private final MessageMetricsCollector metricsCollector = new MessageMetricsCollector();
-
     @Inject
     public Netty4MqttServerTransport(Settings settings, NetworkService networkService, SQLOperations sqlOperations) {
         super(settings);
@@ -148,11 +140,8 @@ public class Netty4MqttServerTransport extends AbstractLifecycleComponent {
 
                         pipeline.addFirst("idleStateHandler", defaultIdleHandler)
                                 .addAfter("idleStateHandler", "idleEventHandler", timeoutHandler)
-                                .addFirst("bytemetrics", new BytesMetricsHandler(bytesMetricsCollector))
                                 .addLast("decoder", new MqttDecoder())
                                 .addLast("encoder", MqttEncoder.INSTANCE)
-                                .addLast("metrics", new MessageMetricsHandler(metricsCollector))
-                                .addLast("messageLogger", new MQTTMessageLogger())
                                 .addLast("handler", handler);
                     }
                 });

--- a/enterprise/mqtt/src/main/java/io/crate/mqtt/netty/NettyUtils.java
+++ b/enterprise/mqtt/src/main/java/io/crate/mqtt/netty/NettyUtils.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ *
+ * Derived from https://github.com/andsel/moquette/blob/master/broker/src/main/java/io/moquette/server/netty/NettyUtils.java
+ */
+
+package io.crate.mqtt.netty;
+
+import io.netty.channel.Channel;
+import io.netty.util.AttributeKey;
+
+/**
+ * Static helpers for reading and writing netty attributes.
+ */
+public class NettyUtils {
+
+    private static final AttributeKey<Object> ATTR_KEY_KEEPALIVE = AttributeKey.valueOf("keepAlive");
+    private static final AttributeKey<Object> ATTR_KEY_CLIENTID = AttributeKey.valueOf("ClientID");
+
+    public static void keepAlive(Channel channel, int keepAlive) {
+        channel.attr(ATTR_KEY_KEEPALIVE).set(keepAlive);
+    }
+
+    public static void clientID(Channel channel, String clientID) {
+        channel.attr(ATTR_KEY_CLIENTID).set(clientID);
+    }
+
+    public static String clientID(Channel channel) {
+        return (String) channel.attr(ATTR_KEY_CLIENTID).get();
+    }
+}

--- a/enterprise/mqtt/src/main/java/io/crate/mqtt/protocol/MqttMessageBuilders.java
+++ b/enterprise/mqtt/src/main/java/io/crate/mqtt/protocol/MqttMessageBuilders.java
@@ -18,7 +18,12 @@
 
 package io.crate.mqtt.protocol;
 
-import io.netty.handler.codec.mqtt.*;
+
+import io.netty.handler.codec.mqtt.MqttFixedHeader;
+import io.netty.handler.codec.mqtt.MqttMessage;
+import io.netty.handler.codec.mqtt.MqttMessageIdVariableHeader;
+import io.netty.handler.codec.mqtt.MqttMessageType;
+import io.netty.handler.codec.mqtt.MqttQoS;
 
 public final class MqttMessageBuilders {
 

--- a/enterprise/mqtt/src/test/java/io/crate/mqtt/protocol/MqttProcessorTest.java
+++ b/enterprise/mqtt/src/test/java/io/crate/mqtt/protocol/MqttProcessorTest.java
@@ -53,7 +53,7 @@ public class MqttProcessorTest {
                 MqttMessageType.CONNECT, false, MqttQoS.AT_LEAST_ONCE, false, 0);
         MqttConnectVariableHeader variableHeader = new MqttConnectVariableHeader(
                 "connect", (byte) 1, false, false, false, (byte) 1, false, false, 60);
-        MqttConnectPayload payload = new MqttConnectPayload("mqttClient", null, null, null, null);
+        MqttConnectPayload payload = new MqttConnectPayload("mqttClient", "someTopic", new byte[0], null, null);
         processor.handleConnect(ch,
                 (MqttConnectMessage) MqttMessageFactory.newMessage(fixedHeader, variableHeader, payload));
 

--- a/enterprise/mqtt/src/test/java/io/crate/mqtt/protocol/MqttQualityOfServiceTest.java
+++ b/enterprise/mqtt/src/test/java/io/crate/mqtt/protocol/MqttQualityOfServiceTest.java
@@ -19,6 +19,7 @@
 package io.crate.mqtt.protocol;
 
 import com.google.common.base.Charsets;
+import io.crate.mqtt.netty.NettyUtils;
 import io.crate.mqtt.operations.MqttIngestService;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -48,7 +49,7 @@ public class MqttQualityOfServiceTest {
 
     @Before
     public void setUp() throws Exception {
-        MqttProcessor.setClientID(ch, "c1");
+        NettyUtils.clientID(ch, "c1");
     }
 
     @Rule

--- a/enterprise/mqtt/src/test/java/io/crate/mqtt/protocol/MqttQualityOfServiceTest.java
+++ b/enterprise/mqtt/src/test/java/io/crate/mqtt/protocol/MqttQualityOfServiceTest.java
@@ -20,12 +20,12 @@ package io.crate.mqtt.protocol;
 
 import com.google.common.base.Charsets;
 import io.crate.mqtt.operations.MqttIngestService;
-import io.moquette.server.netty.NettyUtils;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.handler.codec.mqtt.*;
+import io.netty.handler.codec.mqtt.MqttPublishMessage;
+import io.netty.handler.codec.mqtt.MqttQoS;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -48,7 +48,7 @@ public class MqttQualityOfServiceTest {
 
     @Before
     public void setUp() throws Exception {
-        NettyUtils.clientID(ch, "c1");
+        MqttProcessor.setClientID(ch, "c1");
     }
 
     @Rule
@@ -56,14 +56,13 @@ public class MqttQualityOfServiceTest {
 
     private MqttPublishMessage messageWithQoS(MqttQoS level) {
         ByteBuf payload = Unpooled.copiedBuffer("{}".getBytes(Charsets.UTF_8));
-        MqttPublishMessage mqttPublishMessage = MqttMessageBuilders.publish()
+        return MqttMessageBuilders.publish()
                 .qos(level)
                 .retained(false)
                 .topicName("t1")
                 .messageId(1)
                 .payload(payload)
                 .build();
-        return mqttPublishMessage;
     }
 
     @Test


### PR DESCRIPTION
moquette was used only for gathering some metrics and (debug) logging of
mqtt messages.
if we need this (specially metrics) we should add this without moquette.
this will also fix including the mqtt functionality on distribution.