### PR TITLE
Check for existing views before table creation

### DIFF
--- a/sql/src/main/java/io/crate/analyze/CreateTableAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/CreateTableAnalyzedStatement.java
@@ -47,9 +47,11 @@ public class CreateTableAnalyzedStatement extends AbstractDDLAnalyzedStatement {
 
     public void table(RelationName relationName, boolean ifNotExists, Schemas schemas) {
         relationName.ensureValidForRelationCreation();
-        if (ifNotExists) {
-            noOp = schemas.tableExists(relationName);
-        } else if (schemas.tableExists(relationName)) {
+        boolean tableExists = schemas.tableExists(relationName);
+        boolean viewExists = schemas.viewExists(relationName);
+        if (ifNotExists && !viewExists) {
+            noOp = tableExists;
+        } else if (tableExists || viewExists) {
             throw new RelationAlreadyExists(relationName);
         }
         this.ifNotExists = ifNotExists;

--- a/sql/src/main/java/io/crate/metadata/Schemas.java
+++ b/sql/src/main/java/io/crate/metadata/Schemas.java
@@ -321,4 +321,12 @@ public class Schemas extends AbstractLifecycleComponent implements Iterable<Sche
         }
         return view;
     }
+
+    /**
+     * Performs a lookup to see if a view with the relationName exists.
+     */
+    public boolean viewExists(RelationName relationName) {
+        ViewsMetaData views = clusterService.state().metaData().custom(ViewsMetaData.TYPE);
+        return views != null && views.getView(relationName) != null;
+    }
 }

--- a/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -1024,4 +1024,14 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
         expectedException.expectMessage("Invalid storage option \"columnstore\" for data type \"integer\"");
         e.analyze("create table columnstore_disabled (s int STORAGE WITH (columnstore = false))");
     }
+
+    @Test
+    public void testCreateTableFailsIfNameConflictsWithView() {
+        SQLExecutor executor = SQLExecutor.builder(clusterService)
+            .addView(RelationName.fromIndexName("v1"), "Select * from t1")
+            .build();
+        expectedException.expect(RelationAlreadyExists.class);
+        expectedException.expectMessage("Relation 'doc.v1' already exists");
+        executor.analyze("create table v1 (x int) clustered into 1 shards with (number_of_replicas = 0)");
+    }
 }


### PR DESCRIPTION
This is a safety check which fails before attempting to create a table if a
corresponding view exists. Another check needs to be added during the table
creation process to ensure that no race condition can occur when a view is
created parallel with a table.