### PR TITLE
Add table setting max_ngram_diff and max_shingle_diff 

### DIFF
--- a/blackbox/docs/general/ddl/analyzers.rst
+++ b/blackbox/docs/general/ddl/analyzers.rst
@@ -372,10 +372,10 @@ N-Gram Tokenizer
 .. rubric:: Parameters
 
 min_gram
-    Minimum size in codepoints of a single n-gram. default 1.
+    Minimum length of characters in a gram. default: 1.
 
 max_gram
-    Maximum size in codepoints of a single n-gram. default 2.
+    Maximum length of characters in a gram. default: 2.
 
 token_chars
     Characters classes to keep in the tokens, will split on characters that
@@ -396,10 +396,10 @@ keeps n-grams which start at the beginning of a token.
 .. rubric:: Parameters
 
 min_gram
-    Minimum size in codepoints of a single n-gram. default: 1
+    Minimum length of characters in a gram. default: 1
 
 max_gram
-    Maximum size in codepoints of a single n-gram. default: 2
+    Maximum length of characters in a gram. default: 2
 
 token_chars
     Characters classes to keep in the tokens, will split on characters that

--- a/blackbox/docs/sql/statements/create-table.rst
+++ b/blackbox/docs/sql/statements/create-table.rst
@@ -508,3 +508,15 @@ The column policy is defined like this::
   clauses.
 
 For futher details and examples see :ref:`column_policy` or :ref:`config`.
+
+``max_ngram_diff``
+..................
+
+Specifies the maximum difference between max_ngram and min_ngram when using
+the NGramTokenizer or the NGramTokenFilter. The default is 1.
+
+``max_shingle_diff``
+....................
+
+Specifies the maximum difference between min_shingle_size and max_shingle_size
+when using the ShingleTokenFilter. The default is 3.

