### PR TITLE
Make factory method naming for SessionContext and TransactionContext clearer

### DIFF
--- a/benchmarks/src/test/java/io/crate/analyze/PreExecutionBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/analyze/PreExecutionBenchmark.java
@@ -79,7 +79,7 @@ public class PreExecutionBenchmark {
             .build();
         selectStatement = SqlParser.createStatement("select name from users");
         selectAnalysis =
-            e.analyzer.boundAnalyze(selectStatement, new TransactionContext(SessionContext.create()), ParameterContext.EMPTY);
+            e.analyzer.boundAnalyze(selectStatement, new TransactionContext(SessionContext.systemSessionContext()), ParameterContext.EMPTY);
         plannerContext = e.getPlannerContext(clusterService.state(), new Random(dummySeed));
     }
 
@@ -106,7 +106,7 @@ public class PreExecutionBenchmark {
 
     @Benchmark
     public Analysis measureAnalyzeSimpleSelect() {
-        return e.analyzer.boundAnalyze(selectStatement, new TransactionContext(SessionContext.create()), ParameterContext.EMPTY);
+        return e.analyzer.boundAnalyze(selectStatement, new TransactionContext(SessionContext.systemSessionContext()), ParameterContext.EMPTY);
     }
 
     @Benchmark

--- a/enterprise/mqtt/src/main/java/io/crate/mqtt/operations/MqttIngestService.java
+++ b/enterprise/mqtt/src/main/java/io/crate/mqtt/operations/MqttIngestService.java
@@ -21,18 +21,22 @@ package io.crate.mqtt.operations;
 import com.google.common.collect.ImmutableMap;
 import io.crate.action.sql.BaseResultReceiver;
 import io.crate.action.sql.Option;
-import io.crate.action.sql.Session;
 import io.crate.action.sql.SQLActionException;
 import io.crate.action.sql.SQLOperations;
+import io.crate.action.sql.Session;
 import io.crate.analyze.expressions.ExpressionAnalysisContext;
 import io.crate.analyze.expressions.ExpressionAnalyzer;
 import io.crate.analyze.relations.FieldProvider;
-import io.crate.expression.symbol.InputColumn;
-import io.crate.expression.symbol.Symbol;
+import io.crate.auth.user.User;
+import io.crate.auth.user.UserLookup;
 import io.crate.data.Row;
 import io.crate.data.RowN;
 import io.crate.exceptions.Exceptions;
 import io.crate.exceptions.SQLExceptions;
+import io.crate.expression.InputFactory;
+import io.crate.expression.RowFilter;
+import io.crate.expression.symbol.InputColumn;
+import io.crate.expression.symbol.Symbol;
 import io.crate.ingestion.IngestRuleListener;
 import io.crate.ingestion.IngestionService;
 import io.crate.metadata.Functions;
@@ -41,10 +45,6 @@ import io.crate.metadata.Schemas;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.rule.ingest.IngestRule;
 import io.crate.metadata.table.Operation;
-import io.crate.expression.InputFactory;
-import io.crate.expression.RowFilter;
-import io.crate.auth.user.User;
-import io.crate.auth.user.UserLookup;
 import io.crate.sql.parser.SqlParser;
 import io.crate.sql.tree.QualifiedName;
 import io.crate.types.DataType;
@@ -115,7 +115,7 @@ public class MqttIngestService implements IngestRuleListener {
         };
         this.expressionAnalyzer = new ExpressionAnalyzer(
             functions,
-            new TransactionContext(),
+            TransactionContext.systemTransactionContext(),
             null,
             mqttSourceFieldsProvider,
             null);

--- a/enterprise/mqtt/src/test/java/io/crate/analyze/MqttAnalyzerTest.java
+++ b/enterprise/mqtt/src/test/java/io/crate/analyze/MqttAnalyzerTest.java
@@ -46,7 +46,7 @@ public class MqttAnalyzerTest {
                 "source",
                 QualifiedName.of("table"),
                 Optional.empty());
-        SessionContext sessionContext = SessionContext.create();
+        SessionContext sessionContext = SessionContext.systemSessionContext();
         sessionContext.setDefaultSchema("custom");
         ParameterContext parameterContext = Mockito.mock(ParameterContext.class);
         ParamTypeHints paramTypeHints = Mockito.mock(ParamTypeHints.class);

--- a/sql/src/main/java/io/crate/action/sql/SessionContext.java
+++ b/sql/src/main/java/io/crate/action/sql/SessionContext.java
@@ -46,6 +46,13 @@ public class SessionContext implements StatementAuthorizedValidator, ExceptionAu
     private boolean semiJoinsRewriteEnabled;
     private boolean hashJoinEnabled = true;
 
+    /**
+     * Creates a new SessionContext suitable to use as system SessionContext
+     */
+    public static SessionContext systemSessionContext() {
+        return new SessionContext(null, User.CRATE_USER, s -> { }, e -> { });
+    }
+
     public SessionContext(@Nullable String defaultSchema,
                           User user,
                           StatementAuthorizedValidator statementAuthorizedValidator,
@@ -122,20 +129,5 @@ public class SessionContext implements StatementAuthorizedValidator, ExceptionAu
     @Override
     public void ensureStatementAuthorized(AnalyzedStatement statement) {
         statementAuthorizedValidator.ensureStatementAuthorized(statement);
-    }
-
-    /**
-     * Creates a new SessionContext with default settings.
-     */
-    public static SessionContext create() {
-        return create(User.CRATE_USER);
-    }
-
-    /**
-     * Creates a new SessionContext with a specific user.
-     * Note: User can only set at the beginning of session.
-     */
-    public static SessionContext create(User user) {
-        return new SessionContext(null, user, s -> { }, t -> { });
     }
 }

--- a/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
+++ b/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
@@ -532,7 +532,7 @@ public class ProjectionToProjectorVisitor
 
         private final RamAccountingContext ramAccountingContext;
         private final UUID jobId;
-        private final TransactionContext transactionContext = new TransactionContext(SessionContext.create());
+        private final TransactionContext transactionContext = new TransactionContext(SessionContext.systemSessionContext());
 
         public Context(RamAccountingContext ramAccountingContext, UUID jobId) {
             this.ramAccountingContext = ramAccountingContext;

--- a/sql/src/main/java/io/crate/metadata/TransactionContext.java
+++ b/sql/src/main/java/io/crate/metadata/TransactionContext.java
@@ -38,8 +38,8 @@ public class TransactionContext {
     private final SessionContext sessionContext;
     private Long currentTimeMillis = null;
 
-    public TransactionContext() {
-        this(SessionContext.create());
+    public static TransactionContext systemTransactionContext() {
+        return new TransactionContext(SessionContext.systemSessionContext());
     }
 
     public TransactionContext(SessionContext sessionContext) {

--- a/sql/src/main/java/io/crate/metadata/doc/DocIndexMetaData.java
+++ b/sql/src/main/java/io/crate/metadata/doc/DocIndexMetaData.java
@@ -548,7 +548,7 @@ public class DocIndexMetaData {
         Collection<Reference> references = this.references.values();
         TableReferenceResolver tableReferenceResolver = new TableReferenceResolver(references, ident);
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
-            functions, new TransactionContext(), ParamTypeHints.EMPTY, tableReferenceResolver, null);
+            functions, TransactionContext.systemTransactionContext(), ParamTypeHints.EMPTY, tableReferenceResolver, null);
         ExpressionAnalysisContext context = new ExpressionAnalysisContext();
         for (Reference reference : generatedColumnReferences) {
             GeneratedReference generatedReference = (GeneratedReference) reference;

--- a/sql/src/main/java/io/crate/metadata/view/InternalViewInfoFactory.java
+++ b/sql/src/main/java/io/crate/metadata/view/InternalViewInfoFactory.java
@@ -64,10 +64,11 @@ public class InternalViewInfoFactory implements ViewInfoFactory {
         List<Reference> columns;
         try {
             AnalyzedRelation relation = analyzerProvider.get()
-                .analyze(parsedStmt, new TransactionContext(), ParameterContext.EMPTY);
+                .analyze(parsedStmt, TransactionContext.systemTransactionContext(), ParameterContext.EMPTY);
             final List<Reference> collectedColumns = new ArrayList<>(relation.fields().size());
             relation.fields()
-                .forEach(field -> collectedColumns.add(new Reference(new ReferenceIdent(ident, field.outputName()), RowGranularity.DOC, field.valueType())));
+                .forEach(field -> collectedColumns.add(
+                    new Reference(new ReferenceIdent(ident, field.outputName()), RowGranularity.DOC, field.valueType())));
             columns = collectedColumns;
         } catch (ResourceUnknownException e) {
             // Return ViewInfo with no columns in case the statement could not be analyzed,

--- a/sql/src/test/java/io/crate/action/sql/SessionTest.java
+++ b/sql/src/test/java/io/crate/action/sql/SessionTest.java
@@ -113,7 +113,7 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
             new JobsLogs(() -> false),
             false,
             executor,
-            SessionContext.create());
+            SessionContext.systemSessionContext());
 
         session.parse("S_1", "Select 1 + ? + ?;", Collections.emptyList());
         assertThat(session.getParamType("S_1", 0), is(DataTypes.UNDEFINED));
@@ -135,7 +135,7 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
         SQLExecutor e = SQLExecutor.builder(clusterService).addDocTable(TableDefinitions.USER_TABLE_INFO).build();
         AnalyzedStatement analyzedStatement = e.analyzer.unboundAnalyze(
             SqlParser.createStatement("delete from users where name = ?"),
-            SessionContext.create(),
+            SessionContext.systemSessionContext(),
             ParamTypeHints.EMPTY
         );
         Session.ParameterTypeExtractor typeExtractor = new Session.ParameterTypeExtractor();
@@ -149,7 +149,7 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
         SQLExecutor e = SQLExecutor.builder(clusterService).addDocTable(TableDefinitions.USER_TABLE_INFO).build();
         AnalyzedStatement analyzedStatement = e.analyzer.unboundAnalyze(
             SqlParser.createStatement("update users set name = ? || '_updated' where id = ?"),
-            SessionContext.create(),
+            SessionContext.systemSessionContext(),
             ParamTypeHints.EMPTY
         );
         Session.ParameterTypeExtractor typeExtractor = new Session.ParameterTypeExtractor();
@@ -163,7 +163,7 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
         SQLExecutor e = SQLExecutor.builder(clusterService).addDocTable(TableDefinitions.USER_TABLE_INFO).build();
         AnalyzedStatement analyzedStatement = e.analyzer.unboundAnalyze(
             SqlParser.createStatement("INSERT INTO users (id, name) values (?, ?)"),
-            SessionContext.create(),
+            SessionContext.systemSessionContext(),
             ParamTypeHints.EMPTY
         );
         Session.ParameterTypeExtractor typeExtractor = new Session.ParameterTypeExtractor();
@@ -181,7 +181,7 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
         AnalyzedStatement analyzedStatement = e.analyzer.unboundAnalyze(
             SqlParser.createStatement("INSERT INTO users (id, name) (SELECT id, name FROM users_clustered_by_only " +
                                       "WHERE name = ?)"),
-            SessionContext.create(),
+            SessionContext.systemSessionContext(),
             ParamTypeHints.EMPTY
         );
         Session.ParameterTypeExtractor typeExtractor = new Session.ParameterTypeExtractor();
@@ -199,7 +199,7 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
         AnalyzedStatement analyzedStatement = e.analyzer.unboundAnalyze(
             SqlParser.createStatement("INSERT INTO users (id, name) values (?, ?) " +
                                       "ON DUPLICATE KEY UPDATE name = ?"),
-            SessionContext.create(),
+            SessionContext.systemSessionContext(),
             ParamTypeHints.EMPTY
         );
         Session.ParameterTypeExtractor typeExtractor = new Session.ParameterTypeExtractor();
@@ -210,7 +210,7 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
         analyzedStatement = e.analyzer.unboundAnalyze(
             SqlParser.createStatement("INSERT INTO users (id, name) (SELECT id, name FROM users_clustered_by_only " +
                                       "WHERE name = ?) ON DUPLICATE KEY UPDATE name = ?"),
-            SessionContext.create(),
+            SessionContext.systemSessionContext(),
             ParamTypeHints.EMPTY
         );
         typeExtractor = new Session.ParameterTypeExtractor();
@@ -230,7 +230,7 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
             new JobsLogs(() -> false),
             false,
             executor,
-            SessionContext.create());
+            SessionContext.systemSessionContext());
 
         session.parse("S_1", "select name from sys.cluster;", Collections.emptyList());
         session.bind("Portal", "S_1", Collections.emptyList(), null);
@@ -264,7 +264,7 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
             new JobsLogs(() -> false),
             false,
             executor,
-            SessionContext.create());
+            SessionContext.systemSessionContext());
 
         session.parse("S_1", "select * from sys.cluster;", Collections.emptyList());
         session.bind("Portal", "S_1", Collections.emptyList(), null);
@@ -290,7 +290,7 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
             new JobsLogs(() -> false),
             false,
             executor,
-            SessionContext.create());
+            SessionContext.systemSessionContext());
 
         session.parse("test_prep_stmt", "select * from sys.cluster;", Collections.emptyList());
         session.bind("Portal", "test_prep_stmt", Collections.emptyList(), null);

