### PR TITLE
Extend SqlPrinter to print all JOIN types

### DIFF
--- a/sql/src/main/java/io/crate/analyze/relations/RelationPrinter.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationPrinter.java
@@ -49,7 +49,12 @@ public class RelationPrinter extends AnalyzedRelationVisitor<Void, String> {
 
     @Override
     public String visitQueriedTable(QueriedTable<?> queriedTable, Void context) {
-        return queriedTable.tableRelation().tableInfo().ident().sqlFqn();
+        String fqn = queriedTable.tableRelation().tableInfo().ident().sqlFqn();
+        String qualifiedName = queriedTable.getQualifiedName().toString();
+        if (!fqn.equals(qualifiedName)) {
+            return qualifiedName;
+        }
+        return fqn;
     }
 
     @Override

--- a/sql/src/test/java/io/crate/analyze/CreateViewAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateViewAnalyzerTest.java
@@ -87,13 +87,6 @@ public class CreateViewAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
-    public void testErrorIsThrownForUnsupportedQueries() {
-        expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("Query cannot be used in a VIEW");
-        e.analyze("create view v1 as select t1.x, t1.x as y from t1, t1 as t2");
-    }
-
-    @Test
     public void testCreatingAViewInReadOnlySchemaIsProhibited() {
         for (String schema : Schemas.READ_ONLY_SCHEMAS) {
             try {

--- a/sql/src/test/java/io/crate/analyze/GroupByAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/GroupByAnalyzerTest.java
@@ -310,7 +310,7 @@ public class GroupByAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         QueriedSelectRelation outerRelation = (QueriedSelectRelation) relation;
         assertThat(outerRelation.subRelation(), instanceOf(QueriedSelectRelation.class));
         assertThat(outerRelation.subRelation().querySpec(),
-            isSQL("SELECT max(doc.users.id) GROUP BY doc.users.name"));
+            isSQL("SELECT max(t.id) GROUP BY t.name"));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/analyze/SQLPrinterTest.java
+++ b/sql/src/test/java/io/crate/analyze/SQLPrinterTest.java
@@ -142,8 +142,34 @@ public class SQLPrinterTest extends CrateDummyClusterServiceUnitTest {
                 "SELECT b.\"user\", b.x FROM (SELECT b.\"user\", b.x FROM (SELECT doc.t1.\"user\", doc.t1.x FROM doc.t1) b) b ORDER BY b.\"user\" ASC LIMIT 1 OFFSET 5"),
             // SUBQUERY (group by / having)
             $("select x, cnt from (select x, count(*) as cnt from t1 group by x having count(*) > 1) a",
-                "SELECT a.x, a.cnt FROM (SELECT doc.t1.x, count(*) AS cnt FROM doc.t1 GROUP BY doc.t1.x HAVING (count(*) > 1)) a")
+                "SELECT a.x, a.cnt FROM (SELECT doc.t1.x, count(*) AS cnt FROM doc.t1 GROUP BY doc.t1.x HAVING (count(*) > 1)) a"),
 
+            // JOIN (inner)
+            $("select * from t1 inner join t2 on t1.x = t2.x",
+                "SELECT doc.t1.\"user\", doc.t1.x, doc.t2.name, doc.t2.x FROM doc.t1 INNER JOIN doc.t2 ON (doc.t1.x = doc.t2.x)"),
+            // JOIN (inner, aliased)
+            $("select * from t1 a inner join t2 b on a.x = b.x",
+                "SELECT a.\"user\", a.x, b.name, b.x FROM doc.t1 AS a INNER JOIN doc.t2 AS b ON (a.x = b.x)"),
+            // JOIN (full)
+            $("select * from t1 full join t2 on t1.x = t2.x",
+                "SELECT doc.t1.\"user\", doc.t1.x, doc.t2.name, doc.t2.x FROM doc.t1 FULL JOIN doc.t2 ON (doc.t1.x = doc.t2.x)"),
+            // JOIN (left)
+            $("select * from t1 left join t2 on t1.x = t2.x",
+                "SELECT doc.t1.\"user\", doc.t1.x, doc.t2.name, doc.t2.x FROM doc.t1 LEFT JOIN doc.t2 ON (doc.t1.x = doc.t2.x)"),
+            // JOIN (right)
+            $("select * from t1 right join t2 on t1.x = t2.x",
+                "SELECT doc.t1.\"user\", doc.t1.x, doc.t2.name, doc.t2.x FROM doc.t1 RIGHT JOIN doc.t2 ON (doc.t1.x = doc.t2.x)"),
+            // JOIN (multiple / order by / limit)
+            $("select * from t1 right join t2 on t1.x = t2.x left join t1 b on b.x = t2.x order by b.x limit 1 offset 5",
+                "SELECT doc.t1.\"user\", doc.t1.x, doc.t2.name, doc.t2.x, b.\"user\", b.x FROM doc.t1 RIGHT JOIN doc.t2 ON (doc.t1.x = doc.t2.x) LEFT JOIN doc.t1 AS b ON (b.x = doc.t2.x) ORDER BY b.x ASC LIMIT 1 OFFSET 5"),
+            // JOIN (cross)
+            $("select * from t1, t2", "SELECT doc.t1.\"user\", doc.t1.x, doc.t2.name, doc.t2.x FROM doc.t1 CROSS JOIN doc.t2"),
+            // JOIN (cross, multiple)
+            $("select * from t1, t2, t1 b",
+                "SELECT doc.t1.\"user\", doc.t1.x, doc.t2.name, doc.t2.x, b.\"user\", b.x FROM doc.t1 CROSS JOIN doc.t2 CROSS JOIN doc.t1 AS b"),
+            // JOIN (cross / left)
+            $("select * from t1, t2 left join t1 b on b.x=t2.x",
+                "SELECT doc.t1.\"user\", doc.t1.x, doc.t2.name, doc.t2.x, b.\"user\", b.x FROM doc.t1 CROSS JOIN doc.t2 LEFT JOIN doc.t1 AS b ON (b.x = doc.t2.x)")
         );
     }
 }

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -728,9 +728,9 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         assertThat(relation.querySpec().where().query(), isSQL("null"));
 
         assertThat(relation.joinPairs().get(0).condition(),
-            isSQL("(doc.users.id = doc.users_multi_pk.id)"));
+            isSQL("(u1.id = u2.id)"));
         assertThat(relation.joinPairs().get(1).condition(),
-            isSQL("(doc.users_multi_pk.id = doc.users_clustered_by_only.id)"));
+            isSQL("(u2.id = u3.id)"));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/analyze/SubSelectAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SubSelectAnalyzerTest.java
@@ -131,11 +131,11 @@ public class SubSelectAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(relation.joinPairs().get(0).condition(),
                    isSQL("(t1.i = t2.i)"));
         assertThat(((QueriedRelation)relation.sources().get(new QualifiedName("t1"))).querySpec(),
-                   isSQL("SELECT doc.t1.i, doc.t1.a WHERE (doc.t1.a > '50')"));
+                   isSQL("SELECT t1.i, t1.a WHERE (t1.a > '50')"));
         assertThat(((QueriedSelectRelation)relation.sources().get(new QualifiedName("t1"))).subRelation().querySpec(),
                    isSQL("SELECT doc.t1.a, doc.t1.i ORDER BY doc.t1.a LIMIT 5"));
         assertThat(((QueriedRelation)relation.sources().get(new QualifiedName("t2"))).querySpec(),
-                   isSQL("SELECT doc.t2.b, doc.t2.i WHERE (doc.t2.b > '100')"));
+                   isSQL("SELECT t2.b, t2.i WHERE (t2.b > '100')"));
     }
 
     @Test
