### PR TITLE
expose cgroup metrics to `_node` expression

### DIFF
--- a/sql/src/main/java/io/crate/operation/reference/sys/node/local/NodeOsCgroupExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/local/NodeOsCgroupExpression.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.operation.reference.sys.node.local;
+
+import io.crate.metadata.ReferenceImplementation;
+import io.crate.monitor.ExtendedOsStats;
+import io.crate.operation.reference.NestedObjectExpression;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.lucene.BytesRefs;
+import org.elasticsearch.monitor.os.OsStats;
+
+public class NodeOsCgroupExpression extends NestedObjectExpression {
+
+    private static final String CPUACCT = "cpuacct";
+    private static final String CPU = "cpu";
+    private static final String MEM = "mem";
+
+    NodeOsCgroupExpression(ExtendedOsStats extendedOsStats) {
+        OsStats.Cgroup cgroup = extendedOsStats.osStats().getCgroup();
+        ExtendedOsStats.CgroupMem cgroupMem = extendedOsStats.cgroupMem();
+        childImplementations.put(CPUACCT, new NodeOsCgroupCpuAcctExpression(cgroup));
+        childImplementations.put(CPU, new NodeOsCgroupCpuExpression(cgroup));
+        childImplementations.put(MEM, new NodeOsCgroupMemExpression(cgroupMem));
+    }
+
+    private class NodeOsCgroupCpuAcctExpression extends NestedObjectExpression {
+
+        private static final String CONTROL_GROUP = "control_group";
+        private static final String USAGE_NANOS = "usage_nanos";
+
+        NodeOsCgroupCpuAcctExpression(OsStats.Cgroup cgroup) {
+            childImplementations.put(CONTROL_GROUP, (ReferenceImplementation<BytesRef>) () -> {
+                if (cgroup != null) {
+                    return BytesRefs.toBytesRef(cgroup.getCpuAcctControlGroup());
+                }
+                return null;
+            });
+            childImplementations.put(USAGE_NANOS, (ReferenceImplementation<Long>) () -> {
+                if (cgroup != null) {
+                    return cgroup.getCpuAcctUsageNanos();
+                }
+                return null;
+            });
+        }
+    }
+
+    private class NodeOsCgroupCpuExpression extends NestedObjectExpression {
+
+        private static final String CONTROL_GROUP = "control_group";
+        private static final String CFS_PERIOD_MICROS = "cfs_period_micros";
+        private static final String CFS_QUOTA_MICROS = "cfs_quota_micros";
+        private static final String NUM_ELAPSED_PERIODS = "num_elapsed_periods";
+        private static final String NUM_TIMES_THROTTLED = "num_times_throttled";
+        private static final String TIME_THROTTLED_NANOS = "time_throttled_nanos";
+
+        NodeOsCgroupCpuExpression(OsStats.Cgroup cgroup) {
+            childImplementations.put(CONTROL_GROUP, (ReferenceImplementation<BytesRef>) () -> {
+                if (cgroup != null) {
+                    return BytesRefs.toBytesRef(cgroup.getCpuControlGroup());
+                }
+                return null;
+            });
+            childImplementations.put(CFS_PERIOD_MICROS, (ReferenceImplementation<Long>) () -> {
+                if (cgroup != null) {
+                    return cgroup.getCpuCfsPeriodMicros();
+                }
+                return null;
+            });
+            childImplementations.put(CFS_QUOTA_MICROS, (ReferenceImplementation<Long>) () -> {
+                if (cgroup != null) {
+                    return cgroup.getCpuCfsQuotaMicros();
+                }
+                return null;
+            });
+            childImplementations.put(NUM_ELAPSED_PERIODS, (ReferenceImplementation<Long>) () -> {
+                if (cgroup != null) {
+                    return cgroup.getCpuStat().getNumberOfElapsedPeriods();
+                }
+                return null;
+            });
+            childImplementations.put(NUM_TIMES_THROTTLED, (ReferenceImplementation<Long>) () -> {
+                if (cgroup != null) {
+                    return cgroup.getCpuStat().getNumberOfTimesThrottled();
+                }
+                return null;
+            });
+            childImplementations.put(TIME_THROTTLED_NANOS, (ReferenceImplementation<Long>) () -> {
+                if (cgroup != null) {
+                    return cgroup.getCpuStat().getTimeThrottledNanos();
+                }
+                return null;
+            });
+        }
+    }
+
+    private class NodeOsCgroupMemExpression extends NestedObjectExpression {
+
+        private static final String CONTROL_GROUP = "control_group";
+        private static final String LIMIT_BYTES = "limit_bytes";
+        private static final String USAGE_BYTES = "usage_bytes";
+
+        public NodeOsCgroupMemExpression(ExtendedOsStats.CgroupMem cgroupMem) {
+            childImplementations.put(CONTROL_GROUP, (ReferenceImplementation<BytesRef>) () -> {
+                if (cgroupMem != null) {
+                    return BytesRefs.toBytesRef(cgroupMem.memoryControlGroup());
+                }
+                return null;
+            });
+            childImplementations.put(LIMIT_BYTES, (ReferenceImplementation<BytesRef>) () -> {
+                if (cgroupMem != null) {
+                    return BytesRefs.toBytesRef(cgroupMem.memoryLimitBytes());
+                }
+                return null;
+            });
+            childImplementations.put(USAGE_BYTES, (ReferenceImplementation<BytesRef>) () -> {
+                if (cgroupMem != null) {
+                    return BytesRefs.toBytesRef(cgroupMem.memoryUsageBytes());
+                }
+                return null;
+            });
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/local/NodeOsExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/local/NodeOsExpression.java
@@ -32,6 +32,7 @@ class NodeOsExpression extends NestedObjectExpression {
     private static final String UPTIME = "uptime";
     private static final String TIMESTAMP = "timestamp";
     private static final String PROBE_TIMESTAMP = "probe_timestamp";
+    private static final String CGROUP = "cgroup";
 
     NodeOsExpression(ExtendedOsStats extendedOsStats) {
         addChildImplementations(extendedOsStats);
@@ -55,5 +56,6 @@ class NodeOsExpression extends NestedObjectExpression {
         });
         childImplementations.put(PROBE_TIMESTAMP, extendedOsStats::timestamp);
         childImplementations.put(CPU, new NodeOsCpuExpression(extendedOsStats.cpu()));
+        childImplementations.put(CGROUP, new NodeOsCgroupExpression(extendedOsStats));
     }
 }

--- a/sql/src/test/java/io/crate/monitor/DummyExtendedNodeInfo.java
+++ b/sql/src/test/java/io/crate/monitor/DummyExtendedNodeInfo.java
@@ -24,7 +24,6 @@ package io.crate.monitor;
 
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.env.NodeEnvironment;
-import org.elasticsearch.monitor.os.OsProbe;
 import org.elasticsearch.monitor.os.OsStats;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -82,9 +81,14 @@ public class DummyExtendedNodeInfo implements ExtendedNodeInfo {
 
     @Override
     public ExtendedOsStats osStats() {
+        OsStats.Cpu cpu = new OsStats.Cpu((short) 50, new double[]{0.1, 0.2, 0.3});
+        OsStats.Mem mem = new OsStats.Mem(2048L, 1024L);
+        OsStats.Swap swap = new OsStats.Swap(512L, 256L);
+        OsStats.Cgroup.CpuStat cpuStat= new OsStats.Cgroup.CpuStat(1L, 2L, 3L);
+        OsStats.Cgroup cgroup = new OsStats.Cgroup("/cpuacct", 100L, "/cpu", 80L, 50L, cpuStat);
         ExtendedOsStats.Cpu cpuStats = new ExtendedOsStats.Cpu((short) 0, (short) 4, (short) 94, (short) 10);
-        ExtendedOsStats.CgroupMem cgroupMemStats = new ExtendedOsStats.CgroupMem();
-        OsStats osStats = OsProbe.getInstance().osStats();
+        ExtendedOsStats.CgroupMem cgroupMemStats = new ExtendedOsStats.CgroupMem("/", "2048", "1024");
+        OsStats osStats = new OsStats(1000L, cpu, mem, swap, cgroup);
         ExtendedOsStats extendedOsStats = new ExtendedOsStats(cpuStats, osStats, cgroupMemStats);
         extendedOsStats.uptime(3600L);
         extendedOsStats.loadAverage(new double[]{1, 5, 15});

--- a/sql/src/test/java/io/crate/operation/reference/sys/SysNodesExpressionsTest.java
+++ b/sql/src/test/java/io/crate/operation/reference/sys/SysNodesExpressionsTest.java
@@ -289,6 +289,18 @@ public class SysNodesExpressionsTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
+    public void testOsCgroup() {
+        Reference refInfo = refInfo("sys.nodes.os", DataTypes.OBJECT, RowGranularity.NODE);
+        io.crate.operation.reference.NestedObjectExpression os =
+            (io.crate.operation.reference.NestedObjectExpression) nodeSysExpression.getChildImplementation(refInfo.ident().columnIdent().name());
+        Map<String, Object> v = os.value();
+        Map<String, Object> cgroup = (Map<String, Object>) v.get("cgroup");
+        assertThat(mapToSortedString(cgroup), is("cpu={cfs_period_micros=80, cfs_quota_micros=50, control_group=/cpu, " +
+            "num_elapsed_periods=1, num_times_throttled=2, time_throttled_nanos=3}, cpuacct={control_group=/cpuacct, " +
+            "usage_nanos=100}, mem={control_group=/, limit_bytes=2048, usage_bytes=1024}"));
+    }
+
+    @Test
     public void testProcess() throws Exception {
         Reference refInfo = refInfo("sys.nodes.process", DataTypes.OBJECT, RowGranularity.NODE);
         io.crate.operation.reference.NestedObjectExpression processRef = (io.crate.operation.reference.NestedObjectExpression)

--- a/sql/src/test/java/io/crate/operation/reference/sys/node/local/NodeOsExpressionTest.java
+++ b/sql/src/test/java/io/crate/operation/reference/sys/node/local/NodeOsExpressionTest.java
@@ -25,6 +25,7 @@ package io.crate.operation.reference.sys.node.local;
 import io.crate.metadata.ReferenceImplementation;
 import io.crate.monitor.ExtendedOsStats;
 import io.crate.test.integration.CrateUnitTest;
+import org.elasticsearch.monitor.os.OsStats;
 import org.junit.Test;
 
 import static org.mockito.Mockito.mock;
@@ -33,8 +34,10 @@ public class NodeOsExpressionTest extends CrateUnitTest {
 
     @Test
     public void testOsTimestampNotEvaluatedTwice() throws Exception {
-        ExtendedOsStats osStats = mock(ExtendedOsStats.class);
-        NodeOsExpression nodeOsExpression = new NodeOsExpression(osStats);
+        ExtendedOsStats.Cpu cpu = mock(ExtendedOsStats.Cpu.class);
+        OsStats osStats = mock(OsStats.class);
+        ExtendedOsStats extendedOsStats = new ExtendedOsStats(cpu, osStats, null);
+        NodeOsExpression nodeOsExpression = new NodeOsExpression(extendedOsStats);
         ReferenceImplementation timestampExpr = nodeOsExpression.getChildImplementation("timestamp");
         Long ts1 = (Long) timestampExpr.value();
         Thread.sleep(10L);


### PR DESCRIPTION
this commit adds the missing cgroup metrics introduced on `sys.nodes`
with 33cab6f914c89db5836830ae263728defeb9b8dc to the `_node` expression
as well.