### PR TITLE
Always pass in default schema instead of null

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -70,6 +70,9 @@ Changes
 Fixes
 =====
 
+ - Fixed a bug in the detection of correlated subqueries which are currently
+   unsupported.
+
  - Fixed issue that caused the Monitoring tab in the Admin UI to redirect
    to ``/401`` when the user didn't have privileges for ``sys.cluster`` 
    or ``sys.jobs_log``.

--- a/sql/src/main/java/io/crate/action/sql/SessionContext.java
+++ b/sql/src/main/java/io/crate/action/sql/SessionContext.java
@@ -22,7 +22,6 @@
 
 package io.crate.action.sql;
 
-import com.google.common.base.MoreObjects;
 import io.crate.analyze.AnalyzedStatement;
 import io.crate.exceptions.MissingPrivilegeException;
 import io.crate.metadata.Schemas;
@@ -31,6 +30,7 @@ import io.crate.operation.user.StatementAuthorizedValidator;
 import io.crate.operation.user.User;
 
 import javax.annotation.Nullable;
+import java.util.Objects;
 import java.util.Set;
 
 public class SessionContext implements StatementAuthorizedValidator, ExceptionAuthorizedValidator {
@@ -62,7 +62,17 @@ public class SessionContext implements StatementAuthorizedValidator, ExceptionAu
         this.user = user;
         this.statementAuthorizedValidator = statementAuthorizedValidator;
         this.exceptionAuthorizedValidator = exceptionAuthorizedValidator;
-        setDefaultSchema(defaultSchema);
+        this.defaultSchema = defaultSchema;
+        if (defaultSchema == null) {
+            resetSchema();
+        }
+    }
+
+    /**
+     * Reverts the schema to the built-in default.
+     */
+    public void resetSchema() {
+        defaultSchema = Schemas.DEFAULT_SCHEMA_NAME;
     }
 
     public Set<Option> options() {
@@ -73,8 +83,8 @@ public class SessionContext implements StatementAuthorizedValidator, ExceptionAu
         return defaultSchema;
     }
 
