### PR TITLE
Fixed error thrown when filtering on partitioned table.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -26,3 +26,14 @@ Fixes
 =====
 
 - Do not allow renaming a table when connected to a read-only node.
+
+- Fixed an issue that caused an error to be thrown when filtering on a
+  partitioned table using a column which is a source column for a ``GENERATED``
+  column which in turn is used for partitioning. E.g.::
+
+    CREATE TABLE parted_t(
+        t TIMESTAMP,
+        day TIMESTAMP GENERATED ALWAYS AS date_trunc('day', t)
+    ) PARTITIONED BY (day);
+
+    SELECT * FROM parted_t WHERE t > 1522170000000;

--- a/sql/src/main/java/io/crate/analyze/where/WhereClauseAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/where/WhereClauseAnalyzer.java
@@ -102,11 +102,15 @@ public class WhereClauseAnalyzer {
             return WhereClause.MATCH_ALL;
         }
         WhereClauseValidator.validate(query);
-        Symbol queryGenColsProcessed = GeneratedColumnExpander.maybeExpand(
-            query,
-            table.generatedColumns(),
-            Lists2.concat(table.partitionedByColumns(), Lists2.copyAndReplace(table.primaryKey(), table::getReference))
-        );
+
+        Symbol queryGenColsProcessed = query;
+        if (partitions.isEmpty()) { // Query already analyzed and partitions are extracted
+            queryGenColsProcessed = GeneratedColumnExpander.maybeExpand(
+                query,
+                table.generatedColumns(),
+                Lists2.concat(table.partitionedByColumns(), Lists2.copyAndReplace(table.primaryKey(), table::getReference))
+            );
+        }
         if (!query.equals(queryGenColsProcessed)) {
             query = normalizer.normalize(queryGenColsProcessed, transactionContext);
         }

--- a/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -2155,4 +2155,18 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
         execute("select * from t where p='a' and v='Marvin'");
         assertThat(TestingHelpers.printedTable(response.rows()), is("a| Marvin\n"));
     }
+
+    @Test
+    public void test_partition_filter_on_table_with_generated_column() {
+        execute("create table t (" +
+                "    t timestamp," +
+                "    day timestamp GENERATED ALWAYS AS date_trunc('day', t)) " +
+                "PARTITIONED BY (day)");
+        execute("insert into t(t) values ('2018-03-28T12:00:00+07:00');");
+        execute("insert into t(t) values ('2018-01-01T12:00:00+07:00');");
+        execute("refresh table t");
+
+        execute("select count(*) from t where t > 1000");
+        assertThat(TestingHelpers.printedTable(response.rows()), is("2\n"));
+    }
 }


### PR DESCRIPTION
Exception thrown due to duplicate analysis (unbound + bound) of the
WHERE clause when the column used for filtering is source column of
a generated column of the table which in turn is used for the partitioning.

Regression introduced by fix: 4f9c2a1fe876ee8a415232e782cdc202e4235b6d
Fixes: https://github.com/crate/crate/issues/7105
