### PR TITLE
Re-add join re-ordering optimization

### DIFF
--- a/sql/src/main/java/io/crate/planner/operators/Join.java
+++ b/sql/src/main/java/io/crate/planner/operators/Join.java
@@ -26,7 +26,6 @@ import io.crate.analyze.MultiSourceSelect;
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.WhereClause;
 import io.crate.analyze.relations.AbstractTableRelation;
-import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.JoinPair;
 import io.crate.analyze.relations.QueriedRelation;
 import io.crate.analyze.relations.QuerySplitter;
@@ -85,34 +84,48 @@ public class Join implements LogicalPlan {
 
     static Builder createNodes(MultiSourceSelect mss, WhereClause where) {
         return usedColsByParent -> {
-            Iterator<AnalyzedRelation> it = mss.sources().values().iterator();
 
-            QueriedRelation lhs = (QueriedRelation) it.next();
-            QueriedRelation rhs = (QueriedRelation) it.next();
-            final QualifiedName lhsName = lhs.getQualifiedName();
-            final QualifiedName rhsName = rhs.getQualifiedName();
+            Map<Set<QualifiedName>, JoinPair> joinPairs = mss.joinPairs()
+                .stream()
+                .filter(p -> p.condition() != null)
+                .collect(Collectors.toMap(p -> Sets.newHashSet(p.left(), p.right()), p -> p));
+            Map<Set<QualifiedName>, Symbol> queryParts = getQueryParts(where);
+
+            Collection<QualifiedName> orderedRelationNames;
+            if (mss.sources().size() > 2) {
+                orderedRelationNames = JoinOrdering.getOrderedRelationNames(
+                    mss.isRelationReOrderAllowed(),
+                    mss.sources().keySet(),
+                    joinPairs.keySet(),
+                    queryParts.keySet()
+                );
+            } else {
+                orderedRelationNames = mss.sources().keySet();
+            }
+
+            Iterator<QualifiedName> it = orderedRelationNames.iterator();
+
+            final QualifiedName lhsName = it.next();
+            final QualifiedName rhsName = it.next();
+            QueriedRelation lhs = (QueriedRelation) mss.sources().get(lhsName);
+            QueriedRelation rhs = (QueriedRelation) mss.sources().get(rhsName);
             Set<QualifiedName> joinNames = new HashSet<>();
             joinNames.add(lhsName);
             joinNames.add(rhsName);
 
-            Map<Set<QualifiedName>, JoinPair> joinPairs = mss.joinPairs()
-                .stream()
-                .collect(Collectors.toMap(p -> Sets.newHashSet(p.left(), p.right()), p -> p));
-
             JoinPair joinLhsRhs = joinPairs.remove(joinNames);
-
-            Set<Symbol> usedFromLeft = new HashSet<>();
-            Set<Symbol> usedFromRight = new HashSet<>();
             final JoinType joinType;
             final Symbol joinCondition;
             if (joinLhsRhs == null) {
                 joinType = JoinType.CROSS;
                 joinCondition = null;
             } else {
-                joinType = joinLhsRhs.joinType();
+                joinType = maybeInvertPair(rhsName, joinLhsRhs);
                 joinCondition = joinLhsRhs.condition();
             }
 
+            Set<Symbol> usedFromLeft = new HashSet<>();
+            Set<Symbol> usedFromRight = new HashSet<>();
             for (JoinPair joinPair : mss.joinPairs()) {
                 addColumnsFrom(joinPair.condition(), usedFromLeft::add, lhs);
                 addColumnsFrom(joinPair.condition(), usedFromRight::add, rhs);
@@ -127,16 +140,29 @@ public class Join implements LogicalPlan {
             LogicalPlan rhsPlan = LogicalPlanner.plan(rhs, FetchMode.NEVER, false).build(usedFromRight);
             LogicalPlan join = new Join(lhsPlan, rhsPlan, joinType, joinCondition);
 
-            Map<Set<QualifiedName>, Symbol> queryParts = getQueryParts(where);
             Symbol query = removeParts(queryParts, lhsName, rhsName);
             join = Filter.create(join, query);
             while (it.hasNext()) {
-                QueriedRelation nextRel = (QueriedRelation) it.next();
+                QueriedRelation nextRel = (QueriedRelation) mss.sources().get(it.next());
                 join = joinWithNext(join, nextRel, usedColsByParent, joinNames, joinPairs, queryParts);
                 joinNames.add(nextRel.getQualifiedName());
             }
+            assert queryParts.isEmpty() : "Must've applied all queryParts";
+            assert joinPairs.isEmpty() : "Must've applied all joinPairs";
+
             return join;
         };
+    }
+
+    private static JoinType maybeInvertPair(QualifiedName rhsName, JoinPair pair) {
+        // A matching joinPair for two relations is retrieved using pairByQualifiedNames.remove(setOf(a, b))
+        // This returns a pair for both cases: (a ⋈ b) and (b ⋈ a) -> invert joinType to execute correct join
+        // Note that this can only happen if a re-ordering optimization happened, otherwise the joinPair would always
+        // be in the correct format.
+        if (pair.right().equals(rhsName)) {
+            return pair.joinType();
+        }
+        return pair.joinType().invert();
     }
 
     private static LogicalPlan joinWithNext(LogicalPlan source,
@@ -156,7 +182,7 @@ public class Join implements LogicalPlan {
             type = JoinType.CROSS;
             condition = null;
         } else {
-            type = joinPair.joinType();
+            type = maybeInvertPair(nextName, joinPair);
             condition = joinPair.condition();
             addColumnsFrom(condition, addToUsedColumns, nextRel);
         }

--- a/sql/src/main/java/io/crate/planner/operators/JoinOrdering.java
+++ b/sql/src/main/java/io/crate/planner/operators/JoinOrdering.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.operators;
+
+import com.carrotsearch.hppc.ObjectIntHashMap;
+import com.google.common.annotations.VisibleForTesting;
+import io.crate.sql.tree.QualifiedName;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+public class JoinOrdering {
+
+    public static Collection<QualifiedName> getOrderedRelationNames(boolean reOrderIsAllowed,
+                                                                    Collection<QualifiedName> sourceRelations,
+                                                                    Set<? extends Set<QualifiedName>> explicitJoinConditions,
+                                                                    Set<? extends Set<QualifiedName>> implicitJoinConditions) {
+        if (!reOrderIsAllowed || (explicitJoinConditions.isEmpty() && implicitJoinConditions.isEmpty())) {
+            return sourceRelations;
+        }
+        return orderByJoinConditions(
+            sourceRelations,
+            explicitJoinConditions,
+            implicitJoinConditions);
+    }
+
+    /**
+     * Returns a the relation re-ordered to apply join conditions further down in the tree.
+     *
+     * (Assuming the relations are consumed from left to right to build a tree of two-relations join nodes)
+     *
+     * @param relations               all relations, e.g. [t1, t2, t3, t3]
+     * @param explicitJoinedRelations contains all relation pairs that have an explicit join condition
+     *                                e.g. {{t1, t2}, {t2, t3}}
+     * @param implicitJoinedRelations contains all relations pairs that have an implicit join condition
+     *                                e.g. {{t1, t2}, {t2, t3}}
+     */
+    static Collection<QualifiedName> orderByJoinConditions(Collection<QualifiedName> relations,
+                                                           Set<? extends Set<QualifiedName>> explicitJoinedRelations,
+                                                           Set<? extends Set<QualifiedName>> implicitJoinedRelations) {
+
+        LinkedHashSet<QualifiedName> bestOrder = new LinkedHashSet<>();
+        List<Set<QualifiedName>> pairsWithJoinConditions = new ArrayList<>(explicitJoinedRelations);
+        pairsWithJoinConditions.addAll(implicitJoinedRelations);
+
+        ObjectIntHashMap<QualifiedName> occurrences =
+            getOccurrencesInJoinConditions(relations.size(), explicitJoinedRelations, implicitJoinedRelations);
+
+        Set<QualifiedName> firstJoinPair = findAndRemoveFirstJoinPair(occurrences, pairsWithJoinConditions);
+        assert firstJoinPair != null : "firstJoinPair should not be null";
+        bestOrder.addAll(firstJoinPair);
+
+        buildBestOrderByJoinConditions(pairsWithJoinConditions, bestOrder);
+        bestOrder.addAll(relations);
+        return bestOrder;
+    }
+
+    private static ObjectIntHashMap<QualifiedName> getOccurrencesInJoinConditions(
+        int numberOfRelations,
+        Set<? extends Set<QualifiedName>> explicitJoinedRelations,
+        Set<? extends Set<QualifiedName>> implicitJoinedRelations) {
+
+        ObjectIntHashMap<QualifiedName> occurrences = new ObjectIntHashMap<>(numberOfRelations);
+        explicitJoinedRelations.forEach(o -> o.forEach(qName -> occurrences.putOrAdd(qName, 1, 1)));
+        implicitJoinedRelations.forEach(o -> o.forEach(qName -> occurrences.putOrAdd(qName, 1, 1)));
+        return occurrences;
+    }
+
+    @VisibleForTesting
+    static Set<QualifiedName> findAndRemoveFirstJoinPair(ObjectIntHashMap<QualifiedName> occurrences,
+                                                         Collection<Set<QualifiedName>> joinPairs) {
+        Iterator<Set<QualifiedName>> setsIterator = joinPairs.iterator();
+        while (setsIterator.hasNext()) {
+            Set<QualifiedName> set = setsIterator.next();
+            for (QualifiedName name : set) {
+                int count = occurrences.getOrDefault(name, 0);
+                if (count > 1) {
+                    setsIterator.remove();
+                    return set;
+                }
+            }
+        }
+        return joinPairs.iterator().next();
+    }
+
+    private static void buildBestOrderByJoinConditions(List<Set<QualifiedName>> sets, LinkedHashSet<QualifiedName> bestOrder) {
+        Iterator<Set<QualifiedName>> setsIterator = sets.iterator();
+        while (setsIterator.hasNext()) {
+            Set<QualifiedName> set = setsIterator.next();
+            for (QualifiedName name: set) {
+                if (bestOrder.contains(name)) {
+                    bestOrder.addAll(set);
+                    setsIterator.remove();
+                    setsIterator = sets.iterator();
+                    break;
+                }
+            }
+        }
+
+        // Add the rest of the relations to the end of the collection
+        sets.forEach(bestOrder::addAll);
+    }
+}

--- a/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -586,7 +586,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         NestedLoop innerNl = (NestedLoop) outerNl.left();
 
         assertThat(((FilterProjection) innerNl.nestedLoopPhase().projections().get(1)).query(),
-            isSQL("((INPUT(2) = INPUT(0)) AND (INPUT(3) = INPUT(1)))"));
+            isSQL("((INPUT(0) = INPUT(2)) AND (INPUT(1) = INPUT(3)))"));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/planner/operators/JoinOrderingTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/JoinOrderingTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.operators;
+
+import com.carrotsearch.hppc.ObjectIntHashMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import io.crate.sql.tree.QualifiedName;
+import io.crate.testing.T3;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class JoinOrderingTest {
+
+    @Test
+    public void testFindFirstJoinPair() {
+        // SELECT * FROM t1, t2, t3 WHERE t1.id = t2.id AND t2.id = t3.id AND t3.id = t4.id
+        ObjectIntHashMap<QualifiedName> occurrences = new ObjectIntHashMap<>(4);
+        occurrences.put(T3.T1, 1);
+        occurrences.put(T3.T2, 1);
+        occurrences.put(T3.T3, 3);
+        occurrences.put(T3.T4, 1);
+        @SuppressWarnings("unchecked")
+        Set<Set<QualifiedName>> sets = Sets.newHashSet(
+            ImmutableSet.of(T3.T1, T3.T2),
+            ImmutableSet.of(T3.T2, T3.T3),
+            ImmutableSet.of(T3.T3, T3.T4)
+        );
+        assertThat(JoinOrdering.findAndRemoveFirstJoinPair(occurrences, sets), is(ImmutableSet.of(T3.T2, T3.T3)));
+    }
+
+    @Test
+    public void testFindFirstJoinPairOnlyOneOccurrence() {
+        // SELECT * FROM t1, t2, t3 WHERE t1.id = t2.id AND t3.id = t4.id
+        ObjectIntHashMap<QualifiedName> occurrences = new ObjectIntHashMap<>(4);
+        occurrences.put(T3.T1, 1);
+        occurrences.put(T3.T2, 1);
+        occurrences.put(T3.T3, 1);
+        occurrences.put(T3.T4, 1);
+        Set<Set<QualifiedName>> sets = Sets.newLinkedHashSet();
+        sets.add(ImmutableSet.of(T3.T1, T3.T2));
+        sets.add(ImmutableSet.of(T3.T2, T3.T3));
+        sets.add(ImmutableSet.of(T3.T3, T3.T4));
+        assertThat(JoinOrdering.findAndRemoveFirstJoinPair(occurrences, sets), is(ImmutableSet.of(T3.T1, T3.T2)));
+    }
+
+    @Test
+    public void testOptimizeJoinNoPresort() throws Exception {
+        Collection<QualifiedName> qualifiedNames = JoinOrdering.orderByJoinConditions(
+            Arrays.asList(T3.T1, T3.T2, T3.T3),
+            ImmutableSet.of(ImmutableSet.of(T3.T1, T3.T2)),
+            ImmutableSet.of(ImmutableSet.of(T3.T2, T3.T3))
+        );
+        assertThat(qualifiedNames, contains(T3.T1, T3.T2, T3.T3));
+    }
+}


### PR DESCRIPTION
This adds back the join-ordering optimization which used to be part of
the `ManyTableConsumer`. The ordering logic is now in the `JoinOrdering`
class - this is pretty much 1:1 the old code, except that some unused
logic regarding "pre-sorted" handling has been removed.