### PR TITLE
Make sure sys.health returns RED if the cluster is not functional

### DIFF
--- a/blackbox/docs/admin/system-information.rst
+++ b/blackbox/docs/admin/system-information.rst
@@ -1259,6 +1259,11 @@ table/partition.
 |                            | not fully replicated.             |             |
 +----------------------------+-----------------------------------+-------------+
 
+Both ``missing_shards`` and ``underreplicated_shards`` might return ``-1`` if
+the cluster is in an unhealthy state that prevents the exact number from being
+calculated. This could be the case when the cluster can't elect a master,
+because there are not enough eligible nodes available.
+
 ::
 
     cr> select * from sys.health order by severity desc, table_name;

--- a/sql/src/test/java/io/crate/integrationtests/BelowMinNumberOfNodesITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/BelowMinNumberOfNodesITest.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 
+import static io.crate.testing.TestingHelpers.printedTable;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -63,6 +64,11 @@ public class BelowMinNumberOfNodesITest extends SQLTransportIntegrationTest {
             Object[][] rows = execute("select port['http'] from sys.nodes order by 1").rows();
             assertThat(rows[0][0], notNullValue());
             assertThat(rows[1][0], nullValue());
+
+            assertThat(
+                printedTable(execute("select health from sys.health order by severity limit 1").rows()),
+                is("RED\n")
+            );
 
             assertThat(getRestStatus(), is(RestStatus.SERVICE_UNAVAILABLE.getStatus()));
         } finally {


### PR DESCRIPTION
Querying `sys.health` could either fail with a
`NodeDisconnectedException` or run into a timeout if the cluster is not
functional. This commit adds a fallback mechanism that makes sure the
table entries are returned, but are marked as unhealthy.

No changes because `sys.health` hasn't been released yet.


A better solution might be to introduce some kind of fallback mechanism
to `sys.shards`, but that's also more difficult to do.