### PR TITLE
Avoid early node termination on graceful stop

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -79,5 +79,8 @@ Changes
 Fixes
 =====
 
+- Fixed a race condition that could cause the decommissioning of nodes using
+  the graceful shutdown procedure to interrupt the execution of active queries.
+
 - Read only queries should no longer fail with a ``TableUnknownException`` in
   case of a shard relocation.

--- a/sql/src/main/java/io/crate/execution/jobs/JobContextService.java
+++ b/sql/src/main/java/io/crate/execution/jobs/JobContextService.java
@@ -120,6 +120,10 @@ public class JobContextService extends AbstractLifecycleComponent {
         return new JobExecutionContext.Builder(jobId, coordinatorNodeId, participatingNodes, jobsLogs);
     }
 
+    public int numActive() {
+        return activeContexts.size();
+    }
+
     public JobExecutionContext createContext(JobExecutionContext.Builder contextBuilder) throws Exception {
         if (contextBuilder.isEmpty()) {
             throw new IllegalArgumentException("JobExecutionContext.Builder must at least contain 1 SubExecutionContext");


### PR DESCRIPTION
Although we move shards away from a node that is being decommissioned,
there is still a small window where it might run operations not
involving shards, like a distributed merge, or even receive new
operations because other nodes based their routing decision on a
slightly outdated cluster state.

This commit therefore changes the DecommissioningService to also check
for the number of active operations before invoking the node shutdown.

In addition, it adds a slight delay - this is a bit of a duct-tape fix
but it works for most cases and can easily be backported.