### PR TITLE
Implement multi-query support for PSQL Protocol's SimpleQuery 

### DIFF
--- a/benchmarks/src/test/java/io/crate/protocols/postgres/QueryStringSplitterBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/protocols/postgres/QueryStringSplitterBenchmark.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.protocols.postgres;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+public class QueryStringSplitterBenchmark {
+
+    @Benchmark
+    public void checkSimpleQuery(Blackhole blackhole) {
+        List<String> queries = QueryStringSplitter.splitQuery("select * from users");
+        blackhole.consume(queries);
+    }
+
+    @Benchmark
+    public void checkMultiQuery(Blackhole blackhole) {
+        List<String> queries = QueryStringSplitter.splitQuery("select id from users;" +
+                                                              "select count(*) from users group by id;" +
+                                                              " -- comment " +
+                                                              "\n select * from users;" +
+                                                              "/* block commment \n */" +
+                                                              "select 1"
+        );
+        blackhole.consume(queries);
+    }
+}

--- a/sql/src/main/java/io/crate/action/sql/BaseResultReceiver.java
+++ b/sql/src/main/java/io/crate/action/sql/BaseResultReceiver.java
@@ -30,7 +30,7 @@ import java.util.concurrent.CompletableFuture;
 
 public class BaseResultReceiver implements ResultReceiver {
 
-    private CompletableFuture<Boolean> completionFuture = new CompletableFuture<>();
+    private CompletableFuture<Void> completionFuture = new CompletableFuture<>();
 
     @Override
     public void setNextRow(Row row) {
@@ -43,7 +43,12 @@ public class BaseResultReceiver implements ResultReceiver {
     @Override
     @OverridingMethodsMustInvokeSuper
     public void allFinished(boolean interrupted) {
-        completionFuture.complete(interrupted);
+        if (interrupted) {
+            completionFuture.completeExceptionally(
+                new InterruptedException("Interrupted before finished receiving results"));
+        } else {
+            completionFuture.complete(null);
+        }
     }
 
     @Override
@@ -53,7 +58,7 @@ public class BaseResultReceiver implements ResultReceiver {
     }
 
     @Override
-    public CompletableFuture<?> completionFuture() {
+    public CompletableFuture<Void> completionFuture() {
         return completionFuture;
     }
 }

--- a/sql/src/main/java/io/crate/protocols/postgres/Portal.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/Portal.java
@@ -34,6 +34,12 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * A portal is the entry point for submitting queries to the cluster.
+ *
+ * It models the portal objects of the PostgreSQL Wire Protocol:
+ * https://www.postgresql.org/docs/current/static/protocol-flow.html
+ */
 public interface Portal {
 
     FormatCodes.FormatCode[] getLastResultFormatCodes();
@@ -59,6 +65,11 @@ public interface Portal {
 
     void execute(ResultReceiver resultReceiver, int maxRows);
 
+    /**
+     * @return Future which will be completed when the results have been received.
+     *         Note: The future is either completed successfully or with an
+     *         exception. The return value is not relevant.
+     */
     CompletableFuture<?> sync(Planner planner, JobsLogs jobsLogs);
 
     void close();

--- a/sql/src/main/java/io/crate/protocols/postgres/QueryStringSplitter.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/QueryStringSplitter.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.protocols.postgres;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.crate.protocols.postgres.QueryStringSplitter.CommentType.LINE;
+import static io.crate.protocols.postgres.QueryStringSplitter.CommentType.MULTI_LINE;
+import static io.crate.protocols.postgres.QueryStringSplitter.CommentType.NO;
+import static io.crate.protocols.postgres.QueryStringSplitter.QuoteType.NONE;
+import static io.crate.protocols.postgres.QueryStringSplitter.QuoteType.SINGLE;
+import static io.crate.protocols.postgres.QueryStringSplitter.QuoteType.DOUBLE;
+
+/**
+ * Splits a query string by semicolon into multiple statements.
+ */
+class QueryStringSplitter {
+
+    enum CommentType {
+        NO,
+        LINE,
+        MULTI_LINE
+    }
+
+    enum QuoteType {
+        NONE,
+        SINGLE,
+        DOUBLE
+    }
+
+    public static List<String> splitQuery(String query) {
+        final List<String> queries = new ArrayList<>(2);
+
+        CommentType commentType = NO;
+        QuoteType quoteType = NONE;
+
+        char[] chars = query.toCharArray();
+
+        int offset = 0;
+        char lastChar = ' ';
+        for (int i = 0; i < chars.length; i++) {
+            char aChar = chars[i];
+            switch (aChar) {
+                case '\'':
+                    if (commentType == NO && quoteType != DOUBLE) {
+                        if (lastChar == '\'') {
+                            // quoting of ' via ''
+                            quoteType = NONE;
+                        } else {
+                            quoteType = quoteType == SINGLE ? NONE : SINGLE;
+                        }
+                    }
+                    break;
+                case '"':
+                    if (commentType == NO && quoteType != SINGLE) {
+                        quoteType = quoteType == DOUBLE ? NONE : DOUBLE;
+                    }
+                    break;
+                case '-':
+                    if (commentType == NO && quoteType == NONE && lastChar == '-') {
+                        commentType = LINE;
+                    }
+                    break;
+                case '*':
+                    if (commentType == NO && quoteType == NONE && lastChar == '/') {
+                        commentType = MULTI_LINE;
+                    }
+                    break;
+                case '/':
+                    if (commentType == MULTI_LINE && lastChar == '*') {
+                        commentType = NO;
+                        offset = i + 1;
+                    }
+                    break;
+                case '\n':
+                    if (commentType == LINE) {
+                        commentType = NO;
+                        offset = i + 1;
+                    }
+                    break;
+                case ';':
+                    if (commentType == NO && quoteType == NONE) {
+                        queries.add(new String(chars, offset, i - offset + 1));
+                        offset = i + 1;
+                    }
+                    break;
+
+                default:
+            }
+            lastChar = aChar;
+        }
+        // statement might not be terminated by semicolon
+        if (offset < chars.length && commentType == NO) {
+            queries.add(new String(chars, offset, chars.length - offset));
+        }
+
+        return queries;
+    }
+}

--- a/sql/src/main/java/io/crate/protocols/postgres/SimplePortal.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/SimplePortal.java
@@ -213,7 +213,8 @@ public class SimplePortal extends AbstractPortal {
 
         jobsLogs.logExecutionStart(jobId, query, sessionContext.user());
         JobsLogsUpdateListener jobsLogsUpdateListener = new JobsLogsUpdateListener(jobId, jobsLogs);
-        CompletableFuture completableFuture = resultReceiver.completionFuture().whenComplete(jobsLogsUpdateListener);
+        CompletableFuture<?> completableFuture = resultReceiver.completionFuture()
+            .whenComplete(jobsLogsUpdateListener);
 
         if (!resumeIfSuspended()) {
             consumer = new RowConsumerToResultReceiver(resultReceiver, maxRows);

--- a/sql/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
+++ b/sql/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
@@ -28,9 +28,9 @@ import io.crate.action.sql.Session;
 import io.crate.auth.AlwaysOKNullAuthentication;
 import io.crate.auth.Authentication;
 import io.crate.auth.AuthenticationMethod;
-import io.crate.execution.engine.collect.stats.JobsLogs;
 import io.crate.auth.user.User;
 import io.crate.auth.user.UserManager;
+import io.crate.execution.engine.collect.stats.JobsLogs;
 import io.crate.planner.DependencyCarrier;
 import io.crate.protocols.postgres.types.PGTypes;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
@@ -47,6 +47,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import javax.annotation.Nullable;
 import java.nio.charset.StandardCharsets;
@@ -55,9 +56,12 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isOneOf;
+import static org.mockito.Matchers.anyChar;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -383,5 +387,99 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
         channel.writeInbound(buffer);
 
         verify(session, times(1)).close();
+    }
+
+    @Test
+    public void testHandleMultipleSimpleQueries() {
+        submitQueriesThroughSimpleQueryMode(false);
+        readReadyForQueryMessage(channel);
+        assertThat(channel.outboundMessages().size() , is(0));
+    }
+
+    @Test
+    public void testHandleMultipleSimpleQueriesWithQueryFailure() {
+        submitQueriesThroughSimpleQueryMode(true);
+        readErrorResponse(channel);
+        readReadyForQueryMessage(channel);
+        assertThat(channel.outboundMessages().size() , is(0));
+    }
+
+    private void submitQueriesThroughSimpleQueryMode(boolean failFirstStatement) {
+        SQLOperations sqlOperations = Mockito.mock(SQLOperations.class);
+        Session session = mock(Session.class);
+        when(sqlOperations.createSession(any(String.class), any(User.class))).thenReturn(session);
+        Session.DescribeResult describeResult = mock(Session.DescribeResult.class);
+        when(describeResult.getFields()).thenReturn(null);
+        when(session.describe(anyChar(), anyString())).thenReturn(describeResult);
+        if (failFirstStatement) {
+            when(session.sync()).thenAnswer(mock -> new RuntimeException("fail"));
+        } else {
+            when(session.sync()).thenReturn(CompletableFuture.completedFuture(null));
+        }
+
+        PostgresWireProtocol ctx =
+            new PostgresWireProtocol(
+                sqlOperations,
+                new AlwaysOKNullAuthentication(),
+                null);
+        channel = new EmbeddedChannel(ctx.decoder, ctx.handler);
+
+        sendStartupMessage(channel);
+        readAuthenticationOK(channel);
+        skipParameterMessages(channel);
+        readReadyForQueryMessage(channel);
+
+        ByteBuf query = Unpooled.buffer();
+        try {
+            // the actual statements don't have to be valid as they are not executed
+            Messages.writeCString(query, "first statement; second statement;".getBytes(StandardCharsets.UTF_8));
+            ctx.handleSimpleQuery(query, channel);
+        } finally {
+            query.release();
+        }
+    }
+
+    private static void sendStartupMessage(EmbeddedChannel channel) {
+        ByteBuf startupMsg = Unpooled.buffer();
+        ClientMessages.sendStartupMessage(startupMsg, "db");
+        channel.writeInbound(startupMsg);
+    }
+
+    private static void readAuthenticationOK(EmbeddedChannel channel) {
+        ByteBuf response = channel.readOutbound();
+        byte[] responseBytes = new byte[9];
+        response.readBytes(responseBytes);
+        // AuthenticationOK: 'R' | int32 len | int32 code
+        assertThat(responseBytes, is(new byte[]{'R', 0, 0, 0, 8, 0, 0, 0, 0}));
+    }
+
+    private static void skipParameterMessages(EmbeddedChannel channel) {
+        int messagesToSkip = 0;
+        for (Object msg : channel.outboundMessages()) {
+            byte messageType = ((ByteBuf) msg).getByte(0);
+            if (messageType != 'S') {
+                break;
+            }
+            messagesToSkip++;
+        }
+        for (int i = 0; i < messagesToSkip; i++) {
+            channel.readOutbound();
+        }
+    }
+
+    private static void readReadyForQueryMessage(EmbeddedChannel channel) {
+        ByteBuf response = channel.readOutbound();
+        byte[] responseBytes = new byte[6];
+        response.readBytes(responseBytes);
+        // ReadyForQuery: 'Z' | int32 len | 'I'
+        assertThat(responseBytes, is(new byte[]{'Z', 0, 0, 0, 5, 'I'}));
+    }
+
+    private static void readErrorResponse(EmbeddedChannel channel) {
+        ByteBuf response = channel.readOutbound();
+        byte[] responseBytes = new byte[5];
+        response.readBytes(responseBytes);
+        // ErrorResponse: 'E' | int32 len | ...
+        assertThat(responseBytes, is(new byte[]{'E', 0, 0, 0, -110}));
     }
 }

--- a/sql/src/test/java/io/crate/protocols/postgres/QueryStringSplitterTest.java
+++ b/sql/src/test/java/io/crate/protocols/postgres/QueryStringSplitterTest.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.protocols.postgres;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertThat;
+
+public class QueryStringSplitterTest {
+
+    @Test
+    public void testEmptyQuery() {
+        assertThat(QueryStringSplitter.splitQuery(";"), contains(";"));
+        assertThat(QueryStringSplitter.splitQuery(";; ;"), contains(";", ";", " ;"));
+    }
+
+    @Test
+    public void testSimpleQuery() {
+        assertThat(QueryStringSplitter.splitQuery("select id from users"), contains("select id from users"));
+        assertThat(QueryStringSplitter.splitQuery("select id from users;"), contains("select id from users;"));
+    }
+
+    @Test
+    public void testMultiQuery() {
+        assertThat(QueryStringSplitter.splitQuery("select 1; select 2"), contains("select 1;", " select 2"));
+        assertThat(QueryStringSplitter.splitQuery("select 1;select 2;"), contains("select 1;", "select 2;"));
+    }
+
+    @Test
+    public void testSingleQuoteEscaping() {
+        assertThat(QueryStringSplitter.splitQuery("select 'Hello ''Joe''';select 2"),
+            contains("select 'Hello ''Joe''';", "select 2"));
+        assertThat(QueryStringSplitter.splitQuery("select 'Hello Semicolon;';select 2"),
+            contains("select 'Hello Semicolon;';", "select 2"));
+        assertThat(QueryStringSplitter.splitQuery("select 'Hello \"Semicolon\";';select 2"),
+            contains("select 'Hello \"Semicolon\";';", "select 2"));
+        assertThat(QueryStringSplitter.splitQuery("select 'Hello comment -- test;';select 2"),
+            contains("select 'Hello comment -- test;';", "select 2"));
+        assertThat(QueryStringSplitter.splitQuery("select 'Hello comment /* bla */;';select 2"),
+            contains("select 'Hello comment /* bla */;';", "select 2"));
+    }
+
+    @Test
+    public void testDoubleQuoteEscaping() {
+        assertThat(QueryStringSplitter.splitQuery("select \"USER\";select \"crazy'Column\""),
+            contains(
+                "select \"USER\";",
+                "select \"crazy'Column\""));
+        assertThat(QueryStringSplitter.splitQuery("select \"SemiColon;\";select \"crazy'Column\""),
+            contains(
+                "select \"SemiColon;\";",
+                "select \"crazy'Column\""));
+        assertThat(QueryStringSplitter.splitQuery("select \"'SemiColon';\";select \"crazy'Column\""),
+            contains(
+                "select \"'SemiColon';\";",
+                "select \"crazy'Column\""));
+        assertThat(QueryStringSplitter.splitQuery("select \"Hello comment -- test;\";select 2"),
+            contains(
+                "select \"Hello comment -- test;\";",
+                "select 2"));
+        assertThat(QueryStringSplitter.splitQuery("select \"Hello comment /* bla */;\"; select 2"),
+            contains(
+                "select \"Hello comment /* bla */;\";",
+                " select 2"));
+    }
+
+    @Test
+    public void testLineComment() {
+        assertThat(QueryStringSplitter.splitQuery("select 1;--select 2"), contains("select 1;"));
+        assertThat(QueryStringSplitter.splitQuery("select 1;--select 2\nselect 3"), contains("select 1;", "select 3"));
+    }
+
+    @Test
+    public void testBlockComment() {
+        assertThat(QueryStringSplitter.splitQuery("select 1; /* just a comment */"), contains("select 1;"));
+        assertThat(QueryStringSplitter.splitQuery("select 1; /* just \n a comment \n */"), contains("select 1;"));
+        assertThat(QueryStringSplitter.splitQuery("select 1; /* just \n a comment \n */select 2"),
+            contains("select 1;",
+                "select 2"));
+    }
+
+    @Test
+    public void testComplexMultiQuery() {
+        assertThat(QueryStringSplitter.splitQuery("select id, 'text' from users;" +
+                                                  "select count(*) from users group by id;" +
+                                                  " -- comment " +
+                                                  "\n select * from users;" +
+                                                  "/* block - commment \n */" +
+                                                  "select \"USER\""),
+            contains("select id, 'text' from users;",
+                     "select count(*) from users group by id;",
+                     " select * from users;",
+                     "select \"USER\""
+            )
+        );
+    }
+}


### PR DESCRIPTION
The Simple Query of the Postgres protocol allows for a query string to contain
multiple statements delimited by semicolon. This patch implements support for
this feature.

Queries are run through the `QueryStringSplitter` which splits a query string
into multiple statements. The resulting statements are executed serially and a
result is returned for each query. Only after processing all queries, the
ReadyForQuery message is sent back to the client.

See: https://www.postgresql.org/docs/9.5/static/protocol-flow.html
