### PR TITLE
Replace PlannerContext.toInteger with SymbolEvaluator

### DIFF
--- a/sql/src/main/java/io/crate/analyze/SymbolEvaluator.java
+++ b/sql/src/main/java/io/crate/analyze/SymbolEvaluator.java
@@ -53,7 +53,8 @@ public final class SymbolEvaluator extends BaseImplementationSymbolVisitor<Row> 
     }
 
     public static Object evaluate(Functions functions,
-                                  Symbol symbol, Row params,
+                                  Symbol symbol,
+                                  Row params,
                                   Map<SelectSymbol, Object> subQueryValues) {
         SymbolEvaluator symbolEval = new SymbolEvaluator(functions, subQueryValues);
         return symbolEval.process(symbol, params).value();

--- a/sql/src/main/java/io/crate/planner/Planner.java
+++ b/sql/src/main/java/io/crate/planner/Planner.java
@@ -36,7 +36,6 @@ import io.crate.analyze.DCLStatement;
 import io.crate.analyze.DDLStatement;
 import io.crate.analyze.DropBlobTableAnalyzedStatement;
 import io.crate.analyze.DropTableAnalyzedStatement;
-import io.crate.analyze.EvaluatingNormalizer;
 import io.crate.analyze.ExplainAnalyzedStatement;
 import io.crate.analyze.InsertFromSubQueryAnalyzedStatement;
 import io.crate.analyze.InsertFromValuesAnalyzedStatement;
@@ -90,7 +89,6 @@ public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
     private static final Logger LOGGER = Loggers.getLogger(Planner.class);
 
     private final ClusterService clusterService;
-    private final EvaluatingNormalizer normalizer;
     private final LogicalPlanner logicalPlanner;
     private final Functions functions;
 
@@ -102,7 +100,6 @@ public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
         this.clusterService = clusterService;
         this.functions = functions;
         this.logicalPlanner = new LogicalPlanner(functions, tableStats);
-        this.normalizer = EvaluatingNormalizer.functionOnlyNormalizer(functions);
 
         this.awarenessAttributes =
             AwarenessAllocationDecider.CLUSTER_ROUTING_ALLOCATION_AWARENESS_ATTRIBUTE_SETTING.get(settings);
@@ -117,10 +114,6 @@ public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
 
     public String[] getAwarenessAttributes() {
         return awarenessAttributes;
-    }
-
-    public EvaluatingNormalizer normalizer() {
-        return normalizer;
     }
 
     public ClusterState currentClusterState() {
@@ -366,6 +359,10 @@ public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
             indices = whereClause.partitions().toArray(new String[whereClause.partitions().size()]);
         }
         return indices;
+    }
+
+    public Functions functions() {
+        return functions;
     }
 }
 

--- a/sql/src/main/java/io/crate/planner/operators/Limit.java
+++ b/sql/src/main/java/io/crate/planner/operators/Limit.java
@@ -45,6 +45,8 @@ import java.util.List;
 import java.util.Map;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static io.crate.analyze.SymbolEvaluator.evaluate;
