### PR TITLE
Added OperationOnInaccessibleRelationException to replace UnsupportedFeatureException when dealing with closed/readonly/blocked operations

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -64,6 +64,12 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that only occurred in Enterprise Edition, when privileges
+  are enabled. This issue would result in an exception about missing
+  privileges being thrown, rather than the expected Unsupported Feature
+  exception, when attempting operations on closed tables/partitions as a
+  user.
+
 - Fixed an issue that caused a ``NullPointerException`` if ``REFRESH TABLE``
   was executed on a table with closed partitions.
 

--- a/blackbox/docs/interfaces/http.txt
+++ b/blackbox/docs/interfaces/http.txt
@@ -325,6 +325,9 @@ Code   Error
 ------ ---------------------------------------------------------------------
 4006   The used column alias is ambiguous.
 ------ ---------------------------------------------------------------------
+4007   The operation is not supported on this relation, as it is not
+       accessible.
+------ ---------------------------------------------------------------------
 4010   User is not authorized to perform the SQL statement.
 ------ ---------------------------------------------------------------------
 4011   Missing privilege for user.

--- a/sql/src/main/java/io/crate/exceptions/OperationOnInaccessibleRelationException.java
+++ b/sql/src/main/java/io/crate/exceptions/OperationOnInaccessibleRelationException.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.exceptions;
+
+import io.crate.metadata.TableIdent;
+
+import java.util.Collection;
+import java.util.Collections;
+
+public class OperationOnInaccessibleRelationException extends ValidationException implements TableScopeException {
+
+    private TableIdent tableIdent;
+
+    public OperationOnInaccessibleRelationException(TableIdent tableIdent, String msg) {
+        super(msg);
+        this.tableIdent = tableIdent;
+    }
+
+    @Override
+    public int errorCode() {
+        return 7;
+    }
+
+    @Override
+    public Collection<TableIdent> getTableIdents() {
+        return Collections.singletonList(tableIdent);
+    }
+}

--- a/sql/src/main/java/io/crate/metadata/table/Operation.java
+++ b/sql/src/main/java/io/crate/metadata/table/Operation.java
@@ -23,6 +23,7 @@
 package io.crate.metadata.table;
 
 import com.google.common.collect.Sets;
+import io.crate.exceptions.OperationOnInaccessibleRelationException;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.settings.Settings;
@@ -102,7 +103,7 @@ public enum Operation {
             } else {
                 exceptionMessage = "The relation \"%s\" doesn't support or allow %s operations.";
             }
-            throw new UnsupportedOperationException(String.format(Locale.ENGLISH,
+            throw new OperationOnInaccessibleRelationException(tableInfo.ident(), String.format(Locale.ENGLISH,
                 exceptionMessage, tableInfo.ident().fqn(), operation));
         }
     }

--- a/sql/src/test/java/io/crate/analyze/AlterTableAddColumnAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/AlterTableAddColumnAnalyzerTest.java
@@ -22,6 +22,7 @@
 package io.crate.analyze;
 
 import io.crate.core.collections.StringObjectMaps;
+import io.crate.exceptions.OperationOnInaccessibleRelationException;
 import io.crate.metadata.ColumnIdent;
 import io.crate.sql.parser.ParsingException;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
@@ -51,7 +52,7 @@ public class AlterTableAddColumnAnalyzerTest extends CrateDummyClusterServiceUni
 
     @Test
     public void testAddColumnOnSystemTableIsNotAllowed() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(OperationOnInaccessibleRelationException.class);
         expectedException.expectMessage("The relation \"sys.shards\" doesn't support or allow ALTER " +
                                         "operations, as it is read-only.");
         e.analyze("alter table sys.shards add column foobar string");

--- a/sql/src/test/java/io/crate/analyze/AlterTableOpenCloseAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/AlterTableOpenCloseAnalyzerTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.analyze;
 
+import io.crate.exceptions.OperationOnInaccessibleRelationException;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import org.junit.Before;
@@ -37,7 +38,7 @@ public class AlterTableOpenCloseAnalyzerTest extends CrateDummyClusterServiceUni
 
     @Test
     public void testCloseSystemTableIsNotAllowed() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(OperationOnInaccessibleRelationException.class);
         expectedException.expectMessage("The relation \"sys.shards\" doesn't support or allow " +
                                         "ALTER OPEN/CLOSE operations, as it is read-only.");
         e.analyze("alter table sys.shards close");

--- a/sql/src/test/java/io/crate/analyze/AlterTableRerouteAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/AlterTableRerouteAnalyzerTest.java
@@ -22,6 +22,7 @@
 
 package io.crate.analyze;
 
