### PR TITLE
Do not require permissions to use table functions

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -63,6 +63,9 @@ Breaking Changes
 Changes
 =======
 
+- Table functions no longer require any permissions to be used. (Enterprise
+  only)
+
 - Added support for ordering on analysed or partitioned columns.
 
 - Changed the primary key constraints of the information schema tables

--- a/enterprise/users/src/main/java/io/crate/auth/user/StatementPrivilegeValidator.java
+++ b/enterprise/users/src/main/java/io/crate/auth/user/StatementPrivilegeValidator.java
@@ -561,11 +561,7 @@ class StatementPrivilegeValidator implements StatementAuthorizedValidator {
 
         @Override
         public Void visitTableFunctionRelation(TableFunctionRelation tableFunctionRelation, RelationContext context) {
-            Privileges.ensureUserHasPrivilege(
-                context.type,
-                Privilege.Clazz.TABLE,
-                tableFunctionRelation.tableInfo().ident().toString(),
-                context.user);
+            // Any user can execute table functions; Queries like `select 1` might be used to do simple connection checks
             return null;
         }
 

--- a/enterprise/users/src/test/java/io/crate/auth/user/StatementPrivilegeValidatorTest.java
+++ b/enterprise/users/src/test/java/io/crate/auth/user/StatementPrivilegeValidatorTest.java
@@ -471,6 +471,11 @@ public class StatementPrivilegeValidatorTest extends CrateDummyClusterServiceUni
         analyze("drop view xx.v1");
         assertAskedForView(Privilege.Type.DDL, "xx.v1");
     }
-}
 
+    @Test
+    public void testTableFunctionsDoNotRequireAnyPermissions() {
+        analyze("select 1");
+        assertThat(validationCallArguments.size(), is(0));
+    }
+}
 


### PR DESCRIPTION
Queries like `select 1` are commonly used for simple connection tests
and table functions don't expose any stored user data so we can allow
them to be executed.