### PR TITLE
Tests/appveyor: Increase default timeout for stmt execution

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,11 +2,12 @@ version: 1.0.{build}
 branches:
   only:
   - master
-install:
-- cmd: >-
-    SET JAVA_OPTS="-Xmx2g"
 
-    SET GRADLE_OPTS="-Dorg.gradle.daemon=false"
+environment:
+    JAVA_OPTS: -Xmx2g
+    CRATE_TESTS_SQL_REQUEST_TIMEOUT: 20
+    GRADLE_OPTS: -Dorg.gradle.daemon=false
+
 build_script:
 - cmd: >-
     git submodule update --init -- es/upstream


### PR DESCRIPTION
Use the same timeout as we use on travis-ci. Currently tests
occasionally fail on appveyor due to a timeout error.