### PR TITLE
Let explicit joins precede implicit joins in FROM clause

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -176,6 +176,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue where the order of the relations in FROM would expose fields
+  between the relations. An error was thrown during execution of the statements.
+
 - Fixed incorrect HTTP responses on the BLOB API of subsequent requests after
   an error response occurred, e.g. 404 Not Found.
 

--- a/sql/src/main/java/io/crate/analyze/relations/FullQualifiedNameFieldProvider.java
+++ b/sql/src/main/java/io/crate/analyze/relations/FullQualifiedNameFieldProvider.java
@@ -134,13 +134,13 @@ public class FullQualifiedNameFieldProvider implements FieldProvider<Field> {
         QualifiedName qn = new QualifiedName(Arrays.asList(schema, columnTableName));
         if (parents.containsRelation(qn)) {
             throw new UnsupportedOperationException(String.format(Locale.ENGLISH,
-                "Cannot use relation \"%s.%s\" in subquery. Correlated subqueries are not supported",
+                "Cannot use relation \"%s.%s\" in this context. It is only accessible in the parent context.",
                 schema,
                 columnTableName));
         }
         if (columnSchema == null && parents.containsRelation(new QualifiedName(columnTableName))) {
             throw new UnsupportedOperationException(String.format(Locale.ENGLISH,
-                "Cannot use relation \"%s\" in subquery. Correlated subqueries are not supported", columnTableName));
+                "Cannot use relation \"%s\" in this context. It is only accessible in the parent context.", columnTableName));
         }
     }
 }

--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalysisContext.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalysisContext.java
@@ -64,7 +64,7 @@ public class RelationAnalysisContext {
         return sources;
     }
 
-    private void addJoinPair(JoinPair joinType) {
+    void addJoinPair(JoinPair joinType) {
         if (joinPairs == null) {
             joinPairs = new ArrayList<>();
         }
@@ -97,7 +97,7 @@ public class RelationAnalysisContext {
         return joinPairs;
     }
 
-    private void addSourceRelation(QualifiedName qualifiedName, AnalyzedRelation relation) {
+    void addSourceRelation(QualifiedName qualifiedName, AnalyzedRelation relation) {
         if (sources.put(qualifiedName, relation) != null) {
             String tableName = qualifiedName.toString();
             if (tableName.startsWith(".")) {

--- a/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/relations/RelationAnalyzer.java
@@ -99,6 +99,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 
 @Singleton
@@ -269,10 +270,19 @@ public class RelationAnalyzer extends DefaultTraversalVisitor<AnalyzedRelation, 
     @Override
     protected AnalyzedRelation visitQuerySpecification(QuerySpecification node, StatementAnalysisContext statementContext) {
         List<Relation> from = node.getFrom().isEmpty() ? EMPTY_ROW_TABLE_RELATION : node.getFrom();
-        statementContext.startRelation();
+        RelationAnalysisContext currentRelationContext = statementContext.startRelation();
 
         for (Relation relation : from) {
+            // different from relations have to be isolated from each other
+            RelationAnalysisContext innerContext = statementContext.startRelation();
             process(relation, statementContext);
+            statementContext.endRelation();
+            for (Map.Entry<QualifiedName, AnalyzedRelation> entry : innerContext.sources().entrySet()) {
+                currentRelationContext.addSourceRelation(entry.getKey(), entry.getValue());
+            }
+            for (JoinPair joinPair : innerContext.joinPairs()) {
+                currentRelationContext.addJoinPair(joinPair);
+            }
         }
 
         RelationAnalysisContext context = statementContext.currentRelationContext();

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -29,6 +29,7 @@ import io.crate.analyze.relations.QueriedRelation;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.exceptions.ConversionException;
 import io.crate.exceptions.RelationUnknown;
+import io.crate.exceptions.RelationValidationException;
 import io.crate.exceptions.UnsupportedFeatureException;
 import io.crate.execution.engine.aggregation.impl.AverageAggregation;
 import io.crate.expression.operator.EqOperator;
@@ -1882,21 +1883,21 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testSubSelectWithAccessToParentRelationThrowsUnsupportedFeature() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("Cannot use relation \"doc.t1\" in subquery. Correlated subqueries are not supported");
+        expectedException.expectMessage("Cannot use relation \"doc.t1\" in this context. It is only accessible in the parent context");
         analyze("select (select 1 from t1 as ti where ti.x = t1.x) from t1");
     }
 
     @Test
     public void testSubSelectWithAccessToParentRelationAliasThrowsUnsupportedFeature() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("Cannot use relation \"tparent\" in subquery. Correlated subqueries are not supported");
+        expectedException.expectMessage("Cannot use relation \"tparent\" in this context. It is only accessible in the parent context");
         analyze("select (select 1 from t1 where t1.x = tparent.x) from t1 as tparent");
     }
 
     @Test
     public void testSubSelectWithAccessToGrandParentRelation() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("Cannot use relation \"grandparent\" in subquery. Correlated subqueries are not supported");
+        expectedException.expectMessage("Cannot use relation \"grandparent\" in this context. It is only accessible in the parent context");
         analyze("select (select (select 1 from t1 where grandparent.x = t1.x) from t1 as parent) from t1 as grandparent");
     }
 
@@ -1917,8 +1918,17 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
             .addDocTable(fooTableInfo)
             .build();
         expectedException.expect(UnsupportedOperationException.class);
-        expectedException.expectMessage("Cannot use relation \"foo.t1\" in subquery. Correlated subqueries are not supported");
+        expectedException.expectMessage("Cannot use relation \"foo.t1\" in this context. It is only accessible in the parent context");
         sqlExecutor2.analyze("select * from t1 where id = (select 1 from t1 as x where x.id = t1.id)");
+    }
+
+    @Test
+    public void testContextForExplicitJoinsPrecedesImplicitJoins() {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("Cannot use relation \"doc.t1\" in this context. It is only accessible in the parent context");
+        // Inner join has to be processed before implicit cross join.
+        // Inner join does not know about t1's fields (!)
+        analyze("select * from t1, t2 inner join t1 b on b.x = t1.x");
     }
 
     @Test


### PR DESCRIPTION
The SQL standard specifies that explicit joins precede implicit joins. For
example:

```
select * from t1, t2 inner join t1 b on b.x = t2.x
               ^^^   ^^^^^^^^^^
             implicit explicit
              cross    inner
              join     join
```

The second join will be evaluated first. The order of the evaluation is
important for the checking the available fields.

```
-- t1.x is not known to the explicit join
select * from t1, t2 inner join t1 b on b.x=t1.x;
```

In the above case we threw a runtime exception during execution:

```
UnsupportedOperationException: Can't handle Symbol x
```

This now fails in the analyzer with

```
RelationValidationException: missing FROM-clause entry for relation '[doc.t1]'
```
