### PR TITLE
removes planner limitations on order/group/aggregate on INDEX OFF cols

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -39,6 +39,9 @@ Breaking Changes
 Changes
 =======
 
+- Added support for ``ORDER BY``, ``GROUP BY`` and global aggregates on columns
+  with disabled indexing (``INDEX OFF``).
+
 - Added cgroup stats to ``sys.nodes``.
 
 - Added the ``typtype`` column to ``pg_catalog.pg_type`` for better

--- a/blackbox/docs/general/ddl/fulltext_indices.txt
+++ b/blackbox/docs/general/ddl/fulltext_indices.txt
@@ -69,12 +69,6 @@ When a not indexed column is queried the query will return an error.
     cr> select * from my_table1b where first_column = 'hello';
     SQLActionException[UnhandledServerException: java.lang.IllegalArgumentException: Cannot search on field [first_column] since it is not indexed.]
 
-.. NOTE::
-
-    Operations such as data aggregations (:ref:`sql_dql_aggregation`), grouping
-    (:ref:`sql_dql_group_by`), and sorting (:ref:`sql_reference_order_by`)
-    only work on indexed fields.
-
 .. _sql_ddl_index_plain:
 
 Plain index (Default)

--- a/sql/src/main/java/io/crate/analyze/relations/DocTableRelation.java
+++ b/sql/src/main/java/io/crate/analyze/relations/DocTableRelation.java
@@ -63,9 +63,6 @@ public class DocTableRelation extends AbstractTableRelation<DocTableInfo> {
             } else if (symbol.indexType() == Reference.IndexType.ANALYZED) {
                 throw new UnsupportedOperationException(
                     SymbolFormatter.format("Cannot ORDER BY '%s': sorting on analyzed/fulltext columns is not possible", symbol));
-            } else if (symbol.indexType() == Reference.IndexType.NO) {
-                throw new UnsupportedOperationException(
-                    SymbolFormatter.format("Cannot ORDER BY '%s': sorting on non-indexed columns is not possible", symbol));
             }
             return null;
         }

--- a/sql/src/main/java/io/crate/planner/node/dql/GroupByConsumer.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/GroupByConsumer.java
@@ -92,9 +92,6 @@ public class GroupByConsumer {
             if (symbol.indexType() == Reference.IndexType.ANALYZED) {
                 throw new IllegalArgumentException(
                     SymbolFormatter.format("Cannot GROUP BY '%s': grouping on analyzed/fulltext columns is not possible", symbol));
-            } else if (symbol.indexType() == Reference.IndexType.NO) {
-                throw new IllegalArgumentException(
-                    SymbolFormatter.format("Cannot GROUP BY '%s': grouping on non-indexed columns is not possible", symbol));
             }
             return null;
         }

--- a/sql/src/main/java/io/crate/planner/operators/HashAggregate.java
+++ b/sql/src/main/java/io/crate/planner/operators/HashAggregate.java
@@ -194,9 +194,6 @@ public class HashAggregate implements LogicalPlan {
                 if (indexType == Reference.IndexType.ANALYZED) {
                     throw new IllegalArgumentException(SymbolFormatter.format(
                         "Cannot select analyzed column '%s' within grouping or aggregations", symbol));
-                } else if (indexType == Reference.IndexType.NO) {
-                    throw new IllegalArgumentException(SymbolFormatter.format(
-                        "Cannot select non-indexed column '%s' within grouping or aggregations", symbol));
                 }
             }
             return null;

--- a/sql/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
@@ -1207,4 +1207,33 @@ public class GroupByAggregateTest extends SQLTransportIntegrationTest {
                 "from employees group by 1");
         assertThat(printedTable(response.rows()), is("{id1=1, id2=36}| 6\n"));
     }
+
+    @Test
+    public void testGroupByOnIndexOff() throws Exception {
+        execute("create table t1 (i int index off, s string index off)");
+        execute("insert into t1 (i, s) values (?,?)",
+            new Object[][]{
+                {1, "foo"},
+                {2, "bar"},
+                {1, "foo"}
+        });
+        refresh();
+        execute("select count(*), i, s from t1 group by i, s ");
+        assertThat(printedTable(response.rows()), is("1| 2| bar\n" +
+                                                     "2| 1| foo\n"));
+    }
+
+    @Test
+    public void testAggregateOnIndexOff() throws Exception {
+        execute("create table t1 (i int index off, s string index off)");
+        execute("insert into t1 (i, s) values (?,?)",
+            new Object[][]{
+                {1, "foo"},
+                {2, "foobar"},
+                {1, "foo"}
+        });
+        refresh();
+        execute("select sum(i), max(s) from t1");
+        assertThat(printedTable(response.rows()), is("4| foobar\n"));
+    }
 }

--- a/sql/src/test/java/io/crate/integrationtests/OrderByITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/OrderByITest.java
@@ -26,6 +26,8 @@ import io.crate.testing.TestingHelpers;
 import org.hamcrest.core.Is;
 import org.junit.Test;
 
+import static org.hamcrest.Matchers.is;
+
 public class OrderByITest extends SQLTransportIntegrationTest {
 
     @Test
@@ -53,4 +55,14 @@ public class OrderByITest extends SQLTransportIntegrationTest {
             "10.0.0.1\n"));
     }
 
+    @Test
+    public void testOrderByWithIndexOff() throws Exception {
+        execute("create table t1 (s string index off)");
+        execute("insert into t1 (s) values (?), (?)", new Object[]{"hello", "foo"});
+        refresh();
+
+        execute("select s from t1 order by s");
+        assertThat(TestingHelpers.printedTable(response.rows()), is("foo\n" +
+                                                                    "hello\n"));
+    }
 }

--- a/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -432,24 +432,10 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
-    public void testOrderByOnIndexOff() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("Cannot ORDER BY 'no_index': sorting on non-indexed columns is not possible");
-        e.plan("select no_index from users u order by 1");
-    }
-
-    @Test
     public void testSelectAnalyzedReferenceInFunctionAggregation() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Cannot select analyzed column 'text' within grouping or aggregations");
         e.plan("select min(substr(text, 0, 2)) from users");
-    }
-
-    @Test
-    public void testSelectNonIndexedReferenceInFunctionAggregation() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Cannot select non-indexed column 'no_index' within grouping or aggregations");
-        e.plan("select min(substr(no_index, 0, 2)) from users");
     }
 
     @Test

--- a/sql/src/test/java/io/crate/planner/consumer/GroupByPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/consumer/GroupByPlannerTest.java
@@ -545,24 +545,10 @@ public class GroupByPlannerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
-    public void testGroupByOnIndexOff() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Cannot GROUP BY 'no_index': grouping on non-indexed columns is not possible");
-        e.plan("select no_index from users u group by 1");
-    }
-
-    @Test
     public void testSelectAnalyzedReferenceInFunctionGroupBy() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Cannot GROUP BY 'text': grouping on analyzed/fulltext columns is not possible");
         e.plan("select substr(text, 0, 2) from users u group by 1");
-    }
-
-    @Test
-    public void testSelectNonIndexedReferenceInFunctionGroupBy() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Cannot GROUP BY 'no_index': grouping on non-indexed columns is not possible");
-        e.plan("select substr(no_index, 0, 2) from users u group by 1");
     }
 
     @Test


### PR DESCRIPTION
this was an artificial planner limitation: grouping, aggregates and
ordering requires doc_values but no index.