### PR TITLE
"Push down" UNION OrderBy to source relations [new impl]

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -55,6 +55,11 @@ Changes
 
 - Added support to change the password of existing users using ``ALTER USER``.
 
+- Added an optimization when UNION ALL is used with ORDER BY. The ORDER BY is
+  now "pushed down" to the left and right side of the union which improves the
+  sorting speed.
+
+
 - Added support for disabling the column store per ``STRING`` column on table
   creation and on adding columns. In conjunction with disabling indexing on that
   column, this will support storing strings greater than 32kb. Be aware that the

--- a/sql/src/main/java/io/crate/jobs/PageDownstreamContext.java
+++ b/sql/src/main/java/io/crate/jobs/PageDownstreamContext.java
@@ -176,9 +176,14 @@ public class PageDownstreamContext extends AbstractExecutionSubContext implement
     private void mergeBuckets() {
         List<KeyIterable<Integer, Row>> buckets = new ArrayList<>(numBuckets);
         for (Map.Entry<Integer, Bucket> entry : bucketsByIdx.entrySet()) {
-            buckets.add(new KeyIterable<>(entry.getKey(), entry.getValue()));
+            if (entry.getValue() != null) {
+                buckets.add(new KeyIterable<>(entry.getKey(), entry.getValue()));
+            }
         }
-        bucketsByIdx.clear();
+        // replace existing buckets with empty ones
+        for (Integer integer : bucketsByIdx.keySet()) {
+            bucketsByIdx.put(integer, null);
+        }
         pagingIterator.merge(buckets);
     }
 

