### PR TITLE
Fix COPY TO with WHERE on primary key

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -181,6 +181,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that caused ``COPY TO`` with filters on primary key columns to
+  fail.
+
 - Fixed an issue that caused queries on the `_uid` column to not match
   correctly.
 

--- a/sql/src/main/java/io/crate/execution/engine/collect/PKLookupOperation.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/PKLookupOperation.java
@@ -23,8 +23,17 @@
 package io.crate.execution.engine.collect;
 
 import io.crate.Constants;
+import io.crate.breaker.RamAccountingContext;
 import io.crate.data.BatchIterator;
+import io.crate.data.CompositeBatchIterator;
 import io.crate.data.InMemoryBatchIterator;
+import io.crate.data.Row;
+import io.crate.data.RowConsumer;
+import io.crate.execution.dsl.projection.Projection;
+import io.crate.execution.engine.collect.collectors.MultiConsumer;
+import io.crate.execution.engine.collect.sources.ShardCollectSource;
+import io.crate.execution.engine.pipeline.ProjectingRowConsumer;
+import io.crate.execution.engine.pipeline.ProjectorFactory;
 import io.crate.planner.operators.PKAndVersion;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.IndexService;
@@ -36,16 +45,22 @@ import org.elasticsearch.index.shard.ShardNotFoundException;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.search.fetch.subphase.FetchSourceContext;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 public final class PKLookupOperation {
 
     private final IndicesService indicesService;
+    private final ShardCollectSource shardCollectSource;
 
-    public PKLookupOperation(IndicesService indicesService) {
+    public PKLookupOperation(IndicesService indicesService, ShardCollectSource shardCollectSource) {
         this.indicesService = indicesService;
+        this.shardCollectSource = shardCollectSource;
     }
 
     public BatchIterator<GetResult> lookup(boolean ignoreMissing, Map<ShardId, List<PKAndVersion>> idsByShard) {
@@ -79,5 +94,84 @@ public final class PKLookupOperation {
                     .filter(GetResult::isExists);
             });
         return InMemoryBatchIterator.of(getResultStream::iterator, null);
+    }
+
+
+    public void runWithShardProjections(UUID jobId,
+                                        RamAccountingContext ramAccountingContext,
+                                        boolean ignoreMissing,
+                                        Map<ShardId, List<PKAndVersion>> idsByShard,
+                                        Collection<? extends Projection> projections,
+                                        RowConsumer nodeConsumer,
+                                        Function<GetResult, Row> resultToRow) {
+        String[] emptyFields = new String[0];
+        ArrayList<ShardAndIds> shardAndIdsList = new ArrayList<>(idsByShard.size());
+        for (Map.Entry<ShardId, List<PKAndVersion>> idsByShardEntry : idsByShard.entrySet()) {
+            ShardId shardId = idsByShardEntry.getKey();
+            IndexService indexService = indicesService.indexService(shardId.getIndex());
+            if (indexService == null) {
+                if (ignoreMissing) {
+                    continue;
+                }
+                throw new IndexNotFoundException(shardId.getIndex());
+            }
+            IndexShard shard = indexService.getShardOrNull(shardId.id());
+            if (shard == null) {
+                if (ignoreMissing) {
+                    continue;
+                }
+                throw new ShardNotFoundException(shardId);
+            }
+            try {
+                shardAndIdsList.add(
+                    new ShardAndIds(
+                        shard,
+                        shardCollectSource.getProjectorFactory(shardId),
+                        idsByShardEntry.getValue()
+                    ));
+            } catch (ShardNotFoundException e) {
+                if (ignoreMissing) {
+                    continue;
+                }
+                throw e;
+            }
+        }
+        MultiConsumer multiConsumer = new MultiConsumer(shardAndIdsList.size(), nodeConsumer, CompositeBatchIterator::new);
+        for (ShardAndIds shardAndIds : shardAndIdsList) {
+            RowConsumer consumer = ProjectingRowConsumer.create(
+                multiConsumer,
+                projections,
+                jobId,
+                ramAccountingContext,
+                shardAndIds.projectorFactory
+            );
+            BatchIterator<Row> batchIterator = InMemoryBatchIterator.of(
+                shardAndIds.value.stream()
+                    .map(pkAndVersion -> shardAndIds.shard.getService().get(
+                        Constants.DEFAULT_MAPPING_TYPE,
+                        pkAndVersion.id(),
+                        emptyFields,
+                        true,
+                        pkAndVersion.version(),
+                        VersionType.EXTERNAL,
+                        FetchSourceContext.FETCH_SOURCE
+                    ))
+                    .map(resultToRow)
+                    ::iterator, null);
+            consumer.accept(batchIterator, null);
+        }
+    }
+
+    private static class ShardAndIds {
+
+        final IndexShard shard;
+        final ProjectorFactory projectorFactory;
+        final List<PKAndVersion> value;
+
+        ShardAndIds(IndexShard shard, ProjectorFactory projectorFactory, List<PKAndVersion> value) {
+            this.shard = shard;
+            this.projectorFactory = projectorFactory;
+            this.value = value;
+        }
     }
 }

