### PR TITLE
introduce index setting `allocation.max_retry`

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -23,6 +23,9 @@ Breaking Changes
 Changes
 =======
 
+- Added new table setting ``allocation.max_retries`` that defines the number of
+  attempts to allocate a shard before giving up and leaving it unallocated.
+
 - Function arguments are now linked to each other, where possible. This enables
   type inference between arguments such that arguments can be converted to match
   a function's signature. For example, ``coalesce(integer, long)`` would have

--- a/blackbox/docs/sql/administration/show_create_table.txt
+++ b/blackbox/docs/sql/administration/show_create_table.txt
@@ -33,6 +33,7 @@ already existing user-created doc tables in the cluster::
     | )                                                   |
     | CLUSTERED BY ("first_column") INTO 5 SHARDS         |
     | WITH (                                              |
+    |    "allocation.max_retries" = 5,                    |
     |    "blocks.metadata" = false,                       |
     |    "blocks.read" = false,                           |
     |    "blocks.read_only" = false,                      |

--- a/blackbox/docs/sql/reference/create_table.txt
+++ b/blackbox/docs/sql/reference/create_table.txt
@@ -408,6 +408,16 @@ Controls shard allocation for a specific table. Can be set to:
 
 :none: No shard allocation allowed.
 
+.. _allocation_max_retries:
+
+``allocation.max_retries``
+..........................
+
+Defines the number of attempts to allocate a shard before giving up and leaving
+the shard unallocated.
+
+:value: Number of retries to allocate a shard. Defaults to 5.
+
 .. _initial_shards_ref:
 
 ``recovery.initial_shards``

--- a/sql/src/main/java/io/crate/analyze/TableParameterInfo.java
+++ b/sql/src/main/java/io/crate/analyze/TableParameterInfo.java
@@ -29,6 +29,7 @@ import io.crate.metadata.table.ColumnPolicy;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.cluster.routing.allocation.decider.EnableAllocationDecider;
+import org.elasticsearch.cluster.routing.allocation.decider.MaxRetryAllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.ShardsLimitAllocationDecider;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.gateway.PrimaryShardAllocator;
@@ -61,6 +62,8 @@ public class TableParameterInfo {
     public static final String ROUTING_ALLOCATION_ENABLE = EnableAllocationDecider.INDEX_ROUTING_ALLOCATION_ENABLE_SETTING.getKey();
     public static final String TOTAL_SHARDS_PER_NODE = ShardsLimitAllocationDecider.INDEX_TOTAL_SHARDS_PER_NODE_SETTING.getKey();
     public static final String MAPPING_TOTAL_FIELDS_LIMIT = MapperService.INDEX_MAPPING_TOTAL_FIELDS_LIMIT_SETTING.getKey();
+    public static final String ALLOCATION_MAX_RETRIES = MaxRetryAllocationDecider.SETTING_ALLOCATION_MAX_RETRY.getKey();
+
     @Deprecated
     public static final String RECOVERY_INITIAL_SHARDS = PrimaryShardAllocator.INDEX_RECOVERY_INITIAL_SHARDS_SETTING.getKey();
     public static final String WARMER_ENABLED = IndexSettings.INDEX_WARMER_ENABLED_SETTING.getKey();
@@ -87,6 +90,7 @@ public class TableParameterInfo {
             .add(WARMER_ENABLED)
             .add(UNASSIGNED_NODE_LEFT_DELAYED_TIMEOUT)
             .add(SETTING_WAIT_FOR_ACTIVE_SHARDS)
+            .add(ALLOCATION_MAX_RETRIES)
             .build();
 
     private static final ImmutableList<String> SUPPORTED_INTERNAL_SETTINGS =
@@ -139,6 +143,7 @@ public class TableParameterInfo {
             .put(TableParameterInfo.REFRESH_INTERVAL, CrateTableSettings.REFRESH_INTERVAL.extractMillis(settings))
             .put(TableParameterInfo.SETTING_WAIT_FOR_ACTIVE_SHARDS, CrateTableSettings.SETTING_WAIT_FOR_ACTIVE_SHARDS.extract(settings))
             .put(TableParameterInfo.UNASSIGNED_NODE_LEFT_DELAYED_TIMEOUT, CrateTableSettings.UNASSIGNED_NODE_LEFT_DELAYED_TIMEOUT.extractMillis(settings))
+            .put(TableParameterInfo.ALLOCATION_MAX_RETRIES, CrateTableSettings.ALLOCATION_MAX_RETRIES.extract(settings))
             .build();
     }
 

--- a/sql/src/main/java/io/crate/analyze/TablePropertiesAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/TablePropertiesAnalyzer.java
@@ -70,6 +70,7 @@ public final class TablePropertiesAnalyzer {
             .put(stripIndexPrefix(TableParameterInfo.UNASSIGNED_NODE_LEFT_DELAYED_TIMEOUT), TableParameterInfo.UNASSIGNED_NODE_LEFT_DELAYED_TIMEOUT)
             .put(stripIndexPrefix(TableParameterInfo.NUMBER_OF_SHARDS), TableParameterInfo.NUMBER_OF_SHARDS)
             .put(stripIndexPrefix(TableParameterInfo.SETTING_WAIT_FOR_ACTIVE_SHARDS), TableParameterInfo.SETTING_WAIT_FOR_ACTIVE_SHARDS)
+            .put(stripIndexPrefix(TableParameterInfo.ALLOCATION_MAX_RETRIES), TableParameterInfo.ALLOCATION_MAX_RETRIES)
             .put("blobs_path", TableParameterInfo.BLOBS_PATH)
             .build();
 
@@ -104,6 +105,7 @@ public final class TablePropertiesAnalyzer {
             .put(TableParameterInfo.UNASSIGNED_NODE_LEFT_DELAYED_TIMEOUT, new SettingsAppliers.TimeSettingsApplier(CrateTableSettings.UNASSIGNED_NODE_LEFT_DELAYED_TIMEOUT))
             .put(TableParameterInfo.NUMBER_OF_SHARDS, new NumberOfShardsSettingsApplier())
             .put(TableParameterInfo.SETTING_WAIT_FOR_ACTIVE_SHARDS, new SettingsAppliers.StringSettingsApplier(CrateTableSettings.SETTING_WAIT_FOR_ACTIVE_SHARDS))
+            .put(TableParameterInfo.ALLOCATION_MAX_RETRIES, new SettingsAppliers.IntSettingsApplier(CrateTableSettings.ALLOCATION_MAX_RETRIES))
             .put(TableParameterInfo.BLOBS_PATH, new BlobPathSettingApplier())
             .build();
 

--- a/sql/src/main/java/io/crate/metadata/settings/CrateTableSettings.java
+++ b/sql/src/main/java/io/crate/metadata/settings/CrateTableSettings.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import io.crate.analyze.TableParameterInfo;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.routing.allocation.decider.MaxRetryAllocationDecider;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.translog.Translog;
@@ -112,4 +113,8 @@ public final class CrateTableSettings {
             return TimeValue.timeValueMinutes(1);
         }
     };
+
+    public static final IntSetting ALLOCATION_MAX_RETRIES = new IntSetting(
+        TableParameterInfo.ALLOCATION_MAX_RETRIES,
+        MaxRetryAllocationDecider.SETTING_ALLOCATION_MAX_RETRY.getDefault(Settings.EMPTY));
 }

--- a/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -834,7 +834,6 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
 
     @Test
     public void testTranslogSyncInterval() throws Exception {
-
         AlterTableAnalyzedStatement analysis =
             e.analyze("alter table users set (\"translog.sync_interval\"='1s')");
         assertThat(analysis.table().ident().name(), is("users"));
@@ -846,6 +845,13 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
     public void testRecoveryShardsValidation() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
         e.analyze("alter table users set (\"recovery.initial_shards\"=\"foo\")");
+    }
+
+    @Test
+    public void testAllocationMaxRetriesValidation() throws Exception {
+        AlterTableAnalyzedStatement analysis =
+            e.analyze("alter table users set (\"allocation.max_retries\"=1)");
+        assertThat(analysis.tableParameter().settings().get(TableParameterInfo.ALLOCATION_MAX_RETRIES), is("1"));
     }
 
     @Test


### PR DESCRIPTION
Defines the number of attempts to allocate a shard before giving up and
leaving the shard unallocated.