### PR TITLE
pgwire: Send a crate_version ParameterStatus to clients

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -28,6 +28,10 @@ Breaking Changes
 Changes
 =======
 
+- Clients using the postgres wire protocol will now receive an additional
+  ``crate_version`` ``ParameterStatus`` message during the connection
+  establishment. This can be used to identify the server as ``CrateDB``.
+
 - Added support to manually retry the allocation of shards that failed to
   allocate using ``ALTER CLUSTER REROUTE RETRY FAILED``.
 

--- a/blackbox/docs/protocols/postgres.txt
+++ b/blackbox/docs/protocols/postgres.txt
@@ -41,7 +41,7 @@ which is why clients should generally enable ``autocommit``.
 Server Compatibility and Implementation Status
 ==============================================
 
-CrateDB emulates PostgreSQL server version ``9.5``
+CrateDB emulates PostgreSQL server version ``9.5``.
 
 Start-Up
 --------
@@ -66,6 +66,21 @@ configured using :doc:`/administration/hba`.
 
 If the enterprise functionality is disabled, all "start up" requests are
 answered with an ``AuthenticationOK`` response.
+
+
+ParameterStatus
+...............
+
+After the authentication has succeeded the server has the possibility to send
+multiple ``ParameterStatus`` messages to the client.
+These are used to communicate information like ``server_version`` (emulates
+PostgreSQL 9.5) or ``server_encoding``.
+
+``CrateDB`` also sends a message containing the ``crate_version`` parameter.
+This contains the current ``CrateDB`` version number.
+
+This information is useful for clients to detect that they're connecting to
+``CrateDB`` instead of a PostgreSQL instance.
 
 
 Database selection

--- a/sql/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
@@ -23,6 +23,7 @@
 package io.crate.protocols.postgres;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.crate.Version;
 import io.crate.action.sql.ResultReceiver;
 import io.crate.action.sql.SQLOperations;
 import io.crate.action.sql.Session;
@@ -384,14 +385,15 @@ class PostgresWireProtocol {
                 }
                 session = sqlOperations.createSession(properties.getProperty("database"), user);
                 Messages.sendAuthenticationOK(channel)
-                    .addListener(f -> sendReadyForQuery(channel));
+                    .addListener(f -> sendParamsAndRdyForQuery(channel));
             } catch (Exception e) {
                 Messages.sendAuthenticationError(channel, e.getMessage());
             }
         }
     }
 
-    private void sendReadyForQuery(Channel channel) {
+    private void sendParamsAndRdyForQuery(Channel channel) {
+        Messages.sendParameterStatus(channel, "crate_version", Version.CURRENT.toString());
         Messages.sendParameterStatus(channel, "server_version", "9.5.0");
         Messages.sendParameterStatus(channel, "server_encoding", "UTF8");
         Messages.sendParameterStatus(channel, "client_encoding", "UTF8");


### PR DESCRIPTION
For clients it may be useful to know that they're communicating with
CrateDB instead of a PostgreSQL instance.
For example to adapt the server capabilities.

One such client is asyncpg, see https://github.com/MagicStack/asyncpg/issues/87