### PR TITLE
Fix a perf regression for select.. order by limit queries

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -129,5 +129,8 @@ Changes
 Fixes
 =====
 
+- Fixed a performance regression introduced in ``2.2.0`` that caused ``SELECT``
+  statements with ``ORDER BY`` and ``LIMIT`` to execute way slower than before
+
 - Fixed support for subscript expressions on the ``values`` column of
   ``information_schema.table_partitions``

--- a/sql/src/main/java/io/crate/planner/node/dql/RoutedCollectPhase.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/RoutedCollectPhase.java
@@ -266,7 +266,7 @@ public class RoutedCollectPhase extends AbstractProjectionsPhase implements Coll
         RoutedCollectPhase result = this;
         Function<Symbol, Symbol> normalize = s -> normalizer.normalize(s, transactionContext);
         List<Symbol> newToCollect = Lists2.copyAndReplace(toCollect, normalize);
-        boolean changed = newToCollect != toCollect();
+        boolean changed = !newToCollect.equals(toCollect);
         WhereClause newWhereClause = whereClause().normalize(normalizer, transactionContext);
         OrderBy orderBy = this.orderBy;
         if (orderBy != null) {

--- a/sql/src/main/java/io/crate/planner/node/dql/RoutedCollectPhase.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/RoutedCollectPhase.java
@@ -286,6 +286,7 @@ public class RoutedCollectPhase extends AbstractProjectionsPhase implements Coll
                 distributionInfo,
                 user
             );
+            result.nodePageSizeHint(nodePageSizeHint);
             result.orderBy(orderBy);
         }
         return result;

--- a/sql/src/test/java/io/crate/planner/node/RoutedCollectPhaseTest.java
+++ b/sql/src/test/java/io/crate/planner/node/RoutedCollectPhaseTest.java
@@ -54,6 +54,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
 
 public class RoutedCollectPhaseTest extends CrateUnitTest {
 
@@ -134,5 +135,26 @@ public class RoutedCollectPhaseTest extends CrateUnitTest {
             normalizer, new TransactionContext(SessionContext.create()));
 
         assertThat(normalizedCollect.nodePageSizeHint(), is(10));
+    }
+
+    @Test
+    public void testNormalizeNoop() throws Exception {
+        RoutedCollectPhase collect = new RoutedCollectPhase(
+            UUID.randomUUID(),
+            1,
+            "collect",
+            new Routing(Collections.emptyMap()),
+            RowGranularity.DOC,
+            Collections.singletonList(Literal.of(10)),
+            Collections.emptyList(),
+            WhereClause.MATCH_ALL,
+            DistributionInfo.DEFAULT_SAME_NODE,
+            null
+        );
+        EvaluatingNormalizer normalizer = EvaluatingNormalizer.functionOnlyNormalizer(getFunctions());
+        RoutedCollectPhase normalizedCollect = collect.normalize(
+            normalizer, new TransactionContext(SessionContext.create()));
+        
+        assertThat(normalizedCollect, sameInstance(collect));
     }
 }


### PR DESCRIPTION
A change in 927b22cac331095ee0bea79feb5c8ed074a8df27 caused a regression
because the `nodePageSizeHint` wasn't preserved when normalizing a
`RoutedCollectPhase`. This caused the collect operation to collect way more
documents than necessary.

The problematic change is
https://github.com/crate/crate/commit/927b22cac331095ee0bea79feb5c8ed074a8df27#diff-117849d9b4075be1753c40c23995c810R273
which causes the `boolean changed = newToCollect != toCollect();` check to
always result in `changed = true`