### PR TITLE
Require Symbol instead of WhereClause in LuceneQueryBuilder

### DIFF
--- a/sql/src/main/java/io/crate/analyze/relations/DocTableRelation.java
+++ b/sql/src/main/java/io/crate/analyze/relations/DocTableRelation.java
@@ -94,9 +94,12 @@ public class DocTableRelation extends AbstractTableRelation<DocTableInfo> {
         }
         List<GeneratedReference> generatedReferences = tableInfo.generatedColumns();
 
-        for (ColumnIdent partitionIdent : tableInfo.partitionedBy()) {
-            ensureNotUpdated(ci, partitionIdent, "Updating a partitioned-by column is not supported");
-            int idx = generatedReferences.indexOf(tableInfo.getReference(partitionIdent));
+        for (Reference partitionRef : tableInfo.partitionedByColumns()) {
+            ensureNotUpdated(ci, partitionRef.column(), "Updating a partitioned-by column is not supported");
+            if (!(partitionRef instanceof GeneratedReference)) {
+                continue;
+            }
+            int idx = generatedReferences.indexOf(partitionRef);
             if (idx >= 0) {
                 GeneratedReference generatedReference = generatedReferences.get(idx);
                 for (Reference reference : generatedReference.referencedReferences()) {

--- a/sql/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
@@ -102,7 +102,7 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
             QueryShardContext queryShardContext = sharedShardContext.indexService().newQueryShardContext(
                 shardId.getId(), searcher.reader(), System::currentTimeMillis, null);
             LuceneQueryBuilder.Context queryContext = luceneQueryBuilder.convert(
-                collectPhase.whereClause(),
+                collectPhase.whereClause().queryOrFallback(),
                 indexShard.mapperService(),
                 queryShardContext,
                 sharedShardContext.indexService().cache()
@@ -144,7 +144,7 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
             QueryShardContext queryShardContext = indexService.newQueryShardContext(
                 indexShard.shardId().getId(), searcher.reader(), System::currentTimeMillis, null);
             queryContext = luceneQueryBuilder.convert(
-                collectPhase.whereClause(),
+                collectPhase.whereClause().queryOrFallback(),
                 indexService.mapperService(),
                 queryShardContext,
                 indexService.cache()

--- a/sql/src/main/java/io/crate/execution/engine/collect/count/InternalCountOperation.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/count/InternalCountOperation.java
@@ -116,7 +116,7 @@ public class InternalCountOperation implements CountOperation {
         IndexShard indexShard = indexService.getShard(shardId);
         try (Engine.Searcher searcher = indexShard.acquireSearcher("count-operation")) {
             LuceneQueryBuilder.Context queryCtx = queryBuilder.convert(
-                whereClause,
+                whereClause.queryOrFallback(),
                 indexService.mapperService(),
                 indexService.newQueryShardContext(shardId, searcher.reader(), System::currentTimeMillis,  null),
                 indexService.cache());

--- a/sql/src/main/java/io/crate/expression/scalar/cast/CastFunctionResolver.java
+++ b/sql/src/main/java/io/crate/expression/scalar/cast/CastFunctionResolver.java
@@ -188,12 +188,7 @@ public class CastFunctionResolver {
         return FUNCTION_MAP.get(returnType) != null;
     }
 
-    private static Function<String, String> TO_TRY_CAST_MAP = new Function<String, String>() {
-        @Override
-        public String apply(String functionName) {
-            return TRY_CAST_PREFIX + functionName;
-        }
-    };
+    private static final Function<String, String> TO_TRY_CAST_MAP = functionName -> TRY_CAST_PREFIX + functionName;
 
     public static Map<DataType, String> tryFunctionsMap() {
         return Maps.transformValues(FUNCTION_MAP, TO_TRY_CAST_MAP);

--- a/sql/src/test/java/io/crate/lucene/LuceneQueryBuilderTest.java
+++ b/sql/src/test/java/io/crate/lucene/LuceneQueryBuilderTest.java
@@ -23,9 +23,9 @@
 package io.crate.lucene;
 
 import com.google.common.collect.ImmutableMap;
-import io.crate.analyze.WhereClause;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.TableRelation;
+import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
@@ -218,16 +218,12 @@ public abstract class LuceneQueryBuilderTest extends CrateUnitTest {
         return analysisModule.getAnalysisRegistry().build(indexSettings);
     }
 
-    private WhereClause asWhereClause(String expression) {
-        return new WhereClause(expressions.normalize(expressions.asSymbol(expression)));
-    }
-
-    protected Query convert(WhereClause clause) {
-        return builder.convert(clause, mapperService, queryShardContext, indexCache).query;
+    protected Query convert(Symbol query) {
+        return builder.convert(query, mapperService, queryShardContext, indexCache).query;
     }
 
     protected Query convert(String expression) {
-        return convert(asWhereClause(expression));
+        return convert(expressions.normalize(expressions.asSymbol(expression)));
     }
 
     private Version indexVersion() {


### PR DESCRIPTION
+2 minor cleanup commits.

The `WhereClause` is quite overloaded, containing things like `docKeys` and
`partitions`, both irrelevant for the `LuceneQueryBuilder`.

Changing the dependency makes it clear that nothing but the `query` is
used.