### PR TITLE
Avoid duplicate method calls in HashJoin.dependencies

### DIFF
--- a/sql/src/main/java/io/crate/planner/operators/HashJoin.java
+++ b/sql/src/main/java/io/crate/planner/operators/HashJoin.java
@@ -88,9 +88,11 @@ class HashJoin extends TwoInputPlan {
 
     @Override
     public Map<LogicalPlan, SelectSymbol> dependencies() {
-        HashMap<LogicalPlan, SelectSymbol> deps = new HashMap<>(lhs.dependencies().size() + rhs.dependencies().size());
-        deps.putAll(lhs.dependencies());
-        deps.putAll(rhs.dependencies());
+        Map<LogicalPlan, SelectSymbol> leftDeps = lhs.dependencies();
+        Map<LogicalPlan, SelectSymbol> rightDeps = rhs.dependencies();
+        HashMap<LogicalPlan, SelectSymbol> deps = new HashMap<>(leftDeps.size() + rightDeps.size());
+        deps.putAll(leftDeps);
+        deps.putAll(rightDeps);
         return deps;
     }
 


### PR DESCRIPTION
Avoids duplicate allocations or calculations in case `dependencies` is
not just a simple property.