### PR TITLE
fix up headings and add tocs

### DIFF
--- a/blackbox/docs/administration/auth_methods.txt
+++ b/blackbox/docs/administration/auth_methods.txt
@@ -17,6 +17,11 @@ There are multiple ways to authenticate against CrateDB.
    failed authentication. If you're receiving an error trying to authenticate,
    first make sure that the user exists.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 .. _auth_trust:
 
 Trust Method

--- a/blackbox/docs/administration/hba.txt
+++ b/blackbox/docs/administration/hba.txt
@@ -22,6 +22,11 @@ See: :ref:`applying-cluster-settings`.
    Host Based Authentication is an
    :ref:`enterprise feature <enterprise_features>`.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 Authentication Against CrateDB
 ==============================
 

--- a/blackbox/docs/administration/ingestion/mqtt.txt
+++ b/blackbox/docs/administration/ingestion/mqtt.txt
@@ -17,6 +17,11 @@ data ingestion.
 
    :ref:`ingestion`
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 .. _ingest_mqtt_config:
 
 Configuration
@@ -84,15 +89,15 @@ The ingestion of data is controlled with :ref:`administration-ingestion-rules`.
 
 Without any defined valid rule, no data will be ingested at all and messages
 will not be acknowledged. The ``PUBLISH`` messages will receive the
-corresponding ``PUBACK`` reply only after the message is stored in all matching 
-ingest rules target tables (as there can be multiple ingestion rules configured 
-for this source). If at least one matching ingestion rule fails to store the 
-incoming message, the client will not receive any reply and will have to resend 
-the request message. 
-Ingest rules execution failures will usually be temporary (eg. a mismatch 
-between a rule target table schema and ingestion source payload structure) and 
-the administrator will have the opportunity to fix the rule execution between 
-message retransmissions (eg. alter the target table schema). 
+corresponding ``PUBACK`` reply only after the message is stored in all matching
+ingest rules target tables (as there can be multiple ingestion rules configured
+for this source). If at least one matching ingestion rule fails to store the
+incoming message, the client will not receive any reply and will have to resend
+the request message.
+Ingest rules execution failures will usually be temporary (eg. a mismatch
+between a rule target table schema and ingestion source payload structure) and
+the administrator will have the opportunity to fix the rule execution between
+message retransmissions (eg. alter the target table schema).
 
 The ``source_ident`` of this implementation is: ``mqtt``
 

--- a/blackbox/docs/administration/ssl.txt
+++ b/blackbox/docs/administration/ssl.txt
@@ -4,10 +4,6 @@
 Secured Communications (SSL/TLS)
 ================================
 
-.. NOTE::
-
-   *Secured Communications* is an Enterprise Edition feature.
-
 Secured communication allows you to encrypt traffic between the CrateDB node
 and a client. This applies to connections using HTTP (i.e. Admin UI, Crash, Rest)
 as well as connections using the PostgreSQL Wire Protocol (i.e. JDBC, psql).
@@ -17,6 +13,15 @@ Note that once SSL is enabled for HTTP connections, only connections using
 HTTPS are allowed. This is in contrast to the PostgreSQL Wire Protocol which
 still allows non-encrypted connections when SSL is enabled. If you want to
 enforce SSL usage, please have a look at :ref:`administration_hba`.
+
+.. NOTE::
+
+   *Secured Communications* is an Enterprise Edition feature.
+
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
 
 SSL/TLS Configuration
 =====================

--- a/blackbox/docs/blob.txt
+++ b/blackbox/docs/blob.txt
@@ -9,6 +9,11 @@ CrateDB includes support to store `binary large objects`_. By utilizing
 CrateDB's cluster features the files can be replicated and sharded just like
 regular data.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 Creating a Table for Blobs
 ==========================
 

--- a/blackbox/docs/cli.txt
+++ b/blackbox/docs/cli.txt
@@ -5,6 +5,14 @@
 Command Line Interface
 ======================
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
+The Basics
+==========
+
 After downloading and extracting the tarball (see :ref:`install_targz`) you
 will be able to invoke the CrateDB command in the ``bin`` directory. The
 excutable is named ``crate``.

--- a/blackbox/docs/configuration/cluster.txt
+++ b/blackbox/docs/configuration/cluster.txt
@@ -12,6 +12,11 @@ cluster settings can be changed at runtime using the
 :ref:`SET/RESET<administration-set-reset>` statement. This is documented at
 :each setting.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 .. _applying-cluster-settings:
 
 Non-Runtime Cluster Wide Settings

--- a/blackbox/docs/configuration/enterprise.txt
+++ b/blackbox/docs/configuration/enterprise.txt
@@ -19,6 +19,11 @@ Enterprise Features
 .. _request an Enterprise Edition license: https://crate.io/enterprise-edition/
 .. _Enterprise Subscription Agreement: https://crate.io/subscription_agreement/
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 .. _conf_enterprise_license:
 
 Enterprise License

--- a/blackbox/docs/configuration/environment.txt
+++ b/blackbox/docs/configuration/environment.txt
@@ -6,10 +6,15 @@
 Environment Variables
 =====================
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 .. _env-crate-home:
 
 ``CRATE_HOME``
---------------
+==============
 
 Specifies the home directory of the installation, it is used to find default
 file paths like e.g. ``config/crate.yml`` or the default data directory
@@ -22,7 +27,7 @@ containing the ``bin/crate`` executable.
              configured relative paths will use this directory as a parent.
 
 ``CRATE_JAVA_OPTS``
--------------------
+===================
 
 This variable allows you to set `Java options`_ for CrateDB, such as as the
 thread stack size.
@@ -37,7 +42,7 @@ exceptions::
 .. _crate-heap-size:
 
 ``CRATE_HEAP_SIZE``
--------------------
+===================
 
 This variable specifies the amount of memory that can be used by the JVM.
 
@@ -54,7 +59,7 @@ So it's important to choose a value high enough for the intended use-case. But
 there are two limitations:
 
 Use max. 50% of available RAM
-.............................
+-----------------------------
 
 Be aware that there is also another user of memory besides CrateDB's HEAP: our
 underlying storage engine `Lucene`_. It leverages the underlying OS for caching
@@ -74,7 +79,7 @@ performance impacts.
 .. _Lucene: https://lucene.apache.org/
 
 Never use more than 30.5 Gigabyte
-.................................
+---------------------------------
 
 In order to save on precious memory on x64 systems the Hotspot Java Virtual
 Machine uses a technique called `Compressed Ordinary object pointers (oops)
@@ -102,7 +107,7 @@ application.
 .. _`Compressed Oops`: https://wiki.openjdk.java.net/display/HotSpot/CompressedOops
 
 Running CrateDB on machines with huge RAM
-.........................................
+-----------------------------------------
 
 If hardware with much more RAM is available, it is suggested to run more than
 one CrateDB instance on that machine with each one having a heap size of around

--- a/blackbox/docs/configuration/logging.txt
+++ b/blackbox/docs/configuration/logging.txt
@@ -6,6 +6,14 @@
 Logging
 =======
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
+Introduction
+============
+
 CrateDB comes, out of the box, with Log4j_ 1.2.x. It tries to simplify log4j
 configuration by using YAML to configure it. The logging configuration file is
 at ``config/log4j2.properties``.
@@ -46,8 +54,8 @@ You get the point.
 
 .. _PropertyConfigurator: https://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/PropertyConfigurator.html
 
-Logger Settings
----------------
+Settings
+========
 
 It's possible to set the log level of loggers at runtime. This is particularly
 useful when debugging problems and there is a need to increase the log level

--- a/blackbox/docs/configuration/node.txt
+++ b/blackbox/docs/configuration/node.txt
@@ -6,6 +6,14 @@
 Node Specific Settings
 ======================
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
+Basics
+======
+
 .. _cluster.name:
 
 **cluster.name**
@@ -32,7 +40,7 @@ Node Specific Settings
   the same configured data path defined via `path.data`_.
 
 Node Types
-----------
+==========
 
 CrateDB supports different kinds of nodes. The following settings can be used
 to differentiate nodes upon startup:
@@ -64,7 +72,7 @@ to differentiate nodes upon startup:
   *Used primarily for testing purposes.*
 
 Examples
-........
+--------
 
 A node by default is eligible as *master* and contains *data*.
 
@@ -98,7 +106,7 @@ Nodes that do not contain *data* and are not eligible as *master* are called
      client: true
 
 Read-only node
---------------
+==============
 
 **node.sql.read_only**
   | *Default:* ``false``
@@ -110,7 +118,7 @@ Read-only node
 .. _conf_hosts:
 
 Hosts
------
+=====
 
 .. _network.host:
 
@@ -153,7 +161,7 @@ Hosts
 .. _conf_ports:
 
 Ports
------
+=====
 
 .. _http.port:
 
@@ -213,7 +221,7 @@ Ports
 .. _conf-node-attributes:
 
 Node Attributes
----------------
+===============
 
 It is possible to apply generic attributes to a node, with configuration
 settings like ``node.key: value``. These attributes can be used for customized
@@ -275,7 +283,7 @@ Paths
   repository type ``fs``.
 
 Plugins
--------
+=======
 
 **plugin.mandatory**
   | *Runtime:* ``no``
@@ -285,7 +293,7 @@ Plugins
   If any plugin listed here is missing, the CrateDB node will fail to start.
 
 Memory
-------
+======
 
 **bootstrap.memory_lock**
   | *Runtime:* ``no``
@@ -297,7 +305,7 @@ Memory
   are locked into RAM.
 
 Garbage Collection
-------------------
+==================
 
 CrateDB logs if JVM garbage collection on different memory pools takes too
 long. The following settings can be used to adjust these timeouts:
@@ -347,7 +355,7 @@ long. The following settings can be used to adjust these timeouts:
 .. _es_api_setting:
 
 Elasticsearch HTTP REST API
----------------------------
+===========================
 
 **es.api.enabled**
   | *Default:* ``false``
@@ -361,7 +369,7 @@ Elasticsearch HTTP REST API
     in inconsistent data. You have been warned!
 
 Cross-Origin Resource Sharing (CORS)
-------------------------------------
+====================================
 
 Many browsers support the `same-origin policy`_ which requires web applications
 to explicitly allow requests across origins. The `cross-origin resource
