### PR TITLE
Gradle: Fix InternalTask.execute deprecation warning

### DIFF
--- a/gradle/javaModule.gradle
+++ b/gradle/javaModule.gradle
@@ -15,9 +15,7 @@ compileJava {
     options.warnings = true
     options.deprecation = true
 
-    doLast() {
-        checkstyleMain.execute()
-    }
+    finalizedBy checkstyleMain
 }
 
 sourceCompatibility = "8"


### PR DESCRIPTION
Fixes:

> The TaskInternal.execute() method has been deprecated and is scheduled
> to be removed in Gradle 5.0. There are better ways to re-use task logic,
> see
> https://docs.gradle.org/4.4/userguide/custom_tasks.html#sec:reusing_task_logic.