### PR TITLE
Remove trappy PartitionName constructors

### DIFF
--- a/sql/src/main/java/io/crate/analyze/InsertFromValuesAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/InsertFromValuesAnalyzedStatement.java
@@ -22,6 +22,7 @@
 package io.crate.analyze;
 
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.IndexParts;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.Reference;
 import io.crate.metadata.doc.DocTableInfo;
@@ -102,8 +103,7 @@ public class InsertFromValuesAnalyzedStatement extends AbstractInsertAnalyzedSta
             for (String columnName : columnNames) {
                 values.add(BytesRefs.toBytesRef(map.get(columnName)));
             }
-            PartitionName partitionName = new PartitionName(tableInfo().ident(), values);
-            partitionValues.add(partitionName.asIndexName());
+            partitionValues.add(IndexParts.toIndexName(tableInfo.ident(), PartitionName.encodeIdent(values)));
         }
         return partitionValues;
     }

--- a/sql/src/main/java/io/crate/metadata/IndexParts.java
+++ b/sql/src/main/java/io/crate/metadata/IndexParts.java
@@ -101,10 +101,6 @@ public class IndexParts {
         return new RelationName(schema, table);
     }
 
-    public PartitionName toPartitionName() {
-        return new PartitionName(schema, table, partitionIdent);
-    }
-
     public String toFullyQualifiedName() {
         return schema + "." + table;
     }

