### PR TITLE
Support ordering on partitioned or analyzed columns

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -60,6 +60,8 @@ Breaking Changes
 Changes
 =======
 
+- Added support for ordering on analysed or partitioned columns.
+
 - Changed the primary key constraints of the information schema tables
   ``table_constraints``, ``referential_constraints``, ``table_partitions``,
   ``key_column_usage``, ``columns``, and ``tables`` to be SQL compliant.

--- a/sql/src/main/java/io/crate/analyze/relations/AbstractTableRelation.java
+++ b/sql/src/main/java/io/crate/analyze/relations/AbstractTableRelation.java
@@ -21,7 +21,6 @@
 
 package io.crate.analyze.relations;
 
-import io.crate.analyze.OrderBy;
 import io.crate.expression.symbol.Field;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Path;
@@ -222,8 +221,5 @@ public abstract class AbstractTableRelation<T extends TableInfo> implements Anal
             return allocatedFields.get(field.path());
         }
         return null;
-    }
-
-    public void validateOrderBy(@Nullable OrderBy orderBy) {
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -2173,4 +2173,18 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
         execute("select count(*) from t where t > 1000");
         assertThat(TestingHelpers.printedTable(response.rows()), is("2\n"));
     }
+
+    @Test
+    public void testOrderingOnPartitionColumn() {
+        execute("create table t (x int, p int) partitioned by (p) " +
+                "clustered into 1 shards with (number_of_replicas = 0)");
+        execute("insert into t (p, x) values (1, 1), (1, 2), (2, 1)");
+        execute("refresh table t");
+        assertThat(
+            printedTable(execute("select p, x from t order by p desc, x asc").rows()),
+            is("2| 1\n" +
+               "1| 1\n" +
+               "1| 2\n")
+        );
+    }
 }

--- a/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TransportSQLActionTest.java
@@ -27,7 +27,6 @@ import io.crate.TimestampFormat;
 import io.crate.action.sql.SQLActionException;
 import io.crate.exceptions.SQLExceptions;
 import io.crate.testing.SQLBulkResponse;
-import io.crate.testing.TestingHelpers;
 import io.crate.testing.UseJdbc;
 import io.crate.testing.UseRandomizedSchema;
 import org.elasticsearch.action.support.WriteRequest;
@@ -53,6 +52,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
+import static io.crate.testing.TestingHelpers.printedTable;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
@@ -1110,7 +1110,7 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
         }
 
         execute("select name from test order by id asc");
