### PR TITLE
Implement Http password authentication.

### DIFF
--- a/enterprise/users/src/main/java/io/crate/operation/auth/HostBasedAuthentication.java
+++ b/enterprise/users/src/main/java/io/crate/operation/auth/HostBasedAuthentication.java
@@ -93,17 +93,14 @@ public class HostBasedAuthentication implements Authentication {
     }
 
     @Nullable
-    private AuthenticationMethod methodForNameAndProtocol(String method, Protocol protocol) {
+    private AuthenticationMethod methodForName(String method) {
         switch (method) {
             case (TrustAuthenticationMethod.NAME):
                 return new TrustAuthenticationMethod(userLookup);
             case (ClientCertAuth.NAME):
                 return new ClientCertAuth(userLookup);
             case (PasswordAuthenticationMethod.NAME):
-                if (Protocol.POSTGRES.equals(protocol)) {
-                    return new PasswordAuthenticationMethod(userLookup);
-                }
-                return null;
+                return new PasswordAuthenticationMethod(userLookup);
             default:
                 return null;
         }
@@ -118,7 +115,7 @@ public class HostBasedAuthentication implements Authentication {
             String methodName = entry.get()
                 .getValue()
                 .getOrDefault(KEY_METHOD, DEFAULT_AUTH_METHOD);
-            return methodForNameAndProtocol(methodName, connProperties.protocol());
+            return methodForName(methodName);
         }
         return null;
     }

--- a/enterprise/users/src/main/java/io/crate/protocols/http/HttpAuthUpstreamHandler.java
+++ b/enterprise/users/src/main/java/io/crate/protocols/http/HttpAuthUpstreamHandler.java
@@ -26,20 +26,24 @@ import io.crate.operation.auth.Protocol;
 import io.crate.operation.user.User;
 import io.crate.protocols.SSL;
 import io.crate.protocols.postgres.ConnectionProperties;
+import io.crate.rest.action.RestSQLAction;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.network.InetAddresses;
+import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 
 import javax.annotation.Nullable;
@@ -83,7 +87,9 @@ public class HttpAuthUpstreamHandler extends SimpleChannelInboundHandler<Object>
 
     private void handleHttpRequest(ChannelHandlerContext ctx, HttpRequest request) {
         SSLSession session = getSession(ctx.channel());
-        String username = userFromRequest(request, session, settings);
+        Tuple<String, SecureString> credentials = credentialsFromRequest(request, session, settings);
+        String username = credentials.v1();
+        SecureString password = credentials.v2();
         InetAddress address = addressFromRequestOrChannel(request, ctx.channel());
         ConnectionProperties connectionProperties = new ConnectionProperties(address, Protocol.HTTP, session);
         AuthenticationMethod authMethod = authService.resolveAuthenticationType(username, connectionProperties);
@@ -95,7 +101,7 @@ public class HttpAuthUpstreamHandler extends SimpleChannelInboundHandler<Object>
             sendUnauthorized(ctx.channel(), errorMessage);
         } else {
             try {
-                User user = authMethod.authenticate(username, null, connectionProperties);
+                User user = authMethod.authenticate(username, password, connectionProperties);
                 if (user != null && LOGGER.isTraceEnabled()) {
                     LOGGER.trace("Authentication succeeded user \"{}\" and method \"{}\".", username, authMethod.name());
                 }
@@ -140,24 +146,30 @@ public class HttpAuthUpstreamHandler extends SimpleChannelInboundHandler<Object>
     }
 
     @VisibleForTesting
-    static String userFromRequest(HttpRequest request, @Nullable SSLSession session, Settings settings) {
-        if (request.headers().contains(AuthSettings.HTTP_HEADER_USER)) {
-            return request.headers().get(AuthSettings.HTTP_HEADER_USER);
+    static Tuple<String, SecureString> credentialsFromRequest(HttpRequest request, @Nullable SSLSession session, Settings settings) {
+        String username = null;
+        if (request.headers().contains(HttpHeaderNames.AUTHORIZATION.toString())) {
+            // Prefer Http Basic Auth
+            return RestSQLAction.extractCredentialsFromHttpBasicAuthHeader(
+                request.headers().get(HttpHeaderNames.AUTHORIZATION.toString()));
+        } else if (request.headers().contains(AuthSettings.HTTP_HEADER_USER)) {
+            // Fallback to deprecated setting
+            username = request.headers().get(AuthSettings.HTTP_HEADER_USER);
         } else {
             // prefer commonName as userName over AUTH_TRUST_HTTP_DEFAULT_HEADER user
             if (session != null) {
                 try {
                     Certificate certificate = session.getPeerCertificates()[0];
-                    String commonName = SSL.extractCN(certificate);
-                    if (commonName != null) {
-                        return commonName;
-                    }
+                    username = SSL.extractCN(certificate);
                 } catch (ArrayIndexOutOfBoundsException | SSLPeerUnverifiedException ignored) {
                     // client cert is optional
                 }
             }
-            return AuthSettings.AUTH_TRUST_HTTP_DEFAULT_HEADER.setting().get(settings);
+            if (username == null) {
+                username = AuthSettings.AUTH_TRUST_HTTP_DEFAULT_HEADER.setting().get(settings);
+            }
         }
+        return new Tuple<>(username, null);
     }
 
     private InetAddress addressFromRequestOrChannel(HttpRequest request, Channel channel) {

--- a/enterprise/users/src/test/java/io/crate/protocols/http/HttpAuthUpstreamHandlerTest.java
+++ b/enterprise/users/src/test/java/io/crate/protocols/http/HttpAuthUpstreamHandlerTest.java
@@ -18,7 +18,6 @@
 
 package io.crate.protocols.http;
 
-import com.google.common.collect.ImmutableSet;
 import io.crate.operation.auth.AlwaysOKAuthentication;
 import io.crate.operation.auth.AlwaysOKNullAuthentication;
 import io.crate.operation.auth.Authentication;
@@ -30,6 +29,7 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.DefaultHttpRequest;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
@@ -111,14 +111,13 @@ public class HttpAuthUpstreamHandlerTest extends CrateUnitTest {
         assertThat(handler.authorized(), is(true));
     }
 
-
     @Test
     public void testNotNoHbaConfig() throws Exception {
         HttpAuthUpstreamHandler handler = new HttpAuthUpstreamHandler(Settings.EMPTY, authService);
         EmbeddedChannel ch = new EmbeddedChannel(handler);
 
         DefaultHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/_sql");
-        request.headers().add("X-User", "Arthur");
+        request.headers().add(HttpHeaderNames.AUTHORIZATION.toString(), "Basic: QWxhZGRpbjpPcGVuU2VzYW1l");
         request.headers().add("X-Real-Ip", "10.1.0.100");
 
         ch.writeInbound(request);
@@ -126,7 +125,7 @@ public class HttpAuthUpstreamHandlerTest extends CrateUnitTest {
 
         assertUnauthorized(
             ch.readOutbound(),
-            "No valid auth.host_based.config entry found for host \"10.1.0.100\", user \"Arthur\", protocol \"http\"\n");
+            "No valid auth.host_based.config entry found for host \"10.1.0.100\", user \"Aladdin\", protocol \"http\"\n");
     }
 
     @Test
@@ -149,7 +148,7 @@ public class HttpAuthUpstreamHandlerTest extends CrateUnitTest {
         when(session.getPeerCertificates()).thenReturn(new Certificate[] { ssc.cert() });
 
         HttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/_sql");
-        String userName = HttpAuthUpstreamHandler.userFromRequest(request, session, Settings.EMPTY);
+        String userName = HttpAuthUpstreamHandler.credentialsFromRequest(request, session, Settings.EMPTY).v1();
 
         assertThat(userName, is("example.com"));
     }
@@ -163,8 +162,7 @@ public class HttpAuthUpstreamHandlerTest extends CrateUnitTest {
         EmbeddedChannel ch = new EmbeddedChannel(handler);
 
         HttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/_sql");
-        request.headers().add("X-User", "crate");
-
+        request.headers().add(HttpHeaderNames.AUTHORIZATION.toString(), "Basic: Y3JhdGU6");
         ch.writeInbound(request);
 
         assertTrue(handler.authorized());
@@ -177,11 +175,11 @@ public class HttpAuthUpstreamHandlerTest extends CrateUnitTest {
         EmbeddedChannel ch = new EmbeddedChannel(handler);
 
         HttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/_sql");
-        request.headers().add("X-User", "Arthur");
+        request.headers().add(HttpHeaderNames.AUTHORIZATION.toString(), "Basic: QWxhZGRpbjpPcGVuU2VzYW1l");
 
         ch.writeInbound(request);
 
         assertFalse(handler.authorized());
-        assertUnauthorized(ch.readOutbound(), "trust authentication failed for user \"Arthur\"\n");
+        assertUnauthorized(ch.readOutbound(), "trust authentication failed for user \"Aladdin\"\n");
     }
 }

--- a/sql/src/main/java/io/crate/operation/auth/AuthSettings.java
+++ b/sql/src/main/java/io/crate/operation/auth/AuthSettings.java
@@ -48,6 +48,7 @@ public final class AuthSettings {
         "auth.trust.http_default_user", "crate", Function.identity(), Setting.Property.NodeScope),
         DataTypes.STRING);
 
+    @Deprecated //Scheduled to be removed as HTTP Basic Auth Header is introduced"
     public static final String HTTP_HEADER_USER = "X-User";
     public static final String HTTP_HEADER_REAL_IP = "X-Real-Ip";
 }

--- a/sql/src/main/java/io/crate/rest/action/RestSQLAction.java
+++ b/sql/src/main/java/io/crate/rest/action/RestSQLAction.java
@@ -26,10 +26,10 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import io.crate.action.sql.BaseResultReceiver;
 import io.crate.action.sql.Option;
-import io.crate.action.sql.Session;
 import io.crate.action.sql.ResultReceiver;
 import io.crate.action.sql.SQLActionException;
 import io.crate.action.sql.SQLOperations;
+import io.crate.action.sql.Session;
 import io.crate.action.sql.parser.SQLXContentSourceContext;
 import io.crate.action.sql.parser.SQLXContentSourceParser;
 import io.crate.analyze.symbol.Field;
@@ -43,11 +43,14 @@ import io.crate.operation.auth.AuthSettings;
 import io.crate.operation.user.ExceptionAuthorizedValidator;
 import io.crate.operation.user.User;
 import io.crate.operation.user.UserManager;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Provider;
 import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.rest.BaseRestHandler;
@@ -60,7 +63,9 @@ import org.elasticsearch.rest.RestStatus;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
@@ -149,11 +154,44 @@ public class RestSQLAction extends BaseRestHandler {
 
     @VisibleForTesting
     User userFromRequest(RestRequest request) {
-        String user = request.header(AuthSettings.HTTP_HEADER_USER);
-        if (user == null) {
-            user = AuthSettings.AUTH_TRUST_HTTP_DEFAULT_HEADER.setting().get(settings);
+        String username = extractUsernameFromHttpBasicAuthHeader(
+            request.header(HttpHeaderNames.AUTHORIZATION.toString()));
+
+        // Fallback to deprecated setting
+        if (username == null) {
+            username = request.header(AuthSettings.HTTP_HEADER_USER);
         }
-        return userManager.findUser(user);
+
+        // Fallback to trusted user from configuration
+        if (username == null) {
+            username = AuthSettings.AUTH_TRUST_HTTP_DEFAULT_HEADER.setting().get(settings);
+        }
+        return userManager.findUser(username);
+    }
+
+    private static String extractUsernameFromHttpBasicAuthHeader(String authHeaderValue) {
+        if (authHeaderValue == null) {
+            return null;
+        }
+        String[] creds = new String(
+            Base64.getDecoder().decode(authHeaderValue.replace("Basic: ", "")),
+            StandardCharsets.UTF_8).split(":");
+        return creds[0];
+    }
+
+    public static Tuple<String, SecureString> extractCredentialsFromHttpBasicAuthHeader(String authHeaderValue) {
+        String username = null;
+        SecureString password = null;
+        if (authHeaderValue != null) {
+            String[] creds = new String(
+                Base64.getDecoder().decode(authHeaderValue.replace("Basic: ", "")),
+                StandardCharsets.UTF_8).split(":");
+            username = creds[0];
+            if (creds.length > 1) {
+                password = new SecureString(creds[1].toCharArray());
+            }
+        }
+        return new Tuple<>(username, password);
     }
 
     private RestChannelConsumer executeSimpleRequest(SQLXContentSourceContext context, final RestRequest request) {

--- a/sql/src/test/java/io/crate/rest/action/RestSQLActionTest.java
+++ b/sql/src/test/java/io/crate/rest/action/RestSQLActionTest.java
@@ -22,13 +22,17 @@
 
 package io.crate.rest.action;
 
+import com.google.common.collect.ImmutableMap;
 import io.crate.action.sql.SQLOperations;
 import io.crate.breaker.CrateCircuitBreakerService;
 import io.crate.operation.auth.AuthSettings;
 import io.crate.operation.user.UserManager;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.testing.DummyUserManager;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.inject.Provider;
+import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestRequest;
@@ -82,7 +86,7 @@ public class RestSQLActionTest extends CrateUnitTest {
     }
 
     @Test
-    public void testUserIfHttpHeaderIsPresent() throws Exception {
+    public void testUserIfHttpBasicAuthIsPresent() {
         RestSQLAction restSQLAction = new RestSQLAction(
             Settings.EMPTY,
             restController,
@@ -91,9 +95,52 @@ public class RestSQLActionTest extends CrateUnitTest {
             circuitBreakerService
         );
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry())
-            .withHeaders(Collections.singletonMap("X-User", Collections.singletonList("other")))
+            .withHeaders(
+                Collections.singletonMap(HttpHeaderNames.AUTHORIZATION.toString(),
+                    Collections.singletonList("Basic: QWxhZGRpbjpPcGVuU2VzYW1l")))
+            .build();
+        assertThat(restSQLAction.userFromRequest(request).name(), is("Aladdin"));
+    }
+
+    @Test
+    public void testUserIfHttpUserHeaderIsPresent() {
+        RestSQLAction restSQLAction = new RestSQLAction(
+            Settings.EMPTY,
+            restController,
+            sqlOperations,
+            USER_MANAGER_PROVIDER,
+            circuitBreakerService
+        );
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry())
+            .withHeaders(Collections.singletonMap(AuthSettings.HTTP_HEADER_USER, Collections.singletonList("other")))
             .build();
         assertThat(restSQLAction.userFromRequest(request).name(), is("other"));
+    }
 
+    @Test
+    public void testUserIfBothHeadersArePresent() {
+        RestSQLAction restSQLAction = new RestSQLAction(
+            Settings.EMPTY,
+            restController,
+            sqlOperations,
+            USER_MANAGER_PROVIDER,
+            circuitBreakerService
+        );
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry())
+            .withHeaders(ImmutableMap.of(
+                AuthSettings.HTTP_HEADER_USER, Collections.singletonList("other"),
+                HttpHeaderNames.AUTHORIZATION.toString(), Collections.singletonList("Basic: QWxhZGRpbjpPcGVuU2VzYW1l")))
+            .build();
+
+        // HTTP Basic Auth Header has higher priority
+        assertThat(restSQLAction.userFromRequest(request).name(), is("Aladdin"));
+    }
+
+    @Test
+    public void testExtractUsernamePasswordFromHttpBasicAuthHeader() {
+        Tuple<String, SecureString> creds =
+            RestSQLAction.extractCredentialsFromHttpBasicAuthHeader("Basic: QXJ0aHVyOkV4Y2FsaWJ1cg==");
+        assertThat(creds.v1(), is("Arthur"));
+        assertThat(creds.v2().toString(), is("Excalibur"));
     }
 }


### PR DESCRIPTION
 - Extract credentials from HTTP basic auth header.
 - Deprecated "X-User" custom HTTP header and keep as a fallback if HTTP basic auth header missing.
 - "password" method is also supported for HTTP protocol (not only PG)