### PR TITLE
Hide overloaded SymbolPrinter#print

### DIFF
--- a/enterprise/users/src/test/java/io/crate/scalar/systeminformation/UserFunctionTest.java
+++ b/enterprise/users/src/test/java/io/crate/scalar/systeminformation/UserFunctionTest.java
@@ -82,12 +82,12 @@ public class UserFunctionTest extends AbstractScalarFunctionsTest {
         setupFunctionsFor(TEST_USER);
         SymbolPrinter printer = new SymbolPrinter(sqlExpressions.functions());
         Symbol f = sqlExpressions.asSymbol("current_user");
-        assertThat(printer.printFullQualified(f), is("current_user"));
+        assertThat(printer.printQualified(f), is("current_user"));
 
         f = sqlExpressions.asSymbol("session_user");
-        assertThat(printer.printFullQualified(f), is("session_user"));
+        assertThat(printer.printQualified(f), is("session_user"));
 
         f = sqlExpressions.asSymbol("user");
-        assertThat(printer.printFullQualified(f), is("current_user"));
+        assertThat(printer.printQualified(f), is("current_user"));
     }
 }

--- a/sql/src/main/java/io/crate/action/sql/DCLStatementDispatcher.java
+++ b/sql/src/main/java/io/crate/action/sql/DCLStatementDispatcher.java
@@ -76,7 +76,7 @@ public class DCLStatementDispatcher implements BiFunction<AnalyzedStatement, Row
             String formattedExpression = null;
             Symbol symbol = parameterContext.apply(node);
             if (symbol != null) {
-                formattedExpression = symbolPrinter.printSimple(symbol);
+                formattedExpression = symbolPrinter.printUnqualified(symbol);
             }
             return formattedExpression;
         }

--- a/sql/src/main/java/io/crate/analyze/AnalyzedTableElements.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedTableElements.java
@@ -289,7 +289,7 @@ public class AnalyzedTableElements {
                 "generated expression value type '%s' not supported for conversion to '%s'", valueType, definedType.getName());
 
             Symbol castFunction = CastFunctionResolver.generateCastFunction(function, definedType, false);
-            formattedExpression = symbolPrinter.print(castFunction, SymbolPrinter.Style.NOT_QUALIFIED);
+            formattedExpression = symbolPrinter.printUnqualified(castFunction);
         } else {
             if (valueType instanceof ArrayType) {
                 columnDefinition.collectionType("array");
@@ -299,7 +299,7 @@ public class AnalyzedTableElements {
             } else {
                 columnDefinition.dataType(valueType.getName());
             }
-            formattedExpression = symbolPrinter.print(function, SymbolPrinter.Style.NOT_QUALIFIED);
+            formattedExpression = symbolPrinter.printUnqualified(function);
         }
 
         columnDefinition.formattedGeneratedExpression(formattedExpression);

--- a/sql/src/main/java/io/crate/analyze/CopyAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CopyAnalyzer.java
@@ -209,7 +209,7 @@ class CopyAnalyzer {
             for (Expression expression : node.columns()) {
                 Symbol symbol = expressionAnalyzer.convert(expression, expressionAnalysisContext);
                 symbol = normalizer.normalize(symbol, analysis.transactionContext());
-                outputNames.add(SymbolPrinter.INSTANCE.printSimple(symbol));
+                outputNames.add(SymbolPrinter.INSTANCE.printUnqualified(symbol));
                 outputs.add(DocReferences.toSourceLookup(symbol));
             }
             columnsDefined = true;

--- a/sql/src/main/java/io/crate/analyze/InsertFromSubQueryAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/InsertFromSubQueryAnalyzer.java
@@ -208,7 +208,7 @@ class InsertFromSubQueryAnalyzer {
             throw new IllegalArgumentException(String.format(Locale.ENGLISH,
                 "Number of target columns (%s) of insert statement doesn't match number of source columns (%s)",
                 targetColumns.stream().map(r -> r.column().sqlFqn()).collect(commaJoiner),
-                querySpec.outputs().stream().map(SymbolPrinter.INSTANCE::printSimple).collect(commaJoiner)));
+                querySpec.outputs().stream().map(SymbolPrinter.INSTANCE::printUnqualified).collect(commaJoiner)));
         }
 
         int failedCastPosition = querySpec.castOutputs(Iterators.transform(targetColumns.iterator(), Symbol::valueType));

