### PR TITLE
Add support for ON CONFLICT DO UPDATE SET with EXCLUDED table

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -60,6 +60,11 @@ Breaking Changes
 Changes
 =======
 
+- Added support for ``INSERT INTO ... ON CONFLICT DO UPDATE SET col = val``
+  which is identical to ``INSERT INTO ... ON DUPLICATE KEY UPDATE col = val``.
+  The special EXCLUDED table can be used to refer to the insert values:
+  ``INSERT INTO ... ON CONFLICT DO UPDATE SET col = EXCLUDED.col``
+
 - Added support for ``DEALLOCATE`` statement which is used by certain Postgres
   Wire Protocol clients (e.g. libpq) to deallocate a prepared statement and
   release its resources.

--- a/enterprise/mqtt/src/main/java/io/crate/mqtt/operations/MqttIngestService.java
+++ b/enterprise/mqtt/src/main/java/io/crate/mqtt/operations/MqttIngestService.java
@@ -108,12 +108,6 @@ public class MqttIngestService implements IngestRuleListener {
         this.inputFactory = new InputFactory(functions);
         this.expressionAnalysisContext = new ExpressionAnalysisContext();
         FieldProvider<Symbol> mqttSourceFieldsProvider = new FieldProvider<Symbol>() {
-
-            @Override
-            public Symbol resolveField(QualifiedName qualifiedName, Operation operation) {
-                return resolveField(qualifiedName, null, operation);
-            }
-
             @Override
             public Symbol resolveField(QualifiedName qualifiedName, @Nullable List<String> path, Operation operation) {
                 return new InputColumn(MQTT_FIELDS_ORDER.get(qualifiedName));

--- a/sql-parser/src/main/java/io/crate/sql/tree/Insert.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/Insert.java
@@ -29,14 +29,22 @@ public abstract class Insert extends Statement {
 
     protected final Table table;
 
+    public enum DuplicateKeyType {
+        ON_DUPLICATE_KEY_UPDATE,
+        ON_CONFLICT_DO_UPDATE_SET,
+        NONE
+    }
+
+    private final DuplicateKeyType duplicateKeyType;
     protected final List<Assignment> onDuplicateKeyAssignments;
     protected final List<String> columns;
 
 
-    Insert(Table table, List<String> columns, List<Assignment> onDuplicateKeyAssignments) {
+    Insert(Table table, List<String> columns, DuplicateKeyType duplicateKeyType, List<Assignment> onDuplicateKeyAssignments) {
         this.table = table;
-        this.onDuplicateKeyAssignments = onDuplicateKeyAssignments;
         this.columns = columns;
+        this.duplicateKeyType = duplicateKeyType;
+        this.onDuplicateKeyAssignments = onDuplicateKeyAssignments;
     }
 
     public Table table() {
@@ -45,6 +53,10 @@ public abstract class Insert extends Statement {
 
     public List<String> columns() {
         return columns;
+    }
+
+    public DuplicateKeyType getDuplicateKeyType() {
+        return duplicateKeyType;
     }
 
     public List<Assignment> onDuplicateKeyAssignments() {

--- a/sql-parser/src/main/java/io/crate/sql/tree/InsertFromSubquery.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/InsertFromSubquery.java
@@ -33,8 +33,9 @@ public class InsertFromSubquery extends Insert {
     public InsertFromSubquery(Table table,
                               Query subQuery,
                               List<String> columns,
+                              DuplicateKeyType duplicateKeyType,
                               List<Assignment> onDuplicateKeyAssignments) {
-        super(table, columns, onDuplicateKeyAssignments);
+        super(table, columns, duplicateKeyType, onDuplicateKeyAssignments);
         this.subQuery = subQuery;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/InsertFromValues.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/InsertFromValues.java
@@ -34,8 +34,9 @@ public class InsertFromValues extends Insert {
     public InsertFromValues(Table table,
                             List<ValuesList> valuesLists,
                             List<String> columns,
+                            DuplicateKeyType duplicateKeyType,
                             List<Assignment> onDuplicateKeyAssignments) {
-        super(table, columns, onDuplicateKeyAssignments);
+        super(table, columns, duplicateKeyType, onDuplicateKeyAssignments);
         this.valuesLists = valuesLists;
 
         int i = 0;

--- a/sql/src/main/java/io/crate/analyze/AlterUserAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/AlterUserAnalyzer.java
@@ -44,11 +44,6 @@ public class AlterUserAnalyzer {
 
     private static final FieldProvider fieldProvider = new FieldProvider() {
         @Override
-        public Symbol resolveField(QualifiedName qualifiedName, Operation operation) {
-            throw new UnsupportedOperationException("Cannot resolve field references");
-        }
-
-        @Override
         public Symbol resolveField(QualifiedName qualifiedName, @Nullable List path, Operation operation) {
             throw new UnsupportedOperationException("Cannot resolve field references");
         }

--- a/sql/src/main/java/io/crate/analyze/CreateUserAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/CreateUserAnalyzer.java
@@ -45,11 +45,6 @@ public class CreateUserAnalyzer {
 
     private static final FieldProvider fieldProvider = new FieldProvider() {
         @Override
-        public Symbol resolveField(QualifiedName qualifiedName, Operation operation) {
-            throw new UnsupportedOperationException("Cannot resolve field references");
-        }
-
-        @Override
         public Symbol resolveField(QualifiedName qualifiedName, @Nullable List path, Operation operation) {
             throw new UnsupportedOperationException("Cannot resolve field references");
         }

--- a/sql/src/main/java/io/crate/analyze/expressions/TableReferenceResolver.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/TableReferenceResolver.java
@@ -49,11 +49,6 @@ public class TableReferenceResolver implements FieldProvider<Reference> {
     }
 
     @Override
-    public Reference resolveField(QualifiedName qualifiedName, Operation operation) {
-        return resolveField(qualifiedName, null, operation);
-    }
-
-    @Override
     public Reference resolveField(QualifiedName qualifiedName, @Nullable List<String> path, Operation operation) {
         List<String> parts = qualifiedName.getParts();
         ColumnIdent columnIdent = new ColumnIdent(parts.get(parts.size() - 1), path);

--- a/sql/src/main/java/io/crate/analyze/relations/ExcludedFieldProvider.java
+++ b/sql/src/main/java/io/crate/analyze/relations/ExcludedFieldProvider.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.analyze.relations;
+
+import io.crate.analyze.ValuesAwareExpressionAnalyzer;
+import io.crate.expression.symbol.Field;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.table.Operation;
+import io.crate.sql.tree.QualifiedName;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+/**
+ * A wrapper for an existing FieldProvider (normally NamedFieldProvider) which
+ *
+ *  a) checks if a QualifiedName matches the excluded table
+ *  b) resolves the column name to Literal specified in the VALUES part of INSERT INTO
+ *
+ * Otherwise it just calls the wrapped field provider.
+ */
+public class ExcludedFieldProvider implements FieldProvider<Symbol> {
+
+    private ValuesAwareExpressionAnalyzer.ValuesResolver valuesResolver;
+    private FieldProvider fieldProvider;
+
+    public ExcludedFieldProvider(FieldProvider fieldProvider, ValuesAwareExpressionAnalyzer.ValuesResolver valuesResolver) {
+        this.fieldProvider = fieldProvider;
+        this.valuesResolver = valuesResolver;
+    }
+
+    @Override
+    public Symbol resolveField(QualifiedName qualifiedName, @Nullable List<String> path, Operation operation) {
+        List<String> parts = qualifiedName.getParts();
+        if (parts.size() == 2 && parts.get(0).equals("excluded")) {
+            String colName = parts.get(1);
+            Symbol symbol = fieldProvider.resolveField(new QualifiedName(colName), path, operation);
+            return valuesResolver.allocateAndResolve((Field) symbol);
+        }
+        return fieldProvider.resolveField(qualifiedName, path, operation);
+    }
+}

--- a/sql/src/main/java/io/crate/analyze/relations/FieldProvider.java
+++ b/sql/src/main/java/io/crate/analyze/relations/FieldProvider.java
@@ -30,7 +30,5 @@ import java.util.List;
 
 public interface FieldProvider<T extends Symbol> {
 
-    T resolveField(QualifiedName qualifiedName, Operation operation);
-
     T resolveField(QualifiedName qualifiedName, @Nullable List<String> path, Operation operation);
 }

--- a/sql/src/main/java/io/crate/analyze/relations/FullQualifiedNameFieldProvider.java
+++ b/sql/src/main/java/io/crate/analyze/relations/FullQualifiedNameFieldProvider.java
@@ -58,10 +58,12 @@ public class FullQualifiedNameFieldProvider implements FieldProvider<Field> {
         this.defaultSchema = Objects.requireNonNull(defaultSchema, "Default schema must not be null");
     }
 
+    @Override
     public Field resolveField(QualifiedName qualifiedName, Operation operation) {
         return resolveField(qualifiedName, null, operation);
     }
 
+    @Override
     public Field resolveField(QualifiedName qualifiedName, @Nullable List<String> path, Operation operation) {
         List<String> parts = qualifiedName.getParts();
         String columnSchema = null;

--- a/sql/src/main/java/io/crate/analyze/relations/FullQualifiedNameFieldProvider.java
+++ b/sql/src/main/java/io/crate/analyze/relations/FullQualifiedNameFieldProvider.java
@@ -59,11 +59,6 @@ public class FullQualifiedNameFieldProvider implements FieldProvider<Field> {
     }
 
     @Override
-    public Field resolveField(QualifiedName qualifiedName, Operation operation) {
-        return resolveField(qualifiedName, null, operation);
-    }
-
-    @Override
     public Field resolveField(QualifiedName qualifiedName, @Nullable List<String> path, Operation operation) {
         List<String> parts = qualifiedName.getParts();
         String columnSchema = null;

--- a/sql/src/main/java/io/crate/analyze/relations/NameFieldProvider.java
+++ b/sql/src/main/java/io/crate/analyze/relations/NameFieldProvider.java
@@ -21,8 +21,8 @@
 
 package io.crate.analyze.relations;
 
-import io.crate.expression.symbol.Field;
 import io.crate.exceptions.ColumnUnknownException;
+import io.crate.expression.symbol.Field;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.TableIdent;
 import io.crate.metadata.table.Operation;

--- a/sql/src/main/java/io/crate/analyze/relations/NameFieldProvider.java
+++ b/sql/src/main/java/io/crate/analyze/relations/NameFieldProvider.java
@@ -45,10 +45,12 @@ public class NameFieldProvider implements FieldProvider<Field> {
         this.relation = relation;
     }
 
+    @Override
     public Field resolveField(QualifiedName qualifiedName, Operation operation) {
         return resolveField(qualifiedName, null, operation);
     }
 
+    @Override
     public Field resolveField(QualifiedName qualifiedName, @Nullable List<String> path, Operation operation) {
         List<String> parts = qualifiedName.getParts();
         ColumnIdent columnIdent = new ColumnIdent(parts.get(parts.size() - 1), path);

--- a/sql/src/main/java/io/crate/analyze/relations/NameFieldProvider.java
+++ b/sql/src/main/java/io/crate/analyze/relations/NameFieldProvider.java
@@ -46,11 +46,6 @@ public class NameFieldProvider implements FieldProvider<Field> {
     }
 
     @Override
-    public Field resolveField(QualifiedName qualifiedName, Operation operation) {
-        return resolveField(qualifiedName, null, operation);
-    }
-
-    @Override
     public Field resolveField(QualifiedName qualifiedName, @Nullable List<String> path, Operation operation) {
         List<String> parts = qualifiedName.getParts();
         ColumnIdent columnIdent = new ColumnIdent(parts.get(parts.size() - 1), path);

--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -690,11 +690,6 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
             statementContext.convertParamFunction(),
             new FieldProvider() {
                 @Override
-                public Symbol resolveField(QualifiedName qualifiedName, Operation operation) {
-                    throw new UnsupportedOperationException("Can only resolve literals");
-                }
-
-                @Override
                 public Symbol resolveField(QualifiedName qualifiedName, @Nullable List path, Operation operation) {
                     throw new UnsupportedOperationException("Can only resolve literals");
                 }

--- a/sql/src/test/java/io/crate/analyze/relations/FieldProviderTest.java
+++ b/sql/src/test/java/io/crate/analyze/relations/FieldProviderTest.java
@@ -60,7 +60,7 @@ public class FieldProviderTest extends CrateUnitTest {
         AnalyzedRelation relation = new DummyRelation("name");
         FieldProvider<Field> resolver = newFQFieldProvider(
             ImmutableMap.of(newQN("too.many.parts"), relation));
-        resolver.resolveField(newQN("name"), Operation.READ);
+        resolver.resolveField(newQN("name"), null, Operation.READ);
     }
 
     @Test
@@ -68,7 +68,7 @@ public class FieldProviderTest extends CrateUnitTest {
         expectedException.expect(RelationUnknown.class);
         expectedException.expectMessage("Relation 'invalid.table' unknown");
         FieldProvider<Field> resolver = newFQFieldProvider(dummySources);
-        resolver.resolveField(newQN("invalid.table.name"), Operation.READ);
+        resolver.resolveField(newQN("invalid.table.name"), null, Operation.READ);
     }
 
     @Test
@@ -76,7 +76,7 @@ public class FieldProviderTest extends CrateUnitTest {
         expectedException.expect(RelationUnknown.class);
         expectedException.expectMessage("Relation 'dummy.invalid' unknown");
         FieldProvider<Field> resolver = newFQFieldProvider(dummySources);
-        resolver.resolveField(newQN("dummy.invalid.name"), Operation.READ);
+        resolver.resolveField(newQN("dummy.invalid.name"), null, Operation.READ);
     }
 
     @Test
@@ -85,14 +85,14 @@ public class FieldProviderTest extends CrateUnitTest {
         expectedException.expectMessage("Relation 'sys.nodes' unknown");
         FieldProvider<Field> resolver = newFQFieldProvider(dummySources);
 
-        resolver.resolveField(newQN("sys.nodes.name"), Operation.READ);
+        resolver.resolveField(newQN("sys.nodes.name"), null, Operation.READ);
     }
 
     @Test
     public void testRegularColumnUnknown() throws Exception {
         expectedException.expect(ColumnUnknownException.class);
         FieldProvider<Field> resolver = newFQFieldProvider(dummySources);
-        resolver.resolveField(newQN("age"), Operation.READ);
+        resolver.resolveField(newQN("age"), null, Operation.READ);
     }
 
     @Test
@@ -101,7 +101,7 @@ public class FieldProviderTest extends CrateUnitTest {
         expectedException.expectMessage("Column age unknown");
         AnalyzedRelation barT = new DummyRelation("name");
         FieldProvider<Field> resolver = newFQFieldProvider(ImmutableMap.of(newQN("bar.t"), barT));
-        resolver.resolveField(newQN("t.age"), Operation.READ);
+        resolver.resolveField(newQN("t.age"), null, Operation.READ);
     }
 
     @Test
@@ -116,14 +116,14 @@ public class FieldProviderTest extends CrateUnitTest {
             newQN("foo.t"), fooT,
             newQN("foo.a"), fooA,
             newQN("custom.t"), customT));
-        Field field = resolver.resolveField(newQN("foo.t.name"), Operation.READ);
+        Field field = resolver.resolveField(newQN("foo.t.name"), null, Operation.READ);
         assertThat(field.relation(), equalTo(fooT));
 
         // reference > dynamicReference - not ambiguous
-        Field tags = resolver.resolveField(newQN("tags"), Operation.READ);
+        Field tags = resolver.resolveField(newQN("tags"), null, Operation.READ);
         assertThat(tags.relation(), equalTo(customT));
 
-        field = resolver.resolveField(newQN("a.name"), Operation.READ);
+        field = resolver.resolveField(newQN("a.name"), null, Operation.READ);
         assertThat(field.relation(), equalTo(fooA));
     }
 
@@ -133,7 +133,7 @@ public class FieldProviderTest extends CrateUnitTest {
         AnalyzedRelation relation = new DummyRelation("name");
         FieldProvider<Field> resolver = newFQFieldProvider(ImmutableMap.of(
             new QualifiedName(Arrays.asList("t")), relation));
-        Field field = resolver.resolveField(newQN("t.name"), Operation.READ);
+        Field field = resolver.resolveField(newQN("t.name"), null, Operation.READ);
         assertThat(field.relation(), equalTo(relation));
         assertThat(field.path().outputName(), is("name"));
     }
@@ -143,7 +143,7 @@ public class FieldProviderTest extends CrateUnitTest {
         // select name from t
         AnalyzedRelation relation = new DummyRelation("name");
         FieldProvider<Field> resolver = newFQFieldProvider(ImmutableMap.of(newQN("doc.t"), relation));
-        Field field = resolver.resolveField(newQN("name"), Operation.READ);
+        Field field = resolver.resolveField(newQN("name"), null, Operation.READ);
         assertThat(field.relation(), equalTo(relation));
         assertThat(field.path().outputName(), is("name"));
     }
@@ -154,7 +154,7 @@ public class FieldProviderTest extends CrateUnitTest {
 
         AnalyzedRelation relation = new DummyRelation("name");
         FieldProvider<Field> resolver = newFQFieldProvider(ImmutableMap.of(newQN("doc.t"), relation));
-        Field field = resolver.resolveField(newQN("doc.t.name"), Operation.INSERT);
+        Field field = resolver.resolveField(newQN("doc.t.name"), null, Operation.INSERT);
         assertThat(field.relation(), equalTo(relation));
         assertThat(field.path().outputName(), is("name"));
     }
@@ -163,7 +163,7 @@ public class FieldProviderTest extends CrateUnitTest {
     public void testTooManyParts() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
         FieldProvider<Field> resolver = newFQFieldProvider(dummySources);
-        resolver.resolveField(new QualifiedName(Arrays.asList("a", "b", "c", "d")), Operation.READ);
+        resolver.resolveField(new QualifiedName(Arrays.asList("a", "b", "c", "d")), null, Operation.READ);
     }
 
     @Test
@@ -171,7 +171,7 @@ public class FieldProviderTest extends CrateUnitTest {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Column reference \"a.b\" has too many parts. A column must not have a schema or a table here.");
         FieldProvider<Field> resolver = new NameFieldProvider(dummyRelation);
-        resolver.resolveField(new QualifiedName(Arrays.asList("a", "b")), Operation.READ);
+        resolver.resolveField(new QualifiedName(Arrays.asList("a", "b")), null, Operation.READ);
     }
 
     @Test
@@ -185,7 +185,7 @@ public class FieldProviderTest extends CrateUnitTest {
                 new QualifiedName(Arrays.asList("custom", "t")), new DummyRelation("name"),
                 new QualifiedName(Arrays.asList("doc", "t")), new DummyRelation("name"))
         );
-        resolver.resolveField(new QualifiedName(Arrays.asList("t", "name")), Operation.READ);
+        resolver.resolveField(new QualifiedName(Arrays.asList("t", "name")), null, Operation.READ);
     }
 
     @Test
@@ -196,7 +196,7 @@ public class FieldProviderTest extends CrateUnitTest {
                 new QualifiedName(Arrays.asList("custom", "t")), new DummyRelation("address"),
                 new QualifiedName(Arrays.asList("doc", "t")), new DummyRelation("name"))
         );
-        resolver.resolveField(new QualifiedName(Arrays.asList("t", "name")), Operation.READ);
+        resolver.resolveField(new QualifiedName(Arrays.asList("t", "name")), null, Operation.READ);
     }
 
     @Test
@@ -204,7 +204,7 @@ public class FieldProviderTest extends CrateUnitTest {
         // select name from doc.t
         AnalyzedRelation relation = new DummyRelation("name");
         FieldProvider<Field> resolver = new NameFieldProvider(relation);
-        Field field = resolver.resolveField(new QualifiedName(Arrays.asList("name")), Operation.READ);
+        Field field = resolver.resolveField(new QualifiedName(Arrays.asList("name")), null, Operation.READ);
         assertThat(field.relation(), equalTo(relation));
     }
 
@@ -214,7 +214,7 @@ public class FieldProviderTest extends CrateUnitTest {
         expectedException.expectMessage("Column unknown unknown");
         AnalyzedRelation relation = new DummyRelation("name");
         FieldProvider<Field> resolver = newFQFieldProvider(ImmutableMap.of(newQN("doc.t"), relation));
-        resolver.resolveField(new QualifiedName(Arrays.asList("unknown")), Operation.READ);
+        resolver.resolveField(new QualifiedName(Arrays.asList("unknown")), null, Operation.READ);
     }
 
     @Test
@@ -222,7 +222,7 @@ public class FieldProviderTest extends CrateUnitTest {
         AnalyzedRelation barT = new DummyRelation("\"Name\"");
 
         FieldProvider<Field> resolver = newFQFieldProvider(ImmutableMap.of(newQN("\"Bar\""), barT));
-        Field field = resolver.resolveField(newQN("\"Foo\".\"Bar\".\"Name\""), Operation.READ);
+        Field field = resolver.resolveField(newQN("\"Foo\".\"Bar\".\"Name\""), null, Operation.READ);
         assertThat(field.relation(), equalTo(barT));
     }
 
@@ -232,7 +232,7 @@ public class FieldProviderTest extends CrateUnitTest {
         expectedException.expectMessage("Column name unknown");
         AnalyzedRelation barT = new DummyRelation("\"Name\"");
         FieldProvider<Field> resolver = newFQFieldProvider(ImmutableMap.of(newQN("bar"), barT));
-        resolver.resolveField(newQN("bar.name"), Operation.READ);
+        resolver.resolveField(newQN("bar.name"), null, Operation.READ);
     }
 
     @Test
@@ -240,7 +240,7 @@ public class FieldProviderTest extends CrateUnitTest {
         AnalyzedRelation barT = new DummyRelation("name");
 
         FieldProvider<Field> resolver = newFQFieldProvider(ImmutableMap.of(newQN("\"Bar\""), barT));
-        Field field = resolver.resolveField(newQN("\"Bar\".name"), Operation.READ);
+        Field field = resolver.resolveField(newQN("\"Bar\".name"), null, Operation.READ);
         assertThat(field.relation(), equalTo(barT));
     }
 
@@ -250,6 +250,6 @@ public class FieldProviderTest extends CrateUnitTest {
         expectedException.expectMessage("Relation 'doc.\"Bar\"' unknown");
         AnalyzedRelation barT = new DummyRelation("name");
         FieldProvider<Field> resolver = newFQFieldProvider(ImmutableMap.of(newQN("bar"), barT));
-        resolver.resolveField(newQN("\"Bar\".name"), Operation.READ);
+        resolver.resolveField(newQN("\"Bar\".name"), null, Operation.READ);
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/IngestionServiceIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/IngestionServiceIntegrationTest.java
@@ -79,12 +79,6 @@ public class IngestionServiceIntegrationTest extends SQLTransportIntegrationTest
         private AtomicReference<Set<Tuple<Predicate<Row>, IngestRule>>> predicateAndIngestRulesReference;
         private final ExpressionAnalysisContext expressionAnalysisContext;
         private FieldProvider<Symbol> inputColumnProvider = new FieldProvider<Symbol>() {
-
-            @Override
-            public Symbol resolveField(QualifiedName qualifiedName, Operation operation) {
-                return resolveField(qualifiedName, null, operation);
-            }
-
             @Override
             public Symbol resolveField(QualifiedName qualifiedName, @Nullable List<String> path, Operation operation) {
                 return new InputColumn(0);


### PR DESCRIPTION
This adds support for insert queries containing ON CONFLICT DO UPDATE SET
expressions with EXCLUDED table references. Tests verify identical semantics as
the ON DUPLICATE KEY statement.

Examples:

```
CREATE TABLE t1 (id int primary key, other string);
INSERT INTO t1 (id, other) values (id, 'str');

-- Set other to 'backing up' on duplicate key 1
INSERT into t1 (id, other) VALUES (1, 'test')
  ON CONFLICT DO UPDATE SET other = 'backing up';

-- which is identical to
INSERT into t1 (id, other) VALUES (1, 'test')
  ON DUPLICATE KEY UPDATE other = 'backing up';

-- Overwrite other with 'test'
INSERT into t1 (id, other) VALUES (1, 'test')
  ON CONFLICT DO UPDATE SET other = excluded.other;

-- which is identical to
INSERT into t1 (id, other) VALUES (1, 'test')
  ON DUPLICATE KEY SET other = values(other);
```

<!--

Thanks for your contribution. Here is a quick checklist of things you should've done:

 - You've read CONTRIBUTING.rst and signed our CLA (https://crate.io/community/contribute/cla/)
 - Wrote a CHANGES.txt entry if this is a change that is relevant for users of CrateDB
 - Ran tests with `./gradlew test itest` (If they fail Jenkins will block this PR anyway)

-->
