### PR TITLE
Introduce type precedence and basic type inference

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -15,6 +15,11 @@ the appropriate section of the docs.
 Breaking Changes
 ================
 
+ - Columns aren't implicitly casted to a type anymore. Whenever columns are
+   compared to Literals (e.g. 'string' or a number), these literals will be
+   converted to the column type but not vice-versa. The column can still be
+   manually casted to a type by using a cast function.
+
  - `GROUP BY` now executes against the real columns and fallbacks to
    substituting possible aliases in case the columns do not exist. This will
    cause statements that used alias values that shadowed multiple columns with

--- a/blackbox/docs/protocols/http.txt
+++ b/blackbox/docs/protocols/http.txt
@@ -153,7 +153,7 @@ be passed to the request::
     ... EOF
     {
       "cols" : [ "date", "position" ],
-      "col_types" : [ 1400, 600 ],
+      "col_types" : [ 11, 9 ],
       "rows" : [ [ 308534400000, 1 ], [ 308534400000, 2 ] ],
       "rowcount" : 2,
       "duration" : ...

--- a/blackbox/docs/protocols/http.txt
+++ b/blackbox/docs/protocols/http.txt
@@ -153,7 +153,7 @@ be passed to the request::
     ... EOF
     {
       "cols" : [ "date", "position" ],
-      "col_types" : [ 11, 9 ],
+      "col_types" : [ 1400, 600 ],
       "rows" : [ [ 308534400000, 1 ], [ 308534400000, 2 ] ],
       "rowcount" : 2,
       "duration" : ...

--- a/blackbox/docs/sql/data_types.txt
+++ b/blackbox/docs/sql/data_types.txt
@@ -182,7 +182,7 @@ Example::
 
     cr> insert into my_table_ips (fqdn, ip_addr)
     ... values ('localhost', 'not.a.real.ip');
-    SQLActionException[ColumnValidationException: Validation failed for ip_addr: 'not.a.real.ip' cannot be cast to type ip]
+    SQLActionException[ColumnValidationException: Validation failed for ip_addr: Cannot cast 'not.a.real.ip' to type ip]
 
 ``timestamp``
 =============
@@ -239,7 +239,7 @@ Examples::
 ::
 
     cr> insert into my_table4 (id, first_column) values (3, 'wrong');
-    SQLActionException[ColumnValidationException: Validation failed for first_column: 'wrong' cannot be cast to type timestamp]
+    SQLActionException[ColumnValidationException: Validation failed for first_column: Cannot cast 'wrong' to type timestamp]
 
 .. NOTE::
 

--- a/core/src/main/java/io/crate/types/ArrayType.java
+++ b/core/src/main/java/io/crate/types/ArrayType.java
@@ -25,7 +25,7 @@ import java.util.Collection;
 
 public class ArrayType extends CollectionType {
 
-    public static final int ID = 100;
+    public static final int ID = Precedence.ArrayType;
 
     public ArrayType(DataType<?> innerType) {
         super(innerType);

--- a/core/src/main/java/io/crate/types/ArrayType.java
+++ b/core/src/main/java/io/crate/types/ArrayType.java
@@ -25,7 +25,7 @@ import java.util.Collection;
 
 public class ArrayType extends CollectionType {
 
-    public static final int ID = Precedence.ArrayType;
+    public static final int ID = 100;
 
     public ArrayType(DataType<?> innerType) {
         super(innerType);
@@ -38,6 +38,11 @@ public class ArrayType extends CollectionType {
     @Override
     public int id() {
         return ID;
+    }
+
+    @Override
+    public Precedence precedence() {
+        return Precedence.ArrayType;
     }
 
     @Override

--- a/core/src/main/java/io/crate/types/BooleanType.java
+++ b/core/src/main/java/io/crate/types/BooleanType.java
@@ -33,7 +33,7 @@ import java.util.Map;
 
 public class BooleanType extends DataType<Boolean> implements Streamer<Boolean>, FixedWidthType {
 
-    public static final int ID = 3;
+    public static final int ID = Precedence.BooleanType;
     public static final BooleanType INSTANCE = new BooleanType();
 
     private BooleanType() {

--- a/core/src/main/java/io/crate/types/BooleanType.java
+++ b/core/src/main/java/io/crate/types/BooleanType.java
@@ -33,7 +33,7 @@ import java.util.Map;
 
 public class BooleanType extends DataType<Boolean> implements Streamer<Boolean>, FixedWidthType {
 
-    public static final int ID = Precedence.BooleanType;
+    public static final int ID = 3;
     public static final BooleanType INSTANCE = new BooleanType();
 
     private BooleanType() {
@@ -50,6 +50,11 @@ public class BooleanType extends DataType<Boolean> implements Streamer<Boolean>,
     @Override
     public int id() {
         return ID;
+    }
+
+    @Override
+    public Precedence precedence() {
+        return Precedence.BooleanType;
     }
 
     @Override

--- a/core/src/main/java/io/crate/types/ByteType.java
+++ b/core/src/main/java/io/crate/types/ByteType.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 public class ByteType extends DataType<Byte> implements Streamer<Byte>, FixedWidthType {
 
     public static final ByteType INSTANCE = new ByteType();
-    public static final int ID = 2;
+    public static final int ID = Precedence.ByteType;
 
     private ByteType() {
     }

--- a/core/src/main/java/io/crate/types/ByteType.java
+++ b/core/src/main/java/io/crate/types/ByteType.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 public class ByteType extends DataType<Byte> implements Streamer<Byte>, FixedWidthType {
 
     public static final ByteType INSTANCE = new ByteType();
-    public static final int ID = Precedence.ByteType;
+    public static final int ID = 2;
 
     private ByteType() {
     }
@@ -39,6 +39,11 @@ public class ByteType extends DataType<Byte> implements Streamer<Byte>, FixedWid
     @Override
     public int id() {
         return ID;
+    }
+
+    @Override
+    public Precedence precedence() {
+        return Precedence.ByteType;
     }
 
     @Override

--- a/core/src/main/java/io/crate/types/DataType.java
+++ b/core/src/main/java/io/crate/types/DataType.java
@@ -43,8 +43,10 @@ public abstract class DataType<T> implements Comparable, Streamable {
      * Precedence list inspired by
      * https://docs.microsoft.com/en-us/sql/t-sql/data-types/data-type-precedence-transact-sql
      *
-     * Note, that using an Enum here doesn't work because we want to use the type ids in
-     * switch statements which allow only compile-time constants.
+     * Note, that using an Enum here with either a constant in the
+     * constructor or an ordinal doesn't work because we want to use
+     * the type ids in switch statements which allow only compile-time
+     * constants.
      */
     @SuppressWarnings("WeakerAccess")
     public static class Precedence {

--- a/core/src/main/java/io/crate/types/DataType.java
+++ b/core/src/main/java/io/crate/types/DataType.java
@@ -37,40 +37,39 @@ public abstract class DataType<T> implements Comparable, Streamable {
      * Type precedence ids which help to decide when a type can be cast
      * into another type without loosing information (upcasting).
      *
-     * Lower number => Lower precedence
-     * Higher number => Higher precedence
+     * Lower ordinal => Lower precedence
+     * Higher ordinal => Higher precedence
      *
      * Precedence list inspired by
      * https://docs.microsoft.com/en-us/sql/t-sql/data-types/data-type-precedence-transact-sql
      *
-     * Note, that using an Enum here with either a constant in the
-     * constructor or an ordinal doesn't work because we want to use
-     * the type ids in switch statements which allow only compile-time
-     * constants.
      */
     @SuppressWarnings("WeakerAccess")
-    public static class Precedence {
-        public static final int NotSupportedType        =  1_00;
-        public static final int UndefinedType           =  2_00;
-        public static final int ByteType                =  3_00;
-        public static final int BooleanType             =  4_00;
-        public static final int ShortType               =  5_00;
-        public static final int IntegerType             =  6_00;
-        public static final int LongType                =  7_00;
-        public static final int FloatType               =  8_00;
-        public static final int DoubleType              =  9_00;
-        public static final int GeoPointType            = 10_00;
-        public static final int GeoShapeType            = 11_00;
-        public static final int IpType                  = 12_00;
-        public static final int StringType              = 13_00;
-        public static final int TimestampType           = 14_00;
-        public static final int ObjectType              = 15_00;
-        public static final int ArrayType               = 16_00;
-        public static final int SetType                 = 17_00;
-        public static final int SingleColumnTableType   = 18_00;
+    public enum Precedence {
+        NotSupportedType,
+        UndefinedType,
+        ByteType,
+        BooleanType,
+        ShortType,
+        IntegerType,
+        LongType,
+        FloatType,
+        DoubleType,
+        GeoPointType,
+        GeoShapeType,
+        IpType,
+        StringType,
+        TimestampType,
+        ObjectType,
+        ArrayType,
+        SetType,
+        SingleColumnTableType,
+        Custom
     }
 
     public abstract int id();
+
+    public abstract Precedence precedence();
 
     public abstract String getName();
 
@@ -79,6 +78,15 @@ public abstract class DataType<T> implements Comparable, Streamable {
     public abstract T value(Object value) throws IllegalArgumentException, ClassCastException;
 
     public abstract int compareValueTo(T val1, T val2);
+
+    /**
+     * Returns true if this DataType precedes the supplied DataType.
+     * @param other The other type to compare against.
+     * @return True if the current type precedes, false otherwise.
+     */
+    public boolean precedes(DataType other) {
+        return this.precedence().ordinal() > other.precedence().ordinal();
+    }
 
     /**
      * check whether a value of this type is convertible to <code>other</code>

--- a/core/src/main/java/io/crate/types/DataType.java
+++ b/core/src/main/java/io/crate/types/DataType.java
@@ -33,6 +33,41 @@ import java.util.Set;
 
 public abstract class DataType<T> implements Comparable, Streamable {
 
+    /**
+     * Type precedence ids which help to decide when a type can be cast
+     * into another type without loosing information (upcasting).
+     *
+     * Lower number => Lower precedence
+     * Higher number => Higher precedence
+     *
+     * Precedence list inspired by
+     * https://docs.microsoft.com/en-us/sql/t-sql/data-types/data-type-precedence-transact-sql
+     *
+     * Note, that using an Enum here doesn't work because we want to use the type ids in
+     * switch statements which allow only compile-time constants.
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static class Precedence {
+        public static final int NotSupportedType        =  1_00;
+        public static final int UndefinedType           =  2_00;
+        public static final int ByteType                =  3_00;
+        public static final int BooleanType             =  4_00;
+        public static final int ShortType               =  5_00;
+        public static final int IntegerType             =  6_00;
+        public static final int LongType                =  7_00;
+        public static final int FloatType               =  8_00;
+        public static final int DoubleType              =  9_00;
+        public static final int GeoPointType            = 10_00;
+        public static final int GeoShapeType            = 11_00;
+        public static final int IpType                  = 12_00;
+        public static final int StringType              = 13_00;
+        public static final int TimestampType           = 14_00;
+        public static final int ObjectType              = 15_00;
+        public static final int ArrayType               = 16_00;
+        public static final int SetType                 = 17_00;
+        public static final int SingleColumnTableType   = 18_00;
+    }
+
     public abstract int id();
 
     public abstract String getName();
@@ -63,6 +98,10 @@ public abstract class DataType<T> implements Comparable, Streamable {
 
     public boolean isNumeric() {
         return DataTypes.NUMERIC_PRIMITIVE_TYPES.contains(this);
+    }
+
+    public boolean isDecimal() {
+        return id() == DoubleType.ID || id() == FloatType.ID;
     }
 
     static <T> int nullSafeCompareValueTo(T val1, T val2, Comparator<T> cmp) {

--- a/core/src/main/java/io/crate/types/DoubleType.java
+++ b/core/src/main/java/io/crate/types/DoubleType.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 public class DoubleType extends DataType<Double> implements FixedWidthType, Streamer<Double> {
 
     public static final DoubleType INSTANCE = new DoubleType();
-    public static final int ID = 6;
+    public static final int ID = Precedence.DoubleType;
 
     private DoubleType() {
     }

--- a/core/src/main/java/io/crate/types/DoubleType.java
+++ b/core/src/main/java/io/crate/types/DoubleType.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 public class DoubleType extends DataType<Double> implements FixedWidthType, Streamer<Double> {
 
     public static final DoubleType INSTANCE = new DoubleType();
-    public static final int ID = Precedence.DoubleType;
+    public static final int ID = 6;
 
     private DoubleType() {
     }
@@ -39,6 +39,11 @@ public class DoubleType extends DataType<Double> implements FixedWidthType, Stre
     @Override
     public int id() {
         return ID;
+    }
+
+    @Override
+    public Precedence precedence() {
+        return Precedence.DoubleType;
     }
 
     @Override

--- a/core/src/main/java/io/crate/types/FloatType.java
+++ b/core/src/main/java/io/crate/types/FloatType.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 public class FloatType extends DataType<Float> implements Streamer<Float>, FixedWidthType {
 
     public static final FloatType INSTANCE = new FloatType();
-    public static final int ID = 7;
+    public static final int ID = Precedence.FloatType;
 
     private FloatType() {
     }

--- a/core/src/main/java/io/crate/types/FloatType.java
+++ b/core/src/main/java/io/crate/types/FloatType.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 public class FloatType extends DataType<Float> implements Streamer<Float>, FixedWidthType {
 
     public static final FloatType INSTANCE = new FloatType();
-    public static final int ID = Precedence.FloatType;
+    public static final int ID = 7;
 
     private FloatType() {
     }
@@ -39,6 +39,11 @@ public class FloatType extends DataType<Float> implements Streamer<Float>, Fixed
     @Override
     public int id() {
         return ID;
+    }
+
+    @Override
+    public Precedence precedence() {
+        return Precedence.FloatType;
     }
 
     @Override

--- a/core/src/main/java/io/crate/types/GeoPointType.java
+++ b/core/src/main/java/io/crate/types/GeoPointType.java
@@ -39,7 +39,7 @@ import java.util.Locale;
 
 public class GeoPointType extends DataType<Double[]> implements Streamer<Double[]>, FixedWidthType {
 
-    public static final int ID = 13;
+    public static final int ID = Precedence.GeoPointType;
     public static final GeoPointType INSTANCE = new GeoPointType();
 
     private GeoPointType() {

--- a/core/src/main/java/io/crate/types/GeoPointType.java
+++ b/core/src/main/java/io/crate/types/GeoPointType.java
@@ -39,7 +39,7 @@ import java.util.Locale;
 
 public class GeoPointType extends DataType<Double[]> implements Streamer<Double[]>, FixedWidthType {
 
-    public static final int ID = Precedence.GeoPointType;
+    public static final int ID = 13;
     public static final GeoPointType INSTANCE = new GeoPointType();
 
     private GeoPointType() {
@@ -50,6 +50,11 @@ public class GeoPointType extends DataType<Double[]> implements Streamer<Double[
     @Override
     public int id() {
         return ID;
+    }
+
+    @Override
+    public Precedence precedence() {
+        return Precedence.GeoPointType;
     }
 
     @Override

--- a/core/src/main/java/io/crate/types/GeoShapeType.java
+++ b/core/src/main/java/io/crate/types/GeoShapeType.java
@@ -36,7 +36,7 @@ import java.util.Map;
 
 public class GeoShapeType extends DataType<Map<String, Object>> implements Streamer<Map<String, Object>> {
 
-    public static final int ID = 14;
+    public static final int ID = Precedence.GeoShapeType;
     public static final GeoShapeType INSTANCE = new GeoShapeType();
 
     private GeoShapeType() {

--- a/core/src/main/java/io/crate/types/GeoShapeType.java
+++ b/core/src/main/java/io/crate/types/GeoShapeType.java
@@ -36,7 +36,7 @@ import java.util.Map;
 
 public class GeoShapeType extends DataType<Map<String, Object>> implements Streamer<Map<String, Object>> {
 
-    public static final int ID = Precedence.GeoShapeType;
+    public static final int ID = 14;
     public static final GeoShapeType INSTANCE = new GeoShapeType();
 
     private GeoShapeType() {
@@ -45,6 +45,11 @@ public class GeoShapeType extends DataType<Map<String, Object>> implements Strea
     @Override
     public int id() {
         return ID;
+    }
+
+    @Override
+    public Precedence precedence() {
+        return Precedence.GeoShapeType;
     }
 
     @Override

--- a/core/src/main/java/io/crate/types/IntegerType.java
+++ b/core/src/main/java/io/crate/types/IntegerType.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 public class IntegerType extends DataType<Integer> implements Streamer<Integer>, FixedWidthType {
 
     public static final IntegerType INSTANCE = new IntegerType();
-    public static final int ID = 9;
+    public static final int ID = Precedence.IntegerType;
 
     private IntegerType() {
     }

--- a/core/src/main/java/io/crate/types/IntegerType.java
+++ b/core/src/main/java/io/crate/types/IntegerType.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 public class IntegerType extends DataType<Integer> implements Streamer<Integer>, FixedWidthType {
 
     public static final IntegerType INSTANCE = new IntegerType();
-    public static final int ID = Precedence.IntegerType;
+    public static final int ID = 9;
 
     private IntegerType() {
     }
@@ -39,6 +39,11 @@ public class IntegerType extends DataType<Integer> implements Streamer<Integer>,
     @Override
     public int id() {
         return ID;
+    }
+
+    @Override
+    public Precedence precedence() {
+        return Precedence.IntegerType;
     }
 
     @Override

--- a/core/src/main/java/io/crate/types/IpType.java
+++ b/core/src/main/java/io/crate/types/IpType.java
@@ -29,7 +29,7 @@ import java.util.Locale;
 
 public class IpType extends StringType {
 
-    public static final int ID = 5;
+    public static final int ID = Precedence.IpType;
     public static final IpType INSTANCE = new IpType();
 
     IpType() {

--- a/core/src/main/java/io/crate/types/IpType.java
+++ b/core/src/main/java/io/crate/types/IpType.java
@@ -29,7 +29,7 @@ import java.util.Locale;
 
 public class IpType extends StringType {
 
-    public static final int ID = Precedence.IpType;
+    public static final int ID = 5;
     public static final IpType INSTANCE = new IpType();
 
     IpType() {

--- a/core/src/main/java/io/crate/types/LongType.java
+++ b/core/src/main/java/io/crate/types/LongType.java
@@ -31,11 +31,16 @@ import java.io.IOException;
 public class LongType extends DataType<Long> implements FixedWidthType, Streamer<Long> {
 
     public static final LongType INSTANCE = new LongType();
-    public static final int ID = Precedence.LongType;
+    public static final int ID = 10;
 
     @Override
     public int id() {
         return ID;
+    }
+
+    @Override
+    public Precedence precedence() {
+        return Precedence.LongType;
     }
 
     @Override

--- a/core/src/main/java/io/crate/types/LongType.java
+++ b/core/src/main/java/io/crate/types/LongType.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 public class LongType extends DataType<Long> implements FixedWidthType, Streamer<Long> {
 
     public static final LongType INSTANCE = new LongType();
-    public static final int ID = 10;
+    public static final int ID = Precedence.LongType;
 
     @Override
     public int id() {

--- a/core/src/main/java/io/crate/types/NotSupportedType.java
+++ b/core/src/main/java/io/crate/types/NotSupportedType.java
@@ -26,7 +26,7 @@ import io.crate.Streamer;
 public class NotSupportedType extends DataType<Void> {
 
     public static final NotSupportedType INSTANCE = new NotSupportedType();
-    public static final int ID = Precedence.NotSupportedType;
+    public static final int ID = 1;
 
     private NotSupportedType() {
     }
@@ -39,6 +39,11 @@ public class NotSupportedType extends DataType<Void> {
     @Override
     public int id() {
         return ID;
+    }
+
+    @Override
+    public Precedence precedence() {
+        return Precedence.NotSupportedType;
     }
 
     @Override

--- a/core/src/main/java/io/crate/types/NotSupportedType.java
+++ b/core/src/main/java/io/crate/types/NotSupportedType.java
@@ -26,7 +26,7 @@ import io.crate.Streamer;
 public class NotSupportedType extends DataType<Void> {
 
     public static final NotSupportedType INSTANCE = new NotSupportedType();
-    public static final int ID = 1;
+    public static final int ID = Precedence.NotSupportedType;
 
     private NotSupportedType() {
     }

--- a/core/src/main/java/io/crate/types/ObjectType.java
+++ b/core/src/main/java/io/crate/types/ObjectType.java
@@ -36,7 +36,7 @@ import java.util.Map;
 public class ObjectType extends DataType<Map<String, Object>> implements Streamer<Map<String, Object>> {
 
     public static final ObjectType INSTANCE = new ObjectType();
-    public static final int ID = 12;
+    public static final int ID = Precedence.ObjectType;
 
     private ObjectType() {
     }

--- a/core/src/main/java/io/crate/types/ObjectType.java
+++ b/core/src/main/java/io/crate/types/ObjectType.java
@@ -36,7 +36,7 @@ import java.util.Map;
 public class ObjectType extends DataType<Map<String, Object>> implements Streamer<Map<String, Object>> {
 
     public static final ObjectType INSTANCE = new ObjectType();
-    public static final int ID = Precedence.ObjectType;
+    public static final int ID = 12;
 
     private ObjectType() {
     }
@@ -44,6 +44,11 @@ public class ObjectType extends DataType<Map<String, Object>> implements Streame
     @Override
     public int id() {
         return ID;
+    }
+
+    @Override
+    public Precedence precedence() {
+        return Precedence.ObjectType;
     }
 
     @Override

--- a/core/src/main/java/io/crate/types/SetType.java
+++ b/core/src/main/java/io/crate/types/SetType.java
@@ -34,7 +34,7 @@ import java.util.Set;
 
 public class SetType extends CollectionType {
 
-    public static final int ID = 101;
+    public static final int ID = Precedence.SetType;
 
     public SetType(DataType<?> innerType) {
         super(innerType);

--- a/core/src/main/java/io/crate/types/SetType.java
+++ b/core/src/main/java/io/crate/types/SetType.java
@@ -34,7 +34,7 @@ import java.util.Set;
 
 public class SetType extends CollectionType {
 
-    public static final int ID = Precedence.SetType;
+    public static final int ID = 101;
 
     public SetType(DataType<?> innerType) {
         super(innerType);
@@ -47,6 +47,11 @@ public class SetType extends CollectionType {
     @Override
     public int id() {
         return ID;
+    }
+
+    @Override
+    public Precedence precedence() {
+        return Precedence.SetType;
     }
 
     @Override

--- a/core/src/main/java/io/crate/types/ShortType.java
+++ b/core/src/main/java/io/crate/types/ShortType.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 public class ShortType extends DataType<Short> implements Streamer<Short>, FixedWidthType {
 
     public static final ShortType INSTANCE = new ShortType();
-    public static final int ID = 8;
+    public static final int ID = Precedence.ShortType;
 
     private ShortType() {
     }

--- a/core/src/main/java/io/crate/types/ShortType.java
+++ b/core/src/main/java/io/crate/types/ShortType.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 public class ShortType extends DataType<Short> implements Streamer<Short>, FixedWidthType {
 
     public static final ShortType INSTANCE = new ShortType();
-    public static final int ID = Precedence.ShortType;
+    public static final int ID = 8;
 
     private ShortType() {
     }
@@ -39,6 +39,11 @@ public class ShortType extends DataType<Short> implements Streamer<Short>, Fixed
     @Override
     public int id() {
         return ID;
+    }
+
+    @Override
+    public Precedence precedence() {
+        return Precedence.ShortType;
     }
 
     @Override

--- a/core/src/main/java/io/crate/types/SingleColumnTableType.java
+++ b/core/src/main/java/io/crate/types/SingleColumnTableType.java
@@ -29,7 +29,7 @@ package io.crate.types;
  */
 public class SingleColumnTableType extends CollectionType {
 
-    public static final int ID = 102;
+    public static final int ID = Precedence.SingleColumnTableType;
 
     public SingleColumnTableType(DataType<?> innerType) {
         super(innerType);

--- a/core/src/main/java/io/crate/types/SingleColumnTableType.java
+++ b/core/src/main/java/io/crate/types/SingleColumnTableType.java
@@ -29,7 +29,7 @@ package io.crate.types;
  */
 public class SingleColumnTableType extends CollectionType {
 
-    public static final int ID = Precedence.SingleColumnTableType;
+    public static final int ID = 102;
 
     public SingleColumnTableType(DataType<?> innerType) {
         super(innerType);
@@ -42,6 +42,11 @@ public class SingleColumnTableType extends CollectionType {
     @Override
     public int id() {
         return ID;
+    }
+
+    @Override
+    public Precedence precedence() {
+        return Precedence.Custom;
     }
 
     @Override

--- a/core/src/main/java/io/crate/types/StringType.java
+++ b/core/src/main/java/io/crate/types/StringType.java
@@ -34,7 +34,7 @@ import java.util.Map;
 
 public class StringType extends DataType<BytesRef> implements Streamer<BytesRef> {
 
-    public static final int ID = 4;
+    public static final int ID = Precedence.StringType;
     public static final StringType INSTANCE = new StringType();
     public static final BytesRef T = new BytesRef("t");
     public static final BytesRef F = new BytesRef("f");

--- a/core/src/main/java/io/crate/types/StringType.java
+++ b/core/src/main/java/io/crate/types/StringType.java
@@ -34,7 +34,7 @@ import java.util.Map;
 
 public class StringType extends DataType<BytesRef> implements Streamer<BytesRef> {
 
-    public static final int ID = Precedence.StringType;
+    public static final int ID = 4;
     public static final StringType INSTANCE = new StringType();
     public static final BytesRef T = new BytesRef("t");
     public static final BytesRef F = new BytesRef("f");
@@ -45,6 +45,11 @@ public class StringType extends DataType<BytesRef> implements Streamer<BytesRef>
     @Override
     public int id() {
         return ID;
+    }
+
+    @Override
+    public Precedence precedence() {
+        return Precedence.StringType;
     }
 
     @Override

--- a/core/src/main/java/io/crate/types/TimestampType.java
+++ b/core/src/main/java/io/crate/types/TimestampType.java
@@ -28,7 +28,7 @@ import org.apache.lucene.util.BytesRef;
 public class TimestampType extends LongType implements Streamer<Long> {
 
     public static final TimestampType INSTANCE = new TimestampType();
-    public static final int ID = 11;
+    public static final int ID = Precedence.TimestampType;
 
     private TimestampType() {
     }

--- a/core/src/main/java/io/crate/types/TimestampType.java
+++ b/core/src/main/java/io/crate/types/TimestampType.java
@@ -28,7 +28,7 @@ import org.apache.lucene.util.BytesRef;
 public class TimestampType extends LongType implements Streamer<Long> {
 
     public static final TimestampType INSTANCE = new TimestampType();
-    public static final int ID = Precedence.TimestampType;
+    public static final int ID = 11;
 
     private TimestampType() {
     }

--- a/core/src/main/java/io/crate/types/UndefinedType.java
+++ b/core/src/main/java/io/crate/types/UndefinedType.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 
 public class UndefinedType extends DataType<Object> implements Streamer<Object> {
 
-    public static final int ID = Precedence.UndefinedType;
+    public static final int ID = 0;
 
     public static final UndefinedType INSTANCE = new UndefinedType();
 
@@ -39,6 +39,11 @@ public class UndefinedType extends DataType<Object> implements Streamer<Object> 
     @Override
     public int id() {
         return ID;
+    }
+
+    @Override
+    public Precedence precedence() {
+        return Precedence.UndefinedType;
     }
 
     @Override

--- a/core/src/main/java/io/crate/types/UndefinedType.java
+++ b/core/src/main/java/io/crate/types/UndefinedType.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 
 public class UndefinedType extends DataType<Object> implements Streamer<Object> {
 
-    public static final int ID = 0;
+    public static final int ID = Precedence.UndefinedType;
 
     public static final UndefinedType INSTANCE = new UndefinedType();
 
@@ -38,7 +38,7 @@ public class UndefinedType extends DataType<Object> implements Streamer<Object> 
 
     @Override
     public int id() {
-        return 0;
+        return ID;
     }
 
     @Override

--- a/enterprise/users/src/test/java/io/crate/operation/user/StatementPrivilegeValidatorTest.java
+++ b/enterprise/users/src/test/java/io/crate/operation/user/StatementPrivilegeValidatorTest.java
@@ -288,7 +288,7 @@ public class StatementPrivilegeValidatorTest extends CrateDummyClusterServiceUni
     @Test
     public void testSelectWithSubSelect() throws Exception {
         analyze("select * from (" +
-                " select users.id from users join parted on users.id = parted.id order by users.name limit 2" +
+                " select users.id from users join parted on users.id = parted.id::long order by users.name limit 2" +
                 ") as users_parted order by users_parted.id");
         assertAskedForTable(Privilege.Type.DQL, "doc.users");
         assertAskedForTable(Privilege.Type.DQL, "doc.parted");

--- a/sql/src/main/java/io/crate/analyze/InsertFromValuesAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/InsertFromValuesAnalyzer.java
@@ -287,14 +287,14 @@ class InsertFromValuesAnalyzer extends AbstractInsertAnalyzer {
         Object[] insertValues = new Object[node.values().size()];
 
         for (int i = 0, valuesSize = node.values().size(); i < valuesSize; i++) {
+            Reference column = context.columns().get(i);
+            final ColumnIdent columnIdent = column.ident().columnIdent();
             Expression expression = node.values().get(i);
             Symbol valuesSymbol = normalizer.normalize(
                 expressionAnalyzer.convert(expression, expressionAnalysisContext),
                 transactionContext);
 
             // implicit type conversion
-            Reference column = context.columns().get(i);
-            final ColumnIdent columnIdent = column.ident().columnIdent();
             Object value;
             try {
                 valuesSymbol = valueNormalizer.normalizeInputForReference(valuesSymbol, column, tableRelation.tableInfo());

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -356,7 +356,7 @@ public class ExpressionAnalyzer {
     /**
      * Indicates whether it is safe to cast to a type which would requires upcasting.
      * @param sourceSymbol The Symbol to cast to the target type.
-     * @param targetType The target type to cat to.
+     * @param targetType The target type to cast to.
      * @return True if it is safe to cast the symbol to the target type.
      */
     private static boolean checkForSpecialTypeHandling(Symbol sourceSymbol, DataType targetType) {

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -349,8 +349,8 @@ public class ExpressionAnalyzer {
             return canBeCasted(sourceInnerType, targetInnerType, symbolToCast);
         }
         return checkForSpecialTypeHandling(symbolToCast, targetType) ||
-                                   sourceType.id() < targetType.id() ||
-                                   sourceType.id() == UndefinedType.ID;
+                                    targetType.precedes(sourceType) ||
+                                    sourceType.id() == UndefinedType.ID;
     }
 
     /**
@@ -365,7 +365,7 @@ public class ExpressionAnalyzer {
         }
         DataType sourceType = sourceSymbol.valueType();
         // handles cases of lower type precedence with potential loss of entropy
-        if (sourceType.id() > targetType.id()) {
+        if (sourceType.precedes(targetType)) {
             if (sourceType.isNumeric()) {
                 Number value = (Number) ((Literal) sourceSymbol).value();
                 if (sourceType.isDecimal()) {

--- a/sql/src/main/java/io/crate/analyze/expressions/ValueNormalizer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ValueNormalizer.java
@@ -27,7 +27,6 @@ import io.crate.analyze.symbol.DynamicReference;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.format.SymbolFormatter;
-import io.crate.analyze.symbol.format.SymbolPrinter;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.exceptions.ColumnValidationException;
 import io.crate.exceptions.ConversionException;
@@ -58,19 +57,11 @@ public class ValueNormalizer {
         assert valueSymbol != null : "valueSymbol must not be null";
 
         DataType<?> targetType = getTargetType(valueSymbol, reference);
+        valueSymbol = ExpressionAnalyzer.castIfNeededOrFail(valueSymbol, targetType);
         if (!(valueSymbol instanceof Literal)) {
-            return ExpressionAnalyzer.castIfNeededOrFail(valueSymbol, targetType);
+            return valueSymbol;
         }
         Literal literal = (Literal) valueSymbol;
-        try {
-            literal = Literal.convert(literal, reference.valueType());
-        } catch (ConversionException e) {
-            throw new ColumnValidationException(
-                reference.ident().columnIdent().name(),
-                tableInfo.ident(),
-                String.format(Locale.ENGLISH, "%s cannot be cast to type %s", SymbolPrinter.INSTANCE.printSimple(valueSymbol),
-                    reference.valueType().getName()));
-        }
         Object value = literal.value();
         if (value == null) {
             return literal;

--- a/sql/src/main/java/io/crate/metadata/Signature.java
+++ b/sql/src/main/java/io/crate/metadata/Signature.java
@@ -28,7 +28,6 @@ import io.crate.types.CollectionType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.SetType;
-import io.crate.types.SingleColumnTableType;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -201,7 +200,6 @@ public class Signature {
 
         ArgMatcher ANY_ARRAY = of(dt -> dt instanceof ArrayType);
         ArgMatcher ANY_SET = of(dt -> dt instanceof SetType);
-        ArgMatcher ANY_SINGLE_COLUMN = of(dt -> dt instanceof SingleColumnTableType);
         ArgMatcher ANY_COLLECTION = of(dt -> dt instanceof CollectionType);
 
         ArgMatcher STRING = rewriteTo(DataTypes.STRING);

--- a/sql/src/main/java/io/crate/operation/aggregation/impl/AverageAggregation.java
+++ b/sql/src/main/java/io/crate/operation/aggregation/impl/AverageAggregation.java
@@ -106,6 +106,11 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
         }
 
         @Override
+        public Precedence precedence() {
+            return Precedence.Custom;
+        }
+
+        @Override
         public String getName() {
             return "average_state";
         }

--- a/sql/src/main/java/io/crate/operation/aggregation/impl/CountAggregation.java
+++ b/sql/src/main/java/io/crate/operation/aggregation/impl/CountAggregation.java
@@ -183,6 +183,11 @@ public class CountAggregation extends AggregationFunction<CountAggregation.LongS
         }
 
         @Override
+        public Precedence precedence() {
+            return Precedence.Custom;
+        }
+
+        @Override
         public String getName() {
             return "long_state";
         }

--- a/sql/src/main/java/io/crate/operation/aggregation/impl/GeometricMeanAggregation.java
+++ b/sql/src/main/java/io/crate/operation/aggregation/impl/GeometricMeanAggregation.java
@@ -127,6 +127,11 @@ public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanA
         }
 
         @Override
+        public Precedence precedence() {
+            return Precedence.UndefinedType;
+        }
+
+        @Override
         public String getName() {
             return "geometric_mean_state";
         }

--- a/sql/src/main/java/io/crate/operation/aggregation/impl/StandardDeviationAggregation.java
+++ b/sql/src/main/java/io/crate/operation/aggregation/impl/StandardDeviationAggregation.java
@@ -93,6 +93,11 @@ public class StandardDeviationAggregation extends AggregationFunction<StandardDe
         }
 
         @Override
+        public Precedence precedence() {
+            return Precedence.Custom;
+        }
+
+        @Override
         public String getName() {
             return "stddev_state";
         }

--- a/sql/src/main/java/io/crate/operation/aggregation/impl/TDigestStateType.java
+++ b/sql/src/main/java/io/crate/operation/aggregation/impl/TDigestStateType.java
@@ -53,6 +53,11 @@ class TDigestStateType extends DataType<TDigestState> implements Streamer<TDiges
     }
 
     @Override
+    public Precedence precedence() {
+        return Precedence.Custom;
+    }
+
+    @Override
     public String getName() {
         return "percentile_state";
     }

--- a/sql/src/main/java/io/crate/operation/aggregation/impl/VarianceAggregation.java
+++ b/sql/src/main/java/io/crate/operation/aggregation/impl/VarianceAggregation.java
@@ -94,6 +94,11 @@ public class VarianceAggregation extends AggregationFunction<VarianceAggregation
         }
 
         @Override
+        public Precedence precedence() {
+            return Precedence.Custom;
+        }
+
+        @Override
         public String getName() {
             return "variance_state";
         }

--- a/sql/src/test/groovy/io/crate/integrationtests/TableFunctionITest.groovy
+++ b/sql/src/test/groovy/io/crate/integrationtests/TableFunctionITest.groovy
@@ -80,7 +80,7 @@ class TableFunctionITest extends SQLTransportIntegrationTest {
         ensureYellow()
         execute("insert into t (id) values (1)");
         execute("refresh table t");
-        assert printedTable(execute("select * from unnest([1, 2]) inner join t on t.id = col1").rows()) == "1| 1\n"
+        assert printedTable(execute("select * from unnest([1, 2]) inner join t on t.id = col1::integer").rows()) == "1| 1\n"
     }
 
     @Test

--- a/sql/src/test/java/io/crate/analyze/InsertFromValuesAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/InsertFromValuesAnalyzerTest.java
@@ -207,7 +207,7 @@ public class InsertFromValuesAnalyzerTest extends CrateDummyClusterServiceUnitTe
     @Test
     public void testInsertWithNumericTypeOutOfRange() throws Exception {
         expectedException.expect(ColumnValidationException.class);
-        expectedException.expectMessage("Validation failed for bytes: 1234 cannot be cast to type byte");
+        expectedException.expectMessage("Validation failed for bytes: Cannot cast 1234 to type byte");
         e.analyze("insert into users (name, id, bytes) values ('Trillian', 4, 1234)");
     }
 
@@ -654,7 +654,7 @@ public class InsertFromValuesAnalyzerTest extends CrateDummyClusterServiceUnitTe
     @Test
     public void testInsertWithBulkArgsTypeMissMatch() throws Exception {
         expectedException.expect(ColumnValidationException.class);
-        expectedException.expectMessage("Validation failed for id: '11!' cannot be cast to type long");
+        expectedException.expectMessage("Validation failed for id: Cannot cast '11!' to type long");
         e.analyze("insert into users (id, name) values (?, ?)",
             new Object[][]{
                 new Object[]{10, "foo"},
@@ -767,8 +767,9 @@ public class InsertFromValuesAnalyzerTest extends CrateDummyClusterServiceUnitTe
     @Test
     public void testInvalidTypeParamLiteral() throws Exception {
         expectedException.expect(ColumnValidationException.class);
-        expectedException.expectMessage("Validation failed for tags: [['the', 'answer'], ['what''s', 'the', " +
-                                        "'question', '?']] cannot be cast to type string_array");
+        expectedException.expectMessage("Validation failed for tags: Cannot cast " +
+                                        "[['the', 'answer'], ['what''s', 'the', 'question', '?']] " +
+                                        "to type string_array");
 
         e.analyze("insert into users (id, name, tags) values (42, 'Deep Thought', [['the', 'answer'], ['what''s', 'the', 'question', '?']])");
 
@@ -777,8 +778,9 @@ public class InsertFromValuesAnalyzerTest extends CrateDummyClusterServiceUnitTe
     @Test
     public void testInvalidTypeParam() throws Exception {
         expectedException.expect(ColumnValidationException.class);
-        expectedException.expectMessage("Validation failed for tags: [['the', 'answer'], ['what''s', 'the', " +
-                                        "'question', '?']] cannot be cast to type string_array");
+        expectedException.expectMessage("Validation failed for tags: Cannot cast " +
+                                        "[['the', 'answer'], ['what''s', 'the', 'question', '?']] " +
+                                        "to type string_array");
 
         e.analyze("insert into users (id, name, tags) values (42, 'Deep Thought', ?)", new Object[]{
             new String[][]{
@@ -792,8 +794,9 @@ public class InsertFromValuesAnalyzerTest extends CrateDummyClusterServiceUnitTe
     @Test
     public void testInvalidTypeBulkParam() throws Exception {
         expectedException.expect(ColumnValidationException.class);
-        expectedException.expectMessage("Validation failed for tags: [['the', 'answer'], ['what''s', 'the', " +
-                                        "'question', '?']] cannot be cast to type string_array");
+        expectedException.expectMessage("Validation failed for tags: Cannot cast " +
+                                        "[['the', 'answer'], ['what''s', 'the', 'question', '?']] " +
+                                        "to type string_array");
 
         e.analyze("insert into users (id, name, tags) values (42, 'Deep Thought', ?)", new Object[][]{
             new Object[]{

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -1342,7 +1342,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     public void testScoreReferenceComparisonWithColumn() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
         expectedException.expectMessage("System column '_score' can only be used within a '>=' comparison without any surrounded predicate");
-        analyze("select * from users where \"_score\" >= id");
+        analyze("select * from users where \"_score\" >= id::float");
     }
 
     @Test
@@ -1604,7 +1604,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
 
     @Test
     public void testExtractFunctionWithWrongType() throws Exception {
-        SelectAnalyzedStatement statement = analyze("select extract(day from name) from users");
+        SelectAnalyzedStatement statement = analyze("select extract(day from name::timestamp) from users");
         Symbol symbol = statement.relation().querySpec().outputs().get(0);
         assertThat(symbol, isFunction("extract_DAY_OF_MONTH"));
 

--- a/sql/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
@@ -174,7 +174,7 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testNumericTypeOutOfRange() throws Exception {
         expectedException.expect(ColumnValidationException.class);
-        expectedException.expectMessage("Validation failed for shorts: -100000 cannot be cast to type short");
+        expectedException.expectMessage("Validation failed for shorts: Cannot cast -100000 to type short");
 
         analyze("update users set shorts=-100000");
     }
@@ -182,7 +182,7 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testNumericOutOfRangeFromFunction() throws Exception {
         expectedException.expect(ColumnValidationException.class);
-        expectedException.expectMessage("Validation failed for bytes: 1234 cannot be cast to type byte");
+        expectedException.expectMessage("Validation failed for bytes: Cannot cast 1234 to type byte");
 
         analyze("update users set bytes=abs(-1234)");
     }
@@ -441,7 +441,8 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testUpdateInvalidType() throws Exception {
         expectedException.expect(ColumnValidationException.class);
-        expectedException.expectMessage("Validation failed for tags: [['a', 'b']] cannot be cast to type string_array");
+        expectedException.expectMessage("Validation failed for tags: Cannot cast " +
+                                        "[['a', 'b']] to type string_array");
         analyze("update users set tags=? where id=1", new Object[]{
             new Object[]{
                 new Object[]{"a", "b"}

--- a/sql/src/test/java/io/crate/integrationtests/ArithmeticIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ArithmeticIntegrationTest.java
@@ -146,7 +146,7 @@ public class ArithmeticIntegrationTest extends SQLTransportIntegrationTest {
             2.2d, 9});
         execute("refresh table t");
 
-        execute("select i from t where round(d) = i order by i");
+        execute("select i from t where round(d)::integer = i order by i");
         assertThat(response.rowCount(), is(2L));
         assertThat((Integer) response.rows()[0][0], is(1));
         assertThat((Integer) response.rows()[1][0], is(2));

--- a/sql/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
@@ -191,7 +191,7 @@ public class InsertIntoIntegrationTest extends SQLTransportIntegrationTest {
         execute("create table t (i ip) with (number_of_replicas=0)");
         ensureYellow();
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("Validation failed for i: '192.168.1.500' cannot be cast to type ip");
+        expectedException.expectMessage("Validation failed for i: Cannot cast '192.168.1.500' to type ip");
         execute("insert into t (i) values ('192.168.1.2'), ('192.168.1.3'),('192.168.1.500')");
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
@@ -464,7 +464,7 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
         execute("select * from" +
                 " (select distinct col1 from t1 order by 1 limit 2 offset 1) t1, " +
                 " (select col1, count(*) as cnt from t2 group by col1 order by 2, 1 limit 2 offset 2) t2 " +
-                "where t1.col1 = t2.cnt " +
+                "where t1.col1 = t2.cnt::integer " +
                 "order by 1 desc, 2, 3 " +
                 "limit 1 offset 1");
         assertThat(printedTable(response.rows()), is("2| 4| 2\n"));
@@ -576,7 +576,7 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
         setup.setUpCharacters();
         executeWith(
             NO_SESSION_SETTINGS_AND_SEMI_JOIN_ENABLED,
-            "select id, name from characters where id in (select col1 from unnest([1,2,3])) order by id",
+            "select id, name from characters where id in (select col1::integer from unnest([1,2,3])) order by id",
             isPrintedTable(
                 "1| Arthur\n" +
                 "2| Ford\n" +

--- a/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -1663,7 +1663,7 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
         execute("insert into t (b, i) values (true, 1), (false, 2), (null, null)");
         execute("refresh table t");
 
-        execute("select b, not b, not (b > i) from t order by b");
+        execute("select b, not b, not (b > i::boolean) from t order by b");
         Object[][] rows = response.rows();
         assertThat((Boolean) rows[0][0], is(false));
         assertThat((Boolean) rows[0][1], is(true));
@@ -1678,7 +1678,7 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
         execute("select b, i from t where not b");
         assertThat(response.rowCount(), is(1L));
 
-        execute("select b, i from t where not b > i");
+        execute("select b, i from t where not b > i::boolean");
         assertThat(response.rowCount(), is(2L));
 
         execute("SELECt b, i FROM t WHERE NOT (i = 1 AND b = TRUE)");

--- a/sql/src/test/java/io/crate/operation/scalar/conditional/ConditionalFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/conditional/ConditionalFunctionTest.java
@@ -140,7 +140,7 @@ public class ConditionalFunctionTest extends AbstractScalarFunctionsTest {
     public void testCaseWithDifferentOperandTypes() throws Exception {
         // x = long
         // a = integer
-        String expression = "case x + 1 when a then 111 end";
+        String expression = "case x + 1 when a::long then 111 end";
         assertEvaluate(expression, 111L,
             Literal.of(110L),    // x
             Literal.of(111));    // a

--- a/sql/src/test/java/io/crate/planner/SubQueryPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/SubQueryPlannerTest.java
@@ -306,7 +306,7 @@ public class SubQueryPlannerTest extends CrateDummyClusterServiceUnitTest {
                                " (select a, count(*) as cnt from t1 group by a) t1 " +
                                "join" +
                                " (select distinct i from t2) t2 " +
-                               "on t1.cnt = t2.i " +
+                               "on t1.cnt = t2.i::long " +
                                "group by t1.a");
         assertThat(nl.nestedLoopPhase().projections().size(), is(3));
         assertThat(nl.nestedLoopPhase().projections().get(1), instanceOf(GroupProjection.class));

--- a/sql/src/test/java/io/crate/planner/consumer/ManyTableConsumerTest.java
+++ b/sql/src/test/java/io/crate/planner/consumer/ManyTableConsumerTest.java
@@ -306,8 +306,8 @@ public class ManyTableConsumerTest extends CrateDummyClusterServiceUnitTest {
                                         " from t1" +
                                         " join t2 on t1.a=t2.b and (t2.b=10 or t1.a=20) " +
                                         " join t3 on t2.b=t3.c" +
-                                        " join users on t1.i=users.id" +
-                                        " join users_multi_pk on t3.z=users_multi_pk.id" +
+                                        " join users on t1.i=users.id::integer" +
+                                        " join users_multi_pk on t3.z=users_multi_pk.id::integer" +
                                         " order by t3.c");
         TwoTableJoin root = ManyTableConsumer.buildTwoTableJoinTree(mss);
         assertThat(root.toString(), is("join.join.join.join.doc.t1.doc.t2.doc.t3.doc.users.doc.users_multi_pk"));

--- a/sql/src/test/java/io/crate/planner/consumer/SemiJoinsTest.java
+++ b/sql/src/test/java/io/crate/planner/consumer/SemiJoinsTest.java
@@ -79,7 +79,7 @@ public class SemiJoinsTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testGatherRewriteCandidatesTwo() throws Exception {
-        Symbol query = asSymbol("a in (select 'foo') and a = 'foo' and x not in (select 1)");
+        Symbol query = asSymbol("a in (select 'foo') and a = 'foo' and x not in (select 1::integer)");
         List<SemiJoins.Candidate> candidates = SemiJoins.gatherRewriteCandidates(query);
         assertThat(candidates.size(), is(2));
 
@@ -160,8 +160,8 @@ public class SemiJoinsTest extends CrateDummyClusterServiceUnitTest {
     public void testWriteWithMultipleInClauses() throws Exception {
         SelectAnalyzedStatement stmt = executor.analyze("select * from t1 " +
                                                         "where " +
-                                                        "   x in (select * from unnest([1, 2])) " +
-                                                        "   and x not in (select 1)");
+                                                        "   x in (select col1::integer from unnest([1, 2])) " +
+                                                        "   and x not in (select 1::integer)");
         QueriedRelation rel = stmt.relation();
         QueriedRelation semiJoins = this.semiJoins.tryRewrite(rel, new TransactionContext(SessionContext.create()));
 


### PR DESCRIPTION
Type precedence during casting enables us to decide if parameters in expressions
can be safely casted to another parameter's type. This is possible by assigning
IDs to all the types which denote the rank of the types. Higher IDs denote
higher precedence.

There are some exceptions where we allow upcasting. When the provided expression
resolves to a Literal and we wouldn't lose entropy when applying a cast, we also
allow upcasting (e.g. int to long, float to double).

The type inference is very basic but works as follows. If we have two
parameters A and B, we first try to cast A to B. This will succeed
depending on the type precedence value of the two parameters. Afterwards we try
to cast B to A. If we applied a cast in step one, we won't cast in step two;
likewise, if we didn't cast in step one we will cast in step two.

Due to these two improvements, we can now remove implicit column casting. That
means that we try to cast Literal values for columns but require an explicit
cast whenever two columns are compared which don't have a matching
type. Column casts should generally be avoided because they can slow down Lucene
queries dramatically.