### PR TITLE
Add TransportCreateTableAction to perform check for existing views

### DIFF
--- a/sql/src/main/java/io/crate/execution/TransportExecutorModule.java
+++ b/sql/src/main/java/io/crate/execution/TransportExecutorModule.java
@@ -22,9 +22,9 @@
 
 package io.crate.execution;
 
-import io.crate.execution.ddl.TransportDropTableAction;
-import io.crate.execution.ddl.TransportOpenCloseTableOrPartitionAction;
-import io.crate.execution.ddl.TransportRenameTableAction;
+import io.crate.execution.ddl.tables.TransportDropTableAction;
+import io.crate.execution.ddl.tables.TransportOpenCloseTableOrPartitionAction;
+import io.crate.execution.ddl.tables.TransportRenameTableAction;
 import io.crate.execution.ddl.views.TransportCreateViewAction;
 import io.crate.execution.ddl.views.TransportDropViewAction;
 import io.crate.execution.dml.delete.TransportShardDeleteAction;

--- a/sql/src/main/java/io/crate/execution/TransportExecutorModule.java
+++ b/sql/src/main/java/io/crate/execution/TransportExecutorModule.java
@@ -22,6 +22,7 @@
 
 package io.crate.execution;
 
+import io.crate.execution.ddl.tables.TransportCreateTableAction;
 import io.crate.execution.ddl.tables.TransportDropTableAction;
 import io.crate.execution.ddl.tables.TransportOpenCloseTableOrPartitionAction;
 import io.crate.execution.ddl.tables.TransportRenameTableAction;
