### PR TITLE
Reflect 2.3.8 release

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -196,18 +196,6 @@ Changes
 Fixes
 =====
 
-- Fixed an issue that caused a ``NullPointerException`` using ``ANY`` on
-  timestamp columns.
-
-- Fixed an issue that resulted in an unusable partitioned table when at least
-  one column was defined with an explicit ``COLUMNSTORE`` setting.
-
-- Fixed an issue that could cause ``JOIN`` queries with ``ORDER BY`` to return
-  incorrect results.
-
-- Fixed an issue that caused ``COPY TO`` with filters on primary key columns to
-  fail.
-
 - Fixed an issue that caused queries on the `_uid` column to not match
   correctly.
 

--- a/blackbox/docs/appendices/release-notes/2.3.8.rst
+++ b/blackbox/docs/appendices/release-notes/2.3.8.rst
@@ -1,0 +1,43 @@
+.. _version_2.3.8:
+
+=============
+Version 2.3.8
+=============
+
+Released on 2018/05/16.
+
+If you are upgrading a cluster, you must be running CrateDB
+:ref:`version_1.1.3` or higher before you upgrade to 2.3.8.
+
+If you want to perform a `rolling upgrade`_, your current CrateDB
+version number must be at least :ref:`version_2.3.0`. Any upgrade
+from a version prior to this will require a `full restart upgrade`_.
+
+.. WARNING::
+
+   Before upgrading, you should `back up your data`_.
+
+.. _rolling upgrade: http://crate.io/docs/crate/guide/best_practices/rolling_upgrade.html
+.. _full restart upgrade: http://crate.io/docs/crate/guide/best_practices/full_restart_upgrade.html
+.. _back up your data: https://crate.io/a/backing-up-and-restoring-crate/
+
+Changelog
+=========
+
+Fixes
+-----
+
+- Fixed an issue that caused a ``NullPointerException`` when using ``ANY`` on
+  timestamp columns.
+
+- Fixed an issue that resulted in an unusable partitioned table when at least
+  one column was defined with an explicit ``COLUMNSTORE`` setting.
+
+- Fixed an issue that would cause ``count(*)`` to return the wrong count when
+  applied to a subquery.
+
+- Fixed an issue that could cause ``JOIN`` queries with ``ORDER BY`` to return
+  incorrect results.
+
+- Fixed an issue that caused ``COPY TO`` with filters on primary key columns to
+  fail.

--- a/blackbox/docs/appendices/release-notes/index.rst
+++ b/blackbox/docs/appendices/release-notes/index.rst
@@ -26,6 +26,7 @@ information and changelog.
 .. toctree::
     :maxdepth: 1
 
+    2.3.8
     2.3.7
     2.3.6
     2.3.5


### PR DESCRIPTION
@mfussenegger There are still Fixes left over after this release, for example https://github.com/crate/crate/commit/32dfc19700b4decc7da5f689f1a7256bb774faab - what is normally the procedure with major releases? Do we discard these master only fix notes?