### PR TITLE
Ensure plans of printed analyzed statements remain consistent

### DIFF
--- a/sql/src/main/java/io/crate/execution/dsl/phases/FetchPhase.java
+++ b/sql/src/main/java/io/crate/execution/dsl/phases/FetchPhase.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
 
@@ -156,5 +157,26 @@ public class FetchPhase implements ExecutionPhase {
 
     public TreeMap<String, Integer> bases() {
         return bases;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        FetchPhase that = (FetchPhase) o;
+        return executionPhaseId == that.executionPhaseId &&
+               Objects.equals(bases, that.bases) &&
+               Objects.equals(tableIndices, that.tableIndices) &&
+               Objects.equals(fetchRefs, that.fetchRefs) &&
+               Objects.equals(executionNodes, that.executionNodes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(bases, tableIndices, fetchRefs, executionPhaseId, executionNodes);
     }
 }

--- a/sql/src/main/java/io/crate/execution/dsl/phases/MergePhase.java
+++ b/sql/src/main/java/io/crate/execution/dsl/phases/MergePhase.java
@@ -41,6 +41,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 /**
@@ -210,5 +211,31 @@ public class MergePhase extends AbstractProjectionsPhase implements UpstreamPhas
             .add("inputTypes", inputTypes)
             .add("orderBy", positionalOrderBy);
         return helper.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        MergePhase that = (MergePhase) o;
+        return numUpstreams == that.numUpstreams &&
+               numInputs == that.numInputs &&
+               Objects.equals(inputTypes, that.inputTypes) &&
+               Objects.equals(executionNodes, that.executionNodes) &&
+               Objects.equals(distributionInfo, that.distributionInfo) &&
+               Objects.equals(positionalOrderBy, that.positionalOrderBy);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), inputTypes, numUpstreams, numInputs, executionNodes,
+            distributionInfo, positionalOrderBy);
     }
 }

--- a/sql/src/main/java/io/crate/execution/dsl/phases/RoutedCollectPhase.java
+++ b/sql/src/main/java/io/crate/execution/dsl/phases/RoutedCollectPhase.java
@@ -43,6 +43,7 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
@@ -290,5 +291,33 @@ public class RoutedCollectPhase extends AbstractProjectionsPhase implements Coll
             result.orderBy(orderBy);
         }
         return result;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        RoutedCollectPhase that = (RoutedCollectPhase) o;
+        return Objects.equals(routing, that.routing) &&
+               Objects.equals(toCollect, that.toCollect) &&
+               maxRowGranularity == that.maxRowGranularity &&
+               Objects.equals(whereClause, that.whereClause) &&
+               Objects.equals(distributionInfo, that.distributionInfo) &&
+               Objects.equals(nodePageSizeHint, that.nodePageSizeHint) &&
+               Objects.equals(orderBy, that.orderBy) &&
+               Objects.equals(user, that.user);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), routing, toCollect, maxRowGranularity, whereClause, distributionInfo,
+            nodePageSizeHint, orderBy, user);
     }
 }

--- a/sql/src/main/java/io/crate/planner/Merge.java
+++ b/sql/src/main/java/io/crate/planner/Merge.java
@@ -38,6 +38,7 @@ import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 public class Merge implements ExecutionPlan, ResultDescription {
 
@@ -252,5 +253,28 @@ public class Merge implements ExecutionPlan, ResultDescription {
     @Override
     public List<DataType> streamOutputs() {
         return mergePhase.outputTypes();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Merge merge = (Merge) o;
+        return unfinishedLimit == merge.unfinishedLimit &&
+               unfinishedOffset == merge.unfinishedOffset &&
+               numOutputs == merge.numOutputs &&
+               maxRowsPerNode == merge.maxRowsPerNode &&
+               Objects.equals(subExecutionPlan, merge.subExecutionPlan) &&
+               Objects.equals(mergePhase, merge.mergePhase) &&
+               Objects.equals(orderBy, merge.orderBy);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(subExecutionPlan, mergePhase, unfinishedLimit, unfinishedOffset, numOutputs, maxRowsPerNode, orderBy);
     }
 }

--- a/sql/src/main/java/io/crate/planner/PositionalOrderBy.java
+++ b/sql/src/main/java/io/crate/planner/PositionalOrderBy.java
@@ -156,4 +156,26 @@ public class PositionalOrderBy {
         }
         return new PositionalOrderBy(indices, orderBy.reverseFlags(), orderBy.nullsFirst());
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PositionalOrderBy that = (PositionalOrderBy) o;
+        return Arrays.equals(indices, that.indices) &&
+               Arrays.equals(reverseFlags, that.reverseFlags) &&
+               Arrays.equals(nullsFirst, that.nullsFirst);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Arrays.hashCode(indices);
+        result = 31 * result + Arrays.hashCode(reverseFlags);
+        result = 31 * result + Arrays.hashCode(nullsFirst);
+        return result;
+    }
 }

--- a/sql/src/main/java/io/crate/planner/UnionExecutionPlan.java
+++ b/sql/src/main/java/io/crate/planner/UnionExecutionPlan.java
@@ -31,6 +31,7 @@ import io.crate.types.DataType;
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Plan for Union which uses a MergePhase to combine the results of two plans (= two inputs).
@@ -163,4 +164,28 @@ public class UnionExecutionPlan implements ExecutionPlan, ResultDescription {
         return mergePhase.outputTypes();
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UnionExecutionPlan that = (UnionExecutionPlan) o;
+        return unfinishedLimit == that.unfinishedLimit &&
+               unfinishedOffset == that.unfinishedOffset &&
+               numOutputs == that.numOutputs &&
+               maxRowsPerNode == that.maxRowsPerNode &&
+               Objects.equals(left, that.left) &&
+               Objects.equals(right, that.right) &&
+               Objects.equals(mergePhase, that.mergePhase) &&
+               Objects.equals(orderBy, that.orderBy);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(left, right, mergePhase, unfinishedLimit, unfinishedOffset, numOutputs,
+            maxRowsPerNode, orderBy);
+    }
 }

--- a/sql/src/main/java/io/crate/planner/node/ddl/ESClusterUpdateSettingsPlan.java
+++ b/sql/src/main/java/io/crate/planner/node/ddl/ESClusterUpdateSettingsPlan.java
@@ -33,6 +33,7 @@ import io.crate.sql.tree.Expression;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public class ESClusterUpdateSettingsPlan implements Plan {
 
@@ -70,5 +71,24 @@ public class ESClusterUpdateSettingsPlan implements Plan {
         ESClusterUpdateSettingsTask task = new ESClusterUpdateSettingsTask(
             this, executor.transportActionProvider().transportClusterUpdateSettingsAction());
         task.execute(consumer, params);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ESClusterUpdateSettingsPlan that = (ESClusterUpdateSettingsPlan) o;
+        return Objects.equals(persistentSettings, that.persistentSettings) &&
+               Objects.equals(transientSettings, that.transientSettings);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(persistentSettings, transientSettings);
     }
 }

--- a/sql/src/main/java/io/crate/planner/node/dml/LegacyUpsertById.java
+++ b/sql/src/main/java/io/crate/planner/node/dml/LegacyUpsertById.java
@@ -34,8 +34,10 @@ import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.lucene.uid.Versions;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -203,5 +205,31 @@ public class LegacyUpsertById implements Plan {
             executor.transportActionProvider().transportBulkCreateIndicesAction()
         );
         return task.executeBulk();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        LegacyUpsertById that = (LegacyUpsertById) o;
+        return numBulkResponses == that.numBulkResponses &&
+               isPartitioned == that.isPartitioned &&
+               ignoreDuplicateKeys == that.ignoreDuplicateKeys &&
+               Objects.equals(items, that.items) &&
+               Objects.equals(bulkIndices, that.bulkIndices) &&
+               Arrays.equals(updateColumns, that.updateColumns) &&
+               Arrays.equals(insertColumns, that.insertColumns);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(numBulkResponses, isPartitioned, items, bulkIndices, ignoreDuplicateKeys);
+        result = 31 * result + Arrays.hashCode(updateColumns);
+        result = 31 * result + Arrays.hashCode(insertColumns);
+        return result;
     }
 }

--- a/sql/src/main/java/io/crate/planner/node/dql/Collect.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/Collect.java
@@ -36,6 +36,7 @@ import io.crate.types.DataType;
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 
 public class Collect implements ExecutionPlan, ResultDescription {
 
@@ -162,5 +163,27 @@ public class Collect implements ExecutionPlan, ResultDescription {
         }
         Projection lastProjection = projections.get(projections.size() - 1);
         return Symbols.typeView(lastProjection.outputs());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Collect collect = (Collect) o;
+        return unfinishedLimit == collect.unfinishedLimit &&
+               unfinishedOffset == collect.unfinishedOffset &&
+               numOutputs == collect.numOutputs &&
+               maxRowsPerNode == collect.maxRowsPerNode &&
+               Objects.equals(collectPhase, collect.collectPhase) &&
+               Objects.equals(orderBy, collect.orderBy);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(collectPhase, unfinishedLimit, unfinishedOffset, numOutputs, maxRowsPerNode, orderBy);
     }
 }

--- a/sql/src/main/java/io/crate/planner/node/dql/CountPlan.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/CountPlan.java
@@ -35,6 +35,7 @@ import io.crate.types.DataType;
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 
 public class CountPlan implements ExecutionPlan, ResultDescription {
 
@@ -125,5 +126,26 @@ public class CountPlan implements ExecutionPlan, ResultDescription {
     @Override
     public List<DataType> streamOutputs() {
         return mergePhase.outputTypes();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CountPlan countPlan = (CountPlan) o;
+        return unfinishedLimit == countPlan.unfinishedLimit &&
+               unfinishedOffset == countPlan.unfinishedOffset &&
+               Objects.equals(countPhase, countPlan.countPhase) &&
+               Objects.equals(mergePhase, countPlan.mergePhase) &&
+               Objects.equals(unfinishedOrderBy, countPlan.unfinishedOrderBy);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(countPhase, mergePhase, unfinishedLimit, unfinishedOffset, unfinishedOrderBy);
     }
 }

--- a/sql/src/main/java/io/crate/planner/node/dql/QueryThenFetch.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/QueryThenFetch.java
@@ -31,6 +31,7 @@ import io.crate.execution.dsl.phases.FetchPhase;
 import io.crate.execution.dsl.projection.Projection;
 
 import javax.annotation.Nullable;
+import java.util.Objects;
 
 public class QueryThenFetch implements ExecutionPlan {
 
@@ -76,5 +77,24 @@ public class QueryThenFetch implements ExecutionPlan {
     @Override
     public void setDistributionInfo(DistributionInfo distributionInfo) {
         subExecutionPlan.setDistributionInfo(distributionInfo);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        QueryThenFetch that = (QueryThenFetch) o;
+        boolean bla = Objects.equals(fetchPhase, that.fetchPhase) &&
+               Objects.equals(subExecutionPlan, that.subExecutionPlan);
+        return bla;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(fetchPhase, subExecutionPlan);
     }
 }

--- a/sql/src/main/java/io/crate/planner/node/dql/join/Join.java
+++ b/sql/src/main/java/io/crate/planner/node/dql/join/Join.java
@@ -33,6 +33,7 @@ import io.crate.types.DataType;
 import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Plan that will execute a join.
@@ -165,5 +166,29 @@ public class Join implements ExecutionPlan, ResultDescription {
     @Override
     public List<DataType> streamOutputs() {
         return joinPhase.outputTypes();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Join join = (Join) o;
+        return limit == join.limit &&
+               offset == join.offset &&
+               numOutputs == join.numOutputs &&
+               maxRowsPerNode == join.maxRowsPerNode &&
+               Objects.equals(left, join.left) &&
+               Objects.equals(right, join.right) &&
+               Objects.equals(joinPhase, join.joinPhase) &&
+               Objects.equals(orderBy, join.orderBy);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(left, right, joinPhase, limit, offset, numOutputs, maxRowsPerNode, orderBy);
     }
 }

--- a/sql/src/test/java/io/crate/analyze/SQLPrinterTest.java
+++ b/sql/src/test/java/io/crate/analyze/SQLPrinterTest.java
@@ -60,11 +60,18 @@ public class SQLPrinterTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testPrintAndAnalyzeRoundTrip() {
-        String actualOutputRound1 = printer.format(e.analyze(input));
-        assertThat(actualOutputRound1, is(expectedOutput));
-        // must be possible to analyze again without error
-        String actualOutputRound2 = printer.format(e.analyze(actualOutputRound1));
-        assertThat(actualOutputRound2, is(expectedOutput));
+        // check if printed analyzed plan matches expected SQL output
+        String firstRoundSql = printer.format(e.analyze(input));
+        assertThat(firstRoundSql, is(expectedOutput));
+
+        // printed plan shouldn't change if analyzed again
+        String secondRoundSql = printer.format(e.analyze(firstRoundSql));
+        assertThat(secondRoundSql, is(expectedOutput));
+
+        // check if all generated plans are identical
+        Object referencePlan = e.plan(input);
+        assertThat(e.plan(firstRoundSql), is(referencePlan));
+        assertThat(e.plan(secondRoundSql), is(referencePlan));
     }
 
 

--- a/sql/src/test/java/io/crate/planner/node/RoutedCollectPhaseTest.java
+++ b/sql/src/test/java/io/crate/planner/node/RoutedCollectPhaseTest.java
@@ -72,7 +72,7 @@ public class RoutedCollectPhaseTest extends CrateUnitTest {
             ImmutableList.<Projection>of(),
             WhereClause.MATCH_ALL,
             DistributionInfo.DEFAULT_MODULO,
-            User.of("not_streamed")
+            null // not streamed
         );
 
         BytesStreamOutput out = new BytesStreamOutput();


### PR DESCRIPTION
When printing analyzed queries with the SqlPrinter, we want to ensure that printed
queries have the same execution plan as the original queries.

This is a safety measurement for our VIEW support. Queries are analyzed and
printed before they are stored as a VIEW.
