### PR TITLE
adds support for disabling doc_values per column

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -39,6 +39,11 @@ Breaking Changes
 Changes
 =======
 
+- Added support for disabling the column store per ``STRING`` column on table
+  creation and on adding columns. In conjunction with disabling indexing on that
+  column, this will support storing strings greater than 32kb. Be aware that the
+  performance of aggregations and groupings on such columns will decrease.
+
 - Added support for ``ORDER BY``, ``GROUP BY`` and global aggregates on columns
   with disabled indexing (``INDEX OFF``).
 

--- a/blackbox/docs/general/ddl/data-types.txt
+++ b/blackbox/docs/general/ddl/data-types.txt
@@ -98,7 +98,8 @@ Columns of type string can also be analyzed. See :ref:`sql_ddl_index_fulltext`.
 .. NOTE::
 
    Maximum indexed string length is restricted to 32766 bytes, when encoded
-   with UTF-8 unless the string is analyzed using full text.
+   with UTF-8 unless the string is analyzed using full text or indexing and
+   the usage of the :ref:`ddl-storage-columnstore` is disabled.
 
 Numeric Types
 =============

--- a/blackbox/docs/general/ddl/index.txt
+++ b/blackbox/docs/general/ddl/index.txt
@@ -15,6 +15,7 @@ Data Definition
    system-columns
    generated_columns
    constraints
+   storage
    partitioned_tables
    sharding
    replication

--- a/blackbox/docs/general/ddl/storage.txt
+++ b/blackbox/docs/general/ddl/storage.txt
@@ -6,6 +6,8 @@
 
 Data storage options can be tuned for each column similar to how indexing is defined.
 
+.. _ddl-storage-columnstore:
+
 Column Store
 ============
 
@@ -25,7 +27,7 @@ Example:
 
     cr> CREATE TABLE t1 (
     ...   id INTEGER,
-    ...   url STRING STORAGE WITH (columnstore = false)
+    ...   url STRING INDEX OFF STORAGE WITH (columnstore = false)
     ... );
     CREATE OK, 1 row affected  (... sec)
 

--- a/blackbox/docs/general/ddl/storage.txt
+++ b/blackbox/docs/general/ddl/storage.txt
@@ -1,0 +1,55 @@
+.. _ddl-storage:
+
+=========
+ Storage
+=========
+
+Data storage options can be tuned for each column similar to how indexing is defined.
+
+Column Store
+============
+
+Beside of storing the row data as-is (and indexing each value by default), each
+value term is stored into a `Column Store`_ by default. The usage of a `Column
+Store`_ is greatly improving global aggregations and groupings and enables
+ordering possiblity as the data for one column is packed at one place. Using the
+`Column Store`_ limits the values of :ref:`data-type-string` columns to a
+maximal length of 32766 bytes.
+
+Turning off the `Column Store`_ in conjunction of :ref:`turning off indexing
+<sql_ddl_index_off>` will remove the length limitation but also will disable
+ordering functionality.
+
+Example:
+::
+
+    cr> CREATE TABLE t1 (
+    ...   id INTEGER,
+    ...   url STRING STORAGE WITH (columnstore = false)
+    ... );
+    CREATE OK, 1 row affected  (... sec)
+
+Doing so will enable support for inserting strings longer than 32766 bytes into
+the ``url`` column, but will also disable the possibility to sort on the ``url``
+column and the performance for global aggregations or groupings using this
+``url`` column will decrease.
+
+.. hide:
+
+    cr> drop table t1;
+    DROP OK, 1 row affected  (... sec)
+
+Supported data types
+--------------------
+
+Controling if values are stored into a `Column Store`_ is only supported on
+follwing data types:
+
+ - :ref:`data-type-string`
+
+For all other :ref:`sql_ddl_datatypes_primitives`, it is enabled by default and
+cannot be disabled. :ref:`sql_ddl_datatypes_compound` and
+:ref:`sql_ddl_datatypes_geographic` do not support storing values into a
+`Column Store`_ at all.
+
+.. _Column Store: https://en.wikipedia.org/wiki/Column-oriented_DBMS

