### PR TITLE
removes no-op optimization on select plans

### DIFF
--- a/sql/src/main/java/io/crate/planner/SelectStatementPlanner.java
+++ b/sql/src/main/java/io/crate/planner/SelectStatementPlanner.java
@@ -96,10 +96,6 @@ class SelectStatementPlanner {
             if (querySpec.where().hasVersions()) {
                 throw new VersionInvalidException();
             }
-            Limits limits = context.getLimits(querySpec);
-            if (querySpec.where().noMatch() || (querySpec.limit() != null && limits.finalLimit() == 0)) {
-                return new NoopPlan(context.jobId());
-            }
             return invokeLogicalPlanner(table, context);
         }
 

--- a/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -478,26 +478,6 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
-    public void testHasNoResultFromLimit() {
-        CountPlan count = e.plan("select count(*) from users limit 1 offset 1");
-        assertThat(count.mergePhase().projections().get(1), instanceOf(TopNProjection.class));
-        assertThat(((TopNProjection) count.mergePhase().projections().get(1)).limit(), is(1));
-        assertThat(((TopNProjection) count.mergePhase().projections().get(1)).offset(), is(1));
-
-        count = e.plan("select count(*) from users limit 0");
-        assertThat(count.mergePhase().projections().get(1), instanceOf(TopNProjection.class));
-        assertThat(((TopNProjection) count.mergePhase().projections().get(1)).limit(), is(0));
-
-        assertThat(e.plan("select * from users order by name limit 0"), instanceOf(NoopPlan.class));
-        assertThat(e.plan("select * from users order by name limit 0 offset 0"), instanceOf(NoopPlan.class));
-    }
-
-    @Test
-    public void testHasNoResultFromQuery() {
-        assertThat(e.plan("select name from users where false"), instanceOf(NoopPlan.class));
-    }
-
-    @Test
     public void testShardQueueSizeCalculation() throws Exception {
         Merge merge = e.plan("select name from users order by name limit 500");
         Collect collect = (Collect) merge.subPlan();


### PR DESCRIPTION
A no-op plan was returned by the select planner if the limit of a select
resulted in 0.
All collect source are already handling where clause no-match cases, so
creating and executing a select plan instead is fine.
Turns out this optimization is not worth the increased complexity
specially when doing further refactoring of plans into logical plan
operators.