### PR TITLE
Don't add columns used in join conditions to NL-outputs

### DIFF
--- a/sql/src/main/java/io/crate/analyze/MultiSourceSelect.java
+++ b/sql/src/main/java/io/crate/analyze/MultiSourceSelect.java
@@ -21,7 +21,13 @@
 
 package io.crate.analyze;
 
-import io.crate.analyze.relations.*;
+import io.crate.analyze.relations.AnalyzedRelation;
+import io.crate.analyze.relations.AnalyzedRelationVisitor;
+import io.crate.analyze.relations.JoinPair;
+import io.crate.analyze.relations.QueriedRelation;
+import io.crate.analyze.relations.RelationNormalizer;
+import io.crate.analyze.relations.RelationSplitter;
+import io.crate.analyze.relations.RemainingOrderBy;
 import io.crate.analyze.symbol.Field;
 import io.crate.analyze.symbol.FieldReplacer;
 import io.crate.analyze.symbol.Symbol;
@@ -33,7 +39,13 @@ import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.QualifiedName;
 
 import javax.annotation.Nonnull;
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 
 public class MultiSourceSelect implements QueriedRelation {
@@ -41,7 +53,7 @@ public class MultiSourceSelect implements QueriedRelation {
     private final Map<QualifiedName, AnalyzedRelation> sources;
     private final Fields fields;
     private final List<JoinPair> joinPairs;
-    private final Set<Symbol> requiredForQuery;
+    private final Set<Symbol> requiredForMerge;
     private final Set<Field> canBeFetched;
     private final Optional<RemainingOrderBy> remainingOrderBy;
     private QualifiedName qualifiedName;
@@ -93,14 +105,14 @@ public class MultiSourceSelect implements QueriedRelation {
         for (JoinPair joinPair : mss.joinPairs) {
             joinPair.replaceCondition(convertFieldInSymbolsToNewRelations);
         }
-        Set<Symbol> requiredForQuery = Sets2.transformedCopy(splitter.requiredForQuery(), convertFieldInSymbolsToNewRelations);
+        Set<Symbol> requiredForMerge = Sets2.transformedCopy(splitter.requiredForMerge(), convertFieldInSymbolsToNewRelations);
         Set<Field> canBeFetched = Sets2.transformedCopy(splitter.canBeFetched(), convertFieldToPointToNewRelations);
         return new MultiSourceSelect(
             mss.sources(),
             mss.fields(),
             querySpec,
             mss.joinPairs,
-            requiredForQuery,
+            requiredForMerge,
             canBeFetched,
             splitter.remainingOrderBy()
         );
@@ -133,7 +145,7 @@ public class MultiSourceSelect implements QueriedRelation {
         for (Path path : outputNames) {
             fields.add(path, new Field(this, path, outputsIterator.next().valueType()));
         }
-        this.requiredForQuery = Collections.emptySet();
+        this.requiredForMerge = Collections.emptySet();
         this.canBeFetched = Collections.emptySet();
         this.remainingOrderBy = Optional.empty();
     }
@@ -142,7 +154,7 @@ public class MultiSourceSelect implements QueriedRelation {
                               Collection<Field> fields,
                               QuerySpec querySpec,
                               List<JoinPair> joinPairs,
-                              Set<Symbol> requiredForQuery,
+                              Set<Symbol> requiredForMerge,
                               Set<Field> canBeFetched,
                               Optional<RemainingOrderBy> remainingOrderBy) {
         this.sources = sources;
@@ -152,13 +164,13 @@ public class MultiSourceSelect implements QueriedRelation {
         for (Field field : fields) {
             this.fields.add(field.path(), new Field(this, field.path(), field.valueType()));
         }
-        this.requiredForQuery = requiredForQuery;
+        this.requiredForMerge = requiredForMerge;
         this.canBeFetched = canBeFetched;
         this.remainingOrderBy = remainingOrderBy;
     }
 
-    public Set<Symbol> requiredForQuery() {
-        return requiredForQuery;
+    public Set<Symbol> requiredForMerge() {
+        return requiredForMerge;
     }
 
     public Set<Field> canBeFetched() {

--- a/sql/src/main/java/io/crate/analyze/relations/RelationSplitter.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationSplitter.java
@@ -58,7 +58,7 @@ import java.util.function.Consumer;
 public final class RelationSplitter {
 
     private final QuerySpec querySpec;
-    private final Set<Symbol> requiredForQuery = new HashSet<>();
+    private final Set<Symbol> requiredForMerge = new HashSet<>();
     private final Map<AnalyzedRelation, QuerySpec> specs;
     private final Map<QualifiedName, AnalyzedRelation> relations;
     private final List<JoinPair> joinPairs;
@@ -94,8 +94,8 @@ public final class RelationSplitter {
         return Optional.ofNullable(remainingOrderBy);
     }
 
-    public Set<Symbol> requiredForQuery() {
-        return requiredForQuery;
+    public Set<Symbol> requiredForMerge() {
+        return requiredForMerge;
     }
 
     public Set<Field> canBeFetched() {
@@ -127,7 +127,7 @@ public final class RelationSplitter {
 
             FieldsVisitor.visitFields(orderBy.orderBySymbols(), f -> {
                 fieldsByRelation.put(f.relation(), f);
-                requiredForQuery.add(f);
+                requiredForMerge.add(f);
             });
         }
 
@@ -174,9 +174,6 @@ public final class RelationSplitter {
                 FieldsVisitor.visitFields(querySpec.orderBy().get().orderBySymbols(), addFieldToMap);
             }
         }
-
-        // everything except the actual outputs is required for query
-        requiredForQuery.addAll(fieldsByRelation.values());
 
         // capture items from the outputs
         canBeFetched = FetchFieldExtractor.process(querySpec.outputs(), fieldsByRelation);
@@ -314,7 +311,7 @@ public final class RelationSplitter {
             if (!(spec.orderBy().isPresent() && (spec.limit().isPresent() || spec.offset().isPresent()))) {
                 orderBy = orderBy.copyAndReplace(Symbols.DEEP_COPY);
                 spec.orderBy(orderBy);
-                requiredForQuery.addAll(orderBy.orderBySymbols());
+                requiredForMerge.addAll(orderBy.orderBySymbols());
             }
         } else {
             remainingOrderBy = new RemainingOrderBy();

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -790,7 +790,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         assertThat(analysis.relation(), instanceOf(MultiSourceSelect.class));
 
         MultiSourceSelect relation = (MultiSourceSelect) analysis.relation();
-        assertThat(relation.requiredForQuery(), contains(isField("id")));
+        assertThat(relation.requiredForMerge(), contains(isField("id")));
     }
 
     @Test
@@ -808,8 +808,17 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         assertThat(analysis.relation(), instanceOf(MultiSourceSelect.class));
 
         MultiSourceSelect relation = (MultiSourceSelect) analysis.relation();
-        assertThat(relation.requiredForQuery(), isSQL(
+        assertThat(relation.requiredForMerge(), isSQL(
             "doc.users.name, doc.users_multi_pk.id, doc.users_multi_pk.name"));
+    }
+
+    @Test
+    public void testJoinConditionIsNotPartOfOutputs() throws Exception {
+        SelectAnalyzedStatement stmt = analyze(
+            "select u1.name from users u1 inner join users u2 on u1.id = u2.id order by u1.date");
+        MultiSourceSelect rel = (MultiSourceSelect) stmt.relation();
+        assertThat(rel.requiredForMerge(), contains(isField("date")));
+        assertThat(rel.querySpec().outputs(), contains(isField("name")));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/analyze/relations/RelationSplitterTest.java
+++ b/sql/src/test/java/io/crate/analyze/relations/RelationSplitterTest.java
@@ -168,7 +168,7 @@ public class RelationSplitterTest extends CrateUnitTest {
         assertThat(querySpec, isSQL("SELECT true ORDER BY doc.t1.a DESC, add(doc.t1.x, doc.t2.y)"));
         assertThat(splitter.remainingOrderBy().isPresent(), is(true));
         assertThat(splitter.remainingOrderBy().get().orderBy(), isSQL("doc.t1.a DESC, add(doc.t1.x, doc.t2.y)"));
-        assertThat(splitter.requiredForQuery(), isSQL("doc.t1.a, doc.t1.x, doc.t2.y"));
+        assertThat(splitter.requiredForMerge(), isSQL("doc.t1.a, doc.t1.x, doc.t2.y"));
         assertThat(splitter.getSpec(T3.TR_1), isSQL("SELECT doc.t1.a, doc.t1.x"));
         assertThat(splitter.getSpec(T3.TR_2), isSQL("SELECT doc.t2.y"));
         assertThat(splitter.canBeFetched(), empty());

--- a/sql/src/test/java/io/crate/planner/consumer/NestedLoopConsumerTest.java
+++ b/sql/src/test/java/io/crate/planner/consumer/NestedLoopConsumerTest.java
@@ -177,14 +177,14 @@ public class NestedLoopConsumerTest extends CrateDummyClusterServiceUnitTest {
             Matchers.contains(instanceOf(FilterProjection.class), instanceOf(EvalProjection.class)));
 
         EvalProjection eval = ((EvalProjection) nestedLoop.nestedLoopPhase().projections().get(1));
-        assertThat(eval.outputs().size(), is(3));
+        assertThat(eval.outputs().size(), is(2));
 
         MergePhase localMergePhase = merge.mergePhase();
         assertThat(localMergePhase.projections(),
             Matchers.contains(instanceOf(FetchProjection.class)));
 
         FetchProjection fetchProjection = (FetchProjection) localMergePhase.projections().get(0);
-        assertThat(fetchProjection.outputs(), isSQL("FETCH(INPUT(0), doc.users._doc['floats']), INPUT(2)"));
+        assertThat(fetchProjection.outputs(), isSQL("FETCH(INPUT(0), doc.users._doc['floats']), INPUT(1)"));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/planner/fetch/MultiSourceFetchPushDownTest.java
+++ b/sql/src/test/java/io/crate/planner/fetch/MultiSourceFetchPushDownTest.java
@@ -32,7 +32,9 @@ import io.crate.testing.SQLExecutor;
 import org.junit.Before;
 import org.junit.Test;
 
+import static io.crate.testing.SymbolMatchers.isField;
 import static io.crate.testing.TestingHelpers.isSQL;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.Is.is;
 
@@ -69,7 +71,6 @@ public class MultiSourceFetchPushDownTest extends CrateDummyClusterServiceUnitTe
         assertThat(srcSpec("t2"), isSQL("SELECT doc.t2._fetchid"));
 
         assertThat(pd.fetchSources().size(), is(2));
-
     }
 
     @Test
@@ -82,4 +83,9 @@ public class MultiSourceFetchPushDownTest extends CrateDummyClusterServiceUnitTe
         assertThat(srcSpec("t2"), isSQL("SELECT doc.t2.b ORDER BY doc.t2.b"));
     }
 
+    @Test
+    public void testPushDownDoesNotAddJoinConditionsAsOutputs() throws Exception {
+        pushDown("select t1.a from t1 inner join t2 on t1.x = t2.y");
+        assertThat(mss.querySpec().outputs(), contains(isField("_fetchid")));
+    }
 }


### PR DESCRIPTION
Fields which are used in a join-condition are not required for a merge.
So they don't have to be added to the MSS outputs.

(This otherwise causes problems with a SEMI-JOIN, as fields from the
right table might get added to the outputs)