### PR TITLE
QueryStringSplitter: Fix single quote escaping inside single quotes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -29,3 +29,7 @@ Fixes
 
 - Fixed support for views with aliased literals in select list / groupBy /
   orderBy.
+
+- Fixed a bug affecting the Postgres Wire Protocol's Simple Query mode and
+  queries which contained strings with escaped single quotes and semicolons,
+  e.g. `'Hello ''Joe'';'`.

--- a/sql/src/main/java/io/crate/protocols/postgres/QueryStringSplitter.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/QueryStringSplitter.java
@@ -54,6 +54,7 @@ class QueryStringSplitter {
 
         CommentType commentType = NO;
         QuoteType quoteType = NONE;
+        boolean restoreSingleQuoteIfEscaped = false;
 
         char[] chars = query.toCharArray();
 
@@ -65,9 +66,14 @@ class QueryStringSplitter {
                 case '\'':
                     if (commentType == NO && quoteType != DOUBLE) {
                         if (lastChar == '\'') {
-                            // quoting of ' via ''
-                            quoteType = NONE;
+                            // Escaping of ' via '', e.g.: 'hello ''Joe''!'
+                            // When we set single quotes state to NONE,
+                            // but we find out this was due to an escaped single quote (''),
+                            // we restore the previous single quote state here.
+                            quoteType = restoreSingleQuoteIfEscaped ? SINGLE : NONE;
+                            restoreSingleQuoteIfEscaped = false;
                         } else {
+                            restoreSingleQuoteIfEscaped = quoteType == SINGLE;
                             quoteType = quoteType == SINGLE ? NONE : SINGLE;
                         }
                     }

--- a/sql/src/test/java/io/crate/protocols/postgres/QueryStringSplitterTest.java
+++ b/sql/src/test/java/io/crate/protocols/postgres/QueryStringSplitterTest.java
@@ -59,6 +59,10 @@ public class QueryStringSplitterTest {
             contains("select 'Hello comment -- test;';", "select 2"));
         assertThat(QueryStringSplitter.splitQuery("select 'Hello comment /* bla */;';select 2"),
             contains("select 'Hello comment /* bla */;';", "select 2"));
+        assertThat(QueryStringSplitter.splitQuery("insert into doc.test (col) values ('aaa'';')"),
+            contains("insert into doc.test (col) values ('aaa'';')"));
+        assertThat(QueryStringSplitter.splitQuery("insert into doc.test (col) values ('aaa' '';')"),
+            contains("insert into doc.test (col) values ('aaa' '';", "')"));
     }
 
     @Test


### PR DESCRIPTION
There was an issue with detecting quoted single quotes inside single
quotes. This would split `'text'';'` into `'text'';` and `'` where it shouldn't
have been split at all because the single quotes are escaped.