### PR TITLE
Initialize logging with log4j2 configuration file

### DIFF
--- a/app/src/main/java/io/crate/bootstrap/CrateDB.java
+++ b/app/src/main/java/io/crate/bootstrap/CrateDB.java
@@ -39,6 +39,7 @@ import org.elasticsearch.monitor.jvm.JvmInfo;
 import org.elasticsearch.node.NodeValidationException;
 import org.elasticsearch.node.internal.CrateSettingsPreparer;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -106,6 +107,7 @@ public class CrateDB extends EnvironmentAwareCommand {
         } else {
             confPath = Paths.get(crateHomePath, "config");
         }
+        System.setProperty("log4j.configurationFile", confPath + File.separator + "log4j2.properties");
         return CrateSettingsPreparer.prepareEnvironment(Settings.EMPTY, settings, confPath);
     }
 


### PR DESCRIPTION
This gets rid of the following warning message at startup by initializing the
logging with our log4j.properties configuration file.

```
ERROR StatusLogger No log4j2 configuration file found. Using default
configuration: logging only errors to the console. Set system property
'log4j2.debug' to show Log4j2 internal initialization logging.
```