--- a/sql/src/main/java/io/crate/metadata/PartitionName.java
+++ b/sql/src/main/java/io/crate/metadata/PartitionName.java
@@ -25,16 +25,18 @@ import com.google.common.collect.ImmutableList;
 import io.crate.types.StringType;
 import org.apache.commons.codec.binary.Base32;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 
 public class PartitionName {
 
@@ -42,26 +44,23 @@ public class PartitionName {
 
     private final RelationName relationName;
 
+    @Nullable
     private List<BytesRef> values;
+
+    @Nullable
     private String indexName;
+
+    @Nullable
     private String ident;
 
-    public PartitionName(RelationName relationName, List<BytesRef> values) {
+    public PartitionName(RelationName relationName, @Nonnull List<BytesRef> values) {
         this.relationName = relationName;
-        this.values = values;
+        this.values = Objects.requireNonNull(values);
     }
 
-    public PartitionName(String tableName, List<BytesRef> values) {
-        this(Schemas.DOC_SCHEMA_NAME, tableName, values);
-    }
-
-    public PartitionName(String schemaName, String tableName, List<BytesRef> values) {
-        this(new RelationName(schemaName, tableName), values);
-    }
-
-    public PartitionName(String schema, String table, String partitionIdent) {
-        this(schema, table, (List<BytesRef>) null);
-        this.ident = partitionIdent;
+    public PartitionName(RelationName relationName, @Nonnull String partitionIdent) {
+        this.relationName = relationName;
+        this.ident = Objects.requireNonNull(partitionIdent);
     }
 
     public static String templateName(String indexName) {
@@ -194,7 +193,7 @@ public class PartitionName {
         if (!indexParts.isPartitioned()) {
             throw new IllegalArgumentException("Invalid index name: " + indexOrTemplate);
         }
-        return indexParts.toPartitionName();
+        return new PartitionName(new RelationName(indexParts.getSchema(), indexParts.getTable()), indexParts.getPartitionIdent());
     }
 
     /**

--- a/sql/src/main/java/io/crate/planner/operators/Get.java
+++ b/sql/src/main/java/io/crate/planner/operators/Get.java
@@ -32,7 +32,9 @@ import io.crate.execution.dsl.projection.builder.ProjectionBuilder;
 import io.crate.execution.engine.pipeline.TopN;
 import io.crate.expression.symbol.SelectSymbol;
 import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.IndexParts;
 import io.crate.metadata.PartitionName;
+import io.crate.metadata.RelationName;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.planner.ExecutionPlan;
 import io.crate.planner.PlannerContext;
@@ -150,11 +152,12 @@ public class Get extends ZeroInputPlan {
     }
 
     public static String indexName(DocTableInfo tableInfo, @Nullable List<BytesRef> partitionValues) {
+        RelationName relation = tableInfo.ident();
         if (tableInfo.isPartitioned()) {
             assert partitionValues != null : "values must not be null";
-            return new PartitionName(tableInfo.ident(), partitionValues).asIndexName();
+            return IndexParts.toIndexName(relation, PartitionName.encodeIdent(partitionValues));
         } else {
-            return tableInfo.ident().indexName();
+            return relation.indexName();
         }
     }
 }

--- a/sql/src/test/groovy/io/crate/planner/statement/CopyToPlannerTest.java
+++ b/sql/src/test/groovy/io/crate/planner/statement/CopyToPlannerTest.java
@@ -65,17 +65,17 @@ public class CopyToPlannerTest extends CrateDummyClusterServiceUnitTest {
                 "   date timestamp," +
                 "   obj object" +
                 ") partitioned by (date) ",
-                new PartitionName("parted", singletonList(new BytesRef("1395874800000"))).asIndexName(),
-                new PartitionName("parted", singletonList(new BytesRef("1395961200000"))).asIndexName(),
-                new PartitionName("parted", singletonList(null)).asIndexName()
+                new PartitionName(new RelationName("doc", "parted"), singletonList(new BytesRef("1395874800000"))).asIndexName(),
+                new PartitionName(new RelationName("doc", "parted"), singletonList(new BytesRef("1395961200000"))).asIndexName(),
+                new PartitionName(new RelationName("doc", "parted"), singletonList(null)).asIndexName()
             )
             .addDocTable(
                 new TestingTableInfo.Builder(new RelationName("doc", "parted_generated"), shardRouting("parted_generated"))
                     .add("ts", DataTypes.TIMESTAMP, null)
                     .addGeneratedColumn("day", DataTypes.TIMESTAMP, "date_trunc('day', ts)", true)
                     .addPartitions(
-                        new PartitionName("parted_generated", Arrays.asList(new BytesRef("1395874800000"))).asIndexName(),
-                        new PartitionName("parted_generated", Arrays.asList(new BytesRef("1395961200000"))).asIndexName())
+                        new PartitionName(new RelationName("doc", "parted_generated"), Arrays.asList(new BytesRef("1395874800000"))).asIndexName(),
+                        new PartitionName(new RelationName("doc", "parted_generated"), Arrays.asList(new BytesRef("1395961200000"))).asIndexName())
             ).build();
     }
 
@@ -117,7 +117,8 @@ public class CopyToPlannerTest extends CrateDummyClusterServiceUnitTest {
     public void testCopyToWithPartitionInWhereClauseRoutesToPartitionIndexOnly() throws Exception {
         Collect collect = plan(
             "copy parted where date = 1395874800000 to directory '/tmp/foo'");
-        String expectedIndex = new PartitionName("parted", singletonList(new BytesRef("1395874800000"))).asIndexName();
+        String expectedIndex = new PartitionName(
+            new RelationName("doc", "parted"), singletonList(new BytesRef("1395874800000"))).asIndexName();
 
         assertThat(
             ((RoutedCollectPhase) collect.collectPhase()).routing().locations().values().stream()

--- a/sql/src/test/java/io/crate/analyze/CopyAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CopyAnalyzerTest.java
@@ -30,6 +30,7 @@ import io.crate.exceptions.SchemaUnknownException;
 import io.crate.exceptions.UnsupportedFeatureException;
 import io.crate.execution.dsl.projection.WriterProjection;
 import io.crate.metadata.PartitionName;
+import io.crate.metadata.RelationName;
 import io.crate.metadata.table.TableInfo;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
@@ -85,7 +86,8 @@ public class CopyAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     public void testCopyFromPartitionedTablePARTITIONKeywordValidArgs() throws Exception {
         CopyFromAnalyzedStatement analysis = e.analyze(
             "copy parted partition (date=1395874800000) from '/some/distant/file.ext'");
-        String parted = new PartitionName("parted", Collections.singletonList(new BytesRef("1395874800000"))).ident();
+        String parted = new PartitionName(
+            new RelationName("doc", "parted"), Collections.singletonList(new BytesRef("1395874800000"))).ident();
         assertThat(analysis.partitionIdent(), equalTo(parted));
     }
 
@@ -195,7 +197,8 @@ public class CopyAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testCopyToFileWithPartitionClause() throws Exception {
         CopyToAnalyzedStatement analysis = e.analyze("copy parted partition (date=1395874800000) to directory '/blah'");
-        String parted = new PartitionName("parted", Collections.singletonList(new BytesRef("1395874800000"))).asIndexName();
+        String parted = new PartitionName(
+            new RelationName("doc", "parted"), Collections.singletonList(new BytesRef("1395874800000"))).asIndexName();
         QuerySpec querySpec = analysis.subQueryRelation().querySpec();
         assertThat(querySpec.where().partitions(), contains(parted));
     }
@@ -203,7 +206,8 @@ public class CopyAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testCopyToDirectoryWithPartitionClause() throws Exception {
         CopyToAnalyzedStatement analysis = e.analyze("copy parted partition (date=1395874800000) to directory '/tmp'");
-        String parted = new PartitionName("parted", Collections.singletonList(new BytesRef("1395874800000"))).asIndexName();
+        String parted = new PartitionName(
+            new RelationName("doc", "parted"), Collections.singletonList(new BytesRef("1395874800000"))).asIndexName();
         QuerySpec querySpec = analysis.subQueryRelation().querySpec();
         assertThat(querySpec.where().partitions(), contains(parted));
         assertThat(analysis.overwrites().size(), is(0));
@@ -227,7 +231,8 @@ public class CopyAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     public void testCopyToWithPartitionIdentAndPartitionInWhereClause() throws Exception {
         CopyToAnalyzedStatement analysis = e.analyze(
             "copy parted partition (date=1395874800000) where date = 1395874800000 to directory '/tmp/foo'");
-        String parted = new PartitionName("parted", Collections.singletonList(new BytesRef("1395874800000"))).asIndexName();
+        String parted = new PartitionName(
+            new RelationName("doc", "parted"), Collections.singletonList(new BytesRef("1395874800000"))).asIndexName();
         QuerySpec querySpec = analysis.subQueryRelation().querySpec();
         assertThat(querySpec.where().partitions(), contains(parted));
     }
@@ -237,7 +242,8 @@ public class CopyAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     public void testCopyToWithPartitionIdentAndWhereClause() throws Exception {
         CopyToAnalyzedStatement analysis = e.analyze(
             "copy parted partition (date=1395874800000) where id = 1 to directory '/tmp/foo'");
-        String parted = new PartitionName("parted", Collections.singletonList(new BytesRef("1395874800000"))).asIndexName();
+        String parted = new PartitionName(
+            new RelationName("doc", "parted"), Collections.singletonList(new BytesRef("1395874800000"))).asIndexName();
         QuerySpec querySpec = analysis.subQueryRelation().querySpec();
         assertThat(querySpec.where().partitions(), contains(parted));
         assertThat(querySpec.where().query(), isFunction("op_="));

--- a/sql/src/test/java/io/crate/analyze/CreateAlterPartitionedTableAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateAlterPartitionedTableAnalyzerTest.java
@@ -24,6 +24,7 @@ package io.crate.analyze;
 import io.crate.exceptions.ColumnUnknownException;
 import io.crate.metadata.FulltextAnalyzerResolver;
 import io.crate.metadata.PartitionName;
+import io.crate.metadata.RelationName;
 import io.crate.sql.parser.ParsingException;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
@@ -274,7 +275,8 @@ public class CreateAlterPartitionedTableAnalyzerTest extends CrateDummyClusterSe
         AlterTableAnalyzedStatement analysis = e.analyze(
             "alter table parted partition (date=1395874800000) set (number_of_replicas='0-all')");
         assertThat(analysis.partitionName().isPresent(), is(true));
-        assertThat(analysis.partitionName().get(), is(new PartitionName("parted", Arrays.asList(new BytesRef("1395874800000")))));
+        assertThat(analysis.partitionName().get(), is(new PartitionName(
+            new RelationName("doc", "parted"), Arrays.asList(new BytesRef("1395874800000")))));
         assertThat(analysis.table().tableParameterInfo(), instanceOf(PartitionedTableParameterInfo.class));
         PartitionedTableParameterInfo tableSettingsInfo = (PartitionedTableParameterInfo) analysis.table().tableParameterInfo();
         assertThat(tableSettingsInfo.partitionTableSettingsInfo(), instanceOf(TableParameterInfo.class));

--- a/sql/src/test/java/io/crate/analyze/InsertFromValuesAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/InsertFromValuesAnalyzerTest.java
@@ -63,7 +63,6 @@ import static io.crate.testing.SymbolMatchers.isReference;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.emptyArray;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
@@ -594,9 +593,9 @@ public class InsertFromValuesAnalyzerTest extends CrateDummyClusterServiceUnitTe
 
     private void validateBulkIndexPartitionedTableAnalysis(InsertFromValuesAnalyzedStatement analysis) {
         assertThat(analysis.generatePartitions(), contains(
-            new PartitionName("parted", Arrays.asList(new BytesRef("13963670051500"))).asIndexName(),
-            new PartitionName("parted", Arrays.asList(new BytesRef("0"))).asIndexName(),
-            new PartitionName("parted", new ArrayList<BytesRef>() {{
+            new PartitionName(new RelationName("doc", "parted"), Arrays.asList(new BytesRef("13963670051500"))).asIndexName(),
+            new PartitionName(new RelationName("doc", "parted"), Arrays.asList(new BytesRef("0"))).asIndexName(),
+            new PartitionName(new RelationName("doc", "parted"), new ArrayList<BytesRef>() {{
                 add(null);
             }}).asIndexName()
         ));
@@ -639,8 +638,8 @@ public class InsertFromValuesAnalyzerTest extends CrateDummyClusterServiceUnitTe
                 2, "2014-05-21", new MapBuilder<String, Object>().put("name", "Arthur").map()
             });
         assertThat(analysis.generatePartitions(), contains(
-            new PartitionName("nested_parted", Arrays.asList(new BytesRef("0"), new BytesRef("Zaphod"))).asIndexName(),
-            new PartitionName("nested_parted", Arrays.asList(new BytesRef("1400630400000"), new BytesRef("Arthur"))).asIndexName()
+            new PartitionName(new RelationName("doc", "nested_parted"), Arrays.asList(new BytesRef("0"), new BytesRef("Zaphod"))).asIndexName(),
+            new PartitionName(new RelationName("doc", "nested_parted"), Arrays.asList(new BytesRef("1400630400000"), new BytesRef("Arthur"))).asIndexName()
 
         ));
         assertThat(analysis.sourceMaps().size(), is(2));

--- a/sql/src/test/java/io/crate/analyze/RefreshAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/RefreshAnalyzerTest.java
@@ -67,7 +67,7 @@ public class RefreshAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testRefreshPartition() throws Exception {
-        PartitionName partition = new PartitionName("parted", Arrays.asList(new BytesRef("1395874800000")));
+        PartitionName partition = new PartitionName(new RelationName("doc", "parted"), Arrays.asList(new BytesRef("1395874800000")));
         RefreshTableAnalyzedStatement analysis = e.analyze("refresh table parted PARTITION (date=1395874800000)");
         assertThat(analysis.indexNames(), contains(".partitioned.parted.04732cpp6ks3ed1o60o30c1g"));
     }

--- a/sql/src/test/java/io/crate/analyze/SnapshotRestoreAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SnapshotRestoreAnalyzerTest.java
@@ -274,7 +274,8 @@ public class SnapshotRestoreAnalyzerTest extends CrateDummyClusterServiceUnitTes
     public void testRestoreSinglePartition() throws Exception {
         RestoreSnapshotAnalyzedStatement statement = analyze(
             "RESTORE SNAPSHOT my_repo.my_snapshot TABLE parted PARTITION (date=123)");
-        PartitionName partition = new PartitionName("parted", ImmutableList.of(new BytesRef("123")));
+        PartitionName partition = new PartitionName(
+            new RelationName("doc", "parted"), ImmutableList.of(new BytesRef("123")));
         assertThat(statement.restoreTables().size(), is(1));
         assertThat(statement.restoreTables().get(0).partitionName(), is(partition));
         assertThat(statement.restoreTables().get(0).tableIdent(), is(new RelationName(Schemas.DOC_SCHEMA_NAME, "parted")));
@@ -284,7 +285,8 @@ public class SnapshotRestoreAnalyzerTest extends CrateDummyClusterServiceUnitTes
     public void testRestoreSinglePartitionToUnknownTable() throws Exception {
         RestoreSnapshotAnalyzedStatement statement = analyze(
             "RESTORE SNAPSHOT my_repo.my_snapshot TABLE unknown_parted PARTITION (date=123)");
-        PartitionName partitionName = new PartitionName("unknown_parted", ImmutableList.of(new BytesRef("123")));
+        PartitionName partitionName = new PartitionName(
+            new RelationName("doc", "unknown_parted"), ImmutableList.of(new BytesRef("123")));
         assertThat(statement.restoreTables().size(), is(1));
         assertThat(statement.restoreTables().get(0).partitionName(), is(partitionName));
         assertThat(statement.restoreTables().get(0).tableIdent(), is(new RelationName(Schemas.DOC_SCHEMA_NAME, "unknown_parted")));

--- a/sql/src/test/java/io/crate/analyze/TableDefinitions.java
+++ b/sql/src/test/java/io/crate/analyze/TableDefinitions.java
@@ -136,9 +136,9 @@ public final class TableDefinitions {
         .add("obj", DataTypes.OBJECT, null, ColumnPolicy.DYNAMIC)
         // add 3 partitions/simulate already done inserts
         .addPartitions(
-            new PartitionName("parted", Arrays.asList(new BytesRef("1395874800000"))).asIndexName(),
-            new PartitionName("parted", Arrays.asList(new BytesRef("1395961200000"))).asIndexName(),
-            new PartitionName("parted", new ArrayList<BytesRef>() {{
+            new PartitionName(new RelationName("doc", "parted"), Arrays.asList(new BytesRef("1395874800000"))).asIndexName(),
+            new PartitionName(new RelationName("doc", "parted"), Arrays.asList(new BytesRef("1395961200000"))).asIndexName(),
+            new PartitionName(new RelationName("doc", "parted"), new ArrayList<BytesRef>() {{
                 add(null);
             }}).asIndexName())
         .build();
@@ -158,8 +158,8 @@ public final class TableDefinitions {
         .add("obj", DataTypes.OBJECT, null, ColumnPolicy.DYNAMIC)
         // add 3 partitions/simulate already done inserts
         .addPartitions(
-            new PartitionName("parted", Arrays.asList(new BytesRef("1395874800000"))).asIndexName(),
-            new PartitionName("parted", Arrays.asList(new BytesRef("1395961200000"))).asIndexName()
+            new PartitionName(new RelationName("doc", "parted"), Arrays.asList(new BytesRef("1395874800000"))).asIndexName(),
+            new PartitionName(new RelationName("doc", "parted"), Arrays.asList(new BytesRef("1395961200000"))).asIndexName()
         )
         .addPrimaryKey("id")
         .addPrimaryKey("date")
@@ -175,9 +175,9 @@ public final class TableDefinitions {
         .add("obj", DataTypes.STRING, Arrays.asList("name"), true)
         // add 3 partitions/simulate already done inserts
         .addPartitions(
-            new PartitionName("multi_parted", Arrays.asList(new BytesRef("1395874800000"), new BytesRef("0"))).asIndexName(),
-            new PartitionName("multi_parted", Arrays.asList(new BytesRef("1395961200000"), new BytesRef("-100"))).asIndexName(),
-            new PartitionName("multi_parted", Arrays.asList(null, new BytesRef("-100"))).asIndexName())
+            new PartitionName(new RelationName("doc", "multi_parted"), Arrays.asList(new BytesRef("1395874800000"), new BytesRef("0"))).asIndexName(),
+            new PartitionName(new RelationName("doc", "multi_parted"), Arrays.asList(new BytesRef("1395961200000"), new BytesRef("-100"))).asIndexName(),
+            new PartitionName(new RelationName("doc", "multi_parted"), Arrays.asList(null, new BytesRef("-100"))).asIndexName())
         .build();
     static final RelationName TEST_NESTED_PARTITIONED_TABLE_IDENT = new RelationName(Schemas.DOC_SCHEMA_NAME, "nested_parted");
     public static final DocTableInfo TEST_NESTED_PARTITIONED_TABLE_INFO = new TestingTableInfo.Builder(
@@ -188,9 +188,9 @@ public final class TableDefinitions {
         .add("obj", DataTypes.STRING, Arrays.asList("name"), true)
         // add 3 partitions/simulate already done inserts
         .addPartitions(
-            new PartitionName("nested_parted", Arrays.asList(new BytesRef("1395874800000"), new BytesRef("Trillian"))).asIndexName(),
-            new PartitionName("nested_parted", Arrays.asList(new BytesRef("1395961200000"), new BytesRef("Ford"))).asIndexName(),
-            new PartitionName("nested_parted", Arrays.asList(null, new BytesRef("Zaphod"))).asIndexName())
+            new PartitionName(new RelationName("doc", "nested_parted"), Arrays.asList(new BytesRef("1395874800000"), new BytesRef("Trillian"))).asIndexName(),
+            new PartitionName(new RelationName("doc", "nested_parted"), Arrays.asList(new BytesRef("1395961200000"), new BytesRef("Ford"))).asIndexName(),
+            new PartitionName(new RelationName("doc", "nested_parted"), Arrays.asList(null, new BytesRef("Zaphod"))).asIndexName())
         .build();
     public static final RelationName TEST_DOC_TRANSACTIONS_TABLE_IDENT = new RelationName(Schemas.DOC_SCHEMA_NAME, "transactions");
     public static final DocTableInfo TEST_DOC_TRANSACTIONS_TABLE_INFO = new TestingTableInfo.Builder(
@@ -245,8 +245,8 @@ public final class TableDefinitions {
                 .add("city", DataTypes.STRING, null)
                 .clusteredBy("city")
                 .addPartitions(
-                    new PartitionName("clustered_parted", Arrays.asList(new BytesRef("1395874800000"))).asIndexName(),
-                    new PartitionName("clustered_parted", Arrays.asList(new BytesRef("1395961200000"))).asIndexName())
+                    new PartitionName(new RelationName("doc", "clustered_parted"), Arrays.asList(new BytesRef("1395874800000"))).asIndexName(),
+                    new PartitionName(new RelationName("doc", "clustered_parted"), Arrays.asList(new BytesRef("1395961200000"))).asIndexName())
                 .build();
 
 

--- a/sql/src/test/java/io/crate/expression/reference/sys/check/cluster/SysChecksTest.java
+++ b/sql/src/test/java/io/crate/expression/reference/sys/check/cluster/SysChecksTest.java
@@ -24,6 +24,7 @@ package io.crate.expression.reference.sys.check.cluster;
 import com.google.common.collect.ImmutableList;
 import io.crate.metadata.ClusterReferenceResolver;
 import io.crate.metadata.PartitionName;
+import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.doc.DocSchemaInfo;
 import io.crate.metadata.doc.DocTableInfo;
@@ -125,7 +126,7 @@ public class SysChecksTest extends CrateUnitTest {
         List<PartitionName> partitions = new ArrayList<>();
 
         for (int i = 0; i < size; i++) {
-            partitions.add(new PartitionName("partition-" + i, Collections.<BytesRef>emptyList()));
+            partitions.add(new PartitionName(new RelationName("doc", "partition-" + i), Collections.emptyList()));
         }
 
         return partitions;

--- a/sql/src/test/java/io/crate/integrationtests/ColumnPolicyIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ColumnPolicyIntegrationTest.java
@@ -397,7 +397,8 @@ public class ColumnPolicyIntegrationTest extends SQLTransportIntegrationTest {
             new Object[]{6, true, false});
         execute("refresh table numbers");
 
-        Map<String, Object> sourceMap = getSourceMap(new PartitionName("numbers", Arrays.asList(new BytesRef("true"))).asIndexName());
+        Map<String, Object> sourceMap = getSourceMap(
+            new PartitionName(new RelationName("doc", "numbers"), Arrays.asList(new BytesRef("true"))).asIndexName());
         assertThat(String.valueOf(sourceMap.get("dynamic")), is(ColumnPolicy.STRICT.value()));
 
         expectedException.expect(SQLActionException.class);
@@ -431,7 +432,8 @@ public class ColumnPolicyIntegrationTest extends SQLTransportIntegrationTest {
             new Object[]{6, true, false});
         execute("refresh table numbers");
 
-        Map<String, Object> sourceMap = getSourceMap(new PartitionName("numbers", Arrays.asList(new BytesRef("true"))).asIndexName());
+        Map<String, Object> sourceMap = getSourceMap(
+            new PartitionName(new RelationName("doc", "numbers"), Arrays.asList(new BytesRef("true"))).asIndexName());
         assertThat(String.valueOf(sourceMap.get("dynamic")), is(ColumnPolicy.STRICT.value()));
 
         expectedException.expect(SQLActionException.class);
@@ -465,7 +467,8 @@ public class ColumnPolicyIntegrationTest extends SQLTransportIntegrationTest {
             new Object[]{6, true, false});
         execute("refresh table numbers");
 
-        Map<String, Object> sourceMap = getSourceMap(new PartitionName("numbers", Collections.singletonList(new BytesRef("true"))).asIndexName());
+        Map<String, Object> sourceMap = getSourceMap(
+            new PartitionName(new RelationName("doc", "numbers"), Collections.singletonList(new BytesRef("true"))).asIndexName());
         assertThat(String.valueOf(sourceMap.get("dynamic")), is("true"));
 
         execute("insert into numbers (num, odd, prime, perfect) values (?, ?, ?, ?)",
@@ -540,7 +543,8 @@ public class ColumnPolicyIntegrationTest extends SQLTransportIntegrationTest {
         execute("refresh table dynamic_table");
         execute("alter table dynamic_table set (column_policy = 'strict')");
         waitNoPendingTasksOnAll();
-        String indexName = new PartitionName("dynamic_table", Arrays.asList(new BytesRef("10.0"))).asIndexName();
+        String indexName = new PartitionName(
+            new RelationName("doc", "dynamic_table"), Arrays.asList(new BytesRef("10.0"))).asIndexName();
         Map<String, Object> sourceMap = getSourceMap(indexName);
         assertThat(String.valueOf(sourceMap.get("dynamic")), is(ColumnPolicy.STRICT.value()));
         execute("alter table dynamic_table reset (column_policy)");
@@ -587,13 +591,16 @@ public class ColumnPolicyIntegrationTest extends SQLTransportIntegrationTest {
         execute("refresh table dynamic_table");
         ensureYellow();
 
-        Map<String, Object> sourceMap = getSourceMap(new PartitionName("dynamic_table", Arrays.asList(new BytesRef("10.0"))).asIndexName());
+        Map<String, Object> sourceMap = getSourceMap(
+            new PartitionName(new RelationName("doc", "dynamic_table"), Arrays.asList(new BytesRef("10.0"))).asIndexName());
         assertThat(String.valueOf(sourceMap.get("dynamic")), is(String.valueOf(ColumnPolicy.DYNAMIC.mappingValue())));
 
-        sourceMap = getSourceMap(new PartitionName("dynamic_table", Arrays.asList(new BytesRef("5.0"))).asIndexName());
+        sourceMap = getSourceMap(new PartitionName(
+            new RelationName("doc", "dynamic_table"), Arrays.asList(new BytesRef("5.0"))).asIndexName());
         assertThat(String.valueOf(sourceMap.get("dynamic")), is(String.valueOf(ColumnPolicy.DYNAMIC.mappingValue())));
 
-        sourceMap = getSourceMap(new PartitionName("dynamic_table", Arrays.asList(new BytesRef("3.0"))).asIndexName());
+        sourceMap = getSourceMap(new PartitionName(
+            new RelationName("doc", "dynamic_table"), Arrays.asList(new BytesRef("3.0"))).asIndexName());
         assertThat(String.valueOf(sourceMap.get("dynamic")), is(String.valueOf(ColumnPolicy.DYNAMIC.mappingValue())));
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/DDLIntegrationTest.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableMap;
 import io.crate.Version;
 import io.crate.action.sql.SQLActionException;
 import io.crate.metadata.PartitionName;
+import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
 import io.crate.testing.TestingHelpers;
 import io.crate.testing.UseJdbc;
@@ -681,7 +682,8 @@ public class DDLIntegrationTest extends SQLTransportIntegrationTest {
         execute("insert into quotes (id, quote, date) values (?, ?, ?)",
             new Object[]{3, "Time is a illusion. Lunchtime doubles so", 1495961200000L}
         );
-        String partition = new PartitionName("quotes", Arrays.asList(new BytesRef("1495961200000"))).asIndexName();
+        String partition = new PartitionName(
+            new RelationName("doc", "quotes"), Arrays.asList(new BytesRef("1495961200000"))).asIndexName();
         GetSettingsResponse settingsResponse = client().admin().indices().prepareGetSettings(partition).execute().get();
         assertThat(settingsResponse.getSetting(partition, IndexMetaData.SETTING_NUMBER_OF_SHARDS), is("5"));
     }

--- a/sql/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
@@ -25,6 +25,7 @@ package io.crate.integrationtests;
 import io.crate.data.Bucket;
 import io.crate.data.CollectionBucket;
 import io.crate.metadata.PartitionName;
+import io.crate.metadata.RelationName;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.SQLTransportExecutor;
 import org.apache.lucene.util.BytesRef;
@@ -107,7 +108,8 @@ public class PartitionedTableConcurrentIntegrationTest extends SQLTransportInteg
         });
         t.start();
 
-        PartitionName partitionName = new PartitionName(sqlExecutor.getDefaultSchema(), "t",
+        PartitionName partitionName = new PartitionName(
+            new RelationName(sqlExecutor.getDefaultSchema(), "t"),
             Collections.singletonList(new BytesRef("a")));
         final String indexName = partitionName.asIndexName();
 
@@ -267,7 +269,8 @@ public class PartitionedTableConcurrentIntegrationTest extends SQLTransportInteg
         });
 
         final CountDownLatch deleteLatch = new CountDownLatch(1);
-        final String partitionName = new PartitionName(sqlExecutor.getDefaultSchema(), "parted",
+        final String partitionName = new PartitionName(
+            new RelationName(sqlExecutor.getDefaultSchema(), "parted"),
             Collections.singletonList(new BytesRef(String.valueOf(idToDelete)))
         ).asIndexName();
         final Object[] deleteArgs = new Object[]{idToDelete};

--- a/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -28,6 +28,7 @@ import io.crate.Version;
 import io.crate.action.sql.SQLActionException;
 import io.crate.metadata.IndexMappings;
 import io.crate.metadata.PartitionName;
+import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
 import io.crate.testing.SQLResponse;
 import io.crate.testing.TestingHelpers;
@@ -152,7 +153,8 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
         ensureYellow();
 
         for (String id : ImmutableList.of("1", "2", "3")) {
-            String partitionName = new PartitionName(sqlExecutor.getDefaultSchema(), "quotes",
+            String partitionName = new PartitionName(
+                new RelationName(sqlExecutor.getDefaultSchema(), "quotes"),
                 ImmutableList.of(new BytesRef(id))).asIndexName();
             assertNotNull(client().admin().cluster().prepareState().execute().actionGet()
                 .getState().metaData().indices().get(partitionName));
@@ -295,7 +297,8 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
 
         assertTrue(clusterService().state().metaData().hasAlias(getFqn("parted")));
 
-        String partitionName = new PartitionName(sqlExecutor.getDefaultSchema(), "parted",
+        String partitionName = new PartitionName(
+            new RelationName(sqlExecutor.getDefaultSchema(), "parted"),
             Collections.singletonList(new BytesRef(String.valueOf(13959981214861L)))
         ).asIndexName();
         MetaData metaData = client().admin().cluster().prepareState().execute().actionGet()
@@ -318,7 +321,8 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
     private void validateInsertPartitionedTable() {
         Set<String> indexUUIDs = new HashSet<>(3);
 
-        String partitionName = new PartitionName(sqlExecutor.getDefaultSchema(), "parted",
+        String partitionName = new PartitionName(
+            new RelationName(sqlExecutor.getDefaultSchema(), "parted"),
             Collections.singletonList(new BytesRef(String.valueOf(13959981214861L)))
         ).asIndexName();
         assertThat(internalCluster().clusterService().state().metaData().hasIndex(partitionName), is(true));
@@ -333,7 +337,8 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
             is(1L)
         );
 
-        partitionName = new PartitionName(sqlExecutor.getDefaultSchema(), "parted",
+        partitionName = new PartitionName(
+            new RelationName(sqlExecutor.getDefaultSchema(), "parted"),
             Collections.singletonList(new BytesRef(String.valueOf(0L)))).asIndexName();
         assertThat(internalCluster().clusterService().state().metaData().hasIndex(partitionName), is(true));
         indexMetaData = client().admin().cluster().prepareState().execute().actionGet()
@@ -349,7 +354,8 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
 
         List<BytesRef> nullList = new ArrayList<>();
         nullList.add(null);
-        partitionName = new PartitionName(sqlExecutor.getDefaultSchema(), "parted", nullList).asIndexName();
+        partitionName = new PartitionName(
+            new RelationName(sqlExecutor.getDefaultSchema(), "parted"), nullList).asIndexName();
         assertThat(internalCluster().clusterService().state().metaData().hasIndex(partitionName), is(true));
         indexMetaData = client().admin().cluster().prepareState().execute().actionGet()
             .getState().metaData().indices().get(partitionName);
@@ -410,7 +416,8 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
         assertThat(response.rowCount(), is(1L));
         ensureYellow();
         refresh();
-        String partitionName = new PartitionName(sqlExecutor.getDefaultSchema(), "parted",
+        String partitionName = new PartitionName(
+            new RelationName(sqlExecutor.getDefaultSchema(), "parted"),
             Arrays.asList(new BytesRef("Ford"), new BytesRef(String.valueOf(13959981214861L)))
         ).asIndexName();
         assertNotNull(client().admin().cluster().prepareState().execute().actionGet()
@@ -489,7 +496,8 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
         assertThat(response.rowCount(), is(1L));
         ensureYellow();
         refresh();
-        String partitionName = new PartitionName(sqlExecutor.getDefaultSchema(), "parted",
+        String partitionName = new PartitionName(
+            new RelationName(sqlExecutor.getDefaultSchema(), "parted"),
             Arrays.asList(new BytesRef("Trillian"), null)).asIndexName();
         assertNotNull(client().admin().cluster().prepareState().execute().actionGet()
             .getState().metaData().indices().get(partitionName).getAliases().get(getFqn("parted")));
@@ -513,7 +521,8 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
         assertThat(response.rowCount(), is(1L));
         ensureYellow();
         refresh();
-        String partitionName = new PartitionName(sqlExecutor.getDefaultSchema(), "parted",
+        String partitionName = new PartitionName(
+            new RelationName(sqlExecutor.getDefaultSchema(), "parted"),
             Arrays.asList(new BytesRef("Trillian"), new BytesRef(dateValue.toString()))).asIndexName();
         assertNotNull(client().admin().cluster().prepareState().execute().actionGet()
             .getState().metaData().indices().get(partitionName).getAliases().get(getFqn("parted")));
@@ -780,8 +789,10 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
                                        "where table_name='parted' and schema_name = ? " +
                                        "order by partition_ident", new Object[]{defaultSchema});
         assertThat(response.rowCount(), is(2L));
-        assertThat((String) response.rows()[0][0], is(new PartitionName(defaultSchema, "parted", ImmutableList.of(new BytesRef("1388534400000"))).ident()));
-        assertThat((String) response.rows()[1][0], is(new PartitionName(defaultSchema, "parted", ImmutableList.of(new BytesRef("1391212800000"))).ident()));
+        assertThat((String) response.rows()[0][0], is(new PartitionName(
+            new RelationName(defaultSchema, "parted"), ImmutableList.of(new BytesRef("1388534400000"))).ident()));
+        assertThat((String) response.rows()[1][0], is(new PartitionName(
+            new RelationName(defaultSchema, "parted"), ImmutableList.of(new BytesRef("1391212800000"))).ident()));
 
         execute("delete from parted where date = '2014-03-01'");
         refresh();
@@ -800,8 +811,10 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
                                        "where table_name='parted' and schema_name = ? " +
                                        "order by partition_ident", new Object[]{sqlExecutor.getDefaultSchema()});
         assertThat(response.rowCount(), is(2L));
-        assertThat((String) response.rows()[0][0], is(new PartitionName(defaultSchema, "parted", ImmutableList.of(new BytesRef("1388534400000"))).ident()));
-        assertThat((String) response.rows()[1][0], is(new PartitionName(defaultSchema, "parted", ImmutableList.of(new BytesRef("1391212800000"))).ident()));
+        assertThat((String) response.rows()[0][0], is(new PartitionName(
+            new RelationName(defaultSchema, "parted"), ImmutableList.of(new BytesRef("1388534400000"))).ident()));
+        assertThat((String) response.rows()[1][0], is(new PartitionName(
+            new RelationName(defaultSchema, "parted"), ImmutableList.of(new BytesRef("1391212800000"))).ident()));
 
         execute("delete from parted where o['dat'] = '2014-03-01'");
         refresh();
@@ -833,9 +846,12 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
                                        "where table_name='quotes' and schema_name = ? " +
                                        "order by partition_ident", new Object[]{defaultSchema});
         assertThat(response.rowCount(), is(3L));
-        assertThat((String) response.rows()[0][0], is(new PartitionName(defaultSchema, "parted", ImmutableList.of(new BytesRef("1395874800000"))).ident()));
-        assertThat((String) response.rows()[1][0], is(new PartitionName(defaultSchema, "parted", ImmutableList.of(new BytesRef("1395961200000"))).ident()));
-        assertThat((String) response.rows()[2][0], is(new PartitionName(defaultSchema, "parted", ImmutableList.of(new BytesRef("1396303200000"))).ident()));
+        assertThat((String) response.rows()[0][0], is(new PartitionName(
+            new RelationName(defaultSchema, "parted"), ImmutableList.of(new BytesRef("1395874800000"))).ident()));
+        assertThat((String) response.rows()[1][0], is(new PartitionName(
+            new RelationName(defaultSchema, "parted"), ImmutableList.of(new BytesRef("1395961200000"))).ident()));
+        assertThat((String) response.rows()[2][0], is(new PartitionName(
+            new RelationName(defaultSchema, "parted"), ImmutableList.of(new BytesRef("1396303200000"))).ident()));
 
         execute("delete from quotes where quote = 'Don''t panic'");
         refresh();
@@ -1327,8 +1343,12 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
         assertTrue(clusterService().state().metaData().hasAlias(getFqn("quotes")));
 
         List<String> partitions = ImmutableList.of(
-            new PartitionName(defaultSchema, "quotes", Collections.singletonList(new BytesRef("1395874800000"))).asIndexName(),
-            new PartitionName(defaultSchema, "quotes", Collections.singletonList(new BytesRef("1395961200000"))).asIndexName()
+            new PartitionName(
+                new RelationName(defaultSchema, "quotes"),
+                Collections.singletonList(new BytesRef("1395874800000"))).asIndexName(),
+            new PartitionName(
+                new RelationName(defaultSchema, "quotes"),
+                Collections.singletonList(new BytesRef("1395961200000"))).asIndexName()
         );
 
         GetSettingsResponse settingsResponse = client().admin().indices().prepareGetSettings(
@@ -1414,8 +1434,12 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
         assertThat(templateSettings.get(IndexMetaData.SETTING_AUTO_EXPAND_REPLICAS), is("0-1"));
 
         List<String> partitions = ImmutableList.of(
-            new PartitionName(sqlExecutor.getDefaultSchema(), "quotes", Collections.singletonList(new BytesRef("1395874800000"))).asIndexName(),
-            new PartitionName(sqlExecutor.getDefaultSchema(), "quotes", Collections.singletonList(new BytesRef("1395961200000"))).asIndexName()
+            new PartitionName(
+                new RelationName(sqlExecutor.getDefaultSchema(), "quotes"),
+                Collections.singletonList(new BytesRef("1395874800000"))).asIndexName(),
+            new PartitionName(
+                new RelationName(sqlExecutor.getDefaultSchema(), "quotes"),
+                Collections.singletonList(new BytesRef("1395961200000"))).asIndexName()
         );
         Thread.sleep(1000);
         GetSettingsResponse settingsResponse = client().admin().indices().prepareGetSettings(
@@ -1446,8 +1470,12 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
         execute("alter table quotes partition (date=1395874800000) set (number_of_replicas=1)");
         ensureYellow();
         List<String> partitions = ImmutableList.of(
-            new PartitionName(sqlExecutor.getDefaultSchema(), "quotes", Collections.singletonList(new BytesRef("1395874800000"))).asIndexName(),
-            new PartitionName(sqlExecutor.getDefaultSchema(), "quotes", Collections.singletonList(new BytesRef("1395961200000"))).asIndexName()
+            new PartitionName(
+                new RelationName(sqlExecutor.getDefaultSchema(), "quotes"),
+                Collections.singletonList(new BytesRef("1395874800000"))).asIndexName(),
+            new PartitionName(
+                new RelationName(sqlExecutor.getDefaultSchema(), "quotes"),
+                Collections.singletonList(new BytesRef("1395961200000"))).asIndexName()
         );
 
         GetSettingsResponse settingsResponse = client().admin().indices().prepareGetSettings(
@@ -1642,7 +1670,8 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
         execute("refresh table dynamic_table");
         ensureGreen();
         MappingMetaData partitionMetaData = clusterService().state().metaData().indices()
-            .get(new PartitionName(sqlExecutor.getDefaultSchema(), "dynamic_table",
+            .get(new PartitionName(
+                new RelationName(sqlExecutor.getDefaultSchema(), "dynamic_table"),
                 Collections.singletonList(new BytesRef("10.0"))).asIndexName())
             .getMappings().get(Constants.DEFAULT_MAPPING_TYPE);
         Map<String, Object> metaMap = (Map) partitionMetaData.getSourceAsMap().get("_meta");
@@ -1650,7 +1679,8 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
         execute("alter table dynamic_table set (column_policy= 'dynamic')");
         waitNoPendingTasksOnAll();
         partitionMetaData = clusterService().state().metaData().indices()
-            .get(new PartitionName(sqlExecutor.getDefaultSchema(), "dynamic_table",
+            .get(new PartitionName(
+                new RelationName(sqlExecutor.getDefaultSchema(), "dynamic_table"),
                 Collections.singletonList(new BytesRef("10.0"))).asIndexName())
             .getMappings().get(Constants.DEFAULT_MAPPING_TYPE);
         metaMap = (Map) partitionMetaData.getSourceAsMap().get("_meta");
@@ -1851,8 +1881,12 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
         assertThat(templateSettings.getAsInt(IndexMetaData.SETTING_NUMBER_OF_SHARDS, 0), is(2));
 
         List<String> partitions = ImmutableList.of(
-            new PartitionName(sqlExecutor.getDefaultSchema(), "quotes", Collections.singletonList(new BytesRef("1395874800000"))).asIndexName(),
-            new PartitionName(sqlExecutor.getDefaultSchema(), "quotes", Collections.singletonList(new BytesRef("1395961200000"))).asIndexName()
+            new PartitionName(
+                new RelationName(sqlExecutor.getDefaultSchema(), "quotes"),
+                Collections.singletonList(new BytesRef("1395874800000"))).asIndexName(),
+            new PartitionName(
+                new RelationName(sqlExecutor.getDefaultSchema(), "quotes"),
+                Collections.singletonList(new BytesRef("1395961200000"))).asIndexName()
         );
         Thread.sleep(1000);
         GetSettingsResponse settingsResponse = client().admin().indices().prepareGetSettings(

--- a/sql/src/test/java/io/crate/metadata/PartitionInfosTest.java
+++ b/sql/src/test/java/io/crate/metadata/PartitionInfosTest.java
@@ -78,7 +78,8 @@ public class PartitionInfosTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testPartitionWithoutMapping() throws Exception {
-        PartitionName partitionName = new PartitionName("test1", ImmutableList.of(new BytesRef("foo")));
+        PartitionName partitionName = new PartitionName(
+            new RelationName("doc", "test1"), ImmutableList.of(new BytesRef("foo")));
         addIndexMetaDataToClusterState(IndexMetaData.builder(partitionName.asIndexName())
             .settings(defaultSettings()).numberOfShards(10).numberOfReplicas(4));
         Iterable<PartitionInfo> partitioninfos = new PartitionInfos(clusterService);
@@ -87,7 +88,8 @@ public class PartitionInfosTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testPartitionWithMeta() throws Exception {
-        PartitionName partitionName = new PartitionName("test1", ImmutableList.of(new BytesRef("foo")));
+        PartitionName partitionName = new PartitionName(
+            new RelationName("doc", "test1"), ImmutableList.of(new BytesRef("foo")));
         IndexMetaData.Builder indexMetaData = IndexMetaData
             .builder(partitionName.asIndexName())
             .settings(defaultSettings())
@@ -107,7 +109,8 @@ public class PartitionInfosTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testPartitionWithMetaMultiCol() throws Exception {
-        PartitionName partitionName = new PartitionName("test1", ImmutableList.of(new BytesRef("foo"), new BytesRef("1")));
+        PartitionName partitionName = new PartitionName(
+            new RelationName("doc", "test1"), ImmutableList.of(new BytesRef("foo"), new BytesRef("1")));
         IndexMetaData.Builder indexMetaData = IndexMetaData
             .builder(partitionName.asIndexName())
             .settings(defaultSettings())

--- a/sql/src/test/java/io/crate/metadata/PartitionNameTest.java
+++ b/sql/src/test/java/io/crate/metadata/PartitionNameTest.java
@@ -26,10 +26,9 @@ import io.crate.test.integration.CrateUnitTest;
 import org.apache.lucene.util.BytesRef;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 
+import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.Is.is;
 
@@ -37,7 +36,7 @@ public class PartitionNameTest extends CrateUnitTest {
 
     @Test
     public void testSingleColumn() throws Exception {
-        PartitionName partitionName = new PartitionName("test", ImmutableList.of(new BytesRef("1")));
+        PartitionName partitionName = new PartitionName(new RelationName("doc", "test"), ImmutableList.of(new BytesRef("1")));
 
         assertThat(partitionName.values().size(), is(1));
         assertEquals(ImmutableList.of(new BytesRef("1")), partitionName.values());
@@ -48,7 +47,7 @@ public class PartitionNameTest extends CrateUnitTest {
 
     @Test
     public void testSingleColumnSchema() throws Exception {
-        PartitionName partitionName = new PartitionName("schema", "test", ImmutableList.of(new BytesRef("1")));
+        PartitionName partitionName = new PartitionName(new RelationName("schema", "test"), ImmutableList.of(new BytesRef("1")));
 
         assertThat(partitionName.values().size(), is(1));
         assertEquals(ImmutableList.of(new BytesRef("1")), partitionName.values());
@@ -59,7 +58,8 @@ public class PartitionNameTest extends CrateUnitTest {
 
     @Test
     public void testMultipleColumns() throws Exception {
-        PartitionName partitionName = new PartitionName("test", ImmutableList.of(new BytesRef("1"), new BytesRef("foo")));
+        PartitionName partitionName = new PartitionName(new RelationName("doc", "test"),
+            ImmutableList.of(new BytesRef("1"), new BytesRef("foo")));
 
         assertThat(partitionName.values().size(), is(2));
         assertEquals(ImmutableList.of(new BytesRef("1"), new BytesRef("foo")), partitionName.values());
@@ -70,7 +70,8 @@ public class PartitionNameTest extends CrateUnitTest {
 
     @Test
     public void testMultipleColumnsSchema() throws Exception {
-        PartitionName partitionName = new PartitionName("schema", "test", ImmutableList.of(new BytesRef("1"), new BytesRef("foo")));
+        PartitionName partitionName = new PartitionName(
+            new RelationName("schema", "test"), ImmutableList.of(new BytesRef("1"), new BytesRef("foo")));
 
         assertThat(partitionName.values().size(), is(2));
         assertEquals(ImmutableList.of(new BytesRef("1"), new BytesRef("foo")), partitionName.values());
@@ -81,9 +82,7 @@ public class PartitionNameTest extends CrateUnitTest {
 
     @Test
     public void testNull() throws Exception {
-        PartitionName partitionName = new PartitionName("test", new ArrayList<BytesRef>() {{
-            add(null);
-        }});
+        PartitionName partitionName = new PartitionName(new RelationName("doc", "test"), singletonList(null));
 
         assertThat(partitionName.values().size(), is(1));
         assertEquals(null, partitionName.values().get(0));
@@ -94,10 +93,7 @@ public class PartitionNameTest extends CrateUnitTest {
 
     @Test
     public void testNullSchema() throws Exception {
-        PartitionName partitionName = new PartitionName("schema", "test", new ArrayList<BytesRef>() {{
-            add(null);
-        }});
-
+        PartitionName partitionName = new PartitionName(new RelationName("schema", "test"), singletonList(null));
         assertThat(partitionName.values().size(), is(1));
         assertEquals(null, partitionName.values().get(0));
 
@@ -107,7 +103,7 @@ public class PartitionNameTest extends CrateUnitTest {
 
     @Test
     public void testEmptyStringValue() throws Exception {
-        PartitionName partitionName = new PartitionName("test", ImmutableList.of(new BytesRef("")));
+        PartitionName partitionName = new PartitionName(new RelationName("doc", "test"), ImmutableList.of(new BytesRef("")));
 
         assertThat(partitionName.values().size(), is(1));
         assertEquals(ImmutableList.of(new BytesRef("")), partitionName.values());
@@ -154,22 +150,27 @@ public class PartitionNameTest extends CrateUnitTest {
 
     @Test
     public void testFromIndexOrTemplate() throws Exception {
-        PartitionName partitionName = new PartitionName("t", Arrays.asList(new BytesRef("a"), new BytesRef("b")));
+        PartitionName partitionName = new PartitionName(
+            new RelationName("doc", "t"), Arrays.asList(new BytesRef("a"), new BytesRef("b")));
         assertThat(partitionName, equalTo(PartitionName.fromIndexOrTemplate(partitionName.asIndexName())));
 
-        partitionName = new PartitionName("t", Arrays.asList(new BytesRef("a"), new BytesRef("b")));
-        assertThat(partitionName, equalTo(PartitionName.fromIndexOrTemplate(partitionName.asIndexName())));
-        assertThat(partitionName.ident(), is("081620j2"));
-
-        partitionName = new PartitionName("schema", "t", Arrays.asList(new BytesRef("a"), new BytesRef("b")));
+        partitionName = new PartitionName(
+            new RelationName("doc", "t"), Arrays.asList(new BytesRef("a"), new BytesRef("b")));
         assertThat(partitionName, equalTo(PartitionName.fromIndexOrTemplate(partitionName.asIndexName())));
         assertThat(partitionName.ident(), is("081620j2"));
 
-        partitionName = new PartitionName( "t", Collections.singletonList(new BytesRef("hoschi")));
+        partitionName = new PartitionName(
+            new RelationName("schema", "t"), Arrays.asList(new BytesRef("a"), new BytesRef("b")));
+        assertThat(partitionName, equalTo(PartitionName.fromIndexOrTemplate(partitionName.asIndexName())));
+        assertThat(partitionName.ident(), is("081620j2"));
+
+        partitionName = new PartitionName(
+            new RelationName("doc", "t"), singletonList(new BytesRef("hoschi")));
         assertThat(partitionName, equalTo(PartitionName.fromIndexOrTemplate(partitionName.asIndexName())));
         assertThat(partitionName.ident(), is("043mgrrjcdk6i"));
 
-        partitionName = new PartitionName("t", Collections.singletonList(null));
+        partitionName = new PartitionName(
+            new RelationName("doc", "t"), singletonList(null));
         assertThat(partitionName, equalTo(PartitionName.fromIndexOrTemplate(partitionName.asIndexName())));
         assertThat(partitionName.ident(), is("0400"));
     }
@@ -227,15 +228,17 @@ public class PartitionNameTest extends CrateUnitTest {
     @Test
     public void testEquals() throws Exception {
         assertTrue(
-            new PartitionName("table", Arrays.asList(new BytesRef("xxx"))).equals(
-                new PartitionName("table", Arrays.asList(new BytesRef("xxx")))));
+            new PartitionName(
+                new RelationName("doc", "table"), Arrays.asList(new BytesRef("xxx"))).equals(
+                new PartitionName(new RelationName("doc", "table"), Arrays.asList(new BytesRef("xxx")))));
         assertTrue(
-            new PartitionName("table", Arrays.asList(new BytesRef("xxx"))).equals(
-                new PartitionName("table", Arrays.asList(new BytesRef("xxx")))));
+            new PartitionName(new RelationName("doc", "table"), Arrays.asList(new BytesRef("xxx"))).equals(
+                new PartitionName(
+                    new RelationName("doc", "table"), Arrays.asList(new BytesRef("xxx")))));
         assertFalse(
-            new PartitionName("table", Arrays.asList(new BytesRef("xxx"))).equals(
-                new PartitionName("schema", "table", Arrays.asList(new BytesRef("xxx")))));
-        PartitionName name = new PartitionName( "table", Arrays.asList(new BytesRef("xxx")));
+            new PartitionName(new RelationName("doc", "table"), Arrays.asList(new BytesRef("xxx"))).equals(
+                new PartitionName(new RelationName("schema", "table"), Arrays.asList(new BytesRef("xxx")))));
+        PartitionName name = new PartitionName(new RelationName("doc", "table"), Arrays.asList(new BytesRef("xxx")));
         assertTrue(name.equals(PartitionName.fromIndexOrTemplate(name.asIndexName())));
     }
 }

--- a/sql/src/test/java/io/crate/metadata/RelationNameTest.java
+++ b/sql/src/test/java/io/crate/metadata/RelationNameTest.java
@@ -44,10 +44,10 @@ public class RelationNameTest extends CrateUnitTest {
         assertThat(RelationName.fromIndexName("t"), is(new RelationName(Schemas.DOC_SCHEMA_NAME, "t")));
         assertThat(RelationName.fromIndexName("s.t"), is(new RelationName("s", "t")));
 
-        PartitionName pn = new PartitionName("s", "t", ImmutableList.of(new BytesRef("v1")));
+        PartitionName pn = new PartitionName(new RelationName("s", "t"), ImmutableList.of(new BytesRef("v1")));
         assertThat(RelationName.fromIndexName(pn.asIndexName()), is(new RelationName("s", "t")));
 
-        pn = new PartitionName( "t", ImmutableList.of(new BytesRef("v1")));
+        pn = new PartitionName(new RelationName("doc", "t"), ImmutableList.of(new BytesRef("v1")));
         assertThat(RelationName.fromIndexName(pn.asIndexName()), is(new RelationName(Schemas.DOC_SCHEMA_NAME, "t")));
     }
 

--- a/sql/src/test/java/io/crate/metadata/doc/DocTableInfoBuilderTest.java
+++ b/sql/src/test/java/io/crate/metadata/doc/DocTableInfoBuilderTest.java
@@ -60,7 +60,8 @@ public class DocTableInfoBuilderTest extends CrateUnitTest {
     @Test
     public void testNoTableInfoFromOrphanedPartition() throws Exception {
         String schemaName = randomSchema();
-        PartitionName partitionName = new PartitionName(schemaName, "test", Collections.singletonList(new BytesRef("boo")));
+        PartitionName partitionName = new PartitionName(
+            new RelationName(schemaName, "test"), Collections.singletonList(new BytesRef("boo")));
         IndexMetaData.Builder indexMetaDataBuilder = IndexMetaData.builder(partitionName.asIndexName())
             .settings(Settings.builder().put("index.version.created", Version.CURRENT).build())
             .numberOfReplicas(0)

--- a/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -121,9 +121,9 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
                 "   date timestamp," +
                 "   obj object" +
                 ") partitioned by (date) ",
-                new PartitionName("parted", singletonList(new BytesRef("1395874800000"))).asIndexName(),
-                new PartitionName("parted", singletonList(new BytesRef("1395961200000"))).asIndexName(),
-                new PartitionName("parted", singletonList(null)).asIndexName()
+                new PartitionName(new RelationName("doc", "parted"), singletonList(new BytesRef("1395874800000"))).asIndexName(),
+                new PartitionName(new RelationName("doc", "parted"), singletonList(new BytesRef("1395961200000"))).asIndexName(),
+                new PartitionName(new RelationName("doc", "parted"), singletonList(null)).asIndexName()
             )
             .build();
     }
@@ -321,7 +321,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
             indices.addAll(entry.getValue().keySet());
         }
         assertThat(indices, Matchers.contains(
-            new PartitionName("parted", Arrays.asList(new BytesRef("123"))).asIndexName()));
+            new PartitionName(new RelationName("doc", "parted"), Arrays.asList(new BytesRef("123"))).asIndexName()));
 
         assertThat(collectPhase.where().representation(), is("Ref{doc.parted_pks.name, string} = 'x'"));
 

--- a/sql/src/test/java/io/crate/planner/WhereClauseOptimizerTest.java
+++ b/sql/src/test/java/io/crate/planner/WhereClauseOptimizerTest.java
@@ -25,6 +25,7 @@ package io.crate.planner;
 import io.crate.analyze.QueriedTable;
 import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.metadata.PartitionName;
+import io.crate.metadata.RelationName;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
@@ -58,9 +59,9 @@ public class WhereClauseOptimizerTest extends CrateDummyClusterServiceUnitTest{
             .addPartitionedTable(
                 "create table parted_pk (id int primary key, date timestamp primary key) " +
                 "partitioned by (date)",
-                new PartitionName("parted_pk", singletonList(new BytesRef("1395874800000"))).asIndexName(),
-                new PartitionName("parted_pk", singletonList(new BytesRef("1395961200000"))).asIndexName(),
-                new PartitionName("parted_pk", singletonList(null)).asIndexName()
+                new PartitionName(new RelationName("doc", "parted_pk"), singletonList(new BytesRef("1395874800000"))).asIndexName(),
+                new PartitionName(new RelationName("doc", "parted_pk"), singletonList(new BytesRef("1395961200000"))).asIndexName(),
+                new PartitionName(new RelationName("doc", "parted_pk"), singletonList(null)).asIndexName()
             )
             .build();
     }


### PR DESCRIPTION
- `PartitionName(tableName, values)` was trappy because it implicitly
 used the `doc` schema. Using this constructor outside of a test would
 most certainly be a bug in that it doesn't use the default session
 schema.

 - `PartitionName(schema, table, values)` was mostly used in tests and
 since it implicitly creates a `RelationName` instance this commit also
 removes it to encourage re-using existing `RelationName` instances and
 avoid `RelationName -> schema, table -> RelationName` roundtrips.