### PR TITLE
fix gradle :blackbox:bootstrap on macOS

### DIFF
--- a/blackbox/bootstrap.sh
+++ b/blackbox/bootstrap.sh
@@ -1,14 +1,25 @@
 #!/bin/bash
 
 if hash python3.6 2> /dev/null; then
-    python3.6 -m venv .venv
+    PYTHON=python3.6 
 elif hash python3 2> /dev/null; then
     # fallback to python3 in case there is no python3.6 alias; should be 3.6
-    python3 -m venv .venv
+    PYTHON=python3
 else
     echo 'python3.6 required'
     exit 1
 fi
 
+case $OSTYPE in
+darwin*)
+    $PYTHON -m venv .venv --without-pip
+    wget https://bootstrap.pypa.io/get-pip.py
+    ./.venv/bin/python get-pip.py
+    rm -f get-pip.py
+    ;;
+*)
+    $PYTHON -m venv .venv
+    ;;
+esac
 .venv/bin/pip install -U pip setuptools wheel
 .venv/bin/pip install -r requirements.txt


### PR DESCRIPTION
fix gradle :blackbox:bootstrap on macOS with latest Python from Anaconda 
```
crate $ gradle :blackbox:buildDocs

> Configure project :core 
Gradle now uses separate output directories for each JVM language, but this build assumes a single directory for all classes from a source set. This behaviour has been deprecated and is scheduled to be removed in Gradle 5.0
        at build_bmqw03zymq71tv8ht2yhw6yof.run(/Users/ysz/src/crate/app/build.gradle:24)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)

> Task :blackbox:bootstrap FAILED
Error: Command '['/Users/ysz/src/crate/blackbox/.venv/bin/python3.6', '-Im', 'ensurepip', '--upgrade', '--default-pip']' returned non-zero exit status 1.
/Users/ysz/src/crate/blackbox/bootstrap.sh: line 13: .venv/bin/pip: No such file or directory
/Users/ysz/src/crate/blackbox/bootstrap.sh: line 14: .venv/bin/pip: No such file or directory


FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':blackbox:bootstrap'.
> Process 'command 'sh'' finished with non-zero exit value 127

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 2s
1 actionable task: 1 executed
```