### PR TITLE
fixes select-multi-PK plan JMH benchmark

### DIFF
--- a/benchmarks/src/test/java/io/crate/analyze/PreExecutionBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/analyze/PreExecutionBenchmark.java
@@ -116,9 +116,14 @@ public class PreExecutionBenchmark {
             .build(plannerContext, null, -1, 0, null, null, Row.EMPTY, Collections.emptyMap());
     }
 
+    /**
+     * This does not measure the build of the execution plan as this requires that the table is part of the cluster state.
+     * (shard routing information would be required)
+     * This is not possible inside JMH because of missing {@link com.carrotsearch.randomizedtesting.RandomizedContext}.
+     */
     @Benchmark
-    public Plan measureParseAnalyzeAndPlanSelectWithMultiPrimaryKeyLookup() throws Exception {
-        return e.plan("select * from users where id = 1 or id = 2 or id = 3 or id = 4 order by id asc");
+    public Plan measureParseAnalyzeAndPlanSelectWithMultiPrimaryKeyLookup() {
+        return e.logicalPlan("select * from users where id = 1 or id = 2 or id = 3 or id = 4 order by id asc");
     }
 
     @Benchmark

--- a/sql/src/test/java/io/crate/testing/SQLExecutor.java
+++ b/sql/src/test/java/io/crate/testing/SQLExecutor.java
@@ -517,17 +517,7 @@ public class SQLExecutor {
             stmt = (AnalyzedStatement) new RelationNormalizer(functions)
                 .normalize(rewrittenRelation, transactionContext);
         }
-        RoutingProvider routingProvider = new RoutingProvider(random.nextInt(), new String[0]);
-        PlannerContext plannerContext = new PlannerContext(
-            planner.currentClusterState(),
-            routingProvider,
-            UUID.randomUUID(),
-            functions,
-            transactionContext,
-            -1,
-            -1
-        );
-        return (T) planner.plan(stmt, plannerContext);
+        return (T) planner.plan(stmt, getPlannerContext(planner.currentClusterState(), random));
     }
 
     public <T> T plan(String stmt, Row row) {

--- a/sql/src/test/java/io/crate/testing/SQLExecutor.java
+++ b/sql/src/test/java/io/crate/testing/SQLExecutor.java
@@ -517,7 +517,17 @@ public class SQLExecutor {
             stmt = (AnalyzedStatement) new RelationNormalizer(functions)
                 .normalize(rewrittenRelation, transactionContext);
         }
-        return (T) planner.plan(stmt, getPlannerContext(planner.currentClusterState()));
+        RoutingProvider routingProvider = new RoutingProvider(random.nextInt(), new String[0]);
+        PlannerContext plannerContext = new PlannerContext(
+            planner.currentClusterState(),
+            routingProvider,
+            UUID.randomUUID(),
+            functions,
+            transactionContext,
+            -1,
+            -1
+        );
+        return (T) planner.plan(stmt, plannerContext);
     }
 
     public <T> T plan(String stmt, Row row) {


### PR DESCRIPTION
We cannot include building of a GET execution plan inside a JMH benchmark as this requires a valid routing entry inside the cluster state.
Creating such a routing is not possible inside JMH benchmarks because of the missing RandomizedContext.
