### PR TITLE
Optimize HashJoin execution by switching sides of relations.

### DIFF
--- a/sql/src/main/java/io/crate/planner/operators/HashJoin.java
+++ b/sql/src/main/java/io/crate/planner/operators/HashJoin.java
@@ -35,7 +35,6 @@ import io.crate.execution.dsl.projection.builder.InputColumns;
 import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
 import io.crate.execution.engine.join.JoinOperations;
 import io.crate.execution.engine.pipeline.TopN;
-import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
@@ -46,6 +45,7 @@ import io.crate.planner.TableStats;
 import io.crate.planner.distribution.DistributionInfo;
 import io.crate.planner.node.dql.join.Join;
 import io.crate.planner.node.dql.join.JoinType;
+import org.elasticsearch.common.collect.Tuple;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -63,19 +63,15 @@ class HashJoin extends TwoInputPlan {
     private final Symbol joinCondition;
     private final TableStats tableStats;
     @VisibleForTesting
-    AnalyzedRelation topMostLeftRelation;
-    @VisibleForTesting
-    AnalyzedRelation rightRelation;
+    final AnalyzedRelation concreteRelation;
 
     HashJoin(LogicalPlan lhs,
              LogicalPlan rhs,
              Symbol joinCondition,
-             AnalyzedRelation topMostLeftRelation,
-             AnalyzedRelation rightRelation,
+             AnalyzedRelation concreteRelation,
              TableStats tableStats) {
         super(lhs, rhs, new ArrayList<>());
-        this.topMostLeftRelation = topMostLeftRelation;
-        this.rightRelation = rightRelation;
+        this.concreteRelation = concreteRelation;
         this.joinCondition = joinCondition;
         this.outputs.addAll(lhs.outputs());
         this.outputs.addAll(rhs.outputs());
@@ -107,18 +103,35 @@ class HashJoin extends TwoInputPlan {
                                Row params,
                                Map<SelectSymbol, Object> subQueryValues) {
 
-        ExecutionPlan left = lhs.build(
+
+        ExecutionPlan leftExecutionPlan = lhs.build(
             plannerContext, projectionBuilder, NO_LIMIT, 0, null, null, params, subQueryValues);
-        ExecutionPlan right = rhs.build(
+        ExecutionPlan rightExecutionPlan = rhs.build(
             plannerContext, projectionBuilder, NO_LIMIT, 0, null, null, params, subQueryValues);
 
-        ResultDescription leftResultDesc = left.resultDescription();
-        ResultDescription rightResultDesc = right.resultDescription();
+        LogicalPlan leftLogicalPlan = lhs;
+        LogicalPlan rightLogicalPlan = rhs;
+
+        boolean tablesSwitched = false;
+        // We move smaller table to the right side since benchmarking
+        // revealed that this improves performance in most cases.
+        if (lhs.numExpectedRows() < rhs.numExpectedRows()) {
+            tablesSwitched = true;
+            leftLogicalPlan = rhs;
+            rightLogicalPlan = lhs;
+
+            ExecutionPlan tmp = leftExecutionPlan;
+            leftExecutionPlan = rightExecutionPlan;
+            rightExecutionPlan = tmp;
+        }
+
+        ResultDescription leftResultDesc = leftExecutionPlan.resultDescription();
+        ResultDescription rightResultDesc = rightExecutionPlan.resultDescription();
         Collection<String> nlExecutionNodes = ImmutableSet.of(plannerContext.handlerNode());
 
         MergePhase leftMerge = null;
         MergePhase rightMerge = null;
-        left.setDistributionInfo(DistributionInfo.DEFAULT_BROADCAST);
+        leftExecutionPlan.setDistributionInfo(DistributionInfo.DEFAULT_BROADCAST);
         if (JoinOperations.isMergePhaseNeeded(nlExecutionNodes, leftResultDesc, false)) {
             leftMerge = JoinOperations.buildMergePhaseForJoin(plannerContext, leftResultDesc, nlExecutionNodes);
         }
@@ -128,51 +141,49 @@ class HashJoin extends TwoInputPlan {
             // if the left and the right plan are executed on the same single node the mergePhase
             // should be omitted. This is the case if the left and right table have only one shards which
             // are on the same node
-            right.setDistributionInfo(DistributionInfo.DEFAULT_SAME_NODE);
+            rightExecutionPlan.setDistributionInfo(DistributionInfo.DEFAULT_SAME_NODE);
         } else {
             if (JoinOperations.isMergePhaseNeeded(nlExecutionNodes, rightResultDesc, false)) {
                 rightMerge = JoinOperations.buildMergePhaseForJoin(plannerContext, rightResultDesc, nlExecutionNodes);
             }
-            right.setDistributionInfo(DistributionInfo.DEFAULT_BROADCAST);
+            rightExecutionPlan.setDistributionInfo(DistributionInfo.DEFAULT_BROADCAST);
         }
 
-        Symbol joinInput = InputColumns.create(joinCondition, Lists2.concat(lhs.outputs(), rhs.outputs()));
-        Map<AnalyzedRelation, List<Symbol>> hashJoinSymbols = HashJoinConditionSymbolsExtractor.extract(joinCondition);
-        List<Symbol> rightHashJoinSymbols = hashJoinSymbols.remove(rightRelation);
-        List<Symbol> rightHashInputs = new ArrayList<>(rightHashJoinSymbols.size());
-        for (Symbol symbol : rightHashJoinSymbols) {
-            rightHashInputs.add(InputColumns.create(symbol, rhs.outputs()));
-        }
-        // All leftover extracted symbols belong to the left relation, the left relation might not be
-        // a concrete table  as the HashJoin can be nested further down a Join tree.
-        List<Symbol> leftHashJoinSymbols =
-            hashJoinSymbols.values().stream().flatMap(List::stream).collect(Collectors.toList());
-        List<Symbol> leftHashInputs = new ArrayList<>(leftHashJoinSymbols.size());
-        for (Symbol symbol : leftHashJoinSymbols) {
-            leftHashInputs.add(InputColumns.create(symbol, lhs.outputs()));
-        }
+        Symbol joinConditionInput = InputColumns.create(
+            joinCondition,
+            Lists2.concat(leftLogicalPlan.outputs(), rightLogicalPlan.outputs()));
+        Tuple<List<Symbol>, List<Symbol>> hashInputs =
+            extractHashJoinInputsFromJoinSymbolsAndSplitPerSide(tablesSwitched);
+
+
+        List<Symbol> joinOutputs = Lists2.concat(leftLogicalPlan.outputs(), rightLogicalPlan.outputs());
+        // The projection operates on the the outputs of the join operation, which may be inverted due to a table switch,
+        // and must produce outputs that match the order of the original outputs the plan.
+        List<Symbol> projectionOutputs = InputColumns.create(
+                outputs,
+                new InputColumns.SourceSymbols(joinOutputs));
 
         HashJoinPhase joinPhase = new HashJoinPhase(
             plannerContext.jobId(),
             plannerContext.nextExecutionPhaseId(),
             "hash-join",
             // JoinPhase ctor wants at least one projection
-            Collections.singletonList(new EvalProjection(InputColumn.fromSymbols(outputs))),
+            Collections.singletonList(new EvalProjection(projectionOutputs)),
             leftMerge,
             rightMerge,
-            lhs.outputs().size(),
-            rhs.outputs().size(),
+            leftLogicalPlan.outputs().size(),
+            rightLogicalPlan.outputs().size(),
             nlExecutionNodes,
-            joinInput,
-            leftHashInputs,
-            rightHashInputs,
-            Symbols.typeView(lhs.outputs()),
-            lhs.estimatedRowSize(),
-            lhs.numExpectedRows());
+            joinConditionInput,
+            hashInputs.v1(),
+            hashInputs.v2(),
+            Symbols.typeView(leftLogicalPlan.outputs()),
+            leftLogicalPlan.estimatedRowSize(),
+            leftLogicalPlan.numExpectedRows());
         return new Join(
             joinPhase,
-            left,
-            right,
+            leftExecutionPlan,
+            rightExecutionPlan,
             TopN.NO_LIMIT,
             0,
             TopN.NO_LIMIT,
@@ -181,9 +192,32 @@ class HashJoin extends TwoInputPlan {
         );
     }
 
+    private Tuple<List<Symbol>, List<Symbol>> extractHashJoinInputsFromJoinSymbolsAndSplitPerSide(boolean switchedTables) {
+        Map<AnalyzedRelation, List<Symbol>> hashJoinSymbols = HashJoinConditionSymbolsExtractor.extract(joinCondition);
+
+        // First extract the symbols that belong to the concrete relation
+        List<Symbol> hashJoinSymbolsForConcreteRelation = hashJoinSymbols.remove(concreteRelation);
+        List<Symbol> hashInputsForConcreteRelation = InputColumns.create(
+            hashJoinSymbolsForConcreteRelation,
+            new InputColumns.SourceSymbols(rhs.outputs()));
+
+        // All leftover extracted symbols belong to the other relation which might be a
+        // "concrete" relation too but can already be a tree of relation.
+        List<Symbol> hashJoinSymbolsForJoinTree =
+            hashJoinSymbols.values().stream().flatMap(List::stream).collect(Collectors.toList());
+        List<Symbol> hashInputsForJoinTree = InputColumns.create(
+            hashJoinSymbolsForJoinTree,
+            new InputColumns.SourceSymbols(lhs.outputs()));
+
+        if (switchedTables) {
+            return new Tuple<>(hashInputsForConcreteRelation, hashInputsForJoinTree);
+        }
+        return new Tuple<>(hashInputsForJoinTree, hashInputsForConcreteRelation);
+    }
+
     @Override
     protected LogicalPlan updateSources(LogicalPlan newLeftSource, LogicalPlan newRightSource) {
-        return new HashJoin(newLeftSource, newRightSource, joinCondition, topMostLeftRelation, rightRelation, tableStats);
+        return new HashJoin(newLeftSource, newRightSource, joinCondition, concreteRelation, tableStats);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
+++ b/sql/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
@@ -200,7 +200,6 @@ public class JoinPlanBuilder implements LogicalPlan.Builder {
                 lhsPlan,
                 rhsPlan,
                 joinCondition,
-                lhs,
                 rhs,
                 tableStats);
         } else {

--- a/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -829,11 +829,13 @@ public class JoinIntegrationTest extends SQLTransportIntegrationTest {
         execute("insert into t2 (x) values (1), (3), (4), (4), (5), (6)");
         execute("refresh table t1, t2");
 
-        TableStats tableStats = internalCluster().getInstance(TableStats.class);
-        ObjectObjectHashMap<TableIdent, TableStats.Stats> newStats = new ObjectObjectHashMap<>();
-        newStats.put(new TableIdent(sqlExecutor.getDefaultSchema(), "t1"), new TableStats.Stats(4L, 16L));
-        newStats.put(new TableIdent(sqlExecutor.getDefaultSchema(), "t2"), new TableStats.Stats(6L, 24L));
-        tableStats.updateTableStats(newStats);
+        Iterable<TableStats> tableStatsOnAllNodes = internalCluster().getInstances(TableStats.class);
+        for (TableStats tableStats : tableStatsOnAllNodes) {
+            ObjectObjectHashMap<TableIdent, TableStats.Stats> newStats = new ObjectObjectHashMap<>();
+            newStats.put(new TableIdent(sqlExecutor.getDefaultSchema(), "t1"), new TableStats.Stats(4L, 16L));
+            newStats.put(new TableIdent(sqlExecutor.getDefaultSchema(), "t2"), new TableStats.Stats(6L, 24L));
+            tableStats.updateTableStats(newStats);
+        }
 
         execute("select a, x from t1 join t2 on t1.a + 1 = t2.x + 1 order by a, x");
         assertThat(TestingHelpers.printedTable(response.rows()),

--- a/sql/src/test/java/io/crate/planner/SubQueryPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/SubQueryPlannerTest.java
@@ -182,12 +182,12 @@ public class SubQueryPlannerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
-    @SuppressWarnings("ConstantConditions")
+    @SuppressWarnings("unchecked")
     public void testJoinOnSubSelectsWithLimitAndOffset() throws Exception {
         Join nl = e.plan("select * from " +
-                         " (select i, a from t1 order by a limit 5 offset 2) t1 " +
+                         " (select i, a from t1 order by a limit 10 offset 2) t1 " +
                          "join" +
-                         " (select i from t2 order by b limit 10 offset 5) t2 " +
+                         " (select i from t2 order by b limit 5 offset 5) t2 " +
                          "on t1.i = t2.i");
         assertThat(nl.joinPhase().projections().size(), is(1));
         assertThat(nl.joinPhase().projections().get(0), instanceOf(EvalProjection.class));
@@ -198,25 +198,24 @@ public class SubQueryPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat("1 node, otherwise mergePhases would be required", left.nodeIds().size(), is(1));
         assertThat(left.orderBy(), isSQL("OrderByPositions{indices=[1], reverseFlags=[false], nullsFirst=[null]}"));
         assertThat(left.collectPhase().projections(), contains(
-            isTopN(5, 2)
+            isTopN(10, 2)
         ));
         Collect right = (Collect) nl.right();
         assertThat("1 node, otherwise mergePhases would be required", right.nodeIds().size(), is(1));
         assertThat(((RoutedCollectPhase) right.collectPhase()).orderBy(), isSQL("doc.t2.b"));
         assertThat(right.collectPhase().projections(), contains(
-            isTopN(10, 5),
+            isTopN(5, 5),
             instanceOf(EvalProjection.class) // strips `b` used in order by from the outputs
         ));
     }
 
-
     @Test
-    @SuppressWarnings("ConstantConditions")
+    @SuppressWarnings("unchecked")
     public void testJoinWithAggregationOnSubSelectsWithLimitAndOffset() throws Exception {
         Join nl = e.plan("select t1.a, count(*) from " +
-                         " (select i, a from t1 order by a limit 5 offset 2) t1 " +
+                         " (select i, a from t1 order by a limit 10 offset 2) t1 " +
                          "join" +
-                         " (select i from t2 order by i desc limit 10 offset 5) t2 " +
+                         " (select i from t2 order by i desc limit 5 offset 5) t2 " +
                          "on t1.i = t2.i " +
                          "group by t1.a");
         assertThat(nl.joinPhase().leftMergePhase(), nullValue());
@@ -226,7 +225,7 @@ public class SubQueryPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat("1 node, otherwise mergePhases would be required", left.nodeIds().size(), is(1));
         assertThat(((RoutedCollectPhase) left.collectPhase()).orderBy(), isSQL("doc.t1.a"));
         assertThat(left.collectPhase().projections(), contains(
-            isTopN(5, 2)
+            isTopN(10, 2)
         ));
         assertThat(left.collectPhase().toCollect(), isSQL("doc.t1.a, doc.t1.i"));
 
@@ -235,7 +234,7 @@ public class SubQueryPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat("1 node, otherwise mergePhases would be required", right.nodeIds().size(), is(1));
         assertThat(((RoutedCollectPhase) right.collectPhase()).orderBy(), isSQL("doc.t2.i DESC"));
         assertThat(right.collectPhase().projections(), contains(
-            isTopN(10, 5)
+            isTopN(5, 5)
         ));
 
 
@@ -247,12 +246,12 @@ public class SubQueryPlannerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
-    @SuppressWarnings("ConstantConditions")
+    @SuppressWarnings("unchecked")
     public void testJoinWithGlobalAggregationOnSubSelectsWithLimitAndOffset() throws Exception {
         Join nl = e.plan("select count(*) from " +
-                         " (select i, a from t1 order by a limit 5 offset 2) t1 " +
+                         " (select i, a from t1 order by a limit 10 offset 2) t1 " +
                          "join" +
-                         " (select i from t2 order by i desc limit 10 offset 5) t2 " +
+                         " (select i from t2 order by i desc limit 5 offset 5) t2 " +
                          "on t1.i = t2.i");
 
         assertThat(nl.joinPhase().leftMergePhase(), nullValue());
@@ -263,7 +262,7 @@ public class SubQueryPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(left.collectPhase().toCollect(), isSQL("doc.t1.i, doc.t1.a"));
         assertThat(((RoutedCollectPhase) left.collectPhase()).orderBy(), isSQL("doc.t1.a"));
         assertThat(left.collectPhase().projections(), contains(
-            isTopN(5, 2),
+            isTopN(10, 2),
             instanceOf(EvalProjection.class)
         ));
 
@@ -272,7 +271,7 @@ public class SubQueryPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat("1 node, otherwise mergePhases would be required", right.nodeIds().size(), is(1));
         assertThat(((RoutedCollectPhase) right.collectPhase()).orderBy(), isSQL("doc.t2.i DESC"));
         assertThat(right.collectPhase().projections(), contains(
-            isTopN(10, 5)
+            isTopN(5, 5)
         ));
 
 


### PR DESCRIPTION
After benchmarking we concluded that the smaller table should be on the right side
of the hash join. In case the left table is loaded into memory in blocks then the right side
is repeated, therefore is better to be the smaller one. In case the left table fits into one block
and there is no repetition of the right one then the benchmarks showed that performance is slightly
better if smaller table is on the left side, but the difference is minimal.

So as a conclusion we switch tables when building the execution
plan to ensure that the smaller table is on the right side.

JMH Benchmarks:
```
Benchmark                                                                                 Mode  Cnt   Score   Error  Units
RowsBatchIteratorBenchmark.measureConsumeHashInnerJoinWith_1Iteration_LeftSmall           avgt  200   0.477 ± 0.062  ms/op
RowsBatchIteratorBenchmark.measureConsumeHashInnerJoinWith_1Iteration_RightSmall          avgt  200   0.652 ± 0.027  ms/op
RowsBatchIteratorBenchmark.measureConsumeHashInnerJoinWith_5BlockIterations_LeftSmall     avgt  200   1.371 ± 0.055  ms/op
RowsBatchIteratorBenchmark.measureConsumeHashInnerJoinWith_5BlockIterations_RightSmall    avgt  200   0.671 ± 0.011  ms/op
RowsBatchIteratorBenchmark.measureConsumeHashInnerJoinWith_10BlockIterations_LeftSmall    avgt  200   2.623 ± 0.021  ms/op
RowsBatchIteratorBenchmark.measureConsumeHashInnerJoinWith_10BlockIterations_RightSmall   avgt  200   0.763 ± 0.004  ms/op
RowsBatchIteratorBenchmark.measureConsumeHashInnerJoinWith_20BlockIterations_LeftSmall    avgt  200   4.935 ± 0.036  ms/op
RowsBatchIteratorBenchmark.measureConsumeHashInnerJoinWith_20BlockIterations_RightSmall   avgt  200   1.010 ± 0.006  ms/op
RowsBatchIteratorBenchmark.measureConsumeHashInnerJoinWith_100BlockIterations_LeftSmall   avgt  200  28.920 ± 0.229  ms/op
RowsBatchIteratorBenchmark.measureConsumeHashInnerJoinWith_100BlockIterations_RightSmall  avgt  200   3.025 ± 0.023  ms/op

```

Integration Benchmarks:
1 Iteration (table fits in memory)
```
      Left              Right         Time(msec)
---------------+------------------+-------------
     1.000     |    1.000.000     |         2180
 1.000.000     |        1.000     |         2230
------------------------------------------------
       100     |       10.000     |          270
    10.000     |         1000     |          260
------------------------------------------------
```

BlockSize = 100
```
      Left              Right         Time(msec)
---------------+------------------+-------------
     1.000     |       10.000     |         1200
    10.000     |        1.000     |          700
------------------------------------------------
     1.000     |      100.000     |         1300
   100.000     |        1.000     |          900
------------------------------------------------
      1000     |    1.000.000     |         4200
 1.000.000     |         1000     |         2300
------------------------------------------------
    10.000     |      100.000     |         6500
   100.000     |       10.000     |         3100
------------------------------------------------
    10.000     |    1.000.000     |        27000
 1.000.000     |       10.000     |         4000
------------------------------------------------
```