@@ -55,6 +56,7 @@ public class TransportExecutorModule extends AbstractModule {
         bind(TransportKillAllNodeAction.class).asEagerSingleton();
         bind(TransportKillJobsNodeAction.class).asEagerSingleton();
         bind(TransportNodeStatsAction.class).asEagerSingleton();
+        bind(TransportCreateTableAction.class).asEagerSingleton();
         bind(TransportRenameTableAction.class).asEagerSingleton();
         bind(TransportOpenCloseTableOrPartitionAction.class).asEagerSingleton();
         bind(TransportDropTableAction.class).asEagerSingleton();

--- a/sql/src/main/java/io/crate/execution/ddl/DDLStatementDispatcher.java
+++ b/sql/src/main/java/io/crate/execution/ddl/DDLStatementDispatcher.java
@@ -52,6 +52,8 @@ import io.crate.analyze.RerouteRetryFailedAnalyzedStatement;
 import io.crate.analyze.RestoreSnapshotAnalyzedStatement;
 import io.crate.blob.v2.BlobAdminClient;
 import io.crate.data.Row;
+import io.crate.execution.ddl.tables.AlterTableOperation;
+import io.crate.execution.ddl.tables.TableCreator;
 import io.crate.metadata.Functions;
 import io.crate.expression.udf.UserDefinedFunctionDDLClient;
 import io.crate.auth.user.UserManager;

--- a/sql/src/main/java/io/crate/execution/ddl/TransportSchemaUpdateAction.java
+++ b/sql/src/main/java/io/crate/execution/ddl/TransportSchemaUpdateAction.java
@@ -25,6 +25,8 @@ package io.crate.execution.ddl;
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import io.crate.Constants;
 import io.crate.action.FutureActionListener;
+import io.crate.execution.ddl.SchemaUpdateRequest;
+import io.crate.execution.ddl.SchemaUpdateResponse;
 import io.crate.execution.support.ActionListeners;
 import io.crate.metadata.IndexParts;
 import io.crate.metadata.PartitionName;

--- a/sql/src/main/java/io/crate/execution/ddl/tables/AlterTableOperation.java
+++ b/sql/src/main/java/io/crate/execution/ddl/tables/AlterTableOperation.java
@@ -20,7 +20,7 @@
  * agreement.
  */
 
-package io.crate.execution.ddl;
+package io.crate.execution.ddl.tables;
 
 import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import com.google.common.annotations.VisibleForTesting;

--- a/sql/src/main/java/io/crate/execution/ddl/tables/CreateAnalyzerTask.java
+++ b/sql/src/main/java/io/crate/execution/ddl/tables/CreateAnalyzerTask.java
@@ -20,7 +20,7 @@
  * agreement.
  */
 
-package io.crate.execution.ddl;
+package io.crate.execution.ddl.tables;
 
 import io.crate.data.Row;
 import io.crate.data.Row1;

--- a/sql/src/main/java/io/crate/execution/ddl/tables/CreateTableRequest.java
+++ b/sql/src/main/java/io/crate/execution/ddl/tables/CreateTableRequest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.ddl.tables;
+
+import io.crate.metadata.RelationName;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest;
+import org.elasticsearch.action.support.master.MasterNodeRequest;
+import org.elasticsearch.cluster.ack.AckedRequest;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.unit.TimeValue;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+
+import static org.elasticsearch.action.support.master.AcknowledgedRequest.DEFAULT_ACK_TIMEOUT;
+
+/**
+ * Creates a table represented by an ES index or an ES template (partitioned table).
+ * Checks for existing views in the meta data of the master node before creating the table.
+ *
+ * Encapsulates either a {@link CreateIndexRequest} or a {@link PutIndexTemplateRequest}.
+ */
+public class CreateTableRequest extends MasterNodeRequest<CreateTableRequest> implements AckedRequest {
+
+    private CreateIndexRequest createIndexRequest;
+    private PutIndexTemplateRequest putIndexTemplateRequest;
+
+    public CreateTableRequest(CreateIndexRequest createIndexRequest) {
+        this.createIndexRequest = createIndexRequest;
+    }
+
+    public CreateTableRequest(PutIndexTemplateRequest putIndexTemplateRequest) {
+        this.putIndexTemplateRequest = putIndexTemplateRequest;
+    }
+
+    CreateTableRequest() {
+    }
+
+    @Nullable
+    public CreateIndexRequest getCreateIndexRequest() {
+        return createIndexRequest;
+    }
+
+    @Nullable
+    public PutIndexTemplateRequest getPutIndexTemplateRequest() {
+        return putIndexTemplateRequest;
+    }
+
+    public RelationName getTableName() {
+        if (createIndexRequest != null) {
+            return RelationName.fromIndexName(createIndexRequest.index());
+        } else if (putIndexTemplateRequest != null) {
+            return RelationName.fromIndexName(putIndexTemplateRequest.aliases().iterator().next().name());
+        } else {
+            throw new IllegalStateException("Unknown request type");
+        }
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        return null;
+    }
+
+    @Override
+    public TimeValue ackTimeout() {
+        return DEFAULT_ACK_TIMEOUT;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        if (in.readBoolean()) {
+            createIndexRequest = new CreateIndexRequest();
+            createIndexRequest.readFrom(in);
+        } else {
+            putIndexTemplateRequest = new PutIndexTemplateRequest();
+            putIndexTemplateRequest.readFrom(in);
+        }
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        boolean isIndexRequest = createIndexRequest != null;
+        out.writeBoolean(isIndexRequest);
+        MasterNodeRequest request = isIndexRequest ? createIndexRequest : putIndexTemplateRequest;
+        request.writeTo(out);
+    }
+}

--- a/sql/src/main/java/io/crate/execution/ddl/tables/CreateTableResponse.java
+++ b/sql/src/main/java/io/crate/execution/ddl/tables/CreateTableResponse.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.ddl.tables;
+
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+public final class CreateTableResponse extends ActionResponse {
+
+    private boolean allShardsAcked;
+
+    public CreateTableResponse(boolean allShardsAcked) {
+        this.allShardsAcked = allShardsAcked;
+    }
+
+    CreateTableResponse() {
+    }
+
+    public boolean isAllShardsAcked() {
+        return allShardsAcked;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        allShardsAcked = in.readBoolean();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeBoolean(allShardsAcked);
+    }
+}

--- a/sql/src/main/java/io/crate/execution/ddl/tables/DropTableRequest.java
+++ b/sql/src/main/java/io/crate/execution/ddl/tables/DropTableRequest.java
@@ -20,7 +20,7 @@
  * agreement.
  */
 
-package io.crate.execution.ddl;
+package io.crate.execution.ddl.tables;
 
 import io.crate.metadata.RelationName;
 import org.elasticsearch.action.ActionRequestValidationException;
@@ -32,27 +32,21 @@ import java.io.IOException;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
-public class RenameTableRequest extends AcknowledgedRequest<RenameTableRequest> {
+public class DropTableRequest extends AcknowledgedRequest<DropTableRequest> {
 
-    private RelationName sourceRelationName;
-    private RelationName targetRelationName;
+    private RelationName relationName;
     private boolean isPartitioned;
 
-    RenameTableRequest() {
+    public DropTableRequest() {
     }
 
-    public RenameTableRequest(RelationName sourceRelationName, RelationName targetRelationName, boolean isPartitioned) {
-        this.sourceRelationName = sourceRelationName;
-        this.targetRelationName = targetRelationName;
+    public DropTableRequest(RelationName relationName, boolean isPartitioned) {
+        this.relationName = relationName;
         this.isPartitioned = isPartitioned;
     }
 
-    public RelationName sourceTableIdent() {
-        return sourceRelationName;
-    }
-
-    public RelationName targetTableIdent() {
-        return targetRelationName;
+    public RelationName tableIdent() {
+        return relationName;
     }
 
     public boolean isPartitioned() {
@@ -62,8 +56,8 @@ public class RenameTableRequest extends AcknowledgedRequest<RenameTableRequest> 
     @Override
     public ActionRequestValidationException validate() {
         ActionRequestValidationException validationException = null;
-        if (sourceRelationName == null || targetRelationName == null) {
-            validationException = addValidationError("source and target table ident must not be null", null);
+        if (relationName == null) {
+            validationException = addValidationError("table ident must not be null", null);
         }
         return validationException;
     }
@@ -71,16 +65,14 @@ public class RenameTableRequest extends AcknowledgedRequest<RenameTableRequest> 
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        sourceRelationName = new RelationName(in);
-        targetRelationName = new RelationName(in);
+        relationName = new RelationName(in);
         isPartitioned = in.readBoolean();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        sourceRelationName.writeTo(out);
-        targetRelationName.writeTo(out);
+        relationName.writeTo(out);
         out.writeBoolean(isPartitioned);
     }
 }

--- a/sql/src/main/java/io/crate/execution/ddl/tables/DropTableResponse.java
+++ b/sql/src/main/java/io/crate/execution/ddl/tables/DropTableResponse.java
@@ -20,7 +20,7 @@
  * agreement.
  */
 
-package io.crate.execution.ddl;
+package io.crate.execution.ddl.tables;
 
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.io.stream.StreamInput;

--- a/sql/src/main/java/io/crate/execution/ddl/tables/DropTableTask.java
+++ b/sql/src/main/java/io/crate/execution/ddl/tables/DropTableTask.java
@@ -20,7 +20,7 @@
  * agreement.
  */
 
-package io.crate.execution.ddl;
+package io.crate.execution.ddl.tables;
 
 import io.crate.data.InMemoryBatchIterator;
 import io.crate.data.Row;

--- a/sql/src/main/java/io/crate/execution/ddl/tables/OpenCloseTableOrPartitionResponse.java
+++ b/sql/src/main/java/io/crate/execution/ddl/tables/OpenCloseTableOrPartitionResponse.java
@@ -20,7 +20,7 @@
  * agreement.
  */
 
-package io.crate.execution.ddl;
+package io.crate.execution.ddl.tables;
 
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -28,12 +28,12 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 
-public class RenameTableResponse extends AcknowledgedResponse {
+public class OpenCloseTableOrPartitionResponse extends AcknowledgedResponse {
 
-    public RenameTableResponse() {
+    OpenCloseTableOrPartitionResponse() {
     }
 
-    public RenameTableResponse(boolean acknowledged) {
+    OpenCloseTableOrPartitionResponse(boolean acknowledged) {
         super(acknowledged);
     }
 

--- a/sql/src/main/java/io/crate/execution/ddl/tables/RenameTableRequest.java
+++ b/sql/src/main/java/io/crate/execution/ddl/tables/RenameTableRequest.java
@@ -20,7 +20,7 @@
  * agreement.
  */
 
-package io.crate.execution.ddl;
+package io.crate.execution.ddl.tables;
 
 import io.crate.metadata.RelationName;
 import org.elasticsearch.action.ActionRequestValidationException;
@@ -28,47 +28,42 @@ import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
-import javax.annotation.Nullable;
 import java.io.IOException;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
-public class OpenCloseTableOrPartitionRequest extends AcknowledgedRequest<OpenCloseTableOrPartitionRequest> {
+public class RenameTableRequest extends AcknowledgedRequest<RenameTableRequest> {
 
-    private RelationName relationName;
-    @Nullable
-    private String partitionIndexName;
-    private boolean openTable = false;
+    private RelationName sourceRelationName;
+    private RelationName targetRelationName;
+    private boolean isPartitioned;
 
-    OpenCloseTableOrPartitionRequest() {
+    RenameTableRequest() {
     }
 
-    public OpenCloseTableOrPartitionRequest(RelationName relationName,
-                                            @Nullable String partitionIndexName,
-                                            boolean openTable) {
-        this.relationName = relationName;
-        this.partitionIndexName = partitionIndexName;
-        this.openTable = openTable;
+    public RenameTableRequest(RelationName sourceRelationName, RelationName targetRelationName, boolean isPartitioned) {
+        this.sourceRelationName = sourceRelationName;
+        this.targetRelationName = targetRelationName;
+        this.isPartitioned = isPartitioned;
     }
 
-    public RelationName tableIdent() {
-        return relationName;
+    public RelationName sourceTableIdent() {
+        return sourceRelationName;
     }
 
-    @Nullable
-    public String partitionIndexName() {
-        return partitionIndexName;
+    public RelationName targetTableIdent() {
+        return targetRelationName;
     }
 
-    boolean isOpenTable() {
-        return openTable;
+    public boolean isPartitioned() {
+        return isPartitioned;
     }
 
     @Override
     public ActionRequestValidationException validate() {
         ActionRequestValidationException validationException = null;
-        if (relationName == null) {
-            validationException = addValidationError("table ident must not be null", null);
+        if (sourceRelationName == null || targetRelationName == null) {
+            validationException = addValidationError("source and target table ident must not be null", null);
         }
         return validationException;
     }
@@ -76,16 +71,16 @@ public class OpenCloseTableOrPartitionRequest extends AcknowledgedRequest<OpenCl
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        relationName = new RelationName(in);
-        partitionIndexName = in.readOptionalString();
-        openTable = in.readBoolean();
+        sourceRelationName = new RelationName(in);
+        targetRelationName = new RelationName(in);
+        isPartitioned = in.readBoolean();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        relationName.writeTo(out);
-        out.writeOptionalString(partitionIndexName);
-        out.writeBoolean(openTable);
+        sourceRelationName.writeTo(out);
+        targetRelationName.writeTo(out);
+        out.writeBoolean(isPartitioned);
     }
 }

--- a/sql/src/main/java/io/crate/execution/ddl/tables/RenameTableResponse.java
+++ b/sql/src/main/java/io/crate/execution/ddl/tables/RenameTableResponse.java
@@ -20,7 +20,7 @@
  * agreement.
  */
 
-package io.crate.execution.ddl;
+package io.crate.execution.ddl.tables;
 
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -28,12 +28,12 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 
-public class OpenCloseTableOrPartitionResponse extends AcknowledgedResponse {
+public class RenameTableResponse extends AcknowledgedResponse {
 
-    OpenCloseTableOrPartitionResponse() {
+    public RenameTableResponse() {
     }
 
-    OpenCloseTableOrPartitionResponse(boolean acknowledged) {
+    public RenameTableResponse(boolean acknowledged) {
         super(acknowledged);
     }
 

--- a/sql/src/main/java/io/crate/execution/ddl/tables/TableCreator.java
+++ b/sql/src/main/java/io/crate/execution/ddl/tables/TableCreator.java
@@ -20,7 +20,7 @@
  * agreement.
  */
 
-package io.crate.execution.ddl;
+package io.crate.execution.ddl.tables;
 
 import com.google.common.base.Joiner;
 import io.crate.Constants;

--- a/sql/src/main/java/io/crate/execution/ddl/tables/TableCreator.java
+++ b/sql/src/main/java/io/crate/execution/ddl/tables/TableCreator.java
@@ -34,14 +34,10 @@ import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
-import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
-import org.elasticsearch.action.admin.indices.create.TransportCreateIndexAction;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexResponse;
 import org.elasticsearch.action.admin.indices.delete.TransportDeleteIndexAction;
 import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest;
-import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateResponse;
-import org.elasticsearch.action.admin.indices.template.put.TransportPutIndexTemplateAction;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.metadata.AliasOrIndex;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
@@ -66,20 +62,17 @@ public class TableCreator {
 
     private final ClusterService clusterService;
     private final IndexNameExpressionResolver indexNameExpressionResolver;
-    private final TransportPutIndexTemplateAction transportPutIndexTemplateAction;
-    private final TransportCreateIndexAction transportCreateIndexAction;
+    private final TransportCreateTableAction transportCreateTableAction;
     private final TransportDeleteIndexAction transportDeleteIndexAction;
 
     @Inject
     public TableCreator(ClusterService clusterService,
                         IndexNameExpressionResolver indexNameExpressionResolver,
-                        TransportPutIndexTemplateAction transportPutIndexTemplateAction,
-                        TransportCreateIndexAction transportCreateIndexAction,
+                        TransportCreateTableAction transportCreateIndexAction,
                         TransportDeleteIndexAction transportDeleteIndexAction) {
         this.clusterService = clusterService;
         this.indexNameExpressionResolver = indexNameExpressionResolver;
-        this.transportPutIndexTemplateAction = transportPutIndexTemplateAction;
-        this.transportCreateIndexAction = transportCreateIndexAction;
+        this.transportCreateTableAction = transportCreateIndexAction;
         this.transportDeleteIndexAction = transportDeleteIndexAction;
     }
 
@@ -112,37 +105,26 @@ public class TableCreator {
     }
 
     private void createTable(final CompletableFuture<Long> result, final CreateTableAnalyzedStatement statement) {
+        final CreateTableRequest createTableRequest;
         if (statement.templateName() != null) {
-            transportPutIndexTemplateAction.execute(createTemplateRequest(statement), new ActionListener<PutIndexTemplateResponse>() {
-                @Override
-                public void onResponse(PutIndexTemplateResponse response) {
-                    if (!response.isAcknowledged()) {
-                        warnNotAcknowledged(String.format(Locale.ENGLISH, "creating table '%s'", statement.tableIdent().fqn()));
-                    }
-                    result.complete(SUCCESS_RESULT);
-                }
-
-                @Override
-                public void onFailure(Exception e) {
-                    setException(result, e, statement);
-                }
-            });
+            createTableRequest = new CreateTableRequest(createTemplateRequest(statement));
         } else {
-            transportCreateIndexAction.execute(createIndexRequest(statement), new ActionListener<CreateIndexResponse>() {
-                @Override
-                public void onResponse(CreateIndexResponse response) {
-                    if (!response.isAcknowledged()) {
-                        warnNotAcknowledged(String.format(Locale.ENGLISH, "creating table '%s'", statement.tableIdent().fqn()));
-                    }
-                    result.complete(SUCCESS_RESULT);
-                }
-
-                @Override
-                public void onFailure(Exception e) {
-                    setException(result, e, statement);
-                }
-            });
+            createTableRequest = new CreateTableRequest(createIndexRequest(statement));
         }
+        transportCreateTableAction.execute(createTableRequest, new ActionListener<CreateTableResponse>() {
+            @Override
+            public void onResponse(CreateTableResponse response) {
+                if (!response.isAllShardsAcked()) {
+                    warnNotAcknowledged(String.format(Locale.ENGLISH, "creating table '%s'", statement.tableIdent().fqn()));
+                }
+                result.complete(SUCCESS_RESULT);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                setException(result, e, statement);
+            }
+        });
     }
 
 

--- a/sql/src/main/java/io/crate/execution/ddl/tables/TransportCreateTableAction.java
+++ b/sql/src/main/java/io/crate/execution/ddl/tables/TransportCreateTableAction.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.ddl.tables;
+
+import io.crate.exceptions.RelationAlreadyExists;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.view.ViewsMetaData;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
+import org.elasticsearch.action.admin.indices.create.TransportCreateIndexAction;
+import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest;
+import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateResponse;
+import org.elasticsearch.action.admin.indices.template.put.TransportPutIndexTemplateAction;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+/**
+ * Action to perform creation of tables on the master but avoid race conditions with creating views.
+ *
+ * Regular tables are created through the creation of ES indices, see {@link TransportCreateIndexAction}.
+ * Partitioned tables are created through ES templates, see {@link TransportPutIndexTemplateAction}.
+ *
+ * To atomically run the actions on the master, this action wraps around the ES actions and runs them
+ * inside this action on the master with checking for views beforehand.
+ *
+ * See also: {@link io.crate.execution.ddl.views.TransportCreateViewAction}
+ */
+public class TransportCreateTableAction extends TransportMasterNodeAction<CreateTableRequest, CreateTableResponse> {
+
+    public static final String NAME = "tables:admin/create";
+
+    private final TransportCreateIndexAction transportCreateIndexAction;
+    private final TransportPutIndexTemplateAction transportPutIndexTemplateAction;
+
+    @Inject
+    public TransportCreateTableAction(Settings settings,
+                                      TransportService transportService,
+                                      ClusterService clusterService,
+                                      ThreadPool threadPool,
+                                      ActionFilters actionFilters,
+                                      IndexNameExpressionResolver indexNameExpressionResolver,
+                                      TransportCreateIndexAction transportCreateIndexAction,
+                                      TransportPutIndexTemplateAction transportPutIndexTemplateAction) {
+        super(settings,
+            NAME,
+            transportService,
+            clusterService, threadPool,
+            actionFilters,
+            indexNameExpressionResolver,
+            CreateTableRequest::new);
+        this.transportCreateIndexAction = transportCreateIndexAction;
+        this.transportPutIndexTemplateAction = transportPutIndexTemplateAction;
+    }
+
+    @Override
+    protected String executor() {
+        return ThreadPool.Names.SAME;
+    }
+
+    @Override
+    protected CreateTableResponse newResponse() {
+        return new CreateTableResponse();
+    }
+
+    @Override
+    protected ClusterBlockException checkBlock(CreateTableRequest request, ClusterState state) {
+        if (request.getCreateIndexRequest() != null) {
+            CreateIndexRequest createIndexRequest = request.getCreateIndexRequest();
+            return transportCreateIndexAction.checkBlock(createIndexRequest, state);
+        } else if (request.getPutIndexTemplateRequest() != null) {
+            PutIndexTemplateRequest putIndexTemplateRequest = request.getPutIndexTemplateRequest();
+            return transportPutIndexTemplateAction.checkBlock(putIndexTemplateRequest, state);
+        } else {
+            throw new IllegalStateException("Unknown table request");
+        }
+    }
+
+    @Override
+    protected void masterOperation(final CreateTableRequest request, final ClusterState state, final ActionListener<CreateTableResponse> listener) {
+        final RelationName relationName = request.getTableName();
+        if (viewsExists(relationName, state)) {
+            listener.onFailure(new RelationAlreadyExists(relationName));
+            return;
+        }
+        if (request.getCreateIndexRequest() != null) {
+            CreateIndexRequest createIndexRequest = request.getCreateIndexRequest();
+            ActionListener<CreateIndexResponse> wrappedListener = ActionListener.wrap(
+                response -> listener.onResponse(new CreateTableResponse(response.isShardsAcked())),
+                listener::onFailure
+            );
+            transportCreateIndexAction.masterOperation(createIndexRequest, state, wrappedListener);
+        } else if (request.getPutIndexTemplateRequest() != null) {
+            PutIndexTemplateRequest putIndexTemplateRequest = request.getPutIndexTemplateRequest();
+            ActionListener<PutIndexTemplateResponse> wrappedListener = ActionListener.wrap(
+                response -> listener.onResponse(new CreateTableResponse(response.isAcknowledged())),
+                listener::onFailure
+            );
+            transportPutIndexTemplateAction.masterOperation(putIndexTemplateRequest, state, wrappedListener);
+        } else {
+            throw new IllegalStateException("Unknown table request");
+        }
+    }
+
+    private static boolean viewsExists(RelationName relationName, ClusterState state) {
+        ViewsMetaData views = state.metaData().custom(ViewsMetaData.TYPE);
+        return views != null && views.contains(relationName);
+    }
+}

--- a/sql/src/main/java/io/crate/execution/ddl/tables/TransportDropTableAction.java
+++ b/sql/src/main/java/io/crate/execution/ddl/tables/TransportDropTableAction.java
@@ -20,8 +20,9 @@
  * agreement.
  */
 
-package io.crate.execution.ddl;
+package io.crate.execution.ddl.tables;
 
+import io.crate.execution.ddl.AbstractDDLTransportAction;
 import io.crate.metadata.cluster.DDLClusterStateService;
 import io.crate.metadata.cluster.DropTableClusterStateTaskExecutor;
 import org.elasticsearch.action.support.ActionFilters;

--- a/sql/src/main/java/io/crate/execution/ddl/tables/TransportOpenCloseTableOrPartitionAction.java
+++ b/sql/src/main/java/io/crate/execution/ddl/tables/TransportOpenCloseTableOrPartitionAction.java
@@ -20,8 +20,9 @@
  * agreement.
  */
 
-package io.crate.execution.ddl;
+package io.crate.execution.ddl.tables;
 
+import io.crate.execution.ddl.AbstractDDLTransportAction;
 import io.crate.metadata.cluster.CloseTableClusterStateTaskExecutor;
 import io.crate.metadata.cluster.DDLClusterStateService;
 import io.crate.metadata.cluster.OpenTableClusterStateTaskExecutor;

--- a/sql/src/main/java/io/crate/execution/ddl/tables/TransportRenameTableAction.java
+++ b/sql/src/main/java/io/crate/execution/ddl/tables/TransportRenameTableAction.java
@@ -20,8 +20,9 @@
  * agreement.
  */
 
-package io.crate.execution.ddl;
+package io.crate.execution.ddl.tables;
 
+import io.crate.execution.ddl.AbstractDDLTransportAction;
 import io.crate.metadata.cluster.DDLClusterStateService;
 import io.crate.metadata.cluster.RenameTableClusterStateExecutor;
 import org.elasticsearch.action.support.ActionFilters;

--- a/sql/src/main/java/io/crate/execution/ddl/views/TransportCreateViewAction.java
+++ b/sql/src/main/java/io/crate/execution/ddl/views/TransportCreateViewAction.java
@@ -112,7 +112,7 @@ public final class TransportCreateViewAction extends TransportMasterNodeAction<C
     }
 
     private static boolean conflictsWithView(CreateViewRequest request, ViewsMetaData views) {
-        return !request.replaceExisting() && views != null && views.contains(request.name().fqn());
+        return !request.replaceExisting() && views != null && views.contains(request.name());
     }
 
     @Override

--- a/sql/src/main/java/io/crate/metadata/cluster/AbstractOpenCloseTableClusterStateTaskExecutor.java
+++ b/sql/src/main/java/io/crate/metadata/cluster/AbstractOpenCloseTableClusterStateTaskExecutor.java
@@ -22,7 +22,7 @@
 
 package io.crate.metadata.cluster;
 
-import io.crate.execution.ddl.OpenCloseTableOrPartitionRequest;
+import io.crate.execution.ddl.tables.OpenCloseTableOrPartitionRequest;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
 import org.elasticsearch.action.support.IndicesOptions;

--- a/sql/src/main/java/io/crate/metadata/cluster/CloseTableClusterStateTaskExecutor.java
+++ b/sql/src/main/java/io/crate/metadata/cluster/CloseTableClusterStateTaskExecutor.java
@@ -22,7 +22,7 @@
 
 package io.crate.metadata.cluster;
 
-import io.crate.execution.ddl.OpenCloseTableOrPartitionRequest;
+import io.crate.execution.ddl.tables.OpenCloseTableOrPartitionRequest;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.metadata.IndexMetaData;

--- a/sql/src/main/java/io/crate/metadata/cluster/DDLClusterStateHelpers.java
+++ b/sql/src/main/java/io/crate/metadata/cluster/DDLClusterStateHelpers.java
@@ -23,7 +23,7 @@
 package io.crate.metadata.cluster;
 
 import io.crate.Constants;
-import io.crate.execution.ddl.AlterTableOperation;
+import io.crate.execution.ddl.tables.AlterTableOperation;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
 import org.elasticsearch.cluster.metadata.IndexMetaData;

--- a/sql/src/main/java/io/crate/metadata/cluster/DropTableClusterStateTaskExecutor.java
+++ b/sql/src/main/java/io/crate/metadata/cluster/DropTableClusterStateTaskExecutor.java
@@ -22,7 +22,7 @@
 
 package io.crate.metadata.cluster;
 
-import io.crate.execution.ddl.DropTableRequest;
+import io.crate.execution.ddl.tables.DropTableRequest;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
 import org.elasticsearch.action.support.IndicesOptions;

--- a/sql/src/main/java/io/crate/metadata/cluster/OpenTableClusterStateTaskExecutor.java
+++ b/sql/src/main/java/io/crate/metadata/cluster/OpenTableClusterStateTaskExecutor.java
@@ -22,7 +22,7 @@
 
 package io.crate.metadata.cluster;
 
-import io.crate.execution.ddl.OpenCloseTableOrPartitionRequest;
+import io.crate.execution.ddl.tables.OpenCloseTableOrPartitionRequest;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterState;

--- a/sql/src/main/java/io/crate/metadata/cluster/RenameTableClusterStateExecutor.java
+++ b/sql/src/main/java/io/crate/metadata/cluster/RenameTableClusterStateExecutor.java
@@ -23,7 +23,7 @@
 package io.crate.metadata.cluster;
 
 import io.crate.Constants;
-import io.crate.execution.ddl.RenameTableRequest;
+import io.crate.execution.ddl.tables.RenameTableRequest;
 import io.crate.metadata.IndexParts;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;

--- a/sql/src/main/java/io/crate/metadata/view/ViewsMetaData.java
+++ b/sql/src/main/java/io/crate/metadata/view/ViewsMetaData.java
@@ -163,6 +163,10 @@ public class ViewsMetaData extends AbstractNamedDiffable<MetaData.Custom> implem
         return Objects.hash(viewByName);
     }
 
+    public boolean contains(RelationName relationName) {
+        return contains(relationName.fqn());
+    }
+
     public boolean contains(String name) {
         return viewByName.containsKey(name);
     }

--- a/sql/src/main/java/io/crate/metadata/view/ViewsMetaData.java
+++ b/sql/src/main/java/io/crate/metadata/view/ViewsMetaData.java
@@ -164,11 +164,7 @@ public class ViewsMetaData extends AbstractNamedDiffable<MetaData.Custom> implem
     }
 
     public boolean contains(RelationName relationName) {
-        return contains(relationName.fqn());
-    }
-
-    public boolean contains(String name) {
-        return viewByName.containsKey(name);
+        return viewByName.containsKey(relationName.fqn());
     }
 
     public Iterable<String> names() {

--- a/sql/src/main/java/io/crate/planner/DependencyCarrier.java
+++ b/sql/src/main/java/io/crate/planner/DependencyCarrier.java
@@ -25,7 +25,7 @@ package io.crate.planner;
 import io.crate.action.sql.DCLStatementDispatcher;
 import io.crate.execution.TransportActionProvider;
 import io.crate.execution.ddl.DDLStatementDispatcher;
-import io.crate.execution.ddl.TransportDropTableAction;
+import io.crate.execution.ddl.tables.TransportDropTableAction;
 import io.crate.execution.ddl.views.TransportCreateViewAction;
 import io.crate.execution.ddl.views.TransportDropViewAction;
 import io.crate.execution.dsl.projection.builder.ProjectionBuilder;

--- a/sql/src/main/java/io/crate/planner/node/ddl/CreateAnalyzerPlan.java
+++ b/sql/src/main/java/io/crate/planner/node/ddl/CreateAnalyzerPlan.java
@@ -26,7 +26,7 @@ package io.crate.planner.node.ddl;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.data.Row;
 import io.crate.data.RowConsumer;
-import io.crate.execution.ddl.CreateAnalyzerTask;
+import io.crate.execution.ddl.tables.CreateAnalyzerTask;
 import io.crate.planner.Plan;
 import io.crate.planner.PlannerContext;
 import io.crate.planner.DependencyCarrier;

--- a/sql/src/main/java/io/crate/planner/node/ddl/DropTablePlan.java
+++ b/sql/src/main/java/io/crate/planner/node/ddl/DropTablePlan.java
@@ -24,7 +24,7 @@ package io.crate.planner.node.ddl;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.data.Row;
 import io.crate.data.RowConsumer;
-import io.crate.execution.ddl.DropTableTask;
+import io.crate.execution.ddl.tables.DropTableTask;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Plan;

--- a/sql/src/test/java/io/crate/execution/ddl/tables/AlterTableOperationTest.java
+++ b/sql/src/test/java/io/crate/execution/ddl/tables/AlterTableOperationTest.java
@@ -20,9 +20,10 @@
  * agreement.
  */
 
-package io.crate.execution.ddl;
+package io.crate.execution.ddl.tables;
 
 import io.crate.Constants;
+import io.crate.execution.ddl.tables.AlterTableOperation;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
 import io.crate.test.integration.CrateUnitTest;

--- a/sql/src/test/java/io/crate/execution/ddl/tables/TransportRenameTableActionTest.java
+++ b/sql/src/test/java/io/crate/execution/ddl/tables/TransportRenameTableActionTest.java
@@ -20,8 +20,10 @@
  * agreement.
  */
 
-package io.crate.execution.ddl;
+package io.crate.execution.ddl.tables;
 
+import io.crate.execution.ddl.tables.RenameTableRequest;
+import io.crate.execution.ddl.tables.TransportRenameTableAction;
 import io.crate.integrationtests.SQLTransportIntegrationTest;
 import io.crate.metadata.RelationName;
 import org.elasticsearch.test.ESIntegTestCase;

--- a/sql/src/test/java/io/crate/integrationtests/ViewsITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ViewsITest.java
@@ -22,6 +22,7 @@
 
 package io.crate.integrationtests;
 
+import io.crate.metadata.RelationName;
 import io.crate.metadata.view.ViewsMetaData;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.hamcrest.Matchers;
@@ -41,13 +42,13 @@ public class ViewsITest extends SQLTransportIntegrationTest {
         for (ClusterService clusterService : internalCluster().getInstances(ClusterService.class)) {
             ViewsMetaData views = clusterService.state().metaData().custom(ViewsMetaData.TYPE);
             assertThat(views, Matchers.notNullValue());
-            assertThat(views.contains(sqlExecutor.getDefaultSchema() + ".v1"), is(true));
+            assertThat(views.contains(RelationName.fromIndexName(sqlExecutor.getDefaultSchema() + ".v1")), is(true));
         }
         assertThat(printedTable(execute("select * from v1").rows()), is("1\n"));
         execute("drop view v1");
         for (ClusterService clusterService : internalCluster().getInstances(ClusterService.class)) {
             ViewsMetaData views = clusterService.state().metaData().custom(ViewsMetaData.TYPE);
-            assertThat(views.contains(sqlExecutor.getDefaultSchema() + ".v1"), is(false));
+            assertThat(views.contains(RelationName.fromIndexName(sqlExecutor.getDefaultSchema() + ".v1")), is(false));
         }
     }
 
@@ -60,7 +61,7 @@ public class ViewsITest extends SQLTransportIntegrationTest {
         for (ClusterService clusterService : internalCluster().getInstances(ClusterService.class)) {
             ViewsMetaData views = clusterService.state().metaData().custom(ViewsMetaData.TYPE);
             assertThat(views, Matchers.notNullValue());
-            assertThat(views.contains(sqlExecutor.getDefaultSchema() + ".v2"), is(true));
+            assertThat(views.contains(RelationName.fromIndexName(sqlExecutor.getDefaultSchema() + ".v2")), is(true));
         }
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/ViewsITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ViewsITest.java
@@ -88,6 +88,30 @@ public class ViewsITest extends SQLTransportIntegrationTest {
     }
 
     @Test
+    public void testCreateTableFailsIfNameConflictsWithView() throws Exception {
+        // First plan the create table which should conflict with the view,
+        PlanForNode viewConflictingTableCreation =
+            plan("create table v4 (x int) clustered into 1 shards with (number_of_replicas = 0)");
+        // then create the actual view. This way we circumvent the analyzer check for existing views.
+        execute("create view v4 as select 1");
+
+        expectedException.expectMessage("Relation '" + sqlExecutor.getDefaultSchema() + ".v4' already exists");
+        execute(viewConflictingTableCreation).getResult();
+    }
+
+    @Test
+    public void testCreatePartitionedTableFailsIfNameConflictsWithView() throws Exception {
+        // First plan the create table which should conflict with the view,
+        PlanForNode viewConflictingTableCreation =
+            plan("create table v5 (x int) clustered into 1 shards with (number_of_replicas = 0)");
+        // then create the actual view. This way we circumvent the analyzer check for existing views.
+        execute("create view v5 as select 1");
+
+        expectedException.expectMessage("Relation '" + sqlExecutor.getDefaultSchema() + ".v5' already exists");
+        execute(viewConflictingTableCreation).getResult();
+    }
+
+    @Test
     public void testDropViewFailsIfViewIsMissing() {
         expectedException.expectMessage("Relations not found: " + sqlExecutor.getDefaultSchema() + ".v1");
         execute("drop view v1");


### PR DESCRIPTION
When creating tables, we have to check for existing views now. This can only be
done in a safe way (i.e. preventing race conditions) if we perform the check
for existing views in the same master process which creates the tables itself.

This wraps around TransportCreateIndexAction and TransportPutIndexTemplateAction
to implement a check for views.