### PR TITLE
Fix order by push down for joins

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -108,6 +108,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that causes ``JOINS`` with certain ``ORDER BY`` constructs to
+  fail.
+
 - Fixed an issue that would cause queries and data manipulation statements with
   explicit ``WHERE`` conditions to throw ``NullPointerException`` when running
   against a table with a composite primary key.

--- a/sql/src/main/java/io/crate/planner/PositionalOrderBy.java
+++ b/sql/src/main/java/io/crate/planner/PositionalOrderBy.java
@@ -39,7 +39,7 @@ public class PositionalOrderBy {
     private final boolean[] reverseFlags;
     private final Boolean[] nullsFirst;
 
-    private PositionalOrderBy(int[] indices, boolean[] reverseFlags, Boolean[] nullsFirst) {
+    public PositionalOrderBy(int[] indices, boolean[] reverseFlags, Boolean[] nullsFirst) {
         assert indices.length == reverseFlags.length && reverseFlags.length == nullsFirst.length
             : "all parameters to OrderByPositions must have the same length";
         // PositionalOrderBy should be null if there is no order by

--- a/sql/src/main/java/io/crate/planner/consumer/OrderByPositionVisitor.java
+++ b/sql/src/main/java/io/crate/planner/consumer/OrderByPositionVisitor.java
@@ -27,6 +27,7 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitor;
 import org.elasticsearch.common.inject.Singleton;
 
+import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
 
@@ -62,16 +63,28 @@ public class OrderByPositionVisitor extends SymbolVisitor<OrderByPositionVisitor
     private OrderByPositionVisitor() {
     }
 
-    public static int[] orderByPositions(Collection<? extends Symbol> orderBySymbols,
-                                         List<? extends Symbol> outputSymbols) {
+    @Nullable
+    public static int[] orderByPositionsOrNull(Collection<? extends Symbol> orderBySymbols,
+                                               List<? extends Symbol> outputSymbols) {
         Context context = new Context(outputSymbols);
         for (Symbol orderBySymbol : orderBySymbols) {
             INSTANCE.process(orderBySymbol, context);
         }
-        assert context.orderByPositions.size() == orderBySymbols.size()
-            : "Must have an orderByPosition for each symbol. " +
-              "Got " + context.orderByPositions + " from ORDER BY " + orderBySymbols + " and outputs: " + outputSymbols;
-        return context.orderByPositions();
+        if (context.orderByPositions.size() == orderBySymbols.size()) {
+            return context.orderByPositions();
+        }
+        return null;
+    }
+
+    public static int[] orderByPositions(Collection<? extends Symbol> orderBySymbols,
+                                         List<? extends Symbol> outputSymbols) {
+        int[] positions = orderByPositionsOrNull(orderBySymbols, outputSymbols);
+        if (positions == null) {
+            throw new IllegalArgumentException(
+                "Must have an orderByPosition for each symbol. Got ORDER BY " + orderBySymbols + " and outputs: " +
+                outputSymbols);
+        }
+        return positions;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/FetchOrEval.java
+++ b/sql/src/main/java/io/crate/planner/operators/FetchOrEval.java
@@ -28,6 +28,13 @@ import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.DocTableRelation;
 import io.crate.analyze.relations.QueriedDocTable;
+import io.crate.collections.Lists2;
+import io.crate.data.Row;
+import io.crate.execution.dsl.phases.FetchPhase;
+import io.crate.execution.dsl.projection.EvalProjection;
+import io.crate.execution.dsl.projection.FetchProjection;
+import io.crate.execution.dsl.projection.builder.InputColumns;
+import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
 import io.crate.expression.symbol.FetchReference;
 import io.crate.expression.symbol.Field;
 import io.crate.expression.symbol.FieldReplacer;
@@ -37,8 +44,6 @@ import io.crate.expression.symbol.RefReplacer;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
-import io.crate.collections.Lists2;
-import io.crate.data.Row;
 import io.crate.metadata.DocReferences;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RowGranularity;
@@ -51,12 +56,7 @@ import io.crate.planner.PositionalOrderBy;
 import io.crate.planner.ReaderAllocations;
 import io.crate.planner.consumer.FetchMode;
 import io.crate.planner.node.dql.QueryThenFetch;
-import io.crate.execution.dsl.phases.FetchPhase;
 import io.crate.planner.node.fetch.FetchSource;
-import io.crate.execution.dsl.projection.EvalProjection;
-import io.crate.execution.dsl.projection.FetchProjection;
-import io.crate.execution.dsl.projection.builder.InputColumns;
-import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
 import io.crate.types.DataTypes;
 
 import javax.annotation.Nullable;
@@ -431,18 +431,18 @@ class FetchOrEval extends OneInputPlan {
     }
 
     @Override
-    public LogicalPlan tryOptimize(@Nullable LogicalPlan pushDown) {
+    public LogicalPlan tryOptimize(@Nullable LogicalPlan pushDown, SymbolMapper mapper) {
         if (pushDown instanceof Order) {
-            LogicalPlan newPlan = source.tryOptimize(pushDown);
+            LogicalPlan newPlan = source.tryOptimize(pushDown, mapper);
             if (newPlan != null && newPlan != source) {
-                return updateSource(newPlan);
+                return updateSource(newPlan, mapper);
             }
         }
-        return super.tryOptimize(pushDown);
+        return super.tryOptimize(pushDown, mapper);
     }
 
     @Override
-    protected LogicalPlan updateSource(LogicalPlan newSource) {
+    protected LogicalPlan updateSource(LogicalPlan newSource, SymbolMapper mapper) {
         return new FetchOrEval(newSource, outputs, fetchMode, doFetch);
     }
 

--- a/sql/src/main/java/io/crate/planner/operators/Filter.java
+++ b/sql/src/main/java/io/crate/planner/operators/Filter.java
@@ -102,7 +102,7 @@ class Filter extends OneInputPlan {
     }
 
     @Override
-    protected LogicalPlan updateSource(LogicalPlan newSource) {
+    protected LogicalPlan updateSource(LogicalPlan newSource, SymbolMapper mapper) {
         return new Filter(newSource, queryClause);
     }
 

--- a/sql/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
+++ b/sql/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
@@ -182,7 +182,7 @@ public class GroupHashAggregate extends OneInputPlan {
     }
 
     @Override
-    protected LogicalPlan updateSource(LogicalPlan newSource) {
+    protected LogicalPlan updateSource(LogicalPlan newSource, SymbolMapper mapper) {
         return new GroupHashAggregate(newSource, groupKeys, aggregates);
     }
 

--- a/sql/src/main/java/io/crate/planner/operators/Insert.java
+++ b/sql/src/main/java/io/crate/planner/operators/Insert.java
@@ -25,15 +25,15 @@ package io.crate.planner.operators;
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.relations.QueriedRelation;
-import io.crate.expression.symbol.SelectSymbol;
-import io.crate.expression.symbol.Symbol;
 import io.crate.data.Row;
-import io.crate.planner.ExecutionPlan;
-import io.crate.planner.Merge;
-import io.crate.planner.PlannerContext;
 import io.crate.execution.dsl.projection.ColumnIndexWriterProjection;
 import io.crate.execution.dsl.projection.MergeCountProjection;
 import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
+import io.crate.expression.symbol.SelectSymbol;
+import io.crate.expression.symbol.Symbol;
+import io.crate.planner.ExecutionPlan;
+import io.crate.planner.Merge;
+import io.crate.planner.PlannerContext;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
@@ -72,7 +72,7 @@ public class Insert extends OneInputPlan {
     }
 
     @Override
-    protected LogicalPlan updateSource(LogicalPlan newSource) {
+    protected LogicalPlan updateSource(LogicalPlan newSource, SymbolMapper mapper) {
         return new Insert(newSource, relation, projection);
     }
 

--- a/sql/src/main/java/io/crate/planner/operators/Limit.java
+++ b/sql/src/main/java/io/crate/planner/operators/Limit.java
@@ -23,19 +23,19 @@
 package io.crate.planner.operators;
 
 import io.crate.analyze.OrderBy;
+import io.crate.data.Row;
+import io.crate.execution.dsl.phases.ExecutionPhases;
+import io.crate.execution.dsl.projection.TopNProjection;
+import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
+import io.crate.execution.engine.pipeline.TopN;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
-import io.crate.data.Row;
-import io.crate.execution.engine.pipeline.TopN;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.Merge;
 import io.crate.planner.PlannerContext;
 import io.crate.planner.ResultDescription;
-import io.crate.execution.dsl.phases.ExecutionPhases;
-import io.crate.execution.dsl.projection.TopNProjection;
-import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
@@ -104,7 +104,7 @@ class Limit extends OneInputPlan {
     }
 
     @Override
-    protected LogicalPlan updateSource(LogicalPlan newSource) {
+    protected LogicalPlan updateSource(LogicalPlan newSource, SymbolMapper mapper) {
         return new Limit(newSource, limit, offset);
     }
 

--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlan.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlan.java
@@ -122,6 +122,7 @@ public interface LogicalPlan extends Plan {
      *
      * For example, pushing down an *Order*:
      *
+     * <pre>
      *       *Order*                   Union
      *          |                     /     \
      *          |                    /       \
@@ -132,9 +133,11 @@ public interface LogicalPlan extends Plan {
      *               |                       |
      *               |                       |
      *            Collect                 Collect
+     * </pre>
      *
      * Then combining two Order(s):
      *
+     * <pre>
      *        Union                  Union
      *       /     \                /     \
      *      /       \              /       \
@@ -145,13 +148,19 @@ public interface LogicalPlan extends Plan {
      *              |
      *              |
      *           Collect
+     * </pre>
      *
      * @param pushDown The LogicalPlan which gets "pushed down". {@code null} if currently
      *                 no plan gets pushed. If null, recurses to find other push down candidates.
+     * @param mapper a function used to map symbols from the previous source to the new source.
+     *               For example in a Join:
+     *               If the OrderBy that is above of a join is moved beneath the join on one side
+     *               the orderBySymbols must be changed to be based on the new outputs (For example, from Field[t2.x] to Reference[x].
+     *               To accomplish that, the Join operator can pass on an appropriate SymbolMapper when calling tryOptimize on its sources.
      * @return A new LogicalPlan or null if rewriting/optimizing is not possible.
      */
     @Nullable
-    LogicalPlan tryOptimize(@Nullable LogicalPlan pushDown);
+    LogicalPlan tryOptimize(@Nullable LogicalPlan pushDown, SymbolMapper mapper);
 
     /**
      * Uses the current shard allocation information to create a physical execution plan.

--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -153,7 +153,7 @@ public class LogicalPlanner {
      * @return The optimized plan or the original if optimizing is not possible
      */
     private static LogicalPlan tryOptimize(LogicalPlan plan) {
-        LogicalPlan optimizedPlan = plan.tryOptimize(null);
+        LogicalPlan optimizedPlan = plan.tryOptimize(null, SymbolMapper.identity());
         if (optimizedPlan == null) {
             return plan;
         }

--- a/sql/src/main/java/io/crate/planner/operators/MultiPhase.java
+++ b/sql/src/main/java/io/crate/planner/operators/MultiPhase.java
@@ -24,9 +24,9 @@ package io.crate.planner.operators;
 
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.relations.QueriedRelation;
-import io.crate.expression.symbol.SelectSymbol;
 import io.crate.data.Row;
 import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
+import io.crate.expression.symbol.SelectSymbol;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.MultiPhasePlan;
 import io.crate.planner.PlannerContext;
@@ -70,7 +70,7 @@ public class MultiPhase extends OneInputPlan {
     }
 
     @Override
-    protected LogicalPlan updateSource(LogicalPlan newSource) {
+    protected LogicalPlan updateSource(LogicalPlan newSource, SymbolMapper mapper) {
         return new MultiPhase(newSource, dependencies);
     }
 

--- a/sql/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
+++ b/sql/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
@@ -249,7 +249,7 @@ class NestedLoopJoin extends TwoInputPlan {
     }
 
     @Override
-    public LogicalPlan tryOptimize(@Nullable LogicalPlan pushDown) {
+    public LogicalPlan tryOptimize(@Nullable LogicalPlan pushDown, SymbolMapper mapper) {
         if (pushDown instanceof Order) {
             /* Move the orderBy expression to the sub-relation if possible.
              *
@@ -271,7 +271,7 @@ class NestedLoopJoin extends TwoInputPlan {
                 if (relationsInOrderBy.size() == 1) {
                     AnalyzedRelation relationInOrderBy = relationsInOrderBy.iterator().next();
                     if (relationInOrderBy == topMostLeftRelation) {
-                        LogicalPlan newLhs = lhs.tryOptimize(pushDown);
+                        LogicalPlan newLhs = lhs.tryOptimize(pushDown, SymbolMapper.fromMap(expressionMapping));
                         if (newLhs != null) {
                             return updateSources(newLhs, rhs);
                         }
@@ -279,7 +279,7 @@ class NestedLoopJoin extends TwoInputPlan {
                 }
             }
         }
-        return super.tryOptimize(pushDown);
+        return super.tryOptimize(pushDown, mapper);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/OneInputPlan.java
+++ b/sql/src/main/java/io/crate/planner/operators/OneInputPlan.java
@@ -60,14 +60,14 @@ abstract class OneInputPlan extends LogicalPlanBase {
 
 
     @Override
-    public LogicalPlan tryOptimize(@Nullable LogicalPlan pushDown) {
+    public LogicalPlan tryOptimize(@Nullable LogicalPlan pushDown, SymbolMapper mapper) {
         if (pushDown != null) {
             // can't push down
             return null;
         }
-        LogicalPlan newPlan = source.tryOptimize(null);
+        LogicalPlan newPlan = source.tryOptimize(null, mapper);
         if (newPlan != source) {
-            return updateSource(newPlan);
+            return updateSource(newPlan, mapper);
         }
         return this;
     }
@@ -98,6 +98,6 @@ abstract class OneInputPlan extends LogicalPlanBase {
      * @param newSource A new {@link LogicalPlan} as a source.
      * @return A new copy of this {@link OneInputPlan} with the new source.
      */
-    protected abstract LogicalPlan updateSource(LogicalPlan newSource);
+    protected abstract LogicalPlan updateSource(LogicalPlan newSource, SymbolMapper mapper);
 
 }

--- a/sql/src/main/java/io/crate/planner/operators/RelationBoundary.java
+++ b/sql/src/main/java/io/crate/planner/operators/RelationBoundary.java
@@ -96,14 +96,14 @@ public class RelationBoundary extends OneInputPlan {
     }
 
     @Override
-    public LogicalPlan tryOptimize(@Nullable LogicalPlan pushDown) {
+    public LogicalPlan tryOptimize(@Nullable LogicalPlan pushDown, SymbolMapper mapper) {
         if (pushDown instanceof Order) {
-            LogicalPlan newSource = source.tryOptimize(pushDown);
+            LogicalPlan newSource = source.tryOptimize(pushDown, mapper);
             if (newSource != null && newSource != source) {
-                return updateSource(newSource);
+                return updateSource(newSource, mapper);
             }
         }
-        return super.tryOptimize(pushDown);
+        return super.tryOptimize(pushDown, mapper);
     }
 
     @Override
@@ -130,7 +130,7 @@ public class RelationBoundary extends OneInputPlan {
     }
 
     @Override
-    protected LogicalPlan updateSource(LogicalPlan newSource) {
+    protected LogicalPlan updateSource(LogicalPlan newSource, SymbolMapper mapper) {
         return new RelationBoundary(newSource, relation, outputs, expressionMapping, dependencies);
     }
 

--- a/sql/src/main/java/io/crate/planner/operators/RootRelationBoundary.java
+++ b/sql/src/main/java/io/crate/planner/operators/RootRelationBoundary.java
@@ -23,12 +23,12 @@
 package io.crate.planner.operators;
 
 import io.crate.analyze.OrderBy;
-import io.crate.expression.symbol.SelectSymbol;
 import io.crate.data.Row;
+import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
+import io.crate.expression.symbol.SelectSymbol;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.Merge;
 import io.crate.planner.PlannerContext;
-import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
 
 import javax.annotation.Nullable;
 import java.util.Map;
@@ -64,7 +64,7 @@ public class RootRelationBoundary extends OneInputPlan {
     }
 
     @Override
-    protected LogicalPlan updateSource(LogicalPlan newSource) {
+    protected LogicalPlan updateSource(LogicalPlan newSource, SymbolMapper mapper) {
         return new RootRelationBoundary(newSource);
     }
 

--- a/sql/src/main/java/io/crate/planner/operators/TwoInputPlan.java
+++ b/sql/src/main/java/io/crate/planner/operators/TwoInputPlan.java
@@ -49,12 +49,12 @@ abstract class TwoInputPlan extends LogicalPlanBase {
     }
 
     @Override
-    public LogicalPlan tryOptimize(@Nullable LogicalPlan pushDown) {
+    public LogicalPlan tryOptimize(@Nullable LogicalPlan pushDown, SymbolMapper mapper) {
         if (pushDown != null) {
             return null;
         }
-        LogicalPlan newLhs = lhs.tryOptimize(null);
-        LogicalPlan newRhs = rhs.tryOptimize(null);
+        LogicalPlan newLhs = lhs.tryOptimize(null, mapper);
+        LogicalPlan newRhs = rhs.tryOptimize(null, mapper);
         if (newLhs != lhs || newRhs != rhs) {
             return updateSources(newLhs, newRhs);
         }

--- a/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -871,4 +871,34 @@ public class JoinIntegrationTest extends SQLTransportIntegrationTest {
             is("0| 0| 0\n" +
                "1| 1| 1\n"));
     }
+
+    @Test
+    public void testInnerJoinWithPushDownOptimizations() {
+        execute("CREATE TABLE t1 (id INTEGER)");
+        execute("CREATE TABLE t2 (id INTEGER, name STRING, id_t1 INTEGER)");
+
+        execute("INSERT INTO t1 (id) VALUES (1), (2)");
+        execute("INSERT INTO t2 (id, name, id_t1) VALUES (1, 'A', 1), (2, 'B', 2), (3, 'C', 2)");
+        execute("REFRESH TABLE t1, t2");
+
+        assertThat(printedTable(execute(
+            "SELECT t1.id, t2.id FROM t2 INNER JOIN t1 ON t1.id = t2.id_t1 ORDER BY lower(t2.name)").rows()),
+            is("1| 1\n" +
+               "2| 2\n" +
+               "2| 3\n")
+        );
+
+        assertThat(printedTable(execute(
+            "SELECT t1.id, t2.id, t2.name FROM t2 INNER JOIN t1 ON t1.id = t2.id_t1 ORDER BY lower(t2.name)").rows()),
+            is("1| 1| A\n" +
+               "2| 2| B\n" +
+               "2| 3| C\n"));
+
+        assertThat(printedTable(execute(
+            "SELECT t1.id, t2.id, lower(t2.name) FROM t2 INNER JOIN t1 ON t1.id = t2.id_t1 ORDER BY lower(t2.name)").rows()),
+            is("1| 1| a\n" +
+               "2| 2| b\n" +
+               "2| 3| c\n")
+        );
+    }
 }

--- a/sql/src/test/java/io/crate/planner/operators/JoinTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/JoinTest.java
@@ -180,4 +180,5 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         assertThat(join.left(), instanceOf(Join.class));
         assertThat(((Join)join.left()).joinPhase(), instanceOf(HashJoinPhase.class));
     }
+
 }


### PR DESCRIPTION
// note for reviewer: Although the push-down logic change is only in
// master, the bug is also present in 2.3 (but happening due to an issue in
// the MultiSourceSelect pushdown. I intent to backport the whole pushdown
// changes)


The `Order` operators `tryOptimize` implementation was specific to
`UNION` and didn't work in the case of JOINS where the outputs of the
new source are different from the outputs of the old source.

For example, here is how it works for Union:

    select x from t1
    union all
    select y from t2
    order by x

    --------

    ORDER [U.x]
    UNION
        COLLECT [t1 | x]
        --
        COLLECT [t2 | y]

    tryOptimize -->

    UNION
        ORDER [x]
        COLLECT [t1 | x]
        --
        ORDER [y]
        COLLECT [t2 | y]

The logic how this symbol mapping takes place (`U.x -> y` in the example
above) was implemented in the `Order` operator, but that logic is
specific to `Union`. In a `Join`, the mapping must be different:

    ORDER [t2.x]
    JOIN [t1.x, t2.x]
        COLLECT [t1 | x]
        --
        COLLECT [t2 | x]

    tryOptimize -->

    JOIN [t1.x, t2.x]
        COLLECT [t1 | x]
        --
        ORDER [x]
        Collect [t2 | x]

Here the mapping is `t2.x -> x (Field -> Reference)`.

In order to fix this, this commit moves the mapping logic into a
separate function that can be passed as argument to `tryOptimize`, so
that each parent operator can pass different implementation to its
children.