--- a/blackbox/docs/sql/statements/create_table.txt
+++ b/blackbox/docs/sql/statements/create_table.txt
@@ -31,7 +31,7 @@ Synopsis
 
 where ``base_column_definition``::
 
-    column_name data_type [ column_constraint [ ... ] ]
+    column_name data_type [ column_constraint [ ... ] ]  [ storage_options ]
 
 where ``generated_column_definition`` is::
 
@@ -46,6 +46,10 @@ where ``column_constraint`` is::
       INDEX { OFF | USING { PLAIN |
                             FULLTEXT [ WITH ( analyzer = analyzer_name ) ]  }
     }
+
+where ``storage_options`` is::
+
+    STORAGE WITH ( option = value_expression [, ... ] )
 
 and ``table_constraint`` is::
 
@@ -126,9 +130,14 @@ Column Constraints
 Column constraints are constraints that are applied on each column of the table
 separately.
 
-The supported column constraints are:
-
 For further details see :ref:`column_constraints`.
+
+Storage options
+...............
+
+Storage options can be applied on each column of the table separately.
+
+For further details and available options see :ref:`ddl-storage`.
 
 Parameters
 ==========

--- a/blackbox/docs/src/doc_tests/tests.py
+++ b/blackbox/docs/src/doc_tests/tests.py
@@ -452,6 +452,7 @@ def test_suite():
                'general/ddl/fulltext_indices.txt',
                'general/ddl/system-columns.txt',
                'general/ddl/alter_table.txt',
+               'general/ddl/storage.txt',
                'administration/runtime-config.txt',
                'general/ddl/show_create_table.txt',
                'general/user_defined_functions.txt',

--- a/sql-parser/src/main/antlr/SqlBase.g4
+++ b/sql-parser/src/main/antlr/SqlBase.g4
@@ -512,6 +512,7 @@ columnConstraint
     | NOT NULL                                                                       #columnConstraintNotNull
     | INDEX USING method=ident withProperties?                                       #columnIndexConstraint
     | INDEX OFF                                                                      #columnIndexOff
+    | STORAGE withProperties                                                         #columnStorageDefinition
     ;
 
 withProperties
@@ -594,7 +595,7 @@ nonReserved
     | GRAPHVIZ | HOUR | IGNORED | KEY | KILL | LOGICAL | LOCAL | MATERIALIZED | MINUTE
     | MONTH | OFF | ONLY | OVER | OPTIMIZE | PARTITION | PARTITIONED | PARTITIONS | PLAIN
     | PRECEDING | RANGE | REFRESH | ROW | ROWS | SCHEMAS | SECOND | SESSION
-    | SHARDS | SHOW | STRICT | SYSTEM | TABLES | TABLESAMPLE | TEXT | TIME
+    | SHARDS | SHOW | STORAGE | STRICT | SYSTEM | TABLES | TABLESAMPLE | TEXT | TIME
     | TIMESTAMP | TO | TOKENIZER | TOKEN_FILTERS | TYPE | VALUES | VIEW | YEAR
     | REPOSITORY | SNAPSHOT | RESTORE | GENERATED | ALWAYS | BEGIN
     | ISOLATION | TRANSACTION | CHARACTERISTICS | LEVEL | LANGUAGE | OPEN | CLOSE | RENAME
@@ -786,6 +787,7 @@ OFF: 'OFF';
 FULLTEXT: 'FULLTEXT';
 PLAIN: 'PLAIN';
 INDEX: 'INDEX';
+STORAGE: 'STORAGE';
 
 DYNAMIC: 'DYNAMIC';
 STRICT: 'STRICT';

--- a/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
+++ b/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
@@ -31,6 +31,7 @@ import io.crate.sql.tree.ClusteredBy;
 import io.crate.sql.tree.CollectionColumnType;
 import io.crate.sql.tree.ColumnConstraint;
 import io.crate.sql.tree.ColumnDefinition;
+import io.crate.sql.tree.ColumnStorageDefinition;
 import io.crate.sql.tree.ColumnType;
 import io.crate.sql.tree.CopyFrom;
 import io.crate.sql.tree.CrateTableOption;
