### PR TITLE
COPY FROM with CSV input

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -178,6 +178,10 @@ Changes
 - Implemented a ``NodeInfo`` JMX MBean to expose useful information (id, name)
   about the node.
 
+- Added support for CSV file inputs in ``COPY FROM`` statements. Input type is
+  inferred using the file's extension or can be set using the optional ``WITH``
+  clause and specifying the ``format``.
+
 Fixes
 =====
 

--- a/benchmarks/src/test/java/io/crate/execution/engine/reader/CsvReaderBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/execution/engine/reader/CsvReaderBenchmark.java
@@ -1,0 +1,120 @@
+package io.crate.execution.engine.reader;
+
+import com.google.common.collect.ImmutableMap;
+import io.crate.data.BatchIterator;
+import io.crate.data.Input;
+import io.crate.data.Row;
+import io.crate.execution.engine.collect.files.FileReadingIterator;
+import io.crate.execution.engine.collect.files.LineCollectorExpression;
+import io.crate.execution.engine.collect.files.LocalFsFileInputFactory;
+import io.crate.expression.InputFactory;
+import io.crate.expression.reference.file.FileLineReferenceResolver;
+import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.FunctionResolver;
+import io.crate.metadata.Functions;
+import io.crate.metadata.Reference;
+import io.crate.types.DataTypes;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static io.crate.execution.dsl.phases.FileUriCollectPhase.InputFormat.CSV;
+import static io.crate.testing.TestingHelpers.createReference;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+public class CsvReaderBenchmark {
+
+    private String fileUri;
+    private InputFactory inputFactory;
+    File tempFile;
+
+    @Setup
+    public void create_temp_file_and_uri() throws IOException {
+        Functions functions = new Functions(
+            ImmutableMap.<FunctionIdent, FunctionImplementation>of(),
+            ImmutableMap.<String, FunctionResolver>of()
+        );
+        inputFactory = new InputFactory(functions);
+        tempFile = File.createTempFile("temp", null);
+        fileUri = tempFile.toURI().getPath();
+        try (OutputStreamWriter writer = new OutputStreamWriter(new FileOutputStream(tempFile), StandardCharsets.UTF_8)) {
+            writer.write("name,id\n");
+            writer.write("Arthur,4\n");
+            writer.write("Trillian,5\n");
+            writer.write("Emma,5\n");
+            writer.write("Emily,9\n");
+            writer.write("Sarah,5\n");
+            writer.write("John,5\n");
+            writer.write("Mical,9\n");
+            writer.write("Mary,5\n");
+            writer.write("Jimmy,9\n");
+            writer.write("Tom,5\n");
+            writer.write("Neil,0\n");
+            writer.write("Rose,5\n");
+            writer.write("Gobnait,5\n");
+            writer.write("Rory,1\n");
+            writer.write("Martin,11\n");
+            writer.write("Arthur,4\n");
+            writer.write("Trillian,5\n");
+            writer.write("Emma,5\n");
+            writer.write("Emily,9\n");
+            writer.write("Sarah,5\n");
+            writer.write("John,5\n");
+            writer.write("Mical,9\n");
+            writer.write("Mary,5\n");
+            writer.write("Jimmy,9\n");
+            writer.write("Tom,5\n");
+            writer.write("Neil,0\n");
+            writer.write("Rose,5\n");
+            writer.write("Gobnait,5\n");
+            writer.write("Rory,1\n");
+            writer.write("Martin,11\n");
+        }
+    }
+
+    @Benchmark()
+    public void measureFileReadingIteratorForCSV(Blackhole blackhole) {
+        Reference raw = createReference("_raw", DataTypes.STRING);
+        InputFactory.Context<LineCollectorExpression<?>> ctx = inputFactory.ctxForRefs(FileLineReferenceResolver::getImplementation);
+
+        List<Input<?>> inputs = Collections.singletonList(ctx.add(raw));
+        BatchIterator<Row> batchIterator = FileReadingIterator.newInstance(
+            Collections.singletonList(fileUri),
+            inputs,
+            ctx.expressions(),
+            null,
+            ImmutableMap.of(
+                LocalFsFileInputFactory.NAME, new LocalFsFileInputFactory()),
+            false,
+            1,
+            0,
+            CSV);
+
+        while (batchIterator.moveNext()) {
+            blackhole.consume(batchIterator.currentElement().get(0));
+        }
+    }
+
+    @TearDown
+    public void cleanup() throws InterruptedException {
+        tempFile.deleteOnExit();
+    }
+}

