### PR TITLE
Added REROUTE MOVE subcommand to ALTER TABLE

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -23,6 +23,9 @@ Breaking Changes
 Changes
 =======
 
+- Added support to manually control the allocation of shards using
+  ``ALTER TABLE REROUTE``.
+
 - Added new system table ``sys.allocations`` which lists shards and their
   allocation state including the reasoning why they are in a certain state.
 

--- a/blackbox/docs/sql/reference/alter_table.txt
+++ b/blackbox/docs/sql/reference/alter_table.txt
@@ -25,6 +25,7 @@ Synopsis
         | OPEN
         | CLOSE
         | RENAME TO table_ident
+        | REROUTE reroute_option
       }
 
 where ``column_constraint`` is::
@@ -35,29 +36,13 @@ where ``column_constraint`` is::
                             FULLTEXT [ WITH ( analyzer = analyzer_name ) ]  }
     }
 
+
 Description
 ===========
 
-ALTER TABLE can be used to alter an existing table.
-
-``SET`` can be used to change a table parameter to a different value. Using
-``RESET`` will reset the parameter to its default value.
-
-``ADD COLUMN`` can be used to add an additional column to a table.
-
-While columns can be added at any time, adding a new
-:ref:`generated column <ref-generated-columns>` is only possible if the table
-is empty.
-
-``OPEN`` and ``CLOSE`` can be used to open or close the table, respectively.
-Closing a table prevents all operations, except ``ALTER TABLE ... OPEN``, to
-fail. Operations on closed partitions will not produce an exception, but will
-have no effect. Similarly, like ``SELECT`` and ``INSERT`` on partitioned will
-exclude closed partitions and continue working.
-
-``RENAME TO`` can be used to rename a table, while maintaining its schema and
-data. During this operation the table will be closed, and all operations upon
-the table will fail until the rename operation is completed.
+``ALTER TABLE`` can be used to modify an existing table definition. It provides
+options to add columns, modify constraints, enabling or disabling
+table parameters and allows to execute a shard reroute allocation.
 
 Use the ``BLOB`` keyword in order to alter a blob table (see
 :ref:`blob_support`). Blob tables cannot have custom columns which means that
@@ -68,19 +53,10 @@ table **only** and not for any possible existing partitions. So these changes
 will only be applied to new partitions. The ``ONLY`` keyword cannot be used
 together with a `PARTITION`_ clause.
 
-Parameters
-==========
+See the CREATE TABLE :ref:`with_clause` for a list of available parameters.
 
 :table_ident: The name (optionally schema-qualified) of the table to alter.
 
-:parameter: The name of the parameter that is set to a new value or its
-            default.
-
-:column_name: Name of the column which should be added.
-
-:data_type: data type of the column which should be added.
-
-See the CREATE TABLE :ref:`with_clause` for a list of available parameters.
 
 .. _ref-alter-table-partition-clause:
 
@@ -112,3 +88,73 @@ columns with a value each to identify the partition to alter.
 :value: The columns value.
 
 .. SEEALSO:: :ref:`Alter Partitioned Tables <partitioned_tables_alter>`
+
+
+Arguments
+=========
+
+``SET/RESET``
+-------------
+
+Can be used to change a table parameter to a different value.
+Using ``RESET`` will reset the parameter to its default value.
+
+:parameter: The name of the parameter that is set to a new value or its
+            default.
+
+``ADD COLUMN``
+--------------
+
+Can be used to add an additional column to a table. While columns can be added
+at any time, adding a new :ref:`generated column <ref-generated-columns>` is
+only possible if the table is empty.
+
+:data_type:   data type of the column which should be added.
+
+:column_name: Name of the column which should be added.
+
+``OPEN/CLOSE``
+--------------
+
+Can be used to open or close the table, respectively. Closing a table prevents
+all operations, except ``ALTER TABLE ... OPEN``, to fail. Operations on closed
+partitions will not produce an exception, but will have no effect. Similarly,
+like ``SELECT`` and ``INSERT`` on partitioned will exclude closed partitions and
+continue working.
+
+``RENAME TO``
+-------------
+Can be used to rename a table, while maintaining its schema and data. During
+this operation the table will be closed, and all operations upon the table will
+fail until the rename operation is completed.
+
+``REROUTE``
+-----------
+
+The ``REROUTE`` command provides an option to manually control the
+allocation of shards. It allows to move shards between nodes in a cluster.
+
+::
+
+    [ REROUTE reroute_option]
+
+
+where ``reroute_option`` is::
+
+    { MOVE SHARD shard_id FROM node_id TO node_id }
+
+:shard_id:  The shard id. Ranges from 0 up to the specified number of
+            :ref:`sys-shards`  shards of a table.
+
+:node_id:   The node ID within the cluster. See :ref:`sys-nodes` how to gain the
+            unique ID.
+
+
+``REROUTE`` suports the following options to start/stop shard allocation:
+
+**MOVE**
+    A started shard gets moved from one node to another. It requests a
+    ``table_ident`` and a ``shard_id`` to identify the shard that receives the
+    new allocation. Specify ``FROM node_id`` for the node to move the shard from
+    and ``TO node_id`` to move the shard to.
+

