### PR TITLE
Add support for ON CONFLICT DO NOTHING 

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -73,6 +73,9 @@ Changes
   ``information_schema.views`` and they show up in
   ``information_schema.tables`` as well as ``information_schema.columns``
 
+- Added support for ``INSERT INTO ... ON CONFLICT DO NOTHING``. The statement
+  ignores insert values which would cause duplicate keys.
+
 - Arrays can now contain mixed types if they're safely convertible. JSON
   libraries tend to encode values like ``[ 0.0, 1.2]`` as ``[ 0, 1.2 ]``, this
   caused an error because of the strict type match we enforced before.

--- a/blackbox/docs/sql/statements/insert.rst
+++ b/blackbox/docs/sql/statements/insert.rst
@@ -22,9 +22,9 @@ Synopsis
     INSERT INTO table_ident
       [ ( column_ident [, ...] ) ]
       { VALUES ( expression [, ...] ) [, ...] | ( query ) | query }
-      [ ON CONFLICT (column_ident [, ...])
-          DO UPDATE SET { column_ident = expression } [, ...] |
-        ON DUPLICATE KEY UPDATE { column_ident = expression } [, ...]]
+      [ ON CONFLICT (column_ident [, ...]) DO UPDATE SET { column_ident = expression [, ...] } |
+        ON CONFLICT [ ( column_ident [, ...] ) ] DO NOTHING |
+        ON DUPLICATE KEY UPDATE { column_ident = expression [, ...] } ]
 
 Description
 ===========
@@ -74,7 +74,7 @@ of the current row can be referenced.
 
 ``ON CONFLICT DO UPDATE SET`` works just like ``ON DUPLICATE KEY UPDATE``, but
 its syntax is slightly different. Additionally, it requires to specify the key
-columns to perform the duplicate key check against.
+columns (conflict target) to perform the duplicate key check against.
 
 ::
 
@@ -91,6 +91,35 @@ statement values. For example:
 
 The above statement would update ``col2`` to ``42`` if ``col1`` was a primary
 key and the value ``1`` already existed for ``col1``.
+
+``ON CONFLICT DO NOTHING``
+--------------------------
+
+When ``ON CONFLICT DO NOTHING`` is specified, rows which caused a duplicate
+key conflict will not be inserted. No exception will be thrown. For example:
+
+::
+
+     INSERT INTO t (col1, col2) VALUES (1, 42)
+     ON CONFLICT DO NOTHING
+
+In the above statement, if ``col1`` had a primary key constraint and the value
+``1`` already existed for ``col1``, no insert would be performed. The conflict
+target after ``ON CONFLICT`` is optional.
+
+``ON CONFLICT DO NOTHING``
+--------------------------
+
+When ``ON CONFLICT DO NOTHING`` is specified, rows which caused a duplicate
+key conflict will not be inserted. No exception will be thrown. For example:
+
+::
+
+     INSERT INTO t (col1, col2) VALUES (1, 42)
+     ON CONFLICT DO NOTHING
+
+In the above statement, if ``col1`` had a primary key constraint and the value
+``1`` already existed for ``col1``, no insert would be performed.
 
 Insert From Dynamic Queries Constraints
 ---------------------------------------

--- a/blackbox/docs/sql/statements/insert.rst
+++ b/blackbox/docs/sql/statements/insert.rst
@@ -107,20 +107,6 @@ In the above statement, if ``col1`` had a primary key constraint and the value
 ``1`` already existed for ``col1``, no insert would be performed. The conflict
 target after ``ON CONFLICT`` is optional.
 
-``ON CONFLICT DO NOTHING``
---------------------------
-
-When ``ON CONFLICT DO NOTHING`` is specified, rows which caused a duplicate
-key conflict will not be inserted. No exception will be thrown. For example:
-
-::
-
-     INSERT INTO t (col1, col2) VALUES (1, 42)
-     ON CONFLICT DO NOTHING
-
-In the above statement, if ``col1`` had a primary key constraint and the value
-``1`` already existed for ``col1``, no insert would be performed.
-
 Insert From Dynamic Queries Constraints
 ---------------------------------------
 

