### PR TITLE
Add support for ALTER USER

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -39,6 +39,8 @@ Breaking Changes
 Changes
 =======
 
+- Added support to change the password of existing users using ``ALTER USER``.
+
 - Added support for disabling the column store per ``STRING`` column on table
   creation and on adding columns. In conjunction with disabling indexing on that
   column, this will support storing strings greater than 32kb. Be aware that the

--- a/blackbox/docs/administration/user-management.txt
+++ b/blackbox/docs/administration/user-management.txt
@@ -21,11 +21,16 @@ Introduction
 A CrateDB cluster contains a set of database users. A database user is a
 principle at cluster level.
 
-Users can be created using the `CREATE USER`_ statement and removed using the
-analoguous `DROP USER`_ statement. These statements are database management
-statements that can only be invoked by superusers that already exist in the
-CrateDB cluster. Also the users table `sys.users` is only readable by
-superusers.
+User account information is stored in the cluster metatdata of CrateDB and
+supports the following statements to create, alter and drop users:
+
+    * `CREATE USER`_
+    * `ALTER USER`_
+    * `DROP USER`_
+
+These statements are database management statements that can only be invoked by
+superusers that already exist in the CrateDB cluster. Also the users table
+`sys.users` is only readable by superusers.
 
 When CrateDB is started, the cluster contains one predefined superuser. This
 user is called ``crate``. It is not possible to create any other superusers
@@ -62,6 +67,22 @@ statement returns an error::
 
     cr> CREATE USER "Custom User";
     SQLActionException[UserAlreadyExistsException: User 'Custom User' already exists]
+
+
+``ALTER USER``
+==============
+
+To alter the password for an existing user from the CrateDB database cluster use
+the :ref:`ref-alter-user` SQL statement::
+
+    cr> ALTER USER user_a SET password = 'pass';
+    ALTER OK, 1 row affected (... sec)
+
+The password can be reset (cleared) if specified as ``NULL``::
+
+    cr> ALTER USER user_a SET password = NULL;
+    ALTER OK, 1 row affected (... sec)
+
 
 ``DROP USER``
 =============

--- a/blackbox/docs/sql/statements/alter_user.txt
+++ b/blackbox/docs/sql/statements/alter_user.txt
@@ -1,0 +1,47 @@
+.. highlight:: psql
+.. _ref-alter-user:
+
+==============
+``ALTER USER``
+==============
+
+Alter an existing database user.
+
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
+Synopsis
+========
+
+::
+
+    ALTER USER
+      SET ( user_parameter = value [, ...] )
+
+
+Description
+===========
+
+``ALTER USER`` applies a change to existing database users. Only existing
+superusers or the user itself have the priviledge to alter an existing database
+user.
+
+
+Arguments
+=========
+
+``SET``
+-------
+
+Changes a user parameter to a different value. The following ``user_parameter``
+are supported to alter an existing user account:
+
+:password: The password as cleartext entered as string literal. ``NULL`` removes
+           the password from the user.
+
+.. note::
+
+    Passwords cannot be set for the ``crate`` superuser. For security reasons it
+    is recommended to authenticate as ``crate`` using a client certificate.

--- a/blackbox/docs/sql/statements/index.txt
+++ b/blackbox/docs/sql/statements/index.txt
@@ -9,6 +9,7 @@ SQL Statements
 
     alter_table
     alter_cluster
+    alter_user
     copy_from
     copy_to
     create_analyzer

--- a/enterprise/users/src/main/java/io/crate/metadata/UsersMetaData.java
+++ b/enterprise/users/src/main/java/io/crate/metadata/UsersMetaData.java
@@ -61,7 +61,7 @@ public class UsersMetaData extends AbstractNamedDiffable<MetaData.Custom> implem
         return users.containsKey(name);
     }
 
