### PR TITLE
Fixed NullOperators test with random DataTypes.

### DIFF
--- a/sql/src/test/java/io/crate/integrationtests/LuceneQueryBuilderIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/LuceneQueryBuilderIntegrationTest.java
@@ -21,7 +21,6 @@
 
 package io.crate.integrationtests;
 
-import com.carrotsearch.randomizedtesting.annotations.Repeat;
 import io.crate.testing.DataTypeTesting;
 import io.crate.types.DataType;
 import org.elasticsearch.common.settings.Settings;
@@ -288,7 +287,6 @@ public class LuceneQueryBuilderIntegrationTest extends SQLTransportIntegrationTe
         execute("select count(*) from t2 where id != any(select id from t1)");
         assertThat(response.rows()[0][0], is(1L));
     }
-
 
     @Test
     public void testNullOperators() throws Exception {

--- a/sql/src/test/java/io/crate/testing/DataTypeTesting.java
+++ b/sql/src/test/java/io/crate/testing/DataTypeTesting.java
@@ -46,6 +46,7 @@ import io.crate.types.TimestampType;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.function.Supplier;
 
@@ -59,7 +60,7 @@ public class DataTypeTesting {
         .build();
 
     public static DataType<?> randomType() {
-        return RandomPicks.randomFrom(RandomizedContext.current().getRandom(),ALL_TYPES_EXCEPT_ARRAYS);
+        return RandomPicks.randomFrom(RandomizedContext.current().getRandom(), ALL_TYPES_EXCEPT_ARRAYS);
     }
 
     @SuppressWarnings("unchecked")
@@ -106,7 +107,13 @@ public class DataTypeTesting {
                 };
 
             case GeoShapeType.ID:
-                return () -> (T) GeoShapeType.INSTANCE.value("POINT (10.2 32.2)");
+                return () -> {
+                    // Can't use immutable Collections.singletonMap; insert-analyzer mutates the map
+                    Map<String, Object> geoShape = new HashMap<>(2);
+                    geoShape.put("coordinates", new Double[] {10.2d, 32.2d});
+                    geoShape.put("type", "Point");
+                    return (T) geoShape;
+                };
 
             case ObjectType.ID:
                 Supplier<?> innerValueGenerator = getDataGenerator(randomType());


### PR DESCRIPTION
The issue was that in case of an ObjectType if then GeoShapeType was selected for the value
to insert, the Map representing the GeoShape was Immutable causing ValueNormalizer to fail.