--- a/sql/src/main/java/io/crate/analyze/expressions/ValueNormalizer.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/ValueNormalizer.java
@@ -72,7 +72,7 @@ public final class ValueNormalizer {
             throw new ColumnValidationException(
                 reference.ident().columnIdent().name(),
                 tableInfo.ident(),
-                String.format(Locale.ENGLISH, "Cannot cast %s to type %s", SymbolPrinter.INSTANCE.printSimple(valueSymbol),
+                String.format(Locale.ENGLISH, "Cannot cast %s to type %s", SymbolPrinter.INSTANCE.printUnqualified(valueSymbol),
                     reference.valueType().getName()));
         }
         Object value = literal.value();

--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -570,12 +570,12 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
             } catch (ClassCastException | IllegalArgumentException e) {
                 throw new IllegalArgumentException(String.format(
                     Locale.ENGLISH,
-                    "Cannot use %s in %s clause", SymbolPrinter.INSTANCE.printSimple(symbol), clause));
+                    "Cannot use %s in %s clause", SymbolPrinter.INSTANCE.printUnqualified(symbol), clause));
             }
             if (longLiteral.value() == null) {
                 throw new IllegalArgumentException(String.format(
                     Locale.ENGLISH,
-                    "Cannot use %s in %s clause", SymbolPrinter.INSTANCE.printSimple(symbol), clause));
+                    "Cannot use %s in %s clause", SymbolPrinter.INSTANCE.printUnqualified(symbol), clause));
             }
             symbol = ordinalOutputReference(selectAnalysis.outputSymbols(), longLiteral, clause);
         }
@@ -603,12 +603,12 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
                 } catch (ClassCastException | IllegalArgumentException e) {
                     throw new IllegalArgumentException(String.format(
                         Locale.ENGLISH,
-                        "Cannot use %s in %s clause", SymbolPrinter.INSTANCE.printSimple(symbol), clause));
+                        "Cannot use %s in %s clause", SymbolPrinter.INSTANCE.printUnqualified(symbol), clause));
                 }
                 if (longLiteral.value() == null) {
                     throw new IllegalArgumentException(String.format(
                         Locale.ENGLISH,
-                        "Cannot use %s in %s clause", SymbolPrinter.INSTANCE.printSimple(symbol), clause));
+                        "Cannot use %s in %s clause", SymbolPrinter.INSTANCE.printUnqualified(symbol), clause));
                 }
                 symbol = ordinalOutputReference(selectAnalysis.outputSymbols(), longLiteral, clause);
             }

