### PR TITLE
make ALTER USER syntax consistent

### DIFF
--- a/blackbox/docs/admin/user-management.txt
+++ b/blackbox/docs/admin/user-management.txt
@@ -75,12 +75,12 @@ statement returns an error::
 To alter the password for an existing user from the CrateDB database cluster use
 the :ref:`ref-alter-user` SQL statement::
 
-    cr> ALTER USER user_a SET password = 'pass';
+    cr> ALTER USER user_a SET (password = 'pass');
     ALTER OK, 1 row affected (... sec)
 
 The password can be reset (cleared) if specified as ``NULL``::
 
-    cr> ALTER USER user_a SET password = NULL;
+    cr> ALTER USER user_a SET (password = NULL);
     ALTER OK, 1 row affected (... sec)
 
 

--- a/blackbox/docs/sql/statements/alter-user.txt
+++ b/blackbox/docs/sql/statements/alter-user.txt
@@ -17,7 +17,7 @@ Synopsis
 
 ::
 
-    ALTER USER
+    ALTER USER username
       SET ( user_parameter = value [, ...] )
 
 
@@ -31,6 +31,11 @@ user.
 
 Arguments
 =========
+
+``USERNAME``
+------------
+
+The name by which the user is identified inside the database.
 
 ``SET``
 -------

