### PR TITLE
Remove support for deprecated HTTP ``X-User`` header.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -15,6 +15,10 @@ the appropriate section of the docs.
 Breaking Changes
 ================
 
+- For HTTP authentication, support was dropped for the ``X-User`` header, used
+  to provide a username, which has been deprecated in ``2.3.0.`` in favour of
+  the standard HTTP ``Authorization`` header.
+
 - Dropped support for tables that have been created with CrateDB prior to
   version 2.0. Tables which require upgrading are indicated in the cluster
   checks, including visually shown in the Admin UI, if running the latest 2.2

--- a/enterprise/users/src/main/java/io/crate/protocols/http/HttpAuthUpstreamHandler.java
+++ b/enterprise/users/src/main/java/io/crate/protocols/http/HttpAuthUpstreamHandler.java
@@ -159,9 +159,6 @@ public class HttpAuthUpstreamHandler extends SimpleChannelInboundHandler<Object>
             // Prefer Http Basic Auth
             return CrateRestMainAction.extractCredentialsFromHttpBasicAuthHeader(
                 request.headers().get(HttpHeaderNames.AUTHORIZATION.toString()));
-        } else if (request.headers().contains(AuthSettings.HTTP_HEADER_USER)) {
-            // Fallback to deprecated setting
-            username = request.headers().get(AuthSettings.HTTP_HEADER_USER);
         } else {
             // prefer commonName as userName over AUTH_TRUST_HTTP_DEFAULT_HEADER user
             if (session != null) {

--- a/sql/src/main/java/io/crate/auth/AuthSettings.java
+++ b/sql/src/main/java/io/crate/auth/AuthSettings.java
@@ -48,7 +48,5 @@ public final class AuthSettings {
         "auth.trust.http_default_user", "crate", Function.identity(), Setting.Property.NodeScope),
         DataTypes.STRING);
 
-    @Deprecated //Scheduled to be removed as HTTP Basic Auth Header is introduced"
-    public static final String HTTP_HEADER_USER = "X-User";
     public static final String HTTP_HEADER_REAL_IP = "X-Real-Ip";
 }

--- a/sql/src/main/java/io/crate/rest/action/RestSQLAction.java
+++ b/sql/src/main/java/io/crate/rest/action/RestSQLAction.java
@@ -159,11 +159,6 @@ public class RestSQLAction extends BaseRestHandler {
         String username = CrateRestMainAction.extractCredentialsFromHttpBasicAuthHeader(
             request.header(HttpHeaderNames.AUTHORIZATION.toString())).v1();
 
-        // Fallback to deprecated setting
-        if (username == null || username.isEmpty()) {
-            username = request.header(AuthSettings.HTTP_HEADER_USER);
-        }
-
         // Fallback to trusted user from configuration
         if (username == null || username.isEmpty()) {
             username = AuthSettings.AUTH_TRUST_HTTP_DEFAULT_HEADER.setting().get(settings);

--- a/sql/src/test/java/io/crate/rest/action/RestSQLActionTest.java
+++ b/sql/src/test/java/io/crate/rest/action/RestSQLActionTest.java
@@ -22,11 +22,10 @@
 
 package io.crate.rest.action;
 
-import com.google.common.collect.ImmutableMap;
 import io.crate.action.sql.SQLOperations;
-import io.crate.breaker.CrateCircuitBreakerService;
 import io.crate.auth.AuthSettings;
 import io.crate.auth.user.UserManager;
+import io.crate.breaker.CrateCircuitBreakerService;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.testing.DummyUserManager;
 import io.netty.handler.codec.http.HttpHeaderNames;
@@ -97,40 +96,6 @@ public class RestSQLActionTest extends CrateUnitTest {
                 Collections.singletonMap(HttpHeaderNames.AUTHORIZATION.toString(),
                     Collections.singletonList("Basic QWxhZGRpbjpPcGVuU2VzYW1l")))
             .build();
-        assertThat(restSQLAction.userFromRequest(request).name(), is("Aladdin"));
-    }
-
-    @Test
-    public void testUserIfHttpUserHeaderIsPresent() {
-        RestSQLAction restSQLAction = new RestSQLAction(
-            Settings.EMPTY,
-            restController,
-            sqlOperations,
-            USER_MANAGER_PROVIDER,
-            circuitBreakerService
-        );
-        RestRequest request = new FakeRestRequest.Builder(xContentRegistry())
-            .withHeaders(Collections.singletonMap(AuthSettings.HTTP_HEADER_USER, Collections.singletonList("other")))
-            .build();
-        assertThat(restSQLAction.userFromRequest(request).name(), is("other"));
-    }
-
-    @Test
-    public void testUserFromBasicAuthHeaderHasPrecedenceOverXUser() {
-        RestSQLAction restSQLAction = new RestSQLAction(
-            Settings.EMPTY,
-            restController,
-            sqlOperations,
-            USER_MANAGER_PROVIDER,
-            circuitBreakerService
-        );
-        RestRequest request = new FakeRestRequest.Builder(xContentRegistry())
-            .withHeaders(ImmutableMap.of(
-                AuthSettings.HTTP_HEADER_USER, Collections.singletonList("other"),
-                HttpHeaderNames.AUTHORIZATION.toString(), Collections.singletonList("Basic QWxhZGRpbjpPcGVuU2VzYW1l")))
-            .build();
-
-        // HTTP Basic Auth Header has higher priority
         assertThat(restSQLAction.userFromRequest(request).name(), is("Aladdin"));
     }
 }


### PR DESCRIPTION
The X-User header has been deprecated in 2.3.0 in
favour of the standardized HTTP Basic Auth header.