### PR TITLE
adds hashjoin iterator JMH benchmark

### DIFF
--- a/benchmarks/src/test/java/io/crate/data/join/RowsBatchIteratorBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/data/join/RowsBatchIteratorBenchmark.java
@@ -22,14 +22,17 @@
 
 package io.crate.data.join;
 
+import io.crate.breaker.RamAccountingContext;
+import io.crate.breaker.RowAccounting;
 import io.crate.data.BatchIterator;
-import io.crate.data.CloseAssertingBatchIterator;
 import io.crate.data.InMemoryBatchIterator;
 import io.crate.data.Row;
 import io.crate.data.Row1;
 import io.crate.data.RowN;
-import io.crate.data.SkippingBatchIterator;
+import io.crate.execution.engine.join.RamAccountingBatchIterator;
 import io.crate.testing.RowGenerator;
+import io.crate.types.DataTypes;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Mode;
@@ -38,6 +41,7 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.infra.Blackhole;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
@@ -52,6 +56,11 @@ import static io.crate.data.SentinelRow.SENTINEL;
 @State(Scope.Benchmark)
 public class RowsBatchIteratorBenchmark {
 
+    private static NoopCircuitBreaker NOOP_CIRCUIT_BREAKER = new NoopCircuitBreaker("dummy");
+
+    private final RamAccountingContext ramAccountingContext = new RamAccountingContext("test", NOOP_CIRCUIT_BREAKER);
+    private final RowAccounting rowAccounting = new RowAccounting(Collections.singleton(DataTypes.INTEGER), ramAccountingContext);
+
     // use materialize to not have shared row instances
     // this is done in the startup, otherwise the allocation costs will make up the majority of the benchmark.
     private List<Row> rows = StreamSupport.stream(RowGenerator.range(0, 10_000_000).spliterator(), false)
@@ -63,6 +72,7 @@ public class RowsBatchIteratorBenchmark {
     private final List<Row1> oneThousandRows = IntStream.range(0, 1000).mapToObj(Row1::new).collect(Collectors.toList());
     private final List<Row1> tenThousandRows = IntStream.range(0, 10000).mapToObj(Row1::new).collect(Collectors.toList());
 
+    /*
     @Benchmark
     public void measureConsumeBatchIterator(Blackhole blackhole) throws Exception {
         BatchIterator<Row> it = new InMemoryBatchIterator<>(rows, SENTINEL);
@@ -88,6 +98,7 @@ public class RowsBatchIteratorBenchmark {
             blackhole.consume(skippingIt.currentElement().get(0));
         }
     }
+    */
 
     @Benchmark
     public void measureConsumeNestedLoopJoin(Blackhole blackhole) throws Exception {
@@ -108,6 +119,40 @@ public class RowsBatchIteratorBenchmark {
             InMemoryBatchIterator.of(tenThousandRows, SENTINEL),
             new CombinedRow(1, 1),
             row -> Objects.equals(row.get(0), row.get(1))
+        );
+        while (leftJoin.moveNext()) {
+            blackhole.consume(leftJoin.currentElement().get(0));
+        }
+        leftJoin.moveToStart();
+    }
+
+    @Benchmark
+    public void measureConsumeHashInnerJoin(Blackhole blackhole) {
+        BatchIterator<Row> leftJoin = JoinBatchIterators.hashInnerJoin(
+            new RamAccountingBatchIterator<>(InMemoryBatchIterator.of(oneThousandRows, SENTINEL), rowAccounting),
+            InMemoryBatchIterator.of(tenThousandRows, SENTINEL),
+            new CombinedRow(1, 1),
+            row -> Objects.equals(row.get(0), row.get(1)),
+            row -> Objects.hash(row.get(0)),
+            row -> Objects.hash(row.get(0)),
+            1000
+        );
+        while (leftJoin.moveNext()) {
+            blackhole.consume(leftJoin.currentElement().get(0));
+        }
+        leftJoin.moveToStart();
+    }
+
+    @Benchmark
+    public void measureConsumeHashInnerJoinWithHashCollisions(Blackhole blackhole) {
+        BatchIterator<Row> leftJoin = JoinBatchIterators.hashInnerJoin(
+            new RamAccountingBatchIterator<>(InMemoryBatchIterator.of(oneThousandRows, SENTINEL), rowAccounting),
+            InMemoryBatchIterator.of(tenThousandRows, SENTINEL),
+            new CombinedRow(1, 1),
+            row -> Objects.equals(row.get(0), row.get(1)),
+            row -> (Integer) row.get(0) % 500,
+            row -> (Integer) row.get(0) % 500,
+            1000
         );
         while (leftJoin.moveNext()) {
             blackhole.consume(leftJoin.currentElement().get(0));

--- a/sql/src/main/java/io/crate/execution/engine/join/RamAccountingBatchIterator.java
+++ b/sql/src/main/java/io/crate/execution/engine/join/RamAccountingBatchIterator.java
@@ -42,7 +42,7 @@ public class RamAccountingBatchIterator<T extends Row> extends ForwardingBatchIt
     private final BatchIterator<T> delegateBatchIterator;
     private final RowAccounting rowAccounting;
 
-    RamAccountingBatchIterator(BatchIterator<T> delegatePagingIterator, RowAccounting rowAccounting) {
+    public RamAccountingBatchIterator(BatchIterator<T> delegatePagingIterator, RowAccounting rowAccounting) {
         this.delegateBatchIterator = delegatePagingIterator;
         this.rowAccounting = rowAccounting;
     }


### PR DESCRIPTION
```
Benchmark                                                                 Mode  Cnt    Score   Error  Units
RowsBatchIteratorBenchmark.measureConsumeHashInnerJoin                    avgt  200    0.313 ± 0.003  ms/op
RowsBatchIteratorBenchmark.measureConsumeHashInnerJoinWithHashCollisions  avgt  200    0.539 ± 0.016  ms/op
RowsBatchIteratorBenchmark.measureConsumeNestedLoopJoin                   avgt  200  119.845 ± 1.327  ms/op
RowsBatchIteratorBenchmark.measureConsumeNestedLoopLeftJoin               avgt  200   97.266 ± 6.381  ms/op
```