### PR TITLE
Fold ParamterSymbol type conversions

### DIFF
--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -285,10 +285,8 @@ public class ExpressionAnalyzer {
     private static Symbol cast(Symbol sourceSymbol, DataType targetType, boolean tryCast) {
         if (sourceSymbol.valueType().equals(targetType)) {
             return sourceSymbol;
-        } else if (sourceSymbol.symbolType().isValueSymbol()) {
-            return Literal.convert(sourceSymbol, targetType);
         }
-        return CastFunctionResolver.generateCastFunction(sourceSymbol, targetType, tryCast);
+        return sourceSymbol.cast(targetType, tryCast);
     }
 
     @Nullable

--- a/sql/src/main/java/io/crate/analyze/relations/FullQualifiedNameFieldProvider.java
+++ b/sql/src/main/java/io/crate/analyze/relations/FullQualifiedNameFieldProvider.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Resolves QualifiedNames to Fields considering multiple AnalyzedRelations.
@@ -52,11 +53,9 @@ public class FullQualifiedNameFieldProvider implements FieldProvider<Field> {
                                           AnalyzedRelation> sources,
                                           ParentRelations parents,
                                           String defaultSchema) {
-        assert !sources.isEmpty() : "Must have at least one source";
-        assert defaultSchema != null : "Default schema must not be null";
-        this.sources = sources;
-        this.parents = parents;
-        this.defaultSchema = defaultSchema;
+        this.sources = Objects.requireNonNull(sources, "Please provide a source map.");
+        this.parents = Objects.requireNonNull(parents, "ParentRelations must not be null");
+        this.defaultSchema = Objects.requireNonNull(defaultSchema, "Default schema must not be null");
     }
 
     public Field resolveField(QualifiedName qualifiedName, Operation operation) {

--- a/sql/src/main/java/io/crate/analyze/symbol/Literal.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/Literal.java
@@ -123,8 +123,13 @@ public class Literal<ReturnType> extends Symbol implements Input<ReturnType>, Co
         return SymbolType.LITERAL;
     }
 
+    @Override
+    public Symbol cast(DataType newDataType, boolean tryCast) {
+        return Literal.convert(this, newDataType);
+    }
+
     /**
-     * Literals may be casted if necessary.
+     * Literals always may be casted if required.
      */
     @Override
     public boolean canBeCasted() {

--- a/sql/src/main/java/io/crate/analyze/symbol/ParameterSymbol.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/ParameterSymbol.java
@@ -56,6 +56,11 @@ public class ParameterSymbol extends Symbol {
     }
 
     @Override
+    public ParameterSymbol cast(DataType dataType, boolean tryCast) {
+        return new ParameterSymbol(index, dataType);
+    }
+
+    @Override
     public boolean canBeCasted() {
         return true;
     }

--- a/sql/src/main/java/io/crate/analyze/symbol/Symbol.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/Symbol.java
@@ -21,6 +21,7 @@
 
 package io.crate.analyze.symbol;
 
+import io.crate.operation.scalar.cast.CastFunctionResolver;
 import io.crate.planner.ExplainLeaf;
 import io.crate.types.DataType;
 import io.crate.types.UndefinedType;
@@ -38,6 +39,27 @@ public abstract class Symbol implements FuncArg, Writeable, ExplainLeaf {
     public abstract <C, R> R accept(SymbolVisitor<C, R> visitor, C context);
 
     public abstract DataType valueType();
+
+    /**
+     * Casts this Symbol to a new {@link DataType} by wrapping a cast function around it.
+     * Sublasses of this class may provide another cast methods.
+     * @param newDataType The resulting data type after applying the cast
+     * @return An instance of {@link Function} which casts this symbol.
+     */
+    public final Symbol cast(DataType newDataType) {
+        return cast(newDataType, false);
+    }
+
+    /**
+     * Casts this Symbol to a new {@link DataType} by wrapping a cast function around it.
+     * Sublasses of this class may provide another cast methods.
+     * @param newDataType The resulting data type after applying the cast
+     * @param tryCast If set to true, will return null the symbol cannot be casted.
+     * @return An instance of {@link Function} which casts this symbol.
+     */
+    public Symbol cast(DataType newDataType, boolean tryCast) {
+        return CastFunctionResolver.generateCastFunction(this, newDataType, tryCast);
+    }
 
     @Override
     public String toString() {

--- a/sql/src/test/java/io/crate/analyze/symbol/LiteralTest.java
+++ b/sql/src/test/java/io/crate/analyze/symbol/LiteralTest.java
@@ -28,6 +28,7 @@ import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.junit.Test;
 
+import static io.crate.testing.SymbolMatchers.isLiteral;
 import static org.hamcrest.Matchers.is;
 
 public class LiteralTest extends CrateUnitTest {
@@ -102,5 +103,11 @@ public class LiteralTest extends CrateUnitTest {
         val1 = Literal.of(intTypeNestedArr, new Object[][] {new Object[] {1,2,3,4,5}});
         val2 = Literal.of(intTypeNestedArr, new Object[][] {new Object[] {1,2,3}});
         assertThat(val1.equals(val2), is(false));
+    }
+
+    @Test
+    public void testCasting() {
+        Symbol intLiteral = Literal.of(1);
+        assertThat(intLiteral.cast(DataTypes.LONG), isLiteral(1L));
     }
 }

--- a/sql/src/test/java/io/crate/analyze/symbol/ParameterSymbolTest.java
+++ b/sql/src/test/java/io/crate/analyze/symbol/ParameterSymbolTest.java
@@ -26,6 +26,7 @@ import io.crate.test.integration.CrateUnitTest;
 import io.crate.types.DataTypes;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import static org.hamcrest.core.Is.is;
@@ -44,5 +45,13 @@ public class ParameterSymbolTest extends CrateUnitTest {
 
         assertThat(ps2.index(), is(ps1.index()));
         assertThat(ps2.valueType(), is(ps1.valueType()));
+    }
+
+    @Test
+    public void testCasting() {
+        Symbol parameter = new ParameterSymbol(0, DataTypes.INTEGER);
+        ParameterSymbol newParameter = (ParameterSymbol) parameter.cast(DataTypes.LONG);
+        assertThat(newParameter.valueType(), Matchers.is(DataTypes.LONG));
+        assertThat(newParameter.index(), Matchers.is(0));
     }
 }


### PR DESCRIPTION
This folds any conversions made to parameter symbols, similarly to how we
already fold literal symbols.