### PR TITLE
Added upgrade guide for CrateDB 3.0.0

### DIFF
--- a/blackbox/docs/appendices/release-notes/3.0.0.rst
+++ b/blackbox/docs/appendices/release-notes/3.0.0.rst
@@ -11,8 +11,24 @@ Released on 2018/05/16.
    If you are upgrading a cluster, you must be running CrateDB 2.0.4 or higher
    before you upgrade to 3.0.0.
 
+   We recommend that you upgrade to the latest 2.3 release before moving to
+   3.0.0.
+
    You cannot perform a `rolling upgrade`_ to this version. Any upgrade to this
    version will require a `full restart upgrade`_.
+
+   When restarting, CrateDB will migrate indexes to a newer format. Depending
+   on the amount of data, this may delay node start-up time.
+
+   Please consult the `Upgrade Notes`_ before upgrading.
+
+.. WARNING::
+
+    Tables that were created prior to upgrading to CrateDB 2.x will not
+    function with 3.0 and must be recreated before moving to 3.0.x.
+
+    You can recreate tables using ``COPY TO`` and ``COPY FROM`` while running a
+    2.x release into a new table, or by `inserting the data into a new table`_.
 
 .. WARNING::
 
@@ -214,20 +230,71 @@ Changes
 Upgrade Notes
 =============
 
-Tables Created < 2.0.0
-----------------------
+Configuration Changes
+---------------------
 
-Support for tables created prior to 2.0.0 has been dropped, and these tables
-must be upgraded before upgrading to 3.0.0. This can be done by exporting the
-data using ``COPY TO`` and importing it using ``COPY FROM`` while running
-a version of CrateDB > 2.0.4.
+There are a few configuration changes that you should be aware of before
+restarting the nodes.
 
-EC2 Settings
-------------
+Removed Settings
+................
 
-Several settings to do with the Amazon EC2 service have been removed or renamed.
-All EC2 settings that were previously under ``cloud.aws.*`` have now been renamed
-to ``discovery.ec2.*`` (eg. ``cloud.aws.access_key`` is now
-``discovery.ec2.access_key``). Alongside this, the ``discovery.type`` setting
-has been removed, and in order to enable EC2 discovery, you should will need to
-set ``discovery.zen.hosts_provider`` to ``ec2``.
+- All store level throttle settings (under ``indices.store.throttle.*``) have
+  been removed, and should be removed from your node configuration.
+
+- Similarly, the ``recovery.initial_shards`` configuration option has been
+  removed, and should also be removed from your configuration.
+
+Renamed Settings
+................
+
+- The ``discovery.type`` setting which was previously used to specify whether a
+  cluster should use DNS discovery or the EC2 API, has been removed. Configuring
+  the use of the EC2 API has now been moved to the
+  ``discovery.zen.hosts_provider`` setting.
+
+- The ``bootstrap.seccomp`` setting, which controls system call filters, has
+  been renamed to ``bootstrap.system_call_filter``.
+
+Altered Settings
+................
+
+- The ``path.data`` setting specifies the path or paths where the
+  CrateDB node should store its table data and cluster metadata.
+
+  In CrateDB 3.0.0 and later, this path must *not* contain the cluster name
+  as a directory, as in ``/storage/<CLUSTER_NAME>/data/``.
+
+  Data paths that are incompatible with 3.0.0 will be indicated visually in the
+  `admin UI`_ if you are running the latest 2.2.x or 2.3.x release.
+
+Other Changes
+-------------
+
+- The ``CREATE REPOSITORY`` statement for creating backup repositories has been
+  changed.
+
+  Previously, when using Amazon S3 for backup storage, bucket regions had to be
+  configured explicitly. Bucket regions are now inferred automatically.
+
+  If you want to override this, you can use the :ref:`endpoint parameter
+  <ref-create-repository-types-s3>`.
+
+- Previously, the ``X-User`` HTTP header could be used to provide a username.
+  This head is now deprecated in favour of the standard `HTTP Authorization
+  header`_.
+
+- The ``_node`` column in  the ``sys.shards`` and ``sys.operations`` tables has
+  been renamed to ``node``.
+
+  Additionally, ``node`` object now only includes ``id`` and ``name`` of the
+  node, i.e. ``node['id']`` and ``node['name']``.
+
+  To get the full node information, use ``node['id']`` to join the
+  ``sys.nodes`` table.
+
+.. _admin UI: https://crate.io/docs/clients/admin-ui/en/latest/
+.. _backup: https://crate.io/a/backing-up-and-restoring-cratedb/
+.. _full cluster restart: https://crate.io/docs/crate/guide/en/latest/admin/full-restart-upgrade.html
+.. _HTTP Authorization header: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization
+.. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated


### PR DESCRIPTION
As part of this PR, I've also removed the upgrade notes from 3.0.0 since it was duplicated information, and this makes the 3.0.0 release notes specifically about the release itself, and not the upgrade process.

What do you think? I'm unsure how much detail to add to the upgrade guide - how to upgrade specific distributions, specific stuff for docker, etc?