### PR TITLE
Populate information_schema.key_column_usage table

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -20,8 +20,16 @@ Breaking Changes
    converted to the column type but not vice-versa. The column can still be
    manually cast to a type by using a cast function.
 
+ - Table ``information_schema.table_constraints`` is now returning
+   ``constraint_name`` as type string instead of type array. Constraint type
+   ``PRIMARY_KEY`` has been changed to ``PRIMARY KEY``. Also PRIMARY KEY
+   constraint is not returned when not explicitly defined.
+
 Changes
 =======
+
+- Table ``information_schema.table_constraints`` is now returning ``NOT_NULL``
+  constraints.
 
 - Fixed an issue that caused an error ``Primary key value must not be NULL``
   to be thrown when trying to insert rows in a table that has a generated

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -28,6 +28,9 @@ Breaking Changes
 Changes
 =======
 
+- Table ``information_schema.key_column_usage`` now gets populated with primary
+  key information of user tables.
+
 - Table ``information_schema.table_constraints`` is now returning ``NOT_NULL``
   constraints.
 

--- a/blackbox/docs/sql/information_schema.txt
+++ b/blackbox/docs/sql/information_schema.txt
@@ -411,6 +411,30 @@ type, name and which table they are defined in.
     +--------------------+------------+-...------------------+-------------+
     SELECT 3 rows in set (... sec)
 
+``key_column_usage``
+--------------------
+
+This table may be queried to retrieve primary key information from all user
+tables:
+
+.. hide:
+
+    cr> create table students (id long, department integer, name string, primary key(id, department))
+    CREATE OK, 1 row affected (... sec)
+
+::
+
+    cr> select constraint_name, table_name, column_name, ordinal_position
+    ... from information_schema.key_column_usage
+    ... where table_name = 'students'
+    +-----------------+------------+-------------+------------------+
+    | constraint_name | table_name | column_name | ordinal_position |
+    +-----------------+------------+-------------+------------------+
+    | id_pk           | students   | id          |                1 |
+    | department_pk   | students   | department  |                2 |
+    +-----------------+------------+-------------+------------------+
+    SELECT 2 rows in set (... sec)
+
 .. _is_table_partitions:
 
 ``table_partitions``

--- a/blackbox/docs/sql/information_schema.txt
+++ b/blackbox/docs/sql/information_schema.txt
@@ -388,6 +388,11 @@ type, name and which table they are defined in.
 
     Currently only ``PRIMARY_KEY`` constraints are supported.
 
+.. hide:
+
+    cr> create table tbl (col STRING NOT NULL);
+    CREATE OK, 1 row affected (... sec)
+
 ::
 
     cr> select table_schema, table_name, constraint_name, constraint_type as type
@@ -395,14 +400,15 @@ type, name and which table they are defined in.
     ... where table_name = 'tables'
     ...   or table_name = 'quotes'
     ...   or table_name = 'documents'
-    ... order by table_schema desc, table_name desc limit 10;
-    +--------------------+------------+--------------------------------+-------------+
-    | table_schema       | table_name | constraint_name                | type        |
-    +--------------------+------------+--------------------------------+-------------+
-    | information_schema | tables     | ["table_schema", "table_name"] | PRIMARY_KEY |
-    | doc                | quotes     | ["id"]                         | PRIMARY_KEY |
-    | doc                | documents  | ["_id"]                        | PRIMARY_KEY |
-    +--------------------+------------+--------------------------------+-------------+
+    ...   or table_name = 'tbl'
+    ... order by table_schema desc, table_name asc limit 10;
+    +--------------------+------------+-...------------------+-------------+
+    | table_schema       | table_name | constraint_name      | type        |
+    +--------------------+------------+-...------------------+-------------+
+    | information_schema | tables     | tables_pk            | PRIMARY KEY |
+    | doc                | quotes     | quotes_pk            | PRIMARY KEY |
+    | doc                | tbl        | doc_tbl_col_not_null | CHECK       |
+    +--------------------+------------+-...------------------+-------------+
     SELECT 3 rows in set (... sec)
 
 .. _is_table_partitions:

