### PR TITLE
Fail if downstreams request more data in direct response mode

### DIFF
--- a/sql/src/main/java/io/crate/execution/engine/PagingUnsupportedResultListener.java
+++ b/sql/src/main/java/io/crate/execution/engine/PagingUnsupportedResultListener.java
@@ -22,17 +22,24 @@
 
 package io.crate.execution.engine;
 
+
 import io.crate.execution.jobs.PageResultListener;
 
-class BucketResultListener implements PageResultListener {
+/**
+ * PageResultListener that raises an exception if `needMore(true)` is called.
+ */
+final class PagingUnsupportedResultListener implements PageResultListener {
 
-    BucketResultListener() {
+    static final PagingUnsupportedResultListener INSTANCE = new PagingUnsupportedResultListener();
+
+    private PagingUnsupportedResultListener() {
     }
 
     @Override
     public void needMore(boolean needMore) {
         if (needMore) {
-            ExecutionPhasesTask.LOGGER.warn("requested more data but directResponse doesn't support paging");
+            throw new IllegalStateException(
+                "A downstream requested more data from an upstream, but that is not supported in direct-response mode");
         }
     }
 }

--- a/sql/src/main/java/io/crate/execution/engine/SetBucketAction.java
+++ b/sql/src/main/java/io/crate/execution/engine/SetBucketAction.java
@@ -33,14 +33,14 @@ abstract class SetBucketAction {
     private final List<PageBucketReceiver> pageBucketReceivers;
     private final int bucketIdx;
     private final InitializationTracker initializationTracker;
-    private final BucketResultListener bucketResultListener;
+    private final PagingUnsupportedResultListener pagingUnsupportedResultListener;
 
     SetBucketAction(List<PageBucketReceiver> pageBucketReceivers, int bucketIdx, InitializationTracker initializationTracker) {
         assert !pageBucketReceivers.isEmpty() : "pageBucketReceivers must not be empty";
         this.pageBucketReceivers = pageBucketReceivers;
         this.bucketIdx = bucketIdx;
         this.initializationTracker = initializationTracker;
-        bucketResultListener = new BucketResultListener();
+        pagingUnsupportedResultListener = PagingUnsupportedResultListener.INSTANCE;
     }
 
     protected void setBuckets(List<Bucket> result) {
@@ -49,7 +49,7 @@ abstract class SetBucketAction {
             PageBucketReceiver pageBucketReceiver = pageBucketReceivers.get(i);
             Bucket bucket = result.get(i);
             assert bucket != null : "expected directResponse but didn't get one idx=" + i;
-            pageBucketReceiver.setBucket(bucketIdx, bucket, true, bucketResultListener);
+            pageBucketReceiver.setBucket(bucketIdx, bucket, true, pagingUnsupportedResultListener);
         }
     }
 


### PR DESCRIPTION
If the "direct response" mode is used we don't support paging. So
downstreams cannot request more data from their upstreams.  We should
make sure we create no execution plans that result in such a
constellation by being defensive and fail. If we didn't, we would likely
produce incorrect query results.