### PR TITLE
re-analyze where clause after sub-query excution

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -21,6 +21,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue which resulted in an exception when a routing column was
+  compared against a sub-query inside a ``WHERE`` clause.
+
 - Fixed a performance regression resulting in a table scan instead of a NO-MATCH
   if a sub-query used inside a ``WHERE`` clause returns no result
   (https://github.com/crate/crate/issues/6773).

--- a/sql/src/main/java/io/crate/analyze/symbol/SelectSymbol.java
+++ b/sql/src/main/java/io/crate/analyze/symbol/SelectSymbol.java
@@ -93,7 +93,7 @@ public class SelectSymbol extends Symbol {
 
     @Override
     public String representation() {
-        return "SubQuery{" + relation.getQualifiedName() + '}';
+        return "SubQuery{" + relation.getQualifiedName() + "}@" + hashCode();
     }
 
     public ResultType getResultType() {

--- a/sql/src/main/java/io/crate/analyze/where/WhereClauseAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/where/WhereClauseAnalyzer.java
@@ -27,12 +27,15 @@ import io.crate.analyze.EvaluatingNormalizer;
 import io.crate.analyze.GeneratedColumnExpander;
 import io.crate.analyze.SymbolToTrueVisitor;
 import io.crate.analyze.WhereClause;
+import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.relations.DocTableRelation;
 import io.crate.analyze.symbol.Literal;
+import io.crate.analyze.symbol.SelectSymbol;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.analyze.symbol.Symbols;
 import io.crate.analyze.symbol.ValueSymbolVisitor;
 import io.crate.collections.Lists2;
+import io.crate.data.Row;
 import io.crate.execution.expression.reference.partitioned.PartitionExpression;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Functions;
@@ -44,6 +47,7 @@ import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocSysColumns;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.planner.WhereClauseOptimizer;
+import io.crate.planner.operators.SubQueryAndParamBinder;
 import org.elasticsearch.common.collect.Tuple;
 
 import javax.annotation.Nullable;
@@ -56,6 +60,27 @@ import java.util.Map;
 import java.util.Set;
 
 public class WhereClauseAnalyzer {
+
+    /**
+     * Replace parameters and sub-queries with the related values and analyze the query afterwards.
+     */
+    public static WhereClause bindAndAnalyze(WhereClause where,
+                                             Row params,
+                                             Map<SelectSymbol, Object> subQueryValues,
+                                             AbstractTableRelation tableRelation,
+                                             Functions functions,
+                                             TransactionContext transactionContext) {
+        if (where.hasQuery()) {
+            Symbol query = SubQueryAndParamBinder.convert(where.query(), params, subQueryValues);
+            if (tableRelation instanceof DocTableRelation) {
+                WhereClauseAnalyzer whereClauseAnalyzer = new WhereClauseAnalyzer(functions, (DocTableRelation) tableRelation);
+                return whereClauseAnalyzer.analyze(query, transactionContext);
+            } else {
+                return new WhereClause(query);
+            }
+        }
+        return where;
+    }
 
     private final Functions functions;
     private final DocTableInfo table;

--- a/sql/src/main/java/io/crate/planner/ExplainLeaf.java
+++ b/sql/src/main/java/io/crate/planner/ExplainLeaf.java
@@ -22,7 +22,7 @@
 
 package io.crate.planner;
 
-import java.util.List;
+import java.util.Collection;
 import java.util.stream.Collectors;
 
 /**
@@ -36,7 +36,7 @@ public interface ExplainLeaf {
     String representation();
 
 
-    static String printList(List<? extends ExplainLeaf> leaves) {
+    static String printList(Collection<? extends ExplainLeaf> leaves) {
         return leaves.stream()
             .map(ExplainLeaf::representation)
             .collect(Collectors.joining(", "));

--- a/sql/src/main/java/io/crate/planner/node/management/ExplainPlan.java
+++ b/sql/src/main/java/io/crate/planner/node/management/ExplainPlan.java
@@ -27,12 +27,12 @@ import io.crate.data.InMemoryBatchIterator;
 import io.crate.data.Row;
 import io.crate.data.Row1;
 import io.crate.data.RowConsumer;
-import io.crate.execution.engine.pipeline.TopN;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.Plan;
 import io.crate.planner.PlanPrinter;
 import io.crate.planner.PlannerContext;
+import io.crate.planner.operators.ExplainLogicalPlan;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.planner.statement.CopyStatementPlanner;
 
@@ -61,16 +61,7 @@ public class ExplainPlan implements Plan {
         Map<String, Object> map;
         try {
             if (subPlan instanceof LogicalPlan) {
-                ExecutionPlan executionPlan = ((LogicalPlan) subPlan).build(
-                    plannerContext,
-                    executor.projectionBuilder(),
-                    TopN.NO_LIMIT,
-                    0,
-                    null,
-                    null,
-                    params,
-                    valuesBySubQuery);
-                map = PlanPrinter.objectMap(executionPlan);
+                map = ExplainLogicalPlan.explainMap((LogicalPlan) subPlan, plannerContext, executor.projectionBuilder());
             } else if (subPlan instanceof CopyStatementPlanner.CopyFrom) {
                 ExecutionPlan executionPlan = CopyStatementPlanner.planCopyFromExecution(
                     executor.clusterService().state().nodes(),

--- a/sql/src/main/java/io/crate/planner/operators/Count.java
+++ b/sql/src/main/java/io/crate/planner/operators/Count.java
@@ -27,18 +27,18 @@ import io.crate.analyze.WhereClause;
 import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.SelectSymbol;
+import io.crate.analyze.where.WhereClauseAnalyzer;
 import io.crate.data.Row;
-import io.crate.metadata.Routing;
-import io.crate.metadata.RoutingProvider;
-import io.crate.metadata.table.TableInfo;
-import io.crate.planner.ExecutionPlan;
-import io.crate.planner.PlannerContext;
-import io.crate.planner.distribution.DistributionInfo;
 import io.crate.execution.dsl.phases.CountPhase;
-import io.crate.planner.node.dql.CountPlan;
 import io.crate.execution.dsl.phases.MergePhase;
 import io.crate.execution.dsl.projection.MergeCountProjection;
 import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
+import io.crate.metadata.Routing;
+import io.crate.metadata.RoutingProvider;
+import io.crate.planner.ExecutionPlan;
+import io.crate.planner.PlannerContext;
+import io.crate.planner.distribution.DistributionInfo;
+import io.crate.planner.node.dql.CountPlan;
 import io.crate.types.DataTypes;
 
 import javax.annotation.Nullable;
@@ -52,10 +52,10 @@ public class Count extends ZeroInputPlan {
 
     private static final String COUNT_PHASE_NAME = "count-merge";
 
-    final AbstractTableRelation<TableInfo> tableRelation;
+    final AbstractTableRelation tableRelation;
     final WhereClause where;
 
-    Count(Function countFunction, AbstractTableRelation<TableInfo> tableRelation, WhereClause where) {
+    Count(Function countFunction, AbstractTableRelation tableRelation, WhereClause where) {
         super(Collections.singletonList(countFunction), Collections.singletonList(tableRelation));
         this.tableRelation = tableRelation;
         this.where = where;
@@ -70,16 +70,25 @@ public class Count extends ZeroInputPlan {
                                @Nullable Integer pageSizeHint,
                                Row params,
                                Map<SelectSymbol, Object> subQueryValues) {
+        // bind all parameters and possible subQuery values and re-analyze the query
+        // (could result in a NO_MATCH, routing could've changed, etc).
+        WhereClause boundWhere = WhereClauseAnalyzer.bindAndAnalyze(
+            where,
+            params,
+            subQueryValues,
+            tableRelation,
+            plannerContext.functions(),
+            plannerContext.transactionContext());
 
         Routing routing = plannerContext.allocateRouting(
             tableRelation.tableInfo(),
-            where,
+            boundWhere,
             RoutingProvider.ShardSelection.ANY,
             plannerContext.transactionContext().sessionContext());
         CountPhase countPhase = new CountPhase(
             plannerContext.nextExecutionPhaseId(),
             routing,
-            where,
+            boundWhere,
             DistributionInfo.DEFAULT_BROADCAST
         );
         MergePhase mergePhase = new MergePhase(
@@ -100,5 +109,10 @@ public class Count extends ZeroInputPlan {
     @Override
     public long numExpectedRows() {
         return 1L;
+    }
+
+    @Override
+    public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
+        return visitor.visitCount(this, context);
     }
 }

--- a/sql/src/main/java/io/crate/planner/operators/ExplainLogicalPlan.java
+++ b/sql/src/main/java/io/crate/planner/operators/ExplainLogicalPlan.java
@@ -1,0 +1,213 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.operators;
+
+import com.google.common.collect.ImmutableMap;
+import io.crate.analyze.OrderBy;
+import io.crate.analyze.symbol.SelectSymbol;
+import io.crate.analyze.symbol.format.SymbolPrinter;
+import io.crate.data.Row;
+import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
+import io.crate.execution.engine.pipeline.TopN;
+import io.crate.planner.ExecutionPlan;
+import io.crate.planner.ExplainLeaf;
+import io.crate.planner.PlanPrinter;
+import io.crate.planner.PlannerContext;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ExplainLogicalPlan {
+
+    private static final Visitor VISITOR = new Visitor();
+
+    /**
+     * Tries to build and create an explain map out an {@link ExecutionPlan} out of the given {@link LogicalPlan}.
+     * If it fails, fallback to create the map out of the {@link LogicalPlan}.
+     */
+    public static Map<String, Object> explainMap(LogicalPlan logicalPlan,
+                                                PlannerContext plannerContext,
+                                                ProjectionBuilder projectionBuilder) {
+        try {
+            ExecutionPlan executionPlan = logicalPlan.build(
+                plannerContext,
+                projectionBuilder,
+                TopN.NO_LIMIT,
+                0,
+                null,
+                null,
+                Row.EMPTY,
+                Collections.emptyMap());
+            return PlanPrinter.objectMap(executionPlan);
+        } catch (Exception e) {
+            return VISITOR.process(logicalPlan, new Context(plannerContext, projectionBuilder)).build();
+        }
+    }
+
+    private static Map<String, Object> explainMap(LogicalPlan logicalPlan, Context context) {
+        return explainMap(logicalPlan, context.plannerContext, context.projectionBuilder);
+    }
+
+    private ExplainLogicalPlan() {
+    }
+
+    private static class Context {
+        private final PlannerContext plannerContext;
+        private final ProjectionBuilder projectionBuilder;
+
+        public Context(PlannerContext plannerContext, ProjectionBuilder projectionBuilder) {
+            this.plannerContext = plannerContext;
+            this.projectionBuilder = projectionBuilder;
+        }
+    }
+
+    private static class Visitor extends LogicalPlanVisitor<Context, ImmutableMap.Builder<String, Object>> {
+
+        private static ImmutableMap.Builder<String, Object> createMap(LogicalPlan logicalPlan,
+                                                                      ImmutableMap.Builder<String, Object> subMap) {
+            return ImmutableMap.<String, Object>builder()
+                .put(logicalPlan.getClass().getSimpleName(), subMap.build());
+        }
+
+        private static ImmutableMap.Builder<String, Object> createSubMap() {
+            return ImmutableMap.<String, Object>builder().put("type", "logicalOperator");
+        }
+
+        @Override
+        protected ImmutableMap.Builder<String, Object> visitPlan(LogicalPlan logicalPlan, Context context) {
+            return createMap(logicalPlan, createSubMap());
+        }
+
+        @Override
+        public ImmutableMap.Builder<String, Object> visitMultiPhase(MultiPhase logicalPlan, Context context) {
+            Map<String, Map<String, Object>> dependencies = new HashMap<>(logicalPlan.dependencies().size());
+            for (Map.Entry<LogicalPlan, SelectSymbol> entry : logicalPlan.dependencies().entrySet()) {
+                dependencies.put(entry.getValue().representation(), explainMap(entry.getKey(), context));
+            }
+            return createMap(logicalPlan, createSubMap()
+                .put("source", explainMap(logicalPlan.source, context))
+                .put("dependencies", dependencies));
+        }
+
+        @Override
+        public ImmutableMap.Builder<String, Object> visitFetchOrEval(FetchOrEval logicalPlan, Context context) {
+            return createMap(logicalPlan, createSubMap()
+                .put("fetchRefs", ExplainLeaf.printList(logicalPlan.outputs()))
+                .put("source", explainMap(logicalPlan.source, context)));
+        }
+
+        @Override
+        public ImmutableMap.Builder<String, Object> visitCollect(Collect logicalPlan, Context context) {
+            return createMap(logicalPlan, createSubMap()
+                .put("toCollect", ExplainLeaf.printList(logicalPlan.outputs()))
+                .put("where", logicalPlan.where.query().representation()));
+        }
+
+        @Override
+        public ImmutableMap.Builder<String, Object> visitLimit(Limit logicalPlan, Context context) {
+            return createMap(logicalPlan, createSubMap()
+                .put("limit", SymbolPrinter.INSTANCE.print(logicalPlan.limit, SymbolPrinter.Style.FULL_QUALIFIED))
+                .put("offset", SymbolPrinter.INSTANCE.print(logicalPlan.offset, SymbolPrinter.Style.FULL_QUALIFIED))
+                .put("source", explainMap(logicalPlan.source, context)));
+        }
+
+        @Override
+        public ImmutableMap.Builder<String, Object> visitCount(Count logicalPlan, Context context) {
+            return createMap(logicalPlan, createSubMap()
+                .put("where", logicalPlan.where.query().representation()));
+        }
+
+        @Override
+        public ImmutableMap.Builder<String, Object> visitGet(Get logicalPlan, Context context) {
+            return createMap(logicalPlan, createSubMap()
+                .put("toCollect", ExplainLeaf.printList(logicalPlan.outputs()))
+                .put("docKeys", logicalPlan.docKeys.toString()));
+        }
+
+        @Override
+        public ImmutableMap.Builder<String, Object> visitFilter(Filter logicalPlan, Context context) {
+            return createMap(logicalPlan, createSubMap()
+                .put("filter", logicalPlan.queryClause.query().representation())
+                .put("source", explainMap(logicalPlan.source, context)));
+        }
+
+        @Override
+        public ImmutableMap.Builder<String, Object> visitOrder(Order logicalPlan, Context context) {
+            OrderBy orderBy = logicalPlan.orderBy;
+            StringBuilder sb = new StringBuilder();
+            OrderBy.explainRepresentation(sb, orderBy.orderBySymbols(), orderBy.reverseFlags(), orderBy.nullsFirst());
+            return createMap(logicalPlan, createSubMap()
+                .put("orderBy", sb.toString())
+                .put("source", explainMap(logicalPlan.source, context)));
+        }
+
+        @Override
+        public ImmutableMap.Builder<String, Object> visitUnion(Union logicalPlan, Context context) {
+            return createMap(logicalPlan, createSubMap()
+                .put("left", explainMap(logicalPlan.lhs, context))
+                .put("right", explainMap(logicalPlan.rhs, context)));
+        }
+
+        @Override
+        public ImmutableMap.Builder<String, Object> visitJoin(Join logicalPlan, Context context) {
+            return createMap(logicalPlan, createSubMap()
+                .put("left", explainMap(logicalPlan.lhs, context))
+                .put("right", explainMap(logicalPlan.rhs, context))
+                .put("joinType", logicalPlan.joinType)
+                .put("joinCondition", SymbolPrinter.INSTANCE.print(logicalPlan.joinCondition, SymbolPrinter.Style.FULL_QUALIFIED)));
+        }
+
+        @Override
+        public ImmutableMap.Builder<String, Object> visitGroupHashAggregate(GroupHashAggregate logicalPlan, Context context) {
+            return createMap(logicalPlan, createSubMap()
+                .put("aggregates", ExplainLeaf.printList(logicalPlan.aggregates))
+                .put("groupKeys", ExplainLeaf.printList(logicalPlan.groupKeys))
+                .put("source", explainMap(logicalPlan.source, context)));
+        }
+
+        @Override
+        public ImmutableMap.Builder<String, Object> visitHashAggregate(HashAggregate logicalPlan, Context context) {
+            return createMap(logicalPlan, createSubMap()
+                .put("aggregates", ExplainLeaf.printList(logicalPlan.aggregates))
+                .put("source", explainMap(logicalPlan.source, context)));
+        }
+
+        @Override
+        public ImmutableMap.Builder<String, Object> visitInsert(Insert logicalPlan, Context context) {
+            return createMap(logicalPlan, createSubMap()
+                .put("projection", logicalPlan.projection.mapRepresentation())
+                .put("source", explainMap(logicalPlan.source, context)));
+        }
+
+        @Override
+        public ImmutableMap.Builder<String, Object> visitRelationBoundary(RelationBoundary logicalPlan, Context context) {
+            return ImmutableMap.<String, Object>builder().putAll(explainMap(logicalPlan.source, context));
+        }
+
+        @Override
+        public ImmutableMap.Builder<String, Object> visitRootRelationBoundary(RootRelationBoundary logicalPlan, Context context) {
+            return ImmutableMap.<String, Object>builder().putAll(explainMap(logicalPlan.source, context));
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/planner/operators/FetchOrEval.java
+++ b/sql/src/main/java/io/crate/planner/operators/FetchOrEval.java
@@ -453,4 +453,9 @@ class FetchOrEval extends OneInputPlan {
                ", out=" + outputs +
                '}';
     }
+
+    @Override
+    public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
+        return visitor.visitFetchOrEval(this, context);
+    }
 }

--- a/sql/src/main/java/io/crate/planner/operators/Filter.java
+++ b/sql/src/main/java/io/crate/planner/operators/Filter.java
@@ -108,4 +108,9 @@ class Filter extends OneInputPlan {
     protected LogicalPlan updateSource(LogicalPlan newSource) {
         return new Filter(newSource, queryClause);
     }
+
+    @Override
+    public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
+        return visitor.visitFilter(this, context);
+    }
 }

--- a/sql/src/main/java/io/crate/planner/operators/Get.java
+++ b/sql/src/main/java/io/crate/planner/operators/Get.java
@@ -131,8 +131,14 @@ public class Get extends ZeroInputPlan {
         );
     }
 
+    @Override
     public long numExpectedRows() {
         return docKeys.size();
+    }
+
+    @Override
+    public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
+        return visitor.visitGet(this, context);
     }
 
     public static String indexName(DocTableInfo tableInfo, @Nullable List<BytesRef> partitionValues) {

--- a/sql/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
+++ b/sql/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
@@ -56,8 +56,8 @@ import static io.crate.planner.operators.LogicalPlanner.extractColumns;
 public class GroupHashAggregate extends OneInputPlan {
 
     private static final String DISTRIBUTED_MERGE_PHASE_NAME = "distributed merge";
-    private final List<Function> aggregates;
-    private final List<Symbol> groupKeys;
+    final List<Function> aggregates;
+    final List<Symbol> groupKeys;
 
     public static Builder create(Builder source, List<Symbol> groupKeys, List<Function> aggregates) {
         return (tableStats, parentUsedCols) -> {
@@ -189,6 +189,11 @@ public class GroupHashAggregate extends OneInputPlan {
     public long numExpectedRows() {
         // We don't have any cardinality estimates
         return source.numExpectedRows();
+    }
+
+    @Override
+    public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
+        return visitor.visitGroupHashAggregate(this, context);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/HashAggregate.java
+++ b/sql/src/main/java/io/crate/planner/operators/HashAggregate.java
@@ -163,6 +163,11 @@ public class HashAggregate extends OneInputPlan {
         return 1L;
     }
 
+    @Override
+    public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
+        return visitor.visitHashAggregate(this, context);
+    }
+
     private static class OutputValidatorContext {
         private boolean insideAggregation = false;
     }

--- a/sql/src/main/java/io/crate/planner/operators/Insert.java
+++ b/sql/src/main/java/io/crate/planner/operators/Insert.java
@@ -43,7 +43,7 @@ import java.util.Map;
 public class Insert extends OneInputPlan {
 
     private final QueriedRelation relation;
-    private final ColumnIndexWriterProjection projection;
+    final ColumnIndexWriterProjection projection;
 
     public Insert(LogicalPlan source, QueriedRelation relation, ColumnIndexWriterProjection projection) {
         super(source);
@@ -94,5 +94,10 @@ public class Insert extends OneInputPlan {
     @Override
     public long numExpectedRows() {
         return 1;
+    }
+
+    @Override
+    public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
+        return visitor.visitInsert(this, context);
     }
 }

--- a/sql/src/main/java/io/crate/planner/operators/Join.java
+++ b/sql/src/main/java/io/crate/planner/operators/Join.java
@@ -80,7 +80,7 @@ public class Join extends TwoInputPlan {
     final JoinType joinType;
 
     @Nullable
-    private final Symbol joinCondition;
+    final Symbol joinCondition;
     private final boolean isFiltered;
 
     static Builder createNodes(MultiSourceSelect mss, WhereClause where, SubqueryPlanner subqueryPlanner) {
@@ -457,5 +457,10 @@ public class Join extends TwoInputPlan {
             // We don't have any cardinality estimates, so just take the bigger table
             return Math.max(lhs.numExpectedRows(), rhs.numExpectedRows());
         }
+    }
+
+    @Override
+    public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
+        return visitor.visitJoin(this, context);
     }
 }

--- a/sql/src/main/java/io/crate/planner/operators/Limit.java
+++ b/sql/src/main/java/io/crate/planner/operators/Limit.java
@@ -125,6 +125,11 @@ class Limit extends OneInputPlan {
                '}';
     }
 
+    @Override
+    public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
+        return visitor.visitLimit(this, context);
+    }
+
     static int limitAndOffset(int limit, int offset) {
         if (limit == TopN.NO_LIMIT) {
             return limit;

--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlan.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlan.java
@@ -28,12 +28,12 @@ import io.crate.analyze.symbol.SelectSymbol;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.data.Row;
 import io.crate.data.RowConsumer;
+import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.Plan;
 import io.crate.planner.PlannerContext;
 import io.crate.planner.TableStats;
-import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -44,7 +44,7 @@ import java.util.Set;
  * LogicalPlan is a tree of "Operators"
  * This is a representation of the logical order of operators that need to be executed to produce a correct result.
  *
- * {@link #build(PlannerContext, ProjectionBuilder, int, int, OrderBy, Integer)} is used to create the
+ * {@link #build(PlannerContext, ProjectionBuilder, int, int, OrderBy, Integer, Row, Map)}  is used to create the
  * actual "physical" execution plan.
  *
  * A Operator is something like Limit, OrderBy, HashAggregate, Join, Union, Collect
@@ -58,7 +58,7 @@ import java.util.Set;
  *     Collect [x, y, z]
  * </pre>
  *
- * {@link #build(PlannerContext, ProjectionBuilder, int, int, OrderBy, Integer)} is called
+ * {@link #build(PlannerContext, ProjectionBuilder, int, int, OrderBy, Integer, Row, Map)}  is called
  * on the "root" and flows down.
  * Each time each operator may provide "hints" to the children so that they can decide to eagerly apply parts of the
  * operations
@@ -216,4 +216,6 @@ public interface LogicalPlan extends Plan {
                          Map<SelectSymbol, Object> valuesBySubQuery) {
         LogicalPlanner.execute(this, executor, plannerContext, consumer, params, valuesBySubQuery);
     }
+
+    <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context);
 }

--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlanVisitor.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlanVisitor.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.operators;
+
+import javax.annotation.Nullable;
+
+public class LogicalPlanVisitor<C, R> {
+
+    public R process(LogicalPlan logicalPlan, @Nullable C context) {
+        return logicalPlan.accept(this, context);
+    }
+
+    protected R visitPlan(LogicalPlan logicalPlan, C context) {
+        return null;
+    }
+
+    public R visitMultiPhase(MultiPhase logicalPlan, C context) {
+        return visitPlan(logicalPlan, context);
+    }
+
+    public R visitCollect(Collect logicalPlan, C context) {
+        return visitPlan(logicalPlan, context);
+    }
+
+    public R visitCount(Count logicalPlan, C context) {
+        return visitPlan(logicalPlan, context);
+    }
+
+    public R visitGet(Get logicalPlan, C context) {
+        return visitPlan(logicalPlan, context);
+    }
+
+    public R visitFetchOrEval(FetchOrEval logicalPlan, C context) {
+        return visitPlan(logicalPlan, context);
+    }
+
+    public R visitFilter(Filter logicalPlan, C context) {
+        return visitPlan(logicalPlan, context);
+    }
+
+    public R visitGroupHashAggregate(GroupHashAggregate logicalPlan, C context) {
+        return visitPlan(logicalPlan, context);
+    }
+
+    public R visitHashAggregate(HashAggregate logicalPlan, C context) {
+        return visitPlan(logicalPlan, context);
+    }
+
+    public R visitInsert(Insert logicalPlan, C context) {
+        return visitPlan(logicalPlan, context);
+    }
+
+    public R visitJoin(Join logicalPlan, C context) {
+        return visitPlan(logicalPlan, context);
+    }
+
+    public R visitLimit(Limit logicalPlan, C context) {
+        return visitPlan(logicalPlan, context);
+    }
+
+    public R visitOrder(Order logicalPlan, C context) {
+        return visitPlan(logicalPlan, context);
+    }
+
+    public R visitRelationBoundary(RelationBoundary logicalPlan, C context) {
+        return visitPlan(logicalPlan, context);
+    }
+
+    public R visitRootRelationBoundary(RootRelationBoundary logicalPlan, C context) {
+        return visitPlan(logicalPlan, context);
+    }
+
+    public R visitUnion(Union logicalPlan, C context) {
+        return visitPlan(logicalPlan, context);
+    }
+}

--- a/sql/src/main/java/io/crate/planner/operators/MultiPhase.java
+++ b/sql/src/main/java/io/crate/planner/operators/MultiPhase.java
@@ -26,11 +26,11 @@ import io.crate.analyze.OrderBy;
 import io.crate.analyze.relations.QueriedRelation;
 import io.crate.analyze.symbol.SelectSymbol;
 import io.crate.data.Row;
+import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.MultiPhasePlan;
 import io.crate.planner.PlannerContext;
 import io.crate.planner.SubqueryPlanner;
-import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
 
 import javax.annotation.Nullable;
 import java.util.Map;
@@ -77,5 +77,10 @@ public class MultiPhase extends OneInputPlan {
     @Override
     public long numExpectedRows() {
         return source.numExpectedRows();
+    }
+
+    @Override
+    public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
+        return visitor.visitMultiPhase(this, context);
     }
 }

--- a/sql/src/main/java/io/crate/planner/operators/Order.java
+++ b/sql/src/main/java/io/crate/planner/operators/Order.java
@@ -151,4 +151,9 @@ class Order extends OneInputPlan {
                ", " + orderBy +
                '}';
     }
+
+    @Override
+    public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
+        return visitor.visitOrder(this, context);
+    }
 }

--- a/sql/src/main/java/io/crate/planner/operators/RelationBoundary.java
+++ b/sql/src/main/java/io/crate/planner/operators/RelationBoundary.java
@@ -132,4 +132,9 @@ public class RelationBoundary extends OneInputPlan {
     protected LogicalPlan updateSource(LogicalPlan newSource) {
         return new RelationBoundary(newSource, relation, outputs, expressionMapping, dependencies);
     }
+
+    @Override
+    public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
+        return visitor.visitRelationBoundary(this, context);
+    }
 }

--- a/sql/src/main/java/io/crate/planner/operators/RootRelationBoundary.java
+++ b/sql/src/main/java/io/crate/planner/operators/RootRelationBoundary.java
@@ -72,4 +72,9 @@ public class RootRelationBoundary extends OneInputPlan {
     public String toString() {
         return "RootBoundary{" + source + '}';
     }
+
+    @Override
+    public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
+        return visitor.visitRootRelationBoundary(this, context);
+    }
 }

--- a/sql/src/main/java/io/crate/planner/operators/Union.java
+++ b/sql/src/main/java/io/crate/planner/operators/Union.java
@@ -196,6 +196,11 @@ public class Union extends TwoInputPlan {
         return lhs.numExpectedRows() + rhs.numExpectedRows();
     }
 
+    @Override
+    public <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context) {
+        return visitor.visitUnion(this, context);
+    }
+
     /**
      * Wraps the plan inside a Merge plan if limit or offset need to be applied.
      */

--- a/sql/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
@@ -683,4 +683,20 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
                 "5\n" +
                 "6\n"));
     }
