### PR TITLE
Support subscripts on values of information_schema.table_partitions

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -126,3 +126,6 @@ Changes
 
 Fixes
 =====
+
+- Fixed support for subscript expressions on the ``values`` column of
+  ``information_schema.table_partitions``

--- a/sql/src/main/java/io/crate/operation/reference/MapLookupByPathExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/MapLookupByPathExpression.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.operation.reference;
+
+import io.crate.core.collections.StringObjectMaps;
+import io.crate.metadata.ReferenceImplementation;
+import io.crate.metadata.RowCollectExpression;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+public final class MapLookupByPathExpression<T, R> implements RowCollectExpression<T, R> {
+
+    private final Function<T, Map<String, Object>> getMap;
+    private final List<String> path;
+    private final Function<Object, R> castResultValue;
+    private T state;
+
+    public MapLookupByPathExpression(Function<T, Map<String, Object>> getMap,
+                                     List<String> path,
+                                     Function<Object, R> castResultValue) {
+        this.getMap = getMap;
+        this.path = path;
+        this.castResultValue = castResultValue;
+    }
+
+    @Override
+    public void setNextRow(T row) {
+        this.state = row;
+    }
+
+    @Override
+    public R value() {
+        return castResultValue.apply(StringObjectMaps.fromMapByPath(getMap.apply(state), path));
+    }
+
+    @Override
+    public ReferenceImplementation getChildImplementation(String name) {
+        ArrayList<String> newPath = new ArrayList<>(path.size() + 1);
+        newPath.addAll(path);
+        newPath.add(name);
+        return new MapLookupByPathExpression<>(getMap, newPath, castResultValue);
+    }
+
+}

--- a/sql/src/test/java/io/crate/operation/reference/MapLookupByPathExpressionTest.java
+++ b/sql/src/test/java/io/crate/operation/reference/MapLookupByPathExpressionTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.operation.reference;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class MapLookupByPathExpressionTest {
+
+    @Test
+    public void testInvalidPathResultsInNull() throws Exception {
+        HashMap<String, Object> m = new HashMap<>();
+        m.put("correct", 10);
+        MapLookupByPathExpression<Map<String, Object>, Object> expr =
+            new MapLookupByPathExpression<>(Function.identity(), Collections.singletonList("incorrect"), Function.identity());
+
+        expr.setNextRow(m);
+        assertThat(expr.value(), Matchers.nullValue());
+    }
+
+    @Test
+    public void testCorrectPathReturnsValue() throws Exception {
+        HashMap<String, Object> m = new HashMap<>();
+        m.put("correct", 10);
+        MapLookupByPathExpression<Map<String, Object>, Object> expr =
+            new MapLookupByPathExpression<>(Function.identity(), Collections.singletonList("correct"), Function.identity());
+
+        expr.setNextRow(m);
+        assertThat(expr.value(), Matchers.is(10));
+    }
+}


### PR DESCRIPTION
To support something like `select values['p'] from
information_schema.table_partitions`

If the column doesn't exist it will return null instead of failing. In
addition there is also a implicit cast to string. This is necessary
because for streaming (via pg-wire); It would fail with mixed type which
could be the case if 2+ tables have the same column name for
partitioning but different types.