### PR TITLE
fixes flakiness of static schema query tests

### DIFF
--- a/sql/src/test/java/io/crate/integrationtests/StaticInformationSchemaQueryTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/StaticInformationSchemaQueryTest.java
@@ -31,7 +31,7 @@ public class StaticInformationSchemaQueryTest extends SQLTransportIntegrationTes
     public void tableCreation() throws Exception {
         execute("create table t1 (col1 integer, col2 string) clustered into 7 shards");
         execute("create table t2 (col1 integer, col2 string) clustered into 10 shards");
-        execute("create table t3 (col1 integer, col2 string)");
+        execute("create table t3 (col1 integer, col2 string) clustered into 4 shards");
     }
 
     @Test


### PR DESCRIPTION
flakiness was caused by dynamic templates changing the default number_of_shards