### PR TITLE
Make bulkActions non-nullable

### DIFF
--- a/sql/src/main/java/io/crate/operation/projectors/ColumnIndexWriterProjector.java
+++ b/sql/src/main/java/io/crate/operation/projectors/ColumnIndexWriterProjector.java
@@ -21,7 +21,6 @@
 
 package io.crate.operation.projectors;
 
-import com.google.common.base.MoreObjects;
 import io.crate.analyze.symbol.Assignments;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.data.BatchIterator;
@@ -72,7 +71,7 @@ public class ColumnIndexWriterProjector implements Projector {
                                List<Input<?>> insertInputs,
                                List<? extends CollectExpression<Row, ?>> collectExpressions,
                                @Nullable Map<Reference, Symbol> updateAssignments,
-                               @Nullable Integer bulkActions,
+                               int bulkActions,
                                boolean autoCreateIndices,
                                UUID jobId) {
         RowShardResolver rowShardResolver = new RowShardResolver(
@@ -107,7 +106,7 @@ public class ColumnIndexWriterProjector implements Projector {
             nodeJobsCounter,
             scheduler,
             executor,
-            MoreObjects.firstNonNull(bulkActions, 100),
+            bulkActions,
             jobId,
             rowShardResolver,
             itemFactory,

--- a/sql/src/main/java/io/crate/operation/projectors/IndexWriterProjector.java
+++ b/sql/src/main/java/io/crate/operation/projectors/IndexWriterProjector.java
@@ -21,7 +21,6 @@
 
 package io.crate.operation.projectors;
 
-import com.google.common.base.MoreObjects;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.data.BatchIterator;
 import io.crate.data.CollectingBatchIterator;
@@ -80,7 +79,7 @@ public class IndexWriterProjector implements Projector {
                                 ColumnIdent clusteredByColumn,
                                 Input<?> sourceInput,
                                 List<? extends CollectExpression<Row, ?>> collectExpressions,
-                                @Nullable Integer bulkActions,
+                                int bulkActions,
                                 @Nullable String[] includes,
                                 @Nullable String[] excludes,
                                 boolean autoCreateIndices,
@@ -112,7 +111,7 @@ public class IndexWriterProjector implements Projector {
             nodeJobsCounter,
             scheduler,
             executor,
-            MoreObjects.firstNonNull(bulkActions, 100),
+            bulkActions,
             jobId,
             rowShardResolver,
             itemFactory,

--- a/sql/src/main/java/io/crate/planner/projection/AbstractIndexWriterProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/AbstractIndexWriterProjection.java
@@ -45,7 +45,7 @@ public abstract class AbstractIndexWriterProjection extends Projection {
     private static final String BULK_SIZE = "bulk_size";
     private static final int BULK_SIZE_DEFAULT = 10000;
 
-    private Integer bulkActions;
+    private final int bulkActions;
     protected TableIdent tableIdent;
     protected String partitionIdent;
     protected List<ColumnIdent> primaryKeys;
@@ -137,7 +137,7 @@ public abstract class AbstractIndexWriterProjection extends Projection {
         return OUTPUTS;
     }
 
-    public Integer bulkActions() {
+    public int bulkActions() {
         return bulkActions;
     }
 
@@ -158,7 +158,7 @@ public abstract class AbstractIndexWriterProjection extends Projection {
         AbstractIndexWriterProjection that = (AbstractIndexWriterProjection) o;
 
         if (autoCreateIndices != that.autoCreateIndices) return false;
-        if (!bulkActions.equals(that.bulkActions)) return false;
+        if (bulkActions != that.bulkActions) return false;
         if (clusteredByColumn != null ? !clusteredByColumn.equals(that.clusteredByColumn) :
             that.clusteredByColumn != null)
             return false;
@@ -179,7 +179,7 @@ public abstract class AbstractIndexWriterProjection extends Projection {
     @Override
     public int hashCode() {
         int result = super.hashCode();
-        result = 31 * result + bulkActions.hashCode();
+        result = 31 * result + Integer.hashCode(bulkActions);
         result = 31 * result + tableIdent.hashCode();
         result = 31 * result + (partitionIdent != null ? partitionIdent.hashCode() : 0);
         result = 31 * result + primaryKeys.hashCode();


### PR DESCRIPTION
It was already effectively non-nullable due to

    bulkActions = settings.getAsInt(BULK_SIZE, BULK_SIZE_DEFAULT);

This commit changes the type and removes some `Nullable` annotations to
reflect that.