### PR TITLE
Remove isPlanned & markAsPlanned from SelectSymbol

### DIFF
--- a/sql/src/main/java/io/crate/analyze/symbol/SelectSymbol.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/SelectSymbol.java
@@ -37,7 +37,6 @@ public class SelectSymbol extends Symbol {
     private final QueriedRelation relation;
     private final SingleColumnTableType dataType;
     private final ResultType resultType;
-    private boolean isPlanned;
 
     public enum ResultType {
         SINGLE_COLUMN_SINGLE_VALUE,
@@ -95,14 +94,6 @@ public class SelectSymbol extends Symbol {
     @Override
     public String representation() {
         return "SubQuery{" + relation.getQualifiedName() + '}';
-    }
-
-    public boolean isPlanned() {
-        return isPlanned;
-    }
-
-    public void markAsPlanned() {
-        isPlanned = true;
     }
 
     public ResultType getResultType() {

--- a/sql/src/main/java/io/crate/planner/SubqueryPlanner.java
+++ b/sql/src/main/java/io/crate/planner/SubqueryPlanner.java
@@ -69,10 +69,7 @@ public class SubqueryPlanner {
 
         @Override
         public Void visitSelectSymbol(SelectSymbol selectSymbol, Symbol parent) {
-            if (!selectSymbol.isPlanned()) {
-                planSubquery(selectSymbol);
-                selectSymbol.markAsPlanned();
-            }
+            planSubquery(selectSymbol);
             return null;
         }
 


### PR DESCRIPTION
With the new LogicalPlanner it no longer happens that a `SelectSymbol`
is processed twice.