### PR TITLE
Fix default schema handling in PrivilegesAnalyzer

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -72,6 +72,10 @@ Changes
 Fixes
 =====
 
+ - Fixed an issue when using GRANT/REVOKE/DENY statements on a table with a
+   custom schema set. The statements would result in permission changed on the
+   default ``doc`` schema.
+
  - Fixed an issue with ``INNER`` and ``CROSS JOINS`` on more than 2 tables that
    could result in a ``Iterator is not on a row`` error.
 

--- a/enterprise/users/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
+++ b/enterprise/users/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
@@ -254,4 +254,19 @@ public class PrivilegesIntegrationTest extends BaseUsersIntegrationTest {
         expectedException.expectMessage(containsString("Missing 'DQL' privilege for user '"+ TEST_USERNAME + "'"));
         execute("select * from t1", null, testUserSession());
     }
+
+    @Test
+    public void testGrantWithCustomDefaultSchema() {
+        executeAsSuperuser("create table doc.t1 (x int)");
+        executeAsSuperuser("set search_path to 'custom_schema'");
+        executeAsSuperuser("create table t2 (x int)");
+        ensureYellow();
+
+        executeAsSuperuser("grant dql on table t2 to "+ TEST_USERNAME);
+        assertThat(response.rowCount(), is(1L));
+
+        expectedException.expect(SQLActionException.class);
+        expectedException.expectMessage("TableUnknownException: Table 'custom_schema.t1' unknown");
+        executeAsSuperuser("grant dql on table t1 to "+ TEST_USERNAME);
+    }
 }

--- a/sql/src/main/java/io/crate/analyze/Analyzer.java
+++ b/sql/src/main/java/io/crate/analyze/Analyzer.java
@@ -354,17 +354,23 @@ public class Analyzer {
 
         @Override
         public AnalyzedStatement visitGrantPrivilege(GrantPrivilege node, Analysis context) {
-            return privilegesAnalyzer.analyzeGrant(node, context.sessionContext().user());
+            return privilegesAnalyzer.analyzeGrant(node,
+                context.sessionContext().user(),
+                context.sessionContext().defaultSchema());
         }
 
         @Override
         public AnalyzedStatement visitDenyPrivilege(DenyPrivilege node, Analysis context) {
-            return privilegesAnalyzer.analyzeDeny(node, context.sessionContext().user());
+            return privilegesAnalyzer.analyzeDeny(node,
+                context.sessionContext().user(),
+                context.sessionContext().defaultSchema());
         }
 
         @Override
         public AnalyzedStatement visitRevokePrivilege(RevokePrivilege node, Analysis context) {
-            return privilegesAnalyzer.analyzeRevoke(node, context.sessionContext().user());
+            return privilegesAnalyzer.analyzeRevoke(node,
+                context.sessionContext().user(),
+                context.sessionContext().defaultSchema());
         }
 
         @Override

--- a/sql/src/main/java/io/crate/protocols/postgres/SimplePortal.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/SimplePortal.java
@@ -112,7 +112,7 @@ public class SimplePortal extends AbstractPortal {
                 fields(),
                 resultReceiver, maxRows, this.params, sessionContext, portalContext);
             return portal.bind(statementName, query, statement, params, resultFormatCodes);
-        } else if (this.statement != null) {
+        } else if (this.statement != null && this.analysis != null) {
             assert consumer == null : "Existing portal must not have a consumer";
             if (portalContext.isReadOnly()) { // Cannot have a batch operation in read only mode
                 throw new ReadOnlyException();


### PR DESCRIPTION
This allows to use GRANT/DENY/REVOKE when a schema different from `doc` is set
and the schema is not specified in the statement. For example:

`GRANT DQL on tableName to userName`

Before, this would always use the `doc` schema.