### PR TITLE
Stop handling the USR2 signal on windows platforms.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -180,6 +180,10 @@ Changes
 Fixes
 =====
 
+- As Windows does not support sending signals, stop attempting to handle the 
+  ``USR2`` signal on windows platforms as it just pollutes the logs with a big 
+  warning.
+
 - Fixed an issue that caused queries on the `_uid` column to not match
   correctly.
 

--- a/sql/src/main/java/io/crate/cluster/gracefulstop/DecommissioningService.java
+++ b/sql/src/main/java/io/crate/cluster/gracefulstop/DecommissioningService.java
@@ -28,6 +28,7 @@ import io.crate.execution.engine.collect.stats.JobsLogs;
 import io.crate.execution.jobs.JobContextService;
 import io.crate.settings.CrateSetting;
 import io.crate.types.DataTypes;
+import org.apache.lucene.util.Constants;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
@@ -150,11 +151,13 @@ public class DecommissioningService extends AbstractLifecycleComponent implement
         // Signal handling here breaks FlightRecorder
         // So this is a undocumented switch to disable this for benchmarking purposes
         if (!System.getProperty("crate.signal_handler.disabled", "false").equalsIgnoreCase("true")) {
-            try {
-                Signal signal = new Signal("USR2");
-                Signal.handle(signal, this);
-            } catch (IllegalArgumentException e) {
-                logger.warn("SIGUSR2 signal not supported on {}.", System.getProperty("os.name"), e);
+            if (Constants.WINDOWS == false) {
+                try {
+                    Signal signal = new Signal("USR2");
+                    Signal.handle(signal, this);
+                } catch (IllegalArgumentException e) {
+                    logger.warn("SIGUSR2 signal not supported on {}.", System.getProperty("os.name"), e);
+                }
             }
         }
         this.executorService = executorService;


### PR DESCRIPTION
Windows does not support sending signals, so attempting to handle them
just results in a big warning message at startup (when there's actually
nothing wrong).
This commit disables the attempt to even handle the USR2 signal on windows
platforms.

<!--

Thank you for your contribution. Here is a quick checklist of things you should've done:

 - You've read CONTRIBUTING.rst and signed our CLA (https://crate.io/community/contribute/cla/)
 - Wrote a CHANGES.txt entry if this is a change that is relevant for users of CrateDB
 - Run tests with `./gradlew test itest` (If they fail Jenkins will block this PR anyway)

-->