+import static io.crate.planner.operators.LogicalPlanner.NO_LIMIT;
 
 class Limit implements LogicalPlan {
 
@@ -78,8 +80,10 @@ class Limit implements LogicalPlan {
                                @Nullable Integer pageSizeHint,
                                Row params,
                                Map<SelectSymbol, Object> subQueryValues) {
-        int limit = firstNonNull(plannerContext.toInteger(this.limit), LogicalPlanner.NO_LIMIT);
-        int offset = firstNonNull(plannerContext.toInteger(this.offset), 0);
+        int limit = firstNonNull(
+            DataTypes.INTEGER.value(evaluate(plannerContext.functions(), this.limit, params, subQueryValues)), NO_LIMIT);
+        int offset = firstNonNull(
+            DataTypes.INTEGER.value(evaluate(plannerContext.functions(), this.offset, params, subQueryValues)), 0);
 
         ExecutionPlan executionPlan = source.build(
             plannerContext, projectionBuilder, limit, offset, order, pageSizeHint, params, subQueryValues);

--- a/sql/src/main/java/io/crate/protocols/postgres/BatchPortal.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/BatchPortal.java
@@ -139,7 +139,7 @@ class BatchPortal extends AbstractPortal {
                 planner.currentClusterState(),
                 routingProvider,
                 jobId,
-                planner.normalizer(),
+                planner.functions(),
                 transactionContext,
                 0,
                 0

--- a/sql/src/main/java/io/crate/protocols/postgres/BulkPortal.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/BulkPortal.java
@@ -129,7 +129,7 @@ class BulkPortal extends AbstractPortal {
             planner.currentClusterState(),
             routingProvider,
             jobId,
-            planner.normalizer(),
+            planner.functions(),
             transactionContext,
             0,
             maxRows

--- a/sql/src/main/java/io/crate/protocols/postgres/SimplePortal.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/SimplePortal.java
@@ -168,7 +168,7 @@ public class SimplePortal extends AbstractPortal {
             planner.currentClusterState(),
             routingProvider,
             jobId,
-            planner.normalizer(),
+            planner.functions(),
             transactionContext,
             defaultLimit,
             maxRows
@@ -213,7 +213,7 @@ public class SimplePortal extends AbstractPortal {
             planner.currentClusterState(),
             routingProvider,
             jobId,
-            planner.normalizer(),
+            planner.functions(),
             transactionContext,
             defaultLimit,
             maxRows

--- a/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
@@ -50,10 +50,10 @@ import io.crate.metadata.TransactionContext;
 import io.crate.metadata.table.TableInfo;
 import io.crate.operation.Paging;
 import io.crate.operation.user.User;
+import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Plan;
 import io.crate.planner.Planner;
 import io.crate.planner.PlannerContext;
-import io.crate.planner.DependencyCarrier;
 import io.crate.plugin.BlobPlugin;
 import io.crate.plugin.CrateCorePlugin;
 import io.crate.plugin.HttpTransportPlugin;
@@ -415,7 +415,7 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
             planner.currentClusterState(),
             routingProvider,
             UUID.randomUUID(),
-            planner.normalizer(),
+            planner.functions(),
             transactionContext,
             0,
             0

--- a/sql/src/test/java/io/crate/planner/PlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/PlannerTest.java
@@ -1,7 +1,6 @@
 package io.crate.planner;
 
 import io.crate.action.sql.SessionContext;
-import io.crate.analyze.EvaluatingNormalizer;
 import io.crate.analyze.WhereClause;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.RoutingProvider;
@@ -33,12 +32,10 @@ import static org.hamcrest.core.Is.is;
 public class PlannerTest extends CrateDummyClusterServiceUnitTest {
 
     private SQLExecutor e;
-    private EvaluatingNormalizer normalizer;
 
     @Before
     public void prepare() {
         e = SQLExecutor.builder(clusterService).build();
-        normalizer = EvaluatingNormalizer.functionOnlyNormalizer(e.functions());
     }
 
     @Test
@@ -85,7 +82,7 @@ public class PlannerTest extends CrateDummyClusterServiceUnitTest {
             clusterService.state(),
             new RoutingProvider(Randomness.get().nextInt(), new String[0]),
             UUID.randomUUID(),
-            normalizer,
+            e.functions(),
             new TransactionContext(SessionContext.create()),
             0,
             0);

--- a/sql/src/test/java/io/crate/testing/SQLExecutor.java
+++ b/sql/src/test/java/io/crate/testing/SQLExecutor.java
@@ -136,7 +136,7 @@ public class SQLExecutor {
             clusterState,
             new RoutingProvider(random.nextInt(), new String[0]),
             UUID.randomUUID(),
-            planner.normalizer(),
+            functions,
             new TransactionContext(sessionContext),
             -1,
             -1
@@ -359,7 +359,7 @@ public class SQLExecutor {
             planner.currentClusterState(),
             routingProvider,
             jobId,
-            planner.normalizer(),
+            functions,
             transactionContext,
             softLimit,
             fetchSize
@@ -406,7 +406,7 @@ public class SQLExecutor {
             planner.currentClusterState(),
             routingProvider,
             UUID.randomUUID(),
-            planner.normalizer(),
+            functions,
             transactionContext,
             0,
             0


### PR DESCRIPTION
To keep supporting `select * from t1 limit ?` once we've removed the bound select analyzer.