### PR TITLE
Remove jobId from the ExecutionPlan interface

### DIFF
--- a/sql/src/main/java/io/crate/planner/ExecutionPlan.java
+++ b/sql/src/main/java/io/crate/planner/ExecutionPlan.java
@@ -25,13 +25,10 @@ import io.crate.planner.distribution.DistributionInfo;
 import io.crate.planner.projection.Projection;
 
 import javax.annotation.Nullable;
-import java.util.UUID;
 
 public interface ExecutionPlan {
 
     <C, R> R accept(ExecutionPlanVisitor<C, R> visitor, C context);
-
-    UUID jobId();
 
     /**
      * Add a projection to the plan.

--- a/sql/src/main/java/io/crate/planner/Merge.java
+++ b/sql/src/main/java/io/crate/planner/Merge.java
@@ -35,7 +35,6 @@ import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.UUID;
 
 public class Merge implements ExecutionPlan, ResultDescription {
 
@@ -169,11 +168,6 @@ public class Merge implements ExecutionPlan, ResultDescription {
     @Override
     public <C, R> R accept(ExecutionPlanVisitor<C, R> visitor, C context) {
         return visitor.visitMerge(this, context);
-    }
-
-    @Override
-    public UUID jobId() {
-        return subExecutionPlan.jobId();
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/UnionExecutionPlan.java
+++ b/sql/src/main/java/io/crate/planner/UnionExecutionPlan.java
@@ -31,7 +31,6 @@ import io.crate.types.DataType;
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
-import java.util.UUID;
 
 /**
  * Plan for Union which uses a MergePhase to combine the results of two plans (= two inputs).
@@ -97,11 +96,6 @@ public class UnionExecutionPlan implements ExecutionPlan, ResultDescription {
     @Override
     public <C, R> R accept(ExecutionPlanVisitor<C, R> visitor, C context) {
         return visitor.visitUnionPlan(this, context);
-    }
-
-    @Override
-    public UUID jobId() {
-        return mergePhase.jobId();
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/node/dql/Collect.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/Collect.java
@@ -34,7 +34,6 @@ import io.crate.types.DataType;
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
-import java.util.UUID;
 
 public class Collect implements ExecutionPlan, ResultDescription {
 
@@ -81,11 +80,6 @@ public class Collect implements ExecutionPlan, ResultDescription {
     @Override
     public <C, R> R accept(ExecutionPlanVisitor<C, R> visitor, C context) {
         return visitor.visitCollect(this, context);
-    }
-
-    @Override
-    public UUID jobId() {
-        return collectPhase.jobId();
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/node/dql/CountPlan.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/CountPlan.java
@@ -33,13 +33,11 @@ import io.crate.types.DataType;
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
-import java.util.UUID;
 
 public class CountPlan implements ExecutionPlan, ResultDescription {
 
     private final CountPhase countPhase;
     private final MergePhase mergePhase;
-    private final UUID id;
 
     private int unfinishedLimit = TopN.NO_LIMIT;
     private int unfinishedOffset = 0;
@@ -50,7 +48,6 @@ public class CountPlan implements ExecutionPlan, ResultDescription {
     public CountPlan(CountPhase countPhase, MergePhase mergePhase) {
         this.countPhase = countPhase;
         this.mergePhase = mergePhase;
-        this.id = mergePhase.jobId();
     }
 
     public CountPhase countPhase() {
@@ -65,12 +62,6 @@ public class CountPlan implements ExecutionPlan, ResultDescription {
     public <C, R> R accept(ExecutionPlanVisitor<C, R> visitor, C context) {
         return visitor.visitCountPlan(this, context);
     }
-
-    @Override
-    public UUID jobId() {
-        return id;
-    }
-
 
     @Override
     public void addProjection(Projection projection) {

--- a/sql/src/main/java/io/crate/planner/node/dql/ESGet.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/ESGet.java
@@ -33,13 +33,13 @@ import io.crate.data.Row;
 import io.crate.data.RowConsumer;
 import io.crate.executor.transport.task.elasticsearch.ESGetTask;
 import io.crate.metadata.doc.DocTableInfo;
+import io.crate.planner.DependencyCarrier;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.ExecutionPlanVisitor;
 import io.crate.planner.Plan;
 import io.crate.planner.PlannerContext;
 import io.crate.planner.PositionalOrderBy;
 import io.crate.planner.ResultDescription;
-import io.crate.planner.DependencyCarrier;
 import io.crate.planner.distribution.DistributionInfo;
 import io.crate.planner.projection.Projection;
 import io.crate.types.DataType;
@@ -47,7 +47,6 @@ import io.crate.types.DataType;
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 import static io.crate.data.SentinelRow.SENTINEL;
 
@@ -167,11 +166,6 @@ public class ESGet implements Plan, ExecutionPlan {
     @Override
     public <C, R> R accept(ExecutionPlanVisitor<C, R> visitor, C context) {
         return visitor.visitESGet(this, context);
-    }
-
-    @Override
-    public UUID jobId() {
-        return null;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/node/dql/QueryThenFetch.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/QueryThenFetch.java
@@ -31,7 +31,6 @@ import io.crate.planner.node.fetch.FetchPhase;
 import io.crate.planner.projection.Projection;
 
 import javax.annotation.Nullable;
-import java.util.UUID;
 
 public class QueryThenFetch implements ExecutionPlan {
 
@@ -54,11 +53,6 @@ public class QueryThenFetch implements ExecutionPlan {
     @Override
     public <C, R> R accept(ExecutionPlanVisitor<C, R> visitor, C context) {
         return visitor.visitQueryThenFetch(this, context);
-    }
-
-    @Override
-    public UUID jobId() {
-        return subExecutionPlan.jobId();
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/node/dql/join/NestedLoop.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/join/NestedLoop.java
@@ -145,12 +145,6 @@ public class NestedLoop implements ExecutionPlan, ResultDescription {
     }
 
     @Override
-    public UUID jobId() {
-        return jobId;
-    }
-
-
-    @Override
     public void addProjection(Projection projection) {
         nestedLoopPhase.addProjection(projection);
         numOutputs = projection.outputs().size();


### PR DESCRIPTION
Currently the only usage is on the CollectPhase; so the jobId doesn't
have to be part of the ExecutionPlan interface