--- a/enterprise/users/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
+++ b/enterprise/users/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
@@ -185,7 +185,7 @@ public class PrivilegesIntegrationTest extends BaseUsersIntegrationTest {
         executeAsSuperuser("create table t1 (x int) partitioned by (x) clustered into 1 shards with (number_of_replicas = 0)");
         executeAsSuperuser("insert into t1 values (1)");
         executeAsSuperuser("insert into t1 values (2)");
-        executeAsSuperuser("create table my_schema.t2 (x int) clustered into 1 shards with (number_of_replicas = 0)");
+        executeAsSuperuser("create table my_schema.t2 (x int primary key) clustered into 1 shards with (number_of_replicas = 0)");
         executeAsSuperuser("create table other_schema.t3 (x int) clustered into 1 shards with (number_of_replicas = 0)");
 
         executeAsSuperuser("create function my_schema.foo(long)" +

--- a/sql/src/main/java/io/crate/metadata/information/InformationKeyColumnUsageTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/information/InformationKeyColumnUsageTableInfo.java
@@ -28,13 +28,20 @@ import com.google.common.collect.ImmutableSortedMap;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
-import io.crate.metadata.RowContextCollectorExpression;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.TableIdent;
 import io.crate.metadata.expressions.RowCollectExpressionFactory;
+import io.crate.operation.collect.sources.InformationSchemaIterables;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
+import static io.crate.metadata.RowContextCollectorExpression.forFunction;
+import static io.crate.metadata.RowContextCollectorExpression.objToBytesRef;
+import static io.crate.operation.collect.sources.InformationSchemaIterables.PK_SUFFIX;
+
+/**
+ * Table which contains the primary keys of all user tables.
+ */
 public class InformationKeyColumnUsageTableInfo extends InformationTableInfo {
 
     public static final String NAME = "key_column_usage";
@@ -59,27 +66,27 @@ public class InformationKeyColumnUsageTableInfo extends InformationTableInfo {
         static final Reference TABLE_SCHEMA = createRef(Columns.TABLE_SCHEMA, DataTypes.STRING);
         static final Reference TABLE_NAME = createRef(Columns.TABLE_NAME, DataTypes.STRING);
         static final Reference COLUMN_NAME = createRef(Columns.COLUMN_NAME, DataTypes.STRING);
-        static final Reference ORDINAL_POSITION = createRef(Columns.ORDINAL_POSITION, DataTypes.SHORT);
+        static final Reference ORDINAL_POSITION = createRef(Columns.ORDINAL_POSITION, DataTypes.INTEGER);
     }
 
-    public static ImmutableMap<ColumnIdent, RowCollectExpressionFactory<Void>> expressions() {
-        return ImmutableMap.<ColumnIdent, RowCollectExpressionFactory<Void>>builder()
+    public static ImmutableMap<ColumnIdent, RowCollectExpressionFactory<InformationSchemaIterables.KeyColumnUsage>> expressions() {
+        return ImmutableMap.<ColumnIdent, RowCollectExpressionFactory<InformationSchemaIterables.KeyColumnUsage>>builder()
             .put(Columns.CONSTRAINT_CATALOG,
-                () -> RowContextCollectorExpression.objToBytesRef(r -> null))
+                () -> objToBytesRef(InformationSchemaIterables.KeyColumnUsage::getSchema))
             .put(Columns.CONSTRAINT_SCHEMA,
-                () -> RowContextCollectorExpression.objToBytesRef(r -> null))
+                () -> objToBytesRef(k -> "public"))
             .put(Columns.CONSTRAINT_NAME,
-                () -> RowContextCollectorExpression.objToBytesRef(r -> null))
+                () -> objToBytesRef(k -> k.getPkColumnName() + PK_SUFFIX))
             .put(Columns.TABLE_CATALOG,
-                () -> RowContextCollectorExpression.objToBytesRef(r -> null))
+                () -> objToBytesRef(InformationSchemaIterables.KeyColumnUsage::getSchema))
             .put(Columns.TABLE_SCHEMA,
-                () -> RowContextCollectorExpression.objToBytesRef(r -> null))
+                () -> objToBytesRef(k -> "public"))
             .put(Columns.TABLE_NAME,
-                () -> RowContextCollectorExpression.objToBytesRef(r -> null))
+                () -> objToBytesRef(InformationSchemaIterables.KeyColumnUsage::getTableName))
             .put(Columns.COLUMN_NAME,
-                () -> RowContextCollectorExpression.objToBytesRef(r -> null))
+                () -> objToBytesRef(InformationSchemaIterables.KeyColumnUsage::getPkColumnName))
             .put(Columns.ORDINAL_POSITION,
-                () -> RowContextCollectorExpression.forFunction(null))
+                () -> forFunction(InformationSchemaIterables.KeyColumnUsage::getOrdinal))
             .build();
     }
 