@@ -552,6 +553,15 @@ public final class SqlFormatter {
                     builder.append(" ");
                     node.properties().accept(this, indent);
                 }
+            }
+            return null;
+        }
+
+        @Override
+        public Void visitColumnStorageDefinition(ColumnStorageDefinition node, Integer indent) {
+            builder.append("STORAGE ");
+            if (!node.properties().isEmpty()) {
+                node.properties().accept(this, indent);
             }
             return null;
         }

--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -53,6 +53,7 @@ import io.crate.sql.tree.ClusteredBy;
 import io.crate.sql.tree.CollectionColumnType;
 import io.crate.sql.tree.ColumnConstraint;
 import io.crate.sql.tree.ColumnDefinition;
+import io.crate.sql.tree.ColumnStorageDefinition;
 import io.crate.sql.tree.ColumnType;
 import io.crate.sql.tree.ComparisonExpression;
 import io.crate.sql.tree.CopyFrom;
@@ -626,6 +627,12 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
             visit(context.columns().primaryExpression(), Expression.class),
             visitIfPresent(context.withProperties(), GenericProperties.class)
                 .orElse(GenericProperties.EMPTY));
+    }
+
+    @Override
+    public Node visitColumnStorageDefinition(SqlBaseParser.ColumnStorageDefinitionContext ctx) {
+        return new ColumnStorageDefinition(visitIfPresent(ctx.withProperties(), GenericProperties.class)
+            .orElse(GenericProperties.EMPTY));
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
@@ -365,6 +365,10 @@ public abstract class AstVisitor<R, C> {
         return visitNode(node, context);
     }
 
+    public R visitColumnStorageDefinition(ColumnStorageDefinition node, C context) {
+        return visitNode(node, context);
+    }
+
     public R visitGenericProperties(GenericProperties node, C context) {
         return visitNode(node, context);
     }

--- a/sql-parser/src/main/java/io/crate/sql/tree/ColumnStorageDefinition.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/ColumnStorageDefinition.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.sql.tree;
+
+import com.google.common.base.MoreObjects;
+
+import java.util.Objects;
+
+public class ColumnStorageDefinition extends ColumnConstraint {
+
+    private final GenericProperties properties;
+
+    public ColumnStorageDefinition(GenericProperties properties) {
+        this.properties = properties;
+    }
+
+    public GenericProperties properties() {
+        return properties;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitColumnStorageDefinition(this, context);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ColumnStorageDefinition that = (ColumnStorageDefinition) o;
+        return Objects.equals(properties, that.properties);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(properties);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+            .add("properties", properties)
+            .toString();
+    }
+}

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -324,6 +324,8 @@ public class TestStatementBuilder {
         printStatement("create table test (col1 int, col2 timestamp) partitioned by (col1) clustered by (col2)");
         printStatement("create table test (col1 int, col2 timestamp) clustered by (col2) partitioned by (col1)");
         printStatement("create table test (col1 int, col2 object as (col3 timestamp)) partitioned by (col2['col3'])");
+
+        printStatement("create table test (col1 string storage with (columnstore = false))");
     }
 
     @Test

--- a/sql/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedColumnDefinition.java
@@ -42,6 +42,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
+import static org.elasticsearch.index.mapper.TypeParsers.DOC_VALUES;
+
 public class AnalyzedColumnDefinition {
 
     private static final Set<String> UNSUPPORTED_PK_TYPES = Sets.newHashSet(
@@ -78,6 +80,7 @@ public class AnalyzedColumnDefinition {
     private boolean isIndex = false;
     private ArrayList<String> copyToTargets;
     private boolean isParentColumn;
+    private boolean columnStore = true;
 
     @Nullable
     private String formattedGeneratedExpression;
@@ -237,6 +240,10 @@ public class AnalyzedColumnDefinition {
         } else if (dataType().equals("object")) {
             objectMapping(mapping);
         }
+
+        if (columnStore == false) {
+            mapping.put(DOC_VALUES, "false");
+        }
         return mapping;
     }
 
@@ -373,4 +380,11 @@ public class AnalyzedColumnDefinition {
         return generatedExpression;
     }
 
+    void setColumnStore(boolean columnStore) {
+        this.columnStore = columnStore;
+    }
+
+    public boolean isColumnStoreEnabled() {
+        return columnStore;
+    }
 }

--- a/sql/src/main/java/io/crate/analyze/AnalyzedTableElements.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedTableElements.java
@@ -247,6 +247,7 @@ public class AnalyzedTableElements {
         }
         validateIndexDefinitions(tableIdent);
         validatePrimaryKeys(tableIdent);
+        validateColumnStorageDefinitions();
     }
 
     private void validateGeneratedColumns(TableIdent tableIdent,
@@ -358,6 +359,17 @@ public class AnalyzedTableElements {
             }
             if (!columnTypes.get(columnIdent).equalsIgnoreCase("string")) {
                 throw new IllegalArgumentException("INDEX definition only support 'string' typed source columns");
+            }
+        }
+    }
+
+    private void validateColumnStorageDefinitions() {
+        for (AnalyzedColumnDefinition columnDefinition : columns) {
+            DataType dataType = DataTypes.ofMappingName(columnDefinition.dataType());
+            if (columnDefinition.isColumnStoreEnabled() == false && dataType != DataTypes.STRING) {
+                throw new IllegalArgumentException(
+                    String.format(Locale.ENGLISH, "Invalid storage option \"columnstore\" for data type \"%s\"",
+                        dataType.getName()));
             }
         }
     }