@@ -411,7 +419,7 @@ sharing`_ settings in CrateDB allow for configuring these.
 .. _`cross-origin resource sharing`: https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS
 
 Blobs
------
+=====
 
 **blobs.path**
   | *Runtime:* ``no``
@@ -425,7 +433,7 @@ Blobs
 .. _ref-configuration-repositories:
 
 Repositories
-------------
+============
 
 Repositories are used to :ref:`backup <snapshot-restore>` a CrateDB cluster.
 
@@ -463,7 +471,7 @@ See also the :ref:`path.repo <conf-path-repo>` Setting.
 .. _`JarURLConnection documentation`: http://docs.oracle.com/javase/8/docs/api/java/net/JarURLConnection.html
 
 Queries
--------
+=======
 
 .. _conf-indices-query-bool.max_clause_count:
 

--- a/blackbox/docs/discovery.txt
+++ b/blackbox/docs/discovery.txt
@@ -4,6 +4,11 @@
 Cloud Discovery
 ===============
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 Amazon EC2 Discovery
 ====================
 

--- a/blackbox/docs/installation.txt
+++ b/blackbox/docs/installation.txt
@@ -14,6 +14,11 @@ This page documents the most basic sort of CrateDB installation.
 
    To learn more, check out the `install section`_ of the CrateDB Guide.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 Prerequisites
 =============
 

--- a/blackbox/docs/monitoring/index.txt
+++ b/blackbox/docs/monitoring/index.txt
@@ -11,11 +11,10 @@ The JMX monitoring plugin exposes query metrics via the `JMX`_ API.
    The JMX monitoring plugin is an :ref:`enterprise feature
    <enterprise_features>`.
 
-To use this plugin, you must:
+.. rubric:: Table of Contents
 
-- `Enable the Enterprise License`_
-- `Enable Collecting Stats`_
-- `Enable the JMX API`_
+.. contents::
+   :local:
 
 Enable the Enterprise License
 -----------------------------

--- a/blackbox/docs/plugins.txt
+++ b/blackbox/docs/plugins.txt
@@ -16,6 +16,11 @@ A plugin must at least:
 
 See our `CrateDB example plugin`_ for details about that.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 .. _plugins_crate_dep:
 
 Plugin CrateDB Dependency

--- a/blackbox/docs/protocols/crate-postgres-sql.txt
+++ b/blackbox/docs/protocols/crate-postgres-sql.txt
@@ -4,6 +4,14 @@
 CrateDB SQL and PostgreSQL
 ==========================
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
+Introduction
+============
+
 CrateDB uses the PostgreSQL Wire Protocol (since CrateDB 0.56), which makes it
 easy to use many PostgreSQL compatible tools and libraries directly with
 CrateDB. However, many of these tools assume that they are talking to

--- a/blackbox/docs/protocols/http.txt
+++ b/blackbox/docs/protocols/http.txt
@@ -6,6 +6,14 @@
 SQL HTTP Endpoint
 =================
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
+Introduction
+============
+
 CrateDB provides a HTTP Endpoint that can be used to submit SQL queries. The
 endpoint is accessible under ``<servername:port>/_sql``.
 

--- a/blackbox/docs/protocols/postgres.txt
+++ b/blackbox/docs/protocols/postgres.txt
@@ -4,6 +4,14 @@
 Postgres Wire Protocol
 ======================
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
+Introduction
+============
+
 CrateDB contains experimental support for the `PostgreSQL wire protocol v3`_.
 
 If a node is started with postgres support enabled it will bind to port

--- a/blackbox/docs/sql/administration/ingestion_rules.txt
+++ b/blackbox/docs/sql/administration/ingestion_rules.txt
@@ -18,15 +18,14 @@ Ingestion Rules
 Ingestion rules define where and how the incoming data of a specific ingestion
 source should be routed and stored.
 
-This document will show you how to:
-
-- Create ingestion rules
-- List existing ingestion rules
-- Delete ingestion rules
-
 .. SEEALSO::
 
    :ref:`ingestion`
+
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
 
 Creating Ingestion Rules
 ========================

--- a/blackbox/docs/sql/administration/privileges.txt
+++ b/blackbox/docs/sql/administration/privileges.txt
@@ -5,6 +5,14 @@
 Privileges
 ==========
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
+Introduction
+============
+
 The superuser uses ``GRANT``, ``DENY`` and ``REVOKE`` statements to control
 access to the resource. The privileges are either applied on the whole cluster
 or on instances of objects such as schema, or table.

--- a/blackbox/docs/sql/administration/user_defined_functions.txt
+++ b/blackbox/docs/sql/administration/user_defined_functions.txt
@@ -15,6 +15,11 @@ User Defined Functions
    by default. You can enable the :ref:`conf_lang_js_enabled` via the
    configuration file.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 ``CREATE OR REPLACE``
 =====================
 

--- a/blackbox/docs/sql/administration/user_management.txt
+++ b/blackbox/docs/sql/administration/user_management.txt
@@ -1,7 +1,29 @@
 .. _administration_user_management:
 
+===============
 User Management
 ===============
+
+.. NOTE::
+
+   User management is an
+   :ref:`enterprise feature <enterprise_features>`.
+
+.. hide:
+
+    This document is not included in the doctest suite and therefore the
+    following statements are not executed.
+
+    The reason for that is, that the HTTP protocol does not support user
+    authentication yet.
+
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
+Introduction
+============
 
 A CrateDB cluster contains a set of database users. A database user is a
 principle at cluster level.
@@ -17,21 +39,8 @@ user is called ``crate``. It is not possible to create any other superusers
 
 Users cannot be backed up or restored.
 
-.. NOTE::
-
-   User management is an
-   :ref:`enterprise feature <enterprise_features>`.
-
-.. hide:
-
-    This document is not included in the doctest suite and therefore the
-    following statements are not executed.
-
-    The reason for that is, that the HTTP protocol does not support user
-    authentication yet.
-
 ``CREATE USER``
----------------
+===============
 
 To create a new user for the CrateDB database cluster use the
 :doc:`/sql/reference/create_user` SQL statement::
@@ -58,7 +67,7 @@ statement returns an error::
     SQLActionException[UserAlreadyExistsException: User 'Custom User' already exists]
 
 ``DROP USER``
--------------
+=============
 
 .. hide:
 
@@ -80,7 +89,7 @@ statement returns an error::
 It is not possible to drop the built-in superuser ``crate``.
 
 List Users
-----------
+==========
 
 CrateDB exposes database users via the read-only ``sys.users`` system table.
 The ``sys.users`` table shows all users in the cluster which can be used for

--- a/blackbox/docs/sql/aggregation.txt
+++ b/blackbox/docs/sql/aggregation.txt
@@ -5,6 +5,14 @@
 Aggregation
 ===========
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
+Introduction
+============
+
 An *aggregation function* operates on multiple values of the specified column
 of your `SELECT`. For example, ``SELECT avg(temperature)`` will return the
 average value of the ``temperature`` column across all rows being considered.

--- a/blackbox/docs/sql/analyzer.txt
+++ b/blackbox/docs/sql/analyzer.txt
@@ -4,6 +4,11 @@
 Builtin Tools for Fulltext Search in Crate
 ==========================================
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 .. _analyzer-overview:
 
 Overview
@@ -76,8 +81,7 @@ into the following tokens
 
     quick, brown, fox, jumps, lazy, dog
 
-Parameters
-..........
+.. rubric:: Parameters
 
 stopwords
     A list of stopwords to initialize the :ref:`stop-tokenfilter` filter with.
@@ -124,8 +128,7 @@ Uses a :ref:`whitespace-tokenizer` tokenizer
 Uses a :ref:`lowercase-tokenizer` Tokenizer, with :ref:`stop-tokenfilter` Token
 Filter.
 
-Parameters
-..........
+.. rubric:: Parameters
 
 stopwords
     A list of stopwords to initialize the :ref:'stop-tokenfilter` filter with.
@@ -154,8 +157,7 @@ Creates one single token from the field-contents.
 An analyzer of type pattern that can flexibly separate text into terms via a
 regular expression.
 
-Parameters
-..........
+.. rubric:: Parameters
 
 lowercase
     Should terms be lowercased or not. Defaults to true.
@@ -190,8 +192,7 @@ The following types are supported:
 ``lithuanian``, ``norwegian``, ``persian``, ``portuguese``, ``romanian``,
 ``russian``, ``sorani``, ``spanish``, ``swedish``, ``turkish``, ``thai``.
 
-Parameters
-..........
+.. rubric:: Parameters
 
 stopwords
     A list of stopwords to initialize the stop filter with. Defaults to the
@@ -220,8 +221,7 @@ Uses the :ref:`standard-tokenizer` Tokenizer, with :ref:`standard-tokenfilter`
 filter, :ref:`lowercase-tokenfilter` filter, :ref:`stop-tokenfilter` filter,
 and :ref:`snowball-tokenfilter` filter.
 
-Parameters
-..........
+.. rubric:: Parameters
 
 stopwords
     A list of stopwords to initialize the stop filter with. Defaults to the
@@ -245,8 +245,7 @@ removed. It uses the :ref:`standard-tokenizer` Tokenizer and the following
 filters: :ref:`lowercase-tokenfilter`, :ref:`asciifolding-tokenfilter`,
 :ref:`fingerprint-tokenfilter` and ref:`stop-tokenfilter`.
 
-Parameters
-..........
+.. rubric:: Parameters
 
 separator
     The character to use to concatenate the terms. Defaults to a space.
@@ -279,8 +278,7 @@ good tokenizer for most European language documents. The tokenizer implements
 the Unicode Text Segmentation algorithm, as specified in Unicode Standard Annex
 #29.
 
