### PR TITLE
Override disk.watermark.* settings of CrateLayer

### DIFF
--- a/blackbox/bwc/create_bwc_index.py
+++ b/blackbox/bwc/create_bwc_index.py
@@ -111,6 +111,10 @@ def create_index(index_name, crate_home, output_dir):
         transport_port=CRATE_TRANSPORT_PORT,
         settings={
             'es.api.enabled': True,
+            # The disk.watermark settings can be removed once crate-python > 0.21.1 has been released
+            "cluster.routing.allocation.disk.watermark.low" : "100k",
+            "cluster.routing.allocation.disk.watermark.high" : "10k",
+            "cluster.routing.allocation.disk.watermark.flood_stage" : "1k",
         }
     )
     crate_layer.start()

--- a/blackbox/docs/src/doc_tests/process_test.py
+++ b/blackbox/docs/src/doc_tests/process_test.py
@@ -115,6 +115,12 @@ class GracefulStopTest(unittest.TestCase):
                 host='localhost',
                 port=GLOBAL_PORT_POOL.get(),
                 transport_port=transport_port_range,
+                settings={
+                    # The disk.watermark settings can be removed once crate-python > 0.21.1 has been released
+                    "cluster.routing.allocation.disk.watermark.low" : "100k",
+                    "cluster.routing.allocation.disk.watermark.high" : "10k",
+                    "cluster.routing.allocation.disk.watermark.flood_stage" : "1k",
+                },
                 cluster_name=self.__class__.__name__)
             client = Client(layer.crate_servers)
             self.crates.append(layer)

--- a/blackbox/monitoring/src/tests.py
+++ b/blackbox/monitoring/src/tests.py
@@ -163,7 +163,11 @@ def test_suite():
         },
         settings={
             'stats.enabled': True,
-            'license.enterprise': True
+            'license.enterprise': True,
+            # The disk.watermark settings can be removed once crate-python > 0.21.1 has been released
+            "cluster.routing.allocation.disk.watermark.low" : "100k",
+            "cluster.routing.allocation.disk.watermark.high" : "10k",
+            "cluster.routing.allocation.disk.watermark.flood_stage" : "1k",
         }
     )
     suite.addTest(s)


### PR DESCRIPTION
These changes are necessary due to the new watermark.flood_stage setting in ES
6. The testing layer has been adapted and will be released once we have upgraded
to ES 6.1. We can then remove these again.