### PR TITLE
Fix delete by id document not found handling

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -107,3 +107,7 @@ Fixes
 
 - The target table name used in ``ALTER TABLE ... RENAME TO`` is now correctly
   validated.
+
+- Fixed a regression that caused ``DELETE`` statements with a filter on
+  ``PRIMARY KEY`` columns that don't match to fail instead of returning with a
+  row count of 0.

--- a/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/ESDeleteTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/elasticsearch/ESDeleteTask.java
@@ -141,8 +141,7 @@ public class ESDeleteTask extends JobTask {
         public void onResponse(ShardResponse response) {
             ShardResponse.Failure failure = response.failures().get(0);
             if (failure != null) {
-                if (failure.versionConflict()) {
-                    // treat version conflict as rows affected = 0
+                if (failure.versionConflict() || failure.message().contains("Document not found")) {
                     result.complete(0L);
                 } else {
                     result.completeExceptionally(new Exception(failure.message()));

--- a/sql/src/test/java/io/crate/integrationtests/DeleteIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/DeleteIntegrationTest.java
@@ -49,6 +49,13 @@ public class DeleteIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    public void testDeleteOnPKNoMatch() throws Exception {
+        execute("create table t (id string primary key)");
+        execute("delete from t where id = 'nope'");
+        assertThat(response.rowCount(), is(0L));
+    }
+
+    @Test
     public void testDeleteWithWhere() throws Exception {
         String fqn = getFqn("test");
         createIndex(fqn);


### PR DESCRIPTION
The fix here checks the error message which is not ideal. But adding a
flag to ignore not-found errors or something like that would break
serialization and this needs to be backported.