### PR TITLE
Make MultiActionListener more generic

### DIFF
--- a/sql/src/main/java/io/crate/executor/transport/executionphases/InterceptingRowConsumer.java
+++ b/sql/src/main/java/io/crate/executor/transport/executionphases/InterceptingRowConsumer.java
@@ -27,7 +27,6 @@ import io.crate.data.Row;
 import io.crate.data.RowConsumer;
 import io.crate.exceptions.SQLExceptions;
 import io.crate.executor.transport.kill.KillJobsRequest;
-import io.crate.executor.transport.kill.KillResponse;
 import io.crate.executor.transport.kill.TransportKillJobsNodeAction;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
@@ -82,10 +81,10 @@ class InterceptingRowConsumer implements RowConsumer {
             consumer.accept(iterator, null);
         } else {
             transportKillJobsNodeAction.broadcast(
-                new KillJobsRequest(Collections.singletonList(jobId)), new ActionListener<KillResponse>() {
+                new KillJobsRequest(Collections.singletonList(jobId)), new ActionListener<Long>() {
                     @Override
-                    public void onResponse(KillResponse killResponse) {
-                        LOGGER.trace("Killed {} jobs before forwarding the failure={}", killResponse.numKilled(), failure);
+                    public void onResponse(Long numKilled) {
+                        LOGGER.trace("Killed {} jobs before forwarding the failure={}", numKilled, failure);
                         consumer.accept(null, failure);
                     }
 

--- a/sql/src/main/java/io/crate/executor/transport/task/KillJobTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/KillJobTask.java
@@ -22,8 +22,9 @@
 package io.crate.executor.transport.task;
 
 import com.google.common.collect.ImmutableList;
-import io.crate.data.RowConsumer;
 import io.crate.data.Row;
+import io.crate.data.Row1;
+import io.crate.data.RowConsumer;
 import io.crate.executor.JobTask;
 import io.crate.executor.transport.OneRowActionListener;
 import io.crate.executor.transport.kill.KillJobsRequest;
@@ -47,7 +48,6 @@ public class KillJobTask extends JobTask {
     @Override
     public void execute(RowConsumer consumer, Row parameters) {
         KillJobsRequest request = new KillJobsRequest(ImmutableList.of(jobToKill));
-        nodeAction.broadcast(request,
-            new OneRowActionListener<>(consumer, KillTask.KILL_RESPONSE_TO_ROW_FUNCTION));
+        nodeAction.broadcast(request, new OneRowActionListener<>(consumer, Row1::new));
     }
 }

--- a/sql/src/main/java/io/crate/executor/transport/task/KillTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/KillTask.java
@@ -21,28 +21,18 @@
 
 package io.crate.executor.transport.task;
 
-import io.crate.data.RowConsumer;
 import io.crate.data.Row;
 import io.crate.data.Row1;
+import io.crate.data.RowConsumer;
 import io.crate.executor.JobTask;
 import io.crate.executor.transport.OneRowActionListener;
 import io.crate.executor.transport.kill.KillAllRequest;
-import io.crate.executor.transport.kill.KillResponse;
 import io.crate.executor.transport.kill.TransportKillAllNodeAction;
 
-import javax.annotation.Nullable;
 import java.util.UUID;
-import java.util.function.Function;
 
 public class KillTask extends JobTask {
 
-    static final Function<KillResponse, Row> KILL_RESPONSE_TO_ROW_FUNCTION = new Function<KillResponse, Row>() {
-        @Nullable
-        @Override
-        public Row apply(@Nullable KillResponse input) {
-            return new Row1(input == null ? -1 : input.numKilled());
-        }
-    };
     private final TransportKillAllNodeAction nodeAction;
 
     public KillTask(TransportKillAllNodeAction nodeAction, UUID jobId) {
@@ -52,7 +42,6 @@ public class KillTask extends JobTask {
 
     @Override
     public void execute(RowConsumer consumer, Row parameters) {
-        nodeAction.broadcast(new KillAllRequest(),
-            new OneRowActionListener<>(consumer, KILL_RESPONSE_TO_ROW_FUNCTION));
+        nodeAction.broadcast(new KillAllRequest(), new OneRowActionListener<>(consumer, Row1::new));
     }
 }

--- a/sql/src/main/java/io/crate/jobs/transport/NodeDisconnectJobMonitorService.java
+++ b/sql/src/main/java/io/crate/jobs/transport/NodeDisconnectJobMonitorService.java
@@ -23,7 +23,6 @@
 package io.crate.jobs.transport;
 
 import io.crate.executor.transport.kill.KillJobsRequest;
-import io.crate.executor.transport.kill.KillResponse;
 import io.crate.executor.transport.kill.TransportKillJobsNodeAction;
 import io.crate.jobs.JobContextService;
 import org.apache.logging.log4j.Logger;
@@ -39,8 +38,8 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportConnectionListener;
 import org.elasticsearch.transport.TransportService;
 
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -98,16 +97,16 @@ public class NodeDisconnectJobMonitorService extends AbstractLifecycleComponent 
             contexts.addAll(jobContextService.getJobIdsByParticipatingNodes(node.getId()).collect(Collectors.toList()));
             KillJobsRequest killJobsRequest = new KillJobsRequest(contexts);
             if (!contexts.isEmpty()) {
-                killJobsNodeAction.broadcast(killJobsRequest, new ActionListener<KillResponse>() {
+                killJobsNodeAction.broadcast(killJobsRequest, new ActionListener<Long>() {
                     @Override
-                    public void onResponse(KillResponse killResponse) {
+                    public void onResponse(Long numKilled) {
                     }
 
                     @Override
                     public void onFailure(Exception e) {
                         LOGGER.warn("failed to send kill request to nodes");
                     }
-                }, Arrays.asList(node.getId()));
+                }, Collections.singletonList(node.getId()));
             } else {
                 return;
             }

--- a/sql/src/main/java/io/crate/operation/collect/collectors/RemoteCollector.java
+++ b/sql/src/main/java/io/crate/operation/collect/collectors/RemoteCollector.java
@@ -27,10 +27,9 @@ import io.crate.action.job.JobRequest;
 import io.crate.action.job.JobResponse;
 import io.crate.action.job.TransportJobAction;
 import io.crate.breaker.RamAccountingContext;
-import io.crate.data.RowConsumer;
 import io.crate.data.Row;
+import io.crate.data.RowConsumer;
 import io.crate.executor.transport.kill.KillJobsRequest;
-import io.crate.executor.transport.kill.KillResponse;
 import io.crate.executor.transport.kill.TransportKillJobsNodeAction;
 import io.crate.jobs.JobContextService;
 import io.crate.jobs.JobExecutionContext;
@@ -176,10 +175,10 @@ public class RemoteCollector implements CrateCollector {
 
     private void killRemoteContext() {
         transportKillJobsNodeAction.broadcast(new KillJobsRequest(Collections.singletonList(jobId)),
-            new ActionListener<KillResponse>() {
+            new ActionListener<Long>() {
 
                 @Override
-                public void onResponse(KillResponse killResponse) {
+                public void onResponse(Long numKilled) {
                     context.kill();
                 }
 


### PR DESCRIPTION
This changes the `MultiActionListener` to use a
state-supplier/accumulator pattern. This way it's a bit more flexible
and can be used for cases where the results shouldn't be collected into
a list.