### PR TITLE
Improvements to default schema handling

### DIFF
--- a/enterprise/lang-js/src/test/java/io/crate/operation/language/JavaScriptUDFIntegrationTest.java
+++ b/enterprise/lang-js/src/test/java/io/crate/operation/language/JavaScriptUDFIntegrationTest.java
@@ -68,7 +68,7 @@ public class JavaScriptUDFIntegrationTest extends SQLTransportIntegrationTest {
     public void testJavascriptFunction() throws Exception {
         execute("CREATE FUNCTION subtract_js(LONG, LONG) " +
                 "RETURNS LONG LANGUAGE JAVASCRIPT AS 'function subtract_js(x, y) { return x-y; }'");
-        assertFunctionIsCreatedOnAll(Schemas.DEFAULT_SCHEMA_NAME, "subtract_js", ImmutableList.of(DataTypes.LONG, DataTypes.LONG));
+        assertFunctionIsCreatedOnAll(Schemas.DOC_SCHEMA_NAME, "subtract_js", ImmutableList.of(DataTypes.LONG, DataTypes.LONG));
         execute("SELECT SUBTRACT_JS(a, b) FROM test ORDER BY a ASC");
         assertThat(response.rowCount(), is(2L));
         assertThat(response.rows()[0][0], is(2L));

--- a/enterprise/lang-js/src/test/java/io/crate/operation/language/JavascriptUserDefinedFunctionTest.java
+++ b/enterprise/lang-js/src/test/java/io/crate/operation/language/JavascriptUserDefinedFunctionTest.java
@@ -71,7 +71,7 @@ public class JavascriptUserDefinedFunctionTest extends AbstractScalarFunctionsTe
 
     private void registerUserDefinedFunction(String name, DataType returnType, List<DataType> types, String definition) throws ScriptException {
         UserDefinedFunctionMetaData udfMeta = new UserDefinedFunctionMetaData(
-            Schemas.DEFAULT_SCHEMA_NAME,
+            Schemas.DOC_SCHEMA_NAME,
             name,
             types.stream().map(FunctionArgumentDefinition::of).collect(Collectors.toList()),
             returnType,
@@ -82,10 +82,10 @@ public class JavascriptUserDefinedFunctionTest extends AbstractScalarFunctionsTe
         String validation = udfService.getLanguage(JS).validate(udfMeta);
         if (validation == null) {
             functionImplementations.put(
-                new FunctionIdent(Schemas.DEFAULT_SCHEMA_NAME, name, types),
+                new FunctionIdent(Schemas.DOC_SCHEMA_NAME, name, types),
                 udfService.getLanguage(JS).createFunctionImplementation(udfMeta)
             );
-            functions.registerUdfResolversForSchema(Schemas.DEFAULT_SCHEMA_NAME, functionImplementations);
+            functions.registerUdfResolversForSchema(Schemas.DOC_SCHEMA_NAME, functionImplementations);
         } else {
             throw new ScriptException(validation);
         }
@@ -106,7 +106,7 @@ public class JavascriptUserDefinedFunctionTest extends AbstractScalarFunctionsTe
     @Test
     public void testInvalidJavascript() throws ScriptException{
         UserDefinedFunctionMetaData udfMeta = new UserDefinedFunctionMetaData(
-            Schemas.DEFAULT_SCHEMA_NAME,
+            Schemas.DOC_SCHEMA_NAME,
             "f",
             Collections.singletonList(FunctionArgumentDefinition.of(DataTypes.DOUBLE)),
             DataTypes.DOUBLE_ARRAY,
@@ -121,7 +121,7 @@ public class JavascriptUserDefinedFunctionTest extends AbstractScalarFunctionsTe
     @Test
     public void testValidJavascript() throws Exception {
         UserDefinedFunctionMetaData udfMeta = new UserDefinedFunctionMetaData(
-            Schemas.DEFAULT_SCHEMA_NAME,
+            Schemas.DOC_SCHEMA_NAME,
             "f",
             Collections.singletonList(FunctionArgumentDefinition.of(DataTypes.DOUBLE_ARRAY)),
             DataTypes.DOUBLE,

--- a/enterprise/users/src/main/java/io/crate/operation/user/Privileges.java
+++ b/enterprise/users/src/main/java/io/crate/operation/user/Privileges.java
@@ -21,6 +21,7 @@ package io.crate.operation.user;
 import com.google.common.annotations.VisibleForTesting;
 import io.crate.analyze.user.Privilege;
 import io.crate.exceptions.MissingPrivilegeException;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.information.InformationSchemaInfo;
 
 import javax.annotation.Nullable;
@@ -73,7 +74,7 @@ class Privileges {
         assert ident != null : "ident must not be null if privilege class is not 'CLUSTER'";
         String schemaName;
         if (Privilege.Clazz.TABLE.equals(clazz)) {
-            schemaName = Privilege.schemaNameFromTableIdent(ident);
+            schemaName = Schemas.getSchemaName(ident);
         } else {
             schemaName = ident;
         }

--- a/enterprise/users/src/test/java/io/crate/scalar/systeminformation/UserFunctionTest.java
+++ b/enterprise/users/src/test/java/io/crate/scalar/systeminformation/UserFunctionTest.java
@@ -18,7 +18,6 @@
 
 package io.crate.scalar.systeminformation;
 
-import io.crate.action.sql.SessionContext;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.format.SymbolPrinter;
 import io.crate.operation.scalar.AbstractScalarFunctionsTest;
@@ -38,8 +37,7 @@ public class UserFunctionTest extends AbstractScalarFunctionsTest {
     private static final User TEST_USER = new User("testUser", Collections.emptySet(), Collections.emptySet());
 
     private void setupFunctionsFor(@Nullable User user) {
-        SessionContext sessionContext = new SessionContext(null, user, s -> {}, t -> {});
-        sqlExpressions = new SqlExpressions(tableSources, null, null, sessionContext,
+        sqlExpressions = new SqlExpressions(tableSources, null, null, user,
             new UsersScalarFunctionModule());
         functions = sqlExpressions.functions();
     }

--- a/sql/src/jmh/java/io/crate/operation/collect/collectors/OrderedLuceneBatchIteratorBenchmark.java
+++ b/sql/src/jmh/java/io/crate/operation/collect/collectors/OrderedLuceneBatchIteratorBenchmark.java
@@ -29,6 +29,7 @@ import io.crate.data.Input;
 import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RowGranularity;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.TableIdent;
 import io.crate.operation.projectors.sorting.OrderingByPosition;
 import io.crate.operation.reference.doc.lucene.CollectorContext;
@@ -99,7 +100,7 @@ public class OrderedLuceneBatchIteratorBenchmark {
             new CollectorFieldsVisitor(0)
         );
         reference = new Reference(
-            new ReferenceIdent(new TableIdent(null, "dummyTable"), columnName), RowGranularity.DOC, DataTypes.INTEGER);
+            new ReferenceIdent(new TableIdent(Schemas.DOC_SCHEMA_NAME, "dummyTable"), columnName), RowGranularity.DOC, DataTypes.INTEGER);
         orderBy = new OrderBy(
             Collections.singletonList(reference),
             reverseFlags,

--- a/sql/src/main/java/io/crate/action/sql/SessionContext.java
+++ b/sql/src/main/java/io/crate/action/sql/SessionContext.java
@@ -72,7 +72,7 @@ public class SessionContext implements StatementAuthorizedValidator, ExceptionAu
      * Reverts the schema to the built-in default.
      */
     public void resetSchema() {
-        defaultSchema = Schemas.DEFAULT_SCHEMA_NAME;
+        defaultSchema = Schemas.DOC_SCHEMA_NAME;
     }
 
     public Set<Option> options() {
@@ -110,6 +110,14 @@ public class SessionContext implements StatementAuthorizedValidator, ExceptionAu
      * Creates a new SessionContext with default settings.
      */
     public static SessionContext create() {
-        return new SessionContext(null, null, s -> {}, t -> {});
+        return create(null);
+    }
+
+    /**
+     * Creates a new SessionContext with a specific user.
+     * Note: User can only set at the beginning of session.
+     */
+    public static SessionContext create(User user) {
+        return new SessionContext(null, user, s -> {}, t -> {});
     }
 }

--- a/sql/src/main/java/io/crate/analyze/UnboundAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/UnboundAnalyzer.java
@@ -89,8 +89,9 @@ class UnboundAnalyzer {
 
         @Override
         protected AnalyzedRelation visitShowColumns(ShowColumns node, Analysis context) {
-            Tuple<Query, ParameterContext> tuple = showStatementAnalyzer.rewriteShow(node);
-            return relationAnalyzer.analyzeUnbound(tuple.v1(), context.sessionContext(), tuple.v2().typeHints());
+            SessionContext sessionContext = context.sessionContext();
+            Tuple<Query, ParameterContext> tuple = showStatementAnalyzer.rewriteShow(node, sessionContext.defaultSchema());
+            return relationAnalyzer.analyzeUnbound(tuple.v1(), sessionContext, tuple.v2().typeHints());
         }
 
         @Override

--- a/sql/src/main/java/io/crate/analyze/relations/FullQualifiedNameFieldProvider.java
+++ b/sql/src/main/java/io/crate/analyze/relations/FullQualifiedNameFieldProvider.java
@@ -124,8 +124,9 @@ public class FullQualifiedNameFieldProvider implements FieldProvider<Field> {
         }
         if (lastField == null) {
             if (!schemaMatched || !tableNameMatched) {
-                raiseUnsupportedFeatureIfInParentScope(columnSchema, columnTableName);
-                throw RelationUnknownException.of(columnSchema, columnTableName);
+                String schema = columnSchema == null ? defaultSchema : columnSchema;
+                raiseUnsupportedFeatureIfInParentScope(columnSchema, columnTableName, schema);
+                throw RelationUnknownException.of(schema, columnTableName);
             }
             QualifiedName tableName = sources.entrySet().iterator().next().getKey();
             TableIdent tableIdent = TableIdent.fromIndexName(tableName.toString());
@@ -134,8 +135,7 @@ public class FullQualifiedNameFieldProvider implements FieldProvider<Field> {
         return lastField;
     }
 
-    private void raiseUnsupportedFeatureIfInParentScope(String columnSchema, String columnTableName) {
-        String schema = columnSchema == null ? defaultSchema : columnSchema;
+    private void raiseUnsupportedFeatureIfInParentScope(String columnSchema, String columnTableName, String schema) {
         QualifiedName qn = new QualifiedName(Arrays.asList(schema, columnTableName));
         if (parents.containsRelation(qn)) {
             throw new UnsupportedOperationException(String.format(Locale.ENGLISH,

--- a/sql/src/main/java/io/crate/analyze/user/Privilege.java
+++ b/sql/src/main/java/io/crate/analyze/user/Privilege.java
@@ -59,17 +59,6 @@ public class Privilege implements Writeable {
         public static final List<Clazz> VALUES = ImmutableList.copyOf(values());
     }
 
-    /**
-     * Parses the schema name out of a given table ident string.
-     */
-    public static String schemaNameFromTableIdent(String ident) {
-        int dotPos = ident.indexOf('.');
-        if (dotPos == -1) {
-            return Schemas.DEFAULT_SCHEMA_NAME;
-        }
-        return ident.substring(0, dotPos);
-    }
-
 
     private final State state;
     private final PrivilegeIdent ident;

--- a/sql/src/main/java/io/crate/exceptions/RelationUnknownException.java
+++ b/sql/src/main/java/io/crate/exceptions/RelationUnknownException.java
@@ -24,7 +24,6 @@ package io.crate.exceptions;
 
 import io.crate.metadata.TableIdent;
 
-import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.Locale;
 
@@ -32,7 +31,7 @@ public class RelationUnknownException extends ResourceUnknownException implement
 
     private final TableIdent tableIdent;
 
-    public static RelationUnknownException of(@Nullable String schemaName, String tableName) {
+    public static RelationUnknownException of(String schemaName, String tableName) {
         return new RelationUnknownException(new TableIdent(schemaName, tableName));
     }
 

--- a/sql/src/main/java/io/crate/operation/reference/sys/shard/ShardSchemaNameExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/shard/ShardSchemaNameExpression.java
@@ -26,22 +26,13 @@ import io.crate.metadata.Schemas;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.index.shard.ShardId;
 
-import java.util.regex.Matcher;
-
 public class ShardSchemaNameExpression implements ReferenceImplementation<BytesRef> {
 
-    private static final BytesRef DOC_SCHEMA_NAME = new BytesRef(Schemas.DEFAULT_SCHEMA_NAME);
     private final BytesRef schemaName;
 
     public ShardSchemaNameExpression(ShardId shardId) {
         String indexName = shardId.getIndexName();
-        Matcher matcher = Schemas.SCHEMA_PATTERN.matcher(indexName);
-        if (matcher.matches()) {
-            schemaName = new BytesRef(matcher.group(1));
-        } else {
-            schemaName = DOC_SCHEMA_NAME;
-        }
-
+        this.schemaName = new BytesRef(Schemas.getSchemaName(indexName));
     }
 
     @Override

--- a/sql/src/main/java/io/crate/operation/reference/sys/shard/ShardTableNameExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/shard/ShardTableNameExpression.java
@@ -26,8 +26,6 @@ import io.crate.metadata.Schemas;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.index.shard.ShardId;
 
-import java.util.regex.Matcher;
-
 public class ShardTableNameExpression implements ReferenceImplementation<BytesRef> {
 
     private final BytesRef value;
@@ -37,12 +35,7 @@ public class ShardTableNameExpression implements ReferenceImplementation<BytesRe
         if (PartitionName.isPartition(index)) {
             value = new BytesRef(PartitionName.fromIndexOrTemplate(index).tableIdent().name());
         } else {
-            Matcher matcher = Schemas.SCHEMA_PATTERN.matcher(index);
-            if (matcher.matches()) {
-                value = new BytesRef(matcher.group(2));
-            } else {
-                value = new BytesRef(index);
-            }
+            value = new BytesRef(Schemas.getTableName(index));
         }
     }
 

--- a/sql/src/main/java/io/crate/operation/tablefunctions/EmptyRowTableFunction.java
+++ b/sql/src/main/java/io/crate/operation/tablefunctions/EmptyRowTableFunction.java
@@ -53,7 +53,7 @@ import java.util.List;
 public class EmptyRowTableFunction {
 
     private final static String NAME = "empty_row";
-    private final static TableIdent TABLE_IDENT = new TableIdent(null, NAME);
+    private final static TableIdent TABLE_IDENT = new TableIdent("", NAME);
 
     static class EmptyRowTableFunctionImplementation implements TableFunctionImplementation {
 

--- a/sql/src/main/java/io/crate/operation/tablefunctions/UnnestFunction.java
+++ b/sql/src/main/java/io/crate/operation/tablefunctions/UnnestFunction.java
@@ -60,7 +60,7 @@ import java.util.NoSuchElementException;
 public class UnnestFunction {
 
     private static final String NAME = "unnest";
-    private static final TableIdent TABLE_IDENT = new TableIdent(null, NAME);
+    private static final TableIdent TABLE_IDENT = new TableIdent("", NAME);
 
     static class UnnestTableFunctionImplementation implements TableFunctionImplementation {
 

--- a/sql/src/main/java/io/crate/operation/user/UserPrivileges.java
+++ b/sql/src/main/java/io/crate/operation/user/UserPrivileges.java
@@ -24,6 +24,7 @@ package io.crate.operation.user;
 
 import io.crate.analyze.user.Privilege;
 import io.crate.analyze.user.PrivilegeIdent;
+import io.crate.metadata.Schemas;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -85,7 +86,7 @@ class UserPrivileges implements Iterable<Privilege> {
             case TABLE:
                 foundPrivilege = hasAnyTablePrivilege(ident);
                 if (foundPrivilege == false) {
-                    String schemaIdent = Privilege.schemaNameFromTableIdent(ident);
+                    String schemaIdent = Schemas.getSchemaName(ident);
                     foundPrivilege = hasAnySchemaPrivilege(schemaIdent);
                     if (foundPrivilege == false) {
                         foundPrivilege = hasAnyClusterPrivilege();
@@ -113,7 +114,7 @@ class UserPrivileges implements Iterable<Privilege> {
                     foundPrivilege = privilegesMap.get(new PrivilegeIdent(type, Privilege.Clazz.CLUSTER, null));
                     break;
                 case TABLE:
-                    String schemaIdent = Privilege.schemaNameFromTableIdent(ident);
+                    String schemaIdent = Schemas.getSchemaName(ident);
                     foundPrivilege = privilegesMap.get(new PrivilegeIdent(type, Privilege.Clazz.SCHEMA, schemaIdent));
                     if (foundPrivilege == null) {
                         foundPrivilege = privilegesMap.get(new PrivilegeIdent(type, Privilege.Clazz.CLUSTER, null));

--- a/sql/src/test/java/io/crate/analyze/EvaluatingNormalizerTest.java
+++ b/sql/src/test/java/io/crate/analyze/EvaluatingNormalizerTest.java
@@ -12,6 +12,7 @@ import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.ReferenceImplementation;
 import io.crate.metadata.RowGranularity;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.TableIdent;
 import io.crate.metadata.TransactionContext;
 import io.crate.operation.operator.AndOperator;
@@ -69,7 +70,7 @@ public class EvaluatingNormalizerTest extends CrateUnitTest {
             functionInfo(EqOperator.NAME, DataTypes.DOUBLE), Arrays.<Symbol>asList(load_1, d01));
 
         Symbol name_ref = new Reference(
-            new ReferenceIdent(new TableIdent(null, "foo"), "name"),
+            new ReferenceIdent(new TableIdent(Schemas.DOC_SCHEMA_NAME, "foo"), "name"),
             RowGranularity.DOC,
             DataTypes.STRING);
         Symbol x_literal = Literal.of("x");

--- a/sql/src/test/java/io/crate/analyze/InsertFromSubQueryAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/InsertFromSubQueryAnalyzerTest.java
@@ -26,6 +26,7 @@ import io.crate.analyze.symbol.InputColumn;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.metadata.Reference;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.TableIdent;
 import io.crate.metadata.table.TestingTableInfo;
 import io.crate.operation.scalar.SubstrFunction;
@@ -54,7 +55,7 @@ public class InsertFromSubQueryAnalyzerTest extends CrateDummyClusterServiceUnit
     public void prepare() {
         SQLExecutor.Builder builder = SQLExecutor.builder(clusterService).enableDefaultTables();
 
-        TableIdent usersGeneratedIdent = new TableIdent(null, "users_generated");
+        TableIdent usersGeneratedIdent = new TableIdent(Schemas.DOC_SCHEMA_NAME, "users_generated");
         TestingTableInfo.Builder usersGenerated = new TestingTableInfo.Builder(usersGeneratedIdent, SHARD_ROUTING)
             .add("id", DataTypes.LONG)
             .add("firstname", DataTypes.STRING)

--- a/sql/src/test/java/io/crate/analyze/InsertFromValuesAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/InsertFromValuesAnalyzerTest.java
@@ -32,6 +32,7 @@ import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.Reference.IndexType;
 import io.crate.metadata.Routing;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.TableIdent;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.ColumnPolicy;
@@ -67,13 +68,13 @@ import static org.hamcrest.core.Is.is;
 
 public class InsertFromValuesAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
-    private static final TableIdent TEST_ALIAS_TABLE_IDENT = new TableIdent(null, "alias");
+    private static final TableIdent TEST_ALIAS_TABLE_IDENT = new TableIdent(Schemas.DOC_SCHEMA_NAME, "alias");
     private static final DocTableInfo TEST_ALIAS_TABLE_INFO = new TestingTableInfo.Builder(
         TEST_ALIAS_TABLE_IDENT, new Routing(ImmutableMap.<String, Map<String, List<Integer>>>of()))
         .add("bla", DataTypes.STRING, null)
         .isAlias(true).build();
 
-    private static final TableIdent NESTED_CLUSTERED_TABLE_IDENT = new TableIdent(null, "nested_clustered");
+    private static final TableIdent NESTED_CLUSTERED_TABLE_IDENT = new TableIdent(Schemas.DOC_SCHEMA_NAME, "nested_clustered");
     private static final DocTableInfo NESTED_CLUSTERED_TABLE_INFO = new TestingTableInfo.Builder(
         NESTED_CLUSTERED_TABLE_IDENT, new Routing(ImmutableMap.<String, Map<String, List<Integer>>>of()))
         .add("o", DataTypes.OBJECT, null)
@@ -81,7 +82,7 @@ public class InsertFromValuesAnalyzerTest extends CrateDummyClusterServiceUnitTe
         .clusteredBy("o.c")
         .build();
 
-    private static final TableIdent THREE_PK_TABLE_IDENT = new TableIdent(null, "three_pk");
+    private static final TableIdent THREE_PK_TABLE_IDENT = new TableIdent(Schemas.DOC_SCHEMA_NAME, "three_pk");
     private static final DocTableInfo THREE_PK_TABLE_INFO = new TestingTableInfo.Builder(
         THREE_PK_TABLE_IDENT, new Routing(ImmutableMap.of()))
         .add("a", DataTypes.INTEGER)
@@ -102,14 +103,14 @@ public class InsertFromValuesAnalyzerTest extends CrateDummyClusterServiceUnitTe
             .addDocTable(NESTED_CLUSTERED_TABLE_INFO)
             .addDocTable(THREE_PK_TABLE_INFO);
 
-        TableIdent notNullColumnTableIdent = new TableIdent(null, "not_null_column");
+        TableIdent notNullColumnTableIdent = new TableIdent(Schemas.DOC_SCHEMA_NAME, "not_null_column");
         TestingTableInfo.Builder notNullColumnTable = new TestingTableInfo.Builder(
             notNullColumnTableIdent, new Routing(ImmutableMap.of()))
             .add("id", DataTypes.INTEGER, null)
             .add("name", DataTypes.STRING, null, ColumnPolicy.DYNAMIC, IndexType.NOT_ANALYZED, false, false);
         executorBuilder.addDocTable(notNullColumnTable);
 
-        TableIdent generatedColumnTableIdent = new TableIdent(null, "generated_column");
+        TableIdent generatedColumnTableIdent = new TableIdent(Schemas.DOC_SCHEMA_NAME, "generated_column");
         TestingTableInfo.Builder generatedColumnTable = new TestingTableInfo.Builder(
             generatedColumnTableIdent, new Routing(ImmutableMap.<String, Map<String, List<Integer>>>of()))
             .add("ts", DataTypes.TIMESTAMP, null)
@@ -119,7 +120,7 @@ public class InsertFromValuesAnalyzerTest extends CrateDummyClusterServiceUnitTe
             .addGeneratedColumn("name", DataTypes.STRING, "concat(\"user\"['name'], 'bar')", false);
         executorBuilder.addDocTable(generatedColumnTable);
 
-        TableIdent generatedPkColumnTableIdent = new TableIdent(null, "generated_pk_column");
+        TableIdent generatedPkColumnTableIdent = new TableIdent(Schemas.DOC_SCHEMA_NAME, "generated_pk_column");
         TestingTableInfo.Builder generatedPkColumnTable = new TestingTableInfo.Builder(
             generatedPkColumnTableIdent, SHARD_ROUTING)
             .add("serial_no", DataTypes.INTEGER, null)
@@ -131,7 +132,7 @@ public class InsertFromValuesAnalyzerTest extends CrateDummyClusterServiceUnitTe
             .addPrimaryKey("id2");
         executorBuilder.addDocTable(generatedPkColumnTable);
 
-        TableIdent generatedClusteredByTableIdent = new TableIdent(null, "generated_clustered_by_column");
+        TableIdent generatedClusteredByTableIdent = new TableIdent(Schemas.DOC_SCHEMA_NAME, "generated_clustered_by_column");
         TestingTableInfo.Builder clusteredByGeneratedTable = new TestingTableInfo.Builder(
             generatedClusteredByTableIdent, SHARD_ROUTING)
             .add("serial_no", DataTypes.INTEGER, null)
@@ -140,7 +141,7 @@ public class InsertFromValuesAnalyzerTest extends CrateDummyClusterServiceUnitTe
             .clusteredBy("routing_col");
         executorBuilder.addDocTable(clusteredByGeneratedTable);
 
-        TableIdent generatedNestedClusteredByTableIdent = new TableIdent(null, "generated_nested_clustered_by");
+        TableIdent generatedNestedClusteredByTableIdent = new TableIdent(Schemas.DOC_SCHEMA_NAME, "generated_nested_clustered_by");
         TestingTableInfo.Builder generatedNestedClusteredByInfo = new TestingTableInfo.Builder(
             generatedNestedClusteredByTableIdent, SHARD_ROUTING)
             .add("o", DataTypes.OBJECT, null, ColumnPolicy.DYNAMIC)

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -1855,9 +1855,9 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         SelectAnalyzedStatement stmt =
             analyze("select * from unnest(['a'], ['b'], [0], [0], [0], [0], [0], [0], [0], [0], [0])");
 
-        String sqlFields = "doc.unnest.col1, doc.unnest.col2, doc.unnest.col3, doc.unnest.col4, " +
-                           "doc.unnest.col5, doc.unnest.col6, doc.unnest.col7, doc.unnest.col8, " +
-                           "doc.unnest.col9, doc.unnest.col10, doc.unnest.col11";
+        String sqlFields = ".unnest.col1, .unnest.col2, .unnest.col3, .unnest.col4, " +
+                           ".unnest.col5, .unnest.col6, .unnest.col7, .unnest.col8, " +
+                           ".unnest.col9, .unnest.col10, .unnest.col11";
         assertThat(stmt.relation().querySpec().outputs(), isSQL(sqlFields));
         assertThat(stmt.relation().fields(), isSQL(sqlFields));
     }
@@ -1914,6 +1914,6 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testColumnOutputWithSingleRowSubselect() {
         SelectAnalyzedStatement statement = analyze("select 1 = \n (select \n 2\n)\n");
-        assertThat(statement.relation().fields(), isSQL("doc.empty_row.(1 = (SELECT 2))"));
+        assertThat(statement.relation().fields(), isSQL(".empty_row.(1 = (SELECT 2))"));
     }
 }

--- a/sql/src/test/java/io/crate/analyze/SnapshotRestoreAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SnapshotRestoreAnalyzerTest.java
@@ -24,6 +24,7 @@ package io.crate.analyze;
 import com.google.common.collect.ImmutableList;
 import io.crate.exceptions.*;
 import io.crate.metadata.PartitionName;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.TableIdent;
 import io.crate.metadata.blob.BlobSchemaInfo;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
@@ -262,7 +263,7 @@ public class SnapshotRestoreAnalyzerTest extends CrateDummyClusterServiceUnitTes
         PartitionName partition = new PartitionName("parted", ImmutableList.of(new BytesRef("123")));
         assertThat(statement.restoreTables().size(), is(1));
         assertThat(statement.restoreTables().get(0).partitionName(), is(partition));
-        assertThat(statement.restoreTables().get(0).tableIdent(), is(new TableIdent(null, "parted")));
+        assertThat(statement.restoreTables().get(0).tableIdent(), is(new TableIdent(Schemas.DOC_SCHEMA_NAME, "parted")));
     }
 
     @Test
@@ -272,7 +273,7 @@ public class SnapshotRestoreAnalyzerTest extends CrateDummyClusterServiceUnitTes
         PartitionName partitionName = new PartitionName("unknown_parted", ImmutableList.of(new BytesRef("123")));
         assertThat(statement.restoreTables().size(), is(1));
         assertThat(statement.restoreTables().get(0).partitionName(), is(partitionName));
-        assertThat(statement.restoreTables().get(0).tableIdent(), is(new TableIdent(null, "unknown_parted")));
+        assertThat(statement.restoreTables().get(0).tableIdent(), is(new TableIdent(Schemas.DOC_SCHEMA_NAME, "unknown_parted")));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/analyze/TableDefinitions.java
+++ b/sql/src/test/java/io/crate/analyze/TableDefinitions.java
@@ -37,6 +37,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 public final class TableDefinitions {
 
@@ -68,7 +69,7 @@ public final class TableDefinitions {
             .map());
     }
 
-    public static final TableIdent USER_TABLE_IDENT = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "users");
+    public static final TableIdent USER_TABLE_IDENT = new TableIdent(Schemas.DOC_SCHEMA_NAME, "users");
 
     public static final DocTableInfo USER_TABLE_INFO = TestingTableInfo.builder(USER_TABLE_IDENT, SHARD_ROUTING)
         .add("id", DataTypes.LONG, null)
@@ -95,7 +96,7 @@ public final class TableDefinitions {
         .addPrimaryKey("id")
         .clusteredBy("id")
         .build();
-    public static final TableIdent USER_TABLE_IDENT_MULTI_PK = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "users_multi_pk");
+    public static final TableIdent USER_TABLE_IDENT_MULTI_PK = new TableIdent(Schemas.DOC_SCHEMA_NAME, "users_multi_pk");
     public static final DocTableInfo USER_TABLE_INFO_MULTI_PK = TestingTableInfo.builder(USER_TABLE_IDENT_MULTI_PK, SHARD_ROUTING)
         .add("id", DataTypes.LONG, null)
         .add("name", DataTypes.STRING, null)
@@ -106,7 +107,7 @@ public final class TableDefinitions {
         .addPrimaryKey("name")
         .clusteredBy("id")
         .build();
-    public static final TableIdent USER_TABLE_IDENT_CLUSTERED_BY_ONLY = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "users_clustered_by_only");
+    public static final TableIdent USER_TABLE_IDENT_CLUSTERED_BY_ONLY = new TableIdent(Schemas.DOC_SCHEMA_NAME, "users_clustered_by_only");
     public static final DocTableInfo USER_TABLE_INFO_CLUSTERED_BY_ONLY = TestingTableInfo.builder(USER_TABLE_IDENT_CLUSTERED_BY_ONLY, SHARD_ROUTING)
         .add("id", DataTypes.LONG, null)
         .add("name", DataTypes.STRING, null)
@@ -115,13 +116,13 @@ public final class TableDefinitions {
         .add("friends", new ArrayType(DataTypes.OBJECT), null, ColumnPolicy.DYNAMIC)
         .clusteredBy("id")
         .build();
-    static final TableIdent USER_TABLE_REFRESH_INTERVAL_BY_ONLY = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "user_refresh_interval");
+    static final TableIdent USER_TABLE_REFRESH_INTERVAL_BY_ONLY = new TableIdent(Schemas.DOC_SCHEMA_NAME, "user_refresh_interval");
     public static final DocTableInfo USER_TABLE_INFO_REFRESH_INTERVAL_BY_ONLY = TestingTableInfo.builder(USER_TABLE_REFRESH_INTERVAL_BY_ONLY, SHARD_ROUTING)
         .add("id", DataTypes.LONG, null)
         .add("content", DataTypes.STRING, null)
         .clusteredBy("id")
         .build();
-    static final TableIdent NESTED_PK_TABLE_IDENT = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "nested_pk");
+    static final TableIdent NESTED_PK_TABLE_IDENT = new TableIdent(Schemas.DOC_SCHEMA_NAME, "nested_pk");
     public static final DocTableInfo NESTED_PK_TABLE_INFO = TestingTableInfo.builder(NESTED_PK_TABLE_IDENT, SHARD_ROUTING)
         .add("id", DataTypes.LONG, null)
         .add("o", DataTypes.OBJECT, null, ColumnPolicy.DYNAMIC)
@@ -130,7 +131,7 @@ public final class TableDefinitions {
         .addPrimaryKey("o.b")
         .clusteredBy("o.b")
         .build();
-    public static final TableIdent TEST_PARTITIONED_TABLE_IDENT = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "parted");
+    public static final TableIdent TEST_PARTITIONED_TABLE_IDENT = new TableIdent(Schemas.DOC_SCHEMA_NAME, "parted");
     public static final DocTableInfo TEST_PARTITIONED_TABLE_INFO = new TestingTableInfo.Builder(
         TEST_PARTITIONED_TABLE_IDENT, new Routing(ImmutableMap.<String, Map<String, List<Integer>>>of()))
         .add("id", DataTypes.INTEGER, null)
@@ -146,13 +147,13 @@ public final class TableDefinitions {
             }}).asIndexName())
         .build();
     public static final TableIdent TEST_EMPTY_PARTITIONED_TABLE_IDENT =
-        new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "empty_parted");
+        new TableIdent(Schemas.DOC_SCHEMA_NAME, "empty_parted");
     public static final DocTableInfo TEST_EMPTY_PARTITIONED_TABLE_INFO = new TestingTableInfo.Builder(
         TEST_EMPTY_PARTITIONED_TABLE_IDENT, new Routing(ImmutableMap.of()))
         .add("name", DataTypes.STRING, null)
         .add("date", DataTypes.TIMESTAMP, null, true)
         .build();
-    public static final TableIdent PARTED_PKS_IDENT = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "parted_pks");
+    public static final TableIdent PARTED_PKS_IDENT = new TableIdent(Schemas.DOC_SCHEMA_NAME, "parted_pks");
     public static final DocTableInfo PARTED_PKS_TI = new TestingTableInfo.Builder(
         PARTED_PKS_IDENT, PARTED_ROUTING)
         .add("id", DataTypes.INTEGER, null)
@@ -168,7 +169,7 @@ public final class TableDefinitions {
         .addPrimaryKey("date")
         .clusteredBy("id")
         .build();
-    public static final TableIdent TEST_MULTIPLE_PARTITIONED_TABLE_IDENT = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "multi_parted");
+    public static final TableIdent TEST_MULTIPLE_PARTITIONED_TABLE_IDENT = new TableIdent(Schemas.DOC_SCHEMA_NAME, "multi_parted");
     public static final DocTableInfo TEST_MULTIPLE_PARTITIONED_TABLE_INFO = new TestingTableInfo.Builder(
         TEST_MULTIPLE_PARTITIONED_TABLE_IDENT, new Routing(ImmutableMap.<String, Map<String, List<Integer>>>of()))
         .add("id", DataTypes.INTEGER, null)
@@ -182,7 +183,7 @@ public final class TableDefinitions {
             new PartitionName("multi_parted", Arrays.asList(new BytesRef("1395961200000"), new BytesRef("-100"))).asIndexName(),
             new PartitionName("multi_parted", Arrays.asList(null, new BytesRef("-100"))).asIndexName())
         .build();
-    static final TableIdent TEST_NESTED_PARTITIONED_TABLE_IDENT = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "nested_parted");
+    static final TableIdent TEST_NESTED_PARTITIONED_TABLE_IDENT = new TableIdent(Schemas.DOC_SCHEMA_NAME, "nested_parted");
     public static final DocTableInfo TEST_NESTED_PARTITIONED_TABLE_INFO = new TestingTableInfo.Builder(
         TEST_NESTED_PARTITIONED_TABLE_IDENT, new Routing(ImmutableMap.<String, Map<String, List<Integer>>>of()))
         .add("id", DataTypes.INTEGER, null)
@@ -195,7 +196,7 @@ public final class TableDefinitions {
             new PartitionName("nested_parted", Arrays.asList(new BytesRef("1395961200000"), new BytesRef("Ford"))).asIndexName(),
             new PartitionName("nested_parted", Arrays.asList(null, new BytesRef("Zaphod"))).asIndexName())
         .build();
-    public static final TableIdent TEST_DOC_TRANSACTIONS_TABLE_IDENT = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "transactions");
+    public static final TableIdent TEST_DOC_TRANSACTIONS_TABLE_IDENT = new TableIdent(Schemas.DOC_SCHEMA_NAME, "transactions");
     public static final DocTableInfo TEST_DOC_TRANSACTIONS_TABLE_INFO = new TestingTableInfo.Builder(
         TEST_DOC_TRANSACTIONS_TABLE_IDENT, new Routing(ImmutableMap.<String, Map<String, List<Integer>>>of()))
         .add("id", DataTypes.LONG, null)
@@ -204,7 +205,7 @@ public final class TableDefinitions {
         .add("amount", DataTypes.DOUBLE, null)
         .add("timestamp", DataTypes.TIMESTAMP, null)
         .build();
-    public static final TableIdent DEEPLY_NESTED_TABLE_IDENT = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "deeply_nested");
+    public static final TableIdent DEEPLY_NESTED_TABLE_IDENT = new TableIdent(Schemas.DOC_SCHEMA_NAME, "deeply_nested");
     public static final DocTableInfo DEEPLY_NESTED_TABLE_INFO = new TestingTableInfo.Builder(
         DEEPLY_NESTED_TABLE_IDENT, new Routing(ImmutableMap.<String, Map<String, List<Integer>>>of()))
         .add("details", DataTypes.OBJECT, null, ColumnPolicy.DYNAMIC)
@@ -220,19 +221,19 @@ public final class TableDefinitions {
         .add("tags", DataTypes.LONG, Arrays.asList("metadata", "id"))
         .build();
 
-    public static final TableIdent IGNORED_NESTED_TABLE_IDENT = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "ignored_nested");
+    public static final TableIdent IGNORED_NESTED_TABLE_IDENT = new TableIdent(Schemas.DOC_SCHEMA_NAME, "ignored_nested");
     public static final DocTableInfo IGNORED_NESTED_TABLE_INFO = new TestingTableInfo.Builder(
         IGNORED_NESTED_TABLE_IDENT, new Routing(ImmutableMap.<String, Map<String, List<Integer>>>of()))
         .add("details", DataTypes.OBJECT, null, ColumnPolicy.IGNORED)
         .build();
 
-    public static final TableIdent TEST_DOC_LOCATIONS_TABLE_IDENT = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "locations");
+    public static final TableIdent TEST_DOC_LOCATIONS_TABLE_IDENT = new TableIdent(Schemas.DOC_SCHEMA_NAME, "locations");
     public static final DocTableInfo TEST_DOC_LOCATIONS_TABLE_INFO = TestingTableInfo.builder(TEST_DOC_LOCATIONS_TABLE_IDENT, SHARD_ROUTING)
         .add("id", DataTypes.LONG, null)
         .add("loc", DataTypes.GEO_POINT, null)
         .build();
 
-    public static final DocTableInfo TEST_CLUSTER_BY_STRING_TABLE_INFO = TestingTableInfo.builder(new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "bystring"), SHARD_ROUTING)
+    public static final DocTableInfo TEST_CLUSTER_BY_STRING_TABLE_INFO = TestingTableInfo.builder(new TableIdent(Schemas.DOC_SCHEMA_NAME, "bystring"), SHARD_ROUTING)
         .add("name", DataTypes.STRING, null)
         .add("score", DataTypes.DOUBLE, null)
         .addPrimaryKey("name")
@@ -240,7 +241,7 @@ public final class TableDefinitions {
         .build();
 
 
-    public static final TableIdent CLUSTERED_PARTED_IDENT = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "clustered_parted");
+    public static final TableIdent CLUSTERED_PARTED_IDENT = new TableIdent(Schemas.DOC_SCHEMA_NAME, "clustered_parted");
     public static final DocTableInfo CLUSTERED_PARTED = new TestingTableInfo.Builder(
         CLUSTERED_PARTED_IDENT, CLUSTERED_PARTED_ROUTING)
         .add("id", DataTypes.INTEGER, null)

--- a/sql/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
@@ -70,13 +70,13 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         .add("other_obj", DataTypes.OBJECT, null)
         .clusteredBy("obj.name").build();
 
-    private final TableIdent testAliasTableIdent = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "alias");
+    private final TableIdent testAliasTableIdent = new TableIdent(Schemas.DOC_SCHEMA_NAME, "alias");
     private final DocTableInfo testAliasTableInfo = new TestingTableInfo.Builder(
         testAliasTableIdent, new Routing(ImmutableMap.<String, Map<String, List<Integer>>>of()))
         .add("bla", DataTypes.STRING, null)
         .isAlias(true).build();
 
-    private final TableIdent nestedPk = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "t_nested_pk");
+    private final TableIdent nestedPk = new TableIdent(Schemas.DOC_SCHEMA_NAME, "t_nested_pk");
     private final DocTableInfo tiNestedPk = new TestingTableInfo.Builder(
         nestedPk, SHARD_ROUTING)
         .add("o", DataTypes.OBJECT)
@@ -95,14 +95,14 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
             .addDocTable(testAliasTableInfo)
             .addDocTable(tiNestedPk);
 
-        TableIdent partedGeneratedColumnTableIdent = new TableIdent(null, "parted_generated_column");
+        TableIdent partedGeneratedColumnTableIdent = new TableIdent(Schemas.DOC_SCHEMA_NAME, "parted_generated_column");
         TestingTableInfo.Builder partedGeneratedColumnTableInfo = new TestingTableInfo.Builder(
             partedGeneratedColumnTableIdent, new Routing(ImmutableMap.<String, Map<String, List<Integer>>>of()))
             .add("ts", DataTypes.TIMESTAMP, null)
             .addGeneratedColumn("day", DataTypes.TIMESTAMP, "date_trunc('day', ts)", true);
         builder.addDocTable(partedGeneratedColumnTableInfo);
 
-        TableIdent nestedPartedGeneratedColumnTableIdent = new TableIdent(null, "nested_parted_generated_column");
+        TableIdent nestedPartedGeneratedColumnTableIdent = new TableIdent(Schemas.DOC_SCHEMA_NAME, "nested_parted_generated_column");
         TestingTableInfo.Builder nestedPartedGeneratedColumnTableInfo = new TestingTableInfo.Builder(
             nestedPartedGeneratedColumnTableIdent, new Routing(ImmutableMap.<String, Map<String, List<Integer>>>of()))
             .add("user", DataTypes.OBJECT, null)
@@ -188,7 +188,7 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         UpdateAnalyzedStatement statement = analyze("update users set name='Trillian'");
         UpdateAnalyzedStatement.NestedAnalyzedStatement statement1 = statement.nestedStatements().get(0);
         assertThat(statement1.assignments().size(), is(1));
-        assertThat(((DocTableRelation) statement.sourceRelation()).tableInfo().ident(), is(new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, "users")));
+        assertThat(((DocTableRelation) statement.sourceRelation()).tableInfo().ident(), is(new TableIdent(Schemas.DOC_SCHEMA_NAME, "users")));
 
         Reference ref = statement1.assignments().keySet().iterator().next();
         assertThat(ref.ident().tableIdent().name(), is("users"));

--- a/sql/src/test/java/io/crate/analyze/ValueNormalizerTest.java
+++ b/sql/src/test/java/io/crate/analyze/ValueNormalizerTest.java
@@ -54,7 +54,7 @@ import static org.mockito.Mockito.when;
 
 public class ValueNormalizerTest extends CrateUnitTest {
 
-    private static final TableIdent TEST_TABLE_IDENT = new TableIdent(null, "test1");
+    private static final TableIdent TEST_TABLE_IDENT = new TableIdent(Schemas.DOC_SCHEMA_NAME, "test1");
     private static final TableInfo userTableInfo = TestingTableInfo.builder(TEST_TABLE_IDENT,
         new Routing(ImmutableMap.<String, Map<String, List<Integer>>>of()))
         .add("id", DataTypes.LONG, null)

--- a/sql/src/test/java/io/crate/analyze/relations/FieldProviderTest.java
+++ b/sql/src/test/java/io/crate/analyze/relations/FieldProviderTest.java
@@ -51,7 +51,7 @@ public class FieldProviderTest extends CrateUnitTest {
     }
 
     private static FullQualifiedNameFieldProvider newFQFieldProvider(Map<QualifiedName, AnalyzedRelation> sources) {
-        return new FullQualifiedNameFieldProvider(sources, ParentRelations.NO_PARENTS, Schemas.DEFAULT_SCHEMA_NAME);
+        return new FullQualifiedNameFieldProvider(sources, ParentRelations.NO_PARENTS, Schemas.DOC_SCHEMA_NAME);
     }
 
     @Test

--- a/sql/src/test/java/io/crate/analyze/relations/SubselectRewriterTest.java
+++ b/sql/src/test/java/io/crate/analyze/relations/SubselectRewriterTest.java
@@ -70,8 +70,8 @@ public class SubselectRewriterTest extends CrateDummyClusterServiceUnitTest {
         Schemas schemas = new Schemas(
             Settings.EMPTY,
             ImmutableMap.of(
-                Schemas.DEFAULT_SCHEMA_NAME,
-                new DocSchemaInfo(Schemas.DEFAULT_SCHEMA_NAME, clusterService, functions, udfService, docTableInfoFactory)),
+                Schemas.DOC_SCHEMA_NAME,
+                new DocSchemaInfo(Schemas.DOC_SCHEMA_NAME, clusterService, functions, udfService, docTableInfoFactory)),
             clusterService,
             new DocSchemaInfoFactory(docTableInfoFactory, functions, udfService)
         );

--- a/sql/src/test/java/io/crate/executor/transport/ShardUpsertRequestTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/ShardUpsertRequestTest.java
@@ -26,6 +26,7 @@ import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RowGranularity;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.TableIdent;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.types.DataTypes;
@@ -42,7 +43,7 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class ShardUpsertRequestTest extends CrateUnitTest {
 
-    private static final TableIdent CHARACTERS_IDENTS = new TableIdent(null, "characters");
+    private static final TableIdent CHARACTERS_IDENTS = new TableIdent(Schemas.DOC_SCHEMA_NAME, "characters");
 
     private static final Reference ID_REF = new Reference(
         new ReferenceIdent(CHARACTERS_IDENTS, "id"), RowGranularity.DOC, DataTypes.INTEGER);

--- a/sql/src/test/java/io/crate/executor/transport/SnapshotRestoreDDLDispatcherTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/SnapshotRestoreDDLDispatcherTest.java
@@ -25,6 +25,7 @@ package io.crate.executor.transport;
 import com.google.common.collect.ImmutableList;
 import io.crate.analyze.RestoreSnapshotAnalyzedStatement;
 import io.crate.metadata.PartitionName;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.TableIdent;
 import io.crate.test.integration.CrateUnitTest;
 import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsResponse;
@@ -49,11 +50,11 @@ public class SnapshotRestoreDDLDispatcherTest extends CrateUnitTest {
     @Test
     public void testResolveTableIndexWithIgnoreUnavailable() throws Exception {
         CompletableFuture<SnapshotRestoreDDLDispatcher.ResolveIndicesAndTemplatesContext> f = SnapshotRestoreDDLDispatcher.resolveIndexNames(
-            Collections.singletonList(new RestoreSnapshotAnalyzedStatement.RestoreTableInfo(new TableIdent(null, "my_table"),null)),
+            Collections.singletonList(new RestoreSnapshotAnalyzedStatement.RestoreTableInfo(new TableIdent(Schemas.DOC_SCHEMA_NAME, "my_table"),null)),
             true, null, "my_repo"
         );
         SnapshotRestoreDDLDispatcher.ResolveIndicesAndTemplatesContext ctx = f.get();
-        assertThat(ctx.resolvedIndices(), containsInAnyOrder("my_table", PartitionName.templateName(null, "my_table") + "*"));
+        assertThat(ctx.resolvedIndices(), containsInAnyOrder("my_table", PartitionName.templateName(Schemas.DOC_SCHEMA_NAME, "my_table") + "*"));
         assertThat(ctx.resolvedTemplates(), contains(".partitioned.my_table."));
     }
 
@@ -75,14 +76,14 @@ public class SnapshotRestoreDDLDispatcherTest extends CrateUnitTest {
     public void testResolvePartitionedTableIndexFromSnapshot() throws Exception {
         SnapshotRestoreDDLDispatcher.ResolveIndicesAndTemplatesContext ctx = new SnapshotRestoreDDLDispatcher.ResolveIndicesAndTemplatesContext();
         SnapshotRestoreDDLDispatcher.ResolveFromSnapshotActionListener.resolveTableFromSnapshot(
-            new RestoreSnapshotAnalyzedStatement.RestoreTableInfo(new TableIdent(null, "restoreme"), null),
+            new RestoreSnapshotAnalyzedStatement.RestoreTableInfo(new TableIdent(Schemas.DOC_SCHEMA_NAME, "restoreme"), null),
             Collections.singletonList(
                 new SnapshotInfo(new SnapshotId("snapshot01", UUID.randomUUID().toString()),
                     Collections.singletonList(".partitioned.restoreme.046jcchm6krj4e1g60o30c0"), 0L)
             ),
             ctx
         );
-        String template = PartitionName.templateName(null, "restoreme");
+        String template = PartitionName.templateName(Schemas.DOC_SCHEMA_NAME, "restoreme");
         assertThat(ctx.resolvedIndices(), contains(template + "*"));
         assertThat(ctx.resolvedTemplates(), contains(template));
     }
@@ -91,7 +92,7 @@ public class SnapshotRestoreDDLDispatcherTest extends CrateUnitTest {
     public void testResolveEmptyPartitionedTemplate() throws Exception {
         SnapshotRestoreDDLDispatcher.ResolveIndicesAndTemplatesContext ctx = new SnapshotRestoreDDLDispatcher.ResolveIndicesAndTemplatesContext();
         SnapshotRestoreDDLDispatcher.ResolveFromSnapshotActionListener.resolveTableFromSnapshot(
-            new RestoreSnapshotAnalyzedStatement.RestoreTableInfo(new TableIdent(null, "restoreme"), null),
+            new RestoreSnapshotAnalyzedStatement.RestoreTableInfo(new TableIdent(Schemas.DOC_SCHEMA_NAME, "restoreme"), null),
             Collections.singletonList(
                 new SnapshotInfo(new SnapshotId("snapshot01", UUID.randomUUID().toString()), ImmutableList.of(), 0L)
             ),
@@ -100,14 +101,14 @@ public class SnapshotRestoreDDLDispatcherTest extends CrateUnitTest {
         assertThat(ctx.resolvedIndices().size(), is(0));
         // If the snapshot doesn't contain any index which belongs to the table, it could be that the user
         // restores an empty partitioned table. For that case we attempt to restore the table template.
-        assertThat(ctx.resolvedTemplates(), contains(PartitionName.templateName(null, "restoreme")));
+        assertThat(ctx.resolvedTemplates(), contains(PartitionName.templateName(Schemas.DOC_SCHEMA_NAME, "restoreme")));
     }
 
     @Test
     public void testResolveMultiTablesIndexNamesFromSnapshot() throws Exception {
         List<RestoreSnapshotAnalyzedStatement.RestoreTableInfo> tables = Arrays.asList(
-            new RestoreSnapshotAnalyzedStatement.RestoreTableInfo(new TableIdent(null, "my_table"), null),
-            new RestoreSnapshotAnalyzedStatement.RestoreTableInfo(new TableIdent(null, "my_partitioned_table"), null)
+            new RestoreSnapshotAnalyzedStatement.RestoreTableInfo(new TableIdent(Schemas.DOC_SCHEMA_NAME, "my_table"), null),
+            new RestoreSnapshotAnalyzedStatement.RestoreTableInfo(new TableIdent(Schemas.DOC_SCHEMA_NAME, "my_partitioned_table"), null)
         );
         List<SnapshotInfo> snapshots = Arrays.asList(
                 new SnapshotInfo(
@@ -125,8 +126,8 @@ public class SnapshotRestoreDDLDispatcherTest extends CrateUnitTest {
         actionListener.onResponse(response);
 
         SnapshotRestoreDDLDispatcher.ResolveIndicesAndTemplatesContext ctx = future.get();
-        assertThat(ctx.resolvedIndices(), containsInAnyOrder("my_table", PartitionName.templateName(null, "my_partitioned_table") + "*"));
-        assertThat(ctx.resolvedTemplates(), contains(PartitionName.templateName(null, "my_partitioned_table")));
+        assertThat(ctx.resolvedIndices(), containsInAnyOrder("my_table", PartitionName.templateName(Schemas.DOC_SCHEMA_NAME, "my_partitioned_table") + "*"));
+        assertThat(ctx.resolvedTemplates(), contains(PartitionName.templateName(Schemas.DOC_SCHEMA_NAME, "my_partitioned_table")));
     }
 
 }

--- a/sql/src/test/java/io/crate/executor/transport/TransportShardDeleteActionTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/TransportShardDeleteActionTest.java
@@ -22,6 +22,7 @@
 
 package io.crate.executor.transport;
 
+import io.crate.metadata.Schemas;
 import io.crate.metadata.TableIdent;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import org.elasticsearch.Version;
@@ -52,7 +53,7 @@ import static org.mockito.Mockito.*;
 
 public class TransportShardDeleteActionTest extends CrateDummyClusterServiceUnitTest {
 
-    private final static TableIdent TABLE_IDENT = new TableIdent(null, "characters");
+    private final static TableIdent TABLE_IDENT = new TableIdent(Schemas.DOC_SCHEMA_NAME, "characters");
 
     private TransportShardDeleteAction transportShardDeleteAction;
     private IndexShard indexShard;

--- a/sql/src/test/java/io/crate/executor/transport/TransportShardUpsertActionTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/TransportShardUpsertActionTest.java
@@ -95,7 +95,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
 
     private DocTableInfo generatedColumnTableInfo;
 
-    private final static TableIdent TABLE_IDENT = new TableIdent(null, "characters");
+    private final static TableIdent TABLE_IDENT = new TableIdent(Schemas.DOC_SCHEMA_NAME, "characters");
     private final static String PARTITION_INDEX = new PartitionName(TABLE_IDENT, Arrays.asList(new BytesRef("1395874800000"))).asIndexName();
     private final static Reference ID_REF = new Reference(
         new ReferenceIdent(TABLE_IDENT, "id"), RowGranularity.DOC, DataTypes.SHORT);
@@ -183,7 +183,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
     }
 
     private void bindGeneratedColumnTable(Functions functions) {
-        TableIdent generatedColumnTableIdent = new TableIdent(null, "generated_column");
+        TableIdent generatedColumnTableIdent = new TableIdent(Schemas.DOC_SCHEMA_NAME, "generated_column");
         generatedColumnTableInfo = new TestingTableInfo.Builder(
             generatedColumnTableIdent, new Routing(Collections.EMPTY_MAP))
             .add("ts", DataTypes.TIMESTAMP, null)
@@ -310,7 +310,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
             .map();
 
         DocTableInfo docTableInfo = new TestingTableInfo.Builder(
-            new TableIdent(null, "generated_column"),
+            new TableIdent(Schemas.DOC_SCHEMA_NAME, "generated_column"),
             new Routing(Collections.<String, Map<String, List<Integer>>>emptyMap()))
             .add("obj", DataTypes.OBJECT, null)
             .add("obj", new ArrayType(DataTypes.INTEGER), Arrays.asList("arr"))

--- a/sql/src/test/java/io/crate/executor/transport/ddl/TransportRenameTableActionTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/ddl/TransportRenameTableActionTest.java
@@ -50,11 +50,13 @@ public class TransportRenameTableActionTest extends SQLTransportIntegrationTest 
 
     @Test
     public void testRenameOnOpenTableThrowsException() throws Exception {
-        RenameTableRequest request = new RenameTableRequest(TableIdent.fromIndexName("t1"),
-            TableIdent.fromIndexName("t2"), false);
+        String defaultSchema = sqlExecutor.getDefaultSchema();
+        RenameTableRequest request = new RenameTableRequest(
+            TableIdent.fromIndexName(defaultSchema + ".t1"),
+            TableIdent.fromIndexName(defaultSchema + ".t2"), false);
 
         expectedException.expect(RuntimeException.class);
-        expectedException.expectMessage("Table 'doc.t1' is not closed, cannot perform a rename");
+        expectedException.expectMessage(String.format("Table '%s.t1' is not closed, cannot perform a rename", defaultSchema));
         transportRenameTableAction.execute(request).actionGet(5, TimeUnit.SECONDS);
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/ColumnPolicyIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ColumnPolicyIntegrationTest.java
@@ -24,6 +24,7 @@ package io.crate.integrationtests;
 import io.crate.Constants;
 import io.crate.action.sql.SQLActionException;
 import io.crate.metadata.PartitionName;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.TableIdent;
 import io.crate.metadata.table.ColumnPolicy;
 import io.crate.testing.TestingHelpers;
@@ -377,7 +378,7 @@ public class ColumnPolicyIntegrationTest extends SQLTransportIntegrationTest {
         ensureYellow();
 
         GetIndexTemplatesResponse response = client().admin().indices()
-            .prepareGetTemplates(PartitionName.templateName(null, "numbers"))
+            .prepareGetTemplates(PartitionName.templateName(Schemas.DOC_SCHEMA_NAME, "numbers"))
             .execute().actionGet();
         assertThat(response.getIndexTemplates().size(), is(1));
         IndexTemplateMetaData template = response.getIndexTemplates().get(0);
@@ -413,7 +414,7 @@ public class ColumnPolicyIntegrationTest extends SQLTransportIntegrationTest {
         ensureYellow();
 
         GetIndexTemplatesResponse response = client().admin().indices()
-            .prepareGetTemplates(PartitionName.templateName(null, "numbers"))
+            .prepareGetTemplates(PartitionName.templateName(Schemas.DOC_SCHEMA_NAME, "numbers"))
             .execute().actionGet();
         assertThat(response.getIndexTemplates().size(), is(1));
         IndexTemplateMetaData template = response.getIndexTemplates().get(0);
@@ -449,7 +450,7 @@ public class ColumnPolicyIntegrationTest extends SQLTransportIntegrationTest {
         ensureYellow();
 
         GetIndexTemplatesResponse templateResponse = client().admin().indices()
-            .prepareGetTemplates(PartitionName.templateName(null, "numbers"))
+            .prepareGetTemplates(PartitionName.templateName(Schemas.DOC_SCHEMA_NAME, "numbers"))
             .execute().actionGet();
         assertThat(templateResponse.getIndexTemplates().size(), is(1));
         IndexTemplateMetaData template = templateResponse.getIndexTemplates().get(0);
@@ -580,7 +581,7 @@ public class ColumnPolicyIntegrationTest extends SQLTransportIntegrationTest {
         execute("refresh table dynamic_table");
         ensureYellow();
         GetIndexTemplatesResponse response = client().admin().indices()
-            .prepareGetTemplates(PartitionName.templateName(null, "dynamic_table"))
+            .prepareGetTemplates(PartitionName.templateName(Schemas.DOC_SCHEMA_NAME, "dynamic_table"))
             .execute().actionGet();
         assertThat(response.getIndexTemplates().size(), is(1));
         IndexTemplateMetaData template = response.getIndexTemplates().get(0);

--- a/sql/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableMap;
 import io.crate.Version;
 import io.crate.action.sql.SQLActionException;
 import io.crate.metadata.PartitionName;
+import io.crate.metadata.Schemas;
 import io.crate.testing.TestingHelpers;
 import io.crate.testing.UseJdbc;
 import org.apache.lucene.util.BytesRef;
@@ -676,7 +677,7 @@ public class DDLIntegrationTest extends SQLTransportIntegrationTest {
         );
         execute("alter table quotes set (number_of_shards=5)");
 
-        String templateName = PartitionName.templateName(null, "quotes");
+        String templateName = PartitionName.templateName(Schemas.DOC_SCHEMA_NAME, "quotes");
         GetIndexTemplatesResponse templatesResponse =
             client().admin().indices().prepareGetTemplates(templateName).execute().actionGet();
         Settings templateSettings = templatesResponse.getIndexTemplates().get(0).getSettings();

--- a/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -28,6 +28,7 @@ import io.crate.Version;
 import io.crate.action.sql.SQLActionException;
 import io.crate.metadata.IndexMappings;
 import io.crate.metadata.PartitionName;
+import io.crate.metadata.Schemas;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.TestingHelpers;
 import io.crate.testing.UseJdbc;
@@ -274,7 +275,7 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
         execute("create table parted (id integer, name string, date timestamp)" +
                 "partitioned by (date)");
         ensureYellow();
-        String templateName = PartitionName.templateName(null, "parted");
+        String templateName = PartitionName.templateName(Schemas.DOC_SCHEMA_NAME, "parted");
         GetIndexTemplatesResponse templatesResponse = client().admin().indices()
             .prepareGetTemplates(templateName).execute().actionGet();
         assertThat(templatesResponse.getIndexTemplates().get(0).template(),
@@ -1072,7 +1073,7 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
         assertEquals(1L, response.rowCount());
 
         GetIndexTemplatesResponse getIndexTemplatesResponse = client().admin().indices()
-            .prepareGetTemplates(PartitionName.templateName(null, "quotes")).execute().get();
+            .prepareGetTemplates(PartitionName.templateName(Schemas.DOC_SCHEMA_NAME, "quotes")).execute().get();
         assertThat(getIndexTemplatesResponse.getIndexTemplates().size(), is(0));
 
         assertThat(internalCluster().clusterService().state().metaData().indices().size(), is(0));
@@ -1293,7 +1294,7 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
                 "partitioned by(date) clustered into 3 shards with (number_of_replicas='0-all')");
         ensureYellow();
 
-        String templateName = PartitionName.templateName(null, "quotes");
+        String templateName = PartitionName.templateName(Schemas.DOC_SCHEMA_NAME, "quotes");
         GetIndexTemplatesResponse templatesResponse = client().admin().indices()
             .prepareGetTemplates(templateName).execute().actionGet();
         Settings templateSettings = templatesResponse.getIndexTemplates().get(0).getSettings();
@@ -1363,7 +1364,7 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
                 "partitioned by(date) clustered into 3 shards with (number_of_replicas='1')");
         ensureYellow();
 
-        String templateName = PartitionName.templateName(null, "quotes");
+        String templateName = PartitionName.templateName(Schemas.DOC_SCHEMA_NAME, "quotes");
         GetIndexTemplatesResponse templatesResponse = client().admin().indices()
             .prepareGetTemplates(templateName).execute().actionGet();
         Settings templateSettings = templatesResponse.getIndexTemplates().get(0).getSettings();
@@ -1398,7 +1399,7 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
         execute("alter table quotes reset (number_of_replicas)");
         ensureYellow();
 
-        String templateName = PartitionName.templateName(null, "quotes");
+        String templateName = PartitionName.templateName(Schemas.DOC_SCHEMA_NAME, "quotes");
         GetIndexTemplatesResponse templatesResponse = client().admin().indices()
             .prepareGetTemplates(templateName).execute().actionGet();
         Settings templateSettings = templatesResponse.getIndexTemplates().get(0).getSettings();
@@ -1448,7 +1449,7 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
         assertThat(settingsResponse.getSetting(partitions.get(0), IndexMetaData.SETTING_NUMBER_OF_REPLICAS), is("1"));
         assertThat(settingsResponse.getSetting(partitions.get(1), IndexMetaData.SETTING_NUMBER_OF_REPLICAS), is("0"));
 
-        String templateName = PartitionName.templateName(null, "quotes");
+        String templateName = PartitionName.templateName(Schemas.DOC_SCHEMA_NAME, "quotes");
         GetIndexTemplatesResponse templatesResponse = client().admin().indices()
             .prepareGetTemplates(templateName).execute().actionGet();
         Settings templateSettings = templatesResponse.getIndexTemplates().get(0).getSettings();
@@ -1784,7 +1785,7 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
                 "partitioned by(date) clustered into 3 shards with (number_of_replicas='0-all')");
         ensureYellow();
 
-        String templateName = PartitionName.templateName(null, "quotes");
+        String templateName = PartitionName.templateName(Schemas.DOC_SCHEMA_NAME, "quotes");
         GetIndexTemplatesResponse templatesResponse = client().admin().indices()
             .prepareGetTemplates(templateName).execute().actionGet();
         Settings templateSettings = templatesResponse.getIndexTemplates().get(0).getSettings();
@@ -1990,7 +1991,7 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
         execute("insert into foo (name, p) values (?, ?)", new Object[]{"Marvin", 1});
         execute("refresh table foo");
 
-        String templateName = PartitionName.templateName(null, "foo");
+        String templateName = PartitionName.templateName(Schemas.DOC_SCHEMA_NAME, "foo");
         client().admin().indices().prepareDeleteTemplate(templateName).execute().actionGet();
         waitNoPendingTasksOnAll();
         execute("select * from sys.shards where table_name = 'foo'");

--- a/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
@@ -323,7 +323,10 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
         Planner planner = internalCluster().getInstance(Planner.class, nodeName);
 
         ParameterContext parameterContext = new ParameterContext(Row.EMPTY, Collections.<Row>emptyList());
-        Plan plan = planner.plan(analyzer.boundAnalyze(SqlParser.createStatement(stmt), SessionContext.create(), parameterContext), UUID.randomUUID(), 0, 0);
+        SessionContext sessionContext = new SessionContext(sqlExecutor.getDefaultSchema(), null, x -> {}, x -> {});
+        Plan plan = planner.plan(
+            analyzer.boundAnalyze(SqlParser.createStatement(stmt), sessionContext, parameterContext),
+            UUID.randomUUID(), 0, 0);
         return new PlanForNode(plan, nodeName);
     }
 
@@ -454,7 +457,7 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
     }
 
     public void waitForMappingUpdateOnAll(final String tableOrPartition, final String... fieldNames) throws Exception {
-        waitForMappingUpdateOnAll(new TableIdent(null, tableOrPartition), fieldNames);
+        waitForMappingUpdateOnAll(new TableIdent(Schemas.DOC_SCHEMA_NAME, tableOrPartition), fieldNames);
     }
 
     /**

--- a/sql/src/test/java/io/crate/integrationtests/UserDefinedFunctionsIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/UserDefinedFunctionsIntegrationTest.java
@@ -125,11 +125,11 @@ public class UserDefinedFunctionsIntegrationTest extends SQLTransportIntegration
         try {
             execute("create function foo(long)" +
                 " returns string language dummy_lang as 'function foo(x) { return \"1\"; }'");
-            assertFunctionIsCreatedOnAll(Schemas.DEFAULT_SCHEMA_NAME, "foo", ImmutableList.of(DataTypes.LONG));
+            assertFunctionIsCreatedOnAll(Schemas.DOC_SCHEMA_NAME, "foo", ImmutableList.of(DataTypes.LONG));
 
             execute("create function foo(string)" +
                 " returns string language dummy_lang as 'function foo(x) { return x; }'");
-            assertFunctionIsCreatedOnAll(Schemas.DEFAULT_SCHEMA_NAME, "foo", ImmutableList.of(DataTypes.STRING));
+            assertFunctionIsCreatedOnAll(Schemas.DOC_SCHEMA_NAME, "foo", ImmutableList.of(DataTypes.STRING));
 
             execute("select foo(str) from test order by id asc");
             assertThat(response.rows()[0][0], is("DUMMY EATS string"));
@@ -145,10 +145,10 @@ public class UserDefinedFunctionsIntegrationTest extends SQLTransportIntegration
     @Test
     public void testDropFunction() throws Exception {
         execute("create function custom(string) returns string language dummy_lang as 'DUMMY DUMMY DUMMY'");
-        assertFunctionIsCreatedOnAll(Schemas.DEFAULT_SCHEMA_NAME, "custom", ImmutableList.of(DataTypes.STRING));
+        assertFunctionIsCreatedOnAll(Schemas.DOC_SCHEMA_NAME, "custom", ImmutableList.of(DataTypes.STRING));
 
         dropFunction("custom", ImmutableList.of(DataTypes.STRING));
-        assertFunctionIsDeletedOnAll(Schemas.DEFAULT_SCHEMA_NAME, "custom", ImmutableList.of(DataTypes.STRING));
+        assertFunctionIsDeletedOnAll(Schemas.DOC_SCHEMA_NAME, "custom", ImmutableList.of(DataTypes.STRING));
     }
 
     @Test
@@ -170,7 +170,7 @@ public class UserDefinedFunctionsIntegrationTest extends SQLTransportIntegration
             execute("create function subtract_test(long, long, long) " +
                     "returns long language dummy_lang " +
                     "as 'function subtract_test(a, b, c) { return a - b - c; }'");
-            assertFunctionIsCreatedOnAll(Schemas.DEFAULT_SCHEMA_NAME,
+            assertFunctionIsCreatedOnAll(Schemas.DOC_SCHEMA_NAME,
                 "subtract_test",
                 ImmutableList.of(DataTypes.LONG, DataTypes.LONG, DataTypes.LONG)
             );
@@ -196,7 +196,7 @@ public class UserDefinedFunctionsIntegrationTest extends SQLTransportIntegration
         // is created and dropped on the same schema. It proves that creating and dropping
         // functions doesn't affect already registered functions.
         execute("create function foo(long) returns string language dummy_lang as 'f doo()'");
-        assertFunctionIsCreatedOnAll(Schemas.DEFAULT_SCHEMA_NAME, "foo", ImmutableList.of(DataTypes.LONG));
+        assertFunctionIsCreatedOnAll(Schemas.DOC_SCHEMA_NAME, "foo", ImmutableList.of(DataTypes.LONG));
 
         final CountDownLatch latch = new CountDownLatch(50);
         final AtomicReference<Throwable> lastThrowable = new AtomicReference<>();
@@ -206,7 +206,7 @@ public class UserDefinedFunctionsIntegrationTest extends SQLTransportIntegration
             while (latch.getCount() > 0) {
                 try {
                     execute("create function bar(long) returns long language dummy_lang as 'dummy'");
-                    assertFunctionIsCreatedOnAll(Schemas.DEFAULT_SCHEMA_NAME, "bar", ImmutableList.of(DataTypes.LONG));
+                    assertFunctionIsCreatedOnAll(Schemas.DOC_SCHEMA_NAME, "bar", ImmutableList.of(DataTypes.LONG));
                     execute("drop function bar(long)");
                 } catch (Exception e) {
                     lastThrowable.set(e);
@@ -236,6 +236,6 @@ public class UserDefinedFunctionsIntegrationTest extends SQLTransportIntegration
         execute(String.format(Locale.ENGLISH, "drop function %s(%s)",
             name, types.stream().map(DataType::getName).collect(Collectors.joining(", "))));
         assertThat(response.rowCount(), is(1L));
-        assertFunctionIsDeletedOnAll(Schemas.DEFAULT_SCHEMA_NAME, name, types);
+        assertFunctionIsDeletedOnAll(Schemas.DOC_SCHEMA_NAME, name, types);
     }
 }

--- a/sql/src/test/java/io/crate/lucene/LuceneQueryBuilderTest.java
+++ b/sql/src/test/java/io/crate/lucene/LuceneQueryBuilderTest.java
@@ -29,6 +29,7 @@ import io.crate.analyze.relations.TableRelation;
 import io.crate.lucene.match.CrateRegexQuery;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.TableIdent;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.ColumnPolicy;
@@ -114,7 +115,7 @@ public class LuceneQueryBuilderTest extends CrateUnitTest {
 
     @Before
     public void prepare() throws Exception {
-        DocTableInfo users = TestingTableInfo.builder(new TableIdent(null, "users"), null)
+        DocTableInfo users = TestingTableInfo.builder(new TableIdent(Schemas.DOC_SCHEMA_NAME, "users"), null)
             .add("name", DataTypes.STRING)
             .add("x", DataTypes.INTEGER, null, ColumnPolicy.DYNAMIC, Reference.IndexType.NOT_ANALYZED, false, false)
             .add("d", DataTypes.DOUBLE)
@@ -240,13 +241,12 @@ public class LuceneQueryBuilderTest extends CrateUnitTest {
     @Test
     public void testWhereRefEqNullWithDifferentTypes() throws Exception {
         for (DataType type : DataTypes.PRIMITIVE_TYPES) {
-            DocTableInfo tableInfo = TestingTableInfo.builder(new TableIdent(null, "test_primitive"), null)
+            DocTableInfo tableInfo = TestingTableInfo.builder(new TableIdent(Schemas.DOC_SCHEMA_NAME, "test_primitive"), null)
                 .add("x", type)
                 .build();
             TableRelation tableRelation = new TableRelation(tableInfo);
             Map<QualifiedName, AnalyzedRelation> tableSources = ImmutableMap.of(new QualifiedName(tableInfo.ident().name()), tableRelation);
-            SqlExpressions sqlExpressions = new SqlExpressions(
-                tableSources, tableRelation, new Object[]{null}, SessionContext.create());
+            SqlExpressions sqlExpressions = new SqlExpressions(tableSources, tableRelation, new Object[]{null}, null);
 
             Query query = convert(new WhereClause(sqlExpressions.normalize(sqlExpressions.asSymbol("x = ?"))));
 

--- a/sql/src/test/java/io/crate/metadata/DocReferencesTest.java
+++ b/sql/src/test/java/io/crate/metadata/DocReferencesTest.java
@@ -29,7 +29,7 @@ import static org.junit.Assert.*;
 
 public class DocReferencesTest {
 
-    private static final TableIdent tableIdent = new TableIdent(null, "users");
+    private static final TableIdent tableIdent = new TableIdent(Schemas.DOC_SCHEMA_NAME, "users");
 
     private static Reference stringRef(String path) {
         ColumnIdent columnIdent = ColumnIdent.fromPath(path);

--- a/sql/src/test/java/io/crate/metadata/MapBackedRefResolverTest.java
+++ b/sql/src/test/java/io/crate/metadata/MapBackedRefResolverTest.java
@@ -35,7 +35,7 @@ import static org.mockito.Mockito.mock;
 
 public class MapBackedRefResolverTest {
 
-    private static final TableIdent USERS_TI = new TableIdent(null, "users");
+    private static final TableIdent USERS_TI = new TableIdent(Schemas.DOC_SCHEMA_NAME, "users");
 
     @Test
     public void testGetImplementation() throws Exception {

--- a/sql/src/test/java/io/crate/metadata/PartitionNameTest.java
+++ b/sql/src/test/java/io/crate/metadata/PartitionNameTest.java
@@ -157,7 +157,7 @@ public class PartitionNameTest extends CrateUnitTest {
         PartitionName partitionName = new PartitionName("t", Arrays.asList(new BytesRef("a"), new BytesRef("b")));
         assertThat(partitionName, equalTo(PartitionName.fromIndexOrTemplate(partitionName.asIndexName())));
 
-        partitionName = new PartitionName(null, "t", Arrays.asList(new BytesRef("a"), new BytesRef("b")));
+        partitionName = new PartitionName("t", Arrays.asList(new BytesRef("a"), new BytesRef("b")));
         assertThat(partitionName, equalTo(PartitionName.fromIndexOrTemplate(partitionName.asIndexName())));
         assertThat(partitionName.ident(), is("081620j2"));
 
@@ -165,11 +165,11 @@ public class PartitionNameTest extends CrateUnitTest {
         assertThat(partitionName, equalTo(PartitionName.fromIndexOrTemplate(partitionName.asIndexName())));
         assertThat(partitionName.ident(), is("081620j2"));
 
-        partitionName = new PartitionName(null, "t", Collections.singletonList(new BytesRef("hoschi")));
+        partitionName = new PartitionName( "t", Collections.singletonList(new BytesRef("hoschi")));
         assertThat(partitionName, equalTo(PartitionName.fromIndexOrTemplate(partitionName.asIndexName())));
         assertThat(partitionName.ident(), is("043mgrrjcdk6i"));
 
-        partitionName = new PartitionName(null, "t", Collections.<BytesRef>singletonList(null));
+        partitionName = new PartitionName("t", Collections.singletonList(null));
         assertThat(partitionName, equalTo(PartitionName.fromIndexOrTemplate(partitionName.asIndexName())));
         assertThat(partitionName.ident(), is("0400"));
     }
@@ -229,12 +229,12 @@ public class PartitionNameTest extends CrateUnitTest {
             new PartitionName("table", Arrays.asList(new BytesRef("xxx"))).equals(
                 new PartitionName("table", Arrays.asList(new BytesRef("xxx")))));
         assertTrue(
-            new PartitionName(null, "table", Arrays.asList(new BytesRef("xxx"))).equals(
-                new PartitionName(Schemas.DEFAULT_SCHEMA_NAME, "table", Arrays.asList(new BytesRef("xxx")))));
+            new PartitionName("table", Arrays.asList(new BytesRef("xxx"))).equals(
+                new PartitionName("table", Arrays.asList(new BytesRef("xxx")))));
         assertFalse(
             new PartitionName("table", Arrays.asList(new BytesRef("xxx"))).equals(
                 new PartitionName("schema", "table", Arrays.asList(new BytesRef("xxx")))));
-        PartitionName name = new PartitionName(null, "table", Arrays.asList(new BytesRef("xxx")));
+        PartitionName name = new PartitionName( "table", Arrays.asList(new BytesRef("xxx")));
         assertTrue(name.equals(PartitionName.fromIndexOrTemplate(name.asIndexName())));
     }
 }

--- a/sql/src/test/java/io/crate/metadata/ReferenceToLiteralConverterTest.java
+++ b/sql/src/test/java/io/crate/metadata/ReferenceToLiteralConverterTest.java
@@ -34,7 +34,7 @@ import static io.crate.testing.SymbolMatchers.isLiteral;
 
 public class ReferenceToLiteralConverterTest extends CrateUnitTest {
 
-    private static final TableIdent TABLE_IDENT = new TableIdent(null, "characters");
+    private static final TableIdent TABLE_IDENT = new TableIdent(Schemas.DOC_SCHEMA_NAME, "characters");
 
     @Test
     public void testReplaceSimpleReference() throws Exception {

--- a/sql/src/test/java/io/crate/metadata/SchemasITest.java
+++ b/sql/src/test/java/io/crate/metadata/SchemasITest.java
@@ -61,7 +61,7 @@ public class SchemasITest extends SQLTransportIntegrationTest {
                 ") clustered into 10 shards with (number_of_replicas=1)");
         ensureYellow();
 
-        DocTableInfo ti = schemas.getTableInfo(new TableIdent(null, "t1"));
+        DocTableInfo ti = schemas.getTableInfo(new TableIdent(Schemas.DOC_SCHEMA_NAME, "t1"));
         assertThat(ti.ident().name(), is("t1"));
 
         assertThat(ti.columns().size(), is(3));
@@ -95,8 +95,8 @@ public class SchemasITest extends SQLTransportIntegrationTest {
         client().admin().indices().aliases(request).actionGet();
         ensureYellow();
 
-        DocTableInfo terminatorTable = schemas.getTableInfo(new TableIdent(null, "terminator"));
-        DocTableInfo entsafterTable = schemas.getTableInfo(new TableIdent(null, "entsafter"));
+        DocTableInfo terminatorTable = schemas.getTableInfo(new TableIdent(Schemas.DOC_SCHEMA_NAME, "terminator"));
+        DocTableInfo entsafterTable = schemas.getTableInfo(new TableIdent(Schemas.DOC_SCHEMA_NAME, "entsafter"));
 
         assertNotNull(terminatorTable);
         assertFalse(terminatorTable.isAlias());
@@ -117,7 +117,7 @@ public class SchemasITest extends SQLTransportIntegrationTest {
         client().admin().indices().aliases(request).actionGet();
         ensureYellow();
 
-        DocTableInfo entsafterTable = schemas.getTableInfo(new TableIdent(null, "entsafter"));
+        DocTableInfo entsafterTable = schemas.getTableInfo(new TableIdent(Schemas.DOC_SCHEMA_NAME, "entsafter"));
 
         assertNotNull(entsafterTable);
         assertThat(entsafterTable.concreteIndices().length, is(2));

--- a/sql/src/test/java/io/crate/metadata/SchemasTest.java
+++ b/sql/src/test/java/io/crate/metadata/SchemasTest.java
@@ -119,7 +119,7 @@ public class SchemasTest {
                         "burlesque", "Hello, World!Q")
                 )
             ).build();
-        assertThat(Schemas.getNewCurrentSchemas(metaData), contains("new_schema"));
+        assertThat(Schemas.getNewCurrentSchemas(metaData), contains("doc", "new_schema"));
     }
 
     private Schemas getReferenceInfos(SchemaInfo schemaInfo) {

--- a/sql/src/test/java/io/crate/metadata/TableIdentTest.java
+++ b/sql/src/test/java/io/crate/metadata/TableIdentTest.java
@@ -33,7 +33,7 @@ public class TableIdentTest extends CrateUnitTest {
 
     @Test
     public void testIndexName() throws Exception {
-        TableIdent ti = new TableIdent(null, "t");
+        TableIdent ti = new TableIdent(Schemas.DOC_SCHEMA_NAME, "t");
         assertThat(ti.indexName(), is("t"));
         ti = new TableIdent("s", "t");
         assertThat(ti.indexName(), is("s.t"));
@@ -41,26 +41,26 @@ public class TableIdentTest extends CrateUnitTest {
 
     @Test
     public void testFromIndexName() throws Exception {
-        assertThat(TableIdent.fromIndexName("t"), is(new TableIdent(null, "t")));
+        assertThat(TableIdent.fromIndexName("t"), is(new TableIdent(Schemas.DOC_SCHEMA_NAME, "t")));
         assertThat(TableIdent.fromIndexName("s.t"), is(new TableIdent("s", "t")));
 
         PartitionName pn = new PartitionName("s", "t", ImmutableList.of(new BytesRef("v1")));
         assertThat(TableIdent.fromIndexName(pn.asIndexName()), is(new TableIdent("s", "t")));
 
-        pn = new PartitionName(null, "t", ImmutableList.of(new BytesRef("v1")));
-        assertThat(TableIdent.fromIndexName(pn.asIndexName()), is(new TableIdent(null, "t")));
+        pn = new PartitionName( "t", ImmutableList.of(new BytesRef("v1")));
+        assertThat(TableIdent.fromIndexName(pn.asIndexName()), is(new TableIdent(Schemas.DOC_SCHEMA_NAME, "t")));
     }
 
     @Test
     public void testDefaultSchema() throws Exception {
-        TableIdent ti = new TableIdent(null, "t");
+        TableIdent ti = new TableIdent(Schemas.DOC_SCHEMA_NAME, "t");
         assertThat(ti.schema(), is("doc"));
         assertThat(ti, is(new TableIdent("doc", "t")));
     }
 
     @Test
     public void testFQN() throws Exception {
-        TableIdent ti = new TableIdent(null, "t");
+        TableIdent ti = new TableIdent(Schemas.DOC_SCHEMA_NAME, "t");
         assertThat(ti.fqn(), is("doc.t"));
 
         ti = new TableIdent("s", "t");
@@ -69,9 +69,9 @@ public class TableIdentTest extends CrateUnitTest {
 
     @Test
     public void testFqnFromIndexName() throws Exception {
-        assertThat(TableIdent.fqnFromIndexName("t1"), is(Schemas.DEFAULT_SCHEMA_NAME + ".t1"));
+        assertThat(TableIdent.fqnFromIndexName("t1"), is(Schemas.DOC_SCHEMA_NAME + ".t1"));
         assertThat(TableIdent.fqnFromIndexName("my_schema.t1"), is("my_schema.t1"));
-        assertThat(TableIdent.fqnFromIndexName(".partitioned.t1.abc"), is(Schemas.DEFAULT_SCHEMA_NAME + ".t1"));
+        assertThat(TableIdent.fqnFromIndexName(".partitioned.t1.abc"), is(Schemas.DOC_SCHEMA_NAME + ".t1"));
         assertThat(TableIdent.fqnFromIndexName("my_schema..partitioned.t1.abc"), is("my_schema.t1"));
     }
 

--- a/sql/src/test/java/io/crate/metadata/doc/DocIndexMetaDataTest.java
+++ b/sql/src/test/java/io/crate/metadata/doc/DocIndexMetaDataTest.java
@@ -98,7 +98,7 @@ public class DocIndexMetaDataTest extends CrateDummyClusterServiceUnitTest {
     }
 
     private DocIndexMetaData newMeta(IndexMetaData metaData, String name) throws IOException {
-        return new DocIndexMetaData(functions, metaData, new TableIdent(null, name)).build();
+        return new DocIndexMetaData(functions, metaData, new TableIdent(Schemas.DOC_SCHEMA_NAME, name)).build();
     }
 
     @Before
@@ -939,7 +939,7 @@ public class DocIndexMetaDataTest extends CrateDummyClusterServiceUnitTest {
             functions,
             new IndexNameExpressionResolver(Settings.EMPTY)
         );
-        DocSchemaInfo docSchemaInfo = new DocSchemaInfo(Schemas.DEFAULT_SCHEMA_NAME, clusterService, functions, udfService, docTableInfoFactory);
+        DocSchemaInfo docSchemaInfo = new DocSchemaInfo(Schemas.DOC_SCHEMA_NAME, clusterService, functions, udfService, docTableInfoFactory);
         CreateTableStatementAnalyzer analyzer = new CreateTableStatementAnalyzer(
             new Schemas(
                 Settings.EMPTY,

--- a/sql/src/test/java/io/crate/metadata/doc/DocTableInfoTest.java
+++ b/sql/src/test/java/io/crate/metadata/doc/DocTableInfoTest.java
@@ -22,7 +22,7 @@ public class DocTableInfoTest extends CrateUnitTest {
 
     @Test
     public void testGetColumnInfo() throws Exception {
-        TableIdent tableIdent = new TableIdent(null, "dummy");
+        TableIdent tableIdent = new TableIdent(Schemas.DOC_SCHEMA_NAME, "dummy");
 
         DocTableInfo info = new DocTableInfo(
             tableIdent,
@@ -68,7 +68,7 @@ public class DocTableInfoTest extends CrateUnitTest {
     @Test
     public void testGetColumnInfoStrictParent() throws Exception {
 
-        TableIdent dummy = new TableIdent(null, "dummy");
+        TableIdent dummy = new TableIdent(Schemas.DOC_SCHEMA_NAME, "dummy");
         ReferenceIdent foobarIdent = new ReferenceIdent(dummy, new ColumnIdent("foobar"));
         Reference strictParent = new Reference(
             foobarIdent,

--- a/sql/src/test/java/io/crate/operation/collect/DocLevelCollectTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/DocLevelCollectTest.java
@@ -63,15 +63,15 @@ public class DocLevelCollectTest extends SQLTransportIntegrationTest {
 
     private static final String TEST_TABLE_NAME = "test_table";
     private static final Reference testDocLevelReference = new Reference(
-        new ReferenceIdent(new TableIdent(null, TEST_TABLE_NAME), "doc"),
+        new ReferenceIdent(new TableIdent(Schemas.DOC_SCHEMA_NAME, TEST_TABLE_NAME), "doc"),
         RowGranularity.DOC,
         DataTypes.INTEGER);
     private static final Reference underscoreIdReference = new Reference(
-        new ReferenceIdent(new TableIdent(null, TEST_TABLE_NAME), "_id"),
+        new ReferenceIdent(new TableIdent(Schemas.DOC_SCHEMA_NAME, TEST_TABLE_NAME), "_id"),
         RowGranularity.DOC,
         DataTypes.STRING);
     private static final Reference underscoreRawReference = new Reference(
-        new ReferenceIdent(new TableIdent(null, TEST_TABLE_NAME), "_raw"),
+        new ReferenceIdent(new TableIdent(Schemas.DOC_SCHEMA_NAME, TEST_TABLE_NAME), "_raw"),
         RowGranularity.DOC,
         DataTypes.STRING);
 
@@ -183,7 +183,7 @@ public class DocLevelCollectTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testCollectWithPartitionedColumns() throws Throwable {
-        TableIdent tableIdent = new TableIdent(Schemas.DEFAULT_SCHEMA_NAME, PARTITIONED_TABLE_NAME);
+        TableIdent tableIdent = new TableIdent(Schemas.DOC_SCHEMA_NAME, PARTITIONED_TABLE_NAME);
         Routing routing = schemas.getTableInfo(tableIdent).getRouting(WhereClause.MATCH_ALL, null, SessionContext.create());
         RoutedCollectPhase collectNode = getCollectNode(
             Arrays.asList(

--- a/sql/src/test/java/io/crate/operation/collect/collectors/LuceneOrderedDocCollectorTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/collectors/LuceneOrderedDocCollectorTest.java
@@ -31,6 +31,7 @@ import io.crate.data.Row;
 import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RowGranularity;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.TableIdent;
 import io.crate.metadata.doc.DocSysColumns;
 import io.crate.operation.reference.doc.lucene.CollectorContext;
@@ -85,7 +86,7 @@ import static org.mockito.Mockito.mock;
 
 public class LuceneOrderedDocCollectorTest extends RandomizedTest {
 
-    private static final Reference REFERENCE = new Reference(new ReferenceIdent(new TableIdent(null, "table"), "value"), RowGranularity.DOC, DataTypes.LONG);
+    private static final Reference REFERENCE = new Reference(new ReferenceIdent(new TableIdent(Schemas.DOC_SCHEMA_NAME, "table"), "value"), RowGranularity.DOC, DataTypes.LONG);
     private LegacyLongFieldMapper.LongFieldType valueFieldType;
 
     private Directory createLuceneIndex() throws IOException {
@@ -252,7 +253,7 @@ public class LuceneOrderedDocCollectorTest extends RandomizedTest {
         Reference sysColReference =
             new Reference(
                 new ReferenceIdent(
-                    new TableIdent(null, "table"),
+                    new TableIdent(Schemas.DOC_SCHEMA_NAME, "table"),
                     DocSysColumns.SCORE),
                 RowGranularity.DOC, DataTypes.FLOAT);
 

--- a/sql/src/test/java/io/crate/operation/count/InternalCountOperationTest.java
+++ b/sql/src/test/java/io/crate/operation/count/InternalCountOperationTest.java
@@ -58,7 +58,7 @@ public class InternalCountOperationTest extends SQLTransportIntegrationTest {
         assertThat(countOperation.count(index, 0, WhereClause.MATCH_ALL), is(3L));
 
         Schemas schemas = internalCluster().getInstance(Schemas.class);
-        TableInfo tableInfo = schemas.getTableInfo(new TableIdent(null, "t"));
+        TableInfo tableInfo = schemas.getTableInfo(new TableIdent(Schemas.DOC_SCHEMA_NAME, "t"));
         TableRelation tableRelation = new TableRelation(tableInfo);
         Map<QualifiedName, AnalyzedRelation> tableSources = ImmutableMap.<QualifiedName, AnalyzedRelation>of(new QualifiedName(tableInfo.ident().name()), tableRelation);
         SqlExpressions sqlExpressions = new SqlExpressions(tableSources, tableRelation);

--- a/sql/src/test/java/io/crate/operation/fetch/FetchContextTest.java
+++ b/sql/src/test/java/io/crate/operation/fetch/FetchContextTest.java
@@ -27,6 +27,7 @@ import io.crate.action.job.SharedShardContexts;
 import io.crate.core.collections.TreeMapBuilder;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Routing;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.TableIdent;
 import io.crate.planner.fetch.IndexBaseBuilder;
 import io.crate.planner.node.fetch.FetchPhase;
@@ -82,7 +83,7 @@ public class FetchContextTest extends CrateDummyClusterServiceUnitTest {
         ibb.allocate("i1", shards);
 
         HashMultimap<TableIdent, String> tableIndices = HashMultimap.create();
-        tableIndices.put(new TableIdent(null, "i1"), "i1");
+        tableIndices.put(new TableIdent(Schemas.DOC_SCHEMA_NAME, "i1"), "i1");
 
         MetaData metaData = MetaData.builder()
             .put(IndexMetaData.builder("i1")

--- a/sql/src/test/java/io/crate/operation/projectors/IndexWriterProjectorTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/IndexWriterProjectorTest.java
@@ -35,6 +35,7 @@ import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RowGranularity;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.TableIdent;
 import io.crate.metadata.doc.DocSysColumns;
 import io.crate.operation.NodeJobsCounter;
@@ -64,7 +65,7 @@ public class IndexWriterProjectorTest extends SQLTransportIntegrationTest {
 
     private static final ColumnIdent ID_IDENT = new ColumnIdent("id");
 
-    private static final TableIdent bulkImportIdent = new TableIdent(null, "bulk_import");
+    private static final TableIdent bulkImportIdent = new TableIdent(Schemas.DOC_SCHEMA_NAME, "bulk_import");
 
     @Test
     public void testIndexWriter() throws Throwable {
@@ -82,7 +83,7 @@ public class IndexWriterProjectorTest extends SQLTransportIntegrationTest {
             Settings.EMPTY,
             internalCluster().getInstance(TransportBulkCreateIndicesAction.class),
             internalCluster().getInstance(TransportShardUpsertAction.class)::execute,
-            IndexNameResolver.forTable(new TableIdent(null, "bulk_import")),
+            IndexNameResolver.forTable(new TableIdent(Schemas.DOC_SCHEMA_NAME, "bulk_import")),
             new Reference(new ReferenceIdent(bulkImportIdent, DocSysColumns.RAW), RowGranularity.DOC, DataTypes.STRING),
             Arrays.asList(ID_IDENT),
             Arrays.<Symbol>asList(new InputColumn(0)),

--- a/sql/src/test/java/io/crate/operation/projectors/IndexWriterProjectorUnitTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/IndexWriterProjectorUnitTest.java
@@ -31,6 +31,7 @@ import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RowGranularity;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.TableIdent;
 import io.crate.operation.NodeJobsCounter;
 import io.crate.operation.collect.CollectExpression;
@@ -58,7 +59,7 @@ import static org.mockito.Mockito.mock;
 public class IndexWriterProjectorUnitTest extends CrateUnitTest {
 
     private final static ColumnIdent ID_IDENT = new ColumnIdent("id");
-    private static final TableIdent bulkImportIdent = new TableIdent(null, "bulk_import");
+    private static final TableIdent bulkImportIdent = new TableIdent(Schemas.DOC_SCHEMA_NAME, "bulk_import");
     private static Reference rawSourceReference = new Reference(
         new ReferenceIdent(bulkImportIdent, "_raw"), RowGranularity.DOC, DataTypes.STRING);
 
@@ -79,7 +80,7 @@ public class IndexWriterProjectorUnitTest extends CrateUnitTest {
             Settings.EMPTY,
             transportBulkCreateIndicesAction,
             (request, listener) -> {},
-            IndexNameResolver.forTable(new TableIdent(null, "bulk_import")),
+            IndexNameResolver.forTable(new TableIdent(Schemas.DOC_SCHEMA_NAME, "bulk_import")),
             rawSourceReference,
             Arrays.asList(ID_IDENT),
             Arrays.<Symbol>asList(new InputColumn(1)),

--- a/sql/src/test/java/io/crate/operation/scalar/systeminformation/CurrentSchemaFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/systeminformation/CurrentSchemaFunctionTest.java
@@ -22,8 +22,6 @@
 
 package io.crate.operation.scalar.systeminformation;
 
-import io.crate.action.sql.Option;
-import io.crate.action.sql.SessionContext;
 import io.crate.analyze.symbol.Function;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.Functions;
@@ -39,14 +37,15 @@ public class CurrentSchemaFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testNormalizeCurrentSchemaDefaultSchema() throws Exception {
-        sqlExpressions = new SqlExpressions(tableSources, new SessionContext(0, Option.NONE, null, null, s -> {}, t -> {}));
+        sqlExpressions = new SqlExpressions(tableSources);
         functions = sqlExpressions.getInstance(Functions.class);
         assertNormalize("current_schema()", isLiteral("doc"), false);
     }
 
     @Test
     public void testNormalizeCurrentSchemaCustomSchema() throws Exception {
-        sqlExpressions = new SqlExpressions(tableSources, new SessionContext(0, Option.NONE, "custom_schema", null, s -> {}, t -> {}));
+        sqlExpressions = new SqlExpressions(tableSources);
+        sqlExpressions.setDefaultSchema("custom_schema");
         functions = sqlExpressions.getInstance(Functions.class);
         assertNormalize("current_schema()", isLiteral("custom_schema"), false);
     }

--- a/sql/src/test/java/io/crate/operation/udf/UserDefinedFunctionServiceTest.java
+++ b/sql/src/test/java/io/crate/operation/udf/UserDefinedFunctionServiceTest.java
@@ -38,15 +38,15 @@ import static org.hamcrest.Matchers.*;
 public class UserDefinedFunctionServiceTest extends UdfUnitTest {
 
     private final UserDefinedFunctionMetaData same1 = new UserDefinedFunctionMetaData(
-        Schemas.DEFAULT_SCHEMA_NAME, "same", ImmutableList.of(), DataTypes.INTEGER,
+        Schemas.DOC_SCHEMA_NAME, "same", ImmutableList.of(), DataTypes.INTEGER,
         DUMMY_LANG.name(), "function same(){ return 3; }"
     );
     private final UserDefinedFunctionMetaData same2 = new UserDefinedFunctionMetaData(
-        Schemas.DEFAULT_SCHEMA_NAME, "same", ImmutableList.of(), DataTypes.INTEGER,
+        Schemas.DOC_SCHEMA_NAME, "same", ImmutableList.of(), DataTypes.INTEGER,
         DUMMY_LANG.name(), "function same() { return 2; }"
     );
     private final UserDefinedFunctionMetaData different = new UserDefinedFunctionMetaData(
-        Schemas.DEFAULT_SCHEMA_NAME, "different", ImmutableList.of(), DataTypes.INTEGER,
+        Schemas.DOC_SCHEMA_NAME, "different", ImmutableList.of(), DataTypes.INTEGER,
         DUMMY_LANG.name(), "function different() { return 3; }"
     );
 

--- a/sql/src/test/java/io/crate/planner/PlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/PlannerTest.java
@@ -4,6 +4,7 @@ import io.crate.action.sql.SessionContext;
 import io.crate.analyze.EvaluatingNormalizer;
 import io.crate.analyze.WhereClause;
 import io.crate.metadata.PartitionName;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.TableIdent;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.table.TestingTableInfo;
@@ -65,7 +66,7 @@ public class PlannerTest extends CrateDummyClusterServiceUnitTest {
         String[] indices = Planner.indices(TestingTableInfo.builder(custom, shardRouting("t1")).add("id", DataTypes.INTEGER, null).build(), WhereClause.MATCH_ALL);
         assertThat(indices, arrayContainingInAnyOrder("custom.table"));
 
-        indices = Planner.indices(TestingTableInfo.builder(new TableIdent(null, "table"), shardRouting("t1")).add("id", DataTypes.INTEGER, null).build(), WhereClause.MATCH_ALL);
+        indices = Planner.indices(TestingTableInfo.builder(new TableIdent(Schemas.DOC_SCHEMA_NAME, "table"), shardRouting("t1")).add("id", DataTypes.INTEGER, null).build(), WhereClause.MATCH_ALL);
         assertThat(indices, arrayContainingInAnyOrder("table"));
 
         indices = Planner.indices(TestingTableInfo.builder(custom, shardRouting("t1"))

--- a/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -41,6 +41,7 @@ import io.crate.metadata.PartitionName;
 import io.crate.metadata.Reference;
 import io.crate.metadata.Routing;
 import io.crate.metadata.RowGranularity;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.TableIdent;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocTableInfo;
@@ -115,9 +116,9 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     private DocTableInfo bindGeneratedColumnTable() {
-        TableIdent generatedColumnTableIdent = new TableIdent(null, "gc_table");
+        TableIdent generatedColumnTableIdent = new TableIdent(Schemas.DOC_SCHEMA_NAME, "gc_table");
         return new TestingTableInfo.Builder(
-            generatedColumnTableIdent, new Routing(Collections.EMPTY_MAP))
+            generatedColumnTableIdent, new Routing(Collections.emptyMap()))
             .add("revenue", DataTypes.INTEGER, null)
             .add("cost", DataTypes.INTEGER, null)
             .addGeneratedColumn("profit", DataTypes.INTEGER, "subtract(revenue, cost)", false)

--- a/sql/src/test/java/io/crate/planner/node/fetch/FetchPhaseTest.java
+++ b/sql/src/test/java/io/crate/planner/node/fetch/FetchPhaseTest.java
@@ -29,6 +29,7 @@ import com.google.common.collect.Multimap;
 import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RowGranularity;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.TableIdent;
 import io.crate.planner.node.ExecutionPhases;
 import io.crate.types.DataTypes;
@@ -46,7 +47,7 @@ public class FetchPhaseTest {
     @Test
     public void testStreaming() throws Exception {
 
-        TableIdent t1 = new TableIdent(null, "t1");
+        TableIdent t1 = new TableIdent(Schemas.DOC_SCHEMA_NAME, "t1");
 
         TreeMap<String, Integer> bases = new TreeMap<String, Integer>();
         bases.put(t1.name(), 0);
@@ -54,8 +55,8 @@ public class FetchPhaseTest {
 
         Multimap<TableIdent, String> tableIndices = HashMultimap.create();
         tableIndices.put(t1, t1.name());
-        tableIndices.put(new TableIdent(null, "i2"), "i2_s1");
-        tableIndices.put(new TableIdent(null, "i2"), "i2_s2");
+        tableIndices.put(new TableIdent(Schemas.DOC_SCHEMA_NAME, "i2"), "i2_s1");
+        tableIndices.put(new TableIdent(Schemas.DOC_SCHEMA_NAME, "i2"), "i2_s2");
 
         ReferenceIdent nameIdent = new ReferenceIdent(t1, "name");
         Reference name = new Reference(nameIdent, RowGranularity.DOC, DataTypes.STRING);

--- a/sql/src/test/java/io/crate/testing/SQLTransportExecutor.java
+++ b/sql/src/test/java/io/crate/testing/SQLTransportExecutor.java
@@ -31,6 +31,7 @@ import io.crate.action.sql.SQLOperations;
 import io.crate.analyze.symbol.Field;
 import io.crate.data.Row;
 import io.crate.exceptions.SQLExceptions;
+import io.crate.metadata.Schemas;
 import io.crate.operation.user.ExceptionAuthorizedValidator;
 import io.crate.protocols.postgres.types.PGType;
 import io.crate.protocols.postgres.types.PGTypes;
@@ -99,8 +100,14 @@ public class SQLTransportExecutor {
     private static final Logger LOGGER = Loggers.getLogger(SQLTransportExecutor.class);
     private final ClientProvider clientProvider;
 
+    private final String defaultSchema = Schemas.DOC_SCHEMA_NAME;
+
     public SQLTransportExecutor(ClientProvider clientProvider) {
         this.clientProvider = clientProvider;
+    }
+
+    public String getDefaultSchema() {
+        return defaultSchema;
     }
 
     public SQLResponse exec(String statement) {
@@ -195,7 +202,7 @@ public class SQLTransportExecutor {
 
     public ActionFuture<SQLResponse> execute(String stmt, @Nullable Object[] args) {
         return execute(stmt, args, clientProvider.sqlOperations().createSession(
-            null,
+            defaultSchema,
             null,
             Option.NONE,
             DEFAULT_SOFT_LIMIT
@@ -230,7 +237,7 @@ public class SQLTransportExecutor {
 
     private void execute(String stmt, @Nullable Object[][] bulkArgs, final ActionListener<SQLBulkResponse> listener) {
         SQLOperations.Session session = clientProvider.sqlOperations().createSession(
-            null,
+            defaultSchema,
             null,
             Option.NONE,
             DEFAULT_SOFT_LIMIT

--- a/sql/src/test/java/io/crate/testing/T3.java
+++ b/sql/src/test/java/io/crate/testing/T3.java
@@ -59,39 +59,44 @@ public class T3 {
         ImmutableMap.of(CrateDummyClusterServiceUnitTest.NODE_ID,
             ImmutableMap.of("t4", Collections.singletonList(0))));
 
-    public static final DocTableInfo T1_INFO = new TestingTableInfo.Builder(new TableIdent(null, "t1"), t1Routing)
+    public static final DocTableInfo T1_INFO =
+        new TestingTableInfo.Builder(new TableIdent(Schemas.DOC_SCHEMA_NAME, "t1"), t1Routing)
         .add("a", DataTypes.STRING)
         .add("x", DataTypes.INTEGER)
         .add("i", DataTypes.INTEGER)
         .build();
     public static final DocTableRelation TR_1 = new DocTableRelation(T1_INFO);
 
-    public static final DocTableInfo T2_INFO = new TestingTableInfo.Builder(new TableIdent(null, "t2"), t2Routing)
+    public static final DocTableInfo T2_INFO = new TestingTableInfo.Builder(
+        new TableIdent(Schemas.DOC_SCHEMA_NAME, "t2"), t2Routing)
         .add("b", DataTypes.STRING)
         .add("y", DataTypes.INTEGER)
         .add("i", DataTypes.INTEGER)
         .build();
     public static final DocTableRelation TR_2 = new DocTableRelation(T2_INFO);
 
-    public static final DocTableInfo T3_INFO = new TestingTableInfo.Builder(new TableIdent(null, "t3"), t3Routing)
+    public static final DocTableInfo T3_INFO = new TestingTableInfo.Builder(
+        new TableIdent(Schemas.DOC_SCHEMA_NAME, "t3"), t3Routing)
         .add("c", DataTypes.STRING)
         .add("z", DataTypes.INTEGER)
         .build();
     public static final TableRelation TR_3 = new TableRelation(T3_INFO);
 
-    public static final DocTableInfo T4_INFO = new TestingTableInfo.Builder(new TableIdent(null, "t4"), t4Routing)
+    public static final DocTableInfo T4_INFO = new TestingTableInfo.Builder(
+        new TableIdent(Schemas.DOC_SCHEMA_NAME, "t4"), t4Routing)
         .add("id", DataTypes.INTEGER)
         .add("obj", DataTypes.OBJECT)
         .add("obj", DataTypes.INTEGER, ImmutableList.of("i"))
         .add("obj_array", new ArrayType(DataTypes.OBJECT))
         .add("obj_array", DataTypes.INTEGER, ImmutableList.of("i"))
         .build();
+
     public static final TableRelation TR_4 = new TableRelation(T4_INFO);
 
-    public static final QualifiedName T1 = new QualifiedName(Arrays.asList(Schemas.DEFAULT_SCHEMA_NAME, "t1"));
-    public static final QualifiedName T2 = new QualifiedName(Arrays.asList(Schemas.DEFAULT_SCHEMA_NAME, "t2"));
-    public static final QualifiedName T3 = new QualifiedName(Arrays.asList(Schemas.DEFAULT_SCHEMA_NAME, "t3"));
-    public static final QualifiedName T4 = new QualifiedName(Arrays.asList(Schemas.DEFAULT_SCHEMA_NAME, "t4"));
+    public static final QualifiedName T1 = new QualifiedName(Arrays.asList(Schemas.DOC_SCHEMA_NAME, "t1"));
+    public static final QualifiedName T2 = new QualifiedName(Arrays.asList(Schemas.DOC_SCHEMA_NAME, "t2"));
+    public static final QualifiedName T3 = new QualifiedName(Arrays.asList(Schemas.DOC_SCHEMA_NAME, "t3"));
+    public static final QualifiedName T4 = new QualifiedName(Arrays.asList(Schemas.DOC_SCHEMA_NAME, "t4"));
 
     public static final ImmutableList<AnalyzedRelation> RELATIONS = ImmutableList.of(TR_1, TR_2, TR_3, TR_4);
     public static final Map<QualifiedName, AnalyzedRelation> SOURCES = ImmutableMap.of(

--- a/sql/src/test/java/io/crate/testing/TestingHelpers.java
+++ b/sql/src/test/java/io/crate/testing/TestingHelpers.java
@@ -36,6 +36,7 @@ import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RowGranularity;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.TableIdent;
 import io.crate.operation.aggregation.impl.AggregationImplModule;
 import io.crate.operation.operator.OperatorModule;
@@ -172,7 +173,7 @@ public class TestingHelpers {
 
     public static Reference createReference(String tableName, ColumnIdent columnIdent, DataType dataType) {
         return new Reference(
-            new ReferenceIdent(new TableIdent(null, tableName), columnIdent),
+            new ReferenceIdent(new TableIdent(Schemas.DOC_SCHEMA_NAME, tableName), columnIdent),
             RowGranularity.DOC,
             dataType);
     }
@@ -286,7 +287,7 @@ public class TestingHelpers {
         }
         switch (parts.length) {
             case 2:
-                refIdent = new ReferenceIdent(new TableIdent(null, parts[0]), parts[1], nestedParts);
+                refIdent = new ReferenceIdent(new TableIdent(Schemas.DOC_SCHEMA_NAME, parts[0]), parts[1], nestedParts);
                 break;
             case 3:
                 refIdent = new ReferenceIdent(new TableIdent(parts[0], parts[1]), parts[2], nestedParts);


### PR DESCRIPTION
- rename DEFAULT_SCHEMA_NAME to DOC_SCHEMA_NAME
- unify Schema extraction from index name in `Schemas`
- hide Schema regexp pattern
- Get rid of null schema in `TableIdent`, `PartitionName`, `RelationUnknownException`, and others
- pass in current default schema to the `PriviligesAnalyzer`, `ShowStatementAnalyzer`