### PR TITLE
Adapt ShardMinLuceneVersionExpression to new exception type

### DIFF
--- a/sql/src/main/java/io/crate/operation/reference/sys/shard/ShardMinLuceneVersionExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/shard/ShardMinLuceneVersionExpression.java
@@ -22,8 +22,8 @@
 package io.crate.operation.reference.sys.shard;
 
 import io.crate.metadata.ReferenceImplementation;
+import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.index.engine.EngineClosedException;
 import org.elasticsearch.index.shard.IndexShard;
 
 public class ShardMinLuceneVersionExpression implements ReferenceImplementation<BytesRef> {
@@ -43,7 +43,7 @@ public class ShardMinLuceneVersionExpression implements ReferenceImplementation<
         // you might get different results.
         try {
             return new BytesRef(indexShard.minimumCompatibleVersion().toString());
-        } catch (EngineClosedException e) {
+        } catch (AlreadyClosedException e) {
             return null;
         }
     }

--- a/sql/src/test/java/io/crate/operation/reference/sys/SysShardsExpressionsTest.java
+++ b/sql/src/test/java/io/crate/operation/reference/sys/SysShardsExpressionsTest.java
@@ -41,6 +41,7 @@ import io.crate.operation.udf.UserDefinedFunctionService;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.types.DataTypes;
 import io.crate.types.IntegerType;
+import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.Version;
 import org.elasticsearch.cluster.routing.RecoverySource;
@@ -232,7 +233,7 @@ public class SysShardsExpressionsTest extends CrateDummyClusterServiceUnitTest {
             (ReferenceImplementation<BytesRef>) resolver.getImplementation(refInfo);
         assertEquals(new BytesRef(Version.LATEST.toString()), shardExpression.value());
 
-        doThrow(new EngineClosedException(indexShard.shardId())).when(indexShard).minimumCompatibleVersion();
+        doThrow(new AlreadyClosedException("Already closed")).when(indexShard).minimumCompatibleVersion();
         assertThat(shardExpression.value(), nullValue());
     }
 


### PR DESCRIPTION
The exception type has been changed upstream from ES' EngineClosedException
to Lucene's AlreadyClosedException.