### PR TITLE
Added REROUTE ALLOCATE REPLICA subcommand to ALTER TABLE

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -25,6 +25,7 @@ Changes
 
 - Added support to manually control the allocation of shards using
   ``ALTER TABLE REROUTE``.
+  Supported reroute-options: MOVE, ALLOCATE REPLICA
 
 - Added new system table ``sys.allocations`` which lists shards and their
   allocation state including the reasoning why they are in a certain state.

--- a/blackbox/docs/sql/reference/alter_table.txt
+++ b/blackbox/docs/sql/reference/alter_table.txt
@@ -141,7 +141,9 @@ allocation of shards. It allows to move shards between nodes in a cluster.
 
 where ``reroute_option`` is::
 
-    { MOVE SHARD shard_id FROM node_id TO node_id }
+    { MOVE SHARD shard_id FROM node_id TO node_id
+      | ALLOCATE REPLICA SHARD shard_id ON node_id
+    }
 
 :shard_id:  The shard id. Ranges from 0 up to the specified number of
             :ref:`sys-shards`  shards of a table.
@@ -158,3 +160,6 @@ where ``reroute_option`` is::
     new allocation. Specify ``FROM node_id`` for the node to move the shard from
     and ``TO node_id`` to move the shard to.
 
+**ALLOCATE REPLICA**
+    Allows to force allocation of an unassigned replica shard on a specific
+    node.

--- a/sql-parser/src/main/antlr/SqlBase.g4
+++ b/sql-parser/src/main/antlr/SqlBase.g4
@@ -476,6 +476,7 @@ addGeneratedColumnDefinition
 
 rerouteOption
     : MOVE SHARD shardId=parameterOrInteger FROM fromNodeId=parameterOrString TO toNodeId=parameterOrString #rerouteMoveShard
+    | ALLOCATE REPLICA SHARD shardId=parameterOrInteger ON nodeId=parameterOrString                         #rerouteAllocateReplicaShard
     ;
 
 dataType
@@ -602,7 +603,7 @@ nonReserved
     | REPOSITORY | SNAPSHOT | RESTORE | GENERATED | ALWAYS | BEGIN
     | ISOLATION | TRANSACTION | CHARACTERISTICS | LEVEL | LANGUAGE | OPEN | CLOSE | RENAME
     | PRIVILEGES | SCHEMA | INGEST | RULE
-    | REROUTE | MOVE | SHARD
+    | REROUTE | MOVE | SHARD | ALLOCATE | REPLICA
     ;
 
 SELECT: 'SELECT';
@@ -702,6 +703,8 @@ RENAME: 'RENAME';
 REROUTE: 'REROUTE';
 MOVE: 'MOVE';
 SHARD: 'SHARD';
+ALLOCATE: 'ALLOCATE';
+REPLICA: 'REPLICA';
 
 BOOLEAN: 'BOOLEAN';
 BYTE: 'BYTE';

--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -128,6 +128,7 @@ import io.crate.sql.tree.QueryBody;
 import io.crate.sql.tree.QuerySpecification;
 import io.crate.sql.tree.RefreshStatement;
 import io.crate.sql.tree.Relation;
+import io.crate.sql.tree.RerouteAllocateReplicaShard;
 import io.crate.sql.tree.RerouteMoveShard;
 import io.crate.sql.tree.RerouteOption;
 import io.crate.sql.tree.ResetStatement;
@@ -650,6 +651,13 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
             (Expression) visit(context.shardId),
             (Expression) visit(context.fromNodeId),
             (Expression) visit(context.toNodeId));
+    }
+
+    @Override
+    public Node visitRerouteAllocateReplicaShard(SqlBaseParser.RerouteAllocateReplicaShardContext context) {
+        return new RerouteAllocateReplicaShard(
+            (Expression) visit(context.shardId),
+            (Expression) visit(context.nodeId));
     }
 
     // Properties

--- a/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
@@ -481,6 +481,10 @@ public abstract class AstVisitor<R, C> {
         return visitNode(node, context);
     }
 
+    public R visitRerouteAllocateReplicaShard(RerouteAllocateReplicaShard node, C context) {
+        return visitNode(node, context);
+    }
+
     public R visitAddColumnDefinition(AddColumnDefinition node, C context) {
         return visitTableElement(node, context);
     }

