### PR TITLE
send content-type header in unauthorized responses

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -140,6 +140,9 @@ Changes
 Fixes
 =====
 
+- Send ``Content-Type`` header in unauthorized responses so that Safari also
+  prompts for basic authentication.
+
 - Do not allow renaming a table when connected to a read-only node.
 
 - Fixed an issue that would cause a ClassCastException to be thrown instead of

--- a/enterprise/users/src/main/java/io/crate/protocols/http/HttpAuthUpstreamHandler.java
+++ b/enterprise/users/src/main/java/io/crate/protocols/http/HttpAuthUpstreamHandler.java
@@ -143,7 +143,9 @@ public class HttpAuthUpstreamHandler extends SimpleChannelInboundHandler<Object>
         }
         // "Tell" the browser to open the credentials popup
         // It helps to avoid custom login page in AdminUI
-        response.headers().set(HttpHeaderNames.WWW_AUTHENTICATE, WWW_AUTHENTICATE_REALM_MESSAGE);
+        response.headers()
+            .set(HttpHeaderNames.WWW_AUTHENTICATE, WWW_AUTHENTICATE_REALM_MESSAGE)
+            .set(HttpHeaderNames.CONTENT_TYPE, "text/plain");
         channel.writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
     }
 


### PR DESCRIPTION
Safari does not prompt for basic authentication if the header is missing

@mxm Can you verify and test this?