### PR TITLE
Remove content type detection in some places

### DIFF
--- a/sql/src/main/java/io/crate/executor/transport/TransportShardUpsertAction.java
+++ b/sql/src/main/java/io/crate/executor/transport/TransportShardUpsertAction.java
@@ -380,7 +380,7 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
         processGeneratedColumns(tableInfo, pathsToUpdate, updatedGeneratedColumns, true, getResult);
 
         Tuple<XContentType, Map<String, Object>> sourceAndContent =
-            XContentHelper.convertToMap(getResult.internalSourceRef(), true);
+            XContentHelper.convertToMap(getResult.internalSourceRef(), true, XContentType.JSON);
         final XContentType updateSourceContentType = sourceAndContent.v1();
         final Map<String, Object> updatedSourceAsMap = sourceAndContent.v2();
 
@@ -554,7 +554,7 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
         Map<String, Object> sourceAsMap;
         if (isRawSourceInsert) {
             BytesRef source = (BytesRef) insertValues[0];
-            sourceAsMap = XContentHelper.convertToMap(new BytesArray(source), true).v2();
+            sourceAsMap = XContentHelper.convertToMap(new BytesArray(source), true, XContentType.JSON).v2();
         } else {
             sourceAsMap = new LinkedHashMap<>(insertColumns.length);
             for (int i = 0; i < insertColumns.length; i++) {

--- a/sql/src/main/java/io/crate/operation/reference/doc/lucene/DocCollectorExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/doc/lucene/DocCollectorExpression.java
@@ -27,6 +27,7 @@ import io.crate.metadata.doc.DocSysColumns;
 import io.crate.operation.collect.collectors.CollectorFieldsVisitor;
 import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.search.lookup.SourceLookup;
 
 import java.util.Map;
@@ -49,7 +50,7 @@ public class DocCollectorExpression extends LuceneCollectorExpression<Map<String
 
     @Override
     public Map<String, Object> value() {
-        return XContentHelper.convertToMap(visitor.source(), false).v2();
+        return XContentHelper.convertToMap(visitor.source(), false, XContentType.JSON).v2();
     }
 
     public static LuceneCollectorExpression<?> create(final Reference reference) {

--- a/sql/src/main/java/io/crate/operation/reference/file/LineContext.java
+++ b/sql/src/main/java/io/crate/operation/reference/file/LineContext.java
@@ -25,6 +25,7 @@ import io.crate.metadata.ColumnIdent;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentType;
 
 import javax.annotation.Nullable;
 import java.util.LinkedList;
@@ -46,7 +47,7 @@ public class LineContext {
     public Map<String, Object> sourceAsMap() {
         if (parsedSource == null) {
             try {
-                parsedSource = XContentHelper.convertToMap(new BytesArray(rawSource), false).v2();
+                parsedSource = XContentHelper.convertToMap(new BytesArray(rawSource), false, XContentType.JSON).v2();
             } catch (NullPointerException e) {
                 return null;
             }
@@ -60,7 +61,7 @@ public class LineContext {
             // TODO: optimize if collectorContext has prefetchColumns
 
             try {
-                parsedSource = XContentHelper.convertToMap(new BytesArray(rawSource), false).v2();
+                parsedSource = XContentHelper.convertToMap(new BytesArray(rawSource), false, XContentType.JSON).v2();
             } catch (NullPointerException e) {
                 return null;
             }


### PR DESCRIPTION
- We currently always write the source as JSON, so there is no need for
 the content-type detection when it's read again.

 - COPY FROM format is documented as JSON (lines). Therefore the
 content-type detection is also not needed.

 - The `convertToMap` overload that does content-type detection has been
 marked as deprecated.