### PR TITLE
Make select queries more resilient in case of IndexNotFound errors

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -82,6 +82,9 @@ Changes
 Fixes
 =====
 
+- Read only queries should no longer fail with a ``TableUnknownException`` in
+  case of a shard relocation.
+
 - Improved the handling of node disconnects to ensure there are no stale
   queries in case a node dies.
 

--- a/sql/src/main/java/io/crate/action/sql/Session.java
+++ b/sql/src/main/java/io/crate/action/sql/Session.java
@@ -179,6 +179,9 @@ public class Session {
 
         if (!analyzedStatement.isWriteOperation()) {
             resultReceiver = new RetryOnFailureResultReceiver(
+                // not using planner.currentClusterState().metaData()::hasIndex to make sure the *current*
+                // clusterState at the time of the index check is used
+                indexName -> planner.currentClusterState().metaData().hasIndex(indexName),
                 resultReceiver,
                 jobId,
                 (newJobId, retryResultReceiver) -> retryQuery(

--- a/sql/src/main/java/io/crate/protocols/postgres/SimplePortal.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/SimplePortal.java
@@ -191,7 +191,13 @@ public class SimplePortal extends AbstractPortal {
 
         if (!analyzedStatement.isWriteOperation()) {
             resultReceiver = new RetryOnFailureResultReceiver(
-                resultReceiver, jobId, (newJobId, resultReceiver) -> retryQuery(planner, newJobId));
+                // not using planner.currentClusterState().metaData()::hasIndex to make sure the *current*
+                // clusterState at the time of the index check is used
+                indexName -> planner.currentClusterState().metaData().hasIndex(indexName),
+                resultReceiver,
+                jobId,
+                (newJobId, resultReceiver) -> retryQuery(planner, newJobId)
+            );
         }
 
         jobsLogs.logExecutionStart(jobId, query, sessionContext.user());


### PR DESCRIPTION
`IndexNotFoundException` can occur when the last remaining shard of an
index has been moved away from a node.
So far we only retried on `ShardNotFoundException`.