### PR TITLE
added support to trigger allocation for unassigned shards in the cluster

### DIFF
--- a/enterprise/users/src/main/java/io/crate/operation/user/StatementPrivilegeValidator.java
+++ b/enterprise/users/src/main/java/io/crate/operation/user/StatementPrivilegeValidator.java
@@ -55,6 +55,7 @@ import io.crate.analyze.PrivilegesAnalyzedStatement;
 import io.crate.analyze.QueriedSelectRelation;
 import io.crate.analyze.QueriedTable;
 import io.crate.analyze.RefreshTableAnalyzedStatement;
+import io.crate.analyze.RerouteRetryFailedAnalyzedStatement;
 import io.crate.analyze.ResetAnalyzedStatement;
 import io.crate.analyze.RestoreSnapshotAnalyzedStatement;
 import io.crate.analyze.SelectAnalyzedStatement;
@@ -136,6 +137,12 @@ class StatementPrivilegeValidator implements StatementAuthorizedValidator {
 
         @Override
         public Void visitDropIngestRuleStatement(DropIngestionRuleAnalysedStatement analysis, User user) {
+            throwUnauthorized(user);
+            return null;
+        }
+
+        @Override
+        public Void visitRerouteRetryFailedStatement(RerouteRetryFailedAnalyzedStatement analysis, User user) {
             throwUnauthorized(user);
             return null;
         }

--- a/enterprise/users/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
+++ b/enterprise/users/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
@@ -285,4 +285,14 @@ public class PrivilegesIntegrationTest extends BaseUsersIntegrationTest {
         expectedException.expectMessage("TableUnknownException: Table 'custom_schema.t1' unknown");
         executeAsSuperuser("grant dql on table t1 to "+ TEST_USERNAME);
     }
+
+    @Test
+    public void testAlterClusterRerouteRetryFailedPrivileges() {
+        executeAsSuperuser("alter cluster reroute retry failed");
+        assertThat(response.rowCount(), is (0L));
+
+        expectedException.expect(SQLActionException.class);
+        expectedException.expectMessage(containsString("UnauthorizedException: User \"normal\" is not authorized to execute statement"));
+        executeAsNormalUser("alter cluster reroute retry failed");
+    }
 }

--- a/sql-parser/src/main/antlr/SqlBase.g4
+++ b/sql-parser/src/main/antlr/SqlBase.g4
@@ -52,6 +52,7 @@ statement
     | ALTER TABLE alterTableDefinition (OPEN | CLOSE)                                #alterTableOpenClose
     | ALTER TABLE alterTableDefinition RENAME TO qname                               #alterTableRename
     | ALTER TABLE alterTableDefinition REROUTE rerouteOption                         #alterTableReroute
+    | ALTER CLUSTER REROUTE RETRY FAILED                                             #alterClusterRerouteRetryFailed
     | RESET GLOBAL primaryExpression (',' primaryExpression)*                        #resetGlobal
     | SET SESSION CHARACTERISTICS AS TRANSACTION setExpr (setExpr)*                  #setSessionTransactionMode
     | SET (SESSION | LOCAL)? qname
@@ -604,7 +605,7 @@ nonReserved
     | REPOSITORY | SNAPSHOT | RESTORE | GENERATED | ALWAYS | BEGIN
     | ISOLATION | TRANSACTION | CHARACTERISTICS | LEVEL | LANGUAGE | OPEN | CLOSE | RENAME
     | PRIVILEGES | SCHEMA | INGEST | RULE
-    | REROUTE | MOVE | SHARD | ALLOCATE | REPLICA | CANCEL
+    | REROUTE | MOVE | SHARD | ALLOCATE | REPLICA | CANCEL | CLUSTER | RETRY | FAILED
     ;
 
 SELECT: 'SELECT';
@@ -687,6 +688,7 @@ RECURSIVE: 'RECURSIVE';
 CREATE: 'CREATE';
 BLOB: 'BLOB';
 TABLE: 'TABLE';
+CLUSTER: 'CLUSTER';
 REPOSITORY: 'REPOSITORY';
 SNAPSHOT: 'SNAPSHOT';
 ALTER: 'ALTER';
@@ -707,6 +709,8 @@ SHARD: 'SHARD';
 ALLOCATE: 'ALLOCATE';
 REPLICA: 'REPLICA';
 CANCEL: 'CANCEL';
+RETRY: 'RETRY';
+FAILED: 'FAILED';
 
 BOOLEAN: 'BOOLEAN';
 BYTE: 'BYTE';

--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -32,6 +32,7 @@ import io.crate.sql.tree.AddColumnDefinition;
 import io.crate.sql.tree.AliasedRelation;
 import io.crate.sql.tree.AllColumns;
 import io.crate.sql.tree.AlterBlobTable;
+import io.crate.sql.tree.AlterClusterRerouteRetryFailed;
 import io.crate.sql.tree.AlterTable;
 import io.crate.sql.tree.AlterTableAddColumn;
 import io.crate.sql.tree.AlterTableOpenClose;
