### PR TITLE
Add ParameterDescription support for INSERT .. VALUES

### DIFF
--- a/sql/src/main/java/io/crate/analyze/AnalyzedInsertStatement.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedInsertStatement.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.analyze;
+
+import io.crate.analyze.symbol.Symbol;
+import io.crate.metadata.Reference;
+import io.crate.metadata.doc.DocTableInfo;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public final class AnalyzedInsertStatement implements AnalyzedStatement {
+
+    private final DocTableInfo targetTable;
+    private final List<Reference> targetCols;
+    private final List<List<Symbol>> rows;
+    private final Map<Reference, Symbol> onDuplicateKeyAssignments;
+
+    public AnalyzedInsertStatement(DocTableInfo targetTable,
+                                   List<Reference> targetCols,
+                                   List<List<Symbol>> rows,
+                                   Map<Reference, Symbol> onDuplicateKeyAssignments) {
+
+        this.targetTable = targetTable;
+        this.targetCols = targetCols;
+        this.rows = rows;
+        this.onDuplicateKeyAssignments = onDuplicateKeyAssignments;
+    }
+
+    @Override
+    public <C, R> R accept(AnalyzedStatementVisitor<C, R> visitor, C context) {
+        return visitor.visitInsert(this, context);
+    }
+
+    @Override
+    public boolean isWriteOperation() {
+        return true;
+    }
+
+    @Override
+    public void visitSymbols(Consumer<? super Symbol> consumer) {
+        for (List<Symbol> row : rows) {
+            row.forEach(consumer);
+        }
+        onDuplicateKeyAssignments.values().forEach(consumer);
+    }
+}

--- a/sql/src/main/java/io/crate/analyze/AnalyzedStatementVisitor.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedStatementVisitor.java
@@ -214,4 +214,8 @@ public class AnalyzedStatementVisitor<C, R> {
     public R visitAnalyzedUpdateStatement(AnalyzedUpdateStatement statement, C context) {
         return visitAnalyzedStatement(statement, context);
     }
+
+    public R visitInsert(AnalyzedInsertStatement insert, C context) {
+        return visitAnalyzedStatement(insert, context);
+    }
 }

