### PR TITLE
rewrite environment variable docs

### DIFF
--- a/blackbox/docs/appendices/release-notes/2.0.0.rst
+++ b/blackbox/docs/appendices/release-notes/2.0.0.rst
@@ -313,9 +313,10 @@ Heap Size
 
 If you have previously set or configured ``CRATE_MIN_MEM`` or ``CRATE_MAX_MEM``
 in your startup scripts or environment, you must remove both, and replace them
-with a single variable ``CRATE_HEAP_SIZE``. The :ref:`crate-heap-size` variable
-sets both the minimum and maximum memory to allocate, and should be set to
-whatever your previous ``CRATE_MAX_MEM`` was set to.
+with a single variable ``CRATE_HEAP_SIZE``. The :ref:`CRATE_HEAP_SIZE
+<conf-env-heap-size>` variable sets both the minimum and maximum memory to
+allocate, and should be set to whatever your previous ``CRATE_MAX_MEM`` was set
+to.
 
 .. _enterprise edition: https://crate.io/enterprise-edition/
 

--- a/blackbox/docs/config/cluster.rst
+++ b/blackbox/docs/config/cluster.rst
@@ -915,8 +915,9 @@ each of them, the breaker limit can be set.
   | *Default:*    ``5%``
   | *Runtime:*   ``yes``
 
-  The maximum memory that can be used from :ref:`crate-heap-size` for the
-  :ref:`sys.jobs_log <sys-logs>` table on each node.
+  The maximum memory that can be used from :ref:`CRATE_HEAP_SIZE
+  <conf-env-heap-size>` for the :ref:`sys.jobs_log <sys-logs>` table on each
+  node.
 
   When this memory limit is reached, the job log circuit breaker logs an error
   message and clears the :ref:`sys.jobs_log <sys-logs>` table completely.
@@ -927,8 +928,9 @@ each of them, the breaker limit can be set.
   | *Default:*    ``5%``
   | *Runtime:*   ``yes``
 
-  The maximum memory that can be used from :ref:`crate-heap-size` for the
-  :ref:`sys.operations_log <sys-logs>` table on each node.
+  The maximum memory that can be used from :ref:`CRATE_HEAP_SIZE
+  <conf-env-heap-size>` for the :ref:`sys.operations_log <sys-logs>` table on
+  each node.
 
   When this memory limit is reached, the operations log circuit breaker logs an
   error message and clears the :ref:`sys.operations_log <sys-logs>` table

--- a/blackbox/docs/config/logging.rst
+++ b/blackbox/docs/config/logging.rst
@@ -138,7 +138,7 @@ collection logging.
 
 :CRATE_GC_LOG_DIR:
   | Log file directory.
-  | *Default for .tar.gz:* :ref:`env-crate-home`/logs
+  | *Default for .tar.gz:* :ref:`CRATE_HOME <conf-env-crate-home>`/logs
   | *Default for .rpm:* /var/log/crate
   | *Default for .deb:* /var/log/crate
 

--- a/blackbox/docs/general/blobs.rst
+++ b/blackbox/docs/general/blobs.rst
@@ -38,7 +38,7 @@ disk.
 The custom blob data path can be set either globally by config or while
 creating a blob table. The path can be either absolute or relative and must be
 creatable/writable by the user CrateDB is running as. A relative path value is
-relative to :ref:`env-crate-home`.
+relative to :ref:`CRATE_HOME <conf-env-crate-home>`.
 
 Blob data will be stored under this path with the following layout::
 

--- a/blackbox/docs/sql/statements/create-blob-table.rst
+++ b/blackbox/docs/sql/statements/create-blob-table.rst
@@ -46,5 +46,5 @@ Specifies a custom path for storing blob data of a blob table.
 
   The path can be either absolute or relative and must be
   creatable/writable by the user CrateDB is running as. A relative path
-  value is relative to :ref:`env-crate-home`. This path take precedence
-  over any global configured value.
+  value is relative to :ref:`CRATE_HOME <conf-env-crate-home>`. This path take
+  precedence over any global configured value.


### PR DESCRIPTION
rewrite the env var docs

this commit removes the mention of gc logging env vars. that is because once crate/crate/pull/7347 has been merged, I intend to move the gc logging variable docs across and link the two documents properly

as it stands, both this pr and the crate/crate/pull/7347 work as individual commits. the third pr ties the work together

information about memory configuration has been removed and I am going to create a new pr that adds this to the guide. once that is merged (and after this pr is merged) I will update this same document to point to it (probably in the third pr mentioned above)