### PR TITLE
Fix distributed join planning table swap

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -24,6 +24,10 @@ Changes
 Fixes
 =====
 
+ - Fixed a bug that caused incorrect results to be returned for JOIN queries
+   when the table stats indicated that the left table of a join is smaller
+   than the right.
+
  - Fixed passing arguments that contain spaces in crate shell script.
 
  - Fixed an issue that caused a table that is not part of the "doc" schema to

--- a/sql/src/test/java/io/crate/planner/consumer/NestedLoopConsumerTest.java
+++ b/sql/src/test/java/io/crate/planner/consumer/NestedLoopConsumerTest.java
@@ -75,6 +75,7 @@ import static io.crate.testing.TestingHelpers.isSQL;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.mock;
@@ -189,12 +190,30 @@ public class NestedLoopConsumerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testLeftSideIsBroadcastIfLeftTableIsSmaller() throws Exception {
+        assertThat(
+            getTableStats().numDocs(TableDefinitions.USER_TABLE_IDENT),
+            is(lessThan(getTableStats().numDocs(TableDefinitions.USER_TABLE_IDENT_MULTI_PK))));
         Merge merge = plan("select users.name, u2.name from users, users_multi_pk u2 " +
                            "where users.name = u2.name " +
                            "order by users.name, u2.name ");
         NestedLoop nl = (NestedLoop) merge.subPlan();
         Collect collect = (Collect) nl.left();
         assertThat(collect.collectPhase().distributionInfo().distributionType(), is(DistributionType.BROADCAST));
+    }
+
+    @Test
+    public void testRightSideIsNotAlwaysNullIfLeftTableIsSmaller() {
+        assertThat(
+            getTableStats().numDocs(TableDefinitions.USER_TABLE_IDENT),
+            is(lessThan(getTableStats().numDocs(TableDefinitions.USER_TABLE_IDENT_MULTI_PK))));
+        NestedLoop nl = plan("Select * from " +
+                            "(select * from users limit 2) u1, " +
+                            "(select * from users_multi_pk limit 5) u2 " +
+                            "where u1.name = u2.name " +
+                            "order by u1.name, u2.name ");
+        NestedLoopPhase nestedLoopPhase = nl.nestedLoopPhase();
+        assertThat(nestedLoopPhase.leftMergePhase(), is(notNullValue()));
+        assertThat(nestedLoopPhase.rightMergePhase(), is(notNullValue()));
     }
 
 


### PR DESCRIPTION
The MergePhase creation code assumes that the right side always contains the smaller table which will be broadcasted. It swaps the relations/plans if that is not the case. We must not forget to swap back everything because otherwise we change the join sides. Also inverting the join type is not correct.