--- a/benchmarks/src/test/java/io/crate/execution/engine/reader/JsonReaderBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/execution/engine/reader/JsonReaderBenchmark.java
@@ -1,0 +1,118 @@
+package io.crate.execution.engine.reader;
+
+import com.google.common.collect.ImmutableMap;
+import io.crate.data.BatchIterator;
+import io.crate.data.Input;
+import io.crate.data.Row;
+import io.crate.execution.engine.collect.files.FileReadingIterator;
+import io.crate.execution.engine.collect.files.LineCollectorExpression;
+import io.crate.execution.engine.collect.files.LocalFsFileInputFactory;
+import io.crate.expression.InputFactory;
+import io.crate.expression.reference.file.FileLineReferenceResolver;
+import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.FunctionResolver;
+import io.crate.metadata.Functions;
+import io.crate.metadata.Reference;
+import io.crate.types.DataTypes;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static io.crate.execution.dsl.phases.FileUriCollectPhase.InputFormat.JSON;
+import static io.crate.testing.TestingHelpers.createReference;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+public class JsonReaderBenchmark {
+
+    private String fileUri;
+    private InputFactory inputFactory;
+    File tempFile;
+
+    @Setup
+    public void create_temp_file_and_uri() throws IOException {
+        Functions functions = new Functions(
+            ImmutableMap.<FunctionIdent, FunctionImplementation>of(),
+            ImmutableMap.<String, FunctionResolver>of()
+        );
+        inputFactory = new InputFactory(functions);
+        tempFile = File.createTempFile("temp", null);
+        fileUri = tempFile.toURI().getPath();
+        try (OutputStreamWriter writer = new OutputStreamWriter(new FileOutputStream(tempFile), StandardCharsets.UTF_8)) {
+            writer.write("{\"name\": \"Arthur\", \"id\": 4\\n");
+            writer.write("{\"id\": 5, \"name\": \"Trillian\"\n");
+            writer.write("{\"id\": 5, \"name\": \"Emma\"\n");
+            writer.write("{\"id\": 9, \"name\": \"Emily\"\n");
+            writer.write("{\"id\": 5, \"name\": \"Sarah\"\n");
+            writer.write("{\"id\": 5, \"name\": \"John\"\n");
+            writer.write("{\"id\": 9, \"name\": \"Mical\"\n");
+            writer.write("{\"id\": 5, \"name\": \"Mary\"\n");
+            writer.write("{\"id\": 9, \"name\": \"Jimmy\"\n");
+            writer.write("{\"id\": 5, \"name\": \"Tom\"\n");
+            writer.write("{\"id\": 0, \"name\": \"Neil\"\n");
+            writer.write("{\"id\": 5, \"name\": \"Rose\"\n");
+            writer.write("{\"id\": 5, \"name\": \"Gobnait\"\n");
+            writer.write("{\"id\": 1, \"name\": \"Rory\"\n");
+            writer.write("{\"id\": 11, \"name\": \"Martin\"\n");
+            writer.write("{\"id\": 5, \"name\": \"Trillian\"\n");
+            writer.write("{\"id\": 5, \"name\": \"Emma\"\n");
+            writer.write("{\"id\": 9, \"name\": \"Emily\"\n");
+            writer.write("{\"id\": 5, \"name\": \"Sarah\"\n");
+            writer.write("{\"id\": 5, \"name\": \"John\"\n");
+            writer.write("{\"id\": 9, \"name\": \"Mical\"\n");
+            writer.write("{\"id\": 5, \"name\": \"Mary\"\n");
+            writer.write("{\"id\": 9, \"name\": \"Jimmy\"\n");
+            writer.write("{\"id\": 5, \"name\": \"Tom\"\n");
+            writer.write("{\"id\": 0, \"name\": \"Neil\"\n");
+            writer.write("{\"id\": 5, \"name\": \"Rose\"\n");
+            writer.write("{\"id\": 5, \"name\": \"Gobnait\"\n");
+            writer.write("{\"id\": 1, \"name\": \"Rory\"\n");
+            writer.write("{\"id\": 11, \"name\": \"Martin\"\n");
+        }
+    }
+
+    @Benchmark()
+    public void measureFileReadingIteratorForJson(Blackhole blackhole) {
+        Reference raw = createReference("_raw", DataTypes.STRING);
+        InputFactory.Context<LineCollectorExpression<?>> ctx = inputFactory.ctxForRefs(FileLineReferenceResolver::getImplementation);
+
+        List<Input<?>> inputs = Collections.singletonList(ctx.add(raw));
+        BatchIterator<Row> batchIterator = FileReadingIterator.newInstance(
+            Collections.singletonList(fileUri),
+            inputs,
+            ctx.expressions(),
+            null,
+            ImmutableMap.of(
+                LocalFsFileInputFactory.NAME, new LocalFsFileInputFactory()),
+            false,
+            1,
+            0,
+            JSON);
+
+        while (batchIterator.moveNext()) {
+            blackhole.consume(batchIterator.currentElement().get(0));
+        }
+    }
+
+    @TearDown
+    public void cleanup() throws InterruptedException {
+        tempFile.deleteOnExit();
+    }
+}

