### PR TITLE
Refactor the classes of the NestedLoop Batch Iterators.

### DIFF
--- a/benchmarks/src/test/java/io/crate/data/join/RowsBatchIteratorBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/data/join/RowsBatchIteratorBenchmark.java
@@ -20,10 +20,15 @@
  * agreement.
  */
 
-package io.crate.data;
+package io.crate.data.join;
 
-import io.crate.data.join.CombinedRow;
-import io.crate.data.join.NestedLoopBatchIterator;
+import io.crate.data.BatchIterator;
+import io.crate.data.CloseAssertingBatchIterator;
+import io.crate.data.InMemoryBatchIterator;
+import io.crate.data.Row;
+import io.crate.data.Row1;
+import io.crate.data.RowN;
+import io.crate.data.SkippingBatchIterator;
 import io.crate.testing.RowGenerator;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -86,7 +91,7 @@ public class RowsBatchIteratorBenchmark {
 
     @Benchmark
     public void measureConsumeNestedLoopJoin(Blackhole blackhole) throws Exception {
-        BatchIterator<Row> crossJoin = NestedLoopBatchIterator.crossJoin(
+        BatchIterator<Row> crossJoin = JoinBatchIterators.crossJoin(
             InMemoryBatchIterator.of(oneThousandRows, SENTINEL),
             InMemoryBatchIterator.of(tenThousandRows, SENTINEL),
             new CombinedRow(1, 1)
@@ -98,7 +103,7 @@ public class RowsBatchIteratorBenchmark {
 
     @Benchmark
     public void measureConsumeNestedLoopLeftJoin(Blackhole blackhole) throws Exception {
-        BatchIterator<Row> leftJoin = NestedLoopBatchIterator.leftJoin(
+        BatchIterator<Row> leftJoin = JoinBatchIterators.leftJoin(
             InMemoryBatchIterator.of(oneThousandRows, SENTINEL),
             InMemoryBatchIterator.of(tenThousandRows, SENTINEL),
             new CombinedRow(1, 1),

--- a/dex/src/main/java/io/crate/data/InMemoryBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/InMemoryBatchIterator.java
@@ -58,7 +58,7 @@ public class InMemoryBatchIterator<T> implements BatchIterator<T> {
     }
 
     @VisibleForTesting
-    InMemoryBatchIterator(Iterable<? extends T> items, T sentinel) {
+    public InMemoryBatchIterator(Iterable<? extends T> items, T sentinel) {
         this.items = items;
         this.it = items.iterator();
         this.current = sentinel;

--- a/dex/src/main/java/io/crate/data/join/AntiJoinNLBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/join/AntiJoinNLBatchIterator.java
@@ -37,12 +37,12 @@ import java.util.function.Predicate;
  *     }
  * </pre>
  */
-class AntiJoinBatchIterator<L, R, C> extends SemiJoinBatchIterator<L, R, C> {
+class AntiJoinNLBatchIterator<L, R, C> extends SemiJoinNLBatchIterator<L, R, C> {
 
-    AntiJoinBatchIterator(BatchIterator<L> left,
-                          BatchIterator<R> right,
-                          ElementCombiner<L, R, C> combiner,
-                          Predicate<C> joinCondition) {
+    AntiJoinNLBatchIterator(BatchIterator<L> left,
+                            BatchIterator<R> right,
+                            ElementCombiner<L, R, C> combiner,
+                            Predicate<C> joinCondition) {
         super(left, right, combiner, joinCondition);
     }
 

--- a/dex/src/main/java/io/crate/data/join/CrossJoinNLBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/join/CrossJoinNLBatchIterator.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.data.join;
+
+
+import io.crate.data.BatchIterator;
+
+/**
+ * This BatchIterator is used for both CrossJoins and InnerJoins as for the InnerJoins
+ * the joinCondition is tested later on as a filter Projection.
+ *
+ * <pre>
+ *     for (leftRow in left) {
+ *         for (rightRow in right) {
+ *             match?
+ *                  onRow
+ *         }
+ *     }
+ * </pre>
+ */
+public class CrossJoinNLBatchIterator<L, R, C> extends JoinBatchIterator<L, R, C> {
+
+    CrossJoinNLBatchIterator(BatchIterator<L> left,
+                             BatchIterator<R> right,
+                             ElementCombiner<L, R, C> combiner) {
+        super(left, right, combiner);
+    }
+
+    @Override
+    public boolean moveNext() {
+        if (activeIt == left) {
+            return tryAdvanceLeftAndRight();
+        } else {
+            return tryAdvanceRight();
+        }
+    }
+
+    private boolean tryAdvanceLeftAndRight() {
+        while (tryMoveLeft()) {
+            activeIt = right;
+            if (tryMoveRight()) {
+                return true;
+            }
+            if (right.allLoaded() == false) {
+                return false;
+            }
+            right.moveToStart();
+        }
+        return false;
+    }
+
+    private boolean tryAdvanceRight() {
+        if (tryMoveRight()) {
+            return true;
+        }
+        if (right.allLoaded() == false) {
+            return false;
+        }
+
+        // new outer loop iteration
+        right.moveToStart();
+        if (tryMoveLeft()) {
+            return tryMoveRight();
+        }
+        // left is either out of rows or needs to load more data - whatever the case,
+        // next moveNext must operate on left
+        activeIt = left;
+        return false;
+    }
+}

--- a/dex/src/main/java/io/crate/data/join/FullOuterJoinNLBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/join/FullOuterJoinNLBatchIterator.java
@@ -27,47 +27,50 @@ import io.crate.data.BatchIterator;
 import java.util.function.Predicate;
 
 /**
- * Nested Loop + additional loop afterwards to emit any rows that had no matches
+ * Combination of left + right join:
  *
  * <pre>
  *     for (leftRow in left) {
  *         for (rightRow in right) {
- *             if matched {
- *                 markPosition(pos)
- *                 onRow
- *             }
+ *             match?
+ *               onRow
+ *         }
+ *         if (noMatches) {
+ *             onRow (right-side-null)
  *         }
  *     }
  *
  *     for (rightRow in right) {
- *         if (noMatch(position)) {
- *             onRow (left-side-null)
+ *         if (noMatches) {
+ *              onRow (left-side-null)
  *         }
  *     }
  * </pre>
  */
-class RightJoinBatchIterator<L, R, C> extends NestedLoopBatchIterator<L, R, C> {
+class FullOuterJoinNLBatchIterator<L, R, C> extends JoinBatchIterator<L, R, C> {
 
     private final LuceneLongBitSetWrapper matchedRows = new LuceneLongBitSetWrapper();
     private final Predicate<C> joinCondition;
 
     private boolean postNL = false;
+    private boolean hadMatch = false;
     private int position = -1;
 
-    RightJoinBatchIterator(BatchIterator<L> left,
-                           BatchIterator<R> right,
-                           ElementCombiner<L, R, C> combiner,
-                           Predicate<C> joinCondition) {
+    FullOuterJoinNLBatchIterator(BatchIterator<L> left,
+                                 BatchIterator<R> right,
+                                 ElementCombiner<L, R, C> combiner,
+                                 Predicate<C> joinCondition) {
         super(left, right, combiner);
         this.joinCondition = joinCondition;
     }
 
     @Override
     public void moveToStart() {
-        super.moveToStart();
-        activeIt = left;
         postNL = false;
+        hadMatch = false;
         position = -1;
+        activeIt = left;
+        super.moveToStart();
     }
 
     @Override
@@ -115,6 +118,7 @@ class RightJoinBatchIterator<L, R, C> extends NestedLoopBatchIterator<L, R, C> {
         while (tryMoveRight()) {
             position++;
             if (joinCondition.test(combiner.currentElement())) {
+                hadMatch = true;
                 matchedRows.set(position);
                 return true;
             }
@@ -124,6 +128,12 @@ class RightJoinBatchIterator<L, R, C> extends NestedLoopBatchIterator<L, R, C> {
         }
         position = -1;
         right.moveToStart();
+        if (hadMatch == false) {
+            combiner.nullRight();
+            activeIt = left;
+            return true;
+        }
+        hadMatch = false;
         return null;
     }
 

--- a/dex/src/main/java/io/crate/data/join/JoinBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/join/JoinBatchIterator.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.data.join;
+
+import io.crate.data.BatchIterator;
+
+import javax.annotation.Nonnull;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Basic class for BatchIterators that implement the various types of Joins.
+ * <p>
+ * It handles two Iterators the {@link #left} and {@link #right} corresponding to
+ * the left and the right tables of a Join. It uses an element {@link #combiner} which
+ * combines the data from the left and right iterators to produce the final output which
+ * is passed to the consumer of this BatchIterator which gets it via the {@link #currentElement()}.
+ * <p>
+ * A helper {@link #activeIt} variable points to the currently active iterator thus making
+ * transparent to the consumer of this BatchIterator, which calls the methods {@link #allLoaded()}
+ * and {@link #loadNextBatch()}, which of the sides (left or right) are currently processed.
+ * Usually those methods don't need to be overriden.
+ * <p>
+ * The methods {@link #close()} and {@link #kill(Throwable)} are closing or killing the
+ * left and right iterators and usually don't need to be overriden.
+ */
+public abstract class JoinBatchIterator<L, R, C> implements BatchIterator<C> {
+
+    final ElementCombiner<L, R, C> combiner;
+    final BatchIterator<L> left;
+    final BatchIterator<R> right;
+
+    /**
+     * points to the batchIterator which will be used on the next {@link #moveNext()} call
+     */
+    BatchIterator activeIt;
+
+    JoinBatchIterator(BatchIterator<L> left, BatchIterator<R> right, ElementCombiner<L, R, C> combiner) {
+        this.left = left;
+        this.right = right;
+        this.activeIt = left;
+        this.combiner = combiner;
+    }
+
+    @Override
+    public C currentElement() {
+        return combiner.currentElement();
+    }
+
+    @Override
+    public void moveToStart() {
+        left.moveToStart();
+        right.moveToStart();
+        activeIt = left;
+    }
+
+    boolean tryMoveLeft() {
+        if (left.moveNext()) {
+            combiner.setLeft(left.currentElement());
+            return true;
+        }
+        return false;
+    }
+
+    boolean tryMoveRight() {
+        if (right.moveNext()) {
+            combiner.setRight(right.currentElement());
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public void close() {
+        left.close();
+        right.close();
+    }
+
+    @Override
+    public CompletionStage<?> loadNextBatch() {
+        return activeIt.loadNextBatch();
+    }
+
+    @Override
+    public boolean allLoaded() {
+        return activeIt.allLoaded();
+    }
+
+
+    @Override
+    public void kill(@Nonnull Throwable throwable) {
+        left.kill(throwable);
+        right.kill(throwable);
+    }
+}

--- a/dex/src/main/java/io/crate/data/join/LeftJoinNLBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/join/LeftJoinNLBatchIterator.java
@@ -24,7 +24,6 @@ package io.crate.data.join;
 
 import io.crate.data.BatchIterator;
 
-import java.util.concurrent.CompletionStage;
 import java.util.function.Predicate;
 
 /**
@@ -40,15 +39,15 @@ import java.util.function.Predicate;
  *     }
  * </pre>
  */
-class LeftJoinBatchIterator<L, R, C> extends NestedLoopBatchIterator<L, R, C> {
+class LeftJoinNLBatchIterator<L, R, C> extends JoinBatchIterator<L, R, C> {
 
     private final Predicate<C> joinCondition;
     private boolean hadMatch = false;
 
-    LeftJoinBatchIterator(BatchIterator<L> left,
-                          BatchIterator<R> right,
-                          ElementCombiner<L, R, C> combiner,
-                          Predicate<C> joinCondition) {
+    LeftJoinNLBatchIterator(BatchIterator<L> left,
+                            BatchIterator<R> right,
+                            ElementCombiner<L, R, C> combiner,
+                            Predicate<C> joinCondition) {
         super(left, right, combiner);
         this.joinCondition = joinCondition;
     }
@@ -78,11 +77,6 @@ class LeftJoinBatchIterator<L, R, C> extends NestedLoopBatchIterator<L, R, C> {
         }
         activeIt = left;
         return false;
-    }
-
-    @Override
-    public CompletionStage<?> loadNextBatch() {
-        return super.loadNextBatch();
     }
 
     /**

--- a/dex/src/main/java/io/crate/data/join/LuceneLongBitSetWrapper.java
+++ b/dex/src/main/java/io/crate/data/join/LuceneLongBitSetWrapper.java
@@ -25,7 +25,7 @@ package io.crate.data.join;
 import org.apache.lucene.util.LongBitSet;
 
 /**
- * This BitSet is used to mark matched rows between left and right in {@link NestedLoopBatchIterator}
+ * This BitSet is used to mark matched rows between left and right in {@link JoinBatchIterator}
  * <p>
  * Each bit true if the rows in the respective position are matched and therefore we need
  * a structure capable of holding <pre>long</pre> size of bits so java.util.BitSet cannot be used.

--- a/dex/src/main/java/io/crate/data/join/SemiJoinNLBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/join/SemiJoinNLBatchIterator.java
@@ -39,7 +39,7 @@ import java.util.function.Predicate;
  *     }
  * </pre>
  */
-class SemiJoinBatchIterator<L, R, C> implements BatchIterator<L> {
+class SemiJoinNLBatchIterator<L, R, C> implements BatchIterator<L> {
 
     final BatchIterator<L> left;
     final BatchIterator<R> right;
@@ -48,10 +48,10 @@ class SemiJoinBatchIterator<L, R, C> implements BatchIterator<L> {
 
     BatchIterator<?> activeIt;
 
-    SemiJoinBatchIterator(BatchIterator<L> left,
-                          BatchIterator<R> right,
-                          ElementCombiner<L, R, C> combiner,
-                          Predicate<C> joinCondition) {
+    SemiJoinNLBatchIterator(BatchIterator<L> left,
+                            BatchIterator<R> right,
+                            ElementCombiner<L, R, C> combiner,
+                            Predicate<C> joinCondition) {
         this.left = left;
         this.right = right;
         this.combiner = combiner;

--- a/dex/src/test/java/io/crate/data/join/NestedLoopBatchIteratorsTest.java
+++ b/dex/src/test/java/io/crate/data/join/NestedLoopBatchIteratorsTest.java
@@ -20,10 +20,11 @@
  * agreement.
  */
 
-package io.crate.data;
+package io.crate.data.join;
 
-import io.crate.data.join.CombinedRow;
-import io.crate.data.join.NestedLoopBatchIterator;
+import io.crate.data.BatchIterator;
+import io.crate.data.InMemoryBatchIterator;
+import io.crate.data.Row;
 import io.crate.testing.BatchIteratorTester;
 import io.crate.testing.BatchSimulatingIterator;
 import io.crate.testing.TestingBatchIterators;
@@ -42,7 +43,7 @@ import static io.crate.data.SentinelRow.SENTINEL;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
-public class NestedLoopBatchIteratorTest {
+public class NestedLoopBatchIteratorsTest {
 
     private ArrayList<Object[]> threeXThreeRows;
     private ArrayList<Object[]> leftJoinResult;
@@ -56,7 +57,7 @@ public class NestedLoopBatchIteratorTest {
     }
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         threeXThreeRows = new ArrayList<>();
         for (int i = 0; i < 3; i++) {
             for (int j = 0; j < 3; j++) {
@@ -99,7 +100,7 @@ public class NestedLoopBatchIteratorTest {
     @Test
     public void testNestedLoopBatchIterator() throws Exception {
         BatchIteratorTester tester = new BatchIteratorTester(
-            () -> NestedLoopBatchIterator.crossJoin(
+            () -> JoinBatchIterators.crossJoin(
                 TestingBatchIterators.range(0, 3),
                 TestingBatchIterators.range(0, 3),
                 new CombinedRow(1, 1)
@@ -111,7 +112,7 @@ public class NestedLoopBatchIteratorTest {
     @Test
     public void testNestedLoopWithBatchedSource() throws Exception {
         BatchIteratorTester tester = new BatchIteratorTester(
-            () -> NestedLoopBatchIterator.crossJoin(
+            () -> JoinBatchIterators.crossJoin(
                 new BatchSimulatingIterator<>(TestingBatchIterators.range(0, 3), 2, 2, null),
                 new BatchSimulatingIterator<>(TestingBatchIterators.range(0, 3), 2, 2, null),
                 new CombinedRow(1, 1)
@@ -122,7 +123,7 @@ public class NestedLoopBatchIteratorTest {
 
     @Test
     public void testNestedLoopLeftAndRightEmpty() throws Exception {
-        BatchIterator<Row> iterator = NestedLoopBatchIterator.crossJoin(
+        BatchIterator<Row> iterator = JoinBatchIterators.crossJoin(
             InMemoryBatchIterator.empty(SENTINEL),
             InMemoryBatchIterator.empty(SENTINEL),
             new CombinedRow(0, 0)
@@ -134,7 +135,7 @@ public class NestedLoopBatchIteratorTest {
 
     @Test
     public void testNestedLoopLeftEmpty() throws Exception {
-        BatchIterator<Row> iterator = NestedLoopBatchIterator.crossJoin(
+        BatchIterator<Row> iterator = JoinBatchIterators.crossJoin(
             InMemoryBatchIterator.empty(SENTINEL),
             TestingBatchIterators.range(0, 5),
             new CombinedRow(0, 1)
@@ -146,7 +147,7 @@ public class NestedLoopBatchIteratorTest {
 
     @Test
     public void testNestedLoopRightEmpty() throws Exception {
-        BatchIterator<Row> iterator = NestedLoopBatchIterator.crossJoin(
+        BatchIterator<Row> iterator = JoinBatchIterators.crossJoin(
             TestingBatchIterators.range(0, 5),
             InMemoryBatchIterator.empty(SENTINEL),
             new CombinedRow(1, 0)
@@ -159,7 +160,7 @@ public class NestedLoopBatchIteratorTest {
 
     @Test
     public void testLeftJoin() throws Exception {
-        Supplier<BatchIterator<Row>> batchIteratorSupplier = () -> NestedLoopBatchIterator.leftJoin(
+        Supplier<BatchIterator<Row>> batchIteratorSupplier = () -> JoinBatchIterators.leftJoin(
             TestingBatchIterators.range(0, 4),
             TestingBatchIterators.range(2, 6),
             new CombinedRow(1, 1),
@@ -171,7 +172,7 @@ public class NestedLoopBatchIteratorTest {
 
     @Test
     public void testLeftJoinBatchedSource() throws Exception {
-        Supplier<BatchIterator<Row>> batchIteratorSupplier = () -> NestedLoopBatchIterator.leftJoin(
+        Supplier<BatchIterator<Row>> batchIteratorSupplier = () -> JoinBatchIterators.leftJoin(
             new BatchSimulatingIterator<>(TestingBatchIterators.range(0, 4), 2, 2, null),
             new BatchSimulatingIterator<>(TestingBatchIterators.range(2, 6), 2, 2, null),
             new CombinedRow(1, 1),
@@ -183,7 +184,7 @@ public class NestedLoopBatchIteratorTest {
 
     @Test
     public void testRightJoin() throws Exception {
-        Supplier<BatchIterator<Row>> batchIteratorSupplier = () -> NestedLoopBatchIterator.rightJoin(
+        Supplier<BatchIterator<Row>> batchIteratorSupplier = () -> JoinBatchIterators.rightJoin(
             TestingBatchIterators.range(0, 4),
             TestingBatchIterators.range(2, 6),
             new CombinedRow(1, 1),
@@ -195,7 +196,7 @@ public class NestedLoopBatchIteratorTest {
 
     @Test
     public void testRightJoinBatchedSource() throws Exception {
-        Supplier<BatchIterator<Row>> batchIteratorSupplier = () -> NestedLoopBatchIterator.rightJoin(
+        Supplier<BatchIterator<Row>> batchIteratorSupplier = () -> JoinBatchIterators.rightJoin(
             new BatchSimulatingIterator<>(TestingBatchIterators.range(0, 4), 2, 2, null),
             new BatchSimulatingIterator<>(TestingBatchIterators.range(2, 6), 2, 2, null),
             new CombinedRow(1, 1),
@@ -207,7 +208,7 @@ public class NestedLoopBatchIteratorTest {
 
     @Test
     public void testFullOuterJoin() throws Exception {
-        Supplier<BatchIterator<Row>> batchIteratorSupplier = () -> NestedLoopBatchIterator.fullOuterJoin(
+        Supplier<BatchIterator<Row>> batchIteratorSupplier = () -> JoinBatchIterators.fullOuterJoin(
             TestingBatchIterators.range(0, 4),
             TestingBatchIterators.range(2, 6),
             new CombinedRow(1, 1),
@@ -219,7 +220,7 @@ public class NestedLoopBatchIteratorTest {
 
     @Test
     public void testFullOuterJoinBatchedSource() throws Exception {
-        Supplier<BatchIterator<Row>> batchIteratorSupplier = () -> NestedLoopBatchIterator.fullOuterJoin(
+        Supplier<BatchIterator<Row>> batchIteratorSupplier = () -> JoinBatchIterators.fullOuterJoin(
             new BatchSimulatingIterator<>(TestingBatchIterators.range(0, 4), 2, 2, null),
             new BatchSimulatingIterator<>(TestingBatchIterators.range(2, 6), 2, 2, null),
             new CombinedRow(1, 1),
@@ -230,8 +231,8 @@ public class NestedLoopBatchIteratorTest {
     }
 
     @Test
-    public void testMoveToStartWhileRightSideIsActive() throws Exception {
-        BatchIterator<Row> batchIterator = NestedLoopBatchIterator.crossJoin(
+    public void testMoveToStartWhileRightSideIsActive() {
+        BatchIterator<Row> batchIterator = JoinBatchIterators.crossJoin(
             TestingBatchIterators.range(0, 3),
             TestingBatchIterators.range(10, 20),
             new CombinedRow(1, 1)
@@ -250,7 +251,7 @@ public class NestedLoopBatchIteratorTest {
 
     @Test
     public void testSemiJoin() throws Exception {
-        Supplier<BatchIterator<Row>> batchIteratorSupplier = () -> NestedLoopBatchIterator.semiJoin(
+        Supplier<BatchIterator<Row>> batchIteratorSupplier = () -> JoinBatchIterators.semiJoin(
             TestingBatchIterators.range(0, 5),
             TestingBatchIterators.range(2, 6),
             new CombinedRow(1, 0),
@@ -262,7 +263,7 @@ public class NestedLoopBatchIteratorTest {
 
     @Test
     public void testSemiJoinBatchedSource() throws Exception {
-        Supplier<BatchIterator<Row>> batchIteratorSupplier = () -> NestedLoopBatchIterator.semiJoin(
+        Supplier<BatchIterator<Row>> batchIteratorSupplier = () -> JoinBatchIterators.semiJoin(
             new BatchSimulatingIterator<>(TestingBatchIterators.range(0, 5), 2, 2, null),
             new BatchSimulatingIterator<>(TestingBatchIterators.range(2, 6), 2, 2, null),
             new CombinedRow(1, 1),
@@ -274,7 +275,7 @@ public class NestedLoopBatchIteratorTest {
 
     @Test
     public void testSemiJoinLeftEmpty() throws Exception {
-        BatchIterator<Row> iterator = NestedLoopBatchIterator.semiJoin(
+        BatchIterator<Row> iterator = JoinBatchIterators.semiJoin(
             InMemoryBatchIterator.empty(SENTINEL),
             TestingBatchIterators.range(0, 5),
             new CombinedRow(1, 1),
@@ -287,7 +288,7 @@ public class NestedLoopBatchIteratorTest {
 
     @Test
     public void testSemiJoinRightEmpty() throws Exception {
-        BatchIterator<Row> iterator = NestedLoopBatchIterator.semiJoin(
+        BatchIterator<Row> iterator = JoinBatchIterators.semiJoin(
             TestingBatchIterators.range(0, 5),
             InMemoryBatchIterator.empty(SENTINEL),
             new CombinedRow(1, 1),
@@ -300,7 +301,7 @@ public class NestedLoopBatchIteratorTest {
 
     @Test
     public void testAntiJoin() throws Exception {
-        Supplier<BatchIterator<Row>> batchIteratorSupplier = () -> NestedLoopBatchIterator.antiJoin(
+        Supplier<BatchIterator<Row>> batchIteratorSupplier = () -> JoinBatchIterators.antiJoin(
             TestingBatchIterators.range(0, 5),
             TestingBatchIterators.range(2, 4),
             new CombinedRow(1, 1),
@@ -312,7 +313,7 @@ public class NestedLoopBatchIteratorTest {
 
     @Test
     public void testAntiJoinBatchedSource() throws Exception {
-        Supplier<BatchIterator<Row>> batchIteratorSupplier = () -> NestedLoopBatchIterator.antiJoin(
+        Supplier<BatchIterator<Row>> batchIteratorSupplier = () -> JoinBatchIterators.antiJoin(
             new BatchSimulatingIterator<>(TestingBatchIterators.range(0, 5), 2, 2, null),
             new BatchSimulatingIterator<>(TestingBatchIterators.range(2, 4), 2, 2, null),
             new CombinedRow(1, 1),
@@ -324,7 +325,7 @@ public class NestedLoopBatchIteratorTest {
 
     @Test
     public void testAntiJoinLeftEmpty() throws Exception {
-        BatchIterator<Row> iterator = NestedLoopBatchIterator.antiJoin(
+        BatchIterator<Row> iterator = JoinBatchIterators.antiJoin(
             InMemoryBatchIterator.empty(SENTINEL),
             TestingBatchIterators.range(0, 5),
             new CombinedRow(1, 1),
@@ -337,7 +338,7 @@ public class NestedLoopBatchIteratorTest {
 
     @Test
     public void testAntiJoinRightEmpty() throws Exception {
-        Supplier<BatchIterator<Row>> batchIteratorSupplier = () -> NestedLoopBatchIterator.antiJoin(
+        Supplier<BatchIterator<Row>> batchIteratorSupplier = () -> JoinBatchIterators.antiJoin(
             new BatchSimulatingIterator<>(TestingBatchIterators.range(0, 3), 2, 2, null),
             InMemoryBatchIterator.empty(SENTINEL),
             new CombinedRow(1, 1),

--- a/sql/src/main/java/io/crate/execution/engine/join/NestedLoopOperation.java
+++ b/sql/src/main/java/io/crate/execution/engine/join/NestedLoopOperation.java
@@ -28,7 +28,7 @@ import io.crate.data.ListenableBatchIterator;
 import io.crate.data.Row;
 import io.crate.data.RowConsumer;
 import io.crate.data.join.CombinedRow;
-import io.crate.data.join.NestedLoopBatchIterator;
+import io.crate.data.join.JoinBatchIterators;
 import io.crate.planner.node.dql.join.JoinType;
 
 import javax.annotation.Nullable;
@@ -75,26 +75,26 @@ public class NestedLoopOperation implements CompletionListenable {
         CombinedRow combiner = new CombinedRow(leftNumCols, rightNumCols);
         switch (joinType) {
             case CROSS:
-                return NestedLoopBatchIterator.crossJoin(left, right, combiner);
+                return JoinBatchIterators.crossJoin(left, right, combiner);
 
             case INNER:
                 return new FilteringBatchIterator<>(
-                    NestedLoopBatchIterator.crossJoin(left, right, combiner), joinCondition);
+                    JoinBatchIterators.crossJoin(left, right, combiner), joinCondition);
 
             case LEFT:
-                return NestedLoopBatchIterator.leftJoin(left, right, combiner, joinCondition);
+                return JoinBatchIterators.leftJoin(left, right, combiner, joinCondition);
 
             case RIGHT:
-                return NestedLoopBatchIterator.rightJoin(left, right, combiner, joinCondition);
+                return JoinBatchIterators.rightJoin(left, right, combiner, joinCondition);
 
             case FULL:
-                return NestedLoopBatchIterator.fullOuterJoin(left, right, combiner, joinCondition);
+                return JoinBatchIterators.fullOuterJoin(left, right, combiner, joinCondition);
 
             case SEMI:
-                return NestedLoopBatchIterator.semiJoin(left, right, combiner, joinCondition);
+                return JoinBatchIterators.semiJoin(left, right, combiner, joinCondition);
 
             case ANTI:
-                return NestedLoopBatchIterator.antiJoin(left, right, combiner, joinCondition);
+                return JoinBatchIterators.antiJoin(left, right, combiner, joinCondition);
 
             default:
                 throw new AssertionError("Invalid joinType: " + joinType);


### PR DESCRIPTION
We will soon implemenent non-NestedLoop batch iterators, so:
 - Introduce a new JoinIterator abstract class to extend from.
 - Move the CrossJoin logic into a separate iterator: CrossJoinNLBatchIterator
 - Introduce a new JoinIterators utlity class which creates the appropriate Iterator.
 - Rename iterators by adding the NL (nested loop).