### PR TITLE
Fix NPE when trying to reroute a shard to/from a non-data discovery node

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -108,6 +108,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue where a null pointer exception would be thrown when trying to
+  move reroute shards to/from non-data nodes using ``ALTER TABLE REROUTE``.
+
 - Fixed an issue that causes ``JOINS`` with certain ``ORDER BY`` constructs to
   fail.
 


### PR DESCRIPTION
I suppose that because this cannot be cherry-picked to the 2.3 branch? Since the commit is based on different branches.