### PR TITLE
Docs: Updated settings of `CREATE REPOSITORY`.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -15,7 +15,11 @@ the appropriate section of the docs.
 Breaking Changes
 ================
 
-- Renamed ec2 ``cloud.aws.*`` settings to ``discovery.ec2.*`` (eg. 
+- The ``region`` setting for ``CREATE REPOSITORY`` has been removed. It is
+  automatically "guessed" but can still be manually specified by using the
+  ``endpoint`` setting.
+
+- Renamed ec2 ``cloud.aws.*`` settings to ``discovery.ec2.*`` (eg.
   ``cloud.aws.access_key`` is now ``discovery.ec2.access_key``)
 
 - The columns ``number_of_shards``, ``number_of_replicas``, and

--- a/blackbox/docs/sql/statements/create-repository.rst
+++ b/blackbox/docs/sql/statements/create-repository.rst
@@ -209,17 +209,12 @@ A repository that stores its snapshot on the Amazon S3 service.
   does not yet exist, a new bucket will be created on S3 (assuming the
   required permissions are set).
 
-**region**
-  | *Type:*    ``string``
-  | *Default:* ``us-east-1``
-
-  Region where the bucket is located.
-
 **endpoint**
   | *Type:*    ``string``
   | *Default:* Default AWS API endpoint
 
-  Endpoint to the S3 API. Setting a region will override the endpoint setting.
+  Endpoint to the S3 API. If a specific region is desired, specify it by using
+  this setting.
 
 **protocol**
   | *Type:*    ``string``


### PR DESCRIPTION
With ES6 the `region` setting is not used at all, instead
the `endpoint` should be using a URI which specifies also the region.

