### PR TITLE
Tests: Don't use keywords as random schema name

### DIFF
--- a/sql-parser/src/main/java/io/crate/sql/Identifiers.java
+++ b/sql-parser/src/main/java/io/crate/sql/Identifiers.java
@@ -60,7 +60,7 @@ public class Identifiers {
         return isKeyWord(identifier);
     }
 
-    private static boolean isKeyWord(String identifier) {
+    public static boolean isKeyWord(String identifier) {
         if (identifier.length() < 1) {
             return false;
         }

--- a/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
@@ -55,6 +55,7 @@ import io.crate.plugin.CrateCorePlugin;
 import io.crate.plugin.HttpTransportPlugin;
 import io.crate.plugin.SQLPlugin;
 import io.crate.protocols.postgres.PostgresNetty;
+import io.crate.sql.Identifiers;
 import io.crate.sql.parser.SqlParser;
 import io.crate.test.GroovyTestSanitizer;
 import io.crate.test.integration.SystemPropsTestLoggingListener;
@@ -689,7 +690,7 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
             Random random = RandomizedContext.current().getRandom();
             while (true) {
                 String schemaName = RandomStrings.randomAsciiOfLengthBetween(random, 1, 20).toLowerCase();
-                if (!CreateTableStatementAnalyzer.READ_ONLY_SCHEMAS.contains(schemaName)) {
+                if (!CreateTableStatementAnalyzer.READ_ONLY_SCHEMAS.contains(schemaName) && !Identifiers.isKeyWord(schemaName)) {
                     return schemaName;
                 }
             }


### PR DESCRIPTION
Some tests don't quote the randomized schema, resulting in a
`SQLParseException` if the randomized schema is a reserved keyword.

For example `TableAliasIntegrationTest` failed with seed
`66B61DA5AB259CDB:215D1BB444DC21B4`.