### PR TITLE
Remove line length limit in Checkstyle 'LeftCurly' rule

### DIFF
--- a/gradle/checkstyle/rules.xml
+++ b/gradle/checkstyle/rules.xml
@@ -78,7 +78,7 @@
         </module>
         <!--<module name="NeedBraces"/>-->
         <module name="LeftCurly">
-            <property name="maxLineLength" value="100"/>
+            <!--<property name="maxLineLength" value="120"/>-->
         </module>
         <module name="RightCurly">
             <property name="id" value="RightCurlySame"/>


### PR DESCRIPTION
The 'LeftCurly' rule uses a 'maxLineLength' parameter. The latest version of the
IntelliJ Checkstyle plugin seems to only accept this property when the
LineLength module is activated.

Since we don't enforce a line length, I'd suggest commenting out the rule for
now.