### PR TITLE
Dynamically adjust the bulk size if new partitions needs to be created

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -81,6 +81,9 @@ Changes
 Fixes
 =====
 
+- Improves resiliency of ``COPY FROM`` and ``INSERT FROM SUBQUERY`` statements
+  when lot of new partitions will be created on demand.
+
 - Fix a problem that caused ``WITHIN`` queries to return no or incorrect
   results.
 

--- a/sql/src/main/java/io/crate/executor/transport/ShardRequest.java
+++ b/sql/src/main/java/io/crate/executor/transport/ShardRequest.java
@@ -128,6 +128,7 @@ public abstract class ShardRequest<T extends ShardRequest<T, I>, I extends Shard
         return getClass().getSimpleName() + "{" +
                "items=" + items +
                ", shardId=" + shardId +
+               ", timeout=" + timeout +
                '}';
     }
 

--- a/sql/src/main/java/io/crate/executor/transport/TransportActionProvider.java
+++ b/sql/src/main/java/io/crate/executor/transport/TransportActionProvider.java
@@ -29,7 +29,7 @@ import org.elasticsearch.action.admin.cluster.snapshots.create.TransportCreateSn
 import org.elasticsearch.action.admin.cluster.snapshots.delete.TransportDeleteSnapshotAction;
 import org.elasticsearch.action.admin.cluster.snapshots.get.TransportGetSnapshotsAction;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.TransportRestoreSnapshotAction;
-import org.elasticsearch.action.admin.indices.create.TransportBulkCreateIndicesAction;
+import org.elasticsearch.action.admin.indices.create.TransportCreatePartitionsAction;
 import org.elasticsearch.action.admin.indices.delete.TransportDeleteIndexAction;
 import org.elasticsearch.action.get.TransportGetAction;
 import org.elasticsearch.action.get.TransportMultiGetAction;
