### PR TITLE
Remove .txt extension from LICENSE in build pipeline

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -347,7 +347,7 @@ distributions {
         contents {
             into("") {
                 from("$rootDir") {
-                    include 'LICENSE.txt'
+                    include 'LICENSE'
                     include 'NOTICE'
                     include 'README.rst'
                 }


### PR DESCRIPTION
<!--

Thank you for your contribution. Here is a quick checklist of things you should've done:

 - You've read CONTRIBUTING.rst and signed our CLA (https://crate.io/community/contribute/cla/)
 - Wrote a CHANGES.txt entry if this is a change that is relevant for users of CrateDB
 - Run tests with `./gradlew test itest` (If they fail Jenkins will block this PR anyway)

-->