@@ -758,6 +759,11 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
         return new AlterTableReroute(
             (Table) visit(context.alterTableDefinition()),
             (RerouteOption) visit(context.rerouteOption()));
+    }
+
+    @Override
+    public Node visitAlterClusterRerouteRetryFailed(SqlBaseParser.AlterClusterRerouteRetryFailedContext context) {
+        return new AlterClusterRerouteRetryFailed();
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/AlterClusterRerouteRetryFailed.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AlterClusterRerouteRetryFailed.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.sql.tree;
+
+public class AlterClusterRerouteRetryFailed extends Statement {
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitAlterClusterRerouteRetryFailed(this, context);
+    }
+
+    @Override
+    public int hashCode() {
+        return 0;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return this == obj;
+    }
+
+    @Override
+    public String toString() {
+        return "ALTER CLUSTER REROUTE RETRY FAILED";
+    }
+}

--- a/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
@@ -441,6 +441,10 @@ public abstract class AstVisitor<R, C> {
         return visitStatement(node, context);
     }
 
+    public R visitAlterClusterRerouteRetryFailed(AlterClusterRerouteRetryFailed node, C context) {
+        return visitStatement(node, context);
+    }
+
     public R visitCopyTo(CopyTo node, C context) {
         return visitStatement(node, context);
     }

--- a/sql/src/main/java/io/crate/action/sql/DDLStatementDispatcher.java
+++ b/sql/src/main/java/io/crate/action/sql/DDLStatementDispatcher.java
@@ -46,6 +46,7 @@ import io.crate.analyze.RefreshTableAnalyzedStatement;
 import io.crate.analyze.RerouteAllocateReplicaShardAnalyzedStatement;
 import io.crate.analyze.RerouteCancelShardAnalyzedStatement;
 import io.crate.analyze.RerouteMoveShardAnalyzedStatement;
+import io.crate.analyze.RerouteRetryFailedAnalyzedStatement;
 import io.crate.analyze.RestoreSnapshotAnalyzedStatement;
 import io.crate.blob.v2.BlobAdminClient;
 import io.crate.data.Row;
@@ -159,6 +160,11 @@ public class DDLStatementDispatcher implements BiFunction<AnalyzedStatement, Row
         @Override
         public CompletableFuture<Long> visitAlterTableRenameStatement(AlterTableRenameAnalyzedStatement analysis, Row parameters) {
             return alterTableOperation.executeAlterTableRenameTable(analysis);
+        }
+
+        @Override
+        public CompletableFuture<Long> visitRerouteRetryFailedStatement(RerouteRetryFailedAnalyzedStatement analysis, Row parameters) {
+            return RerouteActions.executeRetryFailed(rerouteAction::execute);
         }
 
         @Override

--- a/sql/src/main/java/io/crate/analyze/AnalyzedStatementVisitor.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedStatementVisitor.java
@@ -121,6 +121,10 @@ public class AnalyzedStatementVisitor<C, R> {
         return visitDDLStatement(analysis, context);
     }
 
+    public R visitRerouteRetryFailedStatement(RerouteRetryFailedAnalyzedStatement analysis, C context) {
+        return visitDDLStatement(analysis, context);
+    }
+
     public R visitAlterBlobTableStatement(AlterBlobTableAnalyzedStatement analysis, C context) {
         return visitDDLStatement(analysis, context);
     }

--- a/sql/src/main/java/io/crate/analyze/Analyzer.java
+++ b/sql/src/main/java/io/crate/analyze/Analyzer.java
@@ -31,6 +31,7 @@ import io.crate.metadata.FulltextAnalyzerResolver;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Schemas;
 import io.crate.sql.tree.AlterBlobTable;
+import io.crate.sql.tree.AlterClusterRerouteRetryFailed;
 import io.crate.sql.tree.AlterTable;
 import io.crate.sql.tree.AlterTableAddColumn;
 import io.crate.sql.tree.AlterTableOpenClose;
