### PR TITLE
Add support for ParameterDescription for UPDATE

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -76,7 +76,7 @@ Changes
 - Added support for the PSQL ParameterDescription message which allows to get
   the parameter types in prepared statements up front without specifying the
   actual arguments first. This fixes compatibility issues with some drivers.
-  Only works for ``SELECT`` and ``DELETE` statements at the moment.
+  Only works for ``SELECT``, ``DELETE`` and ``UPDATE`` statements at the moment.
 
 Fixes
 =====

--- a/blackbox/docs/protocols/postgres.txt
+++ b/blackbox/docs/protocols/postgres.txt
@@ -105,8 +105,8 @@ Extended Query
 
 The `Extended Query`_ protocol is implemented with the following limitations:
 
-- The ``ParameterDescription` message only works for ``SELECT`` and ``DELETE``
-  statements.
+- The ``ParameterDescription` message only works for ``SELECT``, ``DELETE`` and
+  ``UPDATE`` statements.
 
 - To optimize the execution of bulk operations the execution of statements is
   delayed until the ``Sync`` message is received

--- a/sql/src/main/java/io/crate/analyze/AnalyzedStatementVisitor.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedStatementVisitor.java
@@ -210,4 +210,8 @@ public class AnalyzedStatementVisitor<C, R> {
     protected R visitAnalyzedDeleteStatement(AnalyzedDeleteStatement statement, C context) {
         return visitAnalyzedStatement(statement, context);
     }
+
+    public R visitAnalyzedUpdateStatement(AnalyzedUpdateStatement statement, C context) {
+        return visitAnalyzedStatement(statement, context);
+    }
 }

--- a/sql/src/main/java/io/crate/analyze/AnalyzedUpdateStatement.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedUpdateStatement.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.analyze;
+
+import io.crate.analyze.relations.AbstractTableRelation;
+import io.crate.analyze.symbol.Symbol;
+import io.crate.metadata.Reference;
+
+import java.util.Map;
+import java.util.function.Consumer;
+
+public final class AnalyzedUpdateStatement implements AnalyzedStatement {
+
+    private final AbstractTableRelation table;
+    private final Map<Reference, Symbol> assignmentByTargetCol;
+    private final Symbol query;
+
+    public AnalyzedUpdateStatement(AbstractTableRelation table, Map<Reference, Symbol> assignmentByTargetCol, Symbol query) {
+        this.table = table;
+        this.assignmentByTargetCol = assignmentByTargetCol;
+        this.query = query;
+    }
+
+    @Override
+    public <C, R> R accept(AnalyzedStatementVisitor<C, R> visitor, C context) {
+        return visitor.visitAnalyzedUpdateStatement(this, context);
+    }
+
+    @Override
+    public boolean isWriteOperation() {
+        return true;
+    }
+
+    @Override
+    public void visitSymbols(Consumer<? super Symbol> consumer) {
+        consumer.accept(query);
+        for (Symbol sourceExpr : assignmentByTargetCol.values()) {
+            consumer.accept(sourceExpr);
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/analyze/Analyzer.java
+++ b/sql/src/main/java/io/crate/analyze/Analyzer.java
@@ -143,12 +143,14 @@ public class Analyzer {
         this.showCreateTableAnalyzer = new ShowCreateTableAnalyzer(schemas);
         this.explainStatementAnalyzer = new ExplainStatementAnalyzer(this);
         this.showStatementAnalyzer = new ShowStatementAnalyzer(this);
+        this.updateAnalyzer = new UpdateAnalyzer(functions, relationAnalyzer);
         this.deleteAnalyzer = new DeleteAnalyzer(functions, relationAnalyzer);
         this.unboundAnalyzer = new UnboundAnalyzer(
             relationAnalyzer,
             showCreateTableAnalyzer,
             showStatementAnalyzer,
-            deleteAnalyzer
+            deleteAnalyzer,
+            updateAnalyzer
         );
         this.createBlobTableAnalyzer = new CreateBlobTableAnalyzer(schemas, numberOfShards);
         this.createAnalyzerStatementAnalyzer = new CreateAnalyzerStatementAnalyzer(fulltextAnalyzerResolver);
@@ -162,7 +164,6 @@ public class Analyzer {
         this.insertFromValuesAnalyzer = new InsertFromValuesAnalyzer(functions, schemas);
         this.insertFromSubQueryAnalyzer = new InsertFromSubQueryAnalyzer(functions, schemas, relationAnalyzer);
         this.copyAnalyzer = new CopyAnalyzer(schemas, functions);
-        this.updateAnalyzer = new UpdateAnalyzer(functions, relationAnalyzer);
         this.dropRepositoryAnalyzer = new DropRepositoryAnalyzer(repositoryService);
         this.createRepositoryAnalyzer = new CreateRepositoryAnalyzer(repositoryService, repositoryParamValidator);
         this.dropSnapshotAnalyzer = new DropSnapshotAnalyzer(repositoryService);

--- a/sql/src/main/java/io/crate/analyze/UnboundAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/UnboundAnalyzer.java
@@ -37,6 +37,7 @@ import io.crate.sql.tree.ShowSchemas;
 import io.crate.sql.tree.ShowTables;
 import io.crate.sql.tree.ShowTransaction;
 import io.crate.sql.tree.Statement;
+import io.crate.sql.tree.Update;
 
 /**
  * Analyzer that can analyze statements without having access to the Parameters/ParameterContext.
@@ -52,12 +53,14 @@ class UnboundAnalyzer {
     UnboundAnalyzer(RelationAnalyzer relationAnalyzer,
                     ShowCreateTableAnalyzer showCreateTableAnalyzer,
                     ShowStatementAnalyzer showStatementAnalyzer,
-                    DeleteAnalyzer deleteAnalyzer) {
+                    DeleteAnalyzer deleteAnalyzer,
+                    UpdateAnalyzer updateAnalyzer) {
         this.dispatcher = new UnboundDispatcher(
             relationAnalyzer,
             showCreateTableAnalyzer,
             showStatementAnalyzer,
-            deleteAnalyzer
+            deleteAnalyzer,
+            updateAnalyzer
         );
     }
 
@@ -71,15 +74,18 @@ class UnboundAnalyzer {
         private final ShowCreateTableAnalyzer showCreateTableAnalyzer;
         private final ShowStatementAnalyzer showStatementAnalyzer;
         private final DeleteAnalyzer deleteAnalyzer;
+        private final UpdateAnalyzer updateAnalyzer;
 
         UnboundDispatcher(RelationAnalyzer relationAnalyzer,
                           ShowCreateTableAnalyzer showCreateTableAnalyzer,
                           ShowStatementAnalyzer showStatementAnalyzer,
-                          DeleteAnalyzer deleteAnalyzer) {
+                          DeleteAnalyzer deleteAnalyzer,
+                          UpdateAnalyzer updateAnalyzer) {
             this.relationAnalyzer = relationAnalyzer;
             this.showCreateTableAnalyzer = showCreateTableAnalyzer;
             this.showStatementAnalyzer = showStatementAnalyzer;
             this.deleteAnalyzer = deleteAnalyzer;
+            this.updateAnalyzer = updateAnalyzer;
         }
 
         @Override
@@ -128,6 +134,11 @@ class UnboundAnalyzer {
         @Override
         public AnalyzedStatement visitDelete(Delete node, Analysis analysis) {
             return deleteAnalyzer.analyze(node, analysis.paramTypeHints(), analysis.transactionContext());
+        }
+
+        @Override
+        public AnalyzedStatement visitUpdate(Update update, Analysis analysis) {
+            return updateAnalyzer.analyze(update, analysis.paramTypeHints(), analysis.transactionContext());
         }
 
         @Override

--- a/sql/src/main/java/io/crate/analyze/UpdateAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/UpdateAnalyzedStatement.java
@@ -30,6 +30,13 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+/**
+ * @deprecated This statement is bulk-operation aware;
+ *             We're moving parameter/bulk awareness out of the analyzer because it breaks ParameterDescription support
+ *             (Parameters are not available during analysis in the postgres protocol)
+ *             Use {@link AnalyzedUpdateStatement} instead
+ */
+@Deprecated
 public class UpdateAnalyzedStatement implements AnalyzedStatement {
 
     private final List<NestedAnalyzedStatement> nestedStatements;

--- a/sql/src/test/java/io/crate/action/sql/SessionTest.java
+++ b/sql/src/test/java/io/crate/action/sql/SessionTest.java
@@ -140,4 +140,18 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
 
         assertThat(parameterTypes, is(new DataType[] { DataTypes.STRING }));
     }
+
+    @Test
+    public void testExtractTypesFromUpdate() throws Exception {
+        SQLExecutor e = SQLExecutor.builder(clusterService).addDocTable(TableDefinitions.USER_TABLE_INFO).build();
+        AnalyzedStatement analyzedStatement = e.analyzer.unboundAnalyze(
+            SqlParser.createStatement("update users set name = ? || '_updated' where id = ?"),
+            SessionContext.create(),
+            ParamTypeHints.EMPTY
+        );
+        Session.ParameterTypeExtractor typeExtractor = new Session.ParameterTypeExtractor();
+        DataType[] parameterTypes = typeExtractor.getParameterTypes(analyzedStatement::visitSymbols);
+
+        assertThat(parameterTypes, is(new DataType[] { DataTypes.STRING, DataTypes.LONG }));
+    }
 }


### PR DESCRIPTION
Similar to #6496

Note that this is currently building a new analyzer method/statement
side-by-side to the existing one.
So using prepared statements results in *two* AnalyzedStatements being
created. First unbound and then after `bind` a second time bound.

We can't remove the "bound analyzer" until we've made some more
interface changes to the `Planner` and `Executor`.