### PR TITLE
Test: Fix test for multiple simple queries and query failure.

### DIFF
--- a/sql/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
+++ b/sql/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
@@ -412,7 +412,7 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
         when(describeResult.getFields()).thenReturn(null);
         when(session.describe(anyChar(), anyString())).thenReturn(describeResult);
         if (failFirstStatement) {
-            when(session.sync()).thenAnswer(mock -> new RuntimeException("fail"));
+            when(session.sync()).thenThrow(new RuntimeException("fail"));
         } else {
             when(session.sync()).thenReturn(CompletableFuture.completedFuture(null));
         }
@@ -480,6 +480,6 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
         byte[] responseBytes = new byte[5];
         response.readBytes(responseBytes);
         // ErrorResponse: 'E' | int32 len | ...
-        assertThat(responseBytes, is(new byte[]{'E', 0, 0, 0, -110}));
+        assertThat(responseBytes, is(new byte[]{'E', 0, 0, 0, 67}));
     }
 }


### PR DESCRIPTION
The Completetable future simulating the failure was returning an Answer
with and exception instead of throwing the dummy exception. As a result
the error response instead of containing the message of the dummy exception
had a ClassCastException. The behaviour was caught by Java9 jenkins tests
as the message of the ClassCastException differs from the one in Java8.