-Parameters
-..........
+.. rubric:: Parameters
 
 max_token_length
     The maximum token length. If a token is seen that exceeds this length then
@@ -299,8 +297,7 @@ company names, email addresses, and internet host names. However, these rules
 don't always work, and the tokenizer doesn't work well for most languages other
 than English.
 
-Parameters
-..........
+.. rubric:: Parameters
 
 max_token_length
     The maximum token length. If a token is seen that exceeds this length then
@@ -316,8 +313,7 @@ max_token_length
 This tokenizer is very similar to :ref:`ngram-tokenizer` but only keeps n-grams
 which start at the beginning of a token.
 
-Parameters
-..........
+.. rubric:: Parameters
 
 min_gram
     Minimum size in codepoints of a single n-gram. default: 1
@@ -340,8 +336,7 @@ token_chars
 
 Emits the entire input as a single token.
 
-Parameters
-..........
+.. rubric:: Parameters
 
 buffer_size
     The term buffer size. Defaults to ``256``.
@@ -373,8 +368,7 @@ converts them to lower case.
 
 ``type='ngram'``
 
-Parameters
-..........
+.. rubric:: Parameters
 
 min_gram
     Minimum size in codepoints of a single n-gram. default 1.
@@ -406,8 +400,7 @@ Divides text at whitespace.
 
 Separates text into terms via a regular expression.
 
-Parameters
-..........
+.. rubric:: Parameters
 
 pattern
     The regular expression pattern, defaults to \\W+.
@@ -446,8 +439,7 @@ Splits Thai text correctly, treats all other languages like the
 Exactly like the :ref:`standard-tokenizer`, but tokenizes emails and urls as
 single tokens.
 
-Parameters
-..........
+.. rubric:: Parameters
 
 max_token_length
     The maximum token length. If a token is seen that exceeds this length then
@@ -470,8 +462,7 @@ And produces tokens::
     /something/something
     /something/something/else
 
-Parameters
-..........
+.. rubric:: Parameters
 
 delimiter
     The character delimiter to use, defaults to /.
@@ -542,8 +533,7 @@ ASCII equivalents, if one exists.
 
 Removes words that are too long or too short for the stream.
 
-Parameters
-..........
+.. rubric:: Parameters
 
 min
     The minimum number. Defaults to 0.
@@ -560,8 +550,7 @@ max
 
 Normalizes token text to lower case.
 
-Parameters
-..........
+.. rubric:: Parameters
 
 language
     For options, see :ref:`language-analyzer` Analyzer.
@@ -573,8 +562,7 @@ language
 
 ``type='ngram'``
 
-Parameters
-..........
+.. rubric:: Parameters
 
 min_gram
     Defaults to 1.
@@ -589,8 +577,7 @@ max_gram
 
 ``type='edge_ngram'``
 
-Parameters
-..........
+.. rubric:: Parameters
 
 min_gram
     Defaults to 1.
@@ -628,8 +615,7 @@ Transforms the token stream as per the Porter stemming algorithm.
 Constructs shingles (token n-grams), combinations of tokens as a single token,
 from a token stream.
 
-Parameters
-..........
+.. rubric:: Parameters
 
 max_shingle_size
     The maximum shingle size. Defaults to 2.
@@ -659,8 +645,7 @@ token_separator
 
 Removes stop words from token streams.
 
-Parameters
-..........
+.. rubric:: Parameters
 
 stopwords
     A list of stop words to use. Defaults to english stop words.
@@ -687,8 +672,7 @@ remove_trailing
 Splits words into subwords and performs optional transformations on subword
 groups.
 
-Parameters
-..........
+.. rubric:: Parameters
 
 generate_word_parts
     If true causes parts of words to be generated: "PowerShot" ⇒ "Power"
@@ -746,8 +730,7 @@ type_table
 A filter that stems words (similar to :ref:`snowball-tokenfilter`, but with
 more options).
 
-Parameters
-..........
+.. rubric:: Parameters
 
 language/name
     arabic, armenian, basque, brazilian, bulgarian, catalan, czech, danish,
@@ -769,8 +752,7 @@ language/name
 Protects words from being modified by stemmers. Must be placed before any
 stemming filters.
 
-Parameters
-..........
+.. rubric:: Parameters
 
 keywords
     A list of words to use.
@@ -803,8 +785,7 @@ for this filter to work correctly.
 
 A filter that stems words using a Snowball-generated stemmer.
 
-Parameters
-..........
+.. rubric:: Parameters
 
 language
     Possible values: Armenian, Basque, Catalan, Danish, Dutch, English,
@@ -822,8 +803,7 @@ language
 Allows to easily handle synonyms during the analysis process. Synonyms are
 configured using a configuration file.
 
-Parameters
-..........
+.. rubric:: Parameters
 
 synonyms_path
     Path to synonyms configuration file
@@ -843,8 +823,7 @@ expand
 
 Decomposes compound words.
 
-Parameters
-..........
+.. rubric:: Parameters
 
 word_list
     A list of words to use.
@@ -883,8 +862,7 @@ Reverses each token.
 
 Removes elisions.
 
-Parameters
-..........
+.. rubric:: Parameters
 
 articles
     A set of stop words articles, for example ``['j', 'l']`` for content like
@@ -899,8 +877,7 @@ articles
 
 Truncates tokens to a specific length.
 
-Parameters
-..........
+.. rubric:: Parameters
 
 length
     Number of characters to truncate to. default 10
@@ -915,8 +892,7 @@ length
 Used to only index unique tokens during analysis. By default it is applied on
 all the token stream.
 
-Parameters
-..........
+.. rubric:: Parameters
 
 only_on_same_position
     If set to true, it will only remove duplicate tokens on the same position.
@@ -930,8 +906,7 @@ only_on_same_position
 
 Emits a token for every capture group in the regular expression
 
-Parameters
-..........
+.. rubric:: Parameters
 
 preserve_original
     If set to true (the default) then it would also emit the original token
@@ -945,8 +920,7 @@ preserve_original
 
 Handle string replacements based on a regular expression.
 
-Parameters
-..........
+.. rubric:: Parameters
 
 pattern
     Regular expression whose matches will be replaced.
@@ -973,8 +947,7 @@ Trims the whitespace surrounding a token.
 
 Limits the number of tokens that are indexed per document and field.
 
-Parameters
-..........
+.. rubric:: Parameters
 
 max_token_count
     The maximum number of tokens that should be indexed per document and field.
@@ -997,8 +970,7 @@ expected to have its own directory named after its associated locale
 (language). This dictionary directory is expected to hold both the \*.aff and
 \*.dic files (all of which will automatically be picked up).
 
-Parameters
-..........
+.. rubric:: Parameters
 
 ignore_case
     If true, dictionary matching will be case insensitive (defaults to false)
@@ -1034,8 +1006,7 @@ Generates bigrams for frequently occuring terms. Single terms are still
 indexed. It can be used as an alternative to the :ref:`stop-tokenfilter` Token
 filter when we don't want to completely ignore common terms.
 
-Parameters
-..........
+.. rubric:: Parameters
 
 common_words
     A list of common words to use.
@@ -1100,8 +1071,7 @@ Split tokens up by delimiter (default ``|``) into the real token being indexed
 and the payload stored additionally into the index. For example
 ``Trillian|65535`` will be indexed as ``Trillian`` with ``65535`` as payload.
 
-Parameter
-.........
+.. rubric:: Parameters
 
 encoding
     How the payload should be interpreted, possible values are ``float`` for
@@ -1124,8 +1094,7 @@ variations.
 All other tokens will be filtered. This filter works like an inverse
 `stop-tokenfilter`_ filter.
 
-Parameter
-.........
+.. rubric:: Parameters
 
 keep_words
     A list of words to keep and index as tokens.
@@ -1147,8 +1116,7 @@ keep_words_path
 Override any previous stemmer that recognizes keywords with a custom mapping,
 defined by ``rules`` or ``rules_path``. One of these settings has to be set.
 
-Parameter
-.........
+.. rubric:: Parameters
 
 rules
     A list of rules for overriding, in the form of ``[<source>=><replacement>]
@@ -1166,8 +1134,7 @@ rules_path
 
 Handle Chinese, Japanese and Korean (CJK) bigrams.
 
-Parameters
-..........
+.. rubric:: Parameters
 
 output_bigrams
     Boolean flag to enable a combined unigram+bigram approach.
@@ -1224,8 +1191,7 @@ Builtin Char Filter
 
 ``type='mapping'``
 
-Parameters
-..........
+.. rubric:: Parameters
 
 mappings
     A list of mappings as strings of the form ``[<source>=><replacement>] e.g.
@@ -1252,8 +1218,7 @@ Strips out HTML elements from an analyzed text.
 
 Manipulates the characters in a string before analysis with a regex.
 
-Parameters
-..........
+.. rubric:: Parameters
 
 pattern
     Regex whose matches will be replaced
@@ -1271,8 +1236,7 @@ replacement
 
 Keeps only the tokens with a token type contained in a predefined set.
 
-Parameter
-.........
+.. rubric:: Parameters
 
 types
     A list of token types to keep.
@@ -1288,8 +1252,7 @@ Hashes each token of the token stream and divides the resulting hashes into
 buckets, keeping the lowest-valued hashes per bucket. It then returns these
 hashes as tokens.
 
-Parameters
-..........
+.. rubric:: Parameters
 
 hash_count
     The number of hashes to hash the token stream with. Defaults to ``1``.
@@ -1317,8 +1280,7 @@ with_rotation
  providing a token that can be clustered on. It does this by sorting the
  tokens, deduplicating and then concatenating them back into a single token.
 
-Parameters
-..........
+.. rubric:: Parameters
 
 separator
     Separator which is used for concatenating the tokens. Defaults to a space.

