### PR TITLE
Do where clause optimization in planner instead of analyzer

### DIFF
--- a/sql/src/main/java/io/crate/planner/operators/Collect.java
+++ b/sql/src/main/java/io/crate/planner/operators/Collect.java
@@ -30,7 +30,6 @@ import io.crate.analyze.WhereClause;
 import io.crate.analyze.relations.AbstractTableRelation;
 import io.crate.analyze.relations.DocTableRelation;
 import io.crate.analyze.relations.TableFunctionRelation;
-import io.crate.analyze.where.DocKeys;
 import io.crate.analyze.where.WhereClauseAnalyzer;
 import io.crate.data.Row;
 import io.crate.exceptions.UnsupportedFeatureException;
@@ -100,11 +99,7 @@ class Collect extends ZeroInputPlan {
     public static LogicalPlan.Builder create(QueriedTable relation,
                                              List<Symbol> toCollect,
                                              WhereClause where) {
-        if (where.docKeys().isPresent() && !((DocTableInfo) relation.tableRelation().tableInfo()).isAlias()) {
-            DocKeys docKeys = where.docKeys().get();
-            return ((tableStats, usedBeforeNextFetch) ->
-                        new Get(((QueriedTable) relation), docKeys, toCollect, tableStats));
-        }
+        assert !where.docKeys().isPresent() : "If whereClause has docKeys a Get operator should be used";
         return (tableStats, usedColumns) -> new Collect(
             relation,
             toCollect,

--- a/sql/src/main/java/io/crate/planner/operators/Union.java
+++ b/sql/src/main/java/io/crate/planner/operators/Union.java
@@ -22,7 +22,6 @@
 
 package io.crate.planner.operators;
 
-import io.crate.action.sql.SessionContext;
 import io.crate.analyze.OrderBy;
 import io.crate.analyze.relations.QueriedRelation;
 import io.crate.analyze.relations.UnionSelect;
@@ -33,6 +32,8 @@ import io.crate.execution.engine.pipeline.TopN;
 import io.crate.expression.symbol.FieldsVisitor;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.Functions;
+import io.crate.metadata.TransactionContext;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.Merge;
 import io.crate.planner.PlannerContext;
@@ -63,7 +64,7 @@ import static io.crate.planner.operators.Limit.limitAndOffset;
  */
 public class Union extends TwoInputPlan {
 
-    static Builder create(UnionSelect ttr, SubqueryPlanner subqueryPlanner, SessionContext sessionContext) {
+    static Builder create(UnionSelect ttr, SubqueryPlanner subqueryPlanner, Functions functions, TransactionContext txnCtx) {
         return (tableStats, usedColsByParent) -> {
 
             QueriedRelation left = ttr.left();
@@ -79,11 +80,11 @@ public class Union extends TwoInputPlan {
             usedFromRight.addAll(right.outputs());
 
             LogicalPlan lhsPlan = LogicalPlanner
-                .plan(left, FetchMode.NEVER_CLEAR, subqueryPlanner, false, sessionContext)
+                .plan(left, FetchMode.NEVER_CLEAR, subqueryPlanner, false, functions, txnCtx)
                 .build(tableStats, usedFromLeft);
 
             LogicalPlan rhsPlan = LogicalPlanner
-                .plan(right, FetchMode.NEVER_CLEAR, subqueryPlanner, false, sessionContext)
+                .plan(right, FetchMode.NEVER_CLEAR, subqueryPlanner, false, functions, txnCtx)
                 .build(tableStats, usedFromRight);
 
             return new Union(lhsPlan, rhsPlan, ttr.outputs());


### PR DESCRIPTION
- Aligns select handling more closely with delete and update handling
 where the `WhereClause` optimization is also done in the planner.

 - Solves an issue with the round-trip printing that is being introduced
 in https://github.com/crate/crate/pull/7195
 (Running the `WhereClauseAnalyzer` expands generated columns, so
 printing the analyzed statements includes additional expressions in the
 whereClause)