### PR TITLE
Change release notes generation process to look for rst files, not txt

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -321,7 +321,7 @@ task chooseReleaseNotes(dependsOn: [':core:getVersion']) {
     doLast {
         def version = project(':core').getVersion.version
         def releaseNotesDir = "$rootDir/blackbox/docs/appendices/release-notes"
-        def releaseNotesFile = version.replaceAll('-.*', '') + '.txt'
+        def releaseNotesFile = version.replaceAll('-.*', '') + '.rst'
         if (new File(releaseNotesDir + "/" + releaseNotesFile).exists()) {
             copy {
                 from("$releaseNotesDir") {


### PR DESCRIPTION
<!--

Thank you for your contribution. Here is a quick checklist of things you should've done:

 - You've read CONTRIBUTING.rst and signed our CLA (https://crate.io/community/contribute/cla/)
 - Wrote a CHANGES.txt entry if this is a change that is relevant for users of CrateDB
 - Run tests with `./gradlew test itest` (If they fail Jenkins will block this PR anyway)

-->
