### PR TITLE
Remove index.translog.flush_threshold_period setting from docs.

### DIFF
--- a/blackbox/docs/sql/reference/create_table.txt
+++ b/blackbox/docs/sql/reference/create_table.txt
@@ -345,13 +345,6 @@ Sets size of transaction log prior to flushing.
 
 :value: Size (bytes) of translog.
 
-``translog.flush_threshold_period``
-...................................
-
-Sets period of no flushing after which force flush occurs.
-
-:value: Period length in milliseconds.
-
 ``translog.disable_flush``
 ..........................
 


### PR DESCRIPTION
The setting has been removed with ES 5 upgrade and the removal is
already included in the 2.0.0 Breaking Changes.

https://github.com/crate/crate/blob/master/blackbox/docs/release_notes/2.0.0.txt#L103