### PR TITLE
Fixed ClassCastException in describe() of BatchPortal.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -122,3 +122,6 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that would cause a ClassCastException to be thrown instead of
+  BatchUpdateException with a descriptive message, when using batched prepared
+  statements with ``SELECT`` queries.

--- a/sql/src/main/java/io/crate/protocols/postgres/BatchPortal.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/BatchPortal.java
@@ -130,11 +130,11 @@ class BatchPortal extends AbstractPortal {
 
     @Override
     public List<Field> describe() {
-        AnalyzedStatement lastAnalyzedStatement = analyzedStatements.get(analyzedStatements.size() - 1);
+        AnalyzedStatement lastAnalyzedStatement = getLastAnalyzedStatement();
         if (lastAnalyzedStatement instanceof AnalyzedRelation == false) {
             return null;
         }
-        List<Field> fields = ((AnalyzedRelation) analyzedStatements).fields();
+        List<Field> fields = ((AnalyzedRelation) lastAnalyzedStatement).fields();
         outputTypes.add(Symbols.typeView(fields));
         return fields;
     }


### PR DESCRIPTION
The issue was discovered by new crate-qa test:
https://github.com/crate/crate-qa/pull/51/files#diff-4ebb99449d934c2947c0fbc26ced5d93
