### PR TITLE
Add toString override for Blobstore classes

### DIFF
--- a/blob/src/main/java/io/crate/blob/BlobTransferRequest.java
+++ b/blob/src/main/java/io/crate/blob/BlobTransferRequest.java
@@ -78,4 +78,12 @@ public abstract class BlobTransferRequest<T extends ReplicationRequest<T>>
     public UUID transferId() {
         return transferId;
     }
+
+    @Override
+    public String toString() {
+        return "BlobTransferRequest{" +
+               "last=" + last +
+               ", transferId=" + transferId +
+               '}';
+    }
 }

--- a/blob/src/main/java/io/crate/blob/DeleteBlobRequest.java
+++ b/blob/src/main/java/io/crate/blob/DeleteBlobRequest.java
@@ -56,4 +56,11 @@ public class DeleteBlobRequest extends ReplicationRequest<DeleteBlobRequest> {
         super.writeTo(out);
         out.write(digest);
     }
+
+    @Override
+    public String toString() {
+        return "DeleteBlobRequest{" +
+               "digest=" + id() +
+               '}';
+    }
 }

--- a/blob/src/main/java/io/crate/blob/PutChunkReplicaRequest.java
+++ b/blob/src/main/java/io/crate/blob/PutChunkReplicaRequest.java
@@ -79,4 +79,14 @@ public class PutChunkReplicaRequest extends ReplicationRequest<PutChunkReplicaRe
     public boolean isLast() {
         return isLast;
     }
+
+    @Override
+    public String toString() {
+        return "PutChunkReplicaRequest{" +
+               "sourceNodeId='" + sourceNodeId + '\'' +
+               ", transferId=" + transferId +
+               ", currentPos=" + currentPos +
+               ", isLast=" + isLast +
+               '}';
+    }
 }


### PR DESCRIPTION
Subclasses of ReplicationRequest should have a toString override in the
Elasticsearch v6.x. All other subclasses already have an override.