--- a/sql-parser/src/main/java/io/crate/sql/tree/RerouteAllocateReplicaShard.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/RerouteAllocateReplicaShard.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.sql.tree;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+
+public class RerouteAllocateReplicaShard extends RerouteOption {
+
+    private final Expression nodeId;
+    private final Expression shardId;
+
+    public RerouteAllocateReplicaShard(Expression shardId, Expression nodeId) {
+        this.shardId = shardId;
+        this.nodeId = nodeId;
+    }
+
+    public Expression nodeId() {
+        return nodeId;
+    }
+
+    public Expression shardId() {
+        return shardId;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(shardId, nodeId);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+
+        RerouteAllocateReplicaShard that = (RerouteAllocateReplicaShard) obj;
+
+        if (!shardId.equals(that.shardId)) return false;
+        if (!nodeId.equals(that.nodeId)) return false;
+
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+            .add("shardId", shardId)
+            .add("nodeId", nodeId).toString();
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitRerouteAllocateReplicaShard(this, context);
+    }
+}

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -1121,6 +1121,7 @@ public class TestStatementBuilder {
     public void testAlterTableReroute() throws Exception {
         printStatement("alter table t reroute move shard 1 from 'node1' to 'node2'");
         printStatement("alter table t partition (parted_col = ?) reroute move shard ? from ? to ?");
+        printStatement("alter table t reroute allocate replica shard 1 on 'node1'");
     }
 
     @Test

--- a/sql/src/main/java/io/crate/analyze/AlterTableRerouteAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/AlterTableRerouteAnalyzer.java
@@ -29,6 +29,7 @@ import io.crate.metadata.table.ShardedTable;
 import io.crate.sql.tree.AlterTableReroute;
 import io.crate.sql.tree.Assignment;
 import io.crate.sql.tree.AstVisitor;
+import io.crate.sql.tree.RerouteAllocateReplicaShard;
 import io.crate.sql.tree.RerouteMoveShard;
 
 import java.util.List;
@@ -67,6 +68,12 @@ public class AlterTableRerouteAnalyzer {
         public RerouteAnalyzedStatement visitRerouteMoveShard(RerouteMoveShard node, Context context) {
             return new RerouteMoveShardAnalyzedStatement(
                 context.tableInfo, context.partitionProperties, node.shardId(),node.fromNodeId(), node.toNodeId());
+        }
+
+        @Override
+        public RerouteAnalyzedStatement visitRerouteAllocateReplicaShard(RerouteAllocateReplicaShard node, Context context) {
+            return new RerouteAllocateReplicaShardAnalyzedStatement(
+                context.tableInfo, context.partitionProperties, node.shardId(), node.nodeId());
         }
     }
 }

--- a/sql/src/main/java/io/crate/analyze/AnalyzedStatementVisitor.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedStatementVisitor.java
@@ -192,4 +192,8 @@ public class AnalyzedStatementVisitor<C, R> {
     protected R visitRerouteMoveShard(RerouteMoveShardAnalyzedStatement analysis, C context) {
         return visitDDLStatement(analysis, context);
     }
+
+    protected R visitRerouteAllocateReplicaShard(RerouteAllocateReplicaShardAnalyzedStatement analysis, C context) {
+        return visitDDLStatement(analysis, context);
+    }
 }

--- a/sql/src/main/java/io/crate/analyze/RerouteAllocateReplicaShardAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/RerouteAllocateReplicaShardAnalyzedStatement.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.analyze;
+
+import io.crate.metadata.table.ShardedTable;
+import io.crate.sql.tree.Assignment;
+import io.crate.sql.tree.Expression;
+
+import java.util.List;
+
+public class RerouteAllocateReplicaShardAnalyzedStatement extends RerouteAnalyzedStatement {
+
+    private final Expression shardId;
+    private final Expression nodeId;
+
+    public RerouteAllocateReplicaShardAnalyzedStatement(ShardedTable tableInfo,
+                                                        List<Assignment> partitionProperties,
+                                                        Expression shardId,
+                                                        Expression nodeId) {
+        super(tableInfo, partitionProperties);
+        this.shardId = shardId;
+        this.nodeId = nodeId;
+    }
+
+    @Override
+    public <C, R> R accept(AnalyzedStatementVisitor<C, R> visitor, C context) {
+        return visitor.visitRerouteAllocateReplicaShard(this, context);
+    }
+
+    public Expression shardId() {
+        return shardId;
+    }
+
+    public Expression nodeId() {
+        return nodeId;
+    }
+}

