### PR TITLE
added custom metadata for views

### DIFF
--- a/enterprise/users/src/test/java/io/crate/metadata/CustomMetaDataTest.java
+++ b/enterprise/users/src/test/java/io/crate/metadata/CustomMetaDataTest.java
@@ -24,6 +24,8 @@ package io.crate.metadata;
 
 import io.crate.expression.udf.UserDefinedFunctionsMetaData;
 import io.crate.expression.udf.UserDefinedFunctionsMetaDataTest;
+import io.crate.metadata.view.ViewsMetaData;
+import io.crate.metadata.view.ViewsMetaDataTest;
 import io.crate.plugin.SQLPlugin;
 import org.elasticsearch.cluster.ClusterModule;
 import org.elasticsearch.cluster.metadata.MetaData;
@@ -62,6 +64,8 @@ public class CustomMetaDataTest {
                 UserDefinedFunctionsMetaDataTest.DUMMY_UDF_META_DATA)
             .putCustom(UsersPrivilegesMetaData.TYPE,
                 UsersPrivilegesMetaDataTest.createMetaData())
+            .putCustom(ViewsMetaData.TYPE,
+                ViewsMetaDataTest.createMetaData())
             .generateClusterUuidIfNeeded()
             .version(1L)
             .build();

--- a/sql/src/main/java/io/crate/expression/udf/UserDefinedFunctionsMetaData.java
+++ b/sql/src/main/java/io/crate/expression/udf/UserDefinedFunctionsMetaData.java
@@ -29,7 +29,6 @@ package io.crate.expression.udf;
 import com.google.common.annotations.VisibleForTesting;
 import io.crate.types.DataType;
 import org.elasticsearch.cluster.AbstractNamedDiffable;
-import org.elasticsearch.cluster.NamedDiff;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -61,10 +60,6 @@ public class UserDefinedFunctionsMetaData extends AbstractNamedDiffable<MetaData
     @VisibleForTesting
     public static UserDefinedFunctionsMetaData of(UserDefinedFunctionMetaData... functions) {
         return new UserDefinedFunctionsMetaData(Arrays.asList(functions));
-    }
-
-    public static NamedDiff<MetaData.Custom> readDiffFrom(StreamInput in) throws IOException {
-        return readDiffFrom(MetaData.Custom.class, TYPE, in);
     }
 
     public void add(UserDefinedFunctionMetaData function) {

--- a/sql/src/main/java/io/crate/metadata/view/View.java
+++ b/sql/src/main/java/io/crate/metadata/view/View.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.view;
+
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.io.stream.Writeable;
+
+import java.io.IOException;
+
+public class View implements Writeable {
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+
+    }
+}

--- a/sql/src/main/java/io/crate/metadata/view/ViewsMetaData.java
+++ b/sql/src/main/java/io/crate/metadata/view/ViewsMetaData.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.view;
+
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.cluster.AbstractNamedDiffable;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public class ViewsMetaData extends AbstractNamedDiffable<MetaData.Custom> implements MetaData.Custom {
+
+    public static final String TYPE = "views";
+    private final Map<String, String> queryByName;
+
+    ViewsMetaData(Map<String, String> queryByName) {
+        this.queryByName = queryByName;
+    }
+
+    public ViewsMetaData(StreamInput in) throws IOException {
+        int numUsers = in.readVInt();
+        queryByName = new HashMap<>(numUsers);
+        for (int i = 0; i < numUsers; i++) {
+            queryByName.put(in.readString(), in.readString());
+        }
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVInt(queryByName.size());
+        for (Map.Entry<String, String> view : queryByName.entrySet()) {
+            out.writeString(view.getKey());
+            out.writeString(view.getValue());
+        }
+    }
+
+    @Override
+    public EnumSet<MetaData.XContentContext> context() {
+        return EnumSet.of(MetaData.XContentContext.GATEWAY, MetaData.XContentContext.SNAPSHOT);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return TYPE;
+    }
+
+
+    /*
+     * ViewsMetaData XContent has the following structure:
+     *
+     * <pre>
+     *     {
+     *       "views": {
+     *         "docs.my_view": {
+     *           "stmt": "select x, y from t1 where z = 'a'"
+     *         }
+     *       }
+     *     }
+     * </pre>
+     *
+     * Where docs.my_view is the full qualified name of the view
+     * and the value of "stmt" is the analyzed SELECT statement.
+     */
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(TYPE);
+        for (Map.Entry<String, String> entry : queryByName.entrySet()) {
+            builder.startObject(entry.getKey());
+            {
+                builder.field("stmt", entry.getValue());
+            }
+            builder.endObject();
+        }
+        builder.endObject();
+        return builder;
+    }
+
+    public static ViewsMetaData fromXContent(XContentParser parser) throws IOException {
+        Map<String, String> views = new HashMap<>();
+
+        if (parser.nextToken() == XContentParser.Token.FIELD_NAME && parser.currentName().equals(TYPE)) {
+            if (parser.nextToken() == XContentParser.Token.START_OBJECT) {
+                while (parser.nextToken() == XContentParser.Token.FIELD_NAME) {
+                    String viewName = parser.currentName();
+                    if (parser.nextToken() == XContentParser.Token.START_OBJECT) {
+                        while (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+                            if ("stmt".equals(parser.currentName())) {
+                                parser.nextToken();
+                                views.put(viewName, parser.text());
+                            }
+                        }
+                    }
+                }
+            }
+            if (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+                // each custom metadata is packed inside an object.
+                // each custom must move the parser to the end otherwise possible following customs won't be read
+                throw new ElasticsearchParseException("failed to parse views, expected an object token at the end");
+            }
+        }
+        return new ViewsMetaData(views);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ViewsMetaData that = (ViewsMetaData) o;
+        return queryByName.equals(that.queryByName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(queryByName);
+    }
+
+}