--- a/sql/src/main/java/io/crate/execution/engine/collect/ShardCollectorProvider.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/ShardCollectorProvider.java
@@ -167,4 +167,8 @@ public abstract class ShardCollectorProvider {
                                                             SharedShardContext sharedShardContext,
                                                             JobCollectContext jobCollectContext,
                                                             boolean requiresRepeat);
+
+    public ProjectorFactory getProjectorFactory() {
+        return projectorFactory;
+    }
 }

--- a/sql/src/main/java/io/crate/execution/engine/collect/collectors/CompositeCollector.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/collectors/CompositeCollector.java
@@ -27,7 +27,6 @@ import io.crate.data.Row;
 import io.crate.data.RowConsumer;
 import io.crate.execution.engine.collect.CrateCollector;
 
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -70,48 +69,4 @@ public class CompositeCollector implements CrateCollector {
         }
     }
 
-    static class MultiConsumer implements RowConsumer {
-
-        private final BatchIterator<Row>[] iterators;
-        private final RowConsumer consumer;
-        private final Function<BatchIterator<Row>[], BatchIterator<Row>> compositeBatchIteratorFactory;
-
-        private int remainingAccepts;
-        private Throwable lastFailure;
-
-        MultiConsumer(int numAccepts,
-                      RowConsumer consumer,
-                      Function<BatchIterator<Row>[], BatchIterator<Row>> compositeBatchIteratorFactory) {
-            this.remainingAccepts = numAccepts;
-            this.iterators = new BatchIterator[numAccepts];
-            this.consumer = consumer;
-            this.compositeBatchIteratorFactory = compositeBatchIteratorFactory;
-        }
-
-        @Override
-        public void accept(BatchIterator<Row> iterator, @Nullable Throwable failure) {
-            int remaining;
-            synchronized (iterators) {
-                remainingAccepts--;
-                remaining = remainingAccepts;
-                if (failure != null) {
-                    lastFailure = failure;
-                }
-                iterators[remaining] = iterator;
-            }
-            if (remaining == 0) {
-                // null checks to avoid using the factory with potential null-entries within the iterators
-                if (lastFailure == null) {
-                    consumer.accept(compositeBatchIteratorFactory.apply(iterators), null);
-                } else {
-                    consumer.accept(null, lastFailure);
-                }
-            }
-        }
-
-        @Override
-        public boolean requiresScroll() {
-            return consumer.requiresScroll();
-        }
-    }
 }