+
+    /**
+     * Test that results from subQueries are bound to the parent query's where clause
+     * BEFORE creating any execution phase (for this test case: before resolving the routing)
+     */
+    @Test
+    public void testWhereSubsSelectAsClusteredByValue() {
+        execute("create table t1 (id int, r int) clustered by(r)");
+        execute("insert into t1 (id, r) values (1, 1), (2, 2)");
+        refresh();
+        execute("select id from t1 where r = (select r from t1 where id = 1)");
+        assertThat(response.rowCount(), is(1L));
+
+        execute("select count(*) from t1 where r = (select r from t1 where id = 1)");
+        assertThat(response.rowCount(), is(1L));
+    }
 }

--- a/sql/src/test/java/io/crate/integrationtests/SysClusterTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysClusterTest.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 
 public class SysClusterTest extends SQLTransportIntegrationTest {
@@ -57,7 +58,7 @@ public class SysClusterTest extends SQLTransportIntegrationTest {
         execute("explain select * from sys.cluster limit 2"); // using limit to test projection serialization as well
         assertThat(response.rowCount(), is(1L));
         Map<String, Object> map = (Map<String, Object>) response.rows()[0][0];
-        assertThat(map.get("planType"), is("Collect"));
+        assertThat(map.keySet(), contains("Collect"));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/planner/consumer/SemiJoinsTest.java
+++ b/sql/src/test/java/io/crate/planner/consumer/SemiJoinsTest.java
@@ -30,9 +30,8 @@ import io.crate.analyze.symbol.Function;
 import io.crate.analyze.symbol.SelectSymbol;
 import io.crate.analyze.symbol.Symbol;
 import io.crate.metadata.TransactionContext;
-import io.crate.planner.ExecutionPlan;
 import io.crate.planner.node.dql.join.JoinType;
-import io.crate.planner.node.dql.join.NestedLoop;
+import io.crate.planner.operators.LogicalPlan;
 import io.crate.sql.tree.QualifiedName;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
@@ -43,12 +42,12 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.List;
 
+import static io.crate.planner.operators.LogicalPlannerTest.isPlan;
 import static io.crate.testing.T3.T1;
 import static io.crate.testing.TestingHelpers.getFunctions;
 import static io.crate.testing.TestingHelpers.isSQL;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 
 public class SemiJoinsTest extends CrateDummyClusterServiceUnitTest {
@@ -147,8 +146,18 @@ public class SemiJoinsTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testDisabledByDefault() throws Exception {
-        ExecutionPlan executionPlan = executor.plan("select * from t1 where a in (select 'foo')");
-        assertThat(executionPlan, not(instanceOf(NestedLoop.class)));
+        LogicalPlan logicalPlan = executor.logicalPlan("select * from t1 where a in (select 'foo')");
+        assertThat(logicalPlan, isPlan(getFunctions(),
+            "RootBoundary[a, x, i]\n" +
+            "MultiPhase[\n" +
+            "    subQueries[\n" +
+            "        RootBoundary['foo']\n" +
+            "        OrderBy[''foo'' ASC NULLS LAST]\n" +
+            "        Collect[.empty_row | ['foo'] | All]\n" +
+            "    ]\n" +
+            "    FetchOrEval[a, x, i]\n" +
+            "    Collect[doc.t1 | [_fetchid] | (a = ANY(SelectSymbol{string_table}))]\n" +
+            "]\n"));
     }
 
     @Test


### PR DESCRIPTION
Fixes an error if a subquery is used in comparison with a routing/clustered-by column.

This fix requires to adjust how an explain plan output is generated because
a logical plan containing a sub-query symbol cannot be built into an execution plan without
executing the sub-queries. Introducing a logical plan printer which kicks in
if building an execution plan (and so using the execution plan printer) fails.

This PR is almost identical to https://github.com/crate/crate/pull/6791, just the commit message and CHANGES entries are updated to what this commit really fixes.