### PR TITLE
Enable `valuesort` result validation for sqllogic tests.

### DIFF
--- a/blackbox/sqllogictest/src/sqllogictest.py
+++ b/blackbox/sqllogictest/src/sqllogictest.py
@@ -169,17 +169,24 @@ class Query:
             if row is None:
                 rows[i] = row = 'NULL'
             fmt = self.result_formats[i % len(self.result_formats)]
-            if fmt == 'I' and row != 'NULL':
-                rows[i] = int(row)
+            if (row != 'NULL'):
+                if fmt == 'I':
+                    rows[i] = int(row)
+                elif fmt == 'R':
+                    rows[i] = float(row)
+                elif fmt == 'T':
+                    rows[i] = str(row)
 
     def execute(self, cursor):
         cursor.execute(self.query)
         rows = cursor.fetchall()
-        if self.sort == 'rowsort':
+
+        if len(rows) > 1 and self.sort == 'rowsort':
             rows = sorted(rows, key=lambda row: [str(c) for c in row])
-        elif self.sort == 'valuesort':
-            raise NotImplementedError('valuesort not implemented')
+        # flatten the row values for comparison
         rows = [col for row in rows for col in row]
+        if self.sort == 'valuesort':
+            rows = sorted(rows, key=lambda v: str(v))
         self.format_rows(rows)
         self.validate_result(rows, self.result_formats)
 

--- a/blackbox/sqllogictest/src/tests.py
+++ b/blackbox/sqllogictest/src/tests.py
@@ -22,7 +22,7 @@ faulthandler.enable()
 
 # might want to change this to a blacklist at some point
 FILE_WHITELIST = [re.compile(o) for o in [
-    'select[1-4].test',
+    'select[1-5].test',
     'random/select/slt_good_\d+.test',
     'random/groupby/slt_good_\d+.test',
 ]]


### PR DESCRIPTION
There are some queries that are validated using `valuesort` method
which were ignored up to now.