### PR TITLE
Add a sys.jobs_metrics table

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -18,6 +18,8 @@ Breaking Changes
 Changes
 =======
 
+- Added a ``sys.jobs_metrics`` table which contains query latency information.
+
 Fixes
 =====
 

--- a/blackbox/docs/admin/system-information.rst
+++ b/blackbox/docs/admin/system-information.rst
@@ -1042,6 +1042,40 @@ Every request that queries data or manipulates data is considered a "job" if it
 is a valid query. Requests that are not valid queries (for example, a request
 that tries to query a non-existent table) will not show up as jobs.
 
+Jobs Metrics
+------------
+
+The ``sys.jobs_metrics`` table provides an overview of the query latency in the
+cluster for each node. Jobs metrics are not persisted across node restarts.
+
+.. note::
+
+  In order to reduce the memory requirements for these metrics, the times are
+  statistically sampled and therefore may have slight inaccuracies.
+
+``sys.jobs_metrics`` Table Schema
+.................................
+
++------------------------------------+----------------------------------------------------+---------------+
+| Column Name                        | Description                                        |  Return Type  |
++====================================+====================================================+===============+
+| ``node``                           | An object containing the id and name of the node   | ``OBJECT``    |
+|                                    | on which the metrics have been sampled.            |               |
++------------------------------------+----------------------------------------------------+---------------+
+| ``total_count``                    | Total number of queries executed                   | ``LONG``      |
++------------------------------------+----------------------------------------------------+---------------+
+| ``mean``                           | The mean query latency in ms                       | ``DOUBLE``    |
++------------------------------------+----------------------------------------------------+---------------+
+| ``stdev``                          | The standard deviation of the query latencies      | ``DOUBLE``    |
++------------------------------------+----------------------------------------------------+---------------+
+| ``max``                            | The maximum query latency in ms                    | ``LONG``      |
++------------------------------------+----------------------------------------------------+---------------+
+| ``min``                            | The minimum query latency in ms                    | ``LONG``      |
++------------------------------------+----------------------------------------------------+---------------+
+| ``percentiles``                    | An object containing different percentiles         | ``OBJECT``    |
++------------------------------------+----------------------------------------------------+---------------+
+
+
 .. _sys-operations:
 
 Operations

--- a/blackbox/docs/general/information-schema.rst
+++ b/blackbox/docs/general/information-schema.rst
@@ -88,6 +88,7 @@ number of replicas.
     | sys                | health                  | BASE TABLE |             NULL | NULL               |
     | sys                | jobs                    | BASE TABLE |             NULL | NULL               |
     | sys                | jobs_log                | BASE TABLE |             NULL | NULL               |
+    | sys                | jobs_metrics            | BASE TABLE |             NULL | NULL               |
     | sys                | node_checks             | BASE TABLE |             NULL | NULL               |
     | sys                | nodes                   | BASE TABLE |             NULL | NULL               |
     | sys                | operations              | BASE TABLE |             NULL | NULL               |
@@ -99,7 +100,7 @@ number of replicas.
     | sys                | summits                 | BASE TABLE |             NULL | NULL               |
     | sys                | users                   | BASE TABLE |             NULL | NULL               |
     +--------------------+-------------------------+------------+------------------+--------------------+
-    SELECT 32 rows in set (... sec)
+    SELECT 33 rows in set (... sec)
 
 The table also contains additional information such as specified routing
 (:ref:`sql_ddl_sharding`) and partitioned by (:ref:`partitioned_tables`)