--- a/blackbox/docs/sql/arithmetic.txt
+++ b/blackbox/docs/sql/arithmetic.txt
@@ -13,6 +13,11 @@ numeric data types or timestamps.
     The same restrictions that apply to scalar functions also apply to
     arithmetic operators. See :ref:`scalar`.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 Supported operators
 -------------------
 

--- a/blackbox/docs/sql/array_comparisons.txt
+++ b/blackbox/docs/sql/array_comparisons.txt
@@ -12,6 +12,11 @@ These :ref:`sql_operators` are supported for doing array comparisons.
 
 For additional examples of row comparisons, see :ref:`sql_subquery_expressions`.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 .. _sql_in_array_comparison:
 
 ``IN (value [, ...])``

--- a/blackbox/docs/sql/crate-standard-sql.txt
+++ b/blackbox/docs/sql/crate-standard-sql.txt
@@ -8,6 +8,11 @@ CrateDB aims to provide an SQL implementation that is familiar to anyone having
 used other databases providing a standards-compliant SQL language. However, it
 is worth being aware of some unique characteristics in CrateDB's SQL dialect.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 Data Types
 ==========
 

--- a/blackbox/docs/sql/data_types.txt
+++ b/blackbox/docs/sql/data_types.txt
@@ -14,6 +14,11 @@ records are queried.
 Data type names are reserved words and need to be escaped when used as column
 names.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 Classification
 ==============
 

--- a/blackbox/docs/sql/ddl/alter_table.txt
+++ b/blackbox/docs/sql/ddl/alter_table.txt
@@ -9,6 +9,11 @@
    ``ALTER COLUMN`` and ``DROP COLUMN`` actions are not currently supported.
    See :ref:`crate_standard_sql`.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 Updating Parameters
 ===================
 

--- a/blackbox/docs/sql/ddl/basics.txt
+++ b/blackbox/docs/sql/ddl/basics.txt
@@ -2,6 +2,14 @@
 Table Basics
 ============
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
+Introduction
+============
+
 To create a table use the ``CREATE TABLE`` command. You must at least specify a
 name for the table and names and types of the columns.
 

--- a/blackbox/docs/sql/ddl/indices_full_search.txt
+++ b/blackbox/docs/sql/ddl/indices_full_search.txt
@@ -12,6 +12,11 @@ separate tokens is done by an analyzer. In order to create fulltext search
 queries a :ref:`fulltext index with an analyzer <sql_ddl_index_fulltext>` must
 be defined for the related columns.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 .. _sql_ddl_index_definition:
 
 Index Definition

--- a/blackbox/docs/sql/ddl/sharding.txt
+++ b/blackbox/docs/sql/ddl/sharding.txt
@@ -4,6 +4,14 @@
 Sharding
 ========
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
+Introduction
+============
+
 Every table partition (see :ref:`partitioned_tables`) is split into a
 configured number of shards. Shards are then distributed across the cluster. As
 nodes are added to the cluster, CrateDB will move shards around to achieve

--- a/blackbox/docs/sql/dml.txt
+++ b/blackbox/docs/sql/dml.txt
@@ -4,6 +4,11 @@
 Data Manipulation
 =================
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 .. _inserting_data:
 
 Inserting Data

--- a/blackbox/docs/sql/fulltext.txt
+++ b/blackbox/docs/sql/fulltext.txt
@@ -10,6 +10,11 @@ In order to use fulltext search on one or more columns, a
 defined while creating the column: either with ``CREATE TABLE`` or ``ALTER
 TABLE ADD COLUMN``. For more information see :ref:`fulltext-indices`.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 .. _predicates_match:
 
 ``MATCH`` Predicate

--- a/blackbox/docs/sql/geo.txt
+++ b/blackbox/docs/sql/geo.txt
@@ -5,6 +5,14 @@
 Geo Search
 ==========
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
+Introduction
+============
+
 CrateDB can be used to store and query geographical information of many kinds
 using the :ref:`geo_point_data_type` and :ref:`geo_shape_data_type` types. With
 these it is possible to store geographical locations, ways, shapes, areas and

--- a/blackbox/docs/sql/information_schema.txt
+++ b/blackbox/docs/sql/information_schema.txt
@@ -5,29 +5,39 @@
 Information Schema
 ==================
 
-The Information Schema is a special schema that contains virtual tables which
+``information_schema`` is a special schema that contains virtual tables which
 are read-only and can be queried to get information about the state of the
 cluster.
 
-.. NOTE::
+.. rubric:: Table of Contents
 
-    When the user management is enabled, accessing the ``information_schema``
-    is open to all users and it does not require any privileges.
+.. contents::
+   :local:
 
-    However, being able to query ``information_schema`` tables will not allow the
-    user to retrieve all the rows in the table, as it can contain information
-    related to tables over which the connected user does not have any privileges.
-    The only rows that will be returned will be the ones the user is allowed to access.
+Access
+======
 
-    For example, if the user ``john`` has any privilege on the ``doc.books`` table
-    but no privilege at all on ``doc.locations``, when ``john`` issues a
-    ``SELECT * FROM information_schema.tables`` statement, the tables information
-    related to the ``doc.locations`` table will not be returned.
+When the user management is enabled, accessing the ``information_schema`` is
+open to all users and it does not require any privileges.
+
+However, being able to query ``information_schema`` tables will not allow the
+user to retrieve all the rows in the table, as it can contain information
+related to tables over which the connected user does not have any privileges.
+The only rows that will be returned will be the ones the user is allowed to
+access.
+
+For example, if the user ``john`` has any privilege on the ``doc.books`` table
+but no privilege at all on ``doc.locations``, when ``john`` issues a ``SELECT *
+FROM information_schema.tables`` statement, the tables information related to
+the ``doc.locations`` table will not be returned.
+
+Virtual Tables
+==============
 
 .. _information_schema_tables:
 
-Tables
-======
+``tables``
+----------
 
 The information schema contains a table called `tables`.
 
@@ -105,8 +115,7 @@ columns::
     +-------------------+--------------+----------------+--------...-+
     SELECT 5 rows in set (... sec)
 
-Tables Specification
---------------------
+.. rubric:: Schema
 
 +----------------------------------+------------------------------------------------------------------------------------+-------------+
 | Name                             | Description                                                                        | Data Type   |
@@ -144,9 +153,51 @@ Tables Specification
 | ``version``                      | A collection of version numbers relevent to the table                              | ``Object``  |
 +----------------------------------+------------------------------------------------------------------------------------+-------------+
 
+``settings``
+............
 
-Columns
-=======
+Table settings specify configuration parameters for tables. Some settings can
+be set during Cluster runtime and others are only applied on cluster restart.
+
+This list of table settings in :ref:`with_clause` shows detailed information
+of each parameter.
+
+Table parameters can be applied with ``CREATE TABLE`` on creation of a table.
+With ``ALTER TABLE`` they can be set on already existing tables.
+
+The following statement creates a new table and sets the refresh interval of
+shards to 500 ms and sets the shard allocation for primary shards only::
+
+    cr> create table parameterized_table (id int, content string)
+    ... with ("refresh_interval"=500, "routing.allocation.enable"='primaries');
+    CREATE OK, 1 row affected (... sec)
+
+The settings can be verified by querying ``information_schema.tables``::
+
+    cr> select settings['routing']['allocation']['enable'] as alloc_enable,
+    ...   settings['refresh_interval'] as refresh_interval
+    ... from information_schema.tables
+    ... where table_name='parameterized_table';
+    +--------------+------------------+
+    | alloc_enable | refresh_interval |
+    +--------------+------------------+
+    | primaries    |              500 |
+    +--------------+------------------+
+    SELECT 1 row in set (... sec)
+
+On existing tables this needs to be done with ``ALTER TABLE`` statement::
+
+    cr> alter table parameterized_table
+    ... set ("routing.allocation.enable"='none');
+    ALTER OK, -1 rows affected (... sec)
+
+.. hide:
+
+    cr> drop table parameterized_table;
+    DROP OK, 1 row affected (... sec)
+
+``columns``
+-----------
 
 This table can be queried to get a list of all available columns of all tables
 and their definition like data type and ordinal position inside the table::
@@ -232,9 +283,7 @@ infinite recursion of your mind, beware!)::
   order they were defined on table creation. Thus the ``ordinal_position``
   reflects the alphabetical position.
 
-
-Columns Specification
----------------------
+.. rubric:: Schema
 
 +-------------------------------+-----------------------------------------------+---------------+
 |            Name               |                Description                    |   Data Type   |
@@ -328,8 +377,8 @@ Columns Specification
 +-------------------------------+-----------------------------------------------+---------------+
 
 
-Table Constraints
-=================
+``table_constraints``
+---------------------
 
 This table can be queried to get a list of all defined table constraints, their
 type, name and which table they are defined in.
@@ -357,8 +406,8 @@ type, name and which table they are defined in.
 
 .. _is_table_partitions:
 
-Table Partitions
-================
+``table_partitions``
+--------------------
 
 This table can be queried to get information about all partitioned tables, Each
 partition of a table is represented as one row. The row contains the
@@ -421,51 +470,8 @@ instead of ``4``::
     +---------------------+--------------------+------------------+--------------------+
     SELECT 2 rows in set (... sec)
 
