### PR TITLE
Fix exception when using IN with _id in aggregations

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -110,6 +110,9 @@ Fixes
 - Handle MultiPolygon shapes in ``WITHIN`` queries correctly instead of
   throwing an exception.
 
+- Fixed an exception which occurred when using _id system column in IN or ANY
+  queries.
+
 - The target table name used in ``ALTER TABLE ... RENAME TO`` is now correctly
   validated.
 

--- a/sql/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/sql/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -48,7 +48,6 @@ import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TermRangeQuery;
 import org.apache.lucene.search.WildcardQuery;
 import org.apache.lucene.spatial.prefix.IntersectsPrefixTreeQuery;
-import org.apache.lucene.spatial.prefix.WithinPrefixTreeQuery;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -183,12 +182,30 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
         Query query = convert("_id = 'i1'");
         assertThat(query, instanceOf(TermInSetQuery.class));
         assertThat(query.toString(), is("_uid:default#i1"));
+
+        query = convert("_id = 1");
+        assertThat(query, instanceOf(TermInSetQuery.class));
+        assertThat(query.toString(), is("_uid:default#1"));
     }
 
     @Test
     public void testAnyEqArrayLiteral() throws Exception {
         Query query = convert("d = any([-1.5, 0.0, 1.5])");
         assertThat(query, instanceOf(PointInSetQuery.class));
+
+        query = convert("_id in ('test','test2')");
+        assertThat(query, instanceOf(TermInSetQuery.class));
+        assertThat(query.toString(), is("_uid:default#test _uid:default#test2"));
+        query = convert("_id in (1, 2)");
+        assertThat(query, instanceOf(TermInSetQuery.class));
+        assertThat(query.toString(), is("_uid:default#1 _uid:default#2"));
+
+        query = convert("_id = any (['test','test2'])");
+        assertThat(query, instanceOf(TermInSetQuery.class));
+        assertThat(query.toString(), is("_uid:default#test _uid:default#test2"));
+        query = convert("_id = any ([1, 2])");
+        assertThat(query, instanceOf(TermInSetQuery.class));
+        assertThat(query.toString(), is("_uid:default#1 _uid:default#2"));
     }
 
     @Test


### PR DESCRIPTION
Queries contaning _id values in in/any expressions where not correctly rewritten
by the `LuceneQueryBuilder`. We need to check if the passed Literal symbol is a collection.

This closes #6564.