### PR TITLE
use human readable, consistent names for execution phases

### DIFF
--- a/sql/src/main/java/io/crate/execution/dsl/phases/CountPhase.java
+++ b/sql/src/main/java/io/crate/execution/dsl/phases/CountPhase.java
@@ -56,11 +56,6 @@ public class CountPhase implements UpstreamPhase {
         return Type.COUNT;
     }
 
-    @Override
-    public String name() {
-        return "count";
-    }
-
     public Routing routing() {
         return routing;
     }

--- a/sql/src/main/java/io/crate/execution/dsl/phases/ExecutionPhase.java
+++ b/sql/src/main/java/io/crate/execution/dsl/phases/ExecutionPhase.java
@@ -41,33 +41,41 @@ public interface ExecutionPhase extends Writeable {
 
 
     enum Type {
-        COLLECT(RoutedCollectPhase::new),
-        COUNT(CountPhase::new),
-        FILE_URI_COLLECT(FileUriCollectPhase::new),
-        MERGE(MergePhase::new),
-        FETCH(FetchPhase::new),
-        NESTED_LOOP(NestedLoopPhase::new),
-        HASH_JOIN(HashJoinPhase::new),
+        COLLECT(RoutedCollectPhase::new, "CollectPhase"),
+        COUNT(CountPhase::new, "CountPhase"),
+        FILE_URI_COLLECT(FileUriCollectPhase::new, "FileUriCollectPhase"),
+        MERGE(MergePhase::new, "MergePhase"),
+        FETCH(FetchPhase::new, "FetchPhase"),
+        NESTED_LOOP(NestedLoopPhase::new, "NestedLoopPhase"),
+        HASH_JOIN(HashJoinPhase::new, "HashJoinPhase"),
         TABLE_FUNCTION_COLLECT(in -> {
-            throw new UnsupportedOperationException("TableFunctionCollectPhase is not streamable"); }),
-        PKLookup(PKLookupPhase::new);
+            throw new UnsupportedOperationException("TableFunctionCollectPhase is not streamable"); }, "TableFunctionCollectPhase"),
+        PK_LOOKUP(PKLookupPhase::new, "PrimaryKeyLookupPhase");
 
         public static final List<Type> VALUES = ImmutableList.copyOf(values());
 
         private final Writeable.Reader<ExecutionPhase> reader;
+        private final String humanName;
 
-        Type(Writeable.Reader<ExecutionPhase> reader) {
+        Type(Reader<ExecutionPhase> reader, String humanName) {
             this.reader = reader;
+            this.humanName = humanName;
         }
 
         public ExecutionPhase fromStream(StreamInput in) throws IOException {
             return reader.read(in);
         }
+
+        public String humanName() {
+            return humanName;
+        }
     }
 
     Type type();
 
-    String name();
+    default String name() {
+        return type().humanName();
+    }
 
     int phaseId();
 

--- a/sql/src/main/java/io/crate/execution/dsl/phases/FetchPhase.java
+++ b/sql/src/main/java/io/crate/execution/dsl/phases/FetchPhase.java
@@ -69,11 +69,6 @@ public class FetchPhase implements ExecutionPhase {
     }
 
     @Override
-    public String name() {
-        return "fetchPhase";
-    }
-
-    @Override
     public int phaseId() {
         return executionPhaseId;
     }