--- a/sql/src/main/java/io/crate/analyze/MetaDataToASTNodeResolver.java
+++ b/sql/src/main/java/io/crate/analyze/MetaDataToASTNodeResolver.java
@@ -29,10 +29,12 @@ import io.crate.metadata.IndexReference;
 import io.crate.metadata.Reference;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.sql.parser.SqlParser;
+import io.crate.sql.tree.BooleanLiteral;
 import io.crate.sql.tree.ClusteredBy;
 import io.crate.sql.tree.CollectionColumnType;
 import io.crate.sql.tree.ColumnConstraint;
 import io.crate.sql.tree.ColumnDefinition;
+import io.crate.sql.tree.ColumnStorageDefinition;
 import io.crate.sql.tree.ColumnType;
 import io.crate.sql.tree.CrateTableOption;
 import io.crate.sql.tree.CreateTable;
@@ -164,6 +166,12 @@ public class MetaDataToASTNodeResolver {
                 if (info instanceof GeneratedReference) {
                     String formattedExpression = ((GeneratedReference) info).formattedGeneratedExpression();
                     expression = SqlParser.createExpression(formattedExpression);
+                }
+
+                if (info.isColumnStoreDisabled()) {
+                    GenericProperties properties = new GenericProperties();
+                    properties.add(new GenericProperty("columnstore", BooleanLiteral.fromObject(false)));
+                    constraints.add(new ColumnStorageDefinition(properties));
                 }
 
                 String columnName = ident.isColumn() ? ident.name() : ident.path().get(ident.path().size() - 1);

--- a/sql/src/main/java/io/crate/analyze/relations/AbstractTableRelation.java
+++ b/sql/src/main/java/io/crate/analyze/relations/AbstractTableRelation.java
@@ -110,7 +110,8 @@ public abstract class AbstractTableRelation<T extends TableInfo> implements Anal
                 dataType,
                 reference.columnPolicy(),
                 reference.indexType(),
-                reference.isNullable());
+                reference.isNullable(),
+                reference.isColumnStoreDisabled());
         } else {
             return reference;
         }

--- a/sql/src/main/java/io/crate/analyze/relations/DocTableRelation.java
+++ b/sql/src/main/java/io/crate/analyze/relations/DocTableRelation.java
@@ -63,6 +63,9 @@ public class DocTableRelation extends AbstractTableRelation<DocTableInfo> {
             } else if (symbol.indexType() == Reference.IndexType.ANALYZED) {
                 throw new UnsupportedOperationException(
                     SymbolFormatter.format("Cannot ORDER BY '%s': sorting on analyzed/fulltext columns is not possible", symbol));
+            } else if (symbol.isColumnStoreDisabled()) {
+                throw new UnsupportedOperationException(
+                    SymbolFormatter.format("Cannot ORDER BY '%s': sorting on columns with disabled 'columnstore' is not possible", symbol));
             }
             return null;
         }

