### PR TITLE
Prevent NodeOperationCtxBenchmark from getting stuck

### DIFF
--- a/sql/src/test/groovy/io/crate/planner/InsertPlannerTest.java
+++ b/sql/src/test/groovy/io/crate/planner/InsertPlannerTest.java
@@ -46,6 +46,7 @@ import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.types.DataTypes;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.Randomness;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -67,7 +68,7 @@ public class InsertPlannerTest extends CrateDummyClusterServiceUnitTest {
 
     @Before
     public void prepare() throws IOException {
-        e = SQLExecutor.builder(clusterService, 2)
+        e = SQLExecutor.builder(clusterService, 2, Randomness.get())
             .addDocTable(TableDefinitions.PARTED_PKS_TI)
             .addTable("create table users (id long primary key, name string, date timestamp) clustered into 4 shards")
             .build();

--- a/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -43,6 +43,7 @@ import io.crate.testing.SQLExecutor;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ClusterServiceUtils;
 import org.junit.Before;
@@ -79,7 +80,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
             .metaData(metaData)
             .build();
         ClusterServiceUtils.setState(clusterService, state);
-        e = SQLExecutor.builder(clusterService, 3).enableDefaultTables().build();
+        e = SQLExecutor.builder(clusterService, 3, Randomness.get()).enableDefaultTables().build();
     }
 
     @Test


### PR DESCRIPTION
The ClusterService wasn't being setup correctly, due to that the
SQLExecutor got stuck updating the clusterState.

(There are more issues with other benchmarks due to `Randomness.get()` calls without a ´RandomizedContext` being available. Fixing this will be a bit more work - so I'll do that separately)