--- a/sql-parser/src/main/antlr/SqlBase.g4
+++ b/sql-parser/src/main/antlr/SqlBase.g4
@@ -51,6 +51,7 @@ statement
         (SET '(' genericProperties ')' | RESET ('(' ident (',' ident)* ')')?)        #alterBlobTableProperties
     | ALTER TABLE alterTableDefinition (OPEN | CLOSE)                                #alterTableOpenClose
     | ALTER TABLE alterTableDefinition RENAME TO qname                               #alterTableRename
+    | ALTER TABLE alterTableDefinition REROUTE rerouteOption                         #alterTableReroute
     | RESET GLOBAL primaryExpression (',' primaryExpression)*                        #resetGlobal
     | SET SESSION CHARACTERISTICS AS TRANSACTION setExpr (setExpr)*                  #setSessionTransactionMode
     | SET (SESSION | LOCAL)? qname
@@ -473,6 +474,10 @@ addGeneratedColumnDefinition
     | subscriptSafe (dataType GENERATED ALWAYS)? AS generatedExpr=expr columnConstraint*
     ;
 
+rerouteOption
+    : MOVE SHARD shardId=parameterOrInteger FROM fromNodeId=parameterOrString TO toNodeId=parameterOrString #rerouteMoveShard
+    ;
+
 dataType
     : STRING_TYPE
     | BOOLEAN
@@ -597,6 +602,7 @@ nonReserved
     | REPOSITORY | SNAPSHOT | RESTORE | GENERATED | ALWAYS | BEGIN
     | ISOLATION | TRANSACTION | CHARACTERISTICS | LEVEL | LANGUAGE | OPEN | CLOSE | RENAME
     | PRIVILEGES | SCHEMA | INGEST | RULE
+    | REROUTE | MOVE | SHARD
     ;
 
 SELECT: 'SELECT';
@@ -692,6 +698,10 @@ OPEN: 'OPEN';
 CLOSE: 'CLOSE';
 
 RENAME: 'RENAME';
+
+REROUTE: 'REROUTE';
+MOVE: 'MOVE';
+SHARD: 'SHARD';
 
 BOOLEAN: 'BOOLEAN';
 BYTE: 'BYTE';

--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -36,6 +36,7 @@ import io.crate.sql.tree.AlterTable;
 import io.crate.sql.tree.AlterTableAddColumn;
 import io.crate.sql.tree.AlterTableOpenClose;
 import io.crate.sql.tree.AlterTableRename;
+import io.crate.sql.tree.AlterTableReroute;
 import io.crate.sql.tree.AnalyzerElement;
 import io.crate.sql.tree.ArithmeticExpression;
 import io.crate.sql.tree.ArrayComparisonExpression;
@@ -127,6 +128,8 @@ import io.crate.sql.tree.QueryBody;
 import io.crate.sql.tree.QuerySpecification;
 import io.crate.sql.tree.RefreshStatement;
 import io.crate.sql.tree.Relation;
+import io.crate.sql.tree.RerouteMoveShard;
+import io.crate.sql.tree.RerouteOption;
 import io.crate.sql.tree.ResetStatement;
 import io.crate.sql.tree.RestoreSnapshot;
 import io.crate.sql.tree.RevokePrivilege;
@@ -641,6 +644,14 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
         return new FunctionArgument(getIdentTextIfPresent(context.ident()), (ColumnType) visit(context.dataType()));
     }
 
+    @Override
+    public Node visitRerouteMoveShard(SqlBaseParser.RerouteMoveShardContext context) {
+        return new RerouteMoveShard(
+            (Expression) visit(context.shardId),
+            (Expression) visit(context.fromNodeId),
+            (Expression) visit(context.toNodeId));
+    }
+
     // Properties
 
     @Override
@@ -722,6 +733,13 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
             (Table) visit(context.alterTableDefinition()),
             getQualifiedName(context.qname())
         );
+    }
+
+    @Override
+    public Node visitAlterTableReroute(SqlBaseParser.AlterTableRerouteContext context) {
+        return new AlterTableReroute(
+            (Table) visit(context.alterTableDefinition()),
+            (RerouteOption) visit(context.rerouteOption()));
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/AlterTableReroute.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AlterTableReroute.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.sql.tree;
+
+import com.google.common.base.MoreObjects;
+
+public class AlterTableReroute extends Statement {
+
+    private final Table table;
+    private final RerouteOption rerouteOption;
+
+    public AlterTableReroute(Table table, RerouteOption rerouteOption) {
+        this.table = table;
+        this.rerouteOption = rerouteOption;
+    }
+
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitAlterTableReroute(this, context);
+    }
+
+    public Table table() {
+        return table;
+    }
+
+    public RerouteOption rerouteOption() {
+        return rerouteOption;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+            .add("table", table)
+            .add("reroute option", rerouteOption).toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        AlterTableReroute that = (AlterTableReroute) o;
+
+        if (!rerouteOption.equals(that.rerouteOption)) return false;
+        if (!table.equals(that.table)) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = table.hashCode();
+        result = 31 * result + rerouteOption.hashCode();
+        return result;
+    }
+}

--- a/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
@@ -433,6 +433,10 @@ public abstract class AstVisitor<R, C> {
         return visitStatement(node, context);
     }
 
+    public R visitAlterTableReroute(AlterTableReroute node, C context) {
+        return visitStatement(node, context);
+    }
+
     public R visitAlterBlobTable(AlterBlobTable node, C context) {
         return visitStatement(node, context);
     }
