### PR TITLE
use DocValues instead of source lookup on generic functions

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -18,6 +18,9 @@ Breaking Changes
 Changes
 =======
 
+- Greatly improved performance of queries that uses scalar functions inside the
+  ``WHERE`` clause.
+
 Fixes
 =====
 


### PR DESCRIPTION
using DocValues over source lookup will greatly increase performance.
the reasons for doing a source lookup instead were mostly related to the 
pre-DocValues era were the fieldcache was used instead.