+import io.crate.exceptions.OperationOnInaccessibleRelationException;
 import io.crate.metadata.TableIdent;
 import io.crate.metadata.blob.BlobSchemaInfo;
 import io.crate.sql.tree.Literal;
@@ -47,7 +48,7 @@ public class AlterTableRerouteAnalyzerTest extends CrateDummyClusterServiceUnitT
 
     @Test
     public void testRerouteOnSystemTableIsNotAllowed() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(OperationOnInaccessibleRelationException.class);
         expectedException.expectMessage("The relation \"sys.cluster\" doesn't support or allow ALTER REROUTE operations, as it is read-only.");
         e.analyze("ALTER TABLE sys.cluster REROUTE MOVE SHARD 0 FROM 'node1' TO 'node2'");
     }

--- a/sql/src/test/java/io/crate/analyze/CopyAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CopyAnalyzerTest.java
@@ -22,6 +22,7 @@
 package io.crate.analyze;
 
 import io.crate.analyze.relations.QueriedDocTable;
+import io.crate.exceptions.OperationOnInaccessibleRelationException;
 import io.crate.expression.symbol.Literal;
 import io.crate.exceptions.PartitionUnknownException;
 import io.crate.exceptions.SchemaUnknownException;
@@ -93,8 +94,11 @@ public class CopyAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         e.analyze("copy unknown from '/some/distant/file.ext'");
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testCopyFromSystemTable() throws Exception {
+        expectedException.expect(OperationOnInaccessibleRelationException.class);
+        expectedException.expectMessage("The relation \"sys.shards\" doesn't support or allow INSERT "+
+                                        "operations, as it is read-only.");
         e.analyze("copy sys.shards from '/nope/nope/still.nope'");
     }
 
@@ -129,7 +133,7 @@ public class CopyAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testCopySysTableTo() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(OperationOnInaccessibleRelationException.class);
         expectedException.expectMessage("The relation \"sys.nodes\" doesn't support or allow COPY TO " +
                                         "operations, as it is read-only.");
         e.analyze("copy sys.nodes to directory '/foo'");

--- a/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -29,6 +29,7 @@ import io.crate.exceptions.ColumnUnknownException;
 import io.crate.exceptions.InvalidColumnNameException;
 import io.crate.exceptions.InvalidSchemaNameException;
 import io.crate.exceptions.InvalidTableNameException;
+import io.crate.exceptions.OperationOnInaccessibleRelationException;
 import io.crate.exceptions.TableAlreadyExistsException;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.FulltextAnalyzerResolver;
@@ -472,7 +473,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
 
     @Test
     public void testAlterSystemTable() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(OperationOnInaccessibleRelationException.class);
         expectedException.expectMessage("The relation \"sys.shards\" doesn't support or allow ALTER " +
                                         "operations, as it is read-only.");
         e.analyze("alter table sys.shards reset (number_of_replicas)");

--- a/sql/src/test/java/io/crate/analyze/DeleteAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/DeleteAnalyzerTest.java
@@ -22,6 +22,7 @@
 package io.crate.analyze;
 
 import io.crate.analyze.relations.DocTableRelation;
+import io.crate.exceptions.OperationOnInaccessibleRelationException;
 import io.crate.expression.symbol.ParameterSymbol;
 import io.crate.exceptions.RelationUnknownException;
 import io.crate.metadata.RowGranularity;
@@ -60,8 +61,11 @@ public class DeleteAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(delete.query(), isFunction(EqOperator.NAME, isReference("name"), isLiteral("Trillian")));
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testDeleteSystemTable() throws Exception {
+        expectedException.expect(OperationOnInaccessibleRelationException.class);
+        expectedException.expectMessage("The relation \"sys.nodes\" doesn't support or allow DELETE "+
+                                        "operations, as it is read-only.");
         e.analyze("delete from sys.nodes where name='Trillian'");
     }
 

--- a/sql/src/test/java/io/crate/analyze/DropTableAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/DropTableAnalyzerTest.java
@@ -24,6 +24,7 @@ package io.crate.analyze;
 import com.google.common.collect.ImmutableList;
 import io.crate.exceptions.SchemaUnknownException;
 import io.crate.exceptions.TableUnknownException;
+import io.crate.exceptions.OperationOnInaccessibleRelationException;
 import io.crate.metadata.TableIdent;
 import io.crate.metadata.doc.DocSchemaInfo;
 import io.crate.metadata.doc.DocTableInfo;
@@ -64,7 +65,7 @@ public class DropTableAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testDropSystemTable() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(OperationOnInaccessibleRelationException.class);
         expectedException.expectMessage("The relation \"sys.cluster\" doesn't support or allow DROP " +
                                         "operations, as it is read-only.");
         e.analyze("drop table sys.cluster");
