### PR TITLE
Replace unsafe SQLDirectExecutor with a quickExec function

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -73,6 +73,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that could result in a ``Bulk operation not supported for
+  RootRelationBoundary`` error when querying ``sys.checks``
+
 - Fixed a bug in parsing the UDF meta data when read from state file during
   node start that could cause other custom meta data (such as users) to
   disappear from cluster state.

--- a/sql/src/main/java/io/crate/execution/ddl/AlterTableOperation.java
+++ b/sql/src/main/java/io/crate/execution/ddl/AlterTableOperation.java
@@ -109,9 +109,10 @@ public class AlterTableOperation {
     private final TransportCloseIndexAction transportCloseIndexAction;
     private final TransportRenameTableAction transportRenameTableAction;
     private final TransportOpenCloseTableOrPartitionAction transportOpenCloseTableOrPartitionAction;
-    private final SQLOperations sqlOperations;
     private final IndexScopedSettings indexScopedSettings;
     private final Logger logger;
+    private final SQLOperations sqlOperations;
+    private Session session;
 
     @Inject
     public AlterTableOperation(ClusterService clusterService,
@@ -134,8 +135,8 @@ public class AlterTableOperation {
         this.transportCloseIndexAction = transportCloseIndexAction;
         this.transportRenameTableAction = transportRenameTableAction;
         this.transportOpenCloseTableOrPartitionAction = transportOpenCloseTableOrPartitionAction;
-        this.sqlOperations = sqlOperations;
         this.indexScopedSettings = indexScopedSettings;
+        this.sqlOperations = sqlOperations;
         logger = Loggers.getLogger(getClass(), settings);
     }
 
@@ -146,13 +147,8 @@ public class AlterTableOperation {
             String stmt =
                 String.format(Locale.ENGLISH, "SELECT COUNT(*) FROM \"%s\".\"%s\"", ident.schema(), ident.name());
 
-            SQLOperations.SQLDirectExecutor sqlDirectExecutor = sqlOperations.createSystemExecutor(
-                null,
-                Session.UNNAMED,
-                stmt,
-                1);
             try {
-                sqlDirectExecutor.execute(new ResultSetReceiver(analysis, result), Collections.emptyList());
+                session().quickExec(stmt, new ResultSetReceiver(analysis, result), Row.EMPTY);
             } catch (Throwable t) {
                 result.completeExceptionally(t);
             }
@@ -160,6 +156,13 @@ public class AlterTableOperation {
             addColumnToTable(analysis, result);
         }
         return result;
+    }
+
+    private Session session() {
+        if (session == null) {
+            this.session = sqlOperations.newSystemSession();
+        }
+        return session;
     }
 
     public CompletableFuture<Long> executeAlterTableOpenClose(final AlterTableOpenCloseAnalyzedStatement analysis) {

--- a/sql/src/main/java/io/crate/protocols/postgres/RetryOnFailureResultReceiver.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/RetryOnFailureResultReceiver.java
@@ -33,18 +33,18 @@ import org.elasticsearch.transport.ConnectTransportException;
 import javax.annotation.Nonnull;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 
-class RetryOnFailureResultReceiver implements ResultReceiver {
+public class RetryOnFailureResultReceiver implements ResultReceiver {
 
     private static final Logger LOGGER = Loggers.getLogger(RetryOnFailureResultReceiver.class);
 
     private final ResultReceiver delegate;
     private final UUID jobId;
-    private final Consumer<UUID> retryAction;
+    private final BiConsumer<UUID, ResultReceiver> retryAction;
     private int attempt = 1;
 
-    RetryOnFailureResultReceiver(ResultReceiver delegate, UUID jobId, Consumer<UUID> retryAction) {
+    public RetryOnFailureResultReceiver(ResultReceiver delegate, UUID jobId, BiConsumer<UUID, ResultReceiver> retryAction) {
         this.delegate = delegate;
         this.jobId = jobId;
         this.retryAction = retryAction;
@@ -82,7 +82,7 @@ class RetryOnFailureResultReceiver implements ResultReceiver {
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("Retrying statement due to a shard failure, attempt={}, jobId={}->{}", attempt, jobId, newJobId);
         }
-        retryAction.accept(newJobId);
+        retryAction.accept(newJobId, this);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/protocols/postgres/SimplePortal.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/SimplePortal.java
@@ -30,15 +30,15 @@ import io.crate.analyze.AnalyzedStatement;
 import io.crate.analyze.Analyzer;
 import io.crate.analyze.ParameterContext;
 import io.crate.analyze.relations.AnalyzedRelation;
-import io.crate.expression.symbol.Field;
 import io.crate.collections.Lists2;
 import io.crate.data.Row;
 import io.crate.data.RowN;
 import io.crate.exceptions.ReadOnlyException;
 import io.crate.exceptions.SQLExceptions;
+import io.crate.execution.engine.collect.stats.JobsLogs;
+import io.crate.expression.symbol.Field;
 import io.crate.metadata.RoutingProvider;
 import io.crate.metadata.TransactionContext;
-import io.crate.execution.engine.collect.stats.JobsLogs;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Plan;
 import io.crate.planner.Planner;
@@ -191,7 +191,7 @@ public class SimplePortal extends AbstractPortal {
 
         if (!analyzedStatement.isWriteOperation()) {
             resultReceiver = new RetryOnFailureResultReceiver(
-                resultReceiver, jobId, newJobId -> retryQuery(planner, newJobId));
+                resultReceiver, jobId, (newJobId, resultReceiver) -> retryQuery(planner, newJobId));
         }
 
         jobsLogs.logExecutionStart(jobId, query, sessionContext.user());

--- a/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
@@ -34,6 +34,7 @@ import io.crate.analyze.Analyzer;
 import io.crate.analyze.CreateTableStatementAnalyzer;
 import io.crate.analyze.ParameterContext;
 import io.crate.auth.user.User;
+import io.crate.auth.user.UserLookup;
 import io.crate.data.Row;
 import io.crate.execution.dml.TransportShardAction;
 import io.crate.execution.dml.delete.TransportShardDeleteAction;
@@ -81,6 +82,7 @@ import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.Randomness;
+import org.elasticsearch.common.inject.ConfigurationException;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.common.unit.TimeValue;
@@ -330,8 +332,15 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
      */
     public SQLResponse systemExecute(String stmt, @Nullable String schema, String node) {
         SQLOperations sqlOperations = internalCluster().getInstance(SQLOperations.class, node);
-        SQLOperations.SQLDirectExecutor directExecutor = sqlOperations.createSystemExecutor(schema, "system_query", stmt, 10_000);
-        response = SQLTransportExecutor.systemExecute(stmt, directExecutor).actionGet(SQLTransportExecutor.REQUEST_TIMEOUT);
+        UserLookup userLookup;
+        try {
+            userLookup = internalCluster().getInstance(UserLookup.class, node);
+        } catch (ConfigurationException ignored) {
+            // If enterprise is not enabled there is no UserLookup instance bound in guice
+            userLookup = userName -> null;
+        }
+        Session session = sqlOperations.createSession(schema, userLookup.findUser("crate"));
+        response = SQLTransportExecutor.execute(stmt, null, session).actionGet(SQLTransportExecutor.REQUEST_TIMEOUT);
         return response;
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/SysCheckerIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysCheckerIntegrationTest.java
@@ -24,9 +24,13 @@ package io.crate.integrationtests;
 import io.crate.expression.reference.sys.check.SysCheck.Severity;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.TestingHelpers;
+import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.common.settings.Settings.builder;
 import static org.hamcrest.Matchers.equalTo;
@@ -97,5 +101,21 @@ public class SysCheckerIntegrationTest extends SQLTransportIntegrationTest {
         execute("insert into bar (id) values (?)", new Object[]{1});
         SQLResponse response = execute("select severity, passed from sys.checks where id=?", new Object[]{2});
         assertThat(TestingHelpers.printedTable(response.rows()), is("2| true\n"));
+    }
+
+    @Test
+    public void testSelectingConcurrentlyFromSysCheckPassesWithoutExceptions() {
+        Settings settings = builder().put("discovery.zen.minimum_master_nodes", 1).build();
+        internalCluster().startNode(settings);
+        internalCluster().startNode(settings);
+        internalCluster().ensureAtLeastNumDataNodes(2);
+
+        ArrayList<ActionFuture<SQLResponse>> responses = new ArrayList<>();
+        for (int i = 0; i < 20; i++) {
+            responses.add(sqlExecutor.execute("select * from sys.checks", null));
+        }
+        for (ActionFuture<SQLResponse> response : responses) {
+            response.actionGet(5, TimeUnit.SECONDS);
+        }
     }
 }

--- a/sql/src/test/java/io/crate/planner/TableStatsServiceTest.java
+++ b/sql/src/test/java/io/crate/planner/TableStatsServiceTest.java
@@ -23,8 +23,8 @@
 package io.crate.planner;
 
 import com.carrotsearch.hppc.ObjectLongMap;
-import io.crate.action.sql.Session;
 import io.crate.action.sql.SQLOperations;
+import io.crate.action.sql.Session;
 import io.crate.data.RowN;
 import io.crate.metadata.TableIdent;
 import io.crate.plugin.SQLPlugin;
@@ -36,10 +36,8 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.junit.Test;
 import org.mockito.Answers;
-import org.mockito.Mockito;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -49,10 +47,10 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyObject;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -135,14 +133,9 @@ public class TableStatsServiceTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testStatsQueriesCorrectly() throws Throwable {
-        final SQLOperations sqlOperations = mock(SQLOperations.class);
-        SQLOperations.SQLDirectExecutor sqlDirectExecutor = mock(SQLOperations.SQLDirectExecutor.class);
-        when(sqlOperations.createSystemExecutor(
-            eq("sys"),
-            eq(TableStatsService.TABLE_STATS),
-            eq(TableStatsService.STMT),
-            eq(TableStatsService.DEFAULT_SOFT_LIMIT)))
-            .thenReturn(sqlDirectExecutor);
+        SQLOperations sqlOperations = mock(SQLOperations.class);
+        Session session = mock(Session.class);
+        when(sqlOperations.newSystemSession()).thenReturn(session);
 
         TableStatsService statsService = new TableStatsService(
             Settings.EMPTY,
@@ -153,9 +146,7 @@ public class TableStatsServiceTest extends CrateDummyClusterServiceUnitTest {
         );
         statsService.run();
 
-        verify(sqlDirectExecutor, times(1)).execute(
-            any(TableStatsService.TableStatsResultReceiver.class),
-            eq(Collections.emptyList()));
+        verify(session, times(1)).quickExec(eq(TableStatsService.STMT), any(), any(), any());
     }
 
     @Test
@@ -176,6 +167,6 @@ public class TableStatsServiceTest extends CrateDummyClusterServiceUnitTest {
         );
 
         statsService.run();
-        Mockito.verify(session, times(0)).sync();
+        verify(session, times(0)).sync();
     }
 }

--- a/sql/src/test/java/io/crate/protocols/postgres/RetryOnFailureResultReceiverTest.java
+++ b/sql/src/test/java/io/crate/protocols/postgres/RetryOnFailureResultReceiverTest.java
@@ -40,7 +40,7 @@ public class RetryOnFailureResultReceiverTest {
         AtomicInteger numRetries = new AtomicInteger(0);
         BaseResultReceiver baseResultReceiver = new BaseResultReceiver();
         RetryOnFailureResultReceiver retryOnFailureResultReceiver =
-            new RetryOnFailureResultReceiver(baseResultReceiver, UUID.randomUUID(), newJobId -> numRetries.incrementAndGet());
+            new RetryOnFailureResultReceiver(baseResultReceiver, UUID.randomUUID(), (newJobId, receiver) -> numRetries.incrementAndGet());
 
         retryOnFailureResultReceiver.fail(new ConnectTransportException(null, "node not connected"));
 

--- a/sql/src/test/java/io/crate/testing/SQLTransportExecutor.java
+++ b/sql/src/test/java/io/crate/testing/SQLTransportExecutor.java
@@ -181,26 +181,6 @@ public class SQLTransportExecutor {
         return clientProvider.pgUrl();
     }
 
-    /**
-     * Executes the stmt on directly on the system using {@link SQLOperations.SQLDirectExecutor}
-     *
-     * @param stmt      the SQL stmt
-     * @param executor  an instance of {@link SQLOperations.SQLDirectExecutor}
-     * @return          an {@link ActionFuture} containing the SQL response
-     */
-    public static ActionFuture<SQLResponse> systemExecute(String stmt, SQLOperations.SQLDirectExecutor executor) {
-        final AdapterActionFuture<SQLResponse, SQLResponse> actionFuture = new PlainActionFuture<>();
-        executor.getSession().parse(UNNAMED, stmt, Collections.emptyList());
-        executor.getSession().bind(UNNAMED, UNNAMED, Collections.emptyList(), null);
-        List<Field> outputFields = executor.getSession().describe('P', UNNAMED).getFields();
-        try {
-            executor.execute(new ResultSetReceiver(actionFuture, executor.getSession().sessionContext(), outputFields), Collections.emptyList());
-        } catch (Throwable t) {
-            actionFuture.onFailure(SQLExceptions.createSQLActionException(t, executor.getSession().sessionContext()));
-        }
-        return actionFuture;
-    }
-
     public ActionFuture<SQLResponse> execute(String stmt, @Nullable Object[] args) {
         return execute(stmt, args, newSession());
     }


### PR DESCRIPTION
The SQLDirectExecutor wasn't thread-safe as it used the Session which by
design is stateful and not thread-safe.

This could cause the portals inside the Session to be promoted to a
`BulkPortal` which then caused regular `Bulk operation not supported for
RootRelationBoundary` errors during queries on `sys.checks`.