--- a/sql/src/main/java/io/crate/metadata/DocReferences.java
+++ b/sql/src/main/java/io/crate/metadata/DocReferences.java
@@ -26,6 +26,8 @@ import io.crate.analyze.symbol.RefReplacer;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.doc.DocSysColumns;
 
+import java.util.function.Predicate;
+
 /**
  * Visitor to change a _doc reference into a regular column reference.
  * <p/>
@@ -58,6 +60,17 @@ public final class DocReferences {
     }
 
     /**
+     * Replace any suitable references within tree with _doc references if condition matches.
+     * Suitable references are any non-system columns from user tables with DOC granularity.
+     * <pre>
+     *     x -> _doc['x']
+     * </pre>
+     */
+    public static Symbol toSourceLookup(Symbol tree, Predicate<Reference> condition) {
+        return RefReplacer.replaceRefs(tree, r -> DocReferences.toSourceLookup(r, condition));
+    }
+
+    /**
      * Rewrite the reference to do a source lookup if possible.
      * @see #toSourceLookup(Symbol)
      *
@@ -73,6 +86,21 @@ public final class DocReferences {
         if (reference.granularity() == RowGranularity.DOC && Schemas.isDefaultOrCustomSchema(ident.tableIdent().schema())) {
             return reference.getRelocated(
                 new ReferenceIdent(ident.tableIdent(), ident.columnIdent().prepend(DocSysColumns.Names.DOC)));
+        }
+        return reference;
+    }
+
+    /**
+     * Rewrite the reference to do a source lookup if possible and given condition matches.
+     * @see #toSourceLookup(Reference)
+     *
+     * <pre>
+     *     x -> _doc['x']
+     * </pre>
+     */
+    private static Reference toSourceLookup(Reference reference, Predicate<Reference> condition) {
+        if (condition.test(reference)) {
+            return toSourceLookup(reference);
         }
         return reference;
     }

--- a/sql/src/main/java/io/crate/metadata/IndexReference.java
+++ b/sql/src/main/java/io/crate/metadata/IndexReference.java
@@ -88,7 +88,7 @@ public class IndexReference extends Reference {
                           IndexType indexType,
                           List<Reference> columns,
                           @Nullable String analyzer) {
-        super(ident, RowGranularity.DOC, DataTypes.STRING, ColumnPolicy.DYNAMIC, indexType, false);
+        super(ident, RowGranularity.DOC, DataTypes.STRING, ColumnPolicy.DYNAMIC, indexType, false, true);
         this.columns = MoreObjects.firstNonNull(columns, Collections.<Reference>emptyList());
         this.analyzer = analyzer;
     }

--- a/sql/src/main/java/io/crate/operation/reference/doc/lucene/LuceneReferenceResolver.java
+++ b/sql/src/main/java/io/crate/operation/reference/doc/lucene/LuceneReferenceResolver.java
@@ -106,6 +106,11 @@ public class LuceneReferenceResolver implements ReferenceResolver<LuceneCollecto
         if (fieldType == null) {
             return new NullValueCollectorExpression(fqn);
         }
+        if (fieldType.hasDocValues() == false) {
+            Reference ref = DocReferences.toSourceLookup(refInfo);
+            return DocCollectorExpression.create(ref);
+        }
+
         switch (refInfo.valueType().id()) {
             case ByteType.ID:
                 return new ByteColumnReference(fqn);

--- a/sql/src/test/java/io/crate/analyze/AlterTableAddColumnAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/AlterTableAddColumnAnalyzerTest.java
@@ -350,4 +350,14 @@ public class AlterTableAddColumnAnalyzerTest extends CrateDummyClusterServiceUni
         assertThat(nameGeneratedColumn.formattedGeneratedExpression(), is("concat(name, 'foo')"));
     }
 
