### PR TITLE
Re-add distributed nl-phase execution

### DIFF
--- a/sql/src/main/java/io/crate/planner/Planner.java
+++ b/sql/src/main/java/io/crate/planner/Planner.java
@@ -232,7 +232,7 @@ public class Planner extends AnalyzedStatementVisitor<Planner.Context, Plan> {
     @Inject
     public Planner(ClusterService clusterService, Functions functions, TableStats tableStats) {
         this.clusterService = clusterService;
-        this.consumingPlanner = new ConsumingPlanner(clusterService, functions, tableStats);
+        this.consumingPlanner = new ConsumingPlanner(functions, tableStats);
         this.copyStatementPlanner = new CopyStatementPlanner(clusterService);
         this.selectStatementPlanner = new SelectStatementPlanner(consumingPlanner);
         normalizer = EvaluatingNormalizer.functionOnlyNormalizer(functions);

--- a/sql/src/main/java/io/crate/planner/consumer/ConsumingPlanner.java
+++ b/sql/src/main/java/io/crate/planner/consumer/ConsumingPlanner.java
@@ -32,7 +32,6 @@ import io.crate.planner.SubqueryPlanner;
 import io.crate.planner.TableStats;
 import io.crate.planner.operators.LogicalPlanner;
 import io.crate.planner.projection.builder.ProjectionBuilder;
-import org.elasticsearch.cluster.service.ClusterService;
 
 import javax.annotation.Nullable;
 import java.util.Map;
@@ -41,12 +40,13 @@ public class ConsumingPlanner {
 
     private final OptimizingRewriter optimizer;
     private final Functions functions;
+    private final TableStats tableStats;
 
-    public ConsumingPlanner(ClusterService clusterService,
-                            Functions functions,
+    public ConsumingPlanner(Functions functions,
                             TableStats tableStats) {
         optimizer = new OptimizingRewriter(functions);
         this.functions = functions;
+        this.tableStats = tableStats;
     }
 
     @Nullable
@@ -67,6 +67,7 @@ public class ConsumingPlanner {
             Map<Plan, SelectSymbol> subQueries = subqueryPlanner.planSubQueries(queriedRelation.querySpec());
             return MultiPhasePlan.createIfNeeded(
                 logicalPlanner.plan(
+                    tableStats,
                     queriedRelation,
                     context,
                     new ProjectionBuilder(functions),

--- a/sql/src/main/java/io/crate/planner/operators/Count.java
+++ b/sql/src/main/java/io/crate/planner/operators/Count.java
@@ -113,4 +113,9 @@ public class Count implements LogicalPlan {
     public List<AbstractTableRelation> baseTables() {
         return baseTables;
     }
+
+    @Override
+    public long numExpectedRows() {
+        return 1L;
+    }
 }

--- a/sql/src/main/java/io/crate/planner/operators/FetchOrEval.java
+++ b/sql/src/main/java/io/crate/planner/operators/FetchOrEval.java
@@ -109,12 +109,12 @@ class FetchOrEval implements LogicalPlan {
                                       List<Symbol> outputs,
                                       FetchMode fetchMode,
                                       boolean isLastFetch) {
-        return usedBeforeNextFetch -> {
+        return (tableStats, usedBeforeNextFetch) -> {
             final LogicalPlan source;
             if (fetchMode == FetchMode.NEVER || !isLastFetch) {
-                source = sourceBuilder.build(usedBeforeNextFetch);
+                source = sourceBuilder.build(tableStats, usedBeforeNextFetch);
             } else {
-                source = sourceBuilder.build(Collections.emptySet());
+                source = sourceBuilder.build(tableStats, Collections.emptySet());
             }
             if (source.outputs().equals(outputs)) {
                 return source;
@@ -365,6 +365,11 @@ class FetchOrEval implements LogicalPlan {
     @Override
     public List<AbstractTableRelation> baseTables() {
         return source.baseTables();
+    }
+
+    @Override
+    public long numExpectedRows() {
+        return source.numExpectedRows();
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
+++ b/sql/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
@@ -61,11 +61,11 @@ public class GroupHashAggregate implements LogicalPlan {
     private final List<Symbol> outputs;
 
     public static Builder create(Builder source, List<Symbol> groupKeys, List<Function> aggregates) {
-        return parentUsedCols -> {
+        return (tableStats, parentUsedCols) -> {
             HashSet<Symbol> usedCols = new HashSet<>();
             usedCols.addAll(groupKeys);
             usedCols.addAll(extractColumns(aggregates));
-            return new GroupHashAggregate(source.build(usedCols), groupKeys, aggregates);
+            return new GroupHashAggregate(source.build(tableStats, usedCols), groupKeys, aggregates);
         };
     }
 
@@ -191,6 +191,12 @@ public class GroupHashAggregate implements LogicalPlan {
     @Override
     public List<AbstractTableRelation> baseTables() {
         return source.baseTables();
+    }
+
+    @Override
+    public long numExpectedRows() {
+        // We don't have any cardinality estimates
+        return source.numExpectedRows();
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/HashAggregate.java
+++ b/sql/src/main/java/io/crate/planner/operators/HashAggregate.java
@@ -152,6 +152,11 @@ public class HashAggregate implements LogicalPlan {
         return source.baseTables();
     }
 
+    @Override
+    public long numExpectedRows() {
+        return 1L;
+    }
+
     private static class OutputValidatorContext {
         private boolean insideAggregation = false;
     }

--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlan.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlan.java
@@ -30,6 +30,7 @@ import io.crate.analyze.symbol.Symbol;
 import io.crate.collections.Lists2;
 import io.crate.planner.Plan;
 import io.crate.planner.Planner;
+import io.crate.planner.TableStats;
 import io.crate.planner.projection.builder.ProjectionBuilder;
 
 import javax.annotation.Nullable;
@@ -56,7 +57,8 @@ import java.util.function.Function;
  *     Collect [x, y, z]
  * </pre>
  *
- * {@link #build(Planner.Context, ProjectionBuilder, int, int, OrderBy, Integer)} is called on the "root" and flows down.
+ * {@link #build(Planner.Context, ProjectionBuilder, int, int, OrderBy, Integer)} is called
+ * on the "root" and flows down.
  * Each time each operator may provide "hints" to the children so that they can decide to eagerly apply parts of the
  * operations
  *
@@ -120,7 +122,7 @@ public interface LogicalPlan {
          *                         outputs: [_fetch, a]
          *                    </pre>
          */
-        LogicalPlan build(Set<Symbol> usedBeforeNextFetch);
+        LogicalPlan build(TableStats tableStats, Set<Symbol> usedBeforeNextFetch);
     }
 
     /**
@@ -168,4 +170,6 @@ public interface LogicalPlan {
     Map<Symbol, Symbol> expressionMapping();
 
     List<AbstractTableRelation> baseTables();
+
+    long numExpectedRows();
 }

--- a/sql/src/main/java/io/crate/planner/operators/Order.java
+++ b/sql/src/main/java/io/crate/planner/operators/Order.java
@@ -50,11 +50,11 @@ class Order implements LogicalPlan {
         if (orderBy == null) {
             return source;
         }
-        return usedColumns -> {
+        return (tableStats, usedColumns) -> {
             Set<Symbol> allUsedColumns = new HashSet<>();
             allUsedColumns.addAll(orderBy.orderBySymbols());
             allUsedColumns.addAll(usedColumns);
-            return new Order(source.build(allUsedColumns), orderBy);
+            return new Order(source.build(tableStats, allUsedColumns), orderBy);
         };
     }
 
@@ -123,6 +123,11 @@ class Order implements LogicalPlan {
     @Override
     public List<AbstractTableRelation> baseTables() {
         return source.baseTables();
+    }
+
+    @Override
+    public long numExpectedRows() {
+        return source.numExpectedRows();
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/RelationBoundary.java
+++ b/sql/src/main/java/io/crate/planner/operators/RelationBoundary.java
@@ -56,7 +56,7 @@ public class RelationBoundary implements LogicalPlan {
     private final QueriedRelation relation;
 
     public static LogicalPlan.Builder create(LogicalPlan.Builder sourceBuilder, QueriedRelation relation) {
-        return usedBeforeNextFetch -> {
+        return (tableStats, usedBeforeNextFetch) -> {
             HashMap<Symbol, Symbol> expressionMapping = new HashMap<>();
             for (Field field : relation.fields()) {
                 expressionMapping.put(
@@ -68,7 +68,7 @@ public class RelationBoundary implements LogicalPlan {
             for (Symbol beforeNextFetch : usedBeforeNextFetch) {
                 mappedUsedColumns.add(mapper.apply(beforeNextFetch));
             }
-            return new RelationBoundary(sourceBuilder.build(mappedUsedColumns), relation);
+            return new RelationBoundary(sourceBuilder.build(tableStats, mappedUsedColumns), relation);
         };
     }
 
@@ -130,6 +130,11 @@ public class RelationBoundary implements LogicalPlan {
     @Override
     public List<AbstractTableRelation> baseTables() {
         return source.baseTables();
+    }
+
+    @Override
+    public long numExpectedRows() {
+        return source.numExpectedRows();
     }
 
     @Override

--- a/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -75,7 +75,6 @@ import io.crate.types.DataTypes;
 import org.apache.lucene.util.BytesRef;
 import org.hamcrest.Matchers;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -674,44 +673,39 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
-    @Ignore("re-enable once distributed NL planning is added back")
     public void testGlobalAggregationOn3TableJoinWithImplicitJoinConditions() {
         Merge plan = e.plan("select count(*) from users t1, users t2, users t3 " +
                             "where t1.id = t2.id and t2.id = t3.id");
         assertThat(plan.subPlan(), instanceOf(NestedLoop.class));
         NestedLoop outerNL = (NestedLoop)plan.subPlan();
-        assertThat(outerNL.nestedLoopPhase().projections().get(0), instanceOf(FilterProjection.class));
-        FilterProjection filterProjection = (FilterProjection) outerNL.nestedLoopPhase().projections().get(0);
-        assertThat(filterProjection.outputs(), isSQL("INPUT(0), INPUT(1)"));
-        assertThat(filterProjection.query(), isSQL("(INPUT(0) = INPUT(1))"));
+        assertThat(outerNL.nestedLoopPhase().projections().get(1), instanceOf(FilterProjection.class));
+        FilterProjection filterProjection = (FilterProjection) outerNL.nestedLoopPhase().projections().get(1);
+        assertThat(filterProjection.query(), isSQL("(INPUT(1) = INPUT(2))"));
         assertThat(outerNL.nestedLoopPhase().outputTypes().size(), is(1));
         assertThat(outerNL.nestedLoopPhase().outputTypes().get(0), is(CountAggregation.LongStateType.INSTANCE));
 
         NestedLoop innerNL = (NestedLoop) outerNL.left();
-        assertThat(innerNL.nestedLoopPhase().projections().get(0), instanceOf(FilterProjection.class));
-        filterProjection = (FilterProjection) innerNL.nestedLoopPhase().projections().get(0);
-        assertThat(filterProjection.outputs(), isSQL("INPUT(0), INPUT(1)"));
+        assertThat(innerNL.nestedLoopPhase().projections().get(1), instanceOf(FilterProjection.class));
+        filterProjection = (FilterProjection) innerNL.nestedLoopPhase().projections().get(1);
         assertThat(filterProjection.query(), isSQL("(INPUT(0) = INPUT(1))"));
-        assertThat(innerNL.nestedLoopPhase().outputTypes().size(), is(1));
+        assertThat(innerNL.nestedLoopPhase().outputTypes().size(), is(2));
         assertThat(innerNL.nestedLoopPhase().outputTypes().get(0), is(DataTypes.LONG));
 
         plan = e.plan("select count(t1.other_id) from users t1, users t2, users t3 " +
                             "where t1.id = t2.id and t2.id = t3.id");
         assertThat(plan.subPlan(), instanceOf(NestedLoop.class));
         outerNL = (NestedLoop)plan.subPlan();
-        assertThat(outerNL.nestedLoopPhase().projections().get(0), instanceOf(FilterProjection.class));
-        filterProjection = (FilterProjection) outerNL.nestedLoopPhase().projections().get(0);
-        assertThat(filterProjection.outputs(), isSQL("INPUT(0), INPUT(1), INPUT(2)"));
-        assertThat(filterProjection.query(), isSQL("(INPUT(1) = INPUT(2))"));
+        assertThat(outerNL.nestedLoopPhase().projections().get(1), instanceOf(FilterProjection.class));
+        filterProjection = (FilterProjection) outerNL.nestedLoopPhase().projections().get(1);
+        assertThat(filterProjection.query(), isSQL("(INPUT(2) = INPUT(3))"));
         assertThat(outerNL.nestedLoopPhase().outputTypes().size(), is(1));
         assertThat(outerNL.nestedLoopPhase().outputTypes().get(0), is(CountAggregation.LongStateType.INSTANCE));
 
         innerNL = (NestedLoop) outerNL.left();
-        assertThat(innerNL.nestedLoopPhase().projections().get(0), instanceOf(FilterProjection.class));
-        filterProjection = (FilterProjection) innerNL.nestedLoopPhase().projections().get(0);
-        assertThat(filterProjection.outputs(), isSQL("INPUT(0), INPUT(1), INPUT(2)"));
+        assertThat(innerNL.nestedLoopPhase().projections().get(1), instanceOf(FilterProjection.class));
+        filterProjection = (FilterProjection) innerNL.nestedLoopPhase().projections().get(1);
         assertThat(filterProjection.query(), isSQL("(INPUT(0) = INPUT(2))"));
-        assertThat(innerNL.nestedLoopPhase().outputTypes().size(), is(2));
+        assertThat(innerNL.nestedLoopPhase().outputTypes().size(), is(3));
         assertThat(innerNL.nestedLoopPhase().outputTypes().get(0), is(DataTypes.LONG));
         assertThat(innerNL.nestedLoopPhase().outputTypes().get(1), is(DataTypes.LONG));
     }

--- a/sql/src/test/java/io/crate/planner/operators/JoinTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/JoinTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.operators;
+
+import com.carrotsearch.hppc.ObjectLongHashMap;
+import io.crate.action.sql.SessionContext;
+import io.crate.analyze.EvaluatingNormalizer;
+import io.crate.analyze.MultiSourceSelect;
+import io.crate.analyze.SelectAnalyzedStatement;
+import io.crate.analyze.TableDefinitions;
+import io.crate.metadata.Functions;
+import io.crate.metadata.TableIdent;
+import io.crate.metadata.TransactionContext;
+import io.crate.planner.Planner;
+import io.crate.planner.TableStats;
+import io.crate.planner.consumer.ConsumingPlanner;
+import io.crate.planner.distribution.DistributionType;
+import io.crate.planner.node.dql.Collect;
+import io.crate.planner.node.dql.join.NestedLoop;
+import io.crate.planner.projection.builder.ProjectionBuilder;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.UUID;
+
+import static io.crate.testing.TestingHelpers.getFunctions;
+import static org.hamcrest.Matchers.is;
+
+public class JoinTest extends CrateDummyClusterServiceUnitTest {
+
+    private SQLExecutor e;
+    private Functions functions = getFunctions();
+    private ProjectionBuilder projectionBuilder = new ProjectionBuilder(functions);
+
+    @Before
+    public void setUpExecutor() throws Exception {
+        e = SQLExecutor.builder(clusterService)
+            .addDocTable(TableDefinitions.USER_TABLE_INFO)
+            .addDocTable(TableDefinitions.TEST_DOC_LOCATIONS_TABLE_INFO)
+            .build();
+    }
+
+    @Test
+    public void testTablesAreSwitchedIfLeftIsSmallerThanRight() throws Exception {
+        SelectAnalyzedStatement stmt = e.analyze("select * from users, locations where users.id = locations.id");
+        MultiSourceSelect mss = (MultiSourceSelect )stmt.relation();
+
+        TableStats tableStats = new TableStats();
+        ObjectLongHashMap<TableIdent> rowCountByTable = new ObjectLongHashMap<>();
+        rowCountByTable.put(TableDefinitions.USER_TABLE_IDENT, 10);
+        rowCountByTable.put(TableDefinitions.TEST_DOC_LOCATIONS_TABLE_IDENT, 10_000);
+        tableStats.updateTableStats(rowCountByTable);
+
+        LogicalPlan operator = Join.createNodes(mss, mss.where()).build(tableStats, Collections.emptySet());
+        Planner.Context context = getContext(tableStats);
+        NestedLoop nl = (NestedLoop) operator.build(context, projectionBuilder, -1, 0, null, null );
+        assertThat(
+            ((Collect) nl.left()).collectPhase().distributionInfo().distributionType(),
+            is(DistributionType.BROADCAST)
+        );
+
+        rowCountByTable.put(TableDefinitions.USER_TABLE_IDENT, 10_000);
+        rowCountByTable.put(TableDefinitions.TEST_DOC_LOCATIONS_TABLE_IDENT, 10);
+        tableStats.updateTableStats(rowCountByTable);
+
+        operator = Join.createNodes(mss, mss.where()).build(tableStats, Collections.emptySet());
+        nl = (NestedLoop) operator.build(context, projectionBuilder, -1, 0, null, null );
+        assertThat(
+            ((Collect) nl.left()).collectPhase().distributionInfo().distributionType(),
+            is(DistributionType.SAME_NODE)
+        );
+    }
+
+    private Planner.Context getContext(TableStats tableStats) {
+        return new Planner.Context(
+                e.planner,
+                clusterService,
+                UUID.randomUUID(),
+                new ConsumingPlanner(functions, tableStats),
+                EvaluatingNormalizer.functionOnlyNormalizer(functions),
+                new TransactionContext(SessionContext.create()),
+                -1,
+                -1
+            );
+    }
+}

--- a/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -27,6 +27,7 @@ import io.crate.analyze.SelectAnalyzedStatement;
 import io.crate.analyze.relations.QueriedRelation;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.format.SymbolPrinter;
+import io.crate.planner.TableStats;
 import io.crate.planner.consumer.FetchMode;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
@@ -42,19 +43,21 @@ import static org.hamcrest.Matchers.equalTo;
 public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
 
     private SQLExecutor sqlExecutor;
+    private TableStats tableStats;
 
     @Before
     public void prepare() {
         sqlExecutor = SQLExecutor.builder(clusterService)
             .enableDefaultTables()
             .build();
+        tableStats = new TableStats();
     }
 
     private LogicalPlan plan(String statement) {
         SelectAnalyzedStatement analyzedStatement = sqlExecutor.analyze(statement);
         QueriedRelation relation = analyzedStatement.relation();
         return LogicalPlanner.plan(relation, FetchMode.WITH_PROPAGATION, true)
-            .build(LogicalPlanner.extractColumns(relation.querySpec().outputs()))
+            .build(tableStats, LogicalPlanner.extractColumns(relation.querySpec().outputs()))
             .tryCollapse();
     }
 


### PR DESCRIPTION
This changes the Join operator planning to behave like the `NestedLoopConsumer` did.

Note that `testGlobalAggregationOn3TableJoinWithImplicitJoinConditions` changed slightly because currently the Join operator always has left+right outputs as outputs (in case of non-SEMI joins). So in some cases the projections have outputs which are not needed. I'll address that in a separate PR. There are still a couple of tests marked as Ignored because of this.