### PR TITLE
Rename the session `semi_join` key to `enable_semijoin`

### DIFF
--- a/sql/src/main/java/io/crate/metadata/settings/session/SessionSettingRegistry.java
+++ b/sql/src/main/java/io/crate/metadata/settings/session/SessionSettingRegistry.java
@@ -32,7 +32,7 @@ import java.util.Map;
 public class SessionSettingRegistry {
 
     public static final String SEARCH_PATH_KEY = "search_path";
-    public static final String SEMI_JOIN_KEY = "semi_joins";
+    public static final String SEMI_JOIN_KEY = "enable_semijoin";
 
     private static final Map<String, SessionSettingApplier> SESSION_SETTINGS =
         ImmutableMap.<String, SessionSettingApplier>builder()

--- a/sql/src/test/java/io/crate/integrationtests/AnyIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/AnyIntegrationTest.java
@@ -106,7 +106,7 @@ public class AnyIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
-    @UseSemiJoins(0) // Executed explicitly both with semi_joins enabled and disabled
+    @UseSemiJoins(0) // Executed explicitly both with enable_semijoin enabled and disabled
     public void testAnyWithSubselect() throws Exception {
         execute("select 2 where 1 = ANY(select 2)");
         assertThat(response.rowCount(), is(0L));

--- a/sql/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SubSelectIntegrationTest.java
@@ -43,7 +43,7 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
     private Setup setup = new Setup(sqlExecutor);
     static final List<List<String>> NO_SESSION_SETTINGS_AND_SEMI_JOIN_ENABLED = Arrays.asList(
         Collections.emptyList(),
-        Collections.singletonList("set semi_joins = true"));
+        Collections.singletonList("set enable_semijoin = true"));
 
     @Test
     public void testSubSelectOrderBy() throws Exception {
@@ -213,7 +213,7 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
-    @UseSemiJoins(0) // Executed explicitly both with semi_joins enabled and disabled
+    @UseSemiJoins(0) // Executed explicitly both with enable_semijoin enabled and disabled
     public void testNestedSubSelectWithOuterJoins() throws Exception {
         execute("create table t1 (a string, i integer, x integer)");
         execute("create table t2 (a string, i integer, y integer)");
@@ -604,7 +604,7 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
-    @UseSemiJoins(0) // Executed explicitly both with semi_joins enabled and disabled
+    @UseSemiJoins(0) // Executed explicitly both with enable_semijoin enabled and disabled
     public void testNestedSubqueryWithAggregatesInMultipleStages() throws Exception {
         setup.setUpJobs();
         setup.setUpEmployees();
@@ -627,7 +627,7 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
-    @UseSemiJoins(0) // Executed explicitly both with semi_joins enabled and disabled
+    @UseSemiJoins(0) // Executed explicitly both with enable_semijoin enabled and disabled
     public void testJoiningSubqueries() throws Exception {
         setup.setUpJobs();
         setup.setUpEmployees();
@@ -649,7 +649,7 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
-    @UseSemiJoins(0) // Executed explicitly both with semi_joins enabled and disabled
+    @UseSemiJoins(0) // Executed explicitly both with enable_semijoin enabled and disabled
     public void testSubqueryWithNestedEquiJoin() throws Exception {
         setup.setUpJobs();
         setup.setUpEmployees();
@@ -669,7 +669,7 @@ public class SubSelectIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
-    @UseSemiJoins(0) // Executed explicitly both with semi_joins enabled and disabled
+    @UseSemiJoins(0) // Executed explicitly both with enable_semijoin enabled and disabled
     public void testSelectWithTwoInOnSubQueryThatCanBeRewrittenToSemiJoins() throws Exception {
         executeWith(
             NO_SESSION_SETTINGS_AND_SEMI_JOIN_ENABLED,

--- a/sql/src/test/java/io/crate/testing/SQLTransportExecutor.java
+++ b/sql/src/test/java/io/crate/testing/SQLTransportExecutor.java
@@ -148,8 +148,8 @@ public class SQLTransportExecutor {
         sessionList.add("set search_path='" + defaultSchema + "'");
 
         if (isSemiJoinsEnabled) {
-            sessionList.add("set semi_joins=true");
-            LOGGER.trace("Executing with semi_joins=true: {}", stmt);
+            sessionList.add("set enable_semijoin=true");
+            LOGGER.trace("Executing with enable_semijoin=true: {}", stmt);
         }
 
         if (pgUrl != null && isJdbcEnabled) {

--- a/sql/src/test/java/io/crate/testing/UseSemiJoins.java
+++ b/sql/src/test/java/io/crate/testing/UseSemiJoins.java
@@ -29,7 +29,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Execute "set semi_joins = true" before the actual statement to allow IN/ANY (Subquery)
+ * Execute "set enable_semijoin = true" before the actual statement to allow IN/ANY (Subquery)
  * to be rewritten to a SEMI/ANTI join.
  */
 @Retention(RetentionPolicy.RUNTIME)


### PR DESCRIPTION
This change is part of an effort to have the query planning session configurations
follow a consistent naming scheme (ie. `enable_${feature}`).
No `CHANGES` entry is created as the semijoins are not documented.