### PR TITLE
tests: Fix flaky NodeSettingsTest

### DIFF
--- a/app/src/test/java/io/crate/node/NodeSettingsTest.java
+++ b/app/src/test/java/io/crate/node/NodeSettingsTest.java
@@ -89,7 +89,7 @@ public class NodeSettingsTest extends CrateUnitTest {
             .put("node.data", true)
             .put(PATH_HOME_SETTING.getKey(), createConfigPath())
             // Avoid connecting to other test nodes
-            .put("network.publish_host", "127.0.0.111");
+            .put("discovery.type", "single-node");
 
         Environment environment = CrateSettingsPreparer.prepareEnvironment(builder.build(), Collections.emptyMap());
         node = new CrateNode(environment);


### PR DESCRIPTION
Could fail with

    Failed to auto-resolve psql publish port, multiple bound addresses [[::1]:5432, 127.0.0.1:5433] with distinct ports and none of them matched the publish address (/127.0.0.111).