--- a/sql/src/main/java/io/crate/analyze/relations/SubselectRewriter.java
+++ b/sql/src/main/java/io/crate/analyze/relations/SubselectRewriter.java
@@ -173,7 +173,7 @@ public final class SubselectRewriter {
                 if (output instanceof Path) {
                     outputNames.add((Path) output);
                 } else {
-                    outputNames.add(new OutputName(SymbolPrinter.INSTANCE.printSimple(output)));
+                    outputNames.add(new OutputName(SymbolPrinter.INSTANCE.printUnqualified(output)));
                 }
             } else {
                 outputNames.add(field);

--- a/sql/src/main/java/io/crate/analyze/validator/GroupBySymbolValidator.java
+++ b/sql/src/main/java/io/crate/analyze/validator/GroupBySymbolValidator.java
@@ -48,7 +48,7 @@ public class GroupBySymbolValidator {
         if (!DataTypes.PRIMITIVE_TYPES.contains(symbol.valueType())) {
             throw new IllegalArgumentException(
                 String.format(Locale.ENGLISH, errorMesage,
-                    SymbolPrinter.INSTANCE.printSimple(symbol),
+                    SymbolPrinter.INSTANCE.printUnqualified(symbol),
                     symbol.valueType()));
         }
     }

--- a/sql/src/main/java/io/crate/analyze/validator/SemanticSortValidator.java
+++ b/sql/src/main/java/io/crate/analyze/validator/SemanticSortValidator.java
@@ -60,7 +60,7 @@ public class SemanticSortValidator {
                 throw new UnsupportedOperationException(
                     String.format(Locale.ENGLISH,
                         "Cannot ORDER BY '%s': invalid return type '%s'.",
-                        SymbolPrinter.INSTANCE.printSimple(symbol),
+                        SymbolPrinter.INSTANCE.printUnqualified(symbol),
                         symbol.valueType())
                 );
             }
@@ -88,7 +88,7 @@ public class SemanticSortValidator {
                 throw new UnsupportedOperationException(
                     String.format(Locale.ENGLISH,
                         "Cannot ORDER BY '%s': invalid data type '%s'.",
-                        SymbolPrinter.INSTANCE.printSimple(field),
+                        SymbolPrinter.INSTANCE.printUnqualified(field),
                         field.valueType())
                 );
             }

--- a/sql/src/main/java/io/crate/exceptions/ConversionException.java
+++ b/sql/src/main/java/io/crate/exceptions/ConversionException.java
@@ -52,14 +52,14 @@ public class ConversionException extends IllegalArgumentException {
             dataTypes.iterator().next().toString();
         if (arg instanceof Symbol) {
             return String.format(Locale.ENGLISH, ERROR_MESSAGE,
-                SymbolPrinter.INSTANCE.printSimple((Symbol) arg), dataTypeString);
+                SymbolPrinter.INSTANCE.printUnqualified((Symbol) arg), dataTypeString);
         }
         return String.format(Locale.ENGLISH, ERROR_MESSAGE, arg, dataTypeString);
     }
 
     private static String generateMessage(Symbol value, DataType type) {
         return String.format(Locale.ENGLISH, ERROR_MESSAGE,
-            SymbolPrinter.INSTANCE.printSimple(value), type.toString());
+            SymbolPrinter.INSTANCE.printUnqualified(value), type.toString());
     }
 
     private static String generateMessage(Object value, DataType type) {

--- a/sql/src/main/java/io/crate/expression/symbol/Symbols.java
+++ b/sql/src/main/java/io/crate/expression/symbol/Symbols.java
@@ -119,7 +119,7 @@ public class Symbols {
         } else if (symbol instanceof Reference) {
             return ((Reference) symbol).column();
         }
-        return new OutputName(SymbolPrinter.INSTANCE.printSimple(symbol));
+        return new OutputName(SymbolPrinter.INSTANCE.printUnqualified(symbol));
     }
 
     private static class HasColumnVisitor extends SymbolVisitor<Path, Boolean> {

--- a/sql/src/main/java/io/crate/expression/symbol/format/SymbolFormatter.java
+++ b/sql/src/main/java/io/crate/expression/symbol/format/SymbolFormatter.java
@@ -41,7 +41,7 @@ public class SymbolFormatter {
             if (s == null) {
                 formattedSymbols[i] = NULL_LOWER;
             } else {
-                formattedSymbols[i] = SymbolPrinter.INSTANCE.printSimple(s);
+                formattedSymbols[i] = SymbolPrinter.INSTANCE.printUnqualified(s);
             }
         }
         return String.format(Locale.ENGLISH, messageTmpl, formattedSymbols);

--- a/sql/src/main/java/io/crate/expression/symbol/format/SymbolPrinter.java
+++ b/sql/src/main/java/io/crate/expression/symbol/format/SymbolPrinter.java
@@ -65,8 +65,8 @@ public final class SymbolPrinter {
     };
 
     public enum Style {
-        NOT_QUALIFIED,
-        FULL_QUALIFIED;
+        UNQUALIFIED,
+        QUALIFIED;
 
         SymbolPrinterContext context() {
             return new SymbolPrinterContext(this);
@@ -80,19 +80,19 @@ public final class SymbolPrinter {
         this.symbolPrintVisitor = new SymbolPrintVisitor(functions);
     }
 
-    public String printSimple(Symbol symbol) {
-        return print(symbol, Style.NOT_QUALIFIED);
+    public String printUnqualified(Symbol symbol) {
+        return print(symbol, Style.UNQUALIFIED);
     }
 
-    public String printFullQualified(Symbol symbol) {
-        return print(symbol, Style.FULL_QUALIFIED);
+    public String printQualified(Symbol symbol) {
+        return print(symbol, Style.QUALIFIED);
     }
 
     /**
      * format a symbol with the given style
      */
-    public String print(Symbol symbol, Style formatStyle) {
-        SymbolPrinterContext context = formatStyle.context();
+    private String print(Symbol symbol, Style style) {
+        SymbolPrinterContext context = style.context();
         symbolPrintVisitor.process(symbol, context);
         return context.formatted();
     }

--- a/sql/src/main/java/io/crate/expression/symbol/format/SymbolPrinterContext.java
+++ b/sql/src/main/java/io/crate/expression/symbol/format/SymbolPrinterContext.java
@@ -36,6 +36,6 @@ final class SymbolPrinterContext {
     }
 
     boolean isFullQualified() {
-        return style == SymbolPrinter.Style.FULL_QUALIFIED;
+        return style == SymbolPrinter.Style.QUALIFIED;
     }
 }

--- a/sql/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
+++ b/sql/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
@@ -174,7 +174,7 @@ public class LuceneQueryBuilder {
         }
         if (LOGGER.isTraceEnabled()) {
             if (whereClause.hasQuery()) {
-                LOGGER.trace("WHERE CLAUSE [{}] -> LUCENE QUERY [{}] ", SymbolPrinter.INSTANCE.printSimple(whereClause.query()), ctx.query);
+                LOGGER.trace("WHERE CLAUSE [{}] -> LUCENE QUERY [{}] ", SymbolPrinter.INSTANCE.printUnqualified(whereClause.query()), ctx.query);
             }
         }
         return ctx;

--- a/sql/src/main/java/io/crate/planner/operators/ExplainLogicalPlan.java
+++ b/sql/src/main/java/io/crate/planner/operators/ExplainLogicalPlan.java
@@ -127,8 +127,8 @@ public class ExplainLogicalPlan {
         @Override
         public ImmutableMap.Builder<String, Object> visitLimit(Limit logicalPlan, Context context) {
             return createMap(logicalPlan, createSubMap()
-                .put("limit", SymbolPrinter.INSTANCE.print(logicalPlan.limit, SymbolPrinter.Style.FULL_QUALIFIED))
-                .put("offset", SymbolPrinter.INSTANCE.print(logicalPlan.offset, SymbolPrinter.Style.FULL_QUALIFIED))
+                .put("limit", SymbolPrinter.INSTANCE.printQualified(logicalPlan.limit))
+                .put("offset", SymbolPrinter.INSTANCE.printQualified(logicalPlan.offset))
                 .put("source", explainMap(logicalPlan.source, context)));
         }
 
@@ -176,7 +176,7 @@ public class ExplainLogicalPlan {
                 .put("right", explainMap(logicalPlan.rhs, context))
                 .put("joinType", logicalPlan.joinType())
                 .put("joinCondition",
-                    SymbolPrinter.INSTANCE.print(logicalPlan.joinCondition(), SymbolPrinter.Style.FULL_QUALIFIED)));
+                    SymbolPrinter.INSTANCE.printQualified(logicalPlan.joinCondition())));
         }
 
         @Override
@@ -186,7 +186,7 @@ public class ExplainLogicalPlan {
                 .put("right", explainMap(logicalPlan.rhs, context))
                 .put("joinType", logicalPlan.joinType())
                 .put("joinCondition",
-                    SymbolPrinter.INSTANCE.print(logicalPlan.joinCondition(), SymbolPrinter.Style.FULL_QUALIFIED)));
+                    SymbolPrinter.INSTANCE.printQualified(logicalPlan.joinCondition())));
         }
 
         @Override

