### PR TITLE
Fix failing test because of randomized locale.

### DIFF
--- a/sql/src/test/java/io/crate/protocols/postgres/types/TimestampTypeStringDecodeTest.java
+++ b/sql/src/test/java/io/crate/protocols/postgres/types/TimestampTypeStringDecodeTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Locale;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 import static org.hamcrest.Matchers.is;
@@ -60,7 +61,7 @@ public class TimestampTypeStringDecodeTest extends BasePGTypeTest<Long> {
     public void testDecodeEncodeUTF8Text() {
         long expectedMsecs = 1514764800000L;
         String prefix = "2018-01-01 00:00:00";
-        String tzString = String.format("%+03d:00", timezoneDiffInHours);
+        String tzString = String.format(Locale.ENGLISH, "%+03d:00", timezoneDiffInHours);
 
         StringBuilder fullTimestamp = new StringBuilder(prefix);
         appendFractionOfSecDigits(fullTimestamp);


### PR DESCRIPTION
Followup of: 9cff70a14bc44d92b82145b652bbde64cc224fbe