--- a/enterprise/users/src/test/java/io/crate/integrationtests/UserManagementIntegrationTest.java
+++ b/enterprise/users/src/test/java/io/crate/integrationtests/UserManagementIntegrationTest.java
@@ -99,8 +99,8 @@ public class UserManagementIntegrationTest extends BaseUsersIntegrationTest {
         assertUserIsCreated("arthur");
         executeAsSuperuser("CREATE USER ford WITH (password = ?)", new Object[]{"foo"});
         assertUserIsCreated("ford");
-        executeAsSuperuser("ALTER USER arthur SET password = ?", new Object[]{"pass"});
-        executeAsSuperuser("ALTER USER ford SET password = ?", new Object[]{"pass"});
+        executeAsSuperuser("ALTER USER arthur SET (password = ?)", new Object[]{"pass"});
+        executeAsSuperuser("ALTER USER ford SET (password = ?)", new Object[]{"pass"});
         executeAsSuperuser("SELECT name, password, superuser FROM sys.users WHERE superuser = FALSE ORDER BY name");
         assertThat(TestingHelpers.printedTable(response.rows()), is("arthur| ********| false\n" +
                                                                     "ford| ********| false\n"));
@@ -110,7 +110,7 @@ public class UserManagementIntegrationTest extends BaseUsersIntegrationTest {
     public void testAlterUserResetPassword() throws Exception {
         executeAsSuperuser("CREATE USER arthur WITH (password = 'foo')");
         assertUserIsCreated("arthur");
-        executeAsSuperuser("ALTER USER arthur SET password = null");
+        executeAsSuperuser("ALTER USER arthur SET (password = null)");
         executeAsSuperuser("SELECT name, password, superuser FROM sys.users WHERE superuser = FALSE ORDER BY name");
         assertThat(TestingHelpers.printedTable(response.rows()), is("arthur| NULL| false\n"));
     }
@@ -119,7 +119,7 @@ public class UserManagementIntegrationTest extends BaseUsersIntegrationTest {
     public void testAlterNonExistingUserThrowsException() throws Exception {
         expectedException.expect(SQLActionException.class);
         expectedException.expectMessage("UserUnknownException: User 'unknown_user' does not exist");
-        executeAsSuperuser("alter user unknown_user set password = 'unknown'");
+        executeAsSuperuser("alter user unknown_user set (password = 'unknown')");
     }
 
     @Test

--- a/enterprise/users/src/test/java/io/crate/operation/user/StatementPrivilegeValidatorTest.java
+++ b/enterprise/users/src/test/java/io/crate/operation/user/StatementPrivilegeValidatorTest.java
@@ -157,12 +157,12 @@ public class StatementPrivilegeValidatorTest extends CrateDummyClusterServiceUni
     public void testAlterOtherUsersNotAllowedAsNormalUser() {
         expectedException.expect(UnauthorizedException.class);
         expectedException.expectMessage(is("User \"normal\" is not authorized to execute statement"));
-        analyze("alter user ford set password = 'pass'");
+        analyze("alter user ford set (password = 'pass')");
     }
 
     @Test
     public void testAlterOwnUserIsAllowed() {
-        analyze("alter user normal set password = 'pass'");
+        analyze("alter user normal set (password = 'pass')");
         assertThat(validationCallArguments.size(), is(0));
     }
 

--- a/sql-parser/src/main/antlr/SqlBase.g4
+++ b/sql-parser/src/main/antlr/SqlBase.g4
@@ -53,7 +53,7 @@ statement
     | ALTER TABLE alterTableDefinition RENAME TO qname                               #alterTableRename
     | ALTER TABLE alterTableDefinition REROUTE rerouteOption                         #alterTableReroute
     | ALTER CLUSTER REROUTE RETRY FAILED                                             #alterClusterRerouteRetryFailed
-    | ALTER USER name=ident SET assignment (',' assignment)*                         #alterUser
+    | ALTER USER name=ident SET '(' genericProperties ')'                            #alterUser
     | RESET GLOBAL primaryExpression (',' primaryExpression)*                        #resetGlobal
     | SET SESSION CHARACTERISTICS AS TRANSACTION setExpr (setExpr)*                  #setSessionTransactionMode
     | SET (SESSION | LOCAL)? qname

--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -781,7 +781,7 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     public Node visitAlterUser(SqlBaseParser.AlterUserContext context) {
         return new AlterUser(
             getIdentText(context.name),
-            visit(context.assignment(), Assignment.class)
+            (GenericProperties) visit(context.genericProperties())
         );
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/AlterUser.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AlterUser.java
@@ -26,21 +26,19 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
-import java.util.List;
-
 public class AlterUser extends Statement {
 
-    private final List<Assignment> assignments;
+    private final GenericProperties genericProperties;
     private final String name;
 
-    public AlterUser(String name, List<Assignment> assignments) {
-        Preconditions.checkNotNull(assignments, "assignments are null");
-        this.assignments = assignments;
+    public AlterUser(String name, GenericProperties genericProperties) {
+        Preconditions.checkNotNull(genericProperties, "assignments are null");
+        this.genericProperties = genericProperties;
         this.name = name;
     }
 
-    public List<Assignment> assignments() {
-        return assignments;
+    public GenericProperties genericProperties() {
+        return genericProperties;
     }
 
     public String name() {
@@ -54,20 +52,20 @@ public class AlterUser extends Statement {
 
         AlterUser alterUser = (AlterUser) o;
 
-        if (!assignments.equals(alterUser.assignments)) return false;
+        if (!genericProperties.equals(alterUser.genericProperties)) return false;
         return name.equals(alterUser.name);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(name, assignments);
+        return Objects.hashCode(name, genericProperties);
     }
 
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
             .add("name", name)
-            .add("assignments", assignments)
+            .add("properties", genericProperties)
             .toString();
     }
 

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -1131,8 +1131,15 @@ public class TestStatementBuilder {
 
     @Test
     public void testAlterUser() throws Exception {
-        printStatement("alter user crate set password = 'password'");
-        printStatement("alter user crate set password = null");
+        printStatement("alter user crate set (password = 'password')");
+        printStatement("alter user crate set (password = null)");
+    }
+
+    @Test
+    public void testAlterUserWithMissingProperties() {
+        expectedException.expect(ParsingException.class);
+        expectedException.expectMessage(containsString("mismatched input '<EOF>' expecting 'SET'"));
+        printStatement("alter user crate");
     }
 
     @Test

--- a/sql/src/main/java/io/crate/analyze/AlterUserAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/AlterUserAnalyzer.java
@@ -24,15 +24,14 @@ package io.crate.analyze;
 
 import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
-import io.crate.analyze.expressions.ExpressionToStringVisitor;
 import io.crate.analyze.relations.FieldProvider;
 import io.crate.analyze.symbol.Symbol;
-import io.crate.data.Row;
 import io.crate.metadata.Functions;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.AlterUser;
-import io.crate.sql.tree.Assignment;
+import io.crate.sql.tree.Expression;
+import io.crate.sql.tree.GenericProperties;
 import io.crate.sql.tree.QualifiedName;
 import org.elasticsearch.common.Nullable;
 
@@ -71,12 +70,11 @@ public class AlterUserAnalyzer {
         );
 
         Map<String, Symbol> rows = new HashMap<>();
-        List<Assignment> assignments = node.assignments();
+        GenericProperties genericProperties = node.genericProperties();
 
-        for (Assignment assignment : assignments) {
-            Symbol valueSymbol = expressionAnalyzer.convert(assignment.expression(), exprContext);
-            String settingName = ExpressionToStringVisitor.convert(assignment.columnName(), Row.EMPTY);
-            rows.put(settingName, valueSymbol);
+        for (Map.Entry<String, Expression> expr : genericProperties.properties().entrySet()) {
+            Symbol valueSymbol = expressionAnalyzer.convert(expr.getValue(), exprContext);
+            rows.put(expr.getKey(), valueSymbol);
         }
 
         return new AlterUserAnalyzedStatement(node.name(), rows);

--- a/sql/src/test/java/io/crate/analyze/UserDDLAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/UserDDLAnalyzerTest.java
@@ -79,14 +79,14 @@ public class UserDDLAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testAlterUserWithPassword() throws Exception {
-        AlterUserAnalyzedStatement analysis = e.analyze("ALTER USER ROOT SET PASSWORD = 'ROOT'");
+        AlterUserAnalyzedStatement analysis = e.analyze("ALTER USER ROOT SET (PASSWORD = 'ROOT')");
         assertThat(analysis.userName(), is("root"));
         assertThat(analysis.properties().get("password"), is(Literal.of("ROOT")));
     }
 
     @Test
     public void testAlterUserResetPassword() throws Exception {
-        AlterUserAnalyzedStatement analysis = e.analyze("ALTER USER ROOT SET PASSWORD = NULL");
+        AlterUserAnalyzedStatement analysis = e.analyze("ALTER USER ROOT SET (PASSWORD = NULL)");
         assertThat(analysis.userName(), is("root"));
         assertThat(analysis.properties().get("password"), is(Literal.of(DataTypes.UNDEFINED, null)));
     }


### PR DESCRIPTION
`ALTER USER` properties need to be specified within parentheses to be
consistent with other statements that use generic properties.