### PR TITLE
Make sure all affected jobs are killed on node disconnects

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -73,6 +73,9 @@ Changes
 Fixes
 =====
 
+- Improved the handling of node disconnects to ensure there are no stale
+  queries in case a node dies.
+
 - Fixed an issue that could result in a ``Bulk operation not supported for
   RootRelationBoundary`` error when querying ``sys.checks``
 


### PR DESCRIPTION
Previously we run the `broadcastKillToParticipatingNodes` logic only if
the node that was killed didn't coordinate any jobs at all. But it's
necessary to always run that to ensure there are no stuck jobs.