### PR TITLE
Change whereClause on Count/CollectPhase to a query symbol

### DIFF
--- a/sql/src/main/java/io/crate/analyze/WhereClause.java
+++ b/sql/src/main/java/io/crate/analyze/WhereClause.java
@@ -34,11 +34,7 @@ import io.crate.expression.symbol.ValueSymbolVisitor;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocSysColumns;
 import org.elasticsearch.common.Nullable;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.io.stream.Streamable;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -47,7 +43,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 
-public class WhereClause extends QueryClause implements Streamable {
+public class WhereClause extends QueryClause {
 
     public static final WhereClause MATCH_ALL = new WhereClause(Literal.BOOLEAN_TRUE);
     public static final WhereClause NO_MATCH = new WhereClause(Literal.BOOLEAN_FALSE);
@@ -58,10 +54,6 @@ public class WhereClause extends QueryClause implements Streamable {
 
     private List<String> partitions = new ArrayList<>();
 
-
-    public WhereClause(StreamInput in) throws IOException {
-        readFrom(in);
-    }
 
     public WhereClause(@Nullable Symbol normalizedQuery,
                        @Nullable DocKeys docKeys,
@@ -122,26 +114,6 @@ public class WhereClause extends QueryClause implements Streamable {
      */
     public List<String> partitions() {
         return partitions;
-    }
-
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        if (in.readBoolean()) {
-            query = Symbols.fromStream(in);
-        } else {
-            noMatch = in.readBoolean();
-        }
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        if (query != null) {
-            out.writeBoolean(true);
-            Symbols.toStream(query, out);
-        } else {
-            out.writeBoolean(false);
-            out.writeBoolean(noMatch);
-        }
     }
 
     @Override

--- a/sql/src/main/java/io/crate/execution/dsl/phases/CountPhase.java
+++ b/sql/src/main/java/io/crate/execution/dsl/phases/CountPhase.java
@@ -22,8 +22,8 @@
 
 package io.crate.execution.dsl.phases;
 
-import io.crate.analyze.WhereClause;
 import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.Routing;
 import io.crate.planner.distribution.DistributionInfo;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -37,16 +37,16 @@ public class CountPhase implements UpstreamPhase {
 
     private final int executionPhaseId;
     private final Routing routing;
-    private WhereClause whereClause;
+    private Symbol where;
     private DistributionInfo distributionInfo;
 
     public CountPhase(int executionPhaseId,
                       Routing routing,
-                      WhereClause whereClause,
+                      Symbol where,
                       DistributionInfo distributionInfo) {
         this.executionPhaseId = executionPhaseId;
         this.routing = routing;
-        this.whereClause = whereClause;
+        this.where = where;
         this.distributionInfo = distributionInfo;
     }
 
@@ -64,8 +64,8 @@ public class CountPhase implements UpstreamPhase {
         return routing;
     }
 
-    public WhereClause whereClause() {
-        return whereClause;
+    public Symbol where() {
+        return where;
     }
 
     @Override
@@ -96,7 +96,7 @@ public class CountPhase implements UpstreamPhase {
     public CountPhase(StreamInput in) throws IOException {
         executionPhaseId = in.readVInt();
         routing = new Routing(in);
-        whereClause = new WhereClause(in);
+        where = Symbols.fromStream(in);
         distributionInfo = DistributionInfo.fromStream(in);
     }
 
@@ -104,11 +104,11 @@ public class CountPhase implements UpstreamPhase {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeVInt(executionPhaseId);
         routing.writeTo(out);
-        whereClause.writeTo(out);
+        Symbols.toStream(where, out);
         distributionInfo.writeTo(out);
     }
 
     public void replaceSymbols(Function<? super Symbol, ? extends Symbol> replaceFunction) {
-        whereClause.replace(replaceFunction);
+        where = replaceFunction.apply(where);
     }
 }

--- a/sql/src/main/java/io/crate/execution/dsl/phases/TableFunctionCollectPhase.java
+++ b/sql/src/main/java/io/crate/execution/dsl/phases/TableFunctionCollectPhase.java
@@ -22,14 +22,13 @@
 
 package io.crate.execution.dsl.phases;
 
-import io.crate.analyze.WhereClause;
+import io.crate.execution.dsl.projection.Projection;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.Routing;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.tablefunctions.TableFunctionImplementation;
 import io.crate.planner.distribution.DistributionInfo;
-import io.crate.execution.dsl.projection.Projection;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
@@ -48,7 +47,7 @@ public class TableFunctionCollectPhase extends RoutedCollectPhase implements Col
                                      List<Literal<?>> functionArguments,
                                      List<Projection> projections,
                                      List<Symbol> outputs,
-                                     WhereClause whereClause) {
+                                     Symbol where) {
         super(jobId,
             phaseId,
             functionImplementation.info().ident().name(),
@@ -56,7 +55,7 @@ public class TableFunctionCollectPhase extends RoutedCollectPhase implements Col
             RowGranularity.DOC,
             outputs,
             projections,
-            whereClause,
+            where,
             DistributionInfo.DEFAULT_BROADCAST,
             null);
         this.functionImplementation = functionImplementation;

--- a/sql/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/LuceneShardCollectorProvider.java
@@ -102,7 +102,7 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
             QueryShardContext queryShardContext = sharedShardContext.indexService().newQueryShardContext(
                 shardId.getId(), searcher.reader(), System::currentTimeMillis, null);
             LuceneQueryBuilder.Context queryContext = luceneQueryBuilder.convert(
-                collectPhase.whereClause().queryOrFallback(),
+                collectPhase.where(),
                 indexShard.mapperService(),
                 queryShardContext,
                 sharedShardContext.indexService().cache()
@@ -144,7 +144,7 @@ public class LuceneShardCollectorProvider extends ShardCollectorProvider {
             QueryShardContext queryShardContext = indexService.newQueryShardContext(
                 indexShard.shardId().getId(), searcher.reader(), System::currentTimeMillis, null);
             queryContext = luceneQueryBuilder.convert(
-                collectPhase.whereClause().queryOrFallback(),
+                collectPhase.where(),
                 indexService.mapperService(),
                 queryShardContext,
                 indexService.cache()

--- a/sql/src/main/java/io/crate/execution/engine/collect/RemoteCollectorFactory.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/RemoteCollectorFactory.java
@@ -140,7 +140,7 @@ public class RemoteCollectorFactory {
             collectPhase.maxRowGranularity(),
             collectPhase.toCollect(),
             new ArrayList<>(Projections.shardProjections(collectPhase.projections())),
-            collectPhase.whereClause(),
+            collectPhase.where(),
             DistributionInfo.DEFAULT_BROADCAST,
             null
         );

--- a/sql/src/main/java/io/crate/execution/engine/collect/count/CountOperation.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/count/CountOperation.java
@@ -21,7 +21,7 @@
 
 package io.crate.execution.engine.collect.count;
 
-import io.crate.analyze.WhereClause;
+import io.crate.expression.symbol.Symbol;
 import org.elasticsearch.common.inject.ImplementedBy;
 import org.elasticsearch.index.Index;
 
@@ -34,7 +34,7 @@ import java.util.concurrent.CompletableFuture;
 public interface CountOperation {
 
     CompletableFuture<Long> count(Map<String, ? extends Collection<Integer>> indexShardMap,
-                                  WhereClause whereClause) throws IOException, InterruptedException;
+                                  Symbol filter) throws IOException, InterruptedException;
 
-    long count(Index index, int shardId, WhereClause whereClause) throws IOException, InterruptedException;
+    long count(Index index, int shardId, Symbol filter) throws IOException, InterruptedException;
 }

--- a/sql/src/main/java/io/crate/execution/jobs/ContextPreparer.java
+++ b/sql/src/main/java/io/crate/execution/jobs/ContextPreparer.java
@@ -539,7 +539,7 @@ public class ContextPreparer extends AbstractComponent {
                 countOperation,
                 consumer,
                 indexShardMap,
-                phase.whereClause()
+                phase.where()
             ));
             return true;
         }

--- a/sql/src/main/java/io/crate/execution/jobs/CountContext.java
+++ b/sql/src/main/java/io/crate/execution/jobs/CountContext.java
@@ -21,13 +21,13 @@
 
 package io.crate.execution.jobs;
 
-import io.crate.analyze.WhereClause;
 import io.crate.data.BatchIterator;
 import io.crate.data.InMemoryBatchIterator;
 import io.crate.data.Row;
 import io.crate.data.Row1;
 import io.crate.data.RowConsumer;
 import io.crate.execution.engine.collect.count.CountOperation;
+import io.crate.expression.symbol.Symbol;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.logging.Loggers;
 
@@ -47,25 +47,25 @@ public class CountContext extends AbstractExecutionSubContext {
     private final CountOperation countOperation;
     private final RowConsumer consumer;
     private final Map<String, List<Integer>> indexShardMap;
-    private final WhereClause whereClause;
+    private final Symbol where;
     private CompletableFuture<Long> countFuture;
 
     public CountContext(int id,
                         CountOperation countOperation,
                         RowConsumer consumer,
                         Map<String, List<Integer>> indexShardMap,
-                        WhereClause whereClause) {
+                        Symbol where) {
         super(id, LOGGER);
         this.countOperation = countOperation;
         this.consumer = consumer;
         this.indexShardMap = indexShardMap;
-        this.whereClause = whereClause;
+        this.where = where;
     }
 
     @Override
     public synchronized void innerStart() {
         try {
-            countFuture = countOperation.count(indexShardMap, whereClause);
+            countFuture = countOperation.count(indexShardMap, where);
         } catch (IOException | InterruptedException e) {
             throw new RuntimeException(e);
         }

--- a/sql/src/main/java/io/crate/planner/PlanPrinter.java
+++ b/sql/src/main/java/io/crate/planner/PlanPrinter.java
@@ -22,7 +22,6 @@
 package io.crate.planner;
 
 import com.google.common.collect.ImmutableMap;
-import io.crate.analyze.WhereClause;
 import io.crate.execution.dsl.phases.AbstractProjectionsPhase;
 import io.crate.execution.dsl.phases.CollectPhase;
 import io.crate.execution.dsl.phases.CountPhase;
@@ -120,10 +119,7 @@ public class PlanPrinter {
             builder.put("toCollect", ExplainLeaf.printList(phase.toCollect()));
             builder = dqlPlanNode(phase, builder);
             builder.put("routing", phase.routing().locations());
-            WhereClause whereClause = phase.whereClause();
-            if (whereClause.hasQuery()) {
-                builder.put("where", whereClause.query().representation());
-            }
+            builder.put("where", phase.where().representation());
             return createMap(phase, builder);
         }
 

--- a/sql/src/main/java/io/crate/planner/operators/Collect.java
+++ b/sql/src/main/java/io/crate/planner/operators/Collect.java
@@ -294,7 +294,7 @@ class Collect extends ZeroInputPlan {
                 functionArguments,
                 Collections.emptyList(),
                 outputs,
-                where
+                where.queryOrFallback()
             );
         }
 
@@ -326,7 +326,7 @@ class Collect extends ZeroInputPlan {
             tableInfo.rowGranularity(),
             boundOutputs,
             Collections.emptyList(),
-            where,
+            where.queryOrFallback(),
             DistributionInfo.DEFAULT_BROADCAST,
             sessionContext.user()
         );

--- a/sql/src/main/java/io/crate/planner/operators/Count.java
+++ b/sql/src/main/java/io/crate/planner/operators/Count.java
@@ -88,7 +88,7 @@ public class Count extends ZeroInputPlan {
         CountPhase countPhase = new CountPhase(
             plannerContext.nextExecutionPhaseId(),
             routing,
-            boundWhere,
+            boundWhere.queryOrFallback(),
             DistributionInfo.DEFAULT_BROADCAST
         );
         MergePhase mergePhase = new MergePhase(

--- a/sql/src/test/java/io/crate/execution/engine/collect/BlobShardCollectorProviderTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/BlobShardCollectorProviderTest.java
@@ -75,7 +75,7 @@ public class BlobShardCollectorProviderTest extends SQLHttpIntegrationTest {
             RowGranularity.SHARD,
             ImmutableList.of(),
             ImmutableList.of(),
-            WhereClause.MATCH_ALL,
+            WhereClause.MATCH_ALL.queryOrFallback(),
             DistributionInfo.DEFAULT_BROADCAST,
             null
         );

--- a/sql/src/test/java/io/crate/execution/engine/collect/DocLevelCollectTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/DocLevelCollectTest.java
@@ -188,7 +188,7 @@ public class DocLevelCollectTest extends SQLTransportIntegrationTest {
             RowGranularity.DOC,
             toCollect,
             ImmutableList.of(),
-            whereClause,
+            whereClause.queryOrFallback(),
             DistributionInfo.DEFAULT_BROADCAST,
             null
         );

--- a/sql/src/test/java/io/crate/execution/engine/collect/HandlerSideLevelCollectTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/HandlerSideLevelCollectTest.java
@@ -24,11 +24,15 @@ package io.crate.execution.engine.collect;
 import com.google.common.collect.ImmutableList;
 import io.crate.action.sql.SessionContext;
 import io.crate.analyze.WhereClause;
+import io.crate.data.Bucket;
+import io.crate.data.CollectionBucket;
+import io.crate.execution.dsl.phases.RoutedCollectPhase;
+import io.crate.execution.dsl.projection.Projection;
+import io.crate.expression.operator.EqOperator;
+import io.crate.expression.reference.sys.cluster.ClusterNameExpression;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
-import io.crate.data.Bucket;
-import io.crate.data.CollectionBucket;
 import io.crate.integrationtests.SQLTransportIntegrationTest;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.FunctionImplementation;
@@ -43,11 +47,7 @@ import io.crate.metadata.Schemas;
 import io.crate.metadata.information.InformationSchemaInfo;
 import io.crate.metadata.sys.SysClusterTableInfo;
 import io.crate.metadata.table.TableInfo;
-import io.crate.expression.operator.EqOperator;
-import io.crate.expression.reference.sys.cluster.ClusterNameExpression;
 import io.crate.planner.distribution.DistributionInfo;
-import io.crate.execution.dsl.phases.RoutedCollectPhase;
-import io.crate.execution.dsl.projection.Projection;
 import io.crate.testing.TestingHelpers;
 import io.crate.testing.TestingRowConsumer;
 import io.crate.types.DataTypes;
@@ -91,7 +91,7 @@ public class HandlerSideLevelCollectTest extends SQLTransportIntegrationTest {
             rowGranularity,
             toCollect,
             ImmutableList.<Projection>of(),
-            whereClause,
+            whereClause.queryOrFallback(),
             DistributionInfo.DEFAULT_BROADCAST,
             null
         );

--- a/sql/src/test/java/io/crate/execution/engine/collect/collectors/NodeStatsIteratorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/collectors/NodeStatsIteratorTest.java
@@ -23,17 +23,17 @@
 package io.crate.execution.engine.collect.collectors;
 
 import io.crate.analyze.OrderBy;
-import io.crate.analyze.WhereClause;
-import io.crate.expression.symbol.Symbol;
 import io.crate.data.BatchIterator;
+import io.crate.execution.dsl.phases.RoutedCollectPhase;
 import io.crate.execution.engine.collect.stats.NodeStatsRequest;
 import io.crate.execution.engine.collect.stats.TransportNodeStatsAction;
+import io.crate.expression.InputFactory;
+import io.crate.expression.symbol.Literal;
+import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.sys.SysNodesTableInfo;
-import io.crate.expression.InputFactory;
-import io.crate.execution.dsl.phases.RoutedCollectPhase;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.testing.BatchIteratorTester;
 import io.crate.types.DataTypes;
@@ -84,7 +84,7 @@ public class NodeStatsIteratorTest extends CrateUnitTest {
             new ReferenceIdent(SysNodesTableInfo.IDENT, SysNodesTableInfo.Columns.HOSTNAME),
             RowGranularity.DOC, DataTypes.STRING);
         collectPhase = mock(RoutedCollectPhase.class);
-        when(collectPhase.whereClause()).thenReturn(WhereClause.NO_MATCH);
+        when(collectPhase.where()).thenReturn(Literal.BOOLEAN_FALSE);
 
         nodes.add(newNode("nodeOne"));
         nodes.add(newNode("nodeTwo"));
@@ -155,7 +155,7 @@ public class NodeStatsIteratorTest extends CrateUnitTest {
         List<Symbol> toCollect = new ArrayList<>();
         toCollect.add(idRef);
         when(collectPhase.toCollect()).thenReturn(toCollect);
-        when(collectPhase.whereClause()).thenReturn(WhereClause.MATCH_ALL);
+        when(collectPhase.where()).thenReturn(Literal.BOOLEAN_TRUE);
         when(collectPhase.orderBy()).thenReturn(new OrderBy(Collections.singletonList(idRef),
             new boolean[]{false}, new Boolean[]{true}));
 

--- a/sql/src/test/java/io/crate/execution/engine/collect/collectors/RemoteCollectorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/collectors/RemoteCollectorTest.java
@@ -23,19 +23,19 @@
 package io.crate.execution.engine.collect.collectors;
 
 import com.google.common.collect.ImmutableMap;
+import io.crate.analyze.WhereClause;
+import io.crate.breaker.RamAccountingContext;
+import io.crate.execution.dsl.phases.RoutedCollectPhase;
+import io.crate.execution.engine.collect.stats.JobsLogs;
+import io.crate.execution.jobs.JobContextService;
+import io.crate.execution.jobs.kill.KillJobsRequest;
+import io.crate.execution.jobs.kill.TransportKillJobsNodeAction;
 import io.crate.execution.jobs.transport.JobRequest;
 import io.crate.execution.jobs.transport.JobResponse;
 import io.crate.execution.jobs.transport.TransportJobAction;
-import io.crate.analyze.WhereClause;
-import io.crate.breaker.RamAccountingContext;
-import io.crate.execution.jobs.kill.KillJobsRequest;
-import io.crate.execution.jobs.kill.TransportKillJobsNodeAction;
-import io.crate.execution.jobs.JobContextService;
 import io.crate.metadata.Routing;
 import io.crate.metadata.RowGranularity;
-import io.crate.execution.engine.collect.stats.JobsLogs;
 import io.crate.planner.distribution.DistributionInfo;
-import io.crate.execution.dsl.phases.RoutedCollectPhase;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.TestingRowConsumer;
 import io.crate.types.DataTypes;
@@ -79,7 +79,7 @@ public class RemoteCollectorTest extends CrateDummyClusterServiceUnitTest {
             RowGranularity.DOC,
             Collections.singletonList(createReference("name", DataTypes.STRING)),
             Collections.emptyList(),
-            WhereClause.MATCH_ALL,
+            WhereClause.MATCH_ALL.queryOrFallback(),
             DistributionInfo.DEFAULT_BROADCAST,
             null
         );

--- a/sql/src/test/java/io/crate/execution/engine/collect/count/InternalCountOperationTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/count/InternalCountOperationTest.java
@@ -22,9 +22,10 @@
 package io.crate.execution.engine.collect.count;
 
 import com.google.common.collect.ImmutableMap;
-import io.crate.analyze.WhereClause;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.TableRelation;
+import io.crate.expression.symbol.Literal;
+import io.crate.expression.symbol.Symbol;
 import io.crate.integrationtests.SQLTransportIntegrationTest;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
@@ -55,7 +56,7 @@ public class InternalCountOperationTest extends SQLTransportIntegrationTest {
         ClusterService clusterService = internalCluster().getDataNodeInstance(ClusterService.class);
         MetaData metaData = clusterService.state().getMetaData();
         Index index = metaData.index(getFqn("t")).getIndex();
-        assertThat(countOperation.count(index, 0, WhereClause.MATCH_ALL), is(3L));
+        assertThat(countOperation.count(index, 0, Literal.BOOLEAN_TRUE), is(3L));
 
         Schemas schemas = internalCluster().getInstance(Schemas.class);
         TableInfo tableInfo = schemas.getTableInfo(new RelationName(sqlExecutor.getDefaultSchema(), "t"));
@@ -63,7 +64,7 @@ public class InternalCountOperationTest extends SQLTransportIntegrationTest {
         Map<QualifiedName, AnalyzedRelation> tableSources = ImmutableMap.<QualifiedName, AnalyzedRelation>of(new QualifiedName(tableInfo.ident().name()), tableRelation);
         SqlExpressions sqlExpressions = new SqlExpressions(tableSources, tableRelation);
 
-        WhereClause whereClause = new WhereClause(sqlExpressions.normalize(sqlExpressions.asSymbol("name = 'Marvin'")));
-        assertThat(countOperation.count(index, 0, whereClause), is(1L));
+        Symbol filter = sqlExpressions.normalize(sqlExpressions.asSymbol("name = 'Marvin'"));
+        assertThat(countOperation.count(index, 0, filter), is(1L));
     }
 }

--- a/sql/src/test/java/io/crate/execution/engine/collect/sources/NodeStatsCollectSourceTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/sources/NodeStatsCollectSourceTest.java
@@ -24,9 +24,9 @@ package io.crate.execution.engine.collect.sources;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
-import io.crate.analyze.WhereClause;
 import io.crate.analyze.relations.AnalyzedRelation;
 import io.crate.analyze.relations.TableRelation;
+import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
@@ -88,9 +88,9 @@ public class NodeStatsCollectSourceTest extends CrateUnitTest {
         Map<QualifiedName, AnalyzedRelation> tableSources = ImmutableMap.<QualifiedName, AnalyzedRelation>of(
             new QualifiedName("sys.nodes"), tableRelation);
         SqlExpressions sqlExpressions = new SqlExpressions(tableSources, tableRelation);
-        WhereClause whereClause = new WhereClause(sqlExpressions.normalize(sqlExpressions.asSymbol(where)));
+        Symbol query = sqlExpressions.normalize(sqlExpressions.asSymbol(where));
 
-        List<DiscoveryNode> nodes = Lists.newArrayList(NodeStatsCollectSource.nodeIds(whereClause,
+        List<DiscoveryNode> nodes = Lists.newArrayList(NodeStatsCollectSource.nodeIds(query,
             discoveryNodes,
             getFunctions()));
         Collections.sort(nodes, new Comparator<DiscoveryNode>() {

--- a/sql/src/test/java/io/crate/execution/engine/collect/sources/SystemCollectSourceTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/sources/SystemCollectSourceTest.java
@@ -35,9 +35,9 @@ import io.crate.expression.reference.sys.snapshot.SysSnapshots;
 import io.crate.integrationtests.SQLTransportIntegrationTest;
 import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
+import io.crate.metadata.RelationName;
 import io.crate.metadata.Routing;
 import io.crate.metadata.RowGranularity;
-import io.crate.metadata.RelationName;
 import io.crate.metadata.shard.unassigned.UnassignedShard;
 import io.crate.metadata.sys.SysShardsTableInfo;
 import io.crate.metadata.sys.SysTableDefinitions;
@@ -83,7 +83,7 @@ public class SystemCollectSourceTest extends SQLTransportIntegrationTest {
             RowGranularity.SHARD,
             Collections.singletonList(shardId),
             ImmutableList.of(),
-            WhereClause.MATCH_ALL,
+            WhereClause.MATCH_ALL.queryOrFallback(),
             DistributionInfo.DEFAULT_BROADCAST,
             null
         );
@@ -117,7 +117,7 @@ public class SystemCollectSourceTest extends SQLTransportIntegrationTest {
             RowGranularity.SHARD,
             ImmutableList.of(),
             ImmutableList.of(),
-            WhereClause.MATCH_ALL,
+            WhereClause.MATCH_ALL.queryOrFallback(),
             DistributionInfo.DEFAULT_BROADCAST,
             null);
 

--- a/sql/src/test/java/io/crate/execution/engine/distribution/DistributingConsumerFactoryTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/distribution/DistributingConsumerFactoryTest.java
@@ -78,7 +78,7 @@ public class DistributingConsumerFactoryTest extends CrateDummyClusterServiceUni
             RowGranularity.DOC,
             ImmutableList.of(),
             ImmutableList.of(),
-            WhereClause.MATCH_ALL,
+            WhereClause.MATCH_ALL.queryOrFallback(),
             DistributionInfo.DEFAULT_MODULO,
             null
         );

--- a/sql/src/test/java/io/crate/execution/jobs/CountContextTest.java
+++ b/sql/src/test/java/io/crate/execution/jobs/CountContextTest.java
@@ -21,9 +21,10 @@
 
 package io.crate.execution.jobs;
 
-import io.crate.analyze.WhereClause;
 import io.crate.exceptions.UnhandledServerException;
 import io.crate.execution.engine.collect.count.CountOperation;
+import io.crate.expression.symbol.Literal;
+import io.crate.expression.symbol.Symbol;
 import io.crate.test.CauseMatcher;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.testing.TestingRowConsumer;
@@ -50,9 +51,9 @@ public class CountContextTest extends CrateUnitTest {
         CompletableFuture<Long> future = new CompletableFuture<>();
 
         CountOperation countOperation = mock(CountOperation.class);
-        when(countOperation.count(anyMap(), any(WhereClause.class))).thenReturn(future);
+        when(countOperation.count(anyMap(), any(Symbol.class))).thenReturn(future);
 
-        CountContext countContext = new CountContext(1, countOperation, new TestingRowConsumer(), null, WhereClause.MATCH_ALL);
+        CountContext countContext = new CountContext(1, countOperation, new TestingRowConsumer(), null, Literal.BOOLEAN_TRUE);
         countContext.prepare();
         countContext.start();
         future.complete(1L);
@@ -62,9 +63,9 @@ public class CountContextTest extends CrateUnitTest {
 
         // on error
         future = new CompletableFuture<>();
-        when(countOperation.count(anyMap(), any(WhereClause.class))).thenReturn(future);
+        when(countOperation.count(anyMap(), any(Symbol.class))).thenReturn(future);
 
-        countContext = new CountContext(2, countOperation, new TestingRowConsumer(), null, WhereClause.MATCH_ALL);
+        countContext = new CountContext(2, countOperation, new TestingRowConsumer(), null, Literal.BOOLEAN_TRUE);
         countContext.prepare();
         countContext.start();
         future.completeExceptionally(new UnhandledServerException("dummy"));
@@ -78,7 +79,7 @@ public class CountContextTest extends CrateUnitTest {
         CompletableFuture<Long> future = mock(CompletableFuture.class);
         CountOperation countOperation = new FakeCountOperation(future);
 
-        CountContext countContext = new CountContext(1, countOperation, new TestingRowConsumer(), null, WhereClause.MATCH_ALL);
+        CountContext countContext = new CountContext(1, countOperation, new TestingRowConsumer(), null, Literal.BOOLEAN_TRUE);
 
         countContext.prepare();
         countContext.start();
@@ -98,12 +99,12 @@ public class CountContextTest extends CrateUnitTest {
 
         @Override
         public CompletableFuture<Long> count(Map<String, ? extends Collection<Integer>> indexShardMap,
-                                             WhereClause whereClause) throws IOException, InterruptedException {
+                                             Symbol filter) throws IOException, InterruptedException {
             return future;
         }
 
         @Override
-        public long count(Index index, int shardId, WhereClause whereClause) throws IOException, InterruptedException {
+        public long count(Index index, int shardId, Symbol filter) throws IOException, InterruptedException {
             return 0;
         }
     }

--- a/sql/src/test/java/io/crate/executor/transport/ExecutionPhasesTaskTest.java
+++ b/sql/src/test/java/io/crate/executor/transport/ExecutionPhasesTaskTest.java
@@ -25,14 +25,14 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 import io.crate.analyze.WhereClause;
 import io.crate.core.collections.TreeMapBuilder;
+import io.crate.execution.dsl.phases.ExecutionPhase;
+import io.crate.execution.dsl.phases.MergePhase;
+import io.crate.execution.dsl.phases.NodeOperation;
+import io.crate.execution.dsl.phases.NodeOperationGrouper;
+import io.crate.execution.dsl.phases.RoutedCollectPhase;
 import io.crate.metadata.Routing;
 import io.crate.metadata.RowGranularity;
-import io.crate.execution.dsl.phases.NodeOperation;
 import io.crate.planner.distribution.DistributionInfo;
-import io.crate.execution.dsl.phases.ExecutionPhase;
-import io.crate.execution.dsl.phases.NodeOperationGrouper;
-import io.crate.execution.dsl.phases.MergePhase;
-import io.crate.execution.dsl.phases.RoutedCollectPhase;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
@@ -64,7 +64,7 @@ public class ExecutionPhasesTaskTest {
             RowGranularity.DOC,
             ImmutableList.of(),
             ImmutableList.of(),
-            WhereClause.MATCH_ALL,
+            WhereClause.MATCH_ALL.queryOrFallback(),
             DistributionInfo.DEFAULT_BROADCAST,
             null
         );

--- a/sql/src/test/java/io/crate/planner/UpdatePlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/UpdatePlannerTest.java
@@ -23,17 +23,17 @@
 package io.crate.planner;
 
 import io.crate.analyze.TableDefinitions;
-import io.crate.expression.symbol.InputColumn;
-import io.crate.expression.symbol.Symbol;
 import io.crate.data.Row;
-import io.crate.metadata.Reference;
-import io.crate.planner.consumer.UpdatePlanner;
-import io.crate.planner.node.dml.UpdateById;
-import io.crate.planner.node.dql.Collect;
 import io.crate.execution.dsl.phases.MergePhase;
 import io.crate.execution.dsl.phases.RoutedCollectPhase;
 import io.crate.execution.dsl.projection.MergeCountProjection;
 import io.crate.execution.dsl.projection.UpdateProjection;
+import io.crate.expression.symbol.InputColumn;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.Reference;
+import io.crate.planner.consumer.UpdatePlanner;
+import io.crate.planner.node.dml.UpdateById;
+import io.crate.planner.node.dql.Collect;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.types.DataTypes;
@@ -43,6 +43,7 @@ import org.junit.Test;
 
 import static io.crate.testing.SymbolMatchers.isLiteral;
 import static io.crate.testing.SymbolMatchers.isReference;
+import static io.crate.testing.TestingHelpers.isSQL;
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.instanceOf;
@@ -71,8 +72,7 @@ public class UpdatePlannerTest extends CrateDummyClusterServiceUnitTest {
 
         RoutedCollectPhase collectPhase = ((RoutedCollectPhase) collect.collectPhase());
         assertThat(collectPhase.routing(), is(TableDefinitions.SHARD_ROUTING));
-        assertFalse(collectPhase.whereClause().noMatch());
-        assertFalse(collectPhase.whereClause().hasQuery());
+        assertThat(collectPhase.where(), isSQL("true"));
         assertThat(collectPhase.projections().size(), is(1));
         assertThat(collectPhase.projections().get(0), instanceOf(UpdateProjection.class));
         assertThat(collectPhase.toCollect().size(), is(1));

--- a/sql/src/test/java/io/crate/planner/node/RoutedCollectPhaseTest.java
+++ b/sql/src/test/java/io/crate/planner/node/RoutedCollectPhaseTest.java
@@ -24,20 +24,19 @@ package io.crate.planner.node;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.crate.action.sql.SessionContext;
-import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.WhereClause;
+import io.crate.execution.dsl.phases.RoutedCollectPhase;
+import io.crate.execution.dsl.projection.Projection;
+import io.crate.expression.eval.EvaluatingNormalizer;
+import io.crate.expression.scalar.cast.CastFunctionResolver;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Value;
 import io.crate.metadata.Routing;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.TransactionContext;
-import io.crate.expression.scalar.cast.CastFunctionResolver;
-import io.crate.auth.user.User;
 import io.crate.planner.distribution.DistributionInfo;
-import io.crate.execution.dsl.phases.RoutedCollectPhase;
-import io.crate.execution.dsl.projection.Projection;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.types.DataTypes;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
@@ -70,7 +69,7 @@ public class RoutedCollectPhaseTest extends CrateUnitTest {
             RowGranularity.DOC,
             toCollect,
             ImmutableList.<Projection>of(),
-            WhereClause.MATCH_ALL,
+            WhereClause.MATCH_ALL.queryOrFallback(),
             DistributionInfo.DEFAULT_MODULO,
             null // not streamed
         );
@@ -102,7 +101,7 @@ public class RoutedCollectPhaseTest extends CrateUnitTest {
             RowGranularity.DOC,
             Collections.singletonList(toInt10),
             Collections.emptyList(),
-            WhereClause.MATCH_ALL,
+            WhereClause.MATCH_ALL.queryOrFallback(),
             DistributionInfo.DEFAULT_SAME_NODE,
             null
         );
@@ -125,7 +124,7 @@ public class RoutedCollectPhaseTest extends CrateUnitTest {
             RowGranularity.DOC,
             Collections.singletonList(toInt10),
             Collections.emptyList(),
-            WhereClause.MATCH_ALL,
+            WhereClause.MATCH_ALL.queryOrFallback(),
             DistributionInfo.DEFAULT_SAME_NODE,
             null
         );
@@ -147,7 +146,7 @@ public class RoutedCollectPhaseTest extends CrateUnitTest {
             RowGranularity.DOC,
             Collections.singletonList(Literal.of(10)),
             Collections.emptyList(),
-            WhereClause.MATCH_ALL,
+            WhereClause.MATCH_ALL.queryOrFallback(),
             DistributionInfo.DEFAULT_SAME_NODE,
             null
         );

--- a/sql/src/test/java/io/crate/planner/node/dql/CountPhaseTest.java
+++ b/sql/src/test/java/io/crate/planner/node/dql/CountPhaseTest.java
@@ -21,9 +21,9 @@
 
 package io.crate.planner.node.dql;
 
-import io.crate.analyze.WhereClause;
 import io.crate.core.collections.TreeMapBuilder;
 import io.crate.execution.dsl.phases.CountPhase;
+import io.crate.expression.symbol.Literal;
 import io.crate.metadata.Routing;
 import io.crate.planner.distribution.DistributionInfo;
 import io.crate.test.integration.CrateUnitTest;
@@ -51,7 +51,7 @@ public class CountPhaseTest extends CrateUnitTest {
                     .put("i2", Arrays.asList(1, 2)).map())
                 .put("n2", TreeMapBuilder.<String, List<Integer>>newMapBuilder()
                     .put("i1", Collections.singletonList(3)).map()).map());
-        CountPhase countPhase = new CountPhase(1, routing, WhereClause.MATCH_ALL, DistributionInfo.DEFAULT_BROADCAST);
+        CountPhase countPhase = new CountPhase(1, routing, Literal.BOOLEAN_TRUE, DistributionInfo.DEFAULT_BROADCAST);
 
         BytesStreamOutput out = new BytesStreamOutput(10);
         countPhase.writeTo(out);


### PR DESCRIPTION
Should make the code a bit more comprehensible and less trappy.
Both `docKeys` and `partitions` are never used on the collect nodes. In
fact, besides the `query` nothing of the `WhereClause` was streamed.