### PR TITLE
allow multipolygon geometry in WITH queries

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -107,6 +107,9 @@ Changes
 Fixes
 =====
 
+- Handle MultiPolygon shapes in ``WITHIN`` queries correctly instead of
+  throwing an exception.
+
 - The target table name used in ``ALTER TABLE ... RENAME TO`` is now correctly
   validated.
 

--- a/blackbox/docs/general/geo.txt
+++ b/blackbox/docs/general/geo.txt
@@ -89,6 +89,16 @@ Let's insert Austria::
     importing geo data, they may not be fully valid. In most cases they could
     be repaired using this tool: https://github.com/tudelft3d/prepair
 
+.. Note::
+
+    When using a polygon shape that resembles a rectangle, and that rectangle
+    is wider than 180 degrees the CrateDB geoshape validator will convert it
+    into a multipolygon consisting of 2 rectangular shapes covering the
+    narrower area between the 4 original points split by the dateline (+/-
+    180deg).
+
+    This is due to CrateDB operating in the geospatial context of the earth.
+
 .. Hidden: refresh countries
 
     cr> REFRESH TABLE countries;

--- a/sql/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
+++ b/sql/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
@@ -28,6 +28,7 @@ import com.google.common.collect.Iterables;
 import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.CoordinateArrays;
 import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.GeometryFactory;
 import io.crate.Constants;
 import io.crate.analyze.MatchOptionsAnalysis;
 import io.crate.analyze.WhereClause;
@@ -131,8 +132,10 @@ import org.elasticsearch.index.query.RegexpFlag;
 import org.elasticsearch.index.search.geo.GeoPolygonQuery;
 import org.elasticsearch.index.search.geo.LegacyInMemoryGeoBoundingBoxQuery;
 import org.locationtech.spatial4j.context.jts.JtsSpatialContext;
+import org.locationtech.spatial4j.exception.InvalidShapeException;
 import org.locationtech.spatial4j.shape.Rectangle;
 import org.locationtech.spatial4j.shape.Shape;
+import org.locationtech.spatial4j.shape.ShapeCollection;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -1052,8 +1055,25 @@ public class LuceneQueryBuilder {
                     context.mapperService);
 
                 Map<String, Object> geoJSON = (Map<String, Object>) innerPair.input().value();
+                Geometry geometry;
                 Shape shape = GeoJSONUtils.map2Shape(geoJSON);
-                Geometry geometry = JtsSpatialContext.GEO.getShapeFactory().getGeometryFrom(shape);
+                if (shape instanceof ShapeCollection) {
+                    int i = 0;
+                    ShapeCollection<Shape> collection = (ShapeCollection) shape;
+                    com.vividsolutions.jts.geom.Polygon[] polygons = new com.vividsolutions.jts.geom.Polygon[collection.size()];
+                    for (Shape s : collection.getShapes()) {
+                        Geometry subGeometry = JtsSpatialContext.GEO.getShapeFactory().getGeometryFrom(s);
+                        if (subGeometry instanceof com.vividsolutions.jts.geom.Polygon) {
+                            polygons[i++] = (com.vividsolutions.jts.geom.Polygon) subGeometry;
+                        } else {
+                            throw new InvalidShapeException("Shape collection must contain only Polygon shapes.");
+                        }
+                    }
+                    GeometryFactory geometryFactory = JtsSpatialContext.GEO.getShapeFactory().getGeometryFactory();
+                    geometry = geometryFactory.createMultiPolygon(polygons);
+                } else {
+                    geometry = JtsSpatialContext.GEO.getShapeFactory().getGeometryFrom(shape);
+                }
 
                 IndexGeoPointFieldData fieldData = context.fieldDataService.getForField(geoPointFieldType);
                 if (geometry.isRectangle()) {

--- a/sql/src/test/java/io/crate/lucene/WithinQueryBuilderTest.java
+++ b/sql/src/test/java/io/crate/lucene/WithinQueryBuilderTest.java
@@ -54,6 +54,13 @@ public class WithinQueryBuilderTest extends LuceneQueryBuilderTest {
     }
 
     @Test
+    public void testWithinRectangleWithDatelineCrossing() throws Exception {
+        // dateline crossing happens in a geo context when a polygon rectangle is wider than 180 degrees
+        Query eqWithinQuery = convert("within(point, 'POLYGON((-95.0 10.0, -95.0 20.0, 95.0 20.0, 95.0 10.0, -95.0 10.0))')");
+        assertThat(eqWithinQuery.toString(), is("LatLonPointInPolygonQuery: field=point:[[10.0, 180.0] [20.0, 180.0] [20.0, 95.0] [10.0, 95.0] [10.0, 180.0] [10.0, -180.0] [10.0, -95.0] [20.0, -95.0] [20.0, -180.0] [10.0, -180.0] [10.0, 180.0] ]"));
+    }
+
+    @Test
     @IndexVersionCreated(Version.V_2_0_0_ID)
     public void testWithinFunctionIndexV_2_0() throws Exception {
         Query eqWithinQuery = convert("within(point, {type='LineString', coordinates=[[0.0, 0.0], [1.0, 1.0], [2.0, 1.0]]})");


### PR DESCRIPTION
When using a POLYGON shape that defines a rectangle that is wider than
180 degrees JTS splits the rectangle into a multi-polygon that is split
by the dateline at +/- 180 degrees.

Fixes https://github.com/crate/crate/issues/6562 so that no exception is
thrown.