### PR TITLE
Do not require DQL permissions for BEGIN and SET SESSION

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -18,6 +18,9 @@ Breaking Changes
 Changes
 =======
 
+- Changed ``BEGIN`` and ``SET SESSION`` to no longer require ``DQL``
+  permissions on the ``CLUSTER`` level.
+
 - Implemented a `Ready` node status JMX metric expressing if the node is ready
   for processing SQL statements.
 

--- a/enterprise/users/src/main/java/io/crate/auth/user/StatementPrivilegeValidator.java
+++ b/enterprise/users/src/main/java/io/crate/auth/user/StatementPrivilegeValidator.java
@@ -352,11 +352,6 @@ class StatementPrivilegeValidator implements StatementAuthorizedValidator {
                 throwUnauthorized(user);
                 return null;
             }
-            Privileges.ensureUserHasPrivilege(
-                Privilege.Type.DQL,
-                Privilege.Clazz.CLUSTER,
-                null,
-                user);
             return null;
         }
 
@@ -449,11 +444,6 @@ class StatementPrivilegeValidator implements StatementAuthorizedValidator {
 
         @Override
         public Void visitBegin(AnalyzedBegin analyzedBegin, User user) {
-            Privileges.ensureUserHasPrivilege(
-                Privilege.Type.DQL,
-                Privilege.Clazz.CLUSTER,
-                null,
-                user);
             return null;
         }
     }

--- a/enterprise/users/src/test/java/io/crate/auth/user/StatementPrivilegeValidatorTest.java
+++ b/enterprise/users/src/test/java/io/crate/auth/user/StatementPrivilegeValidatorTest.java
@@ -26,11 +26,11 @@ import io.crate.analyze.ParameterContext;
 import io.crate.analyze.TableDefinitions;
 import io.crate.analyze.user.Privilege;
 import io.crate.exceptions.UnauthorizedException;
+import io.crate.execution.engine.collect.sources.SysTableRegistry;
 import io.crate.metadata.TableIdent;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.blob.BlobSchemaInfo;
 import io.crate.metadata.cluster.DDLClusterStateService;
-import io.crate.execution.engine.collect.sources.SysTableRegistry;
 import io.crate.sql.parser.SqlParser;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
@@ -359,9 +359,10 @@ public class StatementPrivilegeValidatorTest extends CrateDummyClusterServiceUni
     }
 
     @Test
-    public void testSetSession() throws Exception {
+    public void testSetSessionRequiresNoPermissions() throws Exception {
+        // allowed without any permissions as it affects only the user session;
         analyze("set session foo = 'bar'");
-        assertAskedForCluster(Privilege.Type.DQL);
+        assertThat(validationCallArguments.size(), is(0));
     }
 
     @Test
@@ -383,9 +384,11 @@ public class StatementPrivilegeValidatorTest extends CrateDummyClusterServiceUni
     }
 
     @Test
-    public void testBegin() throws Exception {
+    public void testBeginRequiresNoPermission() throws Exception {
+        // Begin is currently ignored; In other RDMS it's used to start transactions with contain
+        // other statements; these other statements need to be validated
         analyze("begin");
-        assertAskedForCluster(Privilege.Type.DQL);
+        assertThat(validationCallArguments.size(), is(0));
     }
 
     @Test


### PR DESCRIPTION
- BEGIN wraps other statements, the permissions of the inner statements
 are validated instead.

 - SET SESSION only affects the user session, there is no need to
 require permissions.