### PR TITLE
Fixed an error thrown when selecting thread_pools['name'].

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -47,6 +47,11 @@ Breaking Changes
 Changes
 =======
 
+- Fixed an issue that caused an Exception to be thrown when trying to query
+  ``thread_pools['name']`` field of system table ``sys.nodes`` and
+  ``settings['write']['wait_for_active_shards']`` from table
+  ``information_schema.tables``
+
 - Added new "password" authentication method which is available for connections
   via the PostgreSQL wire protocol and HTTP. This method allows clients to
   authenticate using a valid database user and its password. For HTTP, the

--- a/sql/src/main/java/io/crate/metadata/sys/SysNodesTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysNodesTableInfo.java
@@ -241,10 +241,10 @@ public class SysNodesTableInfo extends StaticTableInfo {
             .put(SysNodesTableInfo.Columns.HEAP, NodeHeapStatsExpression::new)
             .put(SysNodesTableInfo.Columns.VERSION, NodeVersionStatsExpression::new)
             .put(SysNodesTableInfo.Columns.THREAD_POOLS, NodeThreadPoolsExpression::new)
-            .put(SysNodesTableInfo.Columns.THREAD_POOLS_NAME, () -> new NodeStatsThreadPoolExpression<String>() {
+            .put(SysNodesTableInfo.Columns.THREAD_POOLS_NAME, () -> new NodeStatsThreadPoolExpression<BytesRef>() {
                 @Override
-                protected String valueForItem(Map.Entry<String, ThreadPools.ThreadPoolExecutorContext> input) {
-                    return input.getKey();
+                protected BytesRef valueForItem(Map.Entry<String, ThreadPools.ThreadPoolExecutorContext> input) {
+                    return BytesRefs.toBytesRef(input.getKey());
                 }
             })
             .put(SysNodesTableInfo.Columns.THREAD_POOLS_ACTIVE, () -> new NodeStatsThreadPoolExpression<Integer>() {

--- a/sql/src/main/java/io/crate/metadata/sys/SysNodesTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysNodesTableInfo.java
@@ -243,43 +243,43 @@ public class SysNodesTableInfo extends StaticTableInfo {
             .put(SysNodesTableInfo.Columns.THREAD_POOLS, NodeThreadPoolsExpression::new)
             .put(SysNodesTableInfo.Columns.THREAD_POOLS_NAME, () -> new NodeStatsThreadPoolExpression<BytesRef>() {
                 @Override
-                protected BytesRef valueForItem(Map.Entry<String, ThreadPools.ThreadPoolExecutorContext> input) {
-                    return BytesRefs.toBytesRef(input.getKey());
+                protected BytesRef valueForItem(Map.Entry<BytesRef, ThreadPools.ThreadPoolExecutorContext> input) {
+                    return input.getKey();
                 }
             })
             .put(SysNodesTableInfo.Columns.THREAD_POOLS_ACTIVE, () -> new NodeStatsThreadPoolExpression<Integer>() {
                 @Override
-                protected Integer valueForItem(Map.Entry<String, ThreadPools.ThreadPoolExecutorContext> input) {
+                protected Integer valueForItem(Map.Entry<BytesRef, ThreadPools.ThreadPoolExecutorContext> input) {
                     return input.getValue().activeCount();
                 }
             })
             .put(SysNodesTableInfo.Columns.THREAD_POOLS_REJECTED, () -> new NodeStatsThreadPoolExpression<Long>() {
                 @Override
-                protected Long valueForItem(Map.Entry<String, ThreadPools.ThreadPoolExecutorContext> input) {
+                protected Long valueForItem(Map.Entry<BytesRef, ThreadPools.ThreadPoolExecutorContext> input) {
                     return input.getValue().rejectedCount();
                 }
             })
             .put(SysNodesTableInfo.Columns.THREAD_POOLS_LARGEST, () -> new NodeStatsThreadPoolExpression<Integer>() {
                 @Override
-                protected Integer valueForItem(Map.Entry<String, ThreadPools.ThreadPoolExecutorContext> input) {
+                protected Integer valueForItem(Map.Entry<BytesRef, ThreadPools.ThreadPoolExecutorContext> input) {
                     return input.getValue().largestPoolSize();
                 }
             })
             .put(SysNodesTableInfo.Columns.THREAD_POOLS_COMPLETED, () -> new NodeStatsThreadPoolExpression<Long>() {
                 @Override
-                protected Long valueForItem(Map.Entry<String, ThreadPools.ThreadPoolExecutorContext> input) {
+                protected Long valueForItem(Map.Entry<BytesRef, ThreadPools.ThreadPoolExecutorContext> input) {
                     return input.getValue().completedTaskCount();
                 }
             })
             .put(SysNodesTableInfo.Columns.THREAD_POOLS_THREADS, () -> new NodeStatsThreadPoolExpression<Integer>() {
                 @Override
-                protected Integer valueForItem(Map.Entry<String, ThreadPools.ThreadPoolExecutorContext> input) {
+                protected Integer valueForItem(Map.Entry<BytesRef, ThreadPools.ThreadPoolExecutorContext> input) {
                     return input.getValue().poolSize();
                 }
             })
             .put(SysNodesTableInfo.Columns.THREAD_POOLS_QUEUE, () -> new NodeStatsThreadPoolExpression<Integer>() {
                 @Override
-                protected Integer valueForItem(Map.Entry<String, ThreadPools.ThreadPoolExecutorContext> input) {
+                protected Integer valueForItem(Map.Entry<BytesRef, ThreadPools.ThreadPoolExecutorContext> input) {
                     return input.getValue().queueSize();
                 }
             })

--- a/sql/src/main/java/io/crate/operation/reference/information/TablesSettingsExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/information/TablesSettingsExpression.java
@@ -206,7 +206,9 @@ public class TablesSettingsExpression extends AbstractTablesSettingsExpression {
         public static final String WAIT_FOR_ACTIVE_SHARDS = "wait_for_active_shards";
 
         private void addChildImplementations() {
-            childImplementations.put(WAIT_FOR_ACTIVE_SHARDS, new TableParameterExpression(TableParameterInfo.SETTING_WAIT_FOR_ACTIVE_SHARDS));
+            childImplementations.put(
+                WAIT_FOR_ACTIVE_SHARDS,
+                new BytesRefTableParameterExpression(TableParameterInfo.SETTING_WAIT_FOR_ACTIVE_SHARDS));
         }
     }
 

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/NodeOsCgroupStatsExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/NodeOsCgroupStatsExpression.java
@@ -23,6 +23,8 @@
 package io.crate.operation.reference.sys.node;
 
 import io.crate.monitor.ExtendedOsStats;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.monitor.os.OsStats;
 
 import java.util.Map;
@@ -57,7 +59,7 @@ public class NodeOsCgroupStatsExpression extends NestedNodeStatsExpression {
         private static final String USAGE_NANOS = "usage_nanos";
 
         public NodeOsCgroupCpuAcctStatsExpression() {
-            childImplementations.put(CONTROL_GROUP, CgroupExpression.forAttribute(OsStats.Cgroup::getCpuAcctControlGroup));
+            childImplementations.put(CONTROL_GROUP, CgroupExpression.forAttribute((r) -> BytesRefs.toBytesRef(r.getCpuAcctControlGroup())));
             childImplementations.put(USAGE_NANOS, CgroupExpression.forAttribute(OsStats.Cgroup::getCpuAcctUsageNanos));
         }
 
@@ -83,7 +85,7 @@ public class NodeOsCgroupStatsExpression extends NestedNodeStatsExpression {
         private static final String TIME_THROTTLED_NANOS = "time_throttled_nanos";
 
         public NodeOsCgroupCpuStatsExpression() {
-            childImplementations.put(CONTROL_GROUP, CgroupExpression.forAttribute(OsStats.Cgroup::getCpuControlGroup));
+            childImplementations.put(CONTROL_GROUP, CgroupExpression.forAttribute((r) -> BytesRefs.toBytesRef(r.getCpuControlGroup())));
             childImplementations.put(CFS_PERIOD_MICROS, CgroupExpression.forAttribute(OsStats.Cgroup::getCpuCfsPeriodMicros));
             childImplementations.put(CFS_QUOTA_MICROS, CgroupExpression.forAttribute(OsStats.Cgroup::getCpuCfsQuotaMicros));
             childImplementations.put(NUM_ELAPSED_PERIODS, CgroupExpression.forAttribute(
@@ -116,37 +118,37 @@ public class NodeOsCgroupStatsExpression extends NestedNodeStatsExpression {
         private static final String USAGE_BYTES = "usage_bytes";
 
         public NodeOsCgroupMemStatsExpression() {
-            childImplementations.put(CONTROL_GROUP, new SimpleNodeStatsExpression<String>() {
+            childImplementations.put(CONTROL_GROUP, new SimpleNodeStatsExpression<BytesRef>() {
                 @Override
-                public String innerValue() {
+                public BytesRef innerValue() {
                     if (row.isComplete()) {
                         ExtendedOsStats.CgroupMem cgroupMem = row.extendedOsStats().cgroupMem();
                         if (cgroupMem != null) {
-                            return cgroupMem.memoryControlGroup();
+                            return BytesRefs.toBytesRef(cgroupMem.memoryControlGroup());
                         }
                     }
                     return null;
                 }
             });
-            childImplementations.put(LIMIT_BYTES, new SimpleNodeStatsExpression<String>() {
+            childImplementations.put(LIMIT_BYTES, new SimpleNodeStatsExpression<BytesRef>() {
                 @Override
-                public String innerValue() {
+                public BytesRef innerValue() {
                     if (row.isComplete()) {
                         ExtendedOsStats.CgroupMem cgroupMem = row.extendedOsStats().cgroupMem();
                         if (cgroupMem != null) {
-                            return cgroupMem.memoryLimitBytes();
+                            return BytesRefs.toBytesRef(cgroupMem.memoryLimitBytes());
                         }
                     }
                     return null;
                 }
             });
-            childImplementations.put(USAGE_BYTES, new SimpleNodeStatsExpression<String>() {
+            childImplementations.put(USAGE_BYTES, new SimpleNodeStatsExpression<BytesRef>() {
                 @Override
-                public String innerValue() {
+                public BytesRef innerValue() {
                     if (row.isComplete()) {
                         ExtendedOsStats.CgroupMem cgroupMem = row.extendedOsStats().cgroupMem();
                         if (cgroupMem != null) {
-                            return cgroupMem.memoryUsageBytes();
+                            return BytesRefs.toBytesRef(cgroupMem.memoryUsageBytes());
                         }
                     }
                     return null;

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/NodeStatsArrayTypeExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/NodeStatsArrayTypeExpression.java
@@ -29,7 +29,15 @@ public abstract class NodeStatsArrayTypeExpression<I, R>
 
     @Override
     public R[] value() {
-        return row.isComplete() ? super.value() : null;
+        if (row.isComplete() == false) {
+            return null;
+        }
+
+        R[] value = super.value();
+        assert value.length == 0 || !(value[0] instanceof String) :
+            "Sys table expressions should not be of type String";
+
+        return value;
     }
 }
 

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/NodeStatsThreadPoolExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/NodeStatsThreadPoolExpression.java
@@ -24,19 +24,20 @@ package io.crate.operation.reference.sys.node;
 
 import com.google.common.collect.Lists;
 import io.crate.monitor.ThreadPools;
+import org.apache.lucene.util.BytesRef;
 
 import java.util.List;
 import java.util.Map;
 
 
 public abstract class NodeStatsThreadPoolExpression<R>
-    extends NodeStatsArrayTypeExpression<Map.Entry<String, ThreadPools.ThreadPoolExecutorContext>, R> {
+    extends NodeStatsArrayTypeExpression<Map.Entry<BytesRef, ThreadPools.ThreadPoolExecutorContext>, R> {
 
     protected NodeStatsThreadPoolExpression() {
     }
 
     @Override
-    protected List<Map.Entry<String, ThreadPools.ThreadPoolExecutorContext>> items() {
+    protected List<Map.Entry<BytesRef, ThreadPools.ThreadPoolExecutorContext>> items() {
         return Lists.newArrayList(this.row.threadPools());
     }
 }

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/NodeThreadPoolsExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/NodeThreadPoolsExpression.java
@@ -25,6 +25,7 @@ package io.crate.operation.reference.sys.node;
 import com.google.common.collect.Lists;
 import io.crate.monitor.ThreadPools;
 import io.crate.operation.reference.sys.ArrayTypeRowContextCollectorExpression;
+import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.lucene.BytesRefs;
 
 import java.util.HashMap;
@@ -33,7 +34,7 @@ import java.util.Map;
 
 
 public class NodeThreadPoolsExpression
-    extends ArrayTypeRowContextCollectorExpression<NodeStatsContext, Map.Entry<String, ThreadPools.ThreadPoolExecutorContext>, Object> {
+    extends ArrayTypeRowContextCollectorExpression<NodeStatsContext, Map.Entry<BytesRef, ThreadPools.ThreadPoolExecutorContext>, Object> {
 
     private static final String POOL_NAME = "name";
     private static final String ACTIVE = "active";
@@ -47,12 +48,12 @@ public class NodeThreadPoolsExpression
     }
 
     @Override
-    protected List<Map.Entry<String, ThreadPools.ThreadPoolExecutorContext>> items() {
+    protected List<Map.Entry<BytesRef, ThreadPools.ThreadPoolExecutorContext>> items() {
         return Lists.newArrayList(this.row.threadPools());
     }
 
     @Override
-    protected Object valueForItem(final Map.Entry<String, ThreadPools.ThreadPoolExecutorContext> input) {
+    protected Object valueForItem(final Map.Entry<BytesRef, ThreadPools.ThreadPoolExecutorContext> input) {
         return new HashMap<String, Object>() {
             {
                 put(POOL_NAME, BytesRefs.toBytesRef(input.getKey()));

--- a/sql/src/main/java/io/crate/operation/reference/sys/node/NodeThreadPoolsExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/sys/node/NodeThreadPoolsExpression.java
@@ -25,6 +25,7 @@ package io.crate.operation.reference.sys.node;
 import com.google.common.collect.Lists;
 import io.crate.monitor.ThreadPools;
 import io.crate.operation.reference.sys.ArrayTypeRowContextCollectorExpression;
+import org.elasticsearch.common.lucene.BytesRefs;
 
 import java.util.HashMap;
 import java.util.List;
@@ -54,7 +55,7 @@ public class NodeThreadPoolsExpression
     protected Object valueForItem(final Map.Entry<String, ThreadPools.ThreadPoolExecutorContext> input) {
         return new HashMap<String, Object>() {
             {
-                put(POOL_NAME, input.getKey());
+                put(POOL_NAME, BytesRefs.toBytesRef(input.getKey()));
                 put(ACTIVE, input.getValue().activeCount());
                 put(COMPLETED, input.getValue().completedTaskCount());
                 put(REJECTED, input.getValue().rejectedCount());

--- a/sql/src/test/java/io/crate/operation/reference/sys/node/NodeStatsContextTest.java
+++ b/sql/src/test/java/io/crate/operation/reference/sys/node/NodeStatsContextTest.java
@@ -24,8 +24,8 @@ package io.crate.operation.reference.sys.node;
 
 import io.crate.Build;
 import io.crate.Version;
-import io.crate.monitor.ThreadPools;
 import io.crate.monitor.ExtendedNodeInfo;
+import io.crate.monitor.ThreadPools;
 import io.crate.test.integration.CrateUnitTest;
 import org.elasticsearch.common.io.stream.InputStreamStreamInput;
 import org.elasticsearch.common.io.stream.OutputStreamStreamOutput;
@@ -154,7 +154,7 @@ public class NodeStatsContextTest extends CrateUnitTest {
                 10 * i + 4,
                 100L * i + 1L,
                 100L * i + 2L);
-            pools1.add(String.format("threadpool-%d", i), ctx);
+            pools1.add(BytesRefs.toBytesRef(String.format("threadpool-%d", i)), ctx);
         }
 
         ByteArrayOutputStream outBuffer = new ByteArrayOutputStream();

--- a/sql/src/test/java/io/crate/testing/BytesRefUtils.java
+++ b/sql/src/test/java/io/crate/testing/BytesRefUtils.java
@@ -92,6 +92,9 @@ public class BytesRefUtils {
             Object value = row[stringColumn.value];
             if (value instanceof BytesRef) {
                 row[stringColumn.value] = ((BytesRef) value).utf8ToString();
+            } else if (value instanceof String) {
+                throw new IllegalArgumentException("Column: " + stringColumn.index + " cannot be of type String, " +
+                                                   "BytesRef should be used instead");
             }
         }
     }
@@ -157,6 +160,9 @@ public class BytesRefUtils {
                     converted[i] = ensureStringValuesInMap((Map<String, Object>) values[i]);
                 }
                 return converted;
+            } else if (firstNotNull instanceof String) {
+                throw new IllegalArgumentException("Column: " + idx + " cannot be of type String, " +
+                                                   "BytesRef should be used instead");
             }
             return values;
         }

--- a/sql/src/test/java/io/crate/testing/SQLTransportExecutor.java
+++ b/sql/src/test/java/io/crate/testing/SQLTransportExecutor.java
@@ -599,7 +599,12 @@ public class SQLTransportExecutor {
 
         @Override
         public void allFinished(boolean interrupted) {
-            listener.onResponse(createSqlResponse());
+            try {
+                SQLResponse response = createSqlResponse();
+                listener.onResponse(response);
+            } catch (Exception e) {
+                listener.onFailure(e);
+            }
             super.allFinished(interrupted);
         }
 


### PR DESCRIPTION
String was used instead of BytesRef.

Since integration tests don't catch this error, due to transformation happening to faciliate easy assertions, added an assertion on the abstract class that handles those expressions to catch such errors in the future and without adding and perf overhead for normal runtime.