--- a/sql/src/main/java/io/crate/plugin/SQLPlugin.java
+++ b/sql/src/main/java/io/crate/plugin/SQLPlugin.java
@@ -56,6 +56,7 @@ import io.crate.metadata.rule.ingest.IngestRulesMetaData;
 import io.crate.metadata.settings.AnalyzerSettings;
 import io.crate.metadata.settings.CrateSettings;
 import io.crate.metadata.sys.MetaDataSysModule;
+import io.crate.metadata.view.ViewsMetaData;
 import io.crate.monitor.MonitorModule;
 import io.crate.protocols.postgres.PostgresNetty;
 import io.crate.protocols.ssl.SslConfigSettings;
@@ -244,14 +245,24 @@ public class SQLPlugin extends Plugin implements ActionPlugin, MapperPlugin, Clu
             IngestRulesMetaData::new
         ));
         entries.add(new NamedWriteableRegistry.Entry(
+            MetaData.Custom.class,
+            ViewsMetaData.TYPE,
+            ViewsMetaData::new
+        ));
+        entries.add(new NamedWriteableRegistry.Entry(
             NamedDiff.class,
             UserDefinedFunctionsMetaData.TYPE,
-            UserDefinedFunctionsMetaData::readDiffFrom
+            in -> UserDefinedFunctionsMetaData.readDiffFrom(MetaData.Custom.class, UserDefinedFunctionsMetaData.TYPE, in)
         ));
         entries.add(new NamedWriteableRegistry.Entry(
             NamedDiff.class,
             IngestRulesMetaData.TYPE,
             in -> IngestRulesMetaData.readDiffFrom(MetaData.Custom.class, IngestRulesMetaData.TYPE, in)
+        ));
+        entries.add(new NamedWriteableRegistry.Entry(
+            NamedDiff.class,
+            ViewsMetaData.TYPE,
+            in -> ViewsMetaData.readDiffFrom(MetaData.Custom.class, ViewsMetaData.TYPE, in)
         ));
         if (userExtension != null) {
             entries.addAll(userExtension.getNamedWriteables());
@@ -271,6 +282,11 @@ public class SQLPlugin extends Plugin implements ActionPlugin, MapperPlugin, Clu
             MetaData.Custom.class,
             new ParseField(IngestRulesMetaData.TYPE),
             IngestRulesMetaData::fromXContent
+        ));
+        entries.add(new NamedXContentRegistry.Entry(
+            MetaData.Custom.class,
+            new ParseField(ViewsMetaData.TYPE),
+            ViewsMetaData::fromXContent
         ));
         if (userExtension != null) {
             entries.addAll(userExtension.getNamedXContent());

--- a/sql/src/test/java/io/crate/metadata/view/ViewsMetaDataTest.java
+++ b/sql/src/test/java/io/crate/metadata/view/ViewsMetaDataTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.view;
+
+import com.google.common.collect.ImmutableMap;
+import io.crate.test.integration.CrateUnitTest;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.hamcrest.core.IsNull.nullValue;
+
+public class ViewsMetaDataTest extends CrateUnitTest {
+
+    public static ViewsMetaData createMetaData() {
+        Map<String, String> map = ImmutableMap.<String, String>builder()
+            .put("doc.my_view", "SELECT x, y FROM t1 WHERE z = 'a'")
+            .put("my_schema.other_view", "SELECT a, b FROM t2 WHERE c = 1")
+            .build();
+        return new ViewsMetaData(map);
+    }
+
+    @Test
+    public void testViewsMetaDataStreaming() throws IOException {
+        ViewsMetaData views = createMetaData();
+        BytesStreamOutput out = new BytesStreamOutput();
+        views.writeTo(out);
+
+        StreamInput in = out.bytes().streamInput();
+        ViewsMetaData views2 = new ViewsMetaData(in);
+        assertEquals(views, views2);
+
+    }
+
+    @Test
+    public void testViewsMetaDataToXContent() throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+
+        // reflects the logic used to process custom metadata in the cluster state
+        builder.startObject();
+
+        ViewsMetaData views = createMetaData();
+        views.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
+
+        XContentParser parser = JsonXContent.jsonXContent.createParser(xContentRegistry(), builder.bytes());
+        parser.nextToken(); // start object
+        ViewsMetaData views2 = ViewsMetaData.fromXContent(parser);
+        assertEquals(views, views2);
+
+        // a metadata custom must consume the surrounded END_OBJECT token, no token must be left
+        assertThat(parser.nextToken(), nullValue());
+    }
+
+}


### PR DESCRIPTION
The ViewsMetaData contains the full qualified view name and the analyzed SELECT statement as string. For simpler extensibility of the XContent the view properties are stored as an OBJECT with the view name as the key of that object. Example:

```json
{
  "views": {
    "doc.myview": {
      "stmt": "SELECT a FROM t1 WHERE b = 1"
    }
  }
}
```
