### PR TITLE
add reference doc for the REROUTE command in ALTER TABLE

### DIFF
--- a/blackbox/docs/sql/reference/alter_table.txt
+++ b/blackbox/docs/sql/reference/alter_table.txt
@@ -25,6 +25,7 @@ Synopsis
         | OPEN
         | CLOSE
         | RENAME TO table_ident
+        | REROUTE reroute_option
       }
 
 where ``column_constraint`` is::
@@ -35,29 +36,13 @@ where ``column_constraint`` is::
                             FULLTEXT [ WITH ( analyzer = analyzer_name ) ]  }
     }
 
+
 Description
 ===========
 
-ALTER TABLE can be used to alter an existing table.
-
-``SET`` can be used to change a table parameter to a different value. Using
-``RESET`` will reset the parameter to its default value.
-
-``ADD COLUMN`` can be used to add an additional column to a table.
-
-While columns can be added at any time, adding a new
-:ref:`generated column <ref-generated-columns>` is only possible if the table
-is empty.
-
-``OPEN`` and ``CLOSE`` can be used to open or close the table, respectively.
-Closing a table prevents all operations, except ``ALTER TABLE ... OPEN``, to
-fail. Operations on closed partitions will not produce an exception, but will
-have no effect. Similarly, like ``SELECT`` and ``INSERT`` on partitioned will
-exclude closed partitions and continue working.
-
-``RENAME TO`` can be used to rename a table, while maintaining its schema and
-data. During this operation the table will be closed, and all operations upon
-the table will fail until the rename operation is completed.
+``ALTER TABLE`` can be used to modify an existing table definition. It provides
+options to alter, add or drop columns and constraints, enabling or disabling
+table parameters and allows to execute a shard reroute allocation.
 
 Use the ``BLOB`` keyword in order to alter a blob table (see
 :ref:`blob_support`). Blob tables cannot have custom columns which means that
@@ -68,19 +53,10 @@ table **only** and not for any possible existing partitions. So these changes
 will only be applied to new partitions. The ``ONLY`` keyword cannot be used
 together with a `PARTITION`_ clause.
 
-Parameters
-==========
+See the CREATE TABLE :ref:`with_clause` for a list of available parameters.
 
 :table_ident: The name (optionally schema-qualified) of the table to alter.
 
-:parameter: The name of the parameter that is set to a new value or its
-            default.
-
-:column_name: Name of the column which should be added.
-
-:data_type: data type of the column which should be added.
-
-See the CREATE TABLE :ref:`with_clause` for a list of available parameters.
 
 .. _ref-alter-table-partition-clause:
 
@@ -112,3 +88,93 @@ columns with a value each to identify the partition to alter.
 :value: The columns value.
 
 .. SEEALSO:: :ref:`Alter Partitioned Tables <partitioned_tables_alter>`
+
+
+Arguments
+=========
+
+``SET/RESET``
+-------------
+
+Can be used to change a table parameter to a different value.
+Using ``RESET`` will reset the parameter to its default value.
+
+:parameter: The name of the parameter that is set to a new value or its
+            default.
+
+``ADD COLUMN``
+--------------
+
+Can be used to add an additional column to a table. While columns can be added
+at any time, adding a new :ref:`generated column <ref-generated-columns>` is
+only possible if the table is empty.
+
+:data_type:   data type of the column which should be added.
+
+:column_name: Name of the column which should be added.
+
+``OPEN/CLOSE``
+--------------
+
+Can be used to open or close the table, respectively. Closing a table prevents
+all operations, except ``ALTER TABLE ... OPEN``, to fail. Operations on closed
+partitions will not produce an exception, but will have no effect. Similarly,
+like ``SELECT`` and ``INSERT`` on partitioned will exclude closed partitions and
+continue working.
+
+``RENAME TO``
+-------------
+Can be used to rename a table, while maintaining its schema and data. During
+this operation the table will be closed, and all operations upon the table will
+fail until the rename operation is completed.
+
+``REROUTE``
+-----------
+
+The ``REROUTE`` command provides various options to manually control the
+allocation of shards. It allows to enforce explicit allocations, cancel them and
+makes it possible to move shards between nodes in a cluster.
+
+::
+
+    [ REROUTE reroute_option]
+
+
+where ``reroute_option`` is::
+
+    { MOVE SHARD shard_id FROM node_id TO node_id
+      | CANCEL SHARD shard_id ON node_id [ WITH (allow_primary = {TRUE|FALSE}) ]
+      | ALLOCATE REPLICA SHARD shard_id ON node_id
+      | RETRY FAILED
+    }
+
+:shard_id:  The shard id. Ranges from 0 up to the specified number of
+            :ref:`sys-shards`  shards of a table.
+
+:node_id:   The node ID within the cluster. See :ref:`sys-nodes` how to gain the
+            unique ID.
+
+
+``REROUTE`` suports the following options to start/stop shard allocation:
+
+**MOVE**
+    A started shard gets moved from one node to another. It requests a
+    ``table_ident`` and a ``shard_id`` to identify the shard that receives the
+    new allocation. Specify ``FROM node_id`` for the node to move the shard from
+    and ``TO node_id`` to move the shard to.
+
+**CANCEL**
+    This cancels the allocation/recovery of a ``shard_id`` of a ``table_ident``
+    on a given ``node_id``. The ``allow_primary`` flag indicates if it is
+    allowed to cancel the allocation of a primary shard.
+
+**ALLOCATE REPLICA**
+    Allows to force allocation of an unassigned replica shard on a specific
+    node.
+
+**RETRY FAILED**
+    The index setting ``index.allocation.max_retries`` indicates the maximum of
+    attempts to to allocate a shard on a node. If this limit is reached it
+    leaves the shard unallocated.
+    This option triggers the allocation-retry of any unallocated shard that
+    belong to the accepted ``table_ident``.


### PR DESCRIPTION
This adds the reference doc of the new introduce shard-reroute feature
as a subcommand of `ALTER TABLE`.

Any additions/improvements are welcome 😄 