### PR TITLE
idea: Disable OptionalUsedAsFieldOrParameterType inspection

### DIFF
--- a/idea/codeInspection.xml
+++ b/idea/codeInspection.xml
@@ -3,5 +3,6 @@
     <option name="myName" value="Project Default"/>
     <inspection_tool class="ForCanBeForeach" enabled_by_default="false"/>
     <inspection_tool class="PointlessBooleanExpression" enabled_by_default="false"/>
+    <inspection_tool class="OptionalUsedAsFieldOrParameterType" enabled_by_default="false"/>
   </profile>
 </component>


### PR DESCRIPTION
- We don't care that Optional doesn't work with Serializable because we
 don't use it
 - We want to avoid creating an Optional on each property/getter access.