### PR TITLE
Convert timestamp to number for arithmetics

### DIFF
--- a/core/src/main/java/io/crate/types/DataType.java
+++ b/core/src/main/java/io/crate/types/DataType.java
@@ -35,7 +35,7 @@ public abstract class DataType<T> implements Comparable, Streamable {
 
     /**
      * Type precedence ids which help to decide when a type can be cast
-     * into another type without loosing information (upcasting).
+     * into another type without losing information (upcasting).
      *
      * Lower ordinal => Lower precedence
      * Higher ordinal => Higher precedence
@@ -54,7 +54,6 @@ public abstract class DataType<T> implements Comparable, Streamable {
         ShortType,
         IntegerType,
         LongType,
-        TimestampType,
         FloatType,
         DoubleType,
         ArrayType,
@@ -68,6 +67,11 @@ public abstract class DataType<T> implements Comparable, Streamable {
 
     public abstract int id();
 
+    /**
+     * Returns the precedence of the type which determines whether the
+     * type should be preferred (higher precedence) or converted (lower
+     * precedence) during type conversions.
+     */
     public abstract Precedence precedence();
 
     public abstract String getName();

--- a/core/src/main/java/io/crate/types/DataTypes.java
+++ b/core/src/main/java/io/crate/types/DataTypes.java
@@ -146,7 +146,7 @@ public final class DataTypes {
             .add(OBJECT)
             .build())
         .put(IP.id(), ImmutableSet.of(STRING))
-        .put(TIMESTAMP.id(), ImmutableSet.of(LONG, STRING))
+        .put(TIMESTAMP.id(), ImmutableSet.of(DOUBLE, LONG, STRING))
         .put(UNDEFINED.id(), ImmutableSet.of()) // actually convertible to every type, see NullType
         .put(GEO_POINT.id(), ImmutableSet.of(new ArrayType(DOUBLE)))
         .put(OBJECT.id(), ImmutableSet.of(GEO_SHAPE))

--- a/core/src/main/java/io/crate/types/LongType.java
+++ b/core/src/main/java/io/crate/types/LongType.java
@@ -153,5 +153,10 @@ public class LongType extends DataType<Long> implements FixedWidthType, Streamer
     public int fixedSize() {
         return 16; // 8 object overhead, 8 long
     }
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof LongType;
+    }
 }
 

--- a/core/src/main/java/io/crate/types/TimestampType.java
+++ b/core/src/main/java/io/crate/types/TimestampType.java
@@ -39,11 +39,6 @@ public class TimestampType extends LongType implements Streamer<Long> {
     }
 
     @Override
-    public Precedence precedence() {
-        return Precedence.TimestampType;
-    }
-
-    @Override
     public String getName() {
         return "timestamp";
     }

--- a/core/src/test/java/io/crate/types/TypeConversionTest.java
+++ b/core/src/test/java/io/crate/types/TypeConversionTest.java
@@ -227,4 +227,9 @@ public class TypeConversionTest extends CrateUnitTest {
         assertThat(DataTypes.STRING.isConvertableTo(DataTypes.GEO_SHAPE), is(true));
         assertThat(DataTypes.OBJECT.isConvertableTo(DataTypes.GEO_SHAPE), is(true));
     }
+
+    @Test
+    public void testTimestampToDoubleConversion() {
+        assertThat(TimestampType.INSTANCE.isConvertableTo(DoubleType.INSTANCE), is(true));
+    }
 }

--- a/sql/src/main/java/io/crate/analyze/symbol/FuncArg.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/FuncArg.java
@@ -38,6 +38,8 @@ public interface FuncArg {
     /**
      * Indicates whether a Symbol can be casted or not.
      * Typically, we only allow casting of Literals.
+     * Note: Convertibility checks have to be performed nevertheless.
+     *       This just indicates whether casting is allowed.
      * @return True is casting is possible, false otherwise.
      */
     boolean canBeCasted();

--- a/sql/src/main/java/io/crate/operation/scalar/arithmetic/ArithmeticFunctions.java
+++ b/sql/src/main/java/io/crate/operation/scalar/arithmetic/ArithmeticFunctions.java
@@ -166,11 +166,8 @@ public class ArithmeticFunctions {
                     break;
 
                 case LongType.ID:
-                    scalar = new BinaryScalar<>(longFunction, name, DataTypes.LONG, features);
-                    break;
-
                 case TimestampType.ID:
-                    scalar = new BinaryScalar<>(longFunction, name, DataTypes.TIMESTAMP, features);
+                    scalar = new BinaryScalar<>(longFunction, name, DataTypes.LONG, features);
                     break;
 
                 default:

--- a/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -889,7 +889,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
 
         Map<String, Object> mappingProperties = analysis.mappingProperties();
         Map<String, Object> dayMapping = (Map<String, Object>) mappingProperties.get("day");
-        assertThat((String) dayMapping.get("type"), is("date"));
+        assertThat((String) dayMapping.get("type"), is("long"));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -220,7 +220,7 @@ public class ShowIntegrationTest extends SQLTransportIntegrationTest {
                 ")");
         execute("show create table test_generated_column");
         assertRow("CREATE TABLE IF NOT EXISTS \"doc\".\"test_generated_column\" (\n" +
-                  "   \"col1\" TIMESTAMP GENERATED ALWAYS AS \"ts\" + 1,\n" +
+                  "   \"col1\" LONG GENERATED ALWAYS AS \"ts\" + 1,\n" +
                   "   \"col2\" STRING GENERATED ALWAYS AS CAST((\"ts\" + 1) AS string),\n" +
                   "   \"col3\" STRING GENERATED ALWAYS AS CAST((\"ts\" + 1) AS string),\n" +
                   "   \"day1\" TIMESTAMP GENERATED ALWAYS AS date_trunc('day', \"ts\"),\n" +

--- a/sql/src/test/java/io/crate/operation/scalar/TypeInferenceTest.java
+++ b/sql/src/test/java/io/crate/operation/scalar/TypeInferenceTest.java
@@ -93,4 +93,14 @@ public class TypeInferenceTest extends AbstractScalarFunctionsTest {
         expectedException.expectMessage("Cannot cast 'foo' to type double");
         assertEvaluate("1 = ANY ([null, 1::integer, 2::long, 3.0, 'foo'])", true);
     }
+
+    /**
+     * Tests that timestamp operations interpret the timestamp as long (legacy feature).
+     */
+    @Test
+    public void testTimestampOperations() {
+        assertEvaluate("3::timestamp - 1", 2L);
+        assertEvaluate("3000::timestamp / 1000", 3L);
+        assertEvaluate("3000::timestamp / 1000.0", 3.0);
+    }
 }


### PR DESCRIPTION
Whenever a timestamp is used in arithmetics, e.g. ts + 1 or ts / 1.0, we
previously operated in the timestamp domain. This led to problems because we
converted long/double to timestamp. Longs are converted by interpreting them as
milliseconds, whereas Doubles are converted as seconds with milliseconds as
fraction. For example:

  1.0 would be interpreted as 1000
  1   would be interpreted as 1

The solution is to treat the timestamp as long and cast it to other data types
when necessary. The result of an arithmetics with a timestamp, will never be a
timestamp but a number data type. Only when functions accept timestamps as the
direct argument, the special double conversion will be performed.