### PR TITLE
use wheels where applicable for blackbox bootstrapping

### DIFF
--- a/blackbox/bootstrap.sh
+++ b/blackbox/bootstrap.sh
@@ -10,5 +10,5 @@ else
     exit 1
 fi
 
-.venv/bin/python -m pip install -U pip setuptools
-.venv/bin/python -m pip install -r requirements.txt
+.venv/bin/pip install -U pip setuptools wheel
+.venv/bin/pip install -r requirements.txt


### PR DESCRIPTION
this removes the warnings of bdist_wheel command not available:

```
Building wheels for collected packages: livereload, MarkupSafe, port-for, sphinx-autobuild, sphinxcontrib-plantuml, tornado
  Running setup.py bdist_wheel for livereload: started
  Failed building wheel for livereload
  Running setup.py bdist_wheel for livereload: finished with status 'error'
  Complete output from command /home/christian/sandbox/crate/crate/blackbox/.venv/bin/python -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-etyjqkv6/livereload/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /tmp/tmpd3rcmrdapip-wheel- --python-tag cp36:
  usage: -c [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
     or: -c --help [cmd1 cmd2 ...]
     or: -c --help-commands
     or: -c cmd --help

  error: invalid command 'bdist_wheel'
```