### PR TITLE
Support parameter expressions in the ANY expression without type hints

### DIFF
--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -613,8 +613,10 @@ public class ExpressionAnalyzer {
             Symbol leftSymbol = process(node.getLeft(), context);
             Symbol arraySymbol = process(node.getRight(), context);
 
+            if (arraySymbol.valueType().equals(DataTypes.UNDEFINED)) {
+                arraySymbol = cast(arraySymbol, new ArrayType(leftSymbol.valueType()));
+            }
             DataType arraySymbolType = arraySymbol.valueType();
-
             if (!DataTypes.isCollectionType(arraySymbolType)) {
                 throw new IllegalArgumentException(
                     SymbolFormatter.format("invalid array expression: '%s'", arraySymbol));
@@ -638,18 +640,21 @@ public class ExpressionAnalyzer {
             if (node.getEscape() != null) {
                 throw new UnsupportedOperationException("ESCAPE is not supported.");
             }
-            Symbol rightSymbol = process(node.getValue(), context);
+            Symbol arraySymbol = process(node.getValue(), context);
             Symbol leftSymbol = process(node.getPattern(), context);
-            DataType rightType = rightSymbol.valueType();
 
+            if (arraySymbol.valueType().equals(DataTypes.UNDEFINED)) {
+                arraySymbol = cast(arraySymbol, new ArrayType(leftSymbol.valueType()));
+            }
+            DataType rightType = arraySymbol.valueType();
             if (!DataTypes.isCollectionType(rightType)) {
                 throw new IllegalArgumentException(
-                    SymbolFormatter.format("invalid array expression: '%s'", rightSymbol));
+                    SymbolFormatter.format("invalid array expression: '%s'", arraySymbol));
             }
 
             String operatorName = node.inverse() ? AnyNotLikeOperator.NAME : AnyLikeOperator.NAME;
 
-            ImmutableList<Symbol> arguments = ImmutableList.of(leftSymbol, rightSymbol);
+            ImmutableList<Symbol> arguments = ImmutableList.of(leftSymbol, arraySymbol);
 
             return allocateFunction(
                 operatorName,

--- a/sql/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -44,6 +44,8 @@ import io.crate.metadata.RowGranularity;
 import io.crate.metadata.TableIdent;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.table.TableInfo;
+import io.crate.operation.operator.any.AnyEqOperator;
+import io.crate.operation.operator.any.AnyLikeOperator;
 import io.crate.operation.scalar.conditional.CoalesceFunction;
 import io.crate.sql.parser.SqlParser;
 import io.crate.sql.tree.ArrayLiteral;
@@ -65,6 +67,7 @@ import java.util.EnumSet;
 import java.util.Map;
 
 import static io.crate.testing.SymbolMatchers.isField;
+import static io.crate.testing.SymbolMatchers.isFunction;
 import static io.crate.testing.SymbolMatchers.isLiteral;
 import static io.crate.testing.TestingHelpers.getFunctions;
 import static io.crate.testing.TestingHelpers.isSQL;
@@ -306,5 +309,17 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     public void testBetweenIsEagerlyEvaluatedIfPossible() throws Exception {
         Symbol x = expressions.asSymbol("5 between 1 and 10");
         assertThat(x, isLiteral(true));
+    }
+
+    @Test
+    public void testParameterExpressionInAny() throws Exception {
+        Symbol s = expressions.asSymbol("5 = ANY(?)");
+        assertThat(s, isFunction(AnyEqOperator.NAME, isLiteral(5L), instanceOf(ParameterSymbol.class)));
+    }
+
+    @Test
+    public void testParameterExpressionInLikeAny() throws Exception {
+        Symbol s = expressions.asSymbol("5 LIKE ANY(?)");
+        assertThat(s, isFunction(AnyLikeOperator.NAME, isLiteral(5L), instanceOf(ParameterSymbol.class)));
     }
 }


### PR DESCRIPTION
Parameter expressions inside ANY didn't work with postgres based clients
that do not send type hints. (asyncpg, pgx, ... etc)

A statement like

    SELECT * FROM t WHERE x = ANY(?)

would fail with the following error:

    invalid array expression: '$1'