### PR TITLE
Added a RamAccountingBatchIterator as a wrapper of a BatchIterator.

### DIFF
--- a/sql/src/main/java/io/crate/execution/engine/join/RamAccountingBatchIterator.java
+++ b/sql/src/main/java/io/crate/execution/engine/join/RamAccountingBatchIterator.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.engine.join;
+
+import io.crate.breaker.RowAccounting;
+import io.crate.data.BatchIterator;
+import io.crate.data.ForwardingBatchIterator;
+import io.crate.data.Row;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Wraps a {@link BatchIterator} and uses {@link io.crate.breaker.RamAccountingContext}
+ * to apply the circuit breaking logic by calculating memory occupied for all rows of the iterator.
+ * <p>
+ * This wrapper can be typically used when the BatchIterator consumer "reads" all
+ * elements of the iterator and keeps them in memory. e.g.: {@link io.crate.data.join.HashInnerJoinBatchIterator}
+ * keeps in memory all elements of the left side to build the HashMap used for the Hash-Join execution.
+ */
+public class RamAccountingBatchIterator<T extends Row> extends ForwardingBatchIterator<T> {
+
+    private final BatchIterator<T> delegateBatchIterator;
+    private final RowAccounting rowAccounting;
+
+    RamAccountingBatchIterator(BatchIterator<T> delegatePagingIterator, RowAccounting rowAccounting) {
+        this.delegateBatchIterator = delegatePagingIterator;
+        this.rowAccounting = rowAccounting;
+    }
+
+    @Override
+    protected BatchIterator<T> delegate() {
+        return delegateBatchIterator;
+    }
+
+    @Override
+    public boolean moveNext() {
+        boolean result = delegateBatchIterator.moveNext();
+        if (result) {
+            rowAccounting.accountForAndMaybeBreak(delegateBatchIterator.currentElement());
+        }
+        return result;
+    }
+
+    @Override
+    public void close() {
+        rowAccounting.close();
+        super.close();
+    }
+
+    @Override
+    public void kill(@Nonnull Throwable throwable) {
+        rowAccounting.close();
+        super.kill(throwable);
+    }
+}

--- a/sql/src/test/java/io/crate/execution/engine/join/RamAccountingBatchIteratorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/join/RamAccountingBatchIteratorTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.engine.join;
+
+import com.google.common.collect.ImmutableList;
+import io.crate.breaker.RamAccountingContext;
+import io.crate.breaker.RowAccounting;
+import io.crate.breaker.RowAccountingTest;
+import io.crate.data.BatchIterator;
+import io.crate.data.Row;
+import io.crate.test.integration.CrateUnitTest;
+import io.crate.testing.TestingBatchIterators;
+import io.crate.testing.TestingRowConsumer;
+import io.crate.types.DataTypes;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.common.breaker.MemoryCircuitBreaker;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
+import org.hamcrest.Matchers;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+public class RamAccountingBatchIteratorTest extends CrateUnitTest {
+
+    private static NoopCircuitBreaker NOOP_CIRCUIT_BREAKER = new NoopCircuitBreaker("dummy");
+
+    private long originalBufferSize;
+
+    @Before
+    public void reduceFlushBufferSize() {
+        originalBufferSize = RamAccountingContext.FLUSH_BUFFER_SIZE;
+        RamAccountingContext.FLUSH_BUFFER_SIZE = 10;
+    }
+
+    @After
+    public void resetFlushBufferSize() {
+        RamAccountingContext.FLUSH_BUFFER_SIZE = originalBufferSize;
+    }
+
+    @Test
+    public void testNoCircuitBreaking() throws Exception {
+        BatchIterator<Row> batchIterator = new RamAccountingBatchIterator<>(
+            TestingBatchIterators.ofValues(Arrays.asList(new BytesRef("a"), new BytesRef("b"), new BytesRef("c"))),
+            new RowAccounting(
+                ImmutableList.of(DataTypes.STRING),
+                new RamAccountingContext("test", NOOP_CIRCUIT_BREAKER)));
+
+        TestingRowConsumer consumer = new TestingRowConsumer();
+        consumer.accept(batchIterator, null);
+        assertThat(
+            consumer.getResult(),
+            Matchers.contains(
+                new Object[] {new BytesRef("a")}, new Object[] {new BytesRef("b")}, new Object[] {new BytesRef("c")}));
+    }
+
+    @Test
+    public void testCircuitBreaking() throws Exception {
+        BatchIterator<Row> batchIterator = new RamAccountingBatchIterator<>(
+            TestingBatchIterators.ofValues(Arrays.asList(new BytesRef("aaa"), new BytesRef("bbb"), new BytesRef("ccc"),
+                                                         new BytesRef("ddd"), new BytesRef("eee"), new BytesRef("fff"))),
+            new RowAccounting(
+                ImmutableList.of(DataTypes.STRING),
+                new RamAccountingContext(
+                    "test",
+                    new MemoryCircuitBreaker(
+                        new ByteSizeValue(34, ByteSizeUnit.BYTES),
+                        1,
+                        Loggers.getLogger(RowAccountingTest.class)))));
+
+        expectedException.expect(CircuitBreakingException.class);
+        expectedException.expectMessage(
+            "Data too large, data for field [test] would be [35/35b], which is larger than the limit of [34/34b]");
+
+        TestingRowConsumer consumer = new TestingRowConsumer();
+        consumer.accept(batchIterator, null);
+        consumer.getResult();
+    }
+}


### PR DESCRIPTION
Introduce this new class that calculates the memory occupied by the elements of the
BatchIterator. The memory is increased on every successful moveNext() which means that
a row is emmitted by the iterator and can be consumed by the caller.

Typically this wrapper class can be used when the BatchIterator consumer "reads" all
elements of the iterator and keeps them in memory. eg: HashInnerJoinBatchIterator