### PR TITLE
re-use an unbound analysis for execution planning

### DIFF
--- a/sql/src/main/java/io/crate/action/sql/Session.java
+++ b/sql/src/main/java/io/crate/action/sql/Session.java
@@ -171,7 +171,7 @@ public class Session {
         try {
             PreparedStmt preparedStmt = getSafeStmt(statementName);
             Portal newPortal = portal.bind(
-                statementName, preparedStmt.query(), preparedStmt.statement(), params, resultFormatCodes);
+                statementName, preparedStmt.query(), preparedStmt.statement(), preparedStmt.analyzedStatement(), params, resultFormatCodes);
             if (portal != newPortal) {
                 portals.put(portalName, newPortal);
                 pendingExecutions.remove(portal);

--- a/sql/src/main/java/io/crate/analyze/AnalyzedDeleteStatement.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedDeleteStatement.java
@@ -59,4 +59,9 @@ public final class AnalyzedDeleteStatement implements AnalyzedStatement {
     public Symbol query() {
         return query;
     }
+
+    @Override
+    public boolean isUnboundPlanningSupported() {
+        return true;
+    }
 }

--- a/sql/src/main/java/io/crate/analyze/AnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedStatement.java
@@ -41,4 +41,12 @@ public interface AnalyzedStatement {
 
     default void visitSymbols(Consumer<? super Symbol> consumer) {
     }
+
+    /**
+     * Defines if an unbound analyzed statement (no parameter are bound yet) can be used
+     * to create execution plans.
+     */
+    default boolean isUnboundPlanningSupported() {
+        return false;
+    }
 }

--- a/sql/src/main/java/io/crate/analyze/AnalyzedUpdateStatement.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedUpdateStatement.java
@@ -70,4 +70,9 @@ public final class AnalyzedUpdateStatement implements AnalyzedStatement {
             consumer.accept(sourceExpr);
         }
     }
+
+    @Override
+    public boolean isUnboundPlanningSupported() {
+        return true;
+    }
 }

--- a/sql/src/main/java/io/crate/analyze/Analyzer.java
+++ b/sql/src/main/java/io/crate/analyze/Analyzer.java
@@ -158,7 +158,8 @@ public class Analyzer {
             deleteAnalyzer,
             updateAnalyzer,
             insertFromValuesAnalyzer,
-            insertFromSubQueryAnalyzer
+            insertFromSubQueryAnalyzer,
+            explainStatementAnalyzer
         );
         this.createBlobTableAnalyzer = new CreateBlobTableAnalyzer(schemas, numberOfShards);
         this.createAnalyzerStatementAnalyzer = new CreateAnalyzerStatementAnalyzer(fulltextAnalyzerResolver);

--- a/sql/src/main/java/io/crate/analyze/Analyzer.java
+++ b/sql/src/main/java/io/crate/analyze/Analyzer.java
@@ -206,7 +206,10 @@ public class Analyzer {
 
         @Override
         protected AnalyzedStatement visitQuery(Query node, Analysis analysis) {
-            AnalyzedRelation relation = relationAnalyzer.analyze(node, analysis);
+            AnalyzedRelation relation = relationAnalyzer.analyze(
+                node,
+                analysis.transactionContext(),
+                analysis.parameterContext());
             analysis.rootRelation(relation);
             return (AnalyzedStatement) relation;
         }

--- a/sql/src/main/java/io/crate/analyze/ExplainAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/ExplainAnalyzedStatement.java
@@ -84,4 +84,9 @@ public class ExplainAnalyzedStatement implements AnalyzedStatement, AnalyzedRela
     public void setQualifiedName(@Nonnull QualifiedName qualifiedName) {
         throw new UnsupportedOperationException("method not supported");
     }
+
+    @Override
+    public boolean isUnboundPlanningSupported() {
+        return true;
+    }
 }

