### PR TITLE
Fix constraint_name in key_column_usage table

### DIFF
--- a/blackbox/docs/sql/information_schema.txt
+++ b/blackbox/docs/sql/information_schema.txt
@@ -430,8 +430,8 @@ tables:
     +-----------------+------------+-------------+------------------+
     | constraint_name | table_name | column_name | ordinal_position |
     +-----------------+------------+-------------+------------------+
-    | id_pk           | students   | id          |                1 |
-    | department_pk   | students   | department  |                2 |
+    | students_pk     | students   | id          |                1 |
+    | students_pk     | students   | department  |                2 |
     +-----------------+------------+-------------+------------------+
     SELECT 2 rows in set (... sec)
 

--- a/sql/src/main/java/io/crate/metadata/information/InformationKeyColumnUsageTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/information/InformationKeyColumnUsageTableInfo.java
@@ -76,7 +76,7 @@ public class InformationKeyColumnUsageTableInfo extends InformationTableInfo {
             .put(Columns.CONSTRAINT_SCHEMA,
                 () -> objToBytesRef(k -> "public"))
             .put(Columns.CONSTRAINT_NAME,
-                () -> objToBytesRef(k -> k.getPkColumnName() + PK_SUFFIX))
+                () -> objToBytesRef(k -> k.getTableName() + PK_SUFFIX))
             .put(Columns.TABLE_CATALOG,
                 () -> objToBytesRef(InformationSchemaIterables.KeyColumnUsage::getSchema))
             .put(Columns.TABLE_SCHEMA,

--- a/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -1202,9 +1202,20 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
 
         final String defaultSchema = sqlExecutor.getDefaultSchema();
         assertThat(response.rows(), arrayContaining(
-            new Object[] {"id2",  defaultSchema, "id2_pk",  "public", 1, defaultSchema, "table2", "public"},
-            new Object[] {"id3",  defaultSchema, "id3_pk",  "public", 1, defaultSchema, "table3", "public"},
-            new Object[] {"name", defaultSchema, "name_pk", "public", 2, defaultSchema, "table3", "public"}
+            new Object[] {"id2",  defaultSchema, "table2_pk",  "public", 1, defaultSchema, "table2", "public"},
+            new Object[] {"id3",  defaultSchema, "table3_pk",  "public", 1, defaultSchema, "table3", "public"},
+            new Object[] {"name", defaultSchema, "table3_pk",  "public", 2, defaultSchema, "table3", "public"}
+        ));
+
+        // check that the constraint name is the same as in table_constraints by joining the two tables
+        execute("select t1.* from information_schema.key_column_usage t1 " +
+                "join information_schema.table_constraints t2 " +
+                "on t1.constraint_name = t2.constraint_name " +
+                "order by t1.table_name, t1.ordinal_position asc");
+        assertThat(response.rows(), arrayContaining(
+            new Object[] {"id2",  defaultSchema, "table2_pk",  "public", 1, defaultSchema, "table2", "public"},
+            new Object[] {"id3",  defaultSchema, "table3_pk",  "public", 1, defaultSchema, "table3", "public"},
+            new Object[] {"name", defaultSchema, "table3_pk",  "public", 2, defaultSchema, "table3", "public"}
         ));
     }
 


### PR DESCRIPTION
The old constraint_name contained the column name instead of the table name.