### PR TITLE
Allow array to geo_point conversions

### DIFF
--- a/core/src/main/java/io/crate/types/CollectionType.java
+++ b/core/src/main/java/io/crate/types/CollectionType.java
@@ -115,7 +115,7 @@ public abstract class CollectionType extends DataType {
 
     @Override
     public boolean isConvertableTo(DataType other) {
-        return other.id() == UndefinedType.ID ||
+        return other.id() == UndefinedType.ID || other.id() == GeoPointType.ID ||
                ((other instanceof CollectionType)
                 && this.innerType.isConvertableTo(((CollectionType) other).innerType()));
     }

--- a/core/src/test/java/io/crate/types/GeoPointTypeTest.java
+++ b/core/src/test/java/io/crate/types/GeoPointTypeTest.java
@@ -83,6 +83,11 @@ public class GeoPointTypeTest extends CrateUnitTest {
     }
 
     @Test
+    public void testConversionFromArrayType() {
+        assertThat(new ArrayType(DataTypes.LONG).isConvertableTo(GeoPointType.INSTANCE), is(true));
+    }
+
+    @Test
     public void testInvalidLatitude() throws Exception {
         expectedException.expectMessage("Failed to validate geo point [lon=54.321000, lat=-123.456000], not a valid location.");
         DataTypes.GEO_POINT.value(new Double[]{54.321, -123.456});


### PR DESCRIPTION
In expressions like `distance(geo_point_col, [1,0])` we don't allow conversions
of columns (e.g. geo_point_col) anymore; instead, we convert the
Literal (e.g. [1,0]) to the column type (e.g. geo_point). This is currently not
possible, so we need to add another rule to allow the conversion.