### PR TITLE
Tests: Make sure randomized schema name is not protected

### DIFF
--- a/sql/src/main/java/io/crate/analyze/CreateTableStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateTableStatementAnalyzer.java
@@ -21,7 +21,7 @@
 
 package io.crate.analyze;
 
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import io.crate.action.sql.SessionContext;
 import io.crate.analyze.expressions.ExpressionToStringVisitor;
 import io.crate.data.Row;
@@ -58,7 +58,7 @@ public class CreateTableStatementAnalyzer extends DefaultTraversalVisitor<Create
     private final Functions functions;
     private final NumberOfShards numberOfShards;
 
-    static final Collection<String> READ_ONLY_SCHEMAS = ImmutableList.of(
+    public static final Collection<String> READ_ONLY_SCHEMAS = ImmutableSet.of(
         SysSchemaInfo.NAME,
         InformationSchemaInfo.NAME,
         PgCatalogSchemaInfo.NAME


### PR DESCRIPTION
Running `TransportExecutorDDLTest` with seed
`F19A8AAEFCA460D4:7DD04E6A11367AB2` failed because the schema name was
randomized to `sys`.