### PR TITLE
Fix target column <> source column mapping for insert from query

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -24,6 +24,10 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that could cause ``INSERT INTO`` statements into partitioned
+  tables to not work correctly. This only occurred if a ``query`` instead of
+  the ``VALUES`` clause was used.
+
 - Fixed the evaluation of JavaScript user defined functions that caused CrateDB
   to crash because of an unhandled assertion when providing the UDF with
   EcmaScript 6 arrow function syntax (``var f = (x) => x;``).

--- a/sql/src/main/java/io/crate/analyze/InsertFromSubQueryAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/InsertFromSubQueryAnalyzedStatement.java
@@ -117,7 +117,7 @@ public class InsertFromSubQueryAnalyzedStatement implements AnalyzedStatement {
         }
 
         List<Symbol> symbols = new ArrayList<>(columns.size());
-        InputColumns.Context inputContext = null;
+        InputColumns.SourceSymbols sourceSymbols = null;
         for (ColumnIdent column : columns) {
             ColumnIdent subscriptColumn = null;
             if (!column.isTopLevel()) {
@@ -138,10 +138,10 @@ public class InsertFromSubQueryAnalyzedStatement implements AnalyzedStatement {
                         "Column \"%s\" is required but is missing from the insert statement", column.sqlFqn()));
                 }
 
-                if (inputContext == null) {
-                    inputContext = new InputColumns.Context(targetColumns);
+                if (sourceSymbols == null) {
+                    sourceSymbols = new InputColumns.SourceSymbols(targetColumns);
                 }
-                Symbol symbol = InputColumns.create(generatedReference.generatedExpression(), inputContext);
+                Symbol symbol = InputColumns.create(generatedReference.generatedExpression(), sourceSymbols);
                 symbols.add(symbol);
             }
         }

--- a/sql/src/main/java/io/crate/execution/dsl/projection/ColumnIndexWriterProjection.java
+++ b/sql/src/main/java/io/crate/execution/dsl/projection/ColumnIndexWriterProjection.java
@@ -76,7 +76,7 @@ public class ColumnIndexWriterProjection extends AbstractIndexWriterProjection {
             targetColsExclPartitionCols.add(column);
         }
         this.clusteredBySymbol = clusteredBySymbol;
