### PR TITLE
removed Iterable interface from SchemaInfo and use getTables() instead

### DIFF
--- a/sql/src/main/java/io/crate/analyze/CreateSnapshotAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateSnapshotAnalyzer.java
@@ -131,7 +131,7 @@ class CreateSnapshotAnalyzer {
                 ImmutableList.copyOf(snapshotIndices));
         } else {
             for (SchemaInfo schemaInfo : schemas) {
-                for (TableInfo tableInfo : schemaInfo) {
+                for (TableInfo tableInfo : schemaInfo.getTables()) {
                     // only check for user generated tables
                     if (tableInfo instanceof DocTableInfo) {
                         Operation.blockedRaiseException(tableInfo, Operation.READ);

--- a/sql/src/main/java/io/crate/execution/engine/collect/sources/CollectSourceResolver.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/sources/CollectSourceResolver.java
@@ -111,17 +111,17 @@ public class CollectSourceResolver {
         nodeDocCollectSources.put(SysClusterTableInfo.IDENT.fqn(), new ProjectorSetupCollectSource(singleRowSource, projectorFactory));
 
         ProjectorSetupCollectSource sysSource = new ProjectorSetupCollectSource(systemCollectSource, projectorFactory);
-        for (TableInfo tableInfo : sysSchemaInfo) {
+        for (TableInfo tableInfo : sysSchemaInfo.getTables()) {
             if (tableInfo.rowGranularity().equals(RowGranularity.DOC)) {
                 nodeDocCollectSources.put(tableInfo.ident().fqn(), sysSource);
             }
         }
         nodeDocCollectSources.put(SysNodesTableInfo.IDENT.fqn(), new ProjectorSetupCollectSource(nodeStatsCollectSource, projectorFactory));
 
-        for (TableInfo tableInfo : pgCatalogSchemaInfo) {
+        for (TableInfo tableInfo : pgCatalogSchemaInfo.getTables()) {
             nodeDocCollectSources.put(tableInfo.ident().fqn(), sysSource);
         }
-        for (TableInfo tableInfo : informationSchemaInfo) {
+        for (TableInfo tableInfo : informationSchemaInfo.getTables()) {
             nodeDocCollectSources.put(tableInfo.ident().fqn(), sysSource);
         }
 

--- a/sql/src/main/java/io/crate/execution/engine/collect/sources/InformationSchemaIterables.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/sources/InformationSchemaIterables.java
@@ -94,7 +94,7 @@ public class InformationSchemaIterables implements ClusterStateListener {
         this.schemas = schemas;
         this.fulltextAnalyzerResolver = fulltextAnalyzerResolver;
         tablesIterable = FluentIterable.from(schemas)
-            .transformAndConcat(schema -> FluentIterable.from(schema)
+            .transformAndConcat(schema -> FluentIterable.from(schema.getTables())
                 .filter(i -> !IndexParts.isPartitioned(i.ident().indexName())));
         partitionInfos = new PartitionInfos(clusterService);
         columnsIterable = tablesIterable.transformAndConcat(ColumnsIterable::new);

--- a/sql/src/main/java/io/crate/expression/reference/sys/check/cluster/NumberOfPartitionsSysCheck.java
+++ b/sql/src/main/java/io/crate/expression/reference/sys/check/cluster/NumberOfPartitionsSysCheck.java
@@ -59,7 +59,7 @@ public class NumberOfPartitionsSysCheck extends AbstractSysCheck {
     }
 
     boolean validateDocTablesPartitioning(SchemaInfo schemaInfo) {
-        for (TableInfo tableInfo : schemaInfo) {
+        for (TableInfo tableInfo : schemaInfo.getTables()) {
             DocTableInfo docTableInfo = (DocTableInfo) tableInfo;
             if (docTableInfo.isPartitioned() && docTableInfo.partitions().size() > PARTITIONS_THRESHOLD) {
                 return false;

--- a/sql/src/main/java/io/crate/metadata/doc/DocSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/doc/DocSchemaInfo.java
@@ -25,7 +25,6 @@ import com.carrotsearch.hppc.ObjectLookupContainer;
 import com.carrotsearch.hppc.cursors.ObjectCursor;
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Iterators;
 import io.crate.blob.v2.BlobIndex;
 import io.crate.exceptions.ResourceUnknownException;
 import io.crate.metadata.Functions;
@@ -140,7 +139,7 @@ public class DocSchemaInfo implements SchemaInfo {
     }
 
     @Override
-    public DocTableInfo getTableInfo(String name) {
+    public TableInfo getTableInfo(String name) {
         try {
             return docTableByName.computeIfAbsent(name, this::innerGetTableInfo);
         } catch (ResourceUnknownException e) {
@@ -292,8 +291,10 @@ public class DocSchemaInfo implements SchemaInfo {
     }
 
     @Override
-    public Iterator<TableInfo> iterator() {
-        return Iterators.transform(tableNames().iterator(), this::getTableInfo);
+    public Iterable<TableInfo> getTables() {
+        return tableNames().stream()
+            .map(this::getTableInfo)
+            ::iterator;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/metadata/information/InformationSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/information/InformationSchemaInfo.java
@@ -29,19 +29,16 @@ import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
 
-import javax.annotation.Nonnull;
-import java.util.Iterator;
-
 @Singleton
 public class InformationSchemaInfo implements SchemaInfo {
 
     public static final String NAME = "information_schema";
 
-    public final ImmutableMap<String, TableInfo> tableInfoMap;
+    private final ImmutableMap<String, TableInfo> tableInfoMap;
 
     @Inject
     public InformationSchemaInfo() {
-        this.tableInfoMap = ImmutableSortedMap.<String, TableInfo>naturalOrder()
+        tableInfoMap = ImmutableSortedMap.<String, TableInfo>naturalOrder()
             .put(InformationTablesTableInfo.NAME, new InformationTablesTableInfo())
             .put(InformationColumnsTableInfo.NAME, new InformationColumnsTableInfo())
             .put(InformationKeyColumnUsageTableInfo.NAME, new InformationKeyColumnUsageTableInfo())
@@ -70,9 +67,8 @@ public class InformationSchemaInfo implements SchemaInfo {
     }
 
     @Override
-    @Nonnull
-    public Iterator<TableInfo> iterator() {
-        return tableInfoMap.values().iterator();
+    public Iterable<TableInfo> getTables() {
+        return tableInfoMap.values();
     }
 
     @Override

--- a/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/pgcatalog/PgCatalogSchemaInfo.java
@@ -29,7 +29,6 @@ import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.common.inject.Inject;
 
 import javax.annotation.Nullable;
-import java.util.Iterator;
 
 public class PgCatalogSchemaInfo implements SchemaInfo {
 
@@ -38,7 +37,7 @@ public class PgCatalogSchemaInfo implements SchemaInfo {
 
     @Inject
     public PgCatalogSchemaInfo() {
-        this.tableInfoMap = ImmutableSortedMap.<String, TableInfo>naturalOrder()
+        tableInfoMap = ImmutableSortedMap.<String, TableInfo>naturalOrder()
             .put(PgTypeTable.IDENT.name(), new PgTypeTable())
             .build();
     }
@@ -63,8 +62,8 @@ public class PgCatalogSchemaInfo implements SchemaInfo {
     }
 
     @Override
-    public Iterator<TableInfo> iterator() {
-        return tableInfoMap.values().iterator();
+    public Iterable<TableInfo> getTables() {
+        return tableInfoMap.values();
     }
 
     @Override

--- a/sql/src/main/java/io/crate/metadata/sys/SysSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysSchemaInfo.java
@@ -27,9 +27,7 @@ import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
 
-import javax.annotation.Nonnull;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 
 @Singleton
@@ -73,9 +71,8 @@ public class SysSchemaInfo implements SchemaInfo {
     }
 
     @Override
-    @Nonnull
-    public Iterator<TableInfo> iterator() {
-        return tableInfos.values().iterator();
+    public Iterable<TableInfo> getTables() {
+        return tableInfos.values();
     }
 
     @Override

--- a/sql/src/main/java/io/crate/metadata/sys/TableHealthService.java
+++ b/sql/src/main/java/io/crate/metadata/sys/TableHealthService.java
@@ -109,7 +109,7 @@ public class TableHealthService extends AbstractComponent {
 
     private Iterable<TableHealth> allAsUnavailable() {
         return StreamSupport.stream(schemas.spliterator(), false)
-            .flatMap(schemaInfo -> StreamSupport.stream(schemaInfo.spliterator(), false))
+            .flatMap(schemaInfo -> StreamSupport.stream(schemaInfo.getTables().spliterator(), false))
             .flatMap(tableInfo -> {
                 if (tableInfo instanceof DocTableInfo) {
                     return healthFromPartitions(tableInfo.ident(), ((DocTableInfo) tableInfo).partitions().stream());

--- a/sql/src/main/java/io/crate/metadata/table/SchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/table/SchemaInfo.java
@@ -25,7 +25,7 @@ import org.elasticsearch.cluster.ClusterChangedEvent;
 
 import javax.annotation.Nullable;
 
-public interface SchemaInfo extends Iterable<TableInfo>, AutoCloseable {
+public interface SchemaInfo extends AutoCloseable {
 
     @Nullable
     TableInfo getTableInfo(String name);
@@ -38,4 +38,7 @@ public interface SchemaInfo extends Iterable<TableInfo>, AutoCloseable {
      * Called when cluster state and so the table definitions changes.
      */
     void update(ClusterChangedEvent event);
+
+    Iterable<TableInfo> getTables();
+
 }

--- a/sql/src/test/java/io/crate/expression/reference/sys/check/cluster/SysChecksTest.java
+++ b/sql/src/test/java/io/crate/expression/reference/sys/check/cluster/SysChecksTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.expression.reference.sys.check.cluster;
 
+import com.google.common.collect.ImmutableList;
 import io.crate.metadata.ClusterReferenceResolver;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.Schemas;
@@ -37,7 +38,6 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 
 import static org.hamcrest.core.Is.is;
@@ -48,7 +48,6 @@ public class SysChecksTest extends CrateUnitTest {
 
     private final ClusterService clusterService = mock(ClusterService.class);
     private final ClusterReferenceResolver referenceResolver = mock(ClusterReferenceResolver.class);
-    private final Iterator docSchemaInfoItr = mock(Iterator.class);
     private final SchemaInfo docSchemaInfo = mock(DocSchemaInfo.class);
     private final DocTableInfo docTableInfo = mock(DocTableInfo.class);
 
@@ -95,10 +94,8 @@ public class SysChecksTest extends CrateUnitTest {
         NumberOfPartitionsSysCheck numberOfPartitionsSysCheck = new NumberOfPartitionsSysCheck(
             mock(Schemas.class));
 
-        when(docSchemaInfo.iterator()).thenReturn(docSchemaInfoItr);
-        when(docSchemaInfoItr.hasNext()).thenReturn(true, true, false);
-        when(docSchemaInfoItr.next()).thenReturn(docTableInfo);
-        when(docTableInfo.isPartitioned()).thenReturn(true, true);
+        when(docSchemaInfo.getTables()).thenReturn(ImmutableList.of(docTableInfo, docTableInfo));
+        when(docTableInfo.isPartitioned()).thenReturn(true);
 
         List<PartitionName> partitionsFirst = buildPartitions(500);
         List<PartitionName> partitionsSecond = buildPartitions(100);
@@ -115,9 +112,7 @@ public class SysChecksTest extends CrateUnitTest {
         NumberOfPartitionsSysCheck numberOfPartitionsSysCheck = new NumberOfPartitionsSysCheck(mock(Schemas.class));
         List<PartitionName> partitions = buildPartitions(1001);
 
-        when(docSchemaInfo.iterator()).thenReturn(docSchemaInfoItr);
-        when(docSchemaInfoItr.hasNext()).thenReturn(true, false);
-        when(docSchemaInfoItr.next()).thenReturn(docTableInfo);
+        when(docSchemaInfo.getTables()).thenReturn(ImmutableList.of(docTableInfo));
         when(docTableInfo.isPartitioned()).thenReturn(true);
         when(docTableInfo.partitions()).thenReturn(partitions);
 

--- a/sql/src/test/java/io/crate/metadata/information/InformationTableInfoTest.java
+++ b/sql/src/test/java/io/crate/metadata/information/InformationTableInfoTest.java
@@ -42,7 +42,7 @@ public class InformationTableInfoTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testColumnsInAlphabeticalColumnOrder() throws Exception {
-        for (TableInfo tableInfo : informationSchemaInfo) {
+        for (TableInfo tableInfo : informationSchemaInfo.getTables()) {
             assertSortedColumns(tableInfo);
         }
     }

--- a/sql/src/test/java/io/crate/metadata/sys/SystemTableInfoTest.java
+++ b/sql/src/test/java/io/crate/metadata/sys/SystemTableInfoTest.java
@@ -42,7 +42,7 @@ public class SystemTableInfoTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testColumnsInAlphabeticalColumnOrder() throws Exception {
-        for (TableInfo tableInfo : sysSchemaInfo) {
+        for (TableInfo tableInfo : sysSchemaInfo.getTables()) {
             assertSortedColumns(tableInfo);
         }
     }


### PR DESCRIPTION
This change has been done in preparation for views, where the SchemaInfo may also provide a list of views, not only tables.
