### PR TITLE
Plan intermediate fetches if sensible

### DIFF
--- a/sql/src/main/java/io/crate/planner/SelectStatementPlanner.java
+++ b/sql/src/main/java/io/crate/planner/SelectStatementPlanner.java
@@ -59,7 +59,7 @@ class SelectStatementPlanner {
         }
 
         private Plan invokeLogicalPlanner(QueriedRelation relation, Planner.Context context) {
-            Plan plan = logicalPlanner.plan(relation, context, FetchMode.WITH_PROPAGATION);
+            Plan plan = logicalPlanner.plan(relation, context, FetchMode.MAYBE_CLEAR);
             if (plan == null) {
                 throw new UnsupportedOperationException("Cannot create plan for: " + relation);
             }

--- a/sql/src/main/java/io/crate/planner/consumer/FetchMode.java
+++ b/sql/src/main/java/io/crate/planner/consumer/FetchMode.java
@@ -23,14 +23,19 @@
 package io.crate.planner.consumer;
 
 /**
- * Component to help make decisions in the planner on how/if fetch-phases should be planned.
- *
- * This is mostly relevant for nested-relations where the plan being created will also contain one or more sub-plans.
- * A planner component for a parent-relation can set a FetchMode on the {@link ConsumerContext} to influence the planning of
- * child-relations.
+ * Used in {@link io.crate.planner.operators.LogicalPlanner} to control how the {@link io.crate.planner.operators.FetchOrEval}
+ * operator should behave.
  */
 public enum FetchMode {
 
-    NEVER,
-    WITH_PROPAGATION
+    /**
+     * Indicates that FetchOrEval should not clear the {@code usedBeforeNextFetch} columns,
+     * but instead propagate them to it's child.
+     */
+    NEVER_CLEAR,
+
+    /**
+     * Indicate that FetchOrEval should clear {@code usedBeforeNextFetch} columns and do a fetch if sensible
+     */
+    MAYBE_CLEAR
 }

--- a/sql/src/main/java/io/crate/planner/consumer/InsertFromSubQueryPlanner.java
+++ b/sql/src/main/java/io/crate/planner/consumer/InsertFromSubQueryPlanner.java
@@ -74,7 +74,7 @@ public final class InsertFromSubQueryPlanner {
                                                   "supported on insert using a sub-query");
         }
         SOURCE_LOOKUP_CONVERTER.process(subRelation, null);
-        Plan plannedSubQuery = plannerContext.planSubRelation(subRelation, FetchMode.NEVER);
+        Plan plannedSubQuery = plannerContext.planSubRelation(subRelation, FetchMode.NEVER_CLEAR);
         if (plannedSubQuery == null) {
             return null;
         }

--- a/sql/src/main/java/io/crate/planner/operators/Collect.java
+++ b/sql/src/main/java/io/crate/planner/operators/Collect.java
@@ -30,6 +30,7 @@ import io.crate.analyze.WhereClause;
 import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.relations.DocTableRelation;
 import io.crate.analyze.relations.TableFunctionRelation;
+import io.crate.analyze.symbol.FieldsVisitor;
 import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.RefVisitor;
@@ -173,6 +174,11 @@ class Collect implements LogicalPlan {
             RefVisitor.visitRefs(symbol, r -> {
                 if (!usedColumns.contains(r) && !Symbols.containsColumn(usedColumns, r.ident().columnIdent())) {
                     unusedCols.add(r);
+                }
+            });
+            FieldsVisitor.visitFields(symbol, f -> {
+                if (!usedColumns.contains(f) && !Symbols.containsColumn(usedColumns, f.path())) {
+                    unusedCols.add(f);
                 }
             });
         }

--- a/sql/src/main/java/io/crate/planner/operators/FetchOrEval.java
+++ b/sql/src/main/java/io/crate/planner/operators/FetchOrEval.java
@@ -64,7 +64,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
 
