### PR TITLE
Allow cast of Function symbol

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -28,6 +28,13 @@ Changes
 Fixes
 =====
 
+- Avoid downcasts in function expressions which could lead to reduced precision.
+  For example:
+    Select round(float_col) + 1.1 would result in
+      Select round(float_col) + 1
+    but is now resolved to
+      Select to_float(round(float_col)) + 1.1
+
 - Ensured natural order of config keys for the Host Based Authentication.
 
 - Fixed encoding/decoding of ``Timestamp`` type for PostgreSQL wire protocol

--- a/sql/src/main/java/io/crate/analyze/symbol/Function.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/Function.java
@@ -67,6 +67,11 @@ public class Function extends Symbol implements Cloneable {
     }
 
     @Override
+    public boolean canBeCasted() {
+        return info.type() == FunctionInfo.Type.SCALAR || info.type() == FunctionInfo.Type.AGGREGATE;
+    }
+
+    @Override
     public SymbolType symbolType() {
         return SymbolType.FUNCTION;
     }

--- a/sql/src/main/java/io/crate/analyze/symbol/Symbol.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/Symbol.java
@@ -67,7 +67,15 @@ public abstract class Symbol implements FuncArg, Writeable, ExplainLeaf {
     }
 
     /**
-     * Typically, we only allow casting of Literals and undefined types.
+     * We only allow casting of
+     * {@link Literal},
+     * {@link Function},
+     * {@link ParameterSymbol},
+     * and Symbols whose type is undefined.
+     *
+     * The reasoning behind this is that we want to avoid
+     * query Lucene performance to drop due to casts. This
+     * is true for {@link Field}/{@link io.crate.metadata.Reference}.
      */
     @Override
     public boolean canBeCasted() {

--- a/sql/src/test/java/io/crate/analyze/GroupByAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/GroupByAnalyzerTest.java
@@ -414,11 +414,13 @@ public class GroupByAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(relation.querySpec().having().query(), isFunction("op_="));
         Function havingFunction = (Function) relation.querySpec().having().query();
         assertThat(havingFunction.arguments().size(), is(2));
-        assertThat(havingFunction.arguments().get(0), isFunction("max"));
-        Function maxFunction = (Function) havingFunction.arguments().get(0);
+        assertThat(havingFunction.arguments().get(0), isFunction("to_long"));
+        Function castFunction = (Function) havingFunction.arguments().get(0);
+        assertThat(castFunction.arguments().get(0), isFunction("max"));
+        Function maxFunction = (Function) castFunction.arguments().get(0);
 
         assertThat(maxFunction.arguments().get(0), isReference("bytes"));
-        assertThat(havingFunction.arguments().get(1), isLiteral((byte) 4, DataTypes.BYTE));
+        assertThat(havingFunction.arguments().get(1), isLiteral(4L));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/analyze/relations/RelationSplitterTest.java
+++ b/sql/src/test/java/io/crate/analyze/relations/RelationSplitterTest.java
@@ -110,7 +110,7 @@ public class RelationSplitterTest extends CrateUnitTest {
         QuerySpec querySpec = fromQuery("x = 1 and y = 3 and x + y = 4");
         RelationSplitter splitter = split(querySpec);
 
-        assertThat(querySpec, isSQL("SELECT true WHERE (add(doc.t1.x, doc.t2.y) = 4)"));
+        assertThat(querySpec, isSQL("SELECT true WHERE (to_long(add(doc.t1.x, doc.t2.y)) = 4)"));
         assertThat(splitter.getSpec(T3.TR_1), isSQL("SELECT doc.t1.x WHERE (doc.t1.x = 1)"));
         assertThat(splitter.getSpec(T3.TR_2), isSQL("SELECT doc.t2.y WHERE (doc.t2.y = 3)"));
     }
@@ -121,7 +121,7 @@ public class RelationSplitterTest extends CrateUnitTest {
         QuerySpec querySpec = fromQuery("x + y + z = 5").limit(Literal.of(30));
         RelationSplitter splitter = split(querySpec);
 
-        assertThat(querySpec, isSQL("SELECT true WHERE (add(add(doc.t1.x, doc.t2.y), doc.t3.z) = 5) LIMIT 30"));
+        assertThat(querySpec, isSQL("SELECT true WHERE (to_long(add(add(doc.t1.x, doc.t2.y), doc.t3.z)) = 5) LIMIT 30"));
         assertThat(splitter.getSpec(T3.TR_1), isSQL("SELECT doc.t1.x"));
         assertThat(splitter.getSpec(T3.TR_2), isSQL("SELECT doc.t2.y"));
         assertThat(splitter.getSpec(T3.TR_3), isSQL("SELECT doc.t3.z"));

--- a/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -120,7 +120,7 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
     public void testHavingGlobalAggregation() throws Exception {
         LogicalPlan plan = plan("select min(a), min(x) from t1 having min(x) < 33 and max(x) > 100");
         assertThat(plan, isPlan("FetchOrEval[min(a), min(x)]\n" +
-                                "Filter[((min(x) < 33) AND (max(x) > 100))]\n" +
+                                "Filter[((cast(min(x) AS long) < 33) AND (cast(max(x) AS long) > 100))]\n" +
                                 "Aggregate[min(a), min(x), max(x)]\n" +
                                 "Collect[doc.t1 | [a, x] | All]\n"));
     }


### PR DESCRIPTION
By allowing casts of Function symbols, we prevent downcasts in expressions
involving functions as function arguments which have lower precedence than other
arguments. For example:

Select round(float_col) + 1.1

As of now results in: Select round(float_col) + 1
Now this results in: Select to_float(round(int_col)) + 1.1