### PR TITLE
create correct logical plan for joins on views

### DIFF
--- a/sql/src/main/java/io/crate/analyze/relations/AnalyzedView.java
+++ b/sql/src/main/java/io/crate/analyze/relations/AnalyzedView.java
@@ -32,6 +32,7 @@ import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.QualifiedName;
 
 import javax.annotation.Nonnull;
+import java.util.ArrayList;
 import java.util.List;
 
 public final class AnalyzedView implements QueriedRelation {
@@ -40,6 +41,7 @@ public final class AnalyzedView implements QueriedRelation {
     private final String owner;
     private final QueriedRelation relation;
     private final Fields fields;
+    private final QuerySpec querySpec;
 
     public AnalyzedView(RelationName name, String owner, QueriedRelation relation) {
         this.name = name;
@@ -49,6 +51,8 @@ public final class AnalyzedView implements QueriedRelation {
         for (Field field : relation.fields()) {
             fields.add(field, new Field(this, field, field.valueType()));
         }
+        querySpec = new QuerySpec()
+            .outputs(new ArrayList<>(relation.fields()));
     }
 
     public String owner() {
@@ -65,7 +69,7 @@ public final class AnalyzedView implements QueriedRelation {
 
     @Override
     public QuerySpec querySpec() {
-        return relation.querySpec();
+        return this.querySpec;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -229,7 +229,7 @@ public class LogicalPlanner {
                                                         FetchMode fetchMode,
                                                         SessionContext sessionContext) {
         if (queriedRelation instanceof AnalyzedView) {
-            queriedRelation = ((AnalyzedView) queriedRelation).relation();
+            return plan(((AnalyzedView) queriedRelation).relation(), fetchMode, subqueryPlanner, false, sessionContext);
         }
         if (queriedRelation instanceof QueriedTable) {
             return Collect.create((QueriedTable) queriedRelation, toCollect, where);
@@ -312,7 +312,6 @@ public class LogicalPlanner {
     }
 
     private class Visitor extends AnalyzedStatementVisitor<PlannerContext, LogicalPlan> {
-
 
         @Override
         protected LogicalPlan visitAnalyzedStatement(AnalyzedStatement analyzedStatement, PlannerContext context) {


### PR DESCRIPTION
added a querySpec to the AnalyzedView, which contains the fields of the
subrelation as outputs, because FetchOrEval generates its outputs from
the outputs of the source relation (AnalyzedView)
