### PR TITLE
fixes row column size definition of sys.shards queries

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -42,6 +42,9 @@ Changes
 Fixes
 =====
 
+ - Fixed an issue that caused ``INSERT`` statements using a subquery on the
+   `sys.shards` system table to fail.
+
  - Upgraded Elasticsearch to v5.6.2
 
  - Update position of the navigation menu elements of the Admin UI.

--- a/sql/src/main/java/io/crate/operation/collect/sources/ShardCollectSource.java
+++ b/sql/src/main/java/io/crate/operation/collect/sources/ShardCollectSource.java
@@ -540,7 +540,7 @@ public class ShardCollectSource extends AbstractComponent implements CollectSour
         }
         return BatchIteratorCollectorBridge.newInstance(
             RowsBatchIterator.newInstance(
-                Iterables.transform(rows, Buckets.arrayToRowFunction()), collectPhase.outputTypes().size()),
+                Iterables.transform(rows, Buckets.arrayToRowFunction()), collectPhase.toCollect().size()),
             consumer
         );
     }

--- a/sql/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
@@ -1311,4 +1311,17 @@ public class InsertIntoIntegrationTest extends SQLTransportIntegrationTest {
         assertThat((String) response.rows()[0][1], is("foo"));
         assertThat((Long) response.rows()[0][0], is(1L));
     }
+
+    @Test
+    public void testInsertIntoFromSystemTable() throws Exception {
+        execute("create table shard_stats (" +
+                "   log_date timestamp," +
+                "   shard_id string," +
+                "   num_docs long)" +
+                " clustered into 1 shards with (number_of_replicas=0)");
+        execute("insert into shard_stats (log_date, shard_id, num_docs) (select CURRENT_TIMESTAMP as log_date, id, num_docs from sys.shards)");
+        refresh();
+        execute("select * from shard_stats");
+        assertThat(response.rowCount(), is(1L));
+    }
 }


### PR DESCRIPTION
the size of the outputs were falsely used as the row column size instead 
of the size of the collect symbols. this could lead to an
ArrayOutOfBoundException if an collect projection changed the output
size to 1 ( e.g. on insert-by-query).
this will solve https://github.com/crate/crate/issues/6375