### PR TITLE
QueryStringSplitter: Remove trailing whitespace

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -33,3 +33,6 @@ Fixes
 - Fixed a bug affecting the Postgres Wire Protocol's Simple Query mode and
   queries which contained strings with escaped single quotes and semicolons,
   e.g. `'Hello ''Joe'';'`.
+
+- Fixed an issue in the Postgres Wire Protocol's Simple Query mode which would
+  send an empty statement if the query string contained trailing whitespace.

--- a/sql/src/main/java/io/crate/protocols/postgres/QueryStringSplitter.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/QueryStringSplitter.java
@@ -58,10 +58,14 @@ class QueryStringSplitter {
 
         char[] chars = query.toCharArray();
 
+        boolean isCurrentlyEmpty = true;
         int offset = 0;
         char lastChar = ' ';
         for (int i = 0; i < chars.length; i++) {
             char aChar = chars[i];
+            if (isCurrentlyEmpty && !Character.isWhitespace(aChar)) {
+                isCurrentlyEmpty = false;
+            }
             switch (aChar) {
                 case '\'':
                     if (commentType == NO && quoteType != DOUBLE) {
@@ -109,6 +113,7 @@ class QueryStringSplitter {
                     if (commentType == NO && quoteType == NONE) {
                         queries.add(new String(chars, offset, i - offset + 1));
                         offset = i + 1;
+                        isCurrentlyEmpty = true;
                     }
                     break;
 
@@ -117,8 +122,11 @@ class QueryStringSplitter {
             lastChar = aChar;
         }
         // statement might not be terminated by semicolon
-        if (offset < chars.length && commentType == NO) {
+        if (!isCurrentlyEmpty && offset < chars.length && commentType == NO) {
             queries.add(new String(chars, offset, chars.length - offset));
+        }
+        if (queries.isEmpty()) {
+            queries.add("");
         }
 
         return queries;

--- a/sql/src/test/java/io/crate/protocols/postgres/QueryStringSplitterTest.java
+++ b/sql/src/test/java/io/crate/protocols/postgres/QueryStringSplitterTest.java
@@ -31,8 +31,13 @@ public class QueryStringSplitterTest {
 
     @Test
     public void testEmptyQuery() {
+        assertThat(QueryStringSplitter.splitQuery("  "), contains(""));
+        assertThat(QueryStringSplitter.splitQuery("      "), contains(""));
         assertThat(QueryStringSplitter.splitQuery(";"), contains(";"));
         assertThat(QueryStringSplitter.splitQuery(";; ;"), contains(";", ";", " ;"));
+        assertThat(QueryStringSplitter.splitQuery(";  "), contains(";"));
+        assertThat(QueryStringSplitter.splitQuery(";;  "), contains(";", ";"));
+        assertThat(QueryStringSplitter.splitQuery("; ;   ;"), contains(";", " ;", "   ;"));
     }
 
     @Test


### PR DESCRIPTION
This only splits the query string if the resulting queries are not empty. It
also adds an empty statement in case the query string doesn't contain any
splittable query.