### PR TITLE
[Test] decrease the simulating loadNextBatch delay

### DIFF
--- a/dex/src/test/java/io/crate/testing/BatchSimulatingIterator.java
+++ b/dex/src/test/java/io/crate/testing/BatchSimulatingIterator.java
@@ -68,7 +68,7 @@ public class BatchSimulatingIterator<T> implements BatchIterator<T> {
         this.numBatches = maxAdditionalFakeBatches;
         this.batchSize = batchSize;
 
-        this.loadNextDelays = new Random(System.currentTimeMillis()).longs(0, 100).iterator();
+        this.loadNextDelays = new Random(System.currentTimeMillis()).longs(0, 5).iterator();
         this.executor = executor == null ? ForkJoinPool.commonPool() : executor;
     }
 


### PR DESCRIPTION
E.g. the HashJoinBatchIteratorTest is heavily using this batch simulating
component, small delays on loadNextBatch will dramatically decrease the
time for this test suite (~50s to now ~3s).
Small delays should be fine for verifying the expected behaviour as well.