### PR TITLE
ES6 Support in Java9 is activated by param: `--language=es6`.

### DIFF
--- a/enterprise/lang-js/src/main/java/io/crate/operation/language/JavaScriptLanguage.java
+++ b/enterprise/lang-js/src/main/java/io/crate/operation/language/JavaScriptLanguage.java
@@ -41,7 +41,7 @@ public class JavaScriptLanguage implements UDFLanguage {
     static final String NAME = "javascript";
 
     private static final NashornScriptEngine ENGINE = (NashornScriptEngine) new NashornScriptEngineFactory()
-        .getScriptEngine("--no-java", "--no-syntax-extensions");
+        .getScriptEngine("--no-java", "--no-syntax-extensions", "--language=es6");
 
     @Inject
     public JavaScriptLanguage(UserDefinedFunctionService udfService) {

--- a/enterprise/lang-js/src/test/java/io/crate/operation/language/JavascriptUserDefinedFunctionTest.java
+++ b/enterprise/lang-js/src/test/java/io/crate/operation/language/JavascriptUserDefinedFunctionTest.java
@@ -49,8 +49,10 @@ import java.util.stream.Collectors;
 import static io.crate.testing.SymbolMatchers.isLiteral;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.startsWith;
 import static org.mockito.Mockito.mock;
 
 public class JavascriptUserDefinedFunctionTest extends AbstractScalarFunctionsTest {
@@ -133,8 +135,15 @@ public class JavascriptUserDefinedFunctionTest extends AbstractScalarFunctionsTe
         );
 
         String validation = udfService.getLanguage(JS).validate(udfMeta);
-        assertThat(validation, startsWith("Invalid JavaScript in function 'doc.f(double)'"));
-        assertThat(validation, endsWith("Failed generating bytecode for <eval>:1"));
+        String javaVersion = System.getProperty("java.specification.version");
+        try {
+            if (Integer.parseInt(javaVersion) >= 9) {
+                assertThat(validation, is(nullValue()));
+            }
+        } catch (NumberFormatException e) {
+            assertThat(validation, startsWith("Invalid JavaScript in function 'doc.f(double)'"));
+            assertThat(validation, endsWith("Failed generating bytecode for <eval>:1"));
+        }
     }
 
     @Test


### PR DESCRIPTION
The `=>` is then supported so the test must be adapted to not fail for Java9
This is a followup of: fa484103f807785442b3f66027ab419bd29467a4