### PR TITLE
Make user on JobContext non-nullable

### DIFF
--- a/enterprise/jmx-monitoring/src/test/java/io/crate/beans/QueryStatsTest.java
+++ b/enterprise/jmx-monitoring/src/test/java/io/crate/beans/QueryStatsTest.java
@@ -19,6 +19,7 @@
 package io.crate.beans;
 
 import com.google.common.collect.ImmutableList;
+import io.crate.auth.user.User;
 import io.crate.execution.engine.collect.stats.JobsLogs;
 import io.crate.expression.reference.sys.job.JobContext;
 import io.crate.expression.reference.sys.job.JobContextLog;
@@ -34,13 +35,13 @@ import static org.junit.Assert.assertThat;
 public class QueryStatsTest {
 
     private final List<JobContextLog> log = ImmutableList.of(
-        new JobContextLog(new JobContext(UUID.randomUUID(), "select name", 100L, null), null, 150L),
-        new JobContextLog(new JobContext(UUID.randomUUID(), "select name", 300L, null), null, 320L),
-        new JobContextLog(new JobContext(UUID.randomUUID(), "update t1 set x = 10", 400L, null), null, 420L),
-        new JobContextLog(new JobContext(UUID.randomUUID(), "insert into t1 (x) values (20)", 111L, null), null, 130L),
-        new JobContextLog(new JobContext(UUID.randomUUID(), "delete from t1", 410L, null), null, 415L),
-        new JobContextLog(new JobContext(UUID.randomUUID(), "delete from t1", 110L, null), null, 120L),
-        new JobContextLog(new JobContext(UUID.randomUUID(), "create table t1 (x int)", 105L, null), null, 106L)
+        new JobContextLog(new JobContext(UUID.randomUUID(), "select name", 100L, User.CRATE_USER), null, 150L),
+        new JobContextLog(new JobContext(UUID.randomUUID(), "select name", 300L, User.CRATE_USER), null, 320L),
+        new JobContextLog(new JobContext(UUID.randomUUID(), "update t1 set x = 10", 400L, User.CRATE_USER), null, 420L),
+        new JobContextLog(new JobContext(UUID.randomUUID(), "insert into t1 (x) values (20)", 111L, User.CRATE_USER), null, 130L),
+        new JobContextLog(new JobContext(UUID.randomUUID(), "delete from t1", 410L, User.CRATE_USER), null, 415L),
+        new JobContextLog(new JobContext(UUID.randomUUID(), "delete from t1", 110L, User.CRATE_USER), null, 120L),
+        new JobContextLog(new JobContext(UUID.randomUUID(), "create table t1 (x int)", 105L, User.CRATE_USER), null, 106L)
     );
 
     @Test

--- a/sql/src/main/java/io/crate/execution/engine/collect/stats/JobsLogs.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/stats/JobsLogs.java
@@ -92,7 +92,7 @@ public class JobsLogs {
      * <p>
      * If {@link #isEnabled()} is false this method won't do anything.
      */
-    public void logExecutionStart(UUID jobId, String statement, @Nullable User user) {
+    public void logExecutionStart(UUID jobId, String statement, User user) {
         activeRequests.increment();
         if (!isEnabled()) {
             return;

--- a/sql/src/main/java/io/crate/expression/reference/sys/job/JobContext.java
+++ b/sql/src/main/java/io/crate/expression/reference/sys/job/JobContext.java
@@ -23,27 +23,20 @@ package io.crate.expression.reference.sys.job;
 
 import io.crate.auth.user.User;
 
-import javax.annotation.Nullable;
 import java.util.UUID;
 
 public class JobContext {
 
     public final UUID id;
-    @Nullable
     public final String username;
     public final String stmt;
     public final long started;
 
-    public JobContext(UUID id, String stmt, long started, @Nullable User user) {
+    public JobContext(UUID id, String stmt, long started, User user) {
         this.id = id;
         this.stmt = stmt;
         this.started = started;
-
-        if (user != null) {
-            this.username = user.name();
-        } else {
-            this.username = null;
-        }
+        this.username = user.name();
     }
 
     public UUID id() {
@@ -54,7 +47,6 @@ public class JobContext {
         return stmt;
     }
 
-    @Nullable
     public String username() {
         return username;
     }

--- a/sql/src/test/java/io/crate/execution/engine/collect/stats/JobsLogsTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/stats/JobsLogsTest.java
@@ -202,7 +202,7 @@ public class JobsLogsTest extends CrateDummyClusterServiceUnitTest {
         JobsLogService stats = new JobsLogService(settings, clusterSettings, scheduler, breakerService);
 
         stats.jobsLogSink.add(new JobContextLog(
-            new JobContext(UUID.randomUUID(), "select 1", 1L, null), null));
+            new JobContext(UUID.randomUUID(), "select 1", 1L, User.CRATE_USER), null));
 
         clusterSettings.applySettings(Settings.builder()
             .put(JobsLogService.STATS_ENABLED_SETTING.getKey(), true)

--- a/sql/src/test/java/io/crate/execution/engine/collect/stats/RamAccountingQueueSinkTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/stats/RamAccountingQueueSinkTest.java
@@ -22,6 +22,7 @@
 
 package io.crate.execution.engine.collect.stats;
 
+import io.crate.auth.user.User;
 import io.crate.breaker.SizeEstimator;
 import io.crate.core.collections.BlockingEvictingQueue;
 import io.crate.expression.reference.sys.job.ContextLog;
@@ -125,13 +126,13 @@ public class RamAccountingQueueSinkTest extends CrateUnitTest {
         ConcurrentLinkedQueue<JobContextLog> q = new ConcurrentLinkedQueue<>();
         ScheduledFuture<?> task = new TimeExpiring(1_000_000L, 1_000_000L).registerTruncateTask(q, scheduler, TimeValue.timeValueSeconds(1L));
         q.add(new JobContextLog(new JobContext(UUID.fromString("067e6162-3b6f-4ae2-a171-2470b63dff01"),
-            "select 1", 1L, null), null, 2000L));
+            "select 1", 1L, User.CRATE_USER), null, 2000L));
         q.add(new JobContextLog(new JobContext(UUID.fromString("067e6162-3b6f-4ae2-a171-2470b63dff02"),
-            "select 1", 1L, null), null, 4000L));
+            "select 1", 1L, User.CRATE_USER), null, 4000L));
         q.add(new JobContextLog(new JobContext(UUID.fromString("067e6162-3b6f-4ae2-a171-2470b63dff03"),
-            "select 1", 1L, null), null, 7000L));
+            "select 1", 1L, User.CRATE_USER), null, 7000L));
 
-        TimeExpiring.instance().removeExpiredLogs(q, 10_000L, 5_000L);
+        TimeExpiring.removeExpiredLogs(q, 10_000L, 5_000L);
         assertThat(q.size(), is(1));
         assertThat(q.iterator().next().id(), is(UUID.fromString("067e6162-3b6f-4ae2-a171-2470b63dff03")));
 


### PR DESCRIPTION
We've made the `User` in the `SessionContext` non-nullable a while ago,
so the user in the `JobContext` can never be null.