### PR TITLE
Flatten UNION queries at parser level

### DIFF
--- a/sql-parser/src/main/antlr/SqlBase.g4
+++ b/sql-parser/src/main/antlr/SqlBase.g4
@@ -103,9 +103,14 @@ queryNoWith:
     ;
 
 queryTerm
-    : queryPrimary                                                                   #queryTermDefault
-    | left=queryTerm operator=INTERSECT setQuant? right=queryTerm                    #setOperation
-    | left=queryTerm operator=(UNION | EXCEPT) setQuant? right=queryTerm             #setOperation
+    : querySpec                                                                      #queryTermDefault
+    | queries+=querySpec operator=(INTERSECT | EXCEPT) queries+=querySpec            #setOperation
+    | queries+=querySpec (unions+=union queries+=querySpec)+                         #setOperation
+    ;
+
+union
+    : UNION
+    | UNION ALL
     ;
 
 setQuant
@@ -113,17 +118,11 @@ setQuant
     | ALL
     ;
 
-queryPrimary
-    : querySpecification                                                             #queryPrimaryDefault
-    | TABLE qname                                                                    #explicitTable
-    | VALUES expr (',' expr)*                                                        #inlineTable
-    ;
-
 sortItem
     : expr ordering=(ASC | DESC)? (NULLS nullOrdering=(FIRST | LAST))?
     ;
 
-querySpecification
+querySpec
     : SELECT setQuant? selectItem (',' selectItem)*
       (FROM relation (',' relation)*)?
       where?

--- a/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
+++ b/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
@@ -77,6 +77,7 @@ import io.crate.sql.tree.StringLiteral;
 import io.crate.sql.tree.Table;
 import io.crate.sql.tree.TableFunction;
 import io.crate.sql.tree.TableSubquery;
+import io.crate.sql.tree.Union;
 import io.crate.sql.tree.With;
 import io.crate.sql.tree.WithQuery;
 
