### PR TITLE
Fix array assignments and type inference of params inside arrays

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -63,6 +63,9 @@ Changes
 Fixes
 =====
 
+- Fixed a regression that caused assignments of arrays including parameter
+  placeholders to not work correctly.
+
 - Fixed a regression which caused ``IS NOT NULL`` predicates on columns of type
   ``array(object)`` to not match correctly.
 


### PR DESCRIPTION
Assignments like `SET ob = [?]` where `ob` is an object array didn't
work correctly because a `to_object_array` cast is not supported and the
type of `[?]` was inferred as `array(undefined)`.

Instead of adding the object array cast function, this commit changes
the `cast` implementation of a `_array` `Function` symbol to propagate
to its elements. This has the advantage that type inference for the
`ParameterDescription` message will work as well.

Fixes https://github.com/crate/crate/issues/6835