### PR TITLE
Remove ordering overhead when parsing source to map

### DIFF
--- a/sql/src/main/java/io/crate/executor/transport/TransportShardUpsertAction.java
+++ b/sql/src/main/java/io/crate/executor/transport/TransportShardUpsertAction.java
@@ -380,7 +380,7 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
         processGeneratedColumns(tableInfo, pathsToUpdate, updatedGeneratedColumns, true, getResult);
 
         Tuple<XContentType, Map<String, Object>> sourceAndContent =
-            XContentHelper.convertToMap(getResult.internalSourceRef(), true, XContentType.JSON);
+            XContentHelper.convertToMap(getResult.internalSourceRef(), false, XContentType.JSON);
         final XContentType updateSourceContentType = sourceAndContent.v1();
         final Map<String, Object> updatedSourceAsMap = sourceAndContent.v2();
 
@@ -554,7 +554,7 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
         Map<String, Object> sourceAsMap;
         if (isRawSourceInsert) {
             BytesRef source = (BytesRef) insertValues[0];
-            sourceAsMap = XContentHelper.convertToMap(new BytesArray(source), true, XContentType.JSON).v2();
+            sourceAsMap = XContentHelper.convertToMap(new BytesArray(source), false, XContentType.JSON).v2();
         } else {
             sourceAsMap = new LinkedHashMap<>(insertColumns.length);
             for (int i = 0; i < insertColumns.length; i++) {

--- a/sql/src/test/java/io/crate/executor/transport/TransportShardUpsertActionTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/TransportShardUpsertActionTest.java
@@ -73,8 +73,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -373,7 +371,9 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
 
         Map<String, Object> sourceMap = transportShardUpsertAction.buildMapFromSource(insertColumns, insertValues, false);
 
-        validateMapOrder(sourceMap, Arrays.asList("ts", "user.name"));
+        assertThat(sourceMap.size(), is(2));
+        assertThat(sourceMap.get("ts"), is(1448274317000L));
+        assertThat(sourceMap.get("user.name"), is("Ford"));
     }
 
     @Test
@@ -392,20 +392,9 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
 
         Map<String, Object> sourceMap = transportShardUpsertAction.buildMapFromSource(insertColumns, insertValues, true);
 
-        validateMapOrder(sourceMap, Arrays.asList("ts", "user.name"));
-    }
-
-    private void validateMapOrder(Map<String, Object> map, List<String> keys) {
-        assertThat(map, instanceOf(LinkedHashMap.class));
-
-        Iterator<String> it = map.keySet().iterator();
-        int idx = 0;
-        while (it.hasNext()) {
-            String key = it.next();
-            assertThat(key, is(keys.get(idx)));
-            idx++;
-        }
-
+        assertThat(sourceMap.size(), is(2));
+        assertThat(sourceMap.get("ts"), is(1448274317000L));
+        assertThat(sourceMap.get("user.name"), is("Ford"));
     }
 
     @Test


### PR DESCRIPTION
We don't require the source to be sorted.
In some other code paths the source was already created unordered, so
this change makes it more consistent and removes a bit of overhead.