### PR TITLE
Fix memory leak in hyperloglog_distinct

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -21,3 +21,4 @@ Changes
 Fixes
 =====
 
+- Fixed a memory leak caused by using the ``hyperloglog_distinct`` function.


### PR DESCRIPTION
The `HyperLogLogPlusPlus` instance was not closed, leading to a leak of
the underlying arrays that are acquired using `BigArrays`