### PR TITLE
Fix HTTP ``Authorization`` header prefix (remove ":")

### DIFF
--- a/blackbox/docs/admin/auth/methods.txt
+++ b/blackbox/docs/admin/auth/methods.txt
@@ -87,7 +87,7 @@ password could potentially be read by anyone sniffing the network.
 .. NOTE::
 
    For HTTP, the password must be encoded together with the username with
-   `BASE64_` and sent together prefixed with ``Basic:`` as string value for
+   `BASE64_` and sent together prefixed with ``Basic `` as string value for
    the ``Authorization`` HTTP header. See also: `HTTP Basic Authentication`_.
 
 .. NOTE::


### PR DESCRIPTION
Followup of: 6f4a8f57668a97c2d9cfc709333d4035d5350f71