### PR TITLE
Parse flags in RegexMatcher strictly

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -21,6 +21,9 @@ Changes
 - Added cluster checks that warn if some tables need to be recreated so that
   they are compatible with future versions of CrateDB >= 3.0.0.
 
+- Functions which accept regular expression flags now throw an error when
+  invalid flags are provided.
+
 Fixes
 =====
 

--- a/sql/src/main/java/io/crate/operation/scalar/regex/RegexMatcher.java
+++ b/sql/src/main/java/io/crate/operation/scalar/regex/RegexMatcher.java
@@ -126,8 +126,12 @@ public class RegexMatcher {
                 case 'd':
                     flags = flags | Pattern.UNIX_LINES;
                     break;
-                default:
+                case ' ':
+                case 'g':
+                    // handled in isGlobalFunction
                     break;
+                default:
+                    throw new IllegalArgumentException("The regular expression flag is unknown: " + flag);
             }
         }
 

--- a/sql/src/test/java/io/crate/operation/scalar/regex/MatchesFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/regex/MatchesFunctionTest.java
@@ -70,7 +70,7 @@ public class MatchesFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testEvaluateWithFlags() throws Exception {
         BytesRef[] expected = new BytesRef[]{new BytesRef("ba")};
-        assertEvaluate("regexp_matches(name, regex_pattern, 'usn')", expected,
+        assertEvaluate("regexp_matches(name, regex_pattern, 'us')", expected,
             Literal.of("foobarbequebaz bar"),
             Literal.of(".*(ba).*"));
     }
@@ -83,15 +83,15 @@ public class MatchesFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testNormalizeSymbolWithFlags() throws Exception {
-        assertNormalize("regexp_matches('foobarbequebaz bar', '.*(ba).*', 'us n')",
+        assertNormalize("regexp_matches('foobarbequebaz bar', '.*(ba).*', 'us')",
             isLiteral(new BytesRef[]{new BytesRef("ba")}, new ArrayType(DataTypes.STRING)));
     }
 
     @Test
     public void testNormalizeSymbolWithInvalidFlags() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: regexp_matches(string, string, long)");
-        assertNormalize("regexp_matches('foobar', 'foo', 1)", null);
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("The regular expression flag is unknown: n");
+        assertNormalize("regexp_matches('foobar', 'foo', 'n')", null);
     }
 
     @Test

--- a/sql/src/test/java/io/crate/operation/scalar/regex/ReplaceFunctionTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/regex/ReplaceFunctionTest.java
@@ -53,15 +53,14 @@ public class ReplaceFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testNormalizeSymbolWithFlags() throws Exception {
-        assertNormalize("regexp_replace('foobarbequebaz bar', '(ba)', 'Crate', 'us n')", isLiteral("fooCraterbequebaz bar"));
+        assertNormalize("regexp_replace('foobarbequebaz bar', '(ba)', 'Crate', 'us')", isLiteral("fooCraterbequebaz bar"));
     }
 
     @Test
     public void testNormalizeSymbolWithInvalidFlags() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("unknown function: regexp_replace(string, string, string, long)");
-
-        assertNormalize("regexp_replace('foobar', 'foo', 'bar', 1)", isLiteral(""));
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("The regular expression flag is unknown: n");
+        assertNormalize("regexp_replace('foobar', 'foo', 'bar', 'n')", isLiteral(""));
     }
 
     @Test


### PR DESCRIPTION
The RegexMatcher would swallow unknown flags. With this patch the RegexMatcher
will throw an error when parsing unknown flags.