### PR TITLE
add cgroup memory stats to sys.nodes

### DIFF
--- a/blackbox/docs/administration/system-information.txt
+++ b/blackbox/docs/administration/system-information.txt
@@ -444,14 +444,14 @@ The table schema is as follows:
 +-------------------------------------------------+------------------------------------------------------+-------------+
 | ``os['cgroup']['cpuacct']``                     | Information about CPU accounting                     | ``OBJECT``  |
 +-------------------------------------------------+------------------------------------------------------+-------------+
-| ``os['cgroup']['cpuacct']['control_group']``    | The path to the cgroup                               | ``STRING``  |
+| ``os['cgroup']['cpuacct']['control_group']``    | The path to the cpu accounting cgroup                | ``STRING``  |
 +-------------------------------------------------+------------------------------------------------------+-------------+
 | ``os['cgroup']['cpuacct']['usage_nanos']``      | The total CPU time (in nanoseconds) consumed by      | ``LONG``    |
 |                                                 | all tasks in this cgroup.                            |             |
 +-------------------------------------------------+------------------------------------------------------+-------------+
 | ``os['cgroup']['cpu']``                         | Information about the CPU subsystem                  | ``OBJECT``  |
 +-------------------------------------------------+------------------------------------------------------+-------------+
-| ``os['cgroup']['cpu']['control_group']``        | The path to the cgroup                               | ``STRING``  |
+| ``os['cgroup']['cpu']['control_group']``        | The path to the cpu cgroup                           | ``STRING``  |
 +-------------------------------------------------+------------------------------------------------------+-------------+
 | ``os['cgroup']['cpu']['cfs_period_micros']``    | The period of time (in microseconds) the cgroup      | ``LONG``    |
 |                                                 | access to the CPU gets reallocated.                  |             |
@@ -468,6 +468,16 @@ The table schema is as follows:
 +-------------------------------------------------+------------------------------------------------------+-------------+
 | ``os['cgroup']['cpu']['time_throttled_nanos']`` | The total time (in nanoseconds) for which tasks in   | ``LONG``    |
 |                                                 | the cgroup have been throttled.                      |             |
++-------------------------------------------------+------------------------------------------------------+-------------+
+| ``os['cgroup']['mem']``                         | Information about memory resources used by tasks in  | ``OBJECT``  |
+|                                                 | a cgroup.                                            |             |
++-------------------------------------------------+------------------------------------------------------+-------------+
+| ``os['cgroup']['mem']['control_group']``        | The path to the memory cgroup                        | ``STRING``  |
++-------------------------------------------------+------------------------------------------------------+-------------+
+| ``os['cgroup']['mem']['usage_bytes']``          | The total current memory usage by processes in       | ``STRING``  |
+|                                                 | the cgroup.                                          |             |
++-------------------------------------------------+------------------------------------------------------+-------------+
+| ``os['cgroup']['mem']['limit_bytes']``          | The max. amount of user memory in the cgroup.        | ``STRING``  |
 +-------------------------------------------------+------------------------------------------------------+-------------+
 
 .. note::