@@ -151,11 +151,11 @@ public class SubSelectAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(relation.joinPairs().get(0).condition(),
             isSQL("(t1.i = t2.i)"));
         assertThat(((QueriedRelation)relation.sources().get(new QualifiedName("t1"))).querySpec(),
-            isSQL("SELECT doc.t1.i, doc.t1.a WHERE (doc.t1.a > '50')"));
+            isSQL("SELECT t1.i, t1.a WHERE (t1.a > '50')"));
         assertThat(((QueriedSelectRelation)relation.sources().get(new QualifiedName("t1"))).subRelation().querySpec(),
             isSQL("SELECT doc.t1.a, doc.t1.i ORDER BY doc.t1.a LIMIT 5"));
         assertThat(((QueriedRelation)relation.sources().get(new QualifiedName("t2"))).querySpec(),
-            isSQL("SELECT doc.t2.b, doc.t2.i WHERE (doc.t2.b > '100')"));
+            isSQL("SELECT t2.b, t2.i WHERE (t2.b > '100')"));
     }
 
     @Test
@@ -222,15 +222,15 @@ public class SubSelectAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(relation.outputs(), isSQL("t1.ma, t1.i, t2.mb, t2.i"));
         assertThat(relation.joinPairs().get(0).condition(), isSQL("(t1.i = t2.i)"));
         QueriedSelectRelation t1Sel = (QueriedSelectRelation) relation.sources().get(new QualifiedName("t1"));