-    public void setDefaultSchema(@Nullable String schema) {
-        defaultSchema = MoreObjects.firstNonNull(schema, Schemas.DEFAULT_SCHEMA_NAME);
+    public void setDefaultSchema(String schema) {
+        defaultSchema = Objects.requireNonNull(schema, "Default schema must never be set to null");
     }
 
     @Nullable

--- a/sql/src/main/java/io/crate/analyze/DeleteAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/DeleteAnalyzer.java
@@ -21,6 +21,7 @@
 
 package io.crate.analyze;
 
+import io.crate.action.sql.SessionContext;
 import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.relations.AnalyzedRelation;
@@ -62,8 +63,9 @@ class DeleteAnalyzer {
         int numNested = 1;
 
         Function<ParameterExpression, Symbol> convertParamFunction = analysis.parameterContext();
+        SessionContext sessionContext = analysis.sessionContext();
         StatementAnalysisContext statementAnalysisContext = new StatementAnalysisContext(
-            analysis.sessionContext(),
+            sessionContext,
             convertParamFunction,
             Operation.DELETE,
             analysis.transactionContext());
@@ -80,9 +82,10 @@ class DeleteAnalyzer {
         DeleteAnalyzedStatement deleteAnalyzedStatement = new DeleteAnalyzedStatement(docTableRelation);
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
             functions,
-            analysis.sessionContext(),
+            sessionContext,
             convertParamFunction,
-            new FullQualifiedNameFieldProvider(relationAnalysisContext.sources(), relationAnalysisContext.parentSources()),
+            new FullQualifiedNameFieldProvider(
+                relationAnalysisContext.sources(), relationAnalysisContext.parentSources(), sessionContext.defaultSchema()),
             null);
         ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext();
         WhereClauseAnalyzer whereClauseAnalyzer = new WhereClauseAnalyzer(

--- a/sql/src/main/java/io/crate/analyze/UpdateAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/UpdateAnalyzer.java
@@ -22,6 +22,7 @@
 package io.crate.analyze;
 
 import com.google.common.collect.Iterables;
+import io.crate.action.sql.SessionContext;
 import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.expressions.ValueNormalizer;
@@ -110,11 +111,13 @@ public class UpdateAnalyzer {
 
         assert Iterables.getOnlyElement(currentRelationContext.sources().values()) == analyzedRelation :
             "currentRelationContext.sources().values() must have one element and equal to analyzedRelation";
+        SessionContext sessionContext = analysis.sessionContext();
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
             functions,
-            analysis.sessionContext(),
+            sessionContext,
             analysis.parameterContext(),
-            new FullQualifiedNameFieldProvider(currentRelationContext.sources(), currentRelationContext.parentSources()),
+            new FullQualifiedNameFieldProvider(
+                currentRelationContext.sources(), currentRelationContext.parentSources(), sessionContext.defaultSchema()),
             null);
         ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext();
 

--- a/sql/src/main/java/io/crate/analyze/relations/FullQualifiedNameFieldProvider.java
+++ b/sql/src/main/java/io/crate/analyze/relations/FullQualifiedNameFieldProvider.java
@@ -47,11 +47,17 @@ public class FullQualifiedNameFieldProvider implements FieldProvider<Field> {
 
     private final Map<QualifiedName, AnalyzedRelation> sources;
     private final ParentRelations parents;
+    private final String defaultSchema;
 
-    public FullQualifiedNameFieldProvider(Map<QualifiedName, AnalyzedRelation> sources, ParentRelations parents) {
+    public FullQualifiedNameFieldProvider(Map<QualifiedName,
+                                          AnalyzedRelation> sources,
+                                          ParentRelations parents,
+                                          String defaultSchema) {
         assert !sources.isEmpty() : "Must have at least one source";
+        assert defaultSchema != null : "Default schema must not be null";
         this.sources = sources;
         this.parents = parents;
+        this.defaultSchema = defaultSchema;
     }
 
     public Field resolveField(QualifiedName qualifiedName, Operation operation) {
@@ -129,7 +135,7 @@ public class FullQualifiedNameFieldProvider implements FieldProvider<Field> {
     }
 
     private void raiseUnsupportedFeatureIfInParentScope(String columnSchema, String columnTableName) {
-        String schema = columnSchema == null ? Schemas.DEFAULT_SCHEMA_NAME : columnSchema;
+        String schema = columnSchema == null ? defaultSchema : columnSchema;
         QualifiedName qn = new QualifiedName(Arrays.asList(schema, columnTableName));
         if (parents.containsRelation(qn)) {
             throw new UnsupportedOperationException(String.format(Locale.ENGLISH,

--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -24,6 +24,7 @@ package io.crate.analyze.relations;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
+import io.crate.action.sql.SQLOperations;
 import io.crate.action.sql.SessionContext;
 import io.crate.analyze.Analysis;
 import io.crate.analyze.HavingClause;
@@ -168,11 +169,13 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
         if (optCriteria.isPresent()) {
             JoinCriteria joinCriteria = optCriteria.get();
             if (joinCriteria instanceof JoinOn) {
+                SessionContext sessionContext = statementContext.sessionContext();
                 ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
                     functions,
-                    statementContext.sessionContext(),
+                    sessionContext,
                     statementContext.convertParamFunction(),
-                    new FullQualifiedNameFieldProvider(relationContext.sources(), relationContext.parentSources()),
+                    new FullQualifiedNameFieldProvider(
+                        relationContext.sources(), relationContext.parentSources(), sessionContext.defaultSchema()),
                     new SubqueryAnalyzer(this, statementContext));
                 try {
                     joinCondition = expressionAnalyzer.convert(
@@ -202,11 +205,12 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
         }
 
         RelationAnalysisContext context = statementContext.currentRelationContext();
+        SessionContext sessionContext = statementContext.sessionContext();
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
             functions,
-            statementContext.sessionContext(),
+            sessionContext,
             statementContext.convertParamFunction(),
-            new FullQualifiedNameFieldProvider(context.sources(), context.parentSources()),
+            new FullQualifiedNameFieldProvider(context.sources(), context.parentSources(), sessionContext.defaultSchema()),
             new SubqueryAnalyzer(this, statementContext));
         ExpressionAnalysisContext expressionAnalysisContext = context.expressionAnalysisContext();
         Symbol querySymbol = expressionAnalyzer.generateQuerySymbol(node.getWhere(), expressionAnalysisContext);

--- a/sql/src/main/java/io/crate/metadata/Schemas.java
+++ b/sql/src/main/java/io/crate/metadata/Schemas.java
@@ -118,7 +118,7 @@ public class Schemas extends AbstractLifecycleComponent implements Iterable<Sche
     }
 
     private SchemaInfo getSchemaInfo(TableIdent ident) {
-        String schemaName = firstNonNull(ident.schema(), DEFAULT_SCHEMA_NAME);
+        String schemaName = ident.schema();
         SchemaInfo schemaInfo = schemas.get(schemaName);
         if (schemaInfo == null) {
             throw new SchemaUnknownException(schemaName);

--- a/sql/src/main/java/io/crate/metadata/settings/session/SessionSettingRegistry.java
+++ b/sql/src/main/java/io/crate/metadata/settings/session/SessionSettingRegistry.java
@@ -29,9 +29,11 @@ import java.util.Map;
 
 public class SessionSettingRegistry {
 
+    public static final String SEARCH_PATH_KEY = "search_path";
+
     private static final Map<String, SessionSettingApplier> SESSION_SETTINGS =
         ImmutableMap.<String, SessionSettingApplier>builder()
-            .put("search_path", (parameters, expressions, context) -> {
+            .put(SEARCH_PATH_KEY, (parameters, expressions, context) -> {
                 if (expressions.size() > 0) {
                     // The search_path takes a schema name as a string or comma-separated list of schema names.
                     // In the second case only the first schema in the list will be used.
@@ -40,7 +42,7 @@ public class SessionSettingRegistry {
                     String schema = ExpressionToStringVisitor.convert(expressions.get(0), parameters);
                     context.setDefaultSchema(schema.trim());
                 } else {
-                    context.setDefaultSchema(null);
+                    context.resetSchema();
                 }
             }).build();
 

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -1882,6 +1882,27 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     }
 
     @Test
+    public void testCustomSchemaSubSelectWithAccessToParentRelation() throws Exception {
+        DocTableInfo fooTableInfo = TestingTableInfo.builder(new TableIdent("foo", "t1"), SHARD_ROUTING)
+            .add("id", DataTypes.LONG, null)
+            .add("name", DataTypes.STRING, null)
+            .addPrimaryKey("id")
+            .build();
+        DocTableInfoFactory fooTableFactory = new TestingDocTableInfoFactory(
+            ImmutableMap.of(fooTableInfo.ident(), fooTableInfo));
+        Functions functions = getFunctions();
+        UserDefinedFunctionService udfService = new UserDefinedFunctionService(clusterService, functions);
+        SQLExecutor sqlExecutor2 = SQLExecutor.builder(clusterService)
+            .setDefaultSchema("foo")
+            .addSchema(new DocSchemaInfo("foo", clusterService, functions, udfService, fooTableFactory))
+            .addDocTable(fooTableInfo)
+            .build();
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("Cannot use relation \"foo.t1\" in subquery. Correlated subqueries are not supported");
+        sqlExecutor2.analyze("select * from t1 where id = (select 1 from t1 as x where x.id = t1.id)");
+    }
+
+    @Test
     public void testColumnOutputWithSingleRowSubselect() {
         SelectAnalyzedStatement statement = analyze("select 1 = \n (select \n 2\n)\n");
         assertThat(statement.relation().fields(), isSQL("doc.empty_row.(1 = (SELECT 2))"));

--- a/sql/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -103,9 +103,10 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     public void testUnsupportedExpressionCurrentDate() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
         expectedException.expectMessage("Unsupported expression current_time");
+        SessionContext sessionContext = SessionContext.create();
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
-            functions, SessionContext.create(), paramTypeHints,
-            new FullQualifiedNameFieldProvider(dummySources, ParentRelations.NO_PARENTS),
+            functions, sessionContext, paramTypeHints,
+            new FullQualifiedNameFieldProvider(dummySources, ParentRelations.NO_PARENTS, sessionContext.defaultSchema()),
             null);
         ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext();
 
@@ -114,11 +115,13 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testQuotedSubscriptExpression() throws Exception {
+        SessionContext sessionContext = new SessionContext(
+            0, EnumSet.of(Option.ALLOW_QUOTED_SUBSCRIPT), null, null, s -> {}, t -> {});
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
             functions,
-            new SessionContext(0, EnumSet.of(Option.ALLOW_QUOTED_SUBSCRIPT), null, null, s -> {}, t -> {}),
+            sessionContext,
             paramTypeHints,
-            new FullQualifiedNameFieldProvider(dummySources, ParentRelations.NO_PARENTS),
+            new FullQualifiedNameFieldProvider(dummySources, ParentRelations.NO_PARENTS, sessionContext.defaultSchema()),
             null);
         ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext();
 
@@ -152,11 +155,13 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     public void testAnalyzeSubscriptFunctionCall() throws Exception {
         // Test when use subscript function is used explicitly then it's handled (and validated)
         // the same way it's handled when the subscript operator `[]` is used
+        SessionContext sessionContext = new SessionContext(
+            0, EnumSet.of(Option.ALLOW_QUOTED_SUBSCRIPT), null, null, s -> {}, t -> {});
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
             functions,
-            new SessionContext(0, EnumSet.of(Option.ALLOW_QUOTED_SUBSCRIPT), null, null, s -> {}, t -> {}),
+            sessionContext,
             paramTypeHints,
-            new FullQualifiedNameFieldProvider(dummySources, ParentRelations.NO_PARENTS),
+            new FullQualifiedNameFieldProvider(dummySources, ParentRelations.NO_PARENTS, sessionContext.defaultSchema()),
             null);
         ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext();
         FunctionCall subscriptFunctionCall = new FunctionCall(
@@ -182,11 +187,12 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
             new QualifiedName("t1"), tr1,
             new QualifiedName("t2"), tr2
         );
+        SessionContext sessionContext = SessionContext.create();
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
             functions,
-            SessionContext.create(),
+            sessionContext,
             paramTypeHints,
-            new FullQualifiedNameFieldProvider(sources, ParentRelations.NO_PARENTS),
+            new FullQualifiedNameFieldProvider(sources, ParentRelations.NO_PARENTS, sessionContext.defaultSchema()),
             null
         );
         Function andFunction = (Function) expressionAnalyzer.convert(

--- a/sql/src/test/java/io/crate/analyze/relations/FieldProviderTest.java
+++ b/sql/src/test/java/io/crate/analyze/relations/FieldProviderTest.java
@@ -26,6 +26,7 @@ import io.crate.analyze.symbol.Field;
 import io.crate.exceptions.AmbiguousColumnException;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.exceptions.RelationUnknownException;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.QualifiedName;
 import io.crate.test.integration.CrateUnitTest;
@@ -50,7 +51,7 @@ public class FieldProviderTest extends CrateUnitTest {
     }
 
     private static FullQualifiedNameFieldProvider newFQFieldProvider(Map<QualifiedName, AnalyzedRelation> sources) {
-        return new FullQualifiedNameFieldProvider(sources, ParentRelations.NO_PARENTS);
+        return new FullQualifiedNameFieldProvider(sources, ParentRelations.NO_PARENTS, Schemas.DEFAULT_SCHEMA_NAME);
     }
 
     @Test

--- a/sql/src/test/java/io/crate/testing/SqlExpressions.java
+++ b/sql/src/test/java/io/crate/testing/SqlExpressions.java
@@ -104,7 +104,7 @@ public class SqlExpressions {
             parameters == null
                 ? ParamTypeHints.EMPTY
                 : new ParameterContext(new RowN(parameters), Collections.<Row>emptyList()),
-            new FullQualifiedNameFieldProvider(sources, ParentRelations.NO_PARENTS),
+            new FullQualifiedNameFieldProvider(sources, ParentRelations.NO_PARENTS, sessionContext.defaultSchema()),
             null
         );
         normalizer = new EvaluatingNormalizer(functions, RowGranularity.DOC, null, fieldResolver);


### PR DESCRIPTION
This removes the code places which set the default schema to 'doc' if a null
schema is given as input. Instead, we pass through the current default schema
from the `SessionContext`.

I'm also working on randomizing the schema in tests but I thought it would be a good idea to get the fix in first.