### PR TITLE
Remove duplicate where analysis & pkCol extraction logic

### DIFF
--- a/sql/src/main/java/io/crate/planner/node/ddl/DeletePartitions.java
+++ b/sql/src/main/java/io/crate/planner/node/ddl/DeletePartitions.java
@@ -78,9 +78,9 @@ public class DeletePartitions implements Plan {
     @VisibleForTesting
     ArrayList<String> getIndices(Functions functions, Row parameters, Map<SelectSymbol, Object> subQueryValues) {
         ArrayList<String> indexNames = new ArrayList<>();
+        Function<Symbol, BytesRef> symbolToBytesRef =
+            s -> DataTypes.STRING.value(SymbolEvaluator.evaluate(functions, s, parameters, subQueryValues));
         for (List<Symbol> partitionValues : partitions) {
-            Function<Symbol, BytesRef> symbolToBytesRef =
-                s -> DataTypes.STRING.value(SymbolEvaluator.evaluate(functions, s, parameters, subQueryValues));
             List<BytesRef> values = Lists2.copyAndReplace(partitionValues, symbolToBytesRef);
             String indexName = IndexParts.toIndexName(relationName, PartitionName.encodeIdent(values));
             indexNames.add(indexName);

--- a/sql/src/main/java/io/crate/planner/operators/Collect.java
+++ b/sql/src/main/java/io/crate/planner/operators/Collect.java
@@ -99,7 +99,6 @@ class Collect extends ZeroInputPlan {
     public static LogicalPlan.Builder create(QueriedTable relation,
                                              List<Symbol> toCollect,
                                              WhereClause where) {
-        assert !where.docKeys().isPresent() : "If whereClause has docKeys a Get operator should be used";
         return (tableStats, usedColumns) -> new Collect(
             relation,
             toCollect,

--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -22,7 +22,6 @@
 
 package io.crate.planner.operators;
 
-import io.crate.action.sql.SessionContext;
 import io.crate.analyze.AnalyzedStatement;
 import io.crate.analyze.AnalyzedStatementVisitor;
 import io.crate.analyze.InsertFromSubQueryAnalyzedStatement;
@@ -242,7 +241,6 @@ public class LogicalPlanner {
                                                         FetchMode fetchMode,
                                                         Functions functions,
                                                         TransactionContext txnCtx) {
-        SessionContext sessionContext = txnCtx.sessionContext();
         if (queriedRelation instanceof AnalyzedView) {
             return plan(((AnalyzedView) queriedRelation).relation(), fetchMode, subqueryPlanner, false, functions, txnCtx);
         }
@@ -267,7 +265,6 @@ public class LogicalPlanner {
                 }
                 return Collect.create(queriedTable, toCollect, new WhereClause(
                     detailedQuery.query(),
-                    null,
                     where.partitions(),
                     detailedQuery.clusteredBy()
                 ));

--- a/sql/src/test/java/io/crate/analyze/CopyAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CopyAnalyzerTest.java
@@ -232,15 +232,6 @@ public class CopyAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(querySpec.where().partitions(), contains(parted));
     }
 
-    @Test
-    public void testCopyToWithPartitionInWhereClause() throws Exception {
-        CopyToAnalyzedStatement analysis = e.analyze(
-            "copy parted where date = 1395874800000 to directory '/tmp/foo'");
-        String parted = new PartitionName("parted", Collections.singletonList(new BytesRef("1395874800000"))).asIndexName();
-        QuerySpec querySpec = analysis.subQueryRelation().querySpec();
-        assertThat(querySpec.where().partitions(), contains(parted));
-        assertThat(analysis.overwrites().size(), is(1));
-    }
 
     @Test
     public void testCopyToWithPartitionIdentAndWhereClause() throws Exception {
@@ -250,13 +241,6 @@ public class CopyAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         QuerySpec querySpec = analysis.subQueryRelation().querySpec();
         assertThat(querySpec.where().partitions(), contains(parted));
         assertThat(querySpec.where().query(), isFunction("op_="));
-    }
-
-    @Test
-    public void testCopyToWithInvalidPartitionInWhereClause() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Given partition ident does not match partition evaluated from where clause");
-        e.analyze("copy parted partition (date=1395874800000) where date = 1395961200000 to directory '/tmp/foo'");
     }
 
     @Test

--- a/sql/src/test/java/io/crate/analyze/where/EqualityExtractorTest.java
+++ b/sql/src/test/java/io/crate/analyze/where/EqualityExtractorTest.java
@@ -81,6 +81,13 @@ public class EqualityExtractorTest extends CrateUnitTest {
     }
 
     @Test
+    public void testNoExtractOnNotEqualsOnSinglePk() {
+        Symbol query = query("x != 1");
+        List<List<Symbol>> matches = analyzeExactX(query);
+        assertNull(matches);
+    }
+
+    @Test
     public void testExtract2ColPKWithAndAndNestedOr() throws Exception {
         Symbol query = query("x = 1 and (i = 2 or i = 3 or i = 4)");
         List<List<Symbol>> matches = analyzeExactXI(query);
@@ -335,6 +342,12 @@ public class EqualityExtractorTest extends CrateUnitTest {
     public void testNoPKExtractionIfFunctionUsingPKIsPresent() throws Exception {
         Symbol query = query("x in (1, 2, 3) and substr(cast(x as string), 0) = 4");
         List<List<Symbol>> matches = analyzeExactX(query);
+        assertThat(matches, nullValue());
+    }
+
+    @Test
+    public void testNoPKExtractionOnNotIn() {
+        List<List<Symbol>> matches = analyzeExactX(query("x not in (1, 2, 3)"));
         assertThat(matches, nullValue());
     }
 }

--- a/sql/src/test/java/io/crate/planner/DeletePlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/DeletePlannerTest.java
@@ -24,15 +24,14 @@ package io.crate.planner;
 
 import com.google.common.collect.Lists;
 import io.crate.analyze.TableDefinitions;
-import io.crate.expression.symbol.ParameterSymbol;
-import io.crate.expression.symbol.Symbol;
 import io.crate.data.Row;
 import io.crate.exceptions.VersionInvalidException;
+import io.crate.expression.symbol.ParameterSymbol;
+import io.crate.expression.symbol.Symbol;
 import io.crate.planner.node.ddl.DeletePartitions;
 import io.crate.planner.node.dml.DeleteById;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
-import io.crate.testing.TestingRowConsumer;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
@@ -45,7 +44,6 @@ import static io.crate.testing.TestingHelpers.isDocKey;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.Mockito.mock;
 
 public class DeletePlannerTest extends CrateDummyClusterServiceUnitTest {
 
@@ -88,16 +86,8 @@ public class DeletePlannerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testDeleteWhereVersionIsNullPredicate() throws Exception {
-        Plan plan = e.plan("delete from users where _version is null");
-
         expectedException.expect(VersionInvalidException.class);
         expectedException.expectMessage(VersionInvalidException.ERROR_MSG);
-        plan.execute(
-            mock(DependencyCarrier.class),
-            e.getPlannerContext(clusterService.state()),
-            new TestingRowConsumer(),
-            Row.EMPTY,
-            Collections.emptyMap()
-        );
+        e.plan("delete from users where _version is null");
     }
 }

--- a/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -105,6 +105,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         e = SQLExecutor.builder(clusterService)
             .addDocTable(TableDefinitions.USER_TABLE_INFO)
             .addDocTable(TableDefinitions.TEST_CLUSTER_BY_STRING_TABLE_INFO)
+            .addDocTable(TableDefinitions.USER_TABLE_INFO_CLUSTERED_BY_ONLY)
             .addDocTable(TableDefinitions.PARTED_PKS_TI)
             .addDocTable(TableDefinitions.IGNORED_NESTED_TABLE_INFO)
             .addDocTable(TableDefinitions.TEST_MULTIPLE_PARTITIONED_TABLE_INFO)

--- a/sql/src/test/java/io/crate/planner/WhereClauseOptimizerTest.java
+++ b/sql/src/test/java/io/crate/planner/WhereClauseOptimizerTest.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner;
+
+import io.crate.analyze.QueriedTable;
+import io.crate.expression.eval.EvaluatingNormalizer;
+import io.crate.metadata.PartitionName;
+import io.crate.metadata.RowGranularity;
+import io.crate.metadata.doc.DocTableInfo;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+import org.apache.lucene.util.BytesRef;
+import org.junit.Before;
+import org.junit.Test;
+
+import static io.crate.testing.SymbolMatchers.isLiteral;
+import static io.crate.testing.TestingHelpers.isDocKey;
+import static java.util.Collections.singletonList;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+
+public class WhereClauseOptimizerTest extends CrateDummyClusterServiceUnitTest{
+
+    private SQLExecutor e;
+
+    @Before
+    public void setUpExecutor() throws Exception {
+        e = SQLExecutor.builder(clusterService)
+            .addTable("create table bystring (name string primary key, score double) " +
+                      "clustered by (name) ")
+            .addTable("create table clustered_by_only (x int) clustered by (x)")
+            .addPartitionedTable(
+                "create table parted (id int, date timestamp) " +
+                "partitioned by (date)"
+            )
+            .addPartitionedTable(
+                "create table parted_pk (id int primary key, date timestamp primary key) " +
+                "partitioned by (date)",
+                new PartitionName("parted_pk", singletonList(new BytesRef("1395874800000"))).asIndexName(),
+                new PartitionName("parted_pk", singletonList(new BytesRef("1395961200000"))).asIndexName(),
+                new PartitionName("parted_pk", singletonList(null)).asIndexName()
+            )
+            .build();
+    }
+
+    private WhereClauseOptimizer.DetailedQuery optimize(String statement) {
+        QueriedTable queriedTable = e.analyze(statement);
+        EvaluatingNormalizer normalizer = new EvaluatingNormalizer(
+            e.functions(),
+            RowGranularity.CLUSTER,
+            null,
+            queriedTable.tableRelation()
+        );
+        return WhereClauseOptimizer.optimize(
+            normalizer,
+            queriedTable.where().queryOrFallback(),
+            ((DocTableInfo) queriedTable.tableRelation().tableInfo()),
+            e.getPlannerContext(clusterService.state()).transactionContext()
+        );
+    }
+
+    @Test
+    public void testFilterOn_IdDoesNotProduceDocKeysIfTableHasOnlyAClusteredByDefinition() {
+        WhereClauseOptimizer.DetailedQuery query = optimize(
+            "select * from clustered_by_only where _id = '1'");
+        assertThat(query.docKeys().isPresent(), is(false));
+    }
+
+    @Test
+    public void testFilterOn_IdOnPartitionedTableDoesNotResultInDocKeys() {
+        WhereClauseOptimizer.DetailedQuery query = optimize(
+            "select * from parted where _id = '1'");
+        assertThat(query.docKeys().isPresent(), is(false));
+    }
+
+    @Test
+    public void testFilterOnPartitionColumnAndPrimaryKeyResultsInDocKeys() {
+        WhereClauseOptimizer.DetailedQuery query = optimize(
+            "select * from parted_pk where id = 1 and date = 1395874800000");
+        assertThat(query.docKeys().toString(), is("Optional[DocKeys{1, 1395874800000}]"));
+        assertThat(query.partitions(), empty());
+    }
+
+    @Test
+    public void testClusteredByValueContainsComma() throws Exception {
+        WhereClauseOptimizer.DetailedQuery query = optimize(
+            "select * from bystring where name = 'a,b,c'");
+        assertThat(query.clusteredBy(), contains(isLiteral("a,b,c")));
+        assertThat(query.docKeys().get().size(), is(1));
+        assertThat(query.docKeys().get().getOnlyKey(), isDocKey("a,b,c"));
+    }
+
+    @Test
+    public void testEmptyClusteredByValue() throws Exception {
+        WhereClauseOptimizer.DetailedQuery query = optimize("select * from bystring where name = ''");
+        assertThat(query.clusteredBy(), contains(isLiteral("")));
+        assertThat(query.docKeys().get().getOnlyKey(), isDocKey(""));
+    }
+
+    @Test
+    public void testFilterOnClusteredByColumnDoesNotResultInDocKeysSimpleEq() {
+        WhereClauseOptimizer.DetailedQuery query = optimize(
+            "select * from clustered_by_only where x = 10");
+        assertThat(query.clusteredBy(), contains(isLiteral(10)));
+        assertThat(query.docKeys().isPresent(), is(false));
+    }
+
+    @Test
+    public void testFilterOnClusteredByColumnDoesNotResultInDocKeysSimpleEqOr() {
+        WhereClauseOptimizer.DetailedQuery query = optimize(
+            "select * from clustered_by_only where x = 10 or x = 20");
+        assertThat(query.clusteredBy(), containsInAnyOrder(isLiteral(10), isLiteral(20)));
+        assertThat(query.docKeys().isPresent(), is(false));
+    }
+
+    @Test
+    public void testFilterOnClusteredByColumnDoesNotResultInDocKeysIn() {
+        WhereClauseOptimizer.DetailedQuery query = optimize(
+            "select * from clustered_by_only where x in (10, 20)");
+        assertThat(query.clusteredBy(), containsInAnyOrder(isLiteral(10), isLiteral(20)));
+        assertThat(query.docKeys().isPresent(), is(false));
+    }
+
+    @Test
+    public void testFilterOnPKAndVersionResultsInDocKeys() {
+        WhereClauseOptimizer.DetailedQuery query = optimize(
+            "select * from bystring where name = 'foo' and _version = 2");
+        assertThat(query.docKeys().toString(), is("Optional[DocKeys{'foo', 2}]"));
+    }
+}


### PR DESCRIPTION
The `WhereClauseOptimizer` was introduced to do a preliminary analysis
of the `WHERE` expression without accessing parameters or sub-query
values. This was necessary to support scalar subqueries in `DELETE` and
`UPDATE` but it duplicated some logic.

This commit streamlines the logic a bit:

 - `WhereClauseOptimizer -> DetailedQuery` is now the first step.

 - A `DetailedQuery` can be converted to a (bound) `WhereClause` without
 re-extracting primary key columns.

 - `WhereClause` no longer contains `docKeys`, these are part of the
 `DetailedQuery`. If they're available no `WhereClause` should be built.