--- a/core/src/main/java/io/crate/monitor/CgroupMemoryProbe.java
+++ b/core/src/main/java/io/crate/monitor/CgroupMemoryProbe.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.monitor;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.elasticsearch.common.io.PathUtils;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * This Class is a subset of the OsStats Service implementation of of ES 6
+ * It provides methods to fetch cgroup memory metrics from the filesystem located in <code>/proc/self/cgroup</code>.
+ *
+ * TODO: The implementation gets obsolete and can be removed when upgrading to ES 6
+ *
+ * @see <a href="github.com/elastic/elasticsearch/blob/6.1/core/src/main/java/org/elasticsearch/monitor/os/OsProbe.java">OsProbe</a>
+ *
+ */
+public class CgroupMemoryProbe {
+
+    private static String readSingleLine(final Path path) throws IOException {
+        try (BufferedReader reader = Files.newBufferedReader(path)) {
+            String line = reader.readLine();
+            assert line != null : "cgroup path leads to an empty file";
+            return line;
+        }
+    }
+
+    /**
+     * The maximum amount of user memory (including file cache).
+     * It is possible that the result value overflows a <code>Long</code> therefore the result type is <code>String</code>
+     */
+    private static String getCgroupMemoryLimitInBytes(final String controlGroup) throws IOException {
+        return readSingleLine(PathUtils.get("/sys/fs/cgroup/memory", controlGroup, "memory.limit_in_bytes"));
+    }
+
+    /**
+     * The total current memory usage by processes in the cgroup (in bytes).
+     * It is possible that the result value overflows a <code>Long</code> therefore the result type is <code>String</code>
+     */
+    private static String getCgroupMemoryUsageInBytes(final String controlGroup) throws IOException {
+        return readSingleLine(PathUtils.get("/sys/fs/cgroup/memory", controlGroup, "memory.usage_in_bytes"));
+    }
+
+    private static boolean areCgroupStatsAvailable() {
+        if (!Files.exists(PathUtils.get("/proc/self/cgroup"))) {
+            return false;
+        }
+        if (!Files.exists(PathUtils.get("/sys/fs/cgroup/memory"))) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Returns the cgroup path to which the CrateDB process belongs.
+     */
+    @VisibleForTesting
+    static String getMemoryControlGroupPath() throws IOException {
+        // this property is to support a hack to workaround an issue with Docker containers mounting the cgroups hierarchy
+        // inconsistently with respect to /proc/self/cgroup; for Docker containers this should be set to "/"
+        final String CONTROL_GROUPS_HIERARCHY_OVERRIDE = System.getProperty("es.cgroups.hierarchy.override");
+        final String CGROUP_MEMORY = "memory";
+
+        try (BufferedReader reader = Files.newBufferedReader(PathUtils.get("/proc/self/cgroup"))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                // Each line contains three colon-separated fields of the form hierarchy-ID:subsystem-list:cgroup-path.
+                final String[] fields = line.split(":");
+                assert fields.length == 3 : "cgroup file has an incorrect hierarchy pattern";
+                final String[] controllers = fields[1].split(",");
+                for (final String controller : controllers) {
+                    final String controlGroupPath;
+                    if (CONTROL_GROUPS_HIERARCHY_OVERRIDE != null) {
+                        // Docker violates the relationship between /proc/self/cgroup and the /sys/fs/cgroup hierarchy.
+                        // It's possible that this will be fixed in future versions of Docker with cgroup namespaces, but
+                        // this requires modern kernels.
+                        controlGroupPath = CONTROL_GROUPS_HIERARCHY_OVERRIDE;
+                    } else {
+                        controlGroupPath = fields[2];
+                    }
+                    if (controller.equals(CGROUP_MEMORY)) {
+                        return controlGroupPath;
+                    }
+                }
+            }
+            return null;
+        }
+    }
+
+    static ExtendedOsStats.CgroupMem getCgroup() {
+        try {
+            if (!areCgroupStatsAvailable()) {
+                return null;
+            } else {
+
+                final String memoryControlGroup = getMemoryControlGroupPath();
+                assert memoryControlGroup != null : "memory cgroup path must not be null";
+                assert memoryControlGroup.isEmpty() == false : "memory cgroup path must no be empty";
+
+                final String cgroupMemoryLimitInBytes = getCgroupMemoryLimitInBytes(memoryControlGroup);
+                final String cgroupMemoryUsageInBytes = getCgroupMemoryUsageInBytes(memoryControlGroup);
+
+                return new ExtendedOsStats.CgroupMem(
+                    memoryControlGroup,
+                    cgroupMemoryLimitInBytes,
+                    cgroupMemoryUsageInBytes);
+            }
+        } catch (IOException e) {
+            return null;
+        }
+    }
+}

