### PR TITLE
Rename UseRandomizedSession to UseRandomizedSchema.

### DIFF
--- a/sql/src/test/java/io/crate/execution/engine/collect/DocLevelCollectTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/DocLevelCollectTest.java
@@ -47,7 +47,7 @@ import io.crate.metadata.RowGranularity;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.TableIdent;
 import io.crate.planner.distribution.DistributionInfo;
-import io.crate.testing.UseRandomizedSession;
+import io.crate.testing.UseRandomizedSchema;
 import io.crate.types.DataTypes;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.Randomness;
@@ -75,7 +75,7 @@ import static org.mockito.Mockito.mock;
 
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 1)
-@UseRandomizedSession(schema = false)
+@UseRandomizedSchema(random = false)
 public class DocLevelCollectTest extends SQLTransportIntegrationTest {
 
     private static final String TEST_TABLE_NAME = "test_table";

--- a/sql/src/test/java/io/crate/integrationtests/AlterTableRerouteIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/AlterTableRerouteIntegrationTest.java
@@ -23,7 +23,7 @@
 package io.crate.integrationtests;
 
 import io.crate.testing.UseJdbc;
-import io.crate.testing.UseRandomizedSession;
+import io.crate.testing.UseRandomizedSchema;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Test;
 
@@ -31,7 +31,7 @@ import static org.hamcrest.core.Is.is;
 
 // ensure that only data nodes are picked for rerouting
 @ESIntegTestCase.ClusterScope(supportsDedicatedMasters = false, numDataNodes = 2, numClientNodes = 0)
-@UseRandomizedSession(schema = false)
+@UseRandomizedSchema(random = false)
 @UseJdbc(0) // reroute table has no rowcount
 public class AlterTableRerouteIntegrationTest extends SQLTransportIntegrationTest {
 

--- a/sql/src/test/java/io/crate/integrationtests/CustomSchemaIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/CustomSchemaIntegrationTest.java
@@ -22,7 +22,7 @@
 package io.crate.integrationtests;
 
 import io.crate.testing.TestingHelpers;
-import io.crate.testing.UseRandomizedSession;
+import io.crate.testing.UseRandomizedSchema;
 import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsRequest;
 import org.junit.Test;
 
@@ -31,7 +31,7 @@ import static org.hamcrest.Matchers.is;
 public class CustomSchemaIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test
-    @UseRandomizedSession(schema = false)
+    @UseRandomizedSchema(random = false)
     public void testInformationSchemaTablesReturnCorrectTablesIfCustomSchemaIsSimilarToTableName() throws Exception {
         // regression test.. this caused foobar to be detected as a table in the foo schema and caused a NPE
         execute("create table foobar (id int primary key) with (number_of_replicas = 0)");

--- a/sql/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -28,7 +28,7 @@ import io.crate.metadata.PartitionName;
 import io.crate.metadata.Schemas;
 import io.crate.testing.TestingHelpers;
 import io.crate.testing.UseJdbc;
-import io.crate.testing.UseRandomizedSession;
+import io.crate.testing.UseRandomizedSchema;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsRequest;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
@@ -49,7 +49,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope()
-@UseRandomizedSession(schema = false)
+@UseRandomizedSchema(random = false)
 public class DDLIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/GeoShapeIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/GeoShapeIntegrationTest.java
@@ -24,7 +24,7 @@ package io.crate.integrationtests;
 
 import com.google.common.collect.ImmutableMap;
 import io.crate.testing.TestingHelpers;
-import io.crate.testing.UseRandomizedSession;
+import io.crate.testing.UseRandomizedSchema;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -114,7 +114,7 @@ public class GeoShapeIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
-    @UseRandomizedSession(schema = false)
+    @UseRandomizedSchema(random = false)
     public void testShowCreateTable() throws Exception {
         execute("create table test (" +
                 "col1 geo_shape INDEX using QUADTREE with (precision='1m', distance_error_pct='0.25')" +
@@ -143,7 +143,7 @@ public class GeoShapeIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
-    @UseRandomizedSession(schema = false)
+    @UseRandomizedSchema(random = false)
     public void testShowCreateTableWithDefaultValues() throws Exception {
         execute("create table test (" +
                 "col1 geo_shape" +

--- a/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -27,7 +27,7 @@ import io.crate.Version;
 import io.crate.action.sql.SQLActionException;
 import io.crate.metadata.IndexMappings;
 import io.crate.testing.TestingHelpers;
-import io.crate.testing.UseRandomizedSession;
+import io.crate.testing.UseRandomizedSchema;
 import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -1048,7 +1048,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     }
 
     @Test
-    @UseRandomizedSession(schema = false)
+    @UseRandomizedSchema(random = false)
     public void testRegexpMatch() throws Exception {
         execute("create blob table blob_t1");
         execute("create table t(id String)");
@@ -1061,7 +1061,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     }
 
     @Test
-    @UseRandomizedSession(schema = false)
+    @UseRandomizedSchema(random = false)
     public void testSelectSchemata() throws Exception {
         execute("select * from information_schema.schemata order by schema_name asc");
         assertThat(response.rowCount(), is(5L));

--- a/sql/src/test/java/io/crate/integrationtests/JobLogIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/JobLogIntegrationTest.java
@@ -24,7 +24,7 @@ package io.crate.integrationtests;
 import io.crate.execution.engine.collect.stats.JobsLogService;
 import io.crate.testing.UseHashJoins;
 import io.crate.testing.UseJdbc;
-import io.crate.testing.UseRandomizedSession;
+import io.crate.testing.UseRandomizedSchema;
 import io.crate.testing.UseSemiJoins;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.hamcrest.Matchers;
@@ -35,7 +35,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 2, numClientNodes = 0, supportsDedicatedMasters = false)
-@UseRandomizedSession(schema = false) // Avoid set session stmt to interfere with tests
+@UseRandomizedSchema(random = false) // Avoid set session stmt to interfere with tests
 @UseSemiJoins(0) // Avoid set session stmt to interfere with tests
 @UseHashJoins(0) // Avoid set session stmt to interfere with tests
 public class JobLogIntegrationTest extends SQLTransportIntegrationTest {

--- a/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -32,7 +32,7 @@ import io.crate.metadata.Schemas;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.TestingHelpers;
 import io.crate.testing.UseJdbc;
-import io.crate.testing.UseRandomizedSession;
+import io.crate.testing.UseRandomizedSchema;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.action.admin.indices.alias.exists.AliasesExistResponse;
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
@@ -1680,7 +1680,7 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
     }
 
     @Test
-    @UseRandomizedSession(schema = false)
+    @UseRandomizedSchema(random = false)
     public void testAlterTableAddColumnOnPartitionedTableWithoutPartitions() throws Exception {
         execute("create table t (id int primary key, date timestamp primary key) " +
                 "partitioned by (date) " +
@@ -1707,7 +1707,7 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
     }
 
     @Test
-    @UseRandomizedSession(schema = false)
+    @UseRandomizedSchema(random = false)
     public void testAlterTableAddColumnOnPartitionedTable() throws Exception {
         execute("create table t (id int primary key, date timestamp primary key) " +
                 "partitioned by (date) " +

--- a/sql/src/test/java/io/crate/integrationtests/PostgresJobsLogsITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PostgresJobsLogsITest.java
@@ -24,7 +24,7 @@ package io.crate.integrationtests;
 
 import io.crate.testing.UseHashJoins;
 import io.crate.testing.UseJdbc;
-import io.crate.testing.UseRandomizedSession;
+import io.crate.testing.UseRandomizedSchema;
 import io.crate.testing.UseSemiJoins;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -44,7 +44,7 @@ import static org.hamcrest.core.Is.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 1, numClientNodes = 0, supportsDedicatedMasters = false)
 @UseJdbc(1)
-@UseRandomizedSession(schema = false) // Avoid set session stmt to interfere with tests
+@UseRandomizedSchema(random = false) // Avoid set session stmt to interfere with tests
 @UseSemiJoins(0) // Avoid set session stmt to interfere with tests
 @UseHashJoins(0) // Avoid set session stmt to interfere with tests
 public class PostgresJobsLogsITest extends SQLTransportIntegrationTest {

--- a/sql/src/test/java/io/crate/integrationtests/ReadOnlyNodeIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ReadOnlyNodeIntegrationTest.java
@@ -28,7 +28,7 @@ import io.crate.action.sql.SQLActionException;
 import io.crate.action.sql.SQLOperations;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.SQLTransportExecutor;
-import io.crate.testing.UseRandomizedSession;
+import io.crate.testing.UseRandomizedSchema;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -43,7 +43,7 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 
 @ESIntegTestCase.ClusterScope(numDataNodes = 1, numClientNodes = 1, transportClientRatio = 0)
-@UseRandomizedSession(schema = false)
+@UseRandomizedSchema(random = false)
 public class ReadOnlyNodeIntegrationTest extends SQLTransportIntegrationTest {
 
     private SQLTransportExecutor readOnlyExecutor;

--- a/sql/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -23,14 +23,14 @@ package io.crate.integrationtests;
 
 import io.crate.action.sql.SQLActionException;
 import io.crate.testing.TestingHelpers;
-import io.crate.testing.UseRandomizedSession;
+import io.crate.testing.UseRandomizedSchema;
 import org.junit.Test;
 
 import java.util.Locale;
 
 import static org.hamcrest.core.Is.is;
 
-@UseRandomizedSession(schema = false)
+@UseRandomizedSchema(random = false)
 public class ShowIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -29,7 +29,7 @@ import io.crate.exceptions.SQLExceptions;
 import io.crate.testing.SQLBulkResponse;
 import io.crate.testing.TestingHelpers;
 import io.crate.testing.UseJdbc;
-import io.crate.testing.UseRandomizedSession;
+import io.crate.testing.UseRandomizedSchema;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.common.xcontent.XContentBuilder;
@@ -1574,7 +1574,7 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
     }
 
     @Test
-    @UseRandomizedSession(schema = false)
+    @UseRandomizedSchema(random = false)
     public void testUnknownTableJobGetsRemoved() throws Exception {
         String uniqueId = UUID.randomUUID().toString();
         String stmtStr = "select '" + uniqueId + "' from foobar";

--- a/sql/src/test/java/io/crate/testing/UseRandomizedSchema.java
+++ b/sql/src/test/java/io/crate/testing/UseRandomizedSchema.java
@@ -29,14 +29,14 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Mark a test to use a Randomized Session Context.
+ * Mark a test to use a random schema .
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Inherited
-public @interface UseRandomizedSession {
+public @interface UseRandomizedSchema {
 
     // true (default): randomize default schema
     // false:          use DOC-Schema as default
-    boolean schema() default true;
+    boolean random() default true;
 }


### PR DESCRIPTION
Initially we thought of merging ``@UseHashJoins`` & ``@UseSemiJoins``
with ``UseRandomizedSession`` but this is causes issues when overriding, eg:

@UseRandomizedSession(schema=true, useHashJoins=0.5, useSemiJoins=0.5)
TestSuperClass

@UseRandomizedSession(schema=false, useHashJoins=0.5, useSemiJoins=0)
TestClass

@UseRandomizedSession(useHashJoins=true)
testMethod()

Then when we get the annotation of the method we get the one that is on
the method itself and not a "merged" version with the annotation of the class.
This means that for the example above the active config for the ``testMethod()``
would be: ``schema=true, useHashJoins=1, useSemiJoins=0.5`` because for schema
and useSemiJoins the default values would be used.

A solution would be to merge the annotation from the class/method hierarchy
manually but this makes things quite complicated.

Instead we rename the ``UseRandomizedSession`` to clarify that we have 3
separate each for the specific randomness config we want to achieve.