--- a/sql/src/main/java/io/crate/execution/dsl/phases/FileUriCollectPhase.java
+++ b/sql/src/main/java/io/crate/execution/dsl/phases/FileUriCollectPhase.java
@@ -49,7 +49,6 @@ public class FileUriCollectPhase extends AbstractProjectionsPhase implements Col
 
     public FileUriCollectPhase(UUID jobId,
                                int phaseId,
-                               String name,
                                Collection<String> executionNodes,
                                Symbol targetUri,
                                List<Symbol> toCollect,
@@ -57,7 +56,7 @@ public class FileUriCollectPhase extends AbstractProjectionsPhase implements Col
                                String compression,
                                Boolean sharedStorage,
                                InputFormat inputFormat) {
-        super(jobId, phaseId, name, projections);
+        super(jobId, phaseId, Type.FILE_URI_COLLECT.humanName(), projections);
         this.executionNodes = executionNodes;
         this.targetUri = targetUri;
         this.toCollect = toCollect;

--- a/sql/src/main/java/io/crate/execution/dsl/phases/HashJoinPhase.java
+++ b/sql/src/main/java/io/crate/execution/dsl/phases/HashJoinPhase.java
@@ -48,7 +48,6 @@ public class HashJoinPhase extends JoinPhase {
 
     public HashJoinPhase(UUID jobId,
                          int executionNodeId,
-                         String name,
                          List<Projection> projections,
                          @Nullable MergePhase leftMergePhase,
                          @Nullable MergePhase rightMergePhase,
@@ -64,7 +63,7 @@ public class HashJoinPhase extends JoinPhase {
         super(
             jobId,
             executionNodeId,
-            name,
+            Type.HASH_JOIN.humanName(),
             projections,
             leftMergePhase,
             rightMergePhase,

--- a/sql/src/main/java/io/crate/execution/dsl/phases/JoinPhase.java
+++ b/sql/src/main/java/io/crate/execution/dsl/phases/JoinPhase.java
@@ -83,9 +83,6 @@ public abstract class JoinPhase extends AbstractProjectionsPhase implements Upst
     }
 
     @Override
-    public abstract Type type();
-
-    @Override
     public Collection<String> nodeIds() {
         if (executionNodes == null) {
             return ImmutableSet.of();

--- a/sql/src/main/java/io/crate/execution/dsl/phases/NestedLoopPhase.java
+++ b/sql/src/main/java/io/crate/execution/dsl/phases/NestedLoopPhase.java
@@ -35,10 +35,9 @@ import java.util.UUID;
 
 public class NestedLoopPhase extends JoinPhase {
 
-
     public NestedLoopPhase(UUID jobId,
                            int executionNodeId,
-                           String name,
+                           boolean isDistributed,
                            List<Projection> projections,
                            @Nullable MergePhase leftMergePhase,
                            @Nullable MergePhase rightMergePhase,
@@ -50,7 +49,7 @@ public class NestedLoopPhase extends JoinPhase {
         super(
             jobId,
             executionNodeId,
-            name,
+            isDistributed ? "Distributed" + Type.NESTED_LOOP.humanName() : Type.NESTED_LOOP.humanName(),
             projections,
             leftMergePhase,
             rightMergePhase,

--- a/sql/src/main/java/io/crate/execution/dsl/phases/PKLookupPhase.java
+++ b/sql/src/main/java/io/crate/execution/dsl/phases/PKLookupPhase.java
@@ -154,7 +154,7 @@ public final class PKLookupPhase extends AbstractProjectionsPhase implements Col
 
     @Override
     public Type type() {
-        return Type.PKLookup;
+        return Type.PK_LOOKUP;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/execution/dsl/phases/TableFunctionCollectPhase.java
+++ b/sql/src/main/java/io/crate/execution/dsl/phases/TableFunctionCollectPhase.java
@@ -50,7 +50,7 @@ public class TableFunctionCollectPhase extends RoutedCollectPhase implements Col
                                      Symbol where) {
         super(jobId,
             phaseId,
-            functionImplementation.info().ident().name(),
+            "TableFunctionCollectPhase",
             routing,
             RowGranularity.DOC,
             outputs,

--- a/sql/src/main/java/io/crate/execution/engine/join/JoinOperations.java
+++ b/sql/src/main/java/io/crate/execution/engine/join/JoinOperations.java
@@ -82,7 +82,7 @@ public final class JoinOperations {
         return new MergePhase(
             plannerContext.jobId(),
             plannerContext.nextExecutionPhaseId(),
-            "join-merge",
+            "JoinMergePhase",
             resultDescription.nodeIds().size(),
             1,
             executionNodes,

--- a/sql/src/main/java/io/crate/planner/Merge.java
+++ b/sql/src/main/java/io/crate/planner/Merge.java
@@ -82,7 +82,7 @@ public class Merge implements ExecutionPlan, ResultDescription {
         MergePhase mergePhase = new MergePhase(
             plannerContext.jobId(),
             plannerContext.nextExecutionPhaseId(),
-            "mergeOnHandler",
+            "MergeOnHandlerPhase",
             resultDescription.nodeIds().size(),
             1,
             handlerNodeIds,

--- a/sql/src/main/java/io/crate/planner/consumer/UpdatePlanner.java
+++ b/sql/src/main/java/io/crate/planner/consumer/UpdatePlanner.java
@@ -211,7 +211,7 @@ public final class UpdatePlanner {
         RoutedCollectPhase collectPhase = new RoutedCollectPhase(
             plannerCtx.jobId(),
             plannerCtx.nextExecutionPhaseId(),
-            "collect",
+            "UpdateCollectPhase",
             routing,
             tableInfo.rowGranularity(),
             newArrayList(idReference),

--- a/sql/src/main/java/io/crate/planner/operators/Collect.java
+++ b/sql/src/main/java/io/crate/planner/operators/Collect.java
@@ -88,7 +88,7 @@ import static io.crate.planner.operators.OperatorUtils.getUnusedColumns;
  */
 class Collect extends ZeroInputPlan {
 
-    private static final String COLLECT_PHASE_NAME = "collect";
+    private static final String COLLECT_PHASE_NAME = "CollectPhase";
     final QueriedTable relation;
     WhereClause where;
 

--- a/sql/src/main/java/io/crate/planner/operators/Count.java
+++ b/sql/src/main/java/io/crate/planner/operators/Count.java
@@ -50,7 +50,7 @@ import java.util.Map;
  */
 public class Count extends ZeroInputPlan {
 
-    private static final String COUNT_PHASE_NAME = "count-merge";
+    private static final String COUNT_PHASE_NAME = "CountMergePhase";
 
     final AbstractTableRelation tableRelation;
     final WhereClause where;

--- a/sql/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
+++ b/sql/src/main/java/io/crate/planner/operators/GroupHashAggregate.java
@@ -56,7 +56,7 @@ import static io.crate.planner.operators.LogicalPlanner.extractColumns;
 
 public class GroupHashAggregate extends OneInputPlan {
 
-    private static final String DISTRIBUTED_MERGE_PHASE_NAME = "distributed merge";
+    private static final String DISTRIBUTED_MERGE_PHASE_NAME = "DistributedMergePhase";
     final List<Function> aggregates;
     final List<Symbol> groupKeys;
 

--- a/sql/src/main/java/io/crate/planner/operators/HashJoin.java
+++ b/sql/src/main/java/io/crate/planner/operators/HashJoin.java
@@ -173,7 +173,6 @@ class HashJoin extends TwoInputPlan {
         HashJoinPhase joinPhase = new HashJoinPhase(
             plannerContext.jobId(),
             plannerContext.nextExecutionPhaseId(),
-            "hash-join",
             Collections.singletonList(JoinOperations.createJoinProjection(outputs, joinOutputs)),
             leftMerge,
             rightMerge,

--- a/sql/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
+++ b/sql/src/main/java/io/crate/planner/operators/NestedLoopJoin.java
@@ -168,7 +168,7 @@ class NestedLoopJoin extends TwoInputPlan {
         NestedLoopPhase nlPhase = new NestedLoopPhase(
             plannerContext.jobId(),
             plannerContext.nextExecutionPhaseId(),
-            isDistributed ? "distributed-nested-loop" : "nested-loop",
+            isDistributed,
             Collections.singletonList(JoinOperations.createJoinProjection(outputs, joinOutputs)),
             joinExecutionNodesAndMergePhases.v2().get(0),
             joinExecutionNodesAndMergePhases.v2().get(1),

--- a/sql/src/main/java/io/crate/planner/operators/Union.java
+++ b/sql/src/main/java/io/crate/planner/operators/Union.java
@@ -143,7 +143,7 @@ public class Union extends TwoInputPlan {
         MergePhase mergePhase = new MergePhase(
             plannerContext.jobId(),
             plannerContext.nextExecutionPhaseId(),
-            "union",
+            "UnionPhase",
             leftResultDesc.nodeIds().size() + rightResultDesc.nodeIds().size(),
             2,
             Collections.singletonList(plannerContext.handlerNode()),

--- a/sql/src/main/java/io/crate/planner/statement/CopyStatementPlanner.java
+++ b/sql/src/main/java/io/crate/planner/statement/CopyStatementPlanner.java
@@ -213,7 +213,6 @@ public final class CopyStatementPlanner {
         FileUriCollectPhase collectPhase = new FileUriCollectPhase(
             context.jobId(),
             context.nextExecutionPhaseId(),
-            "copyFrom",
             getExecutionNodes(allNodes, copyFrom.settings().getAsInt("num_readers", allNodes.getSize()), copyFrom.nodePredicate()),
             copyFrom.uri(),
             toCollect,

--- a/sql/src/main/java/io/crate/planner/statement/DeletePlanner.java
+++ b/sql/src/main/java/io/crate/planner/statement/DeletePlanner.java
@@ -177,7 +177,7 @@ public final class DeletePlanner {
         RoutedCollectPhase collectPhase = new RoutedCollectPhase(
             context.jobId(),
             context.nextExecutionPhaseId(),
-            "collect",
+            "DeleteCollectPhase",
             routing,
             tableInfo.rowGranularity(),
             newArrayList(idReference),

--- a/sql/src/test/java/io/crate/execution/engine/collect/MapSideDataCollectOperationTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/MapSideDataCollectOperationTest.java
@@ -77,7 +77,6 @@ public class MapSideDataCollectOperationTest extends CrateDummyClusterServiceUni
         FileUriCollectPhase collectNode = new FileUriCollectPhase(
             UUID.randomUUID(),
             0,
-            "test",
             Collections.singletonList("noop_id"),
             Literal.of(Paths.get(tmpFile.toURI()).toUri().toString()),
             Arrays.asList(

--- a/sql/src/test/java/io/crate/integrationtests/SysOperationsTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysOperationsTest.java
@@ -55,7 +55,7 @@ public class SysOperationsTest extends SQLTransportIntegrationTest {
             names.add((String) objects[0]);
         }
         Collections.sort(names);
-        assertTrue(names.contains("collect"));
+        assertTrue(names.contains("CollectPhase"));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/TransportSQLActionClassLifecycleTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TransportSQLActionClassLifecycleTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.integrationtests;
 
+import com.carrotsearch.randomizedtesting.annotations.Repeat;
 import io.crate.Build;
 import io.crate.Version;
 import io.crate.action.sql.SQLActionException;
@@ -469,12 +470,10 @@ public class TransportSQLActionClassLifecycleTest extends SQLTransportIntegratio
                 names.add((String) objects[4]);
             }
             assertThat(names, Matchers.anyOf(
-                Matchers.hasItems("distributing collect", "distributing collect"),
-                Matchers.hasItems("collect", "localMerge"),
-
+                Matchers.hasItems("CollectPhase", "MergeOnHandlerPhase"),
                 // the select * from sys.operations_log has 2 collect operations (1 per node)
-                Matchers.hasItems("collect", "collect"),
-                Matchers.hasItems("distributed merge", "localMerge")));
+                Matchers.hasItems("CollectPhase", "CollectPhase")
+            ));
         }, 10L, TimeUnit.SECONDS);
 
         execute("set global transient stats.enabled = false");

--- a/sql/src/test/java/io/crate/planner/node/dql/JoinPhaseTest.java
+++ b/sql/src/test/java/io/crate/planner/node/dql/JoinPhaseTest.java
@@ -90,7 +90,7 @@ public class JoinPhaseTest extends CrateUnitTest {
         NestedLoopPhase node = new NestedLoopPhase(
             jobId,
             1,
-            "nestedLoop",
+            false,
             ImmutableList.of(topNProjection),
             mp1,
             mp2,
@@ -123,7 +123,6 @@ public class JoinPhaseTest extends CrateUnitTest {
         HashJoinPhase node = new HashJoinPhase(
             jobId,
             1,
-            "nestedLoop",
             ImmutableList.of(topNProjection),
             mp1,
             mp2,


### PR DESCRIPTION
This is in preparation for printing the different phases in the response of EXPLAIN ANALYZE.