+
+    @Test
+    public void testAddColumnWithColumnStoreDisabled() throws Exception {
+        AddColumnAnalyzedStatement analysis = e.analyze(
+            "alter table users add column string_no_docvalues string STORAGE WITH (columnstore = false)");
+        Map<String, Object> mapping = analysis.analyzedTableElements().toMapping();
+        assertThat(mapToSortedString(mapping),
+            is("_all={enabled=false}, _meta={primary_keys=[id]}, properties={id={type=long}, " +
+               "string_no_docvalues={doc_values=false, type=keyword}}"));
+    }
 }

--- a/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -1032,4 +1032,19 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
         assertThat(versionMap.get(Version.Property.CREATED.toString()), is(Version.toMap(Version.CURRENT)));
         assertThat(versionMap.get(Version.Property.UPGRADED.toString()), nullValue());
     }
+
+    @Test
+    public void testCreateTableWithColumnStoreDisabled() throws Exception {
+        CreateTableAnalyzedStatement analysis = e.analyze(
+            "create table columnstore_disabled (s string STORAGE WITH (columnstore = false))");
+        Map<String, Object> mappingProperties = analysis.mappingProperties();
+        assertThat(mapToSortedString(mappingProperties), is("s={doc_values=false, type=keyword}"));
+    }
+
+    @Test
+    public void testCreateTableWithColumnStoreDisabledOnInvalidDataType() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Invalid storage option \"columnstore\" for data type \"integer\"");
+        e.analyze("create table columnstore_disabled (s int STORAGE WITH (columnstore = false))");
+    }
 }

--- a/sql/src/test/java/io/crate/integrationtests/StorageOptionsITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/StorageOptionsITest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.integrationtests;
+
+import com.carrotsearch.randomizedtesting.generators.RandomStrings;
+import io.crate.testing.TestingHelpers;
+import org.junit.Test;
+
+import static org.apache.lucene.index.IndexWriter.MAX_TERM_LENGTH;
+import static org.hamcrest.Matchers.is;
+
+public class StorageOptionsITest extends SQLTransportIntegrationTest {
+
+    @Test
+    public void testInsertStringGreaterThanDocValuesLimit() throws Exception {
+        execute("create table t1 (s string index off storage with (columnstore=false))");
+
+        String bigString = RandomStrings.randomRealisticUnicodeOfLength(random(), MAX_TERM_LENGTH + 2);
+        execute("insert into t1 (s) values (?)", new Object[]{bigString});
+        refresh();
+
+        execute("select s from t1 limit 1");
+        assertThat(response.rows()[0][0], is(bigString));
+    }
+
+    @Test
+    public void testAggregationWithDisabledDocValues() throws Exception {
+        execute("create table t1 (s string storage with (columnstore=false))");
+
+        execute("insert into t1 (s) values (?), (?)", new Object[]{"hello", "foo"});
+        refresh();
+
+        execute("select max(s) from t1");
+        assertThat(response.rows()[0][0], is("hello"));
+    }
+
+    @Test
+    public void testGroupByWithDisabledDocValues() throws Exception {
+        execute("create table t1 (s string index off storage with (columnstore=false))");
+
+        execute("insert into t1 (s) values (?), (?)", new Object[]{"hello", "foo"});
+        refresh();
+
+        execute("select count(s), s from t1 group by s order by s");
+        assertThat(TestingHelpers.printedTable(response.rows()), is("1| foo\n" +
+                                                                    "1| hello\n"));
+    }
+
+    @Test
+    public void testOrderByWithDisabledDocValues() throws Exception {
+        execute("create table t1 (s string storage with (columnstore=false))");
+        execute("insert into t1 (s) values (?)", new Object[]{"foo"});
+        refresh();
+
+        expectedException.expectMessage("Cannot ORDER BY 's': sorting on columns with disabled 'columnstore' is not possible");
+        execute("select * from t1 order by s");
+    }
+}


### PR DESCRIPTION
also implements a source lookup fallback for each column with disabled
doc_values. this way aggregations and groupings will work without
doc_values as well.
