### PR TITLE
Fixed error in privileges validation for UNION queries.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -63,6 +63,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that caused ``MissingPrivilegeException`` for non-superusers
+  for queries with ``UNION ALL``.
+
 - Fixed a regression that caused assignments of arrays including parameter
   placeholders to not work correctly.
 

--- a/enterprise/users/src/main/java/io/crate/auth/user/StatementPrivilegeValidator.java
+++ b/enterprise/users/src/main/java/io/crate/auth/user/StatementPrivilegeValidator.java
@@ -65,10 +65,12 @@ import io.crate.analyze.ShowCreateTableAnalyzedStatement;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.AnalyzedRelationVisitor;
 import io.crate.analyze.relations.DocTableRelation;
+import io.crate.analyze.relations.OrderedLimitedRelation;
 import io.crate.analyze.relations.QueriedDocTable;
 import io.crate.analyze.relations.QueriedRelation;
 import io.crate.analyze.relations.TableFunctionRelation;
 import io.crate.analyze.relations.TableRelation;
+import io.crate.analyze.relations.UnionSelect;
 import io.crate.analyze.user.Privilege;
 import io.crate.exceptions.UnauthorizedException;
 import io.crate.metadata.IndexParts;
@@ -488,6 +490,19 @@ class StatementPrivilegeValidator implements StatementAuthorizedValidator {
             for (AnalyzedRelation relation : multiSourceSelect.sources().values()) {
                 process(relation, context);
             }
+            return null;
+        }
+
+        @Override
+        public Void visitOrderedLimitedRelation(OrderedLimitedRelation relation, RelationContext context) {
+            process(relation.childRelation(), context);
+            return null;
+        }
+
+        @Override
+        public Void visitUnionSelect(UnionSelect unionSelect, RelationContext context) {
+            process(unionSelect.left(), context);
+            process(unionSelect.right(), context);
             return null;
         }
 

--- a/enterprise/users/src/test/java/io/crate/auth/user/StatementPrivilegeValidatorTest.java
+++ b/enterprise/users/src/test/java/io/crate/auth/user/StatementPrivilegeValidatorTest.java
@@ -300,6 +300,25 @@ public class StatementPrivilegeValidatorTest extends CrateDummyClusterServiceUni
     }
 
     @Test
+    public void testSelectUnion() throws Exception {
+        analyze("select name from sys.cluster union all select name from users");
+        assertAskedForTable(Privilege.Type.DQL, "sys.cluster");
+        assertAskedForTable(Privilege.Type.DQL, "doc.users");
+    }
+
+    /**
+     * Union with order by (and/or limit) results
+     * in a {@link io.crate.analyze.relations.OrderedLimitedRelation}
+     * which wraps the {@link io.crate.analyze.relations.UnionSelect}
+     */
+    @Test
+    public void testSelectUnionWithOrderBy() throws Exception {
+        analyze("select * from sys.cluster union all select * from users order by 1");
+        assertAskedForTable(Privilege.Type.DQL, "sys.cluster");
+        assertAskedForTable(Privilege.Type.DQL, "doc.users");
+    }
+
+    @Test
     public void testSelectWithSubSelect() throws Exception {
         analyze("select * from (" +
                 " select users.id from users join parted on users.id = parted.id::long order by users.name limit 2" +


### PR DESCRIPTION
Added missing visitor overriden methods for UnionSelect and OrderedLimitedRelation
(wrapping a UnionSelect when ORDER BY and/or LIMIT is involved).