### PR TITLE
replaces recursive upsert retry with iterative solution

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -21,4 +21,7 @@ Changes
 Fixes
 =====
 
+- Fixed a stackoverflow on upserts which could happen by retries on version
+  conflicts.
+
 - Fixed a memory leak caused by using the ``hyperloglog_distinct`` function.

--- a/sql/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
+++ b/sql/src/test/java/io/crate/execution/dml/upsert/TransportShardUpsertActionTest.java
@@ -136,7 +136,7 @@ public class TransportShardUpsertActionTest extends CrateDummyClusterServiceUnit
                                               IndexShard indexShard,
                                               boolean tryInsertFirst,
                                               Collection<ColumnIdent> notUsedNonGeneratedColumns,
-                                              int retryCount) throws ElasticsearchException {
+                                              boolean isRetry) throws ElasticsearchException {
             throw new VersionConflictEngineException(
                 indexShard.shardId(),
                 request.type(),


### PR DESCRIPTION
The recursive retry caused stack overflows when retrying unlimited.
Also adds an upper retry limit to prevent unlimited retries on unexpected
item states (e.g. unexpected version).