### PR TITLE
Fold constants early in ExpressionAnalyzer

### DIFF
--- a/enterprise/mqtt/src/main/java/io/crate/mqtt/operations/MqttIngestService.java
+++ b/enterprise/mqtt/src/main/java/io/crate/mqtt/operations/MqttIngestService.java
@@ -37,6 +37,7 @@ import io.crate.ingestion.IngestionService;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.TableIdent;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.rule.ingest.IngestRule;
 import io.crate.metadata.table.Operation;
 import io.crate.operation.InputFactory;
@@ -117,7 +118,12 @@ public class MqttIngestService implements IngestRuleListener {
                 return new InputColumn(MQTT_FIELDS_ORDER.get(qualifiedName));
             }
         };
-        this.expressionAnalyzer = new ExpressionAnalyzer(functions, null, null, mqttSourceFieldsProvider, null);
+        this.expressionAnalyzer = new ExpressionAnalyzer(
+            functions,
+            new TransactionContext(),
+            null,
+            mqttSourceFieldsProvider,
+            null);
         this.ingestionService = ingestionService;
         this.crateUser = userLookup.findUser("crate");
     }

--- a/enterprise/users/src/main/java/io/crate/scalar/systeminformation/UserFunction.java
+++ b/enterprise/users/src/main/java/io/crate/scalar/systeminformation/UserFunction.java
@@ -33,6 +33,7 @@ import io.crate.types.DataTypes;
 import org.apache.lucene.util.BytesRef;
 
 import javax.annotation.Nullable;
