### PR TITLE
remove incorrect usages of Optional class in parser

### DIFF
--- a/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
+++ b/sql-parser/src/main/java/io/crate/sql/SqlFormatter.java
@@ -293,10 +293,10 @@ public final class SqlFormatter {
         @Override
         protected Void visitSingleColumn(SingleColumn node, Integer indent) {
             builder.append(formatStandaloneExpression(node.getExpression()));
-            if (node.getAlias().isPresent()) {
+            if (node.getAlias() != null) {
                 builder.append(' ')
                     .append('"')
-                    .append(node.getAlias().get())
+                    .append(node.getAlias())
                     .append('"'); // TODO: handle quoting properly
             }
 
@@ -440,7 +440,10 @@ public final class SqlFormatter {
 
         @Override
         public Void visitFunctionArgument(FunctionArgument node, Integer context) {
-            node.name().ifPresent(s -> builder.append(s).append(" "));
+            String name = node.name();
+            if (name != null) {
+                builder.append(name).append(" ");
+            }
             builder.append(node.type());
             return null;
         }
@@ -840,7 +843,7 @@ public final class SqlFormatter {
     };
 
     private static void appendAliasColumns(StringBuilder builder, List<String> columns) {
-        if ((columns != null) && (!columns.isEmpty())) {
+        if (!columns.isEmpty()) {
             builder.append(" (")
                 .append(String.join(", ", columns))
                 .append(')');

--- a/sql-parser/src/main/java/io/crate/sql/tree/AliasedRelation.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AliasedRelation.java
@@ -34,7 +34,8 @@ public class AliasedRelation
 
     public AliasedRelation(Relation relation, String alias, List<String> columnNames) {
         Preconditions.checkNotNull(relation, "relation is null");
-        Preconditions.checkNotNull(alias, " is null");
+        Preconditions.checkNotNull(alias, "alias is null");
+        Preconditions.checkNotNull(columnNames, "columnNames is null");
 
         this.relation = relation;
         this.alias = alias;
@@ -82,7 +83,7 @@ public class AliasedRelation
         if (!alias.equals(that.alias)) {
             return false;
         }
-        if (columnNames != null ? !columnNames.equals(that.columnNames) : that.columnNames != null) {
+        if (!columnNames.equals(that.columnNames)) {
             return false;
         }
         if (!relation.equals(that.relation)) {

--- a/sql-parser/src/main/java/io/crate/sql/tree/CreateAnalyzer.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/CreateAnalyzer.java
@@ -24,16 +24,19 @@ package io.crate.sql.tree;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
+import javax.annotation.Nullable;
 import java.util.List;
-import java.util.Optional;
 
 public class CreateAnalyzer extends Statement {
 
     private final String ident;
-    private final Optional<String> extendedAnalyzer;
+    @Nullable
+    private final String extendedAnalyzer;
     private final List<AnalyzerElement> elements;
 
-    public CreateAnalyzer(String ident, Optional<String> extendedAnalyzer, List<AnalyzerElement> elements) {
+    public CreateAnalyzer(String ident,
+                          @Nullable String extendedAnalyzer,
+                          List<AnalyzerElement> elements) {
         this.ident = ident;
         this.extendedAnalyzer = extendedAnalyzer;
         this.elements = elements;
@@ -43,12 +46,13 @@ public class CreateAnalyzer extends Statement {
         return ident;
     }
 
-    public Optional<String> extendedAnalyzer() {
+    @Nullable
+    public String extendedAnalyzer() {
         return extendedAnalyzer;
     }
 
     public boolean isExtending() {
-        return extendedAnalyzer.isPresent();
+        return extendedAnalyzer != null;
     }
 
     public List<AnalyzerElement> elements() {
@@ -67,11 +71,9 @@ public class CreateAnalyzer extends Statement {
 
         CreateAnalyzer that = (CreateAnalyzer) o;
 
-        if (!elements.equals(that.elements)) return false;
-        if (!extendedAnalyzer.equals(that.extendedAnalyzer)) return false;
-        if (!ident.equals(that.ident)) return false;
-
-        return true;
+        return Objects.equal(elements, that.elements) &&
+               Objects.equal(extendedAnalyzer, that.extendedAnalyzer) &&
+               Objects.equal(ident, that.ident);
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/FunctionArgument.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/FunctionArgument.java
@@ -26,20 +26,22 @@
 
 package io.crate.sql.tree;
 
+import javax.annotation.Nullable;
 import java.util.Objects;
-import java.util.Optional;
 
 public class FunctionArgument extends Node {
 
-    private final Optional<String> name;
+    @Nullable
+    private final String name;
     private final ColumnType type;
 
-    public FunctionArgument(Optional<String> name, ColumnType type) {
+    public FunctionArgument(@Nullable String name, ColumnType type) {
         this.name = name;
         this.type = type;
     }
 
-    public Optional<String> name() {
+    @Nullable
+    public String name() {
         return name;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/ShowColumns.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/ShowColumns.java
@@ -24,6 +24,7 @@ package io.crate.sql.tree;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
+import javax.annotation.Nullable;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -31,14 +32,16 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class ShowColumns extends Statement {
 
     private final QualifiedName table;
-    private final Optional<QualifiedName> schema;
-    private final Optional<String> likePattern;
+    @Nullable
+    private final QualifiedName schema;
+    @Nullable
+    private final String likePattern;
     private final Optional<Expression> where;
 
     public ShowColumns(QualifiedName table,
-                       Optional<QualifiedName> schema,
+                       @Nullable QualifiedName schema,
                        Optional<Expression> where,
-                       Optional<String> likePattern) {
+                       @Nullable String likePattern) {
         this.table = checkNotNull(table, "table is null");
         this.schema = schema;
         this.likePattern = likePattern;
@@ -49,11 +52,13 @@ public class ShowColumns extends Statement {
         return table;
     }
 
-    public Optional<QualifiedName> schema() {
+    @Nullable
+    public QualifiedName schema() {
         return schema;
     }
 
-    public Optional<String> likePattern() {
+    @Nullable
+    public String likePattern() {
         return likePattern;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/ShowSchemas.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/ShowSchemas.java
@@ -23,20 +23,24 @@ package io.crate.sql.tree;
 
 import com.google.common.base.MoreObjects;
 
+import javax.annotation.Nullable;
 import java.util.Objects;
 import java.util.Optional;
 
 public class ShowSchemas extends Statement {
 
-    private final Optional<String> likePattern;
+    @Nullable
+    private final String likePattern;
     private final Optional<Expression> whereExpression;
 
-    public ShowSchemas(Optional<String> likePattern, Optional<Expression> whereExpr) {
+    public ShowSchemas(@Nullable String likePattern,
+                       Optional<Expression> whereExpr) {
         this.likePattern = likePattern;
         this.whereExpression = whereExpr;
     }
 
-    public Optional<String> likePattern() {
+    @Nullable
+    public String likePattern() {
         return likePattern;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/ShowTables.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/ShowTables.java
@@ -24,25 +24,32 @@ package io.crate.sql.tree;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 
+import javax.annotation.Nullable;
 import java.util.Optional;
 
 public class ShowTables extends Statement {
 
-    private final Optional<QualifiedName> schema;
-    private final Optional<String> likePattern;
+    @Nullable
+    private final QualifiedName schema;
+    @Nullable
+    private final String likePattern;
     private final Optional<Expression> whereExpression;
 
-    public ShowTables(Optional<QualifiedName> schema, Optional<String> likePattern, Optional<Expression> whereExpression) {
+    public ShowTables(@Nullable QualifiedName schema,
+                      @Nullable String likePattern,
+                      Optional<Expression> whereExpression) {
         this.schema = schema;
         this.whereExpression = whereExpression;
         this.likePattern = likePattern;
     }
 
-    public Optional<QualifiedName> schema() {
+    @Nullable
+    public QualifiedName schema() {
         return schema;
     }
 
-    public Optional<String> likePattern() {
+    @Nullable
+    public String likePattern() {
         return likePattern;
     }
 
@@ -78,7 +85,7 @@ public class ShowTables extends Statement {
     public String toString() {
         return MoreObjects.toStringHelper(this)
             .add("schema", schema)
-            .add("likePattern", likePattern.toString())
+            .add("likePattern", likePattern)
             .add("whereExpression", whereExpression.toString())
             .toString();
     }

--- a/sql-parser/src/main/java/io/crate/sql/tree/SingleColumn.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/SingleColumn.java
@@ -24,26 +24,26 @@ package io.crate.sql.tree;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 
-import java.util.Optional;
+import javax.annotation.Nullable;
 
 public class SingleColumn
     extends SelectItem {
-    private Optional<String> alias;
+    @Nullable
+    private String alias;
     private Expression expression;
 
-    public SingleColumn(Expression expression, Optional<String> alias) {
+    public SingleColumn(Expression expression, @Nullable String alias) {
         Preconditions.checkNotNull(expression, "expression is null");
-        Preconditions.checkNotNull(alias, "alias is null");
-
         this.expression = expression;
         this.alias = alias;
     }
 
     public SingleColumn(Expression expression) {
-        this(expression, Optional.empty());
+        this(expression, null);
     }
 
-    public Optional<String> getAlias() {
+    @Nullable
+    public String getAlias() {
         return alias;
     }
 
@@ -69,10 +69,9 @@ public class SingleColumn
     }
 
     public String toString() {
-        if (alias.isPresent()) {
-            return expression.toString() + " " + alias.get();
+        if (alias != null) {
+            return expression.toString() + " " + alias;
         }
-
         return expression.toString();
     }
 

--- a/sql/src/main/java/io/crate/analyze/CreateAnalyzerStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateAnalyzerStatementAnalyzer.java
@@ -73,7 +73,7 @@ class CreateAnalyzerStatementAnalyzer
         context.statement.ident(node.ident());
 
         if (node.isExtending()) {
-            context.statement.extendedAnalyzer(node.extendedAnalyzer().get());
+            context.statement.extendedAnalyzer(node.extendedAnalyzer());
         }
 
         for (AnalyzerElement element : node.elements()) {

--- a/sql/src/main/java/io/crate/analyze/FunctionArgumentDefinition.java
+++ b/sql/src/main/java/io/crate/analyze/FunctionArgumentDefinition.java
@@ -75,7 +75,7 @@ public class FunctionArgumentDefinition implements Streamable, ToXContent {
     public static List<FunctionArgumentDefinition> toFunctionArgumentDefinitions(List<FunctionArgument> arguments) {
         return arguments.stream()
             .map(arg -> FunctionArgumentDefinition.of(
-                arg.name().orElse(null),
+                arg.name(),
                 DataTypeAnalyzer.convert(arg.type())))
             .collect(Collectors.toList());
     }

--- a/sql/src/main/java/io/crate/analyze/ShowStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/ShowStatementAnalyzer.java
@@ -92,9 +92,10 @@ class ShowStatementAnalyzer {
          */
         StringBuilder sb = new StringBuilder("SELECT schema_name ");
         sb.append("FROM information_schema.schemata ");
-        if (node.likePattern().isPresent()) {
+        String likePattern = node.likePattern();
+        if (likePattern != null) {
             sb.append("WHERE schema_name LIKE ");
-            singleQuote(sb, node.likePattern().get());
+            singleQuote(sb, likePattern);
         } else if (node.whereExpression().isPresent()) {
             sb.append(String.format(Locale.ENGLISH, "WHERE %s ", node.whereExpression().get().toString()));
         }
@@ -132,14 +133,16 @@ class ShowStatementAnalyzer {
         singleQuote(sb, node.table().toString());
 
         sb.append("AND table_schema = ");
-        if (node.schema().isPresent()) {
-            singleQuote(sb, node.schema().get().toString());
+        QualifiedName schema = node.schema();
+        if (schema != null) {
+            singleQuote(sb, schema.toString());
         } else {
             singleQuote(sb, defaultSchema);
         }
-        if (node.likePattern().isPresent()) {
+        String likePattern = node.likePattern();
+        if (likePattern != null) {
             sb.append("AND column_name LIKE ");
-            singleQuote(sb, node.likePattern().get());
+            singleQuote(sb, likePattern);
         } else if (node.where().isPresent()) {
             sb.append(String.format(Locale.ENGLISH, "AND %s", ExpressionFormatter.formatExpression(node.where().get())));
         }
@@ -178,10 +181,10 @@ class ShowStatementAnalyzer {
          * </code>
          */
         StringBuilder sb = new StringBuilder("SELECT distinct(table_name) as table_name FROM information_schema.tables ");
-        Optional<QualifiedName> schema = node.schema();
-        if (schema.isPresent()) {
+        QualifiedName schema = node.schema();
+        if (schema != null) {
             sb.append("WHERE table_schema = ");
-            singleQuote(sb, schema.get().toString());
+            singleQuote(sb, schema.toString());
         } else {
             sb.append("WHERE table_schema NOT IN (");
             for (int i = 0; i < explicitSchemas.length; i++) {
@@ -198,10 +201,10 @@ class ShowStatementAnalyzer {
             sb.append(whereExpression.get().toString());
             sb.append(")");
         } else {
-            Optional<String> likePattern = node.likePattern();
-            if (likePattern.isPresent()) {
+            String likePattern = node.likePattern();
+            if (likePattern != null) {
                 sb.append(" AND table_name like ");
-                singleQuote(sb, likePattern.get());
+                singleQuote(sb, likePattern);
             }
         }
         sb.append(" ORDER BY 1");

--- a/sql/src/main/java/io/crate/analyze/relations/select/SelectAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/select/SelectAnalyzer.java
@@ -59,8 +59,8 @@ public class SelectAnalyzer {
         @Override
         protected Void visitSingleColumn(SingleColumn node, SelectAnalysis context) {
             Symbol symbol = context.toSymbol(node.getExpression());
-            if (node.getAlias().isPresent()) {
-                context.add(new OutputName(node.getAlias().get()), symbol);
+            if (node.getAlias() != null) {
+                context.add(new OutputName(node.getAlias()), symbol);
             } else {
                 context.add(new OutputName(OutputNameFormatter.format(node.getExpression())), symbol);
             }


### PR DESCRIPTION
Replace Optional usages with Nullable properties, because they are only used for "null checks".
  