### PR TITLE
Add Checkstyle rule to check for missing license headers

### DIFF
--- a/enterprise/enterpriseModule.gradle
+++ b/enterprise/enterpriseModule.gradle
@@ -24,6 +24,12 @@ task getVersion(dependsOn: [':core:getVersion']) {
     }
 }
 
+checkstyle {
+    // only override enterprise specific properties
+    configProperties['licenseHeaderFile'] = "enterprise_header.txt"
+}
+
+
 jar {
     doLast {
         manifest {

--- a/enterprise/lang-js/build.gradle
+++ b/enterprise/lang-js/build.gradle
@@ -1,4 +1,4 @@
-apply from: "$rootDir/gradle/javaModule.gradle"
+apply from: "$rootDir/enterprise/enterpriseModule.gradle"
 
 archivesBaseName = 'lang-js'
 group = 'io.crate'
@@ -32,18 +32,3 @@ dependencies {
         exclude group: 'org.slf4j', module: 'jcl-over-slf4j'
     }
 }
-
-task getVersion(dependsOn: [':core:getVersion']) {
-    doFirst {
-        project.version = project(':core').getVersion.version
-    }
-}
-
-jar {
-    doLast {
-        manifest {
-            attributes("Implementation-Title": description, "Implementation-Version": project.version)
-        }
-    }
-}
-jar.dependsOn('getVersion')

--- a/enterprise/mqtt/src/main/java/io/crate/mqtt/netty/MqttMessageLogger.java
+++ b/enterprise/mqtt/src/main/java/io/crate/mqtt/netty/MqttMessageLogger.java
@@ -1,23 +1,19 @@
 /*
- * Licensed to Crate under one or more contributor license agreements.
- * See the NOTICE file distributed with this work for additional
- * information regarding copyright ownership.  Crate licenses this file
- * to you under the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.  You may
- * obtain a copy of the License at
+ * This file is part of a module with proprietary Enterprise Features.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed to Crate.io Inc. ("Crate.io") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
- * implied.  See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
  *
- * However, if you have executed another commercial license agreement
- * with Crate these terms will supersede the license and you may use the
- * software solely pursuant to the terms of the relevant commercial
- * agreement.
+ * To use this file, Crate.io must have given you permission to enable and
+ * use such Enterprise Features and you must have a valid Enterprise or
+ * Subscription Agreement with Crate.io.  If you enable or use the Enterprise
+ * Features, you represent and warrant that you have a valid Enterprise or
+ * Subscription Agreement with Crate.io.  Your use of the Enterprise Features
+ * if governed by the terms and conditions of your Enterprise or Subscription
+ * Agreement with Crate.io.
  *
  * This code is derived from https://github.com/andsel/moquette/blob/master/broker/src/main/java/io/moquette/server/netty/metrics/MQTTMessageLogger.java
  */

--- a/enterprise/mqtt/src/main/java/io/crate/mqtt/netty/NettyUtils.java
+++ b/enterprise/mqtt/src/main/java/io/crate/mqtt/netty/NettyUtils.java
@@ -1,23 +1,19 @@
 /*
- * Licensed to Crate under one or more contributor license agreements.
- * See the NOTICE file distributed with this work for additional
- * information regarding copyright ownership.  Crate licenses this file
- * to you under the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.  You may
- * obtain a copy of the License at
+ * This file is part of a module with proprietary Enterprise Features.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed to Crate.io Inc. ("Crate.io") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
- * implied.  See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
  *
- * However, if you have executed another commercial license agreement
- * with Crate these terms will supersede the license and you may use the
- * software solely pursuant to the terms of the relevant commercial
- * agreement.
+ * To use this file, Crate.io must have given you permission to enable and
+ * use such Enterprise Features and you must have a valid Enterprise or
+ * Subscription Agreement with Crate.io.  If you enable or use the Enterprise
+ * Features, you represent and warrant that you have a valid Enterprise or
+ * Subscription Agreement with Crate.io.  Your use of the Enterprise Features
+ * if governed by the terms and conditions of your Enterprise or Subscription
+ * Agreement with Crate.io.
  *
  * Derived from https://github.com/andsel/moquette/blob/master/broker/src/main/java/io/moquette/server/netty/NettyUtils.java
  */

--- a/enterprise/users/src/main/java/io/crate/operation/auth/AlwaysOKAuthentication.java
+++ b/enterprise/users/src/main/java/io/crate/operation/auth/AlwaysOKAuthentication.java
@@ -1,23 +1,19 @@
 /*
- * Licensed to Crate under one or more contributor license agreements.
- * See the NOTICE file distributed with this work for additional
- * information regarding copyright ownership.  Crate licenses this file
- * to you under the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.  You may
- * obtain a copy of the License at
+ * This file is part of a module with proprietary Enterprise Features.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed to Crate.io Inc. ("Crate.io") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
- * implied.  See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
  *
- * However, if you have executed another commercial license agreement
- * with Crate these terms will supersede the license and you may use the
- * software solely pursuant to the terms of the relevant commercial
- * agreement.
+ * To use this file, Crate.io must have given you permission to enable and
+ * use such Enterprise Features and you must have a valid Enterprise or
+ * Subscription Agreement with Crate.io.  If you enable or use the Enterprise
+ * Features, you represent and warrant that you have a valid Enterprise or
+ * Subscription Agreement with Crate.io.  Your use of the Enterprise Features
+ * if governed by the terms and conditions of your Enterprise or Subscription
+ * Agreement with Crate.io.
  */
 
 package io.crate.operation.auth;

--- a/enterprise/users/src/main/java/io/crate/operation/auth/ClientCertAuth.java
+++ b/enterprise/users/src/main/java/io/crate/operation/auth/ClientCertAuth.java
@@ -1,23 +1,19 @@
 /*
- * Licensed to Crate under one or more contributor license agreements.
- * See the NOTICE file distributed with this work for additional
- * information regarding copyright ownership.  Crate licenses this file
- * to you under the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.  You may
- * obtain a copy of the License at
+ * This file is part of a module with proprietary Enterprise Features.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed to Crate.io Inc. ("Crate.io") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
- * implied.  See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
  *
- * However, if you have executed another commercial license agreement
- * with Crate these terms will supersede the license and you may use the
- * software solely pursuant to the terms of the relevant commercial
- * agreement.
+ * To use this file, Crate.io must have given you permission to enable and
+ * use such Enterprise Features and you must have a valid Enterprise or
+ * Subscription Agreement with Crate.io.  If you enable or use the Enterprise
+ * Features, you represent and warrant that you have a valid Enterprise or
+ * Subscription Agreement with Crate.io.  Your use of the Enterprise Features
+ * if governed by the terms and conditions of your Enterprise or Subscription
+ * Agreement with Crate.io.
  */
 
 package io.crate.operation.auth;

--- a/enterprise/users/src/main/java/io/crate/operation/auth/PasswordAuthenticationMethod.java
+++ b/enterprise/users/src/main/java/io/crate/operation/auth/PasswordAuthenticationMethod.java
@@ -1,23 +1,19 @@
 /*
- * Licensed to Crate under one or more contributor license agreements.
- * See the NOTICE file distributed with this work for additional
- * information regarding copyright ownership.  Crate licenses this file
- * to you under the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.  You may
- * obtain a copy of the License at
+ * This file is part of a module with proprietary Enterprise Features.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed to Crate.io Inc. ("Crate.io") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
- * implied.  See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
  *
- * However, if you have executed another commercial license agreement
- * with Crate these terms will supersede the license and you may use the
- * software solely pursuant to the terms of the relevant commercial
- * agreement.
+ * To use this file, Crate.io must have given you permission to enable and
+ * use such Enterprise Features and you must have a valid Enterprise or
+ * Subscription Agreement with Crate.io.  If you enable or use the Enterprise
+ * Features, you represent and warrant that you have a valid Enterprise or
+ * Subscription Agreement with Crate.io.  Your use of the Enterprise Features
+ * if governed by the terms and conditions of your Enterprise or Subscription
+ * Agreement with Crate.io.
  */
 
 package io.crate.operation.auth;

--- a/enterprise/users/src/main/java/io/crate/operation/user/AlterUserRequest.java
+++ b/enterprise/users/src/main/java/io/crate/operation/user/AlterUserRequest.java
@@ -1,23 +1,19 @@
 /*
- * Licensed to Crate under one or more contributor license agreements.
- * See the NOTICE file distributed with this work for additional
- * information regarding copyright ownership.  Crate licenses this file
- * to you under the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.  You may
- * obtain a copy of the License at
+ * This file is part of a module with proprietary Enterprise Features.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed to Crate.io Inc. ("Crate.io") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
- * implied.  See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
  *
- * However, if you have executed another commercial license agreement
- * with Crate these terms will supersede the license and you may use the
- * software solely pursuant to the terms of the relevant commercial
- * agreement.
+ * To use this file, Crate.io must have given you permission to enable and
+ * use such Enterprise Features and you must have a valid Enterprise or
+ * Subscription Agreement with Crate.io.  If you enable or use the Enterprise
+ * Features, you represent and warrant that you have a valid Enterprise or
+ * Subscription Agreement with Crate.io.  Your use of the Enterprise Features
+ * if governed by the terms and conditions of your Enterprise or Subscription
+ * Agreement with Crate.io.
  */
 
 package io.crate.operation.user;

--- a/enterprise/users/src/main/java/io/crate/operation/user/TransportAlterUserAction.java
+++ b/enterprise/users/src/main/java/io/crate/operation/user/TransportAlterUserAction.java
@@ -1,23 +1,19 @@
 /*
- * Licensed to Crate under one or more contributor license agreements.
- * See the NOTICE file distributed with this work for additional
- * information regarding copyright ownership.  Crate licenses this file
- * to you under the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.  You may
- * obtain a copy of the License at
+ * This file is part of a module with proprietary Enterprise Features.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed to Crate.io Inc. ("Crate.io") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
- * implied.  See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
  *
- * However, if you have executed another commercial license agreement
- * with Crate these terms will supersede the license and you may use the
- * software solely pursuant to the terms of the relevant commercial
- * agreement.
+ * To use this file, Crate.io must have given you permission to enable and
+ * use such Enterprise Features and you must have a valid Enterprise or
+ * Subscription Agreement with Crate.io.  If you enable or use the Enterprise
+ * Features, you represent and warrant that you have a valid Enterprise or
+ * Subscription Agreement with Crate.io.  Your use of the Enterprise Features
+ * if governed by the terms and conditions of your Enterprise or Subscription
+ * Agreement with Crate.io.
  */
 
 package io.crate.operation.user;

--- a/enterprise/users/src/main/java/io/crate/operation/user/UserManagerDDLModifier.java
+++ b/enterprise/users/src/main/java/io/crate/operation/user/UserManagerDDLModifier.java
@@ -1,23 +1,19 @@
 /*
- * Licensed to Crate under one or more contributor license agreements.
- * See the NOTICE file distributed with this work for additional
- * information regarding copyright ownership.  Crate licenses this file
- * to you under the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.  You may
- * obtain a copy of the License at
+ * This file is part of a module with proprietary Enterprise Features.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed to Crate.io Inc. ("Crate.io") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
- * implied.  See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
  *
- * However, if you have executed another commercial license agreement
- * with Crate these terms will supersede the license and you may use the
- * software solely pursuant to the terms of the relevant commercial
- * agreement.
+ * To use this file, Crate.io must have given you permission to enable and
+ * use such Enterprise Features and you must have a valid Enterprise or
+ * Subscription Agreement with Crate.io.  If you enable or use the Enterprise
+ * Features, you represent and warrant that you have a valid Enterprise or
+ * Subscription Agreement with Crate.io.  Your use of the Enterprise Features
+ * if governed by the terms and conditions of your Enterprise or Subscription
+ * Agreement with Crate.io.
  */
 
 package io.crate.operation.user;

--- a/enterprise/users/src/main/java/io/crate/plugin/AuthenticationHttpAuthHandlerRegistry.java
+++ b/enterprise/users/src/main/java/io/crate/plugin/AuthenticationHttpAuthHandlerRegistry.java
@@ -1,23 +1,19 @@
 /*
- * Licensed to Crate under one or more contributor license agreements.
- * See the NOTICE file distributed with this work for additional
- * information regarding copyright ownership.  Crate licenses this file
- * to you under the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.  You may
- * obtain a copy of the License at
+ * This file is part of a module with proprietary Enterprise Features.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed to Crate.io Inc. ("Crate.io") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
- * implied.  See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
  *
- * However, if you have executed another commercial license agreement
- * with Crate these terms will supersede the license and you may use the
- * software solely pursuant to the terms of the relevant commercial
- * agreement.
+ * To use this file, Crate.io must have given you permission to enable and
+ * use such Enterprise Features and you must have a valid Enterprise or
+ * Subscription Agreement with Crate.io.  If you enable or use the Enterprise
+ * Features, you represent and warrant that you have a valid Enterprise or
+ * Subscription Agreement with Crate.io.  Your use of the Enterprise Features
+ * if governed by the terms and conditions of your Enterprise or Subscription
+ * Agreement with Crate.io.
  */
 
 package io.crate.plugin;

--- a/enterprise/users/src/main/java/io/crate/plugin/AuthenticationModule.java
+++ b/enterprise/users/src/main/java/io/crate/plugin/AuthenticationModule.java
@@ -1,23 +1,19 @@
 /*
- * Licensed to Crate under one or more contributor license agreements.
- * See the NOTICE file distributed with this work for additional
- * information regarding copyright ownership.  Crate licenses this file
- * to you under the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.  You may
- * obtain a copy of the License at
+ * This file is part of a module with proprietary Enterprise Features.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed to Crate.io Inc. ("Crate.io") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
- * implied.  See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
  *
- * However, if you have executed another commercial license agreement
- * with Crate these terms will supersede the license and you may use the
- * software solely pursuant to the terms of the relevant commercial
- * agreement.
+ * To use this file, Crate.io must have given you permission to enable and
+ * use such Enterprise Features and you must have a valid Enterprise or
+ * Subscription Agreement with Crate.io.  If you enable or use the Enterprise
+ * Features, you represent and warrant that you have a valid Enterprise or
+ * Subscription Agreement with Crate.io.  Your use of the Enterprise Features
+ * if governed by the terms and conditions of your Enterprise or Subscription
+ * Agreement with Crate.io.
  */
 
 package io.crate.plugin;

--- a/enterprise/users/src/main/java/io/crate/plugin/UserManagementModule.java
+++ b/enterprise/users/src/main/java/io/crate/plugin/UserManagementModule.java
@@ -1,23 +1,19 @@
 /*
- * Licensed to Crate under one or more contributor license agreements.
- * See the NOTICE file distributed with this work for additional
- * information regarding copyright ownership.  Crate licenses this file
- * to you under the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.  You may
- * obtain a copy of the License at
+ * This file is part of a module with proprietary Enterprise Features.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed to Crate.io Inc. ("Crate.io") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
- * implied.  See the License for the specific language governing
- * permissions and limitations under the License.
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
  *
- * However, if you have executed another commercial license agreement
- * with Crate these terms will supersede the license and you may use the
- * software solely pursuant to the terms of the relevant commercial
- * agreement.
+ * To use this file, Crate.io must have given you permission to enable and
+ * use such Enterprise Features and you must have a valid Enterprise or
+ * Subscription Agreement with Crate.io.  If you enable or use the Enterprise
+ * Features, you represent and warrant that you have a valid Enterprise or
+ * Subscription Agreement with Crate.io.  Your use of the Enterprise Features
+ * if governed by the terms and conditions of your Enterprise or Subscription
+ * Agreement with Crate.io.
  */
 
 package io.crate.plugin;

--- a/gradle/checkstyle/enterprise_header.txt
+++ b/gradle/checkstyle/enterprise_header.txt
@@ -1,0 +1,2 @@
+^/\*
+^ \* (This file is part of a module with proprietary Enterprise Features|Copyright)

--- a/gradle/checkstyle/header.txt
+++ b/gradle/checkstyle/header.txt
@@ -1,0 +1,2 @@
+^/\*
+^ \* (Licensed to|Copyright|This file is part of a module with proprietary Enterprise Features)

--- a/gradle/checkstyle/header.txt
+++ b/gradle/checkstyle/header.txt
@@ -1,2 +1,2 @@
 ^/\*
-^ \* (Licensed to|Copyright|This file is part of a module with proprietary Enterprise Features)
+^ \* (Licensed to|Copyright)

--- a/gradle/checkstyle/rules.xml
+++ b/gradle/checkstyle/rules.xml
@@ -40,6 +40,11 @@
     <property name="severity" value="error"/>
 
     <property name="fileExtensions" value="java, properties, xml"/>
+
+    <module name="RegexpHeader">
+        <property name="headerFile" value="${checkstyleDir}/header.txt"/>
+    </module>
+
     <!-- Checks for whitespace                               -->
     <!-- See http://checkstyle.sf.net/config_whitespace.html -->
     <module name="FileTabCharacter">

--- a/gradle/checkstyle/rules.xml
+++ b/gradle/checkstyle/rules.xml
@@ -42,7 +42,7 @@
     <property name="fileExtensions" value="java, properties, xml"/>
 
     <module name="RegexpHeader">
-        <property name="headerFile" value="${checkstyleDir}/header.txt"/>
+        <property name="headerFile" value="${checkstyleDir}/${licenseHeaderFile}"/>
     </module>
 
     <!-- Checks for whitespace                               -->

--- a/gradle/javaModule.gradle
+++ b/gradle/javaModule.gradle
@@ -93,7 +93,9 @@ checkstyle {
     toolVersion = "8.1"
     def checkstyle_dir = new String("$rootDir/gradle/checkstyle/")
     configProperties = [
-            'checkstyleDir' : checkstyle_dir
+            'checkstyleDir' : checkstyle_dir,
+            // May be overwritten by other modules, e.g. enterprise
+            'licenseHeaderFile' : 'header.txt'
     ]
     configFile = file(checkstyle_dir + "rules.xml")
     checkstyleTest.enabled = false

--- a/sql-parser/src/main/java/io/crate/sql/tree/AliasedRelation.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AliasedRelation.java
@@ -1,23 +1,23 @@
 /*
-* Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
-* license agreements.  See the NOTICE file distributed with this work for
-* additional information regarding copyright ownership.  Crate licenses
-* this file to you under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.  You may
-* obtain a copy of the License at
-*
-*   http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-* License for the specific language governing permissions and limitations
-* under the License.
-*
-* However, if you have executed another commercial license agreement
-* with Crate these terms will supersede the license and you may use the
-* software solely pursuant to the terms of the relevant commercial agreement.
-*/
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
 
 package io.crate.sql.tree;
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/AllColumns.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AllColumns.java
@@ -1,23 +1,23 @@
 /*
-* Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
-* license agreements.  See the NOTICE file distributed with this work for
-* additional information regarding copyright ownership.  Crate licenses
-* this file to you under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.  You may
-* obtain a copy of the License at
-*
-*   http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-* License for the specific language governing permissions and limitations
-* under the License.
-*
-* However, if you have executed another commercial license agreement
-* with Crate these terms will supersede the license and you may use the
-* software solely pursuant to the terms of the relevant commercial agreement.
-*/
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
 
 package io.crate.sql.tree;
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/ArithmeticExpression.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/ArithmeticExpression.java
@@ -1,23 +1,23 @@
 /*
-* Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
-* license agreements.  See the NOTICE file distributed with this work for
-* additional information regarding copyright ownership.  Crate licenses
-* this file to you under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.  You may
-* obtain a copy of the License at
-*
-*   http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
-* License for the specific language governing permissions and limitations
-* under the License.
-*
-* However, if you have executed another commercial license agreement
-* with Crate these terms will supersede the license and you may use the
-* software solely pursuant to the terms of the relevant commercial agreement.
-*/
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
 
 package io.crate.sql.tree;
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/CreateIngestRule.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/CreateIngestRule.java
@@ -1,3 +1,24 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
 package io.crate.sql.tree;
 
 import com.google.common.base.MoreObjects;

--- a/sql-parser/src/main/java/io/crate/sql/tree/DropIngestRule.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/DropIngestRule.java
@@ -1,5 +1,25 @@
-package io.crate.sql.tree;
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
 
+package io.crate.sql.tree;
 
 import com.google.common.base.MoreObjects;
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/GrantPrivilege.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/GrantPrivilege.java
@@ -1,3 +1,24 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
 package io.crate.sql.tree;
 
 import java.util.List;

--- a/sql-parser/src/main/java/io/crate/sql/tree/RevokePrivilege.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/RevokePrivilege.java
@@ -1,3 +1,24 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
 package io.crate.sql.tree;
 
 import java.util.List;

--- a/sql/src/main/java/io/crate/analyze/CreateIngestionRuleAnalysedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/CreateIngestionRuleAnalysedStatement.java
@@ -1,3 +1,25 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
 package io.crate.analyze;
 
 import io.crate.metadata.TableIdent;

--- a/sql/src/main/java/io/crate/analyze/CreateIngestionRuleAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateIngestionRuleAnalyzer.java
@@ -1,3 +1,25 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
 package io.crate.analyze;
 
 

--- a/sql/src/main/java/io/crate/analyze/DropIngestionRuleAnalysedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/DropIngestionRuleAnalysedStatement.java
@@ -1,3 +1,25 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
 package io.crate.analyze;
 
 public class DropIngestionRuleAnalysedStatement implements DCLStatement {

--- a/sql/src/main/java/io/crate/analyze/symbol/Function.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/Function.java
@@ -1,3 +1,25 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
 package io.crate.analyze.symbol;
 
 import com.google.common.base.Preconditions;

--- a/sql/src/main/java/io/crate/analyze/symbol/Literal.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/Literal.java
@@ -1,3 +1,25 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
 package io.crate.analyze.symbol;
 
 import com.google.common.base.Preconditions;

--- a/sql/src/main/java/io/crate/analyze/where/WhereClauseValidator.java
+++ b/sql/src/main/java/io/crate/analyze/where/WhereClauseValidator.java
@@ -1,3 +1,25 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
 package io.crate.analyze.where;
 
 

--- a/sql/src/main/java/io/crate/lucene/LikeQueryBuilder.java
+++ b/sql/src/main/java/io/crate/lucene/LikeQueryBuilder.java
@@ -1,3 +1,25 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
 package io.crate.lucene;
 
 import io.crate.types.DataType;

--- a/sql/src/main/java/io/crate/metadata/IngestionRuleInfo.java
+++ b/sql/src/main/java/io/crate/metadata/IngestionRuleInfo.java
@@ -1,3 +1,25 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
 package io.crate.metadata;
 
 

--- a/sql/src/main/java/io/crate/metadata/IngestionRuleInfos.java
+++ b/sql/src/main/java/io/crate/metadata/IngestionRuleInfos.java
@@ -1,3 +1,25 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
 package io.crate.metadata;
 
 

--- a/sql/src/main/java/io/crate/metadata/Routing.java
+++ b/sql/src/main/java/io/crate/metadata/Routing.java
@@ -1,3 +1,25 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
 package io.crate.metadata;
 
 import com.google.common.base.MoreObjects;

--- a/sql/src/main/java/io/crate/metadata/doc/DocSysColumns.java
+++ b/sql/src/main/java/io/crate/metadata/doc/DocSysColumns.java
@@ -1,3 +1,25 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
 package io.crate.metadata.doc;
 
 import com.google.common.collect.ImmutableMap;

--- a/sql/src/main/java/io/crate/metadata/information/InformationSchemaIngestionRulesTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/information/InformationSchemaIngestionRulesTableInfo.java
@@ -1,3 +1,25 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
 package io.crate.metadata.information;
 
 import com.google.common.collect.ImmutableList;

--- a/sql/src/main/java/io/crate/metadata/shard/unassigned/UnassignedShard.java
+++ b/sql/src/main/java/io/crate/metadata/shard/unassigned/UnassignedShard.java
@@ -1,3 +1,25 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
 package io.crate.metadata.shard.unassigned;
 
 import io.crate.blob.v2.BlobIndex;

--- a/sql/src/main/java/io/crate/operation/AggregationContext.java
+++ b/sql/src/main/java/io/crate/operation/AggregationContext.java
@@ -1,3 +1,25 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
 package io.crate.operation;
 
 import io.crate.data.Input;

--- a/sql/src/main/java/io/crate/operation/PageResultListener.java
+++ b/sql/src/main/java/io/crate/operation/PageResultListener.java
@@ -1,3 +1,25 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
 package io.crate.operation;
 
 

--- a/sql/src/main/java/io/crate/operation/collect/sources/CollectSource.java
+++ b/sql/src/main/java/io/crate/operation/collect/sources/CollectSource.java
@@ -1,3 +1,25 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
 package io.crate.operation.collect.sources;
 
 import io.crate.data.RowConsumer;

--- a/sql/src/main/java/io/crate/operation/operator/CmpOperator.java
+++ b/sql/src/main/java/io/crate/operation/operator/CmpOperator.java
@@ -1,3 +1,25 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
 package io.crate.operation.operator;
 
 import io.crate.core.collections.MapComparator;

--- a/sql/src/main/java/io/crate/operation/operator/GtOperator.java
+++ b/sql/src/main/java/io/crate/operation/operator/GtOperator.java
@@ -1,3 +1,25 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
 package io.crate.operation.operator;
 
 import io.crate.metadata.FunctionInfo;

--- a/sql/src/main/java/io/crate/operation/operator/GteOperator.java
+++ b/sql/src/main/java/io/crate/operation/operator/GteOperator.java
@@ -1,3 +1,25 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
 package io.crate.operation.operator;
 
 import io.crate.metadata.FunctionInfo;

--- a/sql/src/main/java/io/crate/operation/operator/LtOperator.java
+++ b/sql/src/main/java/io/crate/operation/operator/LtOperator.java
@@ -1,3 +1,25 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
 package io.crate.operation.operator;
 
 import io.crate.metadata.FunctionInfo;

--- a/sql/src/main/java/io/crate/operation/operator/LteOperator.java
+++ b/sql/src/main/java/io/crate/operation/operator/LteOperator.java
@@ -1,3 +1,25 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
 package io.crate.operation.operator;
 
 import io.crate.metadata.FunctionInfo;

--- a/sql/src/main/java/io/crate/operation/operator/Operator.java
+++ b/sql/src/main/java/io/crate/operation/operator/Operator.java
@@ -1,3 +1,25 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
 package io.crate.operation.operator;
 
 import com.google.common.collect.ImmutableList;

--- a/sql/src/main/java/io/crate/operation/operator/OperatorModule.java
+++ b/sql/src/main/java/io/crate/operation/operator/OperatorModule.java
@@ -1,3 +1,25 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
 package io.crate.operation.operator;
 
 import io.crate.metadata.FunctionIdent;

--- a/sql/src/main/java/io/crate/operation/operator/OrOperator.java
+++ b/sql/src/main/java/io/crate/operation/operator/OrOperator.java
@@ -1,3 +1,25 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
 package io.crate.operation.operator;
 
 import io.crate.analyze.symbol.Function;

--- a/sql/src/main/java/io/crate/operation/reference/doc/lucene/OrderByCollectorExpression.java
+++ b/sql/src/main/java/io/crate/operation/reference/doc/lucene/OrderByCollectorExpression.java
@@ -1,3 +1,25 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
 package io.crate.operation.reference.doc.lucene;
 
 import io.crate.action.sql.query.SortSymbolVisitor;

--- a/sql/src/main/java/io/crate/operation/scalar/arithmetic/ArithmeticFunctions.java
+++ b/sql/src/main/java/io/crate/operation/scalar/arithmetic/ArithmeticFunctions.java
@@ -1,3 +1,25 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
 package io.crate.operation.scalar.arithmetic;
 
 import com.google.common.collect.Sets;

--- a/sql/src/main/java/io/crate/operation/scalar/arithmetic/BinaryScalar.java
+++ b/sql/src/main/java/io/crate/operation/scalar/arithmetic/BinaryScalar.java
@@ -1,3 +1,25 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
 package io.crate.operation.scalar.arithmetic;
 
 import io.crate.data.Input;

--- a/sql/src/main/java/io/crate/operation/udf/UDFLanguage.java
+++ b/sql/src/main/java/io/crate/operation/udf/UDFLanguage.java
@@ -1,3 +1,25 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
 package io.crate.operation.udf;
 
 import io.crate.metadata.Scalar;

--- a/sql/src/main/java/io/crate/planner/node/dql/join/NestedLoop.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/join/NestedLoop.java
@@ -1,23 +1,23 @@
 /*
-* Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
-* license agreements. See the NOTICE file distributed with this work for
-* additional information regarding copyright ownership. Crate licenses
-* this file to you under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License. You may
-* obtain a copy of the License at
-*
-*   http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-* License for the specific language governing permissions and limitations
-* under the License.
-*
-* However, if you have executed another commercial license agreement
-* with Crate these terms will supersede the license and you may use the
-* software solely pursuant to the terms of the relevant commercial agreement.
-*/
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements. See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership. Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
 
 package io.crate.planner.node.dql.join;
 


### PR DESCRIPTION
- Adds license headers to files currently missing a license.
- Adds a Checkstyle rule to check for missing license headers.