--- a/sql/src/test/java/io/crate/analyze/EvaluatingNormalizerTest.java
+++ b/sql/src/test/java/io/crate/analyze/EvaluatingNormalizerTest.java
@@ -41,7 +41,7 @@ public class EvaluatingNormalizerTest extends CrateUnitTest {
     private Functions functions;
     private Reference dummyLoadInfo;
 
-    private final TransactionContext transactionContext = new TransactionContext(SessionContext.create());
+    private final TransactionContext transactionContext = new TransactionContext(SessionContext.systemSessionContext());
 
     @Before
     public void prepare() throws Exception {

--- a/sql/src/test/java/io/crate/analyze/WhereClauseTest.java
+++ b/sql/src/test/java/io/crate/analyze/WhereClauseTest.java
@@ -68,7 +68,7 @@ public class WhereClauseTest {
     public void testNormalizeEliminatesNulls() {
         WhereClause where = new WhereClause(sqlExpressions.asSymbol("null or x = 10 or a = null"));
         WhereClause normalizedWhere = where.normalize(
-            EvaluatingNormalizer.functionOnlyNormalizer(getFunctions()), new TransactionContext());
+            EvaluatingNormalizer.functionOnlyNormalizer(getFunctions()), TransactionContext.systemTransactionContext());
         assertThat(normalizedWhere.query(), is(sqlExpressions.asSymbol("x = 10")));
     }
 

--- a/sql/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -103,7 +103,7 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         paramTypeHints = ParamTypeHints.EMPTY;
         DummyRelation dummyRelation = new DummyRelation("obj.x", "myObj.x", "myObj.x.AbC");
         dummySources = ImmutableMap.of(new QualifiedName("foo"), dummyRelation);
-        transactionContext = new TransactionContext();
+        transactionContext = TransactionContext.systemTransactionContext();
         context = new ExpressionAnalysisContext();
         functions = getFunctions();
         executor = SQLExecutor.builder(clusterService)
@@ -118,7 +118,7 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     public void testUnsupportedExpressionCurrentDate() throws Exception {
         expectedException.expect(UnsupportedOperationException.class);
         expectedException.expectMessage("Unsupported expression current_time");
-        SessionContext sessionContext = SessionContext.create();
+        SessionContext sessionContext = SessionContext.systemSessionContext();
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
             functions, transactionContext, paramTypeHints,
             new FullQualifiedNameFieldProvider(
@@ -211,7 +211,7 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
             new QualifiedName("t1"), tr1,
             new QualifiedName("t2"), tr2
         );
-        SessionContext sessionContext = SessionContext.create();
+        SessionContext sessionContext = SessionContext.systemSessionContext();
         TransactionContext transactionContext = new TransactionContext(sessionContext);
         ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
             functions,
@@ -260,19 +260,19 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
             Collections.singletonList(Literal.BOOLEAN_FALSE),
             localContext,
             functions,
-            new TransactionContext());
+            TransactionContext.systemTransactionContext());
         Symbol fn2 = ExpressionAnalyzer.allocateFunction(
             functionName,
             Collections.singletonList(Literal.BOOLEAN_FALSE),
             localContext,
             functions,
-            new TransactionContext());
+            TransactionContext.systemTransactionContext());
         Symbol fn3 = ExpressionAnalyzer.allocateFunction(
             functionName,
             Collections.singletonList(Literal.BOOLEAN_TRUE),
             localContext,
             functions,
-            new TransactionContext());
+            TransactionContext.systemTransactionContext());
 
         // different instances
         assertThat(fn1, allOf(

--- a/sql/src/test/java/io/crate/analyze/where/EqualityExtractorTest.java
+++ b/sql/src/test/java/io/crate/analyze/where/EqualityExtractorTest.java
@@ -46,7 +46,7 @@ import static org.hamcrest.core.Is.is;
 @SuppressWarnings("unchecked")
 public class EqualityExtractorTest extends CrateUnitTest {
 
-    private TransactionContext transactionContext = new TransactionContext(SessionContext.create());
+    private TransactionContext transactionContext = new TransactionContext(SessionContext.systemSessionContext());
     private SqlExpressions expressions = new SqlExpressions(ImmutableMap.of(T3.T1, T3.TR_1), T3.TR_1);
     private EvaluatingNormalizer normalizer = EvaluatingNormalizer.functionOnlyNormalizer(getFunctions());
     private EqualityExtractor ee = new EqualityExtractor(normalizer);

--- a/sql/src/test/java/io/crate/analyze/where/NullEliminatorTest.java
+++ b/sql/src/test/java/io/crate/analyze/where/NullEliminatorTest.java
@@ -46,7 +46,7 @@ public class NullEliminatorTest extends CrateUnitTest {
 
     private void assertReplacedAndNormalized(String expression, String expectedString) {
         EvaluatingNormalizer normalizer = EvaluatingNormalizer.functionOnlyNormalizer(getFunctions());
-        assertReplaced(expression, expectedString,  s -> normalizer.normalize(s, new TransactionContext()));
+        assertReplaced(expression, expectedString,  s -> normalizer.normalize(s, TransactionContext.systemTransactionContext()));
     }
 
     private void assertReplaced(String expression, String expectedString, Function<Symbol, Symbol> postProcessor) {

--- a/sql/src/test/java/io/crate/analyze/where/WhereClauseAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/where/WhereClauseAnalyzerTest.java
@@ -79,7 +79,7 @@ public class WhereClauseAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         .put("nodeOne", TreeMapBuilder.<String, List<Integer>>newMapBuilder().put("t1", Arrays.asList(1, 2)).map())
         .put("nodeTow", TreeMapBuilder.<String, List<Integer>>newMapBuilder().put("t1", Arrays.asList(3, 4)).map())
         .map());
-    private final TransactionContext transactionContext = new TransactionContext(SessionContext.create());
+    private final TransactionContext transactionContext = new TransactionContext(SessionContext.systemSessionContext());
     private SQLExecutor e;
 
     @Before

--- a/sql/src/test/java/io/crate/execution/engine/collect/DocLevelCollectTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/DocLevelCollectTest.java
@@ -206,7 +206,7 @@ public class DocLevelCollectTest extends SQLTransportIntegrationTest {
             new RoutingProvider(Randomness.get().nextInt(), new String[0]),
             WhereClause.MATCH_ALL,
             RoutingProvider.ShardSelection.ANY,
-            SessionContext.create());
+            SessionContext.systemSessionContext());
         RoutedCollectPhase collectNode = getCollectNode(
             Arrays.asList(
                 new Reference(new ReferenceIdent(relationName, "id"),

--- a/sql/src/test/java/io/crate/execution/engine/collect/HandlerSideLevelCollectTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/HandlerSideLevelCollectTest.java
@@ -108,7 +108,7 @@ public class HandlerSideLevelCollectTest extends SQLTransportIntegrationTest {
         Routing routing = tableInfo.getRouting(
             clusterService().state(),
             routingProvider,
-            WhereClause.MATCH_ALL, RoutingProvider.ShardSelection.ANY, SessionContext.create());
+            WhereClause.MATCH_ALL, RoutingProvider.ShardSelection.ANY, SessionContext.systemSessionContext());
         Reference clusterNameRef = new Reference(new ReferenceIdent(SysClusterTableInfo.IDENT, new ColumnIdent(ClusterNameExpression.NAME)), RowGranularity.CLUSTER, DataTypes.STRING);
         RoutedCollectPhase collectNode = collectNode(routing, Arrays.<Symbol>asList(clusterNameRef), RowGranularity.CLUSTER);
         Bucket result = collect(collectNode);
@@ -130,7 +130,7 @@ public class HandlerSideLevelCollectTest extends SQLTransportIntegrationTest {
         Routing routing = tablesTableInfo.getRouting(
             clusterService().state(),
             routingProvider,
-            WhereClause.MATCH_ALL, RoutingProvider.ShardSelection.ANY, SessionContext.create());
+            WhereClause.MATCH_ALL, RoutingProvider.ShardSelection.ANY, SessionContext.systemSessionContext());
         List<Symbol> toCollect = new ArrayList<>();
         for (Reference reference : tablesTableInfo.columns()) {
             toCollect.add(reference);
@@ -156,7 +156,7 @@ public class HandlerSideLevelCollectTest extends SQLTransportIntegrationTest {
         Routing routing = tableInfo.getRouting(
             clusterService().state(),
             routingProvider,
-            WhereClause.MATCH_ALL, RoutingProvider.ShardSelection.ANY, SessionContext.create());
+            WhereClause.MATCH_ALL, RoutingProvider.ShardSelection.ANY, SessionContext.systemSessionContext());
         List<Symbol> toCollect = new ArrayList<>();
         for (Reference ref : tableInfo.columns()) {
             toCollect.add(ref);

--- a/sql/src/test/java/io/crate/expression/operator/RegexpMatchCaseInsensitiveOperatorTest.java
+++ b/sql/src/test/java/io/crate/expression/operator/RegexpMatchCaseInsensitiveOperatorTest.java
@@ -41,7 +41,7 @@ public class RegexpMatchCaseInsensitiveOperatorTest extends CrateUnitTest {
             op.info(),
             Arrays.<Symbol>asList(Literal.of(source), Literal.of(pattern))
         );
-        return op.normalizeSymbol(function, new TransactionContext(SessionContext.create()));
+        return op.normalizeSymbol(function, new TransactionContext(SessionContext.systemSessionContext()));
     }
 
     private Boolean regexpNormalize(String source, String pattern) {

--- a/sql/src/test/java/io/crate/expression/operator/RegexpMatchOperatortest.java
+++ b/sql/src/test/java/io/crate/expression/operator/RegexpMatchOperatortest.java
@@ -41,7 +41,7 @@ public class RegexpMatchOperatortest extends CrateUnitTest {
             op.info(),
             Arrays.<Symbol>asList(Literal.of(source), Literal.of(pattern))
         );
-        return op.normalizeSymbol(function, new TransactionContext(SessionContext.create()));
+        return op.normalizeSymbol(function, new TransactionContext(SessionContext.systemSessionContext()));
     }
 
     private Boolean regexpNormalize(String source, String pattern) {

--- a/sql/src/test/java/io/crate/expression/scalar/AbstractScalarFunctionsTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/AbstractScalarFunctionsTest.java
@@ -271,7 +271,7 @@ public abstract class AbstractScalarFunctionsTest extends CrateUnitTest {
     }
 
     protected Symbol normalize(String functionName, Symbol... args) {
-        return normalize(new TransactionContext(SessionContext.create()), functionName, args);
+        return normalize(new TransactionContext(SessionContext.systemSessionContext()), functionName, args);
     }
 
     private class AssertingInput implements Input {

--- a/sql/src/test/java/io/crate/expression/scalar/arithmetic/LogFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/arithmetic/LogFunctionTest.java
@@ -44,7 +44,7 @@ import static org.hamcrest.core.IsNull.nullValue;
 
 public class LogFunctionTest extends AbstractScalarFunctionsTest {
 
-    private TransactionContext transactionContext = new TransactionContext(SessionContext.create());
+    private TransactionContext transactionContext = new TransactionContext(SessionContext.systemSessionContext());
 
     private LogFunction getFunction(String name, DataType value) {
         return (LogFunction) functions.getBuiltin(name, Arrays.asList(value));

--- a/sql/src/test/java/io/crate/expression/scalar/arithmetic/RandomFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/arithmetic/RandomFunctionTest.java
@@ -58,7 +58,7 @@ public class RandomFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void normalizeReference() {
         Function function = new Function(random.info(), Collections.<Symbol>emptyList());
-        Function normalized = (Function) random.normalizeSymbol(function, new TransactionContext(SessionContext.create()));
+        Function normalized = (Function) random.normalizeSymbol(function, new TransactionContext(SessionContext.systemSessionContext()));
         assertThat(normalized, sameInstance(function));
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/IngestionServiceIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/IngestionServiceIntegrationTest.java
@@ -91,7 +91,7 @@ public class IngestionServiceIntegrationTest extends SQLTransportIntegrationTest
             this.inputFactory = new InputFactory(functions);
             this.ingestionService = ingestionService;
             this.expressionAnalysisContext = new ExpressionAnalysisContext();
-            TransactionContext transactionContext = new TransactionContext(SessionContext.create());
+            TransactionContext transactionContext = new TransactionContext(SessionContext.systemSessionContext());
             this.expressionAnalyzer = new ExpressionAnalyzer(
                 functions, transactionContext, null, inputColumnProvider, null);
         }

--- a/sql/src/test/java/io/crate/metadata/SchemasITest.java
+++ b/sql/src/test/java/io/crate/metadata/SchemasITest.java
@@ -78,7 +78,7 @@ public class SchemasITest extends SQLTransportIntegrationTest {
             routingProvider,
             WhereClause.MATCH_ALL,
             RoutingProvider.ShardSelection.ANY,
-            SessionContext.create()
+            SessionContext.systemSessionContext()
         );
 
         Set<String> nodes = routing.nodes();
@@ -140,7 +140,7 @@ public class SchemasITest extends SQLTransportIntegrationTest {
         TableInfo ti = schemas.getTableInfo(new RelationName("sys", "nodes"));
         ClusterService clusterService = clusterService();
         Routing routing = ti.getRouting(
-            clusterService.state(), routingProvider, null, null, SessionContext.create());
+            clusterService.state(), routingProvider, null, null, SessionContext.systemSessionContext());
         assertTrue(routing.hasLocations());
         assertEquals(1, routing.nodes().size());
         for (Map<String, List<Integer>> indices : routing.locations().values()) {
@@ -157,7 +157,7 @@ public class SchemasITest extends SQLTransportIntegrationTest {
         TableInfo ti = schemas.getTableInfo(new RelationName("sys", "shards"));
         ClusterService clusterService = clusterService();
         Routing routing = ti.getRouting(
-            clusterService.state(), routingProvider, null, null, SessionContext.create());
+            clusterService.state(), routingProvider, null, null, SessionContext.systemSessionContext());
 
         Set<String> tables = new HashSet<>();
         Set<String> expectedTables = Sets.newHashSet(getFqn("t2"), getFqn("t3"));
@@ -177,7 +177,7 @@ public class SchemasITest extends SQLTransportIntegrationTest {
         TableInfo ti = schemas.getTableInfo(new RelationName("sys", "cluster"));
         ClusterService clusterService = clusterService();
         assertThat(ti.getRouting(
-            clusterService.state(), routingProvider, null, null, SessionContext.create()
+            clusterService.state(), routingProvider, null, null, SessionContext.systemSessionContext()
         ).locations().size(), is(1));
     }
 }

--- a/sql/src/test/java/io/crate/metadata/doc/DocIndexMetaDataTest.java
+++ b/sql/src/test/java/io/crate/metadata/doc/DocIndexMetaDataTest.java
@@ -973,7 +973,7 @@ public class DocIndexMetaDataTest extends CrateDummyClusterServiceUnitTest {
             new NumberOfShards(clusterService)
         );
 
-        Analysis analysis = new Analysis(new TransactionContext(SessionContext.create()), ParameterContext.EMPTY, ParamTypeHints.EMPTY);
+        Analysis analysis = new Analysis(new TransactionContext(SessionContext.systemSessionContext()), ParameterContext.EMPTY, ParamTypeHints.EMPTY);
         CreateTableAnalyzedStatement analyzedStatement = analyzer.analyze(
             (CreateTable) statement, analysis.parameterContext(), analysis.transactionContext());
 

--- a/sql/src/test/java/io/crate/metadata/table/TestingTableInfo.java
+++ b/sql/src/test/java/io/crate/metadata/table/TestingTableInfo.java
@@ -306,7 +306,7 @@ public class TestingTableInfo extends DocTableInfo {
         }
 
         private void initializeGeneratedExpressions(Functions functions, Collection<Reference> columns) {
-            TransactionContext transactionContext = new TransactionContext();
+            TransactionContext transactionContext = TransactionContext.systemTransactionContext();
             TableReferenceResolver tableReferenceResolver = new TableReferenceResolver(columns, ident);
             ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(
                 functions, transactionContext, null, tableReferenceResolver, null);

--- a/sql/src/test/java/io/crate/operation/aggregation/AggregationTest.java
+++ b/sql/src/test/java/io/crate/operation/aggregation/AggregationTest.java
@@ -107,6 +107,6 @@ public abstract class AggregationTest extends CrateUnitTest {
         }
         AggregationFunction function =
             (AggregationFunction) functions.getBuiltin(functionName, Arrays.asList(argTypes));
-        return function.normalizeSymbol(new Function(function.info(), Arrays.asList(args)), new TransactionContext(SessionContext.create()));
+        return function.normalizeSymbol(new Function(function.info(), Arrays.asList(args)), new TransactionContext(SessionContext.systemSessionContext()));
     }
 }

--- a/sql/src/test/java/io/crate/planner/PlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/PlannerTest.java
@@ -55,7 +55,7 @@ public class PlannerTest extends CrateDummyClusterServiceUnitTest {
             new RoutingProvider(Randomness.get().nextInt(), new String[0]),
             UUID.randomUUID(),
             e.functions(),
-            new TransactionContext(SessionContext.create()),
+            new TransactionContext(SessionContext.systemSessionContext()),
             0,
             0);
 

--- a/sql/src/test/java/io/crate/planner/consumer/SemiJoinsTest.java
+++ b/sql/src/test/java/io/crate/planner/consumer/SemiJoinsTest.java
@@ -106,7 +106,7 @@ public class SemiJoinsTest extends CrateDummyClusterServiceUnitTest {
     public void testSemiJoinRewriteOfWhereClause() throws Exception {
         QueriedRelation rel = executor.analyze("select * from t1 where a in (select 'foo') and x = 10");
         MultiSourceSelect semiJoin = (MultiSourceSelect) semiJoins.tryRewrite(
-            rel, new TransactionContext(SessionContext.create()));
+            rel, new TransactionContext(SessionContext.systemSessionContext()));
 
         assertThat(semiJoin.querySpec().where(), isSQL("true"));
         System.out.println(new SQLPrinter(new SymbolPrinter(getFunctions())).format(semiJoin));
@@ -123,7 +123,7 @@ public class SemiJoinsTest extends CrateDummyClusterServiceUnitTest {
     public void testAntiJoinRewriteOfWhereClause() throws Exception {
         QueriedRelation rel = executor.analyze("select * from t1 where a not in (select 'foo') and x = 10");
         MultiSourceSelect antiJoin = (MultiSourceSelect) semiJoins.tryRewrite(
-            rel, new TransactionContext(SessionContext.create()));
+            rel, new TransactionContext(SessionContext.systemSessionContext()));
 
         assertThat(antiJoin.querySpec().where(), isSQL("true"));
         assertThat(((QueriedRelation) antiJoin.sources().get(QualifiedName.of(T1.toString()))).querySpec(),
@@ -138,7 +138,7 @@ public class SemiJoinsTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testQueryWithOrIsNotRewritten() throws Exception {
         QueriedRelation relation = executor.analyze("select * from t1 where a in (select 'foo') or a = '10'");
-        QueriedRelation semiJoin = semiJoins.tryRewrite(relation, new TransactionContext(SessionContext.create()));
+        QueriedRelation semiJoin = semiJoins.tryRewrite(relation, new TransactionContext(SessionContext.systemSessionContext()));
 
         assertThat(semiJoin, nullValue());
     }
@@ -165,7 +165,7 @@ public class SemiJoinsTest extends CrateDummyClusterServiceUnitTest {
                                                         "where " +
                                                         "   x in (select * from unnest([1, 2])) " +
                                                         "   and x not in (select 1)");
-        QueriedRelation semiJoins = this.semiJoins.tryRewrite(relation, new TransactionContext(SessionContext.create()));
+        QueriedRelation semiJoins = this.semiJoins.tryRewrite(relation, new TransactionContext(SessionContext.systemSessionContext()));
 
         assertThat(semiJoins, instanceOf(MultiSourceSelect.class));
         MultiSourceSelect mss = (MultiSourceSelect) semiJoins;

--- a/sql/src/test/java/io/crate/planner/node/RoutedCollectPhaseTest.java
+++ b/sql/src/test/java/io/crate/planner/node/RoutedCollectPhaseTest.java
@@ -108,7 +108,7 @@ public class RoutedCollectPhaseTest extends CrateUnitTest {
         collect.orderBy(new OrderBy(Collections.singletonList(toInt10), new boolean[]{false}, new Boolean[]{null}));
         EvaluatingNormalizer normalizer = EvaluatingNormalizer.functionOnlyNormalizer(getFunctions());
         RoutedCollectPhase normalizedCollect = collect.normalize(
-            normalizer, new TransactionContext(SessionContext.create()));
+            normalizer, new TransactionContext(SessionContext.systemSessionContext()));
 
         assertThat(normalizedCollect.orderBy(), notNullValue());
     }
@@ -131,7 +131,7 @@ public class RoutedCollectPhaseTest extends CrateUnitTest {
         collect.nodePageSizeHint(10);
         EvaluatingNormalizer normalizer = EvaluatingNormalizer.functionOnlyNormalizer(getFunctions());
         RoutedCollectPhase normalizedCollect = collect.normalize(
-            normalizer, new TransactionContext(SessionContext.create()));
+            normalizer, new TransactionContext(SessionContext.systemSessionContext()));
 
         assertThat(normalizedCollect.nodePageSizeHint(), is(10));
     }
@@ -152,7 +152,7 @@ public class RoutedCollectPhaseTest extends CrateUnitTest {
         );
         EvaluatingNormalizer normalizer = EvaluatingNormalizer.functionOnlyNormalizer(getFunctions());
         RoutedCollectPhase normalizedCollect = collect.normalize(
-            normalizer, new TransactionContext(SessionContext.create()));
+            normalizer, new TransactionContext(SessionContext.systemSessionContext()));
 
         assertThat(normalizedCollect, sameInstance(collect));
     }

--- a/sql/src/test/java/io/crate/planner/operators/JoinTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/JoinTest.java
@@ -51,7 +51,6 @@ import java.util.Collections;
 
 import static io.crate.testing.TestingHelpers.getFunctions;
 import static io.crate.testing.TestingHelpers.isSQL;
-import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -63,7 +62,7 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
     private Functions functions = getFunctions();
     private ProjectionBuilder projectionBuilder = new ProjectionBuilder(functions);
     private PlannerContext plannerCtx;
-    private TransactionContext txnCtx = new TransactionContext();
+    private TransactionContext txnCtx = TransactionContext.systemTransactionContext();
 
     @Before
     public void setUpExecutor() {

--- a/sql/src/test/java/io/crate/protocols/postgres/BulkPortalTest.java
+++ b/sql/src/test/java/io/crate/protocols/postgres/BulkPortalTest.java
@@ -43,7 +43,7 @@ public class BulkPortalTest extends CrateUnitTest {
             Mockito.mock(ResultSetReceiver.class),
             1,
             Collections.emptyList(),
-            SessionContext.create(),
+            SessionContext.systemSessionContext(),
             Mockito.mock(AbstractPortal.PortalContext.class)
         );
 

--- a/sql/src/test/java/io/crate/testing/SQLExecutor.java
+++ b/sql/src/test/java/io/crate/testing/SQLExecutor.java
@@ -394,7 +394,7 @@ public class SQLExecutor {
         public Builder addPartitionedTable(String createTableStmt, String... partitions) throws IOException {
             CreateTable stmt = (CreateTable) SqlParser.createStatement(createTableStmt);
             CreateTableAnalyzedStatement analyzedStmt = createTableStatementAnalyzer.analyze(
-                stmt, ParameterContext.EMPTY, new TransactionContext(SessionContext.create()));
+                stmt, ParameterContext.EMPTY, new TransactionContext(SessionContext.systemSessionContext()));
             if (!analyzedStmt.isPartitioned()) {
                 throw new IllegalArgumentException("use addTable(..) to add non partitioned tables");
             }
@@ -438,7 +438,7 @@ public class SQLExecutor {
         public Builder addTable(String createTableStmt) throws IOException {
             CreateTable stmt = (CreateTable) SqlParser.createStatement(createTableStmt);
             CreateTableAnalyzedStatement analyzedStmt = createTableStatementAnalyzer.analyze(
-                stmt, ParameterContext.EMPTY, new TransactionContext(SessionContext.create()));
+                stmt, ParameterContext.EMPTY, new TransactionContext(SessionContext.systemSessionContext()));
 
             if (analyzedStmt.isPartitioned()) {
                 throw new IllegalArgumentException("use addPartitionedTable(..) to add partitioned tables");

--- a/sql/src/test/java/io/crate/testing/SqlExpressions.java
+++ b/sql/src/test/java/io/crate/testing/SqlExpressions.java
@@ -94,7 +94,7 @@ public class SqlExpressions {
         }
         injector = modulesBuilder.createInjector();
         functions = injector.getInstance(Functions.class);
-        transactionContext = new TransactionContext(SessionContext.create(user));
+        transactionContext = new TransactionContext(new SessionContext(null, user, s -> {}, e -> {}));
         expressionAnalyzer = new ExpressionAnalyzer(
             functions,
             transactionContext,


### PR DESCRIPTION
Makes the usage intention a bit clearer. These methods are convenience
for system related purposes, but are not valid to use for regular user
invoked operations.