### PR TITLE
Tests: Increase timeout for testCopyFromFileWithPartitionCreation

### DIFF
--- a/sql/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
@@ -263,7 +263,7 @@ public class CopyIntegrationTest extends SQLHttpIntegrationTest {
         ensureGreen();
         execute("COPY names PARTITION (group_id = 1) FROM ? WITH (bulk_size = 10, compression = 'gzip')",
             new Object[]{copyFilePath + "test_copy_partition_from.json.gz"},
-            TimeValue.timeValueMinutes(5L));
+            TimeValue.timeValueMinutes(15L));
         assertEquals(10_000L, response.rowCount());
         assertEquals(0, response.rows().length);
 


### PR DESCRIPTION
With the recent resilience improvements to partition creation this test
is now a lot slower because we're effectively creating all partitions
sequentially.
(The bulk_size is dynamically adapted to keep the number of shards that
have to be created *per* node below ~10, otherwise the chance that the
`wait_for_active_shards` timeout is reached becomes too high and it's
likely to cause shard failures later on)