### PR TITLE
Support casts of inner type in SingleColumnTableType

### DIFF
--- a/core/src/main/java/io/crate/types/SingleColumnTableType.java
+++ b/core/src/main/java/io/crate/types/SingleColumnTableType.java
@@ -57,7 +57,11 @@ public class SingleColumnTableType extends CollectionType {
         if (value == null) {
             return null;
         }
-        return (Object[]) value;
+        Object[] array = (Object[]) value;
+        for (int i = 0; i < array.length; i++) {
+            array[i] = innerType.value(array[i]);
+        }
+        return array;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/operation/scalar/cast/CastFunctionResolver.java
+++ b/sql/src/main/java/io/crate/operation/scalar/cast/CastFunctionResolver.java
@@ -79,6 +79,17 @@ public class CastFunctionResolver {
         static final String TO_FLOAT_SET = "to_float_set";
         static final String TO_SHORT_SET = "to_short_set";
         static final String TO_IP_SET = "to_ip_set";
+
+        static final String TO_STRING_TABLE = "to_string_table";
+        static final String TO_LONG_TABLE = "to_long_table";
+        static final String TO_INTEGER_TABLE = "to_int_table";
+        static final String TO_DOUBLE_TABLE = "to_double_table";
+        static final String TO_BOOLEAN_TABLE = "to_boolean_table";
+        static final String TO_BYTE_TABLE = "to_byte_table";
+        static final String TO_FLOAT_TABLE = "to_float_table";
+        static final String TO_SHORT_TABLE = "to_short_table";
+        static final String TO_IP_TABLE = "to_ip_table";
+        static final String TO_TIMESTAMP_TABLE = "to_timestamp_table";
     }
 
     private static final ImmutableMap<DataType, String> PRIMITIVE_FUNCTION_MAP = new ImmutableMap.Builder<DataType, String>()
@@ -125,15 +136,16 @@ public class CastFunctionResolver {
         .build();
 
     private static final ImmutableMap<DataType, String> TABLE_FUNCTION_MAP = new ImmutableMap.Builder<DataType, String>()
-        .put(new SingleColumnTableType(DataTypes.STRING), FunctionNames.TO_STRING_SET)
-        .put(new SingleColumnTableType(DataTypes.LONG), FunctionNames.TO_LONG_SET)
-        .put(new SingleColumnTableType(DataTypes.INTEGER), FunctionNames.TO_INTEGER_SET)
-        .put(new SingleColumnTableType(DataTypes.DOUBLE), FunctionNames.TO_DOUBLE_SET)
-        .put(new SingleColumnTableType(DataTypes.BOOLEAN), FunctionNames.TO_BOOLEAN_SET)
-        .put(new SingleColumnTableType(DataTypes.BYTE), FunctionNames.TO_BYTE_SET)
-        .put(new SingleColumnTableType(DataTypes.FLOAT), FunctionNames.TO_FLOAT_SET)
-        .put(new SingleColumnTableType(DataTypes.SHORT), FunctionNames.TO_SHORT_SET)
-        .put(new SingleColumnTableType(DataTypes.IP), FunctionNames.TO_IP_SET)
+        .put(new SingleColumnTableType(DataTypes.STRING), FunctionNames.TO_STRING_TABLE)
+        .put(new SingleColumnTableType(DataTypes.LONG), FunctionNames.TO_LONG_TABLE)
+        .put(new SingleColumnTableType(DataTypes.INTEGER), FunctionNames.TO_INTEGER_TABLE)
+        .put(new SingleColumnTableType(DataTypes.DOUBLE), FunctionNames.TO_DOUBLE_TABLE)
+        .put(new SingleColumnTableType(DataTypes.BOOLEAN), FunctionNames.TO_BOOLEAN_TABLE)
+        .put(new SingleColumnTableType(DataTypes.BYTE), FunctionNames.TO_BYTE_TABLE)
+        .put(new SingleColumnTableType(DataTypes.FLOAT), FunctionNames.TO_FLOAT_TABLE)
+        .put(new SingleColumnTableType(DataTypes.SHORT), FunctionNames.TO_SHORT_TABLE)
+        .put(new SingleColumnTableType(DataTypes.IP), FunctionNames.TO_IP_TABLE)
+        .put(new SingleColumnTableType(DataTypes.TIMESTAMP), FunctionNames.TO_TIMESTAMP_TABLE)
         .build();
 
     static final ImmutableMap<DataType, String> FUNCTION_MAP = new ImmutableMap.Builder<DataType, String>()

--- a/sql/src/test/java/io/crate/operation/scalar/cast/CastFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/cast/CastFunctionTest.java
@@ -48,6 +48,7 @@ public class CastFunctionTest extends AbstractScalarFunctionsTest {
         assertEvaluate("cast(null as string)", null);
         assertEvaluate("cast(10.4 as long)", 10L);
         assertEvaluate("to_long_array([10.2, 12.3])", new Long[] { 10L, 12L });
+        assertEvaluate("to_double_table([10, 12])", new Double[] { 10.0, 12.0 });
         Map<String, Object> object = new HashMap<>();
         object.put("x", 10);
         assertEvaluate("'{\"x\": 10}'::object", object);


### PR DESCRIPTION
The type system requires data types to be able to convert non-matching types in
the `value(...)` function.