--- a/sql/src/main/java/io/crate/executor/transport/AlterTableOperation.java
+++ b/sql/src/main/java/io/crate/executor/transport/AlterTableOperation.java
@@ -26,20 +26,15 @@ import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import com.google.common.annotations.VisibleForTesting;
 import io.crate.Constants;
 import io.crate.action.FutureActionListener;
-import io.crate.action.sql.Session;
 import io.crate.action.sql.ResultReceiver;
 import io.crate.action.sql.SQLOperations;
+import io.crate.action.sql.Session;
 import io.crate.analyze.AddColumnAnalyzedStatement;
 import io.crate.analyze.AlterTableAnalyzedStatement;
-import io.crate.analyze.AlterTableAnalyzer;
 import io.crate.analyze.AlterTableOpenCloseAnalyzedStatement;
 import io.crate.analyze.AlterTableRenameAnalyzedStatement;
 import io.crate.analyze.PartitionedTableParameterInfo;
-import io.crate.analyze.RerouteAnalyzedStatement;
-import io.crate.analyze.RerouteMoveShardAnalyzedStatement;
 import io.crate.analyze.TableParameter;
-import io.crate.analyze.expressions.ExpressionToNumberVisitor;
-import io.crate.analyze.expressions.ExpressionToStringVisitor;
 import io.crate.concurrent.CompletableFutures;
 import io.crate.concurrent.MultiBiConsumer;
 import io.crate.data.Row;
@@ -54,13 +49,8 @@ import io.crate.metadata.IndexParts;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.TableIdent;
 import io.crate.metadata.doc.DocTableInfo;
-import io.crate.metadata.table.ShardedTable;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchParseException;
-import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteRequest;
-import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteResponse;
-import org.elasticsearch.action.admin.cluster.reroute.TransportClusterRerouteAction;
 import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.admin.indices.close.CloseIndexRequest;
 import org.elasticsearch.action.admin.indices.close.CloseIndexResponse;
