### PR TITLE
Make type guessing for arrays more lenient

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -60,6 +60,10 @@ Breaking Changes
 Changes
 =======
 
+- Arrays can now contain mixed types if they're safely convertible. JSON
+  libraries tend to encode values like ``[ 0.0, 1.2]`` as ``[ 0, 1.2 ]``, this
+  caused an error because of the strict type match we enforced before.
+
 - Added support for ``INSERT INTO ... ON CONFLICT DO UPDATE SET col = val``
   which is identical to ``INSERT INTO ... ON DUPLICATE KEY UPDATE col = val``.
   The special EXCLUDED table can be used to refer to the insert values:

--- a/core/src/main/java/io/crate/types/DataTypes.java
+++ b/core/src/main/java/io/crate/types/DataTypes.java
@@ -155,6 +155,18 @@ public final class DataTypes {
         .put(SingleColumnTableType.ID, ImmutableSet.of()) // convertability handled in SingleColumnTableType
         .build();
 
+    /**
+     * Contains number conversions which are "safe" (= a conversion would not reduce the number of bytes
+     * used to store the value)
+     */
+    private static final ImmutableMap<Integer, Set<DataType>> SAFE_CONVERSIONS = ImmutableMap.<Integer, Set<DataType>>builder()
+        .put(BYTE.id(), ImmutableSet.of(SHORT, INTEGER, LONG, TIMESTAMP, FLOAT, DOUBLE))
+        .put(SHORT.id(), ImmutableSet.of(INTEGER, LONG, TIMESTAMP, FLOAT, DOUBLE))
+        .put(INTEGER.id(), ImmutableSet.of(LONG, TIMESTAMP, FLOAT, DOUBLE))
+        .put(LONG.id(), ImmutableSet.of(TIMESTAMP, DOUBLE))
+        .put(FLOAT.id(), ImmutableSet.of(DOUBLE))
+        .build();
+
     public static boolean isCollectionType(DataType type) {
         return type.id() == ArrayType.ID || type.id() == SetType.ID || type.id() == SingleColumnTableType.ID;
     }
@@ -215,22 +227,40 @@ public final class DataTypes {
     }
 
     private static DataType valueFromList(List<Object> value) {
-        DataType previous = null;
-        DataType current = null;
+        DataType highest = DataTypes.UNDEFINED;
         for (Object o : value) {
             if (o == null) {
                 continue;
             }
-            current = guessType(o);
-            if (previous != null && !current.equals(previous)) {
-                throw new IllegalArgumentException("Mixed dataTypes inside a list are not supported");
+            DataType current = guessType(o);
+            // JSON libraries tend to optimize things like [ 0.0, 1.2 ] to [ 0, 1.2 ]; so we allow mixed types
+            // in such cases.
+            if (!current.equals(highest) && !safeConversionPossible(current, highest)) {
+                throw new IllegalArgumentException(
+                    "Mixed dataTypes inside a list are not supported. Found " + highest + " and " + current);
             }
-            previous = current;
+            if (current.precedes(highest)) {
+                highest = current;
+            }
         }
-        if (current == null) {
-            return new ArrayType(UNDEFINED);
+        return new ArrayType(highest);
+    }
+
+    private static boolean safeConversionPossible(DataType type1, DataType type2) {
+        final DataType source;
+        final DataType target;
+        if (type1.precedes(type2)) {
+            source = type2;
+            target = type1;
+        } else {
+            source = type1;
+            target = type2;
         }
-        return new ArrayType(current);
+        if (source.id() == DataTypes.UNDEFINED.id()) {
+            return true;
+        }
+        Set<DataType> conversions = SAFE_CONVERSIONS.get(source.id());
+        return conversions != null && conversions.contains(target);
     }
 
     private static final ImmutableMap<String, DataType> staticTypesNameMap = ImmutableMap.<String, DataType>builder()

--- a/core/src/test/java/io/crate/DataTypeTest.java
+++ b/core/src/test/java/io/crate/DataTypeTest.java
@@ -28,9 +28,11 @@ import io.crate.types.DataTypes;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -119,6 +121,14 @@ public class DataTypeTest extends CrateUnitTest {
     public void testForValueMixedDataTypeInList() {
         List<Object> objects = Arrays.<Object>asList("foo", 1);
         DataTypes.guessType(objects);
+    }
+
+    @Test
+    public void testListCanContainMixedTypeIfSafeCastIsPossible() {
+        List<Object> objects = Arrays.asList(1, null, 1.2f, 0);
+        Collections.shuffle(objects);
+        DataType<?> dataType = DataTypes.guessType(objects);
+        assertThat(dataType, Matchers.is(new ArrayType(DataTypes.FLOAT)));
     }
 
     @Test

--- a/core/src/test/java/io/crate/types/DataTypesTest.java
+++ b/core/src/test/java/io/crate/types/DataTypesTest.java
@@ -27,7 +27,11 @@ import io.crate.test.integration.CrateUnitTest;
 import org.apache.lucene.util.BytesRef;
 import org.junit.Test;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 import static org.apache.commons.lang3.ObjectUtils.firstNonNull;
 import static org.hamcrest.Matchers.instanceOf;


### PR DESCRIPTION
Some JSON libraries encode `[ 0.0, 1.2 ]` as `[ 0, 1.2 ]` which resulted
in a `Mixed dataTypes inside a list are not supported` error.

This changes the logic to be a bit more lenient and allow casts that are
known to be safe and not cause runtime errors.