### PR TITLE
Resume consumption in search TP instead of scheduler thread

### DIFF
--- a/sql/src/main/java/io/crate/operation/projectors/ColumnIndexWriterProjector.java
+++ b/sql/src/main/java/io/crate/operation/projectors/ColumnIndexWriterProjector.java
@@ -47,6 +47,7 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -58,6 +59,7 @@ public class ColumnIndexWriterProjector implements Projector {
     ColumnIndexWriterProjector(ClusterService clusterService,
                                NodeJobsCounter nodeJobsCounter,
                                ScheduledExecutorService scheduler,
+                               Executor executor,
                                Functions functions,
                                Settings settings,
                                Supplier<String> indexNameResolver,
@@ -104,6 +106,7 @@ public class ColumnIndexWriterProjector implements Projector {
             clusterService,
             nodeJobsCounter,
             scheduler,
+            executor,
             MoreObjects.firstNonNull(bulkActions, 100),
             jobId,
             rowShardResolver,

--- a/sql/src/main/java/io/crate/operation/projectors/IndexWriterProjector.java
+++ b/sql/src/main/java/io/crate/operation/projectors/IndexWriterProjector.java
@@ -55,6 +55,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -66,6 +67,7 @@ public class IndexWriterProjector implements Projector {
     public IndexWriterProjector(ClusterService clusterService,
                                 NodeJobsCounter nodeJobsCounter,
                                 ScheduledExecutorService scheduler,
+                                Executor executor,
                                 Functions functions,
                                 Settings settings,
                                 TransportBulkCreateIndicesAction transportBulkCreateIndicesAction,
@@ -109,6 +111,7 @@ public class IndexWriterProjector implements Projector {
             clusterService,
             nodeJobsCounter,
             scheduler,
+            executor,
             MoreObjects.firstNonNull(bulkActions, 100),
             jobId,
             rowShardResolver,

--- a/sql/src/main/java/io/crate/operation/projectors/ProjectionToProjectorVisitor.java
+++ b/sql/src/main/java/io/crate/operation/projectors/ProjectionToProjectorVisitor.java
@@ -310,6 +310,7 @@ public class ProjectionToProjectorVisitor
             clusterService,
             nodeJobsCounter,
             threadPool.scheduler(),
+            threadPool.executor(ThreadPool.Names.SEARCH),
             functions,
             clusterService.state().metaData().settings(),
             transportActionProvider.transportBulkCreateIndicesAction(),
@@ -346,6 +347,7 @@ public class ProjectionToProjectorVisitor
             clusterService,
             nodeJobsCounter,
             threadPool.scheduler(),
+            threadPool.executor(ThreadPool.Names.SEARCH),
             functions,
             clusterService.state().metaData().settings(),
             IndexNameResolver.create(projection.tableIdent(), projection.partitionIdent(), partitionedByInputs),
@@ -384,6 +386,7 @@ public class ProjectionToProjectorVisitor
         ShardDMLExecutor<ShardUpsertRequest, ShardUpsertRequest.Item> shardDMLExecutor = new ShardDMLExecutor<>(
             ShardDMLExecutor.DEFAULT_BULK_SIZE,
             threadPool.scheduler(),
+            threadPool.executor(ThreadPool.Names.SEARCH),
             resolveUidCollectExpression(projection.uidSymbol()),
             clusterService,
             nodeJobsCounter,
@@ -406,6 +409,7 @@ public class ProjectionToProjectorVisitor
         ShardDMLExecutor<ShardDeleteRequest, ShardDeleteRequest.Item> shardDMLExecutor = new ShardDMLExecutor<>(
             ShardDMLExecutor.DEFAULT_BULK_SIZE,
             threadPool.scheduler(),
+            threadPool.executor(ThreadPool.Names.SEARCH),
             resolveUidCollectExpression(projection.uidSymbol()),
             clusterService,
             nodeJobsCounter,

--- a/sql/src/main/java/io/crate/operation/projectors/ShardDMLExecutor.java
+++ b/sql/src/main/java/io/crate/operation/projectors/ShardDMLExecutor.java
@@ -43,6 +43,7 @@ import org.elasticsearch.common.logging.Loggers;
 import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.BiConsumer;
 import java.util.function.BinaryOperator;
@@ -62,6 +63,7 @@ public class ShardDMLExecutor<TReq extends ShardRequest<TReq, TItem>, TItem exte
 
     private final int bulkSize;
     private final ScheduledExecutorService scheduler;
+    private final Executor executor;
     private final CollectExpression<Row, ?> uidExpression;
     private final NodeJobsCounter nodeJobsCounter;
     private final Supplier<TReq> requestFactory;
@@ -74,6 +76,7 @@ public class ShardDMLExecutor<TReq extends ShardRequest<TReq, TItem>, TItem exte
 
     ShardDMLExecutor(int bulkSize,
                      ScheduledExecutorService scheduler,
+                     Executor executor,
                      CollectExpression<Row, ?> uidExpression,
                      ClusterService clusterService,
                      NodeJobsCounter nodeJobsCounter,
@@ -82,6 +85,7 @@ public class ShardDMLExecutor<TReq extends ShardRequest<TReq, TItem>, TItem exte
                      BiConsumer<TReq, ActionListener<ShardResponse>> transportAction) {
         this.bulkSize = bulkSize;
         this.scheduler = scheduler;
+        this.executor = executor;
         this.uidExpression = uidExpression;
         this.nodeJobsCounter = nodeJobsCounter;
         this.requestFactory = requestFactory;
@@ -124,6 +128,7 @@ public class ShardDMLExecutor<TReq extends ShardRequest<TReq, TItem>, TItem exte
         long initialResult = 0L;
         return new BatchIteratorBackpressureExecutor<>(
             scheduler,
+            executor,
             reqBatchIterator,
             this::executeBatch,
             combinePartialResult,

--- a/sql/src/main/java/io/crate/operation/projectors/sharding/ShardingUpsertExecutor.java
+++ b/sql/src/main/java/io/crate/operation/projectors/sharding/ShardingUpsertExecutor.java
@@ -57,6 +57,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -81,6 +82,7 @@ public class ShardingUpsertExecutor<TReq extends ShardRequest<TReq, TItem>, TIte
     private final GroupRowsByShard<TReq, TItem> grouper;
     private final NodeJobsCounter nodeJobsCounter;
     private final ScheduledExecutorService scheduler;
+    private final Executor executor;
     private final int bulkSize;
     private final UUID jobId;
     private final BiFunction<ShardId, String, TReq> requestFactory;
@@ -90,6 +92,7 @@ public class ShardingUpsertExecutor<TReq extends ShardRequest<TReq, TItem>, TIte
     public ShardingUpsertExecutor(ClusterService clusterService,
                                   NodeJobsCounter nodeJobsCounter,
                                   ScheduledExecutorService scheduler,
+                                  Executor executor,
                                   int bulkSize,
                                   UUID jobId,
                                   RowShardResolver rowShardResolver,
@@ -102,6 +105,7 @@ public class ShardingUpsertExecutor<TReq extends ShardRequest<TReq, TItem>, TIte
                                   TransportBulkCreateIndicesAction createIndicesAction) {
         this.nodeJobsCounter = nodeJobsCounter;
         this.scheduler = scheduler;
+        this.executor = executor;
         this.bulkSize = bulkSize;
         this.jobId = jobId;
         this.requestFactory = requestFactory;
@@ -186,6 +190,7 @@ public class ShardingUpsertExecutor<TReq extends ShardRequest<TReq, TItem>, TIte
 
         BatchIteratorBackpressureExecutor<ShardedRequests<TReq, TItem>, Long> executor = new BatchIteratorBackpressureExecutor<>(
             scheduler,
+            this.executor,
             reqBatchIterator,
             this::execute,
             (a, b) -> a + b,

--- a/sql/src/test/java/io/crate/operation/projectors/BatchIteratorBackpressureExecutorTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/BatchIteratorBackpressureExecutorTest.java
@@ -76,6 +76,7 @@ public class BatchIteratorBackpressureExecutorTest extends CrateUnitTest {
         };
         BatchIteratorBackpressureExecutor<Integer, Integer> executor = new BatchIteratorBackpressureExecutor<>(
             scheduler,
+            this.executor,
             it,
             i -> CompletableFuture.supplyAsync(numRows::incrementAndGet, this.executor),
             (a, b) -> a + b,

--- a/sql/src/test/java/io/crate/operation/projectors/IndexWriterProjectorTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/IndexWriterProjectorTest.java
@@ -75,10 +75,12 @@ public class IndexWriterProjectorTest extends SQLTransportIntegrationTest {
         List<CollectExpression<Row, ?>> collectExpressions = Collections.<CollectExpression<Row, ?>>singletonList(sourceInput);
 
         TableIdent bulkImportIdent = new TableIdent(sqlExecutor.getDefaultSchema(), "bulk_import");
+        ThreadPool threadPool = internalCluster().getInstance(ThreadPool.class);
         IndexWriterProjector writerProjector = new IndexWriterProjector(
             internalCluster().getInstance(ClusterService.class),
             new NodeJobsCounter(),
-            internalCluster().getInstance(ThreadPool.class).scheduler(),
+            threadPool.scheduler(),
+            threadPool.executor(ThreadPool.Names.SEARCH),
             internalCluster().getInstance(Functions.class),
             Settings.EMPTY,
             internalCluster().getInstance(TransportBulkCreateIndicesAction.class),

--- a/sql/src/test/java/io/crate/operation/projectors/IndexWriterProjectorUnitTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/IndexWriterProjectorUnitTest.java
@@ -44,6 +44,8 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.action.admin.indices.create.TransportBulkCreateIndicesAction;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Answers;
 import org.mockito.Mock;
@@ -52,7 +54,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import static io.crate.data.SentinelRow.SENTINEL;
 import static org.mockito.Mockito.mock;
@@ -67,6 +72,23 @@ public class IndexWriterProjectorUnitTest extends CrateUnitTest {
     @Mock(answer = Answers.RETURNS_MOCKS)
     ClusterService clusterService;
 
+    private ExecutorService executor;
+    private ScheduledExecutorService scheduler;
+
+    @Before
+    public void setUpExecutors() throws Exception {
+        scheduler = Executors.newScheduledThreadPool(1);
+        executor = Executors.newFixedThreadPool(1);
+    }
+
+    @After
+    public void tearDownExecutors() throws Exception {
+        scheduler.shutdown();
+        executor.shutdown();
+        scheduler.awaitTermination(10, TimeUnit.SECONDS);
+        executor.awaitTermination(10, TimeUnit.SECONDS);
+    }
+
     @Test
     public void testNullPKValue() throws Throwable {
         InputCollectExpression sourceInput = new InputCollectExpression(0);
@@ -76,7 +98,8 @@ public class IndexWriterProjectorUnitTest extends CrateUnitTest {
         IndexWriterProjector indexWriter = new IndexWriterProjector(
             clusterService,
             new NodeJobsCounter(),
-            Executors.newScheduledThreadPool(1),
+            scheduler,
+            executor,
             TestingHelpers.getFunctions(),
             Settings.EMPTY,
             transportBulkCreateIndicesAction,


### PR DESCRIPTION
This changes the `BatchIteratorBackpressureExecutor` to dispatch the
`BatchIterator` consumption back into the `Search` thread-pool because
there is only a single thread for the scheduler and we shouldn't occupy
that for potentially long running operations.