### PR TITLE
Add ParameterDescription message to extended PSQL protocol

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -43,5 +43,10 @@ Changes
 
 - Added the ``pg_backend_pid()`` function for enhanced PostgreSQL compatibility.
 
+- Added support for the PSQL ParameterDescription message which allows to get
+  the parameter types in prepared statements up front without specifying the
+  actual arguments first. This fixes compatibility issues with some drivers.
+  Only works for Select statements at the moment.
+
 Fixes
 =====

--- a/blackbox/docs/protocols/postgres.txt
+++ b/blackbox/docs/protocols/postgres.txt
@@ -90,8 +90,7 @@ Extended Query
 
 The `Extended Query`_ protocol is implemented with the following limitations:
 
-- ``describe`` messages for an unbound prepared statement always result in a
-  ``NoData`` message instead of a ``ParameterDescription``.
+- The DescribeParameter message only works for Select statements.
 
 - To optimize the execution of bulk operations the execution of statements is
   delayed until the ``Sync`` message is received

--- a/enterprise/users/src/test/java/io/crate/integrationtests/BaseUsersIntegrationTest.java
+++ b/enterprise/users/src/test/java/io/crate/integrationtests/BaseUsersIntegrationTest.java
@@ -20,6 +20,7 @@ package io.crate.integrationtests;
 
 import com.google.common.collect.ImmutableSet;
 import io.crate.action.sql.Option;
+import io.crate.action.sql.Session;
 import io.crate.action.sql.SQLOperations;
 import io.crate.operation.user.User;
 import io.crate.operation.user.UserManagerService;
