### PR TITLE
Use a rows to be consumed indicator when calculating the join block size

### DIFF
--- a/benchmarks/src/test/java/io/crate/data/join/RowsBatchIteratorBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/data/join/RowsBatchIteratorBenchmark.java
@@ -135,10 +135,7 @@ public class RowsBatchIteratorBenchmark {
             row -> Objects.equals(row.get(0), row.get(1)),
             row -> Objects.hash(row.get(0)),
             row -> Objects.hash(row.get(0)),
-            NOOP_CIRCUIT_BREAKER,
-            1000,
-            1000,
-            Integer.MAX_VALUE
+            () -> 1000
         );
         while (leftJoin.moveNext()) {
             blackhole.consume(leftJoin.currentElement().get(0));
@@ -159,10 +156,7 @@ public class RowsBatchIteratorBenchmark {
                 return value < 500 ? value : (value % 100) + 500;
             },
             row -> (Integer) row.get(0) % 500,
-            NOOP_CIRCUIT_BREAKER,
-            1000,
-            1000,
-            Integer.MAX_VALUE
+            () -> 1000
         );
         while (leftJoin.moveNext()) {
             blackhole.consume(leftJoin.currentElement().get(0));

--- a/benchmarks/src/test/java/io/crate/data/join/RowsBatchIteratorBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/data/join/RowsBatchIteratorBenchmark.java
@@ -138,8 +138,7 @@ public class RowsBatchIteratorBenchmark {
             NOOP_CIRCUIT_BREAKER,
             1000,
             1000,
-            -1,
-            false
+            Integer.MAX_VALUE
         );
         while (leftJoin.moveNext()) {
             blackhole.consume(leftJoin.currentElement().get(0));
@@ -163,8 +162,7 @@ public class RowsBatchIteratorBenchmark {
             NOOP_CIRCUIT_BREAKER,
             1000,
             1000,
-            -1,
-            false
+            Integer.MAX_VALUE
         );
         while (leftJoin.moveNext()) {
             blackhole.consume(leftJoin.currentElement().get(0));

--- a/sql/src/main/java/io/crate/execution/dsl/phases/HashJoinPhase.java
+++ b/sql/src/main/java/io/crate/execution/dsl/phases/HashJoinPhase.java
@@ -45,6 +45,7 @@ public class HashJoinPhase extends JoinPhase {
     private final Collection<DataType> leftOutputTypes;
     private final long estimatedRowSizeForLeft;
     private final long numberOfRowsForLeft;
+    private final int rowsToBeConsumed;
 
     public HashJoinPhase(UUID jobId,
                          int executionNodeId,
@@ -60,7 +61,8 @@ public class HashJoinPhase extends JoinPhase {
                          List<Symbol> rightJoinConditionInputs,
                          Collection<DataType> leftOutputTypes,
                          long estimatedRowSizeForLeft,
-                         long numberOfRowsForLeft) {
+                         long numberOfRowsForLeft,
+                         int rowsToBeConsumed) {
         super(
             jobId,
             executionNodeId,
@@ -74,11 +76,13 @@ public class HashJoinPhase extends JoinPhase {
             JoinType.INNER,
             joinCondition);
         assert joinCondition != null : "JoinCondition for HashJoin cannot be null";
+        assert rowsToBeConsumed >= 0 : "RowsToBeConsumed for HashJoin cannot be negative";
         this.leftJoinConditionInputs = leftJoinConditionInputs;
         this.rightJoinConditionInputs = rightJoinConditionInputs;
         this.leftOutputTypes = leftOutputTypes;
         this.estimatedRowSizeForLeft = estimatedRowSizeForLeft;
         this.numberOfRowsForLeft = numberOfRowsForLeft;
+        this.rowsToBeConsumed = rowsToBeConsumed;
     }
 
     public HashJoinPhase(StreamInput in) throws IOException {
@@ -90,6 +94,7 @@ public class HashJoinPhase extends JoinPhase {
 
         estimatedRowSizeForLeft = in.readVLong();
         numberOfRowsForLeft = in.readVLong();
+        rowsToBeConsumed = in.readVInt();
     }
 
     @Override
@@ -102,6 +107,7 @@ public class HashJoinPhase extends JoinPhase {
 
         out.writeVLong(estimatedRowSizeForLeft);
         out.writeVLong(numberOfRowsForLeft);
+        out.writeVInt(rowsToBeConsumed);
     }
 
     @Override
@@ -132,5 +138,9 @@ public class HashJoinPhase extends JoinPhase {
 
     public long numberOfRowsForLeft() {
         return numberOfRowsForLeft;
+    }
+
+    public int rowsToBeConsumed() {
+        return rowsToBeConsumed;
     }
 }

--- a/sql/src/main/java/io/crate/execution/engine/join/BlockSizeCalculator.java
+++ b/sql/src/main/java/io/crate/execution/engine/join/BlockSizeCalculator.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.engine.join;
+
+import io.crate.data.Paging;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+
+import java.util.function.Supplier;
+
+class BlockSizeCalculator implements Supplier<Integer> {
+
+    static final int DEFAULT_BLOCK_SIZE = Paging.PAGE_SIZE;
+
+    private final CircuitBreaker circuitBreaker;
+    private final long estimatedRowSizeForLeft;
+    private final long numberOfRowsForLeft;
+    private final int rowsToBeConsumed;
+
+    BlockSizeCalculator(CircuitBreaker circuitBreaker,
+                        long estimatedRowSizeForLeft,
+                        long numberOfRowsForLeft,
+                        int rowsToBeConsumed) {
+        this.circuitBreaker = circuitBreaker;
+        this.estimatedRowSizeForLeft = estimatedRowSizeForLeft;
+        this.numberOfRowsForLeft = numberOfRowsForLeft;
+        this.rowsToBeConsumed = rowsToBeConsumed;
+    }
+
+    int calculateBlockSize() {
+        if (statisticsUnavailable(circuitBreaker, estimatedRowSizeForLeft, numberOfRowsForLeft)) {
+            return DEFAULT_BLOCK_SIZE;
+        }
+
+        int blockSize = (int) Math.min(Integer.MAX_VALUE, (circuitBreaker.getLimit() - circuitBreaker.getUsed()) / estimatedRowSizeForLeft);
+        blockSize = (int) Math.min(numberOfRowsForLeft, blockSize);
+        // we can encounter operations with explicit limit statement but without any order by clause.
+        // in this case, if the limit is much lower than the default block size, we'll try to keep the block size
+        // smaller than what the given node can handle as we will likely need to consume a smaller number of rows
+        // (imagine a node which can load the entire table in memory so the block size could be in the range of
+        // millions - the table row count - but the operation has `limit 100`)
+        if (rowsToBeConsumed < Integer.MAX_VALUE && rowsToBeConsumed <= DEFAULT_BLOCK_SIZE) {
+            blockSize = Math.min(DEFAULT_BLOCK_SIZE, blockSize);
+        }
+
+        // In case no mem available from circuit breaker then still allocate a small blockSize,
+        // so that at least some rows (min 1) could be processed and a CircuitBreakerException can be triggered.
+        return blockSize <= 0 ? 10 : blockSize;
+    }
+
+    private static boolean statisticsUnavailable(CircuitBreaker circuitBreaker,
+                                                 long estimatedRowSizeForLeft,
+                                                 long numberOfRowsForLeft) {
+        return estimatedRowSizeForLeft <= 0 || numberOfRowsForLeft <= 0 || circuitBreaker.getLimit() == -1;
+    }
+
+    @Override
+    public Integer get() {
+        return calculateBlockSize();
+    }
+}

--- a/sql/src/main/java/io/crate/execution/engine/join/HashJoinOperation.java
+++ b/sql/src/main/java/io/crate/execution/engine/join/HashJoinOperation.java
@@ -73,10 +73,7 @@ public class HashJoinOperation implements CompletionListenable {
                             getHashBuilderFromSymbols(inputFactory, joinLeftInputs),
                             getHashBuilderFromSymbols(inputFactory, joinRightInputs),
                             rowAccounting,
-                            circuitBreaker,
-                            estimatedRowSizeForLeft,
-                            numberOfRowsForLeft,
-                        rowsToBeConsumed
+                            new BlockSizeCalculator(circuitBreaker, estimatedRowSizeForLeft, numberOfRowsForLeft, rowsToBeConsumed)
                         ), completionFuture);
                         nlResultConsumer.accept(joinIterator, null);
                     } catch (Exception e) {
@@ -124,10 +121,7 @@ public class HashJoinOperation implements CompletionListenable {
                                                              Function<Row, Integer> hashBuilderForLeft,
                                                              Function<Row, Integer> hashBuilderForRight,
                                                              RowAccounting rowAccounting,
-                                                             CircuitBreaker circuitBreaker,
-                                                             long estimatedRowSizeForLeft,
-                                                             long numberOfRowsForLeft,
-                                                             int rowsToBeConsumed) {
+                                                             BlockSizeCalculator blockSizeCalculator) {
         CombinedRow combiner = new CombinedRow(leftNumCols, rightNumCols);
         return new HashInnerJoinBatchIterator<>(
             new RamAccountingBatchIterator<>(left, rowAccounting),
@@ -136,9 +130,6 @@ public class HashJoinOperation implements CompletionListenable {
             joinCondition,
             hashBuilderForLeft,
             hashBuilderForRight,
-            circuitBreaker,
-            estimatedRowSizeForLeft,
-            numberOfRowsForLeft,
-            rowsToBeConsumed);
+            blockSizeCalculator);
     }
 }

--- a/sql/src/main/java/io/crate/execution/engine/join/HashJoinOperation.java
+++ b/sql/src/main/java/io/crate/execution/engine/join/HashJoinOperation.java
@@ -57,8 +57,7 @@ public class HashJoinOperation implements CompletionListenable {
                              CircuitBreaker circuitBreaker,
                              long estimatedRowSizeForLeft,
                              long numberOfRowsForLeft,
-                             int limit,
-                             boolean isOrdered) {
+                             int rowsToBeConsumed) {
 
         CompletableFuture.allOf(leftBatchIterator, rightBatchIterator)
             .whenComplete((result, failure) -> {
@@ -77,8 +76,7 @@ public class HashJoinOperation implements CompletionListenable {
                             circuitBreaker,
                             estimatedRowSizeForLeft,
                             numberOfRowsForLeft,
-                            limit,
-                            isOrdered
+                        rowsToBeConsumed
                         ), completionFuture);
                         nlResultConsumer.accept(joinIterator, null);
                     } catch (Exception e) {
@@ -129,8 +127,7 @@ public class HashJoinOperation implements CompletionListenable {
                                                              CircuitBreaker circuitBreaker,
                                                              long estimatedRowSizeForLeft,
                                                              long numberOfRowsForLeft,
-                                                             int limit,
-                                                             boolean isOrdered) {
+                                                             int rowsToBeConsumed) {
         CombinedRow combiner = new CombinedRow(leftNumCols, rightNumCols);
         return new HashInnerJoinBatchIterator<>(
             new RamAccountingBatchIterator<>(left, rowAccounting),
@@ -142,7 +139,6 @@ public class HashJoinOperation implements CompletionListenable {
             circuitBreaker,
             estimatedRowSizeForLeft,
             numberOfRowsForLeft,
-            limit,
-            isOrdered);
+            rowsToBeConsumed);
     }
 }

--- a/sql/src/main/java/io/crate/planner/operators/HashJoin.java
+++ b/sql/src/main/java/io/crate/planner/operators/HashJoin.java
@@ -180,7 +180,8 @@ class HashJoin extends TwoInputPlan {
             hashInputs.v2(),
             Symbols.typeView(leftLogicalPlan.outputs()),
             leftLogicalPlan.estimatedRowSize(),
-            leftLogicalPlan.numExpectedRows());
+            leftLogicalPlan.numExpectedRows(),
+            getRowsToBeConsumed(limit, order));
         return new Join(
             joinPhase,
             leftExecutionPlan,
@@ -191,6 +192,14 @@ class HashJoin extends TwoInputPlan {
             outputs.size(),
             null
         );
+    }
+
+    private int getRowsToBeConsumed(int limit, @Nullable OrderBy order) {
+        if (order != null || limit == NO_LIMIT) {
+            return Integer.MAX_VALUE;
+        } else {
+            return limit;
+        }
     }
 
     private Tuple<List<Symbol>, List<Symbol>> extractHashJoinInputsFromJoinSymbolsAndSplitPerSide(boolean switchedTables) {

--- a/sql/src/test/java/io/crate/execution/engine/join/BlockSizeCalculatorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/join/BlockSizeCalculatorTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.engine.join;
+
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.junit.Test;
+
+import static io.crate.execution.engine.join.BlockSizeCalculator.DEFAULT_BLOCK_SIZE;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class BlockSizeCalculatorTest {
+
+    private static final int ROWS_TO_BE_CONSUMED = 10_000;
+
+    private final CircuitBreaker circuitBreaker = mock(CircuitBreaker.class);
+
+    @Test
+    public void testCalculationOfBlockSize() {
+        when(circuitBreaker.getLimit()).thenReturn(110L);
+        when(circuitBreaker.getUsed()).thenReturn(10L);
+        BlockSizeCalculator blockCalculator100leftRows = new BlockSizeCalculator(circuitBreaker, 5, 100, ROWS_TO_BE_CONSUMED);
+        assertThat(blockCalculator100leftRows.calculateBlockSize(), is(20));
+        BlockSizeCalculator blockCalculator10LeftRows = new BlockSizeCalculator(circuitBreaker, 5, 10, ROWS_TO_BE_CONSUMED);
+        assertThat(blockCalculator10LeftRows.calculateBlockSize(), is(10));
+    }
+
+    @Test
+    public void testBlockSizeIsAdjustedForUnorderedLimitJoins() {
+        when(circuitBreaker.getLimit()).thenReturn(DEFAULT_BLOCK_SIZE + 1L);
+        when(circuitBreaker.getUsed()).thenReturn(0L);
+        long numberOfRowsForLeft = DEFAULT_BLOCK_SIZE + 1;
+        BlockSizeCalculator blockSizeCalculator = new BlockSizeCalculator(circuitBreaker, 1, numberOfRowsForLeft, 100);
+        int blockSize = blockSizeCalculator.calculateBlockSize();
+        assertThat(blockSize, is(DEFAULT_BLOCK_SIZE));
+
+        // even for limit joins we don't use a block size larger than what the available memory dictates
+        when(circuitBreaker.getLimit()).thenReturn(110L);
+        when(circuitBreaker.getUsed()).thenReturn(10L);
+        blockSize = blockSizeCalculator.calculateBlockSize();
+        assertThat(blockSize, is(100));
+    }
+
+    @Test
+    public void testBlockSizeIsNotAdjustedForOrderedLimitJoins() {
+        when(circuitBreaker.getLimit()).thenReturn(DEFAULT_BLOCK_SIZE + 1L);
+        when(circuitBreaker.getUsed()).thenReturn(0L);
+
+        long numberOfRowsForLeft = DEFAULT_BLOCK_SIZE + 1;
+        BlockSizeCalculator blockSizeCalculator = new BlockSizeCalculator(circuitBreaker, 1, numberOfRowsForLeft, Integer.MAX_VALUE);
+        assertThat(blockSizeCalculator.calculateBlockSize(), is(DEFAULT_BLOCK_SIZE + 1));
+    }
+
+    @Test
+    public void testCalculationOfBlockSizeWithMissingStats() {
+        when(circuitBreaker.getLimit()).thenReturn(-1L);
+        BlockSizeCalculator blockSizeCalculator = new BlockSizeCalculator(circuitBreaker, 10, 10, ROWS_TO_BE_CONSUMED);
+        assertThat(blockSizeCalculator.calculateBlockSize(), is(DEFAULT_BLOCK_SIZE));
+
+        when(circuitBreaker.getLimit()).thenReturn(110L);
+        when(circuitBreaker.getUsed()).thenReturn(10L);
+        BlockSizeCalculator blockCalculatorNoNumberOrRowsStats = new BlockSizeCalculator(circuitBreaker, 10, -1, ROWS_TO_BE_CONSUMED);
+        assertThat(blockCalculatorNoNumberOrRowsStats.calculateBlockSize(), is(DEFAULT_BLOCK_SIZE));
+
+        BlockSizeCalculator blockCalculatorNoRowSizeStats = new BlockSizeCalculator(circuitBreaker, -1, 10, ROWS_TO_BE_CONSUMED);
+        assertThat(blockCalculatorNoRowSizeStats.calculateBlockSize(), is(DEFAULT_BLOCK_SIZE));
+    }
+
+    @Test
+    public void testCalculationOfBlockSizeWithNoMemLeft() {
+        when(circuitBreaker.getLimit()).thenReturn(110L);
+        when(circuitBreaker.getUsed()).thenReturn(110L);
+        BlockSizeCalculator blockSizeCalculator = new BlockSizeCalculator(circuitBreaker, 10, 10, ROWS_TO_BE_CONSUMED);
+        assertThat(blockSizeCalculator.calculateBlockSize(), is(10));
+    }
+
+    @Test
+    public void testCalculationOfBlockSizeWithIntegerOverflow() {
+        when(circuitBreaker.getLimit()).thenReturn(Integer.MAX_VALUE + 1L);
+        when(circuitBreaker.getUsed()).thenReturn(0L);
+        BlockSizeCalculator blockSizeCalculator = new BlockSizeCalculator(circuitBreaker, 1, 1, Integer.MAX_VALUE);
+        assertThat(blockSizeCalculator.calculateBlockSize(), is(1));
+    }
+}

--- a/sql/src/test/java/io/crate/execution/engine/join/HashInnerJoinBatchIteratorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/join/HashInnerJoinBatchIteratorTest.java
@@ -140,10 +140,7 @@ public class HashInnerJoinBatchIteratorTest {
             getCol0EqCol1JoinCondition(),
             getHashForLeft(),
             getHashForRight(),
-            circuitBreaker,
-            20, // blockSize = 100/20 = 5
-            100,
-            Integer.MAX_VALUE
+            () -> 5
         );
         BatchIteratorTester tester = new BatchIteratorTester(batchIteratorSupplier);
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
@@ -158,10 +155,7 @@ public class HashInnerJoinBatchIteratorTest {
             getCol0EqCol1JoinCondition(),
             getHashWithCollisions(),
             getHashWithCollisions(),
-            circuitBreaker,
-            20, // blockSize = 100/20 = 5
-            100,
-            Integer.MAX_VALUE
+            () -> 5
         );
         BatchIteratorTester tester = new BatchIteratorTester(batchIteratorSupplier);
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
@@ -176,10 +170,7 @@ public class HashInnerJoinBatchIteratorTest {
             getCol0EqCol1JoinCondition(),
             getHashForLeft(),
             getHashForRight(),
-            circuitBreaker,
-            100, // blockSize = 100/100 = 1
-            100,
-            Integer.MAX_VALUE
+            () -> 1
         );
         BatchIteratorTester tester = new BatchIteratorTester(batchIteratorSupplier);
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
@@ -194,10 +185,7 @@ public class HashInnerJoinBatchIteratorTest {
             getCol0EqCol1JoinCondition(),
             getHashForLeft(),
             getHashForRight(),
-            circuitBreaker,
-            33, // blockSize = 100 / 33 = 3
-            100,
-            Integer.MAX_VALUE
+            () -> 3
         );
         BatchIteratorTester tester = new BatchIteratorTester(batchIteratorSupplier);
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);

--- a/sql/src/test/java/io/crate/execution/engine/join/HashInnerJoinBatchIteratorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/join/HashInnerJoinBatchIteratorTest.java
@@ -143,8 +143,7 @@ public class HashInnerJoinBatchIteratorTest {
             circuitBreaker,
             20, // blockSize = 100/20 = 5
             100,
-            -1,
-            false
+            Integer.MAX_VALUE
         );
         BatchIteratorTester tester = new BatchIteratorTester(batchIteratorSupplier);
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
@@ -162,8 +161,7 @@ public class HashInnerJoinBatchIteratorTest {
             circuitBreaker,
             20, // blockSize = 100/20 = 5
             100,
-            -1,
-            false
+            Integer.MAX_VALUE
         );
         BatchIteratorTester tester = new BatchIteratorTester(batchIteratorSupplier);
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
@@ -181,8 +179,7 @@ public class HashInnerJoinBatchIteratorTest {
             circuitBreaker,
             100, // blockSize = 100/100 = 1
             100,
-            -1,
-            false
+            Integer.MAX_VALUE
         );
         BatchIteratorTester tester = new BatchIteratorTester(batchIteratorSupplier);
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);
@@ -200,8 +197,7 @@ public class HashInnerJoinBatchIteratorTest {
             circuitBreaker,
             33, // blockSize = 100 / 33 = 3
             100,
-            -1,
-            false
+            Integer.MAX_VALUE
         );
         BatchIteratorTester tester = new BatchIteratorTester(batchIteratorSupplier);
         tester.verifyResultAndEdgeCaseBehaviour(expectedResult);

--- a/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -812,7 +812,7 @@ public class JoinIntegrationTest extends SQLTransportIntegrationTest {
         execute("insert into t1 (a) values (0), (1), (1), (2), (2), (4)");
         execute("insert into t2 (x) values (1), (3), (3), (4), (4)");
         execute("refresh table t1, t2");
-        execute("select a, x from t1 join t2 on t1.a + 1 = t2.x + 1  order by a, x");
+        execute("select a, x from t1 join t2 on t1.a + 1 = t2.x + 1 order by a, x");
         assertThat(TestingHelpers.printedTable(response.rows()),
             is("1| 1\n" +
                "1| 1\n" +

--- a/sql/src/test/java/io/crate/planner/node/dql/JoinPhaseTest.java
+++ b/sql/src/test/java/io/crate/planner/node/dql/JoinPhaseTest.java
@@ -135,7 +135,8 @@ public class JoinPhaseTest extends CrateUnitTest {
             Arrays.asList(Literal.of("testRight"), Literal.of(20)),
             Arrays.asList(DataTypes.STRING, DataTypes.INTEGER),
             111,
-            222);
+            222,
+            333);
 
         BytesStreamOutput output = new BytesStreamOutput();
         node.writeTo(output);
@@ -160,5 +161,6 @@ public class JoinPhaseTest extends CrateUnitTest {
         assertThat(node.leftOutputTypes(), is(node2.leftOutputTypes()));
         assertThat(node.estimatedRowSizeForLeft(), is(node2.estimatedRowSizeForLeft()));
         assertThat(node.numberOfRowsForLeft(), is(node2.numberOfRowsForLeft()));
+        assertThat(node.rowsToBeConsumed(), is(node2.rowsToBeConsumed()));
     }
 }


### PR DESCRIPTION
<!--

Thanks for your contribution. Here is a quick checklist of things you should've done:

 - You've read CONTRIBUTING.rst and signed our CLA (https://crate.io/community/contribute/cla/)
 - Wrote a CHANGES.txt entry if this is a change that is relevant for users of CrateDB
 - Ran tests with `./gradlew test itest` (If they fail Jenkins will block this PR anyway)

-->
