### PR TITLE
Fixed randomized schema test execution.

### DIFF
--- a/sql/src/test/java/io/crate/integrationtests/JobLogIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/JobLogIntegrationTest.java
@@ -23,6 +23,7 @@ package io.crate.integrationtests;
 
 import io.crate.execution.engine.collect.stats.JobsLogService;
 import io.crate.testing.UseJdbc;
+import io.crate.testing.UseRandomizedSession;
 import io.crate.testing.UseSemiJoins;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.hamcrest.Matchers;
@@ -33,6 +34,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 2, numClientNodes = 0, supportsDedicatedMasters = false)
+@UseRandomizedSession(schema = false) // Avoid set session stmt to interfere with tests
 @UseSemiJoins(0) // Avoid set session stmt to interfere with tests
 public class JobLogIntegrationTest extends SQLTransportIntegrationTest {
 

--- a/sql/src/test/java/io/crate/integrationtests/PostgresJobsLogsITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PostgresJobsLogsITest.java
@@ -23,6 +23,7 @@
 package io.crate.integrationtests;
 
 import io.crate.testing.UseJdbc;
+import io.crate.testing.UseRandomizedSession;
 import io.crate.testing.UseSemiJoins;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -42,6 +43,7 @@ import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 1, numClientNodes = 0, supportsDedicatedMasters = false)
 @UseJdbc(1)
+@UseRandomizedSession(schema = false) // Avoid set session stmt to interfere with tests
 @UseSemiJoins(0) // Avoid set session stmt to interfere with tests
 public class PostgresJobsLogsITest extends SQLTransportIntegrationTest {
 

--- a/sql/src/test/java/io/crate/testing/SQLTransportExecutor.java
+++ b/sql/src/test/java/io/crate/testing/SQLTransportExecutor.java
@@ -83,6 +83,7 @@ import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 import static io.crate.action.sql.Session.UNNAMED;
+import static io.crate.metadata.Schemas.DOC_SCHEMA_NAME;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
@@ -145,7 +146,9 @@ public class SQLTransportExecutor {
         Random random = RandomizedContext.current().getRandom();
 
         List<String> sessionList = new ArrayList<>();
-        sessionList.add("set search_path='" + defaultSchema + "'");
+        if (defaultSchema != null && !defaultSchema.equals(DOC_SCHEMA_NAME)) {
+            sessionList.add("set search_path='" + defaultSchema + "'");
+        }
 
         if (isSemiJoinsEnabled) {
             sessionList.add("set enable_semijoin=true");
@@ -162,7 +165,7 @@ public class SQLTransportExecutor {
                 sessionList);
         }
         try {
-            if (isSemiJoinsEnabled) {
+            if (!sessionList.isEmpty()) {
                 Session session = newSession();
                 sessionList.forEach((setting) -> exec(setting, session));
                 return execute(stmt, args, session).actionGet(timeout);


### PR DESCRIPTION
The usage or not of a randomized schema was decided by an old
check and therefore random schema was selected only if semi-joins
was enabled for the test (randomly 50-50 chance).

In the future we should "merge" the `@UseSemiJoins` with the `@RandomizedSession` annotation.