### PR TITLE
Do not swallow interrupts in ShardingUpsertExecutor

### DIFF
--- a/sql/src/main/java/io/crate/operation/projectors/sharding/ShardingUpsertExecutor.java
+++ b/sql/src/main/java/io/crate/operation/projectors/sharding/ShardingUpsertExecutor.java
@@ -61,6 +61,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -132,6 +133,7 @@ public class ShardingUpsertExecutor<TReq extends ShardRequest<TReq, TItem>, TIte
     private CompletableFuture<Long> execRequests(Map<ShardLocation, TReq> itemsByShard) {
         final AtomicInteger numRequests = new AtomicInteger(itemsByShard.size());
         final AtomicLong rowCount = new AtomicLong(0L);
+        final AtomicReference<Exception> interrupt = new AtomicReference<>(null);
         final CompletableFuture<Long> rowCountFuture = new CompletableFuture<>();
         Iterator<Map.Entry<ShardLocation, TReq>> it = itemsByShard.entrySet().iterator();
         while (it.hasNext()) {
@@ -142,7 +144,7 @@ public class ShardingUpsertExecutor<TReq extends ShardRequest<TReq, TItem>, TIte
             String nodeId = entry.getKey().nodeId;
             nodeJobsCounter.increment(nodeId);
             ActionListener<ShardResponse> listener =
-                new ShardResponseActionListener(nodeId, rowCount, numRequests, rowCountFuture);
+                new ShardResponseActionListener(nodeId, rowCount, numRequests, interrupt, rowCountFuture);
 
             listener = new RetryListener<>(
                 scheduler,
@@ -199,18 +201,19 @@ public class ShardingUpsertExecutor<TReq extends ShardRequest<TReq, TItem>, TIte
         private final String operationNodeId;
         private final AtomicLong rowCount;
         private final AtomicInteger numRequests;
+        private final AtomicReference<Exception> interrupt;
         private final CompletableFuture<Long> rowCountFuture;
-        InterruptedException interruptedException;
 
         ShardResponseActionListener(String operationNodeId,
                                     AtomicLong rowCount,
                                     AtomicInteger numRequests,
+                                    AtomicReference<Exception> interrupt,
                                     CompletableFuture<Long> rowCountFuture) {
             this.operationNodeId = operationNodeId;
             this.rowCount = rowCount;
             this.numRequests = numRequests;
+            this.interrupt = interrupt;
             this.rowCountFuture = rowCountFuture;
-            interruptedException = null;
         }
 
         @Override
@@ -229,6 +232,7 @@ public class ShardingUpsertExecutor<TReq extends ShardRequest<TReq, TItem>, TIte
 
         private void countdown() {
             if (numRequests.decrementAndGet() == 0) {
+                Exception interruptedException = interrupt.get();
                 if (interruptedException == null) {
                     rowCountFuture.complete(rowCount.get());
                 } else {
@@ -239,7 +243,7 @@ public class ShardingUpsertExecutor<TReq extends ShardRequest<TReq, TItem>, TIte
 
         private void maybeSetInterrupt(@Nullable Exception failure) {
             if (failure instanceof InterruptedException) {
-                interruptedException = (InterruptedException) failure;
+                interrupt.set(failure);
             }
         }
     }


### PR DESCRIPTION
The `interruptedException` was only stored in a local reference in each
`ActionListener`. Due to that The interrupt handling only worked if the
"last" `ActionListener` received a interrupt. Other interrupts were
swallowed.