### PR TITLE
Update SQL compliance page for ON CONFLICT 

### DIFF
--- a/blackbox/docs/appendices/sql-compliance.rst
+++ b/blackbox/docs/appendices/sql-compliance.rst
@@ -57,12 +57,6 @@ Alter Table
 ``ALTER COLUMN`` and ``DROP COLUMN`` actions are not currently supported (see
 :ref:`ref-alter-table`).
 
-Insert, Update, and Delete
-==========================
-
-The keyword :ref:`on_duplicate_key_update`, when used in insert statements to
-perform an upsert, is an alternative to ``ON CONFLICT`` in standard SQL.
-
 System Information Tables
 =========================
 

--- a/sql/src/test/java/io/crate/analyze/InsertFromSubQueryAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/InsertFromSubQueryAnalyzerTest.java
@@ -360,4 +360,27 @@ public class InsertFromSubQueryAnalyzerTest extends CrateDummyClusterServiceUnit
         expectedException.expectMessage("line 1:66: mismatched input 'update' expecting 'NOTHING'");
         e.analyze("insert into users (id, name) (select 1, 'Arthur') on conflict do update set name = excluded.name");
     }
+
+    @Test
+    public void testFromQueryWithInvalidConflictTargetDoNothing() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Conflict target ([id2]) did not match the primary key columns ([id])");
+        e.analyze("insert into users (id, name) (select 1, 'Arthur') on conflict (id2) DO NOTHING");
+    }
+
+    @Test
+    public void testFromQueryWithConflictTargetDoNothingNotMatchingPK() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Number of conflict targets ([id, id2]) did not match the number of primary key columns ([id])");
+        e.analyze("insert into users (id, name) (select 1, 'Arthur') on conflict (id, id2) DO NOTHING");
+    }
+
+    @Test
+    public void testInsertFromValuesWithConflictTargetDoNothingNotMatchingMultiplePKs() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Number of conflict targets ([a, b]) did not match the number of primary key columns ([a, b, c])");
+        e.analyze("insert into three_pk (a, b, c) (select 1, 2, 3) " +
+                  "on conflict (a, b) DO NOTHING");
+    }
+
 }


### PR DESCRIPTION
This updates the SQL compliance page to remove the on conflict limitation.

Also contains a fix to verify conflict target columns in DO NOTHING clauses. 
The conflict target was only verified for the DO UPDATE SET clause, but not for
the DO NOTHING clause.