### PR TITLE
gradle: Increase jaxb_api version to 2.2.2

### DIFF
--- a/gradle/version.properties
+++ b/gradle/version.properties
@@ -14,7 +14,7 @@ elasticsearchhadoop=2.4.0
 slf4j_log4j12=1.7.10
 jackson_jaxrs=1.9.13
 jackson_xc=1.9.13
-jaxb_api=2.1
+jaxb_api=2.2.2
 
 # Crate JDBC
 crate_jdbc=2.1.7

--- a/sql/build.gradle
+++ b/sql/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     compile "com.amazonaws:aws-java-sdk-s3:${versions.aws}"
     compile "org.apache.commons:commons-math3:${versions.commonsmath}"
     // Needed by aws-java-sdk-s3 in Java 9
-    compile "javax.xml:jaxb-api:${versions.jaxb_api}"
+    compile "javax.xml.bind:jaxb-api:${versions.jaxb_api}"
 
     testCompile project(':integration-testing')
     testCompile project(path: ':dex', configuration: 'testOutput')


### PR DESCRIPTION
To match the documentation in `blackbox/docs/admin/discovery.txt` and
the version used in
`es/upstream/plugins/discovery-azure-classic/build.gradle`