--- a/sql/src/main/java/io/crate/analyze/InsertFromSubQueryAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/InsertFromSubQueryAnalyzer.java
@@ -134,7 +134,8 @@ class InsertFromSubQueryAnalyzer {
         DocTableRelation tableRelation = new DocTableRelation(tableInfo);
         FieldProvider fieldProvider = new NameFieldProvider(tableRelation);
 
-        QueriedRelation source = (QueriedRelation) relationAnalyzer.analyze(node.subQuery(), analysis);
+        QueriedRelation source = (QueriedRelation) relationAnalyzer.analyze(
+            node.subQuery(), analysis.transactionContext(), analysis.parameterContext());
 
         List<Reference> targetColumns = new ArrayList<>(resolveTargetColumns(node.columns(), tableInfo, source.fields().size()));
         validateColumnsAndAddCastsIfNecessary(targetColumns, source.querySpec());

--- a/sql/src/main/java/io/crate/analyze/ShowCreateTableAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/ShowCreateTableAnalyzedStatement.java
@@ -86,4 +86,9 @@ public class ShowCreateTableAnalyzedStatement implements AnalyzedStatement, Anal
     public void setQualifiedName(@Nonnull QualifiedName qualifiedName) {
         throw new UnsupportedOperationException("method not supported");
     }
+
+    @Override
+    public boolean isUnboundPlanningSupported() {
+        return true;
+    }
 }

--- a/sql/src/main/java/io/crate/analyze/relations/QueriedRelation.java
+++ b/sql/src/main/java/io/crate/analyze/relations/QueriedRelation.java
@@ -113,4 +113,9 @@ public interface QueriedRelation extends AnalyzedRelation, AnalyzedStatement {
     default boolean isWriteOperation() {
         return false;
     }
+
+    @Override
+    default boolean isUnboundPlanningSupported() {
+        return true;
+    }
 }

--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -24,11 +24,11 @@ package io.crate.analyze.relations;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
-import io.crate.analyze.Analysis;
 import io.crate.analyze.HavingClause;
 import io.crate.analyze.MultiSourceSelect;
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.ParamTypeHints;
+import io.crate.analyze.ParameterContext;
 import io.crate.analyze.QueriedSelectRelation;
 import io.crate.analyze.QueriedTable;
 import io.crate.analyze.QuerySpec;
@@ -123,18 +123,13 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
     public AnalyzedRelation analyzeUnbound(Query query,
                                            TransactionContext transactionContext,
                                            ParamTypeHints paramTypeHints) {
-        return process(query,
-            new StatementAnalysisContext(paramTypeHints, Operation.READ, transactionContext));
+        return analyze(query, new StatementAnalysisContext(paramTypeHints, Operation.READ, transactionContext));
     }
 