@@ -72,7 +73,7 @@ public class DropTableAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testDropInformationSchemaTable() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(OperationOnInaccessibleRelationException.class);
         expectedException.expectMessage("The relation \"information_schema.tables\" doesn't support or allow " +
                                         "DROP operations, as it is read-only.");
         e.analyze("drop table information_schema.tables");
@@ -120,7 +121,7 @@ public class DropTableAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testDropAliasFails() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(OperationOnInaccessibleRelationException.class);
         expectedException.expectMessage("The relation \"doc.alias_table\" doesn't support or allow DROP " +
                                         "operations, as it is read-only.");
         e.analyze("drop table alias_table");
@@ -128,7 +129,7 @@ public class DropTableAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testDropAliasIfExists() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(OperationOnInaccessibleRelationException.class);
         expectedException.expectMessage("The relation \"doc.alias_table\" doesn't support or allow DROP " +
                                         "operations, as it is read-only.");
         e.analyze("drop table if exists alias_table");

--- a/sql/src/test/java/io/crate/analyze/InsertFromValuesAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/InsertFromValuesAnalyzerTest.java
@@ -22,6 +22,7 @@
 package io.crate.analyze;
 
 import com.google.common.collect.ImmutableMap;
+import io.crate.exceptions.OperationOnInaccessibleRelationException;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
 import io.crate.exceptions.ColumnUnknownException;
@@ -307,14 +308,17 @@ public class InsertFromValuesAnalyzerTest extends CrateDummyClusterServiceUnitTe
         InsertFromValuesAnalyzedStatement analysis = e.analyze("insert into users ('a') values (1)");
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testInsertIntoSysTable() throws Exception {
+        expectedException.expect(OperationOnInaccessibleRelationException.class);
+        expectedException.expectMessage("The relation \"sys.nodes\" doesn't support or allow INSERT " +
+                                        "operations, as it is read-only.");
         e.analyze("insert into sys.nodes (id, name) values (666, 'evilNode')");
     }
 
     @Test
     public void testInsertIntoAliasTable() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(OperationOnInaccessibleRelationException.class);
         expectedException.expectMessage("The relation \"doc.alias\" doesn't support or allow INSERT " +
                                         "operations, as it is read-only.");
         e.analyze("insert into alias (bla) values ('blubb')");

--- a/sql/src/test/java/io/crate/analyze/OptimizeTableAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/OptimizeTableAnalyzerTest.java
@@ -23,6 +23,7 @@
 package io.crate.analyze;
 
 import io.crate.exceptions.TableUnknownException;
+import io.crate.exceptions.OperationOnInaccessibleRelationException;
 import io.crate.metadata.TableIdent;
 import io.crate.metadata.blob.BlobSchemaInfo;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
@@ -48,7 +49,7 @@ public class OptimizeTableAnalyzerTest extends CrateDummyClusterServiceUnitTest 
 
     @Test
     public void testOptimizeSystemTable() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(OperationOnInaccessibleRelationException.class);
         expectedException.expectMessage("The relation \"sys.shards\" doesn't support or allow OPTIMIZE " +
                                         "operations, as it is read-only.");
         e.analyze("OPTIMIZE TABLE sys.shards");
@@ -153,7 +154,7 @@ public class OptimizeTableAnalyzerTest extends CrateDummyClusterServiceUnitTest 
 
     @Test
     public void testOptimizeSysPartitioned() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(OperationOnInaccessibleRelationException.class);
         expectedException.expectMessage("The relation \"sys.shards\" doesn't support or allow OPTIMIZE " +
                                         "operations, as it is read-only.");
         e.analyze("OPTIMIZE TABLE sys.shards PARTITION (id='n')");

--- a/sql/src/test/java/io/crate/analyze/RefreshAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/RefreshAnalyzerTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.analyze;
 
+import io.crate.exceptions.OperationOnInaccessibleRelationException;
 import io.crate.exceptions.TableUnknownException;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.TableIdent;
@@ -50,7 +51,7 @@ public class RefreshAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testRefreshSystemTable() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(OperationOnInaccessibleRelationException.class);
         expectedException.expectMessage("The relation \"sys.shards\" doesn't support or allow REFRESH " +
                                         "operations, as it is read-only.");
         e.analyze("refresh table sys.shards");
@@ -58,7 +59,7 @@ public class RefreshAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testRefreshBlobTable() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(OperationOnInaccessibleRelationException.class);
         expectedException.expectMessage("The relation \"blob.blobs\" doesn't support or allow REFRESH " +
                                         "operations.");
         e.analyze("refresh table blob.blobs");
