### PR TITLE
Optimize the block hash join to account for joins with limit

### DIFF
--- a/benchmarks/src/test/java/io/crate/data/join/RowsBatchIteratorBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/data/join/RowsBatchIteratorBenchmark.java
@@ -137,7 +137,9 @@ public class RowsBatchIteratorBenchmark {
             row -> Objects.hash(row.get(0)),
             NOOP_CIRCUIT_BREAKER,
             1000,
-            1000
+            1000,
+            -1,
+            false
         );
         while (leftJoin.moveNext()) {
             blackhole.consume(leftJoin.currentElement().get(0));
@@ -160,7 +162,9 @@ public class RowsBatchIteratorBenchmark {
             row -> (Integer) row.get(0) % 500,
             NOOP_CIRCUIT_BREAKER,
             1000,
-            1000
+            1000,
+            -1,
+            false
         );
         while (leftJoin.moveNext()) {
             blackhole.consume(leftJoin.currentElement().get(0));

--- a/sql/src/main/java/io/crate/execution/engine/join/HashJoinOperation.java
+++ b/sql/src/main/java/io/crate/execution/engine/join/HashJoinOperation.java
@@ -56,7 +56,9 @@ public class HashJoinOperation implements CompletionListenable {
                              InputFactory inputFactory,
                              CircuitBreaker circuitBreaker,
                              long estimatedRowSizeForLeft,
-                             long numberOfRowsForLeft) {
+                             long numberOfRowsForLeft,
+                             int limit,
+                             boolean isOrdered) {
 
         CompletableFuture.allOf(leftBatchIterator, rightBatchIterator)
             .whenComplete((result, failure) -> {
@@ -72,7 +74,9 @@ public class HashJoinOperation implements CompletionListenable {
                         rowAccounting,
                         circuitBreaker,
                         estimatedRowSizeForLeft,
-                        numberOfRowsForLeft
+                        numberOfRowsForLeft,
+                        limit,
+                        isOrdered
                     ), completionFuture);
                     nlResultConsumer.accept(joinIterator, null);
                 } else {
@@ -119,7 +123,9 @@ public class HashJoinOperation implements CompletionListenable {
                                                              RowAccounting rowAccounting,
                                                              CircuitBreaker circuitBreaker,
                                                              long estimatedRowSizeForLeft,
-                                                             long numberOfRowsForLeft) {
+                                                             long numberOfRowsForLeft,
+                                                             int limit,
+                                                             boolean isOrdered) {
         CombinedRow combiner = new CombinedRow(leftNumCols, rightNumCols);
         return new HashInnerJoinBatchIterator<>(
             new RamAccountingBatchIterator<>(left, rowAccounting),
@@ -130,6 +136,8 @@ public class HashJoinOperation implements CompletionListenable {
             hashBuilderForRight,
             circuitBreaker,
             estimatedRowSizeForLeft,
-            numberOfRowsForLeft);
+            numberOfRowsForLeft,
+            limit,
+            isOrdered);
     }
 }

--- a/sql/src/main/java/io/crate/execution/jobs/ContextPreparer.java
+++ b/sql/src/main/java/io/crate/execution/jobs/ContextPreparer.java
@@ -56,6 +56,10 @@ import io.crate.execution.dsl.phases.NodeOperation;
 import io.crate.execution.dsl.phases.PKLookupPhase;
 import io.crate.execution.dsl.phases.RoutedCollectPhase;
 import io.crate.execution.dsl.phases.UpstreamPhase;
+import io.crate.execution.dsl.projection.OrderedTopNProjection;
+import io.crate.execution.dsl.projection.Projection;
+import io.crate.execution.dsl.projection.ProjectionType;
+import io.crate.execution.dsl.projection.TopNProjection;
 import io.crate.execution.engine.collect.JobCollectContext;
 import io.crate.execution.engine.collect.MapSideDataCollectOperation;
 import io.crate.execution.engine.collect.PKLookupOperation;
@@ -728,6 +732,20 @@ public class ContextPreparer extends AbstractComponent {
                 lastConsumer, phase.projections(), phase.jobId(), ramAccountingContext, projectorFactory);
             Predicate<Row> joinCondition = RowFilter.create(inputFactory, phase.joinCondition());
 
+            int limit = -1;
+            boolean isOrdered = false;
+            for (Projection projection : phase.projections()) {
+                if (projection.projectionType().equals(ProjectionType.TOPN_ORDERED)) {
+                    OrderedTopNProjection orderedTopNProjection = (OrderedTopNProjection) projection;
+                    limit = orderedTopNProjection.limit();
+                    isOrdered = true;
+                    break;
+                } else if (projection.projectionType().equals(ProjectionType.TOPN)) {
+                    limit = ((TopNProjection) projection).limit();
+                    break;
+                }
+            }
+
             HashJoinOperation joinOperation = new HashJoinOperation(
                 phase.numLeftOutputs(),
                 phase.numRightOutputs(),
@@ -743,7 +761,9 @@ public class ContextPreparer extends AbstractComponent {
                 inputFactory,
                 circuitBreaker,
                 phase.estimatedRowSizeForLeft(),
-                phase.numberOfRowsForLeft());
+                phase.numberOfRowsForLeft(),
+                limit,
+                isOrdered);
             PageDownstreamContext left = pageDownstreamContextForNestedLoop(
                 phase.phaseId(),
                 context,

--- a/sql/src/test/java/io/crate/execution/engine/join/HashInnerJoinBatchIteratorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/join/HashInnerJoinBatchIteratorTest.java
@@ -142,7 +142,9 @@ public class HashInnerJoinBatchIteratorTest {
             getHashForRight(),
             circuitBreaker,
             20, // blockSize = 100/20 = 5
-            100
+            100,
+            -1,
+            false
         );
         BatchIteratorTester tester = new BatchIteratorTester(batchIteratorSupplier);
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
@@ -159,7 +161,9 @@ public class HashInnerJoinBatchIteratorTest {
             getHashWithCollisions(),
             circuitBreaker,
             20, // blockSize = 100/20 = 5
-            100
+            100,
+            -1,
+            false
         );
         BatchIteratorTester tester = new BatchIteratorTester(batchIteratorSupplier);
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
@@ -176,7 +180,9 @@ public class HashInnerJoinBatchIteratorTest {
             getHashForRight(),
             circuitBreaker,
             100, // blockSize = 100/100 = 1
-            100
+            100,
+            -1,
+            false
         );
         BatchIteratorTester tester = new BatchIteratorTester(batchIteratorSupplier);
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
@@ -193,7 +199,9 @@ public class HashInnerJoinBatchIteratorTest {
             getHashForRight(),
             circuitBreaker,
             33, // blockSize = 100 / 33 = 3
-            100
+            100,
+            -1,
+            false
         );
         BatchIteratorTester tester = new BatchIteratorTester(batchIteratorSupplier);
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);


### PR DESCRIPTION
Unordered joins which contain the limit statement with a very low value
compared to the default block size should use the default block size
instead of what the node is able to handle. The node might be able to load
the entire left table in memory in which case the block size would be the
table row count. This resulted in creating a very large block but we were
only interested in few results (indicated by the limit on the join statement).

<!--

Thanks for your contribution. Here is a quick checklist of things you should've done:

 - You've read CONTRIBUTING.rst and signed our CLA (https://crate.io/community/contribute/cla/)
 - Wrote a CHANGES.txt entry if this is a change that is relevant for users of CrateDB
 - Ran tests with `./gradlew test itest` (If they fail Jenkins will block this PR anyway)

-->
