### PR TITLE
Simplify code by removing null checks and use of instanceof.

### DIFF
--- a/sql/src/main/java/io/crate/planner/operators/Filter.java
+++ b/sql/src/main/java/io/crate/planner/operators/Filter.java
@@ -71,11 +71,8 @@ class Filter extends OneInputPlan {
         assert query.valueType().equals(DataTypes.BOOLEAN)
             : "query must have a boolean result type, got: " + query.valueType();
 
-        if (query instanceof Literal) {
-            Boolean value = (Boolean) ((Literal) query).value();
-            if (value != null && value) {
-                return source;
-            }
+        if (query.symbolType().isValueSymbol() && ((Literal) query).value() == Boolean.TRUE) {
+            return source;
         }
         return new Filter(source, new WhereClause(query));
     }

--- a/sql/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
+++ b/sql/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
@@ -30,7 +30,6 @@ import io.crate.analyze.relations.QueriedRelation;
 import io.crate.analyze.relations.QuerySplitter;
 import io.crate.expression.operator.AndOperator;
 import io.crate.expression.symbol.FieldsVisitor;
-import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.planner.SubqueryPlanner;
 import io.crate.planner.TableStats;
@@ -137,7 +136,7 @@ public class JoinPlanBuilder implements LogicalPlan.Builder {
             rhsPlan,
             joinType,
             joinCondition,
-            query != null && !(query instanceof Literal),
+            !query.symbolType().isValueSymbol(),
             hasOuterJoins,
             lhs);
 
@@ -221,14 +220,13 @@ public class JoinPlanBuilder implements LogicalPlan.Builder {
                 nextPlan,
                 type,
                 condition,
-                query != null && !(query instanceof Literal),
+                !query.symbolType().isValueSymbol(),
                 hasOuterJoins,
                 leftRelation),
             query
         );
     }
 
-    @Nullable
     private static Symbol removeParts(Map<Set<QualifiedName>, Symbol> queryParts, QualifiedName lhsName, QualifiedName rhsName) {
         // query parts can affect a single relation without being pushed down in the outer-join case
         Symbol left = queryParts.remove(Collections.singleton(lhsName));


### PR DESCRIPTION
- The `query` cannot be null instead it's set to Literal.BOOLEAN_TRUE
- `instanceof Literal` replaced with `isValueSymbol()`