### PR TITLE
Remove usages of Optional class

### DIFF
--- a/enterprise/mqtt/src/test/java/io/crate/analyze/MqttAnalyzerTest.java
+++ b/enterprise/mqtt/src/test/java/io/crate/analyze/MqttAnalyzerTest.java
@@ -29,8 +29,6 @@ import io.crate.sql.tree.QualifiedName;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import java.util.Optional;
-
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
@@ -45,7 +43,7 @@ public class MqttAnalyzerTest {
                 "rule",
                 "source",
                 QualifiedName.of("table"),
-                Optional.empty());
+                null);
         SessionContext sessionContext = SessionContext.create();
         sessionContext.setDefaultSchema("custom");
         ParameterContext parameterContext = Mockito.mock(ParameterContext.class);

--- a/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
+++ b/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
@@ -163,9 +163,9 @@ public final class ExpressionFormatter {
                     throw new UnsupportedOperationException("not yet implemented: " + node.getType());
             }
 
-            if (node.getPrecision().isPresent()) {
+            if (node.getPrecision() != null) {
                 builder.append('(')
-                    .append(node.getPrecision().get())
+                    .append(node.getPrecision())
                     .append(')');
             }
 
@@ -440,8 +440,8 @@ public final class ExpressionFormatter {
 
         @Override
         protected String visitAllColumns(AllColumns node, Void context) {
-            if (node.getPrefix().isPresent()) {
-                return node.getPrefix().get() + ".*";
+            if (node.getPrefix() != null) {
+                return node.getPrefix() + ".*";
             }
 
             return "*";

--- a/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
+++ b/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
@@ -335,9 +335,9 @@ public final class ExpressionFormatter {
                 .append(process(node.getCondition(), context))
                 .append(", ")
                 .append(process(node.getTrueValue(), context));
-            if (node.getFalseValue().isPresent()) {
+            if (node.getFalseValue() != null) {
                 builder.append(", ")
-                    .append(process(node.getFalseValue().get(), context));
+                    .append(process(node.getFalseValue(), context));
             }
             builder.append(")");
             return builder.toString();

--- a/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
+++ b/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
@@ -128,9 +128,9 @@ public final class SqlFormatter {
             process(node.table(), indent);
             append(indent, " FROM ");
             process(node.path(), indent);
-            if (node.genericProperties().isPresent()) {
+            if (!node.genericProperties().isEmpty()) {
                 append(indent, " ");
-                process(node.genericProperties().get(), indent);
+                process(node.genericProperties(), indent);
             }
             return null;
         }
@@ -364,9 +364,9 @@ public final class SqlFormatter {
                 }
             }
 
-            if (node.properties().isPresent() && !node.properties().get().isEmpty()) {
+            if (!node.properties().isEmpty()) {
                 builder.append("\n");
-                node.properties().get().accept(this, indent);
+                node.properties().accept(this, indent);
             }
             return null;
         }
@@ -686,19 +686,19 @@ public final class SqlFormatter {
         public Void visitCreateSnapshot(CreateSnapshot node, Integer indent) {
             builder.append("CREATE SNAPSHOT ")
                 .append(quoteIdentifierIfNeeded(node.name().toString()));
-            if (node.tableList().isPresent()) {
+            if (!node.tableList().isEmpty()) {
                 builder.append(" TABLE ");
-                int count = 0, max = node.tableList().get().size();
-                for (Table table : node.tableList().get()) {
+                int count = 0, max = node.tableList().size();
+                for (Table table : node.tableList()) {
                     table.accept(this, indent);
                     if (++count < max) builder.append(",");
                 }
             } else {
                 builder.append(" ALL");
             }
-            if (node.properties().isPresent()) {
+            if (!node.properties().isEmpty()) {
                 builder.append(' ');
-                node.properties().get().accept(this, indent);
+                node.properties().accept(this, indent);
             }
             return null;
         }

--- a/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
+++ b/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
@@ -448,11 +448,11 @@ public final class SqlFormatter {
         @Override
         public Void visitClusteredBy(ClusteredBy node, Integer indent) {
             append(indent, "CLUSTERED");
-            if (node.column().isPresent()) {
-                builder.append(String.format(Locale.ENGLISH, " BY (%s)", node.column().get().toString()));
+            if (node.column() != null) {
+                builder.append(String.format(Locale.ENGLISH, " BY (%s)", node.column().toString()));
             }
-            if (node.numberOfShards().isPresent()) {
-                builder.append(String.format(Locale.ENGLISH, " INTO %s SHARDS", node.numberOfShards().get()));
+            if (node.numberOfShards() != null) {
+                builder.append(String.format(Locale.ENGLISH, " INTO %s SHARDS", node.numberOfShards()));
             }
             return null;
         }

--- a/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
+++ b/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
@@ -293,10 +293,10 @@ public final class SqlFormatter {
         @Override
         protected Void visitSingleColumn(SingleColumn node, Integer indent) {
             builder.append(formatStandaloneExpression(node.getExpression()));
-            if (node.getAlias().isPresent()) {
+            if (node.getAlias() != null) {
                 builder.append(' ')
                     .append('"')
-                    .append(node.getAlias().get())
+                    .append(node.getAlias())
                     .append('"'); // TODO: handle quoting properly
             }
 
@@ -440,7 +440,9 @@ public final class SqlFormatter {
 
         @Override
         public Void visitFunctionArgument(FunctionArgument node, Integer context) {
-            node.name().ifPresent(s -> builder.append(s).append(" "));
+            if (node.name() != null) {
+                builder.append(node.name()).append(" ");
+            }
             builder.append(node.type());
             return null;
         }
@@ -522,8 +524,8 @@ public final class SqlFormatter {
         @Override
         public Void visitObjectColumnType(ObjectColumnType node, Integer indent) {
             builder.append("OBJECT");
-            if (node.objectType().isPresent()) {
-                builder.append(String.format(Locale.ENGLISH, " (%s)", node.objectType().get().toUpperCase(Locale.ENGLISH)));
+            if (node.objectType() != null) {
+                builder.append(String.format(Locale.ENGLISH, " (%s)", node.objectType().toUpperCase(Locale.ENGLISH)));
             }
             if (!node.nestedColumns().isEmpty()) {
                 builder.append(" AS ");
@@ -621,7 +623,7 @@ public final class SqlFormatter {
 
         @Override
         protected Void visitJoin(Join node, Integer indent) {
-            JoinCriteria criteria = node.getCriteria().orElse(null);
+            JoinCriteria criteria = node.getCriteria();
             String type = node.getType().toString();
             if (criteria instanceof NaturalJoin) {
                 type = "NATURAL " + type;

--- a/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
+++ b/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
@@ -157,8 +157,8 @@ public final class SqlFormatter {
 
         @Override
         protected Void visitQuery(Query node, Integer indent) {
-            if (node.getWith().isPresent()) {
-                With with = node.getWith().get();
+            if (node.getWith() != null) {
+                With with = node.getWith();
                 append(indent, "WITH");
                 if (with.isRecursive()) {
                     builder.append(" RECURSIVE");
@@ -188,13 +188,13 @@ public final class SqlFormatter {
                 ).append('\n');
             }
 
-            if (node.getLimit().isPresent()) {
-                append(indent, "LIMIT " + node.getLimit().get())
+            if (node.getLimit() != null) {
+                append(indent, "LIMIT " + node.getLimit())
                     .append('\n');
             }
 
-            if (node.getOffset().isPresent()) {
-                append(indent, "OFFSET " + node.getOffset().get())
+            if (node.getOffset() != null) {
+                append(indent, "OFFSET " + node.getOffset())
                     .append('\n');
             }
 
@@ -226,8 +226,8 @@ public final class SqlFormatter {
 
             builder.append('\n');
 
-            if (node.getWhere().isPresent()) {
-                append(indent, "WHERE " + formatStandaloneExpression(node.getWhere().get()))
+            if (node.getWhere() != null) {
+                append(indent, "WHERE " + formatStandaloneExpression(node.getWhere()))
                     .append('\n');
             }
 
@@ -239,8 +239,8 @@ public final class SqlFormatter {
                     .append('\n');
             }
 
-            if (node.getHaving().isPresent()) {
-                append(indent, "HAVING " + formatStandaloneExpression(node.getHaving().get()))
+            if (node.getHaving() != null) {
+                append(indent, "HAVING " + formatStandaloneExpression(node.getHaving()))
                     .append('\n');
             }
 
@@ -252,13 +252,13 @@ public final class SqlFormatter {
                 ).append('\n');
             }
 
-            if (node.getLimit().isPresent()) {
-                append(indent, "LIMIT " + node.getLimit().get())
+            if (node.getLimit() != null) {
+                append(indent, "LIMIT " + node.getLimit())
                     .append('\n');
             }
 
-            if (node.getOffset().isPresent()) {
-                append(indent, "OFFSET " + node.getOffset().get())
+            if (node.getOffset() != null) {
+                append(indent, "OFFSET " + node.getOffset())
                     .append('\n');
             }
             return null;
@@ -711,8 +711,8 @@ public final class SqlFormatter {
             builder.append(" ON ")
                 .append(quoteIdentifierIfNeeded(node.sourceIdent().toString()));
 
-            if (node.where().isPresent()) {
-                builder.append(" WHERE " + formatExpression(node.where().get()));
+            if (node.where() != null) {
+                builder.append(" WHERE " + formatExpression(node.where()));
             }
             builder.append(" INTO ")
                 .append(quoteIdentifierIfNeeded(node.targetTable().toString()));

--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -1489,7 +1489,7 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
 
     private <T> T visitIfPresent(ParserRuleContext context, Class<T> clazz) {
         return visitIfPresent(context, clazz, null);
-    };
+    }
 
     private <T> T visitIfPresent(ParserRuleContext context, Class<T> clazz, T defaultValue) {
         return Optional.ofNullable(context)

--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -824,7 +824,7 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
         return new WithQuery(
             getIdentText(context.name),
             (Query) visit(context.query()),
-            Optional.ofNullable(getColumnAliases(context.aliasedColumns())).orElse(ImmutableList.of()));
+            getColumnAliases(context.aliasedColumns()));
     }
 
     @Override
@@ -954,6 +954,7 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
         return literal.getValue();
     }
 
+    @Nullable
     private String getIdentTextIfPresentElseNull(SqlBaseParser.IdentContext ident) {
         if (ident == null) {
             return null;
@@ -1513,6 +1514,7 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
             .replace("''", "'");
     }
 
+    @Nullable
     private QualifiedName getQualifiedName(SqlBaseParser.QnameContext context) {
         return Optional.ofNullable(context)
             .map(ctx -> identsToStrings(ctx.ident()))
@@ -1543,10 +1545,9 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     }
 
     private List<String> getColumnAliases(SqlBaseParser.AliasedColumnsContext columnAliasesContext) {
-        if (columnAliasesContext == null) {
-            return null;
-        }
-        return identsToStrings(columnAliasesContext.ident());
+        return Optional.ofNullable(columnAliasesContext)
+            .map(x -> identsToStrings(x.ident()))
+            .orElse(ImmutableList.of());
     }
 
     private static ArithmeticExpression.Type getArithmeticBinaryOperator(Token operator) {

--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -1511,7 +1511,10 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     }
 
     private QualifiedName getQualifiedName(SqlBaseParser.QnameContext context) {
-        return QualifiedName.of(identsToStrings(context.ident()));
+        return Optional.ofNullable(context)
+            .map(ctx -> identsToStrings(ctx.ident()))
+            .map(QualifiedName::of)
+            .orElse(null);
     }
 
     private QualifiedName getQualifiedName(SqlBaseParser.IdentContext context) {

--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -210,7 +210,7 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     public Node visitOptimize(SqlBaseParser.OptimizeContext context) {
         return new OptimizeStatement(
             visit(context.tableWithPartitions().tableWithPartition(), Table.class),
-            visitIfPresent(context.withProperties(), GenericProperties.class));
+            visitIfPresent(context.withProperties(), GenericProperties.class, GenericProperties.EMPTY));
     }
 
     @Override
@@ -220,7 +220,7 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
             (Table) visit(context.table()),
             visit(context.tableElement(), TableElement.class),
             visit(context.crateTableOption(), CrateTableOption.class),
-            visitIfPresent(context.withProperties(), GenericProperties.class),
+            visitIfPresent(context.withProperties(), GenericProperties.class, GenericProperties.EMPTY),
             notExists);
     }
 
@@ -228,8 +228,8 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     public Node visitCreateBlobTable(SqlBaseParser.CreateBlobTableContext context) {
         return new CreateBlobTable(
             (Table) visit(context.table()),
-            visitIfPresent(context.numShards, ClusteredBy.class),
-            visitIfPresent(context.withProperties(), GenericProperties.class));
+            visitIfPresent(context.numShards, ClusteredBy.class, defaultValue),
+            visitIfPresent(context.withProperties(), GenericProperties.class, GenericProperties.EMPTY));
     }
 
     @Override
@@ -237,7 +237,7 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
         return new CreateRepository(
             getIdentText(context.name),
             getIdentText(context.type),
-            visitIfPresent(context.withProperties(), GenericProperties.class));
+            visitIfPresent(context.withProperties(), GenericProperties.class, GenericProperties.EMPTY));
     }
 
     @Override
@@ -245,12 +245,12 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
         if (context.ALL() != null) {
             return new CreateSnapshot(
                 getQualifiedName(context.qname()),
-                visitIfPresent(context.withProperties(), GenericProperties.class));
+                visitIfPresent(context.withProperties(), GenericProperties.class, GenericProperties.EMPTY));
         }
         return new CreateSnapshot(
             getQualifiedName(context.qname()),
             visit(context.tableWithPartitions().tableWithPartition(), Table.class),
-            visitIfPresent(context.withProperties(), GenericProperties.class));
+            visitIfPresent(context.withProperties(), GenericProperties.class, GenericProperties.EMPTY));
     }
 
     @Override
@@ -266,8 +266,7 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     public Node visitCreateUser(SqlBaseParser.CreateUserContext context) {
         return new CreateUser(
             getIdentText(context.name),
-            visitIfPresent(context.withProperties(), GenericProperties.class)
-                .orElse(GenericProperties.EMPTY));
+            visitIfPresent(context.withProperties(), GenericProperties.class, GenericProperties.EMPTY));
     }
 
     @Override
@@ -333,7 +332,7 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     public Node visitNamedProperties(SqlBaseParser.NamedPropertiesContext context) {
         return new NamedProperties(
             getIdentText(context.ident()),
-            visitIfPresent(context.withProperties(), GenericProperties.class));
+            visitIfPresent(context.withProperties(), GenericProperties.class, GenericProperties.EMPTY));
     }
 
     @Override
@@ -341,11 +340,11 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
         if (context.ALL() != null) {
             return new RestoreSnapshot(
                 getQualifiedName(context.qname()),
-                visitIfPresent(context.withProperties(), GenericProperties.class));
+                visitIfPresent(context.withProperties(), GenericProperties.class, GenericProperties.EMPTY));
         }
         return new RestoreSnapshot(getQualifiedName(context.qname()),
             visit(context.tableWithPartitions().tableWithPartition(), Table.class),
-            visitIfPresent(context.withProperties(), GenericProperties.class));
+            visitIfPresent(context.withProperties(), GenericProperties.class, GenericProperties.EMPTY));
     }
 
     @Override
@@ -383,7 +382,7 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
         return new CopyFrom(
             (Table) visit(context.tableWithPartition()),
             (Expression) visit(context.path),
-            visitIfPresent(context.withProperties(), GenericProperties.class));
+            visitIfPresent(context.withProperties(), GenericProperties.class, GenericProperties.EMPTY));
     }
 
     @Override
@@ -395,10 +394,10 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
         return new CopyTo(
             (Table) visit(context.tableWithPartition()),
             columns,
-            visitIfPresent(context.where(), Expression.class),
+            visitIfPresent(context.where(), Expression.class, defaultValue),
             context.DIRECTORY() != null,
             (Expression) visit(context.path),
-            visitIfPresent(context.withProperties(), GenericProperties.class));
+            visitIfPresent(context.withProperties(), GenericProperties.class, GenericProperties.EMPTY));
     }
 
     @Override
@@ -442,7 +441,7 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     public Node visitDelete(SqlBaseParser.DeleteContext context) {
         return new Delete(
             (Relation) visit(context.aliasedRelation()),
-            visitIfPresent(context.where(), Expression.class));
+            visitIfPresent(context.where(), Expression.class, defaultValue));
     }
 
     @Override
@@ -450,7 +449,7 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
         return new Update(
             (Relation) visit(context.aliasedRelation()),
             visit(context.assignment(), Assignment.class),
-            visitIfPresent(context.where(), Expression.class));
+            visitIfPresent(context.where(), Expression.class, defaultValue));
     }
 
     @Override
@@ -511,14 +510,14 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
         return new ShowTables(
             Optional.ofNullable(context.qname()).map(this::getQualifiedName),
             getTextIfPresent(context.pattern).map(AstBuilder::unquote),
-            visitIfPresent(context.where(), Expression.class));
+            visitIfPresent(context.where(), Expression.class, defaultValue));
     }
 
     @Override
     public Node visitShowSchemas(SqlBaseParser.ShowSchemasContext context) {
         return new ShowSchemas(
             getTextIfPresent(context.pattern).map(AstBuilder::unquote),
-            visitIfPresent(context.where(), Expression.class));
+            visitIfPresent(context.where(), Expression.class, defaultValue));
     }
 
     @Override
@@ -526,7 +525,7 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
         return new ShowColumns(
             getQualifiedName(context.tableName),
             Optional.ofNullable(context.schema).map(this::getQualifiedName),
-            visitIfPresent(context.where(), Expression.class),
+            visitIfPresent(context.where(), Expression.class, defaultValue),
             getTextIfPresent(context.pattern).map(AstBuilder::unquote));
     }
 
@@ -579,7 +578,7 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
         return new ColumnDefinition(
             getIdentText(context.ident()),
             null,
-            visitIfPresent(context.dataType(), ColumnType.class).orElse(null),
+            visitIfPresent(context.dataType(), ColumnType.class, null),
             visit(context.columnConstraint(), ColumnConstraint.class));
     }
 
@@ -587,8 +586,8 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     public Node visitGeneratedColumnDefinition(SqlBaseParser.GeneratedColumnDefinitionContext context) {
         return new ColumnDefinition(
             getIdentText(context.ident()),
-            visitIfPresent(context.generatedExpr, Expression.class).orElse(null),
-            visitIfPresent(context.dataType(), ColumnType.class).orElse(null),
+            visitIfPresent(context.generatedExpr, Expression.class, null),
+            visitIfPresent(context.dataType(), ColumnType.class, null),
             visit(context.columnConstraint(), ColumnConstraint.class));
     }
 
@@ -616,8 +615,7 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     public Node visitColumnIndexConstraint(SqlBaseParser.ColumnIndexConstraintContext context) {
         return new IndexColumnConstraint(
             getIdentText(context.method),
-            visitIfPresent(context.withProperties(), GenericProperties.class)
-                .orElse(GenericProperties.EMPTY));
+            visitIfPresent(context.withProperties(), GenericProperties.class, GenericProperties.EMPTY));
     }
 
     @Override
@@ -626,14 +624,13 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
             getIdentText(context.name),
             getIdentText(context.method),
             visit(context.columns().primaryExpression(), Expression.class),
-            visitIfPresent(context.withProperties(), GenericProperties.class)
-                .orElse(GenericProperties.EMPTY));
+            visitIfPresent(context.withProperties(), GenericProperties.class, GenericProperties.EMPTY));
     }
 
     @Override
     public Node visitColumnStorageDefinition(SqlBaseParser.ColumnStorageDefinitionContext ctx) {
-        return new ColumnStorageDefinition(visitIfPresent(ctx.withProperties(), GenericProperties.class)
-            .orElse(GenericProperties.EMPTY));
+        return new ColumnStorageDefinition(
+            visitIfPresent(ctx.withProperties(), GenericProperties.class, GenericProperties.EMPTY));
     }
 
     @Override
@@ -644,13 +641,13 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     @Override
     public Node visitClusteredBy(SqlBaseParser.ClusteredByContext context) {
         return new ClusteredBy(
-            visitIfPresent(context.routing, Expression.class),
-            visitIfPresent(context.numShards, Expression.class));
+            visitIfPresent(context.routing, Expression.class, defaultValue),
+            visitIfPresent(context.numShards, Expression.class, defaultValue));
     }
 
     @Override
     public Node visitClusteredInto(SqlBaseParser.ClusteredIntoContext context) {
-        return new ClusteredBy(null, visitIfPresent(context.numShards, Expression.class));
+        return new ClusteredBy(null, visitIfPresent(context.numShards, Expression.class, defaultValue));
     }
 
     @Override
@@ -678,7 +675,7 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
         return new RerouteCancelShard(
             (Expression) visit(context.shardId),
             (Expression) visit(context.nodeId),
-            visitIfPresent(context.withProperties(), GenericProperties.class)
+            visitIfPresent(context.withProperties(), GenericProperties.class, defaultValue)
                 .orElse(GenericProperties.EMPTY));
     }
 
@@ -707,9 +704,9 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     public Node visitAlterTableProperties(SqlBaseParser.AlterTablePropertiesContext context) {
         Table name = (Table) visit(context.alterTableDefinition());
         if (context.SET() != null) {
-            return new AlterTable(name, (GenericProperties) visit(context.genericProperties()));
+            return new AlterTable(name, (GenericProperties) visit(context.genericProperties()), Collections.emptyList());
         }
-        return new AlterTable(name, identsToStrings(context.ident()));
+        return new AlterTable(name, GenericProperties.EMPTY, identsToStrings(context.ident()));
     }
 
     @Override
@@ -736,7 +733,7 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
         return new AddColumnDefinition(
             (Expression) visit(context.subscriptSafe()),
             null,
-            visitIfPresent(context.dataType(), ColumnType.class).orElse(null),
+            visitIfPresent(context.dataType(), ColumnType.class, null),
             visit(context.columnConstraint(), ColumnConstraint.class));
     }
 
@@ -744,8 +741,8 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     public Node visitAddGeneratedColumnDefinition(SqlBaseParser.AddGeneratedColumnDefinitionContext context) {
         return new AddColumnDefinition(
             (Expression) visit(context.subscriptSafe()),
-            visitIfPresent(context.generatedExpr, Expression.class).orElse(null),
-            visitIfPresent(context.dataType(), ColumnType.class).orElse(null),
+            visitIfPresent(context.generatedExpr, Expression.class, null),
+            visitIfPresent(context.dataType(), ColumnType.class, null),
             visit(context.columnConstraint(), ColumnConstraint.class));
     }
 
@@ -810,7 +807,7 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     public Node visitQuery(SqlBaseParser.QueryContext context) {
         Query body = (Query) visit(context.queryNoWith());
         return new Query(
-            visitIfPresent(context.with(), With.class),
+            visitIfPresent(context.with(), With.class, defaultValue),
             body.getQueryBody(),
             body.getOrderBy(),
             body.getLimit(),
@@ -850,8 +847,8 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
                     query.getGroupBy(),
                     query.getHaving(),
                     visit(context.sortItem(), SortItem.class),
-                    visitIfPresent(context.limit, Expression.class),
-                    visitIfPresent(context.offset, Expression.class)),
+                    visitIfPresent(context.limit, Expression.class, defaultValue),
+                    visitIfPresent(context.offset, Expression.class, defaultValue)),
                 ImmutableList.of(),
                 Optional.empty(),
                 Optional.empty());
@@ -860,8 +857,8 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
             Optional.empty(),
             term,
             visit(context.sortItem(), SortItem.class),
-            visitIfPresent(context.limit, Expression.class),
-            visitIfPresent(context.offset, Expression.class));
+            visitIfPresent(context.limit, Expression.class, defaultValue),
+            visitIfPresent(context.offset, Expression.class, defaultValue));
     }
 
     @Override
