### PR TITLE
Add same-statement precondition to BulkPortal

### DIFF
--- a/sql/src/main/java/io/crate/protocols/postgres/BulkPortal.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/BulkPortal.java
@@ -48,6 +48,7 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
@@ -113,6 +114,14 @@ class BulkPortal extends AbstractPortal {
                        @Nullable AnalyzedStatement analyzedStatement,
                        List<Object> params,
                        @Nullable FormatCodes.FormatCode[] resultFormatCodes) {
+        if (!this.query.equals(query)) {
+            throw new IllegalStateException(
+                String.format(Locale.ENGLISH,
+                    "Bulk portal doesn't expect the query to change.\n" +
+                    "Old query: %s\n" +
+                    "New query: %s\n",
+                    this.query, query));
+        }
         this.bulkArgs.add(params);
         return this;
     }

--- a/sql/src/test/java/io/crate/protocols/postgres/BulkPortalTest.java
+++ b/sql/src/test/java/io/crate/protocols/postgres/BulkPortalTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.protocols.postgres;
+
+import io.crate.action.sql.SessionContext;
+import io.crate.sql.tree.Statement;
+import io.crate.test.integration.CrateUnitTest;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+
+public class BulkPortalTest extends CrateUnitTest {
+
+    @Test
+    public void testPortalDoesNotSupportDifferentStatements() {
+        String query = "select * from t";
+        BulkPortal p1 = new BulkPortal("P1",
+            query,
+            Mockito.mock(Statement.class),
+            null,
+            Collections.emptyList(),
+            Collections.emptyList(),
+            Mockito.mock(ResultSetReceiver.class),
+            1,
+            Collections.emptyList(),
+            SessionContext.create(),
+            Mockito.mock(AbstractPortal.PortalContext.class)
+        );
+
+        p1.bind("S1",
+            query,
+            Mockito.mock(Statement.class),
+            null,
+            Collections.emptyList(),
+            null
+        );
+
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("Bulk portal doesn't expect the query to change.\n" +
+                                        "Old query: select * from t\n" +
+                                        "New query: QUERY CHANGED");
+
+        p1.bind("S2",
+            "QUERY CHANGED",
+            Mockito.mock(Statement.class),
+            null,
+            Collections.emptyList(),
+            null
+        );
+
+    }
+}


### PR DESCRIPTION
The BulkPortal is currently used when the same statement is bound to a portal
twice. This is not always correct since different statements can be send after
sending two identical statements. We should fail early when the statements
change.