@@ -82,8 +72,6 @@ import org.elasticsearch.cluster.metadata.AliasMetaData;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
-import org.elasticsearch.cluster.routing.allocation.command.AllocationCommand;
-import org.elasticsearch.cluster.routing.allocation.command.MoveAllocationCommand;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.inject.Inject;
@@ -97,7 +85,6 @@ import org.elasticsearch.common.xcontent.XContentParser;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -120,7 +107,6 @@ public class AlterTableOperation {
     private final TransportCloseIndexAction transportCloseIndexAction;
     private final TransportRenameTableAction transportRenameTableAction;
     private final TransportOpenCloseTableOrPartitionAction transportOpenCloseTableOrPartitionAction;
-    private final TransportClusterRerouteAction transportClusterRerouteAction;
     private final SQLOperations sqlOperations;
 
     @Inject
@@ -132,8 +118,8 @@ public class AlterTableOperation {
                                TransportCloseIndexAction transportCloseIndexAction,
                                TransportRenameTableAction transportRenameTableAction,
                                TransportOpenCloseTableOrPartitionAction transportOpenCloseTableOrPartitionAction,
-                               TransportClusterRerouteAction transportClusterRerouteAction,
                                SQLOperations sqlOperations) {
+
         this.clusterService = clusterService;
         this.transportPutIndexTemplateAction = transportPutIndexTemplateAction;
         this.transportPutMappingAction = transportPutMappingAction;
@@ -142,7 +128,6 @@ public class AlterTableOperation {
         this.transportCloseIndexAction = transportCloseIndexAction;
         this.transportRenameTableAction = transportRenameTableAction;
         this.transportOpenCloseTableOrPartitionAction = transportOpenCloseTableOrPartitionAction;
-        this.transportClusterRerouteAction = transportClusterRerouteAction;
         this.sqlOperations = sqlOperations;
     }
 
@@ -558,70 +543,6 @@ public class AlterTableOperation {
             }
         }
         return true;
-    }
-
-    @VisibleForTesting
-    static String getRerouteIndex(RerouteAnalyzedStatement statement, Row parameters) throws SQLException {
-        ShardedTable shardedTable = statement.tableInfo();
-        if (shardedTable instanceof DocTableInfo) {
-            DocTableInfo docTableInfo = (DocTableInfo) shardedTable;
-            String indexName = docTableInfo.ident().indexName();
-            PartitionName partitionName = AlterTableAnalyzer.createPartitionName(statement.partitionProperties(),
-                docTableInfo, parameters);
-            if (partitionName != null) {
-                indexName = partitionName.asIndexName();
-            } else if (docTableInfo.isPartitioned()) {
-                throw new SQLException("table is partitioned however no partition clause has been specified");
-            }
-
-            return indexName;
-        }
-
-        // Table is a blob table
-        assert shardedTable.concreteIndices().length == 1 : "table has to contain only 1 index name";
-        return shardedTable.concreteIndices()[0];
-    }
-
-    private CompletableFuture<Long> executeRerouteRequest(AllocationCommand command) {
-        final CompletableFuture<Long> resultFuture = new CompletableFuture<>();
-
-        ClusterRerouteRequest request = new ClusterRerouteRequest();
-        request.add(command);
-        transportClusterRerouteAction.execute(request, new ActionListener<ClusterRerouteResponse>() {
-            @Override
-            public void onResponse(ClusterRerouteResponse clusterRerouteResponse) {
-                if (clusterRerouteResponse.isAcknowledged()) {
-                    resultFuture.complete(1L);
-                } else {
-                    resultFuture.complete(-1L);
-                }
-            }
-
-            @Override
-            public void onFailure(Exception e) {
-                resultFuture.completeExceptionally(e);
-            }
-        });
-        return resultFuture;
-    }
-
-    public CompletableFuture<Long> executeRerouteMoveShard(RerouteMoveShardAnalyzedStatement statement, Row parameters) {
-        String indexName;
-        int shardId;
-        String fromNodeId;
-        String toNodeId;
-
-        try {
-            indexName = getRerouteIndex(statement, parameters);
-            shardId = ExpressionToNumberVisitor.convert(statement.shardId(), parameters).intValue();
-            fromNodeId = ExpressionToStringVisitor.convert(statement.fromNodeId(), parameters);
-            toNodeId = ExpressionToStringVisitor.convert(statement.toNodeId(), parameters);
-        } catch (Exception e) {
-            return CompletableFutures.failedFuture(e);
-        }
-
-        MoveAllocationCommand command = new MoveAllocationCommand(indexName, shardId, fromNodeId, toNodeId);
-        return executeRerouteRequest(command);
     }
 
     private class ResultSetReceiver implements ResultReceiver {

--- a/sql/src/main/java/io/crate/executor/transport/RerouteActions.java
+++ b/sql/src/main/java/io/crate/executor/transport/RerouteActions.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.executor.transport;
+
+import io.crate.action.FutureActionListener;
+import io.crate.analyze.AlterTableAnalyzer;
+import io.crate.analyze.AnalyzedStatementVisitor;
+import io.crate.analyze.RerouteAllocateReplicaShardAnalyzedStatement;
+import io.crate.analyze.RerouteAnalyzedStatement;
+import io.crate.analyze.RerouteMoveShardAnalyzedStatement;
+import io.crate.analyze.expressions.ExpressionToNumberVisitor;
+import io.crate.analyze.expressions.ExpressionToStringVisitor;
+import io.crate.data.Row;
+import io.crate.metadata.PartitionName;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.metadata.table.ShardedTable;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteRequest;
+import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteResponse;
+import org.elasticsearch.cluster.routing.allocation.command.AllocateReplicaAllocationCommand;
+import org.elasticsearch.cluster.routing.allocation.command.MoveAllocationCommand;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiConsumer;
+
+import static io.crate.concurrent.CompletableFutures.failedFuture;
+
+public final class RerouteActions {
+
+    private RerouteActions() {
+
+    }
+
+    static final CompletableFuture<Long> execute(
+        BiConsumer<ClusterRerouteRequest, ActionListener<ClusterRerouteResponse>> rerouteAction,
+        RerouteAnalyzedStatement stmt,
+        Row parameters) {
+
+        ClusterRerouteRequest request;
+        try {
+            request = prepareRequest(stmt, parameters);
+        } catch (Throwable t) {
+            return failedFuture(t);
+        }
+        FutureActionListener<ClusterRerouteResponse, Long> listener =
+            new FutureActionListener<>(r -> r.isAcknowledged() ? 1L : -1L);
+        rerouteAction.accept(request, listener);
+        return listener;
+    }
+
+    static ClusterRerouteRequest prepareRequest(RerouteAnalyzedStatement stmt, Row parameters) {
+        return RequestBuilder.INSTANCE.process(stmt, parameters);
+    }
+
+    static String getRerouteIndex(RerouteAnalyzedStatement statement, Row parameters) throws IllegalArgumentException {
+        ShardedTable shardedTable = statement.tableInfo();
+        if (shardedTable instanceof DocTableInfo) {
+            DocTableInfo docTableInfo = (DocTableInfo) shardedTable;
+            String indexName = docTableInfo.ident().indexName();
+            PartitionName partitionName = AlterTableAnalyzer.createPartitionName(statement.partitionProperties(),
+                docTableInfo, parameters);
+            if (partitionName != null) {
+                indexName = partitionName.asIndexName();
+            } else if (docTableInfo.isPartitioned()) {
+                throw new IllegalArgumentException("table is partitioned however no partition clause has been specified");
+            }
+
+            return indexName;
+        }
+
+        // Table is a blob table
+        assert shardedTable.concreteIndices().length == 1 : "table has to contain only 1 index name";
+        return shardedTable.concreteIndices()[0];
+    }
+
+    private static class RequestBuilder extends AnalyzedStatementVisitor<Row, ClusterRerouteRequest> {
+
+        private static final RequestBuilder INSTANCE = new RequestBuilder();
+
+        @Override
+        protected ClusterRerouteRequest visitRerouteMoveShard(RerouteMoveShardAnalyzedStatement statement,
+                                                              Row parameters) {
+            String indexName = getRerouteIndex(statement, parameters);
+            int shardId = ExpressionToNumberVisitor.convert(statement.shardId(), parameters).intValue();
+            String fromNodeId = ExpressionToStringVisitor.convert(statement.fromNodeId(), parameters);
+            String toNodeId = ExpressionToStringVisitor.convert(statement.toNodeId(), parameters);
+
+            MoveAllocationCommand command = new MoveAllocationCommand(indexName, shardId, fromNodeId, toNodeId);
+            ClusterRerouteRequest request = new ClusterRerouteRequest();
+            request.add(command);
+            return request;
+        }
+
+        @Override
+        protected ClusterRerouteRequest visitRerouteAllocateReplicaShard(RerouteAllocateReplicaShardAnalyzedStatement statement,
+                                                                         Row parameters) {
+            String indexName = getRerouteIndex(statement, parameters);
+            int shardId = ExpressionToNumberVisitor.convert(statement.shardId(), parameters).intValue();
+            String nodeId = ExpressionToStringVisitor.convert(statement.nodeId(), parameters);
+
+            AllocateReplicaAllocationCommand command = new AllocateReplicaAllocationCommand(indexName, shardId, nodeId);
+            ClusterRerouteRequest request = new ClusterRerouteRequest();
+            request.add(command);
+            return request;
+        }
+    }
+}

--- a/sql/src/test/java/io/crate/analyze/AlterTableRerouteAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/AlterTableRerouteAnalyzerTest.java
@@ -77,4 +77,14 @@ public class AlterTableRerouteAnalyzerTest extends CrateDummyClusterServiceUnitT
         assertThat(analyzed.tableInfo().concreteIndices()[0], is("blob.blobs"));
         assertThat(analyzed.isWriteOperation(), is(true));
     }
