### PR TITLE
Set repeat requirement for right source of hash join

### DIFF
--- a/sql/src/main/java/io/crate/execution/engine/join/HashJoinOperation.java
+++ b/sql/src/main/java/io/crate/execution/engine/join/HashJoinOperation.java
@@ -95,7 +95,7 @@ public class HashJoinOperation implements CompletionListenable {
     }
 
     public RowConsumer rightConsumer() {
-        return JoinOperations.getBatchConsumer(rightBatchIterator, false);
+        return JoinOperations.getBatchConsumer(rightBatchIterator, true);
     }
 
     private static Function<Row, Integer> getHashBuilderFromSymbols(InputFactory inputFactory, List<Symbol> inputs) {

--- a/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/JoinIntegrationTest.java
@@ -903,4 +903,18 @@ public class JoinIntegrationTest extends SQLTransportIntegrationTest {
                "2| 3| c\n")
         );
     }
+
+    @Test
+    public void testInnerJoinOnPreSortedRightRelation() {
+        execute("CREATE TABLE t1 (x int) with (number_of_replicas = 0)");
+        execute("insert into t1 (x) values (1) ");
+        execute("refresh table t1");
+        // regression test; the repeat requirement wasn't set correctly for the right side
+        assertThat(
+            printedTable(execute(
+                "select * from (select * from t1 order by x) t1 " +
+                "join (select * from t1 order by x) t2 on t1.x=t2.x").rows()),
+            is("1| 1\n")
+        );
+    }
 }


### PR DESCRIPTION
The `HashInnerJoinBatchIterator` calls `right.moveToStart` so the repeat
requirement needs to be set to true.