### PR TITLE
edit CrateDB license info so that GitHub recognizes it

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,21 +1,3 @@
-Crate
-Copyright 2013-2016 Crate.IO GmbH ("Crate")
-
-
-Licensed to Crate.IO GmbH (referred to in this notice as "Crate")
-under one or more contributor license agreements.  See the NOTICE file
-distributed with this work for additional information regarding copyright
-ownership.
-
-Crate licenses this software to you under the Apache License, Version 2.0.
-However, if you have executed another commercial license agreement with
-Crate these terms will supersede the license and you may use the software
-solely pursuant to the terms of the relevant commercial agreement.
-
-
-=========================================================================
-
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -204,7 +186,7 @@ solely pursuant to the terms of the relevant commercial agreement.
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2013-2016 Crate.IO GmbH ("Crate")
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.rst
+++ b/README.rst
@@ -61,6 +61,20 @@ contributions!
 
 See the `developer docs`_ and the `contribution docs`_ for more information.
 
+
+License
+=======
+
+CrateDB is icensed to Crate.IO GmbH (referred to in this notice as "Crate")
+under one or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information regarding copyright
+ownership.
+
+Crate licenses this software to you under the Apache License, Version 2.0.
+However, if you have executed another commercial license agreement with
+Crate these terms will supersede the license and you may use the software
+solely pursuant to the terms of the relevant commercial agreement.
+
 Help
 ====
 


### PR DESCRIPTION
Hello! 👋

(CCing @dankohn who has requested this work so that the license will appear correctly in https://landscape.cncf.io/selected=crate-io)

GitHub uses a library called Licensee to identify a project's license
type. It shows this information in the status bar and via the API if it
can unambiguously identify the license.

This commit updates the LICENSE.txt file so that it contains only the
full text of the Apache license. It also updates the license file to
reference Crate.IO GmbH ("Crate") as the copyright holder. The info that
was previously stored at the top of LICENSE.txt is now stored under a
new "License" section in the README.

Collectively, these changes allow Licensee to successfully identify the
license type of CrateDB as Apache.