-        columnSymbols = InputColumns.create(targetColsExclPartitionCols, new InputColumns.Context(columns));
+        columnSymbols = InputColumns.create(targetColsExclPartitionCols, new InputColumns.SourceSymbols(columns));
     }
 
     ColumnIndexWriterProjection(StreamInput in) throws IOException {

--- a/sql/src/main/java/io/crate/execution/dsl/projection/ColumnIndexWriterProjection.java
+++ b/sql/src/main/java/io/crate/execution/dsl/projection/ColumnIndexWriterProjection.java
@@ -21,10 +21,10 @@
 
 package io.crate.execution.dsl.projection;
 
-import io.crate.analyze.symbol.InputColumn;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.Symbols;
 import io.crate.collections.Lists2;
+import io.crate.execution.dsl.projection.builder.InputColumns;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
 import io.crate.metadata.TableIdent;
@@ -43,7 +43,7 @@ import java.util.function.Function;
 public class ColumnIndexWriterProjection extends AbstractIndexWriterProjection {
 
     private List<Symbol> columnSymbols;
-    private List<Reference> columnReferences;
+    private List<Reference> targetColsExclPartitionCols;
     @Nullable
     private Map<Reference, Symbol> onDuplicateKeyAssignments;
 
@@ -67,18 +67,16 @@ public class ColumnIndexWriterProjection extends AbstractIndexWriterProjection {
         super(tableIdent, partitionIdent, primaryKeys, clusteredByColumn, settings, primaryKeySymbols, autoCreateIndices);
         this.partitionedBySymbols = partitionedBySymbols;
         this.onDuplicateKeyAssignments = onDuplicateKeyAssignments;
-        this.columnReferences = new ArrayList<>(columns);
+        this.targetColsExclPartitionCols = new ArrayList<>(columns.size() - partitionedByColumns.size());
         this.columnSymbols = new ArrayList<>(columns.size() - partitionedBySymbols.size());
-        this.clusteredBySymbol = clusteredBySymbol;
-
-        for (int i = 0; i < columns.size(); i++) {
-            Reference ref = columns.get(i);
-            if (partitionedByColumns.contains(ref.column())) {
-                columnReferences.remove(i);
-            } else {
-                this.columnSymbols.add(new InputColumn(i, ref.valueType()));
+        for (Reference column : columns) {
+            if (partitionedByColumns.contains(column.column())) {
+                continue;
             }
+            targetColsExclPartitionCols.add(column);
         }
+        this.clusteredBySymbol = clusteredBySymbol;
+        columnSymbols = InputColumns.create(targetColsExclPartitionCols, new InputColumns.Context(columns));
     }
 
     ColumnIndexWriterProjection(StreamInput in) throws IOException {
@@ -89,9 +87,9 @@ public class ColumnIndexWriterProjection extends AbstractIndexWriterProjection {
         }
         if (in.readBoolean()) {
             int length = in.readVInt();
-            columnReferences = new ArrayList<>(length);
+            targetColsExclPartitionCols = new ArrayList<>(length);
             for (int i = 0; i < length; i++) {
-                columnReferences.add(Reference.fromStream(in));
+                targetColsExclPartitionCols.add(Reference.fromStream(in));
             }
         }
 
@@ -109,7 +107,7 @@ public class ColumnIndexWriterProjection extends AbstractIndexWriterProjection {
     }
 
     public List<Reference> columnReferences() {
-        return columnReferences;
+        return targetColsExclPartitionCols;
     }
 
     public Map<Reference, Symbol> onDuplicateKeyAssignments() {
@@ -145,7 +143,7 @@ public class ColumnIndexWriterProjection extends AbstractIndexWriterProjection {
 
         ColumnIndexWriterProjection that = (ColumnIndexWriterProjection) o;
 
-        if (!columnReferences.equals(that.columnReferences)) return false;
+        if (!targetColsExclPartitionCols.equals(that.targetColsExclPartitionCols)) return false;
         if (!columnSymbols.equals(that.columnSymbols)) return false;
         return !(onDuplicateKeyAssignments != null ?
                      !onDuplicateKeyAssignments.equals(that.onDuplicateKeyAssignments)
@@ -156,7 +154,7 @@ public class ColumnIndexWriterProjection extends AbstractIndexWriterProjection {
     public int hashCode() {
         int result = super.hashCode();
         result = 31 * result + columnSymbols.hashCode();
-        result = 31 * result + columnReferences.hashCode();
+        result = 31 * result + targetColsExclPartitionCols.hashCode();
         result = 31 * result + (onDuplicateKeyAssignments != null ? onDuplicateKeyAssignments.hashCode() : 0);
         return result;
     }
@@ -171,12 +169,12 @@ public class ColumnIndexWriterProjection extends AbstractIndexWriterProjection {
             out.writeBoolean(true);
             Symbols.toStream(columnSymbols, out);
         }
-        if (columnReferences == null) {
+        if (targetColsExclPartitionCols == null) {
             out.writeBoolean(false);
         } else {
             out.writeBoolean(true);
-            out.writeVInt(columnReferences.size());
-            for (Reference columnIdent : columnReferences) {
+            out.writeVInt(targetColsExclPartitionCols.size());
+            for (Reference columnIdent : targetColsExclPartitionCols) {
                 Reference.toStream(columnIdent, out);
             }
         }

--- a/sql/src/main/java/io/crate/planner/operators/FetchOrEval.java
+++ b/sql/src/main/java/io/crate/planner/operators/FetchOrEval.java
@@ -420,7 +420,7 @@ class FetchOrEval extends OneInputPlan {
                 executionPlan = Merge.ensureOnHandler(executionPlan, plannerContext);
             }
         }
-        InputColumns.Context ctx = new InputColumns.Context(sourceOutputs);
+        InputColumns.SourceSymbols ctx = new InputColumns.SourceSymbols(sourceOutputs);
         executionPlan.addProjection(
             new EvalProjection(InputColumns.create(this.outputs, ctx)),
             executionPlan.resultDescription().limit(),

--- a/sql/src/main/java/io/crate/planner/operators/Order.java
+++ b/sql/src/main/java/io/crate/planner/operators/Order.java
@@ -82,7 +82,7 @@ class Order extends OneInputPlan {
             // This is likely a order by on a virtual table which is sorted as well
             executionPlan = Merge.ensureOnHandler(executionPlan, plannerContext);
         }
-        InputColumns.Context ctx = new InputColumns.Context(source.outputs());
+        InputColumns.SourceSymbols ctx = new InputColumns.SourceSymbols(source.outputs());
         OrderedTopNProjection topNProjection = new OrderedTopNProjection(
             Limit.limitAndOffset(limit, offset),
             0,

--- a/sql/src/main/java/io/crate/planner/statement/CopyStatementPlanner.java
+++ b/sql/src/main/java/io/crate/planner/statement/CopyStatementPlanner.java
@@ -183,10 +183,10 @@ public final class CopyStatementPlanner {
         String[] excludes = partitionedByNames.size() > 0
             ? partitionedByNames.toArray(new String[partitionedByNames.size()]) : null;
 
-        InputColumns.Context inputColsContext = new InputColumns.Context(toCollect);
+        InputColumns.SourceSymbols sourceSymbols = new InputColumns.SourceSymbols(toCollect);
         Symbol clusteredByInputCol = null;
         if (clusteredBy != null) {
-            clusteredByInputCol = InputColumns.create(table.getReference(clusteredBy), inputColsContext);
+            clusteredByInputCol = InputColumns.create(table.getReference(clusteredBy), sourceSymbols);
         }
         SourceIndexWriterProjection sourceIndexWriterProjection = new SourceIndexWriterProjection(
             table.ident(),
@@ -194,12 +194,12 @@ public final class CopyStatementPlanner {
             table.getReference(DocSysColumns.RAW),
             new InputColumn(rawOrDocIdx, rawOrDoc.valueType()),
             table.primaryKey(),
-            InputColumns.create(table.partitionedByColumns(), inputColsContext),
+            InputColumns.create(table.partitionedByColumns(), sourceSymbols),
             clusteredBy,
             copyFrom.settings(),
             null,
             excludes,
-            InputColumns.create(primaryKeyRefs, inputColsContext),
+            InputColumns.create(primaryKeyRefs, sourceSymbols),
             clusteredByInputCol,
             table.isPartitioned() // autoCreateIndices
         );

--- a/sql/src/test/java/io/crate/execution/dsl/projection/ColumnIndexWriterProjectionTest.java
+++ b/sql/src/test/java/io/crate/execution/dsl/projection/ColumnIndexWriterProjectionTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.dsl.projection;
+
+import io.crate.analyze.symbol.InputColumn;
+import io.crate.analyze.symbol.Symbol;
+import io.crate.execution.dsl.projection.builder.InputColumns;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.Reference;
+import io.crate.metadata.ReferenceIdent;
+import io.crate.metadata.RowGranularity;
+import io.crate.metadata.TableIdent;
+import io.crate.types.DataType;
+import io.crate.types.DataTypes;
+import org.elasticsearch.common.settings.Settings;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertThat;
+
+public class ColumnIndexWriterProjectionTest {
+
+    private TableIdent tableIdent = new TableIdent("dummy", "table");
+
+    @Test
+    public void testTargetColumnRefsAndSymbolsAreCorrectAfterExclusionOfPartitionColumns() {
+        /*
+         *  pk:             [ymd, domain, area, isp]
+         *  partitioned by: [ymd, isp]
+         *  insert into t   (ymd, domain, area, isp, h) select ...
+         *
+         *  We don't write PartitionedBy columns, so they're excluded from the targetColumns:
+         *
+         *  expected targetRefs:      [ domain, area, h ]
+         *  expected column symbols:  [ ic1,   ic2, ic4 ]
+         */
+        ColumnIdent ymd = new ColumnIdent("ymd");
+        ColumnIdent domain = new ColumnIdent("domain");
+        ColumnIdent area = new ColumnIdent("area");
+        ColumnIdent isp = new ColumnIdent("isp");
+        ColumnIdent h = new ColumnIdent("h");
+        Reference ymdRef = partitionRef(ymd, DataTypes.STRING);
+        Reference domainRef = ref(domain, DataTypes.STRING);
+        Reference areaRef = ref(area, DataTypes.STRING);
+        Reference ispRef = partitionRef(isp, DataTypes.STRING);
+        Reference hRef = ref(h, DataTypes.INTEGER);
+        List<ColumnIdent> primaryKeys = Arrays.asList(ymd, domain, area, isp);
+        List<Reference> targetColumns = Arrays.asList(ymdRef, domainRef, areaRef, ispRef, hRef);
+        InputColumns.Context targetColsCtx = new InputColumns.Context(targetColumns);
+        List<Symbol> primaryKeySymbols = InputColumns.create(
+            Arrays.asList(ymdRef, domainRef, areaRef, ispRef), targetColsCtx);
+        List<ColumnIdent> partitionedByColumns = Arrays.asList(ymd, isp);
+        List<Symbol> partitionedBySymbols = InputColumns.create(Arrays.asList(ymdRef, ispRef), targetColsCtx);
+
+        ColumnIndexWriterProjection projection = new ColumnIndexWriterProjection(
+            tableIdent,
+            null,
+            primaryKeys,
+            targetColumns,
+            null,
+            primaryKeySymbols,
+            partitionedByColumns,
+            partitionedBySymbols,
+            null,
+            null,
+            Settings.EMPTY,
+            true
+        );
+
+        assertThat(projection.columnReferences(), Matchers.is(Arrays.asList(
+            domainRef, areaRef, hRef)
+        ));
+        assertThat(projection.columnSymbols(), Matchers.is(Arrays.asList(
+            new InputColumn(1, DataTypes.STRING),
+            new InputColumn(2, DataTypes.STRING),
+            new InputColumn(4, DataTypes.INTEGER))));
+    }
+
+    private Reference ref(ColumnIdent column, DataType type) {
+        return new Reference(new ReferenceIdent(tableIdent, column), RowGranularity.DOC, type);
+    }
+
+    private Reference partitionRef(ColumnIdent column, DataType type) {
+        return new Reference(new ReferenceIdent(tableIdent, column), RowGranularity.PARTITION, type);
+    }
+}

--- a/sql/src/test/java/io/crate/execution/dsl/projection/ColumnIndexWriterProjectionTest.java
+++ b/sql/src/test/java/io/crate/execution/dsl/projection/ColumnIndexWriterProjectionTest.java
@@ -69,7 +69,7 @@ public class ColumnIndexWriterProjectionTest {
         Reference hRef = ref(h, DataTypes.INTEGER);
         List<ColumnIdent> primaryKeys = Arrays.asList(ymd, domain, area, isp);
         List<Reference> targetColumns = Arrays.asList(ymdRef, domainRef, areaRef, ispRef, hRef);
-        InputColumns.Context targetColsCtx = new InputColumns.Context(targetColumns);
+        InputColumns.SourceSymbols targetColsCtx = new InputColumns.SourceSymbols(targetColumns);
         List<Symbol> primaryKeySymbols = InputColumns.create(
             Arrays.asList(ymdRef, domainRef, areaRef, ispRef), targetColsCtx);
         List<ColumnIdent> partitionedByColumns = Arrays.asList(ymd, isp);

--- a/sql/src/test/java/io/crate/execution/dsl/projection/builder/InputColumnsTest.java
+++ b/sql/src/test/java/io/crate/execution/dsl/projection/builder/InputColumnsTest.java
@@ -54,20 +54,20 @@ public class InputColumnsTest extends CrateUnitTest {
 
         Function newSameFn = (Function) sqlExpressions.asSymbol("random()");
         Function newDifferentFn = (Function) sqlExpressions.asSymbol("random()");
-        InputColumns.Context context = new InputColumns.Context(inputSymbols);
+        InputColumns.SourceSymbols sourceSymbols = new InputColumns.SourceSymbols(inputSymbols);
 
-        Symbol replaced1 = InputColumns.create(fn1, context);
+        Symbol replaced1 = InputColumns.create(fn1, sourceSymbols);
         assertThat(replaced1, is(instanceOf(InputColumn.class)));
         assertThat(((InputColumn) replaced1).index(), is(2));
 
-        Symbol replaced2 = InputColumns.create(fn2, context);
+        Symbol replaced2 = InputColumns.create(fn2, sourceSymbols);
         assertThat(replaced2, is(instanceOf(InputColumn.class)));
         assertThat(((InputColumn) replaced2).index(), is(3));
 
-        Symbol replaced3 = InputColumns.create(newSameFn, context);
+        Symbol replaced3 = InputColumns.create(newSameFn, sourceSymbols);
         assertThat(replaced3, is(equalTo(newSameFn))); // not replaced
 
-        Symbol replaced4 = InputColumns.create(newDifferentFn, context);
+        Symbol replaced4 = InputColumns.create(newDifferentFn, sourceSymbols);
         assertThat(replaced4, is(equalTo(newDifferentFn))); // not replaced
     }
 }


### PR DESCRIPTION
Insert from subquery into a partitioned table could either not insert
anything or mix up target / source columns due to the "target column
references" and "target column symbols" generation being broken. They
referred to different columns.

Fixes https://github.com/crate/crate/issues/6744