### PR TITLE
Avoid wrapping RuntimeExceptions in a RuntimeException

### DIFF
--- a/sql/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
+++ b/sql/src/main/java/io/crate/execution/dml/upsert/TransportShardUpsertAction.java
@@ -169,6 +169,9 @@ public class TransportShardUpsertAction extends TransportShardAction<ShardUpsert
                 }
             } catch (Exception e) {
                 if (retryPrimaryException(e)) {
+                    if (e instanceof RuntimeException) {
+                        throw (RuntimeException) e;
+                    }
                     throw new RuntimeException(e);
                 }
                 logger.debug("{} failed to execute upsert for [{}]/[{}]",


### PR DESCRIPTION
It can break `instanceof` checks against more concrete exception types.
This might have caused flakyness of `testDeletePartitionWhileInsertingData`