### PR TITLE
Added REROUTE CANCEL subcommand to ALTER TABLE

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -25,7 +25,7 @@ Changes
 
 - Added support to manually control the allocation of shards using
   ``ALTER TABLE REROUTE``.
-  Supported reroute-options: MOVE, ALLOCATE REPLICA
+  Supported reroute-options: MOVE, ALLOCATE REPLICA, CANCEL
 
 - Added new system table ``sys.allocations`` which lists shards and their
   allocation state including the reasoning why they are in a certain state.

--- a/blackbox/docs/sql/reference/alter_table.txt
+++ b/blackbox/docs/sql/reference/alter_table.txt
@@ -131,8 +131,9 @@ fail until the rename operation is completed.
 ``REROUTE``
 -----------
 
-The ``REROUTE`` command provides an option to manually control the
-allocation of shards. It allows to move shards between nodes in a cluster.
+The ``REROUTE`` command provides various options to manually control the
+allocation of shards. It allows to enforce explicit allocations, cancel them and
+makes it possible to move shards between nodes in a cluster.
 
 ::
 
@@ -143,6 +144,7 @@ where ``reroute_option`` is::
 
     { MOVE SHARD shard_id FROM node_id TO node_id
       | ALLOCATE REPLICA SHARD shard_id ON node_id
+      | CANCEL SHARD shard_id ON node_id [ WITH (allow_primary = {TRUE|FALSE}) ]
     }
 
 :shard_id:  The shard id. Ranges from 0 up to the specified number of
@@ -163,3 +165,8 @@ where ``reroute_option`` is::
 **ALLOCATE REPLICA**
     Allows to force allocation of an unassigned replica shard on a specific
     node.
+
+**CANCEL**
+    This cancels the allocation/recovery of a ``shard_id`` of a ``table_ident``
+    on a given ``node_id``. The ``allow_primary`` flag indicates if it is
+    allowed to cancel the allocation of a primary shard.

--- a/sql-parser/src/main/antlr/SqlBase.g4
+++ b/sql-parser/src/main/antlr/SqlBase.g4
@@ -477,6 +477,7 @@ addGeneratedColumnDefinition
 rerouteOption
     : MOVE SHARD shardId=parameterOrInteger FROM fromNodeId=parameterOrString TO toNodeId=parameterOrString #rerouteMoveShard
     | ALLOCATE REPLICA SHARD shardId=parameterOrInteger ON nodeId=parameterOrString                         #rerouteAllocateReplicaShard
+    | CANCEL SHARD shardId=parameterOrInteger ON nodeId=parameterOrString withProperties?                   #rerouteCancelShard
     ;
 
 dataType
@@ -603,7 +604,7 @@ nonReserved
     | REPOSITORY | SNAPSHOT | RESTORE | GENERATED | ALWAYS | BEGIN
     | ISOLATION | TRANSACTION | CHARACTERISTICS | LEVEL | LANGUAGE | OPEN | CLOSE | RENAME
     | PRIVILEGES | SCHEMA | INGEST | RULE
-    | REROUTE | MOVE | SHARD | ALLOCATE | REPLICA
+    | REROUTE | MOVE | SHARD | ALLOCATE | REPLICA | CANCEL
     ;
 
 SELECT: 'SELECT';
@@ -705,6 +706,7 @@ MOVE: 'MOVE';
 SHARD: 'SHARD';
 ALLOCATE: 'ALLOCATE';
 REPLICA: 'REPLICA';
+CANCEL: 'CANCEL';
 
 BOOLEAN: 'BOOLEAN';
 BYTE: 'BYTE';

--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -129,6 +129,7 @@ import io.crate.sql.tree.QuerySpecification;
 import io.crate.sql.tree.RefreshStatement;
 import io.crate.sql.tree.Relation;
 import io.crate.sql.tree.RerouteAllocateReplicaShard;
+import io.crate.sql.tree.RerouteCancelShard;
 import io.crate.sql.tree.RerouteMoveShard;
 import io.crate.sql.tree.RerouteOption;
 import io.crate.sql.tree.ResetStatement;
@@ -658,6 +659,15 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
         return new RerouteAllocateReplicaShard(
             (Expression) visit(context.shardId),
             (Expression) visit(context.nodeId));
+    }
+
+    @Override
+    public Node visitRerouteCancelShard(SqlBaseParser.RerouteCancelShardContext context) {
+        return new RerouteCancelShard(
+            (Expression) visit(context.shardId),
+            (Expression) visit(context.nodeId),
+            visitIfPresent(context.withProperties(), GenericProperties.class)
+                .orElse(GenericProperties.EMPTY));
     }
 
     // Properties