@@ -589,6 +590,21 @@ public final class SqlFormatter {
         public Void visitPartitionedBy(PartitionedBy node, Integer indent) {
             append(indent, "PARTITIONED BY ");
             appendFlatNodeList(node.columns(), indent);
+            return null;
+        }
+
+        @Override
+        protected Void visitUnion(Union node, Integer context) {
+            List<Relation> relations = node.getRelations();
+            List<Union.Type> unionTypes = node.getUnionTypes();
+            for (int i = 0; i < relations.size(); i++) {
+                process(node.getRelations().get(i), context);
+                builder.append(" ");
+                if (i < relations.size() - 1) {
+                    builder.append(unionTypes.get(i).getRepresentation());
+                    builder.append(" ");
+                }
+            }
             return null;
         }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/DefaultTraversalVisitor.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/DefaultTraversalVisitor.java
@@ -269,8 +269,9 @@ public abstract class DefaultTraversalVisitor<R, C>
 
     @Override
     protected R visitExcept(Except node, C context) {
-        process(node.getLeft(), context);
-        process(node.getRight(), context);
+        for (Relation relation : node.getRelations()) {
+            process(relation, context);
+        }
         return null;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/Except.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/Except.java
@@ -24,32 +24,22 @@ package io.crate.sql.tree;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
 
 public class Except
     extends SetOperation {
-    private final Relation left;
-    private final Relation right;
-    private final boolean distinct;
+    private final List<Relation> relations;
 
-    public Except(Relation left, Relation right, boolean distinct) {
-        Preconditions.checkNotNull(left, "left is null");
-        Preconditions.checkNotNull(right, "right is null");
+    public Except(List<Relation> relations) {
+        Preconditions.checkNotNull(relations, "relations is null");
 
-        this.left = left;
-        this.right = right;
-        this.distinct = distinct;
+        this.relations = ImmutableList.copyOf(relations);
     }
 
-    public Relation getLeft() {
-        return left;
-    }
-
-    public Relation getRight() {
-        return right;
-    }
-
-    public boolean isDistinct() {
-        return distinct;
+    public List<Relation> getRelations() {
+        return relations;
     }
 
     @Override
@@ -60,9 +50,7 @@ public class Except
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
-            .add("left", left)
-            .add("right", right)
-            .add("distinct", distinct)
+            .add("relations", relations)
             .toString();
     }
 
@@ -75,13 +63,11 @@ public class Except
             return false;
         }
         Except o = (Except) obj;
-        return Objects.equal(left, o.left) &&
-               Objects.equal(right, o.right) &&
-               Objects.equal(distinct, o.distinct);
+        return Objects.equal(relations, o.relations);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(left, right, distinct);
+        return Objects.hashCode(relations);
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/Intersect.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/Intersect.java
@@ -31,21 +31,15 @@ import java.util.List;
 public class Intersect
     extends SetOperation {
     private final List<Relation> relations;
-    private final boolean distinct;
 
-    public Intersect(List<Relation> relations, boolean distinct) {
+    public Intersect(List<Relation> relations) {
         Preconditions.checkNotNull(relations, "relations is null");
 
         this.relations = ImmutableList.copyOf(relations);
-        this.distinct = distinct;
     }
 
     public List<Relation> getRelations() {
         return relations;
-    }
-
-    public boolean isDistinct() {
-        return distinct;
     }
 
     @Override
@@ -57,7 +51,6 @@ public class Intersect
     public String toString() {
         return MoreObjects.toStringHelper(this)
             .add("relations", relations)
-            .add("distinct", distinct)
             .toString();
     }
 
@@ -70,12 +63,11 @@ public class Intersect
             return false;
         }
         Intersect o = (Intersect) obj;
-        return Objects.equal(relations, o.relations) &&
-               Objects.equal(distinct, o.distinct);
+        return Objects.equal(relations, o.relations);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(relations, distinct);
+        return Objects.hashCode(relations);
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/Union.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/Union.java
@@ -31,21 +31,38 @@ import java.util.List;
 public class Union
     extends SetOperation {
     private final List<Relation> relations;
-    private final boolean distinct;
+    private final List<Type> unionTypes;
 
-    public Union(List<Relation> relations, boolean distinct) {
+    public enum Type {
+        UNION("UNION"),
+        UNION_ALL("UNION ALL");
+
+        String representation;
+
+        Type(String representation) {
+            this.representation = representation;
+        }
+
+        public String getRepresentation() {
+            return representation;
+        }
+    }
+
+    public Union(List<Relation> relations, List<Type> unionTypes) {
         Preconditions.checkNotNull(relations, "relations is null");
+        Preconditions.checkArgument(relations.size() - 1 == unionTypes.size(),
+            "Union operator types must match the queries provided.");
 
         this.relations = ImmutableList.copyOf(relations);
-        this.distinct = distinct;
+        this.unionTypes = unionTypes;
     }
 
     public List<Relation> getRelations() {
         return relations;
     }
 
-    public boolean isDistinct() {
-        return distinct;
+    public List<Type> getUnionTypes() {
+        return unionTypes;
     }
 
     @Override
@@ -57,7 +74,7 @@ public class Union
     public String toString() {
         return MoreObjects.toStringHelper(this)
             .add("relations", relations)
-            .add("distinct", distinct)
+            .add("unionTypes", unionTypes)
             .toString();
     }
 
@@ -71,11 +88,11 @@ public class Union
         }
         Union o = (Union) obj;
         return Objects.equal(relations, o.relations) &&
-               Objects.equal(distinct, o.distinct);
+               Objects.equal(unionTypes, o.unionTypes);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(relations, distinct);
+        return Objects.hashCode(relations, unionTypes);
     }
 }

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestSqlParser.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestSqlParser.java
@@ -134,14 +134,14 @@ public class TestSqlParser {
     @Test
     public void testTokenizeErrorMiddleOfLine() {
         expectedException.expect(ParsingException.class);
-        expectedException.expectMessage("line 1:25: no viable alternative at input '@'");
+        expectedException.expectMessage("line 1:25: no viable alternative at input 'select * from foo where @'");
         SqlParser.createStatement("select * from foo where @what");
     }
 
     @Test
     public void testTokenizeErrorIncompleteToken() {
         expectedException.expect(ParsingException.class);
-        expectedException.expectMessage("line 1:15: extraneous input ''' expecting");
+        expectedException.expectMessage("line 1:15: no viable alternative at input 'select * from ''");
         SqlParser.createStatement("select * from 'oops");
     }
 
@@ -155,21 +155,21 @@ public class TestSqlParser {
     @Test
     public void testParseErrorMiddleOfLine() {
         expectedException.expect(ParsingException.class);
-        expectedException.expectMessage("line 3:7: no viable alternative at input 'from'");
+        expectedException.expectMessage("line 3:7: no viable alternative at input 'select *\\nfrom x\\nwhere from'");
         SqlParser.createStatement("select *\nfrom x\nwhere from");
     }
 
     @Test
     public void testParseErrorEndOfInput() {
         expectedException.expect(ParsingException.class);
-        expectedException.expectMessage("line 1:14: no viable alternative at input '<EOF>'");
+        expectedException.expectMessage("line 1:14: no viable alternative at input 'select * from'");
         SqlParser.createStatement("select * from");
     }
 
     @Test
     public void testParseErrorEndOfInputWhitespace() {
         expectedException.expect(ParsingException.class);
-        expectedException.expectMessage("line 1:16: no viable alternative at input '<EOF>'");
+        expectedException.expectMessage("line 1:16: no viable alternative at input 'select * from  '");
         SqlParser.createStatement("select * from  ");
     }
 
@@ -242,8 +242,8 @@ public class TestSqlParser {
             SqlParser.createStatement("select *\nfrom x\nwhere from");
             fail("expected exception");
         } catch (ParsingException e) {
-            assertEquals(e.getMessage(), "line 3:7: no viable alternative at input 'from'");
-            assertEquals(e.getErrorMessage(), "no viable alternative at input 'from'");
+            assertEquals(e.getMessage(), "line 3:7: no viable alternative at input 'select *\\nfrom x\\nwhere from'");
+            assertEquals(e.getErrorMessage(), "no viable alternative at input 'select *\\nfrom x\\nwhere from'");
             assertEquals(e.getLineNumber(), 3);
             assertEquals(e.getColumnNumber(), 7);
         }

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -1163,6 +1163,21 @@ public class TestStatementBuilder {
         printStatement("SELECT a WHERE CASE WHEN x <> 0 THEN y/x > 1.5 ELSE false END");
     }
 
+    @Test
+    public void testUnions() throws Exception {
+        printStatement("select * from foo union select * from bar");
+        printStatement("select * from foo union all select * from bar");
+        printStatement("select 1 " +
+                       "union select 2 " +
+                       "union all select 3");
+        printStatement("select 1 union " +
+                       "select 2 union all " +
+                       "select 3 union " +
+                       "select 4 union all " +
+                       "select 5 " +
+                       "order by 1");
+    }
+
     private static void printStatement(String sql) {
         println(sql.trim());
         println("");


### PR DESCRIPTION
This removes the tree structure from the parser and provides a list of all
relations and union types to the Union class.

```
Select 1 UNION Select 2 UNION ALL Select 3
=>
Union([Select 1, Select 2, Select 3], [UNION, UNION_ALL])
```

Note: Commit contains some cleanup in the parser file:

1) Removing support for query type: `TABLE name [order_by] [limit] [offset]`
2) Removing support for query type: `VALUES expr [, expr] [order_by] [limit] [offset]`