### PR TITLE
fixup! adds helper class to detect if hash join is possible

### DIFF
--- a/sql/src/test/java/io/crate/planner/operators/HashJoinDetectorTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/HashJoinDetectorTest.java
@@ -54,7 +54,7 @@ public class HashJoinDetectorTest extends CrateUnitTest {
     public void testNotPossibleOnInnerWithoutAnyEqCondition() {
         Symbol joinCondition = SQL_EXPRESSIONS.asSymbol("t1.x > t2.y and t1.a > t2.b");
         JoinPair joinPair = JoinPair.of(T3.T1, T3.T2, JoinType.INNER, joinCondition);
-        assertThat(HashJoinDetector.isHashJoinPossible(joinPair), is(true));
+        assertThat(HashJoinDetector.isHashJoinPossible(joinPair), is(false));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/planner/operators/HashJoinDetectorTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/HashJoinDetectorTest.java
@@ -58,6 +58,20 @@ public class HashJoinDetectorTest extends CrateUnitTest {
     }
 
     @Test
+    public void testPossibleOnInnerWithEqAndScalarOnOneRelation() {
+        Symbol joinCondition = SQL_EXPRESSIONS.asSymbol("t1.x + t1.i = 2");
+        JoinPair joinPair = JoinPair.of(T3.T1, T3.T2, JoinType.INNER, joinCondition);
+        assertThat(HashJoinDetector.isHashJoinPossible(joinPair), is(true));
+    }
+
+    @Test
+    public void testNotPossibleOnInnerWithEqAndScalarOnMultipleRelations() {
+        Symbol joinCondition = SQL_EXPRESSIONS.asSymbol("t1.x + t2.y = 4");
+        JoinPair joinPair = JoinPair.of(T3.T1, T3.T2, JoinType.INNER, joinCondition);
+        assertThat(HashJoinDetector.isHashJoinPossible(joinPair), is(false));
+    }
+
+    @Test
     public void testNotPossibleOnInnerContainingEqOrAnyCondition() {
         Symbol joinCondition = SQL_EXPRESSIONS.asSymbol("t1.x = t2.y and t1.a = t2.b or t1.i = t2.i");
         JoinPair joinPair = JoinPair.of(T3.T1, T3.T2, JoinType.INNER, joinCondition);


### PR DESCRIPTION
Follow-up of https://github.com/crate/crate/pull/6831/commits/265392b6c1b8665ad6eef34da1b8ce412b84ea6d

Also another restriction is added to the is-hash-join-possible detection:
- For hash joins, it must be possible to hash one side of a EQ operator.
This only works if everything inside this argument is tied to the same
relation. 