-    public void add(String name, @Nullable SecureHash secureHash) {
+    public void put(String name, @Nullable SecureHash secureHash) {
         users.put(name, secureHash);
     }
 

--- a/enterprise/users/src/main/java/io/crate/operation/user/AlterUserRequest.java
+++ b/enterprise/users/src/main/java/io/crate/operation/user/AlterUserRequest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.operation.user;
+
+import io.crate.user.SecureHash;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ValidateActions;
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+public class AlterUserRequest extends AcknowledgedRequest<AlterUserRequest> {
+    private String userName;
+    private SecureHash secureHash;
+
+    public AlterUserRequest() {
+    }
+
+    public AlterUserRequest(String userName, @Nullable SecureHash secureHash) {
+        this.userName = userName;
+        this.secureHash = secureHash;
+    }
+
+    public String userName() {
+        return userName;
+    }
+
+    @Nullable
+    public SecureHash secureHash() {
+        return secureHash;
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        if (userName == null) {
+            return ValidateActions.addValidationError("userName is missing", null);
+        }
+        return null;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        userName = in.readString();
+        secureHash = in.readOptionalWriteable(SecureHash::readFrom);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(userName);
+        out.writeOptionalWriteable(secureHash);
+    }
+}

--- a/enterprise/users/src/main/java/io/crate/operation/user/StatementPrivilegeValidator.java
+++ b/enterprise/users/src/main/java/io/crate/operation/user/StatementPrivilegeValidator.java
@@ -24,6 +24,7 @@ import io.crate.analyze.AlterBlobTableAnalyzedStatement;
 import io.crate.analyze.AlterTableAnalyzedStatement;
 import io.crate.analyze.AlterTableOpenCloseAnalyzedStatement;
 import io.crate.analyze.AlterTableRenameAnalyzedStatement;
+import io.crate.analyze.AlterUserAnalyzedStatement;
 import io.crate.analyze.AnalyzedBegin;
 import io.crate.analyze.AnalyzedDeleteStatement;
 import io.crate.analyze.AnalyzedStatement;
@@ -114,6 +115,15 @@ class StatementPrivilegeValidator implements StatementAuthorizedValidator {
         @Override
         protected Void visitCreateUserStatement(CreateUserAnalyzedStatement analysis, User user) {
             throwUnauthorized(user);
+            return null;
+        }
+
+        @Override
+        public Void visitAlterUserStatement(AlterUserAnalyzedStatement analysis, User user) {
+            // user is allowed to change it's own properties
+            if (!analysis.userName().equals(user.name())) {
+                throwUnauthorized(user);
+            }
             return null;
         }
 

--- a/enterprise/users/src/main/java/io/crate/operation/user/TransportAlterUserAction.java
+++ b/enterprise/users/src/main/java/io/crate/operation/user/TransportAlterUserAction.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.operation.user;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.crate.metadata.UsersMetaData;
+import io.crate.user.SecureHash;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
+import org.elasticsearch.cluster.AckedClusterStateUpdateTask;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Nullable;
+import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+public class TransportAlterUserAction extends TransportMasterNodeAction<AlterUserRequest, WriteUserResponse> {
+
+    @Inject
+    public TransportAlterUserAction(Settings settings,
+                                       TransportService transportService,
+                                       ClusterService clusterService,
+                                       ThreadPool threadPool,
+                                       ActionFilters actionFilters,
+                                       IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, "crate/sql/alter_user", transportService, clusterService, threadPool, actionFilters,
+            indexNameExpressionResolver, AlterUserRequest::new);
+    }
+
+    @Override
+    protected String executor() {
+        return ThreadPool.Names.SAME;
+    }
+
+    @Override
+    protected WriteUserResponse newResponse() {
+        return new WriteUserResponse(true);
+    }
+
+    @Override
+    protected void masterOperation(AlterUserRequest request, ClusterState state, ActionListener<WriteUserResponse> listener) {
+        clusterService.submitStateUpdateTask("alter_user [" + request.userName() + "]",
+            new AckedClusterStateUpdateTask<WriteUserResponse>(Priority.URGENT, request, listener) {
+
+                private boolean userExists = true;
+
+                @Override
+                public ClusterState execute(ClusterState currentState) throws Exception {
+                    MetaData currentMetaData = currentState.metaData();
+                    MetaData.Builder mdBuilder = MetaData.builder(currentMetaData);
+                    userExists = alterUser(
+                        mdBuilder,
+                        request.userName(),
+                        request.secureHash()
+                    );
+                    return ClusterState.builder(currentState).metaData(mdBuilder).build();
+                }
+
+                @Override
+                protected WriteUserResponse newResponse(boolean acknowledged) {
+                    return new WriteUserResponse(acknowledged, userExists);
+                }
+            });
+    }
+
+    @VisibleForTesting
+    static boolean alterUser(MetaData.Builder mdBuilder, String userName, @Nullable SecureHash secureHash) {
+        UsersMetaData oldMetaData = (UsersMetaData) mdBuilder.getCustom(UsersMetaData.TYPE);
+        if (oldMetaData == null || !oldMetaData.contains(userName)) {
+            return false;
+        }
+        // create a new instance of the metadata, to guarantee the cluster changed action.
+        UsersMetaData newMetaData = UsersMetaData.newInstance(oldMetaData);
+        newMetaData.put(userName, secureHash);
+
+        assert !newMetaData.equals(oldMetaData) : "must not be equal to guarantee the cluster change action";
+        mdBuilder.putCustom(UsersMetaData.TYPE, newMetaData);
+
+        return true;
+    }
+
+    @Override
+    protected ClusterBlockException checkBlock(AlterUserRequest request, ClusterState state) {
+        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_WRITE);
+    }
+}

