### PR TITLE
added setting for enabling/disabling shard rebalance

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -28,11 +28,13 @@ Breaking Changes
 Changes
 =======
 
+- Added new cluster setting ``routing.rebalance.enable`` that allows to
+  enable or disable shard rebalancing on the cluster.
+
 - Table ``information_schema.key_column_usage`` now gets populated with primary
   key information of user tables.
 
 - Table ``information_schema.table_constraints`` is now returning ``NOT_NULL``
-  constraints.
 
 - Fixed an issue that caused an error ``Primary key value must not be NULL``
   to be thrown when trying to insert rows in a table that has a generated

--- a/blackbox/docs/configuration/cluster.txt
+++ b/blackbox/docs/configuration/cluster.txt
@@ -587,6 +587,23 @@ Routing Allocation
    recover their unassigned local primary shards immediatelly after restart, in
    case the ``recovery.initial_shards`` setting is satisfied.
 
+.. _cluster.routing.rebalance.enable:
+
+**cluster.routing.rebalance.enable**
+  | *Default:*   ``all``
+  | *Runtime:*  ``yes``
+  | *Allowed Values:* ``all | none | primaries | replicas``
+
+  Enables/Disables rebalancing for different types of shards.
+
+  ``all`` allows shard rebalancing for all types of shards.
+
+  ``none`` disables shard rebalancing for any types.
+
+  ``primaries`` allows shard rebalancing only for primary shards.
+
+  ``replicas`` allows shard rebalancing only for replica shards.
+
 .. _cluster.routing.allocation.allow_rebalance:
 
 **cluster.routing.allocation.allow_rebalance**

--- a/blackbox/docs/sql/ddl/alter_table.txt
+++ b/blackbox/docs/sql/ddl/alter_table.txt
@@ -135,6 +135,13 @@ Shard rerouting can help solve several problems:
     * **"Hot Shards"**: Most of your queries affect certain shards only. These
       shards lie on a node that has insufficient resources.
 
+This command takes these :ref:`Routing Allocation Settings <conf_routing>` into
+account. Once an allocation occurs CrateDB tries (by default) to re-balance
+shards to an even state. CrateDB can be set to disable shard re-balancing 
+with the setting ``cluster.routing.rebalance.enable=None`` to perform only the
+explicit triggered allocations.
+.
+
 .. NOTE::
 
     The command only triggers the allocation and reports back if the process has

--- a/blackbox/docs/sql/system.txt
+++ b/blackbox/docs/sql/system.txt
@@ -121,6 +121,8 @@ applied cluster settings.
     | settings['cluster']['routing']['allocation']['require']['_id']                    | string       |
     | settings['cluster']['routing']['allocation']['require']['_ip']                    | string       |
     | settings['cluster']['routing']['allocation']['require']['_name']                  | string       |
+    | settings['cluster']['routing']['rebalance']                                       | object       |
+    | settings['cluster']['routing']['rebalance']['enable']                             | string       |
     | settings['discovery']                                                             | object       |
     | settings['discovery']['zen']                                                      | object       |
     | settings['discovery']['zen']['minimum_master_nodes']                              | integer      |

--- a/sql/src/main/java/io/crate/metadata/settings/CrateSettings.java
+++ b/sql/src/main/java/io/crate/metadata/settings/CrateSettings.java
@@ -120,6 +120,7 @@ public final class CrateSettings implements ClusterStateListener {
             CrateSetting.of(InternalClusterInfoService.INTERNAL_CLUSTER_INFO_UPDATE_INTERVAL_SETTING, DataTypes.STRING),
             // CLUSTER ROUTING
             CrateSetting.of(EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE_SETTING, DataTypes.STRING),
+            CrateSetting.of(EnableAllocationDecider.CLUSTER_ROUTING_REBALANCE_ENABLE_SETTING, DataTypes.STRING),
             CrateSetting.of(ClusterRebalanceAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ALLOW_REBALANCE_SETTING, DataTypes.STRING),
             CrateSetting.of(ConcurrentRebalanceAllocationDecider.CLUSTER_ROUTING_ALLOCATION_CLUSTER_CONCURRENT_REBALANCE_SETTING, DataTypes.INTEGER),
             CrateSetting.of(ThrottlingAllocationDecider.CLUSTER_ROUTING_ALLOCATION_NODE_INITIAL_PRIMARIES_RECOVERIES_SETTING, DataTypes.INTEGER),

--- a/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -495,7 +495,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultColumns() throws Exception {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(462, response.rowCount());
+        assertEquals(464, response.rowCount());
     }
 
     @Test


### PR DESCRIPTION
this setting allows to enable or disable shard rebalancing for specific
kind of shards.