### PR TITLE
fixes null eliminator traversal and adds post process step to immediatly normalize

### DIFF
--- a/sql/src/main/java/io/crate/analyze/WhereClause.java
+++ b/sql/src/main/java/io/crate/analyze/WhereClause.java
@@ -82,12 +82,13 @@ public class WhereClause extends QueryClause implements Streamable {
         if (noMatch || query == null) {
             return this;
         }
-        Symbol nullReplacedQuery = NullEliminator.eliminateNullsIfPossible(query);
-        Symbol normalizedQuery = normalizer.normalize(nullReplacedQuery, transactionContext);
-        if (normalizedQuery == query) {
+        Symbol normalizedQuery = normalizer.normalize(query, transactionContext);
+        Symbol nullReplacedQuery = NullEliminator.eliminateNullsIfPossible(
+            normalizedQuery, s -> normalizer.normalize(s, transactionContext));
+        if (nullReplacedQuery == query) {
             return this;
         }
-        return new WhereClause(normalizedQuery, docKeys.orElse(null), partitions, clusteredBy.orElse(null));
+        return new WhereClause(nullReplacedQuery, docKeys.orElse(null), partitions, clusteredBy.orElse(null));
     }
 
     public Optional<Set<Symbol>> clusteredBy() {

--- a/sql/src/main/java/io/crate/analyze/where/NullEliminator.java
+++ b/sql/src/main/java/io/crate/analyze/where/NullEliminator.java
@@ -75,6 +75,7 @@ public final class NullEliminator {
             // only operate inside logical operators
             if (Operators.LOGICAL_OPERATORS.contains(functionName)) {
                 boolean currentNullReplacement = context.nullReplacement;
+                boolean currentInsideLogicalOperator = context.insideLogicalOperator;
                 context.insideLogicalOperator = true;
 
                 if (NotPredicate.NAME.equals(functionName)) {
@@ -84,7 +85,7 @@ public final class NullEliminator {
                 Symbol newFunc = super.visitFunction(func, context);
 
                 // reset context
-                context.insideLogicalOperator = false;
+                context.insideLogicalOperator = currentInsideLogicalOperator;
                 context.nullReplacement = currentNullReplacement;
                 return newFunc;
             }

--- a/sql/src/test/java/io/crate/analyze/WhereClauseTest.java
+++ b/sql/src/test/java/io/crate/analyze/WhereClauseTest.java
@@ -83,7 +83,7 @@ public class WhereClauseTest {
 
     @Test
     public void testNormalizeEliminatesNulls() {
-        WhereClause where = new WhereClause(sqlExpressions.asSymbol("null or x = 10"));
+        WhereClause where = new WhereClause(sqlExpressions.asSymbol("null or x = 10 or a = null"));
         WhereClause normalizedWhere = where.normalize(
             EvaluatingNormalizer.functionOnlyNormalizer(getFunctions()), new TransactionContext());
         assertThat(normalizedWhere.query(), is(sqlExpressions.asSymbol("x = 10")));

--- a/sql/src/test/java/io/crate/analyze/where/NullEliminatorTest.java
+++ b/sql/src/test/java/io/crate/analyze/where/NullEliminatorTest.java
@@ -44,11 +44,10 @@ public class NullEliminatorTest extends CrateUnitTest {
     @Test
     public void testNullsReplaced() throws Exception {
         assertReplaced("null and x = null", "false and x = null");
-        assertReplaced("null or x = 1", "false or x = 1");
+        assertReplaced("null or x = 1 or null", "false or x = 1 or false");
         assertReplaced("not(null and x = 1)", "not(true and x = 1)");
         assertReplaced("not(null or not(null and x = 1))", "not(true or not(false and x = 1))");
         assertReplaced("not(null and x = 1) and not(null or x = 2)", "not(true and x = 1) and not(true or x = 2)");
         assertReplaced("null or coalesce(null or x = 1, true)", "false or coalesce(null or x = 1, true)");
     }
-
 }


### PR DESCRIPTION

-  Fixes traversal while eliminating nulls inside queries (follow up of https://github.com/crate/crate/commit/799cdff2a7b41a2bf618b7639bc3b99a0c6a991d)
- Normalizes where query while nulls are eliminated:
This ensures that NULLs are completely optimized on one WhereClause.normalize() run.
Before that, normalize() must have been run at least twice to ensure that all nulls
are eliminated and query was optimized (this is currently the case through
node- and shard-expression normalization, but could change in future).

Example:

	`where null or x = 1 or y = null`

nulls replaced afterwards normalized:

	`where false or x = 1 or null`

normalized and afterwards nulls replaced:

	`where false or x = 1 or false`

normalized and afterwards nulls replaced including post-normalize (now):

	`where x = 1`

