### PR TITLE
do not allow renaming  a table when connected to a read-only node

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -122,6 +122,8 @@ Changes
 Fixes
 =====
 
+- Do not allow renaming a table when connected to a read-only node.
+
 - Fixed an issue that would cause a ClassCastException to be thrown instead of
   BatchUpdateException with a descriptive message, when using batched prepared
   statements with ``SELECT`` queries.

--- a/sql/src/main/java/io/crate/analyze/AlterTableRenameAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/AlterTableRenameAnalyzedStatement.java
@@ -50,6 +50,6 @@ public class AlterTableRenameAnalyzedStatement implements DDLStatement {
 
     @Override
     public boolean isWriteOperation() {
-        return false;
+        return true;
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/ReadOnlyNodeIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ReadOnlyNodeIntegrationTest.java
@@ -244,6 +244,11 @@ public class ReadOnlyNodeIntegrationTest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    public void testForbiddenAlterTableRename() throws Exception {
+        assertReadOnly("ALTER TABLE write_test RENAME TO write_test_new");
+    }
+
+    @Test
     public void testForbiddenSetGlobal() throws Exception {
         assertReadOnly("set global PERSISTENT stats.enabled = false");
     }


### PR DESCRIPTION
fixes #7068 