### PR TITLE
Do authentication check only once per connection

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -18,6 +18,9 @@ Breaking Changes
 Changes
 =======
 
+- Improved the performance of password authentication for connections that are
+  re-used.
+
 Fixes
 =====
 


### PR DESCRIPTION
Verification of the password is very expensive, so we should only do
that once per connection to avoid an immense performance overhead.

Average of 100 `select 1` on a re-used connection:

    Before patch: 49.64 ms
    After  patch:  1.98 ms