### PR TITLE
Deprecate ValueSymbolVisitor class

### DIFF
--- a/sql/src/main/java/io/crate/analyze/symbol/ValueSymbolVisitor.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/ValueSymbolVisitor.java
@@ -31,6 +31,11 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * @deprecated Please use {@link io.crate.analyze.SymbolEvaluator} which takes care of
+ *             evaluating functions and parameters in {@link Symbol}s.
+ */
+@Deprecated
 public abstract class ValueSymbolVisitor<T> extends SymbolVisitor<Void, T> {
 
     public final com.google.common.base.Function<Symbol, T> function =


### PR DESCRIPTION
The `ValueSymbolVisitor` instances have recently been deprecated because it
doesn't handle function evaluation and parameters correctly. We should
additionally deprecate the entire class to prevent it from being used.