### PR TITLE
Remove explicit UseParNewGC JVM flag

### DIFF
--- a/app/src/bin/crate.bat
+++ b/app/src/bin/crate.bat
@@ -40,7 +40,6 @@ REM Enable aggressive optimizations in the JVM
 REM    - Disabled by default as it might cause the JVM to crash
 REM set JAVA_OPTS=%JAVA_OPTS% -XX:+AggressiveOpts
 
-set JAVA_OPTS=%JAVA_OPTS% -XX:+UseParNewGC
 set JAVA_OPTS=%JAVA_OPTS% -XX:+UseConcMarkSweepGC
 
 set JAVA_OPTS=%JAVA_OPTS% -XX:CMSInitiatingOccupancyFraction=75

--- a/app/src/bin/crate.in.sh
+++ b/app/src/bin/crate.in.sh
@@ -46,7 +46,6 @@ if [ "x$CRATE_USE_IPV4" != "x" ]; then
   JAVA_OPTS="$JAVA_OPTS -Djava.net.preferIPv4Stack=true"
 fi
 
-JAVA_OPTS="$JAVA_OPTS -XX:+UseParNewGC"
 JAVA_OPTS="$JAVA_OPTS -XX:+UseConcMarkSweepGC"
 
 JAVA_OPTS="$JAVA_OPTS -XX:CMSInitiatingOccupancyFraction=75"


### PR DESCRIPTION
- The parallel new collector is enabled automatically if the CMS
 collector is enabled
 - `UseParNewGC` was deprecated in JDK8, produces a warning in JDK9 and
 has been removed in JDK10