### PR TITLE
Plan group-by to run parallel on shards if on single node

### DIFF
--- a/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -564,7 +564,8 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat("would require merge with more than 1 nodeIds", collect.nodeIds().size(), is(1));
         List<Projection> projections = collect.collectPhase().projections();
         assertThat(projections, contains(
-            instanceOf(GroupProjection.class),
+            instanceOf(GroupProjection.class), // parallel on shard-level
+            instanceOf(GroupProjection.class), // node-level
             instanceOf(FilterProjection.class),
             instanceOf(EvalProjection.class)
         ));


### PR DESCRIPTION
Similar to cc48ea2a28c3f4b4116e283dcfdc62f7fef7702d this fixes a
performance regression introduced by the LogicalPlanner changes.

This changes GROUP BY operations that run on the handler node to run in
two-phases: First parallel on shard level, then a merge of the partial
results on node level.