### PR TITLE
Fixed issue with PID file already quoted with ".

### DIFF
--- a/app/src/main/dist/bin/crate
+++ b/app/src/main/dist/bin/crate
@@ -156,7 +156,7 @@ while getopts "vdhp:D:X:C:" opt; do
             exit 0
         ;;
         p)
-            pidfile="\"$OPTARG\""
+            pidfile="$OPTARG"
         ;;
         d)
             daemonized="yes"


### PR DESCRIPTION
There is no need to append the PID to the file on our own since this is done
by java ES code when the -Cpidfile setting is set.