### PR TITLE
Add DDL documentation for shard rerouting/allocation

### DIFF
--- a/blackbox/docs/sql/ddl/alter_table.txt
+++ b/blackbox/docs/sql/ddl/alter_table.txt
@@ -115,3 +115,31 @@ table will fail until the rename operation is completed.
 
     Do not run multiple concurrent rename operations on the same table. The rename
     operation is not atomic.
+
+.. _ddl_reroute_shards:
+
+Reroute Shards
+==============
+
+With the ``REROUTE`` command it is possible to control the allocations of
+shards. This gives you the ability to re-balance the cluster state manually.
+The supported reroute options are listed in the reference documentation of
+:ref:`ALTER TABLE REROUTE <alter_table_reroute>`.
+
+Shard rerouting can help solve several problems:
+
+    * **Unassigned shards**: Due to cause of lack of space, shard awareness or
+      any other failure that happens during the automatic shard allocation it is
+      possible to gain unassigned shards in the cluster.
+
+    * **"Hot Shards"**: Most of your queries affect certain shards only. These
+      shards lie on a node that has insufficient resources.
+
+.. NOTE::
+
+    The command only triggers the allocation and reports back if the process has
+    been acknowledged or rejected. Moving or allocating large shards takes more
+    time to complete.
+
+In those two cases it may be necessary to move shards manually to another node
+or force the retry of the allocation process.

--- a/blackbox/docs/sql/reference/alter_table.txt
+++ b/blackbox/docs/sql/reference/alter_table.txt
@@ -128,12 +128,23 @@ Can be used to rename a table, while maintaining its schema and data. During
 this operation the table will be closed, and all operations upon the table will
 fail until the rename operation is completed.
 
+.. _alter_table_reroute:
+
 ``REROUTE``
 -----------
 
 The ``REROUTE`` command provides various options to manually control the
-allocation of shards. It allows to enforce explicit allocations, cancel them and
-makes it possible to move shards between nodes in a cluster.
+allocation of shards. It allows the enforcement of explicit allocations,
+cancellations and the moving of shards between nodes in a cluster. See
+:ref:`ddl_reroute_shards` to get the convenient use-cases.
+
+The rowcount defines if the reroute or allocation process of a shard was
+acknowledged or rejected.
+
+.. NOTE::
+
+   Partitioned tables require a :ref:`Partition Clause <ref-alter-table-partition-clause>`
+   in order to specify a unique ``shard_id``.
 
 ::
 


### PR DESCRIPTION
`ALTER TABLE t ... `

- [x] : `REROUTE MOVE` af3364d21886314721c403fa4979a2aabc7d2e93
- [x] : `REROUTE ALLOCATE REPLICA` ae1e3e040f9aa8ce18393c9aeeac47902d2f8ca3
- [x] : `REROUTE CANCEL` 6a452d13816fceb483934d244b3c9a48729db861