### PR TITLE
Move OrderBy push-down optimization for joins.

### DIFF
--- a/sql/src/main/java/io/crate/analyze/MultiSourceSelect.java
+++ b/sql/src/main/java/io/crate/analyze/MultiSourceSelect.java
@@ -49,7 +49,6 @@ public class MultiSourceSelect implements QueriedRelation {
 
     private final Map<QualifiedName, AnalyzedRelation> sources;
     private final Fields fields;
-    private final boolean relationReOrderAllowed;
     private final List<JoinPair> joinPairs;
     private QualifiedName qualifiedName;
     private QuerySpec querySpec;
@@ -102,8 +101,7 @@ public class MultiSourceSelect implements QueriedRelation {
             mss.sources(),
             mss.fields(),
             querySpec,
-            mss.joinPairs,
-            splitter.relationReOrderAllowed()
+            mss.joinPairs
         );
     }
 
@@ -135,7 +133,6 @@ public class MultiSourceSelect implements QueriedRelation {
         for (Path path : outputNames) {
             fields.add(path, new Field(this, path, outputsIterator.next().valueType()));
         }
-        this.relationReOrderAllowed = true;
     }
 
     private static QualifiedName generateName(Set<QualifiedName> sourceNames) {
@@ -151,28 +148,15 @@ public class MultiSourceSelect implements QueriedRelation {
                               Map<QualifiedName, AnalyzedRelation> sources,
                               Collection<Field> fields,
                               QuerySpec querySpec,
-                              List<JoinPair> joinPairs,
-                              boolean relationReOrderAllowed) {
+                              List<JoinPair> joinPairs) {
         this.qualifiedName = relName;
         this.sources = sources;
         this.joinPairs = joinPairs;
         this.querySpec = querySpec;
         this.fields = new Fields(fields.size());
-        this.relationReOrderAllowed = relationReOrderAllowed;
         for (Field field : fields) {
             this.fields.add(field.path(), new Field(this, field.path(), field.valueType()));
         }
-    }
-
-    /**
-     * @return true if the planner is allowed to re-arrange the order of the relations.
-     *         (Ex.: t1 ⋈ t2 ⋈ t3 may be re-ordered to ((t2 ⋈ t3) ⋈ t1)
-     *
-     *
-     * See also: {@link RelationSplitter#processOrderBy()} and {@link io.crate.planner.operators.JoinOrdering
-     */
-    public boolean isRelationReOrderAllowed() {
-        return relationReOrderAllowed;
     }
 
     public Map<QualifiedName, AnalyzedRelation> sources() {

--- a/sql/src/main/java/io/crate/planner/operators/JoinOrdering.java
+++ b/sql/src/main/java/io/crate/planner/operators/JoinOrdering.java
@@ -42,11 +42,10 @@ final class JoinOrdering {
     private JoinOrdering() {
     }
 
-    static Collection<QualifiedName> getOrderedRelationNames(boolean reOrderIsAllowed,
-                                                             Collection<QualifiedName> sourceRelations,
+    static Collection<QualifiedName> getOrderedRelationNames(Collection<QualifiedName> sourceRelations,
                                                              Set<? extends Set<QualifiedName>> explicitJoinConditions,
                                                              Set<? extends Set<QualifiedName>> implicitJoinConditions) {
-        if (!reOrderIsAllowed || (explicitJoinConditions.isEmpty() && implicitJoinConditions.isEmpty())) {
+        if (explicitJoinConditions.isEmpty() && implicitJoinConditions.isEmpty()) {
             return sourceRelations;
         }
         return orderByJoinConditions(

--- a/sql/src/main/java/io/crate/planner/operators/JoinOrdering.java
+++ b/sql/src/main/java/io/crate/planner/operators/JoinOrdering.java
@@ -33,12 +33,19 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
-public class JoinOrdering {
+/**
+ * Utility class which is used by the {@link Join} for the building of
+ * the join tree, which helps to find the optimal ordering of the tables.
+ */
+final class JoinOrdering {
 
-    public static Collection<QualifiedName> getOrderedRelationNames(boolean reOrderIsAllowed,
-                                                                    Collection<QualifiedName> sourceRelations,
-                                                                    Set<? extends Set<QualifiedName>> explicitJoinConditions,
-                                                                    Set<? extends Set<QualifiedName>> implicitJoinConditions) {
+    private JoinOrdering() {
+    }
+
+    static Collection<QualifiedName> getOrderedRelationNames(boolean reOrderIsAllowed,
+                                                             Collection<QualifiedName> sourceRelations,
+                                                             Set<? extends Set<QualifiedName>> explicitJoinConditions,
+                                                             Set<? extends Set<QualifiedName>> implicitJoinConditions) {
         if (!reOrderIsAllowed || (explicitJoinConditions.isEmpty() && implicitJoinConditions.isEmpty())) {
             return sourceRelations;
         }
@@ -50,7 +57,7 @@ public class JoinOrdering {
 
     /**
      * Returns a the relation re-ordered to apply join conditions further down in the tree.
-     *
+     * <p>
      * (Assuming the relations are consumed from left to right to build a tree of two-relations join nodes)
      *
      * @param relations               all relations, e.g. [t1, t2, t3, t3]
@@ -62,8 +69,6 @@ public class JoinOrdering {
     static Collection<QualifiedName> orderByJoinConditions(Collection<QualifiedName> relations,
                                                            Set<? extends Set<QualifiedName>> explicitJoinedRelations,
                                                            Set<? extends Set<QualifiedName>> implicitJoinedRelations) {
-
-        LinkedHashSet<QualifiedName> bestOrder = new LinkedHashSet<>();
         List<Set<QualifiedName>> pairsWithJoinConditions = new ArrayList<>(explicitJoinedRelations);
         pairsWithJoinConditions.addAll(implicitJoinedRelations);
 
@@ -72,7 +77,7 @@ public class JoinOrdering {
 
         Set<QualifiedName> firstJoinPair = findAndRemoveFirstJoinPair(occurrences, pairsWithJoinConditions);
         assert firstJoinPair != null : "firstJoinPair should not be null";
-        bestOrder.addAll(firstJoinPair);
+        LinkedHashSet<QualifiedName> bestOrder = new LinkedHashSet<>(firstJoinPair);
 
         buildBestOrderByJoinConditions(pairsWithJoinConditions, bestOrder);
         bestOrder.addAll(relations);
@@ -111,7 +116,7 @@ public class JoinOrdering {
         Iterator<Set<QualifiedName>> setsIterator = sets.iterator();
         while (setsIterator.hasNext()) {
             Set<QualifiedName> set = setsIterator.next();
-            for (QualifiedName name: set) {
+            for (QualifiedName name : set) {
                 if (bestOrder.contains(name)) {
                     bestOrder.addAll(set);
                     setsIterator.remove();

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -26,24 +26,10 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.QueriedRelation;
-import io.crate.expression.symbol.Field;
-import io.crate.expression.symbol.Function;
-import io.crate.expression.symbol.Literal;
-import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.SymbolType;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.exceptions.ConversionException;
 import io.crate.exceptions.RelationUnknownException;
 import io.crate.exceptions.UnsupportedFeatureException;
-import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.Functions;
-import io.crate.metadata.TableIdent;
-import io.crate.metadata.doc.DocSchemaInfo;
-import io.crate.metadata.doc.DocTableInfo;
-import io.crate.metadata.doc.DocTableInfoFactory;
-import io.crate.metadata.doc.TestingDocTableInfoFactory;
-import io.crate.metadata.sys.SysNodesTableInfo;
-import io.crate.metadata.table.TestingTableInfo;
 import io.crate.execution.engine.aggregation.impl.AverageAggregation;
 import io.crate.expression.operator.EqOperator;
 import io.crate.expression.operator.LikeOperator;
@@ -59,7 +45,21 @@ import io.crate.expression.scalar.arithmetic.ArithmeticFunctions;
 import io.crate.expression.scalar.cast.CastFunctionResolver;
 import io.crate.expression.scalar.geo.DistanceFunction;
 import io.crate.expression.scalar.regex.MatchesFunction;
+import io.crate.expression.symbol.Field;
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.Literal;
+import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.SymbolType;
 import io.crate.expression.udf.UserDefinedFunctionService;
+import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.Functions;
+import io.crate.metadata.TableIdent;
+import io.crate.metadata.doc.DocSchemaInfo;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.metadata.doc.DocTableInfoFactory;
+import io.crate.metadata.doc.TestingDocTableInfoFactory;
+import io.crate.metadata.sys.SysNodesTableInfo;
+import io.crate.metadata.table.TestingTableInfo;
 import io.crate.sql.parser.ParsingException;
 import io.crate.sql.tree.QualifiedName;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
@@ -789,10 +789,10 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
 
         MultiSourceSelect mss = (MultiSourceSelect) relation;
 
-        assertThat(mss.querySpec().orderBy(), nullValue());
+        assertThat(mss.querySpec().orderBy(), isSQL("doc.users.id"));
         Iterator<Map.Entry<QualifiedName, AnalyzedRelation>> it = mss.sources().entrySet().iterator();
         QueriedRelation usersRel = (QueriedRelation) it.next().getValue();
-        assertThat(usersRel.querySpec().orderBy().orderBySymbols(), isSQL("doc.users.id"));
+        assertThat(usersRel.querySpec().orderBy(), nullValue());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/analyze/SubSelectAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SubSelectAnalyzerTest.java
@@ -175,18 +175,18 @@ public class SubSelectAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
-    public void testJoinOnSubSelectsWithOrderByPushedDown() throws Exception {
+    public void testJoinOnSubSelectsWithOrder() throws Exception {
         MultiSourceSelect relation = analyze("select * from " +
                                              " (select a, i from t1 order by a) t1, " +
                                              " (select b, i from t2 where b > 10) t2 " +
                                              "where t1.a > 50 and t2.b > 100 " +
                                              "order by 2 limit 10");
         assertThat(relation.querySpec(),
-            isSQL("SELECT doc.t1.a, doc.t1.i, doc.t2.b, doc.t2.i LIMIT 10"));
+            isSQL("SELECT doc.t1.a, doc.t1.i, doc.t2.b, doc.t2.i ORDER BY doc.t1.i LIMIT 10"));
         assertThat(((QueriedRelation)relation.sources().get(new QualifiedName("t1"))).querySpec(),
-            isSQL("SELECT doc.t1.i, doc.t1.a WHERE (doc.t1.a > '50') ORDER BY doc.t1.i LIMIT 10"));
+            isSQL("SELECT doc.t1.a, doc.t1.i WHERE (doc.t1.a > '50') ORDER BY doc.t1.a"));
         assertThat(((QueriedRelation)relation.sources().get(new QualifiedName("t2"))).querySpec(),
-            isSQL("SELECT doc.t2.b, doc.t2.i WHERE ((doc.t2.b > '100') AND (doc.t2.b > '10')) LIMIT 10"));
+            isSQL("SELECT doc.t2.b, doc.t2.i WHERE ((doc.t2.b > '100') AND (doc.t2.b > '10'))"));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/analyze/relations/RelationSplitterTest.java
+++ b/sql/src/test/java/io/crate/analyze/relations/RelationSplitterTest.java
@@ -43,7 +43,6 @@ import java.util.Map;
 import static io.crate.testing.TestingHelpers.isSQL;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 
 public class RelationSplitterTest extends CrateUnitTest {
@@ -271,20 +270,6 @@ public class RelationSplitterTest extends CrateUnitTest {
             .having(new HavingClause(asSymbol("t1.x = 10")));
         RelationSplitter splitter = split(qs);
         assertThat(splitter.getSpec(T3.TR_1), isSQL("SELECT doc.t1.x, doc.t1.a"));
-    }
-
-    @Test
-    public void testOrderByIsFullyPushedDownIfPossible() throws Exception {
-        // select t1.a, t2.b from t1 inner join t2 on t1.a = t2.b order by t1.a
-        QuerySpec qs = new QuerySpec()
-            .outputs(Arrays.asList(asSymbol("t1.a"), asSymbol("t2.b")))
-            .orderBy(new OrderBy(
-                Collections.singletonList(asSymbol("t1.a")), new boolean[]{false}, new Boolean[]{null}));
-        JoinPair t1AndT2InnerJoin = JoinPair.of(T3.T1, T3.T2, JoinType.INNER, asSymbol("t1.a = t2.b"));
-
-        RelationSplitter splitter = split(qs, Collections.singletonList(t1AndT2InnerJoin));
-        assertThat(splitter.getSpec(T3.TR_1), isSQL("SELECT doc.t1.a ORDER BY doc.t1.a"));
-        assertThat("remainingOrderBy must be false if it's safe to remove after pushDown", qs.orderBy(), nullValue());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/OuterJoinIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/OuterJoinIntegrationTest.java
@@ -22,6 +22,7 @@
 
 package io.crate.integrationtests;
 
+import com.carrotsearch.randomizedtesting.annotations.Seed;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/sql/src/test/java/io/crate/planner/operators/PushDownTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/PushDownTest.java
@@ -26,6 +26,7 @@ import io.crate.analyze.TableDefinitions;
 import io.crate.planner.TableStats;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
+import io.crate.testing.T3;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -40,18 +41,19 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
     public void setup() {
         tableStats = new TableStats();
         sqlExecutor = SQLExecutor.builder(clusterService)
+            .addDocTable(T3.T1_INFO)
+            .addDocTable(T3.T2_INFO)
             .addDocTable(TableDefinitions.USER_TABLE_INFO)
             .build();
     }
 
+    private LogicalPlan plan(String stmt) {
+        return LogicalPlannerTest.plan(stmt, sqlExecutor, clusterService, tableStats);
+    }
+
     @Test
     public void testOrderByOnUnionIsMovedBeneathUnion() {
-        LogicalPlan plan = LogicalPlannerTest.plan(
-            "Select name from users union all select text from users order by name",
-            sqlExecutor,
-            clusterService,
-            tableStats);
-
+        LogicalPlan plan = plan("Select name from users union all select text from users order by name");
         assertThat(plan, isPlan(sqlExecutor.functions(),  "Boundary[name]\n" +
                                                 "Union[\n" +
                                                     "Boundary[name]\n" +
@@ -66,15 +68,11 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testOrderByOnUnionIsCombinedWithOrderByBeneathUnion() {
-        LogicalPlan plan = LogicalPlannerTest.plan(
+        LogicalPlan plan = plan(
             "Select * from (select name from users order by text) a " +
             "union all " +
             "select text from users " +
-            "order by name",
-            sqlExecutor,
-            clusterService,
-            tableStats);
-
+            "order by name");
         assertThat(plan, isPlan(sqlExecutor.functions(),  "Boundary[name]\n" +
                                                           "Union[\n" +
                                                               "Boundary[name]\n" +
@@ -86,6 +84,90 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
                                                               "Boundary[text]\n" +
                                                               "OrderBy['text' ASC]\n" +
                                                               "Collect[doc.users | [text] | All]\n" +
+                                                          "]\n"));
+    }
+
+    @Test
+    public void testOrderByOnJoinPushedDown() {
+        LogicalPlan plan = plan("select t1.a, t2.b from t1 inner join t2 on t1.a = t2.b order by t1.a");
+        assertThat(plan, isPlan(sqlExecutor.functions(),  "Join[\n" +
+                                                          "    Boundary[a]\n" +
+                                                          "    OrderBy['a' ASC]\n" +
+                                                          "    Collect[doc.t1 | [a] | All]\n" +
+                                                          "    --- INNER ---\n" +
+                                                          "    Boundary[b]\n" +
+                                                          "    Collect[doc.t2 | [b] | All]\n" +
+                                                          "]\n"));
+    }
+
+    @Test
+    public void testOrderByOnJoinWithMultipleRelationsPushedDown() {
+        LogicalPlan plan = plan("select t1.a, t2.b, t3.a from t1 " +
+                                "inner join t2 on t1.a = t2.b " +
+                                "inner join t1 as t3 on t3.a = t2.b " +
+                                "order by t2.b");
+        assertThat(plan, isPlan(sqlExecutor.functions(),  "FetchOrEval[a, b, a]\n" +
+                                                          "Join[\n" +
+                                                          "    Join[\n" +
+                                                          "        Boundary[b]\n" +
+                                                          "        OrderBy['b' ASC]\n" +
+                                                          "        Collect[doc.t2 | [b] | All]\n" +
+                                                          "        --- INNER ---\n" +
+                                                          "        Boundary[a]\n" +
+                                                          "        Collect[doc.t1 | [a] | All]\n" +
+                                                          "]\n" +
+                                                          "    --- INNER ---\n" +
+                                                          "    Boundary[a]\n" +
+                                                          "    Collect[doc.t1 | [a] | All]\n" +
+                                                          "]\n"));
+    }
+
+    @Test
+    public void testOrderByOnJoinOrderOnRightTableNotPushedDown() {
+        LogicalPlan plan = plan("select t1.a, t2.b from t1 inner join t2 on t1.a = t2.b order by t2.b");
+        assertThat(plan, isPlan(sqlExecutor.functions(),  "OrderBy['b' ASC]\n" +
+                                                          "Join[\n" +
+                                                          "    Boundary[a]\n" +
+                                                          "    Collect[doc.t1 | [a] | All]\n" +
+                                                          "    --- INNER ---\n" +
+                                                          "    Boundary[b]\n" +
+                                                          "    Collect[doc.t2 | [b] | All]\n" +
+                                                          "]\n"));
+    }
+
+    @Test
+    public void testOrderByOnJoinOrderOnMultipleTablesNotPushedDown() {
+        LogicalPlan plan = plan("select t1.a, t2.b from t1 inner join t2 on t1.a = t2.b order by t1.a || t2.b");
+        assertThat(plan, isPlan(sqlExecutor.functions(),  "FetchOrEval[a, b]\n" +
+                                                          "OrderBy['concat(a, b)' ASC]\n" +
+                                                          "Join[\n" +
+                                                          "    Boundary[a]\n" +
+                                                          "    Collect[doc.t1 | [a] | All]\n" +
+                                                          "    --- INNER ---\n" +
+                                                          "    Boundary[b]\n" +
+                                                          "    Collect[doc.t2 | [b] | All]\n" +
+                                                          "]\n"));
+    }
+
+    @Test
+    public void testOrderByOnJoinOuterJoinInvolvedNotPushedDown() {
+        LogicalPlan plan = plan("select t1.a, t2.b, t3.a from t1 " +
+                                "inner join t2 on t1.a = t2.b " +
+                                "left join t1 as t3 on t3.a = t1.a " +
+                                "order by t1.a");
+        assertThat(plan, isPlan(sqlExecutor.functions(),  "FetchOrEval[a, b, a]\n" +
+                                                          "OrderBy['a' ASC]\n" +
+                                                          "Join[\n" +
+                                                          "    Join[\n" +
+                                                          "        Boundary[b]\n" +
+                                                          "        Collect[doc.t2 | [b] | All]\n" +
+                                                          "        --- INNER ---\n" +
+                                                          "        Boundary[a]\n" +
+                                                          "        Collect[doc.t1 | [a] | All]\n" +
+                                                          "]\n" +
+                                                          "    --- LEFT ---\n" +
+                                                          "    Boundary[a]\n" +
+                                                          "    Collect[doc.t1 | [a] | All]\n" +
                                                           "]\n"));
     }
 }


### PR DESCRIPTION
Until now the OrderBy push-down optimization took place in the Analysis phase,
and if a successful pushdown was applied it prevented the re-ordering of the
relations of the join in the LogicalPlanner which in turn could prevent the
usage of new join algorithms (eg. hash-join).

This changes moves the OrderBy optimization from the Analysis to the
LogicalPlanner. So now the OrderBy optimization is done through the
`tryOptimize()` mechanism which is already in place.

The OrderBy push-down can only be applied if the symbols of the OrderBy refer
to the top-most left relation of the join tree. This condition is still valid
after this change but the join tree is allowed to be already re-order in an
optimal way based on the join conditions (apply as many join conditions as
early as possible). In the near future the join tree can already be created in
an optimal way also because of the join algorithm chosen and on top of that we
can still try to apply the OrderBy push-down.