### PR TITLE
Make gradle quiet by default

### DIFF
--- a/gradle/javaModule.gradle
+++ b/gradle/javaModule.gradle
@@ -12,11 +12,20 @@ repositories {
 }
 
 compileJava {
-    options.warnings = true
-    options.deprecation = true
+    options.warnings = false
+    options.deprecation = false
+    options.compilerArgs << '-XDignore.symbol.file'
+    options.fork = true
+    options.forkOptions.executable = 'javac'
 
     finalizedBy checkstyleMain
 }
+
+
+javadoc {
+    options.addStringOption('XDignore.symbol.file', '')
+}
+
 
 sourceCompatibility = "8"
 targetCompatibility = "8"

--- a/http/src/test/java/io/crate/plugin/PipelineRegistryTest.java
+++ b/http/src/test/java/io/crate/plugin/PipelineRegistryTest.java
@@ -22,9 +22,8 @@
 
 package io.crate.plugin;
 
-import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
-import org.elasticsearch.common.settings.Settings;
+import io.netty.channel.SimpleChannelInboundHandler;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
@@ -33,19 +32,9 @@ import static org.junit.Assert.assertThat;
 public class PipelineRegistryTest {
 
     private static PipelineRegistry.ChannelPipelineItem channelPipelineItem(String base, String name) {
-        return new PipelineRegistry.ChannelPipelineItem(base, name, () -> new ChannelHandler() {
+        return new PipelineRegistry.ChannelPipelineItem(base, name, () -> new SimpleChannelInboundHandler() {
             @Override
-            public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
-
-            }
-
-            @Override
-            public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
-
-            }
-
-            @Override
-            public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+            protected void channelRead0(ChannelHandlerContext ctx, Object msg) throws Exception {
 
             }
         });

--- a/sql/build.gradle
+++ b/sql/build.gradle
@@ -73,12 +73,3 @@ sourceSets {
         }
     }
 }
-
-// suppress Sun API warnings
-compileJava {
-    options.compilerArgs << '-XDignore.symbol.file'
-    options.fork = true
-}
-javadoc {
-    options.addStringOption('XDignore.symbol.file', '')
-}


### PR DESCRIPTION
Seeing compile errors in the default output is incredibly hard because of
the deprecation warnings. Nobody is paying attention to the output, so
this:

 - Mutes the sun API warnings regarding SignalHandler
 - Removes the deprecation warnings. Use `-Plint-deprecation` to get them or
   view them in the IDE