### PR TITLE
add all concrete schemas to current available schemas

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -21,6 +21,9 @@ Changes
 Fixes
 =====
 
+ - Fixed an issue that caused a table that is not part of the "doc" schema to be
+   unavailable/hidden if it gets closed using ``ALTER TABLE``.
+
  - Fixed an issue where the query circuit breaker would be tripped after 
    running several queries due to incorrect memory tracking. Subsequent 
    operations would've failed due to the lack of circuit breaker cleanup.

--- a/sql/src/main/java/io/crate/metadata/Schemas.java
+++ b/sql/src/main/java/io/crate/metadata/Schemas.java
@@ -174,8 +174,8 @@ public class Schemas extends AbstractLifecycleComponent implements Iterable<Sche
         // 'doc' schema is always available and has the special property that its indices
         // don't have to be prefixed with the schema name
         schemas.add(DOC_SCHEMA_NAME);
-        for (String openIndex : metaData.getConcreteAllOpenIndices()) {
-            addIfSchema(schemas, openIndex);
+        for (String index : metaData.getConcreteAllIndices()) {
+            addIfSchema(schemas, index);
         }
         for (ObjectCursor<String> cursor : metaData.templates().keys()) {
             addIfSchema(schemas, cursor.value);

--- a/sql/src/test/java/io/crate/metadata/SchemasTest.java
+++ b/sql/src/test/java/io/crate/metadata/SchemasTest.java
@@ -30,7 +30,9 @@ import io.crate.metadata.table.TableInfo;
 import io.crate.operation.udf.UserDefinedFunctionMetaData;
 import io.crate.operation.udf.UserDefinedFunctionsMetaData;
 import io.crate.types.DataTypes;
+import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
@@ -45,6 +47,9 @@ import org.mockito.MockitoAnnotations;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_VERSION_CREATED;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.mockito.Mockito.mock;
@@ -120,6 +125,42 @@ public class SchemasTest {
                 )
             ).build();
         assertThat(Schemas.getNewCurrentSchemas(metaData), contains("doc", "new_schema"));
+    }
+
+
+    @Test
+    public void testCurrentSchemas() throws Exception {
+        MetaData metaData = MetaData.builder()
+            .put(IndexMetaData.builder("doc.d1")
+                .state(IndexMetaData.State.OPEN)
+                .settings(Settings.builder()
+                    .put(SETTING_NUMBER_OF_SHARDS, 1)
+                    .put(SETTING_NUMBER_OF_REPLICAS, 0)
+                    .put(SETTING_VERSION_CREATED, Version.CURRENT))
+                .build(), true)
+            .put(IndexMetaData.builder("doc.d2")
+                .state(IndexMetaData.State.CLOSE)
+                .settings(Settings.builder()
+                    .put(SETTING_NUMBER_OF_SHARDS, 1)
+                    .put(SETTING_NUMBER_OF_REPLICAS, 0)
+                    .put(SETTING_VERSION_CREATED, Version.CURRENT))
+                .build(), true)
+            .put(IndexMetaData.builder("foo.f1")
+                .state(IndexMetaData.State.CLOSE)
+                .settings(Settings.builder()
+                    .put(SETTING_NUMBER_OF_SHARDS, 1)
+                    .put(SETTING_NUMBER_OF_REPLICAS, 0)
+                    .put(SETTING_VERSION_CREATED, Version.CURRENT))
+                .build(), true)
+            .put(IndexMetaData.builder("foo.f2")
+                .state(IndexMetaData.State.OPEN)
+                .settings(Settings.builder()
+                    .put(SETTING_NUMBER_OF_SHARDS, 1)
+                    .put(SETTING_NUMBER_OF_REPLICAS, 0)
+                    .put(SETTING_VERSION_CREATED, Version.CURRENT))
+                .build(), true)
+            .build();
+        assertThat(Schemas.getNewCurrentSchemas(metaData), contains("foo", "doc"));
     }
 
     private Schemas getReferenceInfos(SchemaInfo schemaInfo) {


### PR DESCRIPTION
This fixes a bug that caused a table that is not part of the "doc" schema to be unavailable/hidden if it gets closed using ``ALTER TABLE``