### PR TITLE
Use ref.column() instead of ref.ident().columnIdent()

### DIFF
--- a/sql/src/main/java/io/crate/analyze/UpdateAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/UpdateAnalyzer.java
@@ -153,14 +153,14 @@ public final class UpdateAnalyzer {
                 tableInfo
             );
             if (assignmentByTargetCol.put(targetCol, source) != null) {
-                throw new IllegalArgumentException("Target expression repeated: " + targetCol.ident().columnIdent().sqlFqn());
+                throw new IllegalArgumentException("Target expression repeated: " + targetCol.column().sqlFqn());
             }
         }
         return assignmentByTargetCol;
     }
 
     private static boolean hasMatchingParent(TableInfo tableInfo, Reference info, Predicate<Reference> parentMatchPredicate) {
-        ColumnIdent parent = info.ident().columnIdent().getParent();
+        ColumnIdent parent = info.column().getParent();
         while (parent != null) {
             Reference parentInfo = tableInfo.getReference(parent);
             if (parentMatchPredicate.test(parentInfo)) {

--- a/sql/src/main/java/io/crate/analyze/expressions/TableReferenceResolver.java
+++ b/sql/src/main/java/io/crate/analyze/expressions/TableReferenceResolver.java
@@ -59,7 +59,7 @@ public class TableReferenceResolver implements FieldProvider<Reference> {
         }
 
         for (Reference reference : tableReferences) {
-            if (reference.ident().columnIdent().equals(columnIdent)) {
+            if (reference.column().equals(columnIdent)) {
                 if (reference instanceof GeneratedReference) {
                     throw new IllegalArgumentException("A generated column cannot be based on a generated column");
                 }

--- a/sql/src/main/java/io/crate/analyze/where/WhereClauseValidator.java
+++ b/sql/src/main/java/io/crate/analyze/where/WhereClauseValidator.java
@@ -82,7 +82,7 @@ public final class WhereClauseValidator {
 
         @Override
         public Symbol visitReference(Reference symbol, Context context) {
-            validateSysReference(context, symbol.ident().columnIdent().name());
+            validateSysReference(context, symbol.column().name());
             return super.visitReference(symbol, context);
         }
 

--- a/sql/src/main/java/io/crate/execution/engine/collect/collectors/NodeStatsIterator.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/collectors/NodeStatsIterator.java
@@ -22,24 +22,24 @@
 
 package io.crate.execution.engine.collect.collectors;
 
-import io.crate.expression.symbol.DefaultTraversalSymbolVisitor;
-import io.crate.expression.symbol.Symbol;
 import io.crate.concurrent.CompletableFutures;
 import io.crate.data.BatchIterator;
 import io.crate.data.CloseAssertingBatchIterator;
 import io.crate.data.Row;
 import io.crate.exceptions.SQLExceptions;
+import io.crate.execution.dsl.phases.RoutedCollectPhase;
+import io.crate.execution.engine.collect.RowsTransformer;
 import io.crate.execution.engine.collect.stats.NodeStatsRequest;
 import io.crate.execution.engine.collect.stats.NodeStatsResponse;
 import io.crate.execution.engine.collect.stats.TransportNodeStatsAction;
+import io.crate.expression.InputFactory;
+import io.crate.expression.reference.StaticTableReferenceResolver;
+import io.crate.expression.reference.sys.node.NodeStatsContext;
+import io.crate.expression.symbol.DefaultTraversalSymbolVisitor;
+import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Reference;
 import io.crate.metadata.sys.SysNodesTableInfo;
-import io.crate.expression.InputFactory;
-import io.crate.execution.engine.collect.RowsTransformer;
-import io.crate.expression.reference.StaticTableReferenceResolver;
-import io.crate.expression.reference.sys.node.NodeStatsContext;
-import io.crate.execution.dsl.phases.RoutedCollectPhase;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.unit.TimeValue;
@@ -242,7 +242,7 @@ public class NodeStatsIterator implements BatchIterator<Row> {
 
         @Override
         public Void visitReference(Reference symbol, Set<ColumnIdent> context) {
-            context.add(symbol.ident().columnIdent().getRoot());
+            context.add(symbol.column().getRoot());
             return null;
         }
     }

--- a/sql/src/main/java/io/crate/expression/symbol/format/SymbolPrinter.java
+++ b/sql/src/main/java/io/crate/expression/symbol/format/SymbolPrinter.java
@@ -220,14 +220,14 @@ public final class SymbolPrinter {
             List<Symbol> arguments = function.arguments();
             if (arguments.get(0) instanceof Reference &&
                     arguments.get(0).valueType() instanceof ArrayType &&
-                    ((Reference) arguments.get(0)).ident().columnIdent().path().size() > 0) {
+                    ((Reference) arguments.get(0)).column().path().size() > 0) {
                 Reference firstArgument = (Reference) arguments.get(0);
-                context.builder.append(firstArgument.ident().columnIdent().name());
+                context.builder.append(firstArgument.column().name());
                 context.builder.append("[");
                 process(arguments.get(1), context);
                 context.builder.append("]");
                 context.builder.append("['");
-                context.builder.append(firstArgument.ident().columnIdent().path().get(0));
+                context.builder.append(firstArgument.column().path().get(0));
                 context.builder.append("']");
             } else {
                 process(arguments.get(0), context);

--- a/sql/src/main/java/io/crate/planner/consumer/SemiJoins.java
+++ b/sql/src/main/java/io/crate/planner/consumer/SemiJoins.java
@@ -109,7 +109,7 @@ final class SemiJoins {
         // Function to turn Ref(x) back into Field(rel, x); it's required for the MultiSourceSelect structure;
         // (a lot of logic that follows in the Planner after the rewrite is based on Fields)
         java.util.function.Function<? super Symbol, ? extends Symbol> refsToFields =
-            RefReplacer.replaceRefs(r -> sourceRel.getField(r.ident().columnIdent(), Operation.READ));
+            RefReplacer.replaceRefs(r -> sourceRel.getField(r.column(), Operation.READ));
 
         removeRewriteCandidatesFromWhere(rel, rewriteCandidates);
         QuerySpec newTopQS = rel.querySpec().copyAndReplace(refsToFields);
@@ -195,7 +195,7 @@ final class SemiJoins {
     static Symbol makeJoinCondition(Candidate rewriteCandidate, AnalyzedRelation sourceRel) {
         Function anyFunc = RefReplacer.replaceRefs(
             rewriteCandidate.getAnyOpFunction(),
-            r -> sourceRel.getField(r.ident().columnIdent(), Operation.READ));
+            r -> sourceRel.getField(r.column(), Operation.READ));
         String name = anyFunc.info().ident().name();
         assert name.startsWith(AnyOperator.OPERATOR_PREFIX) : "Can only create a join condition from any_";
 

--- a/sql/src/main/java/io/crate/planner/operators/RelationBoundary.java
+++ b/sql/src/main/java/io/crate/planner/operators/RelationBoundary.java
@@ -70,7 +70,7 @@ public class RelationBoundary extends OneInputPlan {
             LogicalPlan source = sourceBuilder.build(tableStats, mappedUsedColumns);
             for (Symbol symbol : source.outputs()) {
                 RefVisitor.visitRefs(symbol, r -> {
-                    Field field = new Field(relation, r.ident().columnIdent(), r.valueType());
+                    Field field = new Field(relation, r.column(), r.valueType());
                     if (reverseMapping.putIfAbsent(r, field) == null) {
                         expressionMapping.put(field, r);
                     }

--- a/sql/src/test/groovy/io/crate/planner/InsertPlannerTest.java
+++ b/sql/src/test/groovy/io/crate/planner/InsertPlannerTest.java
@@ -81,9 +81,9 @@ public class InsertPlannerTest extends CrateDummyClusterServiceUnitTest {
 
         assertThat(legacyUpsertById.insertColumns().length, is(2));
         Reference idRef = legacyUpsertById.insertColumns()[0];
-        assertThat(idRef.ident().columnIdent().fqn(), is("id"));
+        assertThat(idRef.column().fqn(), is("id"));
         Reference nameRef = legacyUpsertById.insertColumns()[1];
-        assertThat(nameRef.ident().columnIdent().fqn(), is("name"));
+        assertThat(nameRef.column().fqn(), is("name"));
 
         assertThat(legacyUpsertById.items().size(), is(1));
         LegacyUpsertById.Item item = legacyUpsertById.items().get(0);
@@ -102,9 +102,9 @@ public class InsertPlannerTest extends CrateDummyClusterServiceUnitTest {
 
         assertThat(legacyUpsertById.insertColumns().length, is(2));
         Reference idRef = legacyUpsertById.insertColumns()[0];
-        assertThat(idRef.ident().columnIdent().fqn(), is("id"));
+        assertThat(idRef.column().fqn(), is("id"));
         Reference nameRef = legacyUpsertById.insertColumns()[1];
-        assertThat(nameRef.ident().columnIdent().fqn(), is("name"));
+        assertThat(nameRef.column().fqn(), is("name"));
 
         assertThat(legacyUpsertById.items().size(), is(2));
 
@@ -171,8 +171,8 @@ public class InsertPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(projection.primaryKeys().size(), is(1));
         assertThat(projection.primaryKeys().get(0).fqn(), is("id"));
         assertThat(projection.columnReferences().size(), is(2));
-        assertThat(projection.columnReferences().get(0).ident().columnIdent().fqn(), is("id"));
-        assertThat(projection.columnReferences().get(1).ident().columnIdent().fqn(), is("name"));
+        assertThat(projection.columnReferences().get(0).column().fqn(), is("id"));
+        assertThat(projection.columnReferences().get(1).column().fqn(), is("name"));
 
         assertNotNull(projection.clusteredByIdent());
         assertThat(projection.clusteredByIdent().fqn(), is("id"));
@@ -201,7 +201,7 @@ public class InsertPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(projection.primaryKeys().get(1).fqn(), is("date"));
 
         assertThat(projection.columnReferences().size(), is(1));
-        assertThat(projection.columnReferences().get(0).ident().columnIdent().fqn(), is("id"));
+        assertThat(projection.columnReferences().get(0).column().fqn(), is("id"));
 
         assertThat(projection.partitionedBySymbols().size(), is(1));
         assertThat(((InputColumn) projection.partitionedBySymbols().get(0)).index(), is(1));
@@ -231,8 +231,8 @@ public class InsertPlannerTest extends CrateDummyClusterServiceUnitTest {
         ColumnIndexWriterProjection projection = (ColumnIndexWriterProjection) mergePhase.projections().get(1);
 
         assertThat(projection.columnReferences().size(), is(2));
-        assertThat(projection.columnReferences().get(0).ident().columnIdent().fqn(), is("name"));
-        assertThat(projection.columnReferences().get(1).ident().columnIdent().fqn(), is("id"));
+        assertThat(projection.columnReferences().get(0).column().fqn(), is("name"));
+        assertThat(projection.columnReferences().get(1).column().fqn(), is("id"));
 
         assertThat(projection.columnSymbols().size(), is(2));
         assertThat(((InputColumn) projection.columnSymbols().get(0)).index(), is(0));
@@ -256,9 +256,9 @@ public class InsertPlannerTest extends CrateDummyClusterServiceUnitTest {
         ColumnIndexWriterProjection projection = (ColumnIndexWriterProjection) collectPhase.projections().get(0);
 
         assertThat(projection.columnReferences().size(), is(3));
-        assertThat(projection.columnReferences().get(0).ident().columnIdent().fqn(), is("date"));
-        assertThat(projection.columnReferences().get(1).ident().columnIdent().fqn(), is("id"));
-        assertThat(projection.columnReferences().get(2).ident().columnIdent().fqn(), is("name"));
+        assertThat(projection.columnReferences().get(0).column().fqn(), is("date"));
+        assertThat(projection.columnReferences().get(1).column().fqn(), is("id"));
+        assertThat(projection.columnReferences().get(2).column().fqn(), is("name"));
         assertThat(((InputColumn) projection.ids().get(0)).index(), is(1));
         assertThat(((InputColumn) projection.clusteredBy()).index(), is(1));
         assertThat(projection.partitionedBySymbols().isEmpty(), is(true));
@@ -277,8 +277,8 @@ public class InsertPlannerTest extends CrateDummyClusterServiceUnitTest {
         ColumnIndexWriterProjection projection = (ColumnIndexWriterProjection) join.joinPhase().projections().get(1);
 
         assertThat(projection.columnReferences().size(), is(2));
-        assertThat(projection.columnReferences().get(0).ident().columnIdent().fqn(), is("id"));
-        assertThat(projection.columnReferences().get(1).ident().columnIdent().fqn(), is("name"));
+        assertThat(projection.columnReferences().get(0).column().fqn(), is("id"));
+        assertThat(projection.columnReferences().get(1).column().fqn(), is("name"));
         assertThat(((InputColumn) projection.ids().get(0)).index(), is(0));
         assertThat(((InputColumn) projection.clusteredBy()).index(), is(0));
         assertThat(projection.partitionedBySymbols().isEmpty(), is(true));
@@ -371,9 +371,9 @@ public class InsertPlannerTest extends CrateDummyClusterServiceUnitTest {
 
         assertThat(node.insertColumns().length, is(2));
         Reference idRef = node.insertColumns()[0];
-        assertThat(idRef.ident().columnIdent().fqn(), is("id"));
+        assertThat(idRef.column().fqn(), is("id"));
         Reference nameRef = node.insertColumns()[1];
-        assertThat(nameRef.ident().columnIdent().fqn(), is("name"));
+        assertThat(nameRef.column().fqn(), is("name"));
 
         assertThat(node.items().size(), is(1));
         LegacyUpsertById.Item item = node.items().get(0);

--- a/sql/src/test/java/io/crate/analyze/GroupByAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/GroupByAnalyzerTest.java
@@ -149,7 +149,7 @@ public class GroupByAnalyzerTest extends CrateDummyClusterServiceUnitTest {
             analyze("select 1/age as age from foo.users group by age order by age");
         assertThat(relation.querySpec().groupBy().isEmpty(), is(false));
         List<Symbol> groupBySymbols = relation.querySpec().groupBy();
-        assertThat(((Reference) groupBySymbols.get(0)).ident().columnIdent().fqn(), is("age"));
+        assertThat(((Reference) groupBySymbols.get(0)).column().fqn(), is("age"));
     }
 
     @Test
@@ -161,7 +161,7 @@ public class GroupByAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         Symbol groupBy = groupBySymbols.get(0);
         assertThat(groupBy, instanceOf(Function.class));
         Function groupByFunction = (Function) groupBy;
-        assertThat(((Reference) groupByFunction.arguments().get(1)).ident().columnIdent().fqn(), is("age"));
+        assertThat(((Reference) groupByFunction.arguments().get(1)).column().fqn(), is("age"));
     }
 
     @Test
@@ -170,7 +170,7 @@ public class GroupByAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         QueriedRelation relation = analyze("select 1/age as height from foo.users group by age");
         assertThat(relation.querySpec().groupBy().isEmpty(), is(false));
         List<Symbol> groupBySymbols = relation.querySpec().groupBy();
-        assertThat(((Reference) groupBySymbols.get(0)).ident().columnIdent().fqn(), is("age"));
+        assertThat(((Reference) groupBySymbols.get(0)).column().fqn(), is("age"));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/analyze/InsertFromValuesAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/InsertFromValuesAnalyzerTest.java
@@ -178,10 +178,10 @@ public class InsertFromValuesAnalyzerTest extends CrateDummyClusterServiceUnitTe
         assertThat(analysis.tableInfo().ident(), is(USER_TABLE_IDENT));
         assertThat(analysis.columns().size(), is(2));
 
-        assertThat(analysis.columns().get(0).ident().columnIdent().name(), is("id"));
+        assertThat(analysis.columns().get(0).column().name(), is("id"));
         assertEquals(DataTypes.LONG, analysis.columns().get(0).valueType());
 
-        assertThat(analysis.columns().get(1).ident().columnIdent().name(), is("name"));
+        assertThat(analysis.columns().get(1).column().name(), is("name"));
         assertEquals(DataTypes.STRING, analysis.columns().get(1).valueType());
 
         assertThat(analysis.sourceMaps().size(), is(1));
@@ -196,10 +196,10 @@ public class InsertFromValuesAnalyzerTest extends CrateDummyClusterServiceUnitTe
         assertThat(analysis.tableInfo().ident(), is(USER_TABLE_IDENT));
         assertThat(analysis.columns().size(), is(2));
 
-        assertThat(analysis.columns().get(0).ident().columnIdent().name(), is("name"));
+        assertThat(analysis.columns().get(0).column().name(), is("name"));
         assertEquals(DataTypes.STRING, analysis.columns().get(0).valueType());
 
-        assertThat(analysis.columns().get(1).ident().columnIdent().name(), is("id"));
+        assertThat(analysis.columns().get(1).column().name(), is("id"));
         assertEquals(DataTypes.LONG, analysis.columns().get(1).valueType());
 
         assertThat(analysis.sourceMaps().size(), is(1));
@@ -260,10 +260,10 @@ public class InsertFromValuesAnalyzerTest extends CrateDummyClusterServiceUnitTe
         assertThat(analysis.tableInfo().ident(), is(USER_TABLE_IDENT));
         assertThat(analysis.columns().size(), is(2));
 
-        assertThat(analysis.columns().get(0).ident().columnIdent().name(), is("id"));
+        assertThat(analysis.columns().get(0).column().name(), is("id"));
         assertEquals(DataTypes.LONG, analysis.columns().get(0).valueType());
 
-        assertThat(analysis.columns().get(1).ident().columnIdent().name(), is("name"));
+        assertThat(analysis.columns().get(1).column().name(), is("name"));
         assertEquals(DataTypes.STRING, analysis.columns().get(1).valueType());
 
         assertThat(analysis.sourceMaps().size(), is(1));
@@ -278,13 +278,13 @@ public class InsertFromValuesAnalyzerTest extends CrateDummyClusterServiceUnitTe
         assertThat(analysis.tableInfo().ident(), is(USER_TABLE_IDENT));
         assertThat(analysis.columns().size(), is(3));
 
-        assertThat(analysis.columns().get(0).ident().columnIdent().name(), is("id"));
+        assertThat(analysis.columns().get(0).column().name(), is("id"));
         assertEquals(DataTypes.LONG, analysis.columns().get(0).valueType());
 
-        assertThat(analysis.columns().get(1).ident().columnIdent().name(), is("other_id"));
+        assertThat(analysis.columns().get(1).column().name(), is("other_id"));
         assertEquals(DataTypes.LONG, analysis.columns().get(1).valueType());
 
-        assertThat(analysis.columns().get(2).ident().columnIdent().name(), is("name"));
+        assertThat(analysis.columns().get(2).column().name(), is("name"));
         assertEquals(DataTypes.STRING, analysis.columns().get(2).valueType());
 
         assertThat(analysis.sourceMaps().size(), is(1));
@@ -300,7 +300,7 @@ public class InsertFromValuesAnalyzerTest extends CrateDummyClusterServiceUnitTe
         assertThat(analysis.tableInfo().ident(), is(USER_TABLE_IDENT));
         assertThat(analysis.columns().size(), is(1));
 
-        assertThat(analysis.columns().get(0).ident().columnIdent().name(), is("id"));
+        assertThat(analysis.columns().get(0).column().name(), is("id"));
         assertEquals(DataTypes.LONG, analysis.columns().get(0).valueType());
 
         assertThat(analysis.sourceMaps().size(), is(1));

--- a/sql/src/test/java/io/crate/analyze/MetaDataToASTNodeResolverTest.java
+++ b/sql/src/test/java/io/crate/analyze/MetaDataToASTNodeResolverTest.java
@@ -119,7 +119,7 @@ public class MetaDataToASTNodeResolverTest extends CrateUnitTest {
     private static ImmutableMap<ColumnIdent, Reference> referencesMap(List<Reference> columns) {
         ImmutableMap.Builder<ColumnIdent, Reference> referencesMap = ImmutableMap.builder();
         for (Reference info : columns) {
-            referencesMap.put(info.ident().columnIdent(), info);
+            referencesMap.put(info.column(), info);
         }
         return referencesMap.build();
     }
@@ -348,7 +348,7 @@ public class MetaDataToASTNodeResolverTest extends CrateUnitTest {
             ImmutableList.of(),
             new ColumnIdent("cluster_column"),
             ImmutableMap.of(),
-            ImmutableList.of(columns.get(1).ident().columnIdent()),
+            ImmutableList.of(columns.get(1).column()),
             ColumnPolicy.DYNAMIC);
 
         CreateTable node = MetaDataToASTNodeResolver.resolveCreateTable(tableInfo);

--- a/sql/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
@@ -208,7 +208,7 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
         Reference ref = update.assignmentByTargetCol().keySet().iterator().next();
         assertThat(ref.ident().tableIdent().name(), is("users"));
-        assertThat(ref.ident().columnIdent().name(), is("name"));
+        assertThat(ref.column().name(), is("name"));
         assertTrue(update.assignmentByTargetCol().containsKey(ref));
 
         Symbol value = update.assignmentByTargetCol().entrySet().iterator().next().getValue();
@@ -223,8 +223,8 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         Reference ref = update.assignmentByTargetCol().keySet().iterator().next();
         assertThat(ref, instanceOf(DynamicReference.class));
         Assert.assertEquals(DataTypes.LONG, ref.valueType());
-        assertThat(ref.ident().columnIdent().isTopLevel(), is(false));
-        assertThat(ref.ident().columnIdent().fqn(), is("details.arms"));
+        assertThat(ref.column().isTopLevel(), is(false));
+        assertThat(ref.column().fqn(), is("details.arms"));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/execution/engine/collect/sources/ColumnsIterableTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/sources/ColumnsIterableTest.java
@@ -45,7 +45,7 @@ public class ColumnsIterableTest {
         ImmutableList<ColumnContext> contexts = ImmutableList.copyOf((Iterable<ColumnContext>) columns);
 
         assertThat(
-            contexts.stream().map(c -> c.info.ident().columnIdent().name()).collect(Collectors.toList()),
+            contexts.stream().map(c -> c.info.column().name()).collect(Collectors.toList()),
             Matchers.contains("a", "x", "i"));
     }
 
@@ -54,10 +54,10 @@ public class ColumnsIterableTest {
         List<String> names = new ArrayList<>(6);
         InformationSchemaIterables.ColumnsIterable columns = new InformationSchemaIterables.ColumnsIterable(T3.T1_INFO);
         for (ColumnContext column : columns) {
-            names.add(column.info.ident().columnIdent().name());
+            names.add(column.info.column().name());
         }
         for (ColumnContext column : columns) {
-            names.add(column.info.ident().columnIdent().name());
+            names.add(column.info.column().name());
         }
         assertThat(names, Matchers.contains("a", "x", "i", "a", "x", "i"));
     }

--- a/sql/src/test/java/io/crate/metadata/doc/DocIndexMetaDataTest.java
+++ b/sql/src/test/java/io/crate/metadata/doc/DocIndexMetaDataTest.java
@@ -301,7 +301,7 @@ public class DocIndexMetaDataTest extends CrateDummyClusterServiceUnitTest {
             @Nullable
             @Override
             public String apply(@Nullable Reference input) {
-                return input.ident().columnIdent().fqn();
+                return input.column().fqn();
             }
         });
         assertThat(fqns, Matchers.is(
@@ -888,9 +888,9 @@ public class DocIndexMetaDataTest extends CrateDummyClusterServiceUnitTest {
         DocIndexMetaData md = newMeta(getIndexMetaData("test_analyzer", builder), "test_analyzer");
         assertThat(md.columns().size(), is(2));
         assertThat(md.columns().get(0).indexType(), is(Reference.IndexType.ANALYZED));
-        assertThat(md.columns().get(0).ident().columnIdent().fqn(), is("content_de"));
+        assertThat(md.columns().get(0).column().fqn(), is("content_de"));
         assertThat(md.columns().get(1).indexType(), is(Reference.IndexType.ANALYZED));
-        assertThat(md.columns().get(1).ident().columnIdent().fqn(), is("content_en"));
+        assertThat(md.columns().get(1).column().fqn(), is("content_en"));
     }
 
     @Test
@@ -1004,7 +1004,7 @@ public class DocIndexMetaDataTest extends CrateDummyClusterServiceUnitTest {
         assertThat(md.indices().get(ColumnIdent.fromPath("fun_name_ft")), instanceOf(IndexReference.class));
         IndexReference indexInfo = md.indices().get(ColumnIdent.fromPath("fun_name_ft"));
         assertThat(indexInfo.indexType(), is(Reference.IndexType.ANALYZED));
-        assertThat(indexInfo.ident().columnIdent().fqn(), is("fun_name_ft"));
+        assertThat(indexInfo.column().fqn(), is("fun_name_ft"));
     }
 
     @Test
@@ -1022,7 +1022,7 @@ public class DocIndexMetaDataTest extends CrateDummyClusterServiceUnitTest {
         assertThat(md.indices().get(ColumnIdent.fromPath("fun_name_ft")), instanceOf(IndexReference.class));
         IndexReference indexInfo = md.indices().get(ColumnIdent.fromPath("fun_name_ft"));
         assertThat(indexInfo.indexType(), is(Reference.IndexType.ANALYZED));
-        assertThat(indexInfo.ident().columnIdent().fqn(), is("fun_name_ft"));
+        assertThat(indexInfo.column().fqn(), is("fun_name_ft"));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/metadata/table/TestingTableInfo.java
+++ b/sql/src/test/java/io/crate/metadata/table/TestingTableInfo.java
@@ -242,7 +242,7 @@ public class TestingTableInfo extends DocTableInfo {
             references.put(ref.column(), ref);
             if (partitionBy) {
                 partitionedByColumns.add(ref);
-                partitionedBy.add(ref.ident().columnIdent());
+                partitionedBy.add(ref.column());
             }
             return this;
         }

--- a/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -369,7 +369,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(aggregationInput.symbolType(), is(SymbolType.INPUT_COLUMN));
 
         assertThat(collectPhase.toCollect().get(0), instanceOf(Reference.class));
-        assertThat(((Reference) collectPhase.toCollect().get(0)).ident().columnIdent().name(), is("name"));
+        assertThat(((Reference) collectPhase.toCollect().get(0)).column().name(), is("name"));
 
         MergePhase mergePhase = globalAggregate.mergePhase();
         assertThat(mergePhase.projections().size(), is(2));

--- a/sql/src/test/java/io/crate/planner/UpdatePlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/UpdatePlannerTest.java
@@ -77,7 +77,7 @@ public class UpdatePlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(collectPhase.projections().get(0), instanceOf(UpdateProjection.class));
         assertThat(collectPhase.toCollect().size(), is(1));
         assertThat(collectPhase.toCollect().get(0), instanceOf(Reference.class));
-        assertThat(((Reference) collectPhase.toCollect().get(0)).ident().columnIdent().fqn(), is("_id"));
+        assertThat(((Reference) collectPhase.toCollect().get(0)).column().fqn(), is("_id"));
 
         UpdateProjection updateProjection = (UpdateProjection) collectPhase.projections().get(0);
         assertThat(updateProjection.uidSymbol(), instanceOf(InputColumn.class));

--- a/sql/src/test/java/io/crate/planner/consumer/GroupByPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/consumer/GroupByPlannerTest.java
@@ -327,8 +327,8 @@ public class GroupByPlannerTest extends CrateDummyClusterServiceUnitTest {
         // collect
         assertThat(collectPhase.toCollect().get(0), instanceOf(Reference.class));
         assertThat(collectPhase.toCollect().size(), is(2));
-        assertThat(((Reference) collectPhase.toCollect().get(0)).ident().columnIdent().name(), is("id"));
-        assertThat(((Reference) collectPhase.toCollect().get(1)).ident().columnIdent().name(), is("name"));
+        assertThat(((Reference) collectPhase.toCollect().get(0)).column().name(), is("id"));
+        assertThat(((Reference) collectPhase.toCollect().get(1)).column().name(), is("name"));
         Projection projection = collectPhase.projections().get(0);
         assertThat(projection, instanceOf(GroupProjection.class));
         GroupProjection groupProjection = (GroupProjection) projection;

--- a/sql/src/test/java/io/crate/testing/SymbolMatchers.java
+++ b/sql/src/test/java/io/crate/testing/SymbolMatchers.java
@@ -143,7 +143,7 @@ public class SymbolMatchers {
         FeatureMatcher<Symbol, String> fm = new FeatureMatcher<Symbol, String>(equalTo(expectedName), "name", "name") {
             @Override
             protected String featureValueOf(Symbol actual) {
-                return ((Reference) actual).ident().columnIdent().outputName();
+                return ((Reference) actual).column().outputName();
             }
         };
         if (dataType == null) {


### PR DESCRIPTION
- It's shorter + law of demeter
 - We might be able to eventually remove the tableIdent/referenceIdent
 altogether