### PR TITLE
Introduce base classes for LogicalPlan interface

### DIFF
--- a/sql/src/main/java/io/crate/planner/operators/Count.java
+++ b/sql/src/main/java/io/crate/planner/operators/Count.java
@@ -27,7 +27,6 @@ import io.crate.analyze.WhereClause;
 import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.SelectSymbol;
-import io.crate.analyze.symbol.Symbol;
 import io.crate.data.Row;
 import io.crate.metadata.Routing;
 import io.crate.metadata.RoutingProvider;
@@ -44,26 +43,21 @@ import io.crate.types.DataTypes;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 /**
  * An optimized version for "select count(*) from t where ..."
  */
-public class Count implements LogicalPlan {
+public class Count extends ZeroInputPlan {
 
     private static final String COUNT_PHASE_NAME = "count-merge";
 
     final AbstractTableRelation<TableInfo> tableRelation;
     final WhereClause where;
 
-    private final List<Symbol> outputs;
-    private final List<AbstractTableRelation> baseTables;
-
     Count(Function countFunction, AbstractTableRelation<TableInfo> tableRelation, WhereClause where) {
-        this.outputs = Collections.singletonList(countFunction);
+        super(Collections.singletonList(countFunction), Collections.singletonList(tableRelation));
         this.tableRelation = tableRelation;
-        this.baseTables = Collections.singletonList(tableRelation);
         this.where = where;
     }
 
@@ -101,31 +95,6 @@ public class Count implements LogicalPlan {
             null
         );
         return new CountPlan(countPhase, mergePhase);
-    }
-
-    @Override
-    public LogicalPlan tryCollapse() {
-        return this;
-    }
-
-    @Override
-    public List<Symbol> outputs() {
-        return outputs;
-    }
-
-    @Override
-    public Map<Symbol, Symbol> expressionMapping() {
-        return Collections.emptyMap();
-    }
-
-    @Override
-    public List<AbstractTableRelation> baseTables() {
-        return baseTables;
-    }
-
-    @Override
-    public Map<LogicalPlan, SelectSymbol> dependencies() {
-        return Collections.emptyMap();
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/FetchOrEval.java
+++ b/sql/src/main/java/io/crate/planner/operators/FetchOrEval.java
@@ -106,10 +106,7 @@ import static io.crate.planner.operators.OperatorUtils.getUnusedColumns;
  *                Fetch 500
  * </pre>
  */
-class FetchOrEval implements LogicalPlan {
-
-    final LogicalPlan source;
-    final List<Symbol> outputs;
+class FetchOrEval extends OneInputPlan {
 
     private final FetchMode fetchMode;
     private final boolean doFetch;
@@ -170,8 +167,7 @@ class FetchOrEval implements LogicalPlan {
     }
 
     private FetchOrEval(LogicalPlan source, List<Symbol> outputs, FetchMode fetchMode, boolean doFetch) {
-        this.source = source;
-        this.outputs = outputs;
+        super(source, outputs);
         this.fetchMode = fetchMode;
         this.doFetch = doFetch;
     }
@@ -435,37 +431,8 @@ class FetchOrEval implements LogicalPlan {
     }
 
     @Override
-    public LogicalPlan tryCollapse() {
-        LogicalPlan collapsed = source.tryCollapse();
-        if (collapsed == this) {
-            return this;
-        }
-        return new FetchOrEval(collapsed, outputs, fetchMode, doFetch);
-    }
-
-    @Override
-    public List<Symbol> outputs() {
-        return outputs;
-    }
-
-    @Override
-    public Map<Symbol, Symbol> expressionMapping() {
-        return source.expressionMapping();
-    }
-
-    @Override
-    public List<AbstractTableRelation> baseTables() {
-        return source.baseTables();
-    }
-
-    @Override
-    public Map<LogicalPlan, SelectSymbol> dependencies() {
-        return source.dependencies();
-    }
-
-    @Override
-    public long numExpectedRows() {
-        return source.numExpectedRows();
+    protected LogicalPlan newInstance(LogicalPlan newSource) {
+        return new FetchOrEval(newSource, outputs, fetchMode, doFetch);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/Filter.java
+++ b/sql/src/main/java/io/crate/planner/operators/Filter.java
@@ -25,7 +25,6 @@ package io.crate.planner.operators;
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.QueryClause;
 import io.crate.analyze.WhereClause;
-import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.SelectSymbol;
 import io.crate.analyze.symbol.Symbol;
@@ -39,15 +38,13 @@ import io.crate.types.DataTypes;
 
 import javax.annotation.Nullable;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import static io.crate.planner.operators.LogicalPlanner.extractColumns;
 
-class Filter implements LogicalPlan {
+class Filter extends OneInputPlan {
 
-    final LogicalPlan source;
     final QueryClause queryClause;
 
     static LogicalPlan.Builder create(LogicalPlan.Builder sourceBuilder, @Nullable QueryClause queryClause) {
@@ -84,7 +81,7 @@ class Filter implements LogicalPlan {
     }
 
     private Filter(LogicalPlan source, QueryClause queryClause) {
-        this.source = source;
+        super(source);
         this.queryClause = queryClause;
     }
 
@@ -108,37 +105,7 @@ class Filter implements LogicalPlan {
     }
 
     @Override
-    public LogicalPlan tryCollapse() {
-        LogicalPlan collapsed = source.tryCollapse();
-        if (collapsed == source) {
-            return this;
-        }
-        return new Filter(collapsed, queryClause);
-    }
-
-    @Override
-    public List<Symbol> outputs() {
-        return source.outputs();
-    }
-
-    @Override
-    public Map<Symbol, Symbol> expressionMapping() {
-        return source.expressionMapping();
-    }
-
-    @Override
-    public List<AbstractTableRelation> baseTables() {
-        return source.baseTables();
-    }
-
-    @Override
-    public Map<LogicalPlan, SelectSymbol> dependencies() {
-        return source.dependencies();
-    }
-
-    @Override
-    public long numExpectedRows() {
-        // We don't have any cardinality estimates
-        return source.numExpectedRows();
+    protected LogicalPlan newInstance(LogicalPlan newSource) {
+        return new Filter(newSource, queryClause);
     }
 }

--- a/sql/src/main/java/io/crate/planner/operators/Get.java
+++ b/sql/src/main/java/io/crate/planner/operators/Get.java
@@ -23,7 +23,6 @@
 package io.crate.planner.operators;
 
 import io.crate.analyze.OrderBy;
-import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.relations.DocTableRelation;
 import io.crate.analyze.relations.QueriedDocTable;
 import io.crate.analyze.symbol.SelectSymbol;
@@ -52,16 +51,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class Get implements LogicalPlan {
+public class Get extends ZeroInputPlan {
 
     final DocTableRelation tableRelation;
     final DocKeys docKeys;
-    private final List<Symbol> outputs;
 
     Get(QueriedDocTable table, DocKeys docKeys, List<Symbol> outputs) {
+        super(outputs, Collections.singletonList(table.tableRelation()));
         this.tableRelation = table.tableRelation();
         this.docKeys = docKeys;
-        this.outputs = outputs;
     }
 
     @Override
@@ -133,32 +131,6 @@ public class Get implements LogicalPlan {
         );
     }
 
-    @Override
-    public LogicalPlan tryCollapse() {
-        return this;
-    }
-
-    @Override
-    public List<Symbol> outputs() {
-        return outputs;
-    }
-
-    @Override
-    public Map<Symbol, Symbol> expressionMapping() {
-        return Collections.emptyMap();
-    }
-
-    @Override
-    public List<AbstractTableRelation> baseTables() {
-        return Collections.singletonList(tableRelation);
-    }
-
-    @Override
-    public Map<LogicalPlan, SelectSymbol> dependencies() {
-        return Collections.emptyMap();
-    }
-
-    @Override
     public long numExpectedRows() {
         return docKeys.size();
     }

--- a/sql/src/main/java/io/crate/planner/operators/HashAggregate.java
+++ b/sql/src/main/java/io/crate/planner/operators/HashAggregate.java
@@ -23,7 +23,6 @@
 package io.crate.planner.operators;
 
 import io.crate.analyze.OrderBy;
-import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.symbol.AggregateMode;
 import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.SelectSymbol;
@@ -52,14 +51,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-public class HashAggregate implements LogicalPlan {
+public class HashAggregate extends OneInputPlan {
 
     private static final String MERGE_PHASE_NAME = "mergeOnHandler";
-    final LogicalPlan source;
     final List<Function> aggregates;
 
     HashAggregate(LogicalPlan source, List<Function> aggregates) {
-        this.source = source;
+        super(source);
         this.aggregates = aggregates;
     }
 
@@ -143,7 +141,7 @@ public class HashAggregate implements LogicalPlan {
         if (collapsed == source) {
             return this;
         }
-        return new HashAggregate(collapsed, aggregates);
+        return newInstance(collapsed);
     }
 
     @Override
@@ -152,18 +150,8 @@ public class HashAggregate implements LogicalPlan {
     }
 
     @Override
-    public Map<Symbol, Symbol> expressionMapping() {
-        return source.expressionMapping();
-    }
-
-    @Override
-    public List<AbstractTableRelation> baseTables() {
-        return source.baseTables();
-    }
-
-    @Override
-    public Map<LogicalPlan, SelectSymbol> dependencies() {
-        return source.dependencies();
+    protected LogicalPlan newInstance(LogicalPlan newSource) {
+        return new HashAggregate(newSource, aggregates);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/Insert.java
+++ b/sql/src/main/java/io/crate/planner/operators/Insert.java
@@ -40,14 +40,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-public class Insert implements LogicalPlan {
+public class Insert extends OneInputPlan {
 
-    private final LogicalPlan source;
     private final QueriedRelation relation;
     private final ColumnIndexWriterProjection projection;
 
     public Insert(LogicalPlan source, QueriedRelation relation, ColumnIndexWriterProjection projection) {
-        this.source = source;
+        super(source);
         this.relation = relation;
         this.projection = projection;
     }
@@ -78,6 +77,11 @@ public class Insert implements LogicalPlan {
     }
 
     @Override
+    protected LogicalPlan newInstance(LogicalPlan newSource) {
+        return new Insert(newSource, relation, projection);
+    }
+
+    @Override
     public List<Symbol> outputs() {
         return relation.outputs();
     }
@@ -90,11 +94,6 @@ public class Insert implements LogicalPlan {
     @Override
     public List<AbstractTableRelation> baseTables() {
         return Collections.emptyList();
-    }
-
-    @Override
-    public Map<LogicalPlan, SelectSymbol> dependencies() {
-        return source.dependencies();
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/Limit.java
+++ b/sql/src/main/java/io/crate/planner/operators/Limit.java
@@ -23,7 +23,6 @@
 package io.crate.planner.operators;
 
 import io.crate.analyze.OrderBy;
-import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.SelectSymbol;
 import io.crate.analyze.symbol.Symbol;
@@ -48,9 +47,8 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import static io.crate.analyze.SymbolEvaluator.evaluate;
 import static io.crate.planner.operators.LogicalPlanner.NO_LIMIT;
 
-class Limit implements LogicalPlan {
+class Limit extends OneInputPlan {
 
-    final LogicalPlan source;
     final Symbol limit;
     final Symbol offset;
 
@@ -66,7 +64,7 @@ class Limit implements LogicalPlan {
     }
 
     private Limit(LogicalPlan source, Symbol limit, Symbol offset) {
-        this.source = source;
+        super(source);
         this.limit = limit;
         this.offset = offset;
     }
@@ -106,32 +104,8 @@ class Limit implements LogicalPlan {
     }
 
     @Override
-    public LogicalPlan tryCollapse() {
-        LogicalPlan collapsed = source.tryCollapse();
-        if (collapsed == source) {
-            return this;
-        }
-        return new Limit(collapsed, limit, offset);
-    }
-
-    @Override
-    public List<Symbol> outputs() {
-        return source.outputs();
-    }
-
-    @Override
-    public Map<Symbol, Symbol> expressionMapping() {
-        return source.expressionMapping();
-    }
-
-    @Override
-    public List<AbstractTableRelation> baseTables() {
-        return source.baseTables();
-    }
-
-    @Override
-    public Map<LogicalPlan, SelectSymbol> dependencies() {
-        return source.dependencies();
+    protected LogicalPlan newInstance(LogicalPlan newSource) {
+        return new Limit(newSource, limit, offset);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlanBase.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlanBase.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.operators;
+
+import io.crate.analyze.relations.AbstractTableRelation;
+import io.crate.analyze.symbol.SelectSymbol;
+import io.crate.analyze.symbol.Symbol;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The abstract base for all {@link LogicalPlan}s.
+ *
+ * For now, this just reduces the amount of boiler plate code each instance
+ * has to implement. Generally, this is an extension point where functionality
+ * resides which is used by all plans.
+ */
+abstract class LogicalPlanBase implements LogicalPlan {
+
+    protected final List<Symbol> outputs;
+    protected final Map<Symbol, Symbol> expressionMapping;
+    protected final List<AbstractTableRelation> baseTables;
+    protected final Map<LogicalPlan, SelectSymbol> dependencies;
+
+    LogicalPlanBase(List<Symbol> outputs,
+                    Map<Symbol, Symbol> expressionMapping,
+                    List<AbstractTableRelation> baseTables,
+                    Map<LogicalPlan, SelectSymbol> dependencies) {
+        this.outputs = outputs;
+        this.expressionMapping = expressionMapping;
+        this.baseTables = baseTables;
+        this.dependencies = dependencies;
+    }
+
+    @Override
+    public List<Symbol> outputs() {
+        return outputs;
+    }
+
+    @Override
+    public Map<Symbol, Symbol> expressionMapping() {
+        return expressionMapping;
+    }
+
+    @Override
+    public List<AbstractTableRelation> baseTables() {
+        return baseTables;
+    }
+
+    @Override
+    public Map<LogicalPlan, SelectSymbol> dependencies() {
+        return dependencies;
+    }
+}

--- a/sql/src/main/java/io/crate/planner/operators/OneInputPlan.java
+++ b/sql/src/main/java/io/crate/planner/operators/OneInputPlan.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.operators;
+
+import io.crate.analyze.relations.AbstractTableRelation;
+import io.crate.analyze.symbol.SelectSymbol;
+import io.crate.analyze.symbol.Symbol;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A {@link LogicalPlan} with one other LogicalPlan as input.
+ */
+abstract class OneInputPlan extends LogicalPlanBase {
+
+    protected final LogicalPlan source;
+
+    OneInputPlan(LogicalPlan source) {
+        this(source, source.outputs());
+    }
+
+    OneInputPlan(LogicalPlan source, Map<LogicalPlan, SelectSymbol> dependencies) {
+        this(source, source.outputs(), source.expressionMapping(), source.baseTables(), dependencies);
+    }
+
+    OneInputPlan(LogicalPlan source, List<Symbol> outputs) {
+        this(source, outputs, source.expressionMapping(), source.baseTables(), source.dependencies());
+    }
+
+    OneInputPlan(LogicalPlan source,
+                 List<Symbol> outputs,
+                 Map<Symbol, Symbol> expressionMapping,
+                 List<AbstractTableRelation> baseTables,
+                 Map<LogicalPlan, SelectSymbol> dependencies) {
+        super(outputs, expressionMapping, baseTables, dependencies);
+        this.source = source;
+    }
+
+    @Override
+    public LogicalPlan tryCollapse() {
+        LogicalPlan newPlan = source.tryCollapse();
+        if (source != newPlan) {
+            return newInstance(newPlan);
+        }
+        return this;
+    }
+
+    /**
+     * If no other information available, return the source's number of rows.
+     * @return The number of rows of the source plan.
+     */
+    @Override
+    public long numExpectedRows() {
+        return source.numExpectedRows();
+    }
+
+    /**
+     * Creates a new LogicalPlan with an updated source. This is necessary
+     * when we collapse plans during plan building or "push down" plans
+     * later on to optimize their execution.
+     *
+     * {@link LogicalPlan}s should be immutable. Fields like sources may only
+     * be updated by creating a new instance of the plan. Since Java does not
+     * allow to copy an instance easily and also instances might apply a custom
+     * logic when they clone itself, this method has to be implemented.
+     * @param newSource A new {@link LogicalPlan} as a source.
+     * @return A new copy of this {@link OneInputPlan} with the new source.
+     */
+    protected abstract LogicalPlan newInstance(LogicalPlan newSource);
+
+}

--- a/sql/src/main/java/io/crate/planner/operators/RootRelationBoundary.java
+++ b/sql/src/main/java/io/crate/planner/operators/RootRelationBoundary.java
@@ -22,11 +22,8 @@
 
 package io.crate.planner.operators;
 
-import com.google.common.annotations.VisibleForTesting;
 import io.crate.analyze.OrderBy;
-import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.symbol.SelectSymbol;
-import io.crate.analyze.symbol.Symbol;
 import io.crate.data.Row;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.Merge;
@@ -34,19 +31,15 @@ import io.crate.planner.PlannerContext;
 import io.crate.planner.projection.builder.ProjectionBuilder;
 
 import javax.annotation.Nullable;
-import java.util.List;
 import java.util.Map;
 
 /**
  * An operator with the primary purpose to ensure that the result is on the handler and no longer distributed.
  */
-public class RootRelationBoundary implements LogicalPlan {
-
-    @VisibleForTesting
-    final LogicalPlan source;
+public class RootRelationBoundary extends OneInputPlan {
 
     public RootRelationBoundary(LogicalPlan source) {
-        this.source = source;
+        super(source);
     }
 
     @Override
@@ -71,37 +64,8 @@ public class RootRelationBoundary implements LogicalPlan {
     }
 
     @Override
-    public LogicalPlan tryCollapse() {
-        LogicalPlan collapsed = source.tryCollapse();
-        if (collapsed == source) {
-            return this;
-        }
-        return new RootRelationBoundary(collapsed);
-    }
-
-    @Override
-    public List<Symbol> outputs() {
-        return source.outputs();
-    }
-
-    @Override
-    public Map<Symbol, Symbol> expressionMapping() {
-        return source.expressionMapping();
-    }
-
-    @Override
-    public List<AbstractTableRelation> baseTables() {
-        return source.baseTables();
-    }
-
-    @Override
-    public Map<LogicalPlan, SelectSymbol> dependencies() {
-        return source.dependencies();
-    }
-
-    @Override
-    public long numExpectedRows() {
-        return source.numExpectedRows();
+    protected LogicalPlan newInstance(LogicalPlan newSource) {
+        return new RootRelationBoundary(newSource);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/TwoInputPlan.java
+++ b/sql/src/main/java/io/crate/planner/operators/TwoInputPlan.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.operators;
+
+import io.crate.analyze.symbol.Symbol;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * A {@link LogicalPlan} with two other LogicalPlans as input.
+ */
+abstract class TwoInputPlan extends LogicalPlanBase {
+
+    final LogicalPlan lhs;
+    final LogicalPlan rhs;
+
+    TwoInputPlan(LogicalPlan left, LogicalPlan right, List<Symbol> outputs) {
+        super(outputs, new HashMap<>(), new ArrayList<>(), Collections.emptyMap());
+        this.lhs = left;
+        this.rhs = right;
+        this.baseTables.addAll(lhs.baseTables());
+        this.baseTables.addAll(rhs.baseTables());
+        this.expressionMapping.putAll(lhs.expressionMapping());
+        this.expressionMapping.putAll(rhs.expressionMapping());
+    }
+
+    @Override
+    public LogicalPlan tryCollapse() {
+        LogicalPlan lhsCollapsed = lhs.tryCollapse();
+        LogicalPlan rhsCollapsed = rhs.tryCollapse();
+        if (lhs != lhsCollapsed || rhs != rhsCollapsed) {
+            return newInstance(lhsCollapsed, rhsCollapsed);
+        }
+        return this;
+    }
+
+    /**
+     * Creates a new LogicalPlan with an updated source. This is necessary
+     * when we collapse plans during plan building or "push down" plans
+     * later on to optimize their execution.
+     *
+     * {@link LogicalPlan}s should be immutable. Fields like sources may only
+     * be updated by creating a new instance of the plan. Since Java does not
+     * allow to copy an instance easily and also instances might apply a custom
+     * logic when they clone itself, this method has to be implemented.
+     * @param newLeftSource A new {@link} LogicalPlan as the left source.
+     * @param newRightSource A new {@link} LogicalPlan as the right source.
+     * @return A new copy of this {@link OneInputPlan} with the new sources.
+     */
+    protected abstract LogicalPlan newInstance(LogicalPlan newLeftSource, LogicalPlan newRightSource);
+}

--- a/sql/src/main/java/io/crate/planner/operators/Union.java
+++ b/sql/src/main/java/io/crate/planner/operators/Union.java
@@ -85,7 +85,7 @@ public class Union extends TwoInputPlan {
                 .plan(right, FetchMode.NEVER_CLEAR, subqueryPlanner, false)
                 .build(tableStats, usedFromRight);
 
-            return new Union(ttr.outputs(), lhsPlan, rhsPlan);
+            return new Union(lhsPlan, rhsPlan, ttr.outputs());
         };
     }
 
@@ -109,7 +109,7 @@ public class Union extends TwoInputPlan {
         });
     }
 
-    Union(List<Symbol> outputs, LogicalPlan lhs, LogicalPlan rhs) {
+    Union(LogicalPlan lhs, LogicalPlan rhs, List<Symbol> outputs) {
         super(lhs, rhs, outputs);
     }
 
@@ -164,7 +164,7 @@ public class Union extends TwoInputPlan {
 
     @Override
     protected LogicalPlan newInstance(LogicalPlan newLeftSource, LogicalPlan newRightSource) {
-        return new Union(outputs, newLeftSource, newRightSource);
+        return new Union(newLeftSource, newRightSource, outputs);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/ZeroInputPlan.java
+++ b/sql/src/main/java/io/crate/planner/operators/ZeroInputPlan.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.operators;
+
+import io.crate.analyze.relations.AbstractTableRelation;
+import io.crate.analyze.symbol.Symbol;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A {@link LogicalPlan} with two no other LogicalPlans as input.
+ */
+abstract class ZeroInputPlan extends LogicalPlanBase {
+
+    public ZeroInputPlan(List<Symbol> outputs, List<AbstractTableRelation> baseTables) {
+        super(outputs, Collections.emptyMap(), baseTables, Collections.emptyMap());
+    }
+
+    @Override
+    public LogicalPlan tryCollapse() {
+        // We don't have any sources, so just return this instance
+        return this;
+    }
+}

--- a/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -261,7 +261,7 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
                 indentation += 4;
                 startLine("subQueries[\n");
                 indentation += 4;
-                for (Map.Entry<LogicalPlan, SelectSymbol> entry : multiPhase.subQueries.entrySet()) {
+                for (Map.Entry<LogicalPlan, SelectSymbol> entry : multiPhase.dependencies.entrySet()) {
                     printPlan(entry.getKey());
                 }
                 indentation -= 4;
@@ -326,7 +326,7 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
                 startLine("Collect[");
                 sb.append(collect.tableInfo.ident());
                 sb.append(" | [");
-                addSymbolsList(collect.toCollect);
+                addSymbolsList(collect.outputs);
                 sb.append("] | ");
                 sb.append(printQueryClause(symbolPrinter, collect.where));
                 sb.append("]\n");


### PR DESCRIPTION
This introduces the following hierarchy to the `LogicalPlan` interface:

```
             LogicalPlan
                 |
           LogicalPlanBase
          /      |        \
         /  OneInputPlan   \
  ZeroInputPlan         TwoInputPlan
```

LogicalPlanBase
============

Takes care of storing outputs, expression mapping, base tables, and
dependencies. These are currently duplicated for every instance of
LogicalPlan.

ZeroInputPlan, OneInputPlan, TwoInputPlan
================================

A plan with no, one, or two inputs derived from LogicalPlanBase. At the moment
they handle only the default `tryCollapse` rule. In an upcoming commit, they
will also handle the default "push down" logic.