### PR TITLE
Fix rowcounts in responses of bulk delete by id operations

### DIFF
--- a/sql/src/main/java/io/crate/executor/transport/task/DeleteByIdTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/DeleteByIdTask.java
@@ -31,6 +31,7 @@ import io.crate.data.Row1;
 import io.crate.data.RowConsumer;
 import io.crate.executor.JobTask;
 import io.crate.executor.MultiActionListener;
+import io.crate.executor.transport.OneRowActionListener;
 import io.crate.executor.transport.ShardDeleteRequest;
 import io.crate.executor.transport.ShardResponse;
 import io.crate.executor.transport.TransportShardDeleteAction;
@@ -91,17 +92,7 @@ public class DeleteByIdTask extends JobTask {
             () -> new long[]{0},
             DeleteByIdTask::updateRowCountOrFail,
             s -> new Row1(s[0]),
-            new ActionListener<Row>() {
-                @Override
-                public void onResponse(Row r) {
-                    consumer.accept(InMemoryBatchIterator.of(r, SENTINEL), null);
-                }
-
-                @Override
-                public void onFailure(Exception e) {
-                    consumer.accept(null, e);
-                }
-            }
+            new OneRowActionListener<>(consumer, Function.identity())
         );
         for (ShardDeleteRequest request : requests.values()) {
             deleteAction.execute(request, listener);

--- a/sql/src/main/java/io/crate/executor/transport/task/DeleteByIdTask.java
+++ b/sql/src/main/java/io/crate/executor/transport/task/DeleteByIdTask.java
@@ -45,11 +45,11 @@ import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.shard.ShardId;
 
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
@@ -108,7 +108,7 @@ public class DeleteByIdTask extends JobTask {
         }
     }
 
-    private static void updateRowCountOrFail(long[] rowCount, ShardResponse response) {
+    static void updateRowCountOrFail(long[] rowCount, ShardResponse response) {
         for (int i = 0; i < response.itemIndices().size(); i++) {
             ShardResponse.Failure failure = response.failures().get(i);
             if (failure == null) {
@@ -155,23 +155,34 @@ public class DeleteByIdTask extends JobTask {
     public final List<CompletableFuture<Long>> executeBulk(List<Row> bulkParams) {
         HashMap<ShardId, ShardDeleteRequest> requests = new HashMap<>(bulkParams.size() * deleteById.docKeys().size());
         ArrayList<CompletableFuture<Long>> results = new ArrayList<>(bulkParams.size());
-        /* Need to generate result rowCount correctly
+        /* Need to be able to map the responses to the correct result rowCount
+         *
          * Example:
          *
-         * bulkParams: [ [1], [2], [3], [4] ]
-         *   shard0: [1, 3]
-         *   shard1: [2, 4]
+         * bulkParams: [ [1, 2], [3, 4] ]
+         *   shard0: [0, 2]
+         *   shard1: [1]
+         *   shard2: [3]
          * ->
-         *  2 requests (per shard)
-         *  4 bulkParams
-         *  4 result futures
+         *  3 requests (per shard)
+         *  2 bulkParams
+         *  2 result futures
+         *
+         *  resultIdxByLocation:
+         *      0 -> 0
+         *      1 -> 0
+         *      2 -> 1
+         *      3 -> 1
          */
         int location = 0;
         IntIntHashMap resultIdxByLocation = new IntIntHashMap(bulkParams.size());
-        for (int i = 0; i < bulkParams.size(); i++) {
-            resultIdxByLocation.put(location, i);
+        for (int resultIdx = 0; resultIdx < bulkParams.size(); resultIdx++) {
             results.add(new CompletableFuture<>());
-            location = addRequests(location, bulkParams.get(i), requests);
+            int prevLocation = location;
+            location = addRequests(location, bulkParams.get(resultIdx), requests);
+            for (int loc = prevLocation;  loc < location; loc++) {
+                resultIdxByLocation.put(loc, resultIdx);
+            }
         }
         if (requests.isEmpty()) {
             results.forEach(s -> s.complete(0L));
@@ -183,7 +194,7 @@ public class DeleteByIdTask extends JobTask {
 
                 @Override
                 public void onResponse(List<ShardResponse> responses) {
-                    long[] rowCounts = getRowCounts(responses, bulkParams, resultIdxByLocation);
+                    long[] rowCounts = getRowCounts(responses, bulkParams.size(), resultIdxByLocation);
                     for (int i = 0; i < results.size(); i++) {
                         results.get(i).complete(rowCounts[i]);
                     }
@@ -200,19 +211,17 @@ public class DeleteByIdTask extends JobTask {
         return results;
     }
 
-    private static long[] getRowCounts(List<ShardResponse> responses,
-                                       List<Row> bulkParams,
-                                       IntIntHashMap resultIdxByLocation) {
-        long[] rowCounts = new long[bulkParams.size()];
-        responses.sort(Comparator.comparingInt(o -> o.itemIndices().get(0)));
+    static long[] getRowCounts(List<ShardResponse> responses,
+                               int numResults,
+                               IntIntHashMap resultIdxByLocation) {
+        long[] rowCounts = new long[numResults];
         for (ShardResponse response : responses) {
-            int resultIdx = -1;
             for (IntCursor locCur : response.itemIndices()) {
-                if (resultIdxByLocation.containsKey(locCur.value)) {
-                    resultIdx = resultIdxByLocation.get(locCur.value);
-                }
                 ShardResponse.Failure failure = response.failures().get(locCur.index);
                 if (failure == null) {
+                    assert resultIdxByLocation.containsKey(locCur.value)
+                        : "resultIdxByLocation map must have an entry for each location";
+                    int resultIdx = resultIdxByLocation.get(locCur.value);
                     rowCounts[resultIdx] += 1;
                 }
             }

--- a/sql/src/test/java/io/crate/executor/transport/task/DeleteByIdTaskTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/task/DeleteByIdTaskTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.executor.transport.task;
+
+import com.carrotsearch.hppc.IntIntHashMap;
+import io.crate.executor.transport.ShardResponse;
+import org.junit.Test;
+
+import java.util.ArrayList;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class DeleteByIdTaskTest {
+
+    @Test
+    public void testBulkRowCountGeneration() throws Exception {
+        ArrayList<ShardResponse> responses = new ArrayList<>();
+        ShardResponse resp1 = new ShardResponse();
+        resp1.add(0, null);
+        resp1.add(2, null);
+        responses.add(resp1);
+        ShardResponse resp2 = new ShardResponse();
+        resp2.add(1, null);
+        responses.add(resp2);
+        ShardResponse resp3 = new ShardResponse();
+        resp2.add(3, null);
+        responses.add(resp3);
+
+        IntIntHashMap resultIdxByLocation = new IntIntHashMap();
+        resultIdxByLocation.put(0, 0);
+        resultIdxByLocation.put(2, 1);
+        resultIdxByLocation.put(1, 0);
+        resultIdxByLocation.put(3, 1);
+
+        long[] rowCounts = DeleteByIdTask.getRowCounts(responses, 2, resultIdxByLocation);
+
+        assertThat(rowCounts.length, is(2));
+        assertThat(rowCounts[0], is(2L));
+        assertThat(rowCounts[1], is(2L));
+    }
+}


### PR DESCRIPTION
This fixes a regression introduced in
a4dd6bd56f7ec37a4d2f13c553825abc87d45feb that could cause bulk
delete-by-id operations to return an incorrect row count or result in a
`ArrayIndexOutOfBoundsException` (Depending on the sharding/number of
shards)