### PR TITLE
Fixed: Wrong results when WHERE clause contains parted and non-parted columns

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -23,6 +23,11 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that caused incorrect results to be returned when ``WHERE``
+  clause filters on a partitioned and an non-partitioned column. E.g.::
+
+    SELECT * FROM t WHERE parted_col='value' AND other_col='some_value'
+
 - Fixed an issue that causes ``JOINS`` with certain ``ORDER BY`` constructs to
   fail.
 

--- a/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -2142,4 +2142,17 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
             is("1| 1\n")
         );
     }
+
+    @Test
+    public void testWhereOnPartitionedAndOtherColumn() {
+        execute("create table t (p string primary key, v string) " +
+                "partitioned by (p) " +
+                "with (number_of_replicas = 0)");
+        execute("insert into t (p, v) values ('a', 'Marvin')");
+        execute("insert into t (p, v) values ('b', 'Marvin')");
+        execute("refresh table t");
+
+        execute("select * from t where p='a' and v='Marvin'");
+        assertThat(TestingHelpers.printedTable(response.rows()), is("a| Marvin\n"));
+    }
 }


### PR DESCRIPTION
Regression caused by: https://github.com/crate/crate/commit/c750e6bcfff1c75d0da31f2745933ecc5a7cf974
Fixes: https://github.com/crate/crate/issues/6990

When the ``WHERE`` clause is analyzed for the 1st time the part with the partitioned columns
is removed from the WhereClause.query and becomes a partition list in. When the ``WHERE`` claused
is re-analyzed this partition list is lost and therefore the final query hits all table partitions.
E.g.:

```
  WHERE part_col1 IN (1, 2) AND other_col = 'value'
  => WhereClause.query: other_col='value', WhereClause.partitions: (1, 2) (1st analysis)
  => WhereClause.query: other_col='value', WhereClause.parititons: () (2nd analysis)

```