### PR TITLE
Upgraded ES to v5.5.2

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -22,16 +22,18 @@ Breaking Changes
    tables have the real column `name`). Statements with aliases that shadowed
    a real column and also retrieve that real column will no longer fail as the
    real column will be used in the `GROUP BY` clause (this will not be
-   ambigous anymore).
+   ambiguous anymore).
 
 Changes
 =======
 
- - Added new tab in Enterprise Edition of the Admin UI to display users 
+ - Upgraded Elasticsearch to v5.5.2.
+
+ - Added new tab in Enterprise Edition of the Admin UI to display users
    and their privileges.
 
  - The documentation link in the Admin UI now points to the documentation
-   for the major.minor (e.g. 2.1) version of CrateDB, instead of 
+   for the major.minor (e.g. 2.1) version of CrateDB, instead of
    major.minor.hotfix (e.g. 2.1.1).
 
  - Added node cluster check for cluster-name folder in data path directory.
@@ -74,10 +76,10 @@ Fixes
    unsupported.
 
  - Fixed issue that caused the Monitoring tab in the Admin UI to redirect
-   to ``/401`` when the user didn't have privileges for ``sys.cluster`` 
+   to ``/401`` when the user didn't have privileges for ``sys.cluster``
    or ``sys.jobs_log``.
 
- - Fix display of redundant parenthesis around expressions visible in 
+ - Fix display of redundant parenthesis around expressions visible in
    `SHOW CREATE` and `EXPLAIN` statements.
 
  - Fixed an issue that caused `path.logs` setting in `crate.yml` to be ignored.

--- a/blob/src/test/java/io/crate/integrationtests/BlobPathITest.java
+++ b/blob/src/test/java/io/crate/integrationtests/BlobPathITest.java
@@ -143,12 +143,7 @@ public class BlobPathITest extends BlobIntegrationTestBase {
         blobAdminClient.dropBlobTable("test");
         String blobRootPath = String.format("%s/nodes/0/indices/.blob_test", tableBlobPath.toString());
 
-        assertBusy(new Runnable() {
-            @Override
-            public void run() {
-                assertFalse(Files.exists(Paths.get(blobRootPath)));
-            }
-        }, 5, TimeUnit.SECONDS);
+        assertBusy(() -> assertFalse(Files.exists(Paths.get(blobRootPath))), 5, TimeUnit.SECONDS);
     }
 
     @Test

