### PR TITLE
exposes sql disabled flag via JMX

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -18,6 +18,9 @@ Breaking Changes
 Changes
 =======
 
+- Implemented a `Ready` node status JMX metric expressing if the node is ready
+  for processing SQL statements.
+
 Fixes
 =====
 

--- a/blackbox/docs/admin/monitoring.txt
+++ b/blackbox/docs/admin/monitoring.txt
@@ -137,6 +137,18 @@ Average duration:
  - ``DeleteQueryAverageDuration``
  - ``OverallQueryAverageDuration``
 
+NodeStatus MBean
+----------------
+
+The ``NodeStatus`` JMX MBean exposes the status of the current node as boolean values.
+
+Metrics can be accessed using the JMX MBean object name
+``io.crate.monitoring:type=NodeStatus`` and the following attributes:
+
+ - ``Ready``
+
+   Defines if the node is able to process SQL statements.
+
 .. _JMX: http://docs.oracle.com/javase/8/docs/technotes/guides/jmx/
 .. _JMX documentation: http://docs.oracle.com/javase/8/docs/technotes/guides/management/agent.html#gdeum
 .. _JConsole: http://docs.oracle.com/javase/8/docs/technotes/guides/management/agent.html#gdeum

--- a/enterprise/jmx-monitoring/src/main/java/io/crate/beans/NodeStatus.java
+++ b/enterprise/jmx-monitoring/src/main/java/io/crate/beans/NodeStatus.java
@@ -1,0 +1,37 @@
+/*
+ * This file is part of a module with proprietary Enterprise Features.
+ *
+ * Licensed to Crate.io Inc. ("Crate.io") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ *
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ *
+ * To use this file, Crate.io must have given you permission to enable and
+ * use such Enterprise Features and you must have a valid Enterprise or
+ * Subscription Agreement with Crate.io.  If you enable or use the Enterprise
+ * Features, you represent and warrant that you have a valid Enterprise or
+ * Subscription Agreement with Crate.io.  Your use of the Enterprise Features
+ * if governed by the terms and conditions of your Enterprise or Subscription
+ * Agreement with Crate.io.
+ */
+
+package io.crate.beans;
+
+import java.util.function.Supplier;
+
+public class NodeStatus implements NodeStatusMBean {
+
+    public static final String NAME = "io.crate.monitoring:type=NodeStatus";
+
+    private final Supplier<Boolean> isEnabledSupplier;
+
+    public NodeStatus(Supplier<Boolean> isEnabledSupplier) {
+        this.isEnabledSupplier = isEnabledSupplier;
+    }
+
+    @Override
+    public boolean isReady() {
+        return isEnabledSupplier.get();
+    }
+}

--- a/enterprise/jmx-monitoring/src/main/java/io/crate/beans/NodeStatusMBean.java
+++ b/enterprise/jmx-monitoring/src/main/java/io/crate/beans/NodeStatusMBean.java
@@ -1,0 +1,33 @@
+/*
+ * This file is part of a module with proprietary Enterprise Features.
+ *
+ * Licensed to Crate.io Inc. ("Crate.io") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ *
+ * Unauthorized copying of this file, via any medium is strictly prohibited.
+ *
+ * To use this file, Crate.io must have given you permission to enable and
+ * use such Enterprise Features and you must have a valid Enterprise or
+ * Subscription Agreement with Crate.io.  If you enable or use the Enterprise
+ * Features, you represent and warrant that you have a valid Enterprise or
+ * Subscription Agreement with Crate.io.  Your use of the Enterprise Features
+ * if governed by the terms and conditions of your Enterprise or Subscription
+ * Agreement with Crate.io.
+ */
+
+package io.crate.beans;
+
+/**
+ * The NodeStatusMBean interface is required to define a standard MBean,
+ * such as a standard MBean is composed of an MBean interface and a class.
+ *
+ * This interface lists the methods for all exposed attributes.
+ *
+ * @see <a href="https://docs.oracle.com/javase/tutorial/jmx/mbeans/standard.html">
+ *     https://docs.oracle.com/javase/tutorial/jmx/mbeans/standard.html</a>
+ */
+public interface NodeStatusMBean {
+
+    boolean isReady();
+}

--- a/enterprise/jmx-monitoring/src/main/java/io/crate/plugin/CrateMonitor.java
+++ b/enterprise/jmx-monitoring/src/main/java/io/crate/plugin/CrateMonitor.java
@@ -18,6 +18,8 @@
 
 package io.crate.plugin;
 
+import io.crate.action.sql.SQLOperations;
+import io.crate.beans.NodeStatus;
 import io.crate.beans.QueryStats;
 import io.crate.execution.engine.collect.stats.JobsLogs;
 import org.apache.logging.log4j.Logger;
@@ -39,9 +41,10 @@ public class CrateMonitor {
     private final MBeanServer mbeanServer = ManagementFactory.getPlatformMBeanServer();
 
     @Inject
-    public CrateMonitor(JobsLogs jobsLogs, Settings settings) {
+    public CrateMonitor(JobsLogs jobsLogs, Settings settings, SQLOperations sqlOperations) {
         logger = Loggers.getLogger(CrateMonitor.class, settings);
         registerMBean(QueryStats.NAME, new QueryStats(jobsLogs));
+        registerMBean(NodeStatus.NAME, new NodeStatus(sqlOperations::isEnabled));
     }
 
     private void registerMBean(String name, Object bean) {

--- a/sql/src/main/java/io/crate/action/sql/SQLOperations.java
+++ b/sql/src/main/java/io/crate/action/sql/SQLOperations.java
@@ -115,6 +115,10 @@ public class SQLOperations {
         disabled = false;
     }
 
+    public boolean isEnabled() {
+        return !disabled;
+    }
+
     /**
      * Create an {@link SQLDirectExecutor} instance.
      *


### PR DESCRIPTION
The SQLOperations class already has a boolean flag defining if new
SQL statements should be accepted for processing. E.g. when doing a
gracefull shutdown, processing SQL must be disabled.
This commit exposes this flag via JMX under a new metric `NodeStatus`.