### PR TITLE
Reuse the MergePhase ramAccountingContext in the RoutedCollectPhase.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -21,6 +21,10 @@ Changes
 Fixes
 =====
 
+ - Fixed an issue where the query circuit breaker would be tripped after 
+   running several queries due to incorrect memory tracking. Subsequent 
+   operations would've failed due to the lack of circuit breaker cleanup.
+
  - Improve shards view performance in the Admin UI
 
  - Remove horizontal scroll from the console editor in the Admin UI.

--- a/sql/src/main/java/io/crate/breaker/RamAccountingContext.java
+++ b/sql/src/main/java/io/crate/breaker/RamAccountingContext.java
@@ -34,6 +34,7 @@ import java.util.concurrent.atomic.AtomicLong;
 @ThreadSafe
 public class RamAccountingContext {
 
+    // this must not be final so tests could adjust it
     // Flush every 2mb
     public static long FLUSH_BUFFER_SIZE = 1024 * 1024 * 2;
 

--- a/sql/src/test/java/io/crate/integrationtests/CircuitBreakerIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/CircuitBreakerIntegrationTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.integrationtests;
+
+import io.crate.breaker.CrateCircuitBreakerService;
+import io.crate.breaker.RamAccountingContext;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+
+@ESIntegTestCase.ClusterScope(numDataNodes = 1, supportsDedicatedMasters = false, numClientNodes = 0)
+public class CircuitBreakerIntegrationTest extends SQLTransportIntegrationTest {
+
+    private long originalBufferSize;
+
+    @Before
+    public void reduceFlushBufferSize() throws Exception {
+        originalBufferSize = RamAccountingContext.FLUSH_BUFFER_SIZE;
+        RamAccountingContext.FLUSH_BUFFER_SIZE = 10;
+    }
+
+    @After
+    public void resetFlushBufferSize() throws Exception {
+        RamAccountingContext.FLUSH_BUFFER_SIZE = originalBufferSize;
+    }
+
+    @Test
+    public void testQueryBreakerIsDecrementedWhenQueryCompletes() {
+        execute("create table t1 (text string)");
+        execute("insert into t1 values ('this is some text'), ('other text')");
+        refresh();
+
+        CrateCircuitBreakerService circuitBreakerService = internalCluster().getInstance(CrateCircuitBreakerService.class);
+        CircuitBreaker queryBreaker = circuitBreakerService.getBreaker(CrateCircuitBreakerService.QUERY);
+        long breakerBytesUsedBeforeQuery = queryBreaker.getUsed();
+
+        execute("select text from t1 group by text");
+
+        assertThat(queryBreaker.getUsed(), is(breakerBytesUsedBeforeQuery));
+    }
+}


### PR DESCRIPTION
The merge phase creates a RamAccountingContext and a ProjectingBatchConsumer
that will use it to track the consumed rows.
In case the upstream is on the same mode, during the merge phase, we do not
register any execution context using the newly created ProjectingBatchConsumer,
but we register the consumer with the PreparerContext for a later phase to pick
it up and use it as part of an execution context.

In the case of the RoutedCollectPhase, a new RamAccountingContext was created and
that *new* context was passed in the execution context for tracking (the execution
context would close the RamAccountingContext during the cleanup phase which is
essential in order to decrement the tracked bytes in the underlying circuit breaker),
while the RamAccountingContext created in the merge phase would've been used in the
ProjectingBatchConsumer but never closed (meaning the accummulated bytes would've never
been substracted in the underlying ciruit breaker).

This commit has the MergePhase register the RamAccoutingContext it creates along with
the ProjectingBatchConsumer in the PreparerContext and the RoutedCollectPhase will use
both if present (in case no RamAccountingContext is found in the PreparerContext, a
new one is created)