@@ -471,6 +475,10 @@ public abstract class AstVisitor<R, C> {
 
     public R visitAlterTableAddColumnStatement(AlterTableAddColumn node, C context) {
         return visitStatement(node, context);
+    }
+
+    public R visitRerouteMoveShard(RerouteMoveShard node, C context) {
+        return visitNode(node, context);
     }
 
     public R visitAddColumnDefinition(AddColumnDefinition node, C context) {

--- a/sql-parser/src/main/java/io/crate/sql/tree/RerouteMoveShard.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/RerouteMoveShard.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.sql.tree;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+
+public class RerouteMoveShard extends RerouteOption {
+
+    private final Expression shardId;
+    private final Expression fromNodeId;
+    private final Expression toNodeId;
+
+    public RerouteMoveShard(Expression shardId, Expression fromNodeId, Expression toNodeId) {
+        this.shardId = shardId;
+        this.fromNodeId = fromNodeId;
+        this.toNodeId = toNodeId;
+    }
+
+    public Expression shardId() {
+        return shardId;
+    }
+
+    public Expression fromNodeId() {
+        return fromNodeId;
+    }
+
+    public Expression toNodeId() {
+        return toNodeId;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(shardId, fromNodeId, toNodeId);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+
+        RerouteMoveShard that = (RerouteMoveShard) obj;
+
+        if (!shardId.equals(that.shardId)) return false;
+        if (!fromNodeId.equals(that.fromNodeId)) return false;
+        if (!toNodeId.equals(that.toNodeId)) return false;
+
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+            .add("shardId", shardId)
+            .add("fromNodeId", fromNodeId)
+            .add("toNodeId", toNodeId).toString();
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitRerouteMoveShard(this, context);
+    }
+}

--- a/sql-parser/src/main/java/io/crate/sql/tree/RerouteOption.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/RerouteOption.java
@@ -6,7 +6,7 @@
  * you may not use this file except in compliance with the License.  You may
  * obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
@@ -19,22 +19,7 @@
  * software solely pursuant to the terms of the relevant commercial agreement.
  */
 
-package io.crate.metadata.table;
+package io.crate.sql.tree;
 
-import io.crate.metadata.ColumnIdent;
-import org.apache.lucene.util.BytesRef;
-
-public interface ShardedTable {
-
-    int numberOfShards();
-
-    BytesRef numberOfReplicas();
-
-    ColumnIdent clusteredBy();
-
-    String routingHashFunction();
-
-    boolean isClosed();
-
-    String[] concreteIndices();
+public abstract class RerouteOption extends Node {
 }

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -1118,6 +1118,12 @@ public class TestStatementBuilder {
     }
 
     @Test
+    public void testAlterTableReroute() throws Exception {
+        printStatement("alter table t reroute move shard 1 from 'node1' to 'node2'");
+        printStatement("alter table t partition (parted_col = ?) reroute move shard ? from ? to ?");
+    }
+
+    @Test
     public void testSubSelects() throws Exception {
         printStatement("select * from (select * from foo) as f");
         printStatement("select * from (select * from (select * from foo) as f1) as f2");

--- a/sql/src/main/java/io/crate/action/sql/DDLStatementDispatcher.java
+++ b/sql/src/main/java/io/crate/action/sql/DDLStatementDispatcher.java
@@ -43,6 +43,7 @@ import io.crate.analyze.DropUserAnalyzedStatement;
 import io.crate.analyze.OptimizeSettings;
 import io.crate.analyze.OptimizeTableAnalyzedStatement;
 import io.crate.analyze.RefreshTableAnalyzedStatement;
+import io.crate.analyze.RerouteMoveShardAnalyzedStatement;
 import io.crate.analyze.RestoreSnapshotAnalyzedStatement;
 import io.crate.blob.v2.BlobAdminClient;
 import io.crate.data.Row;
@@ -243,6 +244,11 @@ public class DDLStatementDispatcher implements BiFunction<AnalyzedStatement, Row
         @Override
         protected CompletableFuture<Long> visitDropUserStatement(DropUserAnalyzedStatement analysis, Row parameters) {
             return userManager.dropUser(analysis.userName(), analysis.ifExists());
+        }
+
+        @Override
+        protected CompletableFuture<Long> visitRerouteMoveShard(RerouteMoveShardAnalyzedStatement analysis, Row parameters) {
+            return alterTableOperation.executeRerouteMoveShard(analysis, parameters);
         }
     }
 

--- a/sql/src/main/java/io/crate/analyze/AlterTableAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/AlterTableAnalyzer.java
@@ -38,7 +38,7 @@ import org.elasticsearch.common.settings.Settings;
 import javax.annotation.Nullable;
 import java.util.List;
 
-class AlterTableAnalyzer {
+public class AlterTableAnalyzer {
 
     private final Schemas schemas;
 

--- a/sql/src/main/java/io/crate/analyze/AlterTableRerouteAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/AlterTableRerouteAnalyzer.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.analyze;
+
+import io.crate.metadata.Schemas;
+import io.crate.metadata.TableIdent;
+import io.crate.metadata.table.Operation;
+import io.crate.metadata.table.ShardedTable;
+import io.crate.sql.tree.AlterTableReroute;
+import io.crate.sql.tree.Assignment;
+import io.crate.sql.tree.AstVisitor;
+import io.crate.sql.tree.RerouteMoveShard;
+
+import java.util.List;
+
+public class AlterTableRerouteAnalyzer {
+
+    private static final RerouteOptionVisitor REROUTE_OPTION_VISITOR = new RerouteOptionVisitor();
+    private final Schemas schemas;
+
+    AlterTableRerouteAnalyzer(Schemas schemas) {
+        this.schemas = schemas;
+    }
+
+    public AnalyzedStatement analyze(AlterTableReroute node, Analysis context) {
+        // safe to expect a `ShardedTable` since REROUTE operation is not allowed on SYS tables at all.
+        ShardedTable tableInfo = schemas.getTableInfo(
+            TableIdent.of(node.table(), context.sessionContext().defaultSchema()),
+            Operation.ALTER_REROUTE);
+        return REROUTE_OPTION_VISITOR.process(node.rerouteOption(), new Context(tableInfo, node.table().partitionProperties()));
+    }
+
+    private class Context {
+
+        final ShardedTable tableInfo;
+        final List<Assignment> partitionProperties;
+
+        private Context(ShardedTable tableInfo, List<Assignment> partitionProperties) {
+            this.tableInfo = tableInfo;
+            this.partitionProperties = partitionProperties;
+        }
+    }
+
+    private static class RerouteOptionVisitor extends AstVisitor<RerouteAnalyzedStatement, Context> {
+
+        @Override
+        public RerouteAnalyzedStatement visitRerouteMoveShard(RerouteMoveShard node, Context context) {
+            return new RerouteMoveShardAnalyzedStatement(
+                context.tableInfo, context.partitionProperties, node.shardId(),node.fromNodeId(), node.toNodeId());
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/analyze/AnalyzedStatementVisitor.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedStatementVisitor.java
@@ -188,4 +188,8 @@ public class AnalyzedStatementVisitor<C, R> {
     public R visitDropIngestRuleStatement(DropIngestionRuleAnalysedStatement analysis, C context) {
         return visitDCLStatement(analysis, context);
     }
+
+    protected R visitRerouteMoveShard(RerouteMoveShardAnalyzedStatement analysis, C context) {
+        return visitDDLStatement(analysis, context);
+    }
 }

--- a/sql/src/main/java/io/crate/analyze/Analyzer.java
+++ b/sql/src/main/java/io/crate/analyze/Analyzer.java
@@ -35,6 +35,7 @@ import io.crate.sql.tree.AlterTable;
 import io.crate.sql.tree.AlterTableAddColumn;
 import io.crate.sql.tree.AlterTableOpenClose;
 import io.crate.sql.tree.AlterTableRename;
+import io.crate.sql.tree.AlterTableReroute;
 import io.crate.sql.tree.AstVisitor;
 import io.crate.sql.tree.BeginStatement;
 import io.crate.sql.tree.CopyFrom;
@@ -118,6 +119,7 @@ public class Analyzer {
     private final DropFunctionAnalyzer dropFunctionAnalyzer;
     private final PrivilegesAnalyzer privilegesAnalyzer;
     private final CreateIngestionRuleAnalyzer createIngestionRuleAnalyzer;
+    private final AlterTableRerouteAnalyzer alterTableRerouteAnalyzer;
 
     @Inject
     public Analyzer(Schemas schemas,
@@ -150,6 +152,7 @@ public class Analyzer {
         this.alterBlobTableAnalyzer = new AlterBlobTableAnalyzer(schemas);
         this.alterTableAddColumnAnalyzer = new AlterTableAddColumnAnalyzer(schemas, fulltextAnalyzerResolver, functions);
         this.alterTableOpenCloseAnalyzer = new AlterTableOpenCloseAnalyzer(schemas);
+        this.alterTableRerouteAnalyzer = new AlterTableRerouteAnalyzer(schemas);
         this.insertFromValuesAnalyzer = new InsertFromValuesAnalyzer(functions, schemas);
         this.insertFromSubQueryAnalyzer = new InsertFromSubQueryAnalyzer(functions, schemas, relationAnalyzer);
         this.copyAnalyzer = new CopyAnalyzer(schemas, functions);
@@ -307,6 +310,11 @@ public class Analyzer {
         @Override
         public AnalyzedStatement visitAlterTableOpenClose(AlterTableOpenClose node, Analysis context) {
             return alterTableOpenCloseAnalyzer.analyze(node, context.sessionContext());
+        }
+
+        @Override
+        public AnalyzedStatement visitAlterTableReroute(AlterTableReroute node, Analysis context) {
+            return alterTableRerouteAnalyzer.analyze(node, context);
         }
 
         @Override

--- a/sql/src/main/java/io/crate/analyze/OptimizeTableAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/OptimizeTableAnalyzer.java
@@ -84,7 +84,7 @@ class OptimizeTableAnalyzer {
         for (Table nodeTable : tables) {
             TableInfo tableInfo = schemas.getTableInfo(TableIdent.of(nodeTable, defaultSchema), Operation.OPTIMIZE);
             if (tableInfo instanceof BlobTableInfo) {
-                indexNames.add(((BlobTableInfo) tableInfo).concreteIndex());
+                indexNames.add(((BlobTableInfo) tableInfo).concreteIndices()[0]);
             } else {
                 indexNames.addAll(TableAnalyzer.filteredIndices(
                     parameterContext,

--- a/sql/src/main/java/io/crate/analyze/RerouteAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/RerouteAnalyzedStatement.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.analyze;
+
+import io.crate.metadata.table.ShardedTable;
+import io.crate.sql.tree.Assignment;
+
+import java.util.List;
+
+public abstract class RerouteAnalyzedStatement implements DDLStatement {
+
+
+    private final ShardedTable tableInfo;
+    private final List<Assignment> partitionProperties;
+
+    public RerouteAnalyzedStatement(ShardedTable tableInfo, List<Assignment> partitionProperties) {
+        this.tableInfo = tableInfo;
+        this.partitionProperties = partitionProperties;
+    }
+
+    public ShardedTable tableInfo() {
+        return tableInfo;
+    }
+
+    public List<Assignment> partitionProperties() {
+        return partitionProperties;
+    }
+}

--- a/sql/src/main/java/io/crate/analyze/RerouteMoveShardAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/RerouteMoveShardAnalyzedStatement.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.analyze;
+
+import io.crate.metadata.table.ShardedTable;
+import io.crate.sql.tree.Assignment;
+import io.crate.sql.tree.Expression;
+
+import java.util.List;
+
+public class RerouteMoveShardAnalyzedStatement extends RerouteAnalyzedStatement {
+
+    private final Expression shardId;
+    private final Expression fromNodeId;
+    private final Expression toNodeId;
+
+    public RerouteMoveShardAnalyzedStatement(ShardedTable tableInfo,
+                                             List<Assignment> partitionPropeties,
+                                             Expression shardId,
+                                             Expression fromNodeId,
+                                             Expression toNodeId) {
+        super(tableInfo, partitionPropeties);
+        this.shardId = shardId;
+        this.fromNodeId = fromNodeId;
+        this.toNodeId = toNodeId;
+    }
+
+    @Override
+    public <C, R> R accept(AnalyzedStatementVisitor<C, R> visitor, C context) {
+        return visitor.visitRerouteMoveShard(this, context);
+    }
+
+    public Expression shardId() {
+        return shardId;
+    }
+
+    public Expression fromNodeId() {
+        return fromNodeId;
+    }
+
+    public Expression toNodeId() {
+        return toNodeId;
+    }
+}

--- a/sql/src/main/java/io/crate/metadata/blob/BlobTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/blob/BlobTableInfo.java
@@ -185,10 +185,6 @@ public class BlobTableInfo implements TableInfo, ShardedTable, StoredTable {
         return Operation.BLOB_OPERATIONS;
     }
 
-    public String concreteIndex() {
-        return index;
-    }
-
     @Override
     public String routingHashFunction() {
         return routingHashFunction;
@@ -197,6 +193,11 @@ public class BlobTableInfo implements TableInfo, ShardedTable, StoredTable {
     @Override
     public boolean isClosed() {
         return closed;
+    }
+
+    @Override
+    public String[] concreteIndices() {
+        return new String[] { index };
     }
 
     @Nullable

--- a/sql/src/main/java/io/crate/metadata/table/Operation.java
+++ b/sql/src/main/java/io/crate/metadata/table/Operation.java
@@ -41,24 +41,25 @@ public enum Operation {
     ALTER("ALTER"),
     ALTER_BLOCKS("ALTER"),
     ALTER_OPEN_CLOSE("ALTER OPEN/CLOSE"),
+    ALTER_REROUTE("ALTER REROUTE"),
     REFRESH("REFRESH"),
     SHOW_CREATE("SHOW CREATE"),
     OPTIMIZE("OPTIMIZE"),
     COPY_TO("COPY TO"),
     RESTORE_SNAPSHOT("RESTORE SNAPSHOT"),
-    CREATE_SNAPSHOT("CREATE SNAPSHOT");
+    CREATE_SNAPSHOT("CREATE SNAPSHOT"),;
 
     public static final EnumSet<Operation> ALL = EnumSet.allOf(Operation.class);
     public static final EnumSet<Operation> SYS_READ_ONLY = EnumSet.of(READ);
     public static final EnumSet<Operation> READ_ONLY = EnumSet.of(READ, ALTER_BLOCKS);
     public static final EnumSet<Operation> OPEN_CLOSE_ONLY = EnumSet.of(ALTER_OPEN_CLOSE);
-    public static final EnumSet<Operation> BLOB_OPERATIONS = EnumSet.of(READ, OPTIMIZE);
+    public static final EnumSet<Operation> BLOB_OPERATIONS = EnumSet.of(READ, OPTIMIZE, ALTER_REROUTE);
     public static final EnumSet<Operation> READ_DISABLED_OPERATIONS = EnumSet.of(UPDATE, INSERT, DELETE, DROP, ALTER,
-        ALTER_OPEN_CLOSE, ALTER_BLOCKS, REFRESH, OPTIMIZE);
+        ALTER_OPEN_CLOSE, ALTER_REROUTE, ALTER_BLOCKS, REFRESH, OPTIMIZE);
     public static final EnumSet<Operation> WRITE_DISABLED_OPERATIONS = EnumSet.of(READ, ALTER, ALTER_OPEN_CLOSE,
-        ALTER_BLOCKS, SHOW_CREATE, REFRESH, OPTIMIZE, COPY_TO, CREATE_SNAPSHOT);
+        ALTER_BLOCKS, ALTER_REROUTE, SHOW_CREATE, REFRESH, OPTIMIZE, COPY_TO, CREATE_SNAPSHOT);
     public static final EnumSet<Operation> METADATA_DISABLED_OPERATIONS = EnumSet.of(READ, UPDATE, INSERT, DELETE,
-        ALTER_BLOCKS, ALTER_OPEN_CLOSE, REFRESH, SHOW_CREATE, OPTIMIZE);
+        ALTER_BLOCKS, ALTER_OPEN_CLOSE, ALTER_REROUTE, REFRESH, SHOW_CREATE, OPTIMIZE);
 
     private final String representation;
 

--- a/sql/src/test/java/io/crate/analyze/AlterTableRerouteAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/AlterTableRerouteAnalyzerTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.analyze;
+
+import io.crate.metadata.TableIdent;
+import io.crate.metadata.blob.BlobSchemaInfo;
+import io.crate.sql.tree.Literal;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.hamcrest.Matchers.is;
+
+public class AlterTableRerouteAnalyzerTest extends CrateDummyClusterServiceUnitTest {
+
+    private SQLExecutor e;
+
+    @Before
+    public void prepare() {
+        TableIdent myBlobsIdent = new TableIdent(BlobSchemaInfo.NAME, "blobs");
+        TestingBlobTableInfo myBlobsTableInfo = TableDefinitions.createBlobTable(myBlobsIdent);
+        e = SQLExecutor.builder(clusterService).addBlobTable(myBlobsTableInfo).enableDefaultTables().build();
+    }
+
+    @Test
+    public void testRerouteOnSystemTableIsNotAllowed() throws Exception {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("The relation \"sys.cluster\" doesn't support or allow ALTER REROUTE operations, as it is read-only.");
+        e.analyze("ALTER TABLE sys.cluster REROUTE MOVE SHARD 0 FROM 'node1' TO 'node2'");
+    }
+
+    @Test
+    public void testRerouteMoveShard() throws Exception {
+        RerouteMoveShardAnalyzedStatement analyzed = e.analyze("ALTER TABLE users REROUTE MOVE SHARD 0 FROM 'nodeOne' TO 'nodeTwo'");
+        assertThat(analyzed.tableInfo().concreteIndices().length, is(1));
+        assertThat(analyzed.tableInfo().concreteIndices()[0], is("users"));
+        assertThat(analyzed.shardId(), is(Literal.fromObject(0)));
+        assertThat(analyzed.fromNodeId(), is(Literal.fromObject("nodeOne")));
+        assertThat(analyzed.toNodeId(), is(Literal.fromObject("nodeTwo")));
+        assertThat(analyzed.isWriteOperation(), is(true));
+    }
+
+    @Test
+    public void testRerouteMoveShardPartitionedTable() throws Exception {
+        RerouteMoveShardAnalyzedStatement analyzed = e.analyze("ALTER TABLE parted PARTITION (date = 1395874800000) REROUTE MOVE SHARD 0 FROM 'nodeOne' TO 'nodeTwo'");
+        assertTrue(Arrays.asList(analyzed.tableInfo().concreteIndices()).contains(".partitioned.parted.04732cpp6ks3ed1o60o30c1g"));
+        assertFalse(analyzed.partitionProperties().isEmpty());
+    }
+
+    @Test
+    public void testRerouteOnBlobTable() throws Exception {
+        RerouteMoveShardAnalyzedStatement analyzed = e.analyze("ALTER TABLE blob.blobs REROUTE MOVE SHARD 0 FROM 'nodeOne' TO 'nodeTwo'");
+        assertThat(analyzed.tableInfo().concreteIndices().length, is(1));
+        assertThat(analyzed.tableInfo().concreteIndices()[0], is("blob.blobs"));
+        assertThat(analyzed.isWriteOperation(), is(true));
+    }
+}

--- a/sql/src/test/java/io/crate/executor/transport/AlterTableOperationTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/AlterTableOperationTest.java
@@ -23,16 +23,33 @@
 package io.crate.executor.transport;
 
 import io.crate.Constants;
+import io.crate.analyze.RerouteMoveShardAnalyzedStatement;
+import io.crate.analyze.TableDefinitions;
+import io.crate.data.Row;
+import io.crate.metadata.TableIdent;
+import io.crate.metadata.blob.BlobSchemaInfo;
+import io.crate.metadata.blob.BlobTableInfo;
+import io.crate.sql.parser.SqlParser;
+import io.crate.sql.tree.Assignment;
+import io.crate.sql.tree.QualifiedName;
+import io.crate.sql.tree.QualifiedNameReference;
+import io.crate.sql.tree.StringLiteral;
 import io.crate.test.integration.CrateUnitTest;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.junit.Test;
 
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.is;
 
 public class AlterTableOperationTest extends CrateUnitTest {
+
+    public static final BlobTableInfo BLOB_TABLE_INFO = TableDefinitions.createBlobTable(
+        new TableIdent(BlobSchemaInfo.NAME, "screenshots"));
 
     @Test
     public void testPrepareAlterTableMappingRequest() throws Exception {
@@ -53,5 +70,78 @@ public class AlterTableOperationTest extends CrateUnitTest {
 
         assertThat(request.type(), is(Constants.DEFAULT_MAPPING_TYPE));
         assertThat(request.source(), is("{\"_meta\":{\"meta2\":\"v2\",\"meta1\":\"v1\"},\"properties\":{\"foo\":\"bar\"}}"));
+    }
+
+    @Test
+    public void testRerouteIndexOfBlobTable() throws Exception {
+        RerouteMoveShardAnalyzedStatement statement = new RerouteMoveShardAnalyzedStatement(
+            BLOB_TABLE_INFO,
+            Collections.emptyList(),
+            SqlParser.createExpression("0"),
+            SqlParser.createExpression("node1"),
+            SqlParser.createExpression("node2")
+        );
+        String index = AlterTableOperation.getRerouteIndex(statement, Row.EMPTY);
+        assertThat(index, is("blob.screenshots"));
+    }
+
+    @Test
+    public void testRerouteIndexOfPartedDocTable() throws Exception {
+        RerouteMoveShardAnalyzedStatement statement = new RerouteMoveShardAnalyzedStatement(
+            TableDefinitions.TEST_PARTITIONED_TABLE_INFO,
+            Arrays.asList(new Assignment(
+                new QualifiedNameReference(new QualifiedName("date")), new StringLiteral("1395874800000"))),
+            SqlParser.createExpression("0"),
+            SqlParser.createExpression("node1"),
+            SqlParser.createExpression("node2")
+        );
+        String index = AlterTableOperation.getRerouteIndex(statement, Row.EMPTY);
+        assertThat(index, is(".partitioned.parted.04732cpp6ks3ed1o60o30c1g"));
+    }
+
+    @Test
+    public void testRerouteIndexOfPartedDocTableWithoutPartitionClause() throws Exception {
+        expectedException.expect(SQLException.class);
+        expectedException.expectMessage("table is partitioned however no partition clause has been specified");
+        RerouteMoveShardAnalyzedStatement statement = new RerouteMoveShardAnalyzedStatement(
+            TableDefinitions.TEST_PARTITIONED_TABLE_INFO,
+            Collections.emptyList(),
+            SqlParser.createExpression("0"),
+            SqlParser.createExpression("node1"),
+            SqlParser.createExpression("node2")
+        );
+        AlterTableOperation.getRerouteIndex(statement, Row.EMPTY);
+    }
+
+    @Test
+    public void testRerouteMoveShardPartitionedTableUnknownPartition() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Referenced partition \".partitioned.parted.04132\" does not exist.");
+        RerouteMoveShardAnalyzedStatement statement = new RerouteMoveShardAnalyzedStatement(
+            TableDefinitions.TEST_PARTITIONED_TABLE_INFO,
+            Arrays.asList(new Assignment(
+                new QualifiedNameReference(new QualifiedName("date")), new StringLiteral("1"))),
+            SqlParser.createExpression("0"),
+            SqlParser.createExpression("node1"),
+            SqlParser.createExpression("node2")
+        );
+
+        AlterTableOperation.getRerouteIndex(statement, Row.EMPTY);
+    }
+
+    @Test
+    public void testRerouteMoveShardUnpartitionedTableWithPartitionClause() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("table 'doc.users' is not partitioned");
+        RerouteMoveShardAnalyzedStatement statement = new RerouteMoveShardAnalyzedStatement(
+            TableDefinitions.USER_TABLE_INFO,
+            Arrays.asList(new Assignment(
+                new QualifiedNameReference(new QualifiedName("date")), new StringLiteral("1"))),
+            SqlParser.createExpression("0"),
+            SqlParser.createExpression("node1"),
+            SqlParser.createExpression("node2")
+        );
+
+        AlterTableOperation.getRerouteIndex(statement, Row.EMPTY);
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/AlterTableRerouteIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/AlterTableRerouteIntegrationTest.java
@@ -1,0 +1,39 @@
+package io.crate.integrationtests;
+
+import io.crate.testing.UseJdbc;
+import io.crate.testing.UseRandomizedSession;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+
+// ensure that only data nodes are picked for rerouting
+@ESIntegTestCase.ClusterScope(supportsDedicatedMasters = false, numDataNodes = 2, numClientNodes = 0)
+@UseRandomizedSession(schema = false)
+@UseJdbc(0) // reroute table has no rowcount
+public class AlterTableRerouteIntegrationTest extends SQLTransportIntegrationTest {
+
+    @Test
+    public void testAlterTableRerouteMoveShard() throws Exception {
+        int shardId = 0;
+        String tableName = "my_table";
+        execute("create table " + tableName + " (" +
+            "id int primary key," +
+            "date timestamp" +
+            ") clustered into 1 shards " +
+            "with (number_of_replicas=0)");
+        ensureGreen();
+        execute("select _node['id'] from sys.shards where id = ? and table_name = ?", new Object[]{shardId, tableName});
+        String fromNode = (String) response.rows()[0][0];
+        execute("select id from sys.nodes where id != ?", new Object[]{fromNode});
+        String toNode = (String) response.rows()[0][0];
+
+        execute("ALTER TABLE my_table REROUTE MOVE SHARD ? FROM ? TO ?", new Object[]{shardId, fromNode, toNode});
+        assertThat(response.rowCount(), is(1L));
+        ensureGreen();
+        execute("select * from sys.shards where id = ? and _node['id'] = ? and table_name = ?", new Object[]{shardId, toNode, tableName});
+        assertBusy(() -> assertThat(response.rowCount(), is(1L)));
+        execute("select * from sys.shards where id = ? and _node['id'] = ? and table_name = ?", new Object[]{shardId, fromNode, tableName});
+        assertBusy(() -> assertThat(response.rowCount(), is(0L)));
+    }
+}

--- a/sql/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -44,6 +44,7 @@ import org.skyscreamer.jsonassert.JSONCompareMode;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.containsString;

--- a/sql/src/test/java/io/crate/metadata/table/OperationTest.java
+++ b/sql/src/test/java/io/crate/metadata/table/OperationTest.java
@@ -46,18 +46,18 @@ public class OperationTest extends CrateUnitTest {
         assertThat(Operation.buildFromIndexSettingsAndState(Settings.builder()
                 .put(IndexMetaData.SETTING_BLOCKS_READ, true).build(), IndexMetaData.State.OPEN),
             containsInAnyOrder(Operation.UPDATE, Operation.INSERT, Operation.DELETE, Operation.DROP, Operation.ALTER,
-                Operation.ALTER_OPEN_CLOSE, Operation.ALTER_BLOCKS, Operation.REFRESH, Operation.OPTIMIZE));
+                Operation.ALTER_OPEN_CLOSE, Operation.ALTER_BLOCKS, Operation.REFRESH, Operation.OPTIMIZE, Operation.ALTER_REROUTE));
 
         assertThat(Operation.buildFromIndexSettingsAndState(Settings.builder()
                 .put(IndexMetaData.SETTING_BLOCKS_WRITE, true).build(), IndexMetaData.State.OPEN),
             containsInAnyOrder(Operation.READ, Operation.ALTER, Operation.ALTER_OPEN_CLOSE, Operation.ALTER_BLOCKS,
                 Operation.SHOW_CREATE, Operation.REFRESH, Operation.OPTIMIZE, Operation.COPY_TO,
-                Operation.CREATE_SNAPSHOT));
+                Operation.CREATE_SNAPSHOT, Operation.ALTER_REROUTE));
 
         assertThat(Operation.buildFromIndexSettingsAndState(Settings.builder()
                 .put(IndexMetaData.SETTING_BLOCKS_METADATA, true).build(), IndexMetaData.State.OPEN),
             containsInAnyOrder(Operation.READ, Operation.UPDATE, Operation.INSERT, Operation.DELETE, Operation.ALTER_BLOCKS,
-                Operation.ALTER_OPEN_CLOSE, Operation.REFRESH, Operation.SHOW_CREATE, Operation.OPTIMIZE));
+                Operation.ALTER_OPEN_CLOSE, Operation.REFRESH, Operation.SHOW_CREATE, Operation.OPTIMIZE, Operation.ALTER_REROUTE));
     }
 
     @Test
@@ -66,18 +66,18 @@ public class OperationTest extends CrateUnitTest {
                 .put(IndexMetaData.SETTING_BLOCKS_READ, true)
                 .put(IndexMetaData.SETTING_BLOCKS_WRITE, true).build(), IndexMetaData.State.OPEN),
             containsInAnyOrder(Operation.ALTER, Operation.ALTER_OPEN_CLOSE, Operation.ALTER_BLOCKS, Operation.REFRESH,
-                Operation.OPTIMIZE));
+                Operation.OPTIMIZE, Operation.ALTER_REROUTE));
 
         assertThat(Operation.buildFromIndexSettingsAndState(Settings.builder()
                 .put(IndexMetaData.SETTING_BLOCKS_WRITE, true)
                 .put(IndexMetaData.SETTING_BLOCKS_METADATA, true).build(), IndexMetaData.State.OPEN),
             containsInAnyOrder(Operation.READ, Operation.ALTER_OPEN_CLOSE, Operation.ALTER_BLOCKS, Operation.REFRESH,
-                Operation.SHOW_CREATE, Operation.OPTIMIZE));
+                Operation.SHOW_CREATE, Operation.OPTIMIZE, Operation.ALTER_REROUTE));
 
         assertThat(Operation.buildFromIndexSettingsAndState(Settings.builder()
                 .put(IndexMetaData.SETTING_BLOCKS_READ, true)
                 .put(IndexMetaData.SETTING_BLOCKS_METADATA, true).build(), IndexMetaData.State.OPEN),
             containsInAnyOrder(Operation.INSERT, Operation.UPDATE, Operation.DELETE, Operation.ALTER_OPEN_CLOSE,
-                Operation.ALTER_BLOCKS, Operation.REFRESH, Operation.OPTIMIZE));
+                Operation.ALTER_BLOCKS, Operation.REFRESH, Operation.OPTIMIZE, Operation.ALTER_REROUTE));
     }
 }


### PR DESCRIPTION
The ``REROUTE`` command provides various options to manually control the
allocation of shards. It uses the ES Cluster Reroute API for allocation.

This commit introduces the reroute option ``REROUTE MOVE`` that allows
to move shards from one node to another.