--- a/sql/src/main/java/io/crate/analyze/TableParameterInfo.java
+++ b/sql/src/main/java/io/crate/analyze/TableParameterInfo.java
@@ -63,6 +63,8 @@ public class TableParameterInfo {
     public static final String TOTAL_SHARDS_PER_NODE = ShardsLimitAllocationDecider.INDEX_TOTAL_SHARDS_PER_NODE_SETTING.getKey();
     public static final String MAPPING_TOTAL_FIELDS_LIMIT = MapperService.INDEX_MAPPING_TOTAL_FIELDS_LIMIT_SETTING.getKey();
     public static final String ALLOCATION_MAX_RETRIES = MaxRetryAllocationDecider.SETTING_ALLOCATION_MAX_RETRY.getKey();
+    public static final String MAX_NGRAM_DIFF = IndexSettings.MAX_NGRAM_DIFF_SETTING.getKey();
+    public static final String MAX_SHINGLE_DIFF = IndexSettings.MAX_SHINGLE_DIFF_SETTING.getKey();
 
     public static final String WARMER_ENABLED = IndexSettings.INDEX_WARMER_ENABLED_SETTING.getKey();
     public static final String UNASSIGNED_NODE_LEFT_DELAYED_TIMEOUT = UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey();
@@ -89,6 +91,8 @@ public class TableParameterInfo {
             .add(UNASSIGNED_NODE_LEFT_DELAYED_TIMEOUT)
             .add(SETTING_WAIT_FOR_ACTIVE_SHARDS)
             .add(ALLOCATION_MAX_RETRIES)
+            .add(MAX_NGRAM_DIFF)
+            .add(MAX_SHINGLE_DIFF)
             .build();
 
     private static final ImmutableList<String> SUPPORTED_INTERNAL_SETTINGS =

--- a/sql/src/main/java/io/crate/analyze/TablePropertiesAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/TablePropertiesAnalyzer.java
@@ -69,6 +69,8 @@ public final class TablePropertiesAnalyzer {
             .put(stripIndexPrefix(TableParameterInfo.NUMBER_OF_SHARDS), TableParameterInfo.NUMBER_OF_SHARDS)
             .put(stripIndexPrefix(TableParameterInfo.SETTING_WAIT_FOR_ACTIVE_SHARDS), TableParameterInfo.SETTING_WAIT_FOR_ACTIVE_SHARDS)
             .put(stripIndexPrefix(TableParameterInfo.ALLOCATION_MAX_RETRIES), TableParameterInfo.ALLOCATION_MAX_RETRIES)
+            .put(stripIndexPrefix(TableParameterInfo.MAX_NGRAM_DIFF), TableParameterInfo.MAX_NGRAM_DIFF)
+            .put(stripIndexPrefix(TableParameterInfo.MAX_SHINGLE_DIFF), TableParameterInfo.MAX_SHINGLE_DIFF)
             .put("blobs_path", TableParameterInfo.BLOBS_PATH)
             .build();
 
@@ -104,6 +106,8 @@ public final class TablePropertiesAnalyzer {
             .put(TableParameterInfo.NUMBER_OF_SHARDS, new NumberOfShardsSettingsApplier())
             .put(TableParameterInfo.SETTING_WAIT_FOR_ACTIVE_SHARDS, new SettingsAppliers.StringSettingsApplier(CrateTableSettings.SETTING_WAIT_FOR_ACTIVE_SHARDS))
             .put(TableParameterInfo.ALLOCATION_MAX_RETRIES, new SettingsAppliers.IntSettingsApplier(CrateTableSettings.ALLOCATION_MAX_RETRIES))
+            .put(TableParameterInfo.MAX_NGRAM_DIFF, new SettingsAppliers.IntSettingsApplier(CrateTableSettings.MAX_NGRAM_DIFF))
+            .put(TableParameterInfo.MAX_SHINGLE_DIFF, new SettingsAppliers.IntSettingsApplier(CrateTableSettings.MAX_SHINGLE_DIFF))
             .put(TableParameterInfo.BLOBS_PATH, new BlobPathSettingApplier())
             .build();
 

--- a/sql/src/main/java/io/crate/metadata/settings/CrateTableSettings.java
+++ b/sql/src/main/java/io/crate/metadata/settings/CrateTableSettings.java
@@ -115,4 +115,8 @@ public final class CrateTableSettings {
     public static final IntSetting ALLOCATION_MAX_RETRIES = new IntSetting(
         TableParameterInfo.ALLOCATION_MAX_RETRIES,
         MaxRetryAllocationDecider.SETTING_ALLOCATION_MAX_RETRY.getDefault(Settings.EMPTY));
+
+    public static final IntSetting MAX_NGRAM_DIFF = new IntSetting(TableParameterInfo.MAX_NGRAM_DIFF, 1);
+    public static final IntSetting MAX_SHINGLE_DIFF = new IntSetting(TableParameterInfo.MAX_SHINGLE_DIFF, 3);
+
 }

--- a/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -228,6 +228,22 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
     }
 
     @Test
+    public void testAlterTableWithMaxNGramDiffSetting() {
+        AlterTableAnalyzedStatement analysisSet = e.analyze(
+            "ALTER TABLE users " +
+            "SET (max_ngram_diff = 42)");
+        assertThat(analysisSet.tableParameter().settings().get(TableParameterInfo.MAX_NGRAM_DIFF), is("42"));
+    }
+
+    @Test
+    public void testAlterTableWithMaxShingleDiffSetting() {
+        AlterTableAnalyzedStatement analysisSet = e.analyze(
+            "ALTER TABLE users " +
+            "SET (max_shingle_diff = 43)");
+        assertThat(analysisSet.tableParameter().settings().get(TableParameterInfo.MAX_SHINGLE_DIFF), is("43"));
+    }
+
+    @Test
     @SuppressWarnings("unchecked")
     public void testCreateTableWithClusteredBy() throws Exception {
         CreateTableAnalyzedStatement analysis = e.analyze(


### PR DESCRIPTION
The index settings `index.max_ngram` and `index.max_shingle_diff` are exposed as table settings.