### PR TITLE
avoid converting of expressions in the analyzer

### DIFF
--- a/sql-parser/src/main/java/io/crate/sql/tree/RerouteCancelShard.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/RerouteCancelShard.java
@@ -25,18 +25,18 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 import javax.annotation.Nullable;
-import java.util.Optional;
 
 public class RerouteCancelShard extends RerouteOption {
 
-    private final Optional<GenericProperties> properties;
     private final Expression nodeId;
     private final Expression shardId;
+    @Nullable
+    private final GenericProperties properties;
 
     public RerouteCancelShard(Expression shardId, Expression nodeId, @Nullable GenericProperties properties) {
         this.shardId = shardId;
         this.nodeId = nodeId;
-        this.properties = Optional.ofNullable(properties);
+        this.properties = properties;
     }
 
     public Expression nodeId() {
@@ -47,7 +47,8 @@ public class RerouteCancelShard extends RerouteOption {
         return shardId;
     }
 
-    public Optional<GenericProperties> properties() {
+    @Nullable
+    public GenericProperties properties() {
         return properties;
     }
 

--- a/sql/src/main/java/io/crate/action/sql/DDLStatementDispatcher.java
+++ b/sql/src/main/java/io/crate/action/sql/DDLStatementDispatcher.java
@@ -250,25 +250,25 @@ public class DDLStatementDispatcher implements BiFunction<AnalyzedStatement, Row
         }
 
         @Override
-        protected CompletableFuture<Long> visitRerouteMoveShard(RerouteMoveShardAnalyzedStatement analysis, Row context) {
+        protected CompletableFuture<Long> visitRerouteMoveShard(RerouteMoveShardAnalyzedStatement analysis, Row parameters) {
             // TODO: implementation
             throw new UnsupportedOperationException("TODO");
         }
 
         @Override
-        protected CompletableFuture<Long> visitRerouteCancelShard(RerouteCancelShardAnalyzedStatement analysis, Row context) {
+        protected CompletableFuture<Long> visitRerouteCancelShard(RerouteCancelShardAnalyzedStatement analysis, Row parameters) {
             // TODO: implementation
             throw new UnsupportedOperationException("TODO");
         }
 
         @Override
-        protected CompletableFuture<Long> visitRerouteAllocateReplicaShard(RerouteAllocateReplicaShardAnalyzedStatement analysis, Row context) {
+        protected CompletableFuture<Long> visitRerouteAllocateReplicaShard(RerouteAllocateReplicaShardAnalyzedStatement analysis, Row parameters) {
             // TODO: implementation
             throw new UnsupportedOperationException("TODO");
         }
 
         @Override
-        protected CompletableFuture<Long> visitRerouteRetryFailed(RerouteRetryFailedAnalyzedStatement analysis, Row context) {
+        protected CompletableFuture<Long> visitRerouteRetryFailed(RerouteRetryFailedAnalyzedStatement analysis, Row parameters) {
             // TODO: implementation
             throw new UnsupportedOperationException("TODO");
         }

--- a/sql/src/main/java/io/crate/analyze/OptimizeTableAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/OptimizeTableAnalyzer.java
@@ -84,7 +84,7 @@ class OptimizeTableAnalyzer {
         for (Table nodeTable : tables) {
             TableInfo tableInfo = schemas.getTableInfo(TableIdent.of(nodeTable, defaultSchema), Operation.OPTIMIZE);
             if (tableInfo instanceof BlobTableInfo) {
-                indexNames.add(((BlobTableInfo) tableInfo).concreteIndex());
+                indexNames.add(((BlobTableInfo) tableInfo).concreteIndices()[0]);
             } else {
                 indexNames.addAll(TableAnalyzer.filteredIndices(
                     parameterContext,

--- a/sql/src/main/java/io/crate/analyze/RerouteAllocateReplicaShardAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/RerouteAllocateReplicaShardAnalyzedStatement.java
@@ -22,19 +22,17 @@
 
 package io.crate.analyze;
 
-import io.crate.metadata.PartitionName;
-import io.crate.metadata.table.TableInfo;
+import io.crate.sql.tree.Expression;
 
 public class RerouteAllocateReplicaShardAnalyzedStatement extends RerouteAnalyzedStatement {
 
-    private final int shardId;
-    private final String nodeId;
+    private final Expression shardId;
+    private final Expression nodeId;
 
-    public RerouteAllocateReplicaShardAnalyzedStatement(TableInfo tableInfo,
-                                                        PartitionName partitionName,
-                                                        int shardId,
-                                                        String nodeId) {
-        super(tableInfo, partitionName);
+    public RerouteAllocateReplicaShardAnalyzedStatement(String[] concreteIndices,
+                                                        Expression shardId,
+                                                        Expression nodeId) {
+        super(concreteIndices);
         this.shardId = shardId;
         this.nodeId = nodeId;
     }
@@ -44,11 +42,11 @@ public class RerouteAllocateReplicaShardAnalyzedStatement extends RerouteAnalyze
         return visitor.visitRerouteAllocateReplicaShard(this, context);
     }
 
-    public int shardId() {
+    public Expression shardId() {
         return shardId;
     }
 
-    public String nodeId() {
+    public Expression nodeId() {
         return nodeId;
     }
 }

--- a/sql/src/main/java/io/crate/analyze/RerouteAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/RerouteAnalyzedStatement.java
@@ -22,29 +22,15 @@
 
 package io.crate.analyze;
 
-import io.crate.metadata.PartitionName;
-import io.crate.metadata.table.TableInfo;
-
-import javax.annotation.Nullable;
-
 public abstract class RerouteAnalyzedStatement implements DDLStatement {
 
-    private TableInfo tableInfo;
-    @Nullable
-    private PartitionName partitionName;
+    private final String[] concreteIndices;
 
-    public RerouteAnalyzedStatement(TableInfo tableInfo, PartitionName partitionName) {
-        this.tableInfo = tableInfo;
-        this.partitionName = partitionName;
+    public RerouteAnalyzedStatement(String[] concreteIndices) {
+        this.concreteIndices = concreteIndices;
     }
 
-    public TableInfo tableInfo() {
-        return tableInfo;
+    public String[] concreteIndices() {
+        return concreteIndices;
     }
-
-    @Nullable
-    public PartitionName partitionName() {
-        return partitionName;
-    }
-
 }

--- a/sql/src/main/java/io/crate/analyze/RerouteCancelShardAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/RerouteCancelShardAnalyzedStatement.java
@@ -22,24 +22,25 @@
 
 package io.crate.analyze;
 
-import io.crate.metadata.PartitionName;
-import io.crate.metadata.table.TableInfo;
+import io.crate.sql.tree.Expression;
+import io.crate.sql.tree.GenericProperties;
+import org.elasticsearch.common.Nullable;
 
 public class RerouteCancelShardAnalyzedStatement extends RerouteAnalyzedStatement {
 
-    private final int shardId;
-    private final String nodeId;
-    private final boolean allowPrimary;
+    private final Expression shardId;
+    private final Expression nodeId;
+    @Nullable
+    private final GenericProperties properties;
 
-    public RerouteCancelShardAnalyzedStatement(TableInfo tableInfo,
-                                               PartitionName partitionName,
-                                               int shardId,
-                                               String nodeId,
-                                               boolean allowPrimary) {
-        super(tableInfo, partitionName);
+    public RerouteCancelShardAnalyzedStatement(String[] concreteIndices,
+                                               Expression shardId,
+                                               Expression nodeId,
+                                               @Nullable GenericProperties properties) {
+        super(concreteIndices);
         this.shardId = shardId;
         this.nodeId = nodeId;
-        this.allowPrimary = allowPrimary;
+        this.properties = properties;
     }
 
     @Override
@@ -47,15 +48,16 @@ public class RerouteCancelShardAnalyzedStatement extends RerouteAnalyzedStatemen
         return visitor.visitRerouteCancelShard(this, context);
     }
 
-    public int shardId() {
+    public Expression shardId() {
         return shardId;
     }
 
-    public String nodeId() {
+    public Expression nodeId() {
         return nodeId;
     }
 
-    public boolean allowPrimary() {
-        return allowPrimary;
+    @Nullable
+    public GenericProperties properties() {
+        return properties;
     }
 }

--- a/sql/src/main/java/io/crate/analyze/RerouteMoveShardAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/RerouteMoveShardAnalyzedStatement.java
@@ -22,21 +22,19 @@
 
 package io.crate.analyze;
 
-import io.crate.metadata.PartitionName;
-import io.crate.metadata.table.TableInfo;
+import io.crate.sql.tree.Expression;
 
 public class RerouteMoveShardAnalyzedStatement extends RerouteAnalyzedStatement {
 
-    private final int shardId;
-    private final String fromNodeId;
-    private final String toNodeId;
+    private final Expression shardId;
+    private final Expression fromNodeId;
+    private final Expression toNodeId;
 
-    public RerouteMoveShardAnalyzedStatement(TableInfo tableInfo,
-                                             PartitionName partitionName,
-                                             int shardId,
-                                             String fromNodeId,
-                                             String toNodeId) {
-        super(tableInfo, partitionName);
+    public RerouteMoveShardAnalyzedStatement(String[] concreteIndices,
+                                             Expression shardId,
+                                             Expression fromNodeId,
+                                             Expression toNodeId) {
+        super(concreteIndices);
         this.shardId = shardId;
         this.fromNodeId = fromNodeId;
         this.toNodeId = toNodeId;
@@ -47,15 +45,15 @@ public class RerouteMoveShardAnalyzedStatement extends RerouteAnalyzedStatement 
         return visitor.visitRerouteMoveShard(this, context);
     }
 
-    public int shardId() {
+    public Expression shardId() {
         return shardId;
     }
 
-    public String fromNodeId() {
+    public Expression fromNodeId() {
         return fromNodeId;
     }
 
-    public String toNodeId() {
+    public Expression toNodeId() {
         return toNodeId;
     }
 }

--- a/sql/src/main/java/io/crate/analyze/RerouteRetryFailedAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/RerouteRetryFailedAnalyzedStatement.java
@@ -22,14 +22,10 @@
 
 package io.crate.analyze;
 
-import io.crate.metadata.PartitionName;
-import io.crate.metadata.table.TableInfo;
-
 public class RerouteRetryFailedAnalyzedStatement extends RerouteAnalyzedStatement {
 
-    public RerouteRetryFailedAnalyzedStatement(TableInfo tableInfo,
-                                               PartitionName partitionName) {
-        super(tableInfo, partitionName);
+    public RerouteRetryFailedAnalyzedStatement(String[] concreteIndices) {
+        super(concreteIndices);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/metadata/blob/BlobTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/blob/BlobTableInfo.java
@@ -185,10 +185,6 @@ public class BlobTableInfo implements TableInfo, ShardedTable, StoredTable {
         return Operation.BLOB_OPERATIONS;
     }
 
-    public String concreteIndex() {
-        return index;
-    }
-
     @Override
     public String routingHashFunction() {
         return routingHashFunction;
@@ -197,6 +193,11 @@ public class BlobTableInfo implements TableInfo, ShardedTable, StoredTable {
     @Override
     public boolean isClosed() {
         return closed;
+    }
+
+    @Override
+    public String[] concreteIndices() {
+        return new String[] {index};
     }
 
     @Nullable

--- a/sql/src/main/java/io/crate/metadata/table/Operation.java
+++ b/sql/src/main/java/io/crate/metadata/table/Operation.java
@@ -41,6 +41,7 @@ public enum Operation {
     ALTER("ALTER"),
     ALTER_BLOCKS("ALTER"),
     ALTER_OPEN_CLOSE("ALTER OPEN/CLOSE"),
+    ALTER_REROUTE("ALTER REROUTE"),
     REFRESH("REFRESH"),
     SHOW_CREATE("SHOW CREATE"),
     OPTIMIZE("OPTIMIZE"),
@@ -52,13 +53,13 @@ public enum Operation {
     public static final EnumSet<Operation> SYS_READ_ONLY = EnumSet.of(READ);
     public static final EnumSet<Operation> READ_ONLY = EnumSet.of(READ, ALTER_BLOCKS);
     public static final EnumSet<Operation> OPEN_CLOSE_ONLY = EnumSet.of(ALTER_OPEN_CLOSE);
-    public static final EnumSet<Operation> BLOB_OPERATIONS = EnumSet.of(READ, OPTIMIZE);
+    public static final EnumSet<Operation> BLOB_OPERATIONS = EnumSet.of(READ, OPTIMIZE, ALTER_REROUTE);
     public static final EnumSet<Operation> READ_DISABLED_OPERATIONS = EnumSet.of(UPDATE, INSERT, DELETE, DROP, ALTER,
-        ALTER_OPEN_CLOSE, ALTER_BLOCKS, REFRESH, OPTIMIZE);
+        ALTER_OPEN_CLOSE, ALTER_REROUTE, ALTER_BLOCKS, REFRESH, OPTIMIZE);
     public static final EnumSet<Operation> WRITE_DISABLED_OPERATIONS = EnumSet.of(READ, ALTER, ALTER_OPEN_CLOSE,
-        ALTER_BLOCKS, SHOW_CREATE, REFRESH, OPTIMIZE, COPY_TO, CREATE_SNAPSHOT);
+        ALTER_REROUTE, ALTER_BLOCKS, SHOW_CREATE, REFRESH, OPTIMIZE, COPY_TO, CREATE_SNAPSHOT);
     public static final EnumSet<Operation> METADATA_DISABLED_OPERATIONS = EnumSet.of(READ, UPDATE, INSERT, DELETE,
-        ALTER_BLOCKS, ALTER_OPEN_CLOSE, REFRESH, SHOW_CREATE, OPTIMIZE);
+        ALTER_BLOCKS, ALTER_OPEN_CLOSE, ALTER_REROUTE, REFRESH, SHOW_CREATE, OPTIMIZE);
 
     private final String representation;
 

--- a/sql/src/main/java/io/crate/metadata/table/ShardedTable.java
+++ b/sql/src/main/java/io/crate/metadata/table/ShardedTable.java
@@ -35,4 +35,6 @@ public interface ShardedTable {
     String routingHashFunction();
 
     boolean isClosed();
+
+    String[] concreteIndices();
 }

--- a/sql/src/test/java/io/crate/metadata/table/OperationTest.java
+++ b/sql/src/test/java/io/crate/metadata/table/OperationTest.java
@@ -46,18 +46,18 @@ public class OperationTest extends CrateUnitTest {
         assertThat(Operation.buildFromIndexSettingsAndState(Settings.builder()
                 .put(IndexMetaData.SETTING_BLOCKS_READ, true).build(), IndexMetaData.State.OPEN),
             containsInAnyOrder(Operation.UPDATE, Operation.INSERT, Operation.DELETE, Operation.DROP, Operation.ALTER,
-                Operation.ALTER_OPEN_CLOSE, Operation.ALTER_BLOCKS, Operation.REFRESH, Operation.OPTIMIZE));
+                Operation.ALTER_OPEN_CLOSE, Operation.ALTER_BLOCKS, Operation.REFRESH, Operation.OPTIMIZE, Operation.ALTER_REROUTE));
 
         assertThat(Operation.buildFromIndexSettingsAndState(Settings.builder()
                 .put(IndexMetaData.SETTING_BLOCKS_WRITE, true).build(), IndexMetaData.State.OPEN),
             containsInAnyOrder(Operation.READ, Operation.ALTER, Operation.ALTER_OPEN_CLOSE, Operation.ALTER_BLOCKS,
                 Operation.SHOW_CREATE, Operation.REFRESH, Operation.OPTIMIZE, Operation.COPY_TO,
-                Operation.CREATE_SNAPSHOT));
+                Operation.CREATE_SNAPSHOT, Operation.ALTER_REROUTE));
 
         assertThat(Operation.buildFromIndexSettingsAndState(Settings.builder()
                 .put(IndexMetaData.SETTING_BLOCKS_METADATA, true).build(), IndexMetaData.State.OPEN),
             containsInAnyOrder(Operation.READ, Operation.UPDATE, Operation.INSERT, Operation.DELETE, Operation.ALTER_BLOCKS,
-                Operation.ALTER_OPEN_CLOSE, Operation.REFRESH, Operation.SHOW_CREATE, Operation.OPTIMIZE));
+                Operation.ALTER_OPEN_CLOSE, Operation.REFRESH, Operation.SHOW_CREATE, Operation.OPTIMIZE, Operation.ALTER_REROUTE));
     }
 
     @Test
@@ -66,18 +66,18 @@ public class OperationTest extends CrateUnitTest {
                 .put(IndexMetaData.SETTING_BLOCKS_READ, true)
                 .put(IndexMetaData.SETTING_BLOCKS_WRITE, true).build(), IndexMetaData.State.OPEN),
             containsInAnyOrder(Operation.ALTER, Operation.ALTER_OPEN_CLOSE, Operation.ALTER_BLOCKS, Operation.REFRESH,
-                Operation.OPTIMIZE));
+                Operation.OPTIMIZE, Operation.ALTER_REROUTE));
 
         assertThat(Operation.buildFromIndexSettingsAndState(Settings.builder()
                 .put(IndexMetaData.SETTING_BLOCKS_WRITE, true)
                 .put(IndexMetaData.SETTING_BLOCKS_METADATA, true).build(), IndexMetaData.State.OPEN),
             containsInAnyOrder(Operation.READ, Operation.ALTER_OPEN_CLOSE, Operation.ALTER_BLOCKS, Operation.REFRESH,
-                Operation.SHOW_CREATE, Operation.OPTIMIZE));
+                Operation.SHOW_CREATE, Operation.OPTIMIZE, Operation.ALTER_REROUTE));
 
         assertThat(Operation.buildFromIndexSettingsAndState(Settings.builder()
                 .put(IndexMetaData.SETTING_BLOCKS_READ, true)
                 .put(IndexMetaData.SETTING_BLOCKS_METADATA, true).build(), IndexMetaData.State.OPEN),
             containsInAnyOrder(Operation.INSERT, Operation.UPDATE, Operation.DELETE, Operation.ALTER_OPEN_CLOSE,
-                Operation.ALTER_BLOCKS, Operation.REFRESH, Operation.OPTIMIZE));
+                Operation.ALTER_BLOCKS, Operation.REFRESH, Operation.OPTIMIZE, Operation.ALTER_REROUTE));
     }
 }


### PR DESCRIPTION
Converting an expression using the parameters from the analysis is unsafe
because there is no parameter description available.