--- a/blackbox/docs/sql/statements/copy-from.rst
+++ b/blackbox/docs/sql/statements/copy-from.rst
@@ -35,14 +35,34 @@ Description
 import.
 
 The nodes in the cluster will attempt to read the files available at the URI
-and import the data. These files have to be UTF-8 encoded and contain a single
-JSON object per line. Any keys in the object will be added as columns,
-regardless of the previously defined table. Empty lines are simply sikpped.
+and import the data.
+
+Supported Formats
+-----------------
+
+CrateDB accepts both JSON and CSV inputs. The format is inferred from the file
+extension (``.json`` or ``.csv`` respectively) if possible. The format can also
+be provided as an option (see :ref:`with_option`). If a format is not specified
+and the format cannot be inferred, the file will be processed as JSON.
+
+Files must be UTF-8 encoded. Any keys in the object will be added as columns,
+regardless of the previously defined table. Empty lines are skipped.
+
+JSON files must contain a single JSON object per line.
 
 Example JSON data::
 
     {"id": 1, "quote": "Don't panic"}
     {"id": 2, "quote": "Ford, you're turning into a penguin. Stop it."}
+
+CSV files must contain a header with comma-separated values, which will
+be added as columns.
+
+Example CSV data::
+
+    id,quote
+    1,"Don't panic"
+    2,"Ford, you're turning into a penguin. Stop it."
 
 See also: :ref:`importing_data`.
 
@@ -184,6 +204,9 @@ each column a value.
    row, hence every row will be imported into the specified partition
    regardless of the value provided for the partition columns.
 
+
+.. _with_option:
+
 ``WITH``
 --------
 
@@ -265,6 +288,13 @@ Default: false
 
 ``COPY FROM`` by default won't overwrite rows if a document with the same
 primary key already exists. Set to true to overwrite duplicate rows.
