### PR TITLE
Fixed an issue that prevented the complete graceful shutdown of CrateDB node.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -81,6 +81,8 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that prevented the complete graceful shutdown of CrateDB node.
+
 - Fixed an issue that causes a NPE for queries that use the ``IN`` or ``ANY``
   operator on timestamp fields.
 

--- a/sql/src/main/java/io/crate/cluster/gracefulstop/DecommissioningService.java
+++ b/sql/src/main/java/io/crate/cluster/gracefulstop/DecommissioningService.java
@@ -48,13 +48,14 @@ import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.threadpool.ThreadPool;
 import sun.misc.Signal;
 import sun.misc.SignalHandler;
 
 import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -78,7 +79,7 @@ public class DecommissioningService extends AbstractLifecycleComponent implement
 
     private final ClusterService clusterService;
     private final JobsLogs jobsLogs;
-    private final ThreadPool threadPool;
+    private final ScheduledExecutorService executorService;
     private final SQLOperations sqlOperations;
     private final TransportClusterHealthAction healthAction;
     private final TransportClusterUpdateSettingsAction updateSettingsAction;
@@ -91,14 +92,31 @@ public class DecommissioningService extends AbstractLifecycleComponent implement
     public DecommissioningService(Settings settings,
                                   final ClusterService clusterService,
                                   JobsLogs jobsLogs,
-                                  ThreadPool threadPool,
                                   SQLOperations sqlOperations,
                                   final TransportClusterHealthAction healthAction,
                                   final TransportClusterUpdateSettingsAction updateSettingsAction) {
+
+        this(
+            settings,
+            clusterService,
+            jobsLogs,
+            Executors.newSingleThreadScheduledExecutor(),
+            sqlOperations,
+            healthAction,
+            updateSettingsAction);
+    }
+
+    @VisibleForTesting
+    protected DecommissioningService(Settings settings,
+                                     final ClusterService clusterService,
+                                     JobsLogs jobsLogs,
+                                     ScheduledExecutorService executorService,
+                                     SQLOperations sqlOperations,
+                                     final TransportClusterHealthAction healthAction,
+                                     final TransportClusterUpdateSettingsAction updateSettingsAction) {
         super(settings);
         this.clusterService = clusterService;
         this.jobsLogs = jobsLogs;
-        this.threadPool = threadPool;
         this.sqlOperations = sqlOperations;
         this.healthAction = healthAction;
         this.updateSettingsAction = updateSettingsAction;
@@ -122,6 +140,7 @@ public class DecommissioningService extends AbstractLifecycleComponent implement
                 logger.warn("SIGUSR2 signal not supported on {}.", System.getProperty("os.name"), e);
             }
         }
+        this.executorService = executorService;
     }
 
     private void removeRemovedNodes(ClusterChangedEvent event) {
@@ -195,12 +214,12 @@ public class DecommissioningService extends AbstractLifecycleComponent implement
                 healthAction.execute(request, new ActionListener<ClusterHealthResponse>() {
                     @Override
                     public void onResponse(ClusterHealthResponse clusterHealthResponse) {
-                        exitIfNoActiveRequests(startTime);
+                        executorService.submit(() -> exitIfNoActiveRequests(startTime));
                     }
 
                     @Override
                     public void onFailure(Exception e) {
-                        forceStopOrAbort(e);
+                        executorService.submit(() -> forceStopOrAbort(e));
                     }
                 });
             }
@@ -235,12 +254,7 @@ public class DecommissioningService extends AbstractLifecycleComponent implement
 
         logger.info("There are still active requests on this node, delaying graceful shutdown");
         // use scheduler instead of busy loop to avoid blocking a listener thread
-        threadPool.scheduler().schedule(new Runnable() {
-            @Override
-            public void run() {
-                exitIfNoActiveRequests(startTime);
-            }
-        }, 5, TimeUnit.SECONDS);
+        executorService.schedule(() -> exitIfNoActiveRequests(startTime), 5, TimeUnit.SECONDS);
     }
 
     void exit() {
@@ -262,6 +276,7 @@ public class DecommissioningService extends AbstractLifecycleComponent implement
 
     @Override
     protected void doClose() {
+        executorService.shutdownNow();
     }
 
     @Override


### PR DESCRIPTION
The onResponse() callbacks were executed by a thread from ClusterService's threadpool.
This thread was calling `System.exit(0)` so the threadpool of ClusterServices could not shutdown properly on the first try. Then we forced the shutdown of the threadpool, so the thread, which has called System.exit(0) and waits for the shutdown hooks to complete,
is killed and the whole process is killed before gracefully shutting down all services.

This is solved by dispatching the onResponse() work to a separate thread defined inside DecommissioningService.