### PR TITLE
Don't require generated primary key column parts to use PKLookup

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -18,6 +18,10 @@ Breaking Changes
 Changes
 =======
 
+- In certain cases it's no longer necessary to explicitly add generated columns
+  that are part of a composite primary key to the ``WHERE`` clause in order to
+  get an execution plan with real-time semantics.
+
 - Greatly improved performance of queries that uses scalar functions inside the
   ``WHERE`` clause.
 

--- a/sql/src/main/java/io/crate/analyze/GeneratedColumnExpander.java
+++ b/sql/src/main/java/io/crate/analyze/GeneratedColumnExpander.java
@@ -33,10 +33,6 @@ import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.SymbolType;
 import io.crate.analyze.symbol.SymbolVisitors;
 import io.crate.analyze.symbol.Symbols;
-import io.crate.metadata.FunctionIdent;
-import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.GeneratedReference;
-import io.crate.metadata.Reference;
 import io.crate.execution.expression.operator.AndOperator;
 import io.crate.execution.expression.operator.EqOperator;
 import io.crate.execution.expression.operator.GtOperator;
@@ -48,6 +44,10 @@ import io.crate.execution.expression.scalar.DateTruncFunction;
 import io.crate.execution.expression.scalar.arithmetic.CeilFunction;
 import io.crate.execution.expression.scalar.arithmetic.FloorFunction;
 import io.crate.execution.expression.scalar.arithmetic.RoundFunction;
+import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.GeneratedReference;
+import io.crate.metadata.Reference;
 import io.crate.types.DataTypes;
 
 import javax.annotation.Nullable;
@@ -83,15 +83,15 @@ public final class GeneratedColumnExpander {
      * <pre>
      *     example for an expansion:
      *
-     *     generatedCols: [day as date_trunc('day', ts)]
-     *     partitionCols: [day]
+     *     generatedCols:       [day as date_trunc('day', ts)]
+     *     expansionCandidates: [day]
      *
      *     input:   ts > $1
      *     output:  ts > $1 and day > date_trunc('day', ts)
      * </pre>
      */
-    public static Symbol maybeExpand(Symbol symbol, List<GeneratedReference> generatedCols, List<Reference> partitionCols) {
-        return COMPARISON_REPLACE_VISITOR.addComparisons(symbol, generatedCols, partitionCols);
+    public static Symbol maybeExpand(Symbol symbol, List<GeneratedReference> generatedCols, List<Reference> expansionCandidates) {
+        return COMPARISON_REPLACE_VISITOR.addComparisons(symbol, generatedCols, expansionCandidates);
     }
 
     private static class ComparisonReplaceVisitor extends FunctionCopyVisitor<ComparisonReplaceVisitor.Context> {
@@ -108,9 +108,9 @@ public final class GeneratedColumnExpander {
             super();
         }
 
-        Symbol addComparisons(Symbol symbol, List<GeneratedReference> generatedCols, List<Reference> partitionCols) {
+        Symbol addComparisons(Symbol symbol, List<GeneratedReference> generatedCols, List<Reference> expansionCandidates) {
             Multimap<Reference, GeneratedReference> referencedSingleReferences =
-                extractGeneratedReferences(generatedCols, partitionCols);
+                extractGeneratedReferences(generatedCols, expansionCandidates);
             if (referencedSingleReferences.isEmpty()) {
                 return symbol;
             } else {

--- a/sql/src/main/java/io/crate/planner/WhereClauseOptimizer.java
+++ b/sql/src/main/java/io/crate/planner/WhereClauseOptimizer.java
@@ -28,6 +28,7 @@ import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.Symbols;
 import io.crate.analyze.where.DocKeys;
 import io.crate.analyze.where.EqualityExtractor;
+import io.crate.collections.Lists2;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocSysColumns;
@@ -90,7 +91,10 @@ public final class WhereClauseOptimizer {
                                          Symbol query,
                                          DocTableInfo table,
                                          TransactionContext txnCtx) {
-        query = GeneratedColumnExpander.maybeExpand(query, table.generatedColumns(), table.partitionedByColumns());
+        query = GeneratedColumnExpander.maybeExpand(
+            query,
+            table.generatedColumns(),
+            Lists2.concat(table.partitionedByColumns(), Lists2.copyAndReplace(table.primaryKey(), table::getReference)));
 
         boolean versionInQuery = Symbols.containsColumn(query, DocSysColumns.VERSION);
         List<ColumnIdent> pkCols = pkColsInclVersion(table, versionInQuery);


### PR DESCRIPTION
We can apply the expansion logic we use for partition columns on primary
key columns as well, so that the primary key detection logic works. This
allows the planner to generate a primary key lookup plan, so that these
queries will have real time semantics.

Fixes https://github.com/crate/crate/issues/6768