@@ -47,7 +47,7 @@ public class TransportActionProvider {
     private final Provider<TransportGetAction> transportGetActionProvider;
     private final Provider<TransportMultiGetAction> transportMultiGetActionProvider;
     private final Provider<TransportShardUpsertAction> transportShardUpsertActionProvider;
-    private final Provider<TransportBulkCreateIndicesAction> transportBulkCreateIndicesActionProvider;
+    private final Provider<TransportCreatePartitionsAction> transportBulkCreateIndicesActionProvider;
 
     private final Provider<TransportJobAction> transportJobInitActionProvider;
     private final Provider<TransportKillAllNodeAction> transportKillAllNodeActionProvider;
@@ -68,7 +68,7 @@ public class TransportActionProvider {
                                    Provider<TransportShardUpsertAction> transportShardUpsertActionProvider,
                                    Provider<TransportKillAllNodeAction> transportKillAllNodeActionProvider,
                                    Provider<TransportJobAction> transportJobInitActionProvider,
-                                   Provider<TransportBulkCreateIndicesAction> transportBulkCreateIndicesActionProvider,
+                                   Provider<TransportCreatePartitionsAction> transportBulkCreateIndicesActionProvider,
                                    Provider<TransportKillJobsNodeAction> transportKillJobsNodeActionProvider,
                                    Provider<TransportDeleteSnapshotAction> transportDeleteSnapshotActionProvider,
                                    Provider<TransportCreateSnapshotAction> transportCreateSnapshotActionProvider,
@@ -91,7 +91,7 @@ public class TransportActionProvider {
         this.transportGetSnapshotsActionProvider = transportGetSnapshotsActionPovider;
     }
 
-    public TransportBulkCreateIndicesAction transportBulkCreateIndicesAction() {
+    public TransportCreatePartitionsAction transportBulkCreateIndicesAction() {
         return transportBulkCreateIndicesActionProvider.get();
     }
 

--- a/sql/src/main/java/io/crate/executor/transport/task/UpsertByIdTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/UpsertByIdTask.java
@@ -38,9 +38,9 @@ import io.crate.operation.projectors.sharding.ShardingUpsertExecutor;
 import io.crate.planner.node.dml.UpsertById;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.admin.indices.create.BulkCreateIndicesRequest;
-import org.elasticsearch.action.admin.indices.create.BulkCreateIndicesResponse;
-import org.elasticsearch.action.admin.indices.create.TransportBulkCreateIndicesAction;
+import org.elasticsearch.action.admin.indices.create.CreatePartitionsRequest;
+import org.elasticsearch.action.admin.indices.create.CreatePartitionsResponse;
+import org.elasticsearch.action.admin.indices.create.TransportCreatePartitionsAction;
 import org.elasticsearch.action.bulk.BackoffPolicy;
 import org.elasticsearch.action.bulk.BulkRequestExecutor;
 import org.elasticsearch.cluster.ClusterState;
@@ -77,7 +77,7 @@ public class UpsertByIdTask extends JobTask {
 
     private final ClusterService clusterService;
     private final ShardUpsertRequest.Builder reqBuilder;
-    private final TransportBulkCreateIndicesAction createIndicesAction;
+    private final TransportCreatePartitionsAction createIndicesAction;
     private final List<UpsertById.Item> items;
     private final ScheduledExecutorService scheduler;
     private final BulkRequestExecutor<ShardUpsertRequest> upsertAction;
@@ -92,11 +92,11 @@ public class UpsertByIdTask extends JobTask {
                           ScheduledExecutorService scheduler,
                           Settings settings,
                           BulkRequestExecutor<ShardUpsertRequest> transportShardUpsertAction,
-                          TransportBulkCreateIndicesAction transportBulkCreateIndicesAction) {
+                          TransportCreatePartitionsAction transportCreatePartitionsAction) {
         super(upsertById.jobId());
         this.scheduler = scheduler;
         this.upsertAction = transportShardUpsertAction;
-        this.createIndicesAction = transportBulkCreateIndicesAction;
+        this.createIndicesAction = transportCreatePartitionsAction;
         this.clusterService = clusterService;
         this.items = upsertById.items();
         this.bulkIndices = upsertById.bulkIndices();
@@ -318,9 +318,9 @@ public class UpsertByIdTask extends JobTask {
         return requestsByShard;
     }
 
-    private CompletableFuture<BulkCreateIndicesResponse> createPendingIndices(Collection<String> indices) {
-        FutureActionListener<BulkCreateIndicesResponse, BulkCreateIndicesResponse> listener = new FutureActionListener<>(r -> r);
-        createIndicesAction.execute(new BulkCreateIndicesRequest(indices, jobId()), listener);
+    private CompletableFuture<CreatePartitionsResponse> createPendingIndices(Collection<String> indices) {
+        FutureActionListener<CreatePartitionsResponse, CreatePartitionsResponse> listener = new FutureActionListener<>(r -> r);
+        createIndicesAction.execute(new CreatePartitionsRequest(indices, jobId()), listener);
         return listener;
     }
 

--- a/sql/src/main/java/io/crate/operation/TableSettingsResolver.java
+++ b/sql/src/main/java/io/crate/operation/TableSettingsResolver.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.operation;
+
+import io.crate.exceptions.TableUnknownException;
+import io.crate.metadata.PartitionName;
+import io.crate.metadata.TableIdent;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.IndexNotFoundException;
+
+public final class TableSettingsResolver {
+
+    public static Settings get(MetaData metaData, TableIdent tableIdent, boolean partitioned) {
+        if (partitioned) {
+            return forPartitionedTable(metaData, tableIdent);
+        }
+        return forTable(metaData, tableIdent);
+    }
+
+    private static Settings forTable(MetaData metaData, TableIdent tableIdent) {
+        IndexMetaData indexMetaData = metaData.index(tableIdent.indexName());
+        if (indexMetaData == null) {
+            throw new IndexNotFoundException(tableIdent.indexName());
+        }
+        return indexMetaData.getSettings();
+    }
+
+    private static Settings forPartitionedTable(MetaData metaData, TableIdent tableIdent) {
+        String templateName = PartitionName.templateName(tableIdent.schema(), tableIdent.name());
+        IndexTemplateMetaData templateMetaData = metaData.templates().get(templateName);
+        if (templateMetaData == null) {
+            throw new TableUnknownException(tableIdent);
+        }
+        return templateMetaData.getSettings();
+    }
+
+    private TableSettingsResolver() {
+    }
+}

--- a/sql/src/main/java/io/crate/operation/projectors/ColumnIndexWriterProjector.java
+++ b/sql/src/main/java/io/crate/operation/projectors/ColumnIndexWriterProjector.java
@@ -61,6 +61,7 @@ public class ColumnIndexWriterProjector implements Projector {
                                Executor executor,
                                Functions functions,
                                Settings settings,
+                               Settings tableSettings,
                                Supplier<String> indexNameResolver,
                                TransportActionProvider transportActionProvider,
                                List<ColumnIdent> primaryKeyIdents,
@@ -115,7 +116,8 @@ public class ColumnIndexWriterProjector implements Projector {
             indexNameResolver,
             autoCreateIndices,
             transportActionProvider.transportShardUpsertAction()::execute,
-            transportActionProvider.transportBulkCreateIndicesAction()
+            transportActionProvider.transportBulkCreateIndicesAction(),
+            tableSettings
         );
     }
 

--- a/sql/src/main/java/io/crate/operation/projectors/IndexWriterProjector.java
+++ b/sql/src/main/java/io/crate/operation/projectors/IndexWriterProjector.java
@@ -69,6 +69,7 @@ public class IndexWriterProjector implements Projector {
                                 Executor executor,
                                 Functions functions,
                                 Settings settings,
+                                Settings tableSettings,
                                 TransportBulkCreateIndicesAction transportBulkCreateIndicesAction,
                                 BulkRequestExecutor<ShardUpsertRequest> shardUpsertAction,
                                 Supplier<String> indexNameResolver,
@@ -120,7 +121,8 @@ public class IndexWriterProjector implements Projector {
             indexNameResolver,
             autoCreateIndices,
             shardUpsertAction,
-            transportBulkCreateIndicesAction
+            transportBulkCreateIndicesAction,
+            tableSettings
         );
     }
 

--- a/sql/src/main/java/io/crate/operation/projectors/IndexWriterProjector.java
+++ b/sql/src/main/java/io/crate/operation/projectors/IndexWriterProjector.java
@@ -37,7 +37,7 @@ import io.crate.operation.collect.RowShardResolver;
 import io.crate.operation.projectors.sharding.ShardingUpsertExecutor;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.action.admin.indices.create.TransportBulkCreateIndicesAction;
+import org.elasticsearch.action.admin.indices.create.TransportCreatePartitionsAction;
 import org.elasticsearch.action.bulk.BulkRequestExecutor;
 import org.elasticsearch.client.Requests;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -70,7 +70,7 @@ public class IndexWriterProjector implements Projector {
                                 Functions functions,
                                 Settings settings,
                                 Settings tableSettings,
-                                TransportBulkCreateIndicesAction transportBulkCreateIndicesAction,
+                                TransportCreatePartitionsAction transportCreatePartitionsAction,
                                 BulkRequestExecutor<ShardUpsertRequest> shardUpsertAction,
                                 Supplier<String> indexNameResolver,
                                 Reference rawSourceReference,
@@ -121,7 +121,7 @@ public class IndexWriterProjector implements Projector {
             indexNameResolver,
             autoCreateIndices,
             shardUpsertAction,
-            transportBulkCreateIndicesAction,
+            transportCreatePartitionsAction,
             tableSettings
         );
     }

--- a/sql/src/main/java/io/crate/operation/projectors/ShardDMLExecutor.java
+++ b/sql/src/main/java/io/crate/operation/projectors/ShardDMLExecutor.java
@@ -123,7 +123,7 @@ public class ShardDMLExecutor<TReq extends ShardRequest<TReq, TItem>, TItem exte
     @Override
     public CompletableFuture<? extends Iterable<Row>> apply(BatchIterator<Row> batchIterator) {
         BatchIterator<TReq> reqBatchIterator =
-            BatchIterators.partition(batchIterator, bulkSize, requestFactory, this::addRowToRequest);
+            BatchIterators.partition(batchIterator, bulkSize, requestFactory, this::addRowToRequest, r -> true);
         BinaryOperator<Long> combinePartialResult = (a, b) -> a + b;
         long initialResult = 0L;
         return new BatchIteratorBackpressureExecutor<>(

--- a/sql/src/main/java/io/crate/operation/projectors/sharding/BulkShardCreationLimiter.java
+++ b/sql/src/main/java/io/crate/operation/projectors/sharding/BulkShardCreationLimiter.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.operation.projectors.sharding;
+
+import io.crate.analyze.NumberOfReplicas;
+import io.crate.executor.transport.ShardRequest;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Settings;
+
+import java.util.function.Predicate;
+
+public class BulkShardCreationLimiter<TReq extends ShardRequest<TReq, TItem>, TItem extends ShardRequest.Item>
+    implements Predicate<ShardedRequests<TReq, TItem>> {
+
+    /**
+     * Defines the maximum number of new shards per node which can be safely created before running into the
+     * <p>wait_for_active_shards</p> timeout of 30sec. Value was wisely chosen after some brave testing.
+     */
+    static final int MAX_NEW_SHARDS_PER_NODE = 10;
+    private static final Logger LOGGER = Loggers.getLogger(BulkShardCreationLimiter.class);
+
+    private final int numDataNodes;
+    private final int numberOfAllShards;
+
+    BulkShardCreationLimiter(Settings tableSettings, int numDataNodes) {
+        this.numDataNodes = numDataNodes;
+        int numberOfShards = IndexMetaData.INDEX_NUMBER_OF_SHARDS_SETTING.get(tableSettings);
+        int numberOfReplicas = NumberOfReplicas.fromSettings(tableSettings, numDataNodes);
+        numberOfAllShards = (numberOfShards + (numberOfShards * numberOfReplicas));
+    }
+
+    @Override
+    public boolean test(ShardedRequests<TReq, TItem> requests) {
+        if (requests.itemsByMissingIndex.isEmpty() == false) {
+            int numberOfShardForAllIndices = numberOfAllShards * requests.itemsByMissingIndex.size();
+            int numberOfShardsPerNode = numberOfShardForAllIndices / numDataNodes;
+            if (numberOfShardsPerNode >= MAX_NEW_SHARDS_PER_NODE) {
+                LOGGER.debug("Number of NEW shards per node {} reached maximum limit of {}",
+                    numberOfShardsPerNode, MAX_NEW_SHARDS_PER_NODE);
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/sql/src/main/java/org/elasticsearch/action/admin/indices/create/CreatePartitionsRequest.java
+++ b/sql/src/main/java/org/elasticsearch/action/admin/indices/create/CreatePartitionsRequest.java
@@ -33,7 +33,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 
-public class BulkCreateIndicesRequest extends AcknowledgedRequest<BulkCreateIndicesRequest> {
+public class CreatePartitionsRequest extends AcknowledgedRequest<CreatePartitionsRequest> {
 
     private Collection<String> indices = ImmutableList.of();
     private UUID jobId;
@@ -41,12 +41,12 @@ public class BulkCreateIndicesRequest extends AcknowledgedRequest<BulkCreateIndi
     /**
      * Constructs a new request to create indices with the specified names.
      */
-    public BulkCreateIndicesRequest(Collection<String> indices, UUID jobId) {
+    public CreatePartitionsRequest(Collection<String> indices, UUID jobId) {
         this.indices = indices;
         this.jobId = jobId;
     }
 
-    public BulkCreateIndicesRequest() {
+    public CreatePartitionsRequest() {
     }
 
     public Collection<String> indices() {

--- a/sql/src/main/java/org/elasticsearch/action/admin/indices/create/CreatePartitionsResponse.java
+++ b/sql/src/main/java/org/elasticsearch/action/admin/indices/create/CreatePartitionsResponse.java
@@ -21,36 +21,30 @@
 
 package org.elasticsearch.action.admin.indices.create;
 
-import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.junit.Test;
+import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+public class CreatePartitionsResponse extends AcknowledgedResponse {
 
-public class BulkCreateIndicesResponseTest {
-
-    @Test
-    public void testSerializationNotAcknowledged() throws Exception {
-        serializeAndAssertAcknowledged(false);
+    public CreatePartitionsResponse(boolean acknowledged) {
+        super(acknowledged);
     }
 
-    @Test
-    public void testSerializationAcknowledged() throws Exception {
-        serializeAndAssertAcknowledged(true);
+    CreatePartitionsResponse() {
     }
 
-    private void serializeAndAssertAcknowledged(boolean acknowledged) throws IOException {
-        BulkCreateIndicesResponse response = new BulkCreateIndicesResponse(acknowledged);
-        BytesStreamOutput out = new BytesStreamOutput();
-        response.writeTo(out);
-        StreamInput in = out.bytes().streamInput();
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        readAcknowledged(in);
+    }
 
-        BulkCreateIndicesResponse responseDeserialized = new BulkCreateIndicesResponse();
-        responseDeserialized.readFrom(in);
-
-        assertThat(responseDeserialized.isAcknowledged(), is(acknowledged));
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        writeAcknowledged(out);
     }
 }

--- a/sql/src/main/java/org/elasticsearch/action/bulk/BulkModule.java
+++ b/sql/src/main/java/org/elasticsearch/action/bulk/BulkModule.java
@@ -21,12 +21,12 @@
 
 package org.elasticsearch.action.bulk;
 
-import org.elasticsearch.action.admin.indices.create.TransportBulkCreateIndicesAction;
+import org.elasticsearch.action.admin.indices.create.TransportCreatePartitionsAction;
 import org.elasticsearch.common.inject.AbstractModule;
 
 public class BulkModule extends AbstractModule {
     @Override
     protected void configure() {
-        bind(TransportBulkCreateIndicesAction.class).asEagerSingleton();
+        bind(TransportCreatePartitionsAction.class).asEagerSingleton();
     }
 }

--- a/sql/src/test/java/io/crate/operation/projectors/IndexWriterProjectorTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/IndexWriterProjectorTest.java
@@ -38,13 +38,13 @@ import io.crate.metadata.RowGranularity;
 import io.crate.metadata.TableIdent;
 import io.crate.metadata.doc.DocSysColumns;
 import io.crate.operation.NodeJobsCounter;
+import io.crate.operation.TableSettingsResolver;
 import io.crate.operation.collect.CollectExpression;
 import io.crate.operation.collect.InputCollectExpression;
 import io.crate.testing.TestingRowConsumer;
 import io.crate.types.DataTypes;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.action.admin.indices.create.TransportBulkCreateIndicesAction;
-import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.Test;
@@ -75,14 +75,16 @@ public class IndexWriterProjectorTest extends SQLTransportIntegrationTest {
         List<CollectExpression<Row, ?>> collectExpressions = Collections.<CollectExpression<Row, ?>>singletonList(sourceInput);
 
         TableIdent bulkImportIdent = new TableIdent(sqlExecutor.getDefaultSchema(), "bulk_import");
+        Settings tableSettings = TableSettingsResolver.get(clusterService().state().getMetaData(), bulkImportIdent, false);
         ThreadPool threadPool = internalCluster().getInstance(ThreadPool.class);
         IndexWriterProjector writerProjector = new IndexWriterProjector(
-            internalCluster().getInstance(ClusterService.class),
+            clusterService(),
             new NodeJobsCounter(),
             threadPool.scheduler(),
             threadPool.executor(ThreadPool.Names.SEARCH),
             internalCluster().getInstance(Functions.class),
             Settings.EMPTY,
+            tableSettings,
             internalCluster().getInstance(TransportBulkCreateIndicesAction.class),
             internalCluster().getInstance(TransportShardUpsertAction.class)::execute,
             IndexNameResolver.forTable(bulkImportIdent),

--- a/sql/src/test/java/io/crate/operation/projectors/IndexWriterProjectorTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/IndexWriterProjectorTest.java
@@ -44,7 +44,7 @@ import io.crate.operation.collect.InputCollectExpression;
 import io.crate.testing.TestingRowConsumer;
 import io.crate.types.DataTypes;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.action.admin.indices.create.TransportBulkCreateIndicesAction;
+import org.elasticsearch.action.admin.indices.create.TransportCreatePartitionsAction;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.Test;
@@ -85,7 +85,7 @@ public class IndexWriterProjectorTest extends SQLTransportIntegrationTest {
             internalCluster().getInstance(Functions.class),
             Settings.EMPTY,
             tableSettings,
-            internalCluster().getInstance(TransportBulkCreateIndicesAction.class),
+            internalCluster().getInstance(TransportCreatePartitionsAction.class),
             internalCluster().getInstance(TransportShardUpsertAction.class)::execute,
             IndexNameResolver.forTable(bulkImportIdent),
             new Reference(new ReferenceIdent(bulkImportIdent, DocSysColumns.RAW), RowGranularity.DOC, DataTypes.STRING),

--- a/sql/src/test/java/io/crate/operation/projectors/IndexWriterProjectorUnitTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/IndexWriterProjectorUnitTest.java
@@ -36,19 +36,16 @@ import io.crate.metadata.TableIdent;
 import io.crate.operation.NodeJobsCounter;
 import io.crate.operation.collect.CollectExpression;
 import io.crate.operation.collect.InputCollectExpression;
-import io.crate.test.integration.CrateUnitTest;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.TestingHelpers;
 import io.crate.testing.TestingRowConsumer;
 import io.crate.types.DataTypes;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.action.admin.indices.create.TransportBulkCreateIndicesAction;
-import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Answers;
-import org.mockito.Mock;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -62,15 +59,12 @@ import java.util.concurrent.TimeUnit;
 import static io.crate.data.SentinelRow.SENTINEL;
 import static org.mockito.Mockito.mock;
 
-public class IndexWriterProjectorUnitTest extends CrateUnitTest {
+public class IndexWriterProjectorUnitTest extends CrateDummyClusterServiceUnitTest {
 
     private final static ColumnIdent ID_IDENT = new ColumnIdent("id");
     private static final TableIdent bulkImportIdent = new TableIdent(Schemas.DOC_SCHEMA_NAME, "bulk_import");
     private static Reference rawSourceReference = new Reference(
         new ReferenceIdent(bulkImportIdent, "_raw"), RowGranularity.DOC, DataTypes.STRING);
-
-    @Mock(answer = Answers.RETURNS_MOCKS)
-    ClusterService clusterService;
 
     private ExecutorService executor;
     private ScheduledExecutorService scheduler;
@@ -101,6 +95,7 @@ public class IndexWriterProjectorUnitTest extends CrateUnitTest {
             scheduler,
             executor,
             TestingHelpers.getFunctions(),
+            Settings.EMPTY,
             Settings.EMPTY,
             transportBulkCreateIndicesAction,
             (request, listener) -> {},

--- a/sql/src/test/java/io/crate/operation/projectors/IndexWriterProjectorUnitTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/IndexWriterProjectorUnitTest.java
@@ -41,7 +41,7 @@ import io.crate.testing.TestingHelpers;
 import io.crate.testing.TestingRowConsumer;
 import io.crate.types.DataTypes;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.action.admin.indices.create.TransportBulkCreateIndicesAction;
+import org.elasticsearch.action.admin.indices.create.TransportCreatePartitionsAction;
 import org.elasticsearch.common.settings.Settings;
 import org.junit.After;
 import org.junit.Before;
@@ -88,7 +88,7 @@ public class IndexWriterProjectorUnitTest extends CrateDummyClusterServiceUnitTe
         InputCollectExpression sourceInput = new InputCollectExpression(0);
         List<CollectExpression<Row, ?>> collectExpressions = Collections.<CollectExpression<Row, ?>>singletonList(sourceInput);
 
-        TransportBulkCreateIndicesAction transportBulkCreateIndicesAction = mock(TransportBulkCreateIndicesAction.class);
+        TransportCreatePartitionsAction transportCreatePartitionsAction = mock(TransportCreatePartitionsAction.class);
         IndexWriterProjector indexWriter = new IndexWriterProjector(
             clusterService,
             new NodeJobsCounter(),
@@ -97,7 +97,7 @@ public class IndexWriterProjectorUnitTest extends CrateDummyClusterServiceUnitTe
             TestingHelpers.getFunctions(),
             Settings.EMPTY,
             Settings.EMPTY,
-            transportBulkCreateIndicesAction,
+            transportCreatePartitionsAction,
             (request, listener) -> {},
             IndexNameResolver.forTable(new TableIdent(Schemas.DOC_SCHEMA_NAME, "bulk_import")),
             rawSourceReference,

--- a/sql/src/test/java/io/crate/operation/projectors/sharding/BulkShardCreationLimiterTest.java
+++ b/sql/src/test/java/io/crate/operation/projectors/sharding/BulkShardCreationLimiterTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.operation.projectors.sharding;
+
+import io.crate.executor.transport.ShardRequest;
+import io.crate.test.integration.CrateUnitTest;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.settings.Settings;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_REPLICAS;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
+import static org.hamcrest.Matchers.is;
+
+public class BulkShardCreationLimiterTest extends CrateUnitTest {
+
+    private static class DummyShardRequest extends ShardRequest<DummyShardRequest, DummyRequestItem> {
+        @Override
+        protected DummyRequestItem readItem(StreamInput input) throws IOException {
+            return null;
+        }
+    }
+
+    private static class DummyRequestItem extends ShardRequest.Item {
+        DummyRequestItem(String id) {
+            super(id);
+        }
+    }
+
+    private static final ShardedRequests<DummyShardRequest, DummyRequestItem> SHARED_REQUESTS = new ShardedRequests<>((s, i) -> new DummyShardRequest());
+    static {
+        SHARED_REQUESTS.add(new DummyRequestItem("1"), "dummy", null);
+    }
+
+    @Test
+    public void testNumberOfShardsGreaterEqualThanLimit() throws Exception {
+        Settings settings = Settings.builder()
+            .put(SETTING_NUMBER_OF_SHARDS, BulkShardCreationLimiter.MAX_NEW_SHARDS_PER_NODE)
+            .put(SETTING_NUMBER_OF_REPLICAS, 0).build();
+        BulkShardCreationLimiter<DummyShardRequest, DummyRequestItem> bulkShardCreationLimiter =
+            new BulkShardCreationLimiter<>(settings, 1);
+
+        assertThat(bulkShardCreationLimiter.test(SHARED_REQUESTS), is(true));
+    }
+
+    @Test
+    public void testNumberOfShardsLessThanLimit() throws Exception {
+        Settings settings = Settings.builder()
+            .put(SETTING_NUMBER_OF_SHARDS, BulkShardCreationLimiter.MAX_NEW_SHARDS_PER_NODE - 1)
+            .put(SETTING_NUMBER_OF_REPLICAS, 0).build();
+        BulkShardCreationLimiter<DummyShardRequest, DummyRequestItem> bulkShardCreationLimiter =
+            new BulkShardCreationLimiter<>(settings, 1);
+
+        assertThat(bulkShardCreationLimiter.test(SHARED_REQUESTS), is(false));
+    }
+
+    @Test
+    public void testNumberOfShardsLessThanLimitWithTwoNodes() throws Exception {
+        Settings settings = Settings.builder()
+            .put(SETTING_NUMBER_OF_SHARDS, BulkShardCreationLimiter.MAX_NEW_SHARDS_PER_NODE)
+            .put(SETTING_NUMBER_OF_REPLICAS, 0).build();
+        BulkShardCreationLimiter<DummyShardRequest, DummyRequestItem> bulkShardCreationLimiter =
+            new BulkShardCreationLimiter<>(settings, 2);
+
+        assertThat(bulkShardCreationLimiter.test(SHARED_REQUESTS), is(false));
+    }
+}

--- a/sql/src/test/java/org/elasticsearch/action/admin/indices/create/CreatePartitionsRequestTest.java
+++ b/sql/src/test/java/org/elasticsearch/action/admin/indices/create/CreatePartitionsRequestTest.java
@@ -33,27 +33,27 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 
 
-public class BulkCreateIndicesRequestTest {
+public class CreatePartitionsRequestTest {
 
     @Test
     public void testSerialization() throws Exception {
         UUID jobId = UUID.randomUUID();
-        BulkCreateIndicesRequest request = new BulkCreateIndicesRequest(Arrays.asList("a", "b", "c"), jobId);
+        CreatePartitionsRequest request = new CreatePartitionsRequest(Arrays.asList("a", "b", "c"), jobId);
         BytesStreamOutput out = new BytesStreamOutput();
         request.writeTo(out);
         StreamInput in = out.bytes().streamInput();
-        BulkCreateIndicesRequest requestDeserialized = new BulkCreateIndicesRequest();
+        CreatePartitionsRequest requestDeserialized = new CreatePartitionsRequest();
         requestDeserialized.readFrom(in);
 
         assertThat(requestDeserialized.indices(), contains("a", "b", "c"));
         assertThat(requestDeserialized.jobId(), is(jobId));
 
         jobId = UUID.randomUUID();
-        request = new BulkCreateIndicesRequest(Arrays.asList("a", "b", "c"), jobId);
+        request = new CreatePartitionsRequest(Arrays.asList("a", "b", "c"), jobId);
         out = new BytesStreamOutput();
         request.writeTo(out);
         in = out.bytes().streamInput();
-        requestDeserialized = new BulkCreateIndicesRequest();
+        requestDeserialized = new CreatePartitionsRequest();
         requestDeserialized.readFrom(in);
 
         assertThat(requestDeserialized.indices(), contains("a", "b", "c"));

--- a/sql/src/test/java/org/elasticsearch/action/admin/indices/create/CreatePartitionsResponseTest.java
+++ b/sql/src/test/java/org/elasticsearch/action/admin/indices/create/CreatePartitionsResponseTest.java
@@ -21,30 +21,36 @@
 
 package org.elasticsearch.action.admin.indices.create;
 
-import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
+import org.junit.Test;
 
 import java.io.IOException;
 
-public class BulkCreateIndicesResponse extends AcknowledgedResponse {
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
-    public BulkCreateIndicesResponse(boolean acknowledged) {
-        super(acknowledged);
+public class CreatePartitionsResponseTest {
+
+    @Test
+    public void testSerializationNotAcknowledged() throws Exception {
+        serializeAndAssertAcknowledged(false);
     }
 
-    BulkCreateIndicesResponse() {
+    @Test
+    public void testSerializationAcknowledged() throws Exception {
+        serializeAndAssertAcknowledged(true);
     }
 
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        readAcknowledged(in);
-    }
+    private void serializeAndAssertAcknowledged(boolean acknowledged) throws IOException {
+        CreatePartitionsResponse response = new CreatePartitionsResponse(acknowledged);
+        BytesStreamOutput out = new BytesStreamOutput();
+        response.writeTo(out);
+        StreamInput in = out.bytes().streamInput();
 
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
-        writeAcknowledged(out);
+        CreatePartitionsResponse responseDeserialized = new CreatePartitionsResponse();
+        responseDeserialized.readFrom(in);
+
+        assertThat(responseDeserialized.isAcknowledged(), is(acknowledged));
     }
 }

--- a/sql/src/test/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitionsActionTest.java
+++ b/sql/src/test/java/org/elasticsearch/action/admin/indices/create/TransportCreatePartitionsActionTest.java
@@ -38,20 +38,20 @@ import java.util.UUID;
 
 import static org.hamcrest.Matchers.is;
 
-public class TransportBulkCreateIndicesActionTest extends SQLTransportIntegrationTest {
+public class TransportCreatePartitionsActionTest extends SQLTransportIntegrationTest {
 
-    TransportBulkCreateIndicesAction action;
+    TransportCreatePartitionsAction action;
 
     @Before
     public void prepare() {
         MockitoAnnotations.initMocks(this);
-        action = internalCluster().getInstance(TransportBulkCreateIndicesAction.class, internalCluster().getMasterName());
+        action = internalCluster().getInstance(TransportCreatePartitionsAction.class, internalCluster().getMasterName());
     }
 
     @Test
     public void testCreateBulkIndicesSimple() throws Exception {
-        BulkCreateIndicesResponse response = action.execute(
-            new BulkCreateIndicesRequest(Arrays.asList("index1", "index2", "index3", "index4"), UUID.randomUUID())
+        CreatePartitionsResponse response = action.execute(
+            new CreatePartitionsRequest(Arrays.asList("index1", "index2", "index3", "index4"), UUID.randomUUID())
         ).actionGet();
         assertThat(response.isAcknowledged(), is(true));
         ensureYellow();
@@ -72,7 +72,7 @@ public class TransportBulkCreateIndicesActionTest extends SQLTransportIntegratio
 
         ClusterState currentState = internalCluster().clusterService().state();
 
-        BulkCreateIndicesRequest request = new BulkCreateIndicesRequest(
+        CreatePartitionsRequest request = new CreatePartitionsRequest(
             Arrays.asList("index_0", "index_1"),
             UUID.randomUUID());
         currentState = action.executeCreateIndices(currentState, request);
@@ -83,8 +83,8 @@ public class TransportBulkCreateIndicesActionTest extends SQLTransportIntegratio
 
     @Test
     public void testCreateBulkIndicesIgnoreExistingSame() throws Exception {
-        BulkCreateIndicesResponse response = action.execute(
-            new BulkCreateIndicesRequest(Arrays.asList("index1", "index2", "index3", "index1"), UUID.randomUUID())
+        CreatePartitionsResponse response = action.execute(
+            new CreatePartitionsRequest(Arrays.asList("index1", "index2", "index3", "index1"), UUID.randomUUID())
         ).actionGet();
         assertThat(response.isAcknowledged(), is(true));
 
@@ -93,16 +93,16 @@ public class TransportBulkCreateIndicesActionTest extends SQLTransportIntegratio
             .execute().actionGet();
         assertThat(indicesExistsResponse.isExists(), is(true));
 
-        BulkCreateIndicesResponse response2 = action.execute(
-            new BulkCreateIndicesRequest(Arrays.asList("index1", "index2", "index3", "index1"), UUID.randomUUID())
+        CreatePartitionsResponse response2 = action.execute(
+            new CreatePartitionsRequest(Arrays.asList("index1", "index2", "index3", "index1"), UUID.randomUUID())
         ).actionGet();
         assertThat(response2.isAcknowledged(), is(true));
     }
 
     @Test
     public void testEmpty() throws Exception {
-        BulkCreateIndicesResponse response = action.execute(
-            new BulkCreateIndicesRequest(ImmutableList.<String>of(), UUID.randomUUID())).actionGet();
+        CreatePartitionsResponse response = action.execute(
+            new CreatePartitionsRequest(ImmutableList.<String>of(), UUID.randomUUID())).actionGet();
         assertThat(response.isAcknowledged(), is(true));
     }
 
@@ -111,9 +111,9 @@ public class TransportBulkCreateIndicesActionTest extends SQLTransportIntegratio
         expectedException.expect(InvalidIndexNameException.class);
         expectedException.expectMessage("Invalid index name [invalid/#haha], must not contain the following characters [ , \", *, \\, <, |, ,, >, /, ?]");
 
-        BulkCreateIndicesRequest bulkCreateIndicesRequest = new BulkCreateIndicesRequest(Arrays.asList("valid", "invalid/#haha"), UUID.randomUUID());
+        CreatePartitionsRequest createPartitionsRequest = new CreatePartitionsRequest(Arrays.asList("valid", "invalid/#haha"), UUID.randomUUID());
         try {
-            action.execute(bulkCreateIndicesRequest).actionGet();
+            action.execute(createPartitionsRequest).actionGet();
             fail("no exception thrown");
         } catch (Throwable t) {
             ensureYellow();


### PR DESCRIPTION
Dynamically adjust the bulk size if new partitions needs to be created
and the number of shards (incl. replicas) per node exceeds a defined
threshold (currently: 10). Otherwise too much shards will be created by
one bulk partition creation request, not all shards become active inside
the defined timeframe and so not all records will be inserted.
Also, while waiting for partitions to be created, consumption of rows
will be paused.

This PR depends on an ES patch, see crate/elasticsearch@7a18739