@@ -295,6 +296,11 @@ public class Analyzer {
         public AnalyzedStatement visitAlterTable(AlterTable node, Analysis context) {
             return alterTableAnalyzer.analyze(
                 node, context.parameterContext().parameters(), context.sessionContext());
+        }
+
+        @Override
+        public AnalyzedStatement visitAlterClusterRerouteRetryFailed(AlterClusterRerouteRetryFailed node, Analysis context) {
+            return new RerouteRetryFailedAnalyzedStatement();
         }
 
         @Override

--- a/sql/src/main/java/io/crate/analyze/RerouteRetryFailedAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/RerouteRetryFailedAnalyzedStatement.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.analyze;
+
+public class RerouteRetryFailedAnalyzedStatement implements DDLStatement {
+
+    @Override
+    public <C, R> R accept(AnalyzedStatementVisitor<C, R> visitor, C context) {
+        return visitor.visitRerouteRetryFailedStatement(this, context);
+    }
+}

--- a/sql/src/main/java/io/crate/executor/transport/RerouteActions.java
+++ b/sql/src/main/java/io/crate/executor/transport/RerouteActions.java
@@ -40,10 +40,14 @@ import io.crate.sql.tree.GenericProperties;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteRequest;
 import org.elasticsearch.action.admin.cluster.reroute.ClusterRerouteResponse;
+import org.elasticsearch.cluster.routing.RoutingNode;
+import org.elasticsearch.cluster.routing.ShardRoutingState;
+import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.cluster.routing.allocation.command.AllocateReplicaAllocationCommand;
 import org.elasticsearch.cluster.routing.allocation.command.CancelAllocationCommand;
 import org.elasticsearch.cluster.routing.allocation.command.MoveAllocationCommand;
 
+import java.util.Iterator;
 import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
@@ -71,6 +75,42 @@ public final class RerouteActions {
             new FutureActionListener<>(r -> r.isAcknowledged() ? 1L : -1L);
         rerouteAction.accept(request, listener);
         return listener;
+    }
+
+
+    public static CompletableFuture<Long> executeRetryFailed(
+        BiConsumer<ClusterRerouteRequest, ActionListener<ClusterRerouteResponse>> rerouteAction) {
+
+        ClusterRerouteRequest request = new ClusterRerouteRequest();
+        request.setRetryFailed(true);
+        FutureActionListener<ClusterRerouteResponse, Long> listener =
+            new FutureActionListener<>(RerouteActions::retryFailedAffectedShardsRowCount);
+        rerouteAction.accept(request, listener);
+        return listener;
+    }
+
+    static long retryFailedAffectedShardsRowCount(ClusterRerouteResponse response) {
+        if (response.isAcknowledged()) {
+            long rowCount = 0L;
+            Iterator<RoutingNode> it = response.getState().getRoutingNodes().iterator();
+            while (it.hasNext()) {
+                RoutingNode routingNode = it.next();
+                // filter shards with failed allocation attempts
+                rowCount += routingNode.shardsWithState(ShardRoutingState.UNASSIGNED, ShardRoutingState.INITIALIZING)
+                    .stream()
+                    .filter(s -> {
+                        if (s.unassignedInfo() != null) {
+                            return s.unassignedInfo().getReason().equals(UnassignedInfo.Reason.ALLOCATION_FAILED);
+                        } else {
+                            return false;
+                        }
+                    })
+                    .count();
+            }
+            return rowCount;
+        } else {
+            return -1L;
+        }
     }
 
     static ClusterRerouteRequest prepareRequest(RerouteAnalyzedStatement stmt, Row parameters) {

--- a/sql/src/test/java/io/crate/executor/transport/RerouteActionsTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/RerouteActionsTest.java
@@ -149,6 +149,18 @@ public class RerouteActionsTest extends CrateUnitTest {
     }
 
     @Test
+    public void testRerouteRetryFailedExecution() throws Exception {
+        AtomicReference<ClusterRerouteRequest> reqRef = new AtomicReference<>();
+
+        RerouteActions.executeRetryFailed((req, listener) -> reqRef.set(req));
+        ClusterRerouteRequest actualRequest = reqRef.get();
+
+        ClusterRerouteRequest request = new ClusterRerouteRequest();
+        request.setRetryFailed(true);
+        assertEquals(request, actualRequest);
+    }
+
+    @Test
     public void testAllocateReplicaShardRequest() throws Exception {
         RerouteAllocateReplicaShardAnalyzedStatement statement = new RerouteAllocateReplicaShardAnalyzedStatement(
             TableDefinitions.USER_TABLE_INFO,


### PR DESCRIPTION
This commit adds the statement ``ALTER CLUSTER REROUTE RETRY FAILED`` that
triggers the allocation for shards in the cluster that have failed allocation attempts.

This command can only be triggered by super-users.

Tests covers privileges and request command only. Setup an integration test that covers a real world use-case is only possible by doing it manually since certain events need to be applied that do not affect a cluster-state change.

Tested it manually with the following scenario:

1. Setup 2-node cluster and create a stopwords file `stopwords.txt` on both nodes
2. Create a stopwords analyzer referring to the stopwords file
`create analyzer stopwords extends stop with (stopwords_path='stopwords.txt');`
3. Create a table using the stopwords analyzer:
```
create table t (
   text string index using fulltext with (analyzer='stopwords')
) with (number_of_replicas=0);
```
4. ✅ state
5. Stop 1 node and remove it's `stopwords.txt` file
6. Start this node again
7. 🔴 state. Contains unassigned shards with 5 failed attempts to allocate
8. Add the missing `stopwords.txt` to the node again
9. Trigger reroute-retry using `ALTER CLUSTER REROUTE RETRY FAILED`
10. ✅ state