### PR TITLE
re-analyze where clause after sub-query excution

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -20,3 +20,9 @@ Changes
 
 Fixes
 =====
+
+- Fixed a performance regression resulting in a table scan instead of a NO-MATCH
+  if a sub-query used inside a ``WHERE`` clause returns no result.
+
+- Fixed an issue which resulted in an exception when a routing column was
+  compared against a sub-query inside a ``WHERE`` clause.

--- a/sql/src/main/java/io/crate/analyze/symbol/SelectSymbol.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/SelectSymbol.java
@@ -93,7 +93,7 @@ public class SelectSymbol extends Symbol {
 
     @Override
     public String representation() {
-        return "SubQuery{" + relation.getQualifiedName() + '}';
+        return "SubQuery{" + relation.getQualifiedName() + "}@" + hashCode();
     }
 
     public ResultType getResultType() {

--- a/sql/src/main/java/io/crate/analyze/where/WhereClauseAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/where/WhereClauseAnalyzer.java
@@ -64,10 +64,10 @@ public class WhereClauseAnalyzer {
     /**
      * Replace parameters and sub-queries with the related values and analyze the query afterwards.
      */
-    public static <TR extends AbstractTableRelation> WhereClause bindAndAnalyze(WhereClause where,
+    public static WhereClause bindAndAnalyze(WhereClause where,
                                                                                 Row params,
                                                                                 Map<SelectSymbol, Object> subQueryValues,
-                                                                                TR tableRelation,
+                                                                                AbstractTableRelation tableRelation,
                                                                                 Functions functions,
                                                                                 TransactionContext transactionContext) {
         if (where.hasQuery()) {

--- a/sql/src/main/java/io/crate/analyze/where/WhereClauseAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/where/WhereClauseAnalyzer.java
@@ -27,12 +27,15 @@ import io.crate.analyze.EvaluatingNormalizer;
 import io.crate.analyze.GeneratedColumnExpander;
 import io.crate.analyze.SymbolToTrueVisitor;
 import io.crate.analyze.WhereClause;
+import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.relations.DocTableRelation;
 import io.crate.analyze.symbol.Literal;
+import io.crate.analyze.symbol.SelectSymbol;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.Symbols;
 import io.crate.analyze.symbol.ValueSymbolVisitor;
 import io.crate.collections.Lists2;
+import io.crate.data.Row;
 import io.crate.execution.expression.reference.partitioned.PartitionExpression;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Functions;
@@ -44,6 +47,7 @@ import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocSysColumns;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.planner.WhereClauseOptimizer;
+import io.crate.planner.operators.SubQueryAndParamBinder;
 import org.elasticsearch.common.collect.Tuple;
 
 import javax.annotation.Nullable;
@@ -56,6 +60,27 @@ import java.util.Map;
 import java.util.Set;
 
 public class WhereClauseAnalyzer {
+
+    /**
+     * Replace parameters and sub-queries with the related values and analyze the query afterwards.
+     */
+    public static <TR extends AbstractTableRelation> WhereClause bindAndAnalyze(WhereClause where,
+                                                                                Row params,
+                                                                                Map<SelectSymbol, Object> subQueryValues,
+                                                                                TR tableRelation,
+                                                                                Functions functions,
+                                                                                TransactionContext transactionContext) {
+        if (where.hasQuery()) {
+            Symbol query = SubQueryAndParamBinder.convert(where.query(), params, subQueryValues);
+            if (tableRelation instanceof DocTableRelation) {
+                WhereClauseAnalyzer whereClauseAnalyzer = new WhereClauseAnalyzer(functions, (DocTableRelation) tableRelation);
+                return whereClauseAnalyzer.analyze(query, transactionContext);
+            } else {
+                return new WhereClause(query);
+            }
+        }
+        return where;
+    }
 
     private final Functions functions;
     private final DocTableInfo table;

--- a/sql/src/main/java/io/crate/planner/ExplainLeaf.java
+++ b/sql/src/main/java/io/crate/planner/ExplainLeaf.java
@@ -22,7 +22,7 @@
 
 package io.crate.planner;
 
-import java.util.List;
+import java.util.Collection;
 import java.util.stream.Collectors;
 
 /**
@@ -36,7 +36,7 @@ public interface ExplainLeaf {
     String representation();
 
 
-    static String printList(List<? extends ExplainLeaf> leaves) {
+    static String printList(Collection<? extends ExplainLeaf> leaves) {
         return leaves.stream()
             .map(ExplainLeaf::representation)
             .collect(Collectors.joining(", "));

--- a/sql/src/main/java/io/crate/planner/PlanPrinter.java
+++ b/sql/src/main/java/io/crate/planner/PlanPrinter.java
@@ -25,21 +25,21 @@ import com.google.common.collect.ImmutableMap;
 import io.crate.analyze.WhereClause;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.format.SymbolPrinter;
-import io.crate.planner.distribution.DistributionInfo;
-import io.crate.execution.dsl.phases.UpstreamPhase;
-import io.crate.execution.dsl.phases.ExecutionPhase;
-import io.crate.execution.dsl.phases.ExecutionPhaseVisitor;
 import io.crate.execution.dsl.phases.AbstractProjectionsPhase;
-import io.crate.planner.node.dql.Collect;
 import io.crate.execution.dsl.phases.CollectPhase;
 import io.crate.execution.dsl.phases.CountPhase;
-import io.crate.execution.dsl.phases.MergePhase;
-import io.crate.planner.node.dql.QueryThenFetch;
-import io.crate.execution.dsl.phases.RoutedCollectPhase;
-import io.crate.planner.node.dql.join.NestedLoop;
-import io.crate.execution.dsl.phases.NestedLoopPhase;
+import io.crate.execution.dsl.phases.ExecutionPhase;
+import io.crate.execution.dsl.phases.ExecutionPhaseVisitor;
 import io.crate.execution.dsl.phases.FetchPhase;
+import io.crate.execution.dsl.phases.MergePhase;
+import io.crate.execution.dsl.phases.NestedLoopPhase;
+import io.crate.execution.dsl.phases.RoutedCollectPhase;
+import io.crate.execution.dsl.phases.UpstreamPhase;
 import io.crate.execution.dsl.projection.Projection;
+import io.crate.planner.distribution.DistributionInfo;
+import io.crate.planner.node.dql.Collect;
+import io.crate.planner.node.dql.QueryThenFetch;
+import io.crate.planner.node.dql.join.NestedLoop;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -56,7 +56,7 @@ public class PlanPrinter {
         return ExecutionPlan2MapVisitor.toMap(executionPlan);
     }
 
-    private static List<Object> refs(Collection<? extends Symbol> symbols) {
+    public static List<Object> refs(Collection<? extends Symbol> symbols) {
         List<Object> refs = new ArrayList<>(symbols.size());
         for (Symbol s : symbols) {
             refs.add(SymbolPrinter.INSTANCE.print(s, SymbolPrinter.Style.FULL_QUALIFIED));
@@ -68,7 +68,18 @@ public class PlanPrinter {
 
         public static final ExecutionPhase2MapVisitor INSTANCE = new ExecutionPhase2MapVisitor();
 
-        private ExecutionPhase2MapVisitor() {
+        private static ImmutableMap.Builder<String, Object> subMap(ExecutionPhase phase) {
+            return newBuilder()
+                .put("type", "executionPhase")
+                .put("id", phase.phaseId())
+                // Converting TreeMap.keySet() to be able to stream
+                .put("executionNodes", new ArrayList<>(phase.nodeIds()));
+        }
+
+        private static ImmutableMap.Builder<String, Object> toMap(ExecutionPhase executionPhase,
+                                                                  ImmutableMap.Builder<String, Object> subMap) {
+            return newBuilder()
+                .put(executionPhase.type().toString(), subMap.build());
         }
 
         static ImmutableMap.Builder<String, Object> toBuilder(ExecutionPhase executionPhase) {
@@ -90,14 +101,12 @@ public class PlanPrinter {
             return ImmutableMap.builder();
         }
 
+        private ExecutionPhase2MapVisitor() {
+        }
+
         @Override
         protected ImmutableMap.Builder<String, Object> visitExecutionPhase(ExecutionPhase phase, Void context) {
-            return newBuilder()
-                .put("phaseType", phase.type().toString())
-                .put("id", phase.phaseId())
-                // Converting TreeMap.keySet() to be able to stream
-                .put("executionNodes", new ArrayList<>(phase.nodeIds())
-                );
+            return toMap(phase, subMap(phase));
         }
 
         private ImmutableMap.Builder<String, Object> process(DistributionInfo info) {
@@ -119,46 +128,47 @@ public class PlanPrinter {
 
         @Override
         public ImmutableMap.Builder<String, Object> visitRoutedCollectPhase(RoutedCollectPhase phase, Void context) {
-            ImmutableMap.Builder<String, Object> builder = visitCollectPhase(phase, context);
+            ImmutableMap.Builder<String, Object> builder = upstreamPhase(phase, subMap(phase));
+            builder.put("toCollect", refs(phase.toCollect()));
             builder = dqlPlanNode(phase, builder);
             builder.put("routing", phase.routing().locations());
             WhereClause whereClause = phase.whereClause();
             if (whereClause.hasQuery()) {
                 builder.put("where", whereClause.query().representation());
             }
-            return builder;
+            return toMap(phase, builder);
         }
 
         @Override
         public ImmutableMap.Builder<String, Object> visitCollectPhase(CollectPhase phase, Void context) {
-            ImmutableMap.Builder<String, Object> builder = upstreamPhase(phase, visitExecutionPhase(phase, context));
+            ImmutableMap.Builder<String, Object> builder = upstreamPhase(phase, subMap(phase));
             builder.put("toCollect", refs(phase.toCollect()));
-            return builder;
+            return toMap(phase, builder);
         }
 
         @Override
         public ImmutableMap.Builder<String, Object> visitCountPhase(CountPhase phase, Void context) {
-            return upstreamPhase(phase, visitExecutionPhase(phase, context));
+            return toMap(phase, upstreamPhase(phase, subMap(phase)));
         }
 
         @Override
         public ImmutableMap.Builder<String, Object> visitFetchPhase(FetchPhase phase, Void context) {
-            return visitExecutionPhase(phase, context)
-                .put("fetchRefs", refs(phase.fetchRefs()));
+            return toMap(phase, subMap(phase)
+                .put("fetchRefs", refs(phase.fetchRefs())));
         }
 
         @Override
         public ImmutableMap.Builder<String, Object> visitMergePhase(MergePhase phase, Void context) {
-            ImmutableMap.Builder<String, Object> b = upstreamPhase(phase, visitExecutionPhase(phase, context));
-            return dqlPlanNode(phase, b);
+            ImmutableMap.Builder<String, Object> b = upstreamPhase(phase, subMap(phase));
+            return toMap(phase, dqlPlanNode(phase, b));
         }
 
         @Override
         public ImmutableMap.Builder<String, Object> visitNestedLoopPhase(NestedLoopPhase phase, Void context) {
             ImmutableMap.Builder<String, Object> b = upstreamPhase(
                 phase,
-                visitExecutionPhase(phase, context).put("joinType", phase.joinType()));
-            return dqlPlanNode(phase, b);
+                subMap(phase).put("joinType", phase.joinType()));
+            return toMap(phase, dqlPlanNode(phase, b));
         }
     }
 
@@ -170,10 +180,19 @@ public class PlanPrinter {
             return ImmutableMap.builder();
         }
 
+        private static ImmutableMap.Builder<String, Object> subMap() {
+            return newBuilder().put("type", "executionPlan");
+        }
+
+        private static ImmutableMap.Builder<String, Object> toMap(ExecutionPlan executionPlan,
+                                                                  ImmutableMap.Builder<String, Object> subMap) {
+            return newBuilder()
+                .put(executionPlan.getClass().getSimpleName(), subMap.build());
+        }
+
         @Override
         protected ImmutableMap.Builder<String, Object> visitPlan(ExecutionPlan executionPlan, Void context) {
-            return newBuilder()
-                .put("planType", executionPlan.getClass().getSimpleName());
+            return toMap(executionPlan, subMap());
         }
 
         private static Map<String, Object> phaseMap(@Nullable ExecutionPhase node) {
@@ -191,40 +210,38 @@ public class PlanPrinter {
 
         @Override
         public ImmutableMap.Builder<String, Object> visitCollect(Collect plan, Void context) {
-            ImmutableMap.Builder<String, Object> b = visitPlan(plan, context)
-                .put("collectPhase", phaseMap(plan.collectPhase()));
-            return b;
+            return toMap(plan, subMap()
+                .put("collectPhase", phaseMap(plan.collectPhase())));
         }
 
         @Override
         public ImmutableMap.Builder<String, Object> visitNestedLoop(NestedLoop plan, Void context) {
-            return newBuilder()
-                .put("planType", plan.getClass().getSimpleName())
+            return toMap(plan, subMap()
                 .put("left", process(plan.left(), context).build())
                 .put("right", process(plan.right(), context).build())
-                .put("nestedLoopPhase", phaseMap(plan.nestedLoopPhase()));
+                .put("nestedLoopPhase", phaseMap(plan.nestedLoopPhase())));
         }
 
         @Override
         public ImmutableMap.Builder<String, Object> visitQueryThenFetch(QueryThenFetch plan, Void context) {
-            return visitPlan(plan, context)
+            return toMap(plan, subMap()
                 .put("subPlan", toMap(plan.subPlan()))
-                .put("fetchPhase", phaseMap(plan.fetchPhase()));
+                .put("fetchPhase", phaseMap(plan.fetchPhase())));
         }
 
         @Override
         public ImmutableMap.Builder<String, Object> visitMerge(Merge merge, Void context) {
-            return visitPlan(merge, context)
+            return toMap(merge, subMap()
                 .put("subPlan", toMap(merge.subPlan()))
-                .put("mergePhase", phaseMap(merge.mergePhase()));
+                .put("mergePhase", phaseMap(merge.mergePhase())));
         }
 
         @Override
         public ImmutableMap.Builder<String, Object> visitUnionPlan(UnionExecutionPlan unionExecutionPlan, Void context) {
-            return visitPlan(unionExecutionPlan, context)
+            return toMap(unionExecutionPlan, subMap()
                 .put("left", toMap(unionExecutionPlan.left()))
                 .put("right", toMap(unionExecutionPlan.right()))
-                .put("mergePhase", phaseMap(unionExecutionPlan.mergePhase()));
+                .put("mergePhase", phaseMap(unionExecutionPlan.mergePhase())));
         }
     }
 }

--- a/sql/src/main/java/io/crate/planner/node/management/ExplainPlan.java
+++ b/sql/src/main/java/io/crate/planner/node/management/ExplainPlan.java
@@ -27,7 +27,6 @@ import io.crate.data.InMemoryBatchIterator;
 import io.crate.data.Row;
 import io.crate.data.Row1;
 import io.crate.data.RowConsumer;
-import io.crate.execution.engine.pipeline.TopN;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.Plan;
@@ -61,16 +60,7 @@ public class ExplainPlan implements Plan {
         Map<String, Object> map;
         try {
             if (subPlan instanceof LogicalPlan) {
-                ExecutionPlan executionPlan = ((LogicalPlan) subPlan).build(
-                    plannerContext,
-                    executor.projectionBuilder(),
-                    TopN.NO_LIMIT,
-                    0,
-                    null,
-                    null,
-                    params,
-                    valuesBySubQuery);
-                map = PlanPrinter.objectMap(executionPlan);
+                map = ((LogicalPlan) subPlan).explainMap(plannerContext, executor.projectionBuilder());
             } else if (subPlan instanceof CopyStatementPlanner.CopyFrom) {
                 ExecutionPlan executionPlan = CopyStatementPlanner.planCopyFromExecution(
                     executor.clusterService().state().nodes(),

--- a/sql/src/main/java/io/crate/planner/node/management/ExplainPlan.java
+++ b/sql/src/main/java/io/crate/planner/node/management/ExplainPlan.java
@@ -32,6 +32,7 @@ import io.crate.planner.ExecutionPlan;
 import io.crate.planner.Plan;
 import io.crate.planner.PlanPrinter;
 import io.crate.planner.PlannerContext;
+import io.crate.planner.operators.ExplainLogicalPlan;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.statement.CopyStatementPlanner;
 
@@ -60,7 +61,7 @@ public class ExplainPlan implements Plan {
         Map<String, Object> map;
         try {
             if (subPlan instanceof LogicalPlan) {
-                map = ((LogicalPlan) subPlan).explainMap(plannerContext, executor.projectionBuilder());
+                map = ExplainLogicalPlan.explainMap((LogicalPlan) subPlan, plannerContext, executor.projectionBuilder());
             } else if (subPlan instanceof CopyStatementPlanner.CopyFrom) {
                 ExecutionPlan executionPlan = CopyStatementPlanner.planCopyFromExecution(
                     executor.clusterService().state().nodes(),

--- a/sql/src/main/java/io/crate/planner/operators/Count.java
+++ b/sql/src/main/java/io/crate/planner/operators/Count.java
@@ -23,8 +23,8 @@
 package io.crate.planner.operators;
 
 import io.crate.analyze.OrderBy;
-import io.crate.analyze.QueriedTableRelation;
 import io.crate.analyze.WhereClause;
+import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.SelectSymbol;
 import io.crate.analyze.where.WhereClauseAnalyzer;
@@ -52,12 +52,12 @@ public class Count extends ZeroInputPlan {
 
     private static final String COUNT_PHASE_NAME = "count-merge";
 
-    final QueriedTableRelation relation;
+    final AbstractTableRelation tableRelation;
     final WhereClause where;
 
-    Count(Function countFunction, QueriedTableRelation relation, WhereClause where) {
-        super(Collections.singletonList(countFunction), Collections.singletonList(relation.tableRelation()));
-        this.relation = relation;
+    Count(Function countFunction, AbstractTableRelation tableRelation, WhereClause where) {
+        super(Collections.singletonList(countFunction), Collections.singletonList(tableRelation));
+        this.tableRelation = tableRelation;
         this.where = where;
     }
 
@@ -76,12 +76,12 @@ public class Count extends ZeroInputPlan {
             where,
             params,
             subQueryValues,
-            relation.tableRelation(),
+            tableRelation,
             plannerContext.functions(),
             plannerContext.transactionContext());
 
         Routing routing = plannerContext.allocateRouting(
-            relation.tableRelation().tableInfo(),
+            tableRelation.tableInfo(),
             boundWhere,
             RoutingProvider.ShardSelection.ANY,
             plannerContext.transactionContext().sessionContext());

--- a/sql/src/main/java/io/crate/planner/operators/ExplainLogicalPlan.java
+++ b/sql/src/main/java/io/crate/planner/operators/ExplainLogicalPlan.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.operators;
+
+import com.google.common.collect.ImmutableMap;
+import io.crate.analyze.OrderBy;
+import io.crate.analyze.symbol.Function;
+import io.crate.analyze.symbol.SelectSymbol;
+import io.crate.analyze.symbol.Symbol;
+import io.crate.analyze.symbol.format.SymbolPrinter;
+import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
+import io.crate.planner.PlannerContext;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static io.crate.planner.PlanPrinter.refs;
+
+public class ExplainLogicalPlan {
+
+    private static final Visitor VISITOR = new Visitor();
+
+    public static Map<String, Object> objectMap(LogicalPlan logicalPlan,
+                                                PlannerContext plannerContext,
+                                                ProjectionBuilder projectionBuilder) {
+        return VISITOR.process(logicalPlan, new Context(plannerContext, projectionBuilder)).build();
+    }
+
+    private static class Context {
+        private final PlannerContext plannerContext;
+        private final ProjectionBuilder projectionBuilder;
+
+        public Context(PlannerContext plannerContext, ProjectionBuilder projectionBuilder) {
+            this.plannerContext = plannerContext;
+            this.projectionBuilder = projectionBuilder;
+        }
+    }
+
+    private static class Visitor extends LogicalPlanVisitor<Context, ImmutableMap.Builder<String, Object>> {
+
+        private static ImmutableMap.Builder<String, Object> newBuilder() {
+            return ImmutableMap.builder();
+        }
+
+        private static ImmutableMap.Builder<String, Object> subMap() {
+            return newBuilder().put("type", "logicalOperator");
+        }
+
+        private static ImmutableMap.Builder<String, Object> toMap(LogicalPlan logicalPlan,
+                                                                  ImmutableMap.Builder<String, Object> subMap) {
+            return newBuilder()
+                .put(logicalPlan.getClass().getSimpleName(), subMap.build());
+        }
+
+        private static Map<String, Object> explainMap(LogicalPlan logicalPlan, Context context) {
+            return logicalPlan.explainMap(context.plannerContext, context.projectionBuilder);
+        }
+
+        @Override
+        protected ImmutableMap.Builder<String, Object> visitPlan(LogicalPlan logicalPlan, Context context) {
+            return toMap(logicalPlan, subMap());
+        }
+
+        @Override
+        public ImmutableMap.Builder<String, Object> visitMultiPhase(MultiPhase logicalPlan, Context context) {
+            Map<String, Map<String, Object>> dependencies = new HashMap<>(logicalPlan.dependencies().size());
+            for (Map.Entry<LogicalPlan, SelectSymbol> entry : logicalPlan.dependencies().entrySet()) {
+                dependencies.put(entry.getValue().representation(), explainMap(entry.getKey(), context));
+            }
+            return toMap(logicalPlan, subMap()
+                .put("source", explainMap(logicalPlan.source, context))
+                .put("dependencies", dependencies));
+        }
+
+        @Override
+        public ImmutableMap.Builder<String, Object> visitFetchOrEval(FetchOrEval logicalPlan, Context context) {
+            return toMap(logicalPlan, subMap()
+                .put("fetchRefs", refs(logicalPlan.outputs()))
+                .put("source", explainMap(logicalPlan.source, context)));
+        }
+
+        @Override
+        public ImmutableMap.Builder<String, Object> visitCollect(Collect logicalPlan, Context context) {
+            return toMap(logicalPlan, subMap()
+                .put("toCollect", refs(logicalPlan.outputs()))
+                .put("where", logicalPlan.where.query().representation()));
+        }
+
+        @Override
+        public ImmutableMap.Builder<String, Object> visitLimit(Limit logicalPlan, Context context) {
+            return toMap(logicalPlan, subMap()
+                .put("limit", SymbolPrinter.INSTANCE.print(logicalPlan.limit, SymbolPrinter.Style.FULL_QUALIFIED))
+                .put("offset", SymbolPrinter.INSTANCE.print(logicalPlan.offset, SymbolPrinter.Style.FULL_QUALIFIED))
+                .put("source", explainMap(logicalPlan.source, context)));
+        }
+
+        @Override
+        public ImmutableMap.Builder<String, Object> visitCount(Count logicalPlan, Context context) {
+            return toMap(logicalPlan, subMap()
+                .put("where", logicalPlan.where.query().representation()));
+        }
+
+        @Override
+        public ImmutableMap.Builder<String, Object> visitGet(Get logicalPlan, Context context) {
+            return toMap(logicalPlan, subMap()
+                .put("toCollect", refs(logicalPlan.outputs()))
+                .put("docKeys", logicalPlan.docKeys.toString()));
+        }
+
+        @Override
+        public ImmutableMap.Builder<String, Object> visitFilter(Filter logicalPlan, Context context) {
+            return toMap(logicalPlan, subMap()
+                .put("filter", logicalPlan.queryClause.query().representation())
+                .put("source", explainMap(logicalPlan.source, context)));
+        }
+
+        @Override
+        public ImmutableMap.Builder<String, Object> visitOrder(Order logicalPlan, Context context) {
+            OrderBy orderBy = logicalPlan.orderBy;
+            StringBuilder sb = new StringBuilder();
+            OrderBy.explainRepresentation(sb, orderBy.orderBySymbols(), orderBy.reverseFlags(), orderBy.nullsFirst());
+            return toMap(logicalPlan, subMap()
+                .put("orderBy", sb.toString())
+                .put("source", explainMap(logicalPlan.source, context)));
+        }
+
+        @Override
+        public ImmutableMap.Builder<String, Object> visitUnion(Union logicalPlan, Context context) {
+            return toMap(logicalPlan, subMap()
+                .put("left", explainMap(logicalPlan.lhs, context))
+                .put("right", explainMap(logicalPlan.rhs, context)));
+        }
+
+        @Override
+        public ImmutableMap.Builder<String, Object> visitJoin(Join logicalPlan, Context context) {
+            return toMap(logicalPlan, subMap()
+                .put("left", explainMap(logicalPlan.lhs, context))
+                .put("right", explainMap(logicalPlan.rhs, context))
+                .put("joinType", logicalPlan.joinType)
+                .put("joinCondition", SymbolPrinter.INSTANCE.print(logicalPlan.joinCondition, SymbolPrinter.Style.FULL_QUALIFIED)));
+        }
+
+        @Override
+        public ImmutableMap.Builder<String, Object> visitGroupHashAggregate(GroupHashAggregate logicalPlan, Context context) {
+            List<Object> aggregates = new ArrayList<>(logicalPlan.aggregates);
+            for (Function function : logicalPlan.aggregates) {
+                aggregates.add(SymbolPrinter.INSTANCE.print(function, SymbolPrinter.Style.FULL_QUALIFIED));
+            }
+            List<Object> groupKeys = new ArrayList<>(logicalPlan.groupKeys);
+            for (Symbol symbol : logicalPlan.groupKeys) {
+                aggregates.add(SymbolPrinter.INSTANCE.print(symbol, SymbolPrinter.Style.FULL_QUALIFIED));
+            }
+            return toMap(logicalPlan, subMap()
+                .put("aggregates", aggregates)
+                .put("groupKeys", groupKeys)
+                .put("source", explainMap(logicalPlan.source, context)));
+        }
+
+        @Override
+        public ImmutableMap.Builder<String, Object> visitHashAggregate(HashAggregate logicalPlan, Context context) {
+            List<Object> aggregates = new ArrayList<>(logicalPlan.aggregates);
+            for (Function function : logicalPlan.aggregates) {
+                aggregates.add(SymbolPrinter.INSTANCE.print(function, SymbolPrinter.Style.FULL_QUALIFIED));
+            }
+            return toMap(logicalPlan, subMap()
+                .put("aggregates", aggregates)
+                .put("source", explainMap(logicalPlan.source, context)));
+        }
+
+        @Override
+        public ImmutableMap.Builder<String, Object> visitInsert(Insert logicalPlan, Context context) {
+            return toMap(logicalPlan, subMap()
+                .put("projection", logicalPlan.projection.mapRepresentation())
+                .put("source", explainMap(logicalPlan.source, context)));
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/planner/operators/FetchOrEval.java
+++ b/sql/src/main/java/io/crate/planner/operators/FetchOrEval.java
@@ -453,4 +453,9 @@ class FetchOrEval extends OneInputPlan {
                ", out=" + outputs +
                '}';
     }
+
+    @Override
+    public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
+        return visitor.visitFetchOrEval(this, context);
+    }
 }

--- a/sql/src/main/java/io/crate/planner/operators/Filter.java
+++ b/sql/src/main/java/io/crate/planner/operators/Filter.java
@@ -108,4 +108,9 @@ class Filter extends OneInputPlan {
     protected LogicalPlan updateSource(LogicalPlan newSource) {
         return new Filter(newSource, queryClause);
     }
+
+    @Override
+    public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
+        return visitor.visitFilter(this, context);
+    }
 }

--- a/sql/src/main/java/io/crate/planner/operators/Get.java
+++ b/sql/src/main/java/io/crate/planner/operators/Get.java
@@ -131,8 +131,14 @@ public class Get extends ZeroInputPlan {
         );
     }
 
+    @Override
     public long numExpectedRows() {
         return docKeys.size();
+    }
+
+    @Override
+    public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
+        return visitor.visitGet(this, context);
     }
 
     public static String indexName(DocTableInfo tableInfo, @Nullable List<BytesRef> partitionValues) {

--- a/sql/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
+++ b/sql/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
@@ -56,8 +56,8 @@ import static io.crate.planner.operators.LogicalPlanner.extractColumns;
 public class GroupHashAggregate extends OneInputPlan {
 
     private static final String DISTRIBUTED_MERGE_PHASE_NAME = "distributed merge";
-    private final List<Function> aggregates;
-    private final List<Symbol> groupKeys;
+    final List<Function> aggregates;
+    final List<Symbol> groupKeys;
 
     public static Builder create(Builder source, List<Symbol> groupKeys, List<Function> aggregates) {
         return (tableStats, parentUsedCols) -> {
@@ -189,6 +189,11 @@ public class GroupHashAggregate extends OneInputPlan {
     public long numExpectedRows() {
         // We don't have any cardinality estimates
         return source.numExpectedRows();
+    }
+
+    @Override
+    public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
+        return visitor.visitGroupHashAggregate(this, context);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/HashAggregate.java
+++ b/sql/src/main/java/io/crate/planner/operators/HashAggregate.java
@@ -140,7 +140,7 @@ public class HashAggregate extends OneInputPlan {
             aggregates.get(0).info().equals(CountAggregation.COUNT_STAR_FUNCTION)) {
 
             Collect collect = (Collect) collapsed;
-            return new Count(aggregates.get(0), collect.relation.tableRelation(), collect.where);
+            return new Count(aggregates.get(0), collect.relation, collect.where);
         }
         if (collapsed == source) {
             return this;
@@ -161,6 +161,11 @@ public class HashAggregate extends OneInputPlan {
     @Override
     public long numExpectedRows() {
         return 1L;
+    }
+
+    @Override
+    public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
+        return visitor.visitHashAggregate(this, context);
     }
 
     private static class OutputValidatorContext {

--- a/sql/src/main/java/io/crate/planner/operators/HashAggregate.java
+++ b/sql/src/main/java/io/crate/planner/operators/HashAggregate.java
@@ -140,7 +140,7 @@ public class HashAggregate extends OneInputPlan {
             aggregates.get(0).info().equals(CountAggregation.COUNT_STAR_FUNCTION)) {
 
             Collect collect = (Collect) collapsed;
-            return new Count(aggregates.get(0), collect.relation, collect.where);
+            return new Count(aggregates.get(0), collect.relation.tableRelation(), collect.where);
         }
         if (collapsed == source) {
             return this;

--- a/sql/src/main/java/io/crate/planner/operators/Insert.java
+++ b/sql/src/main/java/io/crate/planner/operators/Insert.java
@@ -43,7 +43,7 @@ import java.util.Map;
 public class Insert extends OneInputPlan {
 
     private final QueriedRelation relation;
-    private final ColumnIndexWriterProjection projection;
+    final ColumnIndexWriterProjection projection;
 
     public Insert(LogicalPlan source, QueriedRelation relation, ColumnIndexWriterProjection projection) {
         super(source);
@@ -94,5 +94,10 @@ public class Insert extends OneInputPlan {
     @Override
     public long numExpectedRows() {
         return 1;
+    }
+
+    @Override
+    public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
+        return visitor.visitInsert(this, context);
     }
 }

--- a/sql/src/main/java/io/crate/planner/operators/Join.java
+++ b/sql/src/main/java/io/crate/planner/operators/Join.java
@@ -80,7 +80,7 @@ public class Join extends TwoInputPlan {
     final JoinType joinType;
 
     @Nullable
-    private final Symbol joinCondition;
+    final Symbol joinCondition;
     private final boolean isFiltered;
 
     static Builder createNodes(MultiSourceSelect mss, WhereClause where, SubqueryPlanner subqueryPlanner) {
@@ -457,5 +457,10 @@ public class Join extends TwoInputPlan {
             // We don't have any cardinality estimates, so just take the bigger table
             return Math.max(lhs.numExpectedRows(), rhs.numExpectedRows());
         }
+    }
+
+    @Override
+    public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
+        return visitor.visitJoin(this, context);
     }
 }

--- a/sql/src/main/java/io/crate/planner/operators/Limit.java
+++ b/sql/src/main/java/io/crate/planner/operators/Limit.java
@@ -125,6 +125,11 @@ class Limit extends OneInputPlan {
                '}';
     }
 
+    @Override
+    public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
+        return visitor.visitLimit(this, context);
+    }
+
     static int limitAndOffset(int limit, int offset) {
         if (limit == TopN.NO_LIMIT) {
             return limit;

--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlan.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlan.java
@@ -29,16 +29,13 @@ import io.crate.analyze.symbol.Symbol;
 import io.crate.data.Row;
 import io.crate.data.RowConsumer;
 import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
-import io.crate.execution.engine.pipeline.TopN;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.Plan;
-import io.crate.planner.PlanPrinter;
 import io.crate.planner.PlannerContext;
 import io.crate.planner.TableStats;
 
 import javax.annotation.Nullable;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -218,24 +215,6 @@ public interface LogicalPlan extends Plan {
                          Row params,
                          Map<SelectSymbol, Object> valuesBySubQuery) {
         LogicalPlanner.execute(this, executor, plannerContext, consumer, params, valuesBySubQuery);
-    }
-
-    default Map<String, Object> explainMap(PlannerContext plannerContext,
-                                           ProjectionBuilder projectionBuilder) {
-        try {
-            ExecutionPlan executionPlan = build(
-                plannerContext,
-                projectionBuilder,
-                TopN.NO_LIMIT,
-                0,
-                null,
-                null,
-                Row.EMPTY,
-                Collections.emptyMap());
-            return PlanPrinter.objectMap(executionPlan);
-        } catch (Exception e) {
-            return ExplainLogicalPlan.objectMap(this, plannerContext, projectionBuilder);
-        }
     }
 
     <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context);

--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlanVisitor.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlanVisitor.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.operators;
+
+import javax.annotation.Nullable;
+
+public class LogicalPlanVisitor<C, R> {
+
+    public R process(LogicalPlan logicalPlan, @Nullable C context) {
+        return logicalPlan.accept(this, context);
+    }
+
+    protected R visitPlan(LogicalPlan logicalPlan, C context) {
+        return null;
+    }
+
+    public R visitMultiPhase(MultiPhase logicalPlan, C context) {
+        return visitPlan(logicalPlan, context);
+    }
+
+    public R visitCollect(Collect logicalPlan, C context) {
+        return visitPlan(logicalPlan, context);
+    }
+
+    public R visitCount(Count logicalPlan, C context) {
+        return visitPlan(logicalPlan, context);
+    }
+
+    public R visitGet(Get logicalPlan, C context) {
+        return visitPlan(logicalPlan, context);
+    }
+
+    public R visitFetchOrEval(FetchOrEval logicalPlan, C context) {
+        return visitPlan(logicalPlan, context);
+    }
+
+    public R visitFilter(Filter logicalPlan, C context) {
+        return visitPlan(logicalPlan, context);
+    }
+
+    public R visitGroupHashAggregate(GroupHashAggregate logicalPlan, C context) {
+        return visitPlan(logicalPlan, context);
+    }
+
+    public R visitHashAggregate(HashAggregate logicalPlan, C context) {
+        return visitPlan(logicalPlan, context);
+    }
+
+    public R visitInsert(Insert logicalPlan, C context) {
+        return visitPlan(logicalPlan, context);
+    }
+
+    public R visitJoin(Join logicalPlan, C context) {
+        return visitPlan(logicalPlan, context);
+    }
+
+    public R visitLimit(Limit logicalPlan, C context) {
+        return visitPlan(logicalPlan, context);
+    }
+
+    public R visitOrder(Order logicalPlan, C context) {
+        return visitPlan(logicalPlan, context);
+    }
+
+    public R visitRelationBoundary(RelationBoundary logicalPlan, C context) {
+        return visitPlan(logicalPlan, context);
+    }
+
+    public R visitRootRelationBoundary(RootRelationBoundary logicalPlan, C context) {
+        return visitPlan(logicalPlan, context);
+    }
+
+    public R visitUnion(Union logicalPlan, C context) {
+        return visitPlan(logicalPlan, context);
+    }
+}

--- a/sql/src/main/java/io/crate/planner/operators/MultiPhase.java
+++ b/sql/src/main/java/io/crate/planner/operators/MultiPhase.java
@@ -26,11 +26,11 @@ import io.crate.analyze.OrderBy;
 import io.crate.analyze.relations.QueriedRelation;
 import io.crate.analyze.symbol.SelectSymbol;
 import io.crate.data.Row;
+import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.MultiPhasePlan;
 import io.crate.planner.PlannerContext;
 import io.crate.planner.SubqueryPlanner;
-import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
 
 import javax.annotation.Nullable;
 import java.util.Map;
@@ -77,5 +77,10 @@ public class MultiPhase extends OneInputPlan {
     @Override
     public long numExpectedRows() {
         return source.numExpectedRows();
+    }
+
+    @Override
+    public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
+        return visitor.visitMultiPhase(this, context);
     }
 }

--- a/sql/src/main/java/io/crate/planner/operators/Order.java
+++ b/sql/src/main/java/io/crate/planner/operators/Order.java
@@ -151,4 +151,9 @@ class Order extends OneInputPlan {
                ", " + orderBy +
                '}';
     }
+
+    @Override
+    public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
+        return visitor.visitOrder(this, context);
+    }
 }

--- a/sql/src/main/java/io/crate/planner/operators/RelationBoundary.java
+++ b/sql/src/main/java/io/crate/planner/operators/RelationBoundary.java
@@ -132,4 +132,14 @@ public class RelationBoundary extends OneInputPlan {
     protected LogicalPlan updateSource(LogicalPlan newSource) {
         return new RelationBoundary(newSource, relation, outputs, expressionMapping, dependencies);
     }
+
+    @Override
+    public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
+        return visitor.visitRelationBoundary(this, context);
+    }
+
+    @Override
+    public Map<String, Object> explainMap(PlannerContext plannerContext, ProjectionBuilder projectionBuilder) {
+        return source.explainMap(plannerContext, projectionBuilder);
+    }
 }

--- a/sql/src/main/java/io/crate/planner/operators/RelationBoundary.java
+++ b/sql/src/main/java/io/crate/planner/operators/RelationBoundary.java
@@ -137,9 +137,4 @@ public class RelationBoundary extends OneInputPlan {
     public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
         return visitor.visitRelationBoundary(this, context);
     }
-
-    @Override
-    public Map<String, Object> explainMap(PlannerContext plannerContext, ProjectionBuilder projectionBuilder) {
-        return source.explainMap(plannerContext, projectionBuilder);
-    }
 }

--- a/sql/src/main/java/io/crate/planner/operators/RootRelationBoundary.java
+++ b/sql/src/main/java/io/crate/planner/operators/RootRelationBoundary.java
@@ -74,11 +74,6 @@ public class RootRelationBoundary extends OneInputPlan {
     }
 
     @Override
-    public Map<String, Object> explainMap(PlannerContext plannerContext, ProjectionBuilder projectionBuilder) {
-        return source.explainMap(plannerContext, projectionBuilder);
-    }
-
-    @Override
     public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
         return visitor.visitRootRelationBoundary(this, context);
     }

--- a/sql/src/main/java/io/crate/planner/operators/RootRelationBoundary.java
+++ b/sql/src/main/java/io/crate/planner/operators/RootRelationBoundary.java
@@ -72,4 +72,14 @@ public class RootRelationBoundary extends OneInputPlan {
     public String toString() {
         return "RootBoundary{" + source + '}';
     }
+
+    @Override
+    public Map<String, Object> explainMap(PlannerContext plannerContext, ProjectionBuilder projectionBuilder) {
+        return source.explainMap(plannerContext, projectionBuilder);
+    }
+
+    @Override
+    public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
+        return visitor.visitRootRelationBoundary(this, context);
+    }
 }

--- a/sql/src/main/java/io/crate/planner/operators/Union.java
+++ b/sql/src/main/java/io/crate/planner/operators/Union.java
@@ -196,6 +196,11 @@ public class Union extends TwoInputPlan {
         return lhs.numExpectedRows() + rhs.numExpectedRows();
     }
 
+    @Override
+    public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
+        return visitor.visitUnion(this, context);
+    }
+
     /**
      * Wraps the plan inside a Merge plan if limit or offset need to be applied.
      */

--- a/sql/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
@@ -683,4 +683,20 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
                 "5\n" +
                 "6\n"));
     }
+
+    /**
+     * Test that results from subQueries are bound to the parent query's where clause
+     * BEFORE creating any execution phase (for this test case: before resolving the routing)
+     */
+    @Test
+    public void testWhereSubsSelectAsClusteredByValue() {
+        execute("create table t1 (id int, r int) clustered by(r)");
+        execute("insert into t1 (id, r) values (1, 1), (2, 2)");
+        refresh();
+        execute("select id from t1 where r = (select r from t1 where id = 1)");
+        assertThat(response.rowCount(), is(1L));
+
+        execute("select count(*) from t1 where r = (select r from t1 where id = 1)");
+        assertThat(response.rowCount(), is(1L));
+    }
 }

--- a/sql/src/test/java/io/crate/integrationtests/SysClusterTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysClusterTest.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 
 public class SysClusterTest extends SQLTransportIntegrationTest {
@@ -57,7 +58,7 @@ public class SysClusterTest extends SQLTransportIntegrationTest {
         execute("explain select * from sys.cluster limit 2"); // using limit to test projection serialization as well
         assertThat(response.rowCount(), is(1L));
         Map<String, Object> map = (Map<String, Object>) response.rows()[0][0];
-        assertThat(map.get("planType"), is("Collect"));
+        assertThat(map.keySet(), contains("Collect"));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/planner/ExplainPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/ExplainPlannerTest.java
@@ -23,7 +23,9 @@
 package io.crate.planner;
 
 import com.google.common.collect.ImmutableList;
+import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
 import io.crate.planner.node.management.ExplainPlan;
+import io.crate.planner.operators.LogicalPlan;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import org.junit.Before;
@@ -32,6 +34,7 @@ import org.junit.Test;
 import java.util.List;
 import java.util.Map;
 
+import static io.crate.testing.TestingHelpers.getFunctions;
 import static org.hamcrest.Matchers.greaterThan;
 
 public class ExplainPlannerTest extends CrateDummyClusterServiceUnitTest {
@@ -65,10 +68,11 @@ public class ExplainPlannerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testPrinter() throws Exception {
         for (String statement : EXPLAIN_TEST_STATEMENTS) {
-            ExecutionPlan plan = e.plan(statement);
+            LogicalPlan plan = e.logicalPlan(statement);
             Map<String, Object> map = null;
             try {
-                map = PlanPrinter.objectMap(plan);
+                map = plan.explainMap(
+                    e.getPlannerContext(clusterService.state()), new ProjectionBuilder(getFunctions()));
             } catch (Exception e) {
                 fail("statement not printable: " + statement);
             }

--- a/sql/src/test/java/io/crate/planner/ExplainPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/ExplainPlannerTest.java
@@ -25,6 +25,7 @@ package io.crate.planner;
 import com.google.common.collect.ImmutableList;
 import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
 import io.crate.planner.node.management.ExplainPlan;
+import io.crate.planner.operators.ExplainLogicalPlan;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
@@ -57,7 +58,7 @@ public class ExplainPlannerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
-    public void testExplain() throws Exception {
+    public void testExplain() {
         for (String statement : EXPLAIN_TEST_STATEMENTS) {
             ExplainPlan plan = e.plan("explain " + statement);
             assertNotNull(plan);
@@ -66,13 +67,15 @@ public class ExplainPlannerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
-    public void testPrinter() throws Exception {
+    public void testPrinter() {
         for (String statement : EXPLAIN_TEST_STATEMENTS) {
             LogicalPlan plan = e.logicalPlan(statement);
             Map<String, Object> map = null;
             try {
-                map = plan.explainMap(
-                    e.getPlannerContext(clusterService.state()), new ProjectionBuilder(getFunctions()));
+                map = ExplainLogicalPlan.explainMap(
+                    plan,
+                    e.getPlannerContext(clusterService.state()),
+                    new ProjectionBuilder(getFunctions()));
             } catch (Exception e) {
                 fail("statement not printable: " + statement);
             }

--- a/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -343,7 +343,7 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
             if (plan instanceof Count) {
                 Count count = (Count) plan;
                 startLine("Count[");
-                sb.append(count.relation.tableRelation().tableInfo().ident());
+                sb.append(count.tableRelation.tableInfo().ident());
                 sb.append(" | ");
                 sb.append(printQueryClause(symbolPrinter, count.where));
                 sb.append("]\n");

--- a/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -343,7 +343,7 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
             if (plan instanceof Count) {
                 Count count = (Count) plan;
                 startLine("Count[");
-                sb.append(count.tableRelation.tableInfo().ident());
+                sb.append(count.relation.tableRelation().tableInfo().ident());
                 sb.append(" | ");
                 sb.append(printQueryClause(symbolPrinter, count.where));
                 sb.append("]\n");


### PR DESCRIPTION
This fixes:
 - that a query was executed as a table scan and a generic "null" filter
   instead of immediately returning a NO-MATCH result when the included subquery
   returns no result. (https://github.com/crate/crate/issues/6773)
 - that an exception was raised when a subquery was used in comparison with a
   routing/clustered-by column.

Also it was required to adjust how an explain plan output is generated because
a logical plan containing a sub-query symbol cannot be built into an execution plan without
executing the sub-queries. Introducing a logical plan printer which kicks in if building 
an execution plan (and so using the execution plan printer) fails.