--- a/sql/src/main/java/io/crate/execution/engine/collect/collectors/MultiConsumer.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/collectors/MultiConsumer.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.engine.collect.collectors;
+
+import io.crate.data.BatchIterator;
+import io.crate.data.Row;
+import io.crate.data.RowConsumer;
+
+import javax.annotation.Nullable;
+import java.util.function.Function;
+
+public class MultiConsumer implements RowConsumer {
+
+    private final BatchIterator<Row>[] iterators;
+    private final RowConsumer consumer;
+    private final Function<BatchIterator<Row>[], BatchIterator<Row>> compositeBatchIteratorFactory;
+
+    private int remainingAccepts;
+    private Throwable lastFailure;
+
+    public MultiConsumer(int numAccepts,
+                         RowConsumer consumer,
+                         Function<BatchIterator<Row>[], BatchIterator<Row>> compositeBatchIteratorFactory) {
+        this.remainingAccepts = numAccepts;
+        this.iterators = new BatchIterator[numAccepts];
+        this.consumer = consumer;
+        this.compositeBatchIteratorFactory = compositeBatchIteratorFactory;
+    }
+
+    @Override
+    public void accept(BatchIterator<Row> iterator, @Nullable Throwable failure) {
+        int remaining;
+        synchronized (iterators) {
+            remainingAccepts--;
+            remaining = remainingAccepts;
+            if (failure != null) {
+                lastFailure = failure;
+            }
+            iterators[remaining] = iterator;
+        }
+        if (remaining == 0) {
+            // null checks to avoid using the factory with potential null-entries within the iterators
+            if (lastFailure == null) {
+                consumer.accept(compositeBatchIteratorFactory.apply(iterators), null);
+            } else {
+                consumer.accept(null, lastFailure);
+            }
+        }
+    }
+
+    @Override
+    public boolean requiresScroll() {
+        return consumer.requiresScroll();
+    }
+}

--- a/sql/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectSource.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectSource.java
@@ -223,6 +223,12 @@ public class ShardCollectSource extends AbstractComponent implements CollectSour
         indexEventListenerProxy.addLast(new LifecycleListener());
     }
 
