### PR TITLE
Invert usage of @UseJdbc

### DIFF
--- a/sql/src/test/java/io/crate/executor/transport/TransportExecutorDDLTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/TransportExecutorDDLTest.java
@@ -34,6 +34,7 @@ import io.crate.planner.node.ddl.ESDeletePartition;
 import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.Literal;
 import io.crate.testing.TestingBatchConsumer;
+import io.crate.testing.UseJdbc;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsRequest;
@@ -108,6 +109,7 @@ public class TransportExecutorDDLTest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    @UseJdbc(0) // create table has no rowcount
     public void testCreateTableWithOrphanedAlias() throws Exception {
         String partitionName = new PartitionName("test", Collections.singletonList(new BytesRef("foo"))).asIndexName();
         client().admin().indices().prepareCreate(partitionName)

--- a/sql/src/test/java/io/crate/integrationtests/AnyIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/AnyIntegrationTest.java
@@ -22,7 +22,6 @@
 package io.crate.integrationtests;
 
 import io.crate.testing.TestingHelpers;
-import io.crate.testing.UseJdbc;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.Is;
 import org.junit.Test;
@@ -31,7 +30,6 @@ import static io.crate.integrationtests.SubSelectIntegrationTest.NO_SESSION_SETT
 import static io.crate.testing.TestingHelpers.isPrintedTable;
 import static org.hamcrest.Matchers.is;
 
-@UseJdbc
 public class AnyIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/ArithmeticIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ArithmeticIntegrationTest.java
@@ -23,7 +23,6 @@ package io.crate.integrationtests;
 
 import io.crate.action.sql.SQLActionException;
 import io.crate.testing.TestingHelpers;
-import io.crate.testing.UseJdbc;
 import org.junit.Test;
 
 import java.util.Locale;
@@ -33,8 +32,6 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 
-
-@UseJdbc
 public class ArithmeticIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/CastIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/CastIntegrationTest.java
@@ -22,7 +22,6 @@
 
 package io.crate.integrationtests;
 
-import io.crate.testing.UseJdbc;
 import org.hamcrest.Matcher;
 import org.junit.Test;
 
@@ -30,8 +29,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.collection.IsArrayContainingInOrder.arrayContaining;
 
-
-@UseJdbc
 public class CastIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/ColumnPolicyIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ColumnPolicyIntegrationTest.java
@@ -28,7 +28,6 @@ import io.crate.metadata.Schemas;
 import io.crate.metadata.TableIdent;
 import io.crate.metadata.table.ColumnPolicy;
 import io.crate.testing.TestingHelpers;
-import io.crate.testing.UseJdbc;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesResponse;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
@@ -54,7 +53,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 1)
-@UseJdbc
 public class ColumnPolicyIntegrationTest extends SQLTransportIntegrationTest {
 
     private String copyFilePath = Paths.get(getClass().getResource("/essetup/data/copy").toURI()).toUri().toString();

--- a/sql/src/test/java/io/crate/integrationtests/ConcurrencyIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ConcurrencyIntegrationTest.java
@@ -21,7 +21,6 @@
 
 package io.crate.integrationtests;
 
-import io.crate.testing.UseJdbc;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -32,7 +31,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-@UseJdbc
 public class ConcurrencyIntegrationTest extends SQLTransportIntegrationTest {
 
     private ExecutorService executor;

--- a/sql/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableList;
 import io.crate.action.sql.SQLActionException;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.TestingHelpers;
+import io.crate.testing.UseJdbc;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Rule;
 import org.junit.Test;
@@ -58,6 +59,7 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 2, randomDynamicTemplates = false)
+@UseJdbc(0) // Copy has no row count
 public class CopyIntegrationTest extends SQLHttpIntegrationTest {
 
     private final String copyFilePath =

--- a/sql/src/test/java/io/crate/integrationtests/CountStarIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/CountStarIntegrationTest.java
@@ -22,12 +22,10 @@
 package io.crate.integrationtests;
 
 import io.crate.action.sql.SQLActionException;
-import io.crate.testing.UseJdbc;
 import org.junit.Test;
 
 import static org.hamcrest.core.Is.is;
 
-@UseJdbc
 public class CountStarIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/CrateSettingsIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/CrateSettingsIntegrationTest.java
@@ -1,13 +1,10 @@
 package io.crate.integrationtests;
 
-
 import io.crate.testing.SQLResponse;
-import io.crate.testing.UseJdbc;
 import org.junit.Test;
 
 import java.util.Locale;
 
-@UseJdbc
 public class CrateSettingsIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/CreateTableIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/CreateTableIntegrationTest.java
@@ -21,7 +21,6 @@
 
 package io.crate.integrationtests;
 
-import io.crate.testing.UseJdbc;
 import org.junit.Test;
 
 import java.util.concurrent.ExecutorService;
@@ -31,7 +30,6 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.hamcrest.Matchers.is;
 
-@UseJdbc
 public class CreateTableIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/CustomSchemaIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/CustomSchemaIntegrationTest.java
@@ -22,13 +22,11 @@
 package io.crate.integrationtests;
 
 import io.crate.testing.TestingHelpers;
-import io.crate.testing.UseJdbc;
 import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsRequest;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
 
-@UseJdbc
 public class CustomSchemaIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -49,7 +49,6 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(randomDynamicTemplates = false)
-@UseJdbc
 public class DDLIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/DeleteIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/DeleteIntegrationTest.java
@@ -23,12 +23,10 @@
 package io.crate.integrationtests;
 
 import io.crate.testing.SQLBulkResponse;
-import io.crate.testing.UseJdbc;
 import org.junit.Test;
 
 import static org.hamcrest.core.Is.is;
 
-@UseJdbc
 public class DeleteIntegrationTest extends SQLTransportIntegrationTest {
 
     private Setup setup = new Setup(sqlExecutor);

--- a/sql/src/test/java/io/crate/integrationtests/EmptyStringRoutingIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/EmptyStringRoutingIntegrationTest.java
@@ -38,7 +38,6 @@ import static org.hamcrest.core.Is.is;
  * the contract of having the same value of the routing field on only one shard. So in Crate the behaviour is
  * different and is asserted via tests in this class.
  */
-@UseJdbc
 public class EmptyStringRoutingIntegrationTest extends SQLTransportIntegrationTest {
 
     @Rule

--- a/sql/src/test/java/io/crate/integrationtests/FetchOperationIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/FetchOperationIntegrationTest.java
@@ -25,7 +25,6 @@ import io.crate.planner.Merge;
 import io.crate.planner.node.dql.QueryThenFetch;
 import io.crate.planner.projection.FetchProjection;
 import io.crate.testing.TestingBatchConsumer;
-import io.crate.testing.UseJdbc;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Test;
@@ -37,7 +36,6 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 2, numClientNodes = 0)
-@UseJdbc
 public class FetchOperationIntegrationTest extends SQLTransportIntegrationTest {
 
     private void setUpCharacters() {

--- a/sql/src/test/java/io/crate/integrationtests/FulltextAnalyzerResolverTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/FulltextAnalyzerResolverTest.java
@@ -25,7 +25,6 @@ import com.google.common.base.Joiner;
 import io.crate.action.sql.SQLActionException;
 import io.crate.metadata.FulltextAnalyzerResolver;
 import io.crate.testing.SQLResponse;
-import io.crate.testing.UseJdbc;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.common.settings.Settings;
 import org.junit.After;
@@ -47,7 +46,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
 import static org.hamcrest.collection.IsMapContaining.hasKey;
 
-@UseJdbc
 public class FulltextAnalyzerResolverTest extends SQLTransportIntegrationTest {
 
     private static FulltextAnalyzerResolver fulltextAnalyzerResolver;

--- a/sql/src/test/java/io/crate/integrationtests/GeoShapeIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/GeoShapeIntegrationTest.java
@@ -24,7 +24,6 @@ package io.crate.integrationtests;
 
 import com.google.common.collect.ImmutableMap;
 import io.crate.testing.TestingHelpers;
-import io.crate.testing.UseJdbc;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -37,7 +36,6 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.core.Is.is;
 
-@UseJdbc
 public class GeoShapeIntegrationTest extends SQLTransportIntegrationTest {
 
     private static final Map GEO_SHAPE1 = ImmutableMap.of(

--- a/sql/src/test/java/io/crate/integrationtests/GroupByAggregateBreakerTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/GroupByAggregateBreakerTest.java
@@ -24,12 +24,10 @@ package io.crate.integrationtests;
 import io.crate.action.sql.SQLActionException;
 import io.crate.breaker.CrateCircuitBreakerService;
 import io.crate.breaker.RamAccountingContext;
-import io.crate.testing.UseJdbc;
 import org.elasticsearch.common.settings.Settings;
 import org.junit.Before;
 import org.junit.Test;
 
-@UseJdbc
 public class GroupByAggregateBreakerTest extends SQLTransportIntegrationTest {
 
     @Override

--- a/sql/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
@@ -27,7 +27,6 @@ import io.crate.data.ArrayBucket;
 import io.crate.operation.Paging;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.TestingHelpers;
-import io.crate.testing.UseJdbc;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.hamcrest.core.Is;
 import org.junit.Before;
@@ -42,7 +41,6 @@ import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.isIn;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 2, numClientNodes = 0, supportsDedicatedMasters = false)
-@UseJdbc
 public class GroupByAggregateTest extends SQLTransportIntegrationTest {
 
     private Setup setup = new Setup(sqlExecutor);
@@ -669,7 +667,7 @@ public class GroupByAggregateTest extends SQLTransportIntegrationTest {
         expectedException.expectMessage("column 'details_ignored['lol']' must appear in the GROUP BY clause or be used in an aggregation function");
         execute("select details_ignored['lol'] from characters group by race");
     }
-    
+
     @Test
     public void testGroupByUnknownGroupByColumn() throws Exception {
         this.setup.groupBySetup();

--- a/sql/src/test/java/io/crate/integrationtests/InformationSchemaQueryTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InformationSchemaQueryTest.java
@@ -22,7 +22,6 @@
 package io.crate.integrationtests;
 
 import io.crate.testing.SQLResponse;
-import io.crate.testing.UseJdbc;
 import org.elasticsearch.action.admin.indices.close.CloseIndexRequest;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -30,7 +29,6 @@ import org.junit.Test;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
-@UseJdbc
 public class InformationSchemaQueryTest extends SQLTransportIntegrationTest {
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -27,7 +27,6 @@ import io.crate.Version;
 import io.crate.action.sql.SQLActionException;
 import io.crate.metadata.IndexMappings;
 import io.crate.testing.TestingHelpers;
-import io.crate.testing.UseJdbc;
 import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -44,9 +43,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
-
 @ESIntegTestCase.ClusterScope(numDataNodes = 2)
-@UseJdbc
 public class InformationSchemaTest extends SQLTransportIntegrationTest {
 
     private final Joiner commaJoiner = Joiner.on(", ");

--- a/sql/src/test/java/io/crate/integrationtests/IngestRulesIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/IngestRulesIntegrationTest.java
@@ -25,6 +25,7 @@ package io.crate.integrationtests;
 import io.crate.action.sql.SQLActionException;
 import io.crate.metadata.rule.ingest.IngestRule;
 import io.crate.metadata.rule.ingest.IngestRulesMetaData;
+import io.crate.testing.UseJdbc;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.junit.After;
@@ -40,6 +41,7 @@ import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 import static io.crate.testing.TestingHelpers.printedTable;
 import static org.hamcrest.Matchers.is;
 
+@UseJdbc(0) // create ingest rule has no rowcount
 public class IngestRulesIntegrationTest extends SQLTransportIntegrationTest {
 
     private static final String INGEST_RULE_NAME = "testingestrule";

--- a/sql/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
@@ -26,6 +26,7 @@ import io.crate.action.sql.SQLActionException;
 import io.crate.testing.SQLBulkResponse;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.TestingHelpers;
+import io.crate.testing.UseJdbc;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -128,7 +129,7 @@ public class InsertIntoIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
+    @UseJdbc(0) // avoid casting errors: Timestamp instead of Long
     public void testInsertCoreTypesAsArray() throws Exception {
         execute("create table test (" +
                 "\"boolean\" array(boolean), " +
@@ -288,6 +289,7 @@ public class InsertIntoIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    @UseJdbc(0) // inserting object array equires special treatment for PostgreSQL
     public void testInsertEmptyObjectArray() throws Exception {
         execute("create table test (" +
                 "  id integer primary key," +
@@ -609,6 +611,7 @@ public class InsertIntoIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    @UseJdbc(0) // inserting geo-point array requires special treatment for PostgreSQL
     public void testInsertIntoGeoPointArray() throws Exception {
         execute("create table t (id int, points array(geo_point)) clustered into 1 shards with (number_of_replicas=0)");
         ensureYellow();
@@ -704,8 +707,7 @@ public class InsertIntoIntegrationTest extends SQLTransportIntegrationTest {
 
         // set all 'female' values back to their original values
         execute("insert into t (id, name, female) (select id, name, female from characters) " +
-                "on duplicate key update female = values(female)",
-            new Object[]{true});
+                "on duplicate key update female = values(female)");
         assertThat(response.rowCount(), is(4L));
         refresh();
 

--- a/sql/src/test/java/io/crate/integrationtests/JobContextIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/JobContextIntegrationTest.java
@@ -23,7 +23,6 @@ package io.crate.integrationtests;
 
 import io.crate.jobs.JobContextService;
 import io.crate.jobs.JobExecutionContext;
-import io.crate.testing.UseJdbc;
 import org.junit.Test;
 
 import java.lang.reflect.Field;
@@ -33,7 +32,6 @@ import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.core.Is.is;
 
-@UseJdbc
 public class JobContextIntegrationTest extends SQLTransportIntegrationTest {
 
     Setup setup = new Setup(sqlExecutor);

--- a/sql/src/test/java/io/crate/integrationtests/JobIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/JobIntegrationTest.java
@@ -25,7 +25,6 @@ package io.crate.integrationtests;
 import io.crate.action.sql.SQLActionException;
 import io.crate.action.sql.SQLOperations;
 import io.crate.testing.SQLTransportExecutor;
-import io.crate.testing.UseJdbc;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -34,7 +33,6 @@ import org.junit.Test;
 import javax.annotation.Nullable;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 1, numClientNodes = 1, randomDynamicTemplates = false, supportsDedicatedMasters = false)
-@UseJdbc
 public class JobIntegrationTest extends SQLTransportIntegrationTest {
 
     @Override

--- a/sql/src/test/java/io/crate/integrationtests/JobLogIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/JobLogIntegrationTest.java
@@ -32,7 +32,6 @@ import org.junit.Test;
 import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 2, numClientNodes = 0, supportsDedicatedMasters = false)
-@UseJdbc
 public class JobLogIntegrationTest extends SQLTransportIntegrationTest {
 
     @After

--- a/sql/src/test/java/io/crate/integrationtests/JoinGroupByIntegrationTests.java
+++ b/sql/src/test/java/io/crate/integrationtests/JoinGroupByIntegrationTests.java
@@ -25,7 +25,6 @@ package io.crate.integrationtests;
 import io.crate.data.CollectionBucket;
 import io.crate.operation.projectors.sorting.OrderingByPosition;
 import io.crate.testing.TestingHelpers;
-import io.crate.testing.UseJdbc;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -34,7 +33,6 @@ import java.util.List;
 
 import static org.hamcrest.core.Is.is;
 
-@UseJdbc
 public class JoinGroupByIntegrationTests extends SQLTransportIntegrationTest {
 
     @Before

--- a/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -25,7 +25,6 @@ import io.crate.data.CollectionBucket;
 import io.crate.exceptions.SQLExceptions;
 import io.crate.operation.projectors.sorting.OrderingByPosition;
 import io.crate.testing.TestingHelpers;
-import io.crate.testing.UseJdbc;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Test;
@@ -41,7 +40,6 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(minNumDataNodes = 2)
-@UseJdbc
 public class JoinIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/JoinSingleNodeIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/JoinSingleNodeIntegrationTest.java
@@ -21,11 +21,9 @@
 
 package io.crate.integrationtests;
 
-import io.crate.testing.UseJdbc;
 import org.elasticsearch.test.ESIntegTestCase;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 1, numClientNodes = 0)
-@UseJdbc
 public class JoinSingleNodeIntegrationTest extends JoinIntegrationTest {
 
     /*

--- a/sql/src/test/java/io/crate/integrationtests/KillIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/KillIntegrationTest.java
@@ -25,7 +25,6 @@ import com.google.common.util.concurrent.SettableFuture;
 import io.crate.action.sql.SQLActionException;
 import io.crate.exceptions.SQLExceptions;
 import io.crate.testing.SQLResponse;
-import io.crate.testing.UseJdbc;
 import io.crate.testing.plugin.CrateTestingPlugin;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.plugins.Plugin;
@@ -50,7 +49,6 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
-@UseJdbc
 public class KillIntegrationTest extends SQLTransportIntegrationTest {
 
     private Setup setup = new Setup(sqlExecutor);

--- a/sql/src/test/java/io/crate/integrationtests/LuceneQueryBuilderIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/LuceneQueryBuilderIntegrationTest.java
@@ -22,7 +22,6 @@
 package io.crate.integrationtests;
 
 import io.crate.testing.DataTypeTesting;
-import io.crate.testing.UseJdbc;
 import io.crate.types.DataType;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.search.SearchModule;
@@ -38,7 +37,6 @@ import static io.crate.testing.TestingHelpers.printedTable;
 import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, randomDynamicTemplates = false, transportClientRatio = 0)
-@UseJdbc
 public class LuceneQueryBuilderIntegrationTest extends SQLTransportIntegrationTest {
 
     private static final int NUMBER_OF_BOOLEAN_CLAUSES = 10_000;

--- a/sql/src/test/java/io/crate/integrationtests/MappingDefaultsTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/MappingDefaultsTest.java
@@ -22,14 +22,12 @@
 package io.crate.integrationtests;
 
 import io.crate.testing.SQLResponse;
-import io.crate.testing.UseJdbc;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.index.query.QueryStringQueryBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.junit.Test;
 
-@UseJdbc
 public class MappingDefaultsTest extends SQLTransportIntegrationTest {
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/NodeStatsTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/NodeStatsTest.java
@@ -47,7 +47,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(numClientNodes = 0, numDataNodes = 2, supportsDedicatedMasters = false)
-@UseJdbc
+
 public class NodeStatsTest extends SQLTransportIntegrationTest {
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/ObjectColumnTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ObjectColumnTest.java
@@ -22,6 +22,7 @@
 package io.crate.integrationtests;
 
 import io.crate.action.sql.SQLActionException;
+import io.crate.testing.UseJdbc;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.hamcrest.Matchers;
 import org.junit.Before;
@@ -88,6 +89,7 @@ public class ObjectColumnTest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    @UseJdbc(0) // inserting object requires other treatment for PostgreSQL
     public void testAddColumnToIgnoredObject() throws Exception {
         Map<String, Object> detailMap = new HashMap<String, Object>() {{
             put("num_pages", 240);

--- a/sql/src/test/java/io/crate/integrationtests/OpenCloseTableIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/OpenCloseTableIntegrationTest.java
@@ -22,12 +22,10 @@
 package io.crate.integrationtests;
 
 import io.crate.action.sql.SQLActionException;
-import io.crate.testing.UseJdbc;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.junit.Before;
 import org.junit.Test;
 
-@UseJdbc
 public class OpenCloseTableIntegrationTest extends SQLTransportIntegrationTest {
 
     @Before

--- a/sql/src/test/java/io/crate/integrationtests/OuterJoinIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/OuterJoinIntegrationTest.java
@@ -22,14 +22,12 @@
 
 package io.crate.integrationtests;
 
-import io.crate.testing.UseJdbc;
 import org.junit.Before;
 import org.junit.Test;
 
 import static io.crate.testing.TestingHelpers.printedTable;
 import static org.hamcrest.core.Is.is;
 
-@UseJdbc
 public class OuterJoinIntegrationTest extends SQLTransportIntegrationTest {
 
     @Before

--- a/sql/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
@@ -27,7 +27,6 @@ import io.crate.data.CollectionBucket;
 import io.crate.metadata.PartitionName;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.SQLTransportExecutor;
-import io.crate.testing.UseJdbc;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteRequestBuilder;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
@@ -58,7 +57,6 @@ import static com.carrotsearch.randomizedtesting.RandomizedTest.randomAsciiOfLen
 import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 2)
-@UseJdbc
 public class PartitionedTableConcurrentIntegrationTest extends SQLTransportIntegrationTest {
 
     private final TimeValue ACCEPTABLE_RELOCATION_TIME = new TimeValue(10, TimeUnit.SECONDS);

--- a/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -78,7 +78,6 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 2, numClientNodes = 2)
-@UseJdbc
 public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest {
 
     private Setup setup = new Setup(sqlExecutor);

--- a/sql/src/test/java/io/crate/integrationtests/QueryThenFetchIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/QueryThenFetchIntegrationTest.java
@@ -24,13 +24,11 @@ package io.crate.integrationtests;
 import io.crate.action.sql.SQLActionException;
 import io.crate.operation.Paging;
 import io.crate.testing.TestingHelpers;
-import io.crate.testing.UseJdbc;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
-@UseJdbc
 public class QueryThenFetchIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/RegexpIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/RegexpIntegrationTest.java
@@ -22,12 +22,10 @@
 package io.crate.integrationtests;
 
 import io.crate.action.sql.SQLActionException;
-import io.crate.testing.UseJdbc;
 import org.junit.Test;
 
 import static org.hamcrest.core.Is.is;
 
-@UseJdbc
 public class RegexpIntegrationTest extends SQLTransportIntegrationTest {
 
     private Setup setup = new Setup(sqlExecutor);

--- a/sql/src/test/java/io/crate/integrationtests/RemoteCollectorIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/RemoteCollectorIntegrationTest.java
@@ -24,7 +24,6 @@ package io.crate.integrationtests;
 
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import io.crate.testing.TestingHelpers;
-import io.crate.testing.UseJdbc;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.allocation.command.MoveAllocationCommand;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -36,7 +35,6 @@ import org.junit.Test;
 import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 2)
-@UseJdbc
 public class RemoteCollectorIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/RenameTableIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/RenameTableIntegrationTest.java
@@ -23,10 +23,12 @@
 package io.crate.integrationtests;
 
 import io.crate.testing.TestingHelpers;
+import io.crate.testing.UseJdbc;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
 
+@UseJdbc(0) // rename table has no rowcount
 public class RenameTableIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/RepositoryIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/RepositoryIntegrationTest.java
@@ -34,7 +34,6 @@ import java.util.HashMap;
 
 import static org.hamcrest.Matchers.is;
 
-@UseJdbc
 public class RepositoryIntegrationTest extends SQLTransportIntegrationTest {
 
     @ClassRule

--- a/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
@@ -59,6 +59,7 @@ import io.crate.testing.SQLBulkResponse;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.SQLTransportExecutor;
 import io.crate.testing.TestingBatchConsumer;
+import io.crate.testing.UseJdbc;
 import io.crate.types.DataType;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
@@ -106,6 +107,7 @@ import static org.elasticsearch.http.HttpTransportSettings.SETTING_HTTP_COMPRESS
 import static org.hamcrest.Matchers.is;
 
 @Listeners({SystemPropsTestLoggingListener.class})
+@UseJdbc
 public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
 
     @Rule

--- a/sql/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SQLTypeMappingTest.java
@@ -24,7 +24,6 @@ package io.crate.integrationtests;
 import io.crate.action.sql.SQLActionException;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.TestingHelpers;
-import io.crate.testing.UseJdbc;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Test;
 
@@ -40,7 +39,6 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 
 @ESIntegTestCase.ClusterScope(minNumDataNodes = 2, transportClientRatio = 0)
-@UseJdbc
 public class SQLTypeMappingTest extends SQLTransportIntegrationTest {
 
     private void setUpSimple() throws IOException {

--- a/sql/src/test/java/io/crate/integrationtests/ShardStatsTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ShardStatsTest.java
@@ -22,7 +22,6 @@
 package io.crate.integrationtests;
 
 import io.crate.blob.v2.BlobAdminClient;
-import io.crate.testing.UseJdbc;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -31,9 +30,7 @@ import org.junit.Test;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 
-
 @ESIntegTestCase.ClusterScope(numDataNodes = 2)
-@UseJdbc
 public class ShardStatsTest extends SQLTransportIntegrationTest {
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/ShardingUpsertIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ShardingUpsertIntegrationTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.integrationtests;
 
+import io.crate.testing.UseJdbc;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Test;
@@ -39,6 +40,7 @@ public class ShardingUpsertIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    @UseJdbc(0) // copy has no rowcount
     public void testCopyFromWithLimitedBulkSize() throws Exception {
         execute("create table contributors (" +
             "id integer," +

--- a/sql/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -23,15 +23,12 @@ package io.crate.integrationtests;
 
 import io.crate.action.sql.SQLActionException;
 import io.crate.testing.TestingHelpers;
-import io.crate.testing.UseJdbc;
 import org.junit.Test;
 
 import java.util.Locale;
 
 import static org.hamcrest.core.Is.is;
 
-
-@UseJdbc
 public class ShowIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SnapshotRestoreIntegrationTest.java
@@ -25,6 +25,7 @@ package io.crate.integrationtests;
 import com.google.common.base.Joiner;
 import io.crate.action.sql.SQLActionException;
 import io.crate.testing.TestingHelpers;
+import io.crate.testing.UseJdbc;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.cluster.SnapshotsInProgress;
 import org.elasticsearch.common.settings.Settings;
@@ -44,6 +45,7 @@ import java.util.Locale;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
+@UseJdbc(0) // create/drop repository/snapshot has no rowcount
 public class SnapshotRestoreIntegrationTest extends SQLTransportIntegrationTest {
 
     private static final String REPOSITORY_NAME = "my_repo";

--- a/sql/src/test/java/io/crate/integrationtests/SqlAlchemyIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SqlAlchemyIntegrationTest.java
@@ -21,10 +21,8 @@
 
 package io.crate.integrationtests;
 
-import io.crate.testing.UseJdbc;
 import org.junit.Test;
 
-@UseJdbc
 public class SqlAlchemyIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/StaticInformationSchemaQueryTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/StaticInformationSchemaQueryTest.java
@@ -22,12 +22,9 @@
 package io.crate.integrationtests;
 
 import io.crate.action.sql.SQLActionException;
-import io.crate.testing.UseJdbc;
 import org.junit.Before;
 import org.junit.Test;
 
-
-@UseJdbc
 public class StaticInformationSchemaQueryTest extends SQLTransportIntegrationTest {
 
     @Before

--- a/sql/src/test/java/io/crate/integrationtests/SubSelectGroupByIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SubSelectGroupByIntegrationTest.java
@@ -22,14 +22,12 @@
 
 package io.crate.integrationtests;
 
-import io.crate.testing.UseJdbc;
 import org.junit.Before;
 import org.junit.Test;
 
 import static io.crate.testing.TestingHelpers.printedTable;
 import static org.hamcrest.Matchers.is;
 
-@UseJdbc
 public class SubSelectGroupByIntegrationTest extends SQLTransportIntegrationTest {
 
     @Before

--- a/sql/src/test/java/io/crate/integrationtests/SysCheckerIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysCheckerIntegrationTest.java
@@ -24,7 +24,6 @@ package io.crate.integrationtests;
 import io.crate.operation.reference.sys.check.SysCheck.Severity;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.TestingHelpers;
-import io.crate.testing.UseJdbc;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Test;
@@ -35,7 +34,6 @@ import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope(
     numDataNodes = 0, numClientNodes = 0, supportsDedicatedMasters = false, autoMinMasterNodes = false)
-@UseJdbc
 public class SysCheckerIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/SysClusterSettingsTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysClusterSettingsTest.java
@@ -27,7 +27,6 @@ import io.crate.operation.collect.stats.JobsLogService;
 import io.crate.operation.projectors.ShardingUpsertExecutor;
 import io.crate.settings.CrateSetting;
 import io.crate.settings.SharedSettings;
-import io.crate.testing.UseJdbc;
 import io.crate.udc.service.UDCService;
 import org.apache.lucene.store.StoreRateLimiting;
 import org.elasticsearch.common.settings.Setting;
@@ -45,7 +44,6 @@ import java.util.Map;
 import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope
-@UseJdbc
 public class SysClusterSettingsTest extends SQLTransportIntegrationTest {
 
     @Override

--- a/sql/src/test/java/io/crate/integrationtests/SysClusterTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysClusterTest.java
@@ -22,7 +22,6 @@
 package io.crate.integrationtests;
 
 import io.crate.action.sql.SQLActionException;
-import io.crate.testing.UseJdbc;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -31,7 +30,6 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.is;
 
-@UseJdbc
 public class SysClusterTest extends SQLTransportIntegrationTest {
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/SysNodeCheckerIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysNodeCheckerIntegrationTest.java
@@ -24,7 +24,6 @@ package io.crate.integrationtests;
 
 import io.crate.testing.SQLResponse;
 import io.crate.testing.TestingHelpers;
-import io.crate.testing.UseJdbc;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
@@ -44,7 +43,6 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 2, numClientNodes = 0, supportsDedicatedMasters = false)
-@UseJdbc
 public class SysNodeCheckerIntegrationTest extends SQLTransportIntegrationTest {
 
     private static List<String> dirs = new ArrayList<>();

--- a/sql/src/test/java/io/crate/integrationtests/SysOperationsTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysOperationsTest.java
@@ -22,7 +22,6 @@
 package io.crate.integrationtests;
 
 import io.crate.testing.SQLResponse;
-import io.crate.testing.UseJdbc;
 import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
@@ -35,9 +34,7 @@ import java.util.List;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 
-@UseJdbc
 public class SysOperationsTest extends SQLTransportIntegrationTest {
-
 
     @Before
     public void enableStats() throws Exception {

--- a/sql/src/test/java/io/crate/integrationtests/SysShardMinLuceneVersionTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysShardMinLuceneVersionTest.java
@@ -23,7 +23,6 @@
 package io.crate.integrationtests;
 
 import io.crate.testing.TestingHelpers;
-import io.crate.testing.UseJdbc;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.After;
@@ -35,7 +34,6 @@ import java.nio.file.Path;
 import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 0, numClientNodes = 0)
-@UseJdbc
 public class SysShardMinLuceneVersionTest extends SQLTransportIntegrationTest {
 
     private void startUpNodeWithDataDir(String dataPath) throws IOException {

--- a/sql/src/test/java/io/crate/integrationtests/SysShardsTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysShardsTest.java
@@ -25,7 +25,6 @@ import io.crate.action.sql.SQLActionException;
 import io.crate.metadata.PartitionName;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.TestingHelpers;
-import io.crate.testing.UseJdbc;
 import org.apache.lucene.util.Version;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
@@ -51,7 +50,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
 @ESIntegTestCase.ClusterScope(numClientNodes = 0, numDataNodes = 2, supportsDedicatedMasters = false)
-@UseJdbc
 public class SysShardsTest extends SQLTransportIntegrationTest {
 
     @Before

--- a/sql/src/test/java/io/crate/integrationtests/TableAliasIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TableAliasIntegrationTest.java
@@ -22,7 +22,6 @@
 package io.crate.integrationtests;
 
 import io.crate.action.sql.SQLActionException;
-import io.crate.testing.UseJdbc;
 import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesResponse;
 import org.elasticsearch.cluster.metadata.AliasMetaData;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
@@ -34,7 +33,6 @@ import java.util.Locale;
 import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 1, numClientNodes = 0)
-@UseJdbc
 public class TableAliasIntegrationTest extends SQLTransportIntegrationTest {
 
     private String tableAliasSetup() throws Exception {

--- a/sql/src/test/java/io/crate/integrationtests/TableBlocksIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TableBlocksIntegrationTest.java
@@ -22,7 +22,6 @@
 package io.crate.integrationtests;
 
 import io.crate.action.sql.SQLActionException;
-import io.crate.testing.UseJdbc;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.hamcrest.core.Is;
@@ -32,7 +31,6 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 1)
-@UseJdbc
 public class TableBlocksIntegrationTest extends SQLTransportIntegrationTest {
 
     @ClassRule

--- a/sql/src/test/java/io/crate/integrationtests/TableCompatibilitySysChecksTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TableCompatibilitySysChecksTest.java
@@ -24,7 +24,6 @@ package io.crate.integrationtests;
 
 import io.crate.operation.reference.sys.check.SysCheck;
 import io.crate.operation.reference.sys.check.cluster.TablesNeedUpgradeSysCheck;
-import io.crate.testing.UseJdbc;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.After;
@@ -37,7 +36,6 @@ import static io.crate.operation.reference.sys.check.AbstractSysCheck.LINK_PATTE
 import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 0, numClientNodes = 0)
-@UseJdbc
 public class TableCompatibilitySysChecksTest extends SQLTransportIntegrationTest {
 
     private void startUpNodeWithDataDir(String dataPath) throws IOException {

--- a/sql/src/test/java/io/crate/integrationtests/TableSettingsTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TableSettingsTest.java
@@ -22,14 +22,12 @@
 package io.crate.integrationtests;
 
 import io.crate.action.sql.SQLActionException;
-import io.crate.testing.UseJdbc;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Locale;
 import java.util.Map;
 
-@UseJdbc
 public class TableSettingsTest extends SQLTransportIntegrationTest {
 
     @Before

--- a/sql/src/test/java/io/crate/integrationtests/ThreadPoolsExhaustedIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ThreadPoolsExhaustedIntegrationTest.java
@@ -24,7 +24,6 @@ package io.crate.integrationtests;
 import io.crate.testing.SQLBulkResponse;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.SQLTransportExecutor;
-import io.crate.testing.UseJdbc;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -40,7 +39,6 @@ import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, maxNumDataNodes = 2)
-@UseJdbc
 public class ThreadPoolsExhaustedIntegrationTest extends SQLTransportIntegrationTest {
 
     @Override

--- a/sql/src/test/java/io/crate/integrationtests/TransportSQLActionClassLifecycleTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TransportSQLActionClassLifecycleTest.java
@@ -65,7 +65,6 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(numClientNodes = 0, numDataNodes = 2, supportsDedicatedMasters = false)
-@UseJdbc
 public class TransportSQLActionClassLifecycleTest extends SQLTransportIntegrationTest {
 
     @Rule

--- a/sql/src/test/java/io/crate/integrationtests/TransportSQLActionSingleNodeTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TransportSQLActionSingleNodeTest.java
@@ -27,7 +27,6 @@ import io.crate.action.sql.SQLActionException;
 import io.crate.testing.SQLBulkResponse;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.TestingHelpers;
-import io.crate.testing.UseJdbc;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.After;
@@ -41,7 +40,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 1, numClientNodes = 0, supportsDedicatedMasters = false)
-@UseJdbc
 public class TransportSQLActionSingleNodeTest extends SQLTransportIntegrationTest {
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -61,7 +61,6 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(minNumDataNodes = 2)
-@UseJdbc
 public class TransportSQLActionTest extends SQLTransportIntegrationTest {
 
     private Setup setup = new Setup(sqlExecutor);

--- a/sql/src/test/java/io/crate/integrationtests/UnassignedShardsTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/UnassignedShardsTest.java
@@ -22,14 +22,12 @@
 package io.crate.integrationtests;
 
 import io.crate.testing.TestingHelpers;
-import io.crate.testing.UseJdbc;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 1)
-@UseJdbc
 public class UnassignedShardsTest extends SQLTransportIntegrationTest {
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/UpdateIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/UpdateIntegrationTest.java
@@ -25,7 +25,6 @@ import io.crate.action.sql.SQLActionException;
 import io.crate.analyze.UpdateAnalyzer;
 import io.crate.testing.SQLBulkResponse;
 import io.crate.testing.TestingHelpers;
-import io.crate.testing.UseJdbc;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.junit.Test;
 
@@ -40,7 +39,6 @@ import static io.crate.testing.TestingHelpers.mapToSortedString;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNot.not;
 
-@UseJdbc
 public class UpdateIntegrationTest extends SQLTransportIntegrationTest {
 
     private Setup setup = new Setup(sqlExecutor);

--- a/sql/src/test/java/io/crate/integrationtests/UserDefinedFunctionsIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/UserDefinedFunctionsIntegrationTest.java
@@ -35,6 +35,7 @@ import io.crate.metadata.Schemas;
 import io.crate.operation.udf.UDFLanguage;
 import io.crate.operation.udf.UserDefinedFunctionMetaData;
 import io.crate.operation.udf.UserDefinedFunctionService;
+import io.crate.testing.UseJdbc;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.apache.lucene.util.BytesRef;
@@ -56,6 +57,7 @@ import java.util.stream.Collectors;
 import static org.hamcrest.CoreMatchers.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 2, numClientNodes = 0, randomDynamicTemplates = false)
+@UseJdbc(0) // create/drop function has no rowcount
 public class UserDefinedFunctionsIntegrationTest extends SQLTransportIntegrationTest {
 
     public static class DummyFunction<InputType> extends Scalar<BytesRef, InputType>  {

--- a/sql/src/test/java/io/crate/integrationtests/VersionHandlingIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/VersionHandlingIntegrationTest.java
@@ -23,7 +23,6 @@ package io.crate.integrationtests;
 
 import io.crate.action.sql.SQLActionException;
 import io.crate.analyze.UpdateAnalyzer;
-import io.crate.testing.UseJdbc;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -31,7 +30,6 @@ import java.io.IOException;
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.core.Is.is;
 
-@UseJdbc
 public class VersionHandlingIntegrationTest extends SQLTransportIntegrationTest {
 
     private Setup setup = new Setup(sqlExecutor);

--- a/sql/src/test/java/io/crate/integrationtests/WherePKIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/WherePKIntegrationTest.java
@@ -22,7 +22,6 @@
 package io.crate.integrationtests;
 
 import io.crate.testing.TestingHelpers;
-import io.crate.testing.UseJdbc;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -31,7 +30,6 @@ import java.util.Arrays;
 
 import static org.hamcrest.core.Is.is;
 
-@UseJdbc
 public class WherePKIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test


### PR DESCRIPTION
Apply to superclass `SQLTransportIntegrationTest` of integration tests
and override where necessary.