### PR TITLE
fixes integer overflow on hash join block size calculation

### DIFF
--- a/sql/src/main/java/io/crate/execution/engine/join/HashInnerJoinBatchIterator.java
+++ b/sql/src/main/java/io/crate/execution/engine/join/HashInnerJoinBatchIterator.java
@@ -180,7 +180,7 @@ public class HashInnerJoinBatchIterator<L extends Row, R extends Row, C> extends
             return DEFAULT_BLOCK_SIZE;
         }
 
-        int blockSize = (int) ((circuitBreaker.getLimit() - circuitBreaker.getUsed()) / estimatedRowSizeForLeft);
+        int blockSize = (int) Math.min(Integer.MAX_VALUE, (circuitBreaker.getLimit() - circuitBreaker.getUsed()) / estimatedRowSizeForLeft);
         blockSize = (int) Math.min(numberOfRowsForLeft, blockSize);
         // we can encounter joins which with explicit limit statement but without any order by clause.
         // in this case if the limit is much lower than the default block size we'll try to keep the block size
@@ -193,7 +193,7 @@ public class HashInnerJoinBatchIterator<L extends Row, R extends Row, C> extends
         // In case no mem available from circuit breaker then still allocate a small blockSize,
         // so that at least some rows (min 1) from the left side could be processed and
         // a CircuitBreakerException can be triggered.
-        return blockSize == 0 ? 10 : blockSize;
+        return blockSize <= 0 ? 10 : blockSize;
     }
 
     private static boolean statisticsUnavailable(CircuitBreaker circuitBreaker,

--- a/sql/src/main/java/io/crate/execution/engine/join/HashJoinOperation.java
+++ b/sql/src/main/java/io/crate/execution/engine/join/HashJoinOperation.java
@@ -63,22 +63,27 @@ public class HashJoinOperation implements CompletionListenable {
         CompletableFuture.allOf(leftBatchIterator, rightBatchIterator)
             .whenComplete((result, failure) -> {
                 if (failure == null) {
-                    BatchIterator<Row> joinIterator = new ListenableBatchIterator<>(createHashJoinIterator(
-                        leftBatchIterator.join(),
-                        numLeftCols,
-                        rightBatchIterator.join(),
-                        numRightCols,
-                        joinPredicate,
-                        getHashBuilderFromSymbols(inputFactory, joinLeftInputs),
-                        getHashBuilderFromSymbols(inputFactory, joinRightInputs),
-                        rowAccounting,
-                        circuitBreaker,
-                        estimatedRowSizeForLeft,
-                        numberOfRowsForLeft,
-                        limit,
-                        isOrdered
-                    ), completionFuture);
-                    nlResultConsumer.accept(joinIterator, null);
+                    BatchIterator<Row> joinIterator;
+                    try {
+                        joinIterator = new ListenableBatchIterator<>(createHashJoinIterator(
+                            leftBatchIterator.join(),
+                            numLeftCols,
+                            rightBatchIterator.join(),
+                            numRightCols,
+                            joinPredicate,
+                            getHashBuilderFromSymbols(inputFactory, joinLeftInputs),
+                            getHashBuilderFromSymbols(inputFactory, joinRightInputs),
+                            rowAccounting,
+                            circuitBreaker,
+                            estimatedRowSizeForLeft,
+                            numberOfRowsForLeft,
+                            limit,
+                            isOrdered
+                        ), completionFuture);
+                        nlResultConsumer.accept(joinIterator, null);
+                    } catch (Exception e) {
+                        nlResultConsumer.accept(null, e);
+                    }
                 } else {
                     nlResultConsumer.accept(null, failure);
                 }

--- a/sql/src/test/java/io/crate/execution/engine/join/HashInnerJoinBatchIteratorMemoryTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/join/HashInnerJoinBatchIteratorMemoryTest.java
@@ -138,6 +138,13 @@ public class HashInnerJoinBatchIteratorMemoryTest {
         assertThat(calculateBlockSize(circuitBreaker, 10, 10, -1, false), is(10));
     }
 
+    @Test
+    public void testCalculationOfBlockSizeWithIntegerOverflow() {
+        when(circuitBreaker.getLimit()).thenReturn(Integer.MAX_VALUE + 1L);
+        when(circuitBreaker.getUsed()).thenReturn(0L);
+        assertThat(calculateBlockSize(circuitBreaker, 1, 1, -1, false), is(1));
+    }
+
     private class TestRamAccountingBatchIterator extends RamAccountingBatchIterator<Row> {
 
         private int countCallsForReleaseMem = 0;


### PR DESCRIPTION
If the available HEAP in bytes is greater then Integer.MAX_VALUE, 
casting to integer will result in a negative number due to the overflow.