### PR TITLE
Disable checkstyleTest task during Gradle check

### DIFF
--- a/gradle/javaModule.gradle
+++ b/gradle/javaModule.gradle
@@ -111,6 +111,7 @@ checkstyle {
             'checkstyleDir' : checkstyle_dir
     ]
     configFile = file(checkstyle_dir + "rules.xml")
+    checkstyleTest.enabled = false
 }
 
 jmh {


### PR DESCRIPTION
We run only `checkstyleMain` during regular builds which checks the style of the
main source files, not the test source files.

However, the `check` task also includes `checkstyleTest`. Since we currently
don't enforce style of our tests, it makes sense to disable the check.