### PR TITLE
Fixed incorrect pushdown of LIMIT in case of > 2 table joins.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -21,6 +21,15 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that caused incorrect results for queries with joins on more
+  than 2 tables with implicit join conditions using the ``ON`` clause and
+  ``LIMIT`` is applied. E.g. ::
+
+     SELECT * from t1
+     INNER JOIN t2 on t1.id = t2.id
+     INNER JOIN t3 on t3.id = t2.id
+     LIMIT 100
+
 - Fixed an issue that could cause a ``ALTER TABLE`` statement to fail with an
   exception on partitioned tables created with CrateDB < 1.2.
 

--- a/sql/src/main/java/io/crate/planner/consumer/ManyTableConsumer.java
+++ b/sql/src/main/java/io/crate/planner/consumer/ManyTableConsumer.java
@@ -441,8 +441,12 @@ public class ManyTableConsumer implements Consumer {
         int index = 0;
         for (int i = twoTableJoinList.size() - 1; i >= 0; i--) {
             index = i;
-            WhereClause where = twoTableJoinList.get(i).querySpec().where();
+            TwoTableJoin ttJoin = twoTableJoinList.get(i);
+            WhereClause where = ttJoin.querySpec().where();
             if (where.hasQuery() && !(where.query() instanceof Literal)) {
+                break;
+            }
+            if (ttJoin.joinPair().condition() != null) {
                 break;
             }
         }


### PR DESCRIPTION
When more than 2 tables are involved, we pushdown the limit to
all TwoTableJoin instances of the join tree. Then we detect if there
is filtering involved in the join tree and we remove any pushed-down
limit before the last filtering. Before the fix we detected as filtering
only the filtering happening in where clauses but not the filtering happening
because of the ``ON <condition>`` join conditions.

Fixes: https://github.com/crate/crate/issues/6641