-import static io.crate.planner.operators.Collect.getUnusedColumns;
+import static io.crate.planner.operators.OperatorUtils.getUnusedColumns;
+
 
 /**
  * The FetchOrEval operator is producing the values for all selected expressions.

--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlan.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlan.java
@@ -24,10 +24,7 @@ package io.crate.planner.operators;
 
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.relations.AbstractTableRelation;
-import io.crate.analyze.symbol.FieldReplacer;
-import io.crate.analyze.symbol.RefReplacer;
 import io.crate.analyze.symbol.Symbol;
-import io.crate.collections.Lists2;
 import io.crate.planner.Plan;
 import io.crate.planner.Planner;
 import io.crate.planner.TableStats;
@@ -37,7 +34,6 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
 
 /**
  * LogicalPlan is a tree of "Operators"
@@ -77,28 +73,6 @@ import java.util.function.Function;
  * </pre>
  */
 public interface LogicalPlan {
-
-    static List<Symbol> mappedSymbols(List<Symbol> sourceOutputs, Map<Symbol, Symbol> mapping) {
-        if (mapping.isEmpty()) {
-            return sourceOutputs;
-        }
-        return Lists2.copyAndReplace(sourceOutputs, getMapper(mapping));
-    }
-
-    static Function<Symbol, Symbol> getMapper(Map<Symbol, Symbol> mapping) {
-        return s -> {
-            Symbol mapped = mapping.get(s);
-            if (mapped != null) {
-                return mapped;
-            }
-            mapped = FieldReplacer.replaceFields(s, f -> mapping.getOrDefault(f, f));
-            if (mapped != s) {
-                return mapped;
-            }
-            mapped = RefReplacer.replaceRefs(s, r -> mapping.getOrDefault(r, r));
-            return mapped;
-        };
-    }
 
     interface Builder {
 

--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -103,7 +103,8 @@ public class LogicalPlanner {
                                 collectAndFilter(
                                     relation,
                                     splitPoints.toCollect(),
-                                    relation.where()
+                                    relation.where(),
+                                    fetchMode
                                 ),
                                 relation.groupBy(),
                                 splitPoints.aggregates()),
@@ -116,7 +117,8 @@ public class LogicalPlanner {
                 ),
                 relation.querySpec().outputs(),
                 fetchMode,
-                isLastFetch
+                isLastFetch,
+                relation.limit() != null
             );
         if (isLastFetch) {
             return sourceBuilder;
@@ -139,7 +141,8 @@ public class LogicalPlanner {
 
     private static LogicalPlan.Builder collectAndFilter(QueriedRelation queriedRelation,
                                                         List<Symbol> toCollect,
-                                                        WhereClause where) {
+                                                        WhereClause where,
+                                                        FetchMode fetchMode) {
         if (queriedRelation instanceof QueriedTableRelation) {
             return createCollect((QueriedTableRelation) queriedRelation, toCollect, where);
         }
@@ -149,7 +152,7 @@ public class LogicalPlanner {
         if (queriedRelation instanceof QueriedSelectRelation) {
             QueriedSelectRelation selectRelation = (QueriedSelectRelation) queriedRelation;
             return Filter.create(
-                plan(selectRelation.subRelation(), FetchMode.WITH_PROPAGATION, false),
+                plan(selectRelation.subRelation(), fetchMode, false),
                 where
             );
         }

--- a/sql/src/main/java/io/crate/planner/operators/OperatorUtils.java
+++ b/sql/src/main/java/io/crate/planner/operators/OperatorUtils.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.operators;
+
+import io.crate.analyze.symbol.FieldReplacer;
+import io.crate.analyze.symbol.FieldsVisitor;
+import io.crate.analyze.symbol.RefReplacer;
+import io.crate.analyze.symbol.RefVisitor;
+import io.crate.analyze.symbol.Symbol;
+import io.crate.analyze.symbol.Symbols;
+import io.crate.collections.Lists2;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+final class OperatorUtils {
+
+    private OperatorUtils() {
+    }
+
+    /**
+     * Return columns which are not used.
+     *
+     * Examples:
+     *
+     * <pre>
+     * toCollect: [f(x)]        used: x
+     * unused:    []
+     *
+     * toCollect: [x, f(x)]     used: [f(x)]
+     * unused:    []
+     *
+     * toCollect: [x, y]        used: [x]
+     * unused:    [y]
+     * </pre>
+     */
+    static List<Symbol> getUnusedColumns(List<Symbol> toCollect, Set<Symbol> usedColumns) {
+        List<Symbol> unusedCols = new ArrayList<>();
+        for (Symbol symbol : toCollect) {
+            if (usedColumns.contains(symbol)) {
+                continue;
+            }
+            RefVisitor.visitRefs(symbol, r -> {
+                if (!usedColumns.contains(r) && !Symbols.containsColumn(usedColumns, r.ident().columnIdent())) {
+                    unusedCols.add(r);
+                }
+            });
+            FieldsVisitor.visitFields(symbol, f -> {
+                if (!usedColumns.contains(f) && !Symbols.containsColumn(usedColumns, f.path())) {
+                    unusedCols.add(f);
+                }
+            });
+        }
+        return unusedCols;
+    }
+
+    /**
+     * @return a new list where all symbols are mapped using a mapping function created from {@code mapping}
+     */
+    static List<Symbol> mappedSymbols(List<Symbol> sourceOutputs, Map<Symbol, Symbol> mapping) {
+        if (mapping.isEmpty()) {
+            return sourceOutputs;
+        }
+        return Lists2.copyAndReplace(sourceOutputs, getMapper(mapping));
+    }
+
+    /**
+     * Create a mapping function which will map symbols using {@code mapping}.
+     * This also operates on Reference or Field symbols within functions
+     *
+     * Example
+     * <pre>
+     *     mapping:
+     *      xx    -> add(x, x)
+     *
+     *     usage examples:
+     *      xx      -> add(x, x)
+     *
+     *      f(xx)   -> f(add(x, x)
+     * </pre>
+     */
+    static Function<Symbol, Symbol> getMapper(Map<Symbol, Symbol> mapping) {
+        return s -> {
+            Symbol mapped = mapping.get(s);
+            if (mapped != null) {
+                return mapped;
+            }
+            mapped = FieldReplacer.replaceFields(s, f -> mapping.getOrDefault(f, f));
+            if (mapped != s) {
+                return mapped;
+            }
+            mapped = RefReplacer.replaceRefs(s, r -> mapping.getOrDefault(r, r));
+            return mapped;
+        };
+    }
+}

--- a/sql/src/main/java/io/crate/planner/operators/RelationBoundary.java
+++ b/sql/src/main/java/io/crate/planner/operators/RelationBoundary.java
@@ -63,7 +63,7 @@ public class RelationBoundary implements LogicalPlan {
                     field,
                     ((QueriedRelation) field.relation()).querySpec().outputs().get(field.index()));
             }
-            Function<Symbol, Symbol> mapper = LogicalPlan.getMapper(expressionMapping);
+            Function<Symbol, Symbol> mapper = OperatorUtils.getMapper(expressionMapping);
             HashSet<Symbol> mappedUsedColumns = new HashSet<>();
             for (Symbol beforeNextFetch : usedBeforeNextFetch) {
                 mappedUsedColumns.add(mapper.apply(beforeNextFetch));
@@ -90,7 +90,7 @@ public class RelationBoundary implements LogicalPlan {
                 }
             });
         }
-        this.outputs = LogicalPlan.mappedSymbols(source.outputs(), reverseMapping);
+        this.outputs = OperatorUtils.mappedSymbols(source.outputs(), reverseMapping);
         expressionMapping.putAll(source.expressionMapping());
     }
 

--- a/sql/src/main/java/io/crate/planner/statement/CopyStatementPlanner.java
+++ b/sql/src/main/java/io/crate/planner/statement/CopyStatementPlanner.java
@@ -234,7 +234,7 @@ public class CopyStatementPlanner {
             statement.outputNames(),
             outputFormat);
 
-        Plan plan = context.planSubRelation(statement.subQueryRelation(), FetchMode.NEVER);
+        Plan plan = context.planSubRelation(statement.subQueryRelation(), FetchMode.NEVER_CLEAR);
         if (plan == null) {
             return null;
         }

--- a/sql/src/test/java/io/crate/planner/consumer/GlobalAggregatePlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/consumer/GlobalAggregatePlannerTest.java
@@ -24,11 +24,9 @@ package io.crate.planner.consumer;
 
 import io.crate.analyze.TableDefinitions;
 import io.crate.planner.node.dql.Collect;
-import io.crate.planner.node.dql.QueryThenFetch;
 import io.crate.planner.node.dql.join.NestedLoop;
 import io.crate.planner.projection.AggregationProjection;
 import io.crate.planner.projection.EvalProjection;
-import io.crate.planner.projection.FetchProjection;
 import io.crate.planner.projection.FilterProjection;
 import io.crate.planner.projection.Projection;
 import io.crate.planner.projection.TopNProjection;
@@ -67,15 +65,12 @@ public class GlobalAggregatePlannerTest extends CrateDummyClusterServiceUnitTest
     }
 
     @Test