--- a/core/src/main/java/io/crate/Version.java
+++ b/core/src/main/java/io/crate/Version.java
@@ -41,7 +41,7 @@ public class Version {
 
 
     public static final boolean SNAPSHOT = true;
-    public static final Version CURRENT = new Version(2020099, SNAPSHOT, org.elasticsearch.Version.V_5_4_3_UNRELEASED);
+    public static final Version CURRENT = new Version(2020099, SNAPSHOT, org.elasticsearch.Version.V_5_5_2_UNRELEASED);
 
     static {
         // safe-guard that we don't release a version with DEBUG_MODE set to true

--- a/gradle/version.properties
+++ b/gradle/version.properties
@@ -19,8 +19,8 @@ jackson_xc=1.9.13
 crate_jdbc=2.1.7
 
 # ES deps
-elasticsearch=5.4.3
-lucene=6.5.1
+elasticsearch=5.5.2
+lucene=6.6.0
 
 # ES HDFS
 hadoop2=2.7.1

--- a/sql/src/main/java/io/crate/operation/reference/sys/snapshot/SysSnapshots.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/snapshot/SysSnapshots.java
@@ -33,7 +33,9 @@ import org.elasticsearch.snapshots.SnapshotsService;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Singleton
 public class SysSnapshots {
@@ -54,12 +56,12 @@ public class SysSnapshots {
             final String repositoryName = repository.getMetadata().name();
 
 
-            List<SnapshotId> compatibleSnapshotIds =
-                repositoriesService.repository(repositoryName).getRepositoryData().getSnapshotIds();
-            List<SnapshotId> incompatibleSnapshotIds =
-                repositoriesService.repository(repositoryName).getRepositoryData().getIncompatibleSnapshotIds();
-            List<SnapshotInfo> snapshots =
-                snapshotsService.snapshots(repositoryName, compatibleSnapshotIds, incompatibleSnapshotIds, true);
+            List<SnapshotId> compatibleSnapshotIds = new ArrayList<>(
+                repositoriesService.repository(repositoryName).getRepositoryData().getSnapshotIds());
+            Set<SnapshotId> incompatibleSnapshotIds = new HashSet<>(
+                repositoriesService.repository(repositoryName).getRepositoryData().getIncompatibleSnapshotIds());
+            List<SnapshotInfo> snapshots = new ArrayList<>(
+                snapshotsService.snapshots(repositoryName, compatibleSnapshotIds, incompatibleSnapshotIds, true));
             sysSnapshots.addAll(Lists.transform(snapshots, new Function<SnapshotInfo, SysSnapshot>() {
                 @Nullable
                 @Override

--- a/sql/src/test/java/io/crate/integrationtests/CustomSchemaIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/CustomSchemaIntegrationTest.java
@@ -107,14 +107,11 @@ public class CustomSchemaIntegrationTest extends SQLTransportIntegrationTest {
         execute("drop table custom.foo");
         assertThat(client().admin().indices().exists(new IndicesExistsRequest("custom.foo")).actionGet().isExists(), is(false));
 
-        assertBusy(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    execute("select * from custom.foo");
-                    fail("should wait for cache invalidation");
-                } catch (Exception ignored) {
-                }
+        assertBusy(() -> {
+            try {
+                execute("select * from custom.foo");
+                fail("should wait for cache invalidation");
+            } catch (Exception ignored) {
             }
         });
     }

--- a/sql/src/test/java/io/crate/integrationtests/JobContextIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/JobContextIntegrationTest.java
@@ -75,9 +75,7 @@ public class JobContextIntegrationTest extends SQLTransportIntegrationTest {
         final Field activeContexts = JobContextService.class.getDeclaredField("activeContexts");
         activeContexts.setAccessible(true);
 
-        assertBusy(new Runnable() {
-            @Override
-            public void run() {
+        assertBusy(() -> {
                 for (JobContextService jobContextService : internalCluster().getInstances(JobContextService.class)) {
                     Map<UUID, JobExecutionContext> contextMap = null;
                     try {
@@ -87,9 +85,6 @@ public class JobContextIntegrationTest extends SQLTransportIntegrationTest {
                         fail(e.getMessage());
                     }
                 }
-            }
         }, 1, TimeUnit.SECONDS);
     }
-
-
 }

--- a/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
@@ -87,7 +87,16 @@ import org.junit.rules.Timeout;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
@@ -181,33 +190,30 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
         activeContexts.setAccessible(true);
         activeOperationsSb.setAccessible(true);
         try {
-            assertBusy(new Runnable() {
-                @Override
-                public void run() {
-                    for (JobContextService jobContextService : internalCluster().getInstances(JobContextService.class)) {
-                        try {
-                            //noinspection unchecked
-                            Map<UUID, JobExecutionContext> contexts = (Map<UUID, JobExecutionContext>) activeContexts.get(jobContextService);
-                            assertThat(contexts.size(), is(0));
-                        } catch (IllegalAccessException e) {
-                            throw new RuntimeException(e);
-                        }
+            assertBusy(() -> {
+                for (JobContextService jobContextService : internalCluster().getInstances(JobContextService.class)) {
+                    try {
+                        //noinspection unchecked
+                        Map<UUID, JobExecutionContext> contexts = (Map<UUID, JobExecutionContext>) activeContexts.get(jobContextService);
+                        assertThat(contexts.size(), is(0));
+                    } catch (IllegalAccessException e) {
+                        throw new RuntimeException(e);
                     }
-                    for (TransportShardUpsertAction action : internalCluster().getInstances(TransportShardUpsertAction.class)) {
-                        try {
-                            Multimap<UUID, KillableCallable> operations = (Multimap<UUID, KillableCallable>) activeOperationsSb.get(action);
-                            assertThat(operations.size(), is(0));
-                        } catch (IllegalAccessException e) {
-                            throw new RuntimeException(e);
-                        }
+                }
+                for (TransportShardUpsertAction action : internalCluster().getInstances(TransportShardUpsertAction.class)) {
+                    try {
+                        Multimap<UUID, KillableCallable> operations = (Multimap<UUID, KillableCallable>) activeOperationsSb.get(action);
+                        assertThat(operations.size(), is(0));
+                    } catch (IllegalAccessException e) {
+                        throw new RuntimeException(e);
                     }
-                    for (TransportShardDeleteAction action : internalCluster().getInstances(TransportShardDeleteAction.class)) {
-                        try {
-                            Multimap<UUID, KillableCallable> operations = (Multimap<UUID, KillableCallable>) activeOperationsSb.get(action);
-                            assertThat(operations.size(), is(0));
-                        } catch (IllegalAccessException e) {
-                            throw new RuntimeException(e);
-                        }
+                }
+                for (TransportShardDeleteAction action : internalCluster().getInstances(TransportShardDeleteAction.class)) {
+                    try {
+                        Multimap<UUID, KillableCallable> operations = (Multimap<UUID, KillableCallable>) activeOperationsSb.get(action);
+                        assertThat(operations.size(), is(0));
+                    } catch (IllegalAccessException e) {
+                        throw new RuntimeException(e);
                     }
                 }
             }, 10L, TimeUnit.SECONDS);
@@ -237,15 +243,12 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
     }
 
     public void waitUntilShardOperationsFinished() throws Exception {
-        assertBusy(new Runnable() {
-            @Override
-            public void run() {
-                Iterable<IndicesService> indexServices = internalCluster().getInstances(IndicesService.class);
-                for (IndicesService indicesService : indexServices) {
-                    for (IndexService indexService : indicesService) {
-                        for (IndexShard indexShard : indexService) {
-                            assertThat(indexShard.getActiveOperationsCount(), Matchers.equalTo(0));
-                        }
+        assertBusy(() -> {
+            Iterable<IndicesService> indexServices = internalCluster().getInstances(IndicesService.class);
+            for (IndicesService indicesService : indexServices) {
+                for (IndexService indexService : indicesService) {
+                    for (IndexShard indexShard : indexService) {
+                        assertThat(indexShard.getActiveOperationsCount(), Matchers.equalTo(0));
                     }
                 }
             }
@@ -253,17 +256,13 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
     }
 
     public void waitUntilThreadPoolTasksFinished(final String name) throws Exception {
-        assertBusy(new Runnable() {
-            @Override
-            public void run() {
-                Iterable<ThreadPool> threadPools = internalCluster().getInstances(ThreadPool.class);
-                for (ThreadPool threadPool : threadPools) {
-                    ThreadPoolExecutor executor = (ThreadPoolExecutor) threadPool.executor(name);
-                    assertThat(executor.getActiveCount(), is(0));
-                }
+        assertBusy(() -> {
+            Iterable<ThreadPool> threadPools = internalCluster().getInstances(ThreadPool.class);
+            for (ThreadPool threadPool : threadPools) {
+                ThreadPoolExecutor executor = (ThreadPoolExecutor) threadPool.executor(name);
+                assertThat(executor.getActiveCount(), is(0));
             }
         }, 5, TimeUnit.SECONDS);
-
     }
 
     /**

--- a/sql/src/test/java/io/crate/integrationtests/SysShardMinLuceneVersionTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysShardMinLuceneVersionTest.java
@@ -57,19 +57,19 @@ public class SysShardMinLuceneVersionTest extends SQLTransportIntegrationTest {
                 "where schema_name IN ('doc', 'blob') " +
                 "group by table_name, routing_state, min_lucene_version order by 1, 2, 3");
         assertThat(TestingHelpers.printedTable(response.rows()),
-            is("test_blob_no_upgrade_required| STARTED| 6.5.1| 2\n" +
+            is("test_blob_no_upgrade_required| STARTED| 6.6.0| 2\n" +
                "test_blob_no_upgrade_required| UNASSIGNED| NULL| 2\n" +
-               "test_blob_upgrade_required| STARTED| 6.5.1| 2\n" +
+               "test_blob_upgrade_required| STARTED| 6.6.0| 2\n" +
                "test_blob_upgrade_required| UNASSIGNED| NULL| 2\n" +
                "test_no_upgrade_required| STARTED| 6.2.1| 2\n" +
                "test_no_upgrade_required| UNASSIGNED| NULL| 2\n" +
                "test_no_upgrade_required_parted| STARTED| 6.2.1| 5\n" +
-               "test_no_upgrade_required_parted| STARTED| 6.5.1| 5\n" +
+               "test_no_upgrade_required_parted| STARTED| 6.6.0| 5\n" +
                "test_no_upgrade_required_parted| UNASSIGNED| NULL| 10\n" +
                "test_upgrade_required| STARTED| 5.5.2| 2\n" +
                "test_upgrade_required| UNASSIGNED| NULL| 2\n" +
                "test_upgrade_required_parted| STARTED| 5.5.2| 5\n" +
-               "test_upgrade_required_parted| STARTED| 6.5.1| 5\n" +
+               "test_upgrade_required_parted| STARTED| 6.6.0| 5\n" +
                "test_upgrade_required_parted| UNASSIGNED| NULL| 10\n"));
     }
 
@@ -79,7 +79,7 @@ public class SysShardMinLuceneVersionTest extends SQLTransportIntegrationTest {
         execute("select table_name, routing_state, min_lucene_version, count(*) from sys.shards " +
                 "where table_name IN " +
                 "('test_upgrade_required', 'test_upgrade_required_parted', 'test_blob_upgrade_required') AND " +
-                "routing_state = 'STARTED' AND min_lucene_version <> '6.5.1' " +
+                "routing_state = 'STARTED' AND min_lucene_version <> '6.6.0' " +
                 "group by table_name, routing_state, min_lucene_version order by 1, 2, 3");
         assertThat(TestingHelpers.printedTable(response.rows()),
             is("test_upgrade_required| STARTED| 5.5.2| 2\n" +
@@ -91,7 +91,7 @@ public class SysShardMinLuceneVersionTest extends SQLTransportIntegrationTest {
         execute("select * from sys.shards " +
                 "where table_name IN " +
                 "('test_upgrade_required', 'test_upgrade_required_parted', 'test_blob_upgrade_required') " +
-                "AND min_lucene_version <> '6.5.1'");
+                "AND min_lucene_version <> '6.6.0'");
         assertThat(response.rowCount(), is(0L));
     }
 }

--- a/sql/src/test/java/io/crate/lucene/LuceneQueryBuilderTest.java
+++ b/sql/src/test/java/io/crate/lucene/LuceneQueryBuilderTest.java
@@ -43,6 +43,7 @@ import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
+import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.PointInSetQuery;
 import org.apache.lucene.search.PointRangeQuery;
 import org.apache.lucene.search.Query;
@@ -56,7 +57,6 @@ import org.apache.lucene.spatial.prefix.WithinPrefixTreeQuery;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.compress.CompressedXContent;
-import org.elasticsearch.common.lucene.search.MatchNoDocsQuery;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
@@ -352,7 +352,7 @@ public class LuceneQueryBuilderTest extends CrateUnitTest {
     @Test
     public void testIdQuery() throws Exception {
         Query query = convert("_id = 'i1'");
-        assertThat(query, instanceOf(TermQuery.class));
+        assertThat(query, instanceOf(TermInSetQuery.class));
         assertThat(query.toString(), is("_uid:default#i1"));
     }
 

--- a/sql/src/test/java/io/crate/operation/collect/BlobShardCollectorProviderTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/BlobShardCollectorProviderTest.java
@@ -36,6 +36,7 @@ import io.crate.planner.distribution.DistributionInfo;
 import io.crate.planner.node.dql.RoutedCollectPhase;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.CheckedRunnable;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Test;
@@ -91,7 +92,7 @@ public class BlobShardCollectorProviderTest extends SQLHttpIntegrationTest {
         assertThat(Iterables.size(iterable), is(3));
     }
 
-    private final class Initializer implements Runnable {
+    private final class Initializer implements CheckedRunnable<Exception> {
         @Override
         public void run() {
             try {


### PR DESCRIPTION
Doesn't include breaking changes for us as far as I've seen.
https://www.elastic.co/guide/en/elasticsearch/reference/5.5/breaking-changes-5.5.html

Also enabled 2 hourly jenkins jobs to test both crate and new ES v5.2.2_cherry branch:
https://jenkins.crate.io/job/CrateDB/job/crate_test_hourly_es/
https://jenkins.crate.io/job/crate_ES_5.5.2_test
