### PR TITLE
Implement conflict_target for ON CONFLICT clause in INSERT

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -72,10 +72,11 @@ Changes
 - DEPRECATED: The ``ON DUPLICATE KEY UPDATE`` clause has been deprecated in
   favor of the ``ON CONFLICT DO UPDATE SET`` clause.
 
-- Added support for ``INSERT INTO ... ON CONFLICT DO UPDATE SET col = val``
-  which is identical to ``INSERT INTO ... ON DUPLICATE KEY UPDATE col = val``.
+- Added support for ON CONFLICT clause in insert statements.
+  ``INSERT INTO ... ON CONFLICT (pk_col) DO UPDATE SET col = val`` is identical
+  to ``INSERT INTO ... ON DUPLICATE KEY UPDATE col = val``.
   The special EXCLUDED table can be used to refer to the insert values:
-  ``INSERT INTO ... ON CONFLICT DO UPDATE SET col = EXCLUDED.col``
+  ``INSERT INTO ... ON CONFLICT (pk_col) DO UPDATE SET col = EXCLUDED.col``
 
 - Added support for ``DEALLOCATE`` statement which is used by certain Postgres
   Wire Protocol clients (e.g. libpq) to deallocate a prepared statement and

--- a/blackbox/docs/sql/statements/insert.rst
+++ b/blackbox/docs/sql/statements/insert.rst
@@ -22,7 +22,8 @@ Synopsis
     INSERT INTO table_ident
       [ ( column_ident [, ...] ) ]
       { VALUES ( expression [, ...] ) [, ...] | ( query ) | query }
