### PR TITLE
Do not wrap IndexNotFoundException in UnhandledServerException

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -90,5 +90,5 @@ Fixes
 - Fixed a race condition that could cause the decommissioning of nodes using
   the graceful shutdown procedure to interrupt the execution of active queries.
 
-- Read only queries should no longer fail with a ``TableUnknownException`` in
-  case of a shard relocation.
+- Read only queries should no longer fail with a ``TableUnknownException`` or
+  ``IndexNotFoundException`` in case of a shard relocation.

--- a/sql/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectSource.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectSource.java
@@ -23,9 +23,7 @@ package io.crate.execution.engine.collect.sources;
 
 import com.google.common.base.Suppliers;
 import com.google.common.collect.Iterables;
-import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.analyze.OrderBy;
-import io.crate.expression.symbol.Symbols;
 import io.crate.blob.v2.BlobIndicesService;
 import io.crate.data.AsyncCompositeBatchIterator;
 import io.crate.data.BatchIterator;
@@ -52,13 +50,15 @@ import io.crate.execution.engine.pipeline.ProjectingRowConsumer;
 import io.crate.execution.engine.pipeline.ProjectionToProjectorVisitor;
 import io.crate.execution.engine.pipeline.ProjectorFactory;
 import io.crate.execution.engine.sort.OrderingByPosition;
-import io.crate.expression.InputFactory;
-import io.crate.expression.reference.StaticTableReferenceResolver;
-import io.crate.expression.reference.sys.node.local.NodeSysExpression;
-import io.crate.expression.reference.sys.node.local.NodeSysReferenceResolver;
 import io.crate.execution.jobs.NodeJobsCounter;
 import io.crate.execution.jobs.SharedShardContext;
 import io.crate.execution.jobs.SharedShardContexts;
+import io.crate.expression.InputFactory;
+import io.crate.expression.eval.EvaluatingNormalizer;
+import io.crate.expression.reference.StaticTableReferenceResolver;
+import io.crate.expression.reference.sys.node.local.NodeSysExpression;
+import io.crate.expression.reference.sys.node.local.NodeSysReferenceResolver;
+import io.crate.expression.symbol.Symbols;
 import io.crate.lucene.LuceneQueryBuilder;
 import io.crate.metadata.Functions;
 import io.crate.metadata.IndexParts;
@@ -462,6 +462,9 @@ public class ShardCollectSource extends AbstractComponent implements CollectSour
                         shardId, collectPhase, jobCollectContext, shardCollectorProviderFactory));
                 } catch (InterruptedException e) {
                     throw new RuntimeException(e);
+                } catch (IndexNotFoundException e) {
+                    // Prevent wrapping this to not break retry-detection
+                    throw e;
                 } catch (Exception e) {
                     throw new UnhandledServerException(e);
                 }


### PR DESCRIPTION
This breaks the retry detection as it cannot detect the
`IndexNotFoundException` anymore.

Although the wrapping happened in a `try / catch` block where there is
already a `IndexService` acquired the `ShardCollectorProvider`
re-acquires it and if the index moved or got deleted it can still raise
a `IndexNotFoundException`

`doc_tests.process_test.crate_TestGracefulStopDuringQueryExecution` could fail because of this.