### PR TITLE
Prepare parser for Union support

### DIFF
--- a/sql-parser/src/main/antlr/SqlBase.g4
+++ b/sql-parser/src/main/antlr/SqlBase.g4
@@ -103,9 +103,9 @@ queryNoWith:
     ;
 
 queryTerm
-    : queryPrimary                                                                   #queryTermDefault
-    | left=queryTerm operator=INTERSECT setQuant? right=queryTerm                    #setOperation
-    | left=queryTerm operator=(UNION | EXCEPT) setQuant? right=queryTerm             #setOperation
+    : querySpec                                                                      #queryTermDefault
+    | first=querySpec operator=(INTERSECT | EXCEPT) second=querySpec                 #setOperation
+    | left=queryTerm operator=UNION setQuant? right=queryTerm                        #setOperation
     ;
 
 setQuant
@@ -113,17 +113,11 @@ setQuant
     | ALL
     ;
 
-queryPrimary
-    : querySpecification                                                             #queryPrimaryDefault
-    | TABLE qname                                                                    #explicitTable
-    | VALUES expr (',' expr)*                                                        #inlineTable
-    ;
-
 sortItem
     : expr ordering=(ASC | DESC)? (NULLS nullOrdering=(FIRST | LAST))?
     ;
 
-querySpecification
+querySpec
     : SELECT setQuant? selectItem (',' selectItem)*
       (FROM relation (',' relation)*)?
       where?

--- a/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
+++ b/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
@@ -77,6 +77,7 @@ import io.crate.sql.tree.StringLiteral;
 import io.crate.sql.tree.Table;
 import io.crate.sql.tree.TableFunction;
 import io.crate.sql.tree.TableSubquery;
+import io.crate.sql.tree.Union;
 import io.crate.sql.tree.With;
 import io.crate.sql.tree.WithQuery;
 
