### PR TITLE
Track the TIMESTAMP, BYTE and SHORT types in the sorting visitor.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -112,6 +112,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue where ordering by a ``TIMESTAMP`` scalar would cause the query
+  to get stuck.
+
 - Fixed a potential NPE when running `SHOW CREATE TABLE` with plain type
   indices.
 

--- a/sql/src/main/java/io/crate/execution/engine/sort/SortSymbolVisitor.java
+++ b/sql/src/main/java/io/crate/execution/engine/sort/SortSymbolVisitor.java
@@ -36,13 +36,16 @@ import io.crate.lucene.FieldTypeLookup;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
 import io.crate.metadata.doc.DocSysColumns;
+import io.crate.types.ByteType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import io.crate.types.DoubleType;
 import io.crate.types.FloatType;
 import io.crate.types.IntegerType;
 import io.crate.types.LongType;
+import io.crate.types.ShortType;
 import io.crate.types.StringType;
+import io.crate.types.TimestampType;
 import org.apache.lucene.search.FieldComparator;
 import org.apache.lucene.search.FieldComparatorSource;
 import org.apache.lucene.search.SortField;
@@ -230,6 +233,10 @@ public class SortSymbolVisitor extends SymbolVisitor<SortSymbolVisitor.SortSymbo
     private static Object missingObject(DataType dataType, Object missingValue, boolean reversed) {
         boolean min = sortMissingFirst(missingValue) ^ reversed;
         switch (dataType.id()) {
+            case ByteType.ID:
+                return min ? Byte.MIN_VALUE : Byte.MAX_VALUE;
+            case ShortType.ID:
+                return min ? Short.MIN_VALUE : Short.MAX_VALUE;
             case IntegerType.ID:
                 return min ? Integer.MIN_VALUE : Integer.MAX_VALUE;
             case LongType.ID:
@@ -238,6 +245,8 @@ public class SortSymbolVisitor extends SymbolVisitor<SortSymbolVisitor.SortSymbo
                 return min ? Float.NEGATIVE_INFINITY : Float.POSITIVE_INFINITY;
             case DoubleType.ID:
                 return min ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY;
+            case TimestampType.ID:
+                return min ? Long.MIN_VALUE : Long.MAX_VALUE;
             case StringType.ID:
                 return null;
             default:


### PR DESCRIPTION
Ordering by a scalar that returned ``timestamp`` would fail and cause the
query to get stuck because we were not expecting a timestamp type in the
order by.
This commit also adds the ``byte`` and ``short`` types in case we'll add
scalars that return these types.

<!--

Thanks for your contribution. Here is a quick checklist of things you should've done:

 - You've read CONTRIBUTING.rst and signed our CLA (https://crate.io/community/contribute/cla/)
 - Wrote a CHANGES.txt entry if this is a change that is relevant for users of CrateDB
 - Ran tests with `./gradlew test itest` (If they fail Jenkins will block this PR anyway)

-->