--- a/sql/src/main/java/io/crate/metadata/sys/SysMetricsTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysMetricsTableInfo.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.sys;
+
+import com.google.common.collect.ImmutableMap;
+import io.crate.action.sql.SessionContext;
+import io.crate.analyze.WhereClause;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.Routing;
+import io.crate.metadata.RoutingProvider;
+import io.crate.metadata.RowGranularity;
+import io.crate.metadata.expressions.RowCollectExpressionFactory;
+import io.crate.metadata.table.ColumnRegistrar;
+import io.crate.metadata.table.StaticTableInfo;
+import io.crate.types.DataTypes;
+import org.HdrHistogram.Histogram;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static io.crate.metadata.RowContextCollectorExpression.forFunction;
+
+public class SysMetricsTableInfo extends StaticTableInfo {
+
+    public static final RelationName NAME = new RelationName(SysSchemaInfo.NAME, "jobs_metrics");
+
+    static class Columns {
+        static final ColumnIdent TOTAL_COUNT = new ColumnIdent("total_count");
+        static final ColumnIdent MEAN = new ColumnIdent("mean");
+        static final ColumnIdent STDEV = new ColumnIdent("stdev");
+        static final ColumnIdent MAX = new ColumnIdent("max");
+        static final ColumnIdent MIN = new ColumnIdent("min");
+        static final ColumnIdent PERCENTILES = new ColumnIdent("percentiles");
+        static final ColumnIdent P25 = new ColumnIdent("percentiles", "25");
+        static final ColumnIdent P50 = new ColumnIdent("percentiles", "50");
+        static final ColumnIdent P75 = new ColumnIdent("percentiles", "75");
+        static final ColumnIdent P90 = new ColumnIdent("percentiles", "90");
+        static final ColumnIdent P95 = new ColumnIdent("percentiles", "95");
+        static final ColumnIdent P99 = new ColumnIdent("percentiles", "99");
+        static final ColumnIdent NODE = new ColumnIdent("node");
+        static final ColumnIdent NODE_ID = new ColumnIdent("node", "id");
+        static final ColumnIdent NODE_NAME = new ColumnIdent("node", "name");
+    }
+
+    public static class ClassifiedHist {
+        Histogram histogram;
+        String type;
+
+        public ClassifiedHist(Histogram histogram, String type) {
+            this.histogram = histogram;
+            this.type = type;
+        }
+
+        public Histogram histogram() {
+            return histogram;
+        }
+
+        public String type() {
+            return type;
+        }
+    }
+
+    SysMetricsTableInfo() {
+        super(NAME,
+            new ColumnRegistrar(NAME, RowGranularity.DOC)
+                .register(Columns.TOTAL_COUNT, DataTypes.LONG)
+                .register(Columns.MEAN, DataTypes.DOUBLE)
+                .register(Columns.STDEV, DataTypes.DOUBLE)
+                .register(Columns.MAX, DataTypes.LONG)
+                .register(Columns.MIN, DataTypes.LONG)
+                .register(Columns.PERCENTILES, DataTypes.OBJECT)
+                .register(Columns.P25, DataTypes.LONG)
+                .register(Columns.P50, DataTypes.LONG)
+                .register(Columns.P75, DataTypes.LONG)
+                .register(Columns.P90, DataTypes.LONG)
+                .register(Columns.P95, DataTypes.LONG)
+                .register(Columns.P99, DataTypes.LONG)
+                .register(Columns.NODE, DataTypes.OBJECT)
+                .register(Columns.NODE_ID, DataTypes.STRING)
+                .register(Columns.NODE_NAME, DataTypes.STRING),
+            Collections.emptyList()
+        );
+    }
+
+    public static Map<ColumnIdent, RowCollectExpressionFactory<ClassifiedHist>> expressions(Supplier<DiscoveryNode> localNode) {
+        return ImmutableMap.<ColumnIdent, RowCollectExpressionFactory<ClassifiedHist>>builder()
+            .put(Columns.TOTAL_COUNT, () -> forFunction(h -> h.histogram.getTotalCount()))
+            .put(Columns.MEAN, () -> forFunction(h -> h.histogram.getMean()))
+            .put(Columns.STDEV, () -> forFunction(h -> h.histogram.getStdDeviation()))
+            .put(Columns.MAX, () -> forFunction(h -> h.histogram.getMaxValue()))
+            .put(Columns.MIN, () -> forFunction(h -> h.histogram.getTotalCount() == 0 ? 0 : h.histogram.getMinNonZeroValue()))
+            .put(Columns.PERCENTILES, () -> forFunction(h -> ImmutableMap.builder()
+                .put("25", h.histogram.getValueAtPercentile(25.0))
+                .put("50", h.histogram.getValueAtPercentile(50.0))
+                .put("75", h.histogram.getValueAtPercentile(75.0))
+                .put("90", h.histogram.getValueAtPercentile(90.0))
+                .put("95", h.histogram.getValueAtPercentile(95.0))
+                .put("99", h.histogram.getValueAtPercentile(99.0))
+                .build()
+            ))
+            .put(Columns.P25, () -> forFunction(h -> h.histogram.getValueAtPercentile(25.0)))
+            .put(Columns.P50, () -> forFunction(h -> h.histogram.getValueAtPercentile(50.0)))
+            .put(Columns.P75, () -> forFunction(h -> h.histogram.getValueAtPercentile(75.0)))
+            .put(Columns.P90, () -> forFunction(h -> h.histogram.getValueAtPercentile(90.0)))
+            .put(Columns.P95, () -> forFunction(h -> h.histogram.getValueAtPercentile(95.0)))
+            .put(Columns.P99, () -> forFunction(h -> h.histogram.getValueAtPercentile(99.0)))
+            .put(Columns.NODE, () -> forFunction(ignored -> ImmutableMap.builder()
+                .put("id", new BytesRef(localNode.get().getId()))
+                .put("name", new BytesRef(localNode.get().getName()))
+                .build()
+            ))
+            .put(Columns.NODE_ID, () -> forFunction(ignored -> new BytesRef(localNode.get().getId())))
+            .put(Columns.NODE_NAME, () -> forFunction(ignored -> new BytesRef(localNode.get().getName())))
+            .build();
+    }
+
+    @Override
+    public Routing getRouting(ClusterState state, RoutingProvider routingProvider, WhereClause whereClause, RoutingProvider.ShardSelection shardSelection, SessionContext sessionContext) {
+        return Routing.forTableOnAllNodes(NAME, state.getNodes());
+    }
+
+    @Override
+    public RowGranularity rowGranularity() {
+        return RowGranularity.DOC;
+    }
+}

