### PR TITLE
Change custom ComparatorSource implementations to not extend XFieldComparatorSource

### DIFF
--- a/sql/src/main/java/io/crate/execution/engine/sort/NullFieldComparatorSource.java
+++ b/sql/src/main/java/io/crate/execution/engine/sort/NullFieldComparatorSource.java
@@ -22,12 +22,13 @@
 
 package io.crate.execution.engine.sort;
 
+import io.crate.execution.expression.reference.doc.lucene.LuceneMissingValue;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.FieldComparator;
+import org.apache.lucene.search.FieldComparatorSource;
 import org.apache.lucene.search.LeafFieldComparator;
 import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.SortField;
-import org.elasticsearch.index.fielddata.IndexFieldData;
 
 import java.io.IOException;
 
@@ -37,9 +38,8 @@ import java.io.IOException;
  * <p>
  * Only used on shards with no values for the compared field.
  */
-class NullFieldComparatorSource extends IndexFieldData.XFieldComparatorSource {
+class NullFieldComparatorSource extends FieldComparatorSource {
 
-    private final SortField.Type sortFieldType;
     private final Object missingValue;
     private static final LeafFieldComparator LEAF_FIELD_COMPARATOR = new LeafFieldComparator() {
         @Override
@@ -66,13 +66,7 @@ class NullFieldComparatorSource extends IndexFieldData.XFieldComparatorSource {
     };
 
     NullFieldComparatorSource(SortField.Type sortFieldType, boolean reversed, Boolean nullsFirst) {
-        this.sortFieldType = sortFieldType;
-        missingValue = missingObject(SortOrder.missing(reversed, nullsFirst), reversed);
-    }
-
-    @Override
-    public SortField.Type reducedType() {
-        return sortFieldType;
+        missingValue = LuceneMissingValue.missingValue(reversed, nullsFirst, sortFieldType);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/execution/engine/sort/SortOrder.java
+++ b/sql/src/main/java/io/crate/execution/engine/sort/SortOrder.java
@@ -24,8 +24,8 @@ package io.crate.execution.engine.sort;
 
 class SortOrder {
 
-    static Object missing(boolean reverseFlag, Boolean nullFirst) {
-        Object missing = "_last";
+    static String missing(boolean reverseFlag, Boolean nullFirst) {
+        String missing = "_last";
         if (reverseFlag) {
             missing = "_first";     // null > 'anyValue'; null values at the beginning.
         }

--- a/sql/src/main/java/io/crate/execution/engine/sort/SortSymbolVisitor.java
+++ b/sql/src/main/java/io/crate/execution/engine/sort/SortSymbolVisitor.java
@@ -29,14 +29,14 @@ import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.SymbolVisitor;
 import io.crate.analyze.symbol.format.SymbolFormatter;
 import io.crate.data.Input;
+import io.crate.execution.engine.collect.DocInputFactory;
+import io.crate.execution.expression.InputFactory;
+import io.crate.execution.expression.reference.doc.lucene.CollectorContext;
+import io.crate.execution.expression.reference.doc.lucene.LuceneCollectorExpression;
 import io.crate.lucene.FieldTypeLookup;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
 import io.crate.metadata.doc.DocSysColumns;
-import io.crate.execution.expression.InputFactory;
-import io.crate.execution.engine.collect.DocInputFactory;
-import io.crate.execution.expression.reference.doc.lucene.CollectorContext;
-import io.crate.execution.expression.reference.doc.lucene.LuceneCollectorExpression;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.DoubleType;
@@ -45,6 +45,7 @@ import io.crate.types.IntegerType;
 import io.crate.types.LongType;
 import io.crate.types.StringType;
 import org.apache.lucene.search.FieldComparator;
+import org.apache.lucene.search.FieldComparatorSource;
 import org.apache.lucene.search.SortField;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.mapper.MappedFieldType;
@@ -149,7 +150,7 @@ public class SortSymbolVisitor extends SymbolVisitor<SortSymbolVisitor.SortSymbo
         MultiValueMode sortMode = context.reverseFlag ? MultiValueMode.MAX : MultiValueMode.MIN;
 
         String indexName;
-        IndexFieldData.XFieldComparatorSource fieldComparatorSource;
+        FieldComparatorSource fieldComparatorSource;
         MappedFieldType fieldType = fieldTypeLookup.get(columnIdent.fqn());
         if (fieldType == null) {
             indexName = columnIdent.fqn();

--- a/sql/src/main/java/io/crate/execution/expression/reference/doc/lucene/LuceneMissingValue.java
+++ b/sql/src/main/java/io/crate/execution/expression/reference/doc/lucene/LuceneMissingValue.java
@@ -21,22 +21,11 @@
 
 package io.crate.execution.expression.reference.doc.lucene;
 
-import io.crate.execution.engine.sort.SortSymbolVisitor;
 import io.crate.analyze.OrderBy;
+import io.crate.execution.engine.sort.SortSymbolVisitor;
 import org.apache.lucene.search.SortField;
-import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.BytesRefBuilder;
 
 public class LuceneMissingValue {
-
-    private static final BytesRef MAX_TERM;
-
-    static {
-        BytesRefBuilder builder = new BytesRefBuilder();
-        final char[] chars = Character.toChars(Character.MAX_CODE_POINT);
-        builder.copyChars(chars, 0, chars.length);
-        MAX_TERM = builder.toBytesRef();
-    }
 
     public static Object missingValue(OrderBy orderBy, int orderIndex) {
         assert orderIndex <= orderBy.orderBySymbols().size() : "orderIndex must be < number of orderBy symbols";
@@ -63,7 +52,7 @@ public class LuceneMissingValue {
                 return min ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY;
             case STRING:
             case STRING_VAL:
-                return min ? null : MAX_TERM;
+                return null;
             default:
                 throw new UnsupportedOperationException("Unsupported reduced type: " + type);
         }


### PR DESCRIPTION
It's sufficient to implement `FieldComparatorSource`. We had implemented
`XFieldComparatorSource` because a long time ago we used the ES merge
functionality. This is no longer necessary and changing it helps with the ES 6
upgrade where the `XFieldComparatorSource` changes slightly.