### PR TITLE
Implementation of HTTP password authentication method

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -47,6 +47,13 @@ Breaking Changes
 Changes
 =======
 
+- Added new "password" authentication method which is available for connections
+  via the PostgreSQL wire protocol and HTTP. This method allows clients to
+  authenticate using a valid database user and its password. For HTTP, the
+  ``X-User`` header, used to provide a username, has been deprecated in favor
+  of the standard HTTP ``Authorization`` header with the Basic Authentication
+  Scheme.
+
 - Added ``hyperloglog_distinct`` aggregation function. This is an
   enterprise-only feature.
 
@@ -61,7 +68,6 @@ Changes
 - Added an optimization when UNION ALL is used with ORDER BY. The ORDER BY is
   now "pushed down" to the left and right side of the union which improves the
   sorting speed.
-
 
 - Added support for disabling the column store per ``STRING`` column on table
   creation and on adding columns. In conjunction with disabling indexing on that
@@ -84,10 +90,6 @@ Changes
     SELECT id FROM t1
     UNION ALL
     SELECT id FROM t2
-
-- Added new "password" authentication method which is available for connections
-  via the Postgres Protocol. This method allows clients to authenticate using
-  a valid database user and its password.
 
 - Added ``WITH`` clause to ``CREATE USER`` statement to specify user properties
   upon creation. The single property available right now is the ``password``

--- a/app/src/main/dist/config/crate.yml
+++ b/app/src/main/dist/config/crate.yml
@@ -102,9 +102,9 @@ auth:
 
 # When trust based authentication is used, the server just takes the username
 # provided by the client as is without further validation. The HTTP
-# implementation takes the value of the `X-USER` request header as the
-# username. Since a user is always required for trust based authentication, a
-# default user (in case `X-USER` is not set) can be defined as follows:
+# implementation extracts the username from the standard HTTP Basic Authentication
+# (`Authorization: Basic ...`) request header. In case the `Authorization` header is not set,
+# a default username can be specified as follows:
 #auth:
 #  trust:
 #    http_default_user: dustin

--- a/blackbox/docs/admin/auth/hba.txt
+++ b/blackbox/docs/admin/auth/hba.txt
@@ -136,8 +136,7 @@ default.
 
 And finally the entry ``{method: password}`` means that any existing user (or
 superuser) can authenticate to CrateDB from any IP address using the
-``password`` method. Note that ``password`` authentication is only available
-via Postgres Protocol, even though no protocol is specified.
+``password`` method for both HTTP and PostgreSQL wire protocol.
 
 .. NOTE::
 
@@ -149,7 +148,7 @@ Authenticating as a Superuser
 When CrateDB is started, the cluster contains one predefined superuser. This
 user is called ``crate``.
 
-To enable trust auhentication for the superuser, ``crate`` must be specified in
+To enable trust authentication for the superuser, ``crate`` must be specified in
 the the ``auth.host_based`` setting, like this:
 
 .. code-block:: yaml
@@ -160,3 +159,34 @@ the the ``auth.host_based`` setting, like this:
         config:
           0:
             user: crate
