### PR TITLE
Run everything as super user without enterprise enabled.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -66,6 +66,11 @@ Breaking Changes
 Changes
 =======
 
+- The default user if enterprise is disabled changed from ``null`` to
+  ``crate``. This causes entries in ``sys.jobs`` to show up with ``crate`` as
+  username. Functions like ``user`` will also return ``crate`` if enterprise is
+  enabled but the user module is not available.
+
 - Display the node information (name and id) of jobs in the ``sys.jobs``
   table.
 

--- a/blackbox/docs/admin/system-information.rst
+++ b/blackbox/docs/admin/system-information.rst
@@ -1014,7 +1014,7 @@ that is performing the query::
 
     If the :ref:`enterprise edition <enterprise_features>` is disabled or the
     user management module is not available, the ``username`` is represented as
-    ``NULL``.
+    ``crate``.
 
 Every request that queries data or manipulates data is considered a "job" if it
 is a valid query. Requests that are not valid queries (for example, a request

--- a/blackbox/docs/general/builtins/scalar.rst
+++ b/blackbox/docs/general/builtins/scalar.rst
@@ -1664,7 +1664,7 @@ Example::
    :ref:`enterprise feature <enterprise_features>`.
 
 The ``CURRENT_USER`` system information function returns the name of the
-current connected user or NULL if the user management module is disabled.
+current connected user or ``crate`` if the user management module is disabled.
 
 Returns: ``string``
 
@@ -1721,7 +1721,7 @@ Example::
    :ref:`enterprise feature <enterprise_features>`.
 
 The ``SESSION_USER`` system information function returns the name of the
-current connected user or NULL if the user management module is disabled.
+current connected user or ``crate`` if the user management module is disabled.
 
 Returns: ``string``
 

--- a/enterprise/users/src/main/java/io/crate/auth/user/UserManagerService.java
+++ b/enterprise/users/src/main/java/io/crate/auth/user/UserManagerService.java
@@ -42,17 +42,16 @@ import org.elasticsearch.common.inject.Singleton;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
-import java.util.EnumSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
+import static io.crate.auth.user.User.CRATE_USER;
+
 @Singleton
 public class UserManagerService implements UserManager, ClusterStateListener {
-
-    public static final User CRATE_USER = new User("crate", EnumSet.of(User.Role.SUPERUSER), ImmutableSet.of(), null);
 
     @VisibleForTesting
     static final StatementAuthorizedValidator BYPASS_AUTHORIZATION_CHECKS = s -> {

--- a/enterprise/users/src/main/java/io/crate/metadata/PrivilegesMetaDataUpgrader.java
+++ b/enterprise/users/src/main/java/io/crate/metadata/PrivilegesMetaDataUpgrader.java
@@ -20,7 +20,6 @@
 package io.crate.metadata;
 
 import io.crate.analyze.user.Privilege;
-import io.crate.auth.user.UserManagerService;
 import io.crate.settings.SharedSettings;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.settings.Settings;
@@ -29,6 +28,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import static io.crate.auth.user.User.CRATE_USER;
 
 /**
  * Migration code for existing users, adds all available privilege to each existing user.
@@ -73,7 +74,7 @@ public class PrivilegesMetaDataUpgrader implements CustomMetaDataUpgrader {
                                 privilegeType,
                                 Privilege.Clazz.CLUSTER,
                                 null,
-                                UserManagerService.CRATE_USER.name()));
+                                CRATE_USER.name()));
                     }
                 }
             }

--- a/enterprise/users/src/test/java/io/crate/auth/user/StatementPrivilegeValidatorTest.java
+++ b/enterprise/users/src/test/java/io/crate/auth/user/StatementPrivilegeValidatorTest.java
@@ -49,7 +49,7 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 
-import static io.crate.auth.user.UserManagerService.CRATE_USER;
+import static io.crate.auth.user.User.CRATE_USER;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
@@ -160,13 +160,6 @@ public class StatementPrivilegeValidatorTest extends CrateDummyClusterServiceUni
     public void testSuperUserByPassesValidation() throws Exception {
         analyzeAsSuperUser("select * from sys.cluster");
         assertThat(validationCallArguments.size(), is(0));
-    }
-
-    @Test
-    public void testSelectStatementNotAllowedAsNullUser() throws Exception {
-        expectedException.expect(UnauthorizedException.class);
-        expectedException.expectMessage("User `null` is not authorized to execute statement");
-        analyze("select * from sys.cluster", null);
     }
 
     @Test

--- a/enterprise/users/src/test/java/io/crate/auth/user/UserManagerServiceTest.java
+++ b/enterprise/users/src/test/java/io/crate/auth/user/UserManagerServiceTest.java
@@ -18,21 +18,21 @@
 
 package io.crate.auth.user;
 
+import io.crate.execution.engine.collect.sources.SysTableRegistry;
 import io.crate.metadata.UserDefinitions;
 import io.crate.metadata.UsersMetaData;
 import io.crate.metadata.UsersPrivilegesMetaData;
 import io.crate.metadata.cluster.DDLClusterStateService;
-import io.crate.execution.engine.collect.sources.SysTableRegistry;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Set;
 
+import static io.crate.auth.user.User.CRATE_USER;
 import static io.crate.auth.user.UserManagerService.ALWAYS_FAIL_EXCEPTION_VALIDATOR;
 import static io.crate.auth.user.UserManagerService.ALWAYS_FAIL_STATEMENT_VALIDATOR;
 import static io.crate.auth.user.UserManagerService.BYPASS_AUTHORIZATION_CHECKS;
-import static io.crate.auth.user.UserManagerService.CRATE_USER;
 import static io.crate.auth.user.UserManagerService.NOOP_EXCEPTION_VALIDATOR;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;

--- a/enterprise/users/src/test/java/io/crate/integrationtests/BaseUsersIntegrationTest.java
+++ b/enterprise/users/src/test/java/io/crate/integrationtests/BaseUsersIntegrationTest.java
@@ -19,10 +19,9 @@
 package io.crate.integrationtests;
 
 import io.crate.action.sql.Option;
-import io.crate.action.sql.Session;
 import io.crate.action.sql.SQLOperations;
+import io.crate.action.sql.Session;
 import io.crate.auth.user.User;
-import io.crate.auth.user.UserManagerService;
 import io.crate.testing.SQLResponse;
 import org.junit.Before;
 
@@ -39,7 +38,7 @@ public abstract class BaseUsersIntegrationTest extends SQLTransportIntegrationTe
 
     Session createSuperUserSession(String node) {
         SQLOperations sqlOperations = internalCluster().getInstance(SQLOperations.class, node);
-        return sqlOperations.createSession(null, UserManagerService.CRATE_USER, Option.NONE, DEFAULT_SOFT_LIMIT);
+        return sqlOperations.createSession(null, User.CRATE_USER, Option.NONE, DEFAULT_SOFT_LIMIT);
     }
 
     protected Session createUserSession() {
@@ -49,11 +48,6 @@ public abstract class BaseUsersIntegrationTest extends SQLTransportIntegrationTe
     Session createUserSession(String node) {
         SQLOperations sqlOperations = internalCluster().getInstance(SQLOperations.class, node);
         return sqlOperations.createSession(null, User.of("normal"), Option.NONE, DEFAULT_SOFT_LIMIT);
-    }
-
-    Session createNullUserSession(String node) {
-        SQLOperations sqlOperations = internalCluster().getInstance(SQLOperations.class, node);
-        return sqlOperations.createSession(null, null, Option.NONE, DEFAULT_SOFT_LIMIT);
     }
 
     @Before

--- a/enterprise/users/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
+++ b/enterprise/users/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
@@ -23,7 +23,6 @@ import io.crate.action.sql.SQLOperations;
 import io.crate.action.sql.Session;
 import io.crate.auth.user.User;
 import io.crate.auth.user.UserManager;
-import io.crate.auth.user.UserManagerService;
 import io.crate.expression.udf.UserDefinedFunctionService;
 import io.crate.testing.SQLResponse;
 import org.junit.After;
@@ -124,7 +123,7 @@ public class PrivilegesIntegrationTest extends BaseUsersIntegrationTest {
 
     @Test
     public void testGrantPrivilegeToSuperuserThrowsException() {
-        String superuserName = UserManagerService.CRATE_USER.name();
+        String superuserName = User.CRATE_USER.name();
         expectedException.expect(SQLActionException.class);
         expectedException.expectMessage("UnsupportedFeatureException: Cannot alter privileges for superuser '" +
                                         superuserName + "'");

--- a/enterprise/users/src/test/java/io/crate/integrationtests/UserSessionIntegrationTest.java
+++ b/enterprise/users/src/test/java/io/crate/integrationtests/UserSessionIntegrationTest.java
@@ -18,7 +18,6 @@
 
 package io.crate.integrationtests;
 
-import io.crate.action.sql.SQLActionException;
 import io.crate.execution.engine.collect.stats.JobsLogService;
 import io.crate.settings.SharedSettings;
 import org.elasticsearch.common.settings.Settings;
@@ -53,14 +52,7 @@ public class UserSessionIntegrationTest extends BaseUsersIntegrationTest {
     @Test
     public void testSystemExecutorNullUser() {
         systemExecute("select username from sys.jobs", "sys", getNodeByEnterpriseNode(false));
-        assertNull(response.rows()[0][0]);
-    }
-
-    @Test
-    public void testQueryWithNullUserAndEnabledUserManagement() {
-        expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("MissingPrivilegeException: Missing privilege for user 'User `null` is not authorized to execute statement'");
-        execute("select username from sys.jobs", null, createNullUserSession(getNodeByEnterpriseNode(true)));
+        assertThat(response.rows()[0][0], is("crate"));
     }
 
     private String getNodeByEnterpriseNode(boolean enterpriseEnabled) {

--- a/enterprise/users/src/test/java/io/crate/scalar/systeminformation/UserFunctionTest.java
+++ b/enterprise/users/src/test/java/io/crate/scalar/systeminformation/UserFunctionTest.java
@@ -18,15 +18,13 @@
 
 package io.crate.scalar.systeminformation;
 
+import io.crate.auth.user.User;
+import io.crate.expression.scalar.AbstractScalarFunctionsTest;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.format.SymbolPrinter;
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
-import io.crate.auth.user.User;
 import io.crate.scalar.UsersScalarFunctionModule;
 import io.crate.testing.SqlExpressions;
 import org.junit.Test;
-
-import javax.annotation.Nullable;
 
 import static io.crate.testing.SymbolMatchers.isLiteral;
 import static org.hamcrest.Matchers.is;
@@ -35,7 +33,7 @@ public class UserFunctionTest extends AbstractScalarFunctionsTest {
 
     private static final User TEST_USER = User.of("testUser");
 
-    private void setupFunctionsFor(@Nullable User user) {
+    private void setupFunctionsFor(User user) {
         sqlExpressions = new SqlExpressions(tableSources, null, null, user,
             new UsersScalarFunctionModule());
         functions = sqlExpressions.functions();
@@ -57,24 +55,6 @@ public class UserFunctionTest extends AbstractScalarFunctionsTest {
     public void testNormalizeUser() {
         setupFunctionsFor(TEST_USER);
         assertNormalize("user", isLiteral("testUser"), false);
-    }
-
-    @Test
-    public void testCurrentUserForMissingUserReturnsNull() {
-        setupFunctionsFor(null);
-        assertNormalize("current_user", isLiteral(null), false);
-    }
-
-    @Test
-    public void testUserForMissingUserReturnsNull() {
-        setupFunctionsFor(null);
-        assertNormalize("user", isLiteral(null), false);
-    }
-
-    @Test
-    public void testSessionUserForMissingUserReturnsNull() {
-        setupFunctionsFor(null);
-        assertNormalize("session_user", isLiteral(null), false);
     }
 
     @Test

--- a/sql/src/main/java/io/crate/action/sql/SQLOperations.java
+++ b/sql/src/main/java/io/crate/action/sql/SQLOperations.java
@@ -40,6 +40,8 @@ import org.elasticsearch.transport.NodeDisconnectedException;
 import javax.annotation.Nullable;
 import java.util.Set;
 
+import static io.crate.auth.user.User.CRATE_USER;
+
 
 @Singleton
 public class SQLOperations {
@@ -89,18 +91,20 @@ public class SQLOperations {
     }
 
     public Session newSystemSession() {
-        User user = userManager.findUser("crate");
         return createSession(new SessionContext(
-            SysSchemaInfo.NAME, user, userManager.getStatementValidator(user), userManager.getExceptionValidator(user))
+            SysSchemaInfo.NAME,
+            CRATE_USER,
+            userManager.getStatementValidator(CRATE_USER),
+            userManager.getExceptionValidator(CRATE_USER))
         );
     }
 
-    public Session createSession(@Nullable String defaultSchema, @Nullable User user) {
+    public Session createSession(@Nullable String defaultSchema, User user) {
         return createSession(new SessionContext(defaultSchema, user,
             userManager.getStatementValidator(user), userManager.getExceptionValidator(user)));
     }
 
-    public Session createSession(@Nullable String defaultSchema, @Nullable User user, Set<Option> options, int defaultLimit) {
+    public Session createSession(@Nullable String defaultSchema, User user, Set<Option> options, int defaultLimit) {
         return createSession(new SessionContext(defaultLimit, options, defaultSchema, user,
             userManager.getStatementValidator(user), userManager.getExceptionValidator(user)));
     }

--- a/sql/src/main/java/io/crate/action/sql/SessionContext.java
+++ b/sql/src/main/java/io/crate/action/sql/SessionContext.java
@@ -23,21 +23,21 @@
 package io.crate.action.sql;
 
 import io.crate.analyze.AnalyzedStatement;
-import io.crate.exceptions.MissingPrivilegeException;
-import io.crate.metadata.Schemas;
 import io.crate.auth.user.ExceptionAuthorizedValidator;
 import io.crate.auth.user.StatementAuthorizedValidator;
 import io.crate.auth.user.User;
+import io.crate.exceptions.MissingPrivilegeException;
+import io.crate.metadata.Schemas;
 
 import javax.annotation.Nullable;
-import java.util.Objects;
 import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
 
 public class SessionContext implements StatementAuthorizedValidator, ExceptionAuthorizedValidator {
 
     private final int defaultLimit;
     private final Set<Option> options;
-    @Nullable
     private final User user;
     private final StatementAuthorizedValidator statementAuthorizedValidator;
     private final ExceptionAuthorizedValidator exceptionAuthorizedValidator;
@@ -47,7 +47,7 @@ public class SessionContext implements StatementAuthorizedValidator, ExceptionAu
     private boolean hashJoinEnabled = true;
 
     public SessionContext(@Nullable String defaultSchema,
-                          @Nullable User user,
+                          User user,
                           StatementAuthorizedValidator statementAuthorizedValidator,
                           ExceptionAuthorizedValidator exceptionAuthorizedValidator) {
         this(0, Option.NONE, defaultSchema, user,
@@ -57,12 +57,12 @@ public class SessionContext implements StatementAuthorizedValidator, ExceptionAu
     public SessionContext(int defaultLimit,
                           Set<Option> options,
                           @Nullable String defaultSchema,
-                          @Nullable User user,
+                          User user,
                           StatementAuthorizedValidator statementAuthorizedValidator,
                           ExceptionAuthorizedValidator exceptionAuthorizedValidator) {
         this.defaultLimit = defaultLimit;
         this.options = options;
-        this.user = user;
+        this.user = requireNonNull(user, "User is required");
         this.statementAuthorizedValidator = statementAuthorizedValidator;
         this.exceptionAuthorizedValidator = exceptionAuthorizedValidator;
         this.defaultSchema = defaultSchema;
@@ -87,7 +87,7 @@ public class SessionContext implements StatementAuthorizedValidator, ExceptionAu
     }
 
     public void setDefaultSchema(String schema) {
-        defaultSchema = Objects.requireNonNull(schema, "Default schema must never be set to null");
+        defaultSchema = requireNonNull(schema, "Default schema must never be set to null");
     }
 
     public void setSemiJoinsRewriteEnabled(boolean flag) {
@@ -106,7 +106,6 @@ public class SessionContext implements StatementAuthorizedValidator, ExceptionAu
         this.hashJoinEnabled = hashJoinEnabled;
     }
 
-    @Nullable
     public User user() {
         return user;
     }
@@ -129,7 +128,7 @@ public class SessionContext implements StatementAuthorizedValidator, ExceptionAu
      * Creates a new SessionContext with default settings.
      */
     public static SessionContext create() {
-        return create(null);
+        return create(User.CRATE_USER);
     }
 
     /**

--- a/sql/src/main/java/io/crate/analyze/Analyzer.java
+++ b/sql/src/main/java/io/crate/analyze/Analyzer.java
@@ -87,10 +87,13 @@ import io.crate.sql.tree.Update;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.analysis.AnalysisRegistry;
 
 import java.util.ArrayList;
 import java.util.Locale;
+
+import static io.crate.settings.SharedSettings.ENTERPRISE_LICENSE_SETTING;
 
 @Singleton
 public class Analyzer {
@@ -138,7 +141,8 @@ public class Analyzer {
      *                         instance of the class
      */
     @Inject
-    public Analyzer(Schemas schemas,
+    public Analyzer(Settings settings,
+                    Schemas schemas,
                     Functions functions,
                     RelationAnalyzer relationAnalyzer,
                     ClusterService clusterService,
@@ -192,7 +196,7 @@ public class Analyzer {
         this.restoreSnapshotAnalyzer = new RestoreSnapshotAnalyzer(repositoryService, schemas);
         this.createFunctionAnalyzer = new CreateFunctionAnalyzer();
         this.dropFunctionAnalyzer = new DropFunctionAnalyzer();
-        this.privilegesAnalyzer = new PrivilegesAnalyzer(schemas);
+        this.privilegesAnalyzer = new PrivilegesAnalyzer(schemas, ENTERPRISE_LICENSE_SETTING.setting().get(settings));
         this.createIngestionRuleAnalyzer = new CreateIngestionRuleAnalyzer(schemas);
         this.createUserAnalyzer = new CreateUserAnalyzer(functions);
         this.alterUserAnalyzer = new AlterUserAnalyzer(functions);

--- a/sql/src/main/java/io/crate/auth/AlwaysOKNullAuthentication.java
+++ b/sql/src/main/java/io/crate/auth/AlwaysOKNullAuthentication.java
@@ -31,7 +31,7 @@ public class AlwaysOKNullAuthentication implements Authentication {
     private final AuthenticationMethod alwaysOkNull = new AuthenticationMethod() {
         @Override
         public User authenticate(String userName, SecureString passwd, ConnectionProperties connectionProperties) {
-            return null;
+            return User.CRATE_USER;
         }
 
         @Override

--- a/sql/src/main/java/io/crate/auth/user/User.java
+++ b/sql/src/main/java/io/crate/auth/user/User.java
@@ -34,6 +34,8 @@ import java.util.Set;
 
 public class User {
 
+    public static final User CRATE_USER = new User("crate", EnumSet.of(Role.SUPERUSER), ImmutableSet.of(), null);
+
     public enum Role {
         SUPERUSER
     }

--- a/sql/src/main/java/io/crate/user/StubUserManager.java
+++ b/sql/src/main/java/io/crate/user/StubUserManager.java
@@ -23,12 +23,12 @@
 package io.crate.user;
 
 import io.crate.analyze.user.Privilege;
-import io.crate.concurrent.CompletableFutures;
-import io.crate.exceptions.UnsupportedFeatureException;
 import io.crate.auth.user.ExceptionAuthorizedValidator;
 import io.crate.auth.user.StatementAuthorizedValidator;
 import io.crate.auth.user.User;
 import io.crate.auth.user.UserManager;
+import io.crate.concurrent.CompletableFutures;
+import io.crate.exceptions.UnsupportedFeatureException;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
@@ -67,7 +67,8 @@ public class StubUserManager implements UserManager {
     @Nullable
     @Override
     public User findUser(String userName) {
-        return null;
+        // Without enterprise enabled everything runs as super user
+        return User.CRATE_USER;
     }
 
     @Override

--- a/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -24,6 +24,7 @@ package io.crate.analyze;
 import io.crate.Version;
 import io.crate.action.sql.Option;
 import io.crate.action.sql.SessionContext;
+import io.crate.auth.user.User;
 import io.crate.data.Row;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.exceptions.InvalidColumnNameException;
@@ -746,7 +747,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
     public void testExplicitSchemaHasPrecedenceOverDefaultSchema() throws Exception {
         CreateTableAnalyzedStatement statement = (CreateTableAnalyzedStatement) e.analyzer.boundAnalyze(
             SqlParser.createStatement("create table foo.bar (x string)"),
-            new TransactionContext(new SessionContext(0, Option.NONE, "hoschi", null, s -> {}, t -> {})),
+            new TransactionContext(new SessionContext(0, Option.NONE, "hoschi", User.CRATE_USER, s -> {}, t -> {})),
             new ParameterContext(Row.EMPTY, Collections.<Row>emptyList())).analyzedStatement();
 
         // schema from statement must take precedence
@@ -757,7 +758,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
     public void testDefaultSchemaIsAddedToTableIdentIfNoEplicitSchemaExistsInTheStatement() throws Exception {
         CreateTableAnalyzedStatement statement = (CreateTableAnalyzedStatement) e.analyzer.boundAnalyze(
             SqlParser.createStatement("create table bar (x string)"),
-            new TransactionContext(new SessionContext(0, Option.NONE, "hoschi", null, s -> {}, t -> {})),
+            new TransactionContext(new SessionContext(0, Option.NONE, "hoschi", User.CRATE_USER, s -> {}, t -> {})),
             new ParameterContext(Row.EMPTY, Collections.<Row>emptyList())).analyzedStatement();
 
         assertThat(statement.tableIdent().schema(), is("hoschi"));

--- a/sql/src/test/java/io/crate/analyze/CreateFunctionAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateFunctionAnalyzerTest.java
@@ -28,6 +28,7 @@ package io.crate.analyze;
 
 import io.crate.action.sql.Option;
 import io.crate.action.sql.SessionContext;
+import io.crate.auth.user.User;
 import io.crate.data.Row;
 import io.crate.metadata.TransactionContext;
 import io.crate.sql.parser.SqlParser;
@@ -83,7 +84,7 @@ public class CreateFunctionAnalyzerTest extends CrateDummyClusterServiceUnitTest
         CreateFunctionAnalyzedStatement analysis = (CreateFunctionAnalyzedStatement) e.analyzer.boundAnalyze(
             SqlParser.createStatement("CREATE FUNCTION bar(long, long)" +
                 " RETURNS long LANGUAGE dummy_lang AS 'function(a, b) { return a + b; }'"),
-            new TransactionContext(new SessionContext(0, Option.NONE, "my_schema", null, s -> {}, t -> {})),
+            new TransactionContext(new SessionContext(0, Option.NONE, "my_schema", User.CRATE_USER, s -> {}, t -> {})),
             new ParameterContext(Row.EMPTY, Collections.emptyList())).analyzedStatement();
 
         assertThat(analysis.schema(), is("my_schema"));
@@ -95,7 +96,7 @@ public class CreateFunctionAnalyzerTest extends CrateDummyClusterServiceUnitTest
         CreateFunctionAnalyzedStatement analysis = (CreateFunctionAnalyzedStatement) e.analyzer.boundAnalyze(
             SqlParser.createStatement("CREATE FUNCTION my_other_schema.bar(long, long)" +
                 " RETURNS long LANGUAGE dummy_lang AS 'function(a, b) { return a + b; }'"),
-            new TransactionContext(new SessionContext(0, Option.NONE, "my_schema", null, s -> {}, t -> {})),
+            new TransactionContext(new SessionContext(0, Option.NONE, "my_schema", User.CRATE_USER, s -> {}, t -> {})),
             new ParameterContext(Row.EMPTY, Collections.emptyList())).analyzedStatement();
 
         assertThat(analysis.schema(), is("my_other_schema"));

--- a/sql/src/test/java/io/crate/analyze/DropFunctionAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/DropFunctionAnalyzerTest.java
@@ -28,6 +28,7 @@ package io.crate.analyze;
 
 import io.crate.action.sql.Option;
 import io.crate.action.sql.SessionContext;
+import io.crate.auth.user.User;
 import io.crate.data.Row;
 import io.crate.metadata.TransactionContext;
 import io.crate.sql.parser.SqlParser;
@@ -68,7 +69,7 @@ public class DropFunctionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     public void testDropFunctionWithSessionSetSchema() throws Exception {
         DropFunctionAnalyzedStatement analysis = (DropFunctionAnalyzedStatement) e.analyzer.boundAnalyze(
             SqlParser.createStatement("DROP FUNCTION bar(long, object)"),
-            new TransactionContext(new SessionContext(0, Option.NONE, "my_schema", null, s -> {}, t -> {})),
+            new TransactionContext(new SessionContext(0, Option.NONE, "my_schema", User.CRATE_USER,s -> {}, t -> {})),
             new ParameterContext(Row.EMPTY, Collections.emptyList())).analyzedStatement();
 
         assertThat(analysis.schema(), is("my_schema"));
@@ -79,7 +80,7 @@ public class DropFunctionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     public void testDropFunctionExplicitSchemaSupersedesSessionSchema() throws Exception {
         DropFunctionAnalyzedStatement analysis = (DropFunctionAnalyzedStatement) e.analyzer.boundAnalyze(
             SqlParser.createStatement("DROP FUNCTION my_other_schema.bar(long, object)"),
-            new TransactionContext(new SessionContext(0, Option.NONE, "my_schema", null, s -> {}, t -> {})),
+            new TransactionContext(new SessionContext(0, Option.NONE, "my_schema", User.CRATE_USER, s -> {}, t -> {})),
             new ParameterContext(Row.EMPTY, Collections.emptyList())).analyzedStatement();
 
         assertThat(analysis.schema(), is("my_other_schema"));

--- a/sql/src/test/java/io/crate/analyze/PrivilegesDCLAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/PrivilegesDCLAnalyzerTest.java
@@ -28,8 +28,10 @@ import io.crate.action.sql.Option;
 import io.crate.action.sql.SessionContext;
 import io.crate.analyze.relations.RelationAnalyzer;
 import io.crate.analyze.user.Privilege;
+import io.crate.auth.user.User;
 import io.crate.exceptions.RelationUnknown;
 import io.crate.exceptions.UnsupportedFeatureException;
+import io.crate.expression.udf.UserDefinedFunctionService;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocSchemaInfo;
@@ -37,13 +39,12 @@ import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.doc.DocTableInfoFactory;
 import io.crate.metadata.doc.TestingDocTableInfoFactory;
 import io.crate.metadata.table.TestingTableInfo;
-import io.crate.expression.udf.UserDefinedFunctionService;
-import io.crate.auth.user.User;
 import io.crate.sql.parser.SqlParser;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.types.DataTypes;
 import org.elasticsearch.common.inject.Provider;
+import org.elasticsearch.common.settings.Settings;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -58,6 +59,7 @@ import static io.crate.analyze.user.Privilege.State.REVOKE;
 import static io.crate.analyze.user.Privilege.Type.DDL;
 import static io.crate.analyze.user.Privilege.Type.DML;
 import static io.crate.analyze.user.Privilege.Type.DQL;
+import static io.crate.settings.SharedSettings.ENTERPRISE_LICENSE_SETTING;
 import static io.crate.testing.TestingHelpers.getFunctions;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.contains;
@@ -288,7 +290,9 @@ public class PrivilegesDCLAnalyzerTest extends CrateDummyClusterServiceUnitTest 
     public void testGrantWithoutUserManagementEnabledThrowsException() {
         expectedException.expect(UnsupportedOperationException.class);
         expectedException.expectMessage("User management is not enabled");
-        e = SQLExecutor.builder(clusterService).build();
+        e = SQLExecutor.builder(clusterService)
+            .settings(Settings.builder().put(ENTERPRISE_LICENSE_SETTING.getKey(), false).build())
+            .build();
         e.analyze("GRANT DQL TO test");
     }
 

--- a/sql/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -31,6 +31,7 @@ import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.FullQualifiedNameFieldProvider;
 import io.crate.analyze.relations.ParentRelations;
 import io.crate.analyze.relations.TableRelation;
+import io.crate.auth.user.User;
 import io.crate.expression.operator.EqOperator;
 import io.crate.expression.operator.GtOperator;
 import io.crate.expression.operator.LtOperator;
@@ -132,7 +133,7 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testQuotedSubscriptExpression() throws Exception {
         SessionContext sessionContext = new SessionContext(
-            0, EnumSet.of(Option.ALLOW_QUOTED_SUBSCRIPT), null, null, s -> {}, t -> {});
+            0, EnumSet.of(Option.ALLOW_QUOTED_SUBSCRIPT), null, User.CRATE_USER,s -> {}, t -> {});
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
             functions,
             new TransactionContext(sessionContext),
@@ -175,7 +176,7 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         // Test when use subscript function is used explicitly then it's handled (and validated)
         // the same way it's handled when the subscript operator `[]` is used
         SessionContext sessionContext = new SessionContext(
-            0, EnumSet.of(Option.ALLOW_QUOTED_SUBSCRIPT), null, null, s -> {}, t -> {});
+            0, EnumSet.of(Option.ALLOW_QUOTED_SUBSCRIPT), null, User.CRATE_USER, s -> {}, t -> {});
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
             functions,
             new TransactionContext(sessionContext),

--- a/sql/src/test/java/io/crate/auth/AuthenticationMethodTest.java
+++ b/sql/src/test/java/io/crate/auth/AuthenticationMethodTest.java
@@ -22,6 +22,7 @@
 
 package io.crate.auth;
 
+import io.crate.auth.user.User;
 import io.crate.test.integration.CrateUnitTest;
 import org.junit.Test;
 
@@ -36,6 +37,6 @@ public class AuthenticationMethodTest extends CrateUnitTest {
         AuthenticationMethod alwaysOkNullAuthMethod = alwaysOkNullAuth.resolveAuthenticationType("crate", null);
 
         assertThat(alwaysOkNullAuthMethod.name(), is("alwaysOkNull"));
-        assertNull(alwaysOkNullAuthMethod.authenticate("crate", null, null));
+        assertThat(alwaysOkNullAuthMethod.authenticate("crate", null, null), is(User.CRATE_USER));
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
@@ -113,7 +113,6 @@ import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -340,7 +339,7 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
             userLookup = internalCluster().getInstance(UserLookup.class, node);
         } catch (ConfigurationException ignored) {
             // If enterprise is not enabled there is no UserLookup instance bound in guice
-            userLookup = userName -> null;
+            userLookup = userName -> User.CRATE_USER;
         }
         Session session = sqlOperations.createSession(schema, userLookup.findUser("crate"));
         response = SQLTransportExecutor.execute(stmt, null, session).actionGet(SQLTransportExecutor.REQUEST_TIMEOUT);
@@ -432,7 +431,7 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
         Planner planner = internalCluster().getInstance(Planner.class, nodeName);
 
         ParameterContext parameterContext = new ParameterContext(Row.EMPTY, Collections.<Row>emptyList());
-        SessionContext sessionContext = new SessionContext(sqlExecutor.getDefaultSchema(), null, x -> {}, x -> {});
+        SessionContext sessionContext = new SessionContext(sqlExecutor.getDefaultSchema(), User.CRATE_USER, x -> {}, x -> {});
         TransactionContext transactionContext = new TransactionContext(sessionContext);
         RoutingProvider routingProvider = new RoutingProvider(Randomness.get().nextInt(), planner.getAwarenessAttributes());
         PlannerContext plannerContext = new PlannerContext(
@@ -624,7 +623,7 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
     Session createSessionOnNode(String nodeName) {
         SQLOperations sqlOperations = internalCluster().getInstance(SQLOperations.class, nodeName);
         return sqlOperations.createSession(
-            sqlExecutor.getDefaultSchema(), User.of("crate", EnumSet.of(User.Role.SUPERUSER)), Option.NONE, DEFAULT_SOFT_LIMIT);
+            sqlExecutor.getDefaultSchema(), User.CRATE_USER, Option.NONE, DEFAULT_SOFT_LIMIT);
     }
 
     /**
@@ -638,7 +637,7 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
      */
     Session createSession(@Nullable String defaultSchema, Set<Option> options) {
         SQLOperations sqlOperations = internalCluster().getInstance(SQLOperations.class);
-        return sqlOperations.createSession(defaultSchema, null, options, DEFAULT_SOFT_LIMIT);
+        return sqlOperations.createSession(defaultSchema, User.CRATE_USER, options, DEFAULT_SOFT_LIMIT);
     }
 
     /**

--- a/sql/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/sql/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableMap;
 import io.crate.analyze.WhereClause;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.TableRelation;
+import io.crate.auth.user.User;
 import io.crate.exceptions.ConversionException;
 import io.crate.lucene.match.CrateRegexQuery;
 import io.crate.metadata.RelationName;
@@ -74,7 +75,7 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
                 .build();
             TableRelation tableRelation = new TableRelation(tableInfo);
             Map<QualifiedName, AnalyzedRelation> tableSources = ImmutableMap.of(new QualifiedName(tableInfo.ident().name()), tableRelation);
-            SqlExpressions sqlExpressions = new SqlExpressions(tableSources, tableRelation, new Object[]{null}, null);
+            SqlExpressions sqlExpressions = new SqlExpressions(tableSources, tableRelation, new Object[]{null}, User.CRATE_USER);
 
             Query query = convert(new WhereClause(sqlExpressions.normalize(sqlExpressions.asSymbol("x = ?"))));
 

--- a/sql/src/test/java/io/crate/metadata/settings/session/SessionSettingRegistryTest.java
+++ b/sql/src/test/java/io/crate/metadata/settings/session/SessionSettingRegistryTest.java
@@ -23,6 +23,7 @@
 package io.crate.metadata.settings.session;
 
 import io.crate.action.sql.SessionContext;
+import io.crate.auth.user.User;
 import io.crate.data.Row;
 import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.StringLiteral;
@@ -40,14 +41,14 @@ public class SessionSettingRegistryTest {
 
     @Test
     public void testSemiJoinSessionSetting() {
-        SessionContext sessionContext = new SessionContext(null, null, x -> {}, x -> {});
+        SessionContext sessionContext = new SessionContext(null, User.CRATE_USER, x -> {}, x -> {});
         SessionSettingApplier applier = SessionSettingRegistry.getApplier(SessionSettingRegistry.SEMI_JOIN_KEY);
         assertBooleanNonEmptySetting(sessionContext, sessionContext::getSemiJoinsRewriteEnabled, applier, false);
     }
 
     @Test
     public void testHashJoinSessionSetting() {
-        SessionContext sessionContext = new SessionContext(null, null, x -> {}, x -> {});
+        SessionContext sessionContext = new SessionContext(null, User.CRATE_USER, x -> {}, x -> {});
         SessionSettingApplier applier = SessionSettingRegistry.getApplier(SessionSettingRegistry.HASH_JOIN_KEY);
         assertBooleanNonEmptySetting(sessionContext, sessionContext::isHashJoinEnabled, applier, true);
     }

--- a/sql/src/test/java/io/crate/protocols/postgres/AuthenticationContextTest.java
+++ b/sql/src/test/java/io/crate/protocols/postgres/AuthenticationContextTest.java
@@ -26,7 +26,9 @@ import io.crate.auth.AlwaysOKNullAuthentication;
 import io.crate.auth.Authentication;
 import io.crate.auth.AuthenticationMethod;
 import io.crate.auth.Protocol;
+import io.crate.auth.user.User;
 import io.crate.test.integration.CrateUnitTest;
+import org.elasticsearch.common.logging.Loggers;
 import org.junit.Test;
 
 import java.net.InetAddress;
@@ -45,9 +47,10 @@ public class AuthenticationContextTest extends CrateUnitTest {
         ConnectionProperties connProperties = new ConnectionProperties(
             InetAddress.getByName("127.0.0.1"), Protocol.POSTGRES, null);
         AuthenticationMethod authMethod = AUTHENTICATION.resolveAuthenticationType(userName, connProperties);
-        AuthenticationContext authContext = new AuthenticationContext(authMethod, connProperties, userName, null);
+        AuthenticationContext authContext = new AuthenticationContext(
+            authMethod, connProperties, userName, Loggers.getLogger(AuthenticationContextTest.class));
         authContext.setSecurePassword(passwd);
-        assertNull(authContext.authenticate());
+        assertThat(authContext.authenticate(), is(User.CRATE_USER));
         assertThat(authContext.password().getChars(), is(passwd));
         authContext.close();
 

--- a/sql/src/test/java/io/crate/testing/SQLExecutor.java
+++ b/sql/src/test/java/io/crate/testing/SQLExecutor.java
@@ -101,7 +101,6 @@ import org.elasticsearch.cluster.routing.allocation.decider.SameShardAllocationD
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.inject.ModulesBuilder;
-import org.elasticsearch.common.inject.Provider;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
@@ -190,10 +189,10 @@ public class SQLExecutor {
         private final UserDefinedFunctionService udfService;
         private final Random random;
         private String defaultSchema = Schemas.DOC_SCHEMA_NAME;
-        private User user = null;
-        private Provider<RelationAnalyzer> analyzerProvider = () -> null;
+        private User user = User.CRATE_USER;
 
         private TableStats tableStats = new TableStats();
+        private Settings settings = Settings.EMPTY;
 
         private Builder(ClusterService clusterService, int numNodes, Random random) {
             this.random = random;
@@ -268,6 +267,11 @@ public class SQLExecutor {
             return this;
         }
 
+        public Builder settings(Settings settings) {
+            this.settings = settings;
+            return this;
+        }
+
         /**
          * Adds a couple of tables which are defined in {@link T3} and {@link io.crate.analyze.TableDefinitions}.
          * <p>
@@ -316,6 +320,7 @@ public class SQLExecutor {
             return new SQLExecutor(
                 functions,
                 new Analyzer(
+                    settings,
                     schemas,
                     functions,
                     relationAnalyzer,

--- a/sql/src/test/java/io/crate/testing/SQLTransportExecutor.java
+++ b/sql/src/test/java/io/crate/testing/SQLTransportExecutor.java
@@ -30,6 +30,7 @@ import io.crate.action.sql.SQLActionException;
 import io.crate.action.sql.SQLOperations;
 import io.crate.action.sql.Session;
 import io.crate.auth.user.ExceptionAuthorizedValidator;
+import io.crate.auth.user.User;
 import io.crate.data.Row;
 import io.crate.exceptions.SQLExceptions;
 import io.crate.expression.symbol.Field;
@@ -195,7 +196,7 @@ public class SQLTransportExecutor {
     public Session newSession() {
         return clientProvider.sqlOperations().createSession(
             defaultSchema,
-            null,
+            User.CRATE_USER,
             Option.NONE,
             DEFAULT_SOFT_LIMIT
         );

--- a/sql/src/test/java/io/crate/testing/SqlExpressions.java
+++ b/sql/src/test/java/io/crate/testing/SqlExpressions.java
@@ -23,7 +23,6 @@
 package io.crate.testing;
 
 import io.crate.action.sql.SessionContext;
-import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.analyze.ParamTypeHints;
 import io.crate.analyze.ParameterContext;
 import io.crate.analyze.expressions.ExpressionAnalysisContext;
@@ -32,18 +31,19 @@ import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.FieldResolver;
 import io.crate.analyze.relations.FullQualifiedNameFieldProvider;
 import io.crate.analyze.relations.ParentRelations;
-import io.crate.expression.symbol.Symbol;
+import io.crate.auth.user.User;
 import io.crate.data.Row;
 import io.crate.data.RowN;
-import io.crate.metadata.Functions;
-import io.crate.metadata.RowGranularity;
-import io.crate.metadata.TransactionContext;
 import io.crate.execution.engine.aggregation.impl.AggregationImplModule;
+import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.operator.OperatorModule;
 import io.crate.expression.predicate.PredicateModule;
 import io.crate.expression.scalar.ScalarFunctionModule;
+import io.crate.expression.symbol.Symbol;
 import io.crate.expression.tablefunctions.TableFunctionModule;
-import io.crate.auth.user.User;
+import io.crate.metadata.Functions;
+import io.crate.metadata.RowGranularity;
+import io.crate.metadata.TransactionContext;
 import io.crate.sql.parser.SqlParser;
 import io.crate.sql.tree.QualifiedName;
 import org.elasticsearch.common.inject.AbstractModule;
@@ -64,16 +64,16 @@ public class SqlExpressions {
     private final Functions functions;
 
     public SqlExpressions(Map<QualifiedName, AnalyzedRelation> sources) {
-        this(sources, null, null, null);
+        this(sources, null, null, User.CRATE_USER);
     }
 
     public SqlExpressions(Map<QualifiedName, AnalyzedRelation> sources, Object[] parameters) {
-        this(sources, null, parameters, null);
+        this(sources, null, parameters, User.CRATE_USER);
     }
 
     public SqlExpressions(Map<QualifiedName, AnalyzedRelation> sources,
                           @Nullable FieldResolver fieldResolver) {
-        this(sources, fieldResolver, null, null);
+        this(sources, fieldResolver, null, User.CRATE_USER);
     }
 
     public SqlExpressions(Map<QualifiedName, AnalyzedRelation> sources,


### PR DESCRIPTION
This makes the `User` non-nullable.

For all practical purposes this shouldn't change the behaviour from a
users point of view.

If enterprise is enabled and host-based authentication is *enabled*, a
user was already mandatory to be present.

If enterprise is enabled and host-based authentication is *disabled*, a
user could connect as `null` user, which behaved the same as if
connected as `crate`. This now changed so that it defaults to `crate`.

If enterprise is disabled, everything ran under a `null` user context.
This also changed to run under a `crate` user. Since there were no
privilege checks without enterprise and functions like `user` are not
available without enterprise, this change is mostly invisible to users,
with the exception of `sys.logs` entries which now default to `crate` as
user as well.

Two main motivations for this change:

 - Being able to avoid null checks for the user

 - Not having to worry if a `null` user means "has no privilege" or "has
 all privileges"