+import java.util.Collections;
 import java.util.Locale;
 
 public class UserFunction extends Scalar<BytesRef, Object> implements FunctionFormatSpec {
@@ -45,7 +46,11 @@ public class UserFunction extends Scalar<BytesRef, Object> implements FunctionFo
 
     public UserFunction(String name) {
         this.name = name;
-        this.functionInfo = new FunctionInfo(new FunctionIdent(name, ImmutableList.of()), DataTypes.STRING);
+        this.functionInfo = new FunctionInfo(
+            new FunctionIdent(name, ImmutableList.of()),
+            DataTypes.STRING,
+            FunctionInfo.Type.SCALAR,
+            Collections.emptySet());
     }
 
     @Override

--- a/sql/src/main/java/io/crate/analyze/AlterTableAddColumnAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/AlterTableAddColumnAnalyzer.java
@@ -73,7 +73,7 @@ class AlterTableAddColumnAnalyzer {
             tableInfo.columns(),
             functions,
             analysis.parameterContext(),
-            analysis.sessionContext());
+            analysis.transactionContext());
 
         int numCurrentPks = tableInfo.primaryKey().size();
         if (tableInfo.primaryKey().contains(DocSysColumns.ID)) {

--- a/sql/src/main/java/io/crate/analyze/AnalyzedTableElements.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedTableElements.java
@@ -24,7 +24,6 @@ package io.crate.analyze;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import io.crate.action.sql.SessionContext;
 import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.expressions.TableReferenceResolver;
@@ -38,6 +37,7 @@ import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.TableIdent;
+import io.crate.metadata.TransactionContext;
 import io.crate.operation.scalar.cast.CastFunctionResolver;
 import io.crate.types.ArrayType;
 import io.crate.types.CollectionType;
@@ -238,9 +238,9 @@ public class AnalyzedTableElements {
                              Collection<? extends Reference> existingColumns,
                              Functions functions,
                              ParameterContext parameterContext,
-                             SessionContext sessionContext) {
+                             TransactionContext transactionContext) {
         expandColumnIdents();
-        validateGeneratedColumns(tableIdent, existingColumns, functions, parameterContext, sessionContext);
+        validateGeneratedColumns(tableIdent, existingColumns, functions, parameterContext, transactionContext);
         for (AnalyzedColumnDefinition column : columns) {
             column.validate();
             addCopyToInfo(column);
@@ -253,7 +253,7 @@ public class AnalyzedTableElements {
                                           Collection<? extends Reference> existingColumns,
                                           Functions functions,
                                           ParameterContext parameterContext,
-                                          SessionContext sessionContext) {
+                                          TransactionContext transactionContext) {
         List<Reference> tableReferences = new ArrayList<>();
         for (AnalyzedColumnDefinition columnDefinition : columns) {
             buildReference(tableIdent, columnDefinition, tableReferences);
@@ -262,7 +262,7 @@ public class AnalyzedTableElements {
 
         TableReferenceResolver tableReferenceResolver = new TableReferenceResolver(tableReferences, tableIdent);
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
-            functions, sessionContext, parameterContext, tableReferenceResolver, null);
+            functions, transactionContext, parameterContext, tableReferenceResolver, null);
         SymbolPrinter printer = new SymbolPrinter(functions);
         ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext();
         for (AnalyzedColumnDefinition columnDefinition : columns) {

--- a/sql/src/main/java/io/crate/analyze/Analyzer.java
+++ b/sql/src/main/java/io/crate/analyze/Analyzer.java
@@ -230,7 +230,7 @@ public class Analyzer {
 
         @Override
         public AnalyzedStatement visitCreateTable(CreateTable node, Analysis analysis) {
-            return createTableStatementAnalyzer.analyze(node, analysis.parameterContext(), analysis.sessionContext());
+            return createTableStatementAnalyzer.analyze(node, analysis.parameterContext(), analysis.transactionContext());
         }
 
         public AnalyzedStatement visitShowCreateTable(ShowCreateTable node, Analysis analysis) {

--- a/sql/src/main/java/io/crate/analyze/CopyAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CopyAnalyzer.java
@@ -143,7 +143,7 @@ class CopyAnalyzer {
     private ExpressionAnalyzer createExpressionAnalyzer(Analysis analysis, DocTableRelation tableRelation) {
         return new ExpressionAnalyzer(
             functions,
-            analysis.sessionContext(),
+            analysis.transactionContext(),
             analysis.parameterContext(),
             new NameFieldProvider(tableRelation),
             null);

--- a/sql/src/main/java/io/crate/analyze/CreateTableStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateTableStatementAnalyzer.java
@@ -30,6 +30,7 @@ import io.crate.metadata.FulltextAnalyzerResolver;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.TableIdent;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.information.InformationSchemaInfo;
 import io.crate.metadata.pgcatalog.PgCatalogSchemaInfo;
 import io.crate.metadata.sys.SysSchemaInfo;
@@ -91,11 +92,11 @@ public class CreateTableStatementAnalyzer extends DefaultTraversalVisitor<Create
 
     public CreateTableAnalyzedStatement analyze(CreateTable createTable,
                                                 ParameterContext parameterContext,
-                                                SessionContext sessionContext) {
+                                                TransactionContext transactionContext) {
         CreateTableAnalyzedStatement statement = new CreateTableAnalyzedStatement();
         Row parameters = parameterContext.parameters();
 
-        TableIdent tableIdent = getTableIdent(createTable, sessionContext);
+        TableIdent tableIdent = getTableIdent(createTable, transactionContext.sessionContext());
         statement.table(tableIdent, createTable.ifNotExists(), schemas);
 
         // apply default in case it is not specified in the genericProperties,
@@ -116,7 +117,7 @@ public class CreateTableStatementAnalyzer extends DefaultTraversalVisitor<Create
             Collections.emptyList(),
             functions,
             parameterContext,
-            sessionContext);
+            transactionContext);
 
         // update table settings
         statement.tableParameter().settingsBuilder().put(tableElements.settings());

--- a/sql/src/main/java/io/crate/analyze/GeneratedColumnComparisonReplacer.java
+++ b/sql/src/main/java/io/crate/analyze/GeneratedColumnComparisonReplacer.java
@@ -152,7 +152,7 @@ public class GeneratedColumnComparisonReplacer {
                 Function generatedFunction = (Function) generatedReference.generatedExpression();
                 String operatorName = function.info().ident().name();
                 if (!operatorName.equals(EqOperator.NAME)) {
-                    if (!generatedFunction.info().features().contains(FunctionInfo.Feature.COMPARISON_REPLACEMENT)) {
+                    if (!generatedFunction.info().hasFeature(FunctionInfo.Feature.COMPARISON_REPLACEMENT)) {
                         return null;
                     }
                     // rewrite operator

--- a/sql/src/main/java/io/crate/analyze/InsertFromSubQueryAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/InsertFromSubQueryAnalyzer.java
@@ -24,7 +24,6 @@ package io.crate.analyze;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
-import io.crate.action.sql.SessionContext;
 import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.expressions.ValueNormalizer;
@@ -116,7 +115,6 @@ class InsertFromSubQueryAnalyzer {
             onDuplicateKeyAssignments = processUpdateAssignments(
                 tableRelation,
                 targetColumns,
-                analysis.sessionContext(),
                 analysis.parameterContext(),
                 analysis.transactionContext(),
                 fieldProvider,
@@ -201,13 +199,12 @@ class InsertFromSubQueryAnalyzer {
 
     private Map<Reference, Symbol> processUpdateAssignments(DocTableRelation tableRelation,
                                                             List<Reference> targetColumns,
-                                                            SessionContext sessionContext,
                                                             ParameterContext parameterContext,
                                                             TransactionContext transactionContext,
                                                             FieldProvider fieldProvider,
                                                             List<Assignment> assignments) {
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
-            functions, sessionContext, parameterContext, fieldProvider, null);
+            functions, transactionContext, parameterContext, fieldProvider, null);
         ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext();
 
         EvaluatingNormalizer normalizer = new EvaluatingNormalizer(
@@ -219,7 +216,7 @@ class InsertFromSubQueryAnalyzer {
 
         ValuesResolver valuesResolver = new ValuesResolver(tableRelation, targetColumns);
         ValuesAwareExpressionAnalyzer valuesAwareExpressionAnalyzer = new ValuesAwareExpressionAnalyzer(
-            functions, sessionContext, parameterContext, fieldProvider, valuesResolver);
+            functions, transactionContext, parameterContext, fieldProvider, valuesResolver);
 
         Map<Reference, Symbol> updateAssignments = new HashMap<>(assignments.size());
         for (Assignment assignment : assignments) {

--- a/sql/src/main/java/io/crate/analyze/InsertFromValuesAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/InsertFromValuesAnalyzer.java
@@ -114,7 +114,7 @@ class InsertFromValuesAnalyzer extends AbstractInsertAnalyzer {
         Function<ParameterExpression, Symbol> convertParamFunction = analysis.parameterContext();
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
             functions,
-            analysis.sessionContext(),
+            analysis.transactionContext(),
             convertParamFunction,
             fieldProvider,
             null
@@ -125,7 +125,7 @@ class InsertFromValuesAnalyzer extends AbstractInsertAnalyzer {
         ValuesResolver valuesResolver = new ValuesResolver(tableRelation);
         ExpressionAnalyzer valuesAwareExpressionAnalyzer = new ValuesAwareExpressionAnalyzer(
             functions,
-            analysis.sessionContext(),
+            analysis.transactionContext(),
             convertParamFunction,
             fieldProvider,
             valuesResolver);

--- a/sql/src/main/java/io/crate/analyze/UnboundAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/UnboundAnalyzer.java
@@ -25,6 +25,7 @@ package io.crate.analyze;
 import io.crate.action.sql.SessionContext;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.RelationAnalyzer;
+import io.crate.metadata.TransactionContext;
 import io.crate.sql.SqlFormatter;
 import io.crate.sql.tree.AstVisitor;
 import io.crate.sql.tree.Explain;
@@ -74,32 +75,33 @@ class UnboundAnalyzer {
 
         @Override
         protected AnalyzedRelation visitQuery(Query node, Analysis context) {
-            return relationAnalyzer.analyzeUnbound(node, context.sessionContext(), context.paramTypeHints());
+            return relationAnalyzer.analyzeUnbound(node, context.transactionContext(), context.paramTypeHints());
         }
 
         @Override
         public AnalyzedRelation visitShowTransaction(ShowTransaction showTransaction, Analysis context) {
             Query query = showStatementAnalyzer.rewriteShowTransaction();
-            return relationAnalyzer.analyzeUnbound(query, context.sessionContext(), ParamTypeHints.EMPTY);
+            return relationAnalyzer.analyzeUnbound(query, context.transactionContext(), ParamTypeHints.EMPTY);
         }
 
         @Override
         protected AnalyzedRelation visitShowTables(ShowTables node, Analysis context) {
             Tuple<Query, ParameterContext> tuple = showStatementAnalyzer.rewriteShow(node);
-            return relationAnalyzer.analyzeUnbound(tuple.v1(), context.sessionContext(), tuple.v2().typeHints());
+            return relationAnalyzer.analyzeUnbound(tuple.v1(), context.transactionContext(), tuple.v2().typeHints());
         }
 
         @Override
         protected AnalyzedRelation visitShowSchemas(ShowSchemas node, Analysis context) {
             Tuple<Query, ParameterContext> tuple = showStatementAnalyzer.rewriteShow(node);
-            return relationAnalyzer.analyzeUnbound(tuple.v1(), context.sessionContext(), tuple.v2().typeHints());
+            return relationAnalyzer.analyzeUnbound(tuple.v1(), context.transactionContext(), tuple.v2().typeHints());
         }
 
         @Override
         protected AnalyzedRelation visitShowColumns(ShowColumns node, Analysis context) {
-            SessionContext sessionContext = context.sessionContext();
-            Tuple<Query, ParameterContext> tuple = showStatementAnalyzer.rewriteShow(node, sessionContext.defaultSchema());
-            return relationAnalyzer.analyzeUnbound(tuple.v1(), sessionContext, tuple.v2().typeHints());
+            TransactionContext transactionContext = context.transactionContext();
+            Tuple<Query, ParameterContext> tuple = showStatementAnalyzer.rewriteShow(
+                node, transactionContext.sessionContext().defaultSchema());
+            return relationAnalyzer.analyzeUnbound(tuple.v1(), transactionContext, tuple.v2().typeHints());
         }
 
         @Override

--- a/sql/src/main/java/io/crate/analyze/ValuesAwareExpressionAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/ValuesAwareExpressionAnalyzer.java
@@ -21,7 +21,6 @@
 
 package io.crate.analyze;
 
-import io.crate.action.sql.SessionContext;
 import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.relations.FieldProvider;
@@ -29,6 +28,7 @@ import io.crate.analyze.symbol.Field;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.format.SymbolFormatter;
 import io.crate.metadata.Functions;
+import io.crate.metadata.TransactionContext;
 import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.FunctionCall;
 import io.crate.sql.tree.ParameterExpression;
@@ -73,11 +73,11 @@ public class ValuesAwareExpressionAnalyzer extends ExpressionAnalyzer {
     }
 
     ValuesAwareExpressionAnalyzer(Functions functions,
-                                  SessionContext sessionContext,
+                                  TransactionContext transactionContext,
                                   Function<ParameterExpression, Symbol> convertParamFunction,
                                   FieldProvider fieldProvider,
                                   ValuesResolver valuesResolver) {
-        super(functions, sessionContext, convertParamFunction, fieldProvider, null);
+        super(functions, transactionContext, convertParamFunction, fieldProvider, null);
         this.valuesResolver = valuesResolver;
     }
 

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalysisContext.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalysisContext.java
@@ -21,26 +21,27 @@
 
 package io.crate.analyze.expressions;
 
-import io.crate.analyze.symbol.Function;
-import io.crate.analyze.symbol.Symbol;
-import io.crate.metadata.FunctionInfo;
 import io.crate.sql.tree.ArrayComparisonExpression;
 import io.crate.sql.tree.Expression;
 
 import java.util.IdentityHashMap;
-import java.util.List;
 import java.util.Map;
 
+/**
+ * State which is passed during translation in the {@link ExpressionAnalyzer}.
+ */
 public class ExpressionAnalysisContext {
 
     private final Map<Expression, Object> arrayExpressionsChildren = new IdentityHashMap<>();
 
-    public boolean hasAggregates = false;
+    private boolean hasAggregates;
 
-    Function allocateFunction(FunctionInfo functionInfo, List<Symbol> arguments) {
-        Function newFunction = new Function(functionInfo, arguments);
-        hasAggregates = hasAggregates || functionInfo.type() == FunctionInfo.Type.AGGREGATE;
-        return newFunction;
+    void indicateAggregates() {
+        hasAggregates = true;
+    }
+
+    public boolean hasAggregates() {
+        return hasAggregates;
     }
 
     /**

--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalysisContext.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalysisContext.java
@@ -49,10 +49,11 @@ public class RelationAnalysisContext {
     @Nullable
     private List<JoinPair> joinPairs;
 
-    RelationAnalysisContext(boolean aliasedRelation, ParentRelations parents) {
+    RelationAnalysisContext(boolean aliasedRelation,
+                            ParentRelations parents) {
         this.aliasedRelation = aliasedRelation;
         this.parents = parents;
-        expressionAnalysisContext = new ExpressionAnalysisContext();
+        this.expressionAnalysisContext = new ExpressionAnalysisContext();
     }
 
     boolean isAliasedRelation() {

--- a/sql/src/main/java/io/crate/analyze/relations/StatementAnalysisContext.java
+++ b/sql/src/main/java/io/crate/analyze/relations/StatementAnalysisContext.java
@@ -35,15 +35,12 @@ public class StatementAnalysisContext {
 
     private final Operation currentOperation;
     private final TransactionContext transactionContext;
-    private final SessionContext sessionContext;
     private final Function<ParameterExpression, Symbol> convertParamFunction;
     private final List<RelationAnalysisContext> lastRelationContextQueue = new ArrayList<>();
 
-    public StatementAnalysisContext(SessionContext sessionContext,
-                                    Function<ParameterExpression, Symbol> convertParamFunction,
+    public StatementAnalysisContext(Function<ParameterExpression, Symbol> convertParamFunction,
                                     Operation currentOperation,
                                     TransactionContext transactionContext) {
-        this.sessionContext = sessionContext;
         this.convertParamFunction = convertParamFunction;
         this.currentOperation = currentOperation;
         this.transactionContext = transactionContext;
@@ -69,7 +66,8 @@ public class StatementAnalysisContext {
             RelationAnalysisContext parentCtx = lastRelationContextQueue.get(lastRelationContextQueue.size() - 1);
             parentRelations = parentCtx.parentSources().newLevel(parentCtx.sources());
         }
-        RelationAnalysisContext currentRelationContext = new RelationAnalysisContext(aliasedRelation, parentRelations);
+        RelationAnalysisContext currentRelationContext =
+            new RelationAnalysisContext(aliasedRelation, parentRelations);
         lastRelationContextQueue.add(currentRelationContext);
         return currentRelationContext;
     }
@@ -86,7 +84,7 @@ public class StatementAnalysisContext {
     }
 
     public SessionContext sessionContext() {
-        return sessionContext;
+        return transactionContext.sessionContext();
     }
 
     public Function<ParameterExpression,Symbol> convertParamFunction() {

--- a/sql/src/main/java/io/crate/metadata/FunctionInfo.java
+++ b/sql/src/main/java/io/crate/metadata/FunctionInfo.java
@@ -86,6 +86,14 @@ public class FunctionInfo implements Comparable<FunctionInfo>, Streamable {
         return features;
     }
 
+    public boolean hasFeature(Feature feature) {
+        return features.contains(feature);
+    }
+
+    public boolean isDeterministic() {
+        return hasFeature(Feature.DETERMINISTIC);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/sql/src/main/java/io/crate/metadata/TransactionContext.java
+++ b/sql/src/main/java/io/crate/metadata/TransactionContext.java
@@ -25,6 +25,8 @@ package io.crate.metadata;
 import io.crate.action.sql.SessionContext;
 import org.joda.time.DateTimeUtils;
 
+import java.util.Objects;
+
 /**
  * TransactionContext is a context that is used to keep state which is valid during a transaction.
  *
@@ -36,8 +38,12 @@ public class TransactionContext {
     private final SessionContext sessionContext;
     private Long currentTimeMillis = null;
 
+    public TransactionContext() {
+        this(SessionContext.create());
+    }
+
     public TransactionContext(SessionContext sessionContext) {
-        this.sessionContext = sessionContext;
+        this.sessionContext = Objects.requireNonNull(sessionContext);
     }
 
     /**

--- a/sql/src/main/java/io/crate/metadata/doc/DocIndexMetaData.java
+++ b/sql/src/main/java/io/crate/metadata/doc/DocIndexMetaData.java
@@ -30,7 +30,6 @@ import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 import io.crate.Constants;
 import io.crate.Version;
-import io.crate.action.sql.SessionContext;
 import io.crate.analyze.NumberOfReplicas;
 import io.crate.analyze.ParamTypeHints;
 import io.crate.analyze.TableParameterInfo;
@@ -49,6 +48,7 @@ import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.TableIdent;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.table.ColumnPolicy;
 import io.crate.metadata.table.Operation;
 import io.crate.sql.parser.SqlParser;
@@ -553,7 +553,7 @@ public class DocIndexMetaData {
         Collection<Reference> references = this.references.values();
         TableReferenceResolver tableReferenceResolver = new TableReferenceResolver(references, ident);
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
-            functions, SessionContext.create(), ParamTypeHints.EMPTY, tableReferenceResolver, null);
+            functions, new TransactionContext(), ParamTypeHints.EMPTY, tableReferenceResolver, null);
         ExpressionAnalysisContext context = new ExpressionAnalysisContext();
         for (Reference reference : generatedColumnReferences) {
             GeneratedReference generatedReference = (GeneratedReference) reference;

--- a/sql/src/main/java/io/crate/operation/operator/AndOperator.java
+++ b/sql/src/main/java/io/crate/operation/operator/AndOperator.java
@@ -116,8 +116,10 @@ public class AndOperator extends Operator<Boolean> {
     }
 
     public static Function of(Symbol first, Symbol second) {
-        assert first.valueType().equals(DataTypes.BOOLEAN) : "first symbol must have BOOLEAN return type to create AND function";
-        assert second.valueType().equals(DataTypes.BOOLEAN) : "second symbol must have BOOLEAN return type to create AND function";
+        assert first.valueType().equals(DataTypes.BOOLEAN) || first.valueType().equals(DataTypes.UNDEFINED) :
+            "first symbol must have BOOLEAN return type to create AND function";
+        assert second.valueType().equals(DataTypes.BOOLEAN) || second.valueType().equals(DataTypes.UNDEFINED) :
+            "second symbol must have BOOLEAN return type to create AND function";
 
         return new Function(INFO, Arrays.asList(first, second));
     }

--- a/sql/src/main/java/io/crate/operation/scalar/ExtractFunctions.java
+++ b/sql/src/main/java/io/crate/operation/scalar/ExtractFunctions.java
@@ -147,7 +147,6 @@ public class ExtractFunctions {
                 String field = ValueSymbolVisitor.STRING.process(arg1);
 
                 Scalar<Number, Long> scalar = getScalar(Extract.Field.valueOf(field.toUpperCase(Locale.ENGLISH)));
-                //noinspection ArraysAsListWithZeroOrOneArgument # need mutable list as arg to function
                 Function function = new Function(scalar.info(), ImmutableList.of(symbol.arguments().get(1)));
                 return scalar.normalizeSymbol(function, transactionContext);
             }

--- a/sql/src/main/java/io/crate/operation/scalar/systeminformation/CurrentSchemaFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/systeminformation/CurrentSchemaFunction.java
@@ -37,6 +37,7 @@ import io.crate.types.DataTypes;
 import org.apache.lucene.util.BytesRef;
 
 import javax.annotation.Nullable;
+import java.util.Collections;
 
 
 public class CurrentSchemaFunction extends Scalar<BytesRef, Object> implements FunctionFormatSpec {
@@ -44,7 +45,10 @@ public class CurrentSchemaFunction extends Scalar<BytesRef, Object> implements F
     public static final String NAME = "current_schema";
 
     public static final FunctionInfo INFO = new FunctionInfo(
-        new FunctionIdent(NAME, ImmutableList.of()), DataTypes.STRING);
+        new FunctionIdent(NAME, ImmutableList.of()),
+        DataTypes.STRING,
+        FunctionInfo.Type.SCALAR,
+        Collections.emptySet());
 
     public static void register(ScalarFunctionModule scalarFunctionModule) {
         scalarFunctionModule.register(new CurrentSchemaFunction());

--- a/sql/src/main/java/io/crate/operation/scalar/timestamp/CurrentTimestampFunction.java
+++ b/sql/src/main/java/io/crate/operation/scalar/timestamp/CurrentTimestampFunction.java
@@ -38,6 +38,7 @@ import io.crate.types.DataTypes;
 import org.joda.time.DateTimeUtils;
 
 import java.math.RoundingMode;
+import java.util.Collections;
 import java.util.Locale;
 
 public class CurrentTimestampFunction extends Scalar<Long, Integer> implements FunctionFormatSpec {
@@ -46,7 +47,10 @@ public class CurrentTimestampFunction extends Scalar<Long, Integer> implements F
     public static final int DEFAULT_PRECISION = 3;
 
     public static final FunctionInfo INFO = new FunctionInfo(
-        new FunctionIdent(NAME, ImmutableList.<DataType>of(DataTypes.INTEGER)), DataTypes.TIMESTAMP);
+        new FunctionIdent(NAME, ImmutableList.<DataType>of(DataTypes.INTEGER)),
+        DataTypes.TIMESTAMP,
+        FunctionInfo.Type.SCALAR,
+        Collections.emptySet());
 
     public static void register(ScalarFunctionModule function) {
         function.register(new CurrentTimestampFunction());
@@ -94,9 +98,6 @@ public class CurrentTimestampFunction extends Scalar<Long, Integer> implements F
 
     @Override
     public Symbol normalizeSymbol(Function function, TransactionContext transactionContext) {
-        if (transactionContext == null) {
-            return eval(function, DateTimeUtils.currentTimeMillis());
-        }
         // use evaluatedFunctions map to make sure multiple occurrences of current_timestamp within a query result in the same result
         return eval(function, transactionContext.currentTimeMillis());
     }

--- a/sql/src/main/java/io/crate/planner/projection/builder/InputColumns.java
+++ b/sql/src/main/java/io/crate/planner/projection/builder/InputColumns.java
@@ -29,7 +29,6 @@ import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.InputColumn;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.SymbolType;
-import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.GeneratedReference;
 import io.crate.metadata.Reference;
 import io.crate.types.DataType;
@@ -67,7 +66,7 @@ public final class InputColumns extends DefaultTraversalSymbolVisitor<InputColum
                 if (!input.symbolType().isValueSymbol()) {
                     DataType valueType = input.valueType();
                     if (input.symbolType() == SymbolType.FUNCTION
-                        && !((Function) input).info().features().contains(FunctionInfo.Feature.DETERMINISTIC)) {
+                        && !((Function) input).info().isDeterministic()) {
                         nonDeterministicFunctions.put(input, new InputColumn(i, valueType));
                     } else {
                         this.inputs.put(input, new InputColumn(i, valueType));
@@ -116,7 +115,7 @@ public final class InputColumns extends DefaultTraversalSymbolVisitor<InputColum
     @Override
     public Symbol visitFunction(Function symbol, final Context context) {
         Symbol replacement;
-        if (symbol.info().features().contains(FunctionInfo.Feature.DETERMINISTIC)) {
+        if (symbol.info().isDeterministic()) {
             replacement = context.inputs.get(symbol);
         } else {
             replacement = context.nonDeterministicFunctions.get(symbol);

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -1845,8 +1845,8 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
 
     @Test
     public void testSelectFromNonTableFunction() throws Exception {
-        expectedException.expect(UnsupportedFeatureException.class);
-        expectedException.expectMessage("Non table function abs is not supported in from clause");
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("Non table function 'abs' is not supported in from clause");
         analyze("select * from abs(1)");
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/IngestionServiceIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/IngestionServiceIntegrationTest.java
@@ -32,6 +32,7 @@ import io.crate.data.Row1;
 import io.crate.ingestion.IngestRuleListener;
 import io.crate.ingestion.IngestionService;
 import io.crate.metadata.Functions;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.rule.ingest.IngestRule;
 import io.crate.metadata.table.Operation;
 import io.crate.operation.InputFactory;
@@ -95,7 +96,8 @@ public class IngestionServiceIntegrationTest extends SQLTransportIntegrationTest
             this.inputFactory = new InputFactory(functions);
             this.ingestionService = ingestionService;
             this.expressionAnalysisContext = new ExpressionAnalysisContext();
-            this.expressionAnalyzer = new ExpressionAnalyzer(functions, null, null, inputColumnProvider, null);
+            this.expressionAnalyzer = new ExpressionAnalyzer(
+                functions, null, null, inputColumnProvider, null);
         }
 
         void registerListener() {

--- a/sql/src/test/java/io/crate/integrationtests/PostgresITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PostgresITest.java
@@ -601,7 +601,7 @@ public class PostgresITest extends SQLTransportIntegrationTest {
                 stmt.executeQuery();
                 fail("Should've raised PSQLException");
             } catch (PSQLException e) {
-                assertThat(e.getMessage(), Matchers.containsString("Cannot cast double_array to type integer"));
+                assertThat(e.getMessage(), Matchers.containsString("Cannot cast [10.3, 20.2] to type integer"));
             }
 
             assertSelectNameFromSysClusterWorks(conn);

--- a/sql/src/test/java/io/crate/metadata/doc/DocIndexMetaDataTest.java
+++ b/sql/src/test/java/io/crate/metadata/doc/DocIndexMetaDataTest.java
@@ -964,7 +964,7 @@ public class DocIndexMetaDataTest extends CrateDummyClusterServiceUnitTest {
 
         Analysis analysis = new Analysis(SessionContext.create(), ParameterContext.EMPTY, ParamTypeHints.EMPTY);
         CreateTableAnalyzedStatement analyzedStatement = analyzer.analyze(
-            (CreateTable) statement, analysis.parameterContext(), analysis.sessionContext());
+            (CreateTable) statement, analysis.parameterContext(), analysis.transactionContext());
 
         Settings.Builder settingsBuilder = Settings.builder()
             .put("index.number_of_shards", 1)

--- a/sql/src/test/java/io/crate/metadata/table/TestingTableInfo.java
+++ b/sql/src/test/java/io/crate/metadata/table/TestingTableInfo.java
@@ -42,6 +42,7 @@ import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.Routing;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.TableIdent;
+import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocSysColumns;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.sql.parser.SqlParser;
@@ -287,9 +288,10 @@ public class TestingTableInfo extends DocTableInfo {
         }
 
         private void initializeGeneratedExpressions(Functions functions, Collection<Reference> columns) {
+            TransactionContext transactionContext = new TransactionContext();
             TableReferenceResolver tableReferenceResolver = new TableReferenceResolver(columns, ident);
             ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
-                functions, SessionContext.create(), null, tableReferenceResolver, null);
+                functions, transactionContext, null, tableReferenceResolver, null);
             for (GeneratedReference generatedReferenceInfo : generatedColumns.build()) {
                 Expression expression = SqlParser.createExpression(generatedReferenceInfo.formattedGeneratedExpression());
                 ExpressionAnalysisContext context = new ExpressionAnalysisContext();

--- a/sql/src/test/java/io/crate/operation/udf/UdfUnitTest.java
+++ b/sql/src/test/java/io/crate/operation/udf/UdfUnitTest.java
@@ -62,6 +62,9 @@ public abstract class UdfUnitTest extends CrateUnitTest {
     };
 
     static class DummyFunction extends Scalar<Integer, Integer> {
+
+        public static final Integer RESULT = -42;
+
         private FunctionInfo info;
 
         DummyFunction(FunctionInfo info) {
@@ -75,7 +78,7 @@ public abstract class UdfUnitTest extends CrateUnitTest {
 
         @Override
         public Integer evaluate(Input<Integer>[] args) {
-            return null;
+            return RESULT;
         }
     }
 }

--- a/sql/src/test/java/io/crate/operation/udf/UserDefinedFunctionsTest.java
+++ b/sql/src/test/java/io/crate/operation/udf/UserDefinedFunctionsTest.java
@@ -27,7 +27,6 @@ import com.google.common.collect.ImmutableMap;
 import io.crate.analyze.FunctionArgumentDefinition;
 import io.crate.analyze.TableDefinitions;
 import io.crate.analyze.relations.DocTableRelation;
-import io.crate.analyze.symbol.Function;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.Functions;
@@ -43,6 +42,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import static io.crate.testing.SymbolMatchers.isLiteral;
 
 
 public class UserDefinedFunctionsTest extends UdfUnitTest {
@@ -81,8 +82,6 @@ public class UserDefinedFunctionsTest extends UdfUnitTest {
     public void testOverloadingBuiltinFunctions() throws Exception {
         registerUserDefinedFunction(DUMMY_LANG.name(), "test", "subtract", DataTypes.INTEGER, ImmutableList.of(DataTypes.INTEGER, DataTypes.INTEGER), "function subtract(a, b) { return a + b; }");
         String expr = "test.subtract(2::integer, 1::integer)";
-        Function function = (Function) sqlExpressions.asSymbol(expr);
-        FunctionImplementation impl = functions.getQualified(function.info().ident());
-        assertTrue("function implementation must be of type DummyFunction", impl instanceof DummyFunction);
+        assertThat(sqlExpressions.asSymbol(expr), isLiteral(DummyFunction.RESULT));
     }
 }

--- a/sql/src/test/java/io/crate/testing/SQLExecutor.java
+++ b/sql/src/test/java/io/crate/testing/SQLExecutor.java
@@ -301,17 +301,19 @@ public class SQLExecutor {
      *                If tables are used here they must also be registered in the SQLExecutor having used {@link Builder#addDocTable(DocTableInfo)}
      */
     public Symbol asSymbol(Map<QualifiedName, AnalyzedRelation> sources, String expression) {
+        TransactionContext transactionContext = new TransactionContext(sessionContext);
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
             functions,
-            sessionContext,
+            transactionContext,
             ParamTypeHints.EMPTY,
             new FullQualifiedNameFieldProvider(sources, ParentRelations.NO_PARENTS, sessionContext.defaultSchema()),
             new SubqueryAnalyzer(
                 relAnalyzer,
-                new StatementAnalysisContext(sessionContext, ParamTypeHints.EMPTY, Operation.READ, new TransactionContext(sessionContext))
+                new StatementAnalysisContext(ParamTypeHints.EMPTY, Operation.READ, transactionContext)
             )
         );
-        return expressionAnalyzer.convert(SqlParser.createExpression(expression), new ExpressionAnalysisContext());
+        return expressionAnalyzer.convert(
+            SqlParser.createExpression(expression), new ExpressionAnalysisContext());
     }
 
 

--- a/sql/src/test/java/io/crate/testing/SqlExpressions.java
+++ b/sql/src/test/java/io/crate/testing/SqlExpressions.java
@@ -94,19 +94,21 @@ public class SqlExpressions {
         }
         injector = modulesBuilder.createInjector();
         functions = injector.getInstance(Functions.class);
-        SessionContext sessionContext = SessionContext.create(user);
+        transactionContext = new TransactionContext(SessionContext.create(user));
         expressionAnalyzer = new ExpressionAnalyzer(
             functions,
-            sessionContext,
+            transactionContext,
             parameters == null
                 ? ParamTypeHints.EMPTY
                 : new ParameterContext(new RowN(parameters), Collections.<Row>emptyList()),
-            new FullQualifiedNameFieldProvider(sources, ParentRelations.NO_PARENTS, sessionContext.defaultSchema()),
+            new FullQualifiedNameFieldProvider(
+                sources,
+                ParentRelations.NO_PARENTS,
+                transactionContext.sessionContext().defaultSchema()),
             null
         );
         normalizer = new EvaluatingNormalizer(functions, RowGranularity.DOC, null, fieldResolver);
         expressionAnalysisCtx = new ExpressionAnalysisContext();
-        transactionContext = new TransactionContext(sessionContext);
     }
 
     public Symbol asSymbol(String expression) {


### PR DESCRIPTION
This folds function calls which only contain literals already in the
`ExpressionAnalyzer`. This behavior may be suppressed using a different
`ExpressionAnalysisContext`, e.g. when dealing with expressions for generated
columns. Therefore, there are now two implementations of the
`ExpressionAnalysisContext`, `ExpressionAnalysisNormalizingContext` and `ExpressionAnalysisNonNormalizingContext`.