### PR TITLE
TransportShardUpsertAction: Retry only once on failed update

### DIFF
--- a/sql/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
@@ -131,7 +131,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
                                               IndexShard indexShard,
                                               boolean tryInsertFirst,
                                               Collection<ColumnIdent> notUsedNonGeneratedColumns,
-                                              int retryCount) throws ElasticsearchException {
+                                              boolean isFirstTry) throws ElasticsearchException {
             throw new VersionConflictEngineException(
                 indexShard.shardId(),
                 request.type(),


### PR DESCRIPTION
There was no upper limit on the number of retries, eventually causing a
StackOverflow if the update failed repeatedly.
