### PR TITLE
Add parser support for INSERT with ON CONFLICT

### DIFF
--- a/sql-parser/src/main/antlr/SqlBase.g4
+++ b/sql-parser/src/main/antlr/SqlBase.g4
@@ -62,7 +62,7 @@ statement
         setGlobalAssignment (',' setGlobalAssignment)*                               #setGlobal
     | KILL (ALL | jobId=parameterOrString)                                           #kill
     | INSERT INTO table ('(' ident (',' ident)* ')')? insertSource
-        (ON DUPLICATE KEY UPDATE assignment (',' assignment)*)?                      #insert
+        (onDuplicate | onConflict)?                                                  #insert
     | RESTORE SNAPSHOT qname (ALL | TABLE tableWithPartitions) withProperties?       #restore
     | COPY tableWithPartition FROM path=expr withProperties?                         #copyFrom
     | COPY tableWithPartition columns? where?
@@ -385,6 +385,15 @@ insertSource
    | '(' query ')'
    ;
 
+onDuplicate
+   : ON DUPLICATE KEY UPDATE assignment (',' assignment)*
+   ;
+
+onConflict
+   : ON CONFLICT DO NOTHING
+   | ON CONFLICT DO UPDATE SET assignment (',' assignment)*
+   ;
+
 values
     : '(' expr (',' expr)* ')'
     ;
@@ -595,6 +604,7 @@ nonReserved
     | ISOLATION | TRANSACTION | CHARACTERISTICS | LEVEL | LANGUAGE | OPEN | CLOSE | RENAME
     | PRIVILEGES | SCHEMA | INGEST | RULE
     | REROUTE | MOVE | SHARD | ALLOCATE | REPLICA | CANCEL | CLUSTER | RETRY | FAILED
+    | DO | NOTHING | CONFLICT
     ;
 
 SELECT: 'SELECT';
@@ -770,6 +780,9 @@ DELETE: 'DELETE';
 UPDATE: 'UPDATE';
 KEY: 'KEY';
 DUPLICATE: 'DUPLICATE';
+CONFLICT: 'CONFLICT';
+DO: 'DO';
+NOTHING: 'NOTHING';
 SET: 'SET';
 RESET: 'RESET';
 DEFAULT: 'DEFAULT';

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -717,6 +717,16 @@ public class TestStatementBuilder {
         printStatement("insert into t (a, b) values (1, 2), (3, 4) on duplicate key update a = values (a) + 1, b = 4");
         printStatement("insert into t (a, b) values (1, 2), (3, 4) on duplicate key update a = values (a) + 1, b = values(b) - 2");
 
+        try {
+            printStatement("insert into t (a, b) values (1, 2) on conflict do nothing");
+        } catch (UnsupportedOperationException e) {
+            // this is what we want
+        }
+        printStatement("insert into t (a, b) values (1, 2) on conflict do update set a = a + 1");
+        printStatement("insert into t (a, b) values (1, 2) on conflict do update set a = a + 1, b = 3");
+        printStatement("insert into t (a, b) values (1, 2), (3, 4) on conflict do update set a = excluded.a + 1, b = 4");
+        printStatement("insert into t (a, b) values (1, 2), (3, 4) on conflict do update set a = excluded.a + 1, b = excluded.b - 2");
+
         InsertFromValues insert = (InsertFromValues) SqlParser.createStatement(
                 "insert into test_generated_column (id, ts) values (?, ?) on duplicate key update ts = ?");
         Assignment onDuplicateAssignment = insert.onDuplicateKeyAssignments().get(0);


### PR DESCRIPTION
This adds parser support for
```
INSERT INTO ... ON CONFLICT DO NOTHING
INSERT INTO ... ON CONFLICT DO UPDATE SET col = expr[, ...]
```

The second statement behaves just like
```
INSERT INTO ... ON DUPLICATE KEY UPDATE col = expr[, ...]
```