### PR TITLE
Added reference docs for ALTER CLUSTER

### DIFF
--- a/blackbox/docs/sql/reference/alter_cluster.txt
+++ b/blackbox/docs/sql/reference/alter_cluster.txt
@@ -1,0 +1,54 @@
+.. highlight:: psql
+.. _ref-alter-cluster:
+
+=================
+``ALTER CLUSTER``
+=================
+
+Alter the state of an existing cluster.
+
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
+Synopsis
+========
+
+::
+
+    ALTER CLUSTER
+      { REROUTE RETRY FAILED }
+
+
+Description
+===========
+
+``ALTER CLUSTER`` applies a change to the cluster state.
+
+Arguments
+=========
+
+``REROUTE RETRY FAILED``
+------------------------
+
+The index setting :ref:`allocation.max_retries <allocation_max_retries>`
+indicates the maximum of attempts to allocate a shard on a node. If this limit
+is reached it leaves the shard unallocated.
+This command allows the enforcement to retry the allocation of shards which
+failed to allocate. See :ref:`ddl_reroute_shards` to get convenient use-cases.
+
+.. NOTE::
+
+    This statement can only be invoked by superusers that already exist in the
+    cluster.
+
+The rowcount defines the number of shards that will be allocated.
+A rowcount of ``-1`` reflects an error or indicates that the statement did not
+get acknowledged.
+
+.. NOTE::
+
+    Keep in mind that this statement only triggers the shard re-allocation and
+    is therefore asynchronous. Unassigned shards with large size will take some
+    time to allocate.

--- a/blackbox/docs/sql/sql.txt
+++ b/blackbox/docs/sql/sql.txt
@@ -15,6 +15,7 @@ CrateDB.
     :maxdepth: 1
 
     reference/alter_table
+    reference/alter_cluster
     reference/copy_from
     reference/copy_to
     reference/create_analyzer


### PR DESCRIPTION
This commit includes the reference docs of the statement `ALTER CLUSTER`
that contains the documentation of the subcommand `REROUTE RETRY FAILED`.

Details:
On Shard Rerouting CrateDB will attempt to allocate a shard a maximum of `index.allocation.max_retries` times in a row (defaults to 5), before giving up and leaving the shard unallocated. This scenario can be caused several issues (low disk space, etc.)

Once the problem has been corrected, allocation of all unassigned shards in the cluster can be manually retried by calling `ALTER CLUSTER REROUTE FAILED` to retry the allocation process.

Feedback is welcome !! ❤️ 

As a note:
* Thought about `ALTER DATABASE` first, however, this is a common syntax on databases that support multiple databases (which is called "schemas" in CrateDB)
* `ALTER CLUSTER` is leaned on http://orientdb.com/docs/2.2.x/SQL-Alter-Cluster.html