### PR TITLE
Batch operations complete when the result receivers complete (not only finished)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -21,6 +21,10 @@ Changes
 Fixes
 =====
 
+- Fixed an issue where batch operations executed using the postgres protocol 
+  could've returned 0 as row count, even though the actual row count was 
+  different.
+
 - Fixed a bug which could cause job entries in `sys.jobs` not being removed
   when a connection error occurred while transferring the results of the job
   execution.


### PR DESCRIPTION
We encountered some issues where when executing batch updates using the
postgres protocol, the returned row count for the operation would be 0.
This happened because when the operation is complete we signal that the
backend is read for query (using the readyForQuery message).
We used to consider the operation complete after we sent the "commandComplete"
messages for every batch in the operation.
Due to the commandComplete channel transimission being async, sometimes
we sent readyForQuery before commandComplete would actually be sent.

This commit changes the definition of "operation complete" from "all result
receivers finished" to "all result receivers complete" (ie. commandComplete
was delivered)