### PR TITLE
Fixed 2 issues for TableStats.

### DIFF
--- a/sql/src/main/java/io/crate/planner/TableStats.java
+++ b/sql/src/main/java/io/crate/planner/TableStats.java
@@ -27,6 +27,9 @@ import com.carrotsearch.hppc.ObjectObjectMap;
 import com.google.common.annotations.VisibleForTesting;
 import io.crate.metadata.TableIdent;
 
+/**
+ * Holds table statistics that are updated periodically by {@link TableStatsService}.
+ */
 public class TableStats {
 
     private static final Stats EMPTY_STATS = new Stats();

--- a/sql/src/main/java/io/crate/planner/TableStatsService.java
+++ b/sql/src/main/java/io/crate/planner/TableStatsService.java
@@ -50,6 +50,9 @@ import org.elasticsearch.threadpool.ThreadPool;
 import javax.annotation.Nonnull;
 import java.util.function.Consumer;
 
+/**
+ * Periodically refresh {@link TableStats} based on {@link #refreshInterval}.
+ */
 @Singleton
 public class TableStatsService extends AbstractComponent implements Runnable {
 
@@ -67,7 +70,7 @@ public class TableStatsService extends AbstractComponent implements Runnable {
     private final Session session;
 
     @VisibleForTesting
-    ThreadPool.Cancellable refreshScheduledTask = null;
+    ThreadPool.Cancellable refreshScheduledTask;
     @VisibleForTesting
     TimeValue refreshInterval;
 

--- a/sql/src/main/java/io/crate/planner/TableStatsService.java
+++ b/sql/src/main/java/io/crate/planner/TableStatsService.java
@@ -58,7 +58,7 @@ public class TableStatsService extends AbstractComponent implements Runnable {
         DataTypes.STRING);
 
     static final String STMT = "select cast(sum(num_docs) as long), cast(sum(size) as long), schema_name, table_name " +
-                               "from sys.shards group by 2, 3";
+                               "from sys.shards where primary=true group by 3, 4";
     private static final Statement PARSED_STMT = SqlParser.createStatement(STMT);
 
     private final ClusterService clusterService;

--- a/sql/src/test/java/io/crate/integrationtests/TableStatsServiceIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TableStatsServiceIntegrationTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.integrationtests;
+
+import io.crate.metadata.TableIdent;
+import io.crate.planner.TableStats;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.is;
+
+
+@ESIntegTestCase.ClusterScope(supportsDedicatedMasters = false, numDataNodes = 2, numClientNodes = 0)
+public class TableStatsServiceIntegrationTest extends SQLTransportIntegrationTest {
+
+    @Before
+    public void setRefreshInterval() {
+        execute("set global transient stats.service.interval='50ms'");
+    }
+
+    @After
+    public void setResetInterval() {
+        execute("reset global stats.service.interval");
+    }
+
+    @Test
+    public void testStatsUpdated() throws Exception {
+        execute("create table t1(a int) with (number_of_replicas = 1)");
+        ensureGreen();
+        execute("insert into t1(a) values(1), (2), (3), (4), (5)");
+        execute("refresh table t1");
+        assertBusy(() -> {
+                TableStats tableStats = internalCluster().getDataNodeInstance(TableStats.class);
+                assertThat(tableStats.numDocs(new TableIdent(sqlExecutor.getDefaultSchema(), "t1")), is(5L));
+                // tableStats.tableStats.estimatedSizePerRow() is not tested because it's based on sys.shards size
+                // column which is is cached for 10 secs in ShardSizeExpression which will increase the time needed
+                // to run this test.
+            }, 5, TimeUnit.SECONDS);
+    }
+}


### PR DESCRIPTION
 - Fix group by columns: Followup of 0e54d7ddea034812a3ff36822e8c8acd1936fe2a
 - Only calculate numDocs and Size for primary shards
