### PR TITLE
Add max_token_length to whitespace analyzer 

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -45,6 +45,8 @@ Breaking Changes
 Changes
 =======
 
+- Add max_token_length parameter to whitespace tokenizer.
+
 - Statistics for jobs and operations are enabled by default.  If you don't need
   any statistics, please set ``stats.enabled`` to ``false``.
 

--- a/blackbox/docs/general/ddl/analyzers.rst
+++ b/blackbox/docs/general/ddl/analyzers.rst
@@ -90,7 +90,7 @@ stopwords
 
 max_token_length
     The maximum token length. If a token exceeds this length it is split in
-    max_token_length intervals. Defaults to ``255``.
+    max_token_length chunks. Defaults to ``255``.
 
 .. _default-analyzer:
 
@@ -286,7 +286,7 @@ Standard Annex #29.
 
 max_token_length
     The maximum token length. If a token exceeds this length it is split in
-    max_token_length intervals. Defaults to ``255``.
+    max_token_length chunks. Defaults to ``255``.
 
 .. _classic-tokenizer:
 
@@ -305,7 +305,7 @@ languages other than English.
 
 max_token_length
     The maximum token length. If a token exceeds this length it is split in
-    max_token_length intervals. Defaults to ``255``.
+    max_token_length chunks. Defaults to ``255``.
 
 .. _thai-tokenizer:
 
@@ -350,7 +350,7 @@ The ``whitespace`` tokenizer splits text at whitespace.
 
 max_token_length
     The maximum token length. If a token exceeds this length it is split in
-    max_token_length intervals. Defaults to ``255``.
+    max_token_length chunks. Defaults to ``255``.
 
 .. _uaxemailurl-tokenizer:
 
@@ -366,7 +366,7 @@ tokenizes emails and urls as single tokens.
 
 max_token_length
     The maximum token length. If a token exceeds this length it is split in
-    max_token_length intervals. Defaults to ``255``.
+    max_token_length chunks. Defaults to ``255``.
 
 .. _ngram-tokenizer:
 

--- a/blackbox/docs/general/ddl/analyzers.rst
+++ b/blackbox/docs/general/ddl/analyzers.rst
@@ -346,6 +346,12 @@ Witespace Tokenizer
 
 The ``whitespace`` tokenizer splits text at whitespace.
 
+.. rubric:: Parameters
+
+max_token_length
+    The maximum token length. If a token is seen that exceeds this length then
+    it is discarded. Defaults to ``255``.
+
 .. _uaxemailurl-tokenizer:
 
 UAX URL Email Tokenizer

--- a/blackbox/docs/general/ddl/analyzers.rst
+++ b/blackbox/docs/general/ddl/analyzers.rst
@@ -89,8 +89,8 @@ stopwords
     Defaults to the english stop words.
 
 max_token_length
-    The maximum token length. If a token is seen that exceeds this length then
-    it is discarded. Defaults to ``255``.
+    The maximum token length. If a token exceeds this length it is split in
+    max_token_length intervals. Defaults to ``255``.
 
 .. _default-analyzer:
 
@@ -285,8 +285,8 @@ Standard Annex #29.
 .. rubric:: Parameters
 
 max_token_length
-    The maximum token length. If a token is seen that exceeds this length then
-    it is discarded. Defaults to ``255``.
+    The maximum token length. If a token exceeds this length it is split in
+    max_token_length intervals. Defaults to ``255``.
 
 .. _classic-tokenizer:
 
@@ -304,8 +304,8 @@ languages other than English.
 .. rubric:: Parameters
 
 max_token_length
-    The maximum token length. If a token is seen that exceeds this length then
-    it is split at max_token_length intervals. Defaults to ``255``.
+    The maximum token length. If a token exceeds this length it is split in
+    max_token_length intervals. Defaults to ``255``.
 
 .. _thai-tokenizer:
 
@@ -349,8 +349,8 @@ The ``whitespace`` tokenizer splits text at whitespace.
 .. rubric:: Parameters
 
 max_token_length
-    The maximum token length. If a token is seen that exceeds this length then
-    it is discarded. Defaults to ``255``.
+    The maximum token length. If a token exceeds this length it is split in
+    max_token_length intervals. Defaults to ``255``.
 
 .. _uaxemailurl-tokenizer:
 
@@ -365,8 +365,8 @@ tokenizes emails and urls as single tokens.
 .. rubric:: Parameters
 
 max_token_length
-    The maximum token length. If a token is seen that exceeds this length then
-    it is discarded. Defaults to ``255``.
+    The maximum token length. If a token exceeds this length it is split in
+    max_token_length intervals. Defaults to ``255``.
 
 .. _ngram-tokenizer:
 


### PR DESCRIPTION
Contains two commits. 1) Add the parameter 2) Adjust parameter description for other tokenizers.