### PR TITLE
Fix hashjoin iterator.

### DIFF
--- a/dex/src/main/java/io/crate/data/join/HashInnerJoinBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/join/HashInnerJoinBatchIterator.java
@@ -148,6 +148,9 @@ public class HashInnerJoinBatchIterator<L extends Row, R extends Row, C> extends
                 Object[] currentRow = left.currentElement().materialize();
                 int hash = hashBuilderForLeft.apply(left.currentElement());
                 addToBuffer(currentRow, hash);
+                if (buffer.size() == blockSize) {
+                    break;
+                }
             }
             if (buffer.size() == blockSize || left.allLoaded()) {
                 activeIt = right;


### PR DESCRIPTION
The loop that builds the buffer must exit once the blocksize is reached
and not only when left.allLoaded() is true.

