### PR TITLE
es upstream: remove non-existant syscall

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -21,6 +21,9 @@ Changes
 Fixes
 =====
 
+- Removed non-existant syscall that caused CrateDB to crash on startup with
+  certain Ubuntu kernel versions.
+
 - Ensured natural order of config keys for the Host Based Authentication.
 
 - Fixed encoding/decoding of ``Timestamp`` type for PostgreSQL wire protocol


### PR DESCRIPTION
that caused crate to crash on startup on Ubuntu with specific kernel
versions