### PR TITLE
document password authentication

### DIFF
--- a/blackbox/docs/sql/reference/alter_user.txt
+++ b/blackbox/docs/sql/reference/alter_user.txt
@@ -1,0 +1,46 @@
+.. highlight:: psql
+.. _ref-alter-user:
+
+==============
+``ALTER USER``
+==============
+
+Alter an existing database user.
+
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
+Synopsis
+========
+
+::
+
+    ALTER USER
+      SET ( user_parameter = value [, ...] )
+
+
+Description
+===========
+
+``ALTER USER`` applies a change to existing database users. Only existing
+superusers have the priviledge to alter existing database users.
+
+
+Arguments
+=========
+
+``SET``
+-------
+
+Changes a user parameter to a different value. The following ``user_parameter``
+are supported to alter an existing user account:
+
+:password: The password as cleartext entered as string literal.
+
+.. note::
+
+    Passwords cannot be set for the ``crate`` superuser. For security reasons it
+    is recommended to authenticate as ``crate`` using a client certificate.
+

--- a/blackbox/docs/sql/reference/create_user.txt
+++ b/blackbox/docs/sql/reference/create_user.txt
@@ -16,7 +16,8 @@ Synopsis
 
 .. code-block:: psql
 
-  CREATE USER username;
+  CREATE USER username
+  [ WITH ( user_parameter = value [, ...]) ]
 
 Description
 ===========
@@ -25,6 +26,9 @@ Description
 CrateDB cluster. The newly created user does not have any special privileges.
 The created user can be used to authenticate against CrateDB, see
 :doc:`/administration/hba`.
+
+The statement allows to specify a password for this account. This is not
+necessary if password authentication is disabled.
 
 For usage of the ``CREATE USER`` statement see
 :doc:`/sql/administration/user_management`.
@@ -35,3 +39,13 @@ Parameters
 :username: The unique name of the database user. The name follows the
            principles of a SQL identifier (see
            :ref:`sql_lexical_keywords_identifiers`).
+
+Clauses
+=======
+
+``WITH``
+--------
+
+The following ``user_parameter`` are supported to define a new user account:
+
+:password: The password as cleartext entered as string literal.

--- a/blackbox/docs/sql/sql.txt
+++ b/blackbox/docs/sql/sql.txt
@@ -16,6 +16,7 @@ CrateDB.
 
     reference/alter_table
     reference/alter_cluster
+    reference/alter_user
     reference/copy_from
     reference/copy_to
     reference/create_analyzer


### PR DESCRIPTION
added reference documentation for password authentication to `CREATE USER`
and `ALTER USER`.

This PR only contains the basic reference doc for the affected SQL commands. More documentation on the usage will follow-up.