### PR TITLE
Respect $JAVA_HOME on version check for GC logging

### DIFF
--- a/app/src/bin/crate.in.sh
+++ b/app/src/bin/crate.in.sh
@@ -70,7 +70,12 @@ EOF
   fi
   LOGGC="$GC_LOG_DIR/gc.log"
 
-  JAVA_VERSION=`java -version 2>&1 | awk '/version/ {gsub(/"/, "", $3); split($3, parts, ".")} END {print (parts[1] == 1 ? parts[2] : parts[1])}'`
+  if [ -x "$JAVA_HOME/bin/java" ]; then
+      JAVA="$JAVA_HOME/bin/java"
+  else
+      JAVA=java
+  fi
+  JAVA_VERSION=`$JAVA -version 2>&1 | awk '/version/ {gsub(/"/, "", $3); split($3, parts, ".")} END {print (parts[1] == 1 ? parts[2] : parts[1])}'`
 
   if [ $JAVA_VERSION -ge 9 ]; then
     JAVA_OPTS="$JAVA_OPTS -Xlog:gc*,gc+age=trace,safepoint:file=${LOGGC}:utctime,pid,tags:filecount=${GC_LOG_FILES},filesize=${GC_LOG_SIZE}"


### PR DESCRIPTION
`bin/crate` uses `$JAVA_HOME/bin/java` if it exists to launch crate, so
we also have to use that java to do the version check to determine the
GC logging options.