### PR TITLE
Fix SSL verbosity issue by logging only at startup

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -24,6 +24,9 @@ Changes
 Fixes
 =====
 
+- Fix log verbosity by only logging the HTTP SSL enabled/disabled message once
+  at startup.
+
 - Fixed an issue that could cause ``INSERT INTO`` statements into partitioned
   tables to not work correctly. This only occurred if a ``query`` instead of
   the ``VALUES`` clause was used.

--- a/http/src/main/java/io/crate/plugin/PipelineRegistry.java
+++ b/http/src/main/java/io/crate/plugin/PipelineRegistry.java
@@ -26,10 +26,8 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.inject.Provider;
 import org.elasticsearch.common.inject.Singleton;
-import org.elasticsearch.common.logging.Loggers;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -44,8 +42,6 @@ import java.util.function.Supplier;
  */
 @Singleton
 public class PipelineRegistry {
-
-    private static final Logger LOG = Loggers.getLogger(PipelineRegistry.class);
 
     private final List<ChannelPipelineItem> addBeforeList;
     private Provider<SslContext> sslContextProvider;
@@ -101,11 +97,8 @@ public class PipelineRegistry {
         if (sslContextProvider != null) {
             SslContext sslContext = sslContextProvider.get();
             if (sslContext != null) {
-                LOG.info("HTTP SSL support is enabled.");
                 SslHandler sslHandler = sslContext.newHandler(pipeline.channel().alloc());
                 pipeline.addFirst(sslHandler);
-            } else {
-                LOG.info("HTTP SSL support is disabled.");
             }
         }
     }

--- a/ssl/src/main/java/io/crate/protocols/ssl/SslContextProvider.java
+++ b/ssl/src/main/java/io/crate/protocols/ssl/SslContextProvider.java
@@ -24,6 +24,7 @@ package io.crate.protocols.ssl;
 
 import io.crate.plugin.PipelineRegistry;
 import io.netty.handler.ssl.SslContext;
+import org.apache.log4j.Logger;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Provider;
 import org.elasticsearch.common.inject.Singleton;
@@ -39,6 +40,7 @@ import java.lang.reflect.InvocationTargetException;
 @Singleton
 public class SslContextProvider implements Provider<SslContext> {
 
+    private static final Logger LOG = Logger.getLogger(SslContextProvider.class);
     private static final String SSL_CONTEXT_CLAZZ = "io.crate.protocols.ssl.SslConfiguration";
     private static final String SSL_CONTEXT_METHOD_NAME = "buildSslContext";
 
@@ -50,6 +52,9 @@ public class SslContextProvider implements Provider<SslContext> {
         this.settings = settings;
         if (SslConfigSettings.isHttpsEnabled(settings)) {
             pipelineRegistry.registerSslContextProvider(this);
+            LOG.info("HTTP SSL support is enabled.");
+        } else {
+            LOG.info("HTTP SSL support is disabled.");
         }
     }
 


### PR DESCRIPTION
This moves the info logging to the SslContextProvider which only registers
itself once at the PipelineRegistry, avoiding any additional logging on new
connections.

Regression of bfa092e1a71c1fc8d2744944a254f326c08017ef