### PR TITLE
Add changes entry for the SubselectRewriter removal.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -21,6 +21,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that would cause `count(*)` to return the wrong count when
+  applied to a subquery.
+
 - Fixed an issue that could cause ``JOIN`` queries with ``ORDER BY`` to return
   incorrect results.
 


### PR DESCRIPTION
We removed the SubselectRewriter as it was buggy and for eg. count(*)
would return the wrong count when applied to subqueries.

<!--

Thank you for your contribution. Here is a quick checklist of things you should've done:

 - You've read CONTRIBUTING.rst and signed our CLA (https://crate.io/community/contribute/cla/)
 - Wrote a CHANGES.txt entry if this is a change that is relevant for users of CrateDB
 - Run tests with `./gradlew test itest` (If they fail Jenkins will block this PR anyway)

-->
