### PR TITLE
jmh: Fix PreExecutionBenchmark

### DIFF
--- a/sql/src/jmh/java/io/crate/analyze/PreExecutionBenchmark.java
+++ b/sql/src/jmh/java/io/crate/analyze/PreExecutionBenchmark.java
@@ -56,6 +56,7 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 import java.util.Collections;
+import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.AverageTime)
@@ -100,7 +101,8 @@ public class PreExecutionBenchmark {
         selectStatement = SqlParser.createStatement("select name from users");
         selectAnalysis =
             e.analyzer.boundAnalyze(selectStatement, new TransactionContext(SessionContext.create()), ParameterContext.EMPTY);
-        plannerContext = e.getPlannerContext(clusterService.state());
+        long dummySeed = 10;
+        plannerContext = e.getPlannerContext(clusterService.state(), new Random(dummySeed));
     }
 
     @TearDown

--- a/sql/src/test/java/io/crate/testing/SQLExecutor.java
+++ b/sql/src/test/java/io/crate/testing/SQLExecutor.java
@@ -88,6 +88,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Random;
 import java.util.UUID;
 
 import static io.crate.analyze.TableDefinitions.DEEPLY_NESTED_TABLE_INFO;
@@ -121,10 +122,19 @@ public class SQLExecutor {
     private final SessionContext sessionContext;
     private final TransactionContext transactionContext;
 
+    /**
+     * Shortcut for {@link #getPlannerContext(ClusterState, Random)}
+     * This can only be used if {@link com.carrotsearch.randomizedtesting.RandomizedContext} is available
+     * (e.g. TestCase using {@link com.carrotsearch.randomizedtesting.RandomizedRunner}
+     */
     public PlannerContext getPlannerContext(ClusterState clusterState) {
+        return getPlannerContext(clusterState, Randomness.get());
+    }
+
+    public PlannerContext getPlannerContext(ClusterState clusterState, Random random) {
         return new PlannerContext(
             clusterState,
-            new RoutingProvider(Randomness.get().nextInt(), new String[0]),
+            new RoutingProvider(random.nextInt(), new String[0]),
             UUID.randomUUID(),
             planner.normalizer(),
             new TransactionContext(sessionContext),


### PR DESCRIPTION
Fixes:

     running tests but failed to invoke RandomizedContext#getRandom
	at org.elasticsearch.common.Randomness.get(Randomness.java:105)
	at io.crate.testing.SQLExecutor.getPlannerContext(SQLExecutor.java:127)
	at io.crate.analyze.PreExecutionBenchmark.setup(PreExecutionBenchmark.java:103)