### PR TITLE
Fix INSERT INTO with multiple rows in table with generated primary key

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -80,3 +80,7 @@ Changes
 
 Fixes
 =====
+
+- Fixed an issue that caused ``INSERT INTO .. VALUES`` statements to fail if
+  the ``VALUES`` clause contains multiple rows and the table has a generated
+  column as primary key.

--- a/sql/src/main/java/io/crate/analyze/InsertFromValuesAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/InsertFromValuesAnalyzer.java
@@ -489,8 +489,7 @@ class InsertFromValuesAnalyzer extends AbstractInsertAnalyzer {
             valueSymbol = context.normalizer.normalize(valueSymbol, context.transactionContext);
             if (valueSymbol.symbolType() == SymbolType.LITERAL) {
                 Object value = ((Input) valueSymbol).value();
-                if (primaryKey.contains(reference.ident().columnIdent()) &&
-                    context.analyzedStatement.columns().indexOf(reference) == -1) {
+                if (primaryKey.contains(reference.ident().columnIdent())) {
                     int idx = primaryKey.indexOf(reference.ident().columnIdent());
                     addPrimaryKeyValue(idx, value, context.primaryKeyValues);
                 }

--- a/sql/src/test/java/io/crate/analyze/InsertFromValuesAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/InsertFromValuesAnalyzerTest.java
@@ -1126,6 +1126,22 @@ public class InsertFromValuesAnalyzerTest extends CrateDummyClusterServiceUnitTe
     }
 
     @Test
+    public void testInsertGeneratedPrimaryKeyColumnWithMultiValues() throws Exception {
+        InsertFromValuesAnalyzedStatement analysis = e.analyze(
+            "INSERT INTO generated_pk_column (serial_no, product_no) values (1, 1), (2, 2)"
+        );
+        assertThat(analysis.routingValues(), contains("AgEyATI=", "AgEzATM="));
+        assertThat(analysis.ids(), contains(
+            is(generateId(
+                Arrays.asList(new ColumnIdent("id"), new ColumnIdent("id2")),
+                Arrays.asList(new BytesRef("2"), new BytesRef("2")), new ColumnIdent("id"))),
+            is(generateId(
+                Arrays.asList(new ColumnIdent("id"), new ColumnIdent("id2")),
+                Arrays.asList(new BytesRef("3"), new BytesRef("3")), new ColumnIdent("id")))
+        ));
+    }
+
+    @Test
     public void testInsertGeneratedPrimaryKeyAndPartedColumn() throws Exception {
         InsertFromValuesAnalyzedStatement analysis = e.analyze(
             "INSERT INTO generated_pk_parted_column (ts, value) VALUES (1508848674000, 1)");


### PR DESCRIPTION
Processing the second `VALUES` row didn't pass the validation
because it skipped setting the generated primary key value onto the
context.