### PR TITLE
Utilize index.mapping.single_type

### DIFF
--- a/sql/src/main/java/io/crate/analyze/CreateTableStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateTableStatementAnalyzer.java
@@ -47,6 +47,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Locale;
 
+import static org.elasticsearch.index.mapper.MapperService.INDEX_MAPPING_SINGLE_TYPE_SETTING;
+
 public class CreateTableStatementAnalyzer extends DefaultTraversalVisitor<CreateTableAnalyzedStatement,
     CreateTableStatementAnalyzer.Context> {
 
@@ -123,6 +125,7 @@ public class CreateTableStatementAnalyzer extends DefaultTraversalVisitor<Create
         statement.tableParameter().settingsBuilder().put(tableElements.settings());
         statement.tableParameter().settingsBuilder().put(
             IndexMetaData.SETTING_NUMBER_OF_SHARDS, numberOfShards.defaultNumberOfShards());
+        statement.tableParameter().settingsBuilder().put(INDEX_MAPPING_SINGLE_TYPE_SETTING.getKey(), true);
 
         Context context = new Context(statement, parameterContext);
         statement.analyzedTableElements(tableElements);

--- a/sql/src/main/java/io/crate/operation/reference/doc/lucene/IdFromUidCollectorExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/doc/lucene/IdFromUidCollectorExpression.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.operation.reference.doc.lucene;
+
+import io.crate.metadata.doc.DocSysColumns;
+import io.crate.operation.collect.collectors.CollectorFieldsVisitor;
+import org.apache.lucene.util.BytesRef;
+
+public class IdFromUidCollectorExpression extends LuceneCollectorExpression<BytesRef> {
+
+    public static final String COLUMN_NAME = DocSysColumns.ID.name();
+
+    private CollectorFieldsVisitor visitor;
+
+    public IdFromUidCollectorExpression() {
+        super(COLUMN_NAME);
+    }
+
+    @Override
+    public void startCollect(CollectorContext context) {
+        context.visitor().required(true);
+        this.visitor = context.visitor();
+        this.visitor.addField("_uid");
+    }
+
+    @Override
+    public BytesRef value() {
+        return new BytesRef(visitor.uid().id());
+    }
+}


### PR DESCRIPTION
This causes CREATE TABLE statements to set `index.mapping.single_type`
to `true`. This will become the default with ES 6.0
See https://github.com/elastic/elasticsearch/blob/59600dfe2da47dc8a30bf2f601ff6ead72d3bc78/docs/reference/mapping/removal_of_types.asciidoc

We've never made use of the `type` feature and always set it to
`default`.