### PR TITLE
fixed NPE caused by missing context when building the Lucene query

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -81,6 +81,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that causes a NPE for queries that use the ``IN`` or ``ANY``
+  operator on timestamp fields.
+
 - Improves resiliency of ``COPY FROM`` and ``INSERT FROM SUBQUERY`` statements
   when lot of new partitions will be created on demand.
 

--- a/sql/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
+++ b/sql/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
@@ -186,11 +186,11 @@ public class LuceneQueryBuilder {
         return ctx;
     }
 
-    private static Query termsQuery(@Nullable MappedFieldType fieldType, List values) {
+    private static Query termsQuery(@Nullable MappedFieldType fieldType, List values, QueryShardContext context) {
         if (fieldType == null) {
             return Queries.newMatchNoDocsQuery("column does not exist in this index");
         }
-        return fieldType.termsQuery(values, null);
+        return fieldType.termsQuery(values, context);
     }
 
 
@@ -405,7 +405,7 @@ public class LuceneQueryBuilder {
             @Override
             protected Query applyArrayLiteral(Reference reference, Literal arrayLiteral, Context context) throws IOException {
                 String columnName = reference.ident().columnIdent().fqn();
-                return termsQuery(context.getFieldTypeOrNull(columnName), asList(arrayLiteral));
+                return termsQuery(context.getFieldTypeOrNull(columnName), asList(arrayLiteral), context.queryShardContext);
             }
         }
 
@@ -669,7 +669,7 @@ public class LuceneQueryBuilder {
                     if (values.isEmpty()) {
                         return genericFunctionFilter(input, context);
                     }
-                    Query termsQuery = termsQuery(fieldType, values);
+                    Query termsQuery = termsQuery(fieldType, values, context.queryShardContext);
 
                     // wrap boolTermsFilter and genericFunction filter in an additional BooleanFilter to control the ordering of the filters
                     // termsFilter is applied first

--- a/sql/src/test/java/io/crate/integrationtests/AnyIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/AnyIntegrationTest.java
@@ -178,4 +178,17 @@ public class AnyIntegrationTest extends SQLTransportIntegrationTest {
         assertThat(response.rows()[0][0], is(3));
         assertThat(response.rows()[1][0], is(4));
     }
+
+    @Test
+    public void testAnyOperatorWithFieldThatRequiresConversion() throws Exception {
+        execute("create table t (ts timestamp) clustered into 1 shards with (number_of_replicas = 0)");
+        ensureYellow();
+        execute("insert into t values ('2017-12-31'), ('2016-12-31'), ('2015-12-31')");
+        execute("refresh table t");
+
+        execute("select ts from t where ts = ANY (['2017-12-31', '2016-12-31']) order by ts");
+        assertThat(response.rowCount(), is(2L));
+        assertThat(response.rows()[0][0], is(1483142400000L));
+        assertThat(response.rows()[1][0], is(1514678400000L));
+    }
 }


### PR DESCRIPTION
if a field (e.g. timestamp) requires conversion it needs a context to
apply correct parsing.