--- a/enterprise/users/src/main/java/io/crate/operation/user/TransportCreateUserAction.java
+++ b/enterprise/users/src/main/java/io/crate/operation/user/TransportCreateUserAction.java
@@ -104,7 +104,7 @@ public class TransportCreateUserAction extends TransportMasterNodeAction<CreateU
         }
         // create a new instance of the metadata, to guarantee the cluster changed action.
         UsersMetaData newMetaData = UsersMetaData.newInstance(oldMetaData);
-        newMetaData.add(name, secureHash);
+        newMetaData.put(name, secureHash);
         assert !newMetaData.equals(oldMetaData) : "must not be equal to guarantee the cluster change action";
         mdBuilder.putCustom(UsersMetaData.TYPE, newMetaData);
 

--- a/enterprise/users/src/main/java/io/crate/plugin/UserManagementModule.java
+++ b/enterprise/users/src/main/java/io/crate/plugin/UserManagementModule.java
@@ -22,6 +22,7 @@
 
 package io.crate.plugin;
 
+import io.crate.operation.user.TransportAlterUserAction;
 import io.crate.operation.user.TransportCreateUserAction;
 import io.crate.operation.user.TransportDropUserAction;
 import io.crate.operation.user.TransportPrivilegesAction;
@@ -36,6 +37,7 @@ public class UserManagementModule extends AbstractModule {
     protected void configure() {
         bind(TransportCreateUserAction.class).asEagerSingleton();
         bind(TransportDropUserAction.class).asEagerSingleton();
+        bind(TransportAlterUserAction.class).asEagerSingleton();
         bind(TransportPrivilegesAction.class).asEagerSingleton();
         bind(UserManager.class).to(UserManagerService.class).asEagerSingleton();
         bind(UserLookup.class).to(UserManagerService.class).asEagerSingleton();

--- a/enterprise/users/src/test/java/io/crate/operation/user/StatementPrivilegeValidatorTest.java
+++ b/enterprise/users/src/test/java/io/crate/operation/user/StatementPrivilegeValidatorTest.java
@@ -83,7 +83,7 @@ public class StatementPrivilegeValidatorTest extends CrateDummyClusterServiceUni
             }
         };
         userManager = new UserManagerService(null, null,
-            null, mock(SysTableRegistry.class), clusterService, new DDLClusterStateService());
+            null, null, mock(SysTableRegistry.class), clusterService, new DDLClusterStateService());
 
         TableIdent myBlobsIdent = new TableIdent(BlobSchemaInfo.NAME, "blobs");
         e = SQLExecutor.builder(clusterService)
@@ -151,6 +151,19 @@ public class StatementPrivilegeValidatorTest extends CrateDummyClusterServiceUni
         expectedException.expect(UnauthorizedException.class);
         expectedException.expectMessage(is("User \"normal\" is not authorized to execute statement"));
         analyze("drop user ford");
+    }
+
+    @Test
+    public void testAlterOtherUsersNotAllowedAsNormalUser() {
+        expectedException.expect(UnauthorizedException.class);
+        expectedException.expectMessage(is("User \"normal\" is not authorized to execute statement"));
+        analyze("alter user ford set password = 'pass'");
+    }
+
+    @Test
+    public void testAlterOwnUserIsAllowed() {
+        analyze("alter user normal set password = 'pass'");
+        assertThat(validationCallArguments.size(), is(0));
     }
 
     @Test

