### PR TITLE
Gradle: Update shadow plugin to 2.0.2

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -1,10 +1,11 @@
-apply from: "$rootDir/gradle/javaModule.gradle"
-
 // generate uberjar with all benchmarks
 apply plugin: 'application'
+// mainClassName must come after application but before shadow plugin application
+// to avoid a warning. See https://github.com/johnrengelman/shadow/issues/336
+mainClassName = 'org.openjdk.jmh.Main'
+apply from: "$rootDir/gradle/javaModule.gradle"
 
 archivesBaseName = 'crate-benchmarks'
-mainClassName = 'org.openjdk.jmh.Main'
 
 test.enabled = false
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 }
 
 plugins {
-    id 'com.github.johnrengelman.shadow' version '1.2.4'
+    id 'com.github.johnrengelman.shadow' version '2.0.2'
     id 'com.github.spotbugs' version '1.6.0'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,6 @@ buildscript {
 
 plugins {
     id 'com.github.johnrengelman.shadow' version '1.2.4'
-    id 'me.champeau.gradle.jmh' version '0.4.4'
     id 'com.github.spotbugs' version '1.6.0'
 }
 


### PR DESCRIPTION
Fixes a warning:

     constructor for `org.gradle.api.internal.java.JavaLibrary` is used
    by Shadow plugin v1.2.x, and has been preserved for compatibility.
    This has been deprecated and is scheduled to be removed in Gradle
    5.0. If you're using the Shadow plugin, try upgrading to v2.x.