### PR TITLE
Rewrite queries on _uid to _id

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -180,6 +180,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that caused queries on the `_uid` column to not match
+  correctly.
+
 - Fixed a performance regression which occurred in queries where a literal was
   compared against an array column of a different type. For example:
   ``Select * from t1 where 1 = ANY(int_arr_column)`` <- array column would be

--- a/sql/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/sql/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -393,6 +393,9 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
     public void testRangeQueryForUid() throws Exception {
         Query query = convert("_uid > 'foo'");
         assertThat(query, instanceOf(TermRangeQuery.class));
+        TermRangeQuery rangeQuery = (TermRangeQuery) query;
+        assertThat(rangeQuery.getField(), is("_id"));
+        assertThat(rangeQuery.getLowerTerm().utf8ToString(), is("foo"));
     }
 
     public void testRangeQueryOnDocThrowsException() throws Exception {


### PR DESCRIPTION
The previous logic of prefixing literal values with `default#` was
broken. Since `2.3` uids no longer include the `type` name (`default`).
`_uid` and `_id` became equivalent.
(See f9c5009acabdc695ba15b50fc3ffd7bd57a4809c)

For older incides (created prior to `2.3`) the re-rewrite didn't work
either. We changed `_uid = '1'` to `_id = 'default#1'` which is wrong on
two levels:

 - The assumption that the user uses the `_id` values to query `_uid`.
 If a user writes a query on the `_uid` column he should be able to use
 values retrieved from `SELECT _uid ...`
 - Using `_id` in the query with a literal re-written to match the
 `_uid` values.

This simply removes that logic altogether, the fieldMapper layer will
create the correct queries on the `_uid` column.