+
+    @Test
+    public void testRerouteAllocateReplicaShard() throws Exception {
+        RerouteAllocateReplicaShardAnalyzedStatement analyzed = e.analyze("ALTER TABLE users REROUTE ALLOCATE REPLICA SHARD 0 ON 'nodeOne'");
+        assertThat(analyzed.tableInfo().concreteIndices().length, is(1));
+        assertThat(analyzed.tableInfo().concreteIndices()[0], is("users"));
+        assertThat(analyzed.shardId(), is(Literal.fromObject(0)));
+        assertThat(analyzed.nodeId(), is(Literal.fromObject("nodeOne")));
+        assertThat(analyzed.isWriteOperation(), is(true));
+    }
 }

--- a/sql/src/test/java/io/crate/executor/transport/AlterTableOperationTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/AlterTableOperationTest.java
@@ -23,33 +23,17 @@
 package io.crate.executor.transport;
 
 import io.crate.Constants;
-import io.crate.analyze.RerouteMoveShardAnalyzedStatement;
-import io.crate.analyze.TableDefinitions;
-import io.crate.data.Row;
-import io.crate.metadata.TableIdent;
-import io.crate.metadata.blob.BlobSchemaInfo;
-import io.crate.metadata.blob.BlobTableInfo;
-import io.crate.sql.parser.SqlParser;
-import io.crate.sql.tree.Assignment;
-import io.crate.sql.tree.QualifiedName;
-import io.crate.sql.tree.QualifiedNameReference;
-import io.crate.sql.tree.StringLiteral;
 import io.crate.test.integration.CrateUnitTest;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.junit.Test;
 