@@ -93,7 +94,7 @@ public class RefreshAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testRefreshSysPartitioned() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(OperationOnInaccessibleRelationException.class);
         expectedException.expectMessage("The relation \"sys.shards\" doesn't support or allow REFRESH" +
                                         " operations, as it is read-only.");
         e.analyze("refresh table sys.shards partition (id='n')");
@@ -101,7 +102,7 @@ public class RefreshAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testRefreshBlobPartitioned() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(OperationOnInaccessibleRelationException.class);
         expectedException.expectMessage("The relation \"blob.blobs\" doesn't support or allow REFRESH " +
                                         "operations.");
         e.analyze("refresh table blob.blobs partition (n='n')");

--- a/sql/src/test/java/io/crate/analyze/SnapshotRestoreAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SnapshotRestoreAnalyzerTest.java
@@ -22,6 +22,7 @@
 package io.crate.analyze;
 
 import com.google.common.collect.ImmutableList;
+import io.crate.exceptions.OperationOnInaccessibleRelationException;
 import io.crate.exceptions.PartitionAlreadyExistsException;
 import io.crate.exceptions.PartitionUnknownException;
 import io.crate.exceptions.RepositoryUnknownException;
@@ -179,7 +180,7 @@ public class SnapshotRestoreAnalyzerTest extends CrateDummyClusterServiceUnitTes
 
     @Test
     public void testCreateSnapshotSnapshotSysTable() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(OperationOnInaccessibleRelationException.class);
         expectedException.expectMessage("The relation \"sys.shards\" doesn't support or allow " +
                                         "CREATE SNAPSHOT operations, as it is read-only.");
         analyze("CREATE SNAPSHOT my_repo.my_snapshot TABLE sys.shards");
@@ -194,7 +195,7 @@ public class SnapshotRestoreAnalyzerTest extends CrateDummyClusterServiceUnitTes
 
     @Test
     public void testCreateSnapshotFromBlobTable() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(OperationOnInaccessibleRelationException.class);
         expectedException.expectMessage("The relation \"blob.my_blobs\" doesn't support or allow CREATE SNAPSHOT operations.");
         analyze("CREATE SNAPSHOT my_repo.my_snapshot TABLE blob.my_blobs");
     }

--- a/sql/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
@@ -28,6 +28,7 @@ import io.crate.data.Row1;
 import io.crate.data.RowN;
 import io.crate.exceptions.ColumnValidationException;
 import io.crate.exceptions.TableUnknownException;
+import io.crate.exceptions.OperationOnInaccessibleRelationException;
 import io.crate.exceptions.VersionInvalidException;
 import io.crate.expression.operator.EqOperator;
 import io.crate.expression.predicate.NotPredicate;
@@ -175,8 +176,11 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         analyze("update users set details['arms']=3, details['arms']=5");
     }
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void testUpdateSysTables() throws Exception {
+        expectedException.expect(OperationOnInaccessibleRelationException.class);
+        expectedException.expectMessage("The relation \"sys.nodes\" doesn't support or allow UPDATE " +
+                                        "operations, as it is read-only.");
         analyze("update sys.nodes set fs=?", new Object[]{new HashMap<String, Object>() {{
             put("free", 0);
         }}});

--- a/sql/src/test/java/io/crate/metadata/SchemasTest.java
+++ b/sql/src/test/java/io/crate/metadata/SchemasTest.java
@@ -22,6 +22,7 @@
 package io.crate.metadata;
 
 import com.google.common.collect.ImmutableList;
+import io.crate.exceptions.OperationOnInaccessibleRelationException;
 import io.crate.metadata.doc.DocSchemaInfoFactory;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.Operation;
@@ -80,7 +81,7 @@ public class SchemasTest {
 
     @Test
     public void testSystemSchemaIsNotWritable() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(OperationOnInaccessibleRelationException.class);
         expectedException.expectMessage("The relation \"foo.bar\" doesn't support or allow INSERT " +
                                         "operations, as it is read-only.");
 
@@ -98,7 +99,7 @@ public class SchemasTest {
 
     @Test
     public void testTableAliasIsNotWritable() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expect(OperationOnInaccessibleRelationException.class);
         expectedException.expectMessage("The relation \"foo.bar\" doesn't support or allow INSERT operations.");
 
         TableIdent tableIdent = new TableIdent("foo", "bar");


### PR DESCRIPTION
When attempting an operation on a closed table as a user, instead of the expected exception of an Unsupported Feature being raised, it would instead raise a nonsensical missing privileges exception. This is because this operation would originally throw an UnsupportedFeatureException, which would have no information about the table it was performed on. The privilege checking mechanism would then attempt to check the privileges on nothing and, finding nothing there, throw the incorrect exception.