### PR TITLE
do not merge default crate.yml with custom config path yaml

### DIFF
--- a/app/src/main/java/org/elasticsearch/node/internal/CrateSettingsPreparer.java
+++ b/app/src/main/java/org/elasticsearch/node/internal/CrateSettingsPreparer.java
@@ -80,14 +80,14 @@ public class CrateSettingsPreparer {
         validateKnownSettings(newSettings);
         applyCrateDefaults(newSettings);
 
-        env = new Environment(newSettings.build(), configPath);
+        env = new Environment(newSettings.build(), env.configFile());
 
         // we put back the path.logs so we can use it in the logging configuration file
         newSettings.put(
             Environment.PATH_LOGS_SETTING.getKey(),
             env.logsFile().toAbsolutePath().normalize().toString());
 
-        return new Environment(newSettings.build());
+        return new Environment(newSettings.build(), env.configFile());
     }
 
     static void validateKnownSettings(Settings.Builder builder) {

--- a/app/src/test/resources/org/elasticsearch/node/internal/config_custom/crate.yml
+++ b/app/src/test/resources/org/elasticsearch/node/internal/config_custom/crate.yml
@@ -1,0 +1,1 @@
+cluster.name: custom


### PR DESCRIPTION
if you define a custom configuration path via -Cpath.conf then the
settings in the default crate.yml located in $CRATE_HOME/config must not
be loaded and merged