### PR TITLE
make DefaultTraversalVisitor more functional

### DIFF
--- a/sql-parser/src/main/java/io/crate/sql/tree/DefaultTraversalVisitor.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/DefaultTraversalVisitor.java
@@ -21,8 +21,8 @@
 
 package io.crate.sql.tree;
 
-public abstract class DefaultTraversalVisitor<R, C>
-    extends AstVisitor<R, C> {
+public abstract class DefaultTraversalVisitor<R, C>  extends AstVisitor<R, C> {
+
     @Override
     protected R visitExtract(Extract node, C context) {
         return process(node.getExpression(), context);
@@ -42,7 +42,6 @@ public abstract class DefaultTraversalVisitor<R, C>
     protected R visitArithmeticExpression(ArithmeticExpression node, C context) {
         process(node.getLeft(), context);
         process(node.getRight(), context);
-
         return null;
     }
 
@@ -51,7 +50,6 @@ public abstract class DefaultTraversalVisitor<R, C>
         process(node.getValue(), context);
         process(node.getMin(), context);
         process(node.getMax(), context);
-
         return null;
     }
 
@@ -59,29 +57,20 @@ public abstract class DefaultTraversalVisitor<R, C>
     protected R visitComparisonExpression(ComparisonExpression node, C context) {
         process(node.getLeft(), context);
         process(node.getRight(), context);
-
         return null;
     }
 
     @Override
     protected R visitQuery(Query node, C context) {
-        if (node.getWith().isPresent()) {
-            process(node.getWith().get(), context);
-        }
+        node.getWith().map(x -> process(x, context));
         process(node.getQueryBody(), context);
-        for (SortItem sortItem : node.getOrderBy()) {
-            process(sortItem, context);
-        }
-
+        node.getOrderBy().forEach(x -> process(x, context));
         return null;
     }
 
     @Override
     protected R visitWith(With node, C context) {
-        for (WithQuery query : node.getQueries()) {
-            process(query, context);
-        }
-
+        node.getQueries().forEach(x -> process(x, context));
         return null;
     }
 
@@ -92,17 +81,13 @@ public abstract class DefaultTraversalVisitor<R, C>
 
     @Override
     protected R visitSelect(Select node, C context) {
-        for (SelectItem item : node.getSelectItems()) {
-            process(item, context);
-        }
-
+        node.getSelectItems().forEach(x -> process(x, context));
         return null;
     }
 
     @Override
     protected R visitSingleColumn(SingleColumn node, C context) {
         process(node.getExpression(), context);
-
         return null;
     }
 
@@ -110,7 +95,6 @@ public abstract class DefaultTraversalVisitor<R, C>
     protected R visitWhenClause(WhenClause node, C context) {
         process(node.getOperand(), context);
         process(node.getResult(), context);
-
         return null;
     }
 
@@ -118,38 +102,28 @@ public abstract class DefaultTraversalVisitor<R, C>
     protected R visitInPredicate(InPredicate node, C context) {
         process(node.getValue(), context);
         process(node.getValueList(), context);
-
         return null;
     }
 
     @Override
     protected R visitFunctionCall(FunctionCall node, C context) {
-        for (Expression argument : node.getArguments()) {
-            process(argument, context);
-        }
-
+        node.getArguments().forEach(x -> process(x, context));
         return null;
     }
 
     @Override
     protected R visitSimpleCaseExpression(SimpleCaseExpression node, C context) {
         process(node.getOperand(), context);
-        for (WhenClause clause : node.getWhenClauses()) {
-            process(clause, context);
-        }
+        node.getWhenClauses().forEach(x -> process(x, context));
         if (node.getDefaultValue() != null) {
             process(node.getDefaultValue(), context);
         }
-
         return null;
     }
 
     @Override
     protected R visitInListExpression(InListExpression node, C context) {
-        for (Expression value : node.getValues()) {
-            process(value, context);
-        }
-
+        node.getValues().forEach(x -> process(x, context));
         return null;
     }
 
@@ -157,10 +131,7 @@ public abstract class DefaultTraversalVisitor<R, C>
     protected R visitIfExpression(IfExpression node, C context) {
         process(node.getCondition(), context);
         process(node.getTrueValue(), context);
-        if (node.getFalseValue().isPresent()) {
-            process(node.getFalseValue().get(), context);
-        }
-
+        node.getFalseValue().map(x -> process(x, context));
         return null;
     }
 
@@ -176,13 +147,10 @@ public abstract class DefaultTraversalVisitor<R, C>
 
     @Override
     protected R visitSearchedCaseExpression(SearchedCaseExpression node, C context) {
-        for (WhenClause clause : node.getWhenClauses()) {
-            process(clause, context);
-        }
+        node.getWhenClauses().forEach(x -> process(x, context));
         if (node.getDefaultValue() != null) {
             process(node.getDefaultValue(), context);
         }
-
         return null;
     }
 
@@ -193,7 +161,6 @@ public abstract class DefaultTraversalVisitor<R, C>
         if (node.getEscape() != null) {
             process(node.getEscape(), context);
         }
-
         return null;
     }
 
@@ -211,7 +178,6 @@ public abstract class DefaultTraversalVisitor<R, C>
     protected R visitLogicalBinaryExpression(LogicalBinaryExpression node, C context) {
         process(node.getLeft(), context);
         process(node.getRight(), context);
-
         return null;
     }
 
@@ -227,27 +193,15 @@ public abstract class DefaultTraversalVisitor<R, C>
 
     @Override
     protected R visitQuerySpecification(QuerySpecification node, C context) {
-
         // visit the from first, since this qualifies the select
         if (node.getFrom() != null) {
-            for (Relation relation : node.getFrom()) {
-                process(relation, context);
-            }
+            node.getFrom().forEach(x -> process(x, context));
         }
-
         process(node.getSelect(), context);
-        if (node.getWhere().isPresent()) {
-            process(node.getWhere().get(), context);
-        }
-        for (Expression expression : node.getGroupBy()) {
-            process(expression, context);
-        }
-        if (node.getHaving().isPresent()) {
-            process(node.getHaving().get(), context);
-        }
-        for (SortItem sortItem : node.getOrderBy()) {
-            process(sortItem, context);
-        }
+        node.getWhere().map(x -> process(x, context));
+        node.getGroupBy().forEach(x -> process(x, context));
+        node.getHaving().map(x -> process(x, context));
+        node.getOrderBy().forEach(x -> process(x, context));
         return null;
     }
 
@@ -286,40 +240,33 @@ public abstract class DefaultTraversalVisitor<R, C>
     protected R visitJoin(Join node, C context) {
         process(node.getLeft(), context);
         process(node.getRight(), context);
-
-        if (node.getCriteria().isPresent() && node.getCriteria().get() instanceof JoinOn) {
-            process(((JoinOn) node.getCriteria().get()).getExpression(), context);
-        }
-
+        node.getCriteria().map(x -> {
+            if (x instanceof JoinOn) {
+                process(((JoinOn) x).getExpression(), context);
+            }
+            return null;
+        });
         return null;
     }
 
     @Override
     public R visitInsertFromValues(InsertFromValues node, C context) {
         process(node.table(), context);
-        for (ValuesList valuesList : node.valuesLists()) {
-            process(valuesList, context);
-        }
+        node.valuesLists().forEach(x -> process(x, context));
         return null;
     }
 
     @Override
     public R visitValuesList(ValuesList node, C context) {
-        for (Expression value : node.values()) {
-            process(value, context);
-        }
+        node.values().forEach(x -> process(x, context));
         return null;
     }
 
     @Override
     public R visitUpdate(Update node, C context) {
         process(node.relation(), context);
-        for (Assignment assignment : node.assignements()) {
-            process(assignment, context);
-        }
-        if (node.whereClause().isPresent()) {
-            process(node.whereClause().get(), context);
-        }
+        node.assignements().forEach(x -> process(x, context));
+        node.whereClause().map(x -> process(x, context));
         return null;
     }
 
@@ -357,7 +304,7 @@ public abstract class DefaultTraversalVisitor<R, C>
     @Override
     public R visitDropTable(DropTable node, C context) {
         process(node.table(), context);
-        return super.visitDropTable(node, context);
+        return null;
     }
 
     @Override
@@ -374,20 +321,17 @@ public abstract class DefaultTraversalVisitor<R, C>
 
     @Override
     public R visitRefreshStatement(RefreshStatement node, C context) {
-        for (Table nodeTable : node.tables()) {
-            process(nodeTable, context);
-        }
+        node.tables().forEach(x -> process(x, context));
         return null;
     }
 
     @Override
     public R visitMatchPredicate(MatchPredicate node, C context) {
-        for (MatchPredicateColumnIdent columnIdent : node.idents()) {
-            process(columnIdent.columnIdent(), context);
-            process(columnIdent.boost(), context);
-        }
+        node.idents().forEach(x -> {
+            process(x.columnIdent(), context);
+            process(x.boost(), context);
+        });
         process(node.value(), context);
-
         return null;
     }
 }


### PR DESCRIPTION
* use `forEach(x -> process(x, context))` for processing lists
* use `map(x -> process(x, context))` for optionals to remove isPresent() check