--- a/sql/src/main/java/io/crate/metadata/sys/SysSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysSchemaInfo.java
@@ -55,6 +55,7 @@ public class SysSchemaInfo implements SchemaInfo {
         tableInfos.put(SysSummitsTableInfo.IDENT.name(), new SysSummitsTableInfo());
         tableInfos.put(SysAllocationsTableInfo.IDENT.name(), new SysAllocationsTableInfo());
         tableInfos.put(SysHealthTableInfo.IDENT.name(), new SysHealthTableInfo());
+        tableInfos.put(SysMetricsTableInfo.NAME.name(), new SysMetricsTableInfo());
     }
 
     @Override

--- a/sql/src/main/java/io/crate/metadata/sys/SysTableDefinitions.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysTableDefinitions.java
@@ -112,6 +112,10 @@ public class SysTableDefinitions {
             SysHealthTableInfo.expressions(),
             (user, tableHealth) -> user.hasAnyPrivilege(Privilege.Clazz.TABLE, tableHealth.fqn())
         ));
+        tableDefinitions.put(SysMetricsTableInfo.NAME, new StaticTableDefinition<>(
+            () -> completedFuture(jobsLogs.metrics()),
+            SysMetricsTableInfo.expressions(clusterService::localNode)
+        ));
     }
 
     public StaticTableDefinition<?> get(RelationName relationName) {

--- a/sql/src/test/java/io/crate/execution/engine/collect/stats/JobsLogsTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/stats/JobsLogsTest.java
@@ -23,6 +23,7 @@
 package io.crate.execution.engine.collect.stats;
 
 import com.google.common.collect.ImmutableList;
+import io.crate.auth.user.User;
 import io.crate.breaker.CrateCircuitBreakerService;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.core.collections.BlockingEvictingQueue;
@@ -30,7 +31,6 @@ import io.crate.expression.reference.sys.job.JobContext;
 import io.crate.expression.reference.sys.job.JobContextLog;
 import io.crate.expression.reference.sys.operation.OperationContext;
 import io.crate.expression.reference.sys.operation.OperationContextLog;
-import io.crate.auth.user.User;
 import io.crate.plugin.SQLPlugin;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import org.elasticsearch.common.settings.ClusterSettings;

--- a/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -61,7 +61,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultTables() {
         execute("select * from information_schema.tables order by table_schema, table_name");
-        assertEquals(26L, response.rowCount());
+        assertEquals(27L, response.rowCount());
 
         assertThat(TestingHelpers.printedTable(response.rows()), is(
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| information_schema| columns| information_schema| BASE TABLE| NULL\n" +
@@ -82,6 +82,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| sys| health| sys| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| sys| jobs| sys| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| sys| jobs_log| sys| BASE TABLE| NULL\n" +
+            "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| sys| jobs_metrics| sys| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| sys| node_checks| sys| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| sys| nodes| sys| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| sys| operations| sys| BASE TABLE| NULL\n" +
@@ -186,13 +187,13 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testSearchInformationSchemaTablesRefresh() {
         execute("select * from information_schema.tables");
-        assertEquals(26L, response.rowCount());
+        assertEquals(27L, response.rowCount());
 
         execute("create table t4 (col1 integer, col2 string) with(number_of_replicas=0)");
         ensureYellow(getFqn("t4"));
 
         execute("select * from information_schema.tables");
-        assertEquals(27L, response.rowCount());
+        assertEquals(28L, response.rowCount());
     }
 
     @Test
@@ -568,7 +569,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(496, response.rowCount());
+        assertEquals(511, response.rowCount());
     }
 
     @Test
@@ -785,7 +786,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
         ensureYellow();
         execute("select count(*) from information_schema.tables");
         assertEquals(1, response.rowCount());
-        assertEquals(29L, response.rows()[0][0]);
+        assertEquals(30L, response.rows()[0][0]);
     }
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/MetricsITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/MetricsITest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.integrationtests;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+public class MetricsITest extends SQLTransportIntegrationTest {
+
+    @Test
+    public void testSimpleQueryOnMetrics() {
+        execute("SELECT 1");
+
+        execute("SELECT node, " +
+                "node['id'], " +
+                "node['name'], " +
+                "min, " +
+                "max, " +
+                "mean, " +
+                "percentiles, " +
+                "percentiles['25'], " +
+                "percentiles['50'], " +
+                "percentiles['75'], " +
+                "percentiles['90'], " +
+                "percentiles['95'], " +
+                "percentiles['99'], " +
+                "total_count " +
+                "FROM sys.jobs_metrics ORDER BY max DESC");
+
+        for (Object[] row : response.rows()) {
+            assertThat((long) row[3], Matchers.greaterThanOrEqualTo(0L));
+            assertThat((long) row[4], Matchers.greaterThanOrEqualTo(0L));
+            assertThat((double) row[5], Matchers.greaterThanOrEqualTo(0.0d));
+        }
+    }
+
+    @Test
+    public void testTotalCountOnMetrics() {
+        int numQueries = 10;
+        for (int i = 0; i < numQueries; i++) {
+            execute("SELECT 1");
+        }
+
+        execute("SELECT sum(total_count) FROM sys.jobs_metrics");
+        assertThat((long) response.rows()[0][0], Matchers.greaterThanOrEqualTo((long) numQueries));
+    }
+}

--- a/sql/src/test/java/io/crate/integrationtests/TableSettingsTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TableSettingsTest.java
@@ -85,7 +85,7 @@ public class TableSettingsTest extends SQLTransportIntegrationTest {
     public void testFilterOnNull() throws Exception {
         execute("select * from information_schema.tables " +
                 "where settings IS NULL");
-        assertEquals(26L, response.rowCount());
+        assertEquals(27L, response.rowCount());
         execute("select * from information_schema.tables " +
                 "where table_name = 'settings_table' and settings['warmer']['enabled'] IS NULL");
         assertEquals(0, response.rowCount());


### PR DESCRIPTION
This adds a table which contains query duration latencies.
This is an initial version. We may later improve on this to:

  - Classify queries in some way. E.g. by type (select, update, ..) or
  even down to operator level

  - Reduce the overhead of the metric gathering by using
  connection/thread-local metric recorders