### PR TITLE
Fix NPE for SHOW CREATE TABLE with plain type index

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -112,6 +112,9 @@ Changes
 Fixes
 =====
 
+- Fixed a potential NPE when running `SHOW CREATE TABLE` with plain type
+  indices.
+
 - Fixed an issue that would cause queries ordered by a ``STRING`` scalar with 
   possible ``NULL`` values to get stuck.
 

--- a/sql/src/main/java/io/crate/analyze/MetaDataToASTNodeResolver.java
+++ b/sql/src/main/java/io/crate/analyze/MetaDataToASTNodeResolver.java
@@ -207,9 +207,8 @@ public class MetaDataToASTNodeResolver {
                         }
                         elements.add(new IndexDefinition(name, "fulltext", columns, properties));
                     } else if (indexRef.indexType().equals(Reference.IndexType.NOT_ANALYZED)) {
-                        elements.add(new IndexDefinition(name, "plain", columns, null));
+                        elements.add(new IndexDefinition(name, "plain", columns, GenericProperties.EMPTY));
                     }
-
                 }
             }
             return elements;

--- a/sql/src/test/java/io/crate/analyze/MetaDataToASTNodeResolverTest.java
+++ b/sql/src/test/java/io/crate/analyze/MetaDataToASTNodeResolverTest.java
@@ -393,7 +393,10 @@ public class MetaDataToASTNodeResolverTest extends CrateUnitTest {
                     ImmutableList.of(colA, colB), "english"))
             .put(new ColumnIdent("col_d_a_ft"),
                 new IndexReference(new ReferenceIdent(ident, "col_d_a_ft"), Reference.IndexType.ANALYZED,
-                    ImmutableList.of(colE), "custom_analyzer"));
+                    ImmutableList.of(colE), "custom_analyzer"))
+            .put(new ColumnIdent("col_a_col_b_plain"),
+                new IndexReference(new ReferenceIdent(ident, "col_a_col_b_plain"), Reference.IndexType.NOT_ANALYZED,
+                    ImmutableList.of(colA, colB), null));
 
         DocTableInfo tableInfo = new TestDocTableInfo(
             ident,
@@ -425,7 +428,8 @@ public class MetaDataToASTNodeResolverTest extends CrateUnitTest {
                      "   ),\n" +
                      "   INDEX \"col_d_a_ft\" USING FULLTEXT (\"col_d\"['a']) WITH (\n" +
                      "      analyzer = 'custom_analyzer'\n" +
-                     "   )\n" +
+                     "   ),\n" +
+                     "   INDEX \"col_a_col_b_plain\" USING PLAIN (\"col_a\", \"col_b\")\n" +
                      ")\n" +
                      "CLUSTERED INTO 5 SHARDS\n" +
                      "WITH (\n" +


### PR DESCRIPTION
This affects table indices defined like the following:
```
CREATE table t1 (f1 string, f2 string, INDEX bla using plain(f1,f2));
```

The `SHOW CREATE TABLE t1` would throw a NullPointerException.