### PR TITLE
Add http.cors settings to sandbox crate.yml

### DIFF
--- a/sandbox/crate/config/crate.yml
+++ b/sandbox/crate/config/crate.yml
@@ -12,3 +12,6 @@ ssl.keystore_password: keystorePassword
 ssl.keystore_key_password: serverKeyPassword
 
 path.repo: ./sandbox/crate/repo
+
+http.cors.enabled: true
+http.cors.allow-origin: "*"


### PR DESCRIPTION
So that the instance started from within intellij can be used with a
development instance of the admin-ui.