### PR TITLE
Backport Java 10 fixes

### DIFF
--- a/app/src/bin/crate.bat
+++ b/app/src/bin/crate.bat
@@ -39,7 +39,6 @@ REM Enable aggressive optimizations in the JVM
 REM    - Disabled by default as it might cause the JVM to crash
 REM set JAVA_OPTS=%JAVA_OPTS% -XX:+AggressiveOpts
 
-set JAVA_OPTS=%JAVA_OPTS% -XX:+UseParNewGC
 set JAVA_OPTS=%JAVA_OPTS% -XX:+UseConcMarkSweepGC
 
 set JAVA_OPTS=%JAVA_OPTS% -XX:CMSInitiatingOccupancyFraction=75

--- a/app/src/bin/crate.in.sh
+++ b/app/src/bin/crate.in.sh
@@ -46,7 +46,6 @@ if [ "x$CRATE_USE_IPV4" != "x" ]; then
   JAVA_OPTS="$JAVA_OPTS -Djava.net.preferIPv4Stack=true"
 fi
 
-JAVA_OPTS="$JAVA_OPTS -XX:+UseParNewGC"
 JAVA_OPTS="$JAVA_OPTS -XX:+UseConcMarkSweepGC"
 
 JAVA_OPTS="$JAVA_OPTS -XX:CMSInitiatingOccupancyFraction=75"

--- a/gradle/javaModule.gradle
+++ b/gradle/javaModule.gradle
@@ -109,6 +109,10 @@ test {
         }
     }
 
+    jacoco {
+        enabled = JavaVersion.current() <= JavaVersion.VERSION_1_9
+    }
+
     // ES testing framework adds the resources target build paths to the classpath of the tests,
     // but if the src/[main|test]/resources directories of a project are empty, then these dirs
     // are missing from the target build directory which causes all tests to fail.


### PR DESCRIPTION
Although we don't yet officially support Java 10, this allows us to run the
tests and launch CrateDB using Java 10