### PR TITLE
Add FormatSpec to CountAggregation for proper symbol formatting

### DIFF
--- a/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -144,7 +144,7 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
                                 "        RootBoundary[1]\n" +
                                 "        MultiPhase[\n" +
                                 "            subQueries[\n" +
-                                "                RootBoundary[count()]\n" +
+                                "                RootBoundary[count(*)]\n" +
                                 "                Limit[1;0]\n" +
                                 "                Count[doc.t2 | All]\n" +
                                 "            ]\n" +


### PR DESCRIPTION
Instead of printing it as `count()` it will now be printed as `count(*)`

This is in preparation for `CREATE VIEW` for which we need to be able to
convert an `AnalyzedStatement` into a `String` that can be parsed again.