### PR TITLE
"Push down" UNION OrderBy to source relations

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -39,6 +39,10 @@ Breaking Changes
 Changes
 =======
 
+- Added an optimization when UNION ALL is used with ORDER BY. The ORDER BY is
+  now "pushed down" to the left and right side of the union which improves the
+  sorting speed.
+
 - Added support for disabling the column store per ``STRING`` column on table
   creation and on adding columns. In conjunction with disabling indexing on that
   column, this will support storing strings greater than 32kb. Be aware that the

--- a/sql/src/main/java/io/crate/planner/operators/Collect.java
+++ b/sql/src/main/java/io/crate/planner/operators/Collect.java
@@ -232,6 +232,14 @@ class Collect extends ZeroInputPlan {
     }
 
     @Override
+    public LogicalPlan tryPushDown(@Nullable LogicalPlan pushDown) {
+        if (pushDown instanceof Order) {
+            return ((Order) pushDown).newInstance(this);
+        }
+        return this;
+    }
+
+    @Override
     public boolean preferShardProjections() {
         // Can't run on shard level for system tables
         // (Except tables like sys.shards, but in that case it's better to run operations per node as well,

--- a/sql/src/main/java/io/crate/planner/operators/Limit.java
+++ b/sql/src/main/java/io/crate/planner/operators/Limit.java
@@ -100,6 +100,15 @@ class Limit extends OneInputPlan {
     }
 
     @Override
+    public LogicalPlan tryPushDown(@Nullable LogicalPlan pushDown) {
+        if (pushDown instanceof Order) {
+            // pushing down an order past a limit is not allowed
+            return this;
+        }
+        return super.tryPushDown(pushDown);
+    }
+
+    @Override
     protected LogicalPlan newInstance(LogicalPlan newSource) {
         return new Limit(newSource, limit, offset);
     }

--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlan.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlan.java
@@ -105,6 +105,30 @@ public interface LogicalPlan extends Plan {
     }
 
     /**
+     * Tries to "push-down" a LogicalPlan to this plan or the children of
+     * this plan. A push-down is an optimization which does not change the
+     * outcome of the plan but, ideally, makes it execute more efficiently.
+     *
+     * For example, pushing down an *Order*:
+     *
+     *              *Order*                      Union
+     *                 |                        /     \
+     *                 |                       /       \
+     *               Union                 *Order*  *Order*
+     *              /     \                   |        |
+     *             /       \        =>        |        |
+     *          Collect   Order             Collect  Order
+     *                      |                          |
+     *                      |                          |
+     *                   Collect                    Collect
+     *
+     * @param pushDown The LogicalPLan which gets "pushed down". {@code null} if currently
+     *                 no plan gets pushed. Still can recurse to find other push down candidates.
+     * @return A new LogicalPlan or the same plan if rewriting/optimizing is not possible.
+     */
+    LogicalPlan tryPushDown(@Nullable LogicalPlan pushDown);
+
+    /**
      * Uses the current shard allocation information to create a physical execution plan.
      * <br />
      * {@code limit}, {@code offset}, {@code order} can be passed from one operator to another. Depending on the

--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -114,7 +114,9 @@ public class LogicalPlanner {
             .build(tableStats, new HashSet<>(relation.outputs()))
             .tryCollapse();
 
-        return MultiPhase.createIfNeeded(logicalPlan, relation, subqueryPlanner);
+        LogicalPlan pushDownPlan = logicalPlan.tryPushDown(null);
+
+        return MultiPhase.createIfNeeded(pushDownPlan, relation, subqueryPlanner);
     }
 
     static LogicalPlan.Builder plan(QueriedRelation relation,

--- a/sql/src/main/java/io/crate/planner/operators/OneInputPlan.java
+++ b/sql/src/main/java/io/crate/planner/operators/OneInputPlan.java
@@ -26,6 +26,7 @@ import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.symbol.SelectSymbol;
 import io.crate.analyze.symbol.Symbol;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 
@@ -55,6 +56,16 @@ abstract class OneInputPlan extends LogicalPlanBase {
                  Map<LogicalPlan, SelectSymbol> dependencies) {
         super(outputs, expressionMapping, baseTables, dependencies);
         this.source = source;
+    }
+
+
+    @Override
+    public LogicalPlan tryPushDown(@Nullable LogicalPlan pushDown) {
+        LogicalPlan newPlan = source.tryPushDown(pushDown);
+        if (newPlan != source) {
+            return newInstance(newPlan);
+        }
+        return this;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/TwoInputPlan.java
+++ b/sql/src/main/java/io/crate/planner/operators/TwoInputPlan.java
@@ -24,6 +24,7 @@ package io.crate.planner.operators;
 
 import io.crate.analyze.symbol.Symbol;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -45,6 +46,16 @@ abstract class TwoInputPlan extends LogicalPlanBase {
         this.baseTables.addAll(rhs.baseTables());
         this.expressionMapping.putAll(lhs.expressionMapping());
         this.expressionMapping.putAll(rhs.expressionMapping());
+    }
+
+    @Override
+    public LogicalPlan tryPushDown(@Nullable LogicalPlan pushDown) {
+        LogicalPlan newLhs = lhs.tryPushDown(pushDown);
+        LogicalPlan newRhs = rhs.tryPushDown(pushDown);
+        if (newLhs != lhs || newRhs != rhs) {
+            return newInstance(newLhs, newRhs);
+        }
+        return this;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/Union.java
+++ b/sql/src/main/java/io/crate/planner/operators/Union.java
@@ -148,7 +148,7 @@ public class Union extends TwoInputPlan {
             leftResultDesc.streamOutputs(),
             Collections.emptyList(),
             DistributionInfo.DEFAULT_BROADCAST,
-            null
+            leftResultDesc.orderBy()
         );
 
         return new UnionExecutionPlan(
@@ -160,6 +160,20 @@ public class Union extends TwoInputPlan {
             lhs.outputs().size(),
             TopN.NO_LIMIT
         );
+    }
+
+    @Override
+    public LogicalPlan tryPushDown(@Nullable LogicalPlan pushDown) {
+        if (pushDown instanceof Order) {
+            LogicalPlan newLhs = lhs.tryPushDown(pushDown);
+            LogicalPlan newRhs = rhs.tryPushDown(pushDown);
+            if (newLhs != lhs && newRhs != rhs) {
+                return newInstance(newLhs, newRhs);
+            } else {
+                return this;
+            }
+        }
+        return super.tryPushDown(pushDown);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/ZeroInputPlan.java
+++ b/sql/src/main/java/io/crate/planner/operators/ZeroInputPlan.java
@@ -25,6 +25,7 @@ package io.crate.planner.operators;
 import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.symbol.Symbol;
 
+import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 
@@ -35,6 +36,12 @@ abstract class ZeroInputPlan extends LogicalPlanBase {
 
     public ZeroInputPlan(List<Symbol> outputs, List<AbstractTableRelation> baseTables) {
         super(outputs, Collections.emptyMap(), baseTables, Collections.emptyMap());
+    }
+
+    @Override
+    public LogicalPlan tryPushDown(@Nullable LogicalPlan pushDown) {
+        // We don't have any sources, so just return this instance
+        return this;
     }
 
     @Override

--- a/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -34,6 +34,7 @@ import io.crate.planner.TableStats;
 import io.crate.planner.consumer.FetchMode;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
 import org.junit.Before;
@@ -59,12 +60,7 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     private LogicalPlan plan(String statement) {
-        QueriedRelation relation = sqlExecutor.analyze(statement);
-        PlannerContext context = sqlExecutor.getPlannerContext(clusterService.state());
-        LogicalPlanner logicalPlanner = new LogicalPlanner(getFunctions(), tableStats);
-        SubqueryPlanner subqueryPlanner = new SubqueryPlanner((s) -> logicalPlanner.planSubSelect(s, context));
-
-        return logicalPlanner.plan(relation, context, subqueryPlanner, FetchMode.MAYBE_CLEAR);
+        return plan(statement, sqlExecutor, clusterService, tableStats);
     }
 
     @Test
@@ -204,6 +200,18 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
                                 "Collect[doc.t1 | [_fetchid, _score] | All]\n"));
     }
 
+    public static LogicalPlan plan(String statement,
+                                   SQLExecutor sqlExecutor,
+                                   ClusterService clusterService,
+                                   TableStats tableStats) {
+        QueriedRelation relation = sqlExecutor.analyze(statement);
+        PlannerContext context = sqlExecutor.getPlannerContext(clusterService.state());
+        LogicalPlanner logicalPlanner = new LogicalPlanner(getFunctions(), tableStats);
+        SubqueryPlanner subqueryPlanner = new SubqueryPlanner((s) -> logicalPlanner.planSubSelect(s, context));
+
+        return logicalPlanner.plan(relation, context, subqueryPlanner, FetchMode.MAYBE_CLEAR);
+    }
+
     public static Matcher<LogicalPlan> isPlan(Functions functions, String expectedPlan) {
         return new FeatureMatcher<LogicalPlan, String>(equalTo(expectedPlan), "same output", "output ") {
 
@@ -341,7 +349,17 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
                 sb.append("]\n");
                 return sb.toString();
             }
-            return printPlan(plan);
+            if (plan instanceof Union) {
+                Union union = (Union) plan;
+                startLine("Union[\n");
+                printPlan(union.lhs);
+                startLine("---\n");
+                printPlan(union.rhs);
+                sb.append("]\n");
+                return sb.toString();
+            }
+
+            throw new UnsupportedOperationException("Can't print plan: " + plan);
         }
 
         private void addSymbolsList(Iterable<? extends Symbol> symbols) {

--- a/sql/src/test/java/io/crate/planner/operators/PushDownTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/PushDownTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.operators;
+
+import io.crate.analyze.TableDefinitions;
+import io.crate.planner.TableStats;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+import org.junit.Test;
+
+import static io.crate.planner.operators.LogicalPlannerTest.isPlan;
+
+public class PushDownTest extends CrateDummyClusterServiceUnitTest {
+
+    @Test
+    public void pushDownUnionOrder() {
+
+        TableStats tableStats = new TableStats();
+
+        SQLExecutor sqlExecutor = SQLExecutor.builder(clusterService)
+            .addDocTable(TableDefinitions.USER_TABLE_INFO)
+            .build();
+
+        LogicalPlan plan = LogicalPlannerTest.plan(
+            "Select name from users union all select text from users order by name",
+            sqlExecutor,
+            clusterService,
+            tableStats);
+
+        assertThat(plan, isPlan(sqlExecutor.functions(),  "Boundary[name]\n" +
+                                                "Union[\n" +
+                                                "Boundary[name]\n" +
+                                                "OrderBy[name]\n" +
+                                                "Collect[doc.users | [name] | All]\n" +
+                                                "---\n" +
+                                                "Boundary[text]\n" +
+                                                "OrderBy[text]\n" +
+                                                "Collect[doc.users | [text] | All]\n" +
+                                                "]\n"));
+    }
+}


### PR DESCRIPTION
Queries like `Select id from t1 UNION ALL Select id2 from t2 order by id` are
optimized to perform an order by already in the source relations of the
union. The OrderBy from the union is "pushed down" to the queries on t1 and
t2. The result only needs to run a sorted merge.

```
       *Order*                      Union
          |                        /     \
          |                       /       \
        Union                 *Order*  *Order*
       /     \                   |        |
      /       \        =>        |        |
   Collect   Order             Collect  Order
     t1        |                 t1       |
               |                          |
            Collect                    Collect
              t2                         t2
```

Based on #6608.