@@ -30,28 +31,28 @@ import static io.crate.testing.SQLTransportExecutor.DEFAULT_SOFT_LIMIT;
 
 public abstract class BaseUsersIntegrationTest extends SQLTransportIntegrationTest {
 
-    private SQLOperations.Session superUserSession;
-    private SQLOperations.Session normalUserSession;
+    private Session superUserSession;
+    private Session normalUserSession;
 
-    protected SQLOperations.Session createSuperUserSession() {
+    protected Session createSuperUserSession() {
         return createSuperUserSession(null);
     }
 
-    SQLOperations.Session createSuperUserSession(String node) {
+    Session createSuperUserSession(String node) {
         SQLOperations sqlOperations = internalCluster().getInstance(SQLOperations.class, node);
         return sqlOperations.createSession(null, UserManagerService.CRATE_USER, Option.NONE, DEFAULT_SOFT_LIMIT);
     }
 
-    protected SQLOperations.Session createUserSession() {
+    protected Session createUserSession() {
         return createUserSession(null);
     }
 
-    SQLOperations.Session createUserSession(String node) {
+    Session createUserSession(String node) {
         SQLOperations sqlOperations = internalCluster().getInstance(SQLOperations.class, node);
         return sqlOperations.createSession(null, new User("normal", ImmutableSet.of(), ImmutableSet.of()), Option.NONE, DEFAULT_SOFT_LIMIT);
     }
 
-    SQLOperations.Session createNullUserSession(String node) {
+    Session createNullUserSession(String node) {
         SQLOperations sqlOperations = internalCluster().getInstance(SQLOperations.class, node);
         return sqlOperations.createSession(null, null, Option.NONE, DEFAULT_SOFT_LIMIT);
     }

--- a/enterprise/users/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
+++ b/enterprise/users/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
@@ -18,6 +18,7 @@
 
 package io.crate.integrationtests;
 
+import io.crate.action.sql.Session;
 import io.crate.action.sql.SQLActionException;
 import io.crate.action.sql.SQLOperations;
 import io.crate.operation.udf.UserDefinedFunctionService;
@@ -54,7 +55,7 @@ public class PrivilegesIntegrationTest extends BaseUsersIntegrationTest {
         assertThat(response.rows()[0][0], is(0L));
     }
 
-    private SQLOperations.Session testUserSession() {
+    private Session testUserSession() {
         User user = userManager.findUser(TEST_USERNAME);
         assertThat(user, notNullValue());
         return sqlOperations.createSession(null, user);

--- a/enterprise/users/src/test/java/io/crate/integrationtests/SysPrivilegesIntegrationTest.java
+++ b/enterprise/users/src/test/java/io/crate/integrationtests/SysPrivilegesIntegrationTest.java
@@ -18,8 +18,8 @@
 
 package io.crate.integrationtests;
 
+import io.crate.action.sql.Session;
 import io.crate.action.sql.SQLActionException;
-import io.crate.action.sql.SQLOperations;
 import io.crate.analyze.user.Privilege;
 import io.crate.operation.user.UserManager;
 import io.crate.settings.SharedSettings;
@@ -50,16 +50,16 @@ public class SysPrivilegesIntegrationTest extends BaseUsersIntegrationTest {
     private String nodeEnterpriseDisabled;
 
     @Override
-    protected SQLOperations.Session createSuperUserSession() {
+    protected Session createSuperUserSession() {
         return createSuperUserSession(true);
     }
 
-    private SQLOperations.Session createSuperUserSession(boolean enterpriseEnabled) {
+    private Session createSuperUserSession(boolean enterpriseEnabled) {
         return createSuperUserSession(enterpriseEnabled ? nodeEnterpriseEnabled : nodeEnterpriseDisabled);
     }
 
     @Override
-    protected SQLOperations.Session createUserSession() {
+    protected Session createUserSession() {
         return createUserSession(nodeEnterpriseEnabled);
     }
 

--- a/sql/src/main/java/io/crate/action/sql/SQLOperations.java
+++ b/sql/src/main/java/io/crate/action/sql/SQLOperations.java
@@ -80,7 +80,13 @@ public class SQLOperations {
         if (disabled) {
             throw new NodeDisconnectedException(clusterService.localNode(), "sql");
         }
-        return new Session(analyzer, planner, jobsLogs, isReadOnly, executorProvider.get(), sessionContext);
+        return new Session(
+            analyzer,
+            planner,
+            jobsLogs,
+            isReadOnly,
+            executorProvider.get(),
+            sessionContext);
     }
 
     public Session createSession(@Nullable String defaultSchema, @Nullable User user) {

--- a/sql/src/main/java/io/crate/action/sql/SQLOperations.java
+++ b/sql/src/main/java/io/crate/action/sql/SQLOperations.java
@@ -22,52 +22,24 @@
 
 package io.crate.action.sql;
 
-import com.google.common.base.Preconditions;
 import io.crate.analyze.Analyzer;
-import io.crate.analyze.QuerySpec;
-import io.crate.analyze.relations.AnalyzedRelation;
-import io.crate.analyze.relations.QueriedRelation;
-import io.crate.analyze.symbol.Field;
-import io.crate.analyze.symbol.Function;
-import io.crate.analyze.symbol.MatchPredicate;
-import io.crate.analyze.symbol.ParameterSymbol;
-import io.crate.analyze.symbol.Symbol;
-import io.crate.analyze.symbol.SymbolVisitor;
-import io.crate.exceptions.SQLExceptions;
 import io.crate.executor.Executor;
 import io.crate.operation.collect.stats.JobsLogs;
 import io.crate.operation.user.User;
 import io.crate.operation.user.UserManager;
 import io.crate.planner.Planner;
-import io.crate.protocols.postgres.FormatCodes;
-import io.crate.protocols.postgres.Portal;
-import io.crate.protocols.postgres.SimplePortal;
-import io.crate.sql.parser.SqlParser;
-import io.crate.sql.tree.Statement;
-import io.crate.types.DataType;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Provider;
 import org.elasticsearch.common.inject.Singleton;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.transport.NodeDisconnectedException;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.IdentityHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.SortedSet;
-import java.util.TreeSet;
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
 
 
 @Singleton
@@ -77,11 +49,6 @@ public class SQLOperations {
         "node.sql.read_only",
         false,
         Setting.Property.NodeScope);
-    private static final Logger LOGGER = Loggers.getLogger(SQLOperations.class);
-
-    // Parser can't handle empty statement but postgres requires support for it.
-    // This rewrite is done so that bind/describe calls on an empty statement will work as well
-    private static final Statement EMPTY_STMT = SqlParser.createStatement("select '' from sys.cluster limit 0");
 
     private final Analyzer analyzer;
     private final Planner planner;
@@ -113,7 +80,7 @@ public class SQLOperations {
         if (disabled) {
             throw new NodeDisconnectedException(clusterService.localNode(), "sql");
         }
-        return new Session(executorProvider.get(), sessionContext);
+        return new Session(analyzer, planner, jobsLogs, isReadOnly, executorProvider.get(), sessionContext);
     }
 
     public Session createSession(@Nullable String defaultSchema, @Nullable User user) {
@@ -165,275 +132,12 @@ public class SQLOperations {
     }
 
     /**
-     * Stateful Session
-     * In the PSQL case there is one session per connection.
-     * <p>
-     * <p>
-     * Methods are usually called in the following order:
-     * <p>
-     * <pre>
-     * parse(...)
-     * bind(...)
-     * describe(...) // optional
-     * execute(...)
-     * sync()
-     * </pre>
-     * <p>
-     * Or:
-     * <p>
-     * <pre>
-     * parse(...)
-     * loop:
-     *      bind(...)
-     *      execute(...)
-     * sync()
-     * </pre>
-     * <p>
-     * (https://www.postgresql.org/docs/9.2/static/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY)
-     */
-    public class Session {
-
-        public static final String UNNAMED = "";
-        private final Executor executor;
-        private final SessionContext sessionContext;
-
-        private final Map<String, PreparedStmt> preparedStatements = new HashMap<>();
-        private final Map<String, Portal> portals = new HashMap<>();
-        private final Set<Portal> pendingExecutions = Collections.newSetFromMap(new IdentityHashMap<Portal, Boolean>());
-
-        private Session(Executor executor, SessionContext sessionContext) {
-            this.executor = executor;
-            this.sessionContext = sessionContext;
-        }
-
-        private Portal getOrCreatePortal(String portalName) {
-            Portal portal = portals.get(portalName);
-            if (portal == null) {
-                portal = new SimplePortal(portalName, analyzer, executor, isReadOnly, sessionContext);
-                portals.put(portalName, portal);
-            }
-            return portal;
-        }
-
-        private Portal getSafePortal(String portalName) {
-            Portal portal = portals.get(portalName);
-            if (portal == null) {
-                throw new IllegalArgumentException("Cannot find portal: " + portalName);
-            }
-            return portal;
-        }
-
-        public SessionContext sessionContext() {
-            return sessionContext;
-        }
-
-        public void parse(String statementName, String query, List<DataType> paramTypes) {
-            LOGGER.debug("method=parse stmtName={} query={} paramTypes={}", statementName, query, paramTypes);
-
-            Statement statement;
-            try {
-                statement = SqlParser.createStatement(query);
-            } catch (Throwable t) {
-                if ("".equals(query)) {
-                    statement = EMPTY_STMT;
-                } else {
-                    jobsLogs.logPreExecutionFailure(UUID.randomUUID(), query, SQLExceptions.messageOf(t), sessionContext.user());
-                    throw SQLExceptions.createSQLActionException(t, sessionContext);
-                }
-            }
-            preparedStatements.put(statementName, new PreparedStmt(statement, query, paramTypes));
-        }
-
-        public void bind(String portalName,
-                         String statementName,
-                         List<Object> params,
-                         @Nullable FormatCodes.FormatCode[] resultFormatCodes) {
-            LOGGER.debug("method=bind portalName={} statementName={} params={}", portalName, statementName, params);
-
-            Portal portal = getOrCreatePortal(portalName);
-            try {
-                PreparedStmt preparedStmt = getSafeStmt(statementName);
-                Portal newPortal = portal.bind(
-                    statementName, preparedStmt.query(), preparedStmt.statement(), params, resultFormatCodes);
-                if (portal != newPortal) {
-                    portals.put(portalName, newPortal);
-                    pendingExecutions.remove(portal);
-                } else if (portal.synced()) {
-                    // Make sure existing portal stops receiving results!
-                    portal.close();
-                }
-            } catch (Throwable t) {
-                jobsLogs.logPreExecutionFailure(UUID.randomUUID(), portal.getLastQuery(), SQLExceptions.messageOf(t), sessionContext.user());
-                throw SQLExceptions.createSQLActionException(t, sessionContext);
-            }
-        }
-
-        public DescribeResult describe(char type, String portalOrStatement) {
-            LOGGER.debug("method=describe type={} portalOrStatement={}", type, portalOrStatement);
-            switch (type) {
-                case 'P':
-                    Portal portal = getSafePortal(portalOrStatement);
-                    return new DescribeResult(portal.describe());
-                case 'S':
-                    /*
-                     * describe might be called without prior bind call.
-                     *
-                     * If the client uses server-side prepared statements this is usually the case.
-                     *
-                     * E.g. the statement is first prepared:
-                     *
-                     *      parse stmtName=S_1 query=insert into t (x) values ($1) paramTypes=[integer]
-                     *      describe type=S portalOrStatement=S_1
-                     *      sync
-                     *
-                     * and then used with different bind calls:
-                     *
-                     *      bind portalName= statementName=S_1 params=[0]
-                     *      describe type=P portalOrStatement=
-                     *      execute
-                     *
-                     *      bind portalName= statementName=S_1 params=[1]
-                     *      describe type=P portalOrStatement=
-                     *      execute
-                     */
-                    PreparedStmt preparedStmt = preparedStatements.get(portalOrStatement);
-                    Statement statement = preparedStmt.statement();
-
-                    AnalyzedRelation analyzedRelation;
-                    if (preparedStmt.isRelationInitialized()) {
-                        analyzedRelation = preparedStmt.relation();
-                    } else {
-                        try {
-                            analyzedRelation = analyzer.unboundAnalyze(statement, sessionContext, preparedStmt.paramTypes());
-                            preparedStmt.relation(analyzedRelation);
-                        } catch (Throwable t) {
-                            throw SQLExceptions.createSQLActionException(t, sessionContext);
-                        }
-                    }
-                    if (analyzedRelation == null) {
-                        // statement without result set -> return null for NoData msg
-                        return new DescribeResult(null);
-                    }
-                    ParameterTypeExtractor parameterTypeExtractor = new ParameterTypeExtractor();
-                    DataType[] parameterSymbols = parameterTypeExtractor.getParameterTypes(analyzedRelation);
-                    preparedStmt.setDescribedParameters(parameterSymbols);
-                    return new DescribeResult(analyzedRelation.fields(), parameterSymbols);
-                default:
-                    throw new AssertionError("Unsupported type: " + type);
-            }
-        }
-
-        public void execute(String portalName, int maxRows, ResultReceiver resultReceiver) {
-            LOGGER.debug("method=execute portalName={} maxRows={}", portalName, maxRows);
-
-            Portal portal = getSafePortal(portalName);
-            portal.execute(resultReceiver, maxRows);
-            if (portal.getLastQuery().equalsIgnoreCase("BEGIN")) {
-                portal.sync(planner, jobsLogs);
-                clearState();
-            } else {
-                // delay execution to be able to bundle bulk operations
-                pendingExecutions.add(portal);
-            }
-        }
-
-        public CompletableFuture<?> sync() {
-            switch (pendingExecutions.size()) {
-                case 0:
-                    LOGGER.debug("method=sync pendingExecutions=0");
-                    return CompletableFuture.completedFuture(null);
-                case 1:
-                    Portal portal = pendingExecutions.iterator().next();
-                    LOGGER.debug("method=sync portal={}", portal);
-                    pendingExecutions.clear();
-                    clearState();
-                    return portal.sync(planner, jobsLogs);
-                default:
-                    throw new IllegalStateException(
-                        "Shouldn't have more than 1 pending execution. Got: " + pendingExecutions);
-            }
-        }
-
-        public void clearState() {
-            portals.remove(UNNAMED);
-            preparedStatements.remove(UNNAMED);
-        }
-
-        @Nullable
-        public List<? extends DataType> getOutputTypes(String portalName) {
-            Portal portal = portals.get(portalName);
-            if (portal == null) {
-                return null;
-            }
-            return portal.getLastOutputTypes();
-        }
-
-        public String getQuery(String portalName) {
-            return getSafePortal(portalName).getLastQuery();
-        }
-
-        public DataType getParamType(String statementName, int idx) {
-            PreparedStmt stmt = getSafeStmt(statementName);
-            return stmt.getEffectiveParameterType(idx);
-        }
-
-        private PreparedStmt getSafeStmt(String statementName) {
-            PreparedStmt preparedStmt = preparedStatements.get(statementName);
-            if (preparedStmt == null) {
-                throw new IllegalArgumentException("No statement found with name: " + statementName);
-            }
-            return preparedStmt;
-        }
-
-        @Nullable
-        public FormatCodes.FormatCode[] getResultFormatCodes(String portalOrStatement) {
-            Portal portal = portals.get(portalOrStatement);
-            if (portal == null) {
-                return null;
-            }
-            return portal.getLastResultFormatCodes();
-        }
-
-        /**
-         * Close a portal or prepared statement
-         *
-         * @param type <b>S</b> for prepared statement, <b>P</b> for portal.
-         * @param name name of the prepared statement or the portal (depending on type)
-         */
-        public void close(byte type, String name) {
-            if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("method=close type={} name={}", (char) type, name);
-            }
-
-            switch (type) {
-                case 'P':
-                    Portal portal = portals.remove(name);
-                    if (portal != null) {
-                        portal.close();
-                    }
-                    return;
-                case 'S':
-                    preparedStatements.remove(name);
-                    return;
-                default:
-                    throw new IllegalArgumentException("Invalid type: " + type);
-            }
-        }
-
-        public void close() {
-            for (Portal portal : portals.values()) {
-                portal.close();
-            }
-        }
-    }
-
-    /**
      * Stateful class that uses a prepared statement
      * and can execute it multiple times.
      */
     public static class SQLDirectExecutor {
 
-        private final SQLOperations.Session session;
+        private final Session session;
         private final String preparedStmtName;
 
         private SQLDirectExecutor(Session session, String preparedStmtName, String sqlStmt) {
@@ -448,98 +152,8 @@ public class SQLOperations {
             session.sync().whenComplete((o, throwable) -> session.close((byte) 'P', preparedStmtName));
         }
 
-        public SQLOperations.Session getSession() {
+        public Session getSession() {
             return session;
-        }
-    }
-
-    static class ParameterTypeExtractor extends SymbolVisitor<Void, Void> implements Consumer<Symbol> {
-
-        private final SortedSet<ParameterSymbol> parameterSymbols;
-
-        ParameterTypeExtractor() {
-            this.parameterSymbols = new TreeSet<>(Comparator.comparing(ParameterSymbol::index));
-        }
-
-        @Override
-        public void accept(Symbol symbol) {
-            process(symbol, null);
-        }
-
-        @Override
-        public Void visitFunction(Function function, Void context) {
-            for (Symbol arg : function.arguments()) {
-                process(arg, context);
-            }
-            return null;
-        }
-
-        @Override
-        public Void visitMatchPredicate(MatchPredicate matchPredicate, Void context) {
-            return process(matchPredicate.queryTerm(), context);
-        }
-
-        @Override
-        public Void visitParameterSymbol(ParameterSymbol parameterSymbol, Void context) {
-            parameterSymbols.add(parameterSymbol);
-            return null;
-        }
-
-        /**
-         * Gets the parameters from the AnalyzedRelation, if possible.
-         * @param analyzedRelation The {@link AnalyzedRelation} to retrieve the parameters from.
-         * @return A sorted array with the parameters ($1 comes first, then $2, etc.) or null if #
-         *         parameters can't be obtained.
-         */
-        @Nullable
-        DataType[] getParameterTypes(AnalyzedRelation analyzedRelation) {
-            if (!(analyzedRelation instanceof QueriedRelation)) {
-                return null;
-            }
-            QuerySpec querySpec = ((QueriedRelation) analyzedRelation).querySpec();
-            querySpec.visitSymbols(this);
-            Preconditions.checkState(parameterSymbols.isEmpty() ||
-                                     parameterSymbols.last().index() == parameterSymbols.size() - 1,
-                "The assembled list of ParameterSymbols is invalid. Missing parameters.");
-            DataType[] dataTypes = parameterSymbols.stream()
-                .map(ParameterSymbol::getBoundType)
-                .toArray(DataType[]::new);
-            parameterSymbols.clear();
-            return dataTypes;
-        }
-    }
-
-    /**
-     * Encapsulates the result of a DescribePortal or DescribeParameter message.
-     */
-    public static class DescribeResult {
-
-        @Nullable
-        private final List<Field> fields;
-        @Nullable
-        private DataType[] parameters;
-
-        DescribeResult(@Nullable List<Field> fields) {
-            this.fields = fields;
-        }
-
-        DescribeResult(@Nullable List<Field> fields, @Nullable DataType[] parameters) {
-            this.fields = fields;
-            this.parameters = parameters;
-        }
-
-        @Nullable
-        public List<Field> getFields() {
-            return fields;
-        }
-
-        /**
-         * Returns the described parameters in sorted order ($1, $2, etc.)
-         * @return An array containing the parameters, or null if they could not be obtained.
-         */
-        @Nullable
-        public DataType[] getParameterTypes() {
-            return parameters;
         }
     }
 }

--- a/sql/src/main/java/io/crate/action/sql/Session.java
+++ b/sql/src/main/java/io/crate/action/sql/Session.java
@@ -122,7 +122,7 @@ public class Session {
         this.isReadOnly = isReadOnly;
         this.executor = executor;
         this.sessionContext = sessionContext;
-        this.parameterTypeExtractor = new ParameterTypeExtractor();
+        this.parameterTypeExtractor = new Session.ParameterTypeExtractor();
     }
 
     private Portal getOrCreatePortal(String portalName) {

--- a/sql/src/main/java/io/crate/action/sql/Session.java
+++ b/sql/src/main/java/io/crate/action/sql/Session.java
@@ -1,0 +1,436 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.action.sql;
+
+import com.google.common.base.Preconditions;
+import io.crate.analyze.Analyzer;
+import io.crate.analyze.QuerySpec;
+import io.crate.analyze.relations.AnalyzedRelation;
+import io.crate.analyze.relations.QueriedRelation;
+import io.crate.analyze.symbol.Field;
+import io.crate.analyze.symbol.Function;
+import io.crate.analyze.symbol.MatchPredicate;
+import io.crate.analyze.symbol.ParameterSymbol;
+import io.crate.analyze.symbol.Symbol;
+import io.crate.analyze.symbol.SymbolVisitor;
+import io.crate.exceptions.SQLExceptions;
+import io.crate.executor.Executor;
+import io.crate.operation.collect.stats.JobsLogs;
+import io.crate.planner.Planner;
+import io.crate.protocols.postgres.FormatCodes;
+import io.crate.protocols.postgres.Portal;
+import io.crate.protocols.postgres.SimplePortal;
+import io.crate.sql.parser.SqlParser;
+import io.crate.sql.tree.Statement;
+import io.crate.types.DataType;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.common.logging.Loggers;
+
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+/**
+ * Stateful Session
+ * In the PSQL case there is one session per connection.
+ * <p>
+ * <p>
+ * Methods are usually called in the following order:
+ * <p>
+ * <pre>
+ * parse(...)
+ * bind(...)
+ * describe(...) // optional
+ * execute(...)
+ * sync()
+ * </pre>
+ * <p>
+ * Or:
+ * <p>
+ * <pre>
+ * parse(...)
+ * loop:
+ *      bind(...)
+ *      execute(...)
+ * sync()
+ * </pre>
+ * <p>
+ * (https://www.postgresql.org/docs/9.2/static/protocol-flow.html#PROTOCOL-FLOW-EXT-QUERY)
+ */
+public class Session {
+
+    // Logger name should be SQLOperations here
+    private static final Logger LOGGER = Loggers.getLogger(SQLOperations.class);
+
+    // Parser can't handle empty statement but postgres requires support for it.
+    // This rewrite is done so that bind/describe calls on an empty statement will work as well
+    private static final Statement EMPTY_STMT = SqlParser.createStatement("select '' from sys.cluster limit 0");
+
+    public static final String UNNAMED = "";
+    private final Executor executor;
+    private final SessionContext sessionContext;
+
+    private final Map<String, PreparedStmt> preparedStatements = new HashMap<>();
+    private final Map<String, Portal> portals = new HashMap<>();
+    private final Set<Portal> pendingExecutions = Collections.newSetFromMap(new IdentityHashMap<Portal, Boolean>());
+
+    private final Analyzer analyzer;
+    private final Planner planner;
+    private final JobsLogs jobsLogs;
+    private final boolean isReadOnly;
+    private final ParameterTypeExtractor parameterTypeExtractor;
+
+    public Session(Analyzer analyzer,
+                   Planner planner,
+                   JobsLogs jobsLogs,
+                   boolean isReadOnly,
+                   Executor executor,
+                   SessionContext sessionContext) {
+        this.analyzer = analyzer;
+        this.planner = planner;
+        this.jobsLogs = jobsLogs;
+        this.isReadOnly = isReadOnly;
+        this.executor = executor;
+        this.sessionContext = sessionContext;
+        this.parameterTypeExtractor = new ParameterTypeExtractor();
+    }
+
+    private Portal getOrCreatePortal(String portalName) {
+        Portal portal = portals.get(portalName);
+        if (portal == null) {
+            portal = new SimplePortal(portalName, analyzer, executor, isReadOnly, sessionContext);
+            portals.put(portalName, portal);
+        }
+        return portal;
+    }
+
+    private Portal getSafePortal(String portalName) {
+        Portal portal = portals.get(portalName);
+        if (portal == null) {
+            throw new IllegalArgumentException("Cannot find portal: " + portalName);
+        }
+        return portal;
+    }
+
+    public SessionContext sessionContext() {
+        return sessionContext;
+    }
+
+    public void parse(String statementName, String query, List<DataType> paramTypes) {
+        LOGGER.debug("method=parse stmtName={} query={} paramTypes={}", statementName, query, paramTypes);
+
+        Statement statement;
+        try {
+            statement = SqlParser.createStatement(query);
+        } catch (Throwable t) {
+            if ("".equals(query)) {
+                statement = EMPTY_STMT;
+            } else {
+                jobsLogs.logPreExecutionFailure(UUID.randomUUID(), query, SQLExceptions.messageOf(t), sessionContext.user());
+                throw SQLExceptions.createSQLActionException(t, sessionContext);
+            }
+        }
+        preparedStatements.put(statementName, new PreparedStmt(statement, query, paramTypes));
+    }
+
+    public void bind(String portalName,
+                     String statementName,
+                     List<Object> params,
+                     @Nullable FormatCodes.FormatCode[] resultFormatCodes) {
+        LOGGER.debug("method=bind portalName={} statementName={} params={}", portalName, statementName, params);
+
+        Portal portal = getOrCreatePortal(portalName);
+        try {
+            PreparedStmt preparedStmt = getSafeStmt(statementName);
+            Portal newPortal = portal.bind(
+                statementName, preparedStmt.query(), preparedStmt.statement(), params, resultFormatCodes);
+            if (portal != newPortal) {
+                portals.put(portalName, newPortal);
+                pendingExecutions.remove(portal);
+            } else if (portal.synced()) {
+                // Make sure existing portal stops receiving results!
+                portal.close();
+            }
+        } catch (Throwable t) {
+            jobsLogs.logPreExecutionFailure(UUID.randomUUID(), portal.getLastQuery(), SQLExceptions.messageOf(t), sessionContext.user());
+            throw SQLExceptions.createSQLActionException(t, sessionContext);
+        }
+    }
+
+    public DescribeResult describe(char type, String portalOrStatement) {
+        LOGGER.debug("method=describe type={} portalOrStatement={}", type, portalOrStatement);
+        switch (type) {
+            case 'P':
+                Portal portal = getSafePortal(portalOrStatement);
+                return new DescribeResult(portal.describe());
+            case 'S':
+                /*
+                 * describe might be called without prior bind call.
+                 *
+                 * If the client uses server-side prepared statements this is usually the case.
+                 *
+                 * E.g. the statement is first prepared:
+                 *
+                 *      parse stmtName=S_1 query=insert into t (x) values ($1) paramTypes=[integer]
+                 *      describe type=S portalOrStatement=S_1
+                 *      sync
+                 *
+                 * and then used with different bind calls:
+                 *
+                 *      bind portalName= statementName=S_1 params=[0]
+                 *      describe type=P portalOrStatement=
+                 *      execute
+                 *
+                 *      bind portalName= statementName=S_1 params=[1]
+                 *      describe type=P portalOrStatement=
+                 *      execute
+                 */
+                PreparedStmt preparedStmt = preparedStatements.get(portalOrStatement);
+                Statement statement = preparedStmt.statement();
+
+                AnalyzedRelation analyzedRelation;
+                if (preparedStmt.isRelationInitialized()) {
+                    analyzedRelation = preparedStmt.relation();
+                } else {
+                    try {
+                        analyzedRelation = analyzer.unboundAnalyze(statement, sessionContext, preparedStmt.paramTypes());
+                        preparedStmt.relation(analyzedRelation);
+                    } catch (Throwable t) {
+                        throw SQLExceptions.createSQLActionException(t, sessionContext);
+                    }
+                }
+                if (analyzedRelation == null) {
+                    // statement without result set -> return null for NoData msg
+                    return new DescribeResult(null);
+                }
+                DataType[] parameterSymbols = parameterTypeExtractor.getParameterTypes(analyzedRelation);
+                preparedStmt.setDescribedParameters(parameterSymbols);
+                return new DescribeResult(analyzedRelation.fields(), parameterSymbols);
+            default:
+                throw new AssertionError("Unsupported type: " + type);
+        }
+    }
+
+    public void execute(String portalName, int maxRows, ResultReceiver resultReceiver) {
+        LOGGER.debug("method=execute portalName={} maxRows={}", portalName, maxRows);
+
+        Portal portal = getSafePortal(portalName);
+        portal.execute(resultReceiver, maxRows);
+        if (portal.getLastQuery().equalsIgnoreCase("BEGIN")) {
+            portal.sync(planner, jobsLogs);
+            clearState();
+        } else {
+            // delay execution to be able to bundle bulk operations
+            pendingExecutions.add(portal);
+        }
+    }
+
+    public CompletableFuture<?> sync() {
+        switch (pendingExecutions.size()) {
+            case 0:
+                LOGGER.debug("method=sync pendingExecutions=0");
+                return CompletableFuture.completedFuture(null);
+            case 1:
+                Portal portal = pendingExecutions.iterator().next();
+                LOGGER.debug("method=sync portal={}", portal);
+                pendingExecutions.clear();
+                clearState();
+                return portal.sync(planner, jobsLogs);
+            default:
+                throw new IllegalStateException(
+                    "Shouldn't have more than 1 pending execution. Got: " + pendingExecutions);
+        }
+    }
+
+    public void clearState() {
+        portals.remove(UNNAMED);
+        preparedStatements.remove(UNNAMED);
+    }
+
+    @Nullable
+    public List<? extends DataType> getOutputTypes(String portalName) {
+        Portal portal = portals.get(portalName);
+        if (portal == null) {
+            return null;
+        }
+        return portal.getLastOutputTypes();
+    }
+
+    public String getQuery(String portalName) {
+        return getSafePortal(portalName).getLastQuery();
+    }
+
+    public DataType getParamType(String statementName, int idx) {
+        PreparedStmt stmt = getSafeStmt(statementName);
+        return stmt.getEffectiveParameterType(idx);
+    }
+
+    private PreparedStmt getSafeStmt(String statementName) {
+        PreparedStmt preparedStmt = preparedStatements.get(statementName);
+        if (preparedStmt == null) {
+            throw new IllegalArgumentException("No statement found with name: " + statementName);
+        }
+        return preparedStmt;
+    }
+
+    @Nullable
+    public FormatCodes.FormatCode[] getResultFormatCodes(String portalOrStatement) {
+        Portal portal = portals.get(portalOrStatement);
+        if (portal == null) {
+            return null;
+        }
+        return portal.getLastResultFormatCodes();
+    }
+
+    /**
+     * Close a portal or prepared statement
+     *
+     * @param type <b>S</b> for prepared statement, <b>P</b> for portal.
+     * @param name name of the prepared statement or the portal (depending on type)
+     */
+    public void close(byte type, String name) {
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("method=close type={} name={}", (char) type, name);
+        }
+
+        switch (type) {
+            case 'P':
+                Portal portal = portals.remove(name);
+                if (portal != null) {
+                    portal.close();
+                }
+                return;
+            case 'S':
+                preparedStatements.remove(name);
+                return;
+            default:
+                throw new IllegalArgumentException("Invalid type: " + type);
+        }
+    }
+
+    public void close() {
+        for (Portal portal : portals.values()) {
+            portal.close();
+        }
+    }
+
+    static class ParameterTypeExtractor extends SymbolVisitor<Void, Void> implements Consumer<Symbol> {
+
+        private final SortedSet<ParameterSymbol> parameterSymbols;
+
+        ParameterTypeExtractor() {
+            this.parameterSymbols = new TreeSet<>(Comparator.comparing(ParameterSymbol::index));
+        }
+
+        @Override
+        public void accept(Symbol symbol) {
+            process(symbol, null);
+        }
+
+        @Override
+        public Void visitFunction(Function function, Void context) {
+            for (Symbol arg : function.arguments()) {
+                process(arg, context);
+            }
+            return null;
+        }
+
+        @Override
+        public Void visitMatchPredicate(MatchPredicate matchPredicate, Void context) {
+            return process(matchPredicate.queryTerm(), context);
+        }
+
+        @Override
+        public Void visitParameterSymbol(ParameterSymbol parameterSymbol, Void context) {
+            parameterSymbols.add(parameterSymbol);
+            return null;
+        }
+
+        /**
+         * Gets the parameters from the AnalyzedRelation, if possible.
+         * @param analyzedRelation The {@link AnalyzedRelation} to retrieve the parameters from.
+         * @return A sorted array with the parameters ($1 comes first, then $2, etc.) or null if
+         *         parameters can't be obtained.
+         */
+        @Nullable
+        DataType[] getParameterTypes(AnalyzedRelation analyzedRelation) {
+            if (!(analyzedRelation instanceof QueriedRelation)) {
+                return null;
+            }
+            QuerySpec querySpec = ((QueriedRelation) analyzedRelation).querySpec();
+            querySpec.visitSymbols(this);
+            Preconditions.checkState(parameterSymbols.isEmpty() ||
+                                     parameterSymbols.last().index() == parameterSymbols.size() - 1,
+                "The assembled list of ParameterSymbols is invalid. Missing parameters.");
+            DataType[] dataTypes = parameterSymbols.stream()
+                .map(ParameterSymbol::getBoundType)
+                .toArray(DataType[]::new);
+            parameterSymbols.clear();
+            return dataTypes;
+        }
+    }
+
+    /**
+     * Encapsulates the result of a DescribePortal or DescribeParameter message.
+     */
+    public static class DescribeResult {
+
+        @Nullable
+        private final List<Field> fields;
+        @Nullable
+        private DataType[] parameters;
+
+        DescribeResult(@Nullable List<Field> fields) {
+            this.fields = fields;
+        }
+
+        DescribeResult(@Nullable List<Field> fields, @Nullable DataType[] parameters) {
+            this.fields = fields;
+            this.parameters = parameters;
+        }
+
+        @Nullable
+        public List<Field> getFields() {
+            return fields;
+        }
+
+        /**
+         * Returns the described parameters in sorted order ($1, $2, etc.)
+         * @return An array containing the parameters, or null if they could not be obtained.
+         */
+        @Nullable
+        public DataType[] getParameters() {
+            return parameters;
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/analyze/ParamTypeHints.java
+++ b/sql/src/main/java/io/crate/analyze/ParamTypeHints.java
@@ -44,27 +44,10 @@ public class ParamTypeHints implements Function<ParameterExpression, Symbol> {
     }
 
     /**
-     * get the type for the parameter at position {@code index}
+     * Get the type for the parameter at position {@code index}.
      *
-     * <p>
-     * If the typeHints don't contain a type for the given index it will return Undefined.
-     * In the case of Undefined it would be necessary to figure out the type from the surrounding context.
-     * But this is not yet implemented:
-     * </p>
-     *
-     * Example:
-     *
-     * In the following case the parameter is used with another integer, so the type is likely a integer.
-     *
-     * <pre>
-     *     select $1 * 10
-     * </pre>
-     *
-     * In the following case the type cannot be determined, this should result in an error:
-     *
-     * <pre>
-     *     select $1
-     * </pre>
+     * If the typeHints don't contain a type for the given index it will return Undefined
+     * and it may become defined at a later point in time during analysis.
      */
     public DataType getType(int index) {
         if (index + 1 > types.size()) {

--- a/sql/src/main/java/io/crate/analyze/UnboundAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/UnboundAnalyzer.java
@@ -36,7 +36,6 @@ import io.crate.sql.tree.ShowSchemas;
 import io.crate.sql.tree.ShowTables;
 import io.crate.sql.tree.ShowTransaction;
 import io.crate.sql.tree.Statement;
-import org.elasticsearch.common.collect.Tuple;
 
 /**
  * Analyzer that can analyze statements without having access to the Parameters/ParameterContext.
@@ -86,22 +85,25 @@ class UnboundAnalyzer {
 
         @Override
         protected AnalyzedRelation visitShowTables(ShowTables node, Analysis context) {
-            Tuple<Query, ParameterContext> tuple = showStatementAnalyzer.rewriteShow(node);
-            return relationAnalyzer.analyzeUnbound(tuple.v1(), context.transactionContext(), tuple.v2().typeHints());
+            ParameterContext parameterContext = context.parameterContext();
+            Query query = showStatementAnalyzer.rewriteShowTables(node);
+            return relationAnalyzer.analyzeUnbound(query, context.transactionContext(), parameterContext.typeHints());
         }
 
         @Override
         protected AnalyzedRelation visitShowSchemas(ShowSchemas node, Analysis context) {
-            Tuple<Query, ParameterContext> tuple = showStatementAnalyzer.rewriteShow(node);
-            return relationAnalyzer.analyzeUnbound(tuple.v1(), context.transactionContext(), tuple.v2().typeHints());
+            Query query = showStatementAnalyzer.rewriteShowSchemas(node);
+            return relationAnalyzer.analyzeUnbound(query,
+                context.transactionContext(),
+                context.parameterContext().typeHints());
         }
 
         @Override
         protected AnalyzedRelation visitShowColumns(ShowColumns node, Analysis context) {
             TransactionContext transactionContext = context.transactionContext();
-            Tuple<Query, ParameterContext> tuple = showStatementAnalyzer.rewriteShow(
-                node, transactionContext.sessionContext().defaultSchema());
-            return relationAnalyzer.analyzeUnbound(tuple.v1(), transactionContext, tuple.v2().typeHints());
+            Query query = showStatementAnalyzer.rewriteShowColumns(node,
+                transactionContext.sessionContext().defaultSchema());
+            return relationAnalyzer.analyzeUnbound(query, transactionContext, context.parameterContext().typeHints());
         }
 
         @Override

--- a/sql/src/main/java/io/crate/executor/transport/AlterTableOperation.java
+++ b/sql/src/main/java/io/crate/executor/transport/AlterTableOperation.java
@@ -26,6 +26,7 @@ import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import com.google.common.annotations.VisibleForTesting;
 import io.crate.Constants;
 import io.crate.action.FutureActionListener;
+import io.crate.action.sql.Session;
 import io.crate.action.sql.ResultReceiver;
 import io.crate.action.sql.SQLOperations;
 import io.crate.analyze.AddColumnAnalyzedStatement;
@@ -138,7 +139,7 @@ public class AlterTableOperation {
 
             SQLOperations.SQLDirectExecutor sqlDirectExecutor = sqlOperations.createSystemExecutor(
                 null,
-                SQLOperations.Session.UNNAMED,
+                Session.UNNAMED,
                 stmt,
                 1);
             try {

--- a/sql/src/main/java/io/crate/rest/action/RestSQLAction.java
+++ b/sql/src/main/java/io/crate/rest/action/RestSQLAction.java
@@ -166,7 +166,8 @@ public class RestSQLAction extends BaseRestHandler {
             session.parse(UNNAMED, context.stmt(), Collections.emptyList());
             List<Object> args = context.args() == null ? Collections.emptyList() : Arrays.asList(context.args());
             session.bind(UNNAMED, UNNAMED, args, null);
-            List<Field> outputFields = session.describe('P', UNNAMED);
+            SQLOperations.DescribeResult describeResult = session.describe('P', UNNAMED);
+            List<Field> outputFields = describeResult.getFields();
             if (outputFields == null) {
                 return channel -> {
                     try {
@@ -223,7 +224,8 @@ public class RestSQLAction extends BaseRestHandler {
                     session.execute(UNNAMED, 0, resultReceiver);
                 }
             }
-            List<Field> outputColumns = session.describe('P', UNNAMED);
+            SQLOperations.DescribeResult describeResult = session.describe('P', UNNAMED);
+            List<Field> outputColumns = describeResult.getFields();
             if (outputColumns != null) {
                 throw new UnsupportedOperationException(
                     "Bulk operations for statements that return result sets is not supported");

--- a/sql/src/main/java/io/crate/rest/action/RestSQLAction.java
+++ b/sql/src/main/java/io/crate/rest/action/RestSQLAction.java
@@ -26,6 +26,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import io.crate.action.sql.BaseResultReceiver;
 import io.crate.action.sql.Option;
+import io.crate.action.sql.Session;
 import io.crate.action.sql.ResultReceiver;
 import io.crate.action.sql.SQLActionException;
 import io.crate.action.sql.SQLOperations;
@@ -66,7 +67,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
-import static io.crate.action.sql.SQLOperations.Session.UNNAMED;
+import static io.crate.action.sql.Session.UNNAMED;
 
 @Singleton
 public class RestSQLAction extends BaseRestHandler {
@@ -156,7 +157,7 @@ public class RestSQLAction extends BaseRestHandler {
     }
 
     private RestChannelConsumer executeSimpleRequest(SQLXContentSourceContext context, final RestRequest request) {
-        SQLOperations.Session session = sqlOperations.createSession(
+        Session session = sqlOperations.createSession(
             request.header(REQUEST_HEADER_SCHEMA),
             userFromRequest(request),
             toOptions(request),
@@ -166,7 +167,7 @@ public class RestSQLAction extends BaseRestHandler {
             session.parse(UNNAMED, context.stmt(), Collections.emptyList());
             List<Object> args = context.args() == null ? Collections.emptyList() : Arrays.asList(context.args());
             session.bind(UNNAMED, UNNAMED, args, null);
-            SQLOperations.DescribeResult describeResult = session.describe('P', UNNAMED);
+            Session.DescribeResult describeResult = session.describe('P', UNNAMED);
             List<Field> outputFields = describeResult.getFields();
             if (outputFields == null) {
                 return channel -> {
@@ -204,7 +205,7 @@ public class RestSQLAction extends BaseRestHandler {
     }
 
     private RestChannelConsumer executeBulkRequest(SQLXContentSourceContext context, final RestRequest request) {
-        SQLOperations.Session session = sqlOperations.createSession(
+        Session session = sqlOperations.createSession(
             request.header(REQUEST_HEADER_SCHEMA),
             userFromRequest(request),
             toOptions(request),
@@ -224,7 +225,7 @@ public class RestSQLAction extends BaseRestHandler {
                     session.execute(UNNAMED, 0, resultReceiver);
                 }
             }
-            SQLOperations.DescribeResult describeResult = session.describe('P', UNNAMED);
+            Session.DescribeResult describeResult = session.describe('P', UNNAMED);
             List<Field> outputColumns = describeResult.getFields();
             if (outputColumns != null) {
                 throw new UnsupportedOperationException(

--- a/sql/src/test/java/io/crate/action/sql/SessionTest.java
+++ b/sql/src/test/java/io/crate/action/sql/SessionTest.java
@@ -47,7 +47,7 @@ public class SessionTest extends CrateUnitTest {
 
     @Test
     public void testParameterTypeExtractorNotApplicable() {
-        SQLOperations.ParameterTypeExtractor typeExtractor = new SQLOperations.ParameterTypeExtractor();
+        Session.ParameterTypeExtractor typeExtractor = new Session.ParameterTypeExtractor();
 
         assertThat(typeExtractor.getParameterTypes(null), is(nullValue()));
 
@@ -57,7 +57,7 @@ public class SessionTest extends CrateUnitTest {
 
     @Test
     public void testParameterTypeExtractor() {
-        SQLOperations.ParameterTypeExtractor typeExtractor = new SQLOperations.ParameterTypeExtractor();
+        Session.ParameterTypeExtractor typeExtractor = new Session.ParameterTypeExtractor();
         List<Symbol> symbolsToVisit = new ArrayList<>();
         symbolsToVisit.add(Literal.of(1));
         symbolsToVisit.add(Literal.of("foo"));

--- a/sql/src/test/java/io/crate/action/sql/SessionTest.java
+++ b/sql/src/test/java/io/crate/action/sql/SessionTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.action.sql;
+
+import io.crate.analyze.QuerySpec;
+import io.crate.analyze.relations.AnalyzedRelation;
+import io.crate.analyze.relations.DocTableRelation;
+import io.crate.analyze.relations.QueriedRelation;
+import io.crate.analyze.symbol.Literal;
+import io.crate.analyze.symbol.ParameterSymbol;
+import io.crate.analyze.symbol.Symbol;
+import io.crate.test.integration.CrateUnitTest;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+public class SessionTest extends CrateUnitTest {
+
+    @Test
+    public void testParameterTypeExtractorNotApplicable() {
+        SQLOperations.ParameterTypeExtractor typeExtractor = new SQLOperations.ParameterTypeExtractor();
+
+        assertThat(typeExtractor.getParameterTypes(null), is(nullValue()));
+
+        AnalyzedRelation analyzedRelation = Mockito.mock(DocTableRelation.class);
+        assertThat(typeExtractor.getParameterTypes(analyzedRelation), is(nullValue()));
+    }
+
+    @Test
+    public void testParameterTypeExtractor() {
+        SQLOperations.ParameterTypeExtractor typeExtractor = new SQLOperations.ParameterTypeExtractor();
+        List<Symbol> symbolsToVisit = new ArrayList<>();
+        symbolsToVisit.add(Literal.of(1));
+        symbolsToVisit.add(Literal.of("foo"));
+        symbolsToVisit.add(new ParameterSymbol(1, DataTypes.LONG));
+        symbolsToVisit.add(new ParameterSymbol(0, DataTypes.INTEGER));
+        symbolsToVisit.add(new ParameterSymbol(3, DataTypes.STRING));
+        symbolsToVisit.add(Literal.of("bar"));
+        symbolsToVisit.add(new ParameterSymbol(2, DataTypes.DOUBLE));
+        symbolsToVisit.add(new ParameterSymbol(1, DataTypes.LONG));
+        symbolsToVisit.add(new ParameterSymbol(0, DataTypes.INTEGER));
+        symbolsToVisit.add(Literal.of(1.2));
+
+        QueriedRelation analyzedRelation = Mockito.mock(QueriedRelation.class);
+        Mockito.when(analyzedRelation.querySpec()).thenReturn(new MyQuerySpec(symbolsToVisit));
+
+        DataType[] parameterTypes = typeExtractor.getParameterTypes(analyzedRelation);
+        assertThat(parameterTypes, equalTo(new DataType[] {
+            DataTypes.INTEGER,
+            DataTypes.LONG,
+            DataTypes.DOUBLE,
+            DataTypes.STRING,
+        }));
+
+        symbolsToVisit.add(new ParameterSymbol(4, DataTypes.BOOLEAN));
+        parameterTypes = typeExtractor.getParameterTypes(analyzedRelation);
+        assertThat(parameterTypes, equalTo(new DataType[] {
+            DataTypes.INTEGER,
+            DataTypes.LONG,
+            DataTypes.DOUBLE,
+            DataTypes.STRING,
+            DataTypes.BOOLEAN
+        }));
+
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("The assembled list of ParameterSymbols is invalid.");
+        // remove the double parameter => make the input invalid
+        symbolsToVisit.remove(6);
+        typeExtractor.getParameterTypes(analyzedRelation);
+    }
+
+    private static class MyQuerySpec extends QuerySpec {
+
+        private final List<Symbol> symbolsToVisit;
+
+        private MyQuerySpec(List<Symbol> symbolsToVisit) {
+            this.symbolsToVisit = symbolsToVisit;
+        }
+
+        @Override
+        public void visitSymbols(Consumer<? super Symbol> consumer) {
+            for (Symbol symbol : symbolsToVisit) {
+                consumer.accept(symbol);
+            }
+        }
+    }
+}

--- a/sql/src/test/java/io/crate/analyze/symbol/ParameterSymbolTest.java
+++ b/sql/src/test/java/io/crate/analyze/symbol/ParameterSymbolTest.java
@@ -26,7 +26,6 @@ import io.crate.test.integration.CrateUnitTest;
 import io.crate.types.DataTypes;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import static org.hamcrest.core.Is.is;
@@ -34,7 +33,7 @@ import static org.hamcrest.core.Is.is;
 public class ParameterSymbolTest extends CrateUnitTest {
 
     @Test
-    public void testSerialization() throws Exception {
+    public void testSerializationDefined() throws Exception {
         ParameterSymbol ps1 = new ParameterSymbol(2, DataTypes.INTEGER);
 
         BytesStreamOutput out = new BytesStreamOutput();
@@ -45,13 +44,30 @@ public class ParameterSymbolTest extends CrateUnitTest {
 
         assertThat(ps2.index(), is(ps1.index()));
         assertThat(ps2.valueType(), is(ps1.valueType()));
+        assertThat(ps2.getBoundType(), is(ps1.getBoundType()));
+    }
+
+    @Test
+    public void testSerializationUndefined() throws Exception {
+        ParameterSymbol ps1 = new ParameterSymbol(1, DataTypes.UNDEFINED);
+
+        BytesStreamOutput out = new BytesStreamOutput();
+        ps1.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        ParameterSymbol ps2 = new ParameterSymbol(in);
+
+        assertThat(ps2.index(), is(ps1.index()));
+        assertThat(ps2.valueType(), is(ps1.valueType()));
+        assertThat(ps2.getBoundType(), is(ps1.getBoundType()));
     }
 
     @Test
     public void testCasting() {
         Symbol parameter = new ParameterSymbol(0, DataTypes.INTEGER);
         ParameterSymbol newParameter = (ParameterSymbol) parameter.cast(DataTypes.LONG);
-        assertThat(newParameter.valueType(), Matchers.is(DataTypes.LONG));
-        assertThat(newParameter.index(), Matchers.is(0));
+        assertThat(newParameter.valueType(), is(DataTypes.LONG));
+        assertThat(newParameter.index(), is(0));
+        assertThat(newParameter.getBoundType(), is(DataTypes.INTEGER));
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
@@ -28,6 +28,7 @@ import com.carrotsearch.randomizedtesting.generators.RandomStrings;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import io.crate.action.sql.Option;
+import io.crate.action.sql.Session;
 import io.crate.action.sql.SQLOperations;
 import io.crate.action.sql.SessionContext;
 import io.crate.analyze.Analyzer;
@@ -354,7 +355,7 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
                             String statement,
                             Matcher<SQLResponse> matcher) {
         for (List<String> setSessionStatements : setSessionStatementsList) {
-            SQLOperations.Session session = sqlExecutor.newSession();
+            Session session = sqlExecutor.newSession();
 
             for (String setSessionStatement : setSessionStatements) {
                 sqlExecutor.exec(setSessionStatement, session);
@@ -448,7 +449,7 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
     }
 
     /**
-     * Execute an SQL Statement using a specific {@link SQLOperations.Session}
+     * Execute an SQL Statement using a specific {@link Session}
      * This is useful to execute a query on a specific node or to test using
      * session options like default schema.
      *
@@ -456,7 +457,7 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
      * @param session the Session to use
      * @return the SQLResponse
      */
-    public SQLResponse execute(String stmt, Object[] args, SQLOperations.Session session) {
+    public SQLResponse execute(String stmt, Object[] args, Session session) {
         response = SQLTransportExecutor.execute(stmt, args, session)
             .actionGet(SQLTransportExecutor.REQUEST_TIMEOUT);
         return response;
@@ -566,20 +567,20 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
     }
 
     /**
-     * Creates an {@link SQLOperations.Session} on a specific node.
+     * Creates an {@link Session} on a specific node.
      * This can be used to ensure that a request is performed on a specific node.
      *
      * @param nodeName The name of the node to create the session
      * @return The created session
      */
-    SQLOperations.Session createSessionOnNode(String nodeName) {
+    Session createSessionOnNode(String nodeName) {
         SQLOperations sqlOperations = internalCluster().getInstance(SQLOperations.class, nodeName);
         return sqlOperations.createSession(
             sqlExecutor.getDefaultSchema(), new User("crate", EnumSet.of(User.Role.SUPERUSER), ImmutableSet.of()), Option.NONE, DEFAULT_SOFT_LIMIT);
     }
 
     /**
-     * Creates a {@link SQLOperations.Session} with the given default schema
+     * Creates a {@link Session} with the given default schema
      * and an options list. This is useful if you require a session which differs
      * from the default one.
      *
@@ -587,7 +588,7 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
      * @param options Session options. If no specific options are required, use {@link Option#NONE}
      * @return The created session
      */
-    SQLOperations.Session createSession(@Nullable String defaultSchema, Set<Option> options) {
+    Session createSession(@Nullable String defaultSchema, Set<Option> options) {
         SQLOperations sqlOperations = internalCluster().getInstance(SQLOperations.class);
         return sqlOperations.createSession(defaultSchema, null, options, DEFAULT_SOFT_LIMIT);
     }

--- a/sql/src/test/java/io/crate/planner/TableStatsServiceTest.java
+++ b/sql/src/test/java/io/crate/planner/TableStatsServiceTest.java
@@ -23,6 +23,7 @@
 package io.crate.planner;
 
 import com.carrotsearch.hppc.ObjectLongMap;
+import io.crate.action.sql.Session;
 import io.crate.action.sql.SQLOperations;
 import io.crate.data.RowN;
 import io.crate.metadata.TableIdent;
@@ -163,7 +164,7 @@ public class TableStatsServiceTest extends CrateDummyClusterServiceUnitTest {
         when(clusterService.localNode()).thenReturn(null);
         when(clusterService.getClusterSettings()).thenReturn(this.clusterService.getClusterSettings());
         SQLOperations sqlOperations = mock(SQLOperations.class);
-        SQLOperations.Session session = mock(SQLOperations.Session.class);
+        Session session = mock(Session.class);
         when(sqlOperations.createSession(anyString(), anyObject(), any(), anyInt())).thenReturn(session);
 
         TableStatsService statsService = new TableStatsService(

--- a/sql/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
+++ b/sql/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
@@ -22,6 +22,7 @@
 
 package io.crate.protocols.postgres;
 
+import io.crate.action.sql.Session;
 import io.crate.action.sql.SQLOperations;
 import io.crate.executor.Executor;
 import io.crate.operation.auth.AlwaysOKNullAuthentication;
@@ -64,7 +65,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
     private static final Provider<UserManager> USER_MANAGER_PROVIDER = DummyUserManager::new;
 
     private SQLOperations sqlOperations;
-    private List<SQLOperations.Session> sessions = new ArrayList<>();
+    private List<Session> sessions = new ArrayList<>();
     private EmbeddedChannel channel;
 
     @Before
@@ -129,7 +130,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testFlushMessageResultsInSyncCallOnSession() throws Exception {
         SQLOperations sqlOperations = mock(SQLOperations.class);
-        SQLOperations.Session session = mock(SQLOperations.Session.class);
+        Session session = mock(Session.class);
         when(sqlOperations.createSession(any(String.class), any(User.class))).thenReturn(session);
         PostgresWireProtocol ctx =
             new PostgresWireProtocol(
@@ -166,7 +167,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
 
         channel.writeInbound(buffer);
 
-        SQLOperations.Session session = sessions.get(0);
+        Session session = sessions.get(0);
         // If the query can be retrieved via portalName it means bind worked
         assertThat(session.getQuery("P1"), is("select ?, ?"));
     }

--- a/sql/src/test/java/io/crate/testing/SQLTransportExecutor.java
+++ b/sql/src/test/java/io/crate/testing/SQLTransportExecutor.java
@@ -25,6 +25,7 @@ import com.carrotsearch.randomizedtesting.RandomizedContext;
 import com.google.common.base.MoreObjects;
 import io.crate.action.sql.BaseResultReceiver;
 import io.crate.action.sql.Option;
+import io.crate.action.sql.Session;
 import io.crate.action.sql.ResultReceiver;
 import io.crate.action.sql.SQLActionException;
 import io.crate.action.sql.SQLOperations;
@@ -81,7 +82,7 @@ import java.util.Properties;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
-import static io.crate.action.sql.SQLOperations.Session.UNNAMED;
+import static io.crate.action.sql.Session.UNNAMED;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
@@ -162,7 +163,7 @@ public class SQLTransportExecutor {
         }
         try {
             if (isSemiJoinsEnabled) {
-                SQLOperations.Session session = newSession();
+                Session session = newSession();
                 sessionList.forEach((setting) -> exec(setting, session));
                 return execute(stmt, args, session).actionGet(timeout);
             }
@@ -201,7 +202,7 @@ public class SQLTransportExecutor {
         return execute(stmt, args, newSession());
     }
 
-    public SQLOperations.Session newSession() {
+    public Session newSession() {
         return clientProvider.sqlOperations().createSession(
             defaultSchema,
             null,
@@ -210,13 +211,13 @@ public class SQLTransportExecutor {
         );
     }
 
-    public SQLResponse exec(String statement, SQLOperations.Session session) {
+    public SQLResponse exec(String statement, Session session) {
         return execute(statement, null, session).actionGet(REQUEST_TIMEOUT);
     }
 
     public static ActionFuture<SQLResponse> execute(String stmt,
                                                     @Nullable Object[] args,
-                                                    SQLOperations.Session session) {
+                                                    Session session) {
         final AdapterActionFuture<SQLResponse, SQLResponse> actionFuture = new PlainActionFuture<>();
         execute(stmt, args, actionFuture, session);
         return actionFuture;
@@ -225,7 +226,7 @@ public class SQLTransportExecutor {
     private static void execute(String stmt,
                                 @Nullable Object[] args,
                                 ActionListener<SQLResponse> listener,
-                                SQLOperations.Session session) {
+                                Session session) {
         try {
             session.parse(UNNAMED, stmt, Collections.emptyList());
             List<Object> argsList = args == null ? Collections.emptyList() : Arrays.asList(args);
@@ -245,7 +246,7 @@ public class SQLTransportExecutor {
     }
 
     private void execute(String stmt, @Nullable Object[][] bulkArgs, final ActionListener<SQLBulkResponse> listener) {
-        SQLOperations.Session session = newSession();
+        Session session = newSession();
         try {
             session.parse(UNNAMED, stmt, Collections.<DataType>emptyList());
             if (bulkArgs == null) {

--- a/sql/src/test/java/io/crate/testing/SQLTransportExecutor.java
+++ b/sql/src/test/java/io/crate/testing/SQLTransportExecutor.java
@@ -188,7 +188,7 @@ public class SQLTransportExecutor {
         final AdapterActionFuture<SQLResponse, SQLResponse> actionFuture = new PlainActionFuture<>();
         executor.getSession().parse(UNNAMED, stmt, Collections.emptyList());
         executor.getSession().bind(UNNAMED, UNNAMED, Collections.emptyList(), null);
-        List<Field> outputFields = executor.getSession().describe('P', UNNAMED);
+        List<Field> outputFields = executor.getSession().describe('P', UNNAMED).getFields();
         try {
             executor.execute(new ResultSetReceiver(actionFuture, executor.getSession().sessionContext(), outputFields), Collections.emptyList());
         } catch (Throwable t) {
@@ -230,7 +230,7 @@ public class SQLTransportExecutor {
             session.parse(UNNAMED, stmt, Collections.emptyList());
             List<Object> argsList = args == null ? Collections.emptyList() : Arrays.asList(args);
             session.bind(UNNAMED, UNNAMED, argsList, null);
-            List<Field> outputFields = session.describe('P', UNNAMED);
+            List<Field> outputFields = session.describe('P', UNNAMED).getFields();
             if (outputFields == null) {
                 ResultReceiver resultReceiver = new RowCountReceiver(listener, session.sessionContext());
                 session.execute(UNNAMED, 0, resultReceiver);
@@ -262,7 +262,7 @@ public class SQLTransportExecutor {
                     session.execute(UNNAMED, 0, resultReceiver);
                 }
             }
-            List<Field> outputColumns = session.describe('P', UNNAMED);
+            List<Field> outputColumns = session.describe('P', UNNAMED).getFields();
             if (outputColumns != null) {
                 throw new UnsupportedOperationException(
                     "Bulk operations for statements that return result sets is not supported");

--- a/ssl/src/main/java/io/crate/protocols/postgres/SslReqHandler.java
+++ b/ssl/src/main/java/io/crate/protocols/postgres/SslReqHandler.java
@@ -27,8 +27,6 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
-import org.apache.logging.log4j.Logger;
-import org.elasticsearch.common.logging.Loggers;
 
 /**
  * The handler for dealing with Postgres SSLRequest messages.
@@ -43,7 +41,6 @@ import org.elasticsearch.common.logging.Loggers;
  */
 public final class SslReqHandler {
 
-    private static final Logger log = Loggers.getLogger(SslReqHandler.class);
     /** The total size of the SslRequest message (including the size itself) */
     static final int SSL_REQUEST_BYTE_LENGTH = 8;
     /* The payload of the SSL Request message */


### PR DESCRIPTION
This adds the missing ParameterDescription message to the Postgres wire
protocol. The message is required by some drivers to request the parameter types
in a prepared Statements which don't have arguments assigned yet.

For example, `Select ? in (1, 2, 3)` would describe one parameter of type long.