### PR TITLE
Hash-Join iterator perf improvements

### DIFF
--- a/dex/build.gradle
+++ b/dex/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     compile "com.google.code.findbugs:jsr305:${versions.jsr305}"
     compile "com.google.guava:guava:${versions.guava}"
     compile "org.apache.lucene:lucene-core:${versions.lucene}"
+    compile "com.carrotsearch:hppc:${versions.carrotsearch_hppc}"
     compile project(':shared')
 
     testCompile "junit:junit:${versions.junit}"

--- a/dex/src/main/java/io/crate/data/join/HashInnerJoinBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/join/HashInnerJoinBatchIterator.java
@@ -27,8 +27,8 @@ import io.crate.data.ArrayRow;
 import io.crate.data.BatchIterator;
 import io.crate.data.Row;
 
+import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -151,7 +151,7 @@ public class HashInnerJoinBatchIterator<L extends Row, R extends Row, C> extends
     private void addToBuffer(Object[] currentRow, int hash) {
         List<Object[]> existingRows = buffer.get(hash);
         if (existingRows == null) {
-            existingRows = new LinkedList<>();
+            existingRows = new ArrayList<>();
             buffer.put(hash, existingRows);
         }
         existingRows.add(currentRow);

--- a/dex/src/main/java/io/crate/data/join/HashInnerJoinBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/join/HashInnerJoinBatchIterator.java
@@ -66,7 +66,7 @@ import java.util.function.Predicate;
  * This information is not available for the {@link HashInnerJoinBatchIterator}, so it's the responsibility of the
  * caller to provide those two functions that operate on the left and right rows accordingly and return the hash values.
  */
-class HashInnerJoinBatchIterator<L extends Row, R extends Row, C> extends JoinBatchIterator<L, R, C> {
+public class HashInnerJoinBatchIterator<L extends Row, R extends Row, C> extends JoinBatchIterator<L, R, C> {
 
     private static int DEFAULT_BUFFER_SIZE = 10_000;
     private final Predicate<C> joinCondition;

--- a/es/es-core/build.gradle
+++ b/es/es-core/build.gradle
@@ -25,7 +25,7 @@ dependencies {
 
     // utilities
     compile "org.elasticsearch:elasticsearch-cli:${versions.elasticsearch}"
-    compile "com.carrotsearch:hppc:0.7.1"
+    compile "com.carrotsearch:hppc:${versions.carrotsearch_hppc}"
 
     // time handling
     compile "joda-time:joda-time:${versions.jodatime}"

--- a/gradle/version.properties
+++ b/gradle/version.properties
@@ -45,4 +45,5 @@ commonscodec=1.10
 hamcrest=1.3
 securemock=1.2
 mocksocket=1.2
+carrotsearch_hppc:0.7.1
 

--- a/sql/src/main/java/io/crate/execution/jobs/ContextPreparer.java
+++ b/sql/src/main/java/io/crate/execution/jobs/ContextPreparer.java
@@ -735,7 +735,11 @@ public class ContextPreparer extends AbstractComponent {
                 joinCondition,
                 phase.leftJoinConditionInputs(),
                 phase.rightJoinConditionInputs(),
-                new RowAccounting(phase.leftOutputTypes(), ramAccountingContext),
+                // 110 extra bytes per row =
+                //    96 bytes for each ArrayList +
+                //    7 bytes per key for the IntHashObjectHashMap  (should be 4 but the map pre-allocates more)
+                //    7 bytes perv value (pointer from the map to the list) (should be 4 but the map pre-allocates more)
+                new RowAccounting(phase.leftOutputTypes(), ramAccountingContext, 110),
                 inputFactory,
                 phase.leftNumRowsEstimate());
             PageDownstreamContext left = pageDownstreamContextForNestedLoop(

--- a/sql/src/test/java/io/crate/breaker/RowAccountingTest.java
+++ b/sql/src/test/java/io/crate/breaker/RowAccountingTest.java
@@ -63,4 +63,18 @@ public class RowAccountingTest extends CrateUnitTest {
         expectedException.expect(CircuitBreakingException.class);
         RowGenerator.range(0, 3).forEach(rowAccounting::accountForAndMaybeBreak);
     }
+
+    @Test
+    public void testCircuitBreakingWorksWithExtraSizePerRow() throws Exception {
+        RowAccounting rowAccounting = new RowAccounting(Collections.singletonList(DataTypes.INTEGER),
+            new RamAccountingContext(
+                "test",
+                new MemoryCircuitBreaker(
+                    new ByteSizeValue(10, ByteSizeUnit.BYTES), 1.01, Loggers.getLogger(RowAccountingTest.class))
+            ),
+            2);
+
+        expectedException.expect(CircuitBreakingException.class);
+        RowGenerator.range(0, 2).forEach(rowAccounting::accountForAndMaybeBreak);
+    }
 }


### PR DESCRIPTION
See commit messages.

Benchmarks (with new collision simulation):

With guava Multimap:
```
Benchmark                                                                 Mode  Cnt  Score   Error  Units
RowsBatchIteratorBenchmark.measureConsumeHashInnerJoin                    avgt  200  0.394 ± 0.002  ms/op
RowsBatchIteratorBenchmark.measureConsumeHashInnerJoinWithHashCollisions  avgt  200  0.584 ± 0.004  ms/op
```

With hppc IntObjectHashMap:
```
Benchmark                                                                 Mode  Cnt  Score   Error  Units
RowsBatchIteratorBenchmark.measureConsumeHashInnerJoin                    avgt  200  0.365 ± 0.007  ms/op
RowsBatchIteratorBenchmark.measureConsumeHashInnerJoinWithHashCollisions  avgt  200  0.500 ± 0.003  ms/op
```

With 2 hppc IntObjectHashMaps (to avoid unecessary instantiation of LinkedLists):
```
Benchmark                                                                 Mode  Cnt  Score   Error  Units
RowsBatchIteratorBenchmark.measureConsumeHashInnerJoin                    avgt  200  0.329 ± 0.001  ms/op
RowsBatchIteratorBenchmark.measureConsumeHashInnerJoinWithHashCollisions  avgt  200  0.363 ± 0.001  ms/op
```

Same as above but with ObjectArrayList instead of LinkedList (see https://github.com/crate/crate/pull/6927/commits/eefcc39bc1c3ad53d27021cbbc7dd1e241583018):
```
Benchmark                                                                 Mode  Cnt  Score   Error  Units
RowsBatchIteratorBenchmark.measureConsumeHashInnerJoin                    avgt  200  0.383 ± 0.008  ms/op
RowsBatchIteratorBenchmark.measureConsumeHashInnerJoinWithHashCollisions  avgt  200  0.344 ± 0.006  ms/op
```

With 1 hppc IntObjectHashMap<Object> and use of instance of to see if single Object[] or List<Object[]> (chain due to duplicate values/hash collisions:
```
Benchmark                                                                 Mode  Cnt  Score   Error  Units
RowsBatchIteratorBenchmark.measureConsumeHashInnerJoin                    avgt  200  0.347 ± 0.001  ms/op
RowsBatchIteratorBenchmark.measureConsumeHashInnerJoinWithHashCollisions  avgt  200  0.617 ± 0.002  ms/op
```