@@ -589,6 +590,18 @@ public final class SqlFormatter {
         public Void visitPartitionedBy(PartitionedBy node, Integer indent) {
             append(indent, "PARTITIONED BY ");
             appendFlatNodeList(node.columns(), indent);
+            return null;
+        }
+
+        @Override
+        protected Void visitUnion(Union node, Integer context) {
+            process(node.getLeft(), context);
+            builder.append("UNION ");
+            if (!node.isDistinct()) {
+                builder.append(" ALL");
+            }
+            builder.append(" ");
+            process(node.getRight(), context);
             return null;
         }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/DefaultTraversalVisitor.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/DefaultTraversalVisitor.java
@@ -253,17 +253,15 @@ public abstract class DefaultTraversalVisitor<R, C>
 
     @Override
     protected R visitUnion(Union node, C context) {
-        for (Relation relation : node.getRelations()) {
-            process(relation, context);
-        }
+        process(node.getLeft(), context);
+        process(node.getRight(), context);
         return null;
     }
 
     @Override
     protected R visitIntersect(Intersect node, C context) {
-        for (Relation relation : node.getRelations()) {
-            process(relation, context);
-        }
+        process(node.getLeft(), context);
+        process(node.getRight(), context);
         return null;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/Except.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/Except.java
@@ -25,19 +25,14 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
-public class Except
-    extends SetOperation {
+public class Except extends SetOperation {
+
     private final Relation left;
     private final Relation right;
-    private final boolean distinct;
 
-    public Except(Relation left, Relation right, boolean distinct) {
-        Preconditions.checkNotNull(left, "left is null");
-        Preconditions.checkNotNull(right, "right is null");
-
-        this.left = left;
-        this.right = right;
-        this.distinct = distinct;
+    public Except(Relation left, Relation right) {
+        this.left  = Preconditions.checkNotNull(left, "relation must not be null");
+        this.right = Preconditions.checkNotNull(right, "relation must not be null");
     }
 
     public Relation getLeft() {
@@ -46,10 +41,6 @@ public class Except
 
     public Relation getRight() {
         return right;
-    }
-
-    public boolean isDistinct() {
-        return distinct;
     }
 
     @Override
@@ -62,7 +53,6 @@ public class Except
         return MoreObjects.toStringHelper(this)
             .add("left", left)
             .add("right", right)
-            .add("distinct", distinct)
             .toString();
     }
 
@@ -75,13 +65,11 @@ public class Except
             return false;
         }
         Except o = (Except) obj;
-        return Objects.equal(left, o.left) &&
-               Objects.equal(right, o.right) &&
-               Objects.equal(distinct, o.distinct);
+        return Objects.equal(left, o.left) && Objects.equal(right, o.right);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(left, right, distinct);
+        return Objects.hashCode(left, right);
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/Intersect.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/Intersect.java
@@ -24,28 +24,23 @@ package io.crate.sql.tree;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 
-import java.util.List;
+public class Intersect extends SetOperation {
 
-public class Intersect
-    extends SetOperation {
-    private final List<Relation> relations;
-    private final boolean distinct;
+    private final Relation left;
+    private final Relation right;
 
-    public Intersect(List<Relation> relations, boolean distinct) {
-        Preconditions.checkNotNull(relations, "relations is null");
-
-        this.relations = ImmutableList.copyOf(relations);
-        this.distinct = distinct;
+    public Intersect(Relation left, Relation right) {
+        this.left  = Preconditions.checkNotNull(left, "relation must not be null");
+        this.right = Preconditions.checkNotNull(right, "relation must not be null");
     }
 
-    public List<Relation> getRelations() {
-        return relations;
+    public Relation getLeft() {
+        return left;
     }
 
-    public boolean isDistinct() {
-        return distinct;
+    public Relation getRight() {
+        return right;
     }
 
     @Override
@@ -56,8 +51,8 @@ public class Intersect
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
-            .add("relations", relations)
-            .add("distinct", distinct)
+            .add("left", left)
+            .add("right", right)
             .toString();
     }
 
@@ -70,12 +65,11 @@ public class Intersect
             return false;
         }
         Intersect o = (Intersect) obj;
-        return Objects.equal(relations, o.relations) &&
-               Objects.equal(distinct, o.distinct);
+        return Objects.equal(left, o.left) && Objects.equal(right, o.right);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(relations, distinct);
+        return Objects.hashCode(left, right);
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/Union.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/Union.java
@@ -24,28 +24,29 @@ package io.crate.sql.tree;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 
-import java.util.List;
+public class Union extends SetOperation {
 
-public class Union
-    extends SetOperation {
-    private final List<Relation> relations;
-    private final boolean distinct;
+    private final Relation left;
+    private final Relation right;
+    private final boolean isDistinct;
 
-    public Union(List<Relation> relations, boolean distinct) {
-        Preconditions.checkNotNull(relations, "relations is null");
-
-        this.relations = ImmutableList.copyOf(relations);
-        this.distinct = distinct;
+    public Union(Relation left, Relation right, boolean isDistinct) {
+        this.left  = Preconditions.checkNotNull(left, "relation must not be null");
+        this.right = Preconditions.checkNotNull(right, "relation must not be null");
+        this.isDistinct = isDistinct;
     }
 
-    public List<Relation> getRelations() {
-        return relations;
+    public Relation getLeft() {
+        return left;
+    }
+
+    public Relation getRight() {
+        return right;
     }
 
     public boolean isDistinct() {
-        return distinct;
+        return isDistinct;
     }
 
     @Override
@@ -56,8 +57,9 @@ public class Union
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
-            .add("relations", relations)
-            .add("distinct", distinct)
+            .add("left", left)
+            .add("right", right)
+            .add("isDistinct", isDistinct)
             .toString();
     }
 
@@ -70,12 +72,13 @@ public class Union
             return false;
         }
         Union o = (Union) obj;
-        return Objects.equal(relations, o.relations) &&
-               Objects.equal(distinct, o.distinct);
+        return Objects.equal(left, o.left) &&
+               Objects.equal(right, o.right) &&
+               Objects.equal(isDistinct, o.isDistinct);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(relations, distinct);
+        return Objects.hashCode(left, right, isDistinct);
     }
 }

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestSqlParser.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestSqlParser.java
@@ -134,14 +134,14 @@ public class TestSqlParser {
     @Test
     public void testTokenizeErrorMiddleOfLine() {
         expectedException.expect(ParsingException.class);
-        expectedException.expectMessage("line 1:25: no viable alternative at input '@'");
+        expectedException.expectMessage("line 1:25: no viable alternative at input 'select * from foo where @'");
         SqlParser.createStatement("select * from foo where @what");
     }
 
     @Test
     public void testTokenizeErrorIncompleteToken() {
         expectedException.expect(ParsingException.class);
-        expectedException.expectMessage("line 1:15: extraneous input ''' expecting");
+        expectedException.expectMessage("line 1:15: no viable alternative at input 'select * from ''");
         SqlParser.createStatement("select * from 'oops");
     }
 
@@ -155,21 +155,21 @@ public class TestSqlParser {
     @Test
     public void testParseErrorMiddleOfLine() {
         expectedException.expect(ParsingException.class);
-        expectedException.expectMessage("line 3:7: no viable alternative at input 'from'");
+        expectedException.expectMessage("line 3:7: no viable alternative at input 'select *\\nfrom x\\nwhere from'");
         SqlParser.createStatement("select *\nfrom x\nwhere from");
     }
 
     @Test
     public void testParseErrorEndOfInput() {
         expectedException.expect(ParsingException.class);
-        expectedException.expectMessage("line 1:14: no viable alternative at input '<EOF>'");
+        expectedException.expectMessage("line 1:14: no viable alternative at input 'select * from'");
         SqlParser.createStatement("select * from");
     }
 
     @Test
     public void testParseErrorEndOfInputWhitespace() {
         expectedException.expect(ParsingException.class);
-        expectedException.expectMessage("line 1:16: no viable alternative at input '<EOF>'");
+        expectedException.expectMessage("line 1:16: no viable alternative at input 'select * from  '");
         SqlParser.createStatement("select * from  ");
     }
 
@@ -242,8 +242,8 @@ public class TestSqlParser {
             SqlParser.createStatement("select *\nfrom x\nwhere from");
             fail("expected exception");
         } catch (ParsingException e) {
-            assertEquals(e.getMessage(), "line 3:7: no viable alternative at input 'from'");
-            assertEquals(e.getErrorMessage(), "no viable alternative at input 'from'");
+            assertEquals(e.getMessage(), "line 3:7: no viable alternative at input 'select *\\nfrom x\\nwhere from'");
+            assertEquals(e.getErrorMessage(), "no viable alternative at input 'select *\\nfrom x\\nwhere from'");
             assertEquals(e.getLineNumber(), 3);
             assertEquals(e.getColumnNumber(), 7);
         }

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -1163,6 +1163,24 @@ public class TestStatementBuilder {
         printStatement("SELECT a WHERE CASE WHEN x <> 0 THEN y/x > 1.5 ELSE false END");
     }
 
+    @Test
+    public void testUnions() throws Exception {
+        printStatement("select * from foo union select * from bar");
+        printStatement("select * from foo union all select * from bar");
+        printStatement("select * from foo union distinct select * from bar");
+        printStatement("select 1 " +
+                       "union select 2 " +
+                       "union distinct select 3 " +
+                       "union all select 4");
+        printStatement("select 1 union " +
+                       "select 2 union all " +
+                       "select 3 union " +
+                       "select 4 union all " +
+                       "select 5 union distinct " +
+                       "select 6 " +
+                       "order by 1");
+    }
+
     private static void printStatement(String sql) {
         println(sql.trim());
         println("");


### PR DESCRIPTION
This removes the list structure and emphasizes the tree structure of UNION.

INTERSECT and EXCEPT must not contain additional keywords and cannot be nested.

Removes support for query type: `TABLE name [order_by] [limit] [offset]`.

Removes support for query type: `VALUES expr [, expr] [order_by] [limit] [offset]`.

```
Select 1 UNION Select 2 UNION ALL Select 3
=>
       Union
      /     \
     /       \
    Union   Select 3
   /    \
  /      \
Select 1 Select 2
```