### PR TITLE
Add epoch argument to extract function

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -45,6 +45,10 @@ Breaking Changes
 Changes
 =======
 
+- Added 'epoch' argument to the extract function which returns the number of
+  seconds since Jan 1, 1970. For example:
+  ``extract(epoch from '1970-01-01T00:00:01')`` returns ``1.0`` seconds.
+
 - Fixed and issue that could cause incorrect results for a ``join`` query with
   order by due to the push down optimisation.
 

--- a/blackbox/docs/general/builtins/scalar.rst
+++ b/blackbox/docs/general/builtins/scalar.rst
@@ -423,6 +423,11 @@ The following fields are supported:
   | *Return type:* ``integer``
   | the second field
 
+**EPOCH**
+  | *Return type:* ``double``
+  | The number of seconds since Jan 1, 1970.
+  | Can be negative if earlier than Jan 1, 1970.
+
 .. _`available time zones`: http://www.joda.org/joda-time/timezones.html
 .. _`Joda-Time`: http://www.joda.org/joda-time/
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/Extract.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/Extract.java
@@ -48,7 +48,8 @@ public class Extract
         MINUTE,
         SECOND,
         TIMEZONE_HOUR,
-        TIMEZONE_MINUTE
+        TIMEZONE_MINUTE,
+        EPOCH
     }
 
     public Extract(Expression expression, Expression field) {

--- a/sql/src/test/java/io/crate/expression/scalar/ExtractFunctionsTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/ExtractFunctionsTest.java
@@ -97,4 +97,14 @@ public class ExtractFunctionsTest extends AbstractScalarFunctionsTest {
     public void testSecond() throws Exception {
         assertEvaluate("extract(second from timestamp)", 23);
     }
+
+    @Test
+    public void testExtractEpoch() {
+        assertEvaluate("extract(epoch from '1970-01-01T00:00:01')", 1.0);
+        assertEvaluate("extract(epoch from '1970-01-01T00:00:00.5')", 0.5);
+        assertEvaluate("extract(epoch from '1970-01-01T00:00:00')", 0.0);
+        assertEvaluate("extract(epoch from '1969-12-31T23:59:59')", -1.0);
+        assertEvaluate("extract(epoch from timestamp)", 1392500003.0);
+    }
+
 }


### PR DESCRIPTION
Epoch returns the number of seconds since Jan 1, 1970.

```
> extract(epoch from '1970-01-01T00:00:01') => 1
> extract(epoch from '1970-01-01T00:00:00') => 0
> extract(epoch from '1969-12-31T23:59:59') => -1

> extract(epoch from 1234000) => 1234
> extract(epoch from -1000) => -1
```

Note that the integer boxing didn't change here. The boxing already happened in
the GenericExtractFunction when evaluate is called.