### PR TITLE
Fix nested Limit operators

### DIFF
--- a/sql/src/main/java/io/crate/planner/operators/Collect.java
+++ b/sql/src/main/java/io/crate/planner/operators/Collect.java
@@ -90,11 +90,16 @@ class Collect implements LogicalPlan {
     private final List<AbstractTableRelation> baseTables;
     private final long numExpectedRows;
 
-    Collect(QueriedTableRelation relation,
-            List<Symbol> toCollect,
-            WhereClause where,
-            Set<Symbol> usedBeforeNextFetch,
-            long numExpectedRows) {
+    public static LogicalPlan.Builder create(QueriedTableRelation relation, List<Symbol> toCollect, WhereClause where) {
+        return (tableStats, usedColumns) -> new Collect(
+            relation, toCollect, where, usedColumns, tableStats.numDocs(relation.tableRelation().tableInfo().ident()));
+    }
+
+    private Collect(QueriedTableRelation relation,
+                    List<Symbol> toCollect,
+                    WhereClause where,
+                    Set<Symbol> usedBeforeNextFetch,
+                    long numExpectedRows) {
 
         this.numExpectedRows = numExpectedRows;
         if (where.hasVersions()) {

--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -141,7 +141,7 @@ public class LogicalPlanner {
                                                         WhereClause where,
                                                         FetchMode fetchMode) {
         if (queriedRelation instanceof QueriedTableRelation) {
-            return createCollect((QueriedTableRelation) queriedRelation, toCollect, where);
+            return Collect.create((QueriedTableRelation) queriedRelation, toCollect, where);
         }
         if (queriedRelation instanceof MultiSourceSelect) {
             return Join.createNodes(((MultiSourceSelect) queriedRelation), where);
@@ -154,13 +154,6 @@ public class LogicalPlanner {
             );
         }
         throw new UnsupportedOperationException("Cannot create LogicalPlan from: " + queriedRelation);
-    }
-
-    private static LogicalPlan.Builder createCollect(QueriedTableRelation relation,
-                                                     List<Symbol> toCollect,
-                                                     WhereClause where) {
-        return (tableStats, usedColumns) -> new Collect(
-            relation, toCollect, where, usedColumns, tableStats.numDocs(relation.tableRelation().tableInfo().ident()));
     }
 
     static Set<Symbol> extractColumns(Symbol symbol) {

--- a/sql/src/test/java/io/crate/planner/operators/LimitTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/LimitTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.operators;
+
+import io.crate.analyze.SelectAnalyzedStatement;
+import io.crate.analyze.TableDefinitions;
+import io.crate.analyze.relations.QueriedDocTable;
+import io.crate.analyze.symbol.Literal;
+import io.crate.operation.projectors.TopN;
+import io.crate.planner.Merge;
+import io.crate.planner.Planner;
+import io.crate.planner.TableStats;
+import io.crate.planner.projection.builder.ProjectionBuilder;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.ProjectionMatchers;
+import io.crate.testing.SQLExecutor;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static io.crate.planner.operators.LogicalPlannerTest.isPlan;
+import static org.hamcrest.Matchers.contains;
+
+public class LimitTest extends CrateDummyClusterServiceUnitTest {
+
+    @Test
+    public void testLimitOnLimitOperator() throws Exception {
+        SQLExecutor e = SQLExecutor.builder(clusterService)
+            .addDocTable(TableDefinitions.USER_TABLE_INFO)
+            .build();
+        SelectAnalyzedStatement stmt = e.analyze("select name from users");
+
+        QueriedDocTable queriedDocTable = (QueriedDocTable) stmt.relation();
+        LogicalPlan plan = Limit.create(
+            Limit.create(
+                Collect.create(queriedDocTable, queriedDocTable.outputs(), queriedDocTable.where()),
+                Literal.of(10L),
+                Literal.of(5L)
+            ),
+            Literal.of(20L),
+            Literal.of(7L)
+        ).build(new TableStats(), Collections.emptySet());
+
+        assertThat(plan, isPlan(e.functions(), "Limit[20;7]\n" +
+                                               "Limit[10;5]\n" +
+                                               "Collect[doc.users | [_fetchid] | All]\n"));
+
+        Planner.Context ctx = e.getPlannerContext(clusterService.state(), new TableStats());
+        Merge merge = (Merge) plan.build(
+            ctx,
+            new ProjectionBuilder(e.functions()),
+            TopN.NO_LIMIT,
+            0,
+            null,
+            null
+        );
+        io.crate.planner.node.dql.Collect collect = (io.crate.planner.node.dql.Collect) merge.subPlan();
+        assertThat(collect.collectPhase().projections(), contains(
+            ProjectionMatchers.isTopN(15, 0)
+        ));
+        //noinspection unchecked
+        assertThat(merge.mergePhase().projections(), contains(
+            ProjectionMatchers.isTopN(10, 5),
+            ProjectionMatchers.isTopN(20, 7)
+        ));
+    }
+}

--- a/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -27,6 +27,7 @@ import io.crate.analyze.SelectAnalyzedStatement;
 import io.crate.analyze.relations.QueriedRelation;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.format.SymbolPrinter;
+import io.crate.metadata.Functions;
 import io.crate.planner.TableStats;
 import io.crate.planner.consumer.FetchMode;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
@@ -158,16 +159,20 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
                                 "Collect[doc.t1 | [_fetchid, _score] | All]\n"));
     }
 
-    private Matcher<LogicalPlan> isPlan(String expectedPlan) {
+    public static Matcher<LogicalPlan> isPlan(Functions functions, String expectedPlan) {
         return new FeatureMatcher<LogicalPlan, String>(equalTo(expectedPlan), "same output", "output ") {
 
 
             @Override
             protected String featureValueOf(LogicalPlan actual) {
-                Printer printer = new Printer(new SymbolPrinter(sqlExecutor.functions()));
+                Printer printer = new Printer(new SymbolPrinter(functions));
                 return printer.printPlan(actual);
             }
         };
+    }
+
+    private Matcher<LogicalPlan> isPlan(String expectedPlan) {
+        return isPlan(sqlExecutor.functions(), expectedPlan);
     }
 
     private static class Printer {


### PR DESCRIPTION
The limit operator didn't behave correctly if the source plan is
pre-limited but still distributed.

Currently the `SubselectRewriter` should prevent such a case from happen
as it merges limits if possible, but it was still wrong.