@@ -876,9 +873,9 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
         return new QuerySpecification(
             new Select(isDistinct(context.setQuant()), selectItems),
             relations,
-            visitIfPresent(context.where(), Expression.class),
+            visitIfPresent(context.where(), Expression.class, defaultValue),
             visit(context.expr(), Expression.class),
-            visitIfPresent(context.having, Expression.class),
+            visitIfPresent(context.having, Expression.class, defaultValue),
             ImmutableList.of(),
             Optional.empty(),
             Optional.empty());
@@ -1129,7 +1126,7 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
             getComparisonQuantifier(((TerminalNode) context.setCmpQuantifier().getChild(0)).getSymbol()),
             (Expression) visit(context.value),
             (Expression) visit(context.v),
-            visitIfPresent(context.escape, Expression.class).orElse(null),
+            visitIfPresent(context.escape, Expression.class, null),
             inverse);
     }
 
@@ -1185,14 +1182,14 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
             idents,
             (Expression) visit(context.term),
             getIdentTextIfPresent(context.matchType).orElse(null),
-            visitIfPresent(context.withProperties(), GenericProperties.class).orElse(null));
+            visitIfPresent(context.withProperties(), GenericProperties.class, null));
     }
 
     @Override
     public Node visitMatchPredicateIdent(SqlBaseParser.MatchPredicateIdentContext context) {
         return new MatchPredicateColumnIdent(
             (Expression) visit(context.subscriptSafe()),
-            visitIfPresent(context.boost, Expression.class).orElse(null));
+            visitIfPresent(context.boost, Expression.class, null));
     }
 
     // Value expressions
@@ -1326,14 +1323,14 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
         return new SimpleCaseExpression(
             (Expression) visit(context.valueExpression()),
             visit(context.whenClause(), WhenClause.class),
-            visitIfPresent(context.elseExpr, Expression.class).orElse(null));
+            visitIfPresent(context.elseExpr, Expression.class, null));
     }
 
     @Override
     public Node visitSearchedCase(SqlBaseParser.SearchedCaseContext context) {
         return new SearchedCaseExpression(
             visit(context.whenClause(), WhenClause.class),
-            visitIfPresent(context.elseExpr, Expression.class).orElse(null));
+            visitIfPresent(context.elseExpr, Expression.class, null));
     }
 
     @Override
@@ -1341,7 +1338,7 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
         return new IfExpression(
             (Expression) visit(context.condition),
             (Expression) visit(context.trueValue),
-            visitIfPresent(context.falseValue, Expression.class));
+            visitIfPresent(context.falseValue, Expression.class, defaultValue));
     }
 
     @Override
@@ -1438,7 +1435,7 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
         return new CreateIngestRule(getIdentText(ctx.rule_name),
             getIdentText(ctx.source_ident),
             getQualifiedName(ctx.table_ident),
-            visitIfPresent(ctx.where(), Expression.class));
+            visitIfPresent(ctx.where(), Expression.class, defaultValue));
     }
 
     // Data types
@@ -1490,10 +1487,11 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
         throw new UnsupportedOperationException("not yet implemented");
     }
 