+
+``format``
+''''''''''
+
+This option specifies the format of the input file. Available formats are
+``csv`` or ``json``. If a format is not specified and the format cannot be
+guessed from the file extension, the file will be processed as JSON.
 
 .. _`AWS documentation`: http://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html
 .. _`AWS Java Documentation`: http://docs.aws.amazon.com/AmazonS3/latest/dev/AuthUsingAcctOrUserCredJava.html

--- a/gradle/version.properties
+++ b/gradle/version.properties
@@ -15,6 +15,8 @@ slf4j_log4j12=1.7.10
 jackson_jaxrs=1.9.13
 jackson_xc=1.9.13
 jaxb_api=2.2.2
+jacksondatabind=2.0.1
+jacksondataformatcsv=2.5.1
 
 # Crate JDBC
 crate_jdbc=2.1.7

--- a/sql/build.gradle
+++ b/sql/build.gradle
@@ -22,6 +22,8 @@ dependencies {
     compile "com.google.guava:guava:${versions.guava}"
     compile "com.amazonaws:aws-java-sdk-s3:${versions.aws}"
     compile "org.apache.commons:commons-math3:${versions.commonsmath}"
+    compile "com.fasterxml.jackson.dataformat:jackson-dataformat-csv:${versions.jacksondataformatcsv}"
+    compile "com.fasterxml.jackson.core:jackson-databind:${versions.jacksondatabind}"
     // Needed by aws-java-sdk-s3 in Java 9
     compile "javax.xml.bind:jaxb-api:${versions.jaxb_api}"
 

--- a/sql/src/main/java/io/crate/analyze/CopyFromAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/CopyFromAnalyzedStatement.java
@@ -22,10 +22,11 @@
 
 package io.crate.analyze;
 
+import io.crate.execution.dsl.phases.FileUriCollectPhase;
 import io.crate.expression.symbol.Symbol;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.types.DataType;
-import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.settings.Settings;
 
 import javax.annotation.Nullable;
@@ -37,16 +38,24 @@ public class CopyFromAnalyzedStatement extends AbstractCopyAnalyzedStatement {
     @Nullable
     private final String partitionIdent;
     private final Predicate<DiscoveryNode> nodePredicate;
+    @Nullable
+    private final FileUriCollectPhase.InputFormat inputFormat;
 
     public CopyFromAnalyzedStatement(DocTableInfo table,
                                      Settings settings,
                                      Symbol uri,
                                      @Nullable String partitionIdent,
-                                     Predicate<DiscoveryNode> nodePredicate) {
+                                     Predicate<DiscoveryNode> nodePredicate,
+                                     FileUriCollectPhase.InputFormat inputFormat) {
         super(settings, uri);
         this.table = table;
         this.partitionIdent = partitionIdent;
         this.nodePredicate = nodePredicate;
+        this.inputFormat = inputFormat;
+    }
+
+    public FileUriCollectPhase.InputFormat inputFormat() {
+        return inputFormat;
     }
 
     public DocTableInfo table() {

--- a/sql/src/main/java/io/crate/execution/dsl/projection/WriterProjection.java
+++ b/sql/src/main/java/io/crate/execution/dsl/projection/WriterProjection.java
@@ -95,8 +95,6 @@ public class WriterProjection extends Projection {
         GZIP
     }
 
-
-
     public WriterProjection(List<Symbol> inputs,
                             Symbol uri,
                             @Nullable CompressionType compressionType,

--- a/sql/src/main/java/io/crate/execution/engine/collect/files/LineParser.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/files/LineParser.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.execution.engine.collect.files;
+
+import io.crate.execution.dsl.phases.FileUriCollectPhase;
+import io.crate.operation.collect.files.CSVLineParser;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+
+public class LineParser {
+
+    private CSVLineParser csvLineParser;
+
+    private InputType inputType;
+
+    private enum InputType {
+        CSV,
+        JSON
+    }
+
+    public void readFirstLine(URI currentUri, FileUriCollectPhase.InputFormat inputFormat, BufferedReader currentReader) throws IOException {
+        if (isInputCsv(inputFormat, currentUri)) {
+            csvLineParser = new CSVLineParser();
+            csvLineParser.parseHeader(currentReader);
+            inputType = InputType.CSV;
+        } else {
+            inputType = InputType.JSON;
+        }
+    }
+
+    public byte[] getByteArray(String line) throws IOException {
+        if (inputType == InputType.CSV) {
+            return csvLineParser.parse(line);
+        } else {
+            return line.getBytes(StandardCharsets.UTF_8);
+        }
+    }
+
+    private boolean isInputCsv(FileUriCollectPhase.InputFormat inputFormat, URI currentUri) {
+        return (inputFormat == FileUriCollectPhase.InputFormat.CSV) || currentUri.toString().endsWith(".csv");
+    }
+}

--- a/sql/src/main/java/io/crate/execution/engine/collect/sources/FileCollectSource.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/sources/FileCollectSource.java
@@ -83,7 +83,8 @@ public class FileCollectSource implements CollectSource {
             fileInputFactoryMap,
             fileUriCollectPhase.sharedStorage(),
             readers.length,
-            Arrays.binarySearch(readers, clusterService.state().nodes().getLocalNodeId())
+            Arrays.binarySearch(readers, clusterService.state().nodes().getLocalNodeId()),
+            fileUriCollectPhase.inputFormat()
         );
 
         return BatchIteratorCollectorBridge.newInstance(fileReadingIterator, consumer);

--- a/sql/src/main/java/io/crate/operation/collect/files/CSVLineParser.java
+++ b/sql/src/main/java/io/crate/operation/collect/files/CSVLineParser.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+ * license agreements.  See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.  Crate licenses
+ * this file to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial agreement.
+ */
+
+package io.crate.operation.collect.files;
+
+import com.fasterxml.jackson.databind.MappingIterator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.csv.CsvMapper;
+import com.fasterxml.jackson.dataformat.csv.CsvObjectReader;
+import com.fasterxml.jackson.dataformat.csv.CsvParser;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class CSVLineParser {
+
+    private List<Object> keyList;
+    private ObjectMapper objectMapper = new ObjectMapper();
+    private CsvObjectReader csvReader = new CsvMapper().enable(CsvParser.Feature.TRIM_SPACES)
+        .readerWithTypedSchemaFor(String.class);
+
+    public void parseHeader(BufferedReader currentReader) throws IOException {
+        String header = currentReader.readLine();
+        keyList = csvReader.readValues(header.getBytes(StandardCharsets.UTF_8)).readAll();
+        Set<Object> keySet = new HashSet<>(keyList);
+        keySet.remove("");
+
+        if (keySet.size() != keyList.size() || keySet.size() == 0) {
+            throw new IllegalArgumentException("Invalid header: duplicate entries or no entries present");
+        }
+    }
+
+    public byte[] parse(String row) throws IOException {
+        MappingIterator<Object> iterator = csvReader.readValues(row.getBytes(StandardCharsets.UTF_8));
+        HashMap<Object, Object> csvAsMap = new HashMap<>();
+        int i = 0;
+        while (iterator.hasNext()) {
+            if (iterator.hasNext() && i >= keyList.size()) {
+                throw new IllegalArgumentException("Number of values exceeds number of keys");
+            }
+
+            csvAsMap.put(keyList.get(i), iterator.next());
+            i++;
+        }
+        return objectMapper.writeValueAsBytes(csvAsMap);
+    }
+
+}

--- a/sql/src/main/java/io/crate/planner/statement/CopyStatementPlanner.java
+++ b/sql/src/main/java/io/crate/planner/statement/CopyStatementPlanner.java
@@ -219,7 +219,8 @@ public final class CopyStatementPlanner {
             toCollect,
             projections,
             copyFrom.settings().get("compression", null),
-            copyFrom.settings().getAsBoolean("shared", null)
+            copyFrom.settings().getAsBoolean("shared", null),
+            copyFrom.inputFormat()
         );
 
         Collect collect = new Collect(collectPhase, TopN.NO_LIMIT, 0, 1, 1, null);

--- a/sql/src/test/java/io/crate/execution/engine/collect/MapSideDataCollectOperationTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/MapSideDataCollectOperationTest.java
@@ -86,7 +86,8 @@ public class MapSideDataCollectOperationTest extends CrateDummyClusterServiceUni
             ),
             Collections.emptyList(),
             null,
-            false
+            false,
+            FileUriCollectPhase.InputFormat.JSON
         );
         String threadPoolName = JobCollectContext.threadPoolName(collectNode);
 

--- a/sql/src/test/java/io/crate/execution/engine/collect/files/FileReadingCollectorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/files/FileReadingCollectorTest.java
@@ -33,6 +33,7 @@ import io.crate.data.Bucket;
 import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.data.RowConsumer;
+import io.crate.execution.dsl.phases.FileUriCollectPhase;
 import io.crate.external.S3ClientHelper;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
@@ -288,8 +289,8 @@ public class FileReadingCollectorTest extends CrateUnitTest {
                 })),
             false,
             1,
-            0
-        );
+            0,
+            FileUriCollectPhase.InputFormat.JSON);
     }
 
     private static class WriteBufferAnswer implements Answer<Integer> {

--- a/sql/src/test/java/io/crate/execution/engine/collect/files/LineProcessorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/files/LineProcessorTest.java
@@ -1,0 +1,73 @@
+package io.crate.execution.engine.collect.files;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static io.crate.execution.dsl.phases.FileUriCollectPhase.InputFormat.CSV;
+import static io.crate.execution.dsl.phases.FileUriCollectPhase.InputFormat.JSON;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.*;
+
+public class LineProcessorTest {
+
+    private LineProcessor subjectUnderTest;
+    private URI uri;
+    private BufferedReader bufferedReader;
+
+    @Before
+    public void setup() {
+        subjectUnderTest  = new LineProcessor();
+    }
+
+    @Test
+    public void readFirstLine_givenFileExtensionIsCsv_AndDefaultJSONFileFormat_thenReadsLine() throws URISyntaxException, IOException {
+        uri = new URI ("file.csv");
+        Reader reader = new StringReader("some/string");
+        bufferedReader = new BufferedReader(reader);
+
+        subjectUnderTest.readFirstLine(uri, JSON, bufferedReader);
+
+        assertThat(bufferedReader.readLine(), is(nullValue()));;
+    }
+
+    @Test
+    public void readFirstLine_givenFileFormatIsCsv_thenReadsLine() throws URISyntaxException, IOException {
+        uri = new URI ("file.any");
+        Reader reader = new StringReader("some/string");
+        bufferedReader = new BufferedReader(reader);
+
+        subjectUnderTest.readFirstLine(uri, CSV, bufferedReader);
+
+        assertThat(bufferedReader.readLine(), is(nullValue()));;
+    }
+
+    @Test
+    public void readFirstLine_givenFileExtensionIsJson__AndDefaultJSONFileFormat_thenDoesNotReadLine() throws URISyntaxException, IOException {
+        uri = new URI ("file.json");
+        Reader reader = new StringReader("some/string");
+        bufferedReader = new BufferedReader(reader);
+
+        subjectUnderTest.readFirstLine(uri, JSON, bufferedReader);
+
+        assertThat(bufferedReader.readLine(), is("some/string"));
+    }
+
+    @Test
+    public void readFirstLine_givenFileFormatIsJson_thenDoesNotReadLine() throws URISyntaxException, IOException {
+        uri = new URI ("file.any");
+        Reader reader = new StringReader("some/string");
+        bufferedReader = new BufferedReader(reader);
+
+        subjectUnderTest.readFirstLine(uri, JSON, bufferedReader);
+
+        assertThat(bufferedReader.readLine(), is("some/string"));
+    }
+}

--- a/sql/src/test/java/io/crate/operation/collect/files/CSVLineParserTest.java
+++ b/sql/src/test/java/io/crate/operation/collect/files/CSVLineParserTest.java
@@ -1,0 +1,155 @@
+package io.crate.operation.collect.files;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class CSVLineParserTest {
+
+    private CSVLineParser subjectUnderTest;
+    private byte[] result;
+
+    @Before
+    public void setup(){
+        subjectUnderTest = new CSVLineParser();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void parse_givenEmptyHeader_thenThrowsException() throws IOException {
+        String header = "\n";
+        BufferedReader bufferedReader = new BufferedReader(new StringReader(header));
+        subjectUnderTest.parseHeader(bufferedReader);
+        subjectUnderTest.parse("GER,Germany\n");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void parse_givenDuplicateKey_thenThrowsException() throws IOException {
+        String header = "Code,Country,Country\n";
+        BufferedReader bufferedReader = new BufferedReader(new StringReader(header));
+        subjectUnderTest.parseHeader(bufferedReader);
+        result =subjectUnderTest.parse("GER,Germany,Another\n");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void parse_givenMissingKey_thenThrowsException() throws IOException {
+        String header = "Code,\n";
+        BufferedReader bufferedReader = new BufferedReader(new StringReader(header));
+        subjectUnderTest.parseHeader(bufferedReader);
+        result = subjectUnderTest.parse("GER,Germany\n");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void parse_givenExtraValue_thenIgnoresTheKeyWithoutValue() throws IOException {
+        String header = "Code,Country\n";
+        BufferedReader bufferedReader = new BufferedReader(new StringReader(header));
+        subjectUnderTest.parseHeader(bufferedReader);
+        subjectUnderTest.parse("GER,Germany,Berlin\n");
+    }
+
+    @Test
+    public void parse_givenExtraKey_thenIgnoresTheKeyWithoutValue() throws IOException {
+        String header = "Code,Country,Another\n";
+        BufferedReader bufferedReader = new BufferedReader(new StringReader(header));
+        subjectUnderTest.parseHeader(bufferedReader);
+        result = subjectUnderTest.parse("GER,Germany\n");
+
+        assertThat(result, is("{\"Country\":\"Germany\",\"Code\":\"GER\"}".getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    public void parse_givenCSVInput_thenParsesToMap() throws IOException {
+        String header = "Code,Country\n";
+        BufferedReader bufferedReader = new BufferedReader(new StringReader(header));
+        subjectUnderTest.parseHeader(bufferedReader);
+        result = subjectUnderTest.parse("GER,Germany\n");
+
+        assertThat(result, is("{\"Country\":\"Germany\",\"Code\":\"GER\"}".getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    public void parse_givenEmptyRow_thenParsesToEmptyJson() throws IOException {
+        String header = "Code,Country\n";
+        BufferedReader bufferedReader = new BufferedReader(new StringReader(header));
+        subjectUnderTest.parseHeader(bufferedReader);
+        result = subjectUnderTest.parse("");
+
+        assertThat(result, is("{}".getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    public void parse_givenEmptyRowWithCommas_thenParsesAsEmptyStrings() throws IOException {
+        String header ="Code,Country\n";
+        BufferedReader bufferedReader = new BufferedReader(new StringReader(header));
+        subjectUnderTest.parseHeader(bufferedReader);
+        result = subjectUnderTest.parse(",");
+
+        assertThat(result, is("{\"Country\":\"\",\"Code\":\"\"}".getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    public void parse_givenEscapedComma_thenParsesLineCorrectly() throws IOException {
+        String header = "Code,\"Coun, try\"\n";
+        BufferedReader bufferedReader = new BufferedReader(new StringReader(header));
+        subjectUnderTest.parseHeader(bufferedReader);
+        result = subjectUnderTest.parse("GER,Germany\n");
+
+        assertThat(result, is("{\"Coun, try\":\"Germany\",\"Code\":\"GER\"}".getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    public void parse_givenRowWithMissingValue_thenTheValueIsAssignedToKeyAsAnEmptyString() throws IOException {
+        String header = "Code,Country,City\n";
+        BufferedReader bufferedReader = new BufferedReader(new StringReader(header));
+        subjectUnderTest.parseHeader(bufferedReader);
+        result = subjectUnderTest.parse("GER,,Berlin\n");
+
+        assertThat(result, is("{\"Country\":\"\",\"City\":\"Berlin\",\"Code\":\"GER\"}".getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    public void parse_givenTrailingWhiteSpaceInHeader_thenParsesToMapWithoutWhitespace() throws IOException {
+        String header = "Code ,Country  \n";
+        BufferedReader bufferedReader = new BufferedReader(new StringReader(header));
+        subjectUnderTest.parseHeader(bufferedReader);
+        result = subjectUnderTest.parse("GER,Germany\n");
+
+        assertThat(result, is("{\"Country\":\"Germany\",\"Code\":\"GER\"}".getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    public void parse_givenTrailingWhiteSpaceInRow_thenParsesToMapWithoutWhitespace() throws IOException {
+        String header = "Code ,Country\n";
+        BufferedReader bufferedReader = new BufferedReader(new StringReader(header));
+        subjectUnderTest.parseHeader(bufferedReader);
+        result = subjectUnderTest.parse("GER        ,Germany\n");
+
+        assertThat(result, is("{\"Country\":\"Germany\",\"Code\":\"GER\"}".getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    public void parse_givenPrecedingWhiteSpaceInHeader_thenParsesToMapWithoutWhitespace() throws IOException {
+        String header = "         Code,         Country\n";
+        BufferedReader bufferedReader = new BufferedReader(new StringReader(header));
+        subjectUnderTest.parseHeader(bufferedReader);
+        result = subjectUnderTest.parse("GER,Germany\n");
+
+        assertThat(result, is("{\"Country\":\"Germany\",\"Code\":\"GER\"}".getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    public void parse_givenPrecedingWhiteSpaceInRow_thenParsesToMapWithoutWhitespace() throws IOException {
+        String header = "Code,Country\n";
+        BufferedReader bufferedReader = new BufferedReader(new StringReader(header));
+        subjectUnderTest.parseHeader(bufferedReader);
+        result = subjectUnderTest.parse("GER,               Germany\n");
+
+        assertThat(result, is("{\"Country\":\"Germany\",\"Code\":\"GER\"}".getBytes(StandardCharsets.UTF_8)));
+    }
+}

--- a/sql/src/test/resources/essetup/data/copy/test_copy_from.csv
+++ b/sql/src/test/resources/essetup/data/copy/test_copy_from.csv
@@ -1,0 +1,4 @@
+id,quote
+1,"Don't pañic."
+2,"Would it save you a lot of time if I just gave up and went mad now?"
+3,"Time is an illusion. Lunchtime doubly so."

--- a/sql/src/test/resources/essetup/data/copy/test_copy_from_csv.ext
+++ b/sql/src/test/resources/essetup/data/copy/test_copy_from_csv.ext
@@ -1,0 +1,4 @@
+id,quote
+1,"Don't pañic."
+2,"Would it save you a lot of time if I just gave up and went mad now?"
+3,"Time is an illusion. Lunchtime doubly so."

--- a/sql/src/test/resources/essetup/data/copy/test_copy_from_json.ext
+++ b/sql/src/test/resources/essetup/data/copy/test_copy_from_json.ext
@@ -1,0 +1,3 @@
+{"id": 1, "quote": "Don't pañic."}
+{"id": 2, "quote": "Would it save you a lot of time if I just gave up and went mad now?"}
+{"id": 3, "quote": "Time is an illusion. Lunchtime doubly so."}


### PR DESCRIPTION
PR for allowing CSV input format when importing data via `COPY FROM` .
This can be done using either:
- file extension e.g. `COPY table_ident FROM file.csv`
- `WITH` option e.g. `COPY table_ident FROM file.ext WITH (format='csv')`

Includes updates to `COPY FROM` docs