--- a/sql/src/main/java/io/crate/metadata/information/InformationSchemaTableDefinitions.java
+++ b/sql/src/main/java/io/crate/metadata/information/InformationSchemaTableDefinitions.java
@@ -64,7 +64,7 @@ public class InformationSchemaTableDefinitions {
         ));
         tableDefinitions.put(InformationTableConstraintsTableInfo.IDENT, new StaticTableDefinition<>(
             informationSchemaIterables::constraints,
-            (user, t) -> user.hasAnyPrivilege(Privilege.Clazz.TABLE, t.ident().fqn()),
+            (user, t) -> user.hasAnyPrivilege(Privilege.Clazz.TABLE, t.tableIdent().fqn()),
             InformationTableConstraintsTableInfo.expressions()
         ));
         tableDefinitions.put(InformationRoutinesTableInfo.IDENT, new StaticTableDefinition<>(

--- a/sql/src/main/java/io/crate/metadata/information/InformationSchemaTableDefinitions.java
+++ b/sql/src/main/java/io/crate/metadata/information/InformationSchemaTableDefinitions.java
@@ -82,7 +82,8 @@ public class InformationSchemaTableDefinitions {
             InformationSchemaIngestionRulesTableInfo.expressions()
         ));
         tableDefinitions.put(InformationKeyColumnUsageTableInfo.IDENT, new StaticTableDefinition<>(
-            () -> completedFuture(informationSchemaIterables.keyColumnUsageInfos()),
+            informationSchemaIterables::keyColumnUsage,
+            (user, k) -> user.hasAnyPrivilege(Privilege.Clazz.TABLE, k.getFQN()),
             InformationKeyColumnUsageTableInfo.expressions()
         ));
         tableDefinitions.put(InformationReferentialConstraintsTableInfo.IDENT, new StaticTableDefinition<>(

--- a/sql/src/main/java/io/crate/metadata/information/InformationTableConstraintsTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/information/InformationTableConstraintsTableInfo.java
@@ -31,52 +31,61 @@ import io.crate.metadata.RowContextCollectorExpression;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.TableIdent;
 import io.crate.metadata.expressions.RowCollectExpressionFactory;
-import io.crate.metadata.table.TableInfo;
-import io.crate.types.ArrayType;
+import io.crate.metadata.table.ConstraintInfo;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
-import org.apache.lucene.util.BytesRef;
 
-import java.util.List;
 import java.util.Map;
 
 public class InformationTableConstraintsTableInfo extends InformationTableInfo {
 
     public static final String NAME = "table_constraints";
     public static final TableIdent IDENT = new TableIdent(InformationSchemaInfo.NAME, NAME);
-    private static final BytesRef PRIMARY_KEY = new BytesRef("PRIMARY_KEY");
 
     public static class Columns {
+        static final ColumnIdent CONSTRAINT_CATALOG = new ColumnIdent("constraint_catalog");
+        static final ColumnIdent CONSTRAINT_SCHEMA = new ColumnIdent("constraint_schema");
+        static final ColumnIdent CONSTRAINT_NAME = new ColumnIdent("constraint_name");
+        static final ColumnIdent TABLE_CATALOG = new ColumnIdent("table_catalog");
         static final ColumnIdent TABLE_SCHEMA = new ColumnIdent("table_schema");
         public static final ColumnIdent TABLE_NAME = new ColumnIdent("table_name");
-        static final ColumnIdent CONSTRAINT_NAME = new ColumnIdent("constraint_name");
         static final ColumnIdent CONSTRAINT_TYPE = new ColumnIdent("constraint_type");
+        static final ColumnIdent IS_DEFERRABLE = new ColumnIdent("is_deferrable");
+        static final ColumnIdent INITIALLY_DEFERRED = new ColumnIdent("initially_deferred");
     }
 
     public static class References {
+        static final Reference CONSTRAINT_CATALOG = createRef(Columns.CONSTRAINT_CATALOG, DataTypes.STRING);
+        static final Reference CONSTRAINT_SCHEMA = createRef(Columns.CONSTRAINT_SCHEMA, DataTypes.STRING);
+        static final Reference CONSTRAINT_NAME = createRef(Columns.CONSTRAINT_NAME, DataTypes.STRING);
+        static final Reference TABLE_CATALOG = createRef(Columns.TABLE_CATALOG, DataTypes.STRING);
         static final Reference TABLE_SCHEMA = createRef(Columns.TABLE_SCHEMA, DataTypes.STRING);
         public static final Reference TABLE_NAME = createRef(Columns.TABLE_NAME, DataTypes.STRING);
-        static final Reference CONSTRAINT_NAME = createRef(Columns.CONSTRAINT_NAME, new ArrayType(DataTypes.STRING));
         static final Reference CONSTRAINT_TYPE = createRef(Columns.CONSTRAINT_TYPE, DataTypes.STRING);
+        static final Reference IS_DEFERRABLE = createRef(Columns.IS_DEFERRABLE, DataTypes.STRING);
+        static final Reference INITIALLY_DEFERRED = createRef(Columns.INITIALLY_DEFERRED, DataTypes.STRING);
     }
 
-    public static Map<ColumnIdent, RowCollectExpressionFactory<TableInfo>> expressions() {
-        return ImmutableMap.<ColumnIdent, RowCollectExpressionFactory<TableInfo>>builder()
-            .put(Columns.TABLE_SCHEMA,
-                () -> RowContextCollectorExpression.objToBytesRef(r -> r.ident().schema()))
-            .put(Columns.TABLE_NAME,
-                () -> RowContextCollectorExpression.objToBytesRef(r -> r.ident().name()))
+    public static Map<ColumnIdent, RowCollectExpressionFactory<ConstraintInfo>> expressions() {
+        return ImmutableMap.<ColumnIdent, RowCollectExpressionFactory<ConstraintInfo>>builder()
+            .put(Columns.CONSTRAINT_CATALOG,
+                () -> RowContextCollectorExpression.objToBytesRef(r -> r.tableIdent().schema()))
+            .put(Columns.CONSTRAINT_SCHEMA,
+                () -> RowContextCollectorExpression.objToBytesRef(r -> r.tableIdent().schema()))
             .put(Columns.CONSTRAINT_NAME,
-                () -> RowContextCollectorExpression.forFunction(row -> {
-                    BytesRef[] values = new BytesRef[row.primaryKey().size()];
-                    List<ColumnIdent> primaryKey = row.primaryKey();
-                    for (int i = 0, primaryKeySize = primaryKey.size(); i < primaryKeySize; i++) {
-                        values[i] = new BytesRef(primaryKey.get(i).fqn());
-                    }
-                    return values;
-                }))
+                () -> RowContextCollectorExpression.objToBytesRef(r -> r.constraintName()))
+            .put(Columns.TABLE_CATALOG,
+                () -> RowContextCollectorExpression.objToBytesRef(r -> r.tableIdent().schema()))
+            .put(Columns.TABLE_SCHEMA,
+                () -> RowContextCollectorExpression.objToBytesRef(r -> r.tableIdent().schema()))
+            .put(Columns.TABLE_NAME,
+                () -> RowContextCollectorExpression.objToBytesRef(r -> r.tableIdent().name()))
             .put(Columns.CONSTRAINT_TYPE,
-                () -> RowContextCollectorExpression.objToBytesRef(r -> PRIMARY_KEY))
+                () -> RowContextCollectorExpression.objToBytesRef(r -> r.constraintType()))
+            .put(Columns.IS_DEFERRABLE,
+                () -> RowContextCollectorExpression.objToBytesRef(r -> "NO"))
+            .put(Columns.INITIALLY_DEFERRED,
+                () -> RowContextCollectorExpression.objToBytesRef(r -> "NO"))
             .build();
     }
 
@@ -89,10 +98,15 @@ public class InformationTableConstraintsTableInfo extends InformationTableInfo {
             IDENT,
             ImmutableList.of(),
             ImmutableSortedMap.<ColumnIdent, Reference>naturalOrder()
+                .put(Columns.CONSTRAINT_CATALOG, References.CONSTRAINT_CATALOG)
+                .put(Columns.CONSTRAINT_SCHEMA, References.CONSTRAINT_SCHEMA)
+                .put(Columns.CONSTRAINT_NAME, References.CONSTRAINT_NAME)
+                .put(Columns.TABLE_CATALOG, References.TABLE_CATALOG)
                 .put(Columns.TABLE_SCHEMA, References.TABLE_SCHEMA)
                 .put(Columns.TABLE_NAME, References.TABLE_NAME)
-                .put(Columns.CONSTRAINT_NAME, References.CONSTRAINT_NAME)
                 .put(Columns.CONSTRAINT_TYPE, References.CONSTRAINT_TYPE)
+                .put(Columns.IS_DEFERRABLE, References.IS_DEFERRABLE)
+                .put(Columns.INITIALLY_DEFERRED, References.INITIALLY_DEFERRED)
                 .build()
         );
     }

--- a/sql/src/main/java/io/crate/metadata/table/ConstraintInfo.java
+++ b/sql/src/main/java/io/crate/metadata/table/ConstraintInfo.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.table;
+
+import io.crate.metadata.TableIdent;
+import org.apache.lucene.util.BytesRef;
+
+/**
+ * This class is used as information store of table constraints when
+ * beeing displayed.
+ */
+public class ConstraintInfo {
+
+    /**
+     * Enum that contains type of constraints (that are currently supported
+     * by CrateDB)
+     *
+     * PRIMARY KEY is the primary key constraint of a table.
+     * CHECK       is only used for NOT NULL constraints.
+     */
+    public enum Constraint {
+        PRIMARY_KEY("PRIMARY KEY"),
+        CHECK("CHECK");
+
+        private final String text;
+
+        Constraint(final String text) {
+            this.text = text;
+        }
+
+        public BytesRef getReference() {
+            return new BytesRef(this.text);
+        }
+    }
+
+    private final String constraintName;
+    private final TableIdent tableIdent;
+    private final Constraint constraintType;
+
+    public ConstraintInfo(TableIdent tableIdent, String constraintName, Constraint constraintType) {
+        this.tableIdent = tableIdent;
+        this.constraintName = constraintName;
+        this.constraintType = constraintType;
+    }
+
+    public TableIdent tableIdent() {
+        return this.tableIdent;
+    }
+
+    public String constraintName() {
+        return this.constraintName;
+    }
+
+    public BytesRef constraintType() {
+        return this.constraintType.getReference();
+    }
+}

--- a/sql/src/test/java/io/crate/analyze/relations/RelationAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/relations/RelationAnalyzerTest.java
@@ -49,8 +49,8 @@ public class RelationAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testColumnNameFromArrayComparisonExpression() throws Exception {
-        SelectAnalyzedStatement statement = executor.analyze("select 'foo' = any(constraint_name) " +
-                                                             "from information_schema.table_constraints");
-        assertThat(statement.relation().fields().get(0).path().outputName(), is("'foo' = ANY(constraint_name)"));
+        SelectAnalyzedStatement statement = executor.analyze("select 'foo' = any(partitioned_by) " +
+                                                             "from information_schema.tables");
+        assertThat(statement.relation().fields().get(0).path().outputName(), is("'foo' = ANY(partitioned_by)"));
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -401,10 +401,10 @@ public class DDLIntegrationTest extends SQLTransportIntegrationTest {
         ensureYellow();
         execute("alter table t add column name string primary key");
         execute("select constraint_name from information_schema.table_constraints " +
-                "where table_name = 't' and table_schema = 'doc' and constraint_type = 'PRIMARY_KEY'");
+                "where table_name = 't' and table_schema = 'doc' and constraint_type = 'PRIMARY KEY'");
 
         assertThat(response.rowCount(), is(1L));
-        assertThat((Object[]) response.rows()[0][0], arrayContaining(new Object[]{"name", "id"}));
+        assertThat(response.rows()[0][0], is("t_pk"));
     }
 
     @Test


### PR DESCRIPTION
This populates the previously empty table table key_column_usage inside
information_schema with the primary key information of all user tables.