### PR TITLE
Fixed an issue with multiple aliases on columns and collapseable subselect.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -46,6 +46,13 @@ Changes
 Fixes
 =====
 
+ - Fixed an issue that resulted in aliases overriding column names when a
+   subselect is used and a column appears in the outer SELECT multiple times,
+   without an alias and with alias or with multiple aliases. E.g.::
+
+     SELECT a, a AS newcol FROM (SELECT a FROM t WHERE a > 1)
+     SELECT a AS newcol1, a AS newcol2 FROM (SELECT a FROM t WHERE a > 1)
+
  - Fixed an issue that caused ``INSERT`` statements using a subquery on the
    `sys.shards` system table to fail.
 

--- a/sql/src/main/java/io/crate/analyze/relations/SubselectRewriter.java
+++ b/sql/src/main/java/io/crate/analyze/relations/SubselectRewriter.java
@@ -39,6 +39,7 @@ import io.crate.metadata.OutputName;
 import io.crate.metadata.Path;
 import io.crate.operation.operator.AndOperator;
 import io.crate.planner.Limits;
+import org.elasticsearch.common.collect.Tuple;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -77,7 +78,7 @@ public final class SubselectRewriter {
                     QuerySpec currentWithParentMerged = mergeQuerySpec(currentQS, parentQS);
                     relation = new QueriedSelectRelation(
                         relation.subRelation(),
-                        namesFromOutputs(currentWithParentMerged.outputs(), fieldReplacer.fieldByQSOutputSymbol),
+                        namesFromOutputs(currentWithParentMerged.outputs(), fieldReplacer.fieldsByQsOutputSymbols),
                         currentWithParentMerged
                     );
                     mergedWithParent = true;
@@ -113,7 +114,7 @@ public final class SubselectRewriter {
                 QuerySpec currentWithParentMerged = mergeQuerySpec(currentQS, parentQS);
                 return new QueriedTable(
                     table.tableRelation(),
-                    namesFromOutputs(currentWithParentMerged.outputs(), fieldReplacer.fieldByQSOutputSymbol),
+                    namesFromOutputs(currentWithParentMerged.outputs(), fieldReplacer.fieldsByQsOutputSymbols),
                     currentWithParentMerged
                 );
             }
@@ -132,7 +133,7 @@ public final class SubselectRewriter {
                 QuerySpec currentWithParentMerged = mergeQuerySpec(currentQS, parentQS);
                 return new QueriedDocTable(
                     table.tableRelation(),
-                    namesFromOutputs(currentWithParentMerged.outputs(), fieldReplacer.fieldByQSOutputSymbol),
+                    namesFromOutputs(currentWithParentMerged.outputs(), fieldReplacer.fieldsByQsOutputSymbols),
                     currentWithParentMerged
                 );
             }
@@ -151,7 +152,7 @@ public final class SubselectRewriter {
                 QuerySpec currentWithParentMerged = mergeQuerySpec(currentQS, parentQS);
                 return new MultiSourceSelect(
                     multiSourceSelect.sources(),
-                    namesFromOutputs(currentWithParentMerged.outputs(), fieldReplacer.fieldByQSOutputSymbol),
+                    namesFromOutputs(currentWithParentMerged.outputs(), fieldReplacer.fieldsByQsOutputSymbols),
                     currentWithParentMerged,
                     multiSourceSelect.joinPairs()
                 );
@@ -165,10 +166,11 @@ public final class SubselectRewriter {
      *         It tries to preserve the alias/name of the parent if possible
      */
     private static Collection<Path> namesFromOutputs(Collection<? extends Symbol> outputs,
-                                                     Map<Symbol, Field> replacedFieldsByNewOutput) {
+                                                     Map<Tuple<Symbol, Integer>, Field> replacedFieldsByNewOutput) {
         List<Path> outputNames = new ArrayList<>(outputs.size());
+        int idx = 0;
         for (Symbol output : outputs) {
-            Field field = replacedFieldsByNewOutput.get(output);
+            Field field = replacedFieldsByNewOutput.get(new Tuple<>(output, idx));
             if (field == null) {
                 if (output instanceof Path) {
                     outputNames.add((Path) output);
@@ -178,6 +180,7 @@ public final class SubselectRewriter {
             } else {
                 outputNames.add(field);
             }
+            idx++;
         }
         return outputNames;
     }
@@ -293,7 +296,8 @@ public final class SubselectRewriter {
     private static final class FieldReplacer extends FunctionCopyVisitor<Void> implements Function<Symbol, Symbol> {
 
         private final List<? extends Symbol> outputs;
-        final Map<Symbol, Field> fieldByQSOutputSymbol = new HashMap<>();
+        private final Map<Tuple<Symbol, Integer>, Field> fieldsByQsOutputSymbols = new HashMap<>();
+        private int idx = 0;
 
         FieldReplacer(List<? extends Symbol> outputs, QueriedRelation relation) {
             super();
@@ -314,21 +318,26 @@ public final class SubselectRewriter {
              *
              * divide(Field[x, rel=t1], Field[i, rel=t2]  -> divide(Field[x, rel=aliased_sub], Field[i, rel=aliased_sub])
              */
-            for (Field field : relation.fields()) {
-                fieldByQSOutputSymbol.put(apply(relation.querySpec().outputs().get(field.index())), field);
+            for (; idx < relation.fields().size(); idx++) {
+                Field field = relation.fields().get(idx);
+                addReferencedField(apply(relation.querySpec().outputs().get(field.index())), field);
             }
         }
 
         @Override
         public Symbol visitField(Field field, Void context) {
             Symbol newOutput = outputs.get(field.index());
-            fieldByQSOutputSymbol.putIfAbsent(newOutput, field);
+            addReferencedField(newOutput, field);
             return newOutput;
         }
 
         @Override
         public Symbol apply(Symbol symbol) {
             return process(symbol, null);
+        }
+
+        private void addReferencedField(Symbol symbol, Field field) {
+            fieldsByQsOutputSymbols.put(new Tuple<>(symbol, idx), field);
         }
     }
 }

--- a/sql/src/test/java/io/crate/analyze/SubSelectAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SubSelectAnalyzerTest.java
@@ -229,7 +229,7 @@ public class SubSelectAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
-    public void testPreserveAliasedOnSubSelect() throws Exception {
+    public void testPreserveAliasesOnSubSelect() throws Exception {
         SelectAnalyzedStatement statement = analyze("SELECT tt1.x as a1, min(tt1.x) as a2 " +
                                                     "FROM (select * from t1) as tt1 " +
                                                     "GROUP BY a1");
@@ -237,6 +237,22 @@ public class SubSelectAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(relation.fields().size(), is(2));
         assertThat(relation.fields().get(0), isField("a1"));
         assertThat(relation.fields().get(1), isField("a2"));
+        assertThat(relation.tableRelation().tableInfo(), is(T1_INFO));
+    }
+
+    @Test
+    public void testPreserveMultipleAliasesOnSubSelect() throws Exception {
+        SelectAnalyzedStatement statement =
+            analyze("SELECT tt1.i, i as ii, tt1.ii + 2, ii as iii, abs(x), abs(tt1.x) as absx " +
+                    "FROM (select i, i+1 as ii, x from t1) as tt1");
+        QueriedDocTable relation = (QueriedDocTable) statement.relation();
+        assertThat(relation.fields().size(), is(6));
+        assertThat(relation.fields().get(0), isField("i"));
+        assertThat(relation.fields().get(1), isField("ii"));
+        assertThat(relation.fields().get(2), isField("(ii + 2)"));
+        assertThat(relation.fields().get(3), isField("iii"));
+        assertThat(relation.fields().get(4), isField("abs(x)"));
+        assertThat(relation.fields().get(5), isField("absx"));
         assertThat(relation.tableRelation().tableInfo(), is(T1_INFO));
     }
 }


### PR DESCRIPTION
When a column is used multiple times in the outer select with and without aliases,
or with multiple aliases then we need to keep also an index reference to properly
rewrite the fields when the subselect is collapsed and merged with the parent relation.

Fixes https://github.com/crate/crate/issues/6387