-        assertThat(t1Sel.outputs(), isSQL("doc.t1.i, doc.t1.ma"));
+        assertThat(t1Sel.outputs(), isSQL("t1.i, t1.ma"));
         assertThat(t1Sel.groupBy(), isSQL(""));
-        assertThat(t1Sel.having(), isSQL("(doc.t1.ma > '50')"));
+        assertThat(t1Sel.having(), isSQL("(t1.ma > '50')"));
 
         assertThat(t1Sel.subRelation().groupBy(), isSQL("doc.t1.i"));
         assertThat(t1Sel.subRelation().having(), Matchers.nullValue());
 
         QueriedSelectRelation t2Sel = (QueriedSelectRelation) relation.sources().get(new QualifiedName("t2"));
-        assertThat(t2Sel.outputs(), isSQL("doc.t2.mb, doc.t2.i"));
+        assertThat(t2Sel.outputs(), isSQL("t2.mb, t2.i"));
         assertThat(t2Sel.groupBy(), isSQL(""));
         assertThat(t2Sel.having(), Matchers.nullValue());
 

--- a/sql/src/test/java/io/crate/planner/consumer/SemiJoinsTest.java
+++ b/sql/src/test/java/io/crate/planner/consumer/SemiJoinsTest.java
@@ -110,7 +110,7 @@ public class SemiJoinsTest extends CrateDummyClusterServiceUnitTest {
         assertThat(((QueriedRelation) semiJoin.sources().get(T1)).querySpec(),
             isSQL("SELECT doc.t1.a, doc.t1.x, doc.t1.i WHERE (doc.t1.x = 10)"));
         assertThat(((QueriedRelation) semiJoin.sources().get(new QualifiedName(Arrays.asList("S0", "", "empty_row"))))
-            .querySpec(), isSQL("SELECT .empty_row.'foo'"));
+            .querySpec(), isSQL("SELECT S0..empty_row.'foo'"));
 
         assertThat(semiJoin.joinPairs().get(0).condition(), isSQL("(doc.t1.a = S0..empty_row.'foo')"));
         assertThat(semiJoin.joinPairs().get(0).joinType(), is(JoinType.SEMI));
@@ -126,7 +126,7 @@ public class SemiJoinsTest extends CrateDummyClusterServiceUnitTest {
         assertThat(((QueriedRelation) antiJoin.sources().get(T1)).querySpec(),
             isSQL("SELECT doc.t1.a, doc.t1.x, doc.t1.i WHERE (doc.t1.x = 10)"));
         assertThat(((QueriedRelation) antiJoin.sources().get(new QualifiedName(Arrays.asList("S0", "", "empty_row"))))
-            .querySpec(), isSQL("SELECT .empty_row.'foo'"));
+            .querySpec(), isSQL("SELECT S0..empty_row.'foo'"));
 
         assertThat(antiJoin.joinPairs().get(0).condition(), isSQL("(doc.t1.a = S0..empty_row.'foo')"));
         assertThat(antiJoin.joinPairs().get(0).joinType(), is(JoinType.ANTI));


### PR DESCRIPTION
This enables us to use queries containing join operations in views.