### PR TITLE
Add support for scalar subqueries in DELETE statements

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -39,6 +39,8 @@ Breaking Changes
 Changes
 =======
 
+- Added support for scalar subqueries in DELETE statements.
+
 - Added new "password" authentication method which is available for connections
   via the Postgres Protocol. This method allowes clients to authenticate using
   a valid database user and its password.

--- a/blackbox/docs/sql/general/value_expressions.txt
+++ b/blackbox/docs/sql/general/value_expressions.txt
@@ -184,5 +184,5 @@ the column is unknown.
 
 .. NOTE::
 
-    Scalar subqueries are restricted to SELECT statements and cannot be used in
-    other statements.
+    Scalar subqueries are restricted to SELECT and DELETE statements and cannot
+    be used in other statements.

--- a/sql/src/main/java/io/crate/analyze/DeleteAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/DeleteAnalyzer.java
@@ -23,6 +23,7 @@ package io.crate.analyze;
 
 import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
+import io.crate.analyze.expressions.SubqueryAnalyzer;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.DocTableRelation;
 import io.crate.analyze.relations.FullQualifiedNameFieldProvider;
@@ -66,7 +67,7 @@ final class DeleteAnalyzer {
                 relationCtx.parentSources(),
                 txnContext.sessionContext().defaultSchema()
             ),
-            null
+            new SubqueryAnalyzer(relationAnalyzer, new StatementAnalysisContext(typeHints, Operation.READ, txnContext))
         );
         Symbol query = normalizer.normalize(
             expressionAnalyzer.generateQuerySymbol(delete.getWhere(), new ExpressionAnalysisContext()),

--- a/sql/src/main/java/io/crate/planner/Planner.java
+++ b/sql/src/main/java/io/crate/planner/Planner.java
@@ -173,7 +173,12 @@ public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
 
     @Override
     protected Plan visitAnalyzedDeleteStatement(AnalyzedDeleteStatement statement, PlannerContext context) {
-        return DeletePlanner.planDelete(functions, statement, context);
+        return DeletePlanner.planDelete(
+            functions,
+            statement,
+            new SubqueryPlanner(s -> logicalPlanner.planSubSelect(s, context)),
+            context
+        );
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/SubqueryPlanner.java
+++ b/sql/src/main/java/io/crate/planner/SubqueryPlanner.java
@@ -22,10 +22,10 @@
 
 package io.crate.planner;
 
-import io.crate.analyze.relations.QueriedRelation;
+import io.crate.analyze.AnalyzedStatement;
+import io.crate.analyze.symbol.DefaultTraversalSymbolVisitor;
 import io.crate.analyze.symbol.SelectSymbol;
 import io.crate.analyze.symbol.Symbol;
-import io.crate.analyze.symbol.SymbolVisitor;
 import io.crate.planner.operators.LogicalPlan;
 
 import java.util.HashMap;
@@ -41,9 +41,9 @@ public class SubqueryPlanner {
         this.planSubSelects = planSubSelects;
     }
 
-    public Map<LogicalPlan, SelectSymbol> planSubQueries(QueriedRelation relation) {
+    public Map<LogicalPlan, SelectSymbol> planSubQueries(AnalyzedStatement statement) {
         Visitor visitor = new Visitor();
-        relation.visitSymbols(visitor);
+        statement.visitSymbols(visitor);
         return visitor.subQueries;
     }
 
@@ -52,17 +52,9 @@ public class SubqueryPlanner {
         subQueries.put(subPlan, selectSymbol);
     }
 
-    private class Visitor extends SymbolVisitor<Symbol, Void> implements Consumer<Symbol> {
+    private class Visitor extends DefaultTraversalSymbolVisitor<Symbol, Void> implements Consumer<Symbol> {
 
         private final Map<LogicalPlan, SelectSymbol> subQueries = new HashMap<>();
-
-        @Override
-        public Void visitFunction(io.crate.analyze.symbol.Function function, Symbol parent) {
-            for (Symbol arg : function.arguments()) {
-                process(arg, function);
-            }
-            return null;
-        }
 
         @Override
         public Void visitSelectSymbol(SelectSymbol selectSymbol, Symbol parent) {

--- a/sql/src/test/java/io/crate/analyze/SingleRowSubselectAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SingleRowSubselectAnalyzerTest.java
@@ -23,12 +23,17 @@
 package io.crate.analyze;
 
 import io.crate.analyze.relations.QueriedRelation;
+import io.crate.analyze.symbol.SelectSymbol;
+import io.crate.operation.operator.EqOperator;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import org.junit.Before;
 import org.junit.Test;
 
+import static io.crate.testing.SymbolMatchers.isFunction;
+import static io.crate.testing.SymbolMatchers.isReference;
 import static io.crate.testing.TestingHelpers.isSQL;
+import static org.hamcrest.Matchers.instanceOf;
 
 public class SingleRowSubselectAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
@@ -79,8 +84,8 @@ public class SingleRowSubselectAnalyzerTest extends CrateDummyClusterServiceUnit
 
     @Test
     public void testSingleRowSubselectInWhereClauseOfDelete() throws Exception {
-        expectedException.expectMessage("Subquery not supported in this statement");
-        e.analyze("delete from t1 where x = (select y from t2)");
+        AnalyzedDeleteStatement delete = e.analyze("delete from t1 where x = (select y from t2)");
+        assertThat(delete.query(), isFunction(EqOperator.NAME, isReference("x"), instanceOf(SelectSymbol.class)));
     }
 
     @Test


### PR DESCRIPTION
This integrates the multi-phase planning & execution into the delete
planner and extends the delete specific executor parts.