### PR TITLE
fixes copy-from-file-pattern test

### DIFF
--- a/sql/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/CopyIntegrationTest.java
@@ -64,6 +64,8 @@ public class CopyIntegrationTest extends SQLHttpIntegrationTest {
 
     private final String copyFilePath =
         Paths.get(getClass().getResource("/essetup/data/copy").toURI()).toUri().toString();
+    private final String copyFilePathShared =
+        Paths.get(getClass().getResource("/essetup/data/copy/shared").toURI()).toUri().toString();
     private final String nestedArrayCopyFilePath =
         Paths.get(getClass().getResource("/essetup/data/nested_array").toURI()).toUri().toString();
 
@@ -167,31 +169,17 @@ public class CopyIntegrationTest extends SQLHttpIntegrationTest {
     }
 
     @Test
-    public void testCopyFromDirectory() throws Exception {
+    public void testCopyFromFilePattern() {
         execute("create table quotes (id int primary key, " +
                 "quote string index using fulltext) with (number_of_replicas=0)");
         ensureYellow();
 
-        execute("copy quotes from ? with (shared=true)", new Object[]{copyFilePath + "test_copy_from.json"});
-        assertEquals(3L, response.rowCount());
+        execute("copy quotes from ?", new Object[]{copyFilePathShared + "*.json"});
+        assertEquals(6L, response.rowCount());
         refresh();
 
         execute("select * from quotes");
-        assertEquals(3L, response.rowCount());
-    }
-
-    @Test
-    public void testCopyFromFilePattern() throws Exception {
-        execute("create table quotes (id int primary key, " +
-                "quote string index using fulltext) with (number_of_replicas=0)");
-        ensureYellow();
-
-        execute("copy quotes from ?", new Object[]{copyFilePath + "test_copy_from.json"});
-        assertEquals(3L, response.rowCount());
-        refresh();
-
-        execute("select * from quotes");
-        assertEquals(3L, response.rowCount());
+        assertEquals(6L, response.rowCount());
     }
 
     @Test

--- a/sql/src/test/resources/essetup/data/copy/shared/test_copy_from1.json
+++ b/sql/src/test/resources/essetup/data/copy/shared/test_copy_from1.json
@@ -1,0 +1,3 @@
+{"id": 1, "quote": "Don't pañic."}
+{"id": 3, "quote": "Would it save you a lot of time if I just gave up and went mad now?"}
+{"id": 5, "quote": "Time is an illusion. Lunchtime doubly so."}

--- a/sql/src/test/resources/essetup/data/copy/shared/test_copy_from2.json
+++ b/sql/src/test/resources/essetup/data/copy/shared/test_copy_from2.json
@@ -1,0 +1,3 @@
+{"id": 2, "quote": "Don't pañic."}
+{"id": 4, "quote": "Would it save you a lot of time if I just gave up and went mad now?"}
+{"id": 6, "quote": "Time is an illusion. Lunchtime doubly so."}


### PR DESCRIPTION
Changes the test back to really use a pattern instead of a fqn file, reverts changes made by https://github.com/crate/crate/commit/a9b4e24d4b101052ea20e807e86ffeed207e3db7.
Also removes invalid/senseless `testCopyFromDirectory` test.