### PR TITLE
Clean up JoinPairs API

### DIFF
--- a/sql/src/main/java/io/crate/analyze/Rewriter.java
+++ b/sql/src/main/java/io/crate/analyze/Rewriter.java
@@ -24,14 +24,30 @@ package io.crate.analyze;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
-import io.crate.analyze.relations.*;
-import io.crate.analyze.symbol.*;
+import io.crate.analyze.relations.AnalyzedRelation;
+import io.crate.analyze.relations.JoinPair;
+import io.crate.analyze.relations.JoinPairs;
+import io.crate.analyze.relations.QueriedRelation;
+import io.crate.analyze.relations.QuerySplitter;
+import io.crate.analyze.symbol.Aggregations;
+import io.crate.analyze.symbol.Field;
+import io.crate.analyze.symbol.FieldReplacer;
+import io.crate.analyze.symbol.Literal;
+import io.crate.analyze.symbol.Symbol;
+import io.crate.analyze.symbol.SymbolVisitors;
 import io.crate.operation.operator.AndOperator;
 import io.crate.planner.node.dql.join.JoinType;
 import io.crate.sql.tree.QualifiedName;
 
 import javax.annotation.Nullable;
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 
 public class Rewriter {
@@ -79,12 +95,10 @@ public class Rewriter {
         Map.Entry<QualifiedName, AnalyzedRelation> right = it.next();
         QualifiedName leftName = left.getKey();
         QualifiedName rightName = right.getKey();
-        JoinPair joinPair = JoinPairs.ofRelationsWithMergedConditions(
-            leftName,
-            rightName,
-            mss.joinPairs(),
-            false
-        );
+        JoinPair joinPair = JoinPairs.fuzzyFindPair(mss.joinPairs(), leftName, rightName);
+        if (joinPair == null) {
+            return;
+        }
         assert leftName.equals(joinPair.left()) : "This JoinPair has a different left Qualified name: " + joinPair.left();
         assert rightName.equals(joinPair.right()) : "This JoinPair has a different left Qualified name: " + joinPair.right();
 

--- a/sql/src/main/java/io/crate/analyze/relations/JoinPair.java
+++ b/sql/src/main/java/io/crate/analyze/relations/JoinPair.java
@@ -125,4 +125,13 @@ public class JoinPair {
     public void joinType(JoinType joinType) {
         this.joinType = joinType;
     }
+
+    public JoinPair reverse() {
+        return of(
+            right,
+            left,
+            joinType.invert(),
+            condition
+        );
+    }
 }

--- a/sql/src/main/java/io/crate/planner/consumer/ManyTableConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/ManyTableConsumer.java
@@ -258,7 +258,7 @@ public class ManyTableConsumer implements Consumer {
                                               QualifiedName b,
                                               List<JoinPair> joinPairs,
                                               Set<QualifiedName> outerJoinRelations) {
-        JoinPair joinPair = JoinPairs.ofRelations(a, b, joinPairs, false);
+        JoinPair joinPair = JoinPairs.exactFindPair(joinPairs, a, b);
         // relations are not directly joined and they are part of an outer join
         return (joinPair == null && (outerJoinRelations.contains(a) || outerJoinRelations.contains(b)));
     }
@@ -369,7 +369,7 @@ public class ManyTableConsumer implements Consumer {
             }
 
             // get explicit join definition
-            JoinPair joinPair = JoinPairs.ofRelationsWithMergedConditions(leftName, rightName, joinPairs, true);
+            JoinPair joinPair = JoinPairs.findAndRemovePair(joinPairs, leftName, rightName);
 
             // Search the splittedJoinConditions to find if a join condition
             // can be applied at the current status of the join tree
@@ -546,7 +546,7 @@ public class ManyTableConsumer implements Consumer {
         Iterator<QualifiedName> it = getOrderedRelationNames(mss, ImmutableSet.of(), ImmutableSet.of()).iterator();
         QualifiedName left = it.next();
         QualifiedName right = it.next();
-        JoinPair joinPair = JoinPairs.ofRelationsWithMergedConditions(left, right, mss.joinPairs(), true);
+        JoinPair joinPair = JoinPairs.findAndRemovePair(mss.joinPairs(), left, right);
         QueriedRelation leftRelation = (QueriedRelation) mss.sources().get(left);
         QueriedRelation rightRelation = (QueriedRelation) mss.sources().get(right);
 


### PR DESCRIPTION
- The `consume` logic of `ofRelationsWithMergedConditions` was broken:
   It didn't work if the joinPair was reversed.
   This could lead to fields used in the join-condition being added to
   the output of a nested loop, even if the fields were otherwise not
   used.

 - The method signatures were a bit confusing.

 - Removed the conjunction of the join condition. There is no reason to
   turn the join condition to `R1.id = R2.id and R1.id = R2.id`