--- a/sql-parser/src/main/antlr/SqlBase.g4
+++ b/sql-parser/src/main/antlr/SqlBase.g4
@@ -402,7 +402,7 @@ onDuplicate
    ;
 
 onConflict
-   : ON CONFLICT conflictTarget DO NOTHING
+   : ON CONFLICT conflictTarget? DO NOTHING
    | ON CONFLICT conflictTarget DO UPDATE SET assignment (',' assignment)*
    ;
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/InsertFromSubquery.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/InsertFromSubquery.java
@@ -33,10 +33,8 @@ public class InsertFromSubquery extends Insert {
     public InsertFromSubquery(Table table,
                               Query subQuery,
                               List<String> columns,
-                              DuplicateKeyType duplicateKeyType,
-                              List<Assignment> onDuplicateKeyAssignments,
-                              List<String> constraintColumns) {
-        super(table, columns, duplicateKeyType, onDuplicateKeyAssignments, constraintColumns);
+                              DuplicateKeyContext duplicateKeyContext) {
+        super(table, columns, duplicateKeyContext);
         this.subQuery = subQuery;
     }
 
@@ -68,7 +66,6 @@ public class InsertFromSubquery extends Insert {
             .add("table", table)
             .add("columns", columns)
             .add("subquery", subQuery)
-            .add("assignments", onDuplicateKeyAssignments)
             .toString();
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/InsertFromValues.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/InsertFromValues.java
@@ -34,10 +34,8 @@ public class InsertFromValues extends Insert {
     public InsertFromValues(Table table,
                             List<ValuesList> valuesLists,
                             List<String> columns,
-                            DuplicateKeyType duplicateKeyType,
-                            List<Assignment> onDuplicateKeyAssignments,
-                            List<String> constraintColumns) {
-        super(table, columns, duplicateKeyType, onDuplicateKeyAssignments, constraintColumns);
+                            DuplicateKeyContext duplicateKeyContext) {
+        super(table, columns, duplicateKeyContext);
         this.valuesLists = valuesLists;
 
         int i = 0;
@@ -82,7 +80,6 @@ public class InsertFromValues extends Insert {
             .add("table", table)
             .add("columns", columns)
             .add("values", valuesLists)
-            .add("assignments", onDuplicateKeyAssignments)
             .toString();
     }
 

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -78,7 +78,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class TestStatementBuilder {
 
@@ -784,12 +783,8 @@ public class TestStatementBuilder {
         printStatement("insert into t (a, b) values (1, 2), (3, 4) on duplicate key update a = values (a) + 1, b = 4");
         printStatement("insert into t (a, b) values (1, 2), (3, 4) on duplicate key update a = values (a) + 1, b = values(b) - 2");
 
-        try {
-            printStatement("insert into t (a, b) values (1, 2) on conflict (a,b) do nothing");
-            fail("Should have failed to parse statement.");
-        } catch (UnsupportedOperationException e) {
-            // this is what we want
-        }
+        printStatement("insert into t (a, b) values (1, 2) on conflict do nothing");
+        printStatement("insert into t (a, b) values (1, 2) on conflict (a,b) do nothing");
         printStatement("insert into t (a, b) values (1, 2) on conflict (a) do update set b = b + 1");
         printStatement("insert into t (a, b, c) values (1, 2, 3) on conflict (a, b) do update set a = a + 1, b = 3");
         printStatement("insert into t (a, b, c) values (1, 2), (3, 4) on conflict (c) do update set a = excluded.a + 1, b = 4");
@@ -797,7 +792,7 @@ public class TestStatementBuilder {
 
         InsertFromValues insert = (InsertFromValues) SqlParser.createStatement(
                 "insert into test_generated_column (id, ts) values (?, ?) on duplicate key update ts = ?");
-        Assignment onDuplicateAssignment = insert.onDuplicateKeyAssignments().get(0);
+        Assignment onDuplicateAssignment = insert.getDuplicateKeyContext().getAssignments().get(0);
         assertThat(onDuplicateAssignment.expression(), instanceOf(ParameterExpression.class));
         assertThat(onDuplicateAssignment.expressions().get(0).toString(), is("$3"));
 

--- a/sql/src/main/java/io/crate/analyze/AnalyzedInsertStatement.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedInsertStatement.java
@@ -24,8 +24,8 @@ package io.crate.analyze;
 
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.Reference;
-import org.elasticsearch.common.inject.internal.Nullable;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -36,19 +36,20 @@ public final class AnalyzedInsertStatement implements AnalyzedStatement {
     private List<List<Symbol>> rows;
     @Nullable
     private AnalyzedStatement subRelation;
+
     private final Map<Reference, Symbol> onDuplicateKeyAssignments;
 
     private AnalyzedInsertStatement(Map<Reference, Symbol> onDuplicateKeyAssignments) {
         this.onDuplicateKeyAssignments = onDuplicateKeyAssignments;
     }
 
-    AnalyzedInsertStatement(List<List<Symbol>> rows,
+    AnalyzedInsertStatement(@Nullable List<List<Symbol>> rows,
                             Map<Reference, Symbol> onDuplicateKeyAssignments) {
         this(onDuplicateKeyAssignments);
         this.rows = rows;
     }
 
-    AnalyzedInsertStatement(AnalyzedStatement subRelation,
+    AnalyzedInsertStatement(@Nullable AnalyzedStatement subRelation,
                             Map<Reference, Symbol> onDuplicateKeyAssignments) {
         this(onDuplicateKeyAssignments);
         this.subRelation = subRelation;

--- a/sql/src/main/java/io/crate/analyze/InsertFromSubQueryAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/InsertFromSubQueryAnalyzedStatement.java
@@ -26,6 +26,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import io.crate.analyze.relations.QueriedRelation;
+import io.crate.execution.dsl.projection.builder.InputColumns;
+import io.crate.expression.scalar.SubscriptObjectFunction;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Literal;
@@ -36,8 +38,6 @@ import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.GeneratedReference;
 import io.crate.metadata.Reference;
 import io.crate.metadata.doc.DocTableInfo;
-import io.crate.expression.scalar.SubscriptObjectFunction;
-import io.crate.execution.dsl.projection.builder.InputColumns;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 
@@ -57,7 +57,7 @@ public class InsertFromSubQueryAnalyzedStatement implements AnalyzedStatement {
 
     private final DocTableInfo targetTable;
     private final QueriedRelation subQueryRelation;
-
+    private final boolean ignoreDuplicateKeys;
     @Nullable
     private final Map<Reference, Symbol> onDuplicateKeyAssignments;
     private final List<Reference> targetColumns;
@@ -69,9 +69,11 @@ public class InsertFromSubQueryAnalyzedStatement implements AnalyzedStatement {
     public InsertFromSubQueryAnalyzedStatement(QueriedRelation subQueryRelation,
                                                DocTableInfo tableInfo,
                                                List<Reference> targetColumns,
+                                               boolean ignoreDuplicateKeys,
                                                @Nullable Map<Reference, Symbol> onDuplicateKeyAssignments) {
         this.targetTable = tableInfo;
         this.subQueryRelation = subQueryRelation;
+        this.ignoreDuplicateKeys = ignoreDuplicateKeys;
         this.onDuplicateKeyAssignments = onDuplicateKeyAssignments;
         this.targetColumns = targetColumns;
         Map<ColumnIdent, Integer> columnPositions = toPositionMap(targetColumns);
@@ -188,6 +190,10 @@ public class InsertFromSubQueryAnalyzedStatement implements AnalyzedStatement {
     @Override
     public boolean isWriteOperation() {
         return true;
+    }
+
+    public boolean isIgnoreDuplicateKeys() {
+        return ignoreDuplicateKeys;
     }
 
     @Nullable

--- a/sql/src/main/java/io/crate/analyze/InsertFromValuesAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/InsertFromValuesAnalyzedStatement.java
@@ -36,6 +36,7 @@ import java.util.Map;
 
 public class InsertFromValuesAnalyzedStatement extends AbstractInsertAnalyzedStatement {
 
+    private final boolean ignoreDuplicateKeys;
     private final List<Symbol[]> onDuplicateKeyAssignments = new ArrayList<>();
     private final List<String[]> onDuplicateKeyAssignmentsColumns = new ArrayList<>();
     private final List<Object[]> sourceMaps = new ArrayList<>();
@@ -49,8 +50,9 @@ public class InsertFromValuesAnalyzedStatement extends AbstractInsertAnalyzedSta
 
     private int numAddedGeneratedColumns = 0;
 
-    public InsertFromValuesAnalyzedStatement(DocTableInfo tableInfo, int numBulkResponses) {
+    public InsertFromValuesAnalyzedStatement(DocTableInfo tableInfo, int numBulkResponses, boolean ignoreDuplicateKeys) {
         this.numBulkResponses = numBulkResponses;
+        this.ignoreDuplicateKeys = ignoreDuplicateKeys;
         super.tableInfo(tableInfo);
         if (tableInfo.isPartitioned()) {
             for (Map<String, String> partitionMap : partitionMaps) {
@@ -117,6 +119,10 @@ public class InsertFromValuesAnalyzedStatement extends AbstractInsertAnalyzedSta
         } else {
             routingValues.add(clusteredByValue);
         }
+    }
+
+    public boolean isIgnoreDuplicateKeys() {
+        return ignoreDuplicateKeys;
     }
 
     public void addOnDuplicateKeyAssignments(Symbol[] assignments) {

--- a/sql/src/main/java/io/crate/analyze/ValuesAwareExpressionAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/ValuesAwareExpressionAnalyzer.java
@@ -79,7 +79,7 @@ import java.util.function.Function;
 public class ValuesAwareExpressionAnalyzer extends ExpressionAnalyzer {
 
     private final ValuesResolver valuesResolver;
-    private final Insert.DuplicateKeyType duplicateKeyType;
+    private final Insert.DuplicateKeyContext.Type duplicateKeyType;
 
     /**
      * used to resolve the argument column in VALUES (&lt;argumentColumn&gt;) to the literal or reference
@@ -94,7 +94,7 @@ public class ValuesAwareExpressionAnalyzer extends ExpressionAnalyzer {
                                   Function<ParameterExpression, Symbol> convertParamFunction,
                                   FieldProvider fieldProvider,
                                   ValuesResolver valuesResolver,
-                                  Insert.DuplicateKeyType duplicateKeyType) {
+                                  Insert.DuplicateKeyContext.Type duplicateKeyType) {
         super(functions, transactionContext, convertParamFunction, fieldProvider, null);
         this.valuesResolver = valuesResolver;
         this.duplicateKeyType = duplicateKeyType;
@@ -104,7 +104,7 @@ public class ValuesAwareExpressionAnalyzer extends ExpressionAnalyzer {
     protected Symbol convertFunctionCall(FunctionCall node, ExpressionAnalysisContext context) {
         List<String> parts = node.getName().getParts();
         if (parts.get(0).equals("values")) {
-            if (duplicateKeyType != Insert.DuplicateKeyType.ON_DUPLICATE_KEY_UPDATE) {
+            if (duplicateKeyType != Insert.DuplicateKeyContext.Type.ON_DUPLICATE_KEY_UPDATE) {
                 throw new UnsupportedOperationException("Can't use VALUES outside ON DUPLICATE KEY UPDATE col = VALUES(..)");
             }
             Expression expression = node.getArguments().get(0);

--- a/sql/src/main/java/io/crate/execution/dml/upsert/LegacyUpsertByIdTask.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/LegacyUpsertByIdTask.java
@@ -29,6 +29,7 @@ import io.crate.data.Row1;
 import io.crate.data.RowConsumer;
 import io.crate.exceptions.SQLExceptions;
 import io.crate.execution.dml.ShardResponse;
+import io.crate.execution.dml.upsert.ShardUpsertRequest.DuplicateKeyAction;
 import io.crate.metadata.IndexParts;
 import io.crate.execution.support.RetryListener;
 import io.crate.execution.engine.indexing.ShardingUpsertExecutor;
@@ -108,7 +109,7 @@ public class LegacyUpsertByIdTask {
 
         reqBuilder = new ShardUpsertRequest.Builder(
             ShardingUpsertExecutor.BULK_REQUEST_TIMEOUT_SETTING.setting().get(settings),
-            false,
+            upsertById.isIgnoreDuplicateKeys() ? DuplicateKeyAction.IGNORE : DuplicateKeyAction.UPDATE_OR_FAIL,
             upsertById.numBulkResponses() > 0 || items.size() > 1,
             upsertById.updateColumns(),
             upsertById.insertColumns(),

--- a/sql/src/main/java/io/crate/execution/dml/upsert/UpdateByIdTask.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/UpdateByIdTask.java
@@ -22,6 +22,7 @@
 
 package io.crate.execution.dml.upsert;
 
+import io.crate.execution.dml.upsert.ShardUpsertRequest.DuplicateKeyAction;
 import io.crate.expression.symbol.Assignments;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
@@ -64,7 +65,7 @@ public class UpdateByIdTask {
         createBuilder = (continueOnError) ->
             new ShardUpsertRequest.Builder(
                 ShardingUpsertExecutor.BULK_REQUEST_TIMEOUT_SETTING.setting().get(clusterService.state().metaData().settings()),
-                false,
+                DuplicateKeyAction.UPDATE_OR_FAIL,
                 continueOnError,
                 assignments.targetNames(),
                 null, // missing assignments are for INSERT .. ON DUPLICATE KEY UPDATE

--- a/sql/src/main/java/io/crate/execution/dsl/projection/ColumnIndexWriterProjection.java
+++ b/sql/src/main/java/io/crate/execution/dsl/projection/ColumnIndexWriterProjection.java
@@ -44,6 +44,7 @@ public class ColumnIndexWriterProjection extends AbstractIndexWriterProjection {
 
     private List<Symbol> columnSymbols;
     private List<Reference> targetColsExclPartitionCols;
+    private boolean ignoreDuplicateKeys;
     @Nullable
     private Map<Reference, Symbol> onDuplicateKeyAssignments;
 
@@ -56,6 +57,7 @@ public class ColumnIndexWriterProjection extends AbstractIndexWriterProjection {
                                        @Nullable String partitionIdent,
                                        List<ColumnIdent> primaryKeys,
                                        List<Reference> columns,
+                                       boolean ignoreDuplicateKeys,
                                        @Nullable Map<Reference, Symbol> onDuplicateKeyAssignments,
                                        List<Symbol> primaryKeySymbols,
                                        List<ColumnIdent> partitionedByColumns,
@@ -66,6 +68,7 @@ public class ColumnIndexWriterProjection extends AbstractIndexWriterProjection {
                                        boolean autoCreateIndices) {
         super(relationName, partitionIdent, primaryKeys, clusteredByColumn, settings, primaryKeySymbols, autoCreateIndices);
         this.partitionedBySymbols = partitionedBySymbols;
+        this.ignoreDuplicateKeys = ignoreDuplicateKeys;
         this.onDuplicateKeyAssignments = onDuplicateKeyAssignments;
         this.targetColsExclPartitionCols = new ArrayList<>(columns.size() - partitionedByColumns.size());
         this.columnSymbols = new ArrayList<>(columns.size() - partitionedBySymbols.size());
@@ -93,6 +96,7 @@ public class ColumnIndexWriterProjection extends AbstractIndexWriterProjection {
             }
         }
 
+        ignoreDuplicateKeys = in.readBoolean();
         if (in.readBoolean()) {
             int mapSize = in.readVInt();
             onDuplicateKeyAssignments = new HashMap<>(mapSize);
@@ -108,6 +112,10 @@ public class ColumnIndexWriterProjection extends AbstractIndexWriterProjection {
 
     public List<Reference> columnReferences() {
         return targetColsExclPartitionCols;
+    }
+
+    public boolean isIgnoreDuplicateKeys() {
+        return ignoreDuplicateKeys;
     }
 
     public Map<Reference, Symbol> onDuplicateKeyAssignments() {
@@ -179,6 +187,7 @@ public class ColumnIndexWriterProjection extends AbstractIndexWriterProjection {
             }
         }
 
+        out.writeBoolean(ignoreDuplicateKeys);
         if (onDuplicateKeyAssignments == null) {
             out.writeBoolean(false);
         } else {

--- a/sql/src/main/java/io/crate/execution/engine/indexing/ColumnIndexWriterProjector.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/ColumnIndexWriterProjector.java
@@ -22,6 +22,7 @@
 
 package io.crate.execution.engine.indexing;
 
+import io.crate.execution.dml.upsert.ShardUpsertRequest.DuplicateKeyAction;
 import io.crate.expression.symbol.Assignments;
 import io.crate.expression.symbol.Symbol;
 import io.crate.data.BatchIterator;
@@ -70,6 +71,7 @@ public class ColumnIndexWriterProjector implements Projector {
                                       List<Reference> columnReferences,
                                       List<Input<?>> insertInputs,
                                       List<? extends CollectExpression<Row, ?>> collectExpressions,
+                                      boolean ignoreDuplicateKeys,
                                       @Nullable Map<Reference, Symbol> updateAssignments,
                                       int bulkActions,
                                       boolean autoCreateIndices,
@@ -91,7 +93,7 @@ public class ColumnIndexWriterProjector implements Projector {
         }
         ShardUpsertRequest.Builder builder = new ShardUpsertRequest.Builder(
             ShardingUpsertExecutor.BULK_REQUEST_TIMEOUT_SETTING.setting().get(settings),
-            false, // overwriteDuplicates
+            ignoreDuplicateKeys ? DuplicateKeyAction.IGNORE : DuplicateKeyAction.UPDATE_OR_FAIL,
             true, // continueOnErrors
             updateColumnNames,
             columnReferences.toArray(new Reference[columnReferences.size()]),

--- a/sql/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
+++ b/sql/src/main/java/io/crate/execution/engine/indexing/IndexWriterProjector.java
@@ -22,6 +22,7 @@
 
 package io.crate.execution.engine.indexing;
 
+import io.crate.execution.dml.upsert.ShardUpsertRequest.DuplicateKeyAction;
 import io.crate.expression.symbol.Symbol;
 import io.crate.data.BatchIterator;
 import io.crate.data.CollectingBatchIterator;
@@ -97,7 +98,7 @@ public class IndexWriterProjector implements Projector {
         RowShardResolver rowShardResolver = new RowShardResolver(functions, primaryKeyIdents, primaryKeySymbols, clusteredByColumn, routingSymbol);
         ShardUpsertRequest.Builder builder = new ShardUpsertRequest.Builder(
             ShardingUpsertExecutor.BULK_REQUEST_TIMEOUT_SETTING.setting().get(settings),
-            overwriteDuplicates,
+            overwriteDuplicates ? DuplicateKeyAction.OVERWRITE : DuplicateKeyAction.UPDATE_OR_FAIL,
             true,
             null,
             new Reference[]{rawSourceReference},

--- a/sql/src/main/java/io/crate/planner/Planner.java
+++ b/sql/src/main/java/io/crate/planner/Planner.java
@@ -312,6 +312,7 @@ public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
             analysis.numBulkResponses(),
             tableInfo.isPartitioned(),
             analysis.bulkIndices(),
+            analysis.isIgnoreDuplicateKeys(),
             onDuplicateKeyAssignmentsColumns,
             analysis.columns().toArray(new Reference[analysis.columns().size()])
         );

--- a/sql/src/main/java/io/crate/planner/consumer/InsertFromSubQueryPlanner.java
+++ b/sql/src/main/java/io/crate/planner/consumer/InsertFromSubQueryPlanner.java
@@ -67,6 +67,7 @@ public final class InsertFromSubQueryPlanner {
             null,
             statement.tableInfo().primaryKey(),
             statement.columns(),
+            statement.isIgnoreDuplicateKeys(),
             statement.onDuplicateKeyAssignments(),
             statement.primaryKeySymbols(),
             statement.tableInfo().partitionedBy(),

--- a/sql/src/main/java/io/crate/planner/node/dml/LegacyUpsertById.java
+++ b/sql/src/main/java/io/crate/planner/node/dml/LegacyUpsertById.java
@@ -21,11 +21,11 @@
 
 package io.crate.planner.node.dml;
 
-import io.crate.expression.symbol.SelectSymbol;
-import io.crate.expression.symbol.Symbol;
 import io.crate.data.Row;
 import io.crate.data.RowConsumer;
 import io.crate.execution.dml.upsert.LegacyUpsertByIdTask;
+import io.crate.expression.symbol.SelectSymbol;
+import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.Reference;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Plan;
@@ -109,6 +109,8 @@ public class LegacyUpsertById implements Plan {
     private final List<Item> items;
     private final List<Integer> bulkIndices;
 
+    private final boolean ignoreDuplicateKeys;
+
     @Nullable
     private final String[] updateColumns;
     @Nullable
@@ -117,14 +119,20 @@ public class LegacyUpsertById implements Plan {
     public LegacyUpsertById(int numBulkResponses,
                             boolean isPartitioned,
                             List<Integer> bulkIndices,
+                            boolean ignoreDuplicateKeys,
                             @Nullable String[] updateColumns,
                             @Nullable Reference[] insertColumns) {
         this.numBulkResponses = numBulkResponses;
         this.isPartitioned = isPartitioned;
         this.bulkIndices = bulkIndices;
+        this.ignoreDuplicateKeys = ignoreDuplicateKeys;
         this.updateColumns = updateColumns;
         this.insertColumns = insertColumns;
         this.items = new ArrayList<>();
+    }
+
+    public boolean isIgnoreDuplicateKeys() {
+        return ignoreDuplicateKeys;
     }
 
     @Nullable
@@ -152,7 +160,7 @@ public class LegacyUpsertById implements Plan {
     public void add(String index,
                     String id,
                     String routing,
-                    Symbol[] updateAssignments,
+                    @Nullable Symbol[] updateAssignments,
                     @Nullable Long version,
                     @Nullable Object[] insertValues) {
         items.add(new Item(index, id, routing, updateAssignments, version, insertValues));

--- a/sql/src/test/java/io/crate/execution/dml/upsert/ShardUpsertRequestTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/ShardUpsertRequestTest.java
@@ -22,6 +22,7 @@
 
 package io.crate.execution.dml.upsert;
 
+import io.crate.execution.dml.upsert.ShardUpsertRequest.DuplicateKeyAction;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.Reference;
@@ -58,7 +59,7 @@ public class ShardUpsertRequestTest extends CrateUnitTest {
         UUID jobId = UUID.randomUUID();
         Reference[] missingAssignmentColumns = new Reference[]{ID_REF, NAME_REF};
         ShardUpsertRequest request = new ShardUpsertRequest.Builder(
-            false,
+            DuplicateKeyAction.UPDATE_OR_FAIL,
             false,
             assignmentColumns,
             missingAssignmentColumns,
@@ -70,6 +71,11 @@ public class ShardUpsertRequestTest extends CrateUnitTest {
         request.add(123, new ShardUpsertRequest.Item(
             "99",
             null,
+            new Object[]{99, new BytesRef("Marvin")},
+            null));
+        request.add(42, new ShardUpsertRequest.Item(
+            "99",
+            new Symbol[0],
             new Object[]{99, new BytesRef("Marvin")},
             null));
         request.add(5, new ShardUpsertRequest.Item(

--- a/sql/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
@@ -25,6 +25,7 @@ package io.crate.execution.dml.upsert;
 import io.crate.exceptions.InvalidColumnNameException;
 import io.crate.execution.ddl.SchemaUpdateClient;
 import io.crate.execution.dml.ShardResponse;
+import io.crate.execution.dml.upsert.ShardUpsertRequest.DuplicateKeyAction;
 import io.crate.execution.jobs.JobContextService;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Functions;
@@ -204,7 +205,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
     public void testExceptionWhileProcessingItemsNotContinueOnError() throws Exception {
         ShardId shardId = new ShardId(TABLE_IDENT.indexName(), charactersIndexUUID, 0);
         ShardUpsertRequest request = new ShardUpsertRequest.Builder(
-            false,
+            DuplicateKeyAction.UPDATE_OR_FAIL,
             false,
             null,
             new Reference[]{ID_REF},
@@ -223,7 +224,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
     public void testExceptionWhileProcessingItemsContinueOnError() throws Exception {
         ShardId shardId = new ShardId(TABLE_IDENT.indexName(), charactersIndexUUID, 0);
         ShardUpsertRequest request = new ShardUpsertRequest.Builder(
-            false,
+            DuplicateKeyAction.UPDATE_OR_FAIL,
             true,
             null,
             new Reference[]{ID_REF},
@@ -451,7 +452,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
     public void testKilledSetWhileProcessingItemsDoesNotThrowException() throws Exception {
         ShardId shardId = new ShardId(TABLE_IDENT.indexName(), charactersIndexUUID, 0);
         ShardUpsertRequest request = new ShardUpsertRequest.Builder(
-            false,
+            DuplicateKeyAction.UPDATE_OR_FAIL,
             false,
             null,
             new Reference[]{ID_REF},
@@ -470,7 +471,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
     public void testItemsWithoutSourceAreSkippedOnReplicaOperation() throws Exception {
         ShardId shardId = new ShardId(TABLE_IDENT.indexName(), charactersIndexUUID, 0);
         ShardUpsertRequest request = new ShardUpsertRequest.Builder(
-            false,
+            DuplicateKeyAction.UPDATE_OR_FAIL,
             false,
             null,
             new Reference[]{ID_REF},

--- a/sql/src/test/java/io/crate/execution/dsl/projection/ColumnIndexWriterProjectionTest.java
+++ b/sql/src/test/java/io/crate/execution/dsl/projection/ColumnIndexWriterProjectionTest.java
@@ -80,6 +80,7 @@ public class ColumnIndexWriterProjectionTest {
             null,
             primaryKeys,
             targetColumns,
+            false,
             null,
             primaryKeySymbols,
             partitionedByColumns,


### PR DESCRIPTION
This adds support for the `ON CONFLICT DO NOTHING` clause in insert
statements. When duplicate key conflicts are discovered, e.g. due to a primary
key constraint, no values will be inserted and no errors will be returned.

Example:

```
CREATE TABLE t1 (id int primary key, other string);
INSERT INTO t1 (id, other) VALUES (1, 'str');

-- No values will be inserted if 1 already exits for id
INSERT into t1 (id, other) VALUES (1, 'test') ON CONFLICT DO NOTHING;
```