-Table Settings
-==============
-
-Table settings specify configuration parameters for tables. Some settings can
-be set during Cluster runtime and others are only applied on cluster restart.
-
-This list of table settings in :ref:`with_clause` shows detailed information
-of each parameter.
-
-Table parameters can be applied with ``CREATE TABLE`` on creation of a table.
-With ``ALTER TABLE`` they can be set on already existing tables.
-
-The following statement creates a new table and sets the refresh interval of
-shards to 500 ms and sets the shard allocation for primary shards only::
-
-    cr> create table parameterized_table (id int, content string)
-    ... with ("refresh_interval"=500, "routing.allocation.enable"='primaries');
-    CREATE OK, 1 row affected (... sec)
-
-The settings can be verified by querying ``information_schema.tables``::
-
-    cr> select settings['routing']['allocation']['enable'] as alloc_enable,
-    ...   settings['refresh_interval'] as refresh_interval
-    ... from information_schema.tables
-    ... where table_name='parameterized_table';
-    +--------------+------------------+
-    | alloc_enable | refresh_interval |
-    +--------------+------------------+
-    | primaries    |              500 |
-    +--------------+------------------+
-    SELECT 1 row in set (... sec)
-
-On existing tables this needs to be done with ``ALTER TABLE`` statement::
-
-    cr> alter table parameterized_table
-    ... set ("routing.allocation.enable"='none');
-    ALTER OK, -1 rows affected (... sec)
-
-.. hide:
-
-    cr> drop table parameterized_table;
-    DROP OK, 1 row affected (... sec)
-
-Routines
-========
+``routines``
+------------
 
 The routines table contains tokenizers, token-filters, char-filters, custom
 analyzers created by ``CREATE ANALYZER`` statements (see
@@ -525,8 +531,7 @@ Or get an overview of how many routines and routine types are available::
     +----------+--------------+
     SELECT 4 rows in set (... sec)
 
-Columns
--------
+.. rubric:: Schema
 
 +--------------------+-------------+
 | Name               | Data Type   |
@@ -574,8 +579,8 @@ Columns
     arguments. As the format might change in the future, it should be only used
     to compare it to other instances of ``specific_name``.
 
-Schemata
-========
+``schemata``
+------------
 
 The schemata table lists all existing schemas. These schemas are always
 available: ``blob``, ``doc``, ``information_schema`` and ``sys``::
@@ -594,8 +599,8 @@ available: ``blob``, ``doc``, ``information_schema`` and ``sys``::
 
 .. _sql_features:
 
-SQL Features
-============
+``sql_features``
+----------------
 
 The ``sql_features`` table outlines supported and unsupported SQL features of
 CrateDB based to the current SQL standard (see :ref:`sql_supported_features`)::
@@ -655,14 +660,13 @@ CrateDB based to the current SQL standard (see :ref:`sql_supported_features`)::
 
 .. _information_schema_ingest:
 
-Ingestion Rules
-===============
+``ingestion_rules``
+-------------------
 
 The ``ingestion_rules`` table contains rules created by
 :ref:`create-ingest-rule` statements.
 
-Columns
--------
+.. rubric:: Schema
 
 +--------------------+-------------+
 | Name               | Data Type   |

--- a/blackbox/docs/sql/joins.txt
+++ b/blackbox/docs/sql/joins.txt
@@ -4,6 +4,11 @@
 Joins
 =====
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 .. _cross-joins:
 
 Cross Joins

--- a/blackbox/docs/sql/occ.txt
+++ b/blackbox/docs/sql/occ.txt
@@ -5,6 +5,14 @@
 Optimistic Concurrency Control with CrateDB
 ===========================================
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
+Introduction
+============
+
 Even though CrateDB does not support transactions, `Optimistic Concurrency
 Control`_ can be achieved by using the internal system column :ref:`_version
 <sql_administration_system_column_version>`.

--- a/blackbox/docs/sql/optimize.txt
+++ b/blackbox/docs/sql/optimize.txt
@@ -5,6 +5,14 @@
 Optimize
 ========
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
+Introduction
+============
+
 In CrateDB every table (or if partitioned every partition) consists of
 segments. When inserting/deleting/updating data new segments are created
 following as an append-only strategy, which gives the advantage of fast writes

--- a/blackbox/docs/sql/partitioned_tables.txt
+++ b/blackbox/docs/sql/partitioned_tables.txt
@@ -5,6 +5,14 @@
 Partitioned Tables
 ==================
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
+Introduction
+============
+
 A partitioned table is a virtual table that can be created by naming one or
 more columns by which it is split into separate internal tables, called
 ``partitions``.

--- a/blackbox/docs/sql/queries.txt
+++ b/blackbox/docs/sql/queries.txt
@@ -1,8 +1,17 @@
 .. highlight:: psql
 .. _sql_dql_queries:
 
+===============
 Retrieving Data
 ===============
+
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
+Introduction
+============
 
 Retrieving data from CrateDB is done by using a SQL ``SELECT`` statement. The
 response to a ``SELECT`` query contains the column names of the result, the
@@ -46,7 +55,7 @@ Aliases can be used to change the output name of the columns::
 .. _sql_dql_from_clause:
 
 ``FROM`` Clause
----------------
+===============
 
 The ``FROM`` clause is used to reference the relation this select query is
 based upon. Can be a single table, many tables, table :ref:`JOIN <sql_joins>`
@@ -96,7 +105,7 @@ A table can be aliased for the sake of brevity too::
 .. _sql_dql_joins:
 
 Joins
------
+=====
 
 .. NOTE::
 
@@ -107,7 +116,7 @@ Joins
 .. _sql_dql_distinct_clause:
 
 ``DISTINCT`` Clause
--------------------
+===================
 
 If DISTINCT is specified, one unique row is kept. All other duplicate rows are
 removed from the result set::
@@ -125,7 +134,7 @@ removed from the result set::
 .. _sql_dql_where_clause:
 
 ``WHERE`` Clause
-----------------
+================
 
 A simple where clause example using an equality operator::
 
@@ -138,7 +147,7 @@ A simple where clause example using an equality operator::
     SELECT 1 row in set (... sec)
 
 Comparison Operators
-....................
+--------------------
 
 These :ref:`sql_operators` are supported and can be used for all simple data
 types.
@@ -188,7 +197,7 @@ may fail.
 .. _sql_ddl_regexp:
 
 Regular Expressions
--------------------
+===================
 
 Operators for matching using regular expressions.
 
@@ -293,7 +302,7 @@ Examples::
 .. _sql_dql_like:
 
 ``LIKE``
---------
+========
 
 CrateDB supports the `LIKE` operator. This operator can be used to query for
 rows where only part of a columns value should match something. For example to
@@ -349,7 +358,7 @@ escape them using a backslash::
 .. _sql_dql_not:
 
 ``NOT``
--------
+=======
 
 ``NOT`` negates a boolean expression::
 
@@ -378,7 +387,7 @@ The result type is boolean.
 .. _sql_dql_in:
 
 ``IN``
-------
+======
 
 CrateDB also supports the binary operator ``IN``, which allows you to verify
 the membership of left-hand operand in a right-hand set of expressions. Returns
@@ -408,7 +417,7 @@ The ``IN`` construct can be used in :ref:`sql_subquery_expressions` or
 .. _sql_dql_is_null:
 
 ``IS NULL``
------------
+===========
 
 Returns ``TRUE`` if ``expr`` evaluates to ``NULL``. Given a column reference it
 returns ``TRUE`` if the field contains ``NULL`` or is missing.
@@ -452,7 +461,7 @@ does always return ``NULL`` when comparing ``NULL``.
 .. _sql_dql_is_not_null:
 
 ``IS NOT NULL``
----------------
+===============
 
 Returns ``TRUE`` if ``expr`` does not evaluate to ``NULL``. Additionally, for
 column references it returns ``FALSE`` if the column does not exist.
@@ -487,7 +496,7 @@ does always return ``NULL`` when comparing ``NULL``.
 .. _sql_dql_any_array:
 
 ``ANY (array)``
----------------
+===============
 
 The ANY (or SOME) operator allows to search for elements within arrays. This
 allows to query for rows where an element of an array is, for example, equal to
@@ -537,7 +546,7 @@ The ``ANY`` construct can be used in :ref:`sql_subquery_expressions` or
 
 
 Negating ``ANY``
-................
+----------------
 
 One important thing to notice when using ANY is that negating the ANY operator
 does not behave as negating normal comparison operators.
@@ -602,7 +611,7 @@ for operators
     setting must be changed appropriately on each node.
 
 Limits
-------
+======
 
 As unlimited SELECT queries could break your cluster if the matching rows
 exceed your node's RAM, SELECT statements are limited by default to **10000**
@@ -625,7 +634,7 @@ limit on SELECT statements.
 .. _sql_dql_objects:
 
 Inner Objects and Nested Objects
---------------------------------
+================================
 
 CrateDB supports an ``object`` data type, used for simple storing a whole
 object into a column and it's even possible to select and query for properties
@@ -664,7 +673,7 @@ Inserting objects::
 .. _sql_dql_object_arrays:
 
 Object Arrays
--------------
+=============
 
 Arrays in CrateDB can only be queried for containment using the
 :ref:`sql_dql_any_array` operator. One exception are object arrays. As you can
@@ -731,7 +740,7 @@ Examples::
 .. _sql_dql_object_arrays_select:
 
 Selecting Array Elements
-........................
+------------------------
 
 Array elements can be selected directly using a integer value greater than or
 equal to **1**. The maximum supported array index is **2147483648**. Using an
@@ -761,7 +770,7 @@ index greater than the actual array size results in a NULL value.
 .. _sql_dql_aggregation:
 
 Data Aggregation
-----------------
+================
 
 CrateDB supports :ref:`aggregation` via the following aggregation functions.
 
@@ -953,7 +962,7 @@ Some Examples::
 .. _sql_dql_group_by:
 
 ``GROUP BY``
-------------
+============
 
 CrateDB supports the `group by` clause. This clause can be used to group the
 resulting rows by the value(s) of one or more columns. That means that rows
@@ -999,7 +1008,7 @@ This is useful if used in conjunction with aggregation functions::
 .. _sql_dql_having:
 
 ``HAVING``
-..........
+----------
 
 The having clause is the equivalent to the where clause for the resulting rows
 of a group by clause.

--- a/blackbox/docs/sql/reference/alter_table.txt
+++ b/blackbox/docs/sql/reference/alter_table.txt
@@ -1,11 +1,16 @@
 .. highlight:: psql
 .. _ref-alter-table:
 
-===========
-ALTER TABLE
-===========
+===============
+``ALTER TABLE``
+===============
 
-Alter an existing table
+Alter an existing table.
+
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
 
 Synopsis
 ========
@@ -61,7 +66,7 @@ the ``ADD COLUMN`` keyword won't work.
 While altering a partitioned table, using ``ONLY`` will apply changes for the
 table **only** and not for any possible existing partitions. So these changes
 will only be applied to new partitions. The ``ONLY`` keyword cannot be used
-together with a `PARTITION Clause`_.
+together with a `PARTITION`_ clause.
 
 Parameters
 ==========
@@ -79,8 +84,11 @@ See the CREATE TABLE :ref:`with_clause` for a list of available parameters.
 
 .. _ref-alter-table-partition-clause:
 
-``PARTITION`` Clause
-====================
+Clauses
+=======
+
+``PARTITION``
+-------------
 
 If the table is partitioned this clause can be used to alter only a single
 partition.

--- a/blackbox/docs/sql/reference/constraints.txt
+++ b/blackbox/docs/sql/reference/constraints.txt
@@ -1,22 +1,24 @@
 .. highlight:: psql
 .. _table_constraints:
 
-=================
-Table Constraints
-=================
+===========
+Constraints
+===========
 
-Table constraints are constraints that are applied to more than one column or
-to the table as a whole.
+.. rubric:: Table of Contents
 
-The supported table constraints currently are:
-
- * :ref:`primary_key_constraint`
- * :ref:`index-constraint`
+.. contents::
+   :local:
 
 .. _primary_key_constraint:
 
-``PRIMARY KEY`` Constraint
-==========================
+Tables Constraints
+==================
+
+Table constraints are constraints that are applied to the table as a whole.
+
+``PRIMARY KEY``
+---------------
 
 The PRIMARY KEY constraint specifies that a column or columns of a table can
 contain only unique (non-duplicate), non-null values.
@@ -40,8 +42,8 @@ Adding a PRIMARY KEY column is only possible if the table is empty.
 
 .. _index-constraint:
 
-``INDEX`` Constraint
-====================
+``INDEX``
+---------
 
 The INDEX constraint specifies a specific index method on one or more columns.
 
@@ -66,8 +68,8 @@ The supported column constraints are:
 
 .. _not_null_constraint:
 
-``NOT NULL`` Constraint
------------------------
+``NOT NULL``
+------------
 
 The NOT NULL constraint specifies that a column of a table can contain only
 non-null values.

--- a/blackbox/docs/sql/reference/copy_from.txt
+++ b/blackbox/docs/sql/reference/copy_from.txt
@@ -7,6 +7,11 @@
 
 Copy data from files into a table.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 Synopsis
 ========
 
@@ -149,8 +154,11 @@ Parameters
       supported schemes are listed above. The last part of the path may also
       contain ``*`` wildcards to match multiple files.
 
-``PARTITION`` Clause
-====================
+Clauses
+=======
+
+``PARTITION``
+-------------
 
 For partitioned tables this clause can be used to import data into the
 specified partition. This clause takes one or more partition columns and for
@@ -173,8 +181,8 @@ each column a value.
    row, hence every row will be imported into the specified partition
    regardless of the value provided for the partition columns.
 
-``WITH`` Clause
-===============
+``WITH``
+--------
 
 The optional ``WITH`` clause can specify options for the COPY FROM statement.
 
@@ -183,17 +191,17 @@ The optional ``WITH`` clause can specify options for the COPY FROM statement.
     [ WITH ( option = value [, ...] ) ]
 
 Options
--------
+.......
 
 ``bulk_size``
-.............
+'''''''''''''
 
 CrateDB will process the lines it reads from the ``path`` in bulks. This option
 specifies the size of one batch. The provided value must be greater than 0, the
 default value is 10000.
 
 ``shared``
-..........
+''''''''''
 
 This option should be set to true if the URI's location is accessible by more
 than one CrateDB node to prevent them from importing the same file.
@@ -204,7 +212,7 @@ If an array of URIs is passed to ``COPY FROM`` this option will overwrite the
 default for *all* URIs.
 
 ``node_filters``
-................
+''''''''''''''''
 
 A filter expression to select the nodes to run the *read* operation.
 
@@ -230,7 +238,7 @@ To verify which nodes match the filter, run the statement with
 :doc:`EXPLAIN <explain>`.
 
 ``num_readers``
-...............
+'''''''''''''''
 
 The number of nodes that will read the resources specified in the URI. Defaults
 to the number of nodes available in the cluster. If the option is set to a
@@ -243,12 +251,12 @@ exclude the wrong nodes, causing COPY FROM to read no files or only a subset of
 the files.
 
 ``compression``
-...............
+'''''''''''''''
 
 The default value is ``null``, set to ``gzip`` to read gzipped files.
 
 ``overwrite_duplicates``
-........................
+''''''''''''''''''''''''
 
 Default: false
 

--- a/blackbox/docs/sql/reference/copy_to.txt
+++ b/blackbox/docs/sql/reference/copy_to.txt
@@ -7,6 +7,11 @@
 
 Export table contents to files on CrateDB node machines.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 Synopsis
 ========
 
@@ -47,8 +52,11 @@ Parameters
     Declaring columns changes the output to JSON list format, which is
     currently not supported by the COPY FROM statement.
 
-``WHERE`` Clause
-----------------
+Clauses
+-------
+
+``WHERE``
+.........
 
 `WHERE` clauses use the same syntax as `SELECT` statements, allowing partial
 exports. (see :ref:`sql_dql_where_clause` for more information).
@@ -85,8 +93,11 @@ will be used.
   connections are using the HTTPS protocol. Please make sure you update your
   firewall rules to allow outgoing connections on port ``443``.
 
-``PARTITION`` Clause
-====================
+Clauses
+=======
+
+``PARTITION``
+-------------
 
 If the table is partitioned this clause can be used to only export data from a
 specific partition.
@@ -112,8 +123,8 @@ not part of the partitioned tables.
     the exported files. If a partition column is a generated column, it will
     not be included even if the ``PARTITION`` clause is missing.
 
-``WITH`` Clause
-===============
+``WITH``
+--------
 
 The optional WITH clause can specify parameters for the copy statement.
 
@@ -127,7 +138,7 @@ Possible copy_parameters are:
 ..
 
 ``compression``
----------------
+...............
 
 Define if and how the exported data should be compressed.
 
@@ -140,7 +151,7 @@ Possible values for the ``compression`` setting are:
 .. _format:
 
 ``format``
-----------
+..........
 
 Optional parameter to override default output behavior.
 

--- a/blackbox/docs/sql/reference/create_analyzer.txt
+++ b/blackbox/docs/sql/reference/create_analyzer.txt
@@ -7,6 +7,11 @@
 
 Define a new fulltext analyzer.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 Synopsis
 ========
 

--- a/blackbox/docs/sql/reference/create_blob_table.txt
+++ b/blackbox/docs/sql/reference/create_blob_table.txt
@@ -7,6 +7,11 @@
 
 Define a new table for storing binary large objects.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 Synopsis
 ========
 

--- a/blackbox/docs/sql/reference/create_function.txt
+++ b/blackbox/docs/sql/reference/create_function.txt
@@ -7,6 +7,11 @@
 
 Create a new function.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 Synopsis
 ========
 

--- a/blackbox/docs/sql/reference/create_ingest_rule.txt
+++ b/blackbox/docs/sql/reference/create_ingest_rule.txt
@@ -6,6 +6,11 @@
 
 Defines a new ingestion rule.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 Synopsis
 ========
 .. highlight:: psql

--- a/blackbox/docs/sql/reference/create_repository.txt
+++ b/blackbox/docs/sql/reference/create_repository.txt
@@ -7,6 +7,11 @@
 
 Register a new repository used to store, manage and restore snapshots.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 Synopsis
 ========
 
@@ -29,15 +34,17 @@ Repositories are declared using a ``repository_name`` and ``type``.
 
 Further configuration parameters are given in the WITH Clause.
 
-Parameters
-==========
+.. rubric:: Parameters
 
 :repository_name: the name of the repository as identifier
 
 :type: the type of the repository, see :ref:`ref-create-repository-types`.
 
-``WITH`` Clause
-===============
+Clauses
+=======
+
+``WITH``
+--------
 
 ::
 
@@ -82,8 +89,7 @@ accessible by all master and data nodes in the cluster.
    possible locations for repositories inside the ``crate.yml`` file under
    ``path.repo`` as list of strings.
 
-Parameters
-..........
+.. rubric:: Parameters
 
 .. _ref-create-repository-types-fs-location:
 
@@ -125,8 +131,7 @@ Parameters
 
 A repository that stores its snapshot inside an HDFS file-system.
 
-Parameters
-..........
+.. rubric:: Parameters
 
 **uri**
   | *Type:*    ``string``
@@ -190,8 +195,7 @@ Parameters
 
 A repository that stores its snapshot on the Amazon S3 service.
 
-Parameters
-..........
+.. rubric:: Parameters
 
 **bucket**
   | *Type:*    ``string``
@@ -307,8 +311,7 @@ A read-only repository that points to the location of a
 ``ftp``, ``file`` and ``jar`` urls. It only allows for
 :ref:`ref-restore-snapshot` operations.
 
-Parameters
-..........
+.. rubric:: Parameters
 
 **read_only**
   | *Type:*    ``string``

--- a/blackbox/docs/sql/reference/create_snapshot.txt
+++ b/blackbox/docs/sql/reference/create_snapshot.txt
@@ -8,6 +8,11 @@
 Create a new incremental snapshot inside a repository that contains the current
 state of the given tables and/or partitions and the cluster metadata.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 Synopsis
 ========
 
@@ -65,8 +70,11 @@ Parameters
 
 :partition_column: Column name by which the table is partitioned
 
-``WITH`` Clause
-===============
+Clauses
+=======
+
+``WITH``
+--------
 
 ::
 

--- a/blackbox/docs/sql/reference/create_table.txt
+++ b/blackbox/docs/sql/reference/create_table.txt
@@ -7,6 +7,11 @@
 
 Define a new table.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 Synopsis
 ========
 
@@ -145,16 +150,16 @@ Parameters
                         time a row is inserted or the referenced base columns
                         are updated.
 
-``IF NOT EXISTS`` Clause
-========================
+``IF NOT EXISTS``
+=================
 
 If the optional IF NOT EXISTS clause is used this statement won't do anything
 if the table exists already.
 
 .. _ref_clustered_clause:
 
-``CLUSTERED`` Clause
-====================
+``CLUSTERED``
+=============
 
 The optional CLUSTERED clause specifies how a table should be distributed
 accross a cluster.
@@ -182,8 +187,8 @@ accross a cluster.
 
 .. _partitioned_by_clause:
 
-``PARTITIONED BY`` Clause
-=========================
+``PARTITIONED BY``
+==================
 
 The PARTITIONED clause splits the created table into separate partitions for
 every distinct combination of values in the listed columns.
@@ -211,8 +216,8 @@ Several restrictions apply to columns that can be used here:
 
 .. _with_clause:
 
-``WITH`` Clause
----------------
+``WITH``
+--------
 
 The optional WITH clause can specify parameters for tables.
 

--- a/blackbox/docs/sql/reference/create_user.txt
+++ b/blackbox/docs/sql/reference/create_user.txt
@@ -6,6 +6,11 @@
 
 Create a new database user.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 Synopsis
 ========
 

--- a/blackbox/docs/sql/reference/delete.txt
+++ b/blackbox/docs/sql/reference/delete.txt
@@ -6,6 +6,11 @@
 
 Delete rows of a table
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 Synopsis
 ========
 

--- a/blackbox/docs/sql/reference/deny.txt
+++ b/blackbox/docs/sql/reference/deny.txt
@@ -4,7 +4,13 @@
 ``DENY``
 ========
 
-Denies privilege to an existing user on the whole cluster or on a specific object.
+Denies privilege to an existing user on the whole cluster or on a specific
+object.
+
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
 
 Synopsis
 ========

--- a/blackbox/docs/sql/reference/drop_function.txt
+++ b/blackbox/docs/sql/reference/drop_function.txt
@@ -7,6 +7,11 @@
 
 Drop a function.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 Synopsis
 ========
 

--- a/blackbox/docs/sql/reference/drop_ingest_rule.txt
+++ b/blackbox/docs/sql/reference/drop_ingest_rule.txt
@@ -8,6 +8,11 @@
 
 Deletes an existing ingestion rule.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 Synopsis
 ========
 

--- a/blackbox/docs/sql/reference/drop_repository.txt
+++ b/blackbox/docs/sql/reference/drop_repository.txt
@@ -7,6 +7,11 @@
 
 Unregister a repository.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 Synopsis
 ========
 

--- a/blackbox/docs/sql/reference/drop_snapshot.txt
+++ b/blackbox/docs/sql/reference/drop_snapshot.txt
@@ -7,6 +7,11 @@
 
 Delete an existing snapshot and all files referenced only by this snapshot.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 Synopsis
 ========
 

--- a/blackbox/docs/sql/reference/drop_table.txt
+++ b/blackbox/docs/sql/reference/drop_table.txt
@@ -6,6 +6,11 @@
 
 Remove a table.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 Synopsis
 ========
 

--- a/blackbox/docs/sql/reference/drop_user.txt
+++ b/blackbox/docs/sql/reference/drop_user.txt
@@ -6,6 +6,11 @@
 
 Drop an existing database user.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 Synopsis
 ========
 

--- a/blackbox/docs/sql/reference/explain.txt
+++ b/blackbox/docs/sql/reference/explain.txt
@@ -6,6 +6,11 @@
 
 Explain the plan for a given statement.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 Synopsis
 ========
 

--- a/blackbox/docs/sql/reference/grant.txt
+++ b/blackbox/docs/sql/reference/grant.txt
@@ -6,6 +6,11 @@
 
 Grants privilege to an existing user on the whole cluster or on a specific object.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 Synopsis
 ========
 

--- a/blackbox/docs/sql/reference/insert.txt
+++ b/blackbox/docs/sql/reference/insert.txt
@@ -7,6 +7,11 @@
 
 Create new rows in a table.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 .. _insert_synopsis:
 
 Synopsis
@@ -40,8 +45,8 @@ type conversion will be attempted.
 
 .. _on_duplicate_key_update:
 
-On Duplicate Key Update
------------------------
+``ON DUPLICATE KEY UPDATE``
+---------------------------
 
 If ``ON DUPLICATE KEY UPDATE`` is specified and a row is inserted that would
 cause a duplicate-key conflict, an update of the existing row is performed.

--- a/blackbox/docs/sql/reference/kill.txt
+++ b/blackbox/docs/sql/reference/kill.txt
@@ -7,6 +7,11 @@
 
 Kills active jobs in the CrateDB cluster.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 Synopsis
 ========
 

--- a/blackbox/docs/sql/reference/lexical_structure.txt
+++ b/blackbox/docs/sql/reference/lexical_structure.txt
@@ -12,6 +12,11 @@ The syntax of a command defines its set of valid tokens. A token can be a key
 word, an identifier, a quoted identifier, a literal (or constant), or a special
 character symbol.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 .. _string_literal:
 
 String Literal

--- a/blackbox/docs/sql/reference/optimize.txt
+++ b/blackbox/docs/sql/reference/optimize.txt
@@ -7,6 +7,11 @@
 
 Optimize one or more tables explicitly.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 Synopsis
 ========
 
@@ -47,8 +52,11 @@ Parameters
 
 :partition_column: Column name by which the table is partitioned.
 
-``PARTITION`` Clause
-====================
+Clauses
+=======
+
+``PARTITION``
+-------------
 
 ::
 
@@ -61,8 +69,8 @@ Parameters
 
 :value: The columns value.
 
-``WITH`` Clause
-===============
+``WITH``
+--------
 
 The optional WITH clause can specify parameters for the optimization request.
 

--- a/blackbox/docs/sql/reference/refresh.txt
+++ b/blackbox/docs/sql/reference/refresh.txt
@@ -7,6 +7,11 @@
 
 Refresh one or more tables explicitly.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 Synopsis
 ========
 
@@ -47,8 +52,11 @@ Parameters
 
 :partition_column: Column name by which the table is partitioned.
 
-``PARTITION`` Clause
-====================
+Clauses
+=======
+
+``PARTITION``
+-------------
 
 ::
 

--- a/blackbox/docs/sql/reference/restore_snapshot.txt
+++ b/blackbox/docs/sql/reference/restore_snapshot.txt
@@ -7,6 +7,11 @@
 
 Restore a snapshot into the cluster.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 Synopsis
 ========
 
@@ -45,8 +50,11 @@ Parameters
 
 :partition_column: Column name by which the table is partitioned
 
-``WITH`` Clause
-===============
+Clauses
+=======
+
+``WITH``
+--------
 
 ::
 

--- a/blackbox/docs/sql/reference/revoke.txt
+++ b/blackbox/docs/sql/reference/revoke.txt
@@ -4,7 +4,13 @@
 ``REVOKE``
 ==========
 
-Revokes a previously granted privilege on the whole cluster or on a specific object.
+Revokes a previously granted privilege on the whole cluster or on a specific
+object.
+
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
 
 Synopsis
 ========

--- a/blackbox/docs/sql/reference/select.txt
+++ b/blackbox/docs/sql/reference/select.txt
@@ -7,6 +7,11 @@
 
 Retrieve rows from a table.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 Synopsis
 ========
 
@@ -56,8 +61,8 @@ follows:
 Parameters
 ==========
 
-``SELECT`` List
----------------
+The ``SELECT`` List
+-------------------
 
 The SELECT list specifies expressions that form the output rows of the SELECT
 statement. The expressions can (and usually do) refer to columns computed in
@@ -89,8 +94,11 @@ table_name.* as a shorthand for the columns coming from just that table. In
 these cases it is not possible to specify new names with AS; the output column
 names will be the same as the table columns' names.
 
-``FROM`` Clause
----------------
+Clauses
+-------
+
+``FROM``
+........
 
 The FROM clause specifies the source relation for the SELECT::
 
@@ -99,7 +107,7 @@ The FROM clause specifies the source relation for the SELECT::
 The relation can be any of the following relations.
 
 Table Reference
-...............
+'''''''''''''''
 
 A ``table_reference`` is a table ident with an optional table alias::
 
@@ -118,7 +126,7 @@ A ``table_reference`` is a table ident with an optional table alias::
 .. _sql_reference_joined_tables:
 
 Joined Relation
-...............
+'''''''''''''''
 
 A ``joined_relation`` is a relation which joins two relations together. See
 :ref:`sql_dql_joins` ::
@@ -133,7 +141,7 @@ A ``joined_relation`` is a relation which joins two relations together. See
                  ``boolean``.
 
 Table Function
-..............
+''''''''''''''
 
 ``table_function`` is a function that produces a set of rows and has columns.
 
@@ -153,7 +161,7 @@ Available functions are documented in the :doc:`table functions
 .. _sql_reference_subselect:
 
 Sub Select
-..........
+''''''''''
 
 A ``sub_select`` is another ``SELECT`` statement surrounded by parentheses with
 an alias:
@@ -170,8 +178,8 @@ the inner ``SELECT`` statement.
 
 :alias: An :ref:`alias <sql_reference_table_alias>` for the sub select.
 
-``WHERE`` Clause
-----------------
+``WHERE``
+.........
 
 The optional WHERE clause defines the condition to be met for a row to be
 returned::
@@ -186,8 +194,8 @@ returned::
 
 .. _sql_reference_group_by:
 
-``GROUP BY`` Clause
--------------------
+``GROUP BY``
+............
 
 The optional GROUP BY clause will condense into a single row all selected rows
 that share the same values for the grouped expressions.
@@ -212,8 +220,8 @@ each group, producing a separate value for each group.
 
 .. _sql_reference_having:
 
-``HAVING`` Clause
-.................
+``HAVING``
+''''''''''
 
 The optional HAVING clause defines the condition to be met for values whitin a
 resulting row of a group by clause.
@@ -236,8 +244,8 @@ resulting row of a group by clause.
 
 .. _sql_reference_order_by:
 
-``ORDER BY`` Clause
--------------------
+``ORDER BY``
+............
 
 The ORDER BY clause causes the result rows to be sorted according to the
 specified expression(s).
@@ -277,8 +285,8 @@ Character-string data is sorted by its UTF-8 representation.
   Sorting on :ref:`geo_point_data_type`, :ref:`geo_shape_data_type`,
   :ref:`data-type-array`, and :ref:`object_data_type` is not supported.
 
-``LIMIT`` Clause
-----------------
+``LIMIT``
+.........
 
 The optional LIMIT Clause allows to limit the number or retured result rows::
 
@@ -295,8 +303,8 @@ The optional LIMIT Clause allows to limit the number or retured result rows::
    different subsets of the rows of a table, if there is not an ORDER BY to
    enforce selection of a deterministic subset.
 
-``OFFSET`` Clause
------------------
+``OFFSET``
+..........
 
 The optional OFFSET Clause allows to skip result rows at the beginning::
 

--- a/blackbox/docs/sql/reference/set.txt
+++ b/blackbox/docs/sql/reference/set.txt
@@ -9,6 +9,11 @@ Change and restore settings at runtime. To get an overview of available CrateDB
 settings, see :ref:`configuration`. Only settings documented with *Runtime:*
 ``yes`` can be changed.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 Synopsis
 ========
 

--- a/blackbox/docs/sql/reference/set_transaction.txt
+++ b/blackbox/docs/sql/reference/set_transaction.txt
@@ -1,11 +1,16 @@
 .. highlight:: psql
 .. _ref-set-transation:
 
-===============
-SET TRANSACTION
-===============
+===================
+``SET TRANSACTION``
+===================
 
 Sets the characteristics of transactions.
+
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
 
 Synopsis
 ========

--- a/blackbox/docs/sql/reference/show_columns.txt
+++ b/blackbox/docs/sql/reference/show_columns.txt
@@ -6,6 +6,11 @@
 
 ``SHOW COLUMNS`` displays information about columns in a given table.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 Synopsis
 ========
 
@@ -29,15 +34,18 @@ Parameters
 :table_schema: The name of the schema the tables are appropriate to. If no
                schema name is specified the default schema is set to ``doc``.
 
-``LIKE`` Clause
-===============
+Clauses
+=======
+
+``LIKE``
+--------
 
 The optional ``LIKE`` clause indicates which column names to match. It takes a
 string pattern as a filter and has an equivalent behavior to
 :ref:`sql_dql_like`.
 
-``WHERE`` Clause
-================
+``WHERE``
+---------
 
 The optional WHERE clause defines the condition to be met for a row to be
 returned.

--- a/blackbox/docs/sql/reference/show_create_table.txt
+++ b/blackbox/docs/sql/reference/show_create_table.txt
@@ -7,6 +7,11 @@
 
 Shows the ``CREATE TABLE`` statement that creates the named table.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 Synopsis
 ========
 

--- a/blackbox/docs/sql/reference/show_schemas.txt
+++ b/blackbox/docs/sql/reference/show_schemas.txt
@@ -6,6 +6,11 @@
 
 Lists the table schemas of the database.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 Synopsis
 ========
 
@@ -22,15 +27,18 @@ in alphabetical order.
 The same list can be fetched by querying the the schema names from the
 ``information_schema.schemata`` table.
 
-``LIKE`` Clause
-===============
+Clauses
+=======
+
+``LIKE``
+--------
 
 The optional ``LIKE`` clause indicates which schema names to match. It takes a
 string pattern as a filter and has an equivalent behavior to
 :ref:`sql_dql_like`.
 
-``WHERE`` Clause
-================
+``WHERE``
+---------
 
 The optional WHERE clause defines the condition to be met for a row to be
 returned.

--- a/blackbox/docs/sql/reference/show_tables.txt
+++ b/blackbox/docs/sql/reference/show_tables.txt
@@ -6,6 +6,11 @@
 
 Lists the tables in the database.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 Synopsis
 ========
 
@@ -28,15 +33,18 @@ Parameters
 
 :table_schema: The name of the schema the tables are appropriate to.
 
-``LIKE`` Clause
-===============
+Clauses
+=======
+
+``LIKE``
+--------
 
 The optional ``LIKE`` clause matches only on table names and omits schema
 names. It takes a string pattern as a filter and has an equivalent behavior to
 :ref:`sql_dql_like`.
 
-``WHERE`` Clause
-================
+``WHERE``
+---------
 
 The optional WHERE clause defines the condition to be met for a row to be
 returned.

--- a/blackbox/docs/sql/reference/update.txt
+++ b/blackbox/docs/sql/reference/update.txt
@@ -7,6 +7,11 @@
 
 Update rows of a table.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 Synopsis
 ========
 
@@ -24,7 +29,7 @@ condition. Only the columns to be modified need be mentioned in the SET clause;
 columns not explicitly modified retain their previous values.
 
 Parameters
-----------
+==========
 
 :table_ident: The identifier (optionally schema-qualified) of an
               existing table.

--- a/blackbox/docs/sql/reference/value_expressions.txt
+++ b/blackbox/docs/sql/reference/value_expressions.txt
@@ -9,27 +9,10 @@ Value expressions are expressions which return a single value.
 
 They can be used in many contexts of many statements.
 
-A value expression can be:
+.. rubric:: Table of Contents
 
-- A literal value
-
-- A column reference
-
-- A parameter reference
-
-- A operator invocation
-
-- A subscript expression
-
-- A function call
-
-- A type cast
-
-- An object constructor
-
-- An array constructor
-
-- A scalar subquery
+.. contents::
+   :local:
 
 Literal value
 =============

--- a/blackbox/docs/sql/refresh.txt
+++ b/blackbox/docs/sql/refresh.txt
@@ -5,6 +5,14 @@
 Refresh
 =======
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
+Introduction
+============
+
 CrateDB is `eventually consistent`_. Data written with a former statement is
 not guaranteed to be fetched with the next following select statement for the
 affected rows.

--- a/blackbox/docs/sql/scalar.txt
+++ b/blackbox/docs/sql/scalar.txt
@@ -7,6 +7,11 @@ Scalar Functions
 
 Scalar functions return a single value (not a table).
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 String Functions
 ================
 

--- a/blackbox/docs/sql/snapshot_restore.txt
+++ b/blackbox/docs/sql/snapshot_restore.txt
@@ -4,6 +4,11 @@
 Backup With Snapshot and Restore
 ================================
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 Snapshot
 --------
 

--- a/blackbox/docs/sql/sql.txt
+++ b/blackbox/docs/sql/sql.txt
@@ -20,18 +20,18 @@ CrateDB.
     reference/create_analyzer
     reference/create_blob_table
     reference/create_function
+    reference/create_ingest_rule
     reference/create_repository
     reference/create_snapshot
-    reference/create_ingest_rule
     reference/create_table
     reference/create_user
     reference/constraints
     reference/delete
     reference/deny
     reference/drop_function
+    reference/drop_ingest_rule
     reference/drop_repository
     reference/drop_snapshot
-    reference/drop_ingest_rule
     reference/drop_table
     reference/drop_user
     reference/explain

--- a/blackbox/docs/sql/subquery_expressions.txt
+++ b/blackbox/docs/sql/subquery_expressions.txt
@@ -17,6 +17,11 @@ These :ref:`sql_operators` are supported for subquery expressions.
 To compare a list of values other than subqueries, see
 :ref:`sql_array_comparisons`.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 .. _sql_in_subquery_expression:
 
 ``IN (subquery)``

--- a/blackbox/docs/sql/system.txt
+++ b/blackbox/docs/sql/system.txt
@@ -9,19 +9,10 @@ CrateDB provides the ``sys`` schema which contains virtual tables. These tables
 are read-only and can be queried to get statistical real-time information about
 the cluster, its nodes and their shards:
 
- * :ref:`sys.checks <sys-checks>`
- * :ref:`sys.cluster <sys-cluster>`
- * :ref:`sys.jobs <sys-jobs>`
- * :ref:`sys.jobs_log <sys-logs>`
- * :ref:`sys.nodes <sys-nodes>`
- * :ref:`sys.node_checks <sys-node-checks>`
- * :ref:`sys.operations <sys-operations>`
- * :ref:`sys.operations_log <sys-logs>`
- * :ref:`sys.repositories <sys-repositories>`
- * :ref:`sys.shards <sys-shards>`
- * :ref:`sys.snapshots <sys-snapshots>`
- * :ref:`sys.summits <sys-summits>`
+.. rubric:: Table of Contents
 
+.. contents::
+   :local:
 
 .. _sys-cluster:
 

--- a/blackbox/docs/sql/table_functions.txt
+++ b/blackbox/docs/sql/table_functions.txt
@@ -7,9 +7,14 @@ Table Functions
 Table functions are functions that produce a set of rows. They are used like a
 table or subquery in the FROM clause of a query.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 ``empty_row( )``
 ================
-empty_row doesn't take any argument and produces a table with an empty row and 
+empty_row doesn't take any argument and produces a table with an empty row and
 no column.
 
 ::

--- a/blackbox/docs/udc.txt
+++ b/blackbox/docs/udc.txt
@@ -20,6 +20,11 @@ system collect additional data, we will clearly announce those changes.
 CrateDB is very concerned about your privacy. We do not disclose any personally
 identifiable information.
 
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
 Technical Information
 =====================
 


### PR DESCRIPTION
things this changset does:

- adds a local toc to pages with subheadings (so our big pages have a nice way to see what they contain right at the top and navigate with)
- fixes issues with headings revealed by adding these tocs (for example reshuffling them or adjusting what level they're at)