### PR TITLE
Update documentation for `discovery.type: ec2` breaking change.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -57,6 +57,9 @@ Breaking Changes
   `node['id']` and `node['name']`. In order to get all information a join query
   can be used with `sys.nodes`.
 
+- ``discovery.type`` setting has been removed. To enable EC2 discovery
+  `discovery.zen.hosts_provider`` setting needs to be set to ``ec2``.
+
 Changes
 =======
 
@@ -156,7 +159,7 @@ Changes
 Fixes
 =====
 
-- Fixed an issue that would cause a NullPointerException to be thrown when 
+- Fixed an issue that would cause a NullPointerException to be thrown when
   executing an ``EXPLAIN`` statement for a ``CROSS JOIN``.
 
 - Do not allow renaming a table when connected to a read-only node.

--- a/app/src/main/dist/config/crate.yml
+++ b/app/src/main/dist/config/crate.yml
@@ -532,7 +532,7 @@ auth:
 # SRV DNS records.
 
 # To enable SRV discovery you need to set the discovery type to 'srv'.
-#discovery.type: srv
+#discovery.zen.hosts_provider: srv
 
 # Service discovery requires a query that is used to look up SRV records,
 # this is usually in the format _service._protocol.fqdn
@@ -544,7 +544,7 @@ auth:
 # AWS EC2 API.
 
 # To enable EC2 discovery you need to set the discovery type to 'ec2'.
-#discovery.type: ec2
+#discovery.zen.hosts_provider: ec2
 
 # There are multiple ways to filter EC2 instances:
 #
@@ -587,7 +587,7 @@ auth:
 # the Azure API.
 
 # To enable Azure discovery you need to set the discovery type to 'azure'.
-#discovery.type: azure
+#discovery.zen.hosts_provider: azure
 
 # You should provide resource group name of your instances
 #cloud.azure.management.resourcegroup.name: myrg

--- a/blackbox/docs/config/cluster.rst
+++ b/blackbox/docs/config/cluster.rst
@@ -372,7 +372,8 @@ configuration file.
   | *Default:*  ``not set``
   | *Runtime:*  ``no``
 
-Currently there are two other discovery types: via DNS and via EC2 API.
+Currently there are three other discovery types: via DNS, via EC2 API and via
+Microsoft Azure mechanisms.
 
 When a node starts up with one of these discovery types enabled, it performs a
 lookup using the settings for the specified mechanism listed below. The hosts
@@ -382,15 +383,10 @@ unicast hosts for node discovery.
 The same lookup is also performed by all nodes in a cluster whenever the master
 is re-elected (see `Cluster Meta Data`).
 
-**discovery.type**
-  | *Default:*   ``not set``
-  | *Runtime:*   ``no``
-  | *Allowed Values:*  ``zen``, ``ec2``
-
 **discovery.zen.hosts_provider**
   | *Default:*   ``not set``
   | *Runtime:*   ``no``
-  | *Allowed Values:* ``srv``, ``azure``
+  | *Allowed Values:* ``srv``, ``ec2``, ``azure``
 
 See also: `Discovery`_.
 
@@ -435,7 +431,8 @@ Discovery on Amazon EC2
 ```````````````````````
 
 CrateDB has built-in support for discovery via the EC2 API. To enable EC2
-discovery the ``discovery.type`` setting needs to be set to ``ec2``.
+discovery the ``discovery.zen.hosts_provider`` settings needs to be set to
+``ec2``.
 
 **cloud.aws.access_key**
   | *Runtime:*  ``no``
@@ -508,7 +505,8 @@ Discovery on Microsoft Azure
 ````````````````````````````
 
 CrateDB has built-in support for discovery via the Azure Virtual Machine API.
-To enable Azure discovery set the ``discovery.zen.hosts_provider`` setting to ``azure``.
+To enable Azure discovery set the ``discovery.zen.hosts_provider`` setting to
+``azure``.
 
 **cloud.azure.management.resourcegroup.name**
   | *Runtime:*  ``no``


### PR DESCRIPTION
- ``ec2`` is no longer a valid value for ``discovery.type``. Instead ``discovery.zen.hosts_provider``
needs to be set to ``ec2``
- ``discovery.type`` can only be ``zen`` which is the default or ``single-node`` which is only used for testing
  purposes and it was not exposed in the documentation. Therefore it's removed from documentation.

See ES Breaking change:
https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking_60_settings_changes.html#_discovery_settings
