### PR TITLE
Make `/` and `sys.checks` available if num_nodes < min_nodes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -107,3 +107,7 @@ Changes
 
 Fixes
 =====
+
+- Improved the behaviour in case the cluster drops below the number of minimum
+  nodes. The root REST endpoint will no longer timeout and ``sys.checks`` can
+  still be queried, similar to how ``sys.nodes`` can still be queried.

--- a/http/src/main/java/io/crate/rest/CrateRestMainAction.java
+++ b/http/src/main/java/io/crate/rest/CrateRestMainAction.java
@@ -188,7 +188,12 @@ public class CrateRestMainAction implements RestHandler {
                 channel.sendResponse(new BytesRestResponse(INTERNAL_SERVER_ERROR, ExceptionsHelper.stackTrace(e)));
             }
         };
-        client.executeLocally(ClusterStateAction.INSTANCE, new ClusterStateRequest(), listener);
+        ClusterStateRequest stateReq = new ClusterStateRequest()
+            .blocks(true)
+            .metaData(false)
+            .nodes(false)
+            .local(true);
+        client.executeLocally(ClusterStateAction.INSTANCE, stateReq, listener);
     }
 
     private BytesRestResponse buildResponse(RestRequest.Method method, XContentBuilder builder, RestStatus status) {

--- a/sql/src/main/java/io/crate/expression/reference/sys/check/cluster/TablesNeedUpgradeSysCheck.java
+++ b/sql/src/main/java/io/crate/expression/reference/sys/check/cluster/TablesNeedUpgradeSysCheck.java
@@ -85,12 +85,14 @@ public class TablesNeedUpgradeSysCheck extends AbstractSysCheck {
         } catch (Throwable t) {
             result.completeExceptionally(t);
         }
-        return result.whenComplete((tableNames, throwable) -> {
+        return result.handle((tableNames, throwable) -> {
             if (throwable == null) {
                 tablesNeedUpgrade = tableNames;
             } else {
                 logger.error("error while checking for tables that need upgrade", throwable);
             }
+            // `select * from sys.checks` should not fail if an error occurred here, so swallow exception
+            return null;
         });
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/BelowMinNumberOfNodesITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/BelowMinNumberOfNodesITest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.integrationtests;
+
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClients;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.discovery.zen.ElectMasterService;
+import org.elasticsearch.http.HttpServerTransport;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+@ESIntegTestCase.ClusterScope(numDataNodes = 2, supportsDedicatedMasters = false, autoMinMasterNodes = false, numClientNodes = 0)
+public class BelowMinNumberOfNodesITest extends SQLTransportIntegrationTest {
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal) {
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal))
+            .put("http.enabled", true)
+            .put(ElectMasterService.DISCOVERY_ZEN_MINIMUM_MASTER_NODES_SETTING.getKey(), 2)
+            .build();
+    }
+
+    @Test
+    public void testSysQueriesAreResponsiveIfBelowMinimumMasterNodes() throws IOException {
+        execute("create table t1 (x int) with (number_of_replicas = 1) ");
+
+        internalCluster().stopRandomNonMasterNode();
+
+        try {
+            // we only test that this does not throw an error
+            execute("select count(*) from sys.checks");
+
+            Object[][] rows = execute("select port['http'] from sys.nodes order by 1").rows();
+            assertThat(rows[0][0], notNullValue());
+            assertThat(rows[1][0], nullValue());
+
+            assertThat(getRestStatus(), is(RestStatus.SERVICE_UNAVAILABLE.getStatus()));
+        } finally {
+            // satisfy min_master_nodes again; otherwise the teardown blocks
+            internalCluster().startNode();
+        }
+    }
+
+    private int getRestStatus() throws IOException {
+        HttpServerTransport httpTransport = internalCluster().getInstance(HttpServerTransport.class);
+        InetSocketAddress address = httpTransport.boundAddress().publishAddress().address();
+        HttpGet httpGet = new HttpGet("http://" + address.getHostName() + ":" + address.getPort() + "/");
+        return HttpClients.createDefault().execute(httpGet).getStatusLine().getStatusCode();
+    }
+}


### PR DESCRIPTION
See commit messages

`sys.health`, `sys.shards` and `sys.node_checks` should probably also be changed to handle such a case without running into NodeDisconnected errors. But those require more work, so I'll handle these in separate PRs 