### PR TITLE
fix incorrect responses on BLOB API after an error occurred

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -171,6 +171,9 @@ Changes
 Fixes
 =====
 
+- Fixed incorrect HTTP responses on the BLOB API of subsequent requests after
+  an error response occurred, e.g. 404 Not Found.
+
 - Fixed an issue that caused ``ANY`` to not work correctly on nested arrays.
 
 - Fixed an issue that would cause a NullPointerException to be thrown when

--- a/blob/src/test/java/io/crate/integrationtests/BlobIntegrationTest.java
+++ b/blob/src/test/java/io/crate/integrationtests/BlobIntegrationTest.java
@@ -74,6 +74,18 @@ public class BlobIntegrationTest extends BlobHttpIntegrationTest {
     }
 
     @Test
+    public void testErrorResponseResetsBlobHandlerStateCorrectly() throws IOException {
+        String digest = uploadTinyBlob();
+        CloseableHttpResponse response;
+
+        response = get(blobUri("0000000000000000000000000000000000000000"));
+        assertThat(response.getStatusLine().getStatusCode(), is(404));
+
+        response = get(blobUri(digest));
+        assertThat(response.getStatusLine().getStatusCode(), is(200));
+    }
+
+    @Test
     public void testUploadValidFile() throws IOException {
         String digest = "c520e6109835c876fd98636efec43dd61634b7d3";
         CloseableHttpResponse response = put(blobUri(digest), StringUtils.repeat("a", 1500));


### PR DESCRIPTION
The BLOB API returned error responses (e.g. when a BLOB was not found)
multiple times which caused the client to receive a wrong response.
Only one response is consumed by the client at once, and therefore the
next request consumed the leftover response of the previous request.
This happened on HTTP connections that had the `Connection: keep-alive`
header set (which is default in HTTP/1.1).