--- a/sql/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
+++ b/sql/src/test/java/io/crate/expression/symbol/format/SymbolPrinterTest.java
@@ -84,20 +84,16 @@ public class SymbolPrinterTest extends CrateUnitTest {
     }
 
     private void assertPrint(Symbol s, String formatted) {
-        assertThat(printer.printFullQualified(s), is(formatted));
+        assertThat(printer.printQualified(s), is(formatted));
     }
 
     private void assertPrintStatic(Symbol s, String formatted) {
-        assertThat(SymbolPrinter.INSTANCE.printFullQualified(s), is(formatted));
+        assertThat(SymbolPrinter.INSTANCE.printQualified(s), is(formatted));
     }
 
     private void assertPrintIsParseable(String sql) {
-        assertPrintIsParseable(sql, SymbolPrinter.Style.NOT_QUALIFIED);
-    }
-
-    private void assertPrintIsParseable(String sql, SymbolPrinter.Style style) {
         Symbol symbol = sqlExpressions.asSymbol(sql);
-        String formatted = printer.print(symbol, style);
+        String formatted = printer.printUnqualified(symbol);
         Symbol formattedSymbol = sqlExpressions.asSymbol(formatted);
         assertThat(symbol, is(formattedSymbol));
     }
@@ -272,29 +268,29 @@ public class SymbolPrinterTest extends CrateUnitTest {
     @Test
     public void testFormatQualified() throws Exception {
         Symbol ref = sqlExpressions.asSymbol("doc.formatter.\"CraZy\"");
-        assertThat(printer.printFullQualified(ref), is("doc.formatter.\"CraZy\""));
-        assertThat(printer.printSimple(ref), is("\"CraZy\""));
+        assertThat(printer.printQualified(ref), is("doc.formatter.\"CraZy\""));
+        assertThat(printer.printUnqualified(ref), is("\"CraZy\""));
     }
 
     @Test
     public void testMaxDepthEllipsis() throws Exception {
         Symbol nestedFn = sqlExpressions.asSymbol("abs(sqrt(ln(1+1+1+1+1+1+1+1)))");
-        assertThat(printer.printSimple(nestedFn), is("1.442026886600883"));
+        assertThat(printer.printUnqualified(nestedFn), is("1.442026886600883"));
     }
 
     @Test
     public void testStyles() throws Exception {
         Symbol nestedFn = sqlExpressions.asSymbol("abs(sqrt(ln(bar+cast(\"select\" as long)+1+1+1+1+1+1)))");
-        assertThat(printer.print(nestedFn, SymbolPrinter.Style.FULL_QUALIFIED),
+        assertThat(printer.printQualified(nestedFn),
             is("abs(sqrt(ln((((((((doc.formatter.bar + cast(doc.formatter.\"select\" AS long)) + 1) + 1) + 1) + 1) + 1) + 1))))"));
-        assertThat(printer.print(nestedFn, SymbolPrinter.Style.NOT_QUALIFIED),
+        assertThat(printer.printUnqualified(nestedFn),
             is("abs(sqrt(ln((((((((bar + cast(\"select\" AS long)) + 1) + 1) + 1) + 1) + 1) + 1))))"));
     }
 
     @Test
     public void testFormatOperatorWithStaticInstance() throws Exception {
         Symbol comparisonOperator = sqlExpressions.asSymbol("bar = 1 and foo = 2");
-        String printed = SymbolPrinter.INSTANCE.printFullQualified(comparisonOperator);
+        String printed = SymbolPrinter.INSTANCE.printQualified(comparisonOperator);
         assertThat(
             printed,
             is("((doc.formatter.bar = 1) AND (doc.formatter.foo = '2'))")

--- a/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -327,9 +327,9 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
             if (plan instanceof Limit) {
                 Limit limit = (Limit) plan;
                 startLine("Limit[");
-                sb.append(symbolPrinter.printSimple(limit.limit));
+                sb.append(symbolPrinter.printUnqualified(limit.limit));
                 sb.append(';');
-                sb.append(symbolPrinter.printSimple(limit.offset));
+                sb.append(symbolPrinter.printUnqualified(limit.offset));
                 sb.append("]\n");
                 plan = limit.source;
             }
@@ -339,7 +339,7 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
                 OrderBy.explainRepresentation(
                     sb,
                     order.orderBy.orderBySymbols()
-                        .stream().map(s -> Literal.of(symbolPrinter.printSimple(s))).collect(Collectors.toList()),
+                        .stream().map(s -> Literal.of(symbolPrinter.printUnqualified(s))).collect(Collectors.toList()),
                     order.orderBy.reverseFlags(),
                     order.orderBy.nullsFirst());
                 sb.append("]\n");
@@ -430,7 +430,7 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
         private void addSymbolsList(Iterable<? extends Symbol> symbols) {
             StringJoiner commaJoiner = new StringJoiner(", ");
             for (Symbol symbol : symbols) {
-                commaJoiner.add(symbolPrinter.printSimple(symbol));
+                commaJoiner.add(symbolPrinter.printUnqualified(symbol));
             }
             sb.append(commaJoiner.toString());
         }
@@ -438,7 +438,7 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
 
     private static String printQueryClause(SymbolPrinter printer, QueryClause queryClause) {
         if (queryClause.hasQuery()) {
-            return printer.printSimple(queryClause.query());
+            return printer.printUnqualified(queryClause.query());
         } else if (queryClause.noMatch()) {
             return "None";
         } else {

--- a/sql/src/test/java/io/crate/testing/SQLPrinter.java
+++ b/sql/src/test/java/io/crate/testing/SQLPrinter.java
@@ -110,7 +110,7 @@ public class SQLPrinter {
     }
 
     /**
-     * produces same results as with {@link SymbolPrinter#printFullQualified(Symbol)} but is
+     * produces same results as with {@link SymbolPrinter#printQualified(Symbol)} but is
      * able to format other symbols that {@link SymbolPrinter} is not able to.
      */
     private static class TestingSymbolPrinter {
@@ -127,7 +127,7 @@ public class SQLPrinter {
         }
 
         public void process(Symbol symbol, StringBuilder sb) {
-            sb.append(SymbolPrinter.INSTANCE.printFullQualified(symbol));
+            sb.append(SymbolPrinter.INSTANCE.printQualified(symbol));
         }
 
         public void process(OrderBy orderBy, StringBuilder sb) {


### PR DESCRIPTION
We already expose `printQualified` and `printUnqualified`. Those cover
all functionality.