### PR TITLE
Change assertion for new MacOSX HighSierra.

### DIFF
--- a/integration-testing/src/main/java/io/crate/test/integration/CrateUnitTest.java
+++ b/integration-testing/src/main/java/io/crate/test/integration/CrateUnitTest.java
@@ -48,7 +48,21 @@ public abstract class CrateUnitTest extends ESTestCase {
         MockitoAnnotations.initMocks(this);
     }
 
-    public static boolean isRunningOnWindows() {
+    protected static boolean isRunningOnWindows() {
         return System.getProperty("os.name").startsWith("Windows");
+    }
+
+    protected static boolean isNewMacOSX() {
+        if (!System.getProperty("os.name").equals("Mac OS X")) {
+            return false;
+        }
+        String[] osVersionArray = System.getProperty("os.version").split("\\.");
+        if (Integer.parseInt(osVersionArray[0]) > 10) {
+            return true;
+        }
+        if (Integer.parseInt(osVersionArray[1]) >= 13) {
+            return true;
+        }
+        return false;
     }
 }

--- a/sigar/src/test/java/io/crate/monitor/SigarExtendedNodeInfoTest.java
+++ b/sigar/src/test/java/io/crate/monitor/SigarExtendedNodeInfoTest.java
@@ -62,7 +62,11 @@ public class SigarExtendedNodeInfoTest extends CrateUnitTest {
     public void testNetworkStats() throws Exception {
         ExtendedNetworkStats stats = extendedNodeInfo.networkStats();
         assertThat(stats.timestamp(), greaterThan(0L));
-        assertThat(stats.tcp().activeOpens(), greaterThan(0L));
+        if (isNewMacOSX()) {
+            assertThat(stats.tcp().currEstab(), greaterThan(0L));
+        } else {
+            assertThat(stats.tcp().activeOpens(), greaterThan(0L));
+        }
     }
 
     @Test


### PR DESCRIPTION
activeOpens() is always 0 for MacOSX 10.13