-import java.sql.SQLException;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.is;
 
 public class AlterTableOperationTest extends CrateUnitTest {
 
-    public static final BlobTableInfo BLOB_TABLE_INFO = TableDefinitions.createBlobTable(
-        new TableIdent(BlobSchemaInfo.NAME, "screenshots"));
 
     @Test
     public void testPrepareAlterTableMappingRequest() throws Exception {
@@ -70,78 +54,5 @@ public class AlterTableOperationTest extends CrateUnitTest {
 
         assertThat(request.type(), is(Constants.DEFAULT_MAPPING_TYPE));
         assertThat(request.source(), is("{\"_meta\":{\"meta2\":\"v2\",\"meta1\":\"v1\"},\"properties\":{\"foo\":\"bar\"}}"));
-    }
-
-    @Test
-    public void testRerouteIndexOfBlobTable() throws Exception {
-        RerouteMoveShardAnalyzedStatement statement = new RerouteMoveShardAnalyzedStatement(
-            BLOB_TABLE_INFO,
-            Collections.emptyList(),
-            SqlParser.createExpression("0"),
-            SqlParser.createExpression("node1"),
-            SqlParser.createExpression("node2")
-        );
-        String index = AlterTableOperation.getRerouteIndex(statement, Row.EMPTY);
-        assertThat(index, is("blob.screenshots"));
-    }
-
-    @Test
-    public void testRerouteIndexOfPartedDocTable() throws Exception {
-        RerouteMoveShardAnalyzedStatement statement = new RerouteMoveShardAnalyzedStatement(
-            TableDefinitions.TEST_PARTITIONED_TABLE_INFO,
-            Arrays.asList(new Assignment(
-                new QualifiedNameReference(new QualifiedName("date")), new StringLiteral("1395874800000"))),
-            SqlParser.createExpression("0"),
-            SqlParser.createExpression("node1"),
-            SqlParser.createExpression("node2")
-        );
-        String index = AlterTableOperation.getRerouteIndex(statement, Row.EMPTY);
-        assertThat(index, is(".partitioned.parted.04732cpp6ks3ed1o60o30c1g"));
-    }
-
-    @Test
-    public void testRerouteIndexOfPartedDocTableWithoutPartitionClause() throws Exception {
-        expectedException.expect(SQLException.class);
-        expectedException.expectMessage("table is partitioned however no partition clause has been specified");
-        RerouteMoveShardAnalyzedStatement statement = new RerouteMoveShardAnalyzedStatement(
-            TableDefinitions.TEST_PARTITIONED_TABLE_INFO,
-            Collections.emptyList(),
-            SqlParser.createExpression("0"),
-            SqlParser.createExpression("node1"),
-            SqlParser.createExpression("node2")
-        );
-        AlterTableOperation.getRerouteIndex(statement, Row.EMPTY);
-    }
-
-    @Test
-    public void testRerouteMoveShardPartitionedTableUnknownPartition() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Referenced partition \".partitioned.parted.04132\" does not exist.");
-        RerouteMoveShardAnalyzedStatement statement = new RerouteMoveShardAnalyzedStatement(
-            TableDefinitions.TEST_PARTITIONED_TABLE_INFO,
-            Arrays.asList(new Assignment(
-                new QualifiedNameReference(new QualifiedName("date")), new StringLiteral("1"))),
-            SqlParser.createExpression("0"),
-            SqlParser.createExpression("node1"),
-            SqlParser.createExpression("node2")
-        );
-
-        AlterTableOperation.getRerouteIndex(statement, Row.EMPTY);
-    }
-
-    @Test
-    public void testRerouteMoveShardUnpartitionedTableWithPartitionClause() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("table 'doc.users' is not partitioned");
-        RerouteMoveShardAnalyzedStatement statement = new RerouteMoveShardAnalyzedStatement(
-            TableDefinitions.USER_TABLE_INFO,
-            Arrays.asList(new Assignment(
-                new QualifiedNameReference(new QualifiedName("date")), new StringLiteral("1"))),
-            SqlParser.createExpression("0"),
-            SqlParser.createExpression("node1"),
-            SqlParser.createExpression("node2")
-        );
-
-        AlterTableOperation.getRerouteIndex(statement, Row.EMPTY);
     }
 }