-    @Ignore("TODO: optimize this case again to do early fetch")
-    public void testAggregateOnSubQueryUsesQueryThenFetchIfPossible() throws Exception {
-        QueryThenFetch plan = e.plan("select sum(x) from (select x, i from t1 order by x limit 10) ti");
-        List<Projection> projections = ((Collect) plan.subPlan()).collectPhase().projections();
+    public void testAggregateOnSubQueryNoFetchBecauseColumnInUse() throws Exception {
+        Collect plan = e.plan("select sum(x) from (select x, i from t1 order by x limit 10) ti");
+        List<Projection> projections = plan.collectPhase().projections();
         assertThat(projections, contains(
             instanceOf(TopNProjection.class),
-            instanceOf(FetchProjection.class),
-            instanceOf(AggregationProjection.class),
-            instanceOf(EvalProjection.class)
+            instanceOf(AggregationProjection.class)
         ));
     }
 

--- a/sql/src/test/java/io/crate/planner/operators/OperatorUtilsTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/OperatorUtilsTest.java
@@ -33,10 +33,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThat;
 
-public class CollectTest {
-
+public class OperatorUtilsTest {
 
     @Test
     public void testGetUnusedColsWithNoUnused() throws Exception {
@@ -48,7 +47,7 @@ public class CollectTest {
         Set<Symbol> used = Collections.singleton(xAdd1);
 
         assertThat(
-            Collect.getUnusedColumns(toCollect, used),
+            OperatorUtils.getUnusedColumns(toCollect, used),
             Matchers.emptyIterable()
         );
     }


### PR DESCRIPTION
This changes the LogicalPlanner to plan queries with virtual tables
closer to how the ConsumingPlanner handled them.

Specifically, a case as follows is now again using an early fetch:

    select sum(x) from (select x from t1 limit 500)