+
+Authenticating to Admin UI
+==========================
+
+.. hide:
+
+    cr> CREATE USER admin;
+    CREATE OK, 1 row affected (... sec)
+
+When trying to access the CrateDB admin UI, authentication with the user
+defined with the :ref:`auth.trust.http_default_user
+<auth_trust_http_default_user>` setting (defaults to ``crate``) will be
+attempted initially. If this authentication attempt fails, the browser will
+open the standard popup window where the user is asked to fill in credentials.
+Depending on the HBA configuration, it may be necessary to a username and
+password, or, alternatively, a username only.
+
+Users that log in to the admin UI must be granted `DQL`` privileges at the
+``CLUSTER`` level in order to be able to access the various monitoring
+sections. For example::
+
+    cr> GRANT DQL TO admin;
+    GRANT OK, 1 row affected (... sec)
+
+For more information, consult the :ref:`privileges section
+<administration-privileges>`.
+
+.. hide:
+
+    cr> DROP USER admin;
+    DROP OK, 1 row affected (... sec)

--- a/blackbox/docs/admin/auth/methods.txt
+++ b/blackbox/docs/admin/auth/methods.txt
@@ -41,13 +41,15 @@ client implementations.
 Trust Authentication Over HTTP
 ------------------------------
 
-The HTTP implementation takes the value of the ``X-USER`` request header as the
-username.
+The HTTP implementation extracts the username from the
+`HTTP Basic Authentication`_ request header.
 
 Since a user is always required for trust authentication, it is possible to
-specify a default user in case that the ``X-USER`` header is not set. This is
-useful to allow clients which do not provide the possibility to set any
+specify a default user in case that the ``Authorization`` header is not set.
+This is useful to allow clients which do not provide the possibility to set any
 headers, for example a web browser connecting to the Admin UI.
+
+.. _auth_trust_http_default_user:
 
 The default user can be specified via the ``auth.trust.http_default_user``
 setting like this:
@@ -82,8 +84,11 @@ a password additionally to the username. The password is sent from the client
 to the server in **clear text**, which means that unless SSL is enabled, the
 password could potentially be read by anyone sniffing the network.
 
-Password authentication is only supported over the Postgres Protocol, not over
-HTTP connections.
+.. NOTE::
+
+   For HTTP, the password must be encoded together with the username with
+   `BASE64_` and sent together prefixed with ``Basic:`` as string value for
+   the ``Authorization`` HTTP header. See also: `HTTP Basic Authentication`_.
 
 .. NOTE::
 
@@ -119,3 +124,5 @@ connect using SSL with client certificate.
 
 .. _PBKDF2: https://en.wikipedia.org/wiki/PBKDF2
 .. _SHA-512 hash algorithm: https://en.wikipedia.org/wiki/SHA-2
+.. _HTTP Basic Authentication: https://en.wikipedia.org/wiki/Basic_access_authentication
+.. _BASE64: https://en.wikipedia.org/wiki/Base64

--- a/blackbox/docs/config/enterprise.txt
+++ b/blackbox/docs/config/enterprise.txt
@@ -61,7 +61,7 @@ Trust Authentication
 
   The default user that should be used for authentication when clients connect
   to CrateDB via HTTP protocol and they do not specify a user via the
-  ``X-USER`` request header.
+  ``Authorization`` request header.
 
 Host Based Authentication
 .........................
@@ -128,10 +128,6 @@ The meaning of the fields of the are as follows:
   | Specifies the protocol for which the authentication entry should be used.
   | If no protocol is specified, then this entry will be valid for all
   | protocols that rely on host based authentication see :ref:`auth_trust`).
-  | Certain authentication methods (e.g. ``password``) are only available over
-  | the Postgres Protocol, which means that even if no specific protocol is
-  | specified the HBA entry will only apply users connecting via the Postgres
-  | Protocol.
 
 **auth.host_based.config.${order}.ssl**
   | *Runtime:* ``no``

--- a/blackbox/requirements.txt
+++ b/blackbox/requirements.txt
@@ -4,7 +4,7 @@ argh==0.26.2
 Babel==2.4.0
 colorama==0.3.9
 crash==0.22.3
-crate==0.20.1
+crate==0.21.0
 
 # don't pin crate-docs-theme to a version number so the docs pick up whatever
 # the latest theme happens to be. these packages are installed into a venv, so

--- a/enterprise/users/src/main/java/io/crate/operation/auth/HostBasedAuthentication.java
+++ b/enterprise/users/src/main/java/io/crate/operation/auth/HostBasedAuthentication.java
@@ -93,17 +93,14 @@ public class HostBasedAuthentication implements Authentication {
     }
 
     @Nullable
-    private AuthenticationMethod methodForNameAndProtocol(String method, Protocol protocol) {
+    private AuthenticationMethod methodForName(String method) {
         switch (method) {
             case (TrustAuthenticationMethod.NAME):
                 return new TrustAuthenticationMethod(userLookup);
             case (ClientCertAuth.NAME):
                 return new ClientCertAuth(userLookup);
             case (PasswordAuthenticationMethod.NAME):
-                if (Protocol.POSTGRES.equals(protocol)) {
-                    return new PasswordAuthenticationMethod(userLookup);
-                }
-                return null;
+                return new PasswordAuthenticationMethod(userLookup);
             default:
                 return null;
         }
@@ -118,7 +115,7 @@ public class HostBasedAuthentication implements Authentication {
             String methodName = entry.get()
                 .getValue()
                 .getOrDefault(KEY_METHOD, DEFAULT_AUTH_METHOD);
-            return methodForNameAndProtocol(methodName, connProperties.protocol());
+            return methodForName(methodName);
         }
         return null;
     }

--- a/enterprise/users/src/main/java/io/crate/protocols/http/HttpAuthUpstreamHandler.java
+++ b/enterprise/users/src/main/java/io/crate/protocols/http/HttpAuthUpstreamHandler.java
@@ -61,6 +61,10 @@ import static io.netty.buffer.Unpooled.copiedBuffer;
 public class HttpAuthUpstreamHandler extends SimpleChannelInboundHandler<Object> {
 
     private static final Logger LOGGER = Loggers.getLogger(HttpAuthUpstreamHandler.class);
+    @VisibleForTesting
+    static final String WWW_AUTHENTICATE_REALM_MESSAGE = "Basic realm=\"Please provide credentials " +
+                                                         "(password maybe empty if trust authentication " +
+                                                         "is configured for your user)\")";
     private final Authentication authService;
     private Settings settings;
     private boolean authorized;

--- a/enterprise/users/src/main/java/io/crate/protocols/http/HttpAuthUpstreamHandler.java
+++ b/enterprise/users/src/main/java/io/crate/protocols/http/HttpAuthUpstreamHandler.java
@@ -26,20 +26,24 @@ import io.crate.operation.auth.Protocol;
 import io.crate.operation.user.User;
 import io.crate.protocols.SSL;
 import io.crate.protocols.postgres.ConnectionProperties;
+import io.crate.rest.CrateRestMainAction;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.HttpContent;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpUtil;
 import io.netty.handler.codec.http.HttpVersion;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.network.InetAddresses;
+import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 
 import javax.annotation.Nullable;
@@ -83,7 +87,9 @@ public class HttpAuthUpstreamHandler extends SimpleChannelInboundHandler<Object>
 
     private void handleHttpRequest(ChannelHandlerContext ctx, HttpRequest request) {
         SSLSession session = getSession(ctx.channel());
-        String username = userFromRequest(request, session, settings);
+        Tuple<String, SecureString> credentials = credentialsFromRequest(request, session, settings);
+        String username = credentials.v1();
+        SecureString password = credentials.v2();
         InetAddress address = addressFromRequestOrChannel(request, ctx.channel());
         ConnectionProperties connectionProperties = new ConnectionProperties(address, Protocol.HTTP, session);
         AuthenticationMethod authMethod = authService.resolveAuthenticationType(username, connectionProperties);
@@ -95,7 +101,7 @@ public class HttpAuthUpstreamHandler extends SimpleChannelInboundHandler<Object>
             sendUnauthorized(ctx.channel(), errorMessage);
         } else {
             try {
-                User user = authMethod.authenticate(username, null, connectionProperties);
+                User user = authMethod.authenticate(username, password, connectionProperties);
                 if (user != null && LOGGER.isTraceEnabled()) {
                     LOGGER.trace("Authentication succeeded user \"{}\" and method \"{}\".", username, authMethod.name());
                 }
@@ -131,6 +137,9 @@ public class HttpAuthUpstreamHandler extends SimpleChannelInboundHandler<Object>
         } else {
             response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.UNAUTHORIZED);
         }
+        // "Tell" the browser to open the credentials popup
+        // It helps to avoid custom login page in AdminUI
+        response.headers().set(HttpHeaderNames.WWW_AUTHENTICATE, WWW_AUTHENTICATE_REALM_MESSAGE);
         channel.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
     }
 
@@ -140,24 +149,30 @@ public class HttpAuthUpstreamHandler extends SimpleChannelInboundHandler<Object>
     }
 
     @VisibleForTesting
-    static String userFromRequest(HttpRequest request, @Nullable SSLSession session, Settings settings) {
-        if (request.headers().contains(AuthSettings.HTTP_HEADER_USER)) {
-            return request.headers().get(AuthSettings.HTTP_HEADER_USER);
+    static Tuple<String, SecureString> credentialsFromRequest(HttpRequest request, @Nullable SSLSession session, Settings settings) {
+        String username = null;
+        if (request.headers().contains(HttpHeaderNames.AUTHORIZATION.toString())) {
+            // Prefer Http Basic Auth
+            return CrateRestMainAction.extractCredentialsFromHttpBasicAuthHeader(
+                request.headers().get(HttpHeaderNames.AUTHORIZATION.toString()));
+        } else if (request.headers().contains(AuthSettings.HTTP_HEADER_USER)) {
+            // Fallback to deprecated setting
+            username = request.headers().get(AuthSettings.HTTP_HEADER_USER);
         } else {
             // prefer commonName as userName over AUTH_TRUST_HTTP_DEFAULT_HEADER user
             if (session != null) {
                 try {
                     Certificate certificate = session.getPeerCertificates()[0];
-                    String commonName = SSL.extractCN(certificate);
-                    if (commonName != null) {
-                        return commonName;
-                    }
+                    username = SSL.extractCN(certificate);
                 } catch (ArrayIndexOutOfBoundsException | SSLPeerUnverifiedException ignored) {
                     // client cert is optional
                 }
             }
-            return AuthSettings.AUTH_TRUST_HTTP_DEFAULT_HEADER.setting().get(settings);
+            if (username == null) {
+                username = AuthSettings.AUTH_TRUST_HTTP_DEFAULT_HEADER.setting().get(settings);
+            }
         }
+        return new Tuple<>(username, null);
     }
 
     private InetAddress addressFromRequestOrChannel(HttpRequest request, Channel channel) {

--- a/enterprise/users/src/test/java/io/crate/protocols/http/HttpAuthUpstreamHandlerTest.java
+++ b/enterprise/users/src/test/java/io/crate/protocols/http/HttpAuthUpstreamHandlerTest.java
@@ -44,6 +44,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.cert.Certificate;
 import java.util.EnumSet;
 
+import static io.crate.protocols.http.HttpAuthUpstreamHandler.WWW_AUTHENTICATE_REALM_MESSAGE;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -61,7 +62,7 @@ public class HttpAuthUpstreamHandlerTest extends CrateUnitTest {
     private static void assertUnauthorized(DefaultFullHttpResponse resp, String expectedBody) {
         assertThat(resp.status(), is(HttpResponseStatus.UNAUTHORIZED));
         assertThat(resp.content().toString(StandardCharsets.UTF_8), is(expectedBody));
-        assertThat(resp.headers().get(HttpHeaderNames.WWW_AUTHENTICATE), is("Basic"));
+        assertThat(resp.headers().get(HttpHeaderNames.WWW_AUTHENTICATE), is(WWW_AUTHENTICATE_REALM_MESSAGE));
     }
 
     @Test

--- a/http/src/test/java/io/crate/rest/CrateRestMainActionTest.java
+++ b/http/src/test/java/io/crate/rest/CrateRestMainActionTest.java
@@ -22,6 +22,8 @@
 
 package io.crate.rest;
 
+import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.settings.SecureString;
 import org.junit.Test;
 
 import static io.crate.rest.CrateRestMainAction.isAcceptJson;
@@ -43,5 +45,32 @@ public class CrateRestMainActionTest {
         assertThat(isAcceptJson(null), is(false));
         assertThat(isAcceptJson("text/html"), is(false));
         assertThat(isAcceptJson("application/json"), is(true));
+    }
+
+    @Test
+    public void testExtractUsernamePasswordFromHttpBasicAuthHeader() {
+        Tuple<String, SecureString> creds = CrateRestMainAction.extractCredentialsFromHttpBasicAuthHeader("");
+        assertThat(creds.v1(), is(""));
+        assertThat(creds.v2().toString(), is(""));
+
+        creds = CrateRestMainAction.extractCredentialsFromHttpBasicAuthHeader(null);
+        assertThat(creds.v1(), is(""));
+        assertThat(creds.v2().toString(), is(""));
+
+        creds = CrateRestMainAction.extractCredentialsFromHttpBasicAuthHeader("Basic QXJ0aHVyOkV4Y2FsaWJ1cg==");
+        assertThat(creds.v1(), is("Arthur"));
+        assertThat(creds.v2().toString(), is("Excalibur"));
+
+        creds = CrateRestMainAction.extractCredentialsFromHttpBasicAuthHeader("Basic QXJ0aHVyOjp0ZXN0OnBhc3N3b3JkOg==");
+        assertThat(creds.v1(), is("Arthur"));
+        assertThat(creds.v2().toString(), is(":test:password:"));
+
+        creds = CrateRestMainAction.extractCredentialsFromHttpBasicAuthHeader("Basic QXJ0aHVyOg==");
+        assertThat(creds.v1(), is("Arthur"));
+        assertThat(creds.v2().toString(), is(""));
+
+        creds = CrateRestMainAction.extractCredentialsFromHttpBasicAuthHeader("Basic OnBhc3N3b3Jk");
+        assertThat(creds.v1(), is(""));
+        assertThat(creds.v2().toString(), is("password"));
     }
 }

--- a/sql/src/main/java/io/crate/operation/auth/AuthSettings.java
+++ b/sql/src/main/java/io/crate/operation/auth/AuthSettings.java
@@ -48,6 +48,7 @@ public final class AuthSettings {
         "auth.trust.http_default_user", "crate", Function.identity(), Setting.Property.NodeScope),
         DataTypes.STRING);
 
+    @Deprecated //Scheduled to be removed as HTTP Basic Auth Header is introduced"
     public static final String HTTP_HEADER_USER = "X-User";
     public static final String HTTP_HEADER_REAL_IP = "X-Real-Ip";
 }


### PR DESCRIPTION
- Keeping compatibility with `X-User` HTTP header but deprecate it.
- Standard HTTP Basic Auth header `Authorization` with value `Basic: <user:pass in Base64>` is used