### PR TITLE
Fix bug which led to infinite retries of an indexing attempt

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -20,3 +20,6 @@ Changes
 
 Fixes
 =====
+
+- Fixed a bug which could produce invalid row version numbers under high load
+  scenarios. These version numbers would prevent updating the affected rows.


### PR DESCRIPTION
After indexing succeeds for an item, its VersionType is set to EXTERNAL because
the request will go to the replica where EXTERNAL is the appropriate version
type. However, due to multiple items being transmitted there may be failures
after one or more items are processed.

```java
// update the version on request for the replicas
item.versionType(item.versionType().versionTypeForReplicationAndRecovery());
item.version(indexResult.getVersion());
```

When failures occur, they are propagated down to the TransportReplicationAction
and the action will decide whether to retry the request.

```java
if (cause instanceof ConnectTransportException || cause instanceof NodeClosedException ||
                           (isPrimaryAction && retryPrimaryException(cause))) {
   // retry
```

That means the same request will be retried. However, items have already been
changed. In particular, the VersionType has been set to EXTERNAL for some of the
items. That causes the primary to save Version.MATCH_DELETED (-4) as the
version when inserting a new document. Usually, this version would lead to
generating a valid version number, e.g. 1, but external type versions will be
accepted no matter what.

Now, when a new update is performed afterwards, it will be attempted with
INTERNAL version type, but there is already a document now with version
VERSION.MATCH_DELETED (-4), which causes a VersionConflictException every time
an attempt to update this document is attempted.

```java
private boolean isVersionConflict(long currentVersion, long expectedVersion, boolean deleted) {
       ...
       if (expectedVersion == Versions.MATCH_DELETED) {
           return deleted == false;
       }
       ...
   }
```

Edit: Bug does not exist in master.