--- a/core/src/main/java/io/crate/monitor/ExtendedOsStats.java
+++ b/core/src/main/java/io/crate/monitor/ExtendedOsStats.java
@@ -22,10 +22,12 @@
 
 package io.crate.monitor;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.monitor.os.OsStats;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
@@ -33,6 +35,7 @@ import java.util.concurrent.TimeUnit;
 public class ExtendedOsStats implements Streamable {
 
     private Cpu cpu;
+    private OsStats osStats;
 
     private long timestamp;
     private long uptime = -1;
@@ -47,8 +50,9 @@ public class ExtendedOsStats implements Streamable {
     public ExtendedOsStats() {
     }
 
-    public ExtendedOsStats(Cpu cpu) {
+    public ExtendedOsStats(Cpu cpu, OsStats osStats) {
         this.cpu = cpu;
+        this.osStats = osStats;
     }
 
     public long timestamp() {
@@ -79,6 +83,11 @@ public class ExtendedOsStats implements Streamable {
         return cpu;
     }
 
+    public OsStats osStats() {
+        return osStats;
+    }
+
+    @VisibleForTesting
     public void cpu(Cpu cpu) {
         this.cpu = cpu;
     }
@@ -89,6 +98,7 @@ public class ExtendedOsStats implements Streamable {
         uptime = in.readLong();
         loadAverage = in.readDoubleArray();
         cpu = in.readOptionalStreamable(Cpu::new);
+        osStats = in.readOptionalWriteable(OsStats::new);
     }
 
     @Override
@@ -97,6 +107,7 @@ public class ExtendedOsStats implements Streamable {
         out.writeLong(uptime);
         out.writeDoubleArray(loadAverage);
         out.writeOptionalStreamable(cpu);
+        out.writeOptionalWriteable(osStats);
     }
 
     public static class Cpu implements Streamable {

--- a/core/src/main/java/io/crate/monitor/ZeroExtendedNodeInfo.java
+++ b/core/src/main/java/io/crate/monitor/ZeroExtendedNodeInfo.java
@@ -22,6 +22,7 @@
 
 package io.crate.monitor;
 
+import org.apache.lucene.util.Constants;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.SingleObjectCache;
 import org.elasticsearch.monitor.os.OsProbe;
@@ -67,7 +68,8 @@ public class ZeroExtendedNodeInfo implements ExtendedNodeInfo {
     private ExtendedOsStats osStatsProbe() {
         ExtendedOsStats.Cpu cpu = new ExtendedOsStats.Cpu();
         OsStats osStats = OsProbe.getInstance().osStats();
-        ExtendedOsStats stats = new ExtendedOsStats(cpu, osStats);
+        ExtendedOsStats.CgroupMem cgroupMem = Constants.LINUX ? CgroupMemoryProbe.getCgroup() : null;
+        ExtendedOsStats stats = new ExtendedOsStats(cpu, osStats, cgroupMem);
         stats.timestamp(System.currentTimeMillis());
         return stats;
     }

--- a/core/src/test/java/io/crate/monitor/CgroupMemoryProbeTest.java
+++ b/core/src/test/java/io/crate/monitor/CgroupMemoryProbeTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.monitor;
+
+import io.crate.test.integration.CrateUnitTest;
+import org.apache.lucene.util.Constants;
+import org.elasticsearch.common.io.PathUtils;
+import org.junit.Assume;
+import org.junit.Test;
+
+import java.math.BigInteger;
+import java.nio.file.Files;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.core.Is.is;
+
+public class CgroupMemoryProbeTest extends CrateUnitTest {
+
+    @Test
+    public void testReadMemoryControlGroupPath() throws Exception {
+        Assume.assumeTrue(Constants.LINUX);
+        Assume.assumeTrue(Files.exists(PathUtils.get("/proc/self/cgroup")));
+
+        final String memoryControlGroupPath = CgroupMemoryProbe.getMemoryControlGroupPath();
+        assertNotNull(memoryControlGroupPath);
+    }
+
+    @Test
+    public void testControlGroupPathOverride() throws Exception {
+        Assume.assumeTrue(Constants.LINUX);
+        Assume.assumeTrue(Files.exists(PathUtils.get("/proc/self/cgroup")));
+        System.setProperty("es.cgroups.hierarchy.override", "/");
+
+        final String memoryControlGroupPath = CgroupMemoryProbe.getMemoryControlGroupPath();
+        assertThat(memoryControlGroupPath, is("/"));
+
+        System.clearProperty("es.cgroups.hierarchy.override");
+    }
+
+    @Test
+    public void testCgroupMemoryProbes() throws Exception {
+        Assume.assumeTrue(Constants.LINUX);
+        Assume.assumeTrue(Files.exists(PathUtils.get("/sys/fs/cgroup/memory")));
+        Assume.assumeTrue(Files.exists(PathUtils.get("/proc/self/cgroup")));
+        ExtendedOsStats.CgroupMem cgroupMem = CgroupMemoryProbe.getCgroup();
+
+        assertThat(new BigInteger(cgroupMem.memoryUsageBytes()), greaterThan(BigInteger.ZERO));
+        assertThat(new BigInteger(cgroupMem.memoryLimitBytes()), greaterThan(BigInteger.ZERO));
+    }
+
+    @Test
+    public void testNullMemoryCgroupOnNonLinuxOS() throws Exception {
+        // Test only on OS != Linux
+        Assume.assumeFalse(Constants.LINUX);
+
+        ExtendedOsStats.CgroupMem cgroupMem = CgroupMemoryProbe.getCgroup();
+        assertNull(cgroupMem);
+    }
+}

--- a/sigar/src/main/java/io/crate/monitor/SigarExtendedNodeInfo.java
+++ b/sigar/src/main/java/io/crate/monitor/SigarExtendedNodeInfo.java
@@ -26,6 +26,8 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.SingleObjectCache;
 import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.monitor.os.OsProbe;
+import org.elasticsearch.monitor.os.OsStats;
 import org.hyperic.sigar.CpuPerc;
 import org.hyperic.sigar.FileSystem;
 import org.hyperic.sigar.FileSystemMap;
@@ -175,6 +177,8 @@ public class SigarExtendedNodeInfo implements ExtendedNodeInfo {
         Sigar sigar = sigarService.sigar();
 
         ExtendedOsStats.Cpu cpu;
+        // bypass another caching since probe is cached anyway already
+        OsStats osStats = OsProbe.getInstance().osStats();
         try {
             CpuPerc cpuPerc = sigar.getCpuPerc();
             cpu = new ExtendedOsStats.Cpu(
@@ -188,7 +192,7 @@ public class SigarExtendedNodeInfo implements ExtendedNodeInfo {
             cpu = new ExtendedOsStats.Cpu();
         }
 
-        ExtendedOsStats stats = new ExtendedOsStats(cpu);
+        ExtendedOsStats stats = new ExtendedOsStats(cpu, osStats);
         stats.timestamp(System.currentTimeMillis());
 
         try {

--- a/sigar/src/main/java/io/crate/monitor/SigarExtendedNodeInfo.java
+++ b/sigar/src/main/java/io/crate/monitor/SigarExtendedNodeInfo.java
@@ -22,6 +22,7 @@
 
 package io.crate.monitor;
 
+import org.apache.lucene.util.Constants;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.util.SingleObjectCache;
@@ -177,8 +178,10 @@ public class SigarExtendedNodeInfo implements ExtendedNodeInfo {
         Sigar sigar = sigarService.sigar();
 
         ExtendedOsStats.Cpu cpu;
+        ExtendedOsStats.CgroupMem cgroupMem = Constants.LINUX ? CgroupMemoryProbe.getCgroup() : null;
         // bypass another caching since probe is cached anyway already
         OsStats osStats = OsProbe.getInstance().osStats();
+
         try {
             CpuPerc cpuPerc = sigar.getCpuPerc();
             cpu = new ExtendedOsStats.Cpu(
@@ -192,7 +195,7 @@ public class SigarExtendedNodeInfo implements ExtendedNodeInfo {
             cpu = new ExtendedOsStats.Cpu();
         }
 
-        ExtendedOsStats stats = new ExtendedOsStats(cpu, osStats);
+        ExtendedOsStats stats = new ExtendedOsStats(cpu, osStats, cgroupMem);
         stats.timestamp(System.currentTimeMillis());
 
         try {

--- a/sigar/src/test/java/io/crate/monitor/SigarExtendedNodeInfoTest.java
+++ b/sigar/src/test/java/io/crate/monitor/SigarExtendedNodeInfoTest.java
@@ -32,7 +32,9 @@ import org.junit.Test;
 
 import java.nio.file.Path;
 
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 
 public class SigarExtendedNodeInfoTest extends CrateUnitTest {

--- a/sql/src/main/java/io/crate/metadata/sys/SysNodesTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysNodesTableInfo.java
@@ -175,6 +175,10 @@ public class SysNodesTableInfo extends StaticTableInfo {
         static final ColumnIdent OS_CGROUP_CPU_NUM_ELAPSED_PERIODS = new ColumnIdent(SYS_COL_OS, ImmutableList.of("cgroup", "cpu", "num_elapsed_periods"));
         static final ColumnIdent OS_CGROUP_CPU_NUM_TIMES_THROTTLED = new ColumnIdent(SYS_COL_OS, ImmutableList.of("cgroup", "cpu", "num_times_throttled"));
         static final ColumnIdent OS_CGROUP_CPU_TIME_THROTTLED_NANOS = new ColumnIdent(SYS_COL_OS, ImmutableList.of("cgroup", "cpu", "time_throttled_nanos"));
+        static final ColumnIdent OS_CGROUP_MEM = new ColumnIdent(SYS_COL_OS, ImmutableList.of("cgroup", "mem"));
+        static final ColumnIdent OS_CGROUP_MEM_CONTROL_GROUP = new ColumnIdent(SYS_COL_OS, ImmutableList.of("cgroup", "mem", "control_group"));
+        static final ColumnIdent OS_CGROUP_MEM_LIMIT_BYTES = new ColumnIdent(SYS_COL_OS, ImmutableList.of("cgroup", "mem", "limit_bytes"));
+        static final ColumnIdent OS_CGROUP_MEM_USAGE_BYTES = new ColumnIdent(SYS_COL_OS, ImmutableList.of("cgroup", "mem", "usage_bytes"));
 
         public static final ColumnIdent OS_INFO = new ColumnIdent(SYS_COL_OS_INFO);
         static final ColumnIdent OS_INFO_AVAIL_PROCESSORS = new ColumnIdent(SYS_COL_OS_INFO, ImmutableList.of("available_processors"));
@@ -446,6 +450,10 @@ public class SysNodesTableInfo extends StaticTableInfo {
                 .register(Columns.OS_CGROUP_CPU_NUM_ELAPSED_PERIODS, DataTypes.LONG)
                 .register(Columns.OS_CGROUP_CPU_NUM_TIMES_THROTTLED, DataTypes.LONG)
                 .register(Columns.OS_CGROUP_CPU_TIME_THROTTLED_NANOS, DataTypes.LONG)
+                .register(Columns.OS_CGROUP_MEM, DataTypes.OBJECT)
+                .register(Columns.OS_CGROUP_MEM_CONTROL_GROUP, DataTypes.STRING)
+                .register(Columns.OS_CGROUP_MEM_LIMIT_BYTES, DataTypes.STRING)
+                .register(Columns.OS_CGROUP_MEM_USAGE_BYTES, DataTypes.STRING)
 
                 .register(Columns.OS_INFO, DataTypes.OBJECT)
                 .register(Columns.OS_INFO_AVAIL_PROCESSORS, DataTypes.INTEGER)

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/CgroupExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/CgroupExpression.java
@@ -38,11 +38,10 @@ final class CgroupExpression<R> extends RowContextCollectorExpression<NodeStatsC
     @Override
     public R value() {
         if (row.isComplete()) {
-            OsStats.Cgroup cgroup = row.osStats().getCgroup();
-            if (cgroup == null) {
-                return null;
+            OsStats.Cgroup cgroup = row.extendedOsStats().osStats().getCgroup();
+            if (cgroup != null) {
+                return getter.apply(cgroup);
             }
-            return getter.apply(cgroup);
         }
         return null;
     }

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/NodeOsCgroupStatsExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/NodeOsCgroupStatsExpression.java
@@ -40,11 +40,10 @@ public class NodeOsCgroupStatsExpression extends NestedNodeStatsExpression {
     @Override
     public Map<String, Object> value() {
         if (row.isComplete()) {
-            OsStats.Cgroup cgroup = row.osStats().getCgroup();
-            if (cgroup == null) {
-                return null;
+            OsStats.Cgroup cgroup = row.extendedOsStats().osStats().getCgroup();
+            if (cgroup != null) {
+                return super.value();
             }
-            return super.value();
         }
         return null;
     }
@@ -62,11 +61,10 @@ public class NodeOsCgroupStatsExpression extends NestedNodeStatsExpression {
         @Override
         public Map<String, Object> value() {
             if (row.isComplete()) {
-                OsStats.Cgroup cgroup = row.osStats().getCgroup();
-                if (cgroup == null) {
-                    return null;
+                OsStats.Cgroup cgroup = row.extendedOsStats().osStats().getCgroup();
+                if (cgroup != null) {
+                    return super.value();
                 }
-                return super.value();
             }
             return null;
         }
@@ -99,11 +97,10 @@ public class NodeOsCgroupStatsExpression extends NestedNodeStatsExpression {
         @Override
         public Map<String, Object> value() {
             if (row.isComplete()) {
-                OsStats.Cgroup cgroup = row.osStats().getCgroup();
-                if (cgroup == null) {
-                    return null;
+                OsStats.Cgroup cgroup = row.extendedOsStats().osStats().getCgroup();
+                if (cgroup != null) {
+                    return super.value();
                 }
-                return super.value();
             }
             return null;
         }

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/NodeStatsContextFieldResolver.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/NodeStatsContextFieldResolver.java
@@ -217,7 +217,6 @@ public class NodeStatsContextFieldResolver {
                 @Override
                 public void accept(NodeStatsContext context) {
                     context.timestamp(System.currentTimeMillis());
-                    context.osStats(osService.stats());
                     context.extendedOsStats(extendedNodeInfo.osStats());
                 }
             })

--- a/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -495,7 +495,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultColumns() throws Exception {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(476, response.rowCount());
+        assertEquals(480, response.rowCount());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/NodeStatsTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/NodeStatsTest.java
@@ -35,7 +35,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.allOf;
-import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasItems;
@@ -212,14 +213,14 @@ public class NodeStatsTest extends SQLTransportIntegrationTest {
                                            " os['cgroup']['cpu']['time_throttled_nanos']" +
                                            " from sys.nodes limit 1");
             assertThat(response.rowCount(), is(1L));
-            assertThat((String) response.rows()[0][0], containsString("/"));
-            assertThat((long) response.rows()[0][1], greaterThanOrEqualTo(-1L));
-            assertThat((String) response.rows()[0][2], containsString("/"));
-            assertThat((long) response.rows()[0][3], greaterThanOrEqualTo(-1L));
-            assertThat((long) response.rows()[0][4], greaterThanOrEqualTo(-1L));
-            assertThat((long) response.rows()[0][5], greaterThanOrEqualTo(-1L));
-            assertThat((long) response.rows()[0][6], greaterThanOrEqualTo(-1L));
-            assertThat((long) response.rows()[0][7], greaterThanOrEqualTo(-1L));
+            assertThat(response.rows()[0][0], notNullValue());
+            assertThat((long) response.rows()[0][1], greaterThanOrEqualTo(0L));
+            assertThat(response.rows()[0][2], notNullValue());
+            assertThat((long) response.rows()[0][3], greaterThanOrEqualTo(0L));
+            assertThat((long) response.rows()[0][4], anyOf(equalTo(-1L), greaterThanOrEqualTo(0L)));
+            assertThat((long) response.rows()[0][5], greaterThanOrEqualTo(0L));
+            assertThat((long) response.rows()[0][6], greaterThanOrEqualTo(0L));
+            assertThat((long) response.rows()[0][7], greaterThanOrEqualTo(0L));
         } else {
             // for all other OS cgroup fields should return `null`
             response = execute("select os['cgroup']," +

--- a/sql/src/test/java/io/crate/monitor/DummyExtendedNodeInfo.java
+++ b/sql/src/test/java/io/crate/monitor/DummyExtendedNodeInfo.java
@@ -24,6 +24,8 @@ package io.crate.monitor;
 
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.monitor.os.OsProbe;
+import org.elasticsearch.monitor.os.OsStats;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -81,10 +83,11 @@ public class DummyExtendedNodeInfo implements ExtendedNodeInfo {
     @Override
     public ExtendedOsStats osStats() {
         ExtendedOsStats.Cpu cpuStats = new ExtendedOsStats.Cpu((short) 0, (short) 4, (short) 94, (short) 10);
-        ExtendedOsStats osStats = new ExtendedOsStats(cpuStats);
-        osStats.uptime(3600L);
-        osStats.loadAverage(new double[]{1, 5, 15});
-        return osStats;
+        OsStats osStats = OsProbe.getInstance().osStats();
+        ExtendedOsStats extendedOsStats = new ExtendedOsStats(cpuStats, osStats);
+        extendedOsStats.uptime(3600L);
+        extendedOsStats.loadAverage(new double[]{1, 5, 15});
+        return extendedOsStats;
     }
 
     @Override

--- a/sql/src/test/java/io/crate/monitor/DummyExtendedNodeInfo.java
+++ b/sql/src/test/java/io/crate/monitor/DummyExtendedNodeInfo.java
@@ -83,8 +83,9 @@ public class DummyExtendedNodeInfo implements ExtendedNodeInfo {
     @Override
     public ExtendedOsStats osStats() {
         ExtendedOsStats.Cpu cpuStats = new ExtendedOsStats.Cpu((short) 0, (short) 4, (short) 94, (short) 10);
+        ExtendedOsStats.CgroupMem cgroupMemStats = new ExtendedOsStats.CgroupMem();
         OsStats osStats = OsProbe.getInstance().osStats();
-        ExtendedOsStats extendedOsStats = new ExtendedOsStats(cpuStats, osStats);
+        ExtendedOsStats extendedOsStats = new ExtendedOsStats(cpuStats, osStats, cgroupMemStats);
         extendedOsStats.uptime(3600L);
         extendedOsStats.loadAverage(new double[]{1, 5, 15});
         return extendedOsStats;


### PR DESCRIPTION
This commit adds cgroup memory metrics to the existing `os['cgroup']`
field. Additionally it fixes an issue that leads to an invalid
probe timestamp due to multiple caching for metrics inside the `os`
field.

On OS other than Linux this stats return `NULL`.

Changes entry not necessary since this PR is an addition to https://github.com/crate/crate/commit/94fd8d9839453e5f171c9fcfc85544540a062a09

Newly introduced Cgroup System Property `es.cgroups.hierarchy.override` will be documented in the Docker docs.