### PR TITLE
Ensure Rest Future is completed in case of channel errors

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -21,6 +21,10 @@ Changes
 Fixes
 =====
 
+- Fixed a bug which could cause job entries in `sys.jobs` not being removed
+  when a connection error occurred while transferring the results of the job
+  execution.
+
 - Fixed an issue that could cause a ``ALTER TABLE`` statement to fail with an
   exception on partitioned tables created with CrateDB < 1.2.
 

--- a/sql/src/main/java/io/crate/rest/action/RestResultSetReceiver.java
+++ b/sql/src/main/java/io/crate/rest/action/RestResultSetReceiver.java
@@ -104,7 +104,8 @@ class RestResultSetReceiver extends BaseResultReceiver {
             channel.sendResponse(response);
             super.allFinished(interrupted);
         } catch (Throwable e) {
-            LOGGER.error(e);
+            LOGGER.error("Failed to send final response.", e);
+            super.fail(e);
         } finally {
             rowAccounting.close();
         }

--- a/sql/src/main/java/io/crate/rest/action/RestResultSetReceiver.java
+++ b/sql/src/main/java/io/crate/rest/action/RestResultSetReceiver.java
@@ -117,7 +117,7 @@ class RestResultSetReceiver extends BaseResultReceiver {
             channel.sendResponse(new CrateThrowableRestResponse(channel,
                 createSQLActionException(t, exceptionAuthorizedValidator)));
         } catch (Throwable e) {
-            LOGGER.error("failed to send failure response", e);
+            LOGGER.error("Failed to send error response for failed request.", e, t);
         } finally {
             rowAccounting.close();
             super.fail(t);

--- a/sql/src/test/java/io/crate/rest/action/RestResultSetReceiverTest.java
+++ b/sql/src/test/java/io/crate/rest/action/RestResultSetReceiverTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.rest.action;
+
+import io.crate.breaker.RamAccountingContext;
+import io.crate.breaker.RowAccounting;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.rest.AbstractRestChannel;
+import org.elasticsearch.rest.RestChannel;
+import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.test.rest.FakeRestRequest;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class RestResultSetReceiverTest {
+
+    @Test
+    public void testCompletionFutureIsCompletedAfterChannelErrors() {
+        RestChannel restChannel = new ErroneousChannel();
+        RestResultSetReceiver restResultSetReceiver = new RestResultSetReceiver(
+            restChannel,
+            t -> {},
+            Collections.emptyList(),
+            0,
+            new RowAccounting(Collections.emptyList(),
+                new RamAccountingContext("context", new NoopCircuitBreaker("test"))),
+            false
+        );
+
+        restResultSetReceiver.allFinished(true);
+        assertThat(restResultSetReceiver.completionFuture().isCompletedExceptionally(), is(true));
+    }
+
+    private static class ErroneousChannel extends AbstractRestChannel {
+
+        ErroneousChannel() {
+            super(new FakeRestRequest(), false);
+        }
+
+        @Override
+        public void sendResponse(RestResponse response) {
+            throw new RuntimeException("Failing to test error handling.");
+        }
+    }
+}


### PR DESCRIPTION
When errors occurred (e.g. I/O) during `RestChannel#sendResponse(..)`, the
`CompletableFuture` of `BaseResultReceiver` was not completed. This led to the
`JobsLogsUpdateListener` not removing the job entry from the job log because it
is only informed about the job status once the future has been completed.