--- a/sql/src/main/java/io/crate/analyze/Analyzer.java
+++ b/sql/src/main/java/io/crate/analyze/Analyzer.java
@@ -145,12 +145,14 @@ public class Analyzer {
         this.showStatementAnalyzer = new ShowStatementAnalyzer(this);
         this.updateAnalyzer = new UpdateAnalyzer(functions, relationAnalyzer);
         this.deleteAnalyzer = new DeleteAnalyzer(functions, relationAnalyzer);
+        this.insertFromValuesAnalyzer = new InsertFromValuesAnalyzer(functions, schemas);
         this.unboundAnalyzer = new UnboundAnalyzer(
             relationAnalyzer,
             showCreateTableAnalyzer,
             showStatementAnalyzer,
             deleteAnalyzer,
-            updateAnalyzer
+            updateAnalyzer,
+            insertFromValuesAnalyzer
         );
         this.createBlobTableAnalyzer = new CreateBlobTableAnalyzer(schemas, numberOfShards);
         this.createAnalyzerStatementAnalyzer = new CreateAnalyzerStatementAnalyzer(fulltextAnalyzerResolver);
@@ -161,7 +163,6 @@ public class Analyzer {
         this.alterTableAddColumnAnalyzer = new AlterTableAddColumnAnalyzer(schemas, fulltextAnalyzerResolver, functions);
         this.alterTableOpenCloseAnalyzer = new AlterTableOpenCloseAnalyzer(schemas);
         this.alterTableRerouteAnalyzer = new AlterTableRerouteAnalyzer(schemas);
-        this.insertFromValuesAnalyzer = new InsertFromValuesAnalyzer(functions, schemas);
         this.insertFromSubQueryAnalyzer = new InsertFromSubQueryAnalyzer(functions, schemas, relationAnalyzer);
         this.copyAnalyzer = new CopyAnalyzer(schemas, functions);
         this.dropRepositoryAnalyzer = new DropRepositoryAnalyzer(repositoryService);

--- a/sql/src/main/java/io/crate/analyze/UnboundAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/UnboundAnalyzer.java
@@ -30,6 +30,7 @@ import io.crate.sql.SqlFormatter;
 import io.crate.sql.tree.AstVisitor;
 import io.crate.sql.tree.Delete;
 import io.crate.sql.tree.Explain;
+import io.crate.sql.tree.InsertFromValues;
 import io.crate.sql.tree.Query;
 import io.crate.sql.tree.ShowColumns;
 import io.crate.sql.tree.ShowCreateTable;
@@ -54,13 +55,15 @@ class UnboundAnalyzer {
                     ShowCreateTableAnalyzer showCreateTableAnalyzer,
                     ShowStatementAnalyzer showStatementAnalyzer,
                     DeleteAnalyzer deleteAnalyzer,
-                    UpdateAnalyzer updateAnalyzer) {
+                    UpdateAnalyzer updateAnalyzer,
+                    InsertFromValuesAnalyzer insertFromValuesAnalyzer) {
         this.dispatcher = new UnboundDispatcher(
             relationAnalyzer,
             showCreateTableAnalyzer,
             showStatementAnalyzer,
             deleteAnalyzer,
-            updateAnalyzer
+            updateAnalyzer,
+            insertFromValuesAnalyzer
         );
     }
 
@@ -75,17 +78,25 @@ class UnboundAnalyzer {
         private final ShowStatementAnalyzer showStatementAnalyzer;
         private final DeleteAnalyzer deleteAnalyzer;
         private final UpdateAnalyzer updateAnalyzer;
+        private final InsertFromValuesAnalyzer insertFromValuesAnalyzer;
 
         UnboundDispatcher(RelationAnalyzer relationAnalyzer,
                           ShowCreateTableAnalyzer showCreateTableAnalyzer,
                           ShowStatementAnalyzer showStatementAnalyzer,
                           DeleteAnalyzer deleteAnalyzer,
-                          UpdateAnalyzer updateAnalyzer) {
+                          UpdateAnalyzer updateAnalyzer,
+                          InsertFromValuesAnalyzer insertFromValuesAnalyzer) {
             this.relationAnalyzer = relationAnalyzer;
             this.showCreateTableAnalyzer = showCreateTableAnalyzer;
             this.showStatementAnalyzer = showStatementAnalyzer;
             this.deleteAnalyzer = deleteAnalyzer;
             this.updateAnalyzer = updateAnalyzer;
+            this.insertFromValuesAnalyzer = insertFromValuesAnalyzer;
+        }
+
+        @Override
+        public AnalyzedStatement visitInsertFromValues(InsertFromValues insert, Analysis analysis) {
+            return insertFromValuesAnalyzer.analyze(insert, analysis.paramTypeHints(), analysis.transactionContext());
         }
 
         @Override

--- a/sql/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InsertIntoIntegrationTest.java
@@ -191,7 +191,7 @@ public class InsertIntoIntegrationTest extends SQLTransportIntegrationTest {
         execute("create table t (i ip) with (number_of_replicas=0)");
         ensureYellow();
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("Validation failed for i: Cannot cast '192.168.1.500' to type ip");
+        expectedException.expectMessage("Cannot cast '192.168.1.500' to type ip");
         execute("insert into t (i) values ('192.168.1.2'), ('192.168.1.3'),('192.168.1.500')");
     }
 


### PR DESCRIPTION
Follows the same pattern as in #6499

This will probably need some more modifications once we start using
the unbound analysis in the planner/executor as it lacks generated
column handling. But it's sufficient for the ParameterDescription
purposes.

`INSERT INTO [..] query` handling will be done in a separate commit/PR.
