### PR TITLE
Add the typtype column to pg_catalog.pg_type

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -39,6 +39,9 @@ Breaking Changes
 Changes
 =======
 
+- Added the ``typtype`` column to ``pg_catalog.pg_type`` for better
+  compatibility with certain postgres client libraries.
+
 - Added support for scalar subqueries in DELETE statements.
 
 - Added new "password" authentication method which is available for connections

--- a/blackbox/docs/protocols/postgres.txt
+++ b/blackbox/docs/protocols/postgres.txt
@@ -138,30 +138,30 @@ For compatibility reasons there is a trimmed down `pg_type` table available in
 CrateDB::
 
     cr> select * from pg_catalog.pg_type order by oid;
-    +------+----------+---------+-------------+
-    |  oid | typdelim | typelem | typname     |
-    +------+----------+---------+-------------+
-    |   16 | ,        |       0 | bool        |
-    |   18 | ,        |       0 | char        |
-    |   20 | ,        |       0 | int8        |
-    |   21 | ,        |       0 | int2        |
-    |   23 | ,        |       0 | int4        |
-    |  114 | ,        |       0 | json        |
-    |  199 | ,        |     114 | _json       |
-    |  700 | ,        |       0 | float4      |
-    |  701 | ,        |       0 | float8      |
-    | 1000 | ,        |      16 | _bool       |
-    | 1002 | ,        |      18 | _char       |
-    | 1005 | ,        |      21 | _int2       |
-    | 1007 | ,        |      23 | _int4       |
-    | 1015 | ,        |    1043 | _varchar    |
-    | 1016 | ,        |      20 | _int8       |
-    | 1021 | ,        |     700 | _float4     |
-    | 1022 | ,        |     701 | _float8     |
-    | 1043 | ,        |       0 | varchar     |
-    | 1184 | ,        |       0 | timestampz  |
-    | 1185 | ,        |    1184 | _timestampz |
-    +------+----------+---------+-------------+
+    +------+----------+---------+-------------+---------+
+    |  oid | typdelim | typelem | typname     | typtype |
+    +------+----------+---------+-------------+---------+
+    |   16 | ,        |       0 | bool        | b       |
+    |   18 | ,        |       0 | char        | b       |
+    |   20 | ,        |       0 | int8        | b       |
+    |   21 | ,        |       0 | int2        | b       |
+    |   23 | ,        |       0 | int4        | b       |
+    |  114 | ,        |       0 | json        | b       |
+    |  199 | ,        |     114 | _json       | b       |
+    |  700 | ,        |       0 | float4      | b       |
+    |  701 | ,        |       0 | float8      | b       |
+    | 1000 | ,        |      16 | _bool       | b       |
+    | 1002 | ,        |      18 | _char       | b       |
+    | 1005 | ,        |      21 | _int2       | b       |
+    | 1007 | ,        |      23 | _int4       | b       |
+    | 1015 | ,        |    1043 | _varchar    | b       |
+    | 1016 | ,        |      20 | _int8       | b       |
+    | 1021 | ,        |     700 | _float4     | b       |
+    | 1022 | ,        |     701 | _float8     | b       |
+    | 1043 | ,        |       0 | varchar     | b       |
+    | 1184 | ,        |       0 | timestampz  | b       |
+    | 1185 | ,        |    1184 | _timestampz | b       |
+    +------+----------+---------+-------------+---------+
     SELECT 20 rows in set (... sec)
 
 Show Transaction Isolation

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgTypeTable.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgTypeTable.java
@@ -36,6 +36,7 @@ import io.crate.metadata.table.ColumnRegistrar;
 import io.crate.metadata.table.StaticTableInfo;
 import io.crate.protocols.postgres.types.PGType;
 import io.crate.types.DataTypes;
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.cluster.ClusterState;
 
 import java.util.Collections;
@@ -50,27 +51,39 @@ public class PgTypeTable extends StaticTableInfo {
         static final ColumnIdent TYPNAME = new ColumnIdent("typname");
         static final ColumnIdent TYPDELIM = new ColumnIdent("typdelim");
         static final ColumnIdent TYPELEM = new ColumnIdent("typelem");
+        static final ColumnIdent TYPTYPE = new ColumnIdent("typtype");
     }
+
+    private static final BytesRef TYPTYPE_BASE = new BytesRef("b");
 
     public static Map<ColumnIdent, RowCollectExpressionFactory<PGType>> expressions() {
         return ImmutableMap.<ColumnIdent, RowCollectExpressionFactory<PGType>>builder()
-            .put(PgTypeTable.Columns.OID,
+            .put(Columns.OID,
                 () -> RowContextCollectorExpression.forFunction(PGType::oid))
-            .put(PgTypeTable.Columns.TYPNAME,
+            .put(Columns.TYPNAME,
                 () -> RowContextCollectorExpression.objToBytesRef(PGType::typName))
-            .put(PgTypeTable.Columns.TYPDELIM,
+            .put(Columns.TYPDELIM,
                 () -> RowContextCollectorExpression.objToBytesRef(PGType::typDelim))
-            .put(PgTypeTable.Columns.TYPELEM,
+            .put(Columns.TYPELEM,
                 () -> RowContextCollectorExpression.forFunction(PGType::typElem))
+            .put(Columns.TYPTYPE,
+                () -> new RowContextCollectorExpression<PGType, BytesRef>() {
+
+                    @Override
+                    public BytesRef value() {
+                        return TYPTYPE_BASE;
+                    }
+                })
             .build();
     }
 
     PgTypeTable() {
         super(IDENT, new ColumnRegistrar(IDENT, RowGranularity.DOC)
-                .register("oid", DataTypes.INTEGER, null)
-                .register("typname", DataTypes.STRING, null)
-                .register("typdelim", DataTypes.STRING, null)
-                .register("typelem", DataTypes.INTEGER, null),
+                .register(Columns.OID.name(), DataTypes.INTEGER, null)
+                .register(Columns.TYPNAME.name(), DataTypes.STRING, null)
+                .register(Columns.TYPDELIM.name(), DataTypes.STRING, null)
+                .register(Columns.TYPELEM.name(), DataTypes.INTEGER, null)
+                .register(Columns.TYPTYPE.name(), DataTypes.STRING, null),
             Collections.emptyList());
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -495,7 +495,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultColumns() throws Exception {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(464, response.rowCount());
+        assertEquals(465, response.rowCount());
     }
 
     @Test


### PR DESCRIPTION
See https://www.postgresql.org/docs/10/static/catalog-pg-type.html

For now all types default to `b` (base type).

`pgx` is one client that uses this column. See
https://github.com/jackc/pgx/pull/336