-        assertEquals("Earth\nSaturn\nMoon\nMars\n", TestingHelpers.printedTable(response.rows()));
+        assertEquals("Earth\nSaturn\nMoon\nMars\n", printedTable(response.rows()));
 
         // test bulk update-by-id
         bulkResp = execute("update test set name = concat(name, '-updated') where id = ?", new Object[][]{
@@ -1344,7 +1344,7 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
         String expectedOrderBy =
             "2\n" +
             "1\n";
-        assertEquals(expectedOrderBy, TestingHelpers.printedTable(response.rows()));
+        assertEquals(expectedOrderBy, printedTable(response.rows()));
 
         // aggregation (max())
         String stmtAggregate = "SELECT i, max(distance(p, 'POINT(30.0 30.0)')) " +
@@ -1353,7 +1353,7 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
         execute(stmtAggregate);
         assertThat(response.rowCount(), is(1L));
         String expectedAggregate = "1| 2296582.8899438097\n";
-        assertEquals(expectedAggregate, TestingHelpers.printedTable(response.rows()));
+        assertEquals(expectedAggregate, printedTable(response.rows()));
 
         Double[] row;
         // queries
@@ -1385,7 +1385,7 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
         assertThat(row[1], is(20.0d));
 
         execute("select p from t where distance(p, 'POINT (10 20)') = 152354.3209044634");
-        assertThat(TestingHelpers.printedTable(response.rows()),
+        assertThat(printedTable(response.rows()),
             is("[11.0, 21.0]\n"));
     }
 
@@ -1424,7 +1424,7 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
     @Test
     public void testTwoSubStrOnSameColumn() throws Exception {
         execute("select substr(name, 0, 4), substr(name, 4, 8) from sys.cluster");
-        assertThat(TestingHelpers.printedTable(response.rows()), is("SUIT| TE-CHILD\n"));
+        assertThat(printedTable(response.rows()), is("SUIT| TE-CHILD\n"));
     }
 
 
@@ -1437,7 +1437,7 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
 
         execute("select i, i%3 from t order by i%3, l");
         assertThat(response.rowCount(), is(5L));
-        assertThat(TestingHelpers.printedTable(response.rows()), is(
+        assertThat(printedTable(response.rows()), is(
             "-1| -1\n" +
             "1| 1\n" +
             "10| 1\n" +
@@ -1555,22 +1555,22 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
         assertEquals(_doc2.get("id"), "3");
 
         execute("select name, kind from locations where id in (2,3) order by id");
-        assertEquals(TestingHelpers.printedTable(response.rows()), "Outer Eastern Rim| Galaxy\n" +
-                                                                   "Galactic Sector QQ7 Active J Gamma| Galaxy\n");
+        assertEquals(printedTable(response.rows()), "Outer Eastern Rim| Galaxy\n" +
+                                                    "Galactic Sector QQ7 Active J Gamma| Galaxy\n");
 
         execute("select name, kind, _id from locations where id in (2,3) order by id");
-        assertEquals(TestingHelpers.printedTable(response.rows()), "Outer Eastern Rim| Galaxy| 2\n" +
-                                                                   "Galactic Sector QQ7 Active J Gamma| Galaxy| 3\n");
+        assertEquals(printedTable(response.rows()), "Outer Eastern Rim| Galaxy| 2\n" +
+                                                    "Galactic Sector QQ7 Active J Gamma| Galaxy| 3\n");
 
         execute("select _raw, id from locations where id in (2,3) order by id");
-        assertEquals(TestingHelpers.printedTable(response.rows()), "{\"id\":\"2\",\"name\":\"Outer Eastern Rim\"," +
-                                                                   "\"date\":308534400000,\"kind\":\"Galaxy\",\"position\":2,\"description\":\"The Outer Eastern Rim " +
-                                                                   "of the Galaxy where the Guide has supplanted the Encyclopedia Galactica among its more relaxed " +
-                                                                   "civilisations.\",\"race\":null}| 2\n" +
-                                                                   "{\"id\":\"3\",\"name\":\"Galactic Sector QQ7 Active J Gamma\",\"date\":1367366400000," +
-                                                                   "\"kind\":\"Galaxy\",\"position\":4,\"description\":\"Galactic Sector QQ7 Active J Gamma contains " +
-                                                                   "the Sun Zarss, the planet Preliumtarn of the famed Sevorbeupstry and Quentulus Quazgar Mountains." +
-                                                                   "\",\"race\":null}| 3\n");
+        assertEquals(printedTable(response.rows()), "{\"id\":\"2\",\"name\":\"Outer Eastern Rim\"," +
+                                                    "\"date\":308534400000,\"kind\":\"Galaxy\",\"position\":2,\"description\":\"The Outer Eastern Rim " +
+                                                    "of the Galaxy where the Guide has supplanted the Encyclopedia Galactica among its more relaxed " +
+                                                    "civilisations.\",\"race\":null}| 2\n" +
+                                                    "{\"id\":\"3\",\"name\":\"Galactic Sector QQ7 Active J Gamma\",\"date\":1367366400000," +
+                                                    "\"kind\":\"Galaxy\",\"position\":4,\"description\":\"Galactic Sector QQ7 Active J Gamma contains " +
+                                                    "the Sun Zarss, the planet Preliumtarn of the famed Sevorbeupstry and Quentulus Quazgar Mountains." +
+                                                    "\",\"race\":null}| 3\n");
     }
 
     @Test
@@ -1728,9 +1728,22 @@ public class TransportSQLActionTest extends SQLTransportIntegrationTest {
         // cast is added to have a to_int(2) after the subquery is inserted
         // this causes a normalization on the map-side which used to remove the order by
         execute("select cast((select 2) as integer) * x from t order by 1");
-        assertThat(TestingHelpers.printedTable(response.rows()),
+        assertThat(printedTable(response.rows()),
             is("6\n" +
                "10\n" +
                "20\n"));
+    }
+
+    @Test
+    public void testOrderOnAnalyzedColumn() {
+        execute("create table t (text string index using fulltext) with (number_of_replicas = 0)");
+        execute("insert into t (text) values ('Hello World'), ('The End')");
+        execute("refresh table t");
+
+        assertThat(
+            printedTable(execute("select text from t order by 1 desc").rows()),
+            is("The End\n" +
+               "Hello World\n")
+        );
     }
 }

--- a/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -401,36 +401,14 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test(expected = UnsupportedOperationException.class)
-    public void testSelectPartitionedTableOrderByPartitionedColumn() throws Exception {
-        e.plan("select name from parted order by date");
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
     public void testSelectPartitionedTableOrderByPartitionedColumnInFunction() throws Exception {
         e.plan("select name from parted order by year(date)");
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testSelectOrderByPartitionedNestedColumn() throws Exception {
-        e.plan("select id from multi_parted order by obj['name']");
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testSelectOrderByPartitionedNestedColumnInFunction() throws Exception {
-        e.plan("select id from multi_parted order by format('abc %s', obj['name'])");
     }
 
     @Test(expected = UnsupportedFeatureException.class)
     public void testQueryRequiresScalar() throws Exception {
         // only scalar functions are allowed on system tables because we have no lucene queries
         e.plan("select * from sys.shards where match(table_name, 'characters')");
-    }
-
-    @Test
-    public void testOrderByOnAnalyzed() throws Exception {
-        expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("Cannot ORDER BY 'text': sorting on analyzed/fulltext columns is not possible");
-        e.plan("select text from users u order by 1");
     }
 
     @Test


### PR DESCRIPTION
Ordering on analyzed or partitioned columns was already possible in
certain circumstances. For example if a UNION was involved.

This makes the support consistent for all cases.