### PR TITLE
Fixes `columnstore` boolean parsing

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -188,6 +188,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that resulted in an unusable partitioned table when at least
+  one column was defined with an explicit ``COLUMNSTORE`` setting.
+
 - Fixed an issue that could cause ``JOIN`` queries with ``ORDER BY`` to return
   incorrect results.
 

--- a/sql/src/main/java/io/crate/metadata/doc/DocIndexMetaData.java
+++ b/sql/src/main/java/io/crate/metadata/doc/DocIndexMetaData.java
@@ -46,8 +46,8 @@ import io.crate.metadata.IndexMappings;
 import io.crate.metadata.IndexReference;
 import io.crate.metadata.Reference;
 import io.crate.metadata.ReferenceIdent;
-import io.crate.metadata.RowGranularity;
 import io.crate.metadata.RelationName;
+import io.crate.metadata.RowGranularity;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.table.ColumnPolicy;
 import io.crate.metadata.table.Operation;
@@ -59,6 +59,7 @@ import io.crate.types.DataTypes;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
+import org.elasticsearch.common.Booleans;
 import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.settings.Settings;
 
@@ -375,7 +376,8 @@ public class DocIndexMetaData {
             boolean nullable = !notNullColumns.contains(newIdent);
             columnProperties = furtherColumnProperties(columnProperties);
             Reference.IndexType columnIndexType = getColumnIndexType(columnProperties);
-            boolean columnsStoreDisabled = !(boolean) columnProperties.getOrDefault(DOC_VALUES, true);
+            boolean columnsStoreDisabled = !Booleans.parseBoolean(
+                columnProperties.getOrDefault(DOC_VALUES, true).toString());
             if (columnDataType == DataTypes.GEO_SHAPE) {
                 String geoTree = (String) columnProperties.get("tree");
                 String precision = (String) columnProperties.get("precision");

--- a/sql/src/test/java/io/crate/metadata/doc/DocIndexMetaDataTest.java
+++ b/sql/src/test/java/io/crate/metadata/doc/DocIndexMetaDataTest.java
@@ -1376,4 +1376,11 @@ public class DocIndexMetaDataTest extends CrateDummyClusterServiceUnitTest {
         GeneratedReference generatedReference = md.generatedColumnReferences().get(0);
         assertThat(generatedReference.valueType(), is(new ArrayType(DataTypes.LONG)));
     }
+
+    @Test
+    public void testColumnStoreBooleanIsParsedCorrectly() throws Exception {
+        DocIndexMetaData md = getDocIndexMetaDataFromStatement(
+            "create table t1 (x string STORAGE WITH (columnstore = false))");
+        assertThat(md.columns().get(0).isColumnStoreDisabled(), is(true));
+    }
 }


### PR DESCRIPTION
The `columnstore` column setting value was casted to a boolean instead
of parsing it to a boolean. This is fine for normal tables, as boolean 
strings were implicitly converted to booleans whereas this is not 
happening for index templates.