### PR TITLE
Tests: Fix flakiness of testJobLogWithEnabledAndDisabledStats.

### DIFF
--- a/sql/src/main/java/io/crate/execution/engine/collect/stats/JobsLogService.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/stats/JobsLogService.java
@@ -236,4 +236,9 @@ public class JobsLogService extends AbstractLifecycleComponent implements Provid
     public JobsLogs get() {
         return statsTables();
     }
+
+    @VisibleForTesting
+    public int jobsLogSize() {
+        return jobsLogSize;
+    }
 }

--- a/sql/src/test/java/io/crate/integrationtests/JobLogIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/JobLogIntegrationTest.java
@@ -56,7 +56,9 @@ public class JobLogIntegrationTest extends SQLTransportIntegrationTest {
         assertThat(response.rowCount(), greaterThan(0L));
 
         execute("set global transient stats.jobs_log_size=1");
-        waitNoPendingTasksOnAll();
+        for (JobsLogService jobsLogService : internalCluster().getDataNodeInstances(JobsLogService.class)) {
+            assertBusy(() -> assertThat(jobsLogService.jobsLogSize(), is(1)));
+        }
 
         // Each node can hold only 1 query (the latest one) so in total we should always see 2 queries in
         // the jobs_log. We make sure that we hit both nodes with 2 queries each and then assert that
@@ -77,7 +79,9 @@ public class JobLogIntegrationTest extends SQLTransportIntegrationTest {
                "select id from sys.cluster\n"));
 
         execute("set global transient stats.enabled = false");
-        waitNoPendingTasksOnAll();
+        for (JobsLogService jobsLogService : internalCluster().getDataNodeInstances(JobsLogService.class)) {
+            assertBusy(() -> assertThat(jobsLogService.isEnabled(), is(false)));
+        }
         execute("select * from sys.jobs_log");
         assertThat(response.rowCount(), is(0L));
     }


### PR DESCRIPTION
Added assertBusy validations to make sure that changes issued by
`SET` stmts are applied on both nodes of the cluster.

Follow up to: 521414b6778d3e0f2f012e3afb2209f20e240cfd