### PR TITLE
Respect castability of argument when trying to convert against inner type

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -176,6 +176,11 @@ Changes
 Fixes
 =====
 
+- Fixed a performance regression which occurred in queries where a literal was
+  compared against an array column of a different type. For example:
+  ``Select * from t1 where 1 = ANY(int_arr_column)`` <- array column would be
+  converted to long although 1 could have been converted to integer.
+
 - Fixed an issue where the order of the relations in FROM would expose fields
   between the relations. An error was thrown during execution of the statements.
 

--- a/sql/src/main/java/io/crate/metadata/functions/params/Param.java
+++ b/sql/src/main/java/io/crate/metadata/functions/params/Param.java
@@ -205,7 +205,7 @@ public final class Param {
             if (argDataType instanceof CollectionType) {
                 DataType innerType = Preconditions.checkNotNull(((CollectionType) argDataType).innerType(),
                     "Inner type expected but no inner type for argument: " + funcArg);
-                this.innerType.bind(new ConvertedArg(innerType), multiBind);
+                this.innerType.bind(new ConvertedArg(innerType, funcArg.canBeCasted()), multiBind);
             } else {
                 throw new IllegalArgumentException("DataType with an inner type expected but not provided.");
             }
@@ -237,15 +237,18 @@ public final class Param {
     private static class ConvertedArg implements FuncArg {
 
         private final DataType dataType;
+        private final boolean canBeCasted;
 
         private ConvertedArg(FuncArg sourceArg, DataType targetDataType) {
             Preconditions.checkArgument(sourceArg.canBeCasted(),
                 "Converted argument must be castable.");
             this.dataType = targetDataType;
+            this.canBeCasted = true;
         }
 
-        private ConvertedArg(DataType argumentType) {
+        private ConvertedArg(DataType argumentType, boolean canBeCasted) {
             this.dataType = argumentType;
+            this.canBeCasted = canBeCasted;
         }
 
         @Override
@@ -255,7 +258,7 @@ public final class Param {
 
         @Override
         public boolean canBeCasted() {
-            return true;
+            return canBeCasted;
         }
     }
 

--- a/sql/src/test/java/io/crate/metadata/functions/params/FuncParamsTest.java
+++ b/sql/src/test/java/io/crate/metadata/functions/params/FuncParamsTest.java
@@ -165,6 +165,17 @@ public class FuncParamsTest extends CrateUnitTest {
         params.match(list(castableArg));
     }
 
+    @Test
+    public void testRespectCastableArgumentsWithInnerType() {
+        FuncArg castableArg = new Arg(DataTypes.LONG, true);
+        ArrayType integerArrayType = new ArrayType(DataTypes.INTEGER);
+        FuncArg nonCastableArg = new Arg(integerArrayType, false);
+        FuncParams params = FuncParams.builder(Param.ANY, Param.ANY_ARRAY.withInnerType(Param.ANY)).build();
+
+        List<DataType> signature = params.match(list(castableArg, nonCastableArg));
+        assertThat(signature, is(list(DataTypes.INTEGER, integerArrayType)));
+    }
+
     private static class Arg implements FuncArg {
 
         private final DataType dataType;

--- a/sql/src/test/java/io/crate/metadata/functions/params/FuncParamsTest.java
+++ b/sql/src/test/java/io/crate/metadata/functions/params/FuncParamsTest.java
@@ -166,6 +166,16 @@ public class FuncParamsTest extends CrateUnitTest {
     }
 
     @Test
+    public void testRespectNonCastableArgumentsWithInnerType() {
+        FuncArg nonCastableArg1 = new Arg(DataTypes.LONG, false);
+        FuncArg nonCastableArg2 = new Arg(new ArrayType(DataTypes.INTEGER), false);
+        FuncParams params = FuncParams.builder(Param.ANY, Param.ANY_ARRAY.withInnerType(Param.ANY)).build();
+
+        List<DataType> signature = params.match(list(nonCastableArg1, nonCastableArg2));
+        assertThat(signature, is(list(DataTypes.LONG, new ArrayType(DataTypes.LONG))));
+    }
+
+    @Test
     public void testRespectCastableArgumentsWithInnerType() {
         FuncArg castableArg = new Arg(DataTypes.LONG, true);
         ArrayType integerArrayType = new ArrayType(DataTypes.INTEGER);


### PR DESCRIPTION
When converting an argument to match an inner type of a parameter, we previously
assumed that argument would always be castable. This doesn't have to be the
case. So we preserve this information now.

This happens for parameters of form:

```
[long,                     array(integer)]
 ^^^^                      ^^^^^^^^^^^^^^
 May be castable to int     Not castable
```

The above is an example for parameters of form:

```
FuncParams.of(Param.ANY,
              Param.ANY_ARRAY.withInnerType(Param.ANY))
```