### PR TITLE
Fix issue with blob tables and sys.health.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -24,3 +24,5 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that caused a ``ClassCastException`` to be thrown when querying
+  the ``sys.health`` table on a cluster that has ``blob`` tables.

--- a/sql/src/main/java/io/crate/metadata/sys/TableHealthService.java
+++ b/sql/src/main/java/io/crate/metadata/sys/TableHealthService.java
@@ -32,6 +32,7 @@ import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Schemas;
 import io.crate.metadata.doc.DocTableInfo;
+import io.crate.metadata.table.ShardedTable;
 import io.crate.sql.parser.SqlParser;
 import io.crate.sql.tree.Statement;
 import org.apache.logging.log4j.Logger;
@@ -143,7 +144,7 @@ public class TableHealthService extends AbstractComponent {
             ShardsInfo shardsInfo = entry.getValue();
             RelationName relationName = new RelationName(
                 BytesRefs.toString(ident.tableSchema), BytesRefs.toString(ident.tableName));
-            DocTableInfo tableInfo;
+            ShardedTable tableInfo;
             try {
                 tableInfo = schemas.getTableInfo(relationName);
             } catch (RelationUnknown e) {


### PR DESCRIPTION
Only DocTables where handled before and as a result a
ClassCastException was thrown in case at least one Blob Table exists in the cluster.