--- a/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
@@ -485,6 +485,10 @@ public abstract class AstVisitor<R, C> {
         return visitNode(node, context);
     }
 
+    public R visitRerouteCancelShard(RerouteCancelShard node, C context) {
+        return visitNode(node, context);
+    }
+
     public R visitAddColumnDefinition(AddColumnDefinition node, C context) {
         return visitTableElement(node, context);
     }

--- a/sql-parser/src/main/java/io/crate/sql/tree/GenericProperties.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/GenericProperties.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableMap;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 
 /**
@@ -109,5 +110,9 @@ public class GenericProperties extends Node {
 
     public int size() {
         return properties.size();
+    }
+
+    public Set<String> keys() {
+        return properties.keySet();
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/RerouteCancelShard.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/RerouteCancelShard.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.sql.tree;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+
+import javax.annotation.Nullable;
+
+public class RerouteCancelShard extends RerouteOption {
+
+    private final Expression nodeId;
+    private final Expression shardId;
+    @Nullable
+    private final GenericProperties properties;
+
+    public RerouteCancelShard(Expression shardId, Expression nodeId, @Nullable GenericProperties properties) {
+        this.shardId = shardId;
+        this.nodeId = nodeId;
+        this.properties = properties;
+    }
+
+    public Expression nodeId() {
+        return nodeId;
+    }
+
+    public Expression shardId() {
+        return shardId;
+    }
+
+    @Nullable
+    public GenericProperties properties() {
+        return properties;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(shardId, nodeId, properties);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+
+        RerouteCancelShard that = (RerouteCancelShard) obj;
+
+        if (!shardId.equals(that.shardId)) return false;
+        if (!nodeId.equals(that.nodeId)) return false;
+        if (!properties.equals(that.properties)) return false;
+
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+            .add("shardId", shardId)
+            .add("nodeId", nodeId)
+            .add("properties", properties).toString();
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitRerouteCancelShard(this, context);
+    }
+}

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -1122,6 +1122,8 @@ public class TestStatementBuilder {
         printStatement("alter table t reroute move shard 1 from 'node1' to 'node2'");
         printStatement("alter table t partition (parted_col = ?) reroute move shard ? from ? to ?");
         printStatement("alter table t reroute allocate replica shard 1 on 'node1'");
+        printStatement("alter table t reroute cancel shard 1 on 'node1'");
+        printStatement("alter table t reroute cancel shard 1 on 'node1' with (allow_primary = true)");
     }
 
     @Test

--- a/sql/src/main/java/io/crate/action/sql/DDLStatementDispatcher.java
+++ b/sql/src/main/java/io/crate/action/sql/DDLStatementDispatcher.java
@@ -44,6 +44,7 @@ import io.crate.analyze.OptimizeSettings;
 import io.crate.analyze.OptimizeTableAnalyzedStatement;
 import io.crate.analyze.RefreshTableAnalyzedStatement;
 import io.crate.analyze.RerouteAllocateReplicaShardAnalyzedStatement;
+import io.crate.analyze.RerouteCancelShardAnalyzedStatement;
 import io.crate.analyze.RerouteMoveShardAnalyzedStatement;
 import io.crate.analyze.RestoreSnapshotAnalyzedStatement;
 import io.crate.blob.v2.BlobAdminClient;
@@ -259,6 +260,11 @@ public class DDLStatementDispatcher implements BiFunction<AnalyzedStatement, Row
 
         @Override
         protected CompletableFuture<Long> visitRerouteAllocateReplicaShard(RerouteAllocateReplicaShardAnalyzedStatement analysis, Row parameters) {
+            return RerouteActions.execute(rerouteAction::execute, analysis, parameters);
+        }
+
+        @Override
+        protected CompletableFuture<Long> visitRerouteCancelShard(RerouteCancelShardAnalyzedStatement analysis, Row parameters) {
             return RerouteActions.execute(rerouteAction::execute, analysis, parameters);
         }
     }

--- a/sql/src/main/java/io/crate/analyze/AlterTableRerouteAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/AlterTableRerouteAnalyzer.java
@@ -30,6 +30,7 @@ import io.crate.sql.tree.AlterTableReroute;
 import io.crate.sql.tree.Assignment;
 import io.crate.sql.tree.AstVisitor;
 import io.crate.sql.tree.RerouteAllocateReplicaShard;
+import io.crate.sql.tree.RerouteCancelShard;
 import io.crate.sql.tree.RerouteMoveShard;
 
 import java.util.List;
@@ -74,6 +75,12 @@ public class AlterTableRerouteAnalyzer {
         public RerouteAnalyzedStatement visitRerouteAllocateReplicaShard(RerouteAllocateReplicaShard node, Context context) {
             return new RerouteAllocateReplicaShardAnalyzedStatement(
                 context.tableInfo, context.partitionProperties, node.shardId(), node.nodeId());
+        }
+
+        @Override
+        public RerouteAnalyzedStatement visitRerouteCancelShard(RerouteCancelShard node, Context context) {
+            return new RerouteCancelShardAnalyzedStatement(
+                context.tableInfo, context.partitionProperties, node.shardId(), node.nodeId(), node.properties());
         }
     }
 }

--- a/sql/src/main/java/io/crate/analyze/AnalyzedStatementVisitor.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedStatementVisitor.java
@@ -196,4 +196,8 @@ public class AnalyzedStatementVisitor<C, R> {
     protected R visitRerouteAllocateReplicaShard(RerouteAllocateReplicaShardAnalyzedStatement analysis, C context) {
         return visitDDLStatement(analysis, context);
     }
+
+    protected R visitRerouteCancelShard(RerouteCancelShardAnalyzedStatement analysis, C context) {
+        return visitDDLStatement(analysis, context);
+    }
 }

--- a/sql/src/main/java/io/crate/analyze/RerouteCancelShardAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/RerouteCancelShardAnalyzedStatement.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.analyze;
+
+import io.crate.metadata.table.ShardedTable;
+import io.crate.sql.tree.Assignment;
+import io.crate.sql.tree.Expression;
+import io.crate.sql.tree.GenericProperties;
+import org.elasticsearch.common.Nullable;
+
+import java.util.List;
+
+public class RerouteCancelShardAnalyzedStatement extends RerouteAnalyzedStatement {
+
+    private final Expression shardId;
+    private final Expression nodeId;
+    @Nullable
+    private final GenericProperties properties;
+
+    public RerouteCancelShardAnalyzedStatement(ShardedTable tableInfo,
+                                               List<Assignment> partitionProperties,
+                                               Expression shardId,
+                                               Expression nodeId,
+                                               @Nullable GenericProperties properties) {
+        super(tableInfo, partitionProperties);
+        this.shardId = shardId;
+        this.nodeId = nodeId;
+        this.properties = properties;
+    }
+
+    @Override
+    public <C, R> R accept(AnalyzedStatementVisitor<C, R> visitor, C context) {
+        return visitor.visitRerouteCancelShard(this, context);
+    }
+
+    public Expression shardId() {
+        return shardId;
+    }
+
+    public Expression nodeId() {
+        return nodeId;
+    }
+
+    @Nullable
+    public GenericProperties properties() {
+        return properties;
+    }
+}

--- a/sql/src/test/java/io/crate/analyze/AlterTableRerouteAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/AlterTableRerouteAnalyzerTest.java
@@ -87,4 +87,23 @@ public class AlterTableRerouteAnalyzerTest extends CrateDummyClusterServiceUnitT
         assertThat(analyzed.nodeId(), is(Literal.fromObject("nodeOne")));
         assertThat(analyzed.isWriteOperation(), is(true));
     }
+
+    @Test
+    public void testRerouteCancelShard() throws Exception {
+        RerouteCancelShardAnalyzedStatement analyzed = e.analyze("ALTER TABLE users REROUTE CANCEL SHARD 0 ON 'nodeOne'");
+        assertThat(analyzed.tableInfo().concreteIndices().length, is(1));
+        assertThat(analyzed.tableInfo().concreteIndices()[0], is("users"));
+        assertThat(analyzed.shardId(), is(Literal.fromObject(0)));
+        assertThat(analyzed.nodeId(), is(Literal.fromObject("nodeOne")));
+        assertNull(analyzed.properties().get("allow_primary"));
+        assertThat(analyzed.isWriteOperation(), is(true));
+    }
+
+    @Test
+    public void testRerouteCancelShardWithOptions() throws Exception {
+        RerouteCancelShardAnalyzedStatement analyzed = e.analyze("ALTER TABLE users REROUTE CANCEL SHARD 0 ON 'nodeOne' WITH (allow_primary = TRUE)");
+        assertThat(analyzed.properties().get("allow_primary"), is(Literal.fromObject(true)));
+        analyzed = e.analyze("ALTER TABLE users REROUTE CANCEL SHARD 0 ON 'nodeOne' WITH (allow_primary = FALSE)");
+        assertThat(analyzed.properties().get("allow_primary"), is(Literal.fromObject(false)));
+    }
 }


### PR DESCRIPTION
This commit introduces the reroute option ``REROUTE CANCEL``
that allows to cancel the allocation/recovery of a shard on a node.