### PR TITLE
Fix PreExecutionBenchmarks

### DIFF
--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -18,8 +18,6 @@ dependencies {
 
     compile 'org.openjdk.jmh:jmh-core:1.20'
     compile 'org.openjdk.jmh:jmh-generator-annprocess:1.20'
-    compile "org.hamcrest:hamcrest-all:${versions.hamcrest}"
-    compile "org.elasticsearch:securemock:${versions.securemock}"
 
     // Dependencies of JMH
     runtime 'net.sf.jopt-simple:jopt-simple:4.6'

--- a/benchmarks/src/test/java/io/crate/analyze/PreExecutionBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/analyze/PreExecutionBenchmark.java
@@ -31,7 +31,6 @@ import io.crate.planner.PlannerContext;
 import io.crate.planner.operators.LogicalPlan;
 import io.crate.sql.parser.SqlParser;
 import io.crate.sql.tree.Statement;
-import io.crate.testing.DiscoveryNodes;
 import io.crate.testing.SQLExecutor;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -55,6 +54,7 @@ import java.util.Collections;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
+import static io.crate.testing.DiscoveryNodes.newNode;
 import static org.elasticsearch.test.ClusterServiceUtils.createClusterService;
 
 @BenchmarkMode(Mode.AverageTime)
@@ -71,7 +71,7 @@ public class PreExecutionBenchmark {
     @Setup
     public void setup() throws Exception {
         threadPool = new TestThreadPool("testing");
-        DiscoveryNode localNode = DiscoveryNodes.newNode("benchmarkNode", "n1");
+        DiscoveryNode localNode = newNode("benchmarkNode", "n1");
         ClusterService clusterService = createClusterService(threadPool, localNode);
         long dummySeed = 10;
         e = SQLExecutor.builder(clusterService, 1, new Random(dummySeed))

--- a/sql/src/test/java/io/crate/testing/DiscoveryNodes.java
+++ b/sql/src/test/java/io/crate/testing/DiscoveryNodes.java
@@ -24,22 +24,36 @@ package io.crate.testing;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.test.ESTestCase;
 
 import java.util.Collections;
-
-import static org.elasticsearch.test.ESTestCase.buildNewFakeTransportAddress;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class DiscoveryNodes {
 
+    private static final AtomicInteger PORT_GENERATOR = new AtomicInteger();
+
     public static DiscoveryNode newNode(String nodeId) {
-        return new DiscoveryNode(nodeId, buildNewFakeTransportAddress(), Version.CURRENT);
+        return new DiscoveryNode(
+            nodeId,
+            newFakeAddress(),
+            Version.CURRENT);
+    }
+
+    /**
+     * Re-implementation of {@link ESTestCase#buildNewFakeTransportAddress()}
+     * that does not cause RandomizedTest to be loaded so it's usable in benchmarks
+     */
+    static TransportAddress newFakeAddress() {
+        return new TransportAddress(TransportAddress.META_ADDRESS, PORT_GENERATOR.incrementAndGet());
     }
 
     public static DiscoveryNode newNode(String name, String id) {
         return new DiscoveryNode(
             name,
             id,
-            buildNewFakeTransportAddress(),
+            newFakeAddress(),
             Collections.emptyMap(),
             Collections.emptySet(),
             Version.CURRENT);

--- a/sql/src/test/java/io/crate/testing/SQLExecutor.java
+++ b/sql/src/test/java/io/crate/testing/SQLExecutor.java
@@ -127,11 +127,11 @@ import static io.crate.analyze.TableDefinitions.USER_TABLE_INFO;
 import static io.crate.analyze.TableDefinitions.USER_TABLE_INFO_CLUSTERED_BY_ONLY;
 import static io.crate.analyze.TableDefinitions.USER_TABLE_INFO_MULTI_PK;
 import static io.crate.analyze.TableDefinitions.USER_TABLE_INFO_REFRESH_INTERVAL_BY_ONLY;
+import static io.crate.testing.DiscoveryNodes.newFakeAddress;
 import static io.crate.testing.TestingHelpers.getFunctions;
 import static java.util.Collections.singletonList;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_VERSION_CREATED;
 import static org.elasticsearch.env.Environment.PATH_HOME_SETTING;
-import static org.elasticsearch.test.ESTestCase.buildNewFakeTransportAddress;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -243,7 +243,7 @@ public class SQLExecutor {
         private void addNodesToClusterState(ClusterService clusterService, int numNodes) {
             DiscoveryNodes.Builder builder = DiscoveryNodes.builder();
             for (int i = 1; i <= numNodes; i++) {
-                builder.add(new DiscoveryNode("n" + i, buildNewFakeTransportAddress(), Version.CURRENT));
+                builder.add(new DiscoveryNode("n" + i, newFakeAddress(), Version.CURRENT));
             }
             builder.localNodeId("n1");
             ClusterServiceUtils.setState(


### PR DESCRIPTION
With the ES6 upgrade we started to make use of `buildNewFakeTransportAddress`,
this is problematic because it causes `RandomizedTest` to be loaded, resulting
in `NoClassDefFoundError`:
    
    java.lang.NoClassDefFoundError: com/carrotsearch/randomizedtesting/RandomizedTest
            at org.apache.lucene.util.LuceneTestCase.<clinit>(LuceneTestCase.java:393)
            at io.crate.testing.DiscoveryNodes.newNode(DiscoveryNodes.java:42)
            at io.crate.analyze.PreExecutionBenchmark.setup(PreExecutionBenchmark.java:74)
    
This is because for benchmarks we need to exclude randomizedtesting. Otherwise
we'd run into RandomizedContxt errors because benchmarks are not run within a
test runner.

This re-implements `buildNewFakeTransportAddress` to avoid that.