### PR TITLE
"Push down" UNION OrderBy to source relations

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -39,6 +39,10 @@ Breaking Changes
 Changes
 =======
 
+- Added an optimization when UNION ALL is used with ORDER BY. The ORDER BY is
+  now "pushed down" to the left and right side of the union which improves the
+  sorting speed.
+
 - Added support for disabling the column store per ``STRING`` column on table
   creation and on adding columns. In conjunction with disabling indexing on that
   column, this will support storing strings greater than 32kb. Be aware that the

--- a/sql/src/main/java/io/crate/planner/operators/Collect.java
+++ b/sql/src/main/java/io/crate/planner/operators/Collect.java
@@ -81,15 +81,13 @@ import static io.crate.planner.operators.OperatorUtils.getUnusedColumns;
  *  {@link FetchOrEval} will then later use {@code fetchId} to fetch the values for the columns which are "unused".
  *  See also {@link LogicalPlan.Builder#build(TableStats, Set)}
  */
-class Collect implements LogicalPlan {
+class Collect extends ZeroInputPlan {
 
     private static final String COLLECT_PHASE_NAME = "collect";
     final QueriedTableRelation relation;
     final WhereClause where;
 
-    final List<Symbol> toCollect;
     final TableInfo tableInfo;
-    private final List<AbstractTableRelation> baseTables;
     private final long numExpectedRows;
 
     public static LogicalPlan.Builder create(QueriedTableRelation relation, List<Symbol> toCollect, WhereClause where) {
@@ -102,6 +100,9 @@ class Collect implements LogicalPlan {
                     WhereClause where,
                     Set<Symbol> usedBeforeNextFetch,
                     long numExpectedRows) {
+        super(
+            generateOutputs(toCollect, relation.tableRelation(), usedBeforeNextFetch, where),
+            Collections.singletonList(relation.tableRelation()));
 
         this.numExpectedRows = numExpectedRows;
         if (where.hasVersions()) {
@@ -109,16 +110,20 @@ class Collect implements LogicalPlan {
         }
         this.relation = relation;
         this.where = where;
-        this.baseTables = Collections.singletonList(relation.tableRelation());
-        AbstractTableRelation tableRelation = relation.tableRelation();
         this.tableInfo = relation.tableRelation().tableInfo();
+    }
+
+    private static List<Symbol> generateOutputs(List<Symbol> toCollect,
+                                                AbstractTableRelation tableRelation,
+                                                Set<Symbol> usedBeforeNextFetch,
+                                                WhereClause where) {
         if (tableRelation instanceof DocTableRelation) {
-            this.toCollect = generateToCollectWithFetch(tableInfo.ident(), toCollect, usedBeforeNextFetch);
+            return generateToCollectWithFetch(((DocTableRelation) tableRelation).tableInfo().ident(), toCollect, usedBeforeNextFetch);
         } else {
-            this.toCollect = toCollect;
             if (where.hasQuery()) {
                 NoPredicateVisitor.ensureNoMatchPredicate(where.query());
             }
+            return toCollect;
         }
     }
 
@@ -171,9 +176,9 @@ class Collect implements LogicalPlan {
             collectPhase,
             TopN.NO_LIMIT,
             0,
-            toCollect.size(),
+            outputs.size(),
             limitAndOffset,
-            PositionalOrderBy.of(order, toCollect)
+            PositionalOrderBy.of(order, outputs)
         );
     }
 
@@ -204,7 +209,7 @@ class Collect implements LogicalPlan {
                 tableFunctionRelation.functionImplementation(),
                 functionArguments,
                 Collections.emptyList(),
-                toCollect,
+                outputs,
                 where
             );
         }
@@ -218,7 +223,7 @@ class Collect implements LogicalPlan {
                 RoutingProvider.ShardSelection.ANY,
                 sessionContext),
             tableInfo.rowGranularity(),
-            toCollect,
+            outputs,
             Collections.emptyList(),
             where,
             DistributionInfo.DEFAULT_BROADCAST,
@@ -227,36 +232,11 @@ class Collect implements LogicalPlan {
     }
 
     @Override
-    public LogicalPlan tryCollapse() {
-        return this;
-    }
-
-    @Override
-    public List<Symbol> outputs() {
-        return toCollect;
-    }
-
-    @Override
     public boolean preferShardProjections() {
         // Can't run on shard level for system tables
         // (Except tables like sys.shards, but in that case it's better to run operations per node as well,
         // because otherwise we'd use 1 thread per row which is unnecessary overhead and may use up all available threads)
         return tableInfo instanceof DocTableInfo;
-    }
-
-    public Map<Symbol, Symbol> expressionMapping() {
-        return Collections.emptyMap();
-    }
-
-
-    @Override
-    public List<AbstractTableRelation> baseTables() {
-        return baseTables;
-    }
-
-    @Override
-    public Map<LogicalPlan, SelectSymbol> dependencies() {
-        return Collections.emptyMap();
     }
 
     @Override
@@ -268,7 +248,7 @@ class Collect implements LogicalPlan {
     public String toString() {
         return "Collect{" +
                tableInfo.ident() +
-               ", [" + ExplainLeaf.printList(toCollect) +
+               ", [" + ExplainLeaf.printList(outputs) +
                "], " + where +
                '}';
     }

--- a/sql/src/main/java/io/crate/planner/operators/Count.java
+++ b/sql/src/main/java/io/crate/planner/operators/Count.java
@@ -27,7 +27,6 @@ import io.crate.analyze.WhereClause;
 import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.SelectSymbol;
-import io.crate.analyze.symbol.Symbol;
 import io.crate.data.Row;
 import io.crate.metadata.Routing;
 import io.crate.metadata.RoutingProvider;
@@ -44,26 +43,21 @@ import io.crate.types.DataTypes;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 /**
  * An optimized version for "select count(*) from t where ..."
  */
-public class Count implements LogicalPlan {
+public class Count extends ZeroInputPlan {
 
     private static final String COUNT_PHASE_NAME = "count-merge";
 
     final AbstractTableRelation<TableInfo> tableRelation;
     final WhereClause where;
 
-    private final List<Symbol> outputs;
-    private final List<AbstractTableRelation> baseTables;
-
     Count(Function countFunction, AbstractTableRelation<TableInfo> tableRelation, WhereClause where) {
-        this.outputs = Collections.singletonList(countFunction);
+        super(Collections.singletonList(countFunction), Collections.singletonList(tableRelation));
         this.tableRelation = tableRelation;
-        this.baseTables = Collections.singletonList(tableRelation);
         this.where = where;
     }
 
@@ -101,31 +95,6 @@ public class Count implements LogicalPlan {
             null
         );
         return new CountPlan(countPhase, mergePhase);
-    }
-
-    @Override
-    public LogicalPlan tryCollapse() {
-        return this;
-    }
-
-    @Override
-    public List<Symbol> outputs() {
-        return outputs;
-    }
-
-    @Override
-    public Map<Symbol, Symbol> expressionMapping() {
-        return Collections.emptyMap();
-    }
-
-    @Override
-    public List<AbstractTableRelation> baseTables() {
-        return baseTables;
-    }
-
-    @Override
-    public Map<LogicalPlan, SelectSymbol> dependencies() {
-        return Collections.emptyMap();
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/FetchOrEval.java
+++ b/sql/src/main/java/io/crate/planner/operators/FetchOrEval.java
@@ -106,10 +106,7 @@ import static io.crate.planner.operators.OperatorUtils.getUnusedColumns;
  *                Fetch 500
  * </pre>
  */
-class FetchOrEval implements LogicalPlan {
-
-    final LogicalPlan source;
-    final List<Symbol> outputs;
+class FetchOrEval extends OneInputPlan {
 
     private final FetchMode fetchMode;
     private final boolean doFetch;
@@ -170,8 +167,7 @@ class FetchOrEval implements LogicalPlan {
     }
 
     private FetchOrEval(LogicalPlan source, List<Symbol> outputs, FetchMode fetchMode, boolean doFetch) {
-        this.source = source;
-        this.outputs = outputs;
+        super(source, outputs);
         this.fetchMode = fetchMode;
         this.doFetch = doFetch;
     }
@@ -435,37 +431,8 @@ class FetchOrEval implements LogicalPlan {
     }
 
     @Override
-    public LogicalPlan tryCollapse() {
-        LogicalPlan collapsed = source.tryCollapse();
-        if (collapsed == this) {
-            return this;
-        }
-        return new FetchOrEval(collapsed, outputs, fetchMode, doFetch);
-    }
-
-    @Override
-    public List<Symbol> outputs() {
-        return outputs;
-    }
-
-    @Override
-    public Map<Symbol, Symbol> expressionMapping() {
-        return source.expressionMapping();
-    }
-
-    @Override
-    public List<AbstractTableRelation> baseTables() {
-        return source.baseTables();
-    }
-
-    @Override
-    public Map<LogicalPlan, SelectSymbol> dependencies() {
-        return source.dependencies();
-    }
-
-    @Override
-    public long numExpectedRows() {
-        return source.numExpectedRows();
+    protected LogicalPlan newInstance(LogicalPlan newSource) {
+        return new FetchOrEval(newSource, outputs, fetchMode, doFetch);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/Filter.java
+++ b/sql/src/main/java/io/crate/planner/operators/Filter.java
@@ -25,7 +25,6 @@ package io.crate.planner.operators;
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.QueryClause;
 import io.crate.analyze.WhereClause;
-import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.SelectSymbol;
 import io.crate.analyze.symbol.Symbol;
@@ -39,15 +38,13 @@ import io.crate.types.DataTypes;
 
 import javax.annotation.Nullable;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import static io.crate.planner.operators.LogicalPlanner.extractColumns;
 
-class Filter implements LogicalPlan {
+class Filter extends OneInputPlan {
 
-    final LogicalPlan source;
     final QueryClause queryClause;
 
     static LogicalPlan.Builder create(LogicalPlan.Builder sourceBuilder, @Nullable QueryClause queryClause) {
@@ -84,7 +81,7 @@ class Filter implements LogicalPlan {
     }
 
     private Filter(LogicalPlan source, QueryClause queryClause) {
-        this.source = source;
+        super(source);
         this.queryClause = queryClause;
     }
 
@@ -108,37 +105,7 @@ class Filter implements LogicalPlan {
     }
 
     @Override
-    public LogicalPlan tryCollapse() {
-        LogicalPlan collapsed = source.tryCollapse();
-        if (collapsed == source) {
-            return this;
-        }
-        return new Filter(collapsed, queryClause);
-    }
-
-    @Override
-    public List<Symbol> outputs() {
-        return source.outputs();
-    }
-
-    @Override
-    public Map<Symbol, Symbol> expressionMapping() {
-        return source.expressionMapping();
-    }
-
-    @Override
-    public List<AbstractTableRelation> baseTables() {
-        return source.baseTables();
-    }
-
-    @Override
-    public Map<LogicalPlan, SelectSymbol> dependencies() {
-        return source.dependencies();
-    }
-
-    @Override
-    public long numExpectedRows() {
-        // We don't have any cardinality estimates
-        return source.numExpectedRows();
+    protected LogicalPlan newInstance(LogicalPlan newSource) {
+        return new Filter(newSource, queryClause);
     }
 }

--- a/sql/src/main/java/io/crate/planner/operators/Get.java
+++ b/sql/src/main/java/io/crate/planner/operators/Get.java
@@ -24,7 +24,6 @@ package io.crate.planner.operators;
 
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.QuerySpec;
-import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.relations.DocTableRelation;
 import io.crate.analyze.relations.QueriedDocTable;
 import io.crate.analyze.symbol.SelectSymbol;
@@ -44,7 +43,7 @@ import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 
-public class Get implements LogicalPlan {
+public class Get extends ZeroInputPlan {
 
     public static LogicalPlan create(QueriedDocTable table) {
         QuerySpec querySpec = table.querySpec();
@@ -64,15 +63,14 @@ public class Get implements LogicalPlan {
     private final DocTableRelation tableRelation;
     private final QuerySpec querySpec;
     private final DocKeys docKeys;
-    private final List<Symbol> outputs;
     private final Symbol limit;
     private final Symbol offset;
 
     private Get(QueriedDocTable table, DocKeys docKeys, List<Symbol> outputs, Symbol limit, Symbol offset) {
+        super(outputs, Collections.singletonList(table.tableRelation()));
         this.tableRelation = table.tableRelation();
         this.querySpec = table.querySpec();
         this.docKeys = docKeys;
-        this.outputs = outputs;
         this.limit = limit;
         this.offset = offset;
     }
@@ -99,32 +97,6 @@ public class Get implements LogicalPlan {
         );
     }
 
-    @Override
-    public LogicalPlan tryCollapse() {
-        return this;
-    }
-
-    @Override
-    public List<Symbol> outputs() {
-        return outputs;
-    }
-
-    @Override
-    public Map<Symbol, Symbol> expressionMapping() {
-        return Collections.emptyMap();
-    }
-
-    @Override
-    public List<AbstractTableRelation> baseTables() {
-        return Collections.singletonList(tableRelation);
-    }
-
-    @Override
-    public Map<LogicalPlan, SelectSymbol> dependencies() {
-        return Collections.emptyMap();
-    }
-
-    @Override
     public long numExpectedRows() {
         return docKeys.size();
     }

--- a/sql/src/main/java/io/crate/planner/operators/HashAggregate.java
+++ b/sql/src/main/java/io/crate/planner/operators/HashAggregate.java
@@ -23,7 +23,6 @@
 package io.crate.planner.operators;
 
 import io.crate.analyze.OrderBy;
-import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.symbol.AggregateMode;
 import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.SelectSymbol;
@@ -52,14 +51,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-public class HashAggregate implements LogicalPlan {
+public class HashAggregate extends OneInputPlan {
 
     private static final String MERGE_PHASE_NAME = "mergeOnHandler";
-    final LogicalPlan source;
     final List<Function> aggregates;
 
     HashAggregate(LogicalPlan source, List<Function> aggregates) {
-        this.source = source;
+        super(source);
         this.aggregates = aggregates;
     }
 
@@ -143,7 +141,7 @@ public class HashAggregate implements LogicalPlan {
         if (collapsed == source) {
             return this;
         }
-        return new HashAggregate(collapsed, aggregates);
+        return newInstance(collapsed);
     }
 
     @Override
@@ -152,18 +150,8 @@ public class HashAggregate implements LogicalPlan {
     }
 
     @Override
-    public Map<Symbol, Symbol> expressionMapping() {
-        return source.expressionMapping();
-    }
-
-    @Override
-    public List<AbstractTableRelation> baseTables() {
-        return source.baseTables();
-    }
-
-    @Override
-    public Map<LogicalPlan, SelectSymbol> dependencies() {
-        return source.dependencies();
+    protected LogicalPlan newInstance(LogicalPlan newSource) {
+        return new HashAggregate(newSource, aggregates);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/Insert.java
+++ b/sql/src/main/java/io/crate/planner/operators/Insert.java
@@ -40,14 +40,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-public class Insert implements LogicalPlan {
+public class Insert extends OneInputPlan {
 
-    private final LogicalPlan source;
     private final QueriedRelation relation;
     private final ColumnIndexWriterProjection projection;
 
     public Insert(LogicalPlan source, QueriedRelation relation, ColumnIndexWriterProjection projection) {
-        this.source = source;
+        super(source);
         this.relation = relation;
         this.projection = projection;
     }
@@ -78,6 +77,11 @@ public class Insert implements LogicalPlan {
     }
 
     @Override
+    protected LogicalPlan newInstance(LogicalPlan newSource) {
+        return new Insert(newSource, relation, projection);
+    }
+
+    @Override
     public List<Symbol> outputs() {
         return relation.outputs();
     }
@@ -90,11 +94,6 @@ public class Insert implements LogicalPlan {
     @Override
     public List<AbstractTableRelation> baseTables() {
         return Collections.emptyList();
-    }
-
-    @Override
-    public Map<LogicalPlan, SelectSymbol> dependencies() {
-        return source.dependencies();
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/Limit.java
+++ b/sql/src/main/java/io/crate/planner/operators/Limit.java
@@ -23,7 +23,6 @@
 package io.crate.planner.operators;
 
 import io.crate.analyze.OrderBy;
-import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.SelectSymbol;
 import io.crate.analyze.symbol.Symbol;
@@ -46,9 +45,8 @@ import java.util.Map;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 
-class Limit implements LogicalPlan {
+class Limit extends OneInputPlan {
 
-    final LogicalPlan source;
     final Symbol limit;
     final Symbol offset;
 
@@ -64,7 +62,7 @@ class Limit implements LogicalPlan {
     }
 
     private Limit(LogicalPlan source, Symbol limit, Symbol offset) {
-        this.source = source;
+        super(source);
         this.limit = limit;
         this.offset = offset;
     }
@@ -102,32 +100,8 @@ class Limit implements LogicalPlan {
     }
 
     @Override
-    public LogicalPlan tryCollapse() {
-        LogicalPlan collapsed = source.tryCollapse();
-        if (collapsed == source) {
-            return this;
-        }
-        return new Limit(collapsed, limit, offset);
-    }
-
-    @Override
-    public List<Symbol> outputs() {
-        return source.outputs();
-    }
-
-    @Override
-    public Map<Symbol, Symbol> expressionMapping() {
-        return source.expressionMapping();
-    }
-
-    @Override
-    public List<AbstractTableRelation> baseTables() {
-        return source.baseTables();
-    }
-
-    @Override
-    public Map<LogicalPlan, SelectSymbol> dependencies() {
-        return source.dependencies();
+    protected LogicalPlan newInstance(LogicalPlan newSource) {
+        return new Limit(newSource, limit, offset);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlan.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlan.java
@@ -105,6 +105,29 @@ public interface LogicalPlan extends Plan {
     }
 
     /**
+     * Tries to "push-down" a LogicalPlan to this plan or the children of
+     * this plan. A push-down is an optimization which does not change the
+     * outcome of the plan but, ideally, makes it execute more efficiently.
+     *
+     * For example, pushing down an *Order*:
+     *
+     *              *Order*                      Union
+     *                 |                        /     \
+     *                 |                       /       \
+     *               Union                 *Order*  *Order*
+     *              /     \                   |        |
+     *             /       \        =>        |        |
+     *          Collect   Order             Collect  Order
+     *                      |                          |
+     *                      |                          |
+     *                   Collect                    Collect
+     * @param pushDownDef The {@link PushDownDefinition} which holds the context for the "push down"
+     *                    process.
+     * @return A new LogicalPlan which has to be validated with {@code pushDownDef#matches}.
+     */
+    LogicalPlan tryPushDown(PushDownDefinition pushDownDef);
+
+    /**
      * Uses the current shard allocation information to create a physical execution plan.
      * <br />
      * {@code limit}, {@code offset}, {@code order} can be passed from one operator to another. Depending on the

--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlanBase.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlanBase.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.operators;
+
+import io.crate.analyze.relations.AbstractTableRelation;
+import io.crate.analyze.symbol.SelectSymbol;
+import io.crate.analyze.symbol.Symbol;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The abstract base for all {@link LogicalPlan}s.
+ *
+ * For now, this just reduces the amount of boiler plate code each instance
+ * has to implement. Generally, this is an extension point where functionality
+ * resides which is used by all plans.
+ */
+abstract class LogicalPlanBase implements LogicalPlan {
+
+    protected final List<Symbol> outputs;
+    protected final Map<Symbol, Symbol> expressionMapping;
+    protected final List<AbstractTableRelation> baseTables;
+    protected final Map<LogicalPlan, SelectSymbol> dependencies;
+
+    LogicalPlanBase(List<Symbol> outputs,
+                    Map<Symbol, Symbol> expressionMapping,
+                    List<AbstractTableRelation> baseTables,
+                    Map<LogicalPlan, SelectSymbol> dependencies) {
+        this.outputs = outputs;
+        this.expressionMapping = expressionMapping;
+        this.baseTables = baseTables;
+        this.dependencies = dependencies;
+    }
+
+    @Override
+    public List<Symbol> outputs() {
+        return outputs;
+    }
+
+    @Override
+    public Map<Symbol, Symbol> expressionMapping() {
+        return expressionMapping;
+    }
+
+    @Override
+    public List<AbstractTableRelation> baseTables() {
+        return baseTables;
+    }
+
+    @Override
+    public Map<LogicalPlan, SelectSymbol> dependencies() {
+        return dependencies;
+    }
+}

--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -114,7 +114,16 @@ public class LogicalPlanner {
             .build(tableStats, new HashSet<>(relation.outputs()))
             .tryCollapse();
 
-        return MultiPhase.createIfNeeded(logicalPlan, relation, subqueryPlanner);
+        final LogicalPlan finalPlan;
+        PushDownDefinition pushDownDefinition = PushDownDefinition.UNION_ORDER_BY_PUSH_DOWN.get();
+        LogicalPlan pushDownPlan = logicalPlan.tryPushDown(pushDownDefinition);
+        if (pushDownDefinition.matches()) {
+            finalPlan = pushDownPlan;
+        } else {
+            finalPlan = logicalPlan;
+        }
+
+        return MultiPhase.createIfNeeded(finalPlan, relation, subqueryPlanner);
     }
 
     static LogicalPlan.Builder plan(QueriedRelation relation,

--- a/sql/src/main/java/io/crate/planner/operators/OneInputPlan.java
+++ b/sql/src/main/java/io/crate/planner/operators/OneInputPlan.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.operators;
+
+import io.crate.analyze.relations.AbstractTableRelation;
+import io.crate.analyze.symbol.SelectSymbol;
+import io.crate.analyze.symbol.Symbol;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A {@link LogicalPlan} with one other LogicalPlan as input.
+ */
+abstract class OneInputPlan extends LogicalPlanBase {
+
+    protected final LogicalPlan source;
+
+    OneInputPlan(LogicalPlan source) {
+        this(source, source.outputs());
+    }
+
+    OneInputPlan(LogicalPlan source, Map<LogicalPlan, SelectSymbol> dependencies) {
+        this(source, source.outputs(), source.expressionMapping(), source.baseTables(), dependencies);
+    }
+
+    OneInputPlan(LogicalPlan source, List<Symbol> outputs) {
+        this(source, outputs, source.expressionMapping(), source.baseTables(), source.dependencies());
+    }
+
+    OneInputPlan(LogicalPlan source,
+                 List<Symbol> outputs,
+                 Map<Symbol, Symbol> expressionMapping,
+                 List<AbstractTableRelation> baseTables,
+                 Map<LogicalPlan, SelectSymbol> dependencies) {
+        super(outputs, expressionMapping, baseTables, dependencies);
+        this.source = source;
+    }
+
+    @Override
+    public LogicalPlan tryCollapse() {
+        LogicalPlan newPlan = source.tryCollapse();
+        if (source != newPlan) {
+            return newInstance(newPlan);
+        }
+        return this;
+    }
+
+    /**
+     * If no other information available, return the source's number of rows.
+     * @return The number of rows of the source plan.
+     */
+    @Override
+    public long numExpectedRows() {
+        return source.numExpectedRows();
+    }
+
+    /**
+     * Creates a new LogicalPlan with an updated source. This is necessary
+     * when we collapse plans during plan building or "push down" plans
+     * later on to optimize their execution.
+     *
+     * {@link LogicalPlan}s should be immutable. Fields like sources may only
+     * be updated by creating a new instance of the plan. Since Java does not
+     * allow to copy an instance easily and also instances might apply a custom
+     * logic when they clone itself, this method has to be implemented.
+     * @param newSource A new {@link LogicalPlan} as a source.
+     * @return A new copy of this {@link OneInputPlan} with the new source.
+     */
+    protected abstract LogicalPlan newInstance(LogicalPlan newSource);
+
+}

--- a/sql/src/main/java/io/crate/planner/operators/OneInputPlan.java
+++ b/sql/src/main/java/io/crate/planner/operators/OneInputPlan.java
@@ -57,6 +57,21 @@ abstract class OneInputPlan extends LogicalPlanBase {
         this.source = source;
     }
 
+
+    @Override
+    public LogicalPlan tryPushDown(PushDownDefinition pushDownDef) {
+        pushDownDef.accept(this);
+        LogicalPlan newSource = source.tryPushDown(pushDownDef);
+        if (pushDownDef.pushDown(this)) {
+            return newSource;
+        }
+        LogicalPlan returnPlan = this;
+        if (source != newSource) {
+            returnPlan = newInstance(newSource);
+        }
+        return pushDownDef.insertPushDownPlan(this, returnPlan);
+    }
+
     @Override
     public LogicalPlan tryCollapse() {
         LogicalPlan newPlan = source.tryCollapse();

--- a/sql/src/main/java/io/crate/planner/operators/Order.java
+++ b/sql/src/main/java/io/crate/planner/operators/Order.java
@@ -37,6 +37,7 @@ import io.crate.planner.projection.builder.ProjectionBuilder;
 
 import javax.annotation.Nullable;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -56,7 +57,7 @@ class Order extends OneInputPlan {
         };
     }
 
-    private Order(LogicalPlan source, OrderBy orderBy) {
+    Order(LogicalPlan source, OrderBy orderBy) {
         super(source, Lists2.concatUnique(source.outputs(), orderBy.orderBySymbols()));
         this.orderBy = orderBy;
     }
@@ -103,7 +104,23 @@ class Order extends OneInputPlan {
 
     @Override
     protected LogicalPlan newInstance(LogicalPlan newSource) {
-        return new Order(newSource, orderBy);
+        // Replaces any Symbols which were part of the old orderBy
+        // with the Symbols of the new orderBy at the same position.
+        // This ensures that the orderBy is performed correctly when
+        // its sources have changed.
+        // See tryPushDown of Union
+        List<Symbol> oldOutputs = source.outputs();
+        List<Symbol> newOutputs = newSource.outputs();
+        OrderBy newOrderBy = this.orderBy.copyAndReplace(
+            (symbol) -> {
+                int idx = oldOutputs.indexOf(symbol);
+                if (idx != -1) {
+                    return newOutputs.get(idx);
+                }
+                return symbol;
+            }
+        );
+        return new Order(newSource, newOrderBy);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/PushDownDefinition.java
+++ b/sql/src/main/java/io/crate/planner/operators/PushDownDefinition.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.operators;
+
+import com.google.common.base.Preconditions;
+import io.crate.planner.operators.PushDownDefinition.Node.Type;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * A "push-down" context which verifies a plan/operator can be moved towards
+ * the leafs of the {@link LogicalPlan}. That means the operation will be
+ * executed earlier and possibly make queries execute faster.
+ *
+ * For example, pushing down an *Order*:
+ *
+ *              *Order*                      Union
+ *                 |                        /     \
+ *                 |                       /       \
+ *               Union                 *Order*  *Order*
+ *              /     \                   |        |
+ *             /       \        =>        |        |
+ *          Collect   Order             Collect  Order
+ *                      |                          |
+ *                      |                          |
+ *                   Collect                    Collect
+ *
+ *
+ * This class accepts a partial tree which holds the classes of {@link LogicalPlan}s.
+ * While traversing the plan hierarchy, the matching is performed against this tree.
+ * The results of the push-down have to be checked with the {@code matches} method
+ * to ensure that the graph traversal let to a valid push down scenario.
+ */
+public class PushDownDefinition {
+
+    static final Supplier<PushDownDefinition> UNION_ORDER_BY_PUSH_DOWN;
+
+    static {
+        UNION_ORDER_BY_PUSH_DOWN = () -> {
+            Node pattern =
+                new Node(Order.class, Type.PUSHDOWN,
+                    new Node(RelationBoundary.class, Type.REGULAR,
+                        new Node(Union.class, Type.REGULAR,
+                            new Node(RelationBoundary.class, Type.REGULAR,
+                                new Node(Collect.class, Type.TARGET)),
+                            new Node(RelationBoundary.class,  Type.REGULAR,
+                                new Node(Collect.class, Type.TARGET))
+                        )
+                    )
+                );
+            return new PushDownDefinition(pattern);
+        };
+    }
+
+    static class Node {
+
+        enum Type {
+            // Just a pattern matching node
+            REGULAR,
+            // A node to be pushed down
+            PUSHDOWN,
+            // A target for the push down node
+            TARGET
+        }
+
+        private final Class<? extends LogicalPlan> logicalPlanClass;
+
+        private final Type nodeType;
+
+        private final Node[] children;
+
+        Node(Class<? extends LogicalPlan> logicalPlanClass, Type nodeType, Node... children) {
+            this.logicalPlanClass = logicalPlanClass;
+            this.nodeType = nodeType;
+            this.children = children;
+        }
+
+    }
+
+    private final Deque<Node> toBeVisited;
+
+    /** We can only push down plans with one input */
+    private OneInputPlan pushDownPlan;
+    private final Set<LogicalPlan> targetPlans;
+
+    private boolean matchPossible;
+    private boolean patternFound;
+
+    private PushDownDefinition(Node treePattern) {
+        this.toBeVisited = new ArrayDeque<>();
+        this.targetPlans = new HashSet<>();
+        toBeVisited.push(treePattern);
+        matchPossible = true;
+    }
+
+    /**
+     * Accepts a new {@link LogicalPlan} as part of the plan hierarchy.
+     * This methods needs to be called by every plan/operator.
+     * The traversal has to be performed in depth-first order.
+     * @param plan The (sub)plan to match against the tree pattern.
+     */
+    public void accept(LogicalPlan plan) {
+        Preconditions.checkNotNull(plan, "Plan must never be null");
+        if (!matchPossible || patternFound) {
+            return;
+        }
+        Node currentNode = toBeVisited.removeFirst();
+        if (currentNode.logicalPlanClass.equals(plan.getClass())) {
+            if (currentNode.nodeType == Type.PUSHDOWN) {
+                Preconditions.checkState(pushDownPlan == null,
+                    "Only one push down allowed per PushDownDefinition");
+                if (plan instanceof OneInputPlan) {
+                    pushDownPlan = (OneInputPlan) plan;
+                }
+            } else if (currentNode.nodeType == Type.TARGET) {
+                targetPlans.add(plan);
+            }
+            for (int i = currentNode.children.length - 1; i >= 0; i--) {
+                // add children right to left to ensure left is traversed first
+                toBeVisited.addFirst(currentNode.children[i]);
+            }
+            if (toBeVisited.isEmpty()) {
+                patternFound = true;
+            }
+        } else {
+            matchPossible = false;
+        }
+    }
+
+    boolean pushDown(LogicalPlan plan) {
+        Preconditions.checkNotNull(plan, "Plan must never be null");
+        return matchPossible && pushDownPlan == plan;
+    }
+
+    /**
+     * Performs the actual push-down on returnPlan, if necessary.
+     * @param original The target plan which is the child of the new push down location.
+     * @param returnPlan The updated plan that should be used when inserting a push down plan.
+     * @return The newly updated returnPlan {@link LogicalPlan} if a push down was performed.
+     */
+    LogicalPlan insertPushDownPlan(LogicalPlan original, LogicalPlan returnPlan) {
+        Preconditions.checkNotNull(original, "Plan must never be null");
+        if (!matchPossible) {
+            return returnPlan;
+        }
+        if (targetPlans.contains(original)) {
+            if (pushDownPlan != null) {
+                return pushDownPlan.newInstance(returnPlan);
+            } else {
+                matchPossible = false;
+            }
+        }
+        return returnPlan;
+    }
+
+    /**
+     * Get the status of the matching of this definition against the input tree.
+     * @return True if the definition matched and the push down has been performed correctly.
+     */
+    public boolean matches() {
+        return patternFound;
+    }
+
+}

--- a/sql/src/main/java/io/crate/planner/operators/RootRelationBoundary.java
+++ b/sql/src/main/java/io/crate/planner/operators/RootRelationBoundary.java
@@ -22,11 +22,8 @@
 
 package io.crate.planner.operators;
 
-import com.google.common.annotations.VisibleForTesting;
 import io.crate.analyze.OrderBy;
-import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.symbol.SelectSymbol;
-import io.crate.analyze.symbol.Symbol;
 import io.crate.data.Row;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.Merge;
@@ -34,19 +31,15 @@ import io.crate.planner.PlannerContext;
 import io.crate.planner.projection.builder.ProjectionBuilder;
 
 import javax.annotation.Nullable;
-import java.util.List;
 import java.util.Map;
 
 /**
  * An operator with the primary purpose to ensure that the result is on the handler and no longer distributed.
  */
-public class RootRelationBoundary implements LogicalPlan {
-
-    @VisibleForTesting
-    final LogicalPlan source;
+public class RootRelationBoundary extends OneInputPlan {
 
     public RootRelationBoundary(LogicalPlan source) {
-        this.source = source;
+        super(source);
     }
 
     @Override
@@ -71,37 +64,8 @@ public class RootRelationBoundary implements LogicalPlan {
     }
 
     @Override
-    public LogicalPlan tryCollapse() {
-        LogicalPlan collapsed = source.tryCollapse();
-        if (collapsed == source) {
-            return this;
-        }
-        return new RootRelationBoundary(collapsed);
-    }
-
-    @Override
-    public List<Symbol> outputs() {
-        return source.outputs();
-    }
-
-    @Override
-    public Map<Symbol, Symbol> expressionMapping() {
-        return source.expressionMapping();
-    }
-
-    @Override
-    public List<AbstractTableRelation> baseTables() {
-        return source.baseTables();
-    }
-
-    @Override
-    public Map<LogicalPlan, SelectSymbol> dependencies() {
-        return source.dependencies();
-    }
-
-    @Override
-    public long numExpectedRows() {
-        return source.numExpectedRows();
+    protected LogicalPlan newInstance(LogicalPlan newSource) {
+        return new RootRelationBoundary(newSource);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/TwoInputPlan.java
+++ b/sql/src/main/java/io/crate/planner/operators/TwoInputPlan.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.operators;
+
+import io.crate.analyze.symbol.Symbol;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * A {@link LogicalPlan} with two other LogicalPlans as input.
+ */
+abstract class TwoInputPlan extends LogicalPlanBase {
+
+    final LogicalPlan lhs;
+    final LogicalPlan rhs;
+
+    TwoInputPlan(LogicalPlan left, LogicalPlan right, List<Symbol> outputs) {
+        super(outputs, new HashMap<>(), new ArrayList<>(), Collections.emptyMap());
+        this.lhs = left;
+        this.rhs = right;
+        this.baseTables.addAll(lhs.baseTables());
+        this.baseTables.addAll(rhs.baseTables());
+        this.expressionMapping.putAll(lhs.expressionMapping());
+        this.expressionMapping.putAll(rhs.expressionMapping());
+    }
+
+    @Override
+    public LogicalPlan tryCollapse() {
+        LogicalPlan lhsCollapsed = lhs.tryCollapse();
+        LogicalPlan rhsCollapsed = rhs.tryCollapse();
+        if (lhs != lhsCollapsed || rhs != rhsCollapsed) {
+            return newInstance(lhsCollapsed, rhsCollapsed);
+        }
+        return this;
+    }
+
+    /**
+     * Creates a new LogicalPlan with an updated source. This is necessary
+     * when we collapse plans during plan building or "push down" plans
+     * later on to optimize their execution.
+     *
+     * {@link LogicalPlan}s should be immutable. Fields like sources may only
+     * be updated by creating a new instance of the plan. Since Java does not
+     * allow to copy an instance easily and also instances might apply a custom
+     * logic when they clone itself, this method has to be implemented.
+     * @param newLeftSource A new {@link} LogicalPlan as the left source.
+     * @param newRightSource A new {@link} LogicalPlan as the right source.
+     * @return A new copy of this {@link OneInputPlan} with the new sources.
+     */
+    protected abstract LogicalPlan newInstance(LogicalPlan newLeftSource, LogicalPlan newRightSource);
+}

--- a/sql/src/main/java/io/crate/planner/operators/TwoInputPlan.java
+++ b/sql/src/main/java/io/crate/planner/operators/TwoInputPlan.java
@@ -48,6 +48,18 @@ abstract class TwoInputPlan extends LogicalPlanBase {
     }
 
     @Override
+    public LogicalPlan tryPushDown(PushDownDefinition pushDownDef) {
+        pushDownDef.accept(this);
+        LogicalPlan newLhs = lhs.tryPushDown(pushDownDef);
+        LogicalPlan newRhs = rhs.tryPushDown(pushDownDef);
+        LogicalPlan returnPlan = this;
+        if (lhs != newLhs || rhs != newRhs) {
+            returnPlan = newInstance(newLhs, newRhs);
+        }
+        return pushDownDef.insertPushDownPlan(this, returnPlan);
+    }
+
+    @Override
     public LogicalPlan tryCollapse() {
         LogicalPlan lhsCollapsed = lhs.tryCollapse();
         LogicalPlan rhsCollapsed = rhs.tryCollapse();

--- a/sql/src/main/java/io/crate/planner/operators/Union.java
+++ b/sql/src/main/java/io/crate/planner/operators/Union.java
@@ -85,7 +85,7 @@ public class Union extends TwoInputPlan {
                 .plan(right, FetchMode.NEVER_CLEAR, subqueryPlanner, false)
                 .build(tableStats, usedFromRight);
 
-            return new Union(ttr.outputs(), lhsPlan, rhsPlan);
+            return new Union(lhsPlan, rhsPlan, ttr.outputs());
         };
     }
 
@@ -109,7 +109,7 @@ public class Union extends TwoInputPlan {
         });
     }
 
-    Union(List<Symbol> outputs, LogicalPlan lhs, LogicalPlan rhs) {
+    Union(LogicalPlan lhs, LogicalPlan rhs, List<Symbol> outputs) {
         super(lhs, rhs, outputs);
     }
 
@@ -164,7 +164,7 @@ public class Union extends TwoInputPlan {
 
     @Override
     protected LogicalPlan newInstance(LogicalPlan newLeftSource, LogicalPlan newRightSource) {
-        return new Union(outputs, newLeftSource, newRightSource);
+        return new Union(newLeftSource, newRightSource, outputs);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/Union.java
+++ b/sql/src/main/java/io/crate/planner/operators/Union.java
@@ -148,7 +148,7 @@ public class Union extends TwoInputPlan {
             leftResultDesc.streamOutputs(),
             Collections.emptyList(),
             DistributionInfo.DEFAULT_BROADCAST,
-            null
+            leftResultDesc.orderBy()
         );
 
         return new UnionExecutionPlan(

--- a/sql/src/main/java/io/crate/planner/operators/ZeroInputPlan.java
+++ b/sql/src/main/java/io/crate/planner/operators/ZeroInputPlan.java
@@ -38,6 +38,13 @@ abstract class ZeroInputPlan extends LogicalPlanBase {
     }
 
     @Override
+    public LogicalPlan tryPushDown(PushDownDefinition  pushDownDef) {
+        // We don't have any sources, so just return this instance
+        pushDownDef.accept(this);
+        return pushDownDef.insertPushDownPlan(this, this);
+    }
+
+    @Override
     public LogicalPlan tryCollapse() {
         // We don't have any sources, so just return this instance
         return this;

--- a/sql/src/main/java/io/crate/planner/operators/ZeroInputPlan.java
+++ b/sql/src/main/java/io/crate/planner/operators/ZeroInputPlan.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.operators;
+
+import io.crate.analyze.relations.AbstractTableRelation;
+import io.crate.analyze.symbol.Symbol;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A {@link LogicalPlan} with two no other LogicalPlans as input.
+ */
+abstract class ZeroInputPlan extends LogicalPlanBase {
+
+    public ZeroInputPlan(List<Symbol> outputs, List<AbstractTableRelation> baseTables) {
+        super(outputs, Collections.emptyMap(), baseTables, Collections.emptyMap());
+    }
+
+    @Override
+    public LogicalPlan tryCollapse() {
+        // We don't have any sources, so just return this instance
+        return this;
+    }
+}

--- a/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -261,7 +261,7 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
                 indentation += 4;
                 startLine("subQueries[\n");
                 indentation += 4;
-                for (Map.Entry<LogicalPlan, SelectSymbol> entry : multiPhase.subQueries.entrySet()) {
+                for (Map.Entry<LogicalPlan, SelectSymbol> entry : multiPhase.dependencies.entrySet()) {
                     printPlan(entry.getKey());
                 }
                 indentation -= 4;
@@ -326,7 +326,7 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
                 startLine("Collect[");
                 sb.append(collect.tableInfo.ident());
                 sb.append(" | [");
-                addSymbolsList(collect.toCollect);
+                addSymbolsList(collect.outputs);
                 sb.append("] | ");
                 sb.append(printQueryClause(symbolPrinter, collect.where));
                 sb.append("]\n");

--- a/sql/src/test/java/io/crate/planner/operators/PushDownTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/PushDownTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.operators;
+
+import io.crate.analyze.TableDefinitions;
+import io.crate.planner.TableStats;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+import org.junit.Test;
+
+import static io.crate.planner.operators.LogicalPlannerTest.isPlan;
+
+public class PushDownTest extends CrateDummyClusterServiceUnitTest {
+
+    @Test
+    public void pushDownUnionOrder() {
+
+        TableStats tableStats = new TableStats();
+
+        SQLExecutor sqlExecutor = SQLExecutor.builder(clusterService)
+            .addDocTable(TableDefinitions.USER_TABLE_INFO)
+            .build();
+
+        LogicalPlan plan = LogicalPlannerTest.plan(
+            "Select name from users union all select text from users order by name",
+            sqlExecutor,
+            clusterService,
+            tableStats);
+
+        assertThat(plan, isPlan(sqlExecutor.functions(),  "Boundary[name]\n" +
+                                                "Union[\n" +
+                                                "Boundary[name]\n" +
+                                                "OrderBy[name]\n" +
+                                                "Collect[doc.users | [name] | All]\n" +
+                                                "---\n" +
+                                                "Boundary[text]\n" +
+                                                "OrderBy[text]\n" +
+                                                "Collect[doc.users | [text] | All]\n" +
+                                                "]\n"));
+    }
+}


### PR DESCRIPTION
Queries like `Select id from t1 UNION ALL Select id2 from t2 order by id` are
optimized to perform an order by already in the source relations of the
union. The OrderBy from the union is "pushed down" to the queries on t1 and
t2. The result only needs to run a sorted merge.

```
       *Order*                      Union
          |                        /     \
          |                       /       \
        Union                 *Order*  *Order*
       /     \                   |        |
      /       \        =>        |        |
   Collect   Order             Collect  Order
     t1        |                 t1       |
               |                          |
            Collect                    Collect
              t2                         t2
```

This PR introduces a `tryPushDown(PushDownDefinition)` method on the
LogicalPlan. The method call traverses the LogicalPlan tree and checks with the
`PushDownDefinition` whether a given pattern (e.g. UnionOrderBy push-down) can
be found. The pattern is also a (sub) tree which defines the push down
transformation. A new plan is generated based on the pattern while traversing
the plan. The resulting plan needs to be validated after the translation using
the `PushDownDefinition#matches()` method.
