### PR TITLE
Default SSL on/off message to debug level

### DIFF
--- a/sql/src/main/java/io/crate/protocols/postgres/PostgresNetty.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/PostgresNetty.java
@@ -125,8 +125,10 @@ public class PostgresNetty extends AbstractLifecycleComponent {
         final SslContext sslContext;
         if (SslConfigSettings.isPSQLSslEnabled(settings)) {
             sslContext = sslContextProvider.get();
+            namedLogger.info("PSQL SSL support is enabled.");
         } else {
             sslContext = null;
+            namedLogger.info("PSQL SSL support is disabled.");
         }
         bootstrap.childHandler(new ChannelInitializer<Channel>() {
             @Override

--- a/ssl/src/main/java/io/crate/protocols/postgres/SslReqHandler.java
+++ b/ssl/src/main/java/io/crate/protocols/postgres/SslReqHandler.java
@@ -58,11 +58,6 @@ public final class SslReqHandler {
 
     SslReqHandler(SslContext sslContext) {
         this.sslContext = sslContext;
-        if (sslContext != null) {
-            log.info("PSQL SSL support is enabled.");
-        } else {
-            log.info("PSQL SSL support is disabled.");
-        }
     }
 
     /**


### PR DESCRIPTION
Currently we print the SSL status for every new connection. This add noise to
the log output without much added value.