-      [ ON CONFLICT DO UPDATE SET { column_ident = expression } [, ...] |
+      [ ON CONFLICT (column_ident [, ...])
+          DO UPDATE SET { column_ident = expression } [, ...] |
         ON DUPLICATE KEY UPDATE { column_ident = expression } [, ...]]
 
 Description
@@ -72,11 +73,12 @@ of the current row can be referenced.
 -----------------------------
 
 ``ON CONFLICT DO UPDATE SET`` works just like ``ON DUPLICATE KEY UPDATE``, but
-its syntax is slightly different.
+its syntax is slightly different. Additionally, it requires to specify the key
+columns to perform the duplicate key check against.
 
 ::
 
-     ON CONFLICT DO UPDATE SET { column_ident = expression } [, ...]
+     ON CONFLICT (column_ident, [, ...]) DO UPDATE SET { column_ident = expression } [, ...]
 
 Within expressions in the ``DO UPDATE SET`` clause, you can use the
 ``EXCLUDED`` table to refer to column values from the INSERT
@@ -85,7 +87,7 @@ statement values. For example:
 ::
 
      INSERT INTO t (col1, col2) VALUES (1, 41)
-     ON CONFLICT DO UPDATE SET { col2 = excluded.col2 + 1 }
+     ON CONFLICT (col1) DO UPDATE SET { col2 = excluded.col2 + 1 }
 
 The above statement would update ``col2`` to ``42`` if ``col1`` was a primary
 key and the value ``1`` already existed for ``col1``.

--- a/sql-parser/src/main/antlr/SqlBase.g4
+++ b/sql-parser/src/main/antlr/SqlBase.g4
@@ -402,8 +402,12 @@ onDuplicate
    ;
 
 onConflict
-   : ON CONFLICT DO NOTHING
-   | ON CONFLICT DO UPDATE SET assignment (',' assignment)*
+   : ON CONFLICT conflictTarget DO NOTHING
+   | ON CONFLICT conflictTarget DO UPDATE SET assignment (',' assignment)*
+   ;
+
+conflictTarget
+   : '(' qname (',' qname)* ')'
    ;
 
 values

--- a/sql-parser/src/main/java/io/crate/sql/tree/Insert.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/Insert.java
@@ -38,13 +38,19 @@ public abstract class Insert extends Statement {
     private final DuplicateKeyType duplicateKeyType;
     protected final List<Assignment> onDuplicateKeyAssignments;
     protected final List<String> columns;
+    protected final List<String> constraintColumns;
 
 
-    Insert(Table table, List<String> columns, DuplicateKeyType duplicateKeyType, List<Assignment> onDuplicateKeyAssignments) {
+    Insert(Table table,
+           List<String> columns,
+           DuplicateKeyType duplicateKeyType,
+           List<Assignment> onDuplicateKeyAssignments,
+           List<String> constraintColumns) {
         this.table = table;
         this.columns = columns;
         this.duplicateKeyType = duplicateKeyType;
         this.onDuplicateKeyAssignments = onDuplicateKeyAssignments;
+        this.constraintColumns = constraintColumns;
     }
 
     public Table table() {
@@ -53,6 +59,10 @@ public abstract class Insert extends Statement {
 
     public List<String> columns() {
         return columns;
+    }
+
+    public List<String> getConstraintColumns() {
+        return constraintColumns;
     }
 
     public DuplicateKeyType getDuplicateKeyType() {

--- a/sql-parser/src/main/java/io/crate/sql/tree/InsertFromSubquery.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/InsertFromSubquery.java
@@ -34,8 +34,9 @@ public class InsertFromSubquery extends Insert {
                               Query subQuery,
                               List<String> columns,
                               DuplicateKeyType duplicateKeyType,
-                              List<Assignment> onDuplicateKeyAssignments) {
-        super(table, columns, duplicateKeyType, onDuplicateKeyAssignments);
+                              List<Assignment> onDuplicateKeyAssignments,
+                              List<String> constraintColumns) {
+        super(table, columns, duplicateKeyType, onDuplicateKeyAssignments, constraintColumns);
         this.subQuery = subQuery;
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/InsertFromValues.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/InsertFromValues.java
@@ -35,8 +35,9 @@ public class InsertFromValues extends Insert {
                             List<ValuesList> valuesLists,
                             List<String> columns,
                             DuplicateKeyType duplicateKeyType,
-                            List<Assignment> onDuplicateKeyAssignments) {
-        super(table, columns, duplicateKeyType, onDuplicateKeyAssignments);
+                            List<Assignment> onDuplicateKeyAssignments,
+                            List<String> constraintColumns) {
+        super(table, columns, duplicateKeyType, onDuplicateKeyAssignments, constraintColumns);
         this.valuesLists = valuesLists;
 
         int i = 0;

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -785,15 +785,15 @@ public class TestStatementBuilder {
         printStatement("insert into t (a, b) values (1, 2), (3, 4) on duplicate key update a = values (a) + 1, b = values(b) - 2");
 
         try {
-            printStatement("insert into t (a, b) values (1, 2) on conflict do nothing");
+            printStatement("insert into t (a, b) values (1, 2) on conflict (a,b) do nothing");
             fail("Should have failed to parse statement.");
         } catch (UnsupportedOperationException e) {
             // this is what we want
         }
-        printStatement("insert into t (a, b) values (1, 2) on conflict do update set a = a + 1");
-        printStatement("insert into t (a, b) values (1, 2) on conflict do update set a = a + 1, b = 3");
-        printStatement("insert into t (a, b) values (1, 2), (3, 4) on conflict do update set a = excluded.a + 1, b = 4");
-        printStatement("insert into t (a, b) values (1, 2), (3, 4) on conflict do update set a = excluded.a + 1, b = excluded.b - 2");
+        printStatement("insert into t (a, b) values (1, 2) on conflict (a) do update set b = b + 1");
+        printStatement("insert into t (a, b, c) values (1, 2, 3) on conflict (a, b) do update set a = a + 1, b = 3");
+        printStatement("insert into t (a, b, c) values (1, 2), (3, 4) on conflict (c) do update set a = excluded.a + 1, b = 4");
+        printStatement("insert into t (a, b, c) values (1, 2), (3, 4) on conflict (c) do update set a = excluded.a + 1, b = excluded.b - 2");
 
         InsertFromValues insert = (InsertFromValues) SqlParser.createStatement(
                 "insert into test_generated_column (id, ts) values (?, ?) on duplicate key update ts = ?");


### PR DESCRIPTION
The conflict_target specifies the columns which are part of a primary key
constraint. According to the PostgreSQL INSERT syntax, specifying the
conflict_target is mandatory.

https://www.postgresql.org/docs/9.5/static/sql-insert.html