--- a/enterprise/users/src/test/java/io/crate/operation/user/UserManagerServiceTest.java
+++ b/enterprise/users/src/test/java/io/crate/operation/user/UserManagerServiceTest.java
@@ -46,7 +46,7 @@ public class UserManagerServiceTest extends CrateDummyClusterServiceUnitTest {
     @Before
     public void setUpUserManager() throws Exception {
         userManagerService = new UserManagerService(null, null,
-            null, mock(SysTableRegistry.class), clusterService, new DDLClusterStateService());
+            null, null, mock(SysTableRegistry.class), clusterService, new DDLClusterStateService());
     }
 
     @Test

--- a/sql-parser/src/main/antlr/SqlBase.g4
+++ b/sql-parser/src/main/antlr/SqlBase.g4
@@ -53,6 +53,7 @@ statement
     | ALTER TABLE alterTableDefinition RENAME TO qname                               #alterTableRename
     | ALTER TABLE alterTableDefinition REROUTE rerouteOption                         #alterTableReroute
     | ALTER CLUSTER REROUTE RETRY FAILED                                             #alterClusterRerouteRetryFailed
+    | ALTER USER name=ident SET assignment (',' assignment)*                         #alterUser
     | RESET GLOBAL primaryExpression (',' primaryExpression)*                        #resetGlobal
     | SET SESSION CHARACTERISTICS AS TRANSACTION setExpr (setExpr)*                  #setSessionTransactionMode
     | SET (SESSION | LOCAL)? qname

--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -38,6 +38,7 @@ import io.crate.sql.tree.AlterTableAddColumn;
 import io.crate.sql.tree.AlterTableOpenClose;
 import io.crate.sql.tree.AlterTableRename;
 import io.crate.sql.tree.AlterTableReroute;
+import io.crate.sql.tree.AlterUser;
 import io.crate.sql.tree.AnalyzerElement;
 import io.crate.sql.tree.ArithmeticExpression;
 import io.crate.sql.tree.ArrayComparisonExpression;
