### PR TITLE
simplified construction of User instances

### DIFF
--- a/enterprise/users/src/main/java/io/crate/operation/user/UserManagerService.java
+++ b/enterprise/users/src/main/java/io/crate/operation/user/UserManagerService.java
@@ -119,8 +119,7 @@ public class UserManagerService implements UserManager, ClusterStateListener {
                 if (privilegesMetaData != null) {
                     privileges = privilegesMetaData.getUserPrivileges(userName);
                 }
-                usersBuilder.add(new User(userName, ImmutableSet.of(),
-                    privileges == null ? ImmutableSet.of() : privileges));
+                usersBuilder.add(User.of(userName, privileges));
             }
         }
         return usersBuilder.build();

--- a/enterprise/users/src/test/java/io/crate/integrationtests/BaseUsersIntegrationTest.java
+++ b/enterprise/users/src/test/java/io/crate/integrationtests/BaseUsersIntegrationTest.java
@@ -18,7 +18,6 @@
 
 package io.crate.integrationtests;
 
-import com.google.common.collect.ImmutableSet;
 import io.crate.action.sql.Option;
 import io.crate.action.sql.Session;
 import io.crate.action.sql.SQLOperations;
@@ -49,7 +48,7 @@ public abstract class BaseUsersIntegrationTest extends SQLTransportIntegrationTe
 
     Session createUserSession(String node) {
         SQLOperations sqlOperations = internalCluster().getInstance(SQLOperations.class, node);
-        return sqlOperations.createSession(null, new User("normal", ImmutableSet.of(), ImmutableSet.of()), Option.NONE, DEFAULT_SOFT_LIMIT);
+        return sqlOperations.createSession(null, User.of("normal"), Option.NONE, DEFAULT_SOFT_LIMIT);
     }
 
     Session createNullUserSession(String node) {

--- a/enterprise/users/src/test/java/io/crate/operation/auth/ClientCertAuthTest.java
+++ b/enterprise/users/src/test/java/io/crate/operation/auth/ClientCertAuthTest.java
@@ -32,7 +32,6 @@ import org.junit.Test;
 
 import javax.net.ssl.SSLSession;
 import java.security.cert.Certificate;
-import java.util.Collections;
 
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
@@ -42,7 +41,7 @@ public class ClientCertAuthTest extends CrateUnitTest {
 
     private ConnectionProperties sslConnWithCert;
     // "example.com" is the CN used in SelfSignedCertificate
-    private User exampleUser = new User("example.com", Collections.emptySet(), Collections.emptySet());
+    private User exampleUser = User.of("example.com");
     private SSLSession sslSession;
 
     @Before
@@ -64,7 +63,7 @@ public class ClientCertAuthTest extends CrateUnitTest {
 
     @Test
     public void testLookupValidUserWithCertWithDifferentCN() throws Exception {
-        ClientCertAuth clientCertAuth = new ClientCertAuth(userName -> new User("arthur", Collections.emptySet(), Collections.emptySet()));
+        ClientCertAuth clientCertAuth = new ClientCertAuth(userName -> User.of("arthur"));
 
         expectedException.expectMessage("Common name \"example.com\" in client certificate doesn't match username \"arthur\"");
         clientCertAuth.authenticate("arthur", sslConnWithCert);

--- a/enterprise/users/src/test/java/io/crate/operation/auth/UserAuthenticationMethodTest.java
+++ b/enterprise/users/src/test/java/io/crate/operation/auth/UserAuthenticationMethodTest.java
@@ -26,8 +26,6 @@ import io.crate.operation.user.User;
 import io.crate.test.integration.CrateUnitTest;
 import org.junit.Test;
 
-import java.util.Collections;
-
 import static org.hamcrest.core.Is.is;
 
 public class UserAuthenticationMethodTest extends CrateUnitTest {
@@ -36,7 +34,7 @@ public class UserAuthenticationMethodTest extends CrateUnitTest {
     public void testTrustAuthentication() throws Exception {
         TrustAuthenticationMethod trustAuth = new TrustAuthenticationMethod(userName -> {
             if (userName.equals("crate")) {
-                return new User("crate", Collections.emptySet(), Collections.emptySet());
+                return User.of("crate");
             }
             return null;
         });
@@ -52,7 +50,7 @@ public class UserAuthenticationMethodTest extends CrateUnitTest {
     public void testAlwaysOKAuthentication() throws Exception {
         AlwaysOKAuthentication alwaysOkAuth = new AlwaysOKAuthentication(userName -> {
             if (userName.equals("crate")) {
-                return new User("crate", Collections.emptySet(), Collections.emptySet());
+                return User.of("crate");
             }
             return null;
         });

--- a/enterprise/users/src/test/java/io/crate/operation/user/ExceptionPrivilegeValidatorTest.java
+++ b/enterprise/users/src/test/java/io/crate/operation/user/ExceptionPrivilegeValidatorTest.java
@@ -18,6 +18,7 @@
 
 package io.crate.operation.user;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import io.crate.analyze.user.Privilege;
 import io.crate.exceptions.RelationValidationException;
@@ -31,7 +32,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import static org.hamcrest.Matchers.contains;
@@ -47,7 +47,7 @@ public class ExceptionPrivilegeValidatorTest extends CrateUnitTest {
     @Before
     public void setUpUserAndValidator() {
         validationCallArguments = new ArrayList<>();
-        user = new User("normal", Collections.emptySet(), Collections.emptySet()) {
+        user = new User("normal", ImmutableSet.of(), ImmutableSet.of()) {
 
             @Override
             public boolean hasAnyPrivilege(Privilege.Clazz clazz, String ident) {

--- a/enterprise/users/src/test/java/io/crate/operation/user/PrivilegesTest.java
+++ b/enterprise/users/src/test/java/io/crate/operation/user/PrivilegesTest.java
@@ -23,14 +23,12 @@ import io.crate.exceptions.MissingPrivilegeException;
 import io.crate.test.integration.CrateUnitTest;
 import org.junit.Test;
 
-import java.util.Collections;
-
 public class PrivilegesTest extends CrateUnitTest {
+
+    private static User user = User.of("ford");
 
     @Test
     public void testExceptionIsThrownIfUserHasNotRequiredPrivilege() throws Exception {
-        User user = new User("ford", Collections.emptySet(), Collections.emptySet());
-
         expectedException.expect(MissingPrivilegeException.class);
         expectedException.expectMessage("Missing 'DQL' privilege for user 'ford'");
         Privileges.ensureUserHasPrivilege(Privilege.Type.DQL, Privilege.Clazz.CLUSTER, null, user);
@@ -38,15 +36,12 @@ public class PrivilegesTest extends CrateUnitTest {
 
     @Test
     public void testNoExceptionIsThrownIfUserHasNotRequiredPrivilegeOnInformationSchema() throws Exception {
-        User user = new User("ford", Collections.emptySet(), Collections.emptySet());
         //ensureUserHasPrivilege will not throw an exception if the schema is `information_schema`
         Privileges.ensureUserHasPrivilege(Privilege.Type.DQL, Privilege.Clazz.SCHEMA, "information_schema", user);
     }
 
     @Test
     public void testExceptionIsThrownIfUserHasNotAnyPrivilege() throws Exception {
-        User user = new User("ford", Collections.emptySet(), Collections.emptySet());
-
         expectedException.expect(MissingPrivilegeException.class);
         expectedException.expectMessage("Missing privilege for user 'ford'");
         Privileges.ensureUserHasPrivilege(Privilege.Clazz.CLUSTER, null, user);
@@ -54,8 +49,6 @@ public class PrivilegesTest extends CrateUnitTest {
 
     @Test
     public void testUserWithNoPrivilegeCanAccessInformationSchema() throws Exception {
-        User user = new User("ford", Collections.emptySet(), Collections.emptySet());
-
         //ensureUserHasPrivilege will not throw an exception if the schema is `information_schema`
         Privileges.ensureUserHasPrivilege(Privilege.Clazz.SCHEMA, "information_schema", user);
         Privileges.ensureUserHasPrivilege(Privilege.Clazz.TABLE, "information_schema.table", user);

--- a/enterprise/users/src/test/java/io/crate/operation/user/StatementPrivilegeValidatorTest.java
+++ b/enterprise/users/src/test/java/io/crate/operation/user/StatementPrivilegeValidatorTest.java
@@ -18,6 +18,7 @@
 
 package io.crate.operation.user;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import io.crate.action.sql.Option;
 import io.crate.action.sql.SessionContext;
@@ -43,7 +44,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import static io.crate.operation.user.UserManagerService.CRATE_USER;
@@ -74,7 +74,7 @@ public class StatementPrivilegeValidatorTest extends CrateDummyClusterServiceUni
             .build();
         ClusterServiceUtils.setState(clusterService, clusterState);
 
-        user = new User("normal", Collections.emptySet(), Collections.emptySet()) {
+        user = new User("normal", ImmutableSet.of(), ImmutableSet.of()) {
             @Override
             public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, String ident) {
                 validationCallArguments.add(Lists.newArrayList(type, clazz, ident, user.name()));

--- a/enterprise/users/src/test/java/io/crate/operation/user/UserManagerServiceTest.java
+++ b/enterprise/users/src/test/java/io/crate/operation/user/UserManagerServiceTest.java
@@ -19,7 +19,6 @@
 package io.crate.operation.user;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import io.crate.metadata.UsersMetaData;
 import io.crate.metadata.UsersPrivilegesMetaData;
 import io.crate.metadata.cluster.DDLClusterStateService;
@@ -63,7 +62,7 @@ public class UserManagerServiceTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testNewUser() {
         Set<User> users = UserManagerService.getUsers(new UsersMetaData(ImmutableList.of("arthur")), new UsersPrivilegesMetaData());
-        assertThat(users, containsInAnyOrder(new User("arthur", ImmutableSet.of(), ImmutableSet.of()), CRATE_USER));
+        assertThat(users, containsInAnyOrder(User.of("arthur"), CRATE_USER));
     }
 
     @Test

--- a/enterprise/users/src/test/java/io/crate/protocols/http/HttpAuthUpstreamHandlerTest.java
+++ b/enterprise/users/src/test/java/io/crate/protocols/http/HttpAuthUpstreamHandlerTest.java
@@ -156,7 +156,7 @@ public class HttpAuthUpstreamHandlerTest extends CrateUnitTest {
 
     @Test
     public void testUserAuthenticationWithDisabledHBA() throws Exception {
-        User crateUser = new User("crate", EnumSet.of(User.Role.SUPERUSER), ImmutableSet.of());
+        User crateUser = User.of("crate", EnumSet.of(User.Role.SUPERUSER));
         Authentication authServiceNoHBA = new AlwaysOKAuthentication(userName -> crateUser);
 
         HttpAuthUpstreamHandler handler = new HttpAuthUpstreamHandler(Settings.EMPTY, authServiceNoHBA);

--- a/enterprise/users/src/test/java/io/crate/scalar/systeminformation/UserFunctionTest.java
+++ b/enterprise/users/src/test/java/io/crate/scalar/systeminformation/UserFunctionTest.java
@@ -27,14 +27,13 @@ import io.crate.testing.SqlExpressions;
 import org.junit.Test;
 
 import javax.annotation.Nullable;
-import java.util.Collections;
 
 import static io.crate.testing.SymbolMatchers.isLiteral;
 import static org.hamcrest.Matchers.is;
 
 public class UserFunctionTest extends AbstractScalarFunctionsTest {
 
-    private static final User TEST_USER = new User("testUser", Collections.emptySet(), Collections.emptySet());
+    private static final User TEST_USER = User.of("testUser");
 
     private void setupFunctionsFor(@Nullable User user) {
         sqlExpressions = new SqlExpressions(tableSources, null, null, user,

--- a/sql/src/main/java/io/crate/operation/user/User.java
+++ b/sql/src/main/java/io/crate/operation/user/User.java
@@ -22,9 +22,11 @@
 
 package io.crate.operation.user;
 
+import com.google.common.collect.ImmutableSet;
 import io.crate.analyze.user.Privilege;
 
 import javax.annotation.Nullable;
+import java.util.EnumSet;
 import java.util.Objects;
 import java.util.Set;
 
@@ -40,10 +42,22 @@ public class User {
 
     private final UserPrivileges privileges;
 
-    public User(String name, Set<Role> roles, Set<Privilege> privileges) {
+    User(String name, Set<Role> roles, Set<Privilege> privileges) {
         this.roles = roles;
         this.name = name;
         this.privileges = new UserPrivileges(privileges);
+    }
+
+    public static User of(String name) {
+        return new User(name, ImmutableSet.of(), ImmutableSet.of());
+    }
+
+    public static User of(String name, @Nullable Set<Privilege> privileges) {
+        return new User(name, ImmutableSet.of(), privileges == null ? ImmutableSet.of() : privileges);
+    }
+
+    public static User of(String name, EnumSet<Role> roles) {
+        return new User(name, roles, ImmutableSet.of());
     }
 
     public String name() {

--- a/sql/src/test/java/io/crate/analyze/PrivilegesDCLAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/PrivilegesDCLAnalyzerTest.java
@@ -44,8 +44,6 @@ import io.crate.types.DataTypes;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Collections;
-
 import static io.crate.analyze.TableDefinitions.SHARD_ROUTING;
 import static io.crate.analyze.user.Privilege.Clazz.CLUSTER;
 import static io.crate.analyze.user.Privilege.Clazz.SCHEMA;
@@ -63,7 +61,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 
 public class PrivilegesDCLAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
-    private static final User GRANTOR_TEST_USER = new User("test", Collections.emptySet(), Collections.emptySet());
+    private static final User GRANTOR_TEST_USER = User.of("test");
 
     private static final TableIdent CUSTOM_SCHEMA_IDENT = new TableIdent("my_schema", "locations");
     private static final DocTableInfo CUSTOM_SCHEMA_INFO = TestingTableInfo.builder(CUSTOM_SCHEMA_IDENT, SHARD_ROUTING)

--- a/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
@@ -578,7 +578,7 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
     Session createSessionOnNode(String nodeName) {
         SQLOperations sqlOperations = internalCluster().getInstance(SQLOperations.class, nodeName);
         return sqlOperations.createSession(
-            sqlExecutor.getDefaultSchema(), new User("crate", EnumSet.of(User.Role.SUPERUSER), ImmutableSet.of()), Option.NONE, DEFAULT_SOFT_LIMIT);
+            sqlExecutor.getDefaultSchema(), User.of("crate", EnumSet.of(User.Role.SUPERUSER)), Option.NONE, DEFAULT_SOFT_LIMIT);
     }
 
     /**

--- a/sql/src/test/java/io/crate/operation/collect/stats/JobsLogsTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/stats/JobsLogsTest.java
@@ -23,7 +23,6 @@
 package io.crate.operation.collect.stats;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import io.crate.breaker.CrateCircuitBreakerService;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.core.collections.BlockingEvictingQueue;
@@ -218,7 +217,7 @@ public class JobsLogsTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testExecutionStart() {
         JobsLogs jobsLogs = new JobsLogs(() -> true);
-        User user = new User("arthur", ImmutableSet.of(), ImmutableSet.of());
+        User user = User.of("arthur");
 
         JobContext jobContext = new JobContext(UUID.randomUUID(), "select 1", 1L, user);
         jobsLogs.logExecutionStart(jobContext.id, jobContext.stmt, user);
@@ -232,7 +231,7 @@ public class JobsLogsTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testExecutionFailure() {
         JobsLogs jobsLogs = new JobsLogs(() -> true);
-        User user = new User("arthur", ImmutableSet.of(), ImmutableSet.of());
+        User user = User.of("arthur");
         Queue<JobContextLog> q = new BlockingEvictingQueue<>(1);
 
         jobsLogs.updateJobsLog(new QueueSink<>(q, ramAccountingContext::close));

--- a/sql/src/test/java/io/crate/planner/node/RoutedCollectPhaseTest.java
+++ b/sql/src/test/java/io/crate/planner/node/RoutedCollectPhaseTest.java
@@ -71,7 +71,7 @@ public class RoutedCollectPhaseTest extends CrateUnitTest {
             ImmutableList.<Projection>of(),
             WhereClause.MATCH_ALL,
             DistributionInfo.DEFAULT_MODULO,
-            new User("not_streamed", Collections.emptySet(), Collections.emptySet())
+            User.of("not_streamed")
         );
 
         BytesStreamOutput out = new BytesStreamOutput();

--- a/sql/src/test/java/io/crate/testing/DummyUserManager.java
+++ b/sql/src/test/java/io/crate/testing/DummyUserManager.java
@@ -30,7 +30,6 @@ import io.crate.operation.user.UserManager;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 
 public class DummyUserManager implements UserManager {
@@ -38,7 +37,7 @@ public class DummyUserManager implements UserManager {
     @Nullable
     @Override
     public User findUser(String userName) {
-        return new User(userName, Collections.emptySet(), Collections.emptySet());
+        return User.of(userName);
     }
 
     @Override


### PR DESCRIPTION
Use a static `of()` method that only requires the really necessary arguments to create new User instances.