### PR TITLE
Always visit fields to ensure join condition fields are resolved

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -21,6 +21,9 @@ Changes
 Fixes
 =====
 
+- Fix a NPE exception which could occur when joining four tables with a join
+  condition which referred to fields from the leftmost relation.
+
 - Fix a problem that caused ``WITHIN`` queries to return no or incorrect
   results.
 

--- a/sql/src/main/java/io/crate/planner/consumer/ManyTableConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/ManyTableConsumer.java
@@ -511,9 +511,7 @@ public class ManyTableConsumer implements Consumer {
                 // it's not necessary to extend the output
                 continue;
             }
-            if (relations.contains(leftName) || relations.contains(rightName)) {
-                FieldsVisitor.visitFields(symbol, fieldConsumer);
-            }
+            FieldsVisitor.visitFields(symbol, fieldConsumer);
         }
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -798,4 +798,27 @@ public class JoinIntegrationTest extends SQLTransportIntegrationTest {
                 "        unnest([2]) tt2");
         assertThat(printedTable(response.rows()), is("1| 1| 2\n"));
     }
+
+    @Test
+    public void testJoinWithConditionsReferringToTheFirstTable() {
+        execute("create table j1 (id1 int, id2 int, id3 int, id4 int, id5 int) clustered into 1 shards");
+        execute("create table j2 (id int) clustered into 1 shards");
+        execute("create table j3 (id int) clustered into 1 shards");
+        execute("create table j4 (id int) clustered into 1 shards");
+
+        execute("insert into j1 values (1, 1, 1, 1)");
+        execute("insert into j2 values (1)");
+        execute("insert into j3 values (1)");
+        execute("insert into j4 values (1)");
+
+        refresh();
+
+        execute("select id1 from (select id1, id2, id3, id4 from j1) a" +
+                " left join j2 b on a.id2 = b.id" +
+                " left join j3 c on a.id3 = c.id" +
+                " left join j4 d on a.id4 = d.id");
+
+        assertThat(TestingHelpers.printedTable(response.rows()), is("1\n"));
+
+    }
 }


### PR DESCRIPTION
This is a fix for `2.2` and `2.1`. The issue doesn't exist in master.

The issue occurs with the following query:

```sql
select id1 from (select id1, id2, id3, id4 from j1) a 
left join j2 b on a.id2 = b.id 
left join j3 c on a.id3 = c.id 
left join j4 d on a.id4 = d.id;
```

`id4` is represented as `join.a.b.a['id4']`, so a check for the relation `a` fails in the if block which determines whether to process the field. The names are rewritten later in the process of joining the relations.