### PR TITLE
Fixed Java version parsing in startup scripts

### DIFF
--- a/app/src/bin/crate.in.sh
+++ b/app/src/bin/crate.in.sh
@@ -70,7 +70,8 @@ EOF
   fi
   LOGGC="$GC_LOG_DIR/gc.log"
 
-  JAVA_VERSION=`java -version 2>&1 | awk '/version/ {split($3, array, ".")} END {print array[2]}'`
+  JAVA_VERSION=`java -version 2>&1 | awk '/version/ {gsub(/"/, "", $3); split($3, parts, ".")} END {print (parts[1] == 1 ? parts[2] : parts[1])}'
+
   if [ $JAVA_VERSION -ge 9 ]; then
     JAVA_OPTS="$JAVA_OPTS -Xlog:gc*,gc+age=trace,safepoint:file=${LOGGC}:utctime,pid,tags:filecount=${GC_LOG_FILES},filesize=${GC_LOG_SIZE}"
   fi


### PR DESCRIPTION
The output of `java -version` changed from Java 8 to Java 9, so we need to parse the version string differently.

Example from Debian:

```console
$ /usr/lib/jvm/java-9-openjdk-amd64/bin/java -version
openjdk version "9.0.1"
OpenJDK Runtime Environment (build 9.0.1+11-Debian-1)
OpenJDK 64-Bit Server VM (build 9.0.1+11-Debian-1, mixed mode)
$ /usr/lib/jvm/java-1.8.0-openjdk-amd64/bin/java -version
openjdk version "1.8.0_151"
OpenJDK Runtime Environment (build 1.8.0_151-8u151-b12-1-b12)
OpenJDK 64-Bit Server VM (build 25.151-b12, mixed mode)
```