+    public ProjectorFactory getProjectorFactory(ShardId shardId) {
+        ShardCollectorProvider collectorProvider = getCollectorProviderSafe(shardId);
+        return collectorProvider.getProjectorFactory();
+    }
+
+
     /**
      * Executor that delegates the execution of tasks to the provided {@link Executor} until
      * it starts rejecting tasks with {@link EsRejectedExecutionException} in which case it executes the

--- a/sql/src/main/java/io/crate/execution/jobs/ContextPreparer.java
+++ b/sql/src/main/java/io/crate/execution/jobs/ContextPreparer.java
@@ -56,10 +56,12 @@ import io.crate.execution.dsl.phases.NodeOperation;
 import io.crate.execution.dsl.phases.PKLookupPhase;
 import io.crate.execution.dsl.phases.RoutedCollectPhase;
 import io.crate.execution.dsl.phases.UpstreamPhase;
+import io.crate.execution.dsl.projection.Projection;
 import io.crate.execution.engine.collect.JobCollectContext;
 import io.crate.execution.engine.collect.MapSideDataCollectOperation;
 import io.crate.execution.engine.collect.PKLookupOperation;
 import io.crate.execution.engine.collect.count.CountOperation;
+import io.crate.execution.engine.collect.sources.ShardCollectSource;
 import io.crate.execution.engine.collect.sources.SystemCollectSource;
 import io.crate.execution.engine.distribution.DistributingConsumerFactory;
 import io.crate.execution.engine.distribution.SingleBucketBuilder;
@@ -102,6 +104,9 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 
+import static io.crate.execution.dsl.projection.Projections.nodeProjections;
+import static io.crate.execution.dsl.projection.Projections.shardProjections;
+
 @Singleton
 public class ContextPreparer extends AbstractComponent {
 
@@ -130,6 +135,7 @@ public class ContextPreparer extends AbstractComponent {
                            IndicesService indicesService,
                            Functions functions,
                            SystemCollectSource systemCollectSource,
+                           ShardCollectSource shardCollectSource,
                            BigArrays bigArrays) {
         super(settings);
         nlContextLogger = Loggers.getLogger(JoinContext.class, settings);
@@ -137,7 +143,7 @@ public class ContextPreparer extends AbstractComponent {
         this.collectOperation = collectOperation;
         this.clusterService = clusterService;
         this.countOperation = countOperation;
-        this.pkLookupOperation = new PKLookupOperation(indicesService);
+        this.pkLookupOperation = new PKLookupOperation(indicesService, shardCollectSource);
         circuitBreaker = breakerService.getBreaker(CrateCircuitBreakerService.QUERY);
         this.distributingConsumerFactory = distributingConsumerFactory;
         innerPreparer = new InnerPreparer();
@@ -546,21 +552,28 @@ public class ContextPreparer extends AbstractComponent {
 
         @Override
         public Boolean visitPKLookup(PKLookupPhase pkLookupPhase, PreparerContext context) {
-            RowConsumer rowConsumer = ProjectingRowConsumer.create(
+            Collection<? extends Projection> shardProjections = shardProjections(pkLookupPhase.projections());
+            Collection<? extends Projection> nodeProjections = nodeProjections(pkLookupPhase.projections());
+
+            RamAccountingContext ramAccountingContext = RamAccountingContext.forExecutionPhase(circuitBreaker, pkLookupPhase);
+            RowConsumer nodeRowConsumer = ProjectingRowConsumer.create(
                 context.getRowConsumer(pkLookupPhase, 0),
-                pkLookupPhase.projections(),
+                nodeProjections,
                 pkLookupPhase.jobId(),
-                RamAccountingContext.forExecutionPhase(circuitBreaker, pkLookupPhase),
+                ramAccountingContext,
                 projectorFactory
             );
             context.registerSubContext(new PKLookupContext(
+                pkLookupPhase.jobId(),
                 pkLookupPhase.phaseId(),
+                ramAccountingContext,
                 inputFactory,
                 pkLookupOperation,
                 pkLookupPhase.partitionedByColumns(),
                 pkLookupPhase.toCollect(),
                 pkLookupPhase.getIdsByShardId(clusterService.localNode().getId()),
-                rowConsumer
+                shardProjections,
+                nodeRowConsumer
             ));
             return true;
         }

--- a/sql/src/test/java/io/crate/execution/engine/collect/collectors/MultiConsumerTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/collectors/MultiConsumerTest.java
@@ -42,7 +42,7 @@ public class MultiConsumerTest extends CrateUnitTest {
     @Test
     public void testSuccessfulMultiConsumerUsage() throws Exception {
         TestingRowConsumer batchConsumer = new TestingRowConsumer();
-        RowConsumer consumer = new CompositeCollector.MultiConsumer(2, batchConsumer, CompositeBatchIterator::new);
+        RowConsumer consumer = new MultiConsumer(2, batchConsumer, CompositeBatchIterator::new);
 
         consumer.accept(TestingBatchIterators.range(3, 6), null);
         consumer.accept(TestingBatchIterators.range(0, 3), null);
@@ -60,7 +60,7 @@ public class MultiConsumerTest extends CrateUnitTest {
     @Test
     public void testFirstAcceptNullIteratorDoesNotCauseNPE() throws Exception {
         TestingRowConsumer batchConsumer = new TestingRowConsumer();
-        RowConsumer consumer = new CompositeCollector.MultiConsumer(2, batchConsumer, CompositeBatchIterator::new);
+        RowConsumer consumer = new MultiConsumer(2, batchConsumer, CompositeBatchIterator::new);
         consumer.accept(null, new IllegalStateException("dummy"));
         consumer.accept(InMemoryBatchIterator.empty(SENTINEL), null);
 

--- a/sql/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
@@ -470,6 +470,17 @@ public class CopyIntegrationTest extends SQLHttpIntegrationTest {
     }
 
     @Test
+    public void testCopyToWithWhereOnPrimaryKey() throws Exception {
+        execute("create table t1 (id int primary key) with (number_of_replicas = 0)");
+        execute("insert into t1 (id) values (1)");
+        execute("refresh table t1");
+
+        String uriTemplate = Paths.get(folder.getRoot().toURI()).toUri().toString();
+        SQLResponse response = execute("copy t1 where id = 1 to DIRECTORY ?", new Object[]{uriTemplate});
+        assertThat(response.rowCount(), is(1L));
+    }
+
+    @Test
     public void testCopyToWithWhereNoMatch() throws Exception {
         this.setup.groupBySetup();
 


### PR DESCRIPTION
This adds support for shard projection execution using the
`PKLookupOperation` in order to support actions like `COPY TO WHERE
pkCol = ?` which choose a primary key lookup strategy but also require
shard projections.