### PR TITLE
added custom annotation `UseRandomizedSession` to integrationtests

### DIFF
--- a/enterprise/lang-js/src/test/java/io/crate/operation/language/JavaScriptUDFIntegrationTest.java
+++ b/enterprise/lang-js/src/test/java/io/crate/operation/language/JavaScriptUDFIntegrationTest.java
@@ -20,7 +20,6 @@ package io.crate.operation.language;
 
 import com.google.common.collect.ImmutableList;
 import io.crate.integrationtests.SQLTransportIntegrationTest;
-import io.crate.metadata.Schemas;
 import io.crate.module.JavaScriptLanguageModule;
 import io.crate.settings.SharedSettings;
 import io.crate.testing.TestingHelpers;
@@ -68,7 +67,7 @@ public class JavaScriptUDFIntegrationTest extends SQLTransportIntegrationTest {
     public void testJavascriptFunction() throws Exception {
         execute("CREATE FUNCTION subtract_js(LONG, LONG) " +
                 "RETURNS LONG LANGUAGE JAVASCRIPT AS 'function subtract_js(x, y) { return x-y; }'");
-        assertFunctionIsCreatedOnAll(Schemas.DOC_SCHEMA_NAME, "subtract_js", ImmutableList.of(DataTypes.LONG, DataTypes.LONG));
+        assertFunctionIsCreatedOnAll(sqlExecutor.getDefaultSchema(), "subtract_js", ImmutableList.of(DataTypes.LONG, DataTypes.LONG));
         execute("SELECT SUBTRACT_JS(a, b) FROM test ORDER BY a ASC");
         assertThat(response.rowCount(), is(2L));
         assertThat(response.rows()[0][0], is(2L));

--- a/sql/src/test/java/io/crate/executor/transport/TransportExecutorDDLTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/TransportExecutorDDLTest.java
@@ -89,7 +89,7 @@ public class TransportExecutorDDLTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testCreateTableWithOrphanedPartitions() throws Exception {
-        String partitionName = new PartitionName("test", Collections.singletonList(new BytesRef("foo"))).asIndexName();
+        String partitionName = new PartitionName(sqlExecutor.getDefaultSchema(), "test", Collections.singletonList(new BytesRef("foo"))).asIndexName();
         client().admin().indices().prepareCreate(partitionName)
             .addMapping(Constants.DEFAULT_MAPPING_TYPE, TEST_PARTITIONED_MAPPING)
             .setSettings(TEST_SETTINGS)
@@ -111,7 +111,7 @@ public class TransportExecutorDDLTest extends SQLTransportIntegrationTest {
     @Test
     @UseJdbc(0) // create table has no rowcount
     public void testCreateTableWithOrphanedAlias() throws Exception {
-        String partitionName = new PartitionName("test", Collections.singletonList(new BytesRef("foo"))).asIndexName();
+        String partitionName = new PartitionName(sqlExecutor.getDefaultSchema(), "test", Collections.singletonList(new BytesRef("foo"))).asIndexName();
         client().admin().indices().prepareCreate(partitionName)
             .addMapping(Constants.DEFAULT_MAPPING_TYPE, TEST_PARTITIONED_MAPPING)
             .setSettings(TEST_SETTINGS)
@@ -150,7 +150,7 @@ public class TransportExecutorDDLTest extends SQLTransportIntegrationTest {
         execute("select * from information_schema.table_partitions where table_name = 't'");
         assertThat(response.rowCount(), is(1L));
 
-        String partitionName = new PartitionName("t", ImmutableList.of(new BytesRef("1"))).asIndexName();
+        String partitionName = new PartitionName(sqlExecutor.getDefaultSchema(), "t", ImmutableList.of(new BytesRef("1"))).asIndexName();
         ESDeletePartition plan = new ESDeletePartition(UUID.randomUUID(), partitionName);
 
         TestingBatchConsumer consumer = new TestingBatchConsumer();
@@ -177,7 +177,7 @@ public class TransportExecutorDDLTest extends SQLTransportIntegrationTest {
         assertThat(response.rowCount(), is(1L));
         ensureYellow();
 
-        String partitionName = new PartitionName("t", ImmutableList.of(new BytesRef("1"))).asIndexName();
+        String partitionName = new PartitionName(sqlExecutor.getDefaultSchema(), "t", ImmutableList.of(new BytesRef("1"))).asIndexName();
         assertTrue(client().admin().indices().prepareClose(partitionName).execute().actionGet().isAcknowledged());
 
         ESDeletePartition plan = new ESDeletePartition(UUID.randomUUID(), partitionName);

--- a/sql/src/test/java/io/crate/executor/transport/ddl/TransportRenameTableActionTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/ddl/TransportRenameTableActionTest.java
@@ -50,33 +50,34 @@ public class TransportRenameTableActionTest extends SQLTransportIntegrationTest 
 
     @Test
     public void testRenameOnOpenTableThrowsException() throws Exception {
-        String defaultSchema = sqlExecutor.getDefaultSchema();
         RenameTableRequest request = new RenameTableRequest(
-            TableIdent.fromIndexName(defaultSchema + ".t1"),
-            TableIdent.fromIndexName(defaultSchema + ".t2"), false);
+            TableIdent.fromIndexName(getFqn("t1")),
+            TableIdent.fromIndexName(getFqn("t2")), false);
 
         expectedException.expect(RuntimeException.class);
-        expectedException.expectMessage(String.format("Table '%s.t1' is not closed, cannot perform a rename", defaultSchema));
+        expectedException.expectMessage(String.format("Table '%s' is not closed, cannot perform a rename", getFqn("t1")));
         transportRenameTableAction.execute(request).actionGet(5, TimeUnit.SECONDS);
     }
 
     @Test
     public void testRenameOnOpenPartitionedTableThrowsException() throws Exception {
-        RenameTableRequest request = new RenameTableRequest(TableIdent.fromIndexName("p1"),
-            TableIdent.fromIndexName("p2"), true);
+        String defaultSchema = sqlExecutor.getDefaultSchema();
+        RenameTableRequest request = new RenameTableRequest(TableIdent.fromIndexName(getFqn("p1")),
+            TableIdent.fromIndexName(getFqn("p2")), true);
 
         expectedException.expect(RuntimeException.class);
-        expectedException.expectMessage("Partitioned table 'doc.p1' is not closed, cannot perform a rename");
+        expectedException.expectMessage(String.format("Partitioned table '%s' is not closed, cannot perform a rename", getFqn("p1")));
         transportRenameTableAction.execute(request).actionGet(5, TimeUnit.SECONDS);
     }
 
     @Test
     public void testRenameOnPartitionedTableWithOpenPartitionsThrowsException() throws Exception {
-        RenameTableRequest request = new RenameTableRequest(TableIdent.fromIndexName("p11"),
-            TableIdent.fromIndexName("p12"), true);
+        String defaultSchema = sqlExecutor.getDefaultSchema();
+        RenameTableRequest request = new RenameTableRequest(TableIdent.fromIndexName(getFqn("p11")),
+            TableIdent.fromIndexName(getFqn("p12")), true);
 
         expectedException.expect(RuntimeException.class);
-        expectedException.expectMessage("Partition '.partitioned.p11.04132' of table 'doc.p11' is not closed, cannot perform a rename");
+        expectedException.expectMessage(String.format("Partition '%s..partitioned.p11.04132' of table '%s' is not closed, cannot perform a rename", defaultSchema, getFqn("p11")));
         transportRenameTableAction.execute(request).actionGet(5, TimeUnit.SECONDS);
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/CustomSchemaIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/CustomSchemaIntegrationTest.java
@@ -22,6 +22,7 @@
 package io.crate.integrationtests;
 
 import io.crate.testing.TestingHelpers;
+import io.crate.testing.UseRandomizedSession;
 import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsRequest;
 import org.junit.Test;
 
@@ -30,6 +31,7 @@ import static org.hamcrest.Matchers.is;
 public class CustomSchemaIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test
+    @UseRandomizedSession(schema = false)
     public void testInformationSchemaTablesReturnCorrectTablesIfCustomSchemaIsSimilarToTableName() throws Exception {
         // regression test.. this caused foobar to be detected as a table in the foo schema and caused a NPE
         execute("create table foobar (id int primary key) with (number_of_replicas = 0)");

--- a/sql/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -28,6 +28,7 @@ import io.crate.metadata.PartitionName;
 import io.crate.metadata.Schemas;
 import io.crate.testing.TestingHelpers;
 import io.crate.testing.UseJdbc;
+import io.crate.testing.UseRandomizedSession;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsRequest;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
@@ -49,6 +50,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(randomDynamicTemplates = false)
+@UseRandomizedSession(schema = false)
 public class DDLIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/DeleteIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/DeleteIntegrationTest.java
@@ -34,9 +34,10 @@ public class DeleteIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testDelete() throws Exception {
-        createIndex("test");
+        String fqn = getFqn("test");
+        createIndex(fqn);
         ensureYellow();
-        client().prepareIndex("test", "default", "id1").setSource("{}", XContentType.JSON).execute().actionGet();
+        client().prepareIndex(fqn, "default", "id1").setSource("{}", XContentType.JSON).execute().actionGet();
         refresh();
         execute("delete from test");
         assertEquals(1, response.rowCount());
@@ -47,11 +48,12 @@ public class DeleteIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testDeleteWithWhere() throws Exception {
-        createIndex("test");
+        String fqn = getFqn("test");
+        createIndex(fqn);
         ensureYellow();
-        client().prepareIndex("test", "default", "id1").setSource("{}", XContentType.JSON).execute().actionGet();
-        client().prepareIndex("test", "default", "id2").setSource("{}", XContentType.JSON).execute().actionGet();
-        client().prepareIndex("test", "default", "id3").setSource("{}", XContentType.JSON).execute().actionGet();
+        client().prepareIndex(fqn, "default", "id1").setSource("{}", XContentType.JSON).execute().actionGet();
+        client().prepareIndex(fqn, "default", "id2").setSource("{}", XContentType.JSON).execute().actionGet();
+        client().prepareIndex(fqn, "default", "id3").setSource("{}", XContentType.JSON).execute().actionGet();
         refresh();
         execute("delete from test where \"_id\" = 'id1'");
         assertEquals(1, response.rowCount());

--- a/sql/src/test/java/io/crate/integrationtests/FulltextIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/FulltextIntegrationTest.java
@@ -100,7 +100,7 @@ public class FulltextIntegrationTest extends SQLTransportIntegrationTest  {
     public void testSelectScoreMatchAll() throws Exception {
         execute("create table quotes (quote string) with (number_of_replicas = 0)");
         ensureYellow();
-        assertTrue(client().admin().indices().exists(new IndicesExistsRequest("quotes"))
+        assertTrue(client().admin().indices().exists(new IndicesExistsRequest(getFqn("quotes")))
             .actionGet().isExists());
 
         execute("insert into quotes values (?), (?)",
@@ -144,7 +144,7 @@ public class FulltextIntegrationTest extends SQLTransportIntegrationTest  {
         execute("create table quotes (id int, quote string, " +
                 "index quote_fulltext using fulltext(quote) with (analyzer='english')) with (number_of_replicas = 0)");
         ensureYellow();
-        assertTrue(client().admin().indices().exists(new IndicesExistsRequest("quotes"))
+        assertTrue(client().admin().indices().exists(new IndicesExistsRequest(getFqn("quotes")))
             .actionGet().isExists());
 
         execute("insert into quotes (id, quote) values (?, ?), (?, ?)",
@@ -238,7 +238,7 @@ public class FulltextIntegrationTest extends SQLTransportIntegrationTest  {
         this.setup.setUpLocations();
         refresh();
 
-        SearchResponse searchResponse = client().prepareSearch("locations")
+        SearchResponse searchResponse = client().prepareSearch(getFqn("locations"))
             .setTypes("default")
             .setQuery(QueryBuilders.multiMatchQuery("planet earth", "kind^0.8", "name_description_ft^0.6"))
             .get(TimeValue.timeValueSeconds(1));

--- a/sql/src/test/java/io/crate/integrationtests/GeoShapeIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/GeoShapeIntegrationTest.java
@@ -24,6 +24,7 @@ package io.crate.integrationtests;
 
 import com.google.common.collect.ImmutableMap;
 import io.crate.testing.TestingHelpers;
+import io.crate.testing.UseRandomizedSession;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -90,7 +91,7 @@ public class GeoShapeIntegrationTest extends SQLTransportIntegrationTest {
     public void testIndexWithES() throws Exception {
         execute("create table test (shape geo_shape)");
         ensureYellow();
-        client().prepareIndex("test", "default", "test").setSource(jsonBuilder().startObject()
+        client().prepareIndex(getFqn("test"), "default", "test").setSource(jsonBuilder().startObject()
             .startObject("shape")
             .field("type", "polygon")
             .startArray("coordinates").startArray()
@@ -113,6 +114,7 @@ public class GeoShapeIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    @UseRandomizedSession(schema = false)
     public void testShowCreateTable() throws Exception {
         execute("create table test (" +
                 "col1 geo_shape INDEX using QUADTREE with (precision='1m', distance_error_pct='0.25')" +
@@ -141,6 +143,7 @@ public class GeoShapeIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    @UseRandomizedSession(schema = false)
     public void testShowCreateTableWithDefaultValues() throws Exception {
         execute("create table test (" +
                 "col1 geo_shape" +

--- a/sql/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
@@ -879,12 +879,12 @@ public class GroupByAggregateTest extends SQLTransportIntegrationTest {
     public void testGroupByMultiValueField() throws Exception {
         this.setup.groupBySetup();
         // inserting multiple values not supported anymore
-        client().prepareIndex("characters", Constants.DEFAULT_MAPPING_TYPE).setSource(new HashMap<String, Object>() {{
+        client().prepareIndex(getFqn("characters"), Constants.DEFAULT_MAPPING_TYPE).setSource(new HashMap<String, Object>() {{
             put("race", new String[]{"Android"});
             put("gender", new String[]{"male", "robot"});
             put("name", "Marvin2");
         }}).execute().actionGet();
-        client().prepareIndex("characters", Constants.DEFAULT_MAPPING_TYPE).setSource(new HashMap<String, Object>() {{
+        client().prepareIndex(getFqn("characters"), Constants.DEFAULT_MAPPING_TYPE).setSource(new HashMap<String, Object>() {{
             put("race", new String[]{"Android"});
             put("gender", new String[]{"male", "robot"});
             put("name", "Marvin3");

--- a/sql/src/test/java/io/crate/integrationtests/InformationSchemaQueryTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InformationSchemaQueryTest.java
@@ -40,9 +40,9 @@ public class InformationSchemaQueryTest extends SQLTransportIntegrationTest {
                 "with (number_of_replicas=0)");
 
         ensureYellow();
-        client().admin().indices().close(new CloseIndexRequest("t3")).actionGet();
+        client().admin().indices().close(new CloseIndexRequest(getFqn("t3"))).actionGet();
 
-        execute("select * from information_schema.tables where table_schema = 'doc'");
+        execute("select * from information_schema.tables where table_schema = ?", new Object[]{sqlExecutor.getDefaultSchema()});
         assertEquals(2L, response.rowCount());
         execute("select * from information_schema.columns where table_name = 't3'");
         assertEquals(2, response.rowCount());

--- a/sql/src/test/java/io/crate/integrationtests/IngestRulesIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/IngestRulesIntegrationTest.java
@@ -120,7 +120,7 @@ public class IngestRulesIntegrationTest extends SQLTransportIntegrationTest {
         execute("select target_table from information_schema.ingestion_rules where rule_name = ?",
             new Object[]{INGEST_RULE_NAME});
         assertThat(response.rowCount(), is(1L));
-        assertThat(response.rows()[0][0], is("doc.t2"));
+        assertThat(response.rows()[0][0], is(getFqn("t2")));
     }
 
     private static Set<IngestRule> getAllRules(IngestRulesMetaData ingestRulesMetaData) {

--- a/sql/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
@@ -53,7 +53,7 @@ public class InsertIntoIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testInsertWithColumnNames() throws Exception {
-        prepareCreate("test")
+        prepareCreate(getFqn("test"))
             .addMapping("default",
                 "firstName", "type=keyword",
                 "lastName", "type=keyword")
@@ -87,7 +87,7 @@ public class InsertIntoIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testInsertAllCoreDatatypes() throws Exception {
-        prepareCreate("test")
+        prepareCreate(getFqn("test"))
             .addMapping("default",
                 "boolean", "type=boolean",
                 "datetime", "type=date",
@@ -197,7 +197,7 @@ public class InsertIntoIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testInsertMultipleRows() throws Exception {
-        prepareCreate("test")
+        prepareCreate(getFqn("test"))
             .addMapping("default",
                 "age", "type=integer",
                 "name", "type=keyword")
@@ -217,7 +217,7 @@ public class InsertIntoIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testInsertWithParams() throws Exception {
-        prepareCreate("test")
+        prepareCreate(getFqn("test"))
             .addMapping("default",
                 "age", "type=integer",
                 "name", "type=keyword")
@@ -316,7 +316,7 @@ public class InsertIntoIntegrationTest extends SQLTransportIntegrationTest {
         execute("insert into test (pk_col, message) values (?, ?)", args);
         refresh();
 
-        GetResponse response = client().prepareGet("test", "default", "1").execute().actionGet();
+        GetResponse response = client().prepareGet(getFqn("test"), "default", "1").execute().actionGet();
         assertTrue(response.getSourceAsMap().containsKey("message"));
     }
 
@@ -347,7 +347,7 @@ public class InsertIntoIntegrationTest extends SQLTransportIntegrationTest {
         execute("insert into test (pk_col, message) values (?, ?), (?, ?)", args);
         refresh();
 
-        GetResponse response = client().prepareGet("test", "default", "1").execute().actionGet();
+        GetResponse response = client().prepareGet(getFqn("test"), "default", "1").execute().actionGet();
         assertTrue(response.getSourceAsMap().containsKey("message"));
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/IpTypeCompatibilityTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/IpTypeCompatibilityTest.java
@@ -23,6 +23,7 @@
 package io.crate.integrationtests;
 
 import io.crate.action.sql.SQLActionException;
+import io.crate.testing.UseRandomizedSession;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.After;
@@ -35,6 +36,7 @@ import java.nio.file.Path;
 import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 0, numClientNodes = 0)
+@UseRandomizedSession(schema = false)
 public class IpTypeCompatibilityTest extends SQLTransportIntegrationTest {
 
     @Before

--- a/sql/src/test/java/io/crate/integrationtests/MappingDefaultsTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/MappingDefaultsTest.java
@@ -39,7 +39,7 @@ public class MappingDefaultsTest extends SQLTransportIntegrationTest {
         assertEquals(1, sqlResponse.rowCount());
         refresh();
 
-        SearchRequest searchRequest = new SearchRequest("test")
+        SearchRequest searchRequest = new SearchRequest(getFqn("test"))
             .source(SearchSourceBuilder.searchSource()
                     .query(new QueryStringQueryBuilder("foo").field("query")));
         SearchResponse response = client().search(searchRequest).actionGet();

--- a/sql/src/test/java/io/crate/integrationtests/OdbcIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/OdbcIntegrationTest.java
@@ -34,7 +34,7 @@ public class OdbcIntegrationTest extends SQLTransportIntegrationTest {
     private Setup setup = new Setup(sqlExecutor);
 
     private void executeQuoted(String stmt) {
-        execute(stmt, null, createSession(null, EnumSet.of(Option.ALLOW_QUOTED_SUBSCRIPT)));
+        execute(stmt, null, createSession(sqlExecutor.getDefaultSchema(), EnumSet.of(Option.ALLOW_QUOTED_SUBSCRIPT)));
     }
 
     @Before

--- a/sql/src/test/java/io/crate/integrationtests/OpenCloseTableIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/OpenCloseTableIntegrationTest.java
@@ -42,13 +42,13 @@ public class OpenCloseTableIntegrationTest extends SQLTransportIntegrationTest {
         assertEquals(true, response.rows()[0][0]);
 
         IndexMetaData indexMetaData = client().admin().cluster().prepareState().execute().actionGet().getState().metaData()
-            .indices().get("t");
+            .indices().get(getFqn("t"));
         assertEquals(IndexMetaData.State.CLOSE, indexMetaData.getState());
 
         execute("alter table t open");
 
         indexMetaData = client().admin().cluster().prepareState().execute().actionGet().getState().metaData()
-            .indices().get("t");
+            .indices().get(getFqn("t"));
 
         execute("select closed from information_schema.tables where table_name = 't'");
         assertEquals(1, response.rowCount());
@@ -59,56 +59,56 @@ public class OpenCloseTableIntegrationTest extends SQLTransportIntegrationTest {
     @Test
     public void testClosePreventsInsert() throws Exception {
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("The relation \"doc.t\" doesn't support or allow INSERT operations, " +
-                                        "as it is currently closed");
+        expectedException.expectMessage(String.format("The relation \"%s\" doesn't support or allow INSERT operations, " +
+                                        "as it is currently closed", getFqn("t")));
         execute("insert into t values (1), (2), (3)");
     }
 
     @Test
     public void testClosePreventsSelect() throws Exception {
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("The relation \"doc.t\" doesn't support or allow READ operations, " +
-                                        "as it is currently closed.");
+        expectedException.expectMessage(String.format("The relation \"%s\" doesn't support or allow READ operations, " +
+                                        "as it is currently closed.", getFqn("t")));
         execute("select * from t");
     }
 
     @Test
     public void testClosePreventsDrop() throws Exception {
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("The relation \"doc.t\" doesn't support or allow DROP operations, " +
-                                        "as it is currently closed");
+        expectedException.expectMessage(String.format("The relation \"%s\" doesn't support or allow DROP operations, " +
+                                        "as it is currently closed", getFqn("t")));
         execute("drop table t");
     }
 
     @Test
     public void testClosePreventsAlter() throws Exception {
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("The relation \"doc.t\" doesn't support or allow ALTER operations, " +
-                                        "as it is currently closed");
+        expectedException.expectMessage(String.format("The relation \"%s\" doesn't support or allow ALTER operations, " +
+                                        "as it is currently closed", getFqn("t")));
         execute("alter table t add column x string");
     }
 
     @Test
     public void testClosePreventsRefresh() throws Exception {
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("The relation \"doc.t\" doesn't support or allow REFRESH " +
-                                        "operations, as it is currently closed.");
+        expectedException.expectMessage(String.format("The relation \"%s\" doesn't support or allow REFRESH " +
+                                        "operations, as it is currently closed.", getFqn("t")));
         execute("refresh table t");
     }
 
     @Test
     public void testClosePreventsShowCreate() throws Exception {
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("The relation \"doc.t\" doesn't support or allow SHOW CREATE " +
-                                        "operations, as it is currently closed.");
+        expectedException.expectMessage(String.format("The relation \"%s\" doesn't support or allow SHOW CREATE " +
+                                        "operations, as it is currently closed.", getFqn("t")));
         execute("show create table t");
     }
 
     @Test
     public void testClosePreventsOptimize() throws Exception {
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("The relation \"doc.t\" doesn't support or allow OPTIMIZE " +
-                                        "operations, as it is currently closed.");
+        expectedException.expectMessage(String.format("The relation \"%s\" doesn't support or allow OPTIMIZE " +
+                                        "operations, as it is currently closed.", getFqn("t")));
         execute("optimize table t");
     }
 
@@ -133,8 +133,8 @@ public class OpenCloseTableIntegrationTest extends SQLTransportIntegrationTest {
         refresh();
         execute("alter table partitioned_table close");
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("The relation \"doc.partitioned_table\" doesn't support or allow " +
-                                        "READ operations, as it is currently closed.");
+        expectedException.expectMessage(String.format("The relation \"%s\" doesn't support or allow " +
+                                        "READ operations, as it is currently closed.", getFqn("partitioned_table")));
         execute("select i from partitioned_table");
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/OptimizeTableIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/OptimizeTableIntegrationTest.java
@@ -109,7 +109,7 @@ public class OptimizeTableIntegrationTest extends SQLHttpIntegrationTest {
         ensureYellow();
 
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("No partition for table 'doc.parted' with ident '04130' exists");
+        expectedException.expectMessage(String.format("No partition for table '%s' with ident '04130' exists", getFqn("parted")));
         execute("optimize table parted partition(date=0)");
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
@@ -111,7 +111,8 @@ public class PartitionedTableConcurrentIntegrationTest extends SQLTransportInteg
         });
         t.start();
 
-        PartitionName partitionName = new PartitionName("t", Collections.singletonList(new BytesRef("a")));
+        PartitionName partitionName = new PartitionName(sqlExecutor.getDefaultSchema(), "t",
+            Collections.singletonList(new BytesRef("a")));
         final String indexName = partitionName.asIndexName();
 
         ClusterService clusterService = internalCluster().getInstance(ClusterService.class);
@@ -270,7 +271,7 @@ public class PartitionedTableConcurrentIntegrationTest extends SQLTransportInteg
         });
 
         final CountDownLatch deleteLatch = new CountDownLatch(1);
-        final String partitionName = new PartitionName("parted",
+        final String partitionName = new PartitionName(sqlExecutor.getDefaultSchema(), "parted",
             Collections.singletonList(new BytesRef(String.valueOf(idToDelete)))
         ).asIndexName();
         final Object[] deleteArgs = new Object[]{idToDelete};

--- a/sql/src/test/java/io/crate/integrationtests/ReadOnlyNodeIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ReadOnlyNodeIntegrationTest.java
@@ -28,6 +28,7 @@ import io.crate.action.sql.SQLActionException;
 import io.crate.action.sql.SQLOperations;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.SQLTransportExecutor;
+import io.crate.testing.UseRandomizedSession;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -42,6 +43,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 1, numClientNodes = 1, transportClientRatio = 0)
+@UseRandomizedSession(schema = false)
 public class ReadOnlyNodeIntegrationTest extends SQLTransportIntegrationTest {
 
     private SQLTransportExecutor readOnlyExecutor;

--- a/sql/src/test/java/io/crate/integrationtests/RemoteCollectorIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/RemoteCollectorIntegrationTest.java
@@ -51,7 +51,7 @@ public class RemoteCollectorIntegrationTest extends SQLTransportIntegrationTest 
         PlanForNode plan = plan("update t set x = x * 2");
 
         ClusterService clusterService = internalCluster().getInstance(ClusterService.class);
-        IndexShardRoutingTable t = clusterService.state().routingTable().shardRoutingTable("t", 0);
+        IndexShardRoutingTable t = clusterService.state().routingTable().shardRoutingTable(getFqn("t"), 0);
 
         String sourceNodeId = t.primaryShard().currentNodeId();
         assert sourceNodeId != null;
@@ -65,10 +65,10 @@ public class RemoteCollectorIntegrationTest extends SQLTransportIntegrationTest 
         assert targetNodeId != null;
 
         client().admin().cluster().prepareReroute()
-            .add(new MoveAllocationCommand("t", 0, sourceNodeId, targetNodeId))
+            .add(new MoveAllocationCommand(getFqn("t"), 0, sourceNodeId, targetNodeId))
             .execute().actionGet();
 
-        client().admin().cluster().prepareHealth("t")
+        client().admin().cluster().prepareHealth(getFqn("t"))
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForNoRelocatingShards(true)
             .setTimeout(TimeValue.timeValueSeconds(5)).execute().actionGet();

--- a/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
@@ -117,6 +117,7 @@ import static org.hamcrest.Matchers.is;
 @Listeners({SystemPropsTestLoggingListener.class})
 @UseJdbc
 @UseSemiJoins
+@UseRandomizedSession
 public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
 
     private static final int ORIGINAL_PAGE_SIZE = Paging.PAGE_SIZE;
@@ -180,6 +181,18 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
                     return internalCluster().getInstance(SQLOperations.class);
                 }
             }));
+    }
+
+
+    public String getFqn(String schema, String tableName) {
+        if (schema.equals(Schemas.DOC_SCHEMA_NAME)) {
+           return tableName;
+        }
+        return String.format(Locale.ENGLISH, "%s.%s", schema, tableName);
+    }
+
+    public String getFqn(String tableName) {
+        return getFqn(sqlExecutor.getDefaultSchema(), tableName);
     }
 
     @Before
@@ -505,7 +518,7 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
     }
 
     public void waitForMappingUpdateOnAll(final String tableOrPartition, final String... fieldNames) throws Exception {
-        waitForMappingUpdateOnAll(new TableIdent(Schemas.DOC_SCHEMA_NAME, tableOrPartition), fieldNames);
+        waitForMappingUpdateOnAll(new TableIdent(sqlExecutor.getDefaultSchema(), tableOrPartition), fieldNames);
     }
 
     /**
@@ -554,7 +567,7 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
     SQLOperations.Session createSessionOnNode(String nodeName) {
         SQLOperations sqlOperations = internalCluster().getInstance(SQLOperations.class, nodeName);
         return sqlOperations.createSession(
-            null, new User("crate", EnumSet.of(User.Role.SUPERUSER), ImmutableSet.of()), Option.NONE, DEFAULT_SOFT_LIMIT);
+            sqlExecutor.getDefaultSchema(), new User("crate", EnumSet.of(User.Role.SUPERUSER), ImmutableSet.of()), Option.NONE, DEFAULT_SOFT_LIMIT);
     }
 
     /**

--- a/sql/src/test/java/io/crate/integrationtests/ShardStatsTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ShardStatsTest.java
@@ -91,7 +91,7 @@ public class ShardStatsTest extends SQLTransportIntegrationTest {
                 "with(number_of_replicas=2, \"write.wait_for_active_shards\"=1)");
         ensureYellow();
 
-        execute("select count(*) from sys.shards where schema_name='doc' AND table_name='locations'");
+        execute("select count(*) from sys.shards where table_name='locations'");
         assertThat(response.rowCount(), is(1L));
         assertThat((Long) response.rows()[0][0], is(15L));
     }

--- a/sql/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -23,12 +23,14 @@ package io.crate.integrationtests;
 
 import io.crate.action.sql.SQLActionException;
 import io.crate.testing.TestingHelpers;
+import io.crate.testing.UseRandomizedSession;
 import org.junit.Test;
 
 import java.util.Locale;
 
 import static org.hamcrest.core.Is.is;
 
+@UseRandomizedSession(schema = false)
 public class ShowIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/StaticInformationSchemaQueryTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/StaticInformationSchemaQueryTest.java
@@ -49,23 +49,23 @@ public class StaticInformationSchemaQueryTest extends SQLTransportIntegrationTes
 
     @Test
     public void testGroupByOnInformationSchema() throws Exception {
-        execute("select count(*) from information_schema.columns where table_schema = 'doc' group by table_name order by count(*) desc");
+        execute("select count(*) from information_schema.columns where table_schema = ? group by table_name order by count(*) desc", new Object[]{sqlExecutor.getDefaultSchema()});
         assertEquals(3L, response.rowCount());
 
-        execute("select count(*) from information_schema.columns where table_schema = 'doc' group by column_name order by count(*) desc");
+        execute("select count(*) from information_schema.columns where table_schema = ? group by column_name order by count(*) desc", new Object[]{sqlExecutor.getDefaultSchema()});
         assertEquals(2L, response.rowCount());
         assertEquals(3L, response.rows()[0][0]);
     }
 
     @Test
     public void testSelectStar() throws Exception {
-        execute("select * from information_schema.tables where table_schema = 'doc'");
+        execute("select * from information_schema.tables where table_schema = ?", new Object[]{sqlExecutor.getDefaultSchema()});
         assertEquals(3L, response.rowCount());
     }
 
     @Test
     public void testLike() throws Exception {
-        execute("select * from information_schema.tables where table_schema = 'doc' and table_name like 't%'");
+        execute("select * from information_schema.tables where table_schema = ? and table_name like 't%'", new Object[]{sqlExecutor.getDefaultSchema()});
         assertEquals(3L, response.rowCount());
     }
 
@@ -77,7 +77,7 @@ public class StaticInformationSchemaQueryTest extends SQLTransportIntegrationTes
 
     @Test
     public void testIsNotNull() throws Exception {
-        execute("select * from information_schema.tables where table_name is not null and table_schema = 'doc'");
+        execute("select * from information_schema.tables where table_name is not null and table_schema = ?", new Object[]{sqlExecutor.getDefaultSchema()});
         assertEquals(3L, response.rowCount());
     }
 
@@ -137,7 +137,7 @@ public class StaticInformationSchemaQueryTest extends SQLTransportIntegrationTes
 
     @Test
     public void testNotEqualsString() throws Exception {
-        execute("select table_name from information_schema.tables where table_schema = 'doc' and table_name != 't1'");
+        execute("select table_name from information_schema.tables where table_schema = ? and table_name != 't1'", new Object[]{sqlExecutor.getDefaultSchema()});
         assertEquals(2L, response.rowCount());
         assertTrue(!response.rows()[0][0].equals("t1"));
         assertTrue(!response.rows()[1][0].equals("t1"));
@@ -145,7 +145,7 @@ public class StaticInformationSchemaQueryTest extends SQLTransportIntegrationTes
 
     @Test
     public void testNotEqualsNumber() throws Exception {
-        execute("select table_name, number_of_shards from information_schema.tables where table_schema = 'doc' and number_of_shards != 7");
+        execute("select table_name, number_of_shards from information_schema.tables where table_schema = ? and number_of_shards != 7", new Object[]{sqlExecutor.getDefaultSchema()});
         assertEquals(2L, response.rowCount());
         assertTrue((int) response.rows()[0][1] != 7);
         assertTrue((int) response.rows()[1][1] != 7);
@@ -153,7 +153,7 @@ public class StaticInformationSchemaQueryTest extends SQLTransportIntegrationTes
 
     @Test
     public void testEqualsNumber() throws Exception {
-        execute("select table_name from information_schema.tables where table_schema = 'doc' and number_of_shards = 7");
+        execute("select table_name from information_schema.tables where table_schema = ? and number_of_shards = 7", new Object[]{sqlExecutor.getDefaultSchema()});
         assertEquals(1L, response.rowCount());
         assertEquals("t1", response.rows()[0][0]);
     }
@@ -175,7 +175,7 @@ public class StaticInformationSchemaQueryTest extends SQLTransportIntegrationTes
     @Test
     public void testOrderByStringAndLimit() throws Exception {
         execute("select table_name, number_of_shards, number_of_replicas from information_schema.tables " +
-                " where table_schema = 'doc' order by table_name desc limit 2");
+                " where table_schema = ? order by table_name desc limit 2", new Object[]{sqlExecutor.getDefaultSchema()});
         assertEquals(2L, response.rowCount());
         assertEquals("t3", response.rows()[0][0]);
         assertEquals("t2", response.rows()[1][0]);

--- a/sql/src/test/java/io/crate/integrationtests/SysShardMinLuceneVersionTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysShardMinLuceneVersionTest.java
@@ -23,6 +23,7 @@
 package io.crate.integrationtests;
 
 import io.crate.testing.TestingHelpers;
+import io.crate.testing.UseRandomizedSession;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.After;
@@ -34,6 +35,7 @@ import java.nio.file.Path;
 import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 0, numClientNodes = 0)
+@UseRandomizedSession(schema = false)
 public class SysShardMinLuceneVersionTest extends SQLTransportIntegrationTest {
 
     private void startUpNodeWithDataDir(String dataPath) throws IOException {

--- a/sql/src/test/java/io/crate/integrationtests/SysSnapshotsTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysSnapshotsTest.java
@@ -120,10 +120,11 @@ public class SysSnapshotsTest extends SQLTransportIntegrationTest {
         createSnapshot(snapshotName, tableName);
     }
 
-    private void createSnapshot(String snapshotName, String... tables) {
+    private void createSnapshot(String snapshotName, String table) {
+        String defaultSchema = sqlExecutor.getDefaultSchema();
         CreateSnapshotResponse createSnapshotResponse = client().admin().cluster()
             .prepareCreateSnapshot(REPOSITORY_NAME, snapshotName)
-            .setWaitForCompletion(true).setIndices(tables).get();
+            .setWaitForCompletion(true).setIndices(getFqn(table)).get();
         assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), greaterThan(0));
         assertThat(createSnapshotResponse.getSnapshotInfo().successfulShards(), equalTo(createSnapshotResponse.getSnapshotInfo().totalShards()));
         snapshots.add(snapshotName);
@@ -152,7 +153,7 @@ public class SysSnapshotsTest extends SQLTransportIntegrationTest {
                 StringType.INSTANCE,
                 StringType.INSTANCE
             }));
-        assertThat((String[]) response.rows()[0][0], arrayContaining("test_table"));
+        assertThat((String[]) response.rows()[0][0], arrayContaining(getFqn("test_table")));
         assertThat((Long) response.rows()[0][1], lessThanOrEqualTo(finishedTime));
         assertThat((String) response.rows()[0][2], is("test_snap_1"));
         assertThat((String) response.rows()[0][3], is(REPOSITORY_NAME));

--- a/sql/src/test/java/io/crate/integrationtests/TableBlocksIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TableBlocksIntegrationTest.java
@@ -30,6 +30,8 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import java.util.Locale;
+
 @ESIntegTestCase.ClusterScope(numDataNodes = 1)
 public class TableBlocksIntegrationTest extends SQLTransportIntegrationTest {
 
@@ -59,7 +61,8 @@ public class TableBlocksIntegrationTest extends SQLTransportIntegrationTest {
         ensureYellow();
 
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("The relation \"doc.t1\" doesn't support or allow INSERT operations.");
+        expectedException.expectMessage(String.format(Locale.ENGLISH,
+            "The relation \"%s.t1\" doesn't support or allow INSERT operations.", sqlExecutor.getDefaultSchema()));
         execute("insert into t1 (id) values (1)");
     }
 
@@ -69,7 +72,8 @@ public class TableBlocksIntegrationTest extends SQLTransportIntegrationTest {
         ensureYellow();
 
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("The relation \"doc.t1\" doesn't support or allow UPDATE operations.");
+        expectedException.expectMessage(String.format(Locale.ENGLISH,
+            "The relation \"%s.t1\" doesn't support or allow UPDATE operations.", sqlExecutor.getDefaultSchema()));
         execute("update t1 set id = 2");
     }
 
@@ -79,7 +83,8 @@ public class TableBlocksIntegrationTest extends SQLTransportIntegrationTest {
         ensureYellow();
 
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("The relation \"doc.t1\" doesn't support or allow DELETE operations.");
+        expectedException.expectMessage(String.format(Locale.ENGLISH,
+            "The relation \"%s.t1\" doesn't support or allow DELETE operations.", sqlExecutor.getDefaultSchema()));
         execute("delete from t1");
     }
 
@@ -89,7 +94,8 @@ public class TableBlocksIntegrationTest extends SQLTransportIntegrationTest {
         ensureYellow();
 
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("The relation \"doc.t1\" doesn't support or allow DROP operations.");
+        expectedException.expectMessage(String.format(Locale.ENGLISH,
+            "The relation \"%s.t1\" doesn't support or allow DROP operations.", sqlExecutor.getDefaultSchema()));
         execute("drop table t1");
     }
 
@@ -99,7 +105,8 @@ public class TableBlocksIntegrationTest extends SQLTransportIntegrationTest {
         ensureYellow();
 
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("The relation \"doc.t1\" doesn't support or allow ALTER operations.");
+        expectedException.expectMessage(String.format(Locale.ENGLISH,
+            "The relation \"%s.t1\" doesn't support or allow ALTER operations.", sqlExecutor.getDefaultSchema()));
         execute("alter table t1 add column name string");
     }
 
@@ -109,7 +116,8 @@ public class TableBlocksIntegrationTest extends SQLTransportIntegrationTest {
         ensureYellow();
 
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("The relation \"doc.t1\" doesn't support or allow ALTER operations.");
+        expectedException.expectMessage(String.format(Locale.ENGLISH,
+            "The relation \"%s.t1\" doesn't support or allow ALTER operations.", sqlExecutor.getDefaultSchema()));
         execute("alter table t1 set (number_of_replicas = 1)");
     }
 
@@ -133,7 +141,8 @@ public class TableBlocksIntegrationTest extends SQLTransportIntegrationTest {
         execute("insert into t1 (id) values (1)");
 
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("The relation \"doc.t1\" doesn't support or allow READ operations.");
+        expectedException.expectMessage(String.format(Locale.ENGLISH,
+            "The relation \"%s.t1\" doesn't support or allow READ operations.", sqlExecutor.getDefaultSchema()));
         execute("select * from t1");
     }
 
@@ -145,7 +154,8 @@ public class TableBlocksIntegrationTest extends SQLTransportIntegrationTest {
         execute("insert into t1 (id) values (1)");
 
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("The relation \"doc.t1\" doesn't support or allow READ operations.");
+        expectedException.expectMessage(String.format(Locale.ENGLISH,
+            "The relation \"%s.t1\" doesn't support or allow READ operations.", sqlExecutor.getDefaultSchema()));
         execute("insert into t2 (id) (select id from t1)");
     }
 
@@ -156,7 +166,8 @@ public class TableBlocksIntegrationTest extends SQLTransportIntegrationTest {
         ensureYellow();
 
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("The relation \"doc.t1\" doesn't support or allow READ operations.");
+        expectedException.expectMessage(String.format(Locale.ENGLISH,
+            "The relation \"%s.t1\" doesn't support or allow READ operations.", sqlExecutor.getDefaultSchema()));
         execute("select * from t2, t1");
     }
 
@@ -165,7 +176,8 @@ public class TableBlocksIntegrationTest extends SQLTransportIntegrationTest {
         execute("create table t1 (id integer) with (number_of_replicas = 0, \"blocks.read\" = true)");
 
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("The relation \"doc.t1\" doesn't support or allow COPY TO operations.");
+        expectedException.expectMessage(String.format(Locale.ENGLISH,
+            "The relation \"%s.t1\" doesn't support or allow COPY TO operations.", sqlExecutor.getDefaultSchema()));
         execute("copy t1 to DIRECTORY '/tmp/'");
     }
 
@@ -175,7 +187,8 @@ public class TableBlocksIntegrationTest extends SQLTransportIntegrationTest {
         ensureYellow();
 
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("The relation \"doc.t1\" doesn't support or allow INSERT operations.");
+        expectedException.expectMessage(String.format(Locale.ENGLISH,
+            "The relation \"%s.t1\" doesn't support or allow INSERT operations.", sqlExecutor.getDefaultSchema()));
         execute("copy t1 from '/tmp'");
     }
 
@@ -187,8 +200,8 @@ public class TableBlocksIntegrationTest extends SQLTransportIntegrationTest {
             new Object[]{TEMPORARY_FOLDER.newFolder().getAbsolutePath()});
 
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("The relation \"doc.t1\" doesn't support or allow CREATE SNAPSHOT " +
-                                        "operations.");
+        expectedException.expectMessage(String.format(Locale.ENGLISH,
+            "The relation \"%s.t1\" doesn't support or allow CREATE SNAPSHOT operations.", sqlExecutor.getDefaultSchema()));
         execute("CREATE SNAPSHOT repo.snap TABLE t1 WITH (wait_for_completion=true)");
     }
 
@@ -200,7 +213,8 @@ public class TableBlocksIntegrationTest extends SQLTransportIntegrationTest {
             new Object[]{TEMPORARY_FOLDER.newFolder().getAbsolutePath()});
 
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("The relation \"doc.t1\" doesn't support or allow READ operations.");
+        expectedException.expectMessage(String.format(Locale.ENGLISH,
+            "The relation \"%s.t1\" doesn't support or allow READ operations.", sqlExecutor.getDefaultSchema()));
         execute("CREATE SNAPSHOT repo.snap ALL WITH (wait_for_completion=true)");
     }
 
@@ -215,8 +229,8 @@ public class TableBlocksIntegrationTest extends SQLTransportIntegrationTest {
         assertThat((Boolean) response.rows()[0][0], Is.is(true));
 
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("The relation \"doc.t1\" doesn't support or allow INSERT operations, " +
-                                        "as it is read-only.");
+        expectedException.expectMessage(String.format(Locale.ENGLISH, "The relation \"%s.t1\" doesn't support or allow INSERT operations, " +
+                                        "as it is read-only.", sqlExecutor.getDefaultSchema()));
         execute("insert into t1 (id, name, date) values (?, ?, ?)",
             new Object[]{1, "Ford", 13959981214861L});
     }

--- a/sql/src/test/java/io/crate/integrationtests/TableSettingsTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TableSettingsTest.java
@@ -128,7 +128,7 @@ public class TableSettingsTest extends SQLTransportIntegrationTest {
         // One more column exceeds the limit
         expectedException.expect(SQLActionException.class);
         expectedException.expectMessage(String.format(Locale.ENGLISH,
-            "Limit of total fields [%d] in index [test] has been exceeded", totalFields + 1));
+            "Limit of total fields [%d] in index [%s.test] has been exceeded", totalFields + 1, sqlExecutor.getDefaultSchema()));
         execute("alter table test add column new_column2 int");
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/TransportSQLActionClassLifecycleTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TransportSQLActionClassLifecycleTest.java
@@ -47,6 +47,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
@@ -280,7 +281,8 @@ public class TransportSQLActionClassLifecycleTest extends SQLTransportIntegratio
     @Test
     public void selectMultiGetRequestFromNonExistentTable() throws Exception {
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("TableUnknownException: Table 'doc.non_existent' unknown");
+        expectedException.expectMessage(String.format(Locale.ENGLISH,
+            "TableUnknownException: Table '%s.non_existent' unknown", sqlExecutor.getDefaultSchema()));
         execute("SELECT * FROM \"non_existent\" WHERE \"_id\" in (?,?)", new Object[]{"1", "2"});
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/UnassignedShardsTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/UnassignedShardsTest.java
@@ -33,7 +33,7 @@ public class UnassignedShardsTest extends SQLTransportIntegrationTest {
     @Test
     public void testUnassignedReplicasAreVisibleAsUnassignedInSysShards() throws Exception {
         execute("create table t (id int) clustered into 1 shards with (number_of_replicas=1, \"write.wait_for_active_shards\"=1)");
-        execute("select state, id, table_name from sys.shards where schema_name='doc' AND table_name='t' order by state");
+        execute("select state, id, table_name from sys.shards where schema_name = ? AND table_name='t' order by state", new Object[]{sqlExecutor.getDefaultSchema()});
         assertThat(TestingHelpers.printedTable(response.rows()),
             is("STARTED| 0| t\n" +
                "UNASSIGNED| 0| t\n"));

--- a/sql/src/test/java/io/crate/metadata/SchemasITest.java
+++ b/sql/src/test/java/io/crate/metadata/SchemasITest.java
@@ -61,7 +61,7 @@ public class SchemasITest extends SQLTransportIntegrationTest {
                 ") clustered into 10 shards with (number_of_replicas=1)");
         ensureYellow();
 
-        DocTableInfo ti = schemas.getTableInfo(new TableIdent(Schemas.DOC_SCHEMA_NAME, "t1"));
+        DocTableInfo ti = schemas.getTableInfo(new TableIdent(sqlExecutor.getDefaultSchema(), "t1"));
         assertThat(ti.ident().name(), is("t1"));
 
         assertThat(ti.columns().size(), is(3));
@@ -78,7 +78,7 @@ public class SchemasITest extends SQLTransportIntegrationTest {
         int numShards = 0;
         for (Map.Entry<String, Map<String, List<Integer>>> nodeEntry : routing.locations().entrySet()) {
             for (Map.Entry<String, List<Integer>> indexEntry : nodeEntry.getValue().entrySet()) {
-                assertThat(indexEntry.getKey(), is("t1"));
+                assertThat(indexEntry.getKey(), is(getFqn("t1")));
                 numShards += indexEntry.getValue().size();
             }
         }
@@ -90,13 +90,13 @@ public class SchemasITest extends SQLTransportIntegrationTest {
         execute("create table terminator (model string, good boolean, actor object)");
         IndicesAliasesRequest request = new IndicesAliasesRequest();
         request.addAliasAction(IndicesAliasesRequest.AliasActions.add()
-            .alias("entsafter")
-            .index("terminator"));
+            .alias(getFqn("entsafter"))
+            .index(getFqn("terminator")));
         client().admin().indices().aliases(request).actionGet();
         ensureYellow();
 
-        DocTableInfo terminatorTable = schemas.getTableInfo(new TableIdent(Schemas.DOC_SCHEMA_NAME, "terminator"));
-        DocTableInfo entsafterTable = schemas.getTableInfo(new TableIdent(Schemas.DOC_SCHEMA_NAME, "entsafter"));
+        DocTableInfo terminatorTable = schemas.getTableInfo(new TableIdent(sqlExecutor.getDefaultSchema(), "terminator"));
+        DocTableInfo entsafterTable = schemas.getTableInfo(new TableIdent(sqlExecutor.getDefaultSchema(), "entsafter"));
 
         assertNotNull(terminatorTable);
         assertFalse(terminatorTable.isAlias());
@@ -111,17 +111,17 @@ public class SchemasITest extends SQLTransportIntegrationTest {
         execute("create table transformer (model string, good boolean, actor object)");
         IndicesAliasesRequest request = new IndicesAliasesRequest();
         request.addAliasAction(
-            IndicesAliasesRequest.AliasActions.add().alias("entsafter").index("terminator"));
+            IndicesAliasesRequest.AliasActions.add().alias(getFqn("entsafter")).index(getFqn("terminator")));
         request.addAliasAction(
-            IndicesAliasesRequest.AliasActions.add().alias("entsafter").index("transformer"));
+            IndicesAliasesRequest.AliasActions.add().alias(getFqn("entsafter")).index(getFqn("transformer")));
         client().admin().indices().aliases(request).actionGet();
         ensureYellow();
 
-        DocTableInfo entsafterTable = schemas.getTableInfo(new TableIdent(Schemas.DOC_SCHEMA_NAME, "entsafter"));
+        DocTableInfo entsafterTable = schemas.getTableInfo(new TableIdent(sqlExecutor.getDefaultSchema(), "entsafter"));
 
         assertNotNull(entsafterTable);
         assertThat(entsafterTable.concreteIndices().length, is(2));
-        assertThat(Arrays.asList(entsafterTable.concreteIndices()), containsInAnyOrder("terminator", "transformer"));
+        assertThat(Arrays.asList(entsafterTable.concreteIndices()), containsInAnyOrder(getFqn("terminator"), getFqn("transformer")));
     }
 
 
@@ -146,7 +146,7 @@ public class SchemasITest extends SQLTransportIntegrationTest {
         Routing routing = ti.getRouting(null, null, SessionContext.create());
 
         Set<String> tables = new HashSet<>();
-        Set<String> expectedTables = Sets.newHashSet("t2", "t3");
+        Set<String> expectedTables = Sets.newHashSet(getFqn("t2"), getFqn("t3"));
         int numShards = 0;
         for (Map.Entry<String, Map<String, List<Integer>>> nodeEntry : routing.locations().entrySet()) {
             for (Map.Entry<String, List<Integer>> indexEntry : nodeEntry.getValue().entrySet()) {

--- a/sql/src/test/java/io/crate/operation/collect/DocLevelCollectTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/DocLevelCollectTest.java
@@ -46,6 +46,7 @@ import io.crate.operation.operator.EqOperator;
 import io.crate.planner.distribution.DistributionInfo;
 import io.crate.planner.node.ExecutionPhase;
 import io.crate.planner.node.dql.RoutedCollectPhase;
+import io.crate.testing.UseRandomizedSession;
 import io.crate.types.DataTypes;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.indices.IndicesService;
@@ -72,6 +73,7 @@ import static org.mockito.Mockito.mock;
 
 
 @ESIntegTestCase.ClusterScope(randomDynamicTemplates = false, numDataNodes = 1)
+@UseRandomizedSession(schema = false)
 public class DocLevelCollectTest extends SQLTransportIntegrationTest {
 
     private static final String TEST_TABLE_NAME = "test_table";

--- a/sql/src/test/java/io/crate/operation/collect/ShardCollectorProviderTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/ShardCollectorProviderTest.java
@@ -56,7 +56,7 @@ public class ShardCollectorProviderTest extends SQLTransportIntegrationTest {
     public void testClosedIndicesHaveNoShardEntries() throws Exception {
         execute("create table t(i int) with (number_of_replicas='0-all')");
         ensureGreen();
-        client().admin().indices().close(new CloseIndexRequest("t")).actionGet();
+        client().admin().indices().close(new CloseIndexRequest(getFqn("t"))).actionGet();
         waitUntilShardOperationsFinished();
         assertNoShardEntriesLeftInShardCollectSource();
     }

--- a/sql/src/test/java/io/crate/operation/count/InternalCountOperationTest.java
+++ b/sql/src/test/java/io/crate/operation/count/InternalCountOperationTest.java
@@ -54,11 +54,11 @@ public class InternalCountOperationTest extends SQLTransportIntegrationTest {
         CountOperation countOperation = internalCluster().getDataNodeInstance(CountOperation.class);
         ClusterService clusterService = internalCluster().getDataNodeInstance(ClusterService.class);
         MetaData metaData = clusterService.state().getMetaData();
-        Index index = metaData.index("t").getIndex();
+        Index index = metaData.index(getFqn("t")).getIndex();
         assertThat(countOperation.count(index, 0, WhereClause.MATCH_ALL), is(3L));
 
         Schemas schemas = internalCluster().getInstance(Schemas.class);
-        TableInfo tableInfo = schemas.getTableInfo(new TableIdent(Schemas.DOC_SCHEMA_NAME, "t"));
+        TableInfo tableInfo = schemas.getTableInfo(new TableIdent(sqlExecutor.getDefaultSchema(), "t"));
         TableRelation tableRelation = new TableRelation(tableInfo);
         Map<QualifiedName, AnalyzedRelation> tableSources = ImmutableMap.<QualifiedName, AnalyzedRelation>of(new QualifiedName(tableInfo.ident().name()), tableRelation);
         SqlExpressions sqlExpressions = new SqlExpressions(tableSources, tableRelation);

--- a/sql/src/test/java/io/crate/operation/projectors/IndexWriterProjectorTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/IndexWriterProjectorTest.java
@@ -35,7 +35,6 @@ import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RowGranularity;
-import io.crate.metadata.Schemas;
 import io.crate.metadata.TableIdent;
 import io.crate.metadata.doc.DocSysColumns;
 import io.crate.operation.NodeJobsCounter;
@@ -65,7 +64,6 @@ public class IndexWriterProjectorTest extends SQLTransportIntegrationTest {
 
     private static final ColumnIdent ID_IDENT = new ColumnIdent("id");
 
-    private static final TableIdent bulkImportIdent = new TableIdent(Schemas.DOC_SCHEMA_NAME, "bulk_import");
 
     @Test
     public void testIndexWriter() throws Throwable {
@@ -75,6 +73,7 @@ public class IndexWriterProjectorTest extends SQLTransportIntegrationTest {
         InputCollectExpression sourceInput = new InputCollectExpression(1);
         List<CollectExpression<Row, ?>> collectExpressions = Collections.<CollectExpression<Row, ?>>singletonList(sourceInput);
 
+        TableIdent bulkImportIdent = new TableIdent(sqlExecutor.getDefaultSchema(), "bulk_import");
         IndexWriterProjector writerProjector = new IndexWriterProjector(
             internalCluster().getInstance(ClusterService.class),
             new NodeJobsCounter(),
@@ -83,7 +82,7 @@ public class IndexWriterProjectorTest extends SQLTransportIntegrationTest {
             Settings.EMPTY,
             internalCluster().getInstance(TransportBulkCreateIndicesAction.class),
             internalCluster().getInstance(TransportShardUpsertAction.class)::execute,
-            IndexNameResolver.forTable(new TableIdent(Schemas.DOC_SCHEMA_NAME, "bulk_import")),
+            IndexNameResolver.forTable(bulkImportIdent),
             new Reference(new ReferenceIdent(bulkImportIdent, DocSysColumns.RAW), RowGranularity.DOC, DataTypes.STRING),
             Arrays.asList(ID_IDENT),
             Arrays.<Symbol>asList(new InputColumn(0)),

--- a/sql/src/test/java/io/crate/testing/UseRandomizedSession.java
+++ b/sql/src/test/java/io/crate/testing/UseRandomizedSession.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.testing;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Mark a test to use a Randomized Session Context.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Inherited
+public @interface UseRandomizedSession {
+
+    // true (default): randomize default schema
+    // false:          use DOC-Schema as default
+    boolean schema() default true;
+}


### PR DESCRIPTION
If the test class/method contains a `@UseRandomizedSession` annotation a
random schema name is generated and set as "default schema" on the
`SqlTransportExecutor`. This will ensure that whithin this context
(test method/class) every table that has no explicitly schema defined
will set a generated schema name as default.

Commit 07dfbdbacdb7d45c7897edef5226d76196e14028: Adds the annotation
Commit 275d2bd870f8dbc3d70b8ca1b3e78ed80ddbadd2: Adapts the existing integration tests to use the default schema.