### PR TITLE
Wait for clusterState changes before invoking retries

### DIFF
--- a/blackbox/docs/src/doc_tests/process_test.py
+++ b/blackbox/docs/src/doc_tests/process_test.py
@@ -380,10 +380,5 @@ class TestGracefulStopDuringQueryExecution(GracefulStopTest):
             try:
                 client.sql('select name, count(*) from t1 group by name')
             except Exception as e:
-                # For now we make sure that queries are not killed, but a
-                # TableUnknownException can happen if the queries still target
-                # the node that is being decommissioned and the cluster state
-                # update is too slow (and the internal 3 retries all happen before)
-                if 'TableUnknownException' not in str(e):
-                    errors.append(e)
+                errors.append(e)
         finished.wait()

--- a/sql/src/main/java/io/crate/planner/DependencyCarrier.java
+++ b/sql/src/main/java/io/crate/planner/DependencyCarrier.java
@@ -23,12 +23,12 @@
 package io.crate.planner;
 
 import io.crate.action.sql.DCLStatementDispatcher;
-import io.crate.execution.ddl.DDLStatementDispatcher;
 import io.crate.execution.TransportActionProvider;
+import io.crate.execution.ddl.DDLStatementDispatcher;
 import io.crate.execution.ddl.TransportDropTableAction;
+import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
 import io.crate.execution.engine.PhasesTaskFactory;
 import io.crate.metadata.Functions;
-import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
@@ -118,5 +118,9 @@ public class DependencyCarrier {
 
     public PhasesTaskFactory phasesTaskFactory() {
         return phasesTaskFactory;
+    }
+
+    public ThreadPool threadPool() {
+        return threadPool;
     }
 }


### PR DESCRIPTION
This commit makes sure that we wait for the clusterState to have changed
before invoking a retry. This should reduce the chance for the retry to
fail again, which is likely the case if it used the same cluster state
again to calculate the routing.