### PR TITLE
Fix bulk sizing logic for UPDATE and DELETE queries

### DIFF
--- a/sql/src/main/java/io/crate/operation/projectors/ShardDMLExecutor.java
+++ b/sql/src/main/java/io/crate/operation/projectors/ShardDMLExecutor.java
@@ -123,7 +123,7 @@ public class ShardDMLExecutor<TReq extends ShardRequest<TReq, TItem>, TItem exte
     @Override
     public CompletableFuture<? extends Iterable<Row>> apply(BatchIterator<Row> batchIterator) {
         BatchIterator<TReq> reqBatchIterator =
-            BatchIterators.partition(batchIterator, bulkSize, requestFactory, this::addRowToRequest, r -> true);
+            BatchIterators.partition(batchIterator, bulkSize, requestFactory, this::addRowToRequest, r -> false);
         BinaryOperator<Long> combinePartialResult = (a, b) -> a + b;
         long initialResult = 0L;
         return new BatchIteratorBackpressureExecutor<>(

--- a/sql/src/main/java/io/crate/planner/projection/AbstractIndexWriterProjection.java
+++ b/sql/src/main/java/io/crate/planner/projection/AbstractIndexWriterProjection.java
@@ -21,6 +21,7 @@
 
 package io.crate.planner.projection;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import io.crate.analyze.symbol.Symbol;
@@ -43,7 +44,9 @@ public abstract class AbstractIndexWriterProjection extends Projection {
     private static final List<Symbol> OUTPUTS = ImmutableList.<Symbol>of(new Value(DataTypes.LONG));  // number of rows imported
 
     private static final String BULK_SIZE = "bulk_size";
-    private static final int BULK_SIZE_DEFAULT = 10000;
+
+    @VisibleForTesting
+    public static final int BULK_SIZE_DEFAULT = 10000;
 
     private final int bulkActions;
     protected TableIdent tableIdent;


### PR DESCRIPTION
No changes entry in this PR - I'll add specific entries for 2.1 and 2.2 when I backport it.
