### PR TITLE
enabled sitemap generation through sphinx module in the docs

### DIFF
--- a/blackbox/docs/conf.py
+++ b/blackbox/docs/conf.py
@@ -1,8 +1,10 @@
 from crate.theme.rtd.conf.crate_server import *
 
+site_url = 'https://crate.io/docs/crate/reference/en/latest/'
+
 exclude_patterns = ['out/**', 'tmp/**', 'eggs/**', 'requirements.txt']
 
-extensions = ['crate.sphinx.csv']
+extensions = ['crate.sphinx.csv', 'sphinx_sitemap']
 # crate.theme sets html_favicon to favicon.png which causes a warning because it should be a .ico
 # and in addition there is no favicon.png in this project so it can't find the file
 html_favicon = None


### PR DESCRIPTION
* added extension to `docs/conf.py`
* set base url in `docs/conf.py`
* this will automatically generate a sitemap for every docs build