### PR TITLE
restrict ALTER TABLE REROUTE statements to superusers only

### DIFF
--- a/enterprise/users/src/main/java/io/crate/operation/user/StatementPrivilegeValidator.java
+++ b/enterprise/users/src/main/java/io/crate/operation/user/StatementPrivilegeValidator.java
@@ -56,6 +56,9 @@ import io.crate.analyze.PrivilegesAnalyzedStatement;
 import io.crate.analyze.QueriedSelectRelation;
 import io.crate.analyze.QueriedTable;
 import io.crate.analyze.RefreshTableAnalyzedStatement;
+import io.crate.analyze.RerouteAllocateReplicaShardAnalyzedStatement;
+import io.crate.analyze.RerouteCancelShardAnalyzedStatement;
+import io.crate.analyze.RerouteMoveShardAnalyzedStatement;
 import io.crate.analyze.RerouteRetryFailedAnalyzedStatement;
 import io.crate.analyze.ResetAnalyzedStatement;
 import io.crate.analyze.RestoreSnapshotAnalyzedStatement;
@@ -143,6 +146,24 @@ class StatementPrivilegeValidator implements StatementAuthorizedValidator {
 
         @Override
         public Void visitRerouteRetryFailedStatement(RerouteRetryFailedAnalyzedStatement analysis, User user) {
+            throwUnauthorized(user);
+            return null;
+        }
+
+        @Override
+        protected Void visitRerouteMoveShard(RerouteMoveShardAnalyzedStatement analysis, User user) {
+            throwUnauthorized(user);
+            return null;
+        }
+
+        @Override
+        protected Void visitRerouteAllocateReplicaShard(RerouteAllocateReplicaShardAnalyzedStatement analysis, User user) {
+            throwUnauthorized(user);
+            return null;
+        }
+
+        @Override
+        protected Void visitRerouteCancelShard(RerouteCancelShardAnalyzedStatement analysis, User user) {
             throwUnauthorized(user);
             return null;
         }

--- a/enterprise/users/src/test/java/io/crate/operation/user/StatementPrivilegeValidatorTest.java
+++ b/enterprise/users/src/test/java/io/crate/operation/user/StatementPrivilegeValidatorTest.java
@@ -189,6 +189,34 @@ public class StatementPrivilegeValidatorTest extends CrateDummyClusterServiceUni
     }
 
     @Test
+    public void testRerouteMoveShardNotAllowedAsNormalUser() {
+        expectedException.expect(UnauthorizedException.class);
+        expectedException.expectMessage(is("User \"normal\" is not authorized to execute statement"));
+        analyze("alter table users reroute move shard 0 from 'node1' to 'node2'");
+    }
+
+    @Test
+    public void testRerouteAllocateReplicaNotAllowedAsNormalUser() {
+        expectedException.expect(UnauthorizedException.class);
+        expectedException.expectMessage(is("User \"normal\" is not authorized to execute statement"));
+        analyze("alter table users reroute allocate replica shard 0 on 'node1'");
+    }
+
+    @Test
+    public void testRerouteCancelNotAllowedAsNormalUser() {
+        expectedException.expect(UnauthorizedException.class);
+        expectedException.expectMessage(is("User \"normal\" is not authorized to execute statement"));
+        analyze("alter table users reroute cancel shard 0 on 'node1'");
+    }
+
+    @Test
+    public void testRerouteRetryFailedNotAllowedAsNormalUser() {
+        expectedException.expect(UnauthorizedException.class);
+        expectedException.expectMessage(is("User \"normal\" is not authorized to execute statement"));
+        analyze("alter cluster reroute retry failed");
+    }
+
+    @Test
     public void testAlterTable() throws Exception {
         analyze("alter table users set (number_of_replicas=1)");
         assertAskedForTable(Privilege.Type.DDL, "doc.users");


### PR DESCRIPTION
No Changelog entry necessary since REROUTE feature is not released yet.