### PR TITLE
fixed evaluation of javascript UDF

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -21,6 +21,10 @@ Changes
 Fixes
 =====
 
+- Fixed the evaluation of JavaScript user defined functions that caused CrateDB
+  to crash because of an unhandled assertion when providing the UDF with
+  EcmaScript 6 arrow function syntax (``var f = (x) => x;``).
+
 - Fixed an issue where batch operations executed using the postgres protocol 
   could've returned 0 as row count, even though the actual row count was 
   different.

--- a/enterprise/lang-js/src/main/java/io/crate/operation/language/JavaScriptLanguage.java
+++ b/enterprise/lang-js/src/main/java/io/crate/operation/language/JavaScriptLanguage.java
@@ -60,12 +60,14 @@ public class JavaScriptLanguage implements UDFLanguage {
     public String validate(UserDefinedFunctionMetaData meta) {
         try {
             bindScript(meta.definition());
-        } catch (ScriptException e) {
-            return String.format(Locale.ENGLISH, "Invalid JavaScript in function '%s.%s(%s)': %s",
+        } catch (Throwable t) {
+            // We need to catch throwable because of https://bugs.openjdk.java.net/browse/JDK-8144711
+            return String.format(Locale.ENGLISH, "Invalid JavaScript in function '%s.%s(%s)' AS '%s': %s",
                 meta.schema(),
                 meta.name(),
                 meta.argumentTypes().stream().map(DataType::getName).collect(Collectors.joining(", ")),
-                e.getMessage()
+                meta.definition(),
+                t.getMessage()
             );
         }
         return null;


### PR DESCRIPTION
Providing a JavaScript UDF with EcmaScript 6 arrow function syntax, such as
`var f = (x) => x;`, caused CrateDB to crash, because Java does not
throw a ScriptException but an AssertionError (see
https://bugs.openjdk.java.net/browse/JDK-8144711).