### PR TITLE
Remove row-transformation capability from TopNProjection

### DIFF
--- a/dex/src/main/java/io/crate/data/LimitingBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/LimitingBatchIterator.java
@@ -26,16 +26,16 @@ import io.crate.concurrent.CompletableFutures;
 
 import java.util.concurrent.CompletionStage;
 
-public class LimitingBatchIterator extends CloseAssertingBatchIterator {
+public class LimitingBatchIterator<T> extends CloseAssertingBatchIterator<T> {
 
     private final int endPos;
     private int pos = -1;
 
-    public static BatchIterator newInstance(BatchIterator delegate, int limit) {
-        return new LimitingBatchIterator(delegate, limit);
+    public static <T> BatchIterator<T> newInstance(BatchIterator<T> delegate, int limit) {
+        return new LimitingBatchIterator<>(delegate, limit);
     }
 
-    private LimitingBatchIterator(BatchIterator delegate, int limit) {
+    private LimitingBatchIterator(BatchIterator<T> delegate, int limit) {
         super(delegate);
         this.endPos = limit - 1;
     }

--- a/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/ESGetTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/ESGetTask.java
@@ -26,6 +26,7 @@ import io.crate.Constants;
 import io.crate.analyze.EvaluatingNormalizer;
 import io.crate.analyze.symbol.InputColumn;
 import io.crate.analyze.symbol.Symbol;
+import io.crate.analyze.symbol.Symbols;
 import io.crate.analyze.where.DocKeys;
 import io.crate.collections.Lists2;
 import io.crate.data.InMemoryBatchIterator;
@@ -156,7 +157,7 @@ public class ESGetTask extends JobTask {
                 Projection projection;
                 if (task.esGet.sortSymbols().isEmpty()) {
                     projection = new TopNProjection(
-                        task.esGet.limit(), task.esGet.offset(), InputColumn.fromSymbols(task.esGet.outputs()));
+                        task.esGet.limit(), task.esGet.offset(), Symbols.typeView(task.esGet.outputs()));
                 } else {
                     projection = new OrderedTopNProjection(
                         task.esGet.limit(),

--- a/sql/src/main/java/io/crate/operation/projectors/InputRowProjector.java
+++ b/sql/src/main/java/io/crate/operation/projectors/InputRowProjector.java
@@ -37,16 +37,16 @@ import java.util.List;
 public class InputRowProjector implements Projector {
 
     protected final List<Input<?>> inputs;
-    protected final Iterable<? extends CollectExpression<Row, ?>> collectExpressions;
+    protected final List<? extends CollectExpression<Row, ?>> collectExpressions;
 
     public InputRowProjector(List<Input<?>> inputs,
-                             Iterable<? extends CollectExpression<Row, ?>> collectExpressions) {
+                             List<? extends CollectExpression<Row, ?>> collectExpressions) {
         this.inputs = inputs;
         this.collectExpressions = collectExpressions;
     }
 
     @Override
-    public BatchIterator apply(BatchIterator batchIterator) {
+    public BatchIterator<Row> apply(BatchIterator<Row> batchIterator) {
         return new RowTransformingBatchIterator(batchIterator, inputs, collectExpressions);
     }
 

--- a/sql/src/main/java/io/crate/operation/projectors/ProjectionToProjectorVisitor.java
+++ b/sql/src/main/java/io/crate/operation/projectors/ProjectionToProjectorVisitor.java
@@ -193,13 +193,8 @@ public class ProjectionToProjectorVisitor
 
     @Override
     public Projector visitTopNProjection(TopNProjection projection, Context context) {
-        InputFactory.Context<CollectExpression<Row, ?>> ctx = inputFactory.ctxForInputColumns(projection.outputs());
         assert projection.limit() > TopN.NO_LIMIT : "TopNProjection must have a limit";
-        return new SimpleTopNProjector(
-            ctx.topLevelInputs(),
-            ctx.expressions(),
-            projection.limit(),
-            projection.offset());
+        return new SimpleTopNProjector(projection.limit(), projection.offset());
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/projection/TopNProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/TopNProjection.java
@@ -22,12 +22,13 @@
 package io.crate.planner.projection;
 
 import com.google.common.collect.ImmutableMap;
+import io.crate.analyze.symbol.InputColumn;
 import io.crate.analyze.symbol.Symbol;
-import io.crate.analyze.symbol.SymbolVisitors;
 import io.crate.analyze.symbol.Symbols;
 import io.crate.collections.Lists2;
 import io.crate.operation.projectors.TopN;
 import io.crate.planner.ExplainLeaf;
+import io.crate.types.DataType;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
@@ -42,14 +43,12 @@ public class TopNProjection extends Projection {
     private final int offset;
     private final List<Symbol> outputs;
 
-    public TopNProjection(int limit, int offset, List<Symbol> outputs) {
-        assert outputs.stream().noneMatch(s -> SymbolVisitors.any(Symbols.IS_COLUMN, s))
-            : "TopNProjection doesn't support Field or Reference symbols";
+    public TopNProjection(int limit, int offset, List<DataType> outputTypes) {
         assert limit > TopN.NO_LIMIT : "limit of TopNProjection must not be negative/unlimited";
 
         this.limit = limit;
         this.offset = offset;
-        this.outputs = outputs;
+        this.outputs = InputColumn.fromTypes(outputTypes);
     }
 
     public TopNProjection(StreamInput in) throws IOException {

--- a/sql/src/main/java/io/crate/planner/projection/builder/ProjectionBuilder.java
+++ b/sql/src/main/java/io/crate/planner/projection/builder/ProjectionBuilder.java
@@ -153,7 +153,7 @@ public class ProjectionBuilder {
             }
             return new EvalProjection(InputColumn.fromTypes(strippedInputs));
         }
-        return new TopNProjection(limit, offset, InputColumn.fromTypes(strippedInputs));
+        return new TopNProjection(limit, offset, strippedInputs);
     }
 
     public static WriterProjection writerProjection(Collection<? extends Symbol> inputs,

--- a/sql/src/test/java/io/crate/operation/aggregation/RowTransformingBatchIteratorTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/RowTransformingBatchIteratorTest.java
@@ -36,7 +36,6 @@ import io.crate.testing.TestingBatchIterators;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -47,7 +46,7 @@ import static io.crate.testing.TestingHelpers.getFunctions;
 public class RowTransformingBatchIteratorTest extends CrateUnitTest {
 
     private List<Input<?>> inputs;
-    private Collection<CollectExpression<Row, ?>> expressions;
+    private List<CollectExpression<Row, ?>> expressions;
 
     private List<Object[]> expectedResult = LongStream.range(0, 10)
         .mapToObj(l -> new Object[] { l + 2L })

--- a/sql/src/test/java/io/crate/operation/projectors/ProjectionToProjectorVisitorTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/ProjectionToProjectorVisitorTest.java
@@ -129,8 +129,7 @@ public class ProjectionToProjectorVisitorTest extends CrateUnitTest {
 
     @Test
     public void testSimpleTopNProjection() throws Exception {
-        List<Symbol> outputs = Arrays.asList(Literal.of("foo"), new InputColumn(0));
-        TopNProjection projection = new TopNProjection(10, 2, outputs);
+        TopNProjection projection = new TopNProjection(10, 2, Collections.singletonList(DataTypes.LONG));
 
         Projector projector = visitor.create(projection, RAM_ACCOUNTING_CONTEXT, UUID.randomUUID());
         assertThat(projector, instanceOf(SimpleTopNProjector.class));
@@ -140,7 +139,7 @@ public class ProjectionToProjectorVisitorTest extends CrateUnitTest {
 
         List<Object[]> result = consumer.getResult();
         assertThat(result.size(), is(10));
-        assertThat(result.get(0), is(new Object[]{new BytesRef("foo"), 2}));
+        assertThat(result.get(0), is(new Object[]{2}));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/planner/node/MergeNodeTest.java
+++ b/sql/src/test/java/io/crate/planner/node/MergeNodeTest.java
@@ -24,8 +24,8 @@ package io.crate.planner.node;
 import com.google.common.collect.Sets;
 import io.crate.analyze.symbol.AggregateMode;
 import io.crate.analyze.symbol.Aggregation;
-import io.crate.analyze.symbol.InputColumn;
 import io.crate.analyze.symbol.Symbol;
+import io.crate.analyze.symbol.Symbols;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RowGranularity;
 import io.crate.operation.aggregation.impl.CountAggregation;
@@ -66,7 +66,7 @@ public class MergeNodeTest extends CrateUnitTest {
         );
         GroupProjection groupProjection = new GroupProjection(
             keys, aggregations, AggregateMode.PARTIAL_FINAL, RowGranularity.CLUSTER);
-        TopNProjection topNProjection = new TopNProjection(10, 0, InputColumn.fromSymbols(groupProjection.outputs()));
+        TopNProjection topNProjection = new TopNProjection(10, 0, Symbols.typeView(groupProjection.outputs()));
 
         List<Projection> projections = Arrays.asList(groupProjection, topNProjection);
         MergePhase node = new MergePhase(

--- a/sql/src/test/java/io/crate/planner/projection/TopNProjectionTest.java
+++ b/sql/src/test/java/io/crate/planner/projection/TopNProjectionTest.java
@@ -21,21 +21,19 @@
 
 package io.crate.planner.projection;
 
-import com.google.common.collect.ImmutableList;
-import io.crate.analyze.symbol.Symbol;
-import io.crate.analyze.symbol.Value;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.types.DataTypes;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.junit.Test;
 
+import java.util.Collections;
+
 public class TopNProjectionTest extends CrateUnitTest {
 
     @Test
     public void testStreaming() throws Exception {
-        ImmutableList<Symbol> outputs = ImmutableList.of(new Value(DataTypes.BOOLEAN), new Value(DataTypes.INTEGER));
-        TopNProjection p = new TopNProjection(5, 10, outputs);
+        TopNProjection p = new TopNProjection(5, 10, Collections.singletonList(DataTypes.INTEGER));
 
         BytesStreamOutput out = new BytesStreamOutput();
         Projection.toStream(p, out);


### PR DESCRIPTION
- Changes the `TopNProjection` constructor to enforce a simple
 "row-passthrough" - it can no longer evaluate functions or shuffle
 columns.

 - Adapts the `SimpleTopNProjector` to no longer add a
 `RowTransformingBatchIterator`. This should avoid a bit of overhead
 during query execution.

The planner already adds an `EvalProjection` if a scalar
evaluation or column shuffling is required. So it is no longer necessary
for the `TopNProjection` to provide this functionality as well.