### PR TITLE
Fixed merging of where clauses for collapsable subselects.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -132,6 +132,14 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that caused incorrect results for collapsable subselects which
+  contained a ``WHERE`` clause that results in no match. E.g. ::
+
+    SELECT * FROM (
+      SELECT * FROM t
+      WHERE false
+    ) vt
+
 - Fixed a performance regression introduced in ``2.2.0`` that caused ``SELECT``
   statements with ``ORDER BY`` and ``LIMIT`` to execute way slower than before
 

--- a/sql/src/test/java/io/crate/analyze/WhereClauseTest.java
+++ b/sql/src/test/java/io/crate/analyze/WhereClauseTest.java
@@ -60,4 +60,22 @@ public class WhereClauseTest {
         assertThat(whereLiteralFalse.noMatch(), is(whereReplaced.noMatch()));
         assertThat(whereLiteralFalse.query(), is(whereReplaced.query()));
     }
+
+    @Test
+    public void testMerge() {
+        WhereClause whereLiteralTrue = new WhereClause(Literal.BOOLEAN_TRUE);
+        WhereClause whereLiteralFalse = new WhereClause(Literal.BOOLEAN_FALSE);
+        Symbol query1 = sqlExpressions.asSymbol("x = 1");
+        WhereClause where1 = new WhereClause(query1);
+        Symbol query2 = sqlExpressions.asSymbol("x = 2");
+        WhereClause where2 = new WhereClause(query2);
+        Symbol queryMerged = sqlExpressions.asSymbol("x = 1 and x =2");
+        WhereClause whereMerged = new WhereClause(queryMerged);
+
+        assertThat(whereLiteralFalse.mergeWhere(whereLiteralTrue), is(WhereClause.NO_MATCH));
+        assertThat(whereLiteralTrue.mergeWhere(whereLiteralTrue), is(WhereClause.MATCH_ALL));
+        assertThat(where1.mergeWhere(whereLiteralTrue), is(where1));
+        assertThat(where1.mergeWhere(whereLiteralFalse), is(WhereClause.NO_MATCH));
+        assertThat(where2.mergeWhere(where1), is(whereMerged));
+    }
 }


### PR DESCRIPTION
When one of the where clauses equals NO_MATCH then a
NO_MATCH where clause should be returned.

Fixes: https://github.com/crate/crate/issues/6653