### PR TITLE
Fixed: Wrong plan created for global aggregations with ``JOINs`` on virtual tables.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -72,6 +72,15 @@ Changes
 Fixes
 =====
 
+ - Fixed an issue causing global aggregations with ``JOINs`` on virtual tables
+   (sub-selects) which contain ``LIMIT`` to return incorrect results. E.g.::
+
+     SELECT COUNT(*) FROM
+       (SELECT * FROM t1 ORDER BY a LIMIT 5) t1,
+     JOIN
+       t2
+     ON t1.a = t2.b
+
  - Fixed an issue that caused an error when trying to create a table with a
    generated column expression of type array.
 
@@ -82,4 +91,5 @@ Fixes
  - Fixed an issue with ``INNER`` and ``CROSS JOINS`` on more than 2 tables that
    could result in a ``Iterator is not on a row`` error.
 
- - Fixed empty ``account_user``-column in twitter tutorial plugin of the Admin UI.
+ - Fixed empty ``account_user``-column in twitter tutorial plugin of the
+   Admin UI.

--- a/sql/src/main/java/io/crate/analyze/relations/RelationSplitter.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationSplitter.java
@@ -145,11 +145,12 @@ public final class RelationSplitter {
         // collect all fields from all join conditions
         FieldsVisitor.visitFields(joinConditions, addFieldToMap);
 
-        // push down the limit and offset only if there is no filtering or ordering after the join
-        // and only if the relations are not part of a join condition
+        // push down the limit + offset only if there is no filtering, ordering, global aggregation or grouping
+        // after the join and only if the relations are not part of a join condition.
         Optional<Symbol> limit = querySpec.limit();
         boolean filterNeeded = querySpec.where().hasQuery() && !(querySpec.where().query() instanceof Literal);
-        if (limit.isPresent() && !filterNeeded && !querySpec.orderBy().isPresent()) {
+        if (limit.isPresent() &&  !groupBy.isPresent() && !querySpec.hasAggregates() && !filterNeeded
+            && !querySpec.orderBy().isPresent()) {
             Optional<Symbol> limitAndOffset = Limits.mergeAdd(limit, querySpec.offset());
             for (AnalyzedRelation rel : Sets.difference(specs.keySet(), fieldsByRelation.keySet())) {
                 if (!relationPartOfJoinConditions.contains(rel.getQualifiedName())) {

--- a/sql/src/main/java/io/crate/planner/consumer/MultiSourceAggregationConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/MultiSourceAggregationConsumer.java
@@ -26,7 +26,6 @@ import io.crate.analyze.MultiSourceSelect;
 import io.crate.analyze.QuerySpec;
 import io.crate.analyze.WhereClause;
 import io.crate.analyze.relations.AnalyzedRelation;
-import io.crate.analyze.relations.QueriedRelation;
 import io.crate.analyze.symbol.Field;
 import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Symbol;
@@ -88,13 +87,10 @@ class MultiSourceAggregationConsumer implements Consumer {
         List<Symbol> outputs = new ArrayList<>(splitPoints.toCollect());
         querySpec.outputs(outputs);
         querySpec.hasAggregates(false);
-        // Limit & offset must be applied after the aggregation, so remove it from mss and sources.
+        // Limit & offset must be applied after the aggregation, so remove it from mss.
         // OrderBy can be ignored because it's also applied after aggregation but there is always only 1 row so it
         // wouldn't have any effect.
         removeLimitOffsetAndOrder(querySpec);
-        for (AnalyzedRelation relation : mss.sources().values()) {
-            removeLimitOffsetAndOrder(((QueriedRelation) relation).querySpec());
-        }
 
         // need to change the types on the fields of the MSS to match the new outputs
         ListIterator<Field> fieldsIt = mss.fields().listIterator();


### PR DESCRIPTION
Limit was removed from relations of MSS even if those relations were Sub-selects.
Instead extra check is added to not push down LIMIT to the source relations of MSS in the first place.