--- a/sql/src/test/java/io/crate/executor/transport/RerouteActionsTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/RerouteActionsTest.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.executor.transport;
+
+import io.crate.analyze.RerouteAllocateReplicaShardAnalyzedStatement;
+import io.crate.analyze.RerouteMoveShardAnalyzedStatement;
+import io.crate.analyze.TableDefinitions;
+import io.crate.data.Row;
+import io.crate.metadata.TableIdent;
+import io.crate.metadata.blob.BlobSchemaInfo;
+import io.crate.metadata.blob.BlobTableInfo;
+import io.crate.sql.parser.SqlParser;
+import io.crate.sql.tree.Assignment;
+import io.crate.sql.tree.QualifiedName;
+import io.crate.sql.tree.QualifiedNameReference;
+import io.crate.sql.tree.StringLiteral;
+import io.crate.test.integration.CrateUnitTest;
+import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteRequest;
+import org.elasticsearch.cluster.routing.allocation.command.AllocateReplicaAllocationCommand;
+import org.elasticsearch.cluster.routing.allocation.command.MoveAllocationCommand;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.hamcrest.Matchers.is;
+
+public class RerouteActionsTest extends CrateUnitTest {
+
+    public static final BlobTableInfo BLOB_TABLE_INFO = TableDefinitions.createBlobTable(
+        new TableIdent(BlobSchemaInfo.NAME, "screenshots"));
+
+    @Test
+    public void testRerouteIndexOfBlobTable() throws Exception {
+        RerouteMoveShardAnalyzedStatement statement = new RerouteMoveShardAnalyzedStatement(
+            BLOB_TABLE_INFO,
+            Collections.emptyList(),
+            SqlParser.createExpression("0"),
+            SqlParser.createExpression("node1"),
+            SqlParser.createExpression("node2")
+        );
+        String index = RerouteActions.getRerouteIndex(statement, Row.EMPTY);
+        assertThat(index, is("blob.screenshots"));
+    }
+
+    @Test
+    public void testRerouteIndexOfPartedDocTable() throws Exception {
+        RerouteMoveShardAnalyzedStatement statement = new RerouteMoveShardAnalyzedStatement(
+            TableDefinitions.TEST_PARTITIONED_TABLE_INFO,
+            Arrays.asList(new Assignment(
+                new QualifiedNameReference(new QualifiedName("date")), new StringLiteral("1395874800000"))),
+            SqlParser.createExpression("0"),
+            SqlParser.createExpression("node1"),
+            SqlParser.createExpression("node2")
+        );
+        String index = RerouteActions.getRerouteIndex(statement, Row.EMPTY);
+        assertThat(index, is(".partitioned.parted.04732cpp6ks3ed1o60o30c1g"));
+    }
+
+    @Test
+    public void testRerouteIndexOfPartedDocTableWithoutPartitionClause() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("table is partitioned however no partition clause has been specified");
+        RerouteMoveShardAnalyzedStatement statement = new RerouteMoveShardAnalyzedStatement(
+            TableDefinitions.TEST_PARTITIONED_TABLE_INFO,
+            Collections.emptyList(),
+            SqlParser.createExpression("0"),
+            SqlParser.createExpression("node1"),
+            SqlParser.createExpression("node2")
+        );
+        RerouteActions.getRerouteIndex(statement, Row.EMPTY);
+    }
+
+    @Test
+    public void testRerouteMoveShardPartitionedTableUnknownPartition() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Referenced partition \".partitioned.parted.04132\" does not exist.");
+        RerouteMoveShardAnalyzedStatement statement = new RerouteMoveShardAnalyzedStatement(
+            TableDefinitions.TEST_PARTITIONED_TABLE_INFO,
+            Arrays.asList(new Assignment(
+                new QualifiedNameReference(new QualifiedName("date")), new StringLiteral("1"))),
+            SqlParser.createExpression("0"),
+            SqlParser.createExpression("node1"),
+            SqlParser.createExpression("node2")
+        );
+
+        RerouteActions.getRerouteIndex(statement, Row.EMPTY);
+    }
+
+    @Test
+    public void testRerouteMoveShardUnpartitionedTableWithPartitionClause() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("table 'doc.users' is not partitioned");
+        RerouteMoveShardAnalyzedStatement statement = new RerouteMoveShardAnalyzedStatement(
+            TableDefinitions.USER_TABLE_INFO,
+            Arrays.asList(new Assignment(
+                new QualifiedNameReference(new QualifiedName("date")), new StringLiteral("1"))),
+            SqlParser.createExpression("0"),
+            SqlParser.createExpression("node1"),
+            SqlParser.createExpression("node2")
+        );
+
+        RerouteActions.getRerouteIndex(statement, Row.EMPTY);
+    }
+
+    @Test
+    public void testRerouteExecution() throws Exception {
+        AtomicReference<ClusterRerouteRequest> reqRef = new AtomicReference<>();
+
+        RerouteAllocateReplicaShardAnalyzedStatement statement = new RerouteAllocateReplicaShardAnalyzedStatement(
+            TableDefinitions.USER_TABLE_INFO,
+            Collections.emptyList(),
+            SqlParser.createExpression("0"),
+            SqlParser.createExpression("node1"));
+
+        RerouteActions.execute((req, listener) -> reqRef.set(req), statement, Row.EMPTY);
+        ClusterRerouteRequest actualRequest = reqRef.get();
+
+        ClusterRerouteRequest request = new ClusterRerouteRequest();
+        AllocateReplicaAllocationCommand command = new AllocateReplicaAllocationCommand("users", 0, "node1");
+        request.add(command);
+        assertEquals(request, actualRequest);
+    }
+
+    @Test
+    public void testAllocateReplicaShardRequest() throws Exception {
+        RerouteAllocateReplicaShardAnalyzedStatement statement = new RerouteAllocateReplicaShardAnalyzedStatement(
+            TableDefinitions.USER_TABLE_INFO,
+            Collections.emptyList(),
+            SqlParser.createExpression("0"),
+            SqlParser.createExpression("node1"));
+        ClusterRerouteRequest actualRequest = RerouteActions.prepareRequest(statement, Row.EMPTY);
+
+        ClusterRerouteRequest request = new ClusterRerouteRequest();
+        AllocateReplicaAllocationCommand command = new AllocateReplicaAllocationCommand(
+            TableDefinitions.USER_TABLE_INFO.ident().indexName(), 0, "node1");
+        request.add(command);
+        assertEquals(request, actualRequest);
+    }
+
+    @Test
+    public void testMoveShardRequest() throws Exception {
+        RerouteMoveShardAnalyzedStatement statement = new RerouteMoveShardAnalyzedStatement(
+            TableDefinitions.USER_TABLE_INFO,
+            Collections.EMPTY_LIST,
+            SqlParser.createExpression("0"),
+            SqlParser.createExpression("node1"),
+            SqlParser.createExpression("node2"));
+        ClusterRerouteRequest actualRequest = RerouteActions.prepareRequest(statement, Row.EMPTY);
+
+        ClusterRerouteRequest request = new ClusterRerouteRequest();
+        MoveAllocationCommand command = new MoveAllocationCommand(
+            TableDefinitions.USER_TABLE_INFO.ident().indexName(), 0, "node1", "node2");
+        request.add(command);
+        assertEquals(request, actualRequest);
+    }
+}

--- a/sql/src/test/java/io/crate/integrationtests/AlterTableRerouteIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/AlterTableRerouteIntegrationTest.java
@@ -1,3 +1,25 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
 package io.crate.integrationtests;
 
 import io.crate.testing.UseJdbc;


### PR DESCRIPTION
This commit introduces the reroute option ``REROUTE ALLOCATE REPLICA``
that allows to force the allocation of an unassigned replica shards on a
specific node.