### PR TITLE
Remove clone from Function

### DIFF
--- a/sql/src/main/java/io/crate/expression/symbol/Function.java
+++ b/sql/src/main/java/io/crate/expression/symbol/Function.java
@@ -147,9 +147,4 @@ public class Function extends Symbol implements Cloneable {
         result = 31 * result + info.hashCode();
         return result;
     }
-
-    @Override
-    public Function clone() {
-        return new Function(this.info, this.arguments);
-    }
 }

--- a/sql/src/test/java/io/crate/expression/symbol/FunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/symbol/FunctionTest.java
@@ -63,26 +63,6 @@ public class FunctionTest extends CrateUnitTest {
         assertThat(fn.hashCode(), is(fn2.hashCode()));
     }
 
-    @Test
-    public void testCloning() throws Exception {
-
-        Function fn = new Function(
-            new FunctionInfo(
-                new FunctionIdent(
-                    randomAsciiLettersOfLength(10),
-                    ImmutableList.of(DataTypes.BOOLEAN)
-                ),
-                TestingHelpers.randomPrimitiveType(), FunctionInfo.Type.SCALAR, randomFeatures()),
-            Collections.singletonList(TestingHelpers.createReference(randomAsciiLettersOfLength(2), DataTypes.BOOLEAN))
-        );
-
-        Function fn2 = fn.clone();
-
-        assertThat(fn, is(equalTo(fn2)));
-        assertThat(fn.hashCode(), is(fn2.hashCode()));
-
-    }
-
     private Set<FunctionInfo.Feature> randomFeatures() {
         Set<FunctionInfo.Feature> features = EnumSet.noneOf(FunctionInfo.Feature.class);
         for (FunctionInfo.Feature feature : FunctionInfo.Feature.values()) {


### PR DESCRIPTION
A Function is immutable so there should be no reason to clone it.