### PR TITLE
Mark es.api.enabled as deprecated

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -18,6 +18,12 @@ Breaking Changes
 Changes
 =======
 
+- The setting ``es.api.enabled`` has been marked as deprecated and will be
+  removed in a future version. Once removed it will no longer be possible to
+  use the ES API.
+  Please create feature requests if you're using the ES API and cannot use the
+  SQL interface as substitute.
+
 - Introduced the ``EXPLAIN ANALYZE`` statement for query profiling.
 
 - Added `typbasetype` column to the `pg_catalog.pg_type` table.

--- a/blackbox/docs/config/node.rst
+++ b/blackbox/docs/config/node.rst
@@ -517,6 +517,8 @@ Elasticsearch HTTP REST API
 
   .. WARNING::
 
+    This setting is deprecated and will be removed in the future.
+
     Manipulating your data via elasticsearch API and not via SQL might result
     in inconsistent data. You have been warned!
 

--- a/http/src/main/java/io/crate/rest/CrateRestMainAction.java
+++ b/http/src/main/java/io/crate/rest/CrateRestMainAction.java
@@ -34,6 +34,7 @@ import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Setting;
@@ -103,6 +104,11 @@ public class CrateRestMainAction implements RestHandler {
         Logger logger = Loggers.getLogger(getClass().getPackage().getName(), settings);
         if (esApiEnabled) {
             logger.warn("Unofficial Elasticsearch HTTP REST API is enabled");
+            DeprecationLogger deprecationLogger = new DeprecationLogger(logger);
+            deprecationLogger.deprecated(
+                "\"es.api.enabled\" is deprecated and will be removed in a future version." +
+                "Please use SQL instead and if that is not possible create a feature request " +
+                "on https://github.com/crate/crate/issues explaining your use-case.");
         }
         controller.registerHandler(GET, PATH, this);
         controller.registerHandler(HEAD, PATH, this);


### PR DESCRIPTION
The `es.api.enabled` API has been valueable to get information that is
or was not exposed via SQL. In some cases it could also be used to
repair a broken state by using low-level APIs.

But it also opens up many possibilities which we don't cover with tests.
Due to that it was never officially supported.

It also prevents us to make bigger changes within the ES parts of the
code-base, which we might want to make in the future. We should
deprecate this rather earlier than later to make it easier for people to
migrate and add missing functionality before it's finally removed.