### PR TITLE
Update psycopg2 to 2.7.3.1

### DIFF
--- a/blackbox/requirements.txt
+++ b/blackbox/requirements.txt
@@ -20,7 +20,7 @@ MarkupSafe==1.0
 pathtools==0.1.2
 port-for==0.3.1
 prompt-toolkit==1.0.14
-psycopg2==2.7.1
+psycopg2==2.7.3.1
 Pygments==2.2.0
 pytz==2017.2
 PyYAML==3.12


### PR DESCRIPTION
> The release 2.7.3.1 fixes psycopg2-wheels bug #2 which was in turn
> caused by auditwheel bug #80, resulting in incompatibility with glibc
> 2.26. The problem only affects Linux wheels users,