### PR TITLE
Ensure natural order of keys in HBA config

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -28,6 +28,8 @@ Changes
 Fixes
 =====
 
+- Ensured natural order of config keys for the Host Based Authentication.
+
 - Fixed encoding/decoding of ``Timestamp`` type for PostgreSQL wire protocol
   to support Golang psql drivers.
 

--- a/enterprise/users/src/main/java/io/crate/auth/HostBasedAuthentication.java
+++ b/enterprise/users/src/main/java/io/crate/auth/HostBasedAuthentication.java
@@ -19,7 +19,7 @@
 package io.crate.auth;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedMap;
 import io.crate.auth.user.UserLookup;
 import io.crate.protocols.postgres.ConnectionProperties;
 import org.elasticsearch.common.inject.Inject;
@@ -29,9 +29,9 @@ import org.elasticsearch.common.settings.Settings;
 
 import javax.annotation.Nullable;
 import java.net.InetAddress;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
+import java.util.SortedMap;
 
 
 public class HostBasedAuthentication implements Authentication {
@@ -67,7 +67,7 @@ public class HostBasedAuthentication implements Authentication {
        ...
      }
      */
-    private Map<String, Map<String, String>> hbaConf;
+    private SortedMap<String, Map<String, String>> hbaConf;
     private final UserLookup userLookup;
 
     @Inject
@@ -77,15 +77,11 @@ public class HostBasedAuthentication implements Authentication {
     }
 
     void updateHbaConfig(Map<String, Map<String, String>> hbaMap) {
-        hbaConf = hbaMap;
+        hbaConf = ImmutableSortedMap.<String, Map<String, String>>naturalOrder().putAll(hbaMap).build();
     }
 
-    private Map<String, Map<String, String>> convertHbaSettingsToHbaConf(Settings hbaSetting) {
-        if (hbaSetting.isEmpty()) {
-            return Collections.emptyMap();
-        }
-
-        ImmutableMap.Builder<String, Map<String, String>> hostBasedConf = ImmutableMap.builder();
+    private SortedMap<String, Map<String, String>> convertHbaSettingsToHbaConf(Settings hbaSetting) {
+        ImmutableSortedMap.Builder<String, Map<String, String>> hostBasedConf = ImmutableSortedMap.naturalOrder();
         for (Map.Entry<String, Settings> entry : hbaSetting.getAsGroups().entrySet()) {
             hostBasedConf.put(entry.getKey(), entry.getValue().getAsMap());
         }

--- a/enterprise/users/src/main/java/io/crate/auth/HostBasedAuthentication.java
+++ b/enterprise/users/src/main/java/io/crate/auth/HostBasedAuthentication.java
@@ -72,17 +72,15 @@ public class HostBasedAuthentication implements Authentication {
 
     @Inject
     public HostBasedAuthentication(Settings settings, UserLookup userLookup) {
-        hbaConf = convertHbaSettingsToHbaConf(AuthSettings.AUTH_HOST_BASED_CONFIG_SETTING.setting().get(settings));
+        hbaConf = convertHbaSettingsToHbaConf(settings);
         this.userLookup = userLookup;
     }
 
-    void updateHbaConfig(Map<String, Map<String, String>> hbaMap) {
-        hbaConf = ImmutableSortedMap.<String, Map<String, String>>naturalOrder().putAll(hbaMap).build();
-    }
-
-    private SortedMap<String, Map<String, String>> convertHbaSettingsToHbaConf(Settings hbaSetting) {
+    @VisibleForTesting
+    SortedMap<String, Map<String, String>> convertHbaSettingsToHbaConf(Settings settings) {
+        Settings hbaSettings = AuthSettings.AUTH_HOST_BASED_CONFIG_SETTING.setting().get(settings);
         ImmutableSortedMap.Builder<String, Map<String, String>> hostBasedConf = ImmutableSortedMap.naturalOrder();
-        for (Map.Entry<String, Settings> entry : hbaSetting.getAsGroups().entrySet()) {
+        for (Map.Entry<String, Settings> entry : hbaSettings.getAsGroups().entrySet()) {
             hostBasedConf.put(entry.getKey(), entry.getValue().getAsMap());
         }
         return hostBasedConf.build();


### PR DESCRIPTION
The first commit:

Ensure natural order of keys in HBA config
----
- The order depended on the order defined in the config but didn't necessarily
result in the natural order of the keys.

The second commit improves the testing of the HBA and adds a test case to ensure natural order of the keys:

Refactor HostBasedAuthenticationTest to test key sorting
---

- Remove test-only code in HostBasedAuthentication
- Enable testing of key prefixes in HBA config
- Add a test case to ensure a natural order of keys in the HBA config.