### PR TITLE
Make sure precentile return value matches return type

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -21,6 +21,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that caused the ``percentile`` aggregation to fail if an array
+  containing a single item was passed as ``fractions``.
+
 - Fixed an issue which resulted in an exception when a routing column was
   compared against a sub-query inside a ``WHERE`` clause.
 


### PR DESCRIPTION
The percentile function returned an single double value if the fractions
argument only contained a single item. This then caused an error because
the return type of percentile was advertised as double_array.