-    private <T> Optional<T> visitIfPresent(ParserRuleContext context, Class<T> clazz) {
+    private <T> T visitIfPresent(ParserRuleContext context, Class<T> clazz, T defaultValue) {
         return Optional.ofNullable(context)
             .map(this::visit)
-            .map(clazz::cast);
+            .map(clazz::cast)
+            .orElse(defaultValue);
     }
 
     private <T> List<T> visit(List<? extends ParserRuleContext> contexts, Class<T> clazz) {

--- a/sql-parser/src/main/java/io/crate/sql/tree/AllColumns.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AllColumns.java
@@ -23,22 +23,24 @@ package io.crate.sql.tree;
 
 import com.google.common.base.Preconditions;
 
-import java.util.Optional;
+import javax.annotation.Nullable;
 
 public class AllColumns extends SelectItem {
 
-    private final Optional<QualifiedName> prefix;
+    @Nullable
+    private final QualifiedName prefix;
 
     public AllColumns() {
-        prefix = Optional.empty();
+        prefix = null;
     }
 
     public AllColumns(QualifiedName prefix) {
         Preconditions.checkNotNull(prefix, "prefix is null");
-        this.prefix = Optional.of(prefix);
+        this.prefix = prefix;
     }
 
-    public Optional<QualifiedName> getPrefix() {
+    @Nullable
+    public QualifiedName getPrefix() {
         return prefix;
     }
 
@@ -72,8 +74,8 @@ public class AllColumns extends SelectItem {
 
     @Override
     public String toString() {
-        if (prefix.isPresent()) {
-            return prefix.get() + ".*";
+        if (prefix != null) {
+            return prefix + ".*";
         }
 
         return "*";

--- a/sql-parser/src/main/java/io/crate/sql/tree/AlterBlobTable.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AlterBlobTable.java
@@ -21,16 +21,17 @@
 
 package io.crate.sql.tree;
 
+import java.util.Collections;
 import java.util.List;
 
 public class AlterBlobTable extends AlterTable {
 
     public AlterBlobTable(Table table, GenericProperties genericProperties) {
-        super(table, genericProperties);
+        super(table, genericProperties, Collections.emptyList());
     }
 
     public AlterBlobTable(Table table, List<String> resetProperties) {
-        super(table, resetProperties);
+        super(table, GenericProperties.EMPTY, resetProperties);
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/AlterTable.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AlterTable.java
@@ -22,27 +22,19 @@
 package io.crate.sql.tree;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.collect.ImmutableList;
 
 import java.util.List;
-import java.util.Optional;
 
 public class AlterTable extends Statement {
 
     private final Table table;
-    private final Optional<GenericProperties> genericProperties;
+    private final GenericProperties genericProperties;
     private final List<String> resetProperties;
 
-    public AlterTable(Table table, GenericProperties genericProperties) {
+    public AlterTable(Table table, GenericProperties genericProperties, List<String> resetProperties) {
         this.table = table;
-        this.genericProperties = Optional.of(genericProperties);
-        this.resetProperties = ImmutableList.of();
-    }
-
-    public AlterTable(Table table, List<String> resetProperties) {
-        this.table = table;
+        this.genericProperties = genericProperties;
         this.resetProperties = resetProperties;
-        this.genericProperties = Optional.empty();
     }
 
     @Override
@@ -54,7 +46,7 @@ public class AlterTable extends Statement {
         return table;
     }
 
-    public Optional<GenericProperties> genericProperties() {
+    public GenericProperties genericProperties() {
         return genericProperties;
     }
 
@@ -66,7 +58,8 @@ public class AlterTable extends Statement {
     public String toString() {
         return MoreObjects.toStringHelper(this)
             .add("table", table)
-            .add("properties", genericProperties).toString();
+            .add("properties", genericProperties)
+            .toString();
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/ClusteredBy.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/ClusteredBy.java
@@ -24,24 +24,32 @@ package io.crate.sql.tree;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
-import java.util.Optional;
+import javax.annotation.Nullable;
 
 public class ClusteredBy extends CrateTableOption {
 
-    private final Optional<Expression> column;
-    private final Optional<Expression> numberOfShards;
+    @Nullable
+    private final Expression column;
+    @Nullable
+    private final Expression numberOfShards;
 
-    public ClusteredBy(Optional<Expression> column, Optional<Expression> numberOfShards) {
+    public ClusteredBy(@Nullable Expression column, @Nullable Expression numberOfShards) {
         this.column = column;
         this.numberOfShards = numberOfShards;
     }
 
-    public Optional<Expression> column() {
+    @Nullable
+    public Expression column() {
         return column;
     }
 
-    public Optional<Expression> numberOfShards() {
+    @Nullable
+    public Expression numberOfShards() {
         return numberOfShards;
+    }
+
+    public boolean isEmpty() {
+        return column != null && numberOfShards != null;
     }
 
     @Override
@@ -56,8 +64,8 @@ public class ClusteredBy extends CrateTableOption {
 
         ClusteredBy that = (ClusteredBy) o;
 
-        if (!numberOfShards.equals(that.numberOfShards)) return false;
-        if (!column.equals(that.column)) return false;
+        if (numberOfShards != null ? !numberOfShards.equals(that.numberOfShards) : that.numberOfShards != null) return false;
+        if (column != null ? !column.equals(that.column) : that.column != null) return false;
 
         return true;
     }
@@ -66,7 +74,8 @@ public class ClusteredBy extends CrateTableOption {
     public String toString() {
         return MoreObjects.toStringHelper(this)
             .add("column", column)
-            .add("number of shards", numberOfShards).toString();
+            .add("number of shards", numberOfShards)
+            .toString();
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/CopyFrom.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/CopyFrom.java
@@ -23,17 +23,15 @@ package io.crate.sql.tree;
 
 import com.google.common.base.MoreObjects;
 
-import java.util.Optional;
-
 public class CopyFrom extends Statement {
 
     private final Table table;
     private final Expression path;
-    private final Optional<GenericProperties> genericProperties;
+    private final GenericProperties genericProperties;
 
     public CopyFrom(Table table,
                     Expression path,
-                    Optional<GenericProperties> genericProperties) {
+                    GenericProperties genericProperties) {
 
         this.table = table;
         this.path = path;
@@ -48,7 +46,7 @@ public class CopyFrom extends Statement {
         return path;
     }
 
-    public Optional<GenericProperties> genericProperties() {
+    public GenericProperties genericProperties() {
         return genericProperties;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/CopyTo.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/CopyTo.java
@@ -30,12 +30,11 @@ import java.util.Optional;
 
 public class CopyTo extends Statement {
 
-
     private final Table table;
     private final boolean directoryUri;
     private final Expression targetUri;
 
-    private final Optional<GenericProperties> genericProperties;
+    private final GenericProperties genericProperties;
     private final List<Expression> columns;
     private final Optional<Expression> whereClause;
 
@@ -44,7 +43,7 @@ public class CopyTo extends Statement {
                   Optional<Expression> whereClause,
                   boolean directoryUri,
                   Expression targetUri,
-                  Optional<GenericProperties> genericProperties) {
+                  GenericProperties genericProperties) {
 
         this.table = table;
         this.directoryUri = directoryUri;
@@ -71,7 +70,7 @@ public class CopyTo extends Statement {
     }
 
 
-    public Optional<GenericProperties> genericProperties() {
+    public GenericProperties genericProperties() {
         return genericProperties;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/CopyTo.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/CopyTo.java
@@ -26,7 +26,6 @@ import com.google.common.collect.ImmutableList;
 
 import javax.annotation.Nullable;
 import java.util.List;
-import java.util.Optional;
 
 public class CopyTo extends Statement {
 
@@ -36,11 +35,12 @@ public class CopyTo extends Statement {
 
     private final GenericProperties genericProperties;
     private final List<Expression> columns;
-    private final Optional<Expression> whereClause;
+    @Nullable
+    private final Expression whereClause;
 
     public CopyTo(Table table,
                   @Nullable List<Expression> columns,
-                  Optional<Expression> whereClause,
+                  @Nullable Expression whereClause,
                   boolean directoryUri,
                   Expression targetUri,
                   GenericProperties genericProperties) {
@@ -74,7 +74,8 @@ public class CopyTo extends Statement {
         return genericProperties;
     }
 
-    public Optional<Expression> whereClause() {
+    @Nullable
+    public Expression whereClause() {
         return whereClause;
     }
 
@@ -90,7 +91,7 @@ public class CopyTo extends Statement {
         if (!genericProperties.equals(copyTo.genericProperties)) return false;
         if (!table.equals(copyTo.table)) return false;
         if (!targetUri.equals(copyTo.targetUri)) return false;
-        if (!whereClause.equals(copyTo.whereClause)) return false;
+        if (whereClause != null ? !whereClause.equals(copyTo.whereClause) : copyTo.whereClause != null) return false;
 
         return true;
     }
@@ -102,7 +103,9 @@ public class CopyTo extends Statement {
         result = 31 * result + targetUri.hashCode();
         result = 31 * result + genericProperties.hashCode();
         result = 31 * result + columns.hashCode();
-        result = 31 * result + whereClause.hashCode();
+        if (whereClause != null) {
+            result = 31 * result + whereClause.hashCode();
+        }
         return result;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/CreateAnalyzer.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/CreateAnalyzer.java
@@ -24,16 +24,17 @@ package io.crate.sql.tree;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
+import javax.annotation.Nullable;
 import java.util.List;
-import java.util.Optional;
 
 public class CreateAnalyzer extends Statement {
 
     private final String ident;
-    private final Optional<String> extendedAnalyzer;
+    @Nullable
+    private final String extendedAnalyzer;
     private final List<AnalyzerElement> elements;
 
-    public CreateAnalyzer(String ident, Optional<String> extendedAnalyzer, List<AnalyzerElement> elements) {
+    public CreateAnalyzer(String ident, @Nullable String extendedAnalyzer, List<AnalyzerElement> elements) {
         this.ident = ident;
         this.extendedAnalyzer = extendedAnalyzer;
         this.elements = elements;
@@ -43,12 +44,13 @@ public class CreateAnalyzer extends Statement {
         return ident;
     }
 
-    public Optional<String> extendedAnalyzer() {
+    @Nullable
+    public String extendedAnalyzer() {
         return extendedAnalyzer;
     }
 
     public boolean isExtending() {
-        return extendedAnalyzer.isPresent();
+        return extendedAnalyzer != null;
     }
 
     public List<AnalyzerElement> elements() {
@@ -68,7 +70,7 @@ public class CreateAnalyzer extends Statement {
         CreateAnalyzer that = (CreateAnalyzer) o;
 
         if (!elements.equals(that.elements)) return false;
-        if (!extendedAnalyzer.equals(that.extendedAnalyzer)) return false;
+        if (extendedAnalyzer != null ? !extendedAnalyzer.equals(that.extendedAnalyzer) : that.extendedAnalyzer != null) return false;
         if (!ident.equals(that.ident)) return false;
 
         return true;

--- a/sql-parser/src/main/java/io/crate/sql/tree/CreateBlobTable.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/CreateBlobTable.java
@@ -29,9 +29,9 @@ public class CreateBlobTable extends Statement {
 
     private final Table name;
     private final Optional<ClusteredBy> clusteredBy;
-    private final Optional<GenericProperties> genericProperties;
+    private final GenericProperties genericProperties;
 
-    public CreateBlobTable(Table name, Optional<ClusteredBy> clusteredBy, Optional<GenericProperties> properties) {
+    public CreateBlobTable(Table name, Optional<ClusteredBy> clusteredBy, GenericProperties properties) {
         this.name = name;
         this.clusteredBy = clusteredBy;
         this.genericProperties = properties;
@@ -45,7 +45,7 @@ public class CreateBlobTable extends Statement {
         return clusteredBy;
     }
 
-    public Optional<GenericProperties> genericProperties() {
+    public GenericProperties genericProperties() {
         return genericProperties;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/CreateBlobTable.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/CreateBlobTable.java
@@ -23,15 +23,17 @@ package io.crate.sql.tree;
 
 import com.google.common.base.MoreObjects;
 
+import javax.annotation.Nullable;
 import java.util.Optional;
 
 public class CreateBlobTable extends Statement {
 
     private final Table name;
-    private final Optional<ClusteredBy> clusteredBy;
+    @Nullable
+    private final ClusteredBy clusteredBy;
     private final GenericProperties genericProperties;
 
-    public CreateBlobTable(Table name, Optional<ClusteredBy> clusteredBy, GenericProperties properties) {
+    public CreateBlobTable(Table name, @Nullable ClusteredBy clusteredBy, GenericProperties properties) {
         this.name = name;
         this.clusteredBy = clusteredBy;
         this.genericProperties = properties;
@@ -41,7 +43,8 @@ public class CreateBlobTable extends Statement {
         return name;
     }
 
-    public Optional<ClusteredBy> clusteredBy() {
+    @Nullable
+    public ClusteredBy clusteredBy() {
         return clusteredBy;
     }
 
@@ -56,7 +59,7 @@ public class CreateBlobTable extends Statement {
 
         CreateBlobTable that = (CreateBlobTable) o;
 
-        if (!clusteredBy.equals(that.clusteredBy)) return false;
+        if (clusteredBy != null ? !clusteredBy.equals(that.clusteredBy) : that.clusteredBy != null) return false;
         if (!genericProperties.equals(that.genericProperties)) return false;
         if (!name.equals(that.name)) return false;
 
@@ -66,7 +69,9 @@ public class CreateBlobTable extends Statement {
     @Override
     public int hashCode() {
         int result = name.hashCode();
-        result = 31 * result + clusteredBy.hashCode();
+        if (clusteredBy != null) {
+            result = 31 * result + clusteredBy.hashCode();
+        }
         result = 31 * result + genericProperties.hashCode();
         return result;
     }

--- a/sql-parser/src/main/java/io/crate/sql/tree/CreateBlobTable.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/CreateBlobTable.java
@@ -24,7 +24,6 @@ package io.crate.sql.tree;
 import com.google.common.base.MoreObjects;
 
 import javax.annotation.Nullable;
-import java.util.Optional;
 
 public class CreateBlobTable extends Statement {
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/CreateIngestRule.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/CreateIngestRule.java
@@ -3,7 +3,7 @@ package io.crate.sql.tree;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
-import java.util.Optional;
+import javax.annotation.Nullable;
 
 
 public class CreateIngestRule extends Statement {
@@ -11,12 +11,13 @@ public class CreateIngestRule extends Statement {
     private final String rule;
     private final String source;
     private final QualifiedName target;
-    private final Optional<Expression> where;
+    @Nullable
+    private final Expression where;
 
     public CreateIngestRule(String rule,
                             String sourceIdent,
                             QualifiedName targetTable,
-                            Optional<Expression> where) {
+                            @Nullable Expression where) {
         this.rule = rule;
         this.source = sourceIdent;
         this.target = targetTable;
@@ -35,7 +36,8 @@ public class CreateIngestRule extends Statement {
         return target;
     }
 
-    public Optional<Expression> where() {
+    @Nullable
+    public Expression where() {
         return where;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/CreateRepository.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/CreateRepository.java
@@ -24,17 +24,15 @@ package io.crate.sql.tree;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
-import java.util.Optional;
-
 public class CreateRepository extends Statement {
 
     private final String repository;
     private final String type;
-    private final Optional<GenericProperties> properties;
+    private final GenericProperties properties;
 
     public CreateRepository(String repository,
                             String type,
-                            Optional<GenericProperties> genericProperties) {
+                            GenericProperties genericProperties) {
         this.repository = repository;
         this.type = type;
         this.properties = genericProperties;
@@ -48,7 +46,7 @@ public class CreateRepository extends Statement {
         return type;
     }
 
-    public Optional<GenericProperties> properties() {
+    public GenericProperties properties() {
         return properties;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/CreateSnapshot.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/CreateSnapshot.java
@@ -24,27 +24,27 @@ package io.crate.sql.tree;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
+import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 public class CreateSnapshot extends Statement {
 
     private final QualifiedName name;
-    private final Optional<GenericProperties> properties;
-    private final Optional<List<Table>> tableList;
+    private final GenericProperties properties;
+    private final List<Table> tableList;
 
     public CreateSnapshot(QualifiedName name,
-                          Optional<GenericProperties> genericProperties) {
+                          GenericProperties genericProperties) {
         this.name = name;
         this.properties = genericProperties;
-        this.tableList = Optional.empty();
+        this.tableList = Collections.emptyList();
     }
 
     public CreateSnapshot(QualifiedName name,
                           List<Table> tableList,
-                          Optional<GenericProperties> genericProperties) {
+                          GenericProperties genericProperties) {
         this.name = name;
-        this.tableList = Optional.of(tableList);
+        this.tableList = tableList;
         this.properties = genericProperties;
 
     }
@@ -53,11 +53,11 @@ public class CreateSnapshot extends Statement {
         return this.name;
     }
 
-    public Optional<GenericProperties> properties() {
+    public GenericProperties properties() {
         return properties;
     }
 
-    public Optional<List<Table>> tableList() {
+    public List<Table> tableList() {
         return tableList;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/CreateTable.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/CreateTable.java
@@ -25,7 +25,6 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
 import java.util.List;
-import java.util.Optional;
 
 public class CreateTable extends Statement {
 
@@ -33,12 +32,12 @@ public class CreateTable extends Statement {
     private final List<TableElement> tableElements;
     private final boolean ifNotExists;
     private final List<CrateTableOption> crateTableOptions;
-    private final Optional<GenericProperties> properties;
+    private final GenericProperties properties;
 
     public CreateTable(Table name,
                        List<TableElement> tableElements,
                        List<CrateTableOption> crateTableOptions,
-                       Optional<GenericProperties> genericProperties,
+                       GenericProperties genericProperties,
                        boolean ifNotExists) {
         this.name = name;
         this.tableElements = tableElements;
@@ -63,7 +62,7 @@ public class CreateTable extends Statement {
         return crateTableOptions;
     }
 
-    public Optional<GenericProperties> properties() {
+    public GenericProperties properties() {
         return properties;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/CurrentTime.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/CurrentTime.java
@@ -22,14 +22,14 @@
 package io.crate.sql.tree;
 
 import javax.annotation.Nullable;
-import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class CurrentTime extends Expression {
 
     private final Type type;
-    private final Optional<Integer> precision;
+    @Nullable
+    private final Integer precision;
 
     public enum Type {
         TIME,
@@ -44,14 +44,15 @@ public class CurrentTime extends Expression {
     public CurrentTime(Type type, @Nullable Integer precision) {
         checkNotNull(type, "type is null");
         this.type = type;
-        this.precision = Optional.ofNullable(precision);
+        this.precision = precision;
     }
 
     public Type getType() {
         return type;
     }
 
-    public Optional<Integer> getPrecision() {
+    @Nullable
+    public Integer getPrecision() {
         return precision;
     }
 
@@ -71,7 +72,7 @@ public class CurrentTime extends Expression {
 
         CurrentTime that = (CurrentTime) o;
 
-        if (!precision.equals(that.precision)) {
+        if (precision != null ? !precision.equals(that.precision) : that.precision != null) {
             return false;
         }
         if (type != that.type) {
@@ -84,7 +85,9 @@ public class CurrentTime extends Expression {
     @Override
     public int hashCode() {
         int result = type.hashCode();
-        result = 31 * result + precision.hashCode();
+        if (precision != null) {
+            result = 31 * result + precision.hashCode();
+        }
         return result;
     }
 }

--- a/sql-parser/src/main/java/io/crate/sql/tree/DefaultTraversalVisitor.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/DefaultTraversalVisitor.java
@@ -287,8 +287,8 @@ public abstract class DefaultTraversalVisitor<R, C>
         process(node.getLeft(), context);
         process(node.getRight(), context);
 
-        if (node.getCriteria().isPresent() && node.getCriteria().get() instanceof JoinOn) {
-            process(((JoinOn) node.getCriteria().get()).getExpression(), context);
+        if (node.getCriteria() != null && node.getCriteria() instanceof JoinOn) {
+            process(((JoinOn) node.getCriteria()).getExpression(), context);
         }
 
         return null;

--- a/sql-parser/src/main/java/io/crate/sql/tree/DefaultTraversalVisitor.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/DefaultTraversalVisitor.java
@@ -65,8 +65,8 @@ public abstract class DefaultTraversalVisitor<R, C>
 
     @Override
     protected R visitQuery(Query node, C context) {
-        if (node.getWith().isPresent()) {
-            process(node.getWith().get(), context);
+        if (node.getWith() != null) {
+            process(node.getWith(), context);
         }
         process(node.getQueryBody(), context);
         for (SortItem sortItem : node.getOrderBy()) {
@@ -157,8 +157,8 @@ public abstract class DefaultTraversalVisitor<R, C>
     protected R visitIfExpression(IfExpression node, C context) {
         process(node.getCondition(), context);
         process(node.getTrueValue(), context);
-        if (node.getFalseValue().isPresent()) {
-            process(node.getFalseValue().get(), context);
+        if (node.getFalseValue() != null) {
+            process(node.getFalseValue(), context);
         }
 
         return null;
@@ -236,14 +236,14 @@ public abstract class DefaultTraversalVisitor<R, C>
         }
 
         process(node.getSelect(), context);
-        if (node.getWhere().isPresent()) {
-            process(node.getWhere().get(), context);
+        if (node.getWhere() != null) {
+            process(node.getWhere(), context);
         }
         for (Expression expression : node.getGroupBy()) {
             process(expression, context);
         }
-        if (node.getHaving().isPresent()) {
-            process(node.getHaving().get(), context);
+        if (node.getHaving() != null) {
+            process(node.getHaving(), context);
         }
         for (SortItem sortItem : node.getOrderBy()) {
             process(sortItem, context);
@@ -317,8 +317,8 @@ public abstract class DefaultTraversalVisitor<R, C>
         for (Assignment assignment : node.assignements()) {
             process(assignment, context);
         }
-        if (node.whereClause().isPresent()) {
-            process(node.whereClause().get(), context);
+        if (node.whereClause() != null) {
+            process(node.whereClause(), context);
         }
         return null;
     }

--- a/sql-parser/src/main/java/io/crate/sql/tree/Delete.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/Delete.java
@@ -25,14 +25,15 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
-import java.util.Optional;
+import javax.annotation.Nullable;
 
 public class Delete extends Statement {
 
     private final Relation relation;
-    private final Optional<Expression> where;
+    @Nullable
+    private final Expression where;
 
-    public Delete(Relation relation, Optional<Expression> where) {
+    public Delete(Relation relation, @Nullable Expression where) {
         Preconditions.checkNotNull(relation, "relation is null");
         this.relation = relation;
         this.where = where;
@@ -42,7 +43,8 @@ public class Delete extends Statement {
         return relation;
     }
 
-    public Optional<Expression> getWhere() {
+    @Nullable
+    public Expression getWhere() {
         return where;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/FunctionArgument.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/FunctionArgument.java
@@ -26,20 +26,22 @@
 
 package io.crate.sql.tree;
 
+import javax.annotation.Nullable;
 import java.util.Objects;
-import java.util.Optional;
 
 public class FunctionArgument extends Node {
 
-    private final Optional<String> name;
+    @Nullable
+    private final String name;
     private final ColumnType type;
 
-    public FunctionArgument(Optional<String> name, ColumnType type) {
+    public FunctionArgument(@Nullable String name, ColumnType type) {
         this.name = name;
         this.type = type;
     }
 
-    public Optional<String> name() {
+    @Nullable
+    public String name() {
         return name;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/GenericProperties.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/GenericProperties.java
@@ -48,7 +48,7 @@ import java.util.Set;
  */
 public class GenericProperties extends Node {
 
-    public static final GenericProperties EMPTY = new GenericProperties(ImmutableMap.<String, Expression>of());
+    public static final GenericProperties EMPTY = new GenericProperties(ImmutableMap.of());
 
     private final Map<String, Expression> properties;
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/IfExpression.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/IfExpression.java
@@ -23,7 +23,7 @@ package io.crate.sql.tree;
 
 import com.google.common.base.Objects;
 
-import java.util.Optional;
+import javax.annotation.Nullable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -33,9 +33,10 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class IfExpression extends Expression {
     private final Expression condition;
     private final Expression trueValue;
-    private final Optional<Expression> falseValue;
+    @Nullable
+    private final Expression falseValue;
 
-    public IfExpression(Expression condition, Expression trueValue, Optional<Expression> falseValue) {
+    public IfExpression(Expression condition, Expression trueValue, @Nullable Expression falseValue) {
         this.condition = checkNotNull(condition, "condition is null");
         this.trueValue = checkNotNull(trueValue, "trueValue is null");
         this.falseValue = falseValue;
@@ -49,7 +50,8 @@ public class IfExpression extends Expression {
         return trueValue;
     }
 
-    public Optional<Expression> getFalseValue() {
+    @Nullable
+    public Expression getFalseValue() {
         return falseValue;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/Join.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/Join.java
@@ -23,19 +23,19 @@ package io.crate.sql.tree;
 
 import com.google.common.base.MoreObjects;
 
-import java.util.Optional;
+import javax.annotation.Nullable;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class Join extends Relation {
-    public Join(Type type, Relation left, Relation right, Optional<JoinCriteria> criteria) {
+    public Join(Type type, Relation left, Relation right, @Nullable JoinCriteria criteria) {
         checkNotNull(left, "left is null");
         checkNotNull(right, "right is null");
         if (type.equals(Type.CROSS)) {
-            checkArgument(!criteria.isPresent(), "Cross join cannot have join criteria");
+            checkArgument(criteria == null, "Cross join cannot have join criteria");
         } else {
-            checkArgument(criteria.isPresent(), "No join criteria specified");
+            checkNotNull(criteria, "No join criteria specified");
         }
 
         this.type = type;
@@ -51,7 +51,8 @@ public class Join extends Relation {
     private final Type type;
     private final Relation left;
     private final Relation right;
-    private final Optional<JoinCriteria> criteria;
+    @Nullable
+    private final JoinCriteria criteria;
 
     public Type getType() {
         return type;
@@ -65,7 +66,8 @@ public class Join extends Relation {
         return right;
     }
 
-    public Optional<JoinCriteria> getCriteria() {
+    @Nullable
+    public JoinCriteria getCriteria() {
         return criteria;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/KillStatement.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/KillStatement.java
@@ -21,28 +21,29 @@
 
 package io.crate.sql.tree;
 
-import java.util.Optional;
+import javax.annotation.Nullable;
 
 public class KillStatement extends Statement {
 
-    private final Optional<Expression> jobId;
-
+    @Nullable
+    private final Expression jobId;
 
     public KillStatement() {
-        this.jobId = Optional.empty();
+        this.jobId = null;
     }
 
     public KillStatement(Expression jobId) {
-        this.jobId = Optional.of(jobId);
+        this.jobId = jobId;
     }
 
-    public Optional<Expression> jobId() {
+    @Nullable
+    public Expression jobId() {
         return jobId;
     }
 
     @Override
     public int hashCode() {
-        return jobId.hashCode();
+        return jobId != null ? jobId.hashCode() : 0;
     }
 
     @Override
@@ -52,12 +53,12 @@ public class KillStatement extends Statement {
 
         KillStatement that = (KillStatement) obj;
 
-        return jobId.equals(that.jobId);
+        return jobId != null ? jobId.equals(that.jobId) : that.jobId == null;
     }
 
     @Override
     public String toString() {
-        return jobId.isPresent() ? "KILL '" + jobId.get() + "'" : "KILL ALL";
+        return jobId != null ? "KILL '" + jobId + "'" : "KILL ALL";
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/MatchPredicate.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/MatchPredicate.java
@@ -21,7 +21,6 @@
 
 package io.crate.sql.tree;
 
-import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
@@ -36,13 +35,13 @@ public class MatchPredicate extends Expression {
     private final String matchType;
 
     public MatchPredicate(List<MatchPredicateColumnIdent> idents, Expression value,
-                          @Nullable String matchType, @Nullable GenericProperties properties) {
+                          @Nullable String matchType, GenericProperties properties) {
         Preconditions.checkArgument(idents.size() > 0, "at least one ident must be given");
         Preconditions.checkNotNull(value, "query_term is null");
         this.idents = idents;
         this.value = value;
         this.matchType = matchType;
-        this.properties = MoreObjects.firstNonNull(properties, GenericProperties.EMPTY);
+        this.properties = properties;
     }
 
     public List<MatchPredicateColumnIdent> idents() {

--- a/sql-parser/src/main/java/io/crate/sql/tree/NamedProperties.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/NamedProperties.java
@@ -24,14 +24,12 @@ package io.crate.sql.tree;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
-import java.util.Optional;
-
 public class NamedProperties extends Node {
 
     private final String ident;
-    private final Optional<GenericProperties> properties;
+    private final GenericProperties properties;
 
-    public NamedProperties(String ident, Optional<GenericProperties> properties) {
+    public NamedProperties(String ident, GenericProperties properties) {
         this.ident = ident;
         this.properties = properties;
     }
@@ -40,7 +38,7 @@ public class NamedProperties extends Node {
         return ident;
     }
 
-    public Optional<GenericProperties> properties() {
+    public GenericProperties properties() {
         return properties;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/ObjectColumnType.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/ObjectColumnType.java
@@ -27,20 +27,19 @@ import com.google.common.collect.ImmutableList;
 
 import javax.annotation.Nullable;
 import java.util.List;
-import java.util.Optional;
 
 public class ObjectColumnType extends ColumnType {
 
-    private final Optional<String> objectType;
+    private final String objectType;
     private final List<ColumnDefinition> nestedColumns;
 
     public ObjectColumnType(@Nullable String objectType, @Nullable List<ColumnDefinition> nestedColumns) {
         super("object");
-        this.objectType = Optional.ofNullable(objectType);
+        this.objectType = MoreObjects.firstNonNull(objectType, "dynamic");
         this.nestedColumns = MoreObjects.firstNonNull(nestedColumns, ImmutableList.<ColumnDefinition>of());
     }
 
-    public Optional<String> objectType() {
+    public String objectType() {
         return objectType;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/OptimizeStatement.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/OptimizeStatement.java
@@ -25,14 +25,13 @@ package io.crate.sql.tree;
 import com.google.common.base.MoreObjects;
 
 import java.util.List;
-import java.util.Optional;
 
 public class OptimizeStatement extends Statement {
 
     private final List<Table> tables;
-    private final Optional<GenericProperties> properties;
+    private final GenericProperties properties;
 
-    public OptimizeStatement(List<Table> tables, Optional<GenericProperties> properties) {
+    public OptimizeStatement(List<Table> tables, GenericProperties properties) {
         this.tables = tables;
         this.properties = properties;
     }
@@ -41,7 +40,7 @@ public class OptimizeStatement extends Statement {
         return tables;
     }
 
-    public Optional<GenericProperties> properties() {
+    public GenericProperties properties() {
         return properties;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/QualifiedName.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/QualifiedName.java
@@ -27,9 +27,9 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 public class QualifiedName {
 
@@ -69,14 +69,15 @@ public class QualifiedName {
 
     /**
      * For an identifier of the form "a.b.c.d", returns "a.b.c"
-     * For an identifier of the form "a", returns absent
+     * For an identifier of the form "a", returns NULL
      */
-    public Optional<QualifiedName> getPrefix() {
+    @Nullable
+    public QualifiedName getPrefix() {
         if (parts.size() == 1) {
-            return Optional.empty();
+            return null;
         }
 
-        return Optional.of(QualifiedName.of(parts.subList(0, parts.size() - 1)));
+        return QualifiedName.of(parts.subList(0, parts.size() - 1));
     }
 
     public String getSuffix() {

--- a/sql-parser/src/main/java/io/crate/sql/tree/Query.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/Query.java
@@ -26,7 +26,6 @@ import com.google.common.base.Objects;
 
 import javax.annotation.Nullable;
 import java.util.List;
-import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/Query.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/Query.java
@@ -24,29 +24,30 @@ package io.crate.sql.tree;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class Query extends Statement {
-    private final Optional<With> with;
+    @Nullable
+    private final With with;
     private final QueryBody queryBody;
     private final List<SortItem> orderBy;
-    private final Optional<Expression> limit;
-    private final Optional<Expression> offset;
+    @Nullable
+    private final Expression limit;
+    @Nullable
+    private final Expression offset;
 
     public Query(
-        Optional<With> with,
+        @Nullable With with,
         QueryBody queryBody,
         List<SortItem> orderBy,
-        Optional<Expression> limit,
-        Optional<Expression> offset) {
-        checkNotNull(with, "with is null");
+        @Nullable Expression limit,
+        @Nullable Expression offset) {
         checkNotNull(queryBody, "queryBody is null");
         checkNotNull(orderBy, "orderBy is null");
-        checkNotNull(limit, "limit is null");
-        checkNotNull(offset, "offset is null");
 
         this.with = with;
         this.queryBody = queryBody;
@@ -55,7 +56,8 @@ public class Query extends Statement {
         this.offset = offset;
     }
 
-    public Optional<With> getWith() {
+    @Nullable
+    public With getWith() {
         return with;
     }
 
@@ -67,11 +69,13 @@ public class Query extends Statement {
         return orderBy;
     }
 
-    public Optional<Expression> getLimit() {
+    @Nullable
+    public Expression getLimit() {
         return limit;
     }
 
-    public Optional<Expression> getOffset() {
+    @Nullable
+    public Expression getOffset() {
         return offset;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/QuerySpecification.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/QuerySpecification.java
@@ -26,7 +26,6 @@ import com.google.common.base.Objects;
 
 import javax.annotation.Nullable;
 import java.util.List;
-import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/QuerySpecification.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/QuerySpecification.java
@@ -34,29 +34,29 @@ public class QuerySpecification
     extends QueryBody {
     private final Select select;
     private final List<Relation> from;
-    private final Optional<Expression> where;
+    @Nullable
+    private final Expression where;
     private final List<Expression> groupBy;
-    private final Optional<Expression> having;
+    @Nullable
+    private final Expression having;
     private final List<SortItem> orderBy;
-    private final Optional<Expression> limit;
-    private final Optional<Expression> offset;
+    @Nullable
+    private final Expression limit;
+    @Nullable
+    private final Expression offset;
 
     public QuerySpecification(
         Select select,
         @Nullable List<Relation> from,
-        Optional<Expression> where,
+        @Nullable Expression where,
         List<Expression> groupBy,
-        Optional<Expression> having,
+        @Nullable Expression having,
         List<SortItem> orderBy,
-        Optional<Expression> limit,
-        Optional<Expression> offset) {
+        @Nullable Expression limit,
+        @Nullable Expression offset) {
         checkNotNull(select, "select is null");
-        checkNotNull(where, "where is null");
         checkNotNull(groupBy, "groupBy is null");
-        checkNotNull(having, "having is null");
         checkNotNull(orderBy, "orderBy is null");
-        checkNotNull(limit, "limit is null");
-        checkNotNull(offset, "offset is null");
 
         this.select = select;
         this.from = from;
@@ -76,7 +76,8 @@ public class QuerySpecification
         return from;
     }
 
-    public Optional<Expression> getWhere() {
+    @Nullable
+    public Expression getWhere() {
         return where;
     }
 
@@ -84,7 +85,8 @@ public class QuerySpecification
         return groupBy;
     }
 
-    public Optional<Expression> getHaving() {
+    @Nullable
+    public Expression getHaving() {
         return having;
     }
 
@@ -92,11 +94,13 @@ public class QuerySpecification
         return orderBy;
     }
 
-    public Optional<Expression> getLimit() {
+    @Nullable
+    public Expression getLimit() {
         return limit;
     }
 
-    public Optional<Expression> getOffset() {
+    @Nullable
+    public Expression getOffset() {
         return offset;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/RestoreSnapshot.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/RestoreSnapshot.java
@@ -24,27 +24,27 @@ package io.crate.sql.tree;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
+import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 public class RestoreSnapshot extends Statement {
 
     private final QualifiedName name;
-    private final Optional<GenericProperties> properties;
-    private final Optional<List<Table>> tableList;
+    private final GenericProperties properties;
+    private final List<Table> tableList;
 
-    public RestoreSnapshot(QualifiedName name, Optional<GenericProperties> genericProperties) {
+    public RestoreSnapshot(QualifiedName name, GenericProperties genericProperties) {
         this.name = name;
         this.properties = genericProperties;
-        this.tableList = Optional.empty();
+        this.tableList = Collections.emptyList();
 
     }
 
     public RestoreSnapshot(QualifiedName name,
                            List<Table> tableList,
-                           Optional<GenericProperties> genericProperties) {
+                           GenericProperties genericProperties) {
         this.name = name;
-        this.tableList = Optional.of(tableList);
+        this.tableList = tableList;
         this.properties = genericProperties;
 
     }
@@ -53,11 +53,11 @@ public class RestoreSnapshot extends Statement {
         return this.name;
     }
 
-    public Optional<GenericProperties> properties() {
+    public GenericProperties properties() {
         return properties;
     }
 
-    public Optional<List<Table>> tableList() {
+    public List<Table> tableList() {
         return tableList;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/ShowColumns.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/ShowColumns.java
@@ -24,21 +24,24 @@ package io.crate.sql.tree;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
-import java.util.Optional;
+import javax.annotation.Nullable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public class ShowColumns extends Statement {
 
     private final QualifiedName table;
-    private final Optional<QualifiedName> schema;
-    private final Optional<String> likePattern;
-    private final Optional<Expression> where;
+    @Nullable
+    private final QualifiedName schema;
+    @Nullable
+    private final String likePattern;
+    @Nullable
+    private final Expression where;
 
     public ShowColumns(QualifiedName table,
-                       Optional<QualifiedName> schema,
-                       Optional<Expression> where,
-                       Optional<String> likePattern) {
+                       @Nullable QualifiedName schema,
+                       @Nullable Expression where,
+                       @Nullable String likePattern) {
         this.table = checkNotNull(table, "table is null");
         this.schema = schema;
         this.likePattern = likePattern;
@@ -49,15 +52,18 @@ public class ShowColumns extends Statement {
         return table;
     }
 
-    public Optional<QualifiedName> schema() {
+    @Nullable
+    public QualifiedName schema() {
         return schema;
     }
 
-    public Optional<String> likePattern() {
+    @Nullable
+    public String likePattern() {
         return likePattern;
     }
 
-    public Optional<Expression> where() {
+    @Nullable
+    public Expression where() {
         return where;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/ShowSchemas.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/ShowSchemas.java
@@ -23,24 +23,28 @@ package io.crate.sql.tree;
 
 import com.google.common.base.MoreObjects;
 
+import javax.annotation.Nullable;
 import java.util.Objects;
-import java.util.Optional;
 
 public class ShowSchemas extends Statement {
 
-    private final Optional<String> likePattern;
-    private final Optional<Expression> whereExpression;
+    @Nullable
+    private final String likePattern;
+    @Nullable
+    private final Expression whereExpression;
 
-    public ShowSchemas(Optional<String> likePattern, Optional<Expression> whereExpr) {
+    public ShowSchemas(@Nullable String likePattern, @Nullable Expression whereExpr) {
         this.likePattern = likePattern;
         this.whereExpression = whereExpr;
     }
 
-    public Optional<String> likePattern() {
+    @Nullable
+    public String likePattern() {
         return likePattern;
     }
 
-    public Optional<Expression> whereExpression() {
+    @Nullable
+    public Expression whereExpression() {
         return whereExpression;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/ShowTables.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/ShowTables.java
@@ -24,29 +24,37 @@ package io.crate.sql.tree;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
-import java.util.Optional;
+import javax.annotation.Nullable;
 
 public class ShowTables extends Statement {
 
-    private final Optional<QualifiedName> schema;
-    private final Optional<String> likePattern;
-    private final Optional<Expression> whereExpression;
+    @Nullable
+    private final QualifiedName schema;
+    @Nullable
+    private final String likePattern;
+    @Nullable
+    private final Expression whereExpression;
 
-    public ShowTables(Optional<QualifiedName> schema, Optional<String> likePattern, Optional<Expression> whereExpression) {
+    public ShowTables(@Nullable QualifiedName schema,
+                      @Nullable String likePattern,
+                      @Nullable Expression whereExpression) {
         this.schema = schema;
         this.whereExpression = whereExpression;
         this.likePattern = likePattern;
     }
 
-    public Optional<QualifiedName> schema() {
+    @Nullable
+    public QualifiedName schema() {
         return schema;
     }
 
-    public Optional<String> likePattern() {
+    @Nullable
+    public String likePattern() {
         return likePattern;
     }
 
-    public Optional<Expression> whereExpression() {
+    @Nullable
+    public Expression whereExpression() {
         return whereExpression;
     }
 
@@ -78,8 +86,8 @@ public class ShowTables extends Statement {
     public String toString() {
         return MoreObjects.toStringHelper(this)
             .add("schema", schema)
-            .add("likePattern", likePattern.toString())
-            .add("whereExpression", whereExpression.toString())
+            .add("likePattern", likePattern)
+            .add("whereExpression", whereExpression)
             .toString();
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/SingleColumn.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/SingleColumn.java
@@ -24,26 +24,27 @@ package io.crate.sql.tree;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
-import java.util.Optional;
+import javax.annotation.Nullable;
 
 public class SingleColumn
     extends SelectItem {
-    private Optional<String> alias;
+    @Nullable
+    private String alias;
     private Expression expression;
 
-    public SingleColumn(Expression expression, Optional<String> alias) {
+    public SingleColumn(Expression expression, @Nullable String alias) {
         Preconditions.checkNotNull(expression, "expression is null");
-        Preconditions.checkNotNull(alias, "alias is null");
 
         this.expression = expression;
         this.alias = alias;
     }
 
     public SingleColumn(Expression expression) {
-        this(expression, Optional.empty());
+        this(expression, null);
     }
 
-    public Optional<String> getAlias() {
+    @Nullable
+    public String getAlias() {
         return alias;
     }
 
@@ -69,8 +70,8 @@ public class SingleColumn
     }
 
     public String toString() {
-        if (alias.isPresent()) {
-            return expression.toString() + " " + alias.get();
+        if (alias != null) {
+            return expression.toString() + " " + alias;
         }
 
         return expression.toString();

--- a/sql-parser/src/main/java/io/crate/sql/tree/Tokenizer.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/Tokenizer.java
@@ -24,8 +24,6 @@ package io.crate.sql.tree;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
-import java.util.Optional;
-
 public class Tokenizer extends AnalyzerElement {
 
     private final NamedProperties namedProperties;
@@ -34,7 +32,7 @@ public class Tokenizer extends AnalyzerElement {
         this.namedProperties = namedProperties;
     }
 
-    public Optional<GenericProperties> properties() {
+    public GenericProperties properties() {
         return namedProperties.properties();
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/Update.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/Update.java
@@ -25,16 +25,16 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
+import javax.annotation.Nullable;
 import java.util.List;
-import java.util.Optional;
 
 public class Update extends Statement {
 
     private final Relation relation;
     private final List<Assignment> assignments;
-    private final Optional<Expression> where;
+    private final Expression where;
 
-    public Update(Relation relation, List<Assignment> assignments, Optional<Expression> where) {
+    public Update(Relation relation, List<Assignment> assignments, @Nullable Expression where) {
         Preconditions.checkNotNull(relation, "relation is null");
         Preconditions.checkNotNull(assignments, "assignments are null");
         this.relation = relation;
@@ -50,7 +50,8 @@ public class Update extends Statement {
         return assignments;
     }
 
-    public Optional<Expression> whereClause() {
+    @Nullable
+    public Expression whereClause() {
         return where;
     }
 

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestSqlParser.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestSqlParser.java
@@ -87,19 +87,19 @@ public class TestSqlParser {
     public void testDoubleInQuery() {
         assertStatement("SELECT 123.456E7 FROM DUAL",
             new Query(
-                Optional.empty(),
+                null,
                 new QuerySpecification(
                     selectList(new DoubleLiteral("123.456E7")),
                     table(QualifiedName.of("dual")),
-                    Optional.empty(),
+                    null,
                     ImmutableList.of(),
-                    Optional.empty(),
+                    null,
                     ImmutableList.of(),
-                    Optional.empty(),
-                    Optional.empty()),
+                    null,
+                    null),
                 ImmutableList.of(),
-                Optional.empty(),
-                Optional.empty())
+                null,
+                null)
         );
     }
 

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestSqlParser.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestSqlParser.java
@@ -30,7 +30,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.util.Locale;
-import java.util.Optional;
 
 import static io.crate.sql.SqlFormatter.formatSql;
 import static io.crate.sql.tree.QueryUtil.selectList;

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -188,7 +188,7 @@ public class TestStatementBuilder {
     @Test
     public void testKillJob() {
         KillStatement stmt = (KillStatement) SqlParser.createStatement("KILL $1");
-        assertThat(stmt.jobId().isPresent(), is(true));
+        assertNotNull(stmt.jobId());
     }
 
     @Test

--- a/sql/src/main/java/io/crate/analyze/AlterBlobTableAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/AlterBlobTableAnalyzer.java
@@ -43,7 +43,7 @@ class AlterBlobTableAnalyzer {
         assert BlobSchemaInfo.NAME.equals(tableIdent.schema()) : "schema name must be 'blob'";
         BlobTableInfo tableInfo = schemas.getTableInfo(tableIdent);
         TableParameter tableParameter = new TableParameter();
-        if (node.genericProperties().isPresent()) {
+        if (!node.genericProperties().isEmpty()) {
             TablePropertiesAnalyzer.analyze(
                 tableParameter,
                 tableInfo.tableParameterInfo(),

--- a/sql/src/main/java/io/crate/analyze/AlterTableAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/AlterTableAnalyzedStatement.java
@@ -24,12 +24,13 @@ package io.crate.analyze;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.doc.DocTableInfo;
 
-import java.util.Optional;
+import javax.annotation.Nullable;
 
 public class AlterTableAnalyzedStatement implements DDLStatement {
 
 
     private final DocTableInfo tableInfo;
+    @Nullable
     private final PartitionName partitionName;
     private final TableParameter tableParameter;
     private final boolean excludePartitions;
@@ -48,8 +49,9 @@ public class AlterTableAnalyzedStatement implements DDLStatement {
         return tableInfo;
     }
 
-    public Optional<PartitionName> partitionName() {
-        return Optional.ofNullable(partitionName);
+    @Nullable
+    public PartitionName partitionName() {
+        return partitionName;
     }
 
     public boolean excludePartitions() {

--- a/sql/src/main/java/io/crate/analyze/AlterTableAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/AlterTableAnalyzer.java
@@ -91,7 +91,7 @@ public class AlterTableAnalyzer {
 
     private static TableParameter getTableParameter(AlterTable node, Row parameters, TableParameterInfo tableParameterInfo) {
         TableParameter tableParameter = new TableParameter();
-        if (node.genericProperties().isPresent()) {
+        if (!node.genericProperties().isEmpty()) {
             TablePropertiesAnalyzer.analyze(tableParameter, tableParameterInfo, node.genericProperties(), parameters);
         } else if (!node.resetProperties().isEmpty()) {
             TablePropertiesAnalyzer.analyze(tableParameter, tableParameterInfo, node.resetProperties());

--- a/sql/src/main/java/io/crate/analyze/AlterTableOpenCloseAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/AlterTableOpenCloseAnalyzedStatement.java
@@ -26,10 +26,8 @@ import io.crate.metadata.PartitionName;
 import io.crate.metadata.doc.DocTableInfo;
 
 import javax.annotation.Nullable;
-import java.util.Optional;
 
 public class AlterTableOpenCloseAnalyzedStatement implements DDLStatement {
-
 
     private final DocTableInfo tableInfo;
     private final PartitionName partitionName;
@@ -48,8 +46,9 @@ public class AlterTableOpenCloseAnalyzedStatement implements DDLStatement {
         return tableInfo;
     }
 
-    public Optional<PartitionName> partitionName() {
-        return Optional.ofNullable(partitionName);
+    @Nullable
+    public PartitionName partitionName() {
+        return partitionName;
     }
 
     public boolean openTable() {

--- a/sql/src/main/java/io/crate/analyze/CopyAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CopyAnalyzer.java
@@ -298,9 +298,9 @@ class CopyAnalyzer {
 
             return new WhereClause(
                 whereClause.query(),
-                whereClause.docKeys().orElse(null),
+                whereClause.docKeys(),
                 partitions.isEmpty() ? whereClause.partitions() : partitions,
-                whereClause.clusteredBy().orElse(null)
+                whereClause.clusteredBy()
             );
         }
     }

--- a/sql/src/main/java/io/crate/analyze/CopyAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CopyAnalyzer.java
@@ -119,10 +119,10 @@ class CopyAnalyzer {
         ExpressionAnalysisContext expressionAnalysisContext = new ExpressionAnalysisContext();
         Predicate<DiscoveryNode> nodeFilters = discoveryNode -> true;
         Settings settings = Settings.EMPTY;
-        if (node.genericProperties().isPresent()) {
+        if (!node.genericProperties().isEmpty()) {
             // copy map as items are removed. The GenericProperties map is cached in the query cache and removing
             // items would cause subsequent queries that hit the cache to have different genericProperties
-            Map<String, Expression> properties = new HashMap<>(node.genericProperties().get().properties());
+            Map<String, Expression> properties = new HashMap<>(node.genericProperties().properties());
             nodeFilters = discoveryNodePredicate(analysis.parameterContext().parameters(), properties.remove(NodeFilters.NAME));
             settings = settingsFromProperties(properties, expressionAnalyzer, expressionAnalysisContext);
         }

--- a/sql/src/main/java/io/crate/analyze/CopyAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CopyAnalyzer.java
@@ -72,7 +72,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Predicate;
 
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")

--- a/sql/src/main/java/io/crate/analyze/CopyAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CopyAnalyzer.java
@@ -272,23 +272,21 @@ class CopyAnalyzer {
         return partitions;
     }
 
-    private WhereClause createWhereClause(Optional<Expression> where,
+    private WhereClause createWhereClause(@Nullable Expression where,
                                           DocTableRelation tableRelation,
                                           List<String> partitions,
                                           EvaluatingNormalizer normalizer,
                                           ExpressionAnalyzer expressionAnalyzer,
                                           ExpressionAnalysisContext expressionAnalysisContext,
                                           TransactionContext transactionContext) {
-        WhereClause whereClause = null;
-        if (where.isPresent()) {
-            WhereClauseAnalyzer whereClauseAnalyzer = new WhereClauseAnalyzer(functions, tableRelation);
-            Symbol query = expressionAnalyzer.convert(where.get(), expressionAnalysisContext);
-            whereClause = whereClauseAnalyzer.analyze(normalizer.normalize(query, transactionContext), transactionContext);
-        }
-
-        if (whereClause == null) {
+        if (where == null) {
             return new WhereClause(null, null, partitions, null);
-        } else if (whereClause.noMatch()) {
+        }
+        WhereClauseAnalyzer whereClauseAnalyzer = new WhereClauseAnalyzer(functions, tableRelation);
+        Symbol query = expressionAnalyzer.convert(where, expressionAnalysisContext);
+        WhereClause whereClause = whereClauseAnalyzer.analyze(normalizer.normalize(query, transactionContext), transactionContext);
+
+        if (whereClause.noMatch()) {
             return whereClause;
         } else {
             if (!whereClause.partitions().isEmpty() && !partitions.isEmpty() &&

--- a/sql/src/main/java/io/crate/analyze/CreateAnalyzerStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateAnalyzerStatementAnalyzer.java
@@ -36,12 +36,10 @@ import io.crate.sql.tree.Node;
 import io.crate.sql.tree.StringLiteral;
 import io.crate.sql.tree.TokenFilters;
 import io.crate.sql.tree.Tokenizer;
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.settings.Settings;
 
 import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
 
 import static io.crate.analyze.CreateAnalyzerAnalyzedStatement.getSettingsKey;
 

--- a/sql/src/main/java/io/crate/analyze/CreateAnalyzerStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateAnalyzerStatementAnalyzer.java
@@ -73,7 +73,7 @@ class CreateAnalyzerStatementAnalyzer
         context.statement.ident(node.ident());
 
         if (node.isExtending()) {
-            context.statement.extendedAnalyzer(node.extendedAnalyzer().get());
+            context.statement.extendedAnalyzer(node.extendedAnalyzer());
         }
 
         for (AnalyzerElement element : node.elements()) {

--- a/sql/src/main/java/io/crate/analyze/CreateBlobTableAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateBlobTableAnalyzer.java
@@ -27,7 +27,6 @@ import io.crate.sql.tree.ClusteredBy;
 import io.crate.sql.tree.CreateBlobTable;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 
-import java.util.Optional;
 
 class CreateBlobTableAnalyzer {
 
@@ -45,9 +44,9 @@ class CreateBlobTableAnalyzer {
         statement.table(tableIdent, schemas);
 
         int numShards;
-        Optional<ClusteredBy> clusteredBy = node.clusteredBy();
-        if (clusteredBy.isPresent()) {
-            numShards = numberOfShards.fromClusteredByClause(clusteredBy.get(), parameterContext.parameters());
+        ClusteredBy clusteredBy = node.clusteredBy();
+        if (clusteredBy != null) {
+            numShards = numberOfShards.fromClusteredByClause(clusteredBy, parameterContext.parameters());
         } else {
             numShards = numberOfShards.defaultNumberOfShards();
         }

--- a/sql/src/main/java/io/crate/analyze/CreateIngestionRuleAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateIngestionRuleAnalyzer.java
@@ -21,7 +21,7 @@ public class CreateIngestionRuleAnalyzer {
         return new CreateIngestionRuleAnalysedStatement(node.ruleName(),
             node.sourceIdent(),
             tableIdent,
-            node.where().orElse(null),
+            node.where(),
             context.parameterContext());
     }
 

--- a/sql/src/main/java/io/crate/analyze/CreateSnapshotAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateSnapshotAnalyzer.java
@@ -49,7 +49,6 @@ import org.elasticsearch.snapshots.SnapshotId;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
-import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -75,16 +74,17 @@ class CreateSnapshotAnalyzer {
     }
 
     public CreateSnapshotAnalyzedStatement analyze(CreateSnapshot node, Analysis analysis) {
-        Optional<QualifiedName> repositoryName = node.name().getPrefix();
+        QualifiedName repositoryName = node.name().getPrefix();
         // validate repository
-        Preconditions.checkArgument(repositoryName.isPresent(), "Snapshot must be specified by \"<repository_name>\".\"<snapshot_name>\"");
-        Preconditions.checkArgument(repositoryName.get().getParts().size() == 1,
-            String.format(Locale.ENGLISH, "Invalid repository name '%s'", repositoryName.get()));
-        repositoryService.failIfRepositoryDoesNotExist(repositoryName.get().toString());
+        Preconditions.checkArgument(repositoryName != null,
+            "Snapshot must be specified by \"<repository_name>\".\"<snapshot_name>\"");
+        Preconditions.checkArgument(repositoryName.getParts().size() == 1,
+            String.format(Locale.ENGLISH, "Invalid repository name '%s'", repositoryName));
+        repositoryService.failIfRepositoryDoesNotExist(repositoryName.toString());
 
         // snapshot existence in repo is validated upon execution
         String snapshotName = node.name().getSuffix();
-        Snapshot snapshot = new Snapshot(repositoryName.get().toString(), new SnapshotId(snapshotName, UUID.randomUUID().toString()));
+        Snapshot snapshot = new Snapshot(repositoryName.toString(), new SnapshotId(snapshotName, UUID.randomUUID().toString()));
 
         // validate and extract settings
         Settings settings = GenericPropertiesConverter.settingsFromProperties(

--- a/sql/src/main/java/io/crate/analyze/CreateSnapshotAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateSnapshotAnalyzer.java
@@ -93,8 +93,8 @@ class CreateSnapshotAnalyzer {
         boolean ignoreUnavailable = settings.getAsBoolean(IGNORE_UNAVAILABLE.name(), IGNORE_UNAVAILABLE.defaultValue());
 
         // iterate tables
-        if (node.tableList().isPresent()) {
-            List<Table> tableList = node.tableList().get();
+        if (!node.tableList().isEmpty()) {
+            List<Table> tableList = node.tableList();
             Set<String> snapshotIndices = new HashSet<>(tableList.size());
             for (Table table : tableList) {
                 DocTableInfo docTableInfo;

--- a/sql/src/main/java/io/crate/analyze/CreateTableStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateTableStatementAnalyzer.java
@@ -147,9 +147,9 @@ public class CreateTableStatementAnalyzer extends DefaultTraversalVisitor<Create
 
     @Override
     public CreateTableAnalyzedStatement visitClusteredBy(ClusteredBy clusteredBy, Context context) {
-        if (clusteredBy.column().isPresent()) {
+        if (clusteredBy.column() != null) {
             ColumnIdent routingColumn = ColumnIdent.fromPath(
-                ExpressionToStringVisitor.convert(clusteredBy.column().get(), context.parameterContext.parameters()));
+                ExpressionToStringVisitor.convert(clusteredBy.column(), context.parameterContext.parameters()));
 
             for (AnalyzedColumnDefinition column : context.statement.analyzedTableElements().partitionedByColumns) {
                 if (column.ident().equals(routingColumn)) {

--- a/sql/src/main/java/io/crate/analyze/FunctionArgumentDefinition.java
+++ b/sql/src/main/java/io/crate/analyze/FunctionArgumentDefinition.java
@@ -75,7 +75,7 @@ public class FunctionArgumentDefinition implements Streamable, ToXContent {
     public static List<FunctionArgumentDefinition> toFunctionArgumentDefinitions(List<FunctionArgument> arguments) {
         return arguments.stream()
             .map(arg -> FunctionArgumentDefinition.of(
-                arg.name().orElse(null),
+                arg.name(),
                 DataTypeAnalyzer.convert(arg.type())))
             .collect(Collectors.toList());
     }

--- a/sql/src/main/java/io/crate/analyze/GenericPropertiesConverter.java
+++ b/sql/src/main/java/io/crate/analyze/GenericPropertiesConverter.java
@@ -33,7 +33,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
 
 public class GenericPropertiesConverter {
 
@@ -71,13 +70,13 @@ public class GenericPropertiesConverter {
         return builder.build();
     }
 
-    public static Settings.Builder settingsFromProperties(Optional<GenericProperties> properties,
+    public static Settings.Builder settingsFromProperties(GenericProperties properties,
                                                           ParameterContext parameterContext,
                                                           Map<String, ? extends SettingsApplier> settingAppliers) {
         Settings.Builder builder = Settings.builder();
         setDefaults(settingAppliers, builder);
-        if (properties.isPresent()) {
-            for (Map.Entry<String, Expression> entry : properties.get().properties().entrySet()) {
+        if (!properties.isEmpty()) {
+            for (Map.Entry<String, Expression> entry : properties.properties().entrySet()) {
                 SettingsApplier settingsApplier = settingAppliers.get(entry.getKey());
                 if (settingsApplier == null) {
                     throw new IllegalArgumentException(String.format(Locale.ENGLISH, "setting '%s' not supported", entry.getKey()));

--- a/sql/src/main/java/io/crate/analyze/KillAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/KillAnalyzedStatement.java
@@ -21,23 +21,23 @@
 
 package io.crate.analyze;
 
-import com.google.common.base.Optional;
-
+import javax.annotation.Nullable;
 import java.util.UUID;
 
 public class KillAnalyzedStatement implements AnalyzedStatement {
 
-    private final Optional<UUID> jobId;
+    @Nullable
+    private final UUID jobId;
 
     public KillAnalyzedStatement() {
-        jobId = Optional.absent();
+        jobId = null;
     }
 
     public KillAnalyzedStatement(UUID jobId) {
-        this.jobId = Optional.of(jobId);
+        this.jobId = jobId;
     }
 
-    public Optional<UUID> jobId() {
+    public UUID jobId() {
         return jobId;
     }
 

--- a/sql/src/main/java/io/crate/analyze/KillAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/KillAnalyzer.java
@@ -33,11 +33,11 @@ public class KillAnalyzer {
 
 
     public static KillAnalyzedStatement analyze(KillStatement killStatement, ParameterContext parameterContext) {
-        if (killStatement.jobId().isPresent()) {
+        if (killStatement.jobId() != null) {
             UUID jobId;
             try {
                 jobId = UUID.fromString(ExpressionToStringVisitor
-                    .convert(killStatement.jobId().get(), parameterContext.parameters()));
+                    .convert(killStatement.jobId(), parameterContext.parameters()));
             } catch (Exception e) {
                 throw new IllegalArgumentException("Can not parse job ID", e);
             }

--- a/sql/src/main/java/io/crate/analyze/MetaDataToASTNodeResolver.java
+++ b/sql/src/main/java/io/crate/analyze/MetaDataToASTNodeResolver.java
@@ -66,7 +66,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.TreeMap;
 
 public class MetaDataToASTNodeResolver {

--- a/sql/src/main/java/io/crate/analyze/MetaDataToASTNodeResolver.java
+++ b/sql/src/main/java/io/crate/analyze/MetaDataToASTNodeResolver.java
@@ -224,7 +224,7 @@ public class MetaDataToASTNodeResolver {
                 clusteredByExpression = expressionFromColumn(clusteredBy);
             }
             Expression numShards = new LongLiteral(Integer.toString(tableInfo.numberOfShards()));
-            options.add(new ClusteredBy(Optional.ofNullable(clusteredByExpression), Optional.of(numShards)));
+            options.add(new ClusteredBy(clusteredByExpression, numShards));
             // PARTITIONED BY (...)
             if (tableInfo.isPartitioned() && !tableInfo.partitionedBy().isEmpty()) {
                 options.add(new PartitionedBy(expressionsFromColumns(tableInfo.partitionedBy())));
@@ -263,7 +263,7 @@ public class MetaDataToASTNodeResolver {
             Table table = extractTable();
             List<TableElement> tableElements = extractTableElements();
             List<CrateTableOption> tableOptions = extractTableOptions();
-            Optional<GenericProperties> tableProperties = Optional.of(extractTableProperties());
+            GenericProperties tableProperties = extractTableProperties();
             return new CreateTable(table, tableElements, tableOptions, tableProperties, true);
         }
 

--- a/sql/src/main/java/io/crate/analyze/NumberOfShards.java
+++ b/sql/src/main/java/io/crate/analyze/NumberOfShards.java
@@ -29,8 +29,6 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
 
-import java.util.Optional;
-
 @Singleton
 public class NumberOfShards {
 
@@ -44,9 +42,9 @@ public class NumberOfShards {
     }
 
     int fromClusteredByClause(ClusteredBy clusteredBy, Row parameters) {
-        Optional<Expression> numberOfShards = clusteredBy.numberOfShards();
-        if (numberOfShards.isPresent()) {
-            int numShards = ExpressionToNumberVisitor.convert(numberOfShards.get(), parameters).intValue();
+        Expression numberOfShards = clusteredBy.numberOfShards();
+        if (numberOfShards != null) {
+            int numShards = ExpressionToNumberVisitor.convert(numberOfShards, parameters).intValue();
             if (numShards < 1) {
                 throw new IllegalArgumentException("num_shards in CLUSTERED clause must be greater than 0");
             }

--- a/sql/src/main/java/io/crate/analyze/OptimizeTableAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/OptimizeTableAnalyzer.java
@@ -38,7 +38,6 @@ import org.elasticsearch.common.settings.Settings;
 
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 import static io.crate.analyze.OptimizeSettings.FLUSH;
@@ -94,9 +93,9 @@ class OptimizeTableAnalyzer {
         return indexNames;
     }
 
-    private void validateSettings(Settings settings, Optional<GenericProperties> stmtParameters) {
+    private void validateSettings(Settings settings, GenericProperties stmtParameters) {
         if (settings.getAsBoolean(UPGRADE_SEGMENTS.name(), UPGRADE_SEGMENTS.defaultValue())
-            && stmtParameters.get().size() > 1) {
+            && stmtParameters.size() > 1) {
             throw new IllegalArgumentException("cannot use other parameters if " +
                                                UPGRADE_SEGMENTS.name() + " is set to true");
         }

--- a/sql/src/main/java/io/crate/analyze/RestoreSnapshotAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/RestoreSnapshotAnalyzer.java
@@ -72,8 +72,8 @@ class RestoreSnapshotAnalyzer {
         Settings settings = GenericPropertiesConverter.settingsFromProperties(
             node.properties(), analysis.parameterContext(), SETTINGS).build();
 
-        if (node.tableList().isPresent()) {
-            List<Table> tableList = node.tableList().get();
+        if (!node.tableList().isEmpty()) {
+            List<Table> tableList = node.tableList();
             Set<RestoreSnapshotAnalyzedStatement.RestoreTableInfo> restoreTables = new HashSet<>(tableList.size());
             for (Table table : tableList) {
                 TableIdent tableIdent = TableIdent.of(table, analysis.sessionContext().defaultSchema());

--- a/sql/src/main/java/io/crate/analyze/ShowStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/ShowStatementAnalyzer.java
@@ -33,7 +33,6 @@ import io.crate.sql.tree.ShowSchemas;
 import io.crate.sql.tree.ShowTables;
 
 import java.util.Locale;
-import java.util.Optional;
 
 /**
  * Rewrites the SHOW statements into Select queries.

--- a/sql/src/main/java/io/crate/analyze/ShowStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/ShowStatementAnalyzer.java
@@ -92,11 +92,11 @@ class ShowStatementAnalyzer {
          */
         StringBuilder sb = new StringBuilder("SELECT schema_name ");
         sb.append("FROM information_schema.schemata ");
-        if (node.likePattern().isPresent()) {
+        if (node.likePattern() != null) {
             sb.append("WHERE schema_name LIKE ");
-            singleQuote(sb, node.likePattern().get());
-        } else if (node.whereExpression().isPresent()) {
-            sb.append(String.format(Locale.ENGLISH, "WHERE %s ", node.whereExpression().get().toString()));
+            singleQuote(sb, node.likePattern());
+        } else if (node.whereExpression() != null) {
+            sb.append(String.format(Locale.ENGLISH, "WHERE %s ", node.whereExpression().toString()));
         }
         sb.append("ORDER BY schema_name");
         return (Query) SqlParser.createStatement(sb.toString());
@@ -132,16 +132,16 @@ class ShowStatementAnalyzer {
         singleQuote(sb, node.table().toString());
 
         sb.append("AND table_schema = ");
-        if (node.schema().isPresent()) {
-            singleQuote(sb, node.schema().get().toString());
+        if (node.schema() != null) {
+            singleQuote(sb, node.schema().toString());
         } else {
             singleQuote(sb, defaultSchema);
         }
-        if (node.likePattern().isPresent()) {
+        if (node.likePattern() != null) {
             sb.append("AND column_name LIKE ");
-            singleQuote(sb, node.likePattern().get());
-        } else if (node.where().isPresent()) {
-            sb.append(String.format(Locale.ENGLISH, "AND %s", ExpressionFormatter.formatExpression(node.where().get())));
+            singleQuote(sb, node.likePattern());
+        } else if (node.where() != null) {
+            sb.append(String.format(Locale.ENGLISH, "AND %s", ExpressionFormatter.formatExpression(node.where())));
         }
         sb.append("ORDER BY column_name");
         return (Query) SqlParser.createStatement(sb.toString());
@@ -178,10 +178,10 @@ class ShowStatementAnalyzer {
          * </code>
          */
         StringBuilder sb = new StringBuilder("SELECT distinct(table_name) as table_name FROM information_schema.tables ");
-        Optional<QualifiedName> schema = node.schema();
-        if (schema.isPresent()) {
+        QualifiedName schema = node.schema();
+        if (schema != null) {
             sb.append("WHERE table_schema = ");
-            singleQuote(sb, schema.get().toString());
+            singleQuote(sb, schema.toString());
         } else {
             sb.append("WHERE table_schema NOT IN (");
             for (int i = 0; i < explicitSchemas.length; i++) {
@@ -192,16 +192,16 @@ class ShowStatementAnalyzer {
             }
             sb.append(")");
         }
-        Optional<Expression> whereExpression = node.whereExpression();
-        if (whereExpression.isPresent()) {
+        Expression whereExpression = node.whereExpression();
+        if (whereExpression != null) {
             sb.append(" AND (");
-            sb.append(whereExpression.get().toString());
+            sb.append(whereExpression.toString());
             sb.append(")");
         } else {
-            Optional<String> likePattern = node.likePattern();
-            if (likePattern.isPresent()) {
+            String likePattern = node.likePattern();
+            if (likePattern != null) {
                 sb.append(" AND table_name like ");
-                singleQuote(sb, likePattern.get());
+                singleQuote(sb, likePattern);
             }
         }
         sb.append(" ORDER BY 1");

--- a/sql/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/TableElementsAnalyzer.java
@@ -186,7 +186,7 @@ public class TableElementsAnalyzer {
         public Void visitObjectColumnType(ObjectColumnType node, ColumnDefinitionContext context) {
             context.analyzedColumnDefinition.dataType(node.name());
 
-            switch (node.objectType().orElse("dynamic").toLowerCase(Locale.ENGLISH)) {
+            switch (node.objectType().toLowerCase(Locale.ENGLISH)) {
                 case "dynamic":
                     context.analyzedColumnDefinition.objectType("true");
                     break;

--- a/sql/src/main/java/io/crate/analyze/TablePropertiesAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/TablePropertiesAnalyzer.java
@@ -128,14 +128,14 @@ public final class TablePropertiesAnalyzer {
 
     public static void analyze(TableParameter tableParameter,
                                TableParameterInfo tableParameterInfo,
-                               Optional<GenericProperties> properties,
+                               GenericProperties properties,
                                Row parameters) {
         analyze(tableParameter, tableParameterInfo, properties, parameters, false);
     }
 
     public static void analyze(TableParameter tableParameter,
                                TableParameterInfo tableParameterInfo,
-                               Optional<GenericProperties> properties,
+                               GenericProperties properties,
                                Row parameters,
                                boolean withDefaults) {
         if (withDefaults) {
@@ -146,8 +146,8 @@ public final class TablePropertiesAnalyzer {
                 tableParameter.mappings().put(mappingsApplier.name, mappingsApplier.getDefault());
             }
         }
-        if (properties.isPresent()) {
-            Map<String, Expression> tableProperties = properties.get().properties();
+        if (!properties.isEmpty()) {
+            Map<String, Expression> tableProperties = properties.properties();
             validateTableProperties(tableParameterInfo, tableProperties.keySet());
 
             for (String setting : tableParameterInfo.supportedSettings()) {

--- a/sql/src/main/java/io/crate/analyze/TablePropertiesAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/TablePropertiesAnalyzer.java
@@ -44,7 +44,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
 
 public final class TablePropertiesAnalyzer {
 

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -349,7 +349,7 @@ public class ExpressionAnalyzer {
                 visitExpression(node, context);
             }
             List<Symbol> args = Lists.newArrayList(
-                Literal.of(node.getPrecision().orElse(CurrentTimestampFunction.DEFAULT_PRECISION))
+                Literal.of(node.getPrecision() == null ? CurrentTimestampFunction.DEFAULT_PRECISION : node.getPrecision())
             );
             return allocateFunction(CurrentTimestampFunction.NAME, args, context);
         }

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -127,7 +127,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;

--- a/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ExpressionAnalyzer.java
@@ -201,12 +201,11 @@ public class ExpressionAnalyzer {
         return innerAnalyzer.process(expression, expressionAnalysisContext);
     }
 
-    public Symbol generateQuerySymbol(Optional<Expression> whereExpression, ExpressionAnalysisContext context) {
-        if (whereExpression.isPresent()) {
-            return convert(whereExpression.get(), context);
-        } else {
-            return Literal.BOOLEAN_TRUE;
+    public Symbol generateQuerySymbol(@Nullable Expression whereExpression, ExpressionAnalysisContext context) {
+        if (whereExpression != null) {
+            return convert(whereExpression, context);
         }
+        return Literal.BOOLEAN_TRUE;
     }
 
     protected Symbol convertFunctionCall(FunctionCall node, ExpressionAnalysisContext context) {
@@ -359,13 +358,13 @@ public class ExpressionAnalyzer {
         @Override
         protected Symbol visitIfExpression(IfExpression node, ExpressionAnalysisContext context) {
             // check for global operand
-            Optional<Expression> defaultExpression = node.getFalseValue();
-            List<Symbol> arguments = new ArrayList<>(defaultExpression.isPresent() ? 3 : 2);
+            Expression defaultExpression = node.getFalseValue();
+            List<Symbol> arguments = new ArrayList<>(defaultExpression != null ? 3 : 2);
 
             arguments.add(node.getCondition().accept(innerAnalyzer, context));
             arguments.add(node.getTrueValue().accept(innerAnalyzer, context));
-            if (defaultExpression.isPresent()) {
-                arguments.add(defaultExpression.get().accept(innerAnalyzer, context));
+            if (defaultExpression != null) {
+                arguments.add(defaultExpression.accept(innerAnalyzer, context));
             }
             return allocateFunction(IfFunction.NAME, arguments, context);
         }

--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -95,7 +95,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
-import java.util.Optional;
 
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, StatementAnalysisContext> {
@@ -233,11 +232,10 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
         process(node.getRight(), statementContext);
 
         RelationAnalysisContext relationContext = statementContext.currentRelationContext();
-        Optional<JoinCriteria> optCriteria = node.getCriteria();
+        JoinCriteria optCriteria = node.getCriteria();
         Symbol joinCondition = null;
-        if (optCriteria.isPresent()) {
-            JoinCriteria joinCriteria = optCriteria.get();
-            if (joinCriteria instanceof JoinOn) {
+        if (optCriteria != null) {
+            if (optCriteria instanceof JoinOn) {
                 final TransactionContext transactionContext = statementContext.transactionContext();
                 ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
                     functions,
@@ -250,7 +248,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
                     new SubqueryAnalyzer(this, statementContext));
                 try {
                     joinCondition = expressionAnalyzer.convert(
-                        ((JoinOn) joinCriteria).getExpression(), relationContext.expressionAnalysisContext());
+                        ((JoinOn) optCriteria).getExpression(), relationContext.expressionAnalysisContext());
                 } catch (RelationUnknownException e) {
                     throw new RelationValidationException(e.getTableIdents(),
                         String.format(Locale.ENGLISH,
@@ -258,7 +256,7 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
                 }
             } else {
                 throw new UnsupportedOperationException(String.format(Locale.ENGLISH, "join criteria %s not supported",
-                    joinCriteria.getClass().getSimpleName()));
+                    optCriteria.getClass().getSimpleName()));
             }
         }
 

--- a/sql/src/main/java/io/crate/analyze/relations/select/SelectAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/select/SelectAnalyzer.java
@@ -59,8 +59,8 @@ public class SelectAnalyzer {
         @Override
         protected Void visitSingleColumn(SingleColumn node, SelectAnalysis context) {
             Symbol symbol = context.toSymbol(node.getExpression());
-            if (node.getAlias().isPresent()) {
-                context.add(new OutputName(node.getAlias().get()), symbol);
+            if (node.getAlias() != null) {
+                context.add(new OutputName(node.getAlias()), symbol);
             } else {
                 context.add(new OutputName(OutputNameFormatter.format(node.getExpression())), symbol);
             }
@@ -69,10 +69,10 @@ public class SelectAnalyzer {
 
         @Override
         protected Void visitAllColumns(AllColumns node, SelectAnalysis context) {
-            if (node.getPrefix().isPresent()) {
+            if (node.getPrefix() != null) {
                 // prefix is either: <tableOrAlias>.* or <schema>.<table>
 
-                QualifiedName prefix = node.getPrefix().get();
+                QualifiedName prefix = node.getPrefix();
                 AnalyzedRelation relation = context.sources().get(prefix);
                 if (relation != null) {
                     addAllFieldsFromRelation(context, relation);

--- a/sql/src/main/java/io/crate/analyze/repositories/RepositoryParamValidator.java
+++ b/sql/src/main/java/io/crate/analyze/repositories/RepositoryParamValidator.java
@@ -37,7 +37,6 @@ import org.elasticsearch.common.settings.Settings;
 
 import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 @Singleton
@@ -49,7 +48,7 @@ public class RepositoryParamValidator {
         typeSettings = repositoryTypeSettings;
     }
 
-    public Settings convertAndValidate(String type, Optional<GenericProperties> genericProperties, ParameterContext parameterContext) {
+    public Settings convertAndValidate(String type, GenericProperties genericProperties, ParameterContext parameterContext) {
         TypeSettings typeSettings = this.typeSettings.get(type);
         if (typeSettings == null) {
             throw new IllegalArgumentException(String.format(Locale.ENGLISH, "Invalid repository type \"%s\"", type));
@@ -58,11 +57,11 @@ public class RepositoryParamValidator {
         Map<String, SettingsApplier> allSettings = typeSettings.all();
 
         // create string settings applier for all dynamic settings
-        Optional<GenericProperties> dynamicProperties = typeSettings.dynamicProperties(genericProperties);
-        if (dynamicProperties.isPresent()) {
+        GenericProperties dynamicProperties = typeSettings.dynamicProperties(genericProperties);
+        if (!dynamicProperties.isEmpty()) {
             // allSettings are immutable by default, copy map
             allSettings = Maps.newHashMap(allSettings);
-            for (String key : dynamicProperties.get().properties().keySet()) {
+            for (String key : dynamicProperties.properties().keySet()) {
                 allSettings.put(key, new SettingsAppliers.StringSettingsApplier(new StringSetting(key)));
             }
         }

--- a/sql/src/main/java/io/crate/analyze/repositories/RepositorySettingsModule.java
+++ b/sql/src/main/java/io/crate/analyze/repositories/RepositorySettingsModule.java
@@ -71,22 +71,19 @@ public class RepositorySettingsModule extends AbstractModule {
             .build()) {
 
         @Override
-        public Optional<GenericProperties> dynamicProperties(Optional<GenericProperties> genericProperties) {
-            if (!genericProperties.isPresent()) {
+        public GenericProperties dynamicProperties(GenericProperties genericProperties) {
+            if (genericProperties.isEmpty()) {
                 return genericProperties;
             }
-            GenericProperties dynamicProperties = null;
-            Map<String, Expression> properties = genericProperties.get().properties();
+            GenericProperties dynamicProperties = new GenericProperties();
+            Map<String, Expression> properties = genericProperties.properties();
             for (Map.Entry<String, Expression> entry : properties.entrySet()) {
                 String key = entry.getKey();
                 if (key.startsWith("conf.")) {
-                    if (dynamicProperties == null) {
-                        dynamicProperties = new GenericProperties();
-                    }
                     dynamicProperties.add(new GenericProperty(key, entry.getValue()));
                 }
             }
-            return Optional.ofNullable(dynamicProperties);
+            return dynamicProperties;
         }
     };
 

--- a/sql/src/main/java/io/crate/analyze/repositories/RepositorySettingsModule.java
+++ b/sql/src/main/java/io/crate/analyze/repositories/RepositorySettingsModule.java
@@ -37,7 +37,6 @@ import org.elasticsearch.common.inject.multibindings.MapBinder;
 
 import java.util.Collections;
 import java.util.Map;
-import java.util.Optional;
 
 public class RepositorySettingsModule extends AbstractModule {
 

--- a/sql/src/main/java/io/crate/analyze/repositories/TypeSettings.java
+++ b/sql/src/main/java/io/crate/analyze/repositories/TypeSettings.java
@@ -29,7 +29,6 @@ import io.crate.metadata.settings.SettingsAppliers;
 import io.crate.sql.tree.GenericProperties;
 
 import java.util.Map;
-import java.util.Optional;
 
 public class TypeSettings {
 
@@ -59,7 +58,7 @@ public class TypeSettings {
     /**
      * Return possible dynamic GenericProperties which will not be validated.
      */
-    public Optional<GenericProperties> dynamicProperties(Optional<GenericProperties> genericProperties) {
-        return Optional.empty();
+    public GenericProperties dynamicProperties(GenericProperties genericProperties) {
+        return GenericProperties.EMPTY;
     }
 }

--- a/sql/src/main/java/io/crate/executor/transport/AlterTableOperation.java
+++ b/sql/src/main/java/io/crate/executor/transport/AlterTableOperation.java
@@ -96,7 +96,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 import java.util.stream.Stream;
@@ -168,9 +167,9 @@ public class AlterTableOperation {
     public CompletableFuture<Long> executeAlterTableOpenClose(final AlterTableOpenCloseAnalyzedStatement analysis) {
         FutureActionListener<OpenCloseTableOrPartitionResponse, Long> listener = new FutureActionListener<>(r -> -1L);
         String partitionIndexName = null;
-        Optional<PartitionName> partitionName = analysis.partitionName();
-        if (partitionName.isPresent()) {
-            partitionIndexName = partitionName.get().asIndexName();
+        PartitionName partitionName = analysis.partitionName();
+        if (partitionName != null) {
+            partitionIndexName = partitionName.asIndexName();
         }
         OpenCloseTableOrPartitionRequest request = new OpenCloseTableOrPartitionRequest(
             analysis.tableInfo().ident(), partitionIndexName, analysis.openTable());
@@ -208,9 +207,9 @@ public class AlterTableOperation {
                 analysis.tableParameter().settings(),
                 tableSettingsInfo.partitionTableSettingsInfo().supportedInternalSettings());
 
-            Optional<PartitionName> partitionName = analysis.partitionName();
-            if (partitionName.isPresent()) {
-                String index = partitionName.get().asIndexName();
+            PartitionName partitionName = analysis.partitionName();
+            if (partitionName != null) {
+                String index = partitionName.asIndexName();
                 results.add(updateMapping(analysis.tableParameter().mappings(), index));
                 results.add(updateSettings(parameterWithFilteredSettings, index));
             } else {

--- a/sql/src/main/java/io/crate/metadata/doc/DocTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/doc/DocTableInfo.java
@@ -253,7 +253,7 @@ public class DocTableInfo implements TableInfo, ShardedTable, StoredTable {
             indices = whereClause.partitions().toArray(new String[0]);
         }
         Map<String, Set<String>> routingMap = Collections.emptyMap();
-        if (whereClause.clusteredBy().isPresent()) {
+        if (whereClause.clusteredBy() != null) {
             routingMap = indexNameExpressionResolver.resolveSearchRouting(
                 state, whereClause.routingValues(), indices);
         }

--- a/sql/src/main/java/io/crate/planner/Planner.java
+++ b/sql/src/main/java/io/crate/planner/Planner.java
@@ -274,9 +274,7 @@ public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
 
     @Override
     public Plan visitKillAnalyzedStatement(KillAnalyzedStatement analysis, PlannerContext context) {
-        return analysis.jobId().isPresent() ?
-            new KillPlan(analysis.jobId().get()) :
-            new KillPlan();
+        return new KillPlan(analysis.jobId());
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/WhereClauseOptimizer.java
+++ b/sql/src/main/java/io/crate/planner/WhereClauseOptimizer.java
@@ -33,10 +33,10 @@ import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocSysColumns;
 import io.crate.metadata.doc.DocTableInfo;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 
@@ -66,8 +66,9 @@ public final class WhereClauseOptimizer {
             this.partitionValues = firstNonNull(partitionValues, Collections.emptyList());
         }
 
-        public Optional<DocKeys> docKeys() {
-            return Optional.ofNullable(docKeys);
+        @Nullable
+        public DocKeys docKeys() {
+            return docKeys;
         }
 
         /**

--- a/sql/src/main/java/io/crate/planner/consumer/UpdatePlanner.java
+++ b/sql/src/main/java/io/crate/planner/consumer/UpdatePlanner.java
@@ -115,8 +115,8 @@ public final class UpdatePlanner {
         WhereClauseOptimizer.DetailedQuery detailedQuery = WhereClauseOptimizer.optimize(
             normalizer, query, tableInfo, plannerCtx.transactionContext());
 
-        if (detailedQuery.docKeys().isPresent()) {
-            return new UpdateById(tableInfo, assignmentByTargetCol, detailedQuery.docKeys().get());
+        if (detailedQuery.docKeys() != null) {
+            return new UpdateById(tableInfo, assignmentByTargetCol, detailedQuery.docKeys());
         }
 
         return new Update((plannerContext, params, subQueryValues) ->

--- a/sql/src/main/java/io/crate/planner/node/management/KillPlan.java
+++ b/sql/src/main/java/io/crate/planner/node/management/KillPlan.java
@@ -35,24 +35,28 @@ import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Plan;
 import io.crate.planner.PlannerContext;
 
+import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 
 public class KillPlan implements Plan {
 
-    private final Optional<UUID> jobToKill;
+    @Nullable
+    private final UUID jobToKill;
 
-    public KillPlan() {
-        this.jobToKill = Optional.empty();
+    @VisibleForTesting
+    KillPlan() {
+        this(null);
     }
 
-    public KillPlan(UUID jobToKill) {
-        this.jobToKill = Optional.of(jobToKill);
+    public KillPlan(@Nullable UUID jobToKill) {
+        this.jobToKill = jobToKill;
     }
 
-    public Optional<UUID> jobToKill() {
+    @Nullable
+    @VisibleForTesting
+    public UUID jobToKill() {
         return jobToKill;
     }
 
@@ -60,10 +64,9 @@ public class KillPlan implements Plan {
     void execute(TransportKillAllNodeAction killAllNodeAction,
                  TransportKillJobsNodeAction killjobsNodeAction,
                  RowConsumer consumer) {
-        if (jobToKill.isPresent()) {
-            UUID jobId = jobToKill.get();
+        if (jobToKill != null) {
             killjobsNodeAction.broadcast(
-                new KillJobsRequest(Collections.singletonList(jobId)),
+                new KillJobsRequest(Collections.singletonList(jobToKill)),
                 new OneRowActionListener<>(consumer, Row1::new)
             );
         } else {

--- a/sql/src/main/java/io/crate/planner/operators/Collect.java
+++ b/sql/src/main/java/io/crate/planner/operators/Collect.java
@@ -94,8 +94,8 @@ class Collect extends ZeroInputPlan {
     private final long numExpectedRows;
 
     public static LogicalPlan.Builder create(QueriedTableRelation relation, List<Symbol> toCollect, WhereClause where) {
-        if (where.docKeys().isPresent() && !((DocTableInfo) relation.tableRelation().tableInfo()).isAlias()) {
-            DocKeys docKeys = where.docKeys().get();
+        if (where.docKeys() != null && !((DocTableInfo) relation.tableRelation().tableInfo()).isAlias()) {
+            DocKeys docKeys = where.docKeys();
             return ((tableStats, usedBeforeNextFetch) -> new Get(((QueriedDocTable) relation), docKeys, toCollect));
         }
         return (tableStats, usedColumns) -> new Collect(

--- a/sql/src/main/java/io/crate/planner/statement/DeletePlanner.java
+++ b/sql/src/main/java/io/crate/planner/statement/DeletePlanner.java
@@ -98,8 +98,8 @@ public final class DeletePlanner {
         if (!detailedQuery.partitions().isEmpty()) {
             return new DeletePartitions(table.ident(), detailedQuery.partitions());
         }
-        if (detailedQuery.docKeys().isPresent()) {
-            return new DeleteById(tableRel.tableInfo(), detailedQuery.docKeys().get());
+        if (detailedQuery.docKeys() != null) {
+            return new DeleteById(tableRel.tableInfo(), detailedQuery.docKeys());
         }
         Symbol query = detailedQuery.query();
         if (table.isPartitioned() && query instanceof Input && DataTypes.BOOLEAN.value(((Input) query).value())) {

--- a/sql/src/test/java/io/crate/analyze/CreateAlterPartitionedTableAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateAlterPartitionedTableAnalyzerTest.java
@@ -265,7 +265,7 @@ public class CreateAlterPartitionedTableAnalyzerTest extends CrateDummyClusterSe
     public void testAlterPartitionedTable() throws Exception {
         AlterTableAnalyzedStatement analysis = e.analyze(
             "alter table parted set (number_of_replicas='0-all')");
-        assertThat(analysis.partitionName().isPresent(), is(false));
+        assertNull(analysis.partitionName());
         assertThat(analysis.table().isPartitioned(), is(true));
         assertEquals("0-all", analysis.tableParameter().settings().get(TableParameterInfo.AUTO_EXPAND_REPLICAS));
     }
@@ -274,8 +274,7 @@ public class CreateAlterPartitionedTableAnalyzerTest extends CrateDummyClusterSe
     public void testAlterPartitionedTablePartition() throws Exception {
         AlterTableAnalyzedStatement analysis = e.analyze(
             "alter table parted partition (date=1395874800000) set (number_of_replicas='0-all')");
-        assertThat(analysis.partitionName().isPresent(), is(true));
-        assertThat(analysis.partitionName().get(), is(new PartitionName("parted", Arrays.asList(new BytesRef("1395874800000")))));
+        assertThat(analysis.partitionName(), is(new PartitionName("parted", Arrays.asList(new BytesRef("1395874800000")))));
         assertThat(analysis.table().tableParameterInfo(), instanceOf(PartitionedTableParameterInfo.class));
         PartitionedTableParameterInfo tableSettingsInfo = (PartitionedTableParameterInfo) analysis.table().tableParameterInfo();
         assertThat(tableSettingsInfo.partitionTableSettingsInfo(), instanceOf(TableParameterInfo.class));
@@ -306,7 +305,7 @@ public class CreateAlterPartitionedTableAnalyzerTest extends CrateDummyClusterSe
     public void testAlterPartitionedTableShards() throws Exception {
         AlterTableAnalyzedStatement analysis = e.analyze(
             "alter table parted set (number_of_shards=10)");
-        assertThat(analysis.partitionName().isPresent(), is(false));
+        assertNull(analysis.partitionName());
         assertThat(analysis.table().isPartitioned(), is(true));
         assertThat(analysis.table().tableParameterInfo(), instanceOf(PartitionedTableParameterInfo.class));
         assertEquals("10", analysis.tableParameter().settings().get(TableParameterInfo.NUMBER_OF_SHARDS));

--- a/sql/src/test/java/io/crate/analyze/KillAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/KillAnalyzerTest.java
@@ -43,25 +43,25 @@ public class KillAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testAnalyzeKillAll() throws Exception {
         KillAnalyzedStatement stmt = e.analyze("kill all");
-        assertThat(stmt.jobId().isPresent(), is(false));
+        assertNull(stmt.jobId());
     }
 
     @Test
     public void testAnalyzeKillJobWithParameter() throws Exception {
         UUID jobId = UUID.randomUUID();
         KillAnalyzedStatement stmt = e.analyze("kill $2", new Object[]{2, jobId});
-        assertThat(stmt.jobId().get(), is(jobId));
+        assertThat(stmt.jobId(), is(jobId));
         stmt = e.analyze("kill $1", new Object[]{jobId});
-        assertThat(stmt.jobId().get(), is(jobId));
+        assertThat(stmt.jobId(), is(jobId));
         stmt = e.analyze("kill ?", new Object[]{jobId});
-        assertThat(stmt.jobId().get(), is(jobId));
+        assertThat(stmt.jobId(), is(jobId));
     }
 
     @Test
     public void testAnalyzeKillJobWithLiteral() throws Exception {
         UUID jobId = UUID.randomUUID();
         KillAnalyzedStatement stmt = e.analyze(String.format(Locale.ENGLISH, "kill '%s'", jobId.toString()));
-        assertThat(stmt.jobId().get(), is(jobId));
+        assertThat(stmt.jobId(), is(jobId));
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/sql/src/test/java/io/crate/analyze/NumberOfShardsTest.java
+++ b/sql/src/test/java/io/crate/analyze/NumberOfShardsTest.java
@@ -37,7 +37,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.Locale;
-import java.util.Optional;
 
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
@@ -85,7 +84,7 @@ public class NumberOfShardsTest extends CrateUnitTest {
 
     @Test
     public void testGetNumberOfShards() {
-        ClusteredBy clusteredBy = new ClusteredBy(Optional.of(QNAME_REF), Optional.of(LongLiteral.fromObject(7)));
+        ClusteredBy clusteredBy = new ClusteredBy(QNAME_REF, LongLiteral.fromObject(7));
         assertThat(numberOfShards.fromClusteredByClause(clusteredBy, Row.EMPTY), is(7));
     }
 
@@ -94,7 +93,7 @@ public class NumberOfShardsTest extends CrateUnitTest {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("num_shards in CLUSTERED clause must be greater than 0");
         numberOfShards.fromClusteredByClause(
-            new ClusteredBy(Optional.of(QNAME_REF), Optional.of(LongLiteral.fromObject(0))), Row.EMPTY);
+            new ClusteredBy(QNAME_REF, LongLiteral.fromObject(0)), Row.EMPTY);
     }
 
 }

--- a/sql/src/test/java/io/crate/analyze/RepositoryParamValidatorTest.java
+++ b/sql/src/test/java/io/crate/analyze/RepositoryParamValidatorTest.java
@@ -33,8 +33,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Optional;
-
 import static org.hamcrest.Matchers.is;
 
 public class RepositoryParamValidatorTest extends CrateUnitTest {
@@ -51,7 +49,7 @@ public class RepositoryParamValidatorTest extends CrateUnitTest {
     public void testValidate() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Invalid repository type \"invalid_type\"");
-        validator.convertAndValidate("invalid_type", Optional.of(new GenericProperties()), ParameterContext.EMPTY);
+        validator.convertAndValidate("invalid_type", GenericProperties.EMPTY, ParameterContext.EMPTY);
     }
 
     @Test
@@ -59,7 +57,7 @@ public class RepositoryParamValidatorTest extends CrateUnitTest {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage(
             "The following required parameters are missing to create a repository of type \"fs\": [location]");
-        validator.convertAndValidate("fs", Optional.of(new GenericProperties()), ParameterContext.EMPTY);
+        validator.convertAndValidate("fs", GenericProperties.EMPTY, ParameterContext.EMPTY);
     }
 
     @Test
@@ -69,7 +67,7 @@ public class RepositoryParamValidatorTest extends CrateUnitTest {
         GenericProperties genericProperties = new GenericProperties();
         genericProperties.add(new GenericProperty("location", new StringLiteral("foo")));
         genericProperties.add(new GenericProperty("yay", new StringLiteral("invalid")));
-        validator.convertAndValidate("fs", Optional.of(genericProperties), ParameterContext.EMPTY);
+        validator.convertAndValidate("fs", genericProperties, ParameterContext.EMPTY);
     }
 
     @Test
@@ -77,7 +75,7 @@ public class RepositoryParamValidatorTest extends CrateUnitTest {
         GenericProperties genericProperties = new GenericProperties();
         genericProperties.add(new GenericProperty("path", new StringLiteral("/data")));
         genericProperties.add(new GenericProperty("conf.foobar", new StringLiteral("bar")));
-        Settings settings = validator.convertAndValidate("hdfs", Optional.of(genericProperties), ParameterContext.EMPTY);
+        Settings settings = validator.convertAndValidate("hdfs", genericProperties, ParameterContext.EMPTY);
         assertThat(settings.get("conf.foobar"), is("bar"));
     }
 
@@ -98,7 +96,7 @@ public class RepositoryParamValidatorTest extends CrateUnitTest {
         genericProperties.add(new GenericProperty("region", new StringLiteral("Europe-1")));
         genericProperties.add(new GenericProperty("secret_key", new StringLiteral("thisIsASecretKey")));
         genericProperties.add(new GenericProperty("server_side_encryption", new StringLiteral("false")));
-        Settings settings = validator.convertAndValidate("s3", Optional.of(genericProperties), ParameterContext.EMPTY);
+        Settings settings = validator.convertAndValidate("s3", genericProperties, ParameterContext.EMPTY);
         assertThat(settings.get("access_key"), is("foobar"));
         assertThat(settings.get("base_path"), is("/data"));
         assertThat(settings.get("bucket"), is("myBucket"));

--- a/sql/src/test/java/io/crate/planner/PlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/PlannerTest.java
@@ -95,12 +95,12 @@ public class PlannerTest extends CrateDummyClusterServiceUnitTest {
     public void testKillPlanAll() throws Exception {
         KillPlan killPlan = e.plan("kill all");
         assertThat(killPlan, instanceOf(KillPlan.class));
-        assertThat(killPlan.jobToKill().isPresent(), is(false));
+        assertNull(killPlan.jobToKill());
     }
 
     @Test
     public void testKillPlanJobs() throws Exception {
         KillPlan killJobsPlan = e.plan("kill '6a3d6fb6-1401-4333-933d-b38c9322fca7'");
-        assertThat(killJobsPlan.jobToKill().get().toString(), is("6a3d6fb6-1401-4333-933d-b38c9322fca7"));
+        assertThat(killJobsPlan.jobToKill().toString(), is("6a3d6fb6-1401-4333-933d-b38c9322fca7"));
     }
 }


### PR DESCRIPTION
It was used in an incorrect way almost all over the place only to prevent null checks in favour of `isPresent()` which is not the intended way to use `Optional`.

Additionally annotated all methods that now may return `null` with `@Nullable`.

This is still WIP.
  