### PR TITLE
Change GroupBy plans to not collect scalar functions early

### DIFF
--- a/sql/src/test/java/io/crate/planner/GroupByScalarPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/GroupByScalarPlannerTest.java
@@ -45,11 +45,13 @@ public class GroupByScalarPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(collectPhase.projections().get(0).requiredGranularity(), is(RowGranularity.SHARD));
         assertThat(collectPhase.projections().get(1), instanceOf(EvalProjection.class));
         assertThat(collectPhase.projections().get(1).outputs().get(0), instanceOf(Function.class));
-        assertThat(collectPhase.toCollect(), contains(isFunction("add"), isReference("id", DataTypes.LONG)));
+        assertThat(collectPhase.toCollect(), contains(isReference("id", DataTypes.LONG)));
 
         GroupProjection groupProjection = (GroupProjection) collectPhase.projections().get(0);
         assertThat(groupProjection.keys().get(0).valueType(), is(DataTypes.LONG));
 
+
+        assertThat(collectPhase.projections().get(1).outputs(), contains(isFunction("add")));
 
         MergePhase mergePhase = merge.mergePhase();
 
@@ -69,8 +71,8 @@ public class GroupByScalarPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(collectPhase.projections().get(0), instanceOf(GroupProjection.class));
         assertThat(collectPhase.projections().get(0).requiredGranularity(), is(RowGranularity.SHARD));
         assertThat(collectPhase.projections().get(1), instanceOf(EvalProjection.class));
-        assertThat(collectPhase.projections().get(1).outputs().get(0), instanceOf(Function.class));
-        assertThat(collectPhase.toCollect(), contains(isFunction("abs"), isReference("id", DataTypes.LONG)));
+        assertThat(collectPhase.projections().get(1).outputs().get(0), isFunction("abs"));
+        assertThat(collectPhase.toCollect(), contains(isReference("id", DataTypes.LONG)));
 
         GroupProjection groupProjection = (GroupProjection) collectPhase.projections().get(0);
         assertThat(groupProjection.keys().get(0).valueType(), is(DataTypes.LONG));
@@ -90,7 +92,7 @@ public class GroupByScalarPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(collectPhase.projections().size(), is(1));
         assertThat(collectPhase.projections().get(0), instanceOf(GroupProjection.class));
         assertThat(collectPhase.projections().get(0).requiredGranularity(), is(RowGranularity.SHARD));
-        assertThat(collectPhase.toCollect(), contains(isFunction("abs"), isReference("id", DataTypes.LONG), isReference("other_id", DataTypes.LONG)));
+        assertThat(collectPhase.toCollect(), contains(isReference("id", DataTypes.LONG), isReference("other_id", DataTypes.LONG)));
 
         GroupProjection groupProjection = (GroupProjection) collectPhase.projections().get(0);
         assertThat(groupProjection.keys().size(), is(2));
@@ -101,5 +103,7 @@ public class GroupByScalarPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(mergePhase.projections().size(), is(2));
         assertThat(mergePhase.projections().get(0), instanceOf(GroupProjection.class));
         assertThat(mergePhase.projections().get(1), instanceOf(EvalProjection.class));
+        
+        assertThat(mergePhase.projections().get(1).outputs(), contains(isFunction("abs")));
     }
 }


### PR DESCRIPTION
A query like:

    select x + 10 from t group by x

Resulted in a Plan as follows:

    toCollect:[add(x, 10), x]
    groupBy: IC{1}
    eval: add(IC{0}, 10)

Therefore, it executed the scalar function once for each row, discarded
the result, and run the scalar a second time after the group by
operation.

With these changes the plan that is being generated looks as follows:

    toCollect:[x]
    groupBy: IC{0}
    eval: add(IC{0}, 10)