### PR TITLE
es upstream: remove non-existant syscall

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -24,3 +24,6 @@ Changes
 
 Fixes
 =====
+
+- Removed non-existant syscall that caused CrateDB to crash on startup with
+  certain Ubuntu kernel versions.


### PR DESCRIPTION
that caused crate to crash on startup on Ubuntu with specific kernel
versions