### PR TITLE
Adapt process_test to ignore RelationUnknown

### DIFF
--- a/blackbox/docs/src/doc_tests/process_test.py
+++ b/blackbox/docs/src/doc_tests/process_test.py
@@ -370,7 +370,7 @@ class TestGracefulStopDuringQueryExecution(GracefulStopTest):
                 client.sql(
                     'delete from t1 where name like ?', (pattern,))
             except Exception as e:
-                if 'TableUnknownException' not in str(e):
+                if 'RelationUnknown' not in str(e):
                     errors.append(e)
         finished.wait()
 


### PR DESCRIPTION
Follow up to 435599c789ecb6a7c6823be33740509a235bf84b

Had only grepped for `Table.*unknown` instead of the full exception name :(