### PR TITLE
Rename TableAlreadyExistsException -> RelationAlreadyExists

### DIFF
--- a/blackbox/docs/admin/snapshots.rst
+++ b/blackbox/docs/admin/snapshots.rst
@@ -153,7 +153,7 @@ listing all tables restores the whole snapshot.
 It's not possible to restore tables that exist in the current cluster::
 
     cr> RESTORE SNAPSHOT where_my_snapshots_go.snapshot2 TABLE quotes;
-    SQLActionException[TableAlreadyExistsException: The table 'doc.quotes' already exists.]
+    SQLActionException[RelationAlreadyExists: Relation 'doc.quotes' already exists.]
 
 Single partitions can be either imported into an existing partitioned table the
 partition belongs to.

--- a/blackbox/docs/interfaces/http.rst
+++ b/blackbox/docs/interfaces/http.rst
@@ -359,7 +359,7 @@ Code   Error
 4092   A VersionConflict. Might be thrown if an attempt was made to update
        the same document concurrently.
 ------ ---------------------------------------------------------------------
-4093   A table with the same name exists already.
+4093   A relation with the same name exists already.
 ------ ---------------------------------------------------------------------
 4094   The used table alias contains tables with different schema.
 ------ ---------------------------------------------------------------------

--- a/sql/src/main/java/io/crate/analyze/CreateBlobTableAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/CreateBlobTableAnalyzedStatement.java
@@ -21,7 +21,7 @@
 
 package io.crate.analyze;
 
-import io.crate.exceptions.TableAlreadyExistsException;
+import io.crate.exceptions.RelationAlreadyExists;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.TableIdent;
 
@@ -45,7 +45,7 @@ public class CreateBlobTableAnalyzedStatement extends AbstractDDLAnalyzedStateme
     public void table(TableIdent tableIdent, Schemas schemas) {
         tableIdent.validate();
         if (schemas.tableExists(tableIdent)) {
-            throw new TableAlreadyExistsException(tableIdent);
+            throw new RelationAlreadyExists(tableIdent);
         }
         this.tableIdent = tableIdent;
     }

--- a/sql/src/main/java/io/crate/analyze/CreateTableAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/CreateTableAnalyzedStatement.java
@@ -21,7 +21,7 @@
 
 package io.crate.analyze;
 
-import io.crate.exceptions.TableAlreadyExistsException;
+import io.crate.exceptions.RelationAlreadyExists;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.IndexMappings;
 import io.crate.metadata.PartitionName;
