### PR TITLE
Add a system property to avoid the Signal handler registration

### DIFF
--- a/sql/src/main/java/io/crate/cluster/gracefulstop/DecommissioningService.java
+++ b/sql/src/main/java/io/crate/cluster/gracefulstop/DecommissioningService.java
@@ -112,11 +112,15 @@ public class DecommissioningService extends AbstractLifecycleComponent implement
         clusterSettings.addSettingsUpdateConsumer(GRACEFUL_STOP_FORCE_SETTING.setting(), this::setGracefulStopForce);
         clusterSettings.addSettingsUpdateConsumer(GRACEFUL_STOP_MIN_AVAILABILITY_SETTING.setting(), this::setDataAvailability);
 
-        try {
-            Signal signal = new Signal("USR2");
-            Signal.handle(signal, this);
-        } catch (IllegalArgumentException e) {
-            logger.warn("SIGUSR2 signal not supported on {}.", System.getProperty("os.name"), e);
+        // Signal handling here breaks FlightRecorder
+        // So this is a undocumented switch to disable this for benchmarking purposes
+        if (!System.getProperty("crate.signal_handler.disabled", "false").equalsIgnoreCase("true")) {
+            try {
+                Signal signal = new Signal("USR2");
+                Signal.handle(signal, this);
+            } catch (IllegalArgumentException e) {
+                logger.warn("SIGUSR2 signal not supported on {}.", System.getProperty("os.name"), e);
+            }
         }
     }
 


### PR DESCRIPTION
If the FlightRecorder is used and started it triggers the decomission
process if the `USR2` signal handler is registered.

This adds a switch to prevent that. Since this is only intended for devs
this is an undocumented system property instead of a regular setting.