@@ -774,6 +775,14 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     @Override
     public Node visitAlterClusterRerouteRetryFailed(SqlBaseParser.AlterClusterRerouteRetryFailedContext context) {
         return new AlterClusterRerouteRetryFailed();
+    }
+
+    @Override
+    public Node visitAlterUser(SqlBaseParser.AlterUserContext context) {
+        return new AlterUser(
+            getIdentText(context.name),
+            visit(context.assignment(), Assignment.class)
+        );
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/AlterUser.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AlterUser.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.sql.tree;
+
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
+import com.google.common.base.Preconditions;
+
+import java.util.List;
+
+public class AlterUser extends Statement {
+
+    private final List<Assignment> assignments;
+    private final String name;
+
+    public AlterUser(String name, List<Assignment> assignments) {
+        Preconditions.checkNotNull(assignments, "assignments are null");
+        this.assignments = assignments;
+        this.name = name;
+    }
+
+    public List<Assignment> assignments() {
+        return assignments;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        AlterUser alterUser = (AlterUser) o;
+
+        if (!assignments.equals(alterUser.assignments)) return false;
+        return name.equals(alterUser.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(name, assignments);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+            .add("name", name)
+            .add("assignments", assignments)
+            .toString();
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitAlterUser(this, context);
+    }
+}

--- a/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
@@ -449,6 +449,10 @@ public abstract class AstVisitor<R, C> {
         return visitStatement(node, context);
     }
 
+    public R visitAlterUser(AlterUser node, C context) {
+        return visitStatement(node, context);
+    }
+
     public R visitCopyTo(CopyTo node, C context) {
         return visitStatement(node, context);
     }

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -1130,6 +1130,12 @@ public class TestStatementBuilder {
     }
 
     @Test
+    public void testAlterUser() throws Exception {
+        printStatement("alter user crate set password = 'password'");
+        printStatement("alter user crate set password = null");
+    }
+
+    @Test
     public void testSubSelects() throws Exception {
         printStatement("select * from (select * from foo) as f");
         printStatement("select * from (select * from (select * from foo) as f1) as f2");

--- a/sql/src/main/java/io/crate/action/sql/DDLStatementDispatcher.java
+++ b/sql/src/main/java/io/crate/action/sql/DDLStatementDispatcher.java
@@ -27,6 +27,7 @@ import io.crate.analyze.AlterBlobTableAnalyzedStatement;
 import io.crate.analyze.AlterTableAnalyzedStatement;
 import io.crate.analyze.AlterTableOpenCloseAnalyzedStatement;
 import io.crate.analyze.AlterTableRenameAnalyzedStatement;
+import io.crate.analyze.AlterUserAnalyzedStatement;
 import io.crate.analyze.AnalyzedStatement;
 import io.crate.analyze.AnalyzedStatementVisitor;
 import io.crate.analyze.CreateBlobTableAnalyzedStatement;
@@ -266,6 +267,17 @@ public class DDLStatementDispatcher implements BiFunction<AnalyzedStatement, Row
                 return failedFuture(e);
             }
             return userManager.createUser(analysis.userName(), secureHash);
+        }
+
+        @Override
+        public CompletableFuture<Long> visitAlterUserStatement(AlterUserAnalyzedStatement analysis, Row parameters) {
+            SecureHash secureHash;
+            try {
+                secureHash = UserActions.generateSecureHash(analysis, parameters, functions);
+            } catch (GeneralSecurityException | IllegalArgumentException e) {
+                return failedFuture(e);
+            }
+            return userManager.alterUser(analysis.userName(), secureHash);
         }
 
         @Override

--- a/sql/src/main/java/io/crate/analyze/AlterUserAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/AlterUserAnalyzedStatement.java
@@ -23,18 +23,17 @@
 package io.crate.analyze;
 
 import io.crate.analyze.symbol.Symbol;
-import org.elasticsearch.common.Nullable;
 
 import java.util.Map;
 
-public class CreateUserAnalyzedStatement extends DDLUserAnalyzedStatement {
+public class AlterUserAnalyzedStatement extends DDLUserAnalyzedStatement {
 
-    public CreateUserAnalyzedStatement(String userName, @Nullable Map<String, Symbol> properties) {
+    public AlterUserAnalyzedStatement(String userName, Map<String, Symbol> properties) {
         super(userName, properties);
     }
 
     @Override
     public <C, R> R accept(AnalyzedStatementVisitor<C, R> visitor, C context) {
-        return visitor.visitCreateUserStatement(this, context);
+        return visitor.visitAlterUserStatement(this, context);
     }
 }

--- a/sql/src/main/java/io/crate/analyze/AlterUserAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/AlterUserAnalyzer.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.analyze;
+
+import io.crate.analyze.expressions.ExpressionAnalysisContext;
+import io.crate.analyze.expressions.ExpressionAnalyzer;
+import io.crate.analyze.expressions.ExpressionToStringVisitor;
+import io.crate.analyze.relations.FieldProvider;
+import io.crate.analyze.symbol.Symbol;
+import io.crate.data.Row;
+import io.crate.metadata.Functions;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.table.Operation;
+import io.crate.sql.tree.AlterUser;
+import io.crate.sql.tree.Assignment;
+import io.crate.sql.tree.QualifiedName;
+import org.elasticsearch.common.Nullable;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class AlterUserAnalyzer {
+    private final Functions functions;
+
+    private static final FieldProvider fieldProvider = new FieldProvider() {
+        @Override
+        public Symbol resolveField(QualifiedName qualifiedName, Operation operation) {
+            throw new UnsupportedOperationException("Cannot resolve field references");
+        }
+
+        @Override
+        public Symbol resolveField(QualifiedName qualifiedName, @Nullable List path, Operation operation) {
+            throw new UnsupportedOperationException("Cannot resolve field references");
+        }
+    };
+
+    public AlterUserAnalyzer(Functions functions) {
+        this.functions = functions;
+    }
+
+
+    public AlterUserAnalyzedStatement analyze(AlterUser node, ParamTypeHints typeHints, TransactionContext txnContext) {
+        ExpressionAnalysisContext exprContext = new ExpressionAnalysisContext();
+        ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
+            functions,
+            txnContext,
+            typeHints,
+            fieldProvider,
+            null
+        );
+
+        Map<String, Symbol> rows = new HashMap<>();
+        List<Assignment> assignments = node.assignments();
+
+        for (Assignment assignment : assignments) {
+            Symbol valueSymbol = expressionAnalyzer.convert(assignment.expression(), exprContext);
+            String settingName = ExpressionToStringVisitor.convert(assignment.columnName(), Row.EMPTY);
+            rows.put(settingName, valueSymbol);
+        }
+
+        return new AlterUserAnalyzedStatement(node.name(), rows);
+    }
+}

--- a/sql/src/main/java/io/crate/analyze/AnalyzedStatementVisitor.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedStatementVisitor.java
@@ -123,6 +123,10 @@ public class AnalyzedStatementVisitor<C, R> {
         return visitDDLStatement(analysis, context);
     }
 
+    public R visitAlterUserStatement(AlterUserAnalyzedStatement analysis, C context) {
+        return visitDDLStatement(analysis, context);
+    }
+
     public R visitSetStatement(SetAnalyzedStatement analysis, C context) {
         return visitAnalyzedStatement(analysis, context);
     }

--- a/sql/src/main/java/io/crate/analyze/Analyzer.java
+++ b/sql/src/main/java/io/crate/analyze/Analyzer.java
@@ -37,6 +37,7 @@ import io.crate.sql.tree.AlterTableAddColumn;
 import io.crate.sql.tree.AlterTableOpenClose;
 import io.crate.sql.tree.AlterTableRename;
 import io.crate.sql.tree.AlterTableReroute;
+import io.crate.sql.tree.AlterUser;
 import io.crate.sql.tree.AstVisitor;
 import io.crate.sql.tree.BeginStatement;
 import io.crate.sql.tree.CopyFrom;
@@ -122,6 +123,7 @@ public class Analyzer {
     private final CreateIngestionRuleAnalyzer createIngestionRuleAnalyzer;
     private final AlterTableRerouteAnalyzer alterTableRerouteAnalyzer;
     private final CreateUserAnalyzer createUserAnalyzer;
+    private final AlterUserAnalyzer alterUserAnalyzer;
 
     @Inject
     public Analyzer(Schemas schemas,
@@ -178,6 +180,7 @@ public class Analyzer {
         this.privilegesAnalyzer = new PrivilegesAnalyzer(schemas);
         this.createIngestionRuleAnalyzer = new CreateIngestionRuleAnalyzer(schemas);
         this.createUserAnalyzer = new CreateUserAnalyzer(functions);
+        this.alterUserAnalyzer = new AlterUserAnalyzer(functions);
     }
 
     public Analysis boundAnalyze(Statement statement, TransactionContext transactionContext, ParameterContext parameterContext) {
@@ -379,6 +382,11 @@ public class Analyzer {
                 node.name(),
                 node.ifExists()
             );
+        }
+
+        @Override
+        public AnalyzedStatement visitAlterUser(AlterUser node, Analysis context) {
+            return alterUserAnalyzer.analyze(node, context.paramTypeHints(), context.transactionContext());
         }
 
         @Override

--- a/sql/src/main/java/io/crate/analyze/DDLUserAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/DDLUserAnalyzedStatement.java
@@ -26,15 +26,29 @@ import io.crate.analyze.symbol.Symbol;
 import org.elasticsearch.common.Nullable;
 
 import java.util.Map;
+import java.util.function.Consumer;
 
-public class CreateUserAnalyzedStatement extends DDLUserAnalyzedStatement {
+public abstract class DDLUserAnalyzedStatement implements DDLStatement {
 
-    public CreateUserAnalyzedStatement(String userName, @Nullable Map<String, Symbol> properties) {
-        super(userName, properties);
+    private final String userName;
+    private final Map<String, Symbol> properties;
+
+    public DDLUserAnalyzedStatement(String userName, @Nullable Map<String, Symbol> properties) {
+        this.userName = userName;
+        this.properties = properties;
+    }
+
+    @Nullable
+    public Map<String, Symbol> properties() {
+        return properties;
+    }
+
+    public String userName() {
+        return userName;
     }
 
     @Override
-    public <C, R> R accept(AnalyzedStatementVisitor<C, R> visitor, C context) {
-        return visitor.visitCreateUserStatement(this, context);
+    public void visitSymbols(Consumer<? super Symbol> consumer) {
+        properties.values().forEach(consumer);
     }
 }

--- a/sql/src/main/java/io/crate/operation/user/UserManager.java
+++ b/sql/src/main/java/io/crate/operation/user/UserManager.java
@@ -51,6 +51,15 @@ public interface UserManager extends UserLookup {
     CompletableFuture<Long> dropUser(String userName, boolean ifExists);
 
     /**
+     * Modifies a user
+     *
+     * @param userName name of the existing user to modify
+     * @param secureHash the password-hash consisting of a SHA-512 hash, salt and num. iterations
+     * @return a future which returns the number of rows when the User is modified
+     */
+    CompletableFuture<Long> alterUser(String userName, @Nullable SecureHash secureHash);
+
+    /**
      * Apply given list of {@link Privilege}s for each given user
 
      * @param userNames     List of user names all privileges should be applied for

--- a/sql/src/main/java/io/crate/user/StubUserManager.java
+++ b/sql/src/main/java/io/crate/user/StubUserManager.java
@@ -51,6 +51,13 @@ public class StubUserManager implements UserManager {
     }
 
     @Override
+    public CompletableFuture<Long> alterUser(String userName, @Nullable SecureHash secureHash) {
+        return CompletableFutures.failedFuture(
+            new UnsupportedFeatureException("ALTER USER is only supported in enterprise version")
+        );
+    }
+
+    @Override
     public CompletableFuture<Long> applyPrivileges(Collection<String> userNames, Collection<Privilege> privileges) {
         return CompletableFutures.failedFuture(
             new UnsupportedFeatureException("GRANT or REVOKE privileges is only supported in enterprise version")

--- a/sql/src/test/java/io/crate/analyze/UserDDLAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/UserDDLAnalyzerTest.java
@@ -25,6 +25,7 @@ package io.crate.analyze;
 import io.crate.analyze.symbol.Literal;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
+import io.crate.types.DataTypes;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -74,5 +75,19 @@ public class UserDDLAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         expectedException.expect(UnsupportedOperationException.class);
         expectedException.expectMessage("Cannot resolve field references");
         CreateUserAnalyzedStatement analysis = e.analyze("CREATE USER ROO WITH (PASSWORD = NO_STRING)");
+    }
+
+    @Test
+    public void testAlterUserWithPassword() throws Exception {
+        AlterUserAnalyzedStatement analysis = e.analyze("ALTER USER ROOT SET PASSWORD = 'ROOT'");
+        assertThat(analysis.userName(), is("root"));
+        assertThat(analysis.properties().get("password"), is(Literal.of("ROOT")));
+    }
+
+    @Test
+    public void testAlterUserResetPassword() throws Exception {
+        AlterUserAnalyzedStatement analysis = e.analyze("ALTER USER ROOT SET PASSWORD = NULL");
+        assertThat(analysis.userName(), is("root"));
+        assertThat(analysis.properties().get("password"), is(Literal.of(DataTypes.UNDEFINED, null)));
     }
 }

--- a/sql/src/test/java/io/crate/testing/DummyUserManager.java
+++ b/sql/src/test/java/io/crate/testing/DummyUserManager.java
@@ -52,6 +52,11 @@ public class DummyUserManager implements UserManager {
     }
 
     @Override
+    public CompletableFuture<Long> alterUser(String userName, @Nullable SecureHash secureHash) {
+        return null;
+    }
+
+    @Override
     public CompletableFuture<Long> applyPrivileges(Collection<String> userNames, Collection<Privilege> privileges) {
         return null;
     }

--- a/sql/src/test/java/io/crate/user/UserActionsTest.java
+++ b/sql/src/test/java/io/crate/user/UserActionsTest.java
@@ -28,6 +28,7 @@ import io.crate.analyze.symbol.Literal;
 import io.crate.data.Row;
 import io.crate.metadata.Functions;
 import io.crate.test.integration.CrateUnitTest;
+import io.crate.types.DataTypes;
 import org.elasticsearch.common.settings.SecureString;
 import org.junit.Test;
 
@@ -72,9 +73,15 @@ public class UserActionsTest extends CrateUnitTest {
     }
 
     @Test
+    public void testNoPasswordIfPropertyIsNull() throws Exception {
+        SecureString password = UserActions.getUserPasswordProperty(ImmutableMap.of("password", Literal.of(DataTypes.UNDEFINED, null)), Row.EMPTY, functions);
+        assertNull(password);
+    }
+
+    @Test
     public void testInvalidPasswordProperty() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("\"invalid\" is not a valid setting for CREATE USER");
+        expectedException.expectMessage("\"invalid\" is not a valid user property");
         UserActions.getUserPasswordProperty(ImmutableMap.of("invalid", Literal.of("password")), Row.EMPTY, functions);
     }
 }


### PR DESCRIPTION
This commit adds the ALTER USER ddl-statement which makes it possible to
alter/reset the password for exisiting db users.