@@ -50,7 +50,7 @@ public class CreateTableAnalyzedStatement extends AbstractDDLAnalyzedStatement {
         if (ifNotExists) {
             noOp = schemas.tableExists(tableIdent);
         } else if (schemas.tableExists(tableIdent)) {
-            throw new TableAlreadyExistsException(tableIdent);
+            throw new RelationAlreadyExists(tableIdent);
         }
         this.ifNotExists = ifNotExists;
         this.tableIdent = tableIdent;

--- a/sql/src/main/java/io/crate/analyze/RestoreSnapshotAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/RestoreSnapshotAnalyzer.java
@@ -26,7 +26,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.crate.exceptions.PartitionAlreadyExistsException;
-import io.crate.exceptions.TableAlreadyExistsException;
+import io.crate.exceptions.RelationAlreadyExists;
 import io.crate.execution.ddl.RepositoryService;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.Schemas;
@@ -81,7 +81,7 @@ class RestoreSnapshotAnalyzer {
 
                 if (tableExists) {
                     if (table.partitionProperties().isEmpty()) {
-                        throw new TableAlreadyExistsException(tableIdent);
+                        throw new RelationAlreadyExists(tableIdent);
                     }
 
                     DocTableInfo docTableInfo = schemas.getTableInfo(tableIdent, Operation.RESTORE_SNAPSHOT);

--- a/sql/src/main/java/io/crate/exceptions/RelationAlreadyExists.java
+++ b/sql/src/main/java/io/crate/exceptions/RelationAlreadyExists.java
@@ -26,18 +26,18 @@ import io.crate.metadata.TableIdent;
 import java.util.Collections;
 import java.util.Locale;
 
-public class TableAlreadyExistsException extends ConflictException implements TableScopeException {
+public final class RelationAlreadyExists extends ConflictException implements TableScopeException {
 
     private TableIdent tableIdent;
 
-    private static final String MESSAGE_TMPL = "The table '%s' already exists.";
+    private static final String MESSAGE_TMPL = "Relation '%s' already exists.";
 
-    public TableAlreadyExistsException(TableIdent tableIdent) {
+    public RelationAlreadyExists(TableIdent tableIdent) {
         super(String.format(Locale.ENGLISH, MESSAGE_TMPL, tableIdent));
         this.tableIdent = tableIdent;
     }
 
-    TableAlreadyExistsException(String tableName, Throwable e) {
+    RelationAlreadyExists(String tableName, Throwable e) {
         super(String.format(Locale.ENGLISH, MESSAGE_TMPL, tableName), e);
         this.tableIdent = TableIdent.fromIndexName(tableName);
     }

--- a/sql/src/main/java/io/crate/exceptions/SQLExceptions.java
+++ b/sql/src/main/java/io/crate/exceptions/SQLExceptions.java
@@ -188,11 +188,11 @@ public class SQLExceptions {
                 ((EngineException) e).getIndex().getName(),
                 "A document with the same primary key exists already", e);
         } else if (e instanceof ResourceAlreadyExistsException) {
-            return new TableAlreadyExistsException(((ResourceAlreadyExistsException) e).getIndex().getName(), e);
+            return new RelationAlreadyExists(((ResourceAlreadyExistsException) e).getIndex().getName(), e);
         } else if ((e instanceof InvalidIndexNameException)) {
             if (e.getMessage().contains("already exists as alias")) {
                 // treat an alias like a table as aliases are not officially supported
-                return new TableAlreadyExistsException(((InvalidIndexNameException) e).getIndex().getName(),
+                return new RelationAlreadyExists(((InvalidIndexNameException) e).getIndex().getName(),
                     e);
             }
             return new InvalidTableNameException(((InvalidIndexNameException) e).getIndex().getName(), e);

--- a/sql/src/test/java/io/crate/analyze/BlobTableAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/BlobTableAnalyzerTest.java
@@ -23,7 +23,7 @@ package io.crate.analyze;
 
 import io.crate.blob.v2.BlobIndicesService;
 import io.crate.exceptions.InvalidTableNameException;
-import io.crate.exceptions.TableAlreadyExistsException;
+import io.crate.exceptions.RelationAlreadyExists;
 import io.crate.exceptions.TableUnknownException;
 import io.crate.metadata.TableIdent;
 import io.crate.metadata.blob.BlobSchemaInfo;
@@ -77,7 +77,7 @@ public class BlobTableAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testCreateBlobTableRaisesErrorIfAlreadyExists() throws Exception {
-        expectedException.expect(TableAlreadyExistsException.class);
+        expectedException.expect(RelationAlreadyExists.class);
         e.analyze("create blob table blobs");
     }
 

--- a/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -30,7 +30,7 @@ import io.crate.exceptions.InvalidColumnNameException;
 import io.crate.exceptions.InvalidSchemaNameException;
 import io.crate.exceptions.InvalidTableNameException;
 import io.crate.exceptions.OperationOnInaccessibleRelationException;
-import io.crate.exceptions.TableAlreadyExistsException;
+import io.crate.exceptions.RelationAlreadyExists;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.FulltextAnalyzerResolver;
 import io.crate.metadata.TableIdent;
@@ -736,7 +736,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
 
     @Test
     public void testCreateTableShouldRaiseErrorIfItExists() throws Exception {
-        expectedException.expect(TableAlreadyExistsException.class);
+        expectedException.expect(RelationAlreadyExists.class);
         e.analyze("create table users (\"'test\" string)");
     }
 

--- a/sql/src/test/java/io/crate/analyze/SnapshotRestoreAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SnapshotRestoreAnalyzerTest.java
@@ -27,7 +27,7 @@ import io.crate.exceptions.PartitionAlreadyExistsException;
 import io.crate.exceptions.PartitionUnknownException;
 import io.crate.exceptions.RepositoryUnknownException;
 import io.crate.exceptions.SchemaUnknownException;
-import io.crate.exceptions.TableAlreadyExistsException;
+import io.crate.exceptions.RelationAlreadyExists;
 import io.crate.exceptions.TableUnknownException;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.Schemas;
@@ -258,8 +258,8 @@ public class SnapshotRestoreAnalyzerTest extends CrateDummyClusterServiceUnitTes
 
     @Test
     public void testRestoreExistingTable() throws Exception {
-        expectedException.expect(TableAlreadyExistsException.class);
-        expectedException.expectMessage("The table 'doc.users' already exists.");
+        expectedException.expect(RelationAlreadyExists.class);
+        expectedException.expectMessage("Relation 'doc.users' already exists.");
         analyze("RESTORE SNAPSHOT my_repo.my_snapshot TABLE users");
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -135,7 +135,7 @@ public class DDLIntegrationTest extends SQLTransportIntegrationTest {
         ensureYellow();
 
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("The table 'doc.test' already exists.");
+        expectedException.expectMessage("Relation 'doc.test' already exists.");
         execute("create table test (col1 integer primary key, col2 string)");
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/TableAliasIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TableAliasIntegrationTest.java
@@ -157,7 +157,7 @@ public class TableAliasIntegrationTest extends SQLTransportIntegrationTest {
         String tableAlias = tableAliasSetup();
 
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage(String.format(Locale.ENGLISH, "The table '%s.mytablealias' already exists.", sqlExecutor.getDefaultSchema()));
+        expectedException.expectMessage(String.format(Locale.ENGLISH, "Relation '%s.mytablealias' already exists.", sqlExecutor.getDefaultSchema()));
 
         execute(String.format(Locale.ENGLISH, "create table %s (content string index off)", tableAlias));
     }


### PR DESCRIPTION
So we can re-use the exception for views.