--- a/sql/src/main/java/io/crate/planner/UnionExecutionPlan.java
+++ b/sql/src/main/java/io/crate/planner/UnionExecutionPlan.java
@@ -69,7 +69,8 @@ public class UnionExecutionPlan implements ExecutionPlan, ResultDescription {
                               int unfinishedLimit,
                               int unfinishedOffset,
                               int numOutputs,
-                              int maxRowsPerNode) {
+                              int maxRowsPerNode,
+                              @Nullable PositionalOrderBy orderBy) {
         this.left = left;
         this.right = right;
         Preconditions.checkArgument(mergePhase.numInputs() == 2,
@@ -79,6 +80,7 @@ public class UnionExecutionPlan implements ExecutionPlan, ResultDescription {
         this.unfinishedOffset = unfinishedOffset;
         this.numOutputs = numOutputs;
         this.maxRowsPerNode = maxRowsPerNode;
+        this.orderBy = orderBy;
     }
 
     public MergePhase mergePhase() {

--- a/sql/src/main/java/io/crate/planner/node/dql/MergePhase.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/MergePhase.java
@@ -74,7 +74,7 @@ public class MergePhase extends AbstractProjectionsPhase implements UpstreamPhas
      * @param inputTypes The types of the input rows.
      * @param projections The projections to apply when merging.
      * @param distributionInfo The default strategy to use when distributing the results of the MergePhase.
-     * @param positionalOrderBy The order by positions on wich the input is pre-sorted on; setting this
+     * @param positionalOrderBy The order by positions on which the input is pre-sorted on; setting this
      *                          will result in a sorted merge.
      */
     public MergePhase(UUID jobId,

--- a/sql/src/main/java/io/crate/planner/operators/Collect.java
+++ b/sql/src/main/java/io/crate/planner/operators/Collect.java
@@ -244,6 +244,14 @@ class Collect extends ZeroInputPlan {
     }
 
     @Override
+    public LogicalPlan tryOptimize(@Nullable LogicalPlan pushDown) {
+        if (pushDown instanceof Order) {
+            return ((Order) pushDown).updateSource(this);
+        }
+        return super.tryOptimize(pushDown);
+    }
+
+    @Override
     public boolean preferShardProjections() {
         // Can't run on shard level for system tables
         // (Except tables like sys.shards, but in that case it's better to run operations per node as well,

--- a/sql/src/main/java/io/crate/planner/operators/Count.java
+++ b/sql/src/main/java/io/crate/planner/operators/Count.java
@@ -27,7 +27,6 @@ import io.crate.analyze.WhereClause;
 import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.SelectSymbol;
-import io.crate.analyze.symbol.Symbol;
 import io.crate.data.Row;
 import io.crate.metadata.Routing;
 import io.crate.metadata.RoutingProvider;
@@ -44,26 +43,21 @@ import io.crate.types.DataTypes;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 /**
  * An optimized version for "select count(*) from t where ..."
  */
-public class Count implements LogicalPlan {
+public class Count extends ZeroInputPlan {
 
     private static final String COUNT_PHASE_NAME = "count-merge";
 
     final AbstractTableRelation<TableInfo> tableRelation;
     final WhereClause where;
 
-    private final List<Symbol> outputs;
-    private final List<AbstractTableRelation> baseTables;
-
     Count(Function countFunction, AbstractTableRelation<TableInfo> tableRelation, WhereClause where) {
-        this.outputs = Collections.singletonList(countFunction);
+        super(Collections.singletonList(countFunction), Collections.singletonList(tableRelation));
         this.tableRelation = tableRelation;
-        this.baseTables = Collections.singletonList(tableRelation);
         this.where = where;
     }
 
@@ -101,31 +95,6 @@ public class Count implements LogicalPlan {
             null
         );
         return new CountPlan(countPhase, mergePhase);
-    }
-
-    @Override
-    public LogicalPlan tryCollapse() {
-        return this;
-    }
-
-    @Override
-    public List<Symbol> outputs() {
-        return outputs;
-    }
-
-    @Override
-    public Map<Symbol, Symbol> expressionMapping() {
-        return Collections.emptyMap();
-    }
-
-    @Override
-    public List<AbstractTableRelation> baseTables() {
-        return baseTables;
-    }
-
-    @Override
-    public Map<LogicalPlan, SelectSymbol> dependencies() {
-        return Collections.emptyMap();
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/FetchOrEval.java
+++ b/sql/src/main/java/io/crate/planner/operators/FetchOrEval.java
@@ -431,7 +431,18 @@ class FetchOrEval extends OneInputPlan {
     }
 
     @Override
-    protected LogicalPlan newInstance(LogicalPlan newSource) {
+    public LogicalPlan tryOptimize(@Nullable LogicalPlan pushDown) {
+        if (pushDown instanceof Order) {
+            LogicalPlan newPlan = source.tryOptimize(pushDown);
+            if (newPlan != null && newPlan != source) {
+                return updateSource(newPlan);
+            }
+        }
+        return super.tryOptimize(pushDown);
+    }
+
+    @Override
+    protected LogicalPlan updateSource(LogicalPlan newSource) {
         return new FetchOrEval(newSource, outputs, fetchMode, doFetch);
     }
 

--- a/sql/src/main/java/io/crate/planner/operators/FetchOrEval.java
+++ b/sql/src/main/java/io/crate/planner/operators/FetchOrEval.java
@@ -106,10 +106,7 @@ import static io.crate.planner.operators.OperatorUtils.getUnusedColumns;
  *                Fetch 500
  * </pre>
  */
-class FetchOrEval implements LogicalPlan {
-
-    final LogicalPlan source;
-    final List<Symbol> outputs;
+class FetchOrEval extends OneInputPlan {
 
     private final FetchMode fetchMode;
     private final boolean doFetch;
@@ -170,8 +167,7 @@ class FetchOrEval implements LogicalPlan {
     }
 
     private FetchOrEval(LogicalPlan source, List<Symbol> outputs, FetchMode fetchMode, boolean doFetch) {
-        this.source = source;
-        this.outputs = outputs;
+        super(source, outputs);
         this.fetchMode = fetchMode;
         this.doFetch = doFetch;
     }
@@ -435,37 +431,8 @@ class FetchOrEval implements LogicalPlan {
     }
 
     @Override
-    public LogicalPlan tryCollapse() {
-        LogicalPlan collapsed = source.tryCollapse();
-        if (collapsed == this) {
-            return this;
-        }
-        return new FetchOrEval(collapsed, outputs, fetchMode, doFetch);
-    }
-
-    @Override
-    public List<Symbol> outputs() {
-        return outputs;
-    }
-
-    @Override
-    public Map<Symbol, Symbol> expressionMapping() {
-        return source.expressionMapping();
-    }
-
-    @Override
-    public List<AbstractTableRelation> baseTables() {
-        return source.baseTables();
-    }
-
-    @Override
-    public Map<LogicalPlan, SelectSymbol> dependencies() {
-        return source.dependencies();
-    }
-
-    @Override
-    public long numExpectedRows() {
-        return source.numExpectedRows();
+    protected LogicalPlan newInstance(LogicalPlan newSource) {
+        return new FetchOrEval(newSource, outputs, fetchMode, doFetch);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/Filter.java
+++ b/sql/src/main/java/io/crate/planner/operators/Filter.java
@@ -105,7 +105,7 @@ class Filter extends OneInputPlan {
     }
 
     @Override
-    protected LogicalPlan newInstance(LogicalPlan newSource) {
+    protected LogicalPlan updateSource(LogicalPlan newSource) {
         return new Filter(newSource, queryClause);
     }
 }

--- a/sql/src/main/java/io/crate/planner/operators/Filter.java
+++ b/sql/src/main/java/io/crate/planner/operators/Filter.java
@@ -25,7 +25,6 @@ package io.crate.planner.operators;
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.QueryClause;
 import io.crate.analyze.WhereClause;
-import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.SelectSymbol;
 import io.crate.analyze.symbol.Symbol;
@@ -39,15 +38,13 @@ import io.crate.types.DataTypes;
 
 import javax.annotation.Nullable;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import static io.crate.planner.operators.LogicalPlanner.extractColumns;
 
-class Filter implements LogicalPlan {
+class Filter extends OneInputPlan {
 
-    final LogicalPlan source;
     final QueryClause queryClause;
 
     static LogicalPlan.Builder create(LogicalPlan.Builder sourceBuilder, @Nullable QueryClause queryClause) {
@@ -84,7 +81,7 @@ class Filter implements LogicalPlan {
     }
 
     private Filter(LogicalPlan source, QueryClause queryClause) {
-        this.source = source;
+        super(source);
         this.queryClause = queryClause;
     }
 
@@ -108,37 +105,7 @@ class Filter implements LogicalPlan {
     }
 
     @Override
-    public LogicalPlan tryCollapse() {
-        LogicalPlan collapsed = source.tryCollapse();
-        if (collapsed == source) {
-            return this;
-        }
-        return new Filter(collapsed, queryClause);
-    }
-
-    @Override
-    public List<Symbol> outputs() {
-        return source.outputs();
-    }
-
-    @Override
-    public Map<Symbol, Symbol> expressionMapping() {
-        return source.expressionMapping();
-    }
-
-    @Override
-    public List<AbstractTableRelation> baseTables() {
-        return source.baseTables();
-    }
-
-    @Override
-    public Map<LogicalPlan, SelectSymbol> dependencies() {
-        return source.dependencies();
-    }
-
-    @Override
-    public long numExpectedRows() {
-        // We don't have any cardinality estimates
-        return source.numExpectedRows();
+    protected LogicalPlan newInstance(LogicalPlan newSource) {
+        return new Filter(newSource, queryClause);
     }
 }

--- a/sql/src/main/java/io/crate/planner/operators/Get.java
+++ b/sql/src/main/java/io/crate/planner/operators/Get.java
@@ -23,7 +23,6 @@
 package io.crate.planner.operators;
 
 import io.crate.analyze.OrderBy;
-import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.relations.DocTableRelation;
 import io.crate.analyze.relations.QueriedDocTable;
 import io.crate.analyze.symbol.SelectSymbol;
@@ -52,16 +51,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class Get implements LogicalPlan {
+public class Get extends ZeroInputPlan {
 
     final DocTableRelation tableRelation;
     final DocKeys docKeys;
-    private final List<Symbol> outputs;
 
     Get(QueriedDocTable table, DocKeys docKeys, List<Symbol> outputs) {
+        super(outputs, Collections.singletonList(table.tableRelation()));
         this.tableRelation = table.tableRelation();
         this.docKeys = docKeys;
-        this.outputs = outputs;
     }
 
     @Override
@@ -133,32 +131,6 @@ public class Get implements LogicalPlan {
         );
     }
 
-    @Override
-    public LogicalPlan tryCollapse() {
-        return this;
-    }
-
-    @Override
-    public List<Symbol> outputs() {
-        return outputs;
-    }
-
-    @Override
-    public Map<Symbol, Symbol> expressionMapping() {
-        return Collections.emptyMap();
-    }
-
-    @Override
-    public List<AbstractTableRelation> baseTables() {
-        return Collections.singletonList(tableRelation);
-    }
-
-    @Override
-    public Map<LogicalPlan, SelectSymbol> dependencies() {
-        return Collections.emptyMap();
-    }
-
-    @Override
     public long numExpectedRows() {
         return docKeys.size();
     }

--- a/sql/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
+++ b/sql/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
@@ -181,7 +181,7 @@ public class GroupHashAggregate extends OneInputPlan {
     }
 
     @Override
-    protected LogicalPlan newInstance(LogicalPlan newSource) {
+    protected LogicalPlan updateSource(LogicalPlan newSource) {
         return new GroupHashAggregate(newSource, groupKeys, aggregates);
     }
 

--- a/sql/src/main/java/io/crate/planner/operators/HashAggregate.java
+++ b/sql/src/main/java/io/crate/planner/operators/HashAggregate.java
@@ -128,8 +128,12 @@ public class HashAggregate extends OneInputPlan {
     }
 
     @Override
-    public LogicalPlan tryCollapse() {
-        LogicalPlan collapsed = source.tryCollapse();
+    public LogicalPlan tryOptimize(@Nullable LogicalPlan pushDown) {
+        if (pushDown != null) {
+            // can't push down anything
+            return null;
+        }
+        LogicalPlan collapsed = source.tryOptimize(null);
         if (collapsed instanceof Collect &&
             ((Collect) collapsed).tableInfo instanceof DocTableInfo &&
             aggregates.size() == 1 &&
@@ -141,7 +145,7 @@ public class HashAggregate extends OneInputPlan {
         if (collapsed == source) {
             return this;
         }
-        return newInstance(collapsed);
+        return updateSource(collapsed);
     }
 
     @Override
@@ -150,7 +154,7 @@ public class HashAggregate extends OneInputPlan {
     }
 
     @Override
-    protected LogicalPlan newInstance(LogicalPlan newSource) {
+    protected LogicalPlan updateSource(LogicalPlan newSource) {
         return new HashAggregate(newSource, aggregates);
     }
 

--- a/sql/src/main/java/io/crate/planner/operators/HashAggregate.java
+++ b/sql/src/main/java/io/crate/planner/operators/HashAggregate.java
@@ -23,7 +23,6 @@
 package io.crate.planner.operators;
 
 import io.crate.analyze.OrderBy;
-import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.symbol.AggregateMode;
 import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.SelectSymbol;
@@ -52,14 +51,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-public class HashAggregate implements LogicalPlan {
+public class HashAggregate extends OneInputPlan {
 
     private static final String MERGE_PHASE_NAME = "mergeOnHandler";
-    final LogicalPlan source;
     final List<Function> aggregates;
 
     HashAggregate(LogicalPlan source, List<Function> aggregates) {
-        this.source = source;
+        super(source);
         this.aggregates = aggregates;
     }
 
@@ -143,7 +141,7 @@ public class HashAggregate implements LogicalPlan {
         if (collapsed == source) {
             return this;
         }
-        return new HashAggregate(collapsed, aggregates);
+        return newInstance(collapsed);
     }
 
     @Override
@@ -152,18 +150,8 @@ public class HashAggregate implements LogicalPlan {
     }
 
     @Override
-    public Map<Symbol, Symbol> expressionMapping() {
-        return source.expressionMapping();
-    }
-
-    @Override
-    public List<AbstractTableRelation> baseTables() {
-        return source.baseTables();
-    }
-
-    @Override
-    public Map<LogicalPlan, SelectSymbol> dependencies() {
-        return source.dependencies();
+    protected LogicalPlan newInstance(LogicalPlan newSource) {
+        return new HashAggregate(newSource, aggregates);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/Insert.java
+++ b/sql/src/main/java/io/crate/planner/operators/Insert.java
@@ -40,14 +40,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-public class Insert implements LogicalPlan {
+public class Insert extends OneInputPlan {
 
-    private final LogicalPlan source;
     private final QueriedRelation relation;
     private final ColumnIndexWriterProjection projection;
 
     public Insert(LogicalPlan source, QueriedRelation relation, ColumnIndexWriterProjection projection) {
-        this.source = source;
+        super(source);
         this.relation = relation;
         this.projection = projection;
     }
@@ -78,6 +77,11 @@ public class Insert implements LogicalPlan {
     }
 
     @Override
+    protected LogicalPlan newInstance(LogicalPlan newSource) {
+        return new Insert(newSource, relation, projection);
+    }
+
+    @Override
     public List<Symbol> outputs() {
         return relation.outputs();
     }
@@ -90,11 +94,6 @@ public class Insert implements LogicalPlan {
     @Override
     public List<AbstractTableRelation> baseTables() {
         return Collections.emptyList();
-    }
-
-    @Override
-    public Map<LogicalPlan, SelectSymbol> dependencies() {
-        return source.dependencies();
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/Insert.java
+++ b/sql/src/main/java/io/crate/planner/operators/Insert.java
@@ -72,12 +72,7 @@ public class Insert extends OneInputPlan {
     }
 
     @Override
-    public LogicalPlan tryCollapse() {
-        return this;
-    }
-
-    @Override
-    protected LogicalPlan newInstance(LogicalPlan newSource) {
+    protected LogicalPlan updateSource(LogicalPlan newSource) {
         return new Insert(newSource, relation, projection);
     }
 

--- a/sql/src/main/java/io/crate/planner/operators/Join.java
+++ b/sql/src/main/java/io/crate/planner/operators/Join.java
@@ -437,7 +437,7 @@ public class Join extends TwoInputPlan {
     }
 
     @Override
-    protected LogicalPlan newInstance(LogicalPlan newLeftSource, LogicalPlan newRightSource) {
+    protected LogicalPlan updateSources(LogicalPlan newLeftSource, LogicalPlan newRightSource) {
         return new Join(newLeftSource, newRightSource, joinType, joinCondition, isFiltered);
     }
 

--- a/sql/src/main/java/io/crate/planner/operators/Limit.java
+++ b/sql/src/main/java/io/crate/planner/operators/Limit.java
@@ -104,7 +104,7 @@ class Limit extends OneInputPlan {
     }
 
     @Override
-    protected LogicalPlan newInstance(LogicalPlan newSource) {
+    protected LogicalPlan updateSource(LogicalPlan newSource) {
         return new Limit(newSource, limit, offset);
     }
 

--- a/sql/src/main/java/io/crate/planner/operators/Limit.java
+++ b/sql/src/main/java/io/crate/planner/operators/Limit.java
@@ -23,7 +23,6 @@
 package io.crate.planner.operators;
 
 import io.crate.analyze.OrderBy;
-import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.symbol.Literal;
 import io.crate.analyze.symbol.SelectSymbol;
 import io.crate.analyze.symbol.Symbol;
@@ -48,9 +47,8 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import static io.crate.analyze.SymbolEvaluator.evaluate;
 import static io.crate.planner.operators.LogicalPlanner.NO_LIMIT;
 
-class Limit implements LogicalPlan {
+class Limit extends OneInputPlan {
 
-    final LogicalPlan source;
     final Symbol limit;
     final Symbol offset;
 
@@ -66,7 +64,7 @@ class Limit implements LogicalPlan {
     }
 
     private Limit(LogicalPlan source, Symbol limit, Symbol offset) {
-        this.source = source;
+        super(source);
         this.limit = limit;
         this.offset = offset;
     }
@@ -106,32 +104,8 @@ class Limit implements LogicalPlan {
     }
 
     @Override
-    public LogicalPlan tryCollapse() {
-        LogicalPlan collapsed = source.tryCollapse();
-        if (collapsed == source) {
-            return this;
-        }
-        return new Limit(collapsed, limit, offset);
-    }
-
-    @Override
-    public List<Symbol> outputs() {
-        return source.outputs();
-    }
-
-    @Override
-    public Map<Symbol, Symbol> expressionMapping() {
-        return source.expressionMapping();
-    }
-
-    @Override
-    public List<AbstractTableRelation> baseTables() {
-        return source.baseTables();
-    }
-
-    @Override
-    public Map<LogicalPlan, SelectSymbol> dependencies() {
-        return source.dependencies();
+    protected LogicalPlan newInstance(LogicalPlan newSource) {
+        return new Limit(newSource, limit, offset);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlanBase.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlanBase.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.operators;
+
+import io.crate.analyze.relations.AbstractTableRelation;
+import io.crate.analyze.symbol.SelectSymbol;
+import io.crate.analyze.symbol.Symbol;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The abstract base for all {@link LogicalPlan}s.
+ *
+ * For now, this just reduces the amount of boiler plate code each instance
+ * has to implement. Generally, this is an extension point where functionality
+ * resides which is used by all plans.
+ */
+abstract class LogicalPlanBase implements LogicalPlan {
+
+    protected final List<Symbol> outputs;
+    protected final Map<Symbol, Symbol> expressionMapping;
+    protected final List<AbstractTableRelation> baseTables;
+    protected final Map<LogicalPlan, SelectSymbol> dependencies;
+
+    LogicalPlanBase(List<Symbol> outputs,
+                    Map<Symbol, Symbol> expressionMapping,
+                    List<AbstractTableRelation> baseTables,
+                    Map<LogicalPlan, SelectSymbol> dependencies) {
+        this.outputs = outputs;
+        this.expressionMapping = expressionMapping;
+        this.baseTables = baseTables;
+        this.dependencies = dependencies;
+    }
+
+    @Override
+    public List<Symbol> outputs() {
+        return outputs;
+    }
+
+    @Override
+    public Map<Symbol, Symbol> expressionMapping() {
+        return expressionMapping;
+    }
+
+    @Override
+    public List<AbstractTableRelation> baseTables() {
+        return baseTables;
+    }
+
+    @Override
+    public Map<LogicalPlan, SelectSymbol> dependencies() {
+        return dependencies;
+    }
+}

--- a/sql/src/main/java/io/crate/planner/operators/MultiPhase.java
+++ b/sql/src/main/java/io/crate/planner/operators/MultiPhase.java
@@ -70,7 +70,7 @@ public class MultiPhase extends OneInputPlan {
     }
 
     @Override
-    protected LogicalPlan newInstance(LogicalPlan newSource) {
+    protected LogicalPlan updateSource(LogicalPlan newSource) {
         return new MultiPhase(newSource, dependencies);
     }
 

--- a/sql/src/main/java/io/crate/planner/operators/OneInputPlan.java
+++ b/sql/src/main/java/io/crate/planner/operators/OneInputPlan.java
@@ -26,6 +26,7 @@ import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.symbol.SelectSymbol;
 import io.crate.analyze.symbol.Symbol;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 
@@ -57,11 +58,16 @@ abstract class OneInputPlan extends LogicalPlanBase {
         this.source = source;
     }
 
+
     @Override
-    public LogicalPlan tryCollapse() {
-        LogicalPlan newPlan = source.tryCollapse();
-        if (source != newPlan) {
-            return newInstance(newPlan);
+    public LogicalPlan tryOptimize(@Nullable LogicalPlan pushDown) {
+        if (pushDown != null) {
+            // can't push down
+            return null;
+        }
+        LogicalPlan newPlan = source.tryOptimize(null);
+        if (newPlan != source) {
+            return updateSource(newPlan);
         }
         return this;
     }
@@ -87,6 +93,6 @@ abstract class OneInputPlan extends LogicalPlanBase {
      * @param newSource A new {@link LogicalPlan} as a source.
      * @return A new copy of this {@link OneInputPlan} with the new source.
      */
-    protected abstract LogicalPlan newInstance(LogicalPlan newSource);
+    protected abstract LogicalPlan updateSource(LogicalPlan newSource);
 
 }

--- a/sql/src/main/java/io/crate/planner/operators/OneInputPlan.java
+++ b/sql/src/main/java/io/crate/planner/operators/OneInputPlan.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.operators;
+
+import io.crate.analyze.relations.AbstractTableRelation;
+import io.crate.analyze.symbol.SelectSymbol;
+import io.crate.analyze.symbol.Symbol;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A {@link LogicalPlan} with one other LogicalPlan as input.
+ */
+abstract class OneInputPlan extends LogicalPlanBase {
+
+    protected final LogicalPlan source;
+
+    OneInputPlan(LogicalPlan source) {
+        this(source, source.outputs());
+    }
+
+    OneInputPlan(LogicalPlan source, Map<LogicalPlan, SelectSymbol> dependencies) {
+        this(source, source.outputs(), source.expressionMapping(), source.baseTables(), dependencies);
+    }
+
+    OneInputPlan(LogicalPlan source, List<Symbol> outputs) {
+        this(source, outputs, source.expressionMapping(), source.baseTables(), source.dependencies());
+    }
+
+    OneInputPlan(LogicalPlan source,
+                 List<Symbol> outputs,
+                 Map<Symbol, Symbol> expressionMapping,
+                 List<AbstractTableRelation> baseTables,
+                 Map<LogicalPlan, SelectSymbol> dependencies) {
+        super(outputs, expressionMapping, baseTables, dependencies);
+        this.source = source;
+    }
+
+    @Override
+    public LogicalPlan tryCollapse() {
+        LogicalPlan newPlan = source.tryCollapse();
+        if (source != newPlan) {
+            return newInstance(newPlan);
+        }
+        return this;
+    }
+
+    /**
+     * If no other information available, return the source's number of rows.
+     * @return The number of rows of the source plan.
+     */
+    @Override
+    public long numExpectedRows() {
+        return source.numExpectedRows();
+    }
+
+    /**
+     * Creates a new LogicalPlan with an updated source. This is necessary
+     * when we collapse plans during plan building or "push down" plans
+     * later on to optimize their execution.
+     *
+     * {@link LogicalPlan}s should be immutable. Fields like sources may only
+     * be updated by creating a new instance of the plan. Since Java does not
+     * allow to copy an instance easily and also instances might apply a custom
+     * logic when they clone itself, this method has to be implemented.
+     * @param newSource A new {@link LogicalPlan} as a source.
+     * @return A new copy of this {@link OneInputPlan} with the new source.
+     */
+    protected abstract LogicalPlan newInstance(LogicalPlan newSource);
+
+}

--- a/sql/src/main/java/io/crate/planner/operators/RelationBoundary.java
+++ b/sql/src/main/java/io/crate/planner/operators/RelationBoundary.java
@@ -95,6 +95,17 @@ public class RelationBoundary extends OneInputPlan {
     }
 
     @Override
+    public LogicalPlan tryOptimize(@Nullable LogicalPlan pushDown) {
+        if (pushDown instanceof Order) {
+            LogicalPlan newSource = source.tryOptimize(pushDown);
+            if (newSource != null && newSource != source) {
+                return updateSource(newSource);
+            }
+        }
+        return super.tryOptimize(pushDown);
+    }
+
+    @Override
     public ExecutionPlan build(PlannerContext plannerContext,
                                ProjectionBuilder projectionBuilder,
                                int limit,
@@ -118,7 +129,7 @@ public class RelationBoundary extends OneInputPlan {
     }
 
     @Override
-    protected LogicalPlan newInstance(LogicalPlan newSource) {
+    protected LogicalPlan updateSource(LogicalPlan newSource) {
         return new RelationBoundary(newSource, relation, outputs, expressionMapping, dependencies);
     }
 }

--- a/sql/src/main/java/io/crate/planner/operators/RootRelationBoundary.java
+++ b/sql/src/main/java/io/crate/planner/operators/RootRelationBoundary.java
@@ -64,7 +64,7 @@ public class RootRelationBoundary extends OneInputPlan {
     }
 
     @Override
-    protected LogicalPlan newInstance(LogicalPlan newSource) {
+    protected LogicalPlan updateSource(LogicalPlan newSource) {
         return new RootRelationBoundary(newSource);
     }
 

--- a/sql/src/main/java/io/crate/planner/operators/RootRelationBoundary.java
+++ b/sql/src/main/java/io/crate/planner/operators/RootRelationBoundary.java
@@ -22,11 +22,8 @@
 
 package io.crate.planner.operators;
 
-import com.google.common.annotations.VisibleForTesting;
 import io.crate.analyze.OrderBy;
-import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.symbol.SelectSymbol;
-import io.crate.analyze.symbol.Symbol;
 import io.crate.data.Row;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.Merge;
@@ -34,19 +31,15 @@ import io.crate.planner.PlannerContext;
 import io.crate.planner.projection.builder.ProjectionBuilder;
 
 import javax.annotation.Nullable;
-import java.util.List;
 import java.util.Map;
 
 /**
  * An operator with the primary purpose to ensure that the result is on the handler and no longer distributed.
  */
-public class RootRelationBoundary implements LogicalPlan {
-
-    @VisibleForTesting
-    final LogicalPlan source;
+public class RootRelationBoundary extends OneInputPlan {
 
     public RootRelationBoundary(LogicalPlan source) {
-        this.source = source;
+        super(source);
     }
 
     @Override
@@ -71,37 +64,8 @@ public class RootRelationBoundary implements LogicalPlan {
     }
 
     @Override
-    public LogicalPlan tryCollapse() {
-        LogicalPlan collapsed = source.tryCollapse();
-        if (collapsed == source) {
-            return this;
-        }
-        return new RootRelationBoundary(collapsed);
-    }
-
-    @Override
-    public List<Symbol> outputs() {
-        return source.outputs();
-    }
-
-    @Override
-    public Map<Symbol, Symbol> expressionMapping() {
-        return source.expressionMapping();
-    }
-
-    @Override
-    public List<AbstractTableRelation> baseTables() {
-        return source.baseTables();
-    }
-
-    @Override
-    public Map<LogicalPlan, SelectSymbol> dependencies() {
-        return source.dependencies();
-    }
-
-    @Override
-    public long numExpectedRows() {
-        return source.numExpectedRows();
+    protected LogicalPlan newInstance(LogicalPlan newSource) {
+        return new RootRelationBoundary(newSource);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/TwoInputPlan.java
+++ b/sql/src/main/java/io/crate/planner/operators/TwoInputPlan.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.operators;
+
+import io.crate.analyze.symbol.Symbol;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * A {@link LogicalPlan} with two other LogicalPlans as input.
+ */
+abstract class TwoInputPlan extends LogicalPlanBase {
+
+    final LogicalPlan lhs;
+    final LogicalPlan rhs;
+
+    TwoInputPlan(LogicalPlan left, LogicalPlan right, List<Symbol> outputs) {
+        super(outputs, new HashMap<>(), new ArrayList<>(), Collections.emptyMap());
+        this.lhs = left;
+        this.rhs = right;
+        this.baseTables.addAll(lhs.baseTables());
+        this.baseTables.addAll(rhs.baseTables());
+        this.expressionMapping.putAll(lhs.expressionMapping());
+        this.expressionMapping.putAll(rhs.expressionMapping());
+    }
+
+    @Override
+    public LogicalPlan tryCollapse() {
+        LogicalPlan lhsCollapsed = lhs.tryCollapse();
+        LogicalPlan rhsCollapsed = rhs.tryCollapse();
+        if (lhs != lhsCollapsed || rhs != rhsCollapsed) {
+            return newInstance(lhsCollapsed, rhsCollapsed);
+        }
+        return this;
+    }
+
+    /**
+     * Creates a new LogicalPlan with an updated source. This is necessary
+     * when we collapse plans during plan building or "push down" plans
+     * later on to optimize their execution.
+     *
+     * {@link LogicalPlan}s should be immutable. Fields like sources may only
+     * be updated by creating a new instance of the plan. Since Java does not
+     * allow to copy an instance easily and also instances might apply a custom
+     * logic when they clone itself, this method has to be implemented.
+     * @param newLeftSource A new {@link} LogicalPlan as the left source.
+     * @param newRightSource A new {@link} LogicalPlan as the right source.
+     * @return A new copy of this {@link OneInputPlan} with the new sources.
+     */
+    protected abstract LogicalPlan newInstance(LogicalPlan newLeftSource, LogicalPlan newRightSource);
+}

--- a/sql/src/main/java/io/crate/planner/operators/TwoInputPlan.java
+++ b/sql/src/main/java/io/crate/planner/operators/TwoInputPlan.java
@@ -24,6 +24,7 @@ package io.crate.planner.operators;
 
 import io.crate.analyze.symbol.Symbol;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -48,11 +49,14 @@ abstract class TwoInputPlan extends LogicalPlanBase {
     }
 
     @Override
-    public LogicalPlan tryCollapse() {
-        LogicalPlan lhsCollapsed = lhs.tryCollapse();
-        LogicalPlan rhsCollapsed = rhs.tryCollapse();
-        if (lhs != lhsCollapsed || rhs != rhsCollapsed) {
-            return newInstance(lhsCollapsed, rhsCollapsed);
+    public LogicalPlan tryOptimize(@Nullable LogicalPlan pushDown) {
+        if (pushDown != null) {
+            return null;
+        }
+        LogicalPlan newLhs = lhs.tryOptimize(null);
+        LogicalPlan newRhs = rhs.tryOptimize(null);
+        if (newLhs != lhs || newRhs != rhs) {
+            return updateSources(newLhs, newRhs);
         }
         return this;
     }
@@ -70,5 +74,5 @@ abstract class TwoInputPlan extends LogicalPlanBase {
      * @param newRightSource A new {@link} LogicalPlan as the right source.
      * @return A new copy of this {@link OneInputPlan} with the new sources.
      */
-    protected abstract LogicalPlan newInstance(LogicalPlan newLeftSource, LogicalPlan newRightSource);
+    protected abstract LogicalPlan updateSources(LogicalPlan newLeftSource, LogicalPlan newRightSource);
 }

--- a/sql/src/main/java/io/crate/planner/operators/Union.java
+++ b/sql/src/main/java/io/crate/planner/operators/Union.java
@@ -23,7 +23,6 @@
 package io.crate.planner.operators;
 
 import io.crate.analyze.OrderBy;
-import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.relations.QueriedRelation;
 import io.crate.analyze.relations.UnionSelect;
 import io.crate.analyze.symbol.FieldsVisitor;
@@ -43,7 +42,6 @@ import io.crate.planner.node.dql.MergePhase;
 import io.crate.planner.projection.builder.ProjectionBuilder;
 
 import javax.annotation.Nullable;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -62,15 +60,7 @@ import static io.crate.planner.operators.Limit.limitAndOffset;
  * intermediate fetches occur by passing all columns to the nested plans
  * and setting {@code FetchMode.NEVER_CLEAR}.
  */
-public class Union implements LogicalPlan {
-
-    private final List<Symbol> unionOutputs;
-    private final LogicalPlan lhs;
-    private final LogicalPlan rhs;
-
-    private final HashMap<Symbol, Symbol> expressionMapping;
-
-    private final ArrayList<AbstractTableRelation> baseTables;
+public class Union extends TwoInputPlan {
 
     static Builder create(UnionSelect ttr, SubqueryPlanner subqueryPlanner) {
         return (tableStats, usedColsByParent) -> {
@@ -95,7 +85,7 @@ public class Union implements LogicalPlan {
                 .plan(right, FetchMode.NEVER_CLEAR, subqueryPlanner, false)
                 .build(tableStats, usedFromRight);
 
-            return new Union(ttr.outputs(), lhsPlan, rhsPlan);
+            return new Union(lhsPlan, rhsPlan, ttr.outputs());
         };
     }
 
@@ -119,16 +109,8 @@ public class Union implements LogicalPlan {
         });
     }
 
-    private Union(List<Symbol> outputs, LogicalPlan lhs, LogicalPlan rhs) {
-        this.unionOutputs = outputs;
-        this.lhs = lhs;
-        this.rhs = rhs;
-        this.baseTables = new ArrayList<>();
-        this.baseTables.addAll(lhs.baseTables());
-        this.baseTables.addAll(rhs.baseTables());
-        this.expressionMapping = new HashMap<>();
-        this.expressionMapping.putAll(lhs.expressionMapping());
-        this.expressionMapping.putAll(rhs.expressionMapping());
+    Union(LogicalPlan lhs, LogicalPlan rhs, List<Symbol> outputs) {
+        super(lhs, rhs, outputs);
     }
 
     @Override
@@ -181,28 +163,8 @@ public class Union implements LogicalPlan {
     }
 
     @Override
-    public LogicalPlan tryCollapse() {
-        LogicalPlan lhsCollapsed = lhs.tryCollapse();
-        LogicalPlan rhsCollapsed = rhs.tryCollapse();
-        if (lhs != lhsCollapsed || rhs != rhsCollapsed) {
-            return new Union(unionOutputs, lhsCollapsed, rhsCollapsed);
-        }
-        return this;
-    }
-
-    @Override
-    public List<Symbol> outputs() {
-        return unionOutputs;
-    }
-
-    @Override
-    public Map<Symbol, Symbol> expressionMapping() {
-        return expressionMapping;
-    }
-
-    @Override
-    public List<AbstractTableRelation> baseTables() {
-        return baseTables;
+    protected LogicalPlan newInstance(LogicalPlan newLeftSource, LogicalPlan newRightSource) {
+        return new Union(newLeftSource, newRightSource, outputs);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/ZeroInputPlan.java
+++ b/sql/src/main/java/io/crate/planner/operators/ZeroInputPlan.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.operators;
+
+import io.crate.analyze.relations.AbstractTableRelation;
+import io.crate.analyze.symbol.Symbol;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A {@link LogicalPlan} with two no other LogicalPlans as input.
+ */
+abstract class ZeroInputPlan extends LogicalPlanBase {
+
+    public ZeroInputPlan(List<Symbol> outputs, List<AbstractTableRelation> baseTables) {
+        super(outputs, Collections.emptyMap(), baseTables, Collections.emptyMap());
+    }
+
+    @Override
+    public LogicalPlan tryCollapse() {
+        // We don't have any sources, so just return this instance
+        return this;
+    }
+}

--- a/sql/src/main/java/io/crate/planner/operators/ZeroInputPlan.java
+++ b/sql/src/main/java/io/crate/planner/operators/ZeroInputPlan.java
@@ -25,6 +25,7 @@ package io.crate.planner.operators;
 import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.symbol.Symbol;
 
+import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 
@@ -38,7 +39,10 @@ abstract class ZeroInputPlan extends LogicalPlanBase {
     }
 
     @Override
-    public LogicalPlan tryCollapse() {
+    public LogicalPlan tryOptimize(@Nullable LogicalPlan pushDown) {
+        if (pushDown != null) {
+            return null;
+        }
         // We don't have any sources, so just return this instance
         return this;
     }

--- a/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -261,7 +261,7 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
                 indentation += 4;
                 startLine("subQueries[\n");
                 indentation += 4;
-                for (Map.Entry<LogicalPlan, SelectSymbol> entry : multiPhase.subQueries.entrySet()) {
+                for (Map.Entry<LogicalPlan, SelectSymbol> entry : multiPhase.dependencies.entrySet()) {
                     printPlan(entry.getKey());
                 }
                 indentation -= 4;
@@ -326,7 +326,7 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
                 startLine("Collect[");
                 sb.append(collect.tableInfo.ident());
                 sb.append(" | [");
-                addSymbolsList(collect.toCollect);
+                addSymbolsList(collect.outputs);
                 sb.append("] | ");
                 sb.append(printQueryClause(symbolPrinter, collect.where));
                 sb.append("]\n");

--- a/sql/src/test/java/io/crate/planner/operators/PushDownTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/PushDownTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.operators;
+
+import io.crate.analyze.TableDefinitions;
+import io.crate.planner.TableStats;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+import org.junit.Test;
+
+import static io.crate.planner.operators.LogicalPlannerTest.isPlan;
+
+public class PushDownTest extends CrateDummyClusterServiceUnitTest {
+
+    @Test
+    public void testOrderByOnUnionIsMovedBeneathUnion() {
+
+        TableStats tableStats = new TableStats();
+
+        SQLExecutor sqlExecutor = SQLExecutor.builder(clusterService)
+            .addDocTable(TableDefinitions.USER_TABLE_INFO)
+            .build();
+
+        LogicalPlan plan = LogicalPlannerTest.plan(
+            "Select name from users union all select text from users order by name",
+            sqlExecutor,
+            clusterService,
+            tableStats);
+
+        assertThat(plan, isPlan(sqlExecutor.functions(),  "Boundary[name]\n" +
+                                                "Union[\n" +
+                                                    "Boundary[name]\n" +
+                                                    "OrderBy[name]\n" +
+                                                    "Collect[doc.users | [name] | All]\n" +
+                                                "---\n" +
+                                                    "Boundary[text]\n" +
+                                                    "OrderBy[text]\n" +
+                                                    "Collect[doc.users | [text] | All]\n" +
+                                                "]\n"));
+    }
+
+    @Test
+    public void testOrderByOnUnionIsCombinedWithOrderByBeneathUnion() {
+
+        TableStats tableStats = new TableStats();
+
+        SQLExecutor sqlExecutor = SQLExecutor.builder(clusterService)
+            .addDocTable(TableDefinitions.USER_TABLE_INFO)
+            .build();
+
+        LogicalPlan plan = LogicalPlannerTest.plan(
+            "Select * from (select name from users order by text) a " +
+            "union all " +
+            "select text from users " +
+            "order by name",
+            sqlExecutor,
+            clusterService,
+            tableStats);
+
+        assertThat(plan, isPlan(sqlExecutor.functions(),  "Boundary[name]\n" +
+                                                          "Union[\n" +
+                                                              "Boundary[name]\n" +
+                                                              "Boundary[name]\n" +
+                                                              "FetchOrEval[name]\n" +
+                                                              "OrderBy[name]\n" +
+                                                              "Collect[doc.users | [name, text] | All]\n" +
+                                                          "---\n" +
+                                                              "Boundary[text]\n" +
+                                                              "OrderBy[text]\n" +
+                                                              "Collect[doc.users | [text] | All]\n" +
+                                                          "]\n"));
+    }
+}


### PR DESCRIPTION
Queries like `Select id from t1 UNION ALL Select id2 from t2 order by id` are
optimized to perform an order by already in the source relations of the
union. The OrderBy from the union is "pushed down" to the queries on t1 and
t2. The result only needs to run a sorted merge.

Additionally, if two Order are discovered in a row, they will be combined.
```
       *Order*                   Union                  Union
          |                     /     \                /     \
          |                    /       \              /       \
        Union              *Order*  *Order*       *Order*  *Order*
       /     \                |        |             |        |
      /       \      =>       |        |     =>      |        |
   Collect   Order          Collect  Order        Collect  Collect
     t1        |              t1       |            t1       t2
               |                       |
            Collect                 Collect
              t2                      t2
```
Operators allowed to push down an Order: Union, RelationBoundary, FetchOrEval.

This moves the `tryCollapse` inside the newly introduced `tryOptimize` method
which traverses the entire plan. If a pushdown operator is discovered, it will
be pushed and then the rest of the graph will be traversed.

Overhaul of #6609 as an alternative to #6635.