### PR TITLE
Planner: Don't add join condition fields to QS outputs in aggregates on join

### DIFF
--- a/sql/src/main/java/io/crate/analyze/relations/JoinPairs.java
+++ b/sql/src/main/java/io/crate/analyze/relations/JoinPairs.java
@@ -24,13 +24,10 @@ package io.crate.analyze.relations;
 
 import com.google.common.collect.ImmutableList;
 import io.crate.analyze.QuerySpec;
-import io.crate.analyze.symbol.Field;
-import io.crate.analyze.symbol.FieldsVisitor;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.sql.tree.QualifiedName;
 
 import javax.annotation.Nullable;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -148,19 +145,5 @@ public final class JoinPairs {
         if (joinPair.isOuterRelation(right)) {
             rightQuerySpec.orderBy(null);
         }
-    }
-
-    /**
-     * Extracts the fields from the given join conditions and returns a list.
-     */
-    public static List<Field> extractFieldsFromJoinConditions(Iterable<JoinPair> joinPairs) {
-        List<Field> outputs = new ArrayList<>();
-        for (JoinPair pair : joinPairs) {
-            Symbol condition = pair.condition();
-            if (condition != null) {
-                FieldsVisitor.visitFields(condition, outputs::add);
-            }
-        }
-        return outputs;
     }
 }

--- a/sql/src/main/java/io/crate/planner/consumer/MultiSourceAggregationConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/MultiSourceAggregationConsumer.java
@@ -37,6 +37,7 @@ import io.crate.planner.Planner;
 import io.crate.planner.projection.builder.ProjectionBuilder;
 import io.crate.planner.projection.builder.SplitPoints;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
@@ -86,9 +87,7 @@ class MultiSourceAggregationConsumer implements Consumer {
 
     private static void removeAggregationsAndLimitsFromMSS(MultiSourceSelect mss, SplitPoints splitPoints) {
         QuerySpec querySpec = mss.querySpec();
-        List<Symbol> outputs = Lists2.concatUnique(
-            splitPoints.toCollect(),
-            JoinPairs.extractFieldsFromJoinConditions(mss.joinPairs()));
+        List<Symbol> outputs = new ArrayList<>(splitPoints.toCollect());
         querySpec.outputs(outputs);
         querySpec.hasAggregates(false);
         // Limit & offset must be applied after the aggregation, so remove it from mss and sources.

--- a/sql/src/main/java/io/crate/planner/consumer/MultiSourceGroupByConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/MultiSourceGroupByConsumer.java
@@ -25,14 +25,13 @@ package io.crate.planner.consumer;
 import io.crate.analyze.MultiSourceSelect;
 import io.crate.analyze.QuerySpec;
 import io.crate.analyze.relations.AnalyzedRelation;
-import io.crate.analyze.relations.JoinPairs;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.Symbols;
-import io.crate.collections.Lists2;
 import io.crate.planner.Plan;
 import io.crate.planner.projection.builder.ProjectionBuilder;
 import io.crate.planner.projection.builder.SplitPoints;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -101,10 +100,7 @@ public class MultiSourceGroupByConsumer implements Consumer {
          */
         private static void updateQuerySpec(MultiSourceSelect mss, SplitPoints splitPoints) {
             QuerySpec querySpec = mss.querySpec();
-            List<Symbol> outputs = Lists2.concatUnique(
-                splitPoints.toCollect(),
-                JoinPairs.extractFieldsFromJoinConditions(mss.joinPairs())
-            );
+            List<Symbol> outputs = new ArrayList<>(splitPoints.toCollect());
             querySpec.outputs(outputs);
             querySpec.hasAggregates(false);
             removePostGroupingActions(querySpec);


### PR DESCRIPTION
They're not required and it would otherwise break semi joins. They don't
support outputs from the right relation.