-    public AnalyzedRelation analyze(Node node, Analysis analysis) {
-        return analyze(
-            node,
-            new StatementAnalysisContext(
-                analysis.parameterContext(),
-                Operation.READ,
-                analysis.transactionContext())
-        );
+    public AnalyzedRelation analyze(Node node,
+                                    TransactionContext transactionContext,
+                                    ParameterContext parameterContext) {
+        return analyze(node, new StatementAnalysisContext(parameterContext, Operation.READ, transactionContext));
     }
 
     @Override

--- a/sql/src/main/java/io/crate/analyze/relations/RelationNormalizer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationNormalizer.java
@@ -90,7 +90,7 @@ public final class RelationNormalizer {
         @Override
         public AnalyzedRelation visitQueriedDocTable(QueriedDocTable table, TransactionContext context) {
             table.normalize(functions, context);
-            table.analyzeWhereClause(functions, context);
+            table.optimizeWhereClause(normalizer, context);
             return table;
         }
 

--- a/sql/src/main/java/io/crate/analyze/where/EqualityExtractor.java
+++ b/sql/src/main/java/io/crate/analyze/where/EqualityExtractor.java
@@ -70,7 +70,7 @@ public class EqualityExtractor {
         this.normalizer = normalizer;
     }
 
-    List<List<Symbol>> extractParentMatches(List<ColumnIdent> columns, Symbol symbol, @Nullable TransactionContext transactionContext) {
+    public List<List<Symbol>> extractParentMatches(List<ColumnIdent> columns, Symbol symbol, @Nullable TransactionContext transactionContext) {
         return extractMatches(columns, symbol, false, transactionContext);
     }
 

--- a/sql/src/main/java/io/crate/protocols/postgres/Portal.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/Portal.java
@@ -24,6 +24,7 @@ package io.crate.protocols.postgres;
 
 import io.crate.action.sql.ResultReceiver;
 import io.crate.expression.symbol.Field;
+import io.crate.analyze.AnalyzedStatement;
 import io.crate.execution.engine.collect.stats.JobsLogs;
 import io.crate.planner.Planner;
 import io.crate.sql.tree.Statement;
@@ -45,8 +46,12 @@ public interface Portal {
      * If bind() is called on a synced portal, all pending result receiving operations must be stopped.
      * This is primarily relevant for the UNNAMED simple portal.
      */
-    Portal bind(String statementName, String query, Statement statement,
-                List<Object> params, @Nullable FormatCodes.FormatCode[] resultFormatCodes);
+    Portal bind(String statementName,
+                String query,
+                Statement statement,
+                @Nullable AnalyzedStatement analyzedStatement,
+                List<Object> params,
+                @Nullable FormatCodes.FormatCode[] resultFormatCodes);
 
     List<Field> describe();
 

--- a/sql/src/test/java/io/crate/analyze/relations/SubselectRewriterTest.java
+++ b/sql/src/test/java/io/crate/analyze/relations/SubselectRewriterTest.java
@@ -24,9 +24,7 @@ package io.crate.analyze.relations;
 
 import com.google.common.collect.ImmutableMap;
 import io.crate.action.sql.SessionContext;
-import io.crate.analyze.Analysis;
 import io.crate.analyze.MultiSourceSelect;
-import io.crate.analyze.ParamTypeHints;
 import io.crate.analyze.ParameterContext;
 import io.crate.analyze.QueriedSelectRelation;
 import io.crate.expression.symbol.Field;
@@ -80,11 +78,10 @@ public class SubselectRewriterTest extends CrateDummyClusterServiceUnitTest {
     }
 
     private QueriedRelation rewrite(String stmt) {
-        return (QueriedRelation) analyzer.analyze(SqlParser.createStatement(stmt), new Analysis(
+        return (QueriedRelation) analyzer.analyze(SqlParser.createStatement(stmt),
             new TransactionContext(SessionContext.create()),
-            ParameterContext.EMPTY,
-            ParamTypeHints.EMPTY
-        ));
+            ParameterContext.EMPTY
+        );
     }
 
     @Test

--- a/sql/src/test/java/io/crate/analyze/where/WhereClauseAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/where/WhereClauseAnalyzerTest.java
@@ -28,6 +28,7 @@ import io.crate.analyze.AnalyzedDeleteStatement;
 import io.crate.analyze.AnalyzedUpdateStatement;
 import io.crate.analyze.WhereClause;
 import io.crate.analyze.relations.DocTableRelation;
+import io.crate.analyze.relations.QueriedDocTable;
 import io.crate.analyze.relations.QueriedRelation;
 import io.crate.core.collections.TreeMapBuilder;
 import io.crate.data.RowN;
@@ -61,6 +62,7 @@ import java.util.Map;
 import static io.crate.testing.SymbolMatchers.isFunction;
 import static io.crate.testing.SymbolMatchers.isLiteral;
 import static io.crate.testing.SymbolMatchers.isReference;
+import static io.crate.testing.TestingHelpers.getFunctions;
 import static io.crate.testing.TestingHelpers.isDocKey;
 import static io.crate.testing.TestingHelpers.isNullDocKey;
 import static io.crate.testing.TestingHelpers.isSQL;
@@ -197,6 +199,11 @@ public class WhereClauseAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     private WhereClause analyzeSelect(String stmt, Object... args) {
         QueriedRelation rel = e.analyze(stmt, args);
+        if (rel instanceof QueriedDocTable) {
+            WhereClauseAnalyzer whereClauseAnalyzer = new WhereClauseAnalyzer(
+                getFunctions(), ((QueriedDocTable) rel).tableRelation());
+            return whereClauseAnalyzer.analyze(rel.where().query(), transactionContext);
+        }
         return rel.where();
     }
 


### PR DESCRIPTION
changes the portals to re-use an unbound analysis when available and supported.
tests were also successfully run with forced jdbc and prepared statements (instead of let the runner choose random usages of it)