### PR TITLE
Fixed: Error thrown preventing bootstrap when `ingestion.mqtt.enabled…

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -21,8 +21,11 @@ Changes
 Fixes
 =====
 
- - Fixed an issue where the query circuit breaker would be tripped after 
-   running several queries due to incorrect memory tracking. Subsequent 
+ - Fixed: Bootstrap fails with error when ``ingestion.mqtt.enabled`` is
+   defined when ``license.enterprise`` is set to false.
+
+ - Fixed an issue where the query circuit breaker would be tripped after
+   running several queries due to incorrect memory tracking. Subsequent
    operations would've failed due to the lack of circuit breaker cleanup.
 
  - Improve shards view performance in the Admin UI

--- a/enterprise/mqtt/src/main/java/io/crate/mqtt/MqttModule.java
+++ b/enterprise/mqtt/src/main/java/io/crate/mqtt/MqttModule.java
@@ -29,11 +29,6 @@ import org.elasticsearch.common.settings.Setting;
 import java.util.Collection;
 import java.util.Collections;
 
-import static io.crate.mqtt.netty.Netty4MqttServerTransport.MQTT_ENABLED_SETTING;
-import static io.crate.mqtt.netty.Netty4MqttServerTransport.MQTT_PORT_SETTING;
-import static io.crate.mqtt.netty.Netty4MqttServerTransport.MQTT_TIMEOUT_SETTING;
-import static io.crate.mqtt.netty.Netty4MqttServerTransport.SSL_MQTT_ENABLED;
-
 public class MqttModule extends AbstractModule implements IngestionModules {
 
     @Override
@@ -53,9 +48,6 @@ public class MqttModule extends AbstractModule implements IngestionModules {
 
     @Override
     public Collection<Setting<?>> getSettings() {
-        return ImmutableList.of(MQTT_ENABLED_SETTING.setting(),
-            SSL_MQTT_ENABLED.setting(),
-            MQTT_PORT_SETTING.setting(),
-            MQTT_TIMEOUT_SETTING.setting());
+        return Collections.emptyList();
     }
 }

--- a/enterprise/mqtt/src/main/java/io/crate/mqtt/netty/Netty4MqttServerTransport.java
+++ b/enterprise/mqtt/src/main/java/io/crate/mqtt/netty/Netty4MqttServerTransport.java
@@ -26,12 +26,11 @@ import io.crate.metadata.Functions;
 import io.crate.mqtt.operations.MqttIngestService;
 import io.crate.mqtt.protocol.MqttProcessor;
 import io.crate.netty.CrateChannelBootstrapFactory;
+import io.crate.operation.mqtt.MqttSettings;
 import io.crate.operation.user.UserManager;
 import io.crate.protocols.postgres.BindPostgresException;
 import io.crate.protocols.ssl.SslContextProvider;
-import io.crate.settings.CrateSetting;
 import io.crate.settings.SharedSettings;
-import io.crate.types.DataTypes;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.bootstrap.ServerBootstrapConfig;
 import io.netty.channel.Channel;
@@ -49,7 +48,6 @@ import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.network.NetworkAddress;
 import org.elasticsearch.common.network.NetworkService;
-import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.common.transport.InetSocketTransportAddress;
@@ -67,30 +65,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Function;
 
 @Singleton
 public class Netty4MqttServerTransport extends AbstractLifecycleComponent {
 
-    public static final CrateSetting<Boolean> MQTT_ENABLED_SETTING = CrateSetting.of(
-        Setting.boolSetting("ingestion.mqtt.enabled", false, Setting.Property.NodeScope),
-        DataTypes.BOOLEAN);
-
-    public static final CrateSetting<Boolean> SSL_MQTT_ENABLED = CrateSetting.of(
-        Setting.boolSetting("ssl.ingestion.mqtt.enabled", false, Setting.Property.NodeScope),
-        DataTypes.BOOLEAN);
-
-    public static final CrateSetting<String> MQTT_PORT_SETTING = CrateSetting.of(new Setting<>(
-        "ingestion.mqtt.port", "1883",
-        Function.identity(), Setting.Property.NodeScope), DataTypes.STRING);
-
-    public static final CrateSetting<TimeValue> MQTT_TIMEOUT_SETTING = CrateSetting.of(Setting.timeSetting(
-        "ingestion.mqtt.timeout", TimeValue.timeValueSeconds(10L), TimeValue.timeValueSeconds(1L),
-        Setting.Property.NodeScope), DataTypes.STRING);
-
     static boolean isMQTTSslEnabled(Settings settings) {
         return SharedSettings.ENTERPRISE_LICENSE_SETTING.setting().get(settings) &&
-               SSL_MQTT_ENABLED.setting().get(settings);
+               MqttSettings.SSL_MQTT_ENABLED.setting().get(settings);
     }
 
     private final NetworkService networkService;
@@ -120,9 +101,9 @@ public class Netty4MqttServerTransport extends AbstractLifecycleComponent {
         this.networkService = networkService;
         logger = Loggers.getLogger("mqtt", settings);
         isEnterprise = SharedSettings.ENTERPRISE_LICENSE_SETTING.setting().get(settings);
-        isEnabled = MQTT_ENABLED_SETTING.setting().get(settings);
-        port = MQTT_PORT_SETTING.setting().get(settings);
-        defaultIdleTimeout = MQTT_TIMEOUT_SETTING.setting().get(settings);
+        isEnabled = MqttSettings.MQTT_ENABLED_SETTING.setting().get(settings);
+        port = MqttSettings.MQTT_PORT_SETTING.setting().get(settings);
+        defaultIdleTimeout = MqttSettings.MQTT_TIMEOUT_SETTING.setting().get(settings);
         mqttMessageLogger = new MqttMessageLogger(settings);
         mqttIngestService = new MqttIngestService(functions, sqlOperations, userManager, ingestionService);
         this.sslContextProvider = sslContextProvider;
@@ -198,7 +179,7 @@ public class Netty4MqttServerTransport extends AbstractLifecycleComponent {
                                     boundAddresses +
                                     " with distinct ports and none of them matched the publish address (" +
                                     publishInetAddress + "). " +
-                                    "Please specify a unique port by setting " + MQTT_PORT_SETTING.getKey());
+                                    "Please specify a unique port by setting " + MqttSettings.MQTT_PORT_SETTING.getKey());
     }
 
     private TransportAddress bindAddress(final InetAddress hostAddress) {

--- a/enterprise/mqtt/src/test/java/io/crate/mqtt/netty/CrateMqttSslTransportIntegrationTest.java
+++ b/enterprise/mqtt/src/test/java/io/crate/mqtt/netty/CrateMqttSslTransportIntegrationTest.java
@@ -24,6 +24,7 @@ package io.crate.mqtt.netty;
 
 import io.crate.integrationtests.SQLTransportIntegrationTest;
 import io.crate.mqtt.operations.MqttIngestService;
+import io.crate.operation.mqtt.MqttSettings;
 import io.crate.protocols.ssl.SslConfigSettings;
 import io.crate.settings.SharedSettings;
 import org.eclipse.paho.client.mqttv3.IMqttDeliveryToken;
@@ -84,9 +85,9 @@ public class CrateMqttSslTransportIntegrationTest extends SQLTransportIntegratio
         return Settings.builder()
             .put(super.nodeSettings(nodeOrdinal))
             .put(SharedSettings.ENTERPRISE_LICENSE_SETTING.getKey(), true)
-            .put(Netty4MqttServerTransport.SSL_MQTT_ENABLED.getKey(), true)
-            .put(Netty4MqttServerTransport.MQTT_ENABLED_SETTING.getKey(), true)
-            .put(Netty4MqttServerTransport.MQTT_PORT_SETTING.getKey(), 8883)
+            .put(MqttSettings.SSL_MQTT_ENABLED.getKey(), true)
+            .put(MqttSettings.MQTT_ENABLED_SETTING.getKey(), true)
+            .put(MqttSettings.MQTT_PORT_SETTING.getKey(), 8883)
             .put(SslConfigSettings.SSL_KEYSTORE_FILEPATH.getKey(), keyStoreFile)
             .put(SslConfigSettings.SSL_KEYSTORE_PASSWORD.getKey(), "keystorePassword")
             .put(SslConfigSettings.SSL_KEYSTORE_KEY_PASSWORD.getKey(), "serverKeyPassword")

--- a/enterprise/mqtt/src/test/java/io/crate/mqtt/operations/MqttIntegrationTest.java
+++ b/enterprise/mqtt/src/test/java/io/crate/mqtt/operations/MqttIntegrationTest.java
@@ -21,6 +21,7 @@ package io.crate.mqtt.operations;
 import io.crate.integrationtests.SQLTransportIntegrationTest;
 import io.crate.mqtt.netty.Client;
 import io.crate.mqtt.netty.Netty4MqttServerTransport;
+import io.crate.operation.mqtt.MqttSettings;
 import io.crate.settings.SharedSettings;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.logging.Loggers;
@@ -29,9 +30,6 @@ import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.junit.After;
 import org.junit.Before;
-
-import static io.crate.mqtt.netty.Netty4MqttServerTransport.MQTT_ENABLED_SETTING;
-import static io.crate.mqtt.netty.Netty4MqttServerTransport.MQTT_PORT_SETTING;
 
 public abstract class MqttIntegrationTest extends SQLTransportIntegrationTest {
 
@@ -66,8 +64,8 @@ public abstract class MqttIntegrationTest extends SQLTransportIntegrationTest {
         return Settings.builder()
             .put(super.nodeSettings(nodeOrdinal))
             .put(SharedSettings.ENTERPRISE_LICENSE_SETTING.getKey(), true)
-            .put(MQTT_ENABLED_SETTING.getKey(), true)
-            .put(MQTT_PORT_SETTING.getKey(), PORT_RANGE)
+            .put(MqttSettings.MQTT_ENABLED_SETTING.getKey(), true)
+            .put(MqttSettings.MQTT_PORT_SETTING.getKey(), PORT_RANGE)
             .build();
     }
 }

--- a/sql/src/main/java/io/crate/operation/mqtt/MqttSettings.java
+++ b/sql/src/main/java/io/crate/operation/mqtt/MqttSettings.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.operation.mqtt;
+
+import io.crate.settings.CrateSetting;
+import io.crate.types.DataTypes;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.unit.TimeValue;
+
+import java.util.function.Function;
+
+public final class MqttSettings {
+
+    private MqttSettings() {
+    }
+
+    public static final CrateSetting<Boolean> MQTT_ENABLED_SETTING = CrateSetting.of(
+        Setting.boolSetting("ingestion.mqtt.enabled", false, Setting.Property.NodeScope),
+        DataTypes.BOOLEAN);
+
+    public static final CrateSetting<Boolean> SSL_MQTT_ENABLED = CrateSetting.of(
+        Setting.boolSetting("ssl.ingestion.mqtt.enabled", false, Setting.Property.NodeScope),
+        DataTypes.BOOLEAN);
+
+    public static final CrateSetting<String> MQTT_PORT_SETTING = CrateSetting.of(new Setting<>(
+        "ingestion.mqtt.port", "1883",
+        Function.identity(), Setting.Property.NodeScope), DataTypes.STRING);
+
+    public static final CrateSetting<TimeValue> MQTT_TIMEOUT_SETTING = CrateSetting.of(Setting.timeSetting(
+        "ingestion.mqtt.timeout", TimeValue.timeValueSeconds(10L), TimeValue.timeValueSeconds(1L),
+        Setting.Property.NodeScope), DataTypes.STRING);
+}

--- a/sql/src/main/java/io/crate/plugin/SQLPlugin.java
+++ b/sql/src/main/java/io/crate/plugin/SQLPlugin.java
@@ -49,6 +49,7 @@ import io.crate.operation.aggregation.impl.AggregationImplModule;
 import io.crate.operation.auth.AuthSettings;
 import io.crate.operation.collect.CollectOperationModule;
 import io.crate.operation.collect.files.FileCollectModule;
+import io.crate.operation.mqtt.MqttSettings;
 import io.crate.operation.operator.OperatorModule;
 import io.crate.operation.predicate.PredicateModule;
 import io.crate.operation.reference.sys.check.SysChecksModule;
@@ -152,10 +153,11 @@ public class SQLPlugin extends Plugin implements ActionPlugin, MapperPlugin, Clu
         settings.add(SslConfigSettings.SSL_KEYSTORE_PASSWORD.setting());
         settings.add(SslConfigSettings.SSL_KEYSTORE_KEY_PASSWORD.setting());
 
-        // Settings for ingestion implementations
-        if (ingestionModules != null) {
-            settings.addAll(ingestionModules.getSettings());
-        }
+        // Settings for ingestion implementations (available only in the Enterprise version)
+        settings.add(MqttSettings.MQTT_ENABLED_SETTING.setting());
+        settings.add(MqttSettings.SSL_MQTT_ENABLED.setting());
+        settings.add(MqttSettings.MQTT_PORT_SETTING.setting());
+        settings.add(MqttSettings.MQTT_TIMEOUT_SETTING.setting());
 
         // also add CrateSettings
         for (CrateSetting crateSetting : CrateSettings.CRATE_CLUSTER_SETTINGS) {


### PR DESCRIPTION
…` is defined and `license.enterprise`=false

MQTT settings were only registered if `license.enterprise` = true so ES is complaining for unknown settings. Moved MQTT settings to a separate class MqttSettings in `sql` module and always register them even if MqttModule is not loaded.