### PR TITLE
validate on primary key update assignments

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -21,6 +21,9 @@ Changes
 Fixes
 =====
 
+- Enforce validation of column constraints for ``INSERT`` statements with a
+  subquery as source and in combination with ``ON DUPLICATE KEY UPDATE``.
+
 - Fixed an issue that caused an error to be thrown when using ``GROUP BY`` or
   ``DISTINCT`` on a column of type ``IP`` in case there are rows with null
   value for that column.

--- a/sql/src/main/java/io/crate/analyze/CopyAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CopyAnalyzer.java
@@ -115,8 +115,7 @@ class CopyAnalyzer {
             RowGranularity.CLUSTER,
             null,
             tableRelation);
-        ExpressionAnalyzer expressionAnalyzer = createExpressionAnalyzer(analysis, tableRelation);
-        expressionAnalyzer.setResolveFieldsOperation(Operation.INSERT);
+        ExpressionAnalyzer expressionAnalyzer = createExpressionAnalyzer(analysis, tableRelation, Operation.INSERT);
         ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext();
         Predicate<DiscoveryNode> nodeFilters = discoveryNode -> true;
         Settings settings = Settings.EMPTY;
@@ -140,13 +139,14 @@ class CopyAnalyzer {
     }
 
 
-    private ExpressionAnalyzer createExpressionAnalyzer(Analysis analysis, DocTableRelation tableRelation) {
+    private ExpressionAnalyzer createExpressionAnalyzer(Analysis analysis, DocTableRelation tableRelation, Operation operation) {
         return new ExpressionAnalyzer(
             functions,
             analysis.transactionContext(),
             analysis.parameterContext(),
             new NameFieldProvider(tableRelation),
-            null);
+            null,
+            operation);
     }
 
     private static Predicate<DiscoveryNode> discoveryNodePredicate(Row parameters, @Nullable Expression nodeFiltersExpression) {
@@ -178,7 +178,7 @@ class CopyAnalyzer {
             RowGranularity.CLUSTER,
             null,
             tableRelation);
-        ExpressionAnalyzer expressionAnalyzer = createExpressionAnalyzer(analysis, tableRelation);
+        ExpressionAnalyzer expressionAnalyzer = createExpressionAnalyzer(analysis, tableRelation, Operation.READ);
         ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext();
 
         Symbol uri = expressionAnalyzer.convert(node.targetUri(), expressionAnalysisContext);

--- a/sql/src/main/java/io/crate/analyze/InsertFromSubQueryAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/InsertFromSubQueryAnalyzer.java
@@ -276,6 +276,7 @@ class InsertFromSubQueryAnalyzer {
                                                             List<Assignment> assignments) {
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
             functions, transactionContext, parameterContext, fieldProvider, null);
+        expressionAnalyzer.setResolveFieldsOperation(Operation.UPDATE);
 
         return getUpdateAssignments(
             functions, tableRelation, targetColumns, expressionAnalyzer, transactionContext, parameterContext, assignments);

--- a/sql/src/main/java/io/crate/analyze/UpdateAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/UpdateAnalyzer.java
@@ -128,9 +128,9 @@ public final class UpdateAnalyzer {
             txnCtx,
             typeHints,
             new NameFieldProvider(table),
-            subqueryAnalyzer
+            subqueryAnalyzer,
+            Operation.UPDATE
         );
-        targetExprAnalyzer.setResolveFieldsOperation(Operation.UPDATE);
         assert assignments instanceof RandomAccess
             : "assignments should implement RandomAccess for indexed loop to avoid iterator allocations";
         TableInfo tableInfo = table.tableInfo();

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -160,7 +160,7 @@ public class ExpressionAnalyzer {
     private final SubqueryAnalyzer subQueryAnalyzer;
     private final Functions functions;
     private final InnerExpressionAnalyzer innerAnalyzer;
-    private Operation operation = Operation.READ;
+    private final Operation operation;
 
     private static final Pattern SUBSCRIPT_SPLIT_PATTERN = Pattern.compile("^([^\\.\\[]+)(\\.*)([^\\[]*)(\\['.*'\\])");
 
@@ -169,12 +169,22 @@ public class ExpressionAnalyzer {
                               java.util.function.Function<ParameterExpression, Symbol> convertParamFunction,
                               FieldProvider fieldProvider,
                               @Nullable SubqueryAnalyzer subQueryAnalyzer) {
+        this(functions, transactionContext, convertParamFunction, fieldProvider, subQueryAnalyzer, Operation.READ);
+    }
+
+    public ExpressionAnalyzer(Functions functions,
+                              TransactionContext transactionContext,
+                              java.util.function.Function<ParameterExpression, Symbol> convertParamFunction,
+                              FieldProvider fieldProvider,
+                              @Nullable SubqueryAnalyzer subQueryAnalyzer,
+                              Operation operation) {
         this.functions = functions;
         this.transactionContext = transactionContext;
         this.convertParamFunction = convertParamFunction;
         this.fieldProvider = fieldProvider;
         this.subQueryAnalyzer = subQueryAnalyzer;
         this.innerAnalyzer = new InnerExpressionAnalyzer();
+        this.operation = operation;
     }
 
     /**
@@ -243,8 +253,15 @@ public class ExpressionAnalyzer {
         }
     }
 
-    public void setResolveFieldsOperation(Operation operation) {
-        this.operation = operation;
+    public ExpressionAnalyzer copyForOperation(Operation operation) {
+        return new ExpressionAnalyzer(
+            functions,
+            transactionContext,
+            convertParamFunction,
+            fieldProvider,
+            subQueryAnalyzer,
+            operation
+        );
     }
 
     /**

--- a/sql/src/test/java/io/crate/analyze/InsertFromSubQueryAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/InsertFromSubQueryAnalyzerTest.java
@@ -25,6 +25,7 @@ import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.InputColumn;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.exceptions.ColumnUnknownException;
+import io.crate.exceptions.ColumnValidationException;
 import io.crate.metadata.Reference;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.TableIdent;
@@ -234,6 +235,13 @@ public class InsertFromSubQueryAnalyzerTest extends CrateDummyClusterServiceUnit
         expectedException.expectMessage("Column does_not_exist unknown");
         e.analyze("insert into users (id, name) (select id, name from users) " +
                   "on duplicate key update name = values (does_not_exist)");
+    }
+
+    @Test
+    public void testFromQueryWithOnDuplicateKeyPrimaryKeyUpdate() {
+        expectedException.expect(ColumnValidationException.class);
+        expectedException.expectMessage("Updating a clustered-by column is not supported");
+        e.analyze("insert into users (id, name) (select 1, 'Arthur') on duplicate key update id = id + 1");
     }
 
     @Test


### PR DESCRIPTION
enforce validation of on duplicate key assignments in INSERT statements that use a subquery as source, e.g.

```sql
INSERT INTO (id, name) (SELECT 1, 'foo') ON DUPLICATE KEY UPDATE id = id + 1;
```

Made the `operation` of the ExpressionAnalyzer immutable to remove confusion about its value.