### PR TITLE
Prepare HTTP SQL handler to keep sessions open per HTTP connection

### DIFF
--- a/blackbox/docs/interfaces/http.rst
+++ b/blackbox/docs/interfaces/http.rst
@@ -27,13 +27,25 @@ the statement is sent as value associated to the key ``stmt``.
 A simple ``SELECT`` statement can be submitted like this::
 
     sh$ curl -sS -H 'Content-Type: application/json' \
-    ... -X POST '127.0.0.1:4200/_sql?pretty' \
+    ... -X POST '127.0.0.1:4200/_sql' \
     ... -d '{"stmt":"select name, position from locations order by id limit 2"}'
     {
-      "cols" : [ "name", "position" ],
-      "rows" : [ [ "North West Ripple", 1 ], [ "Arkintoofle Minor", 3 ] ],
-      "rowcount" : 2,
-      "duration" : ...
+      "cols": [
+        "name",
+        "position"
+      ],
+      "rows": [
+        [
+          "North West Ripple",
+          1
+        ],
+        [
+          "Arkintoofle Minor",
+          3
+        ]
+      ],
+      "rowcount": 2,
+      "duration": ...
     }
 
 .. NOTE::
@@ -59,7 +71,7 @@ The placeholders will then be substituted with values from an array that is
 expected under the ``args`` key::
 
     sh$ curl -sS -H 'Content-Type: application/json' \
-    ... -X POST '127.0.0.1:4200/_sql?pretty' -d@- <<- EOF
+    ... -X POST '127.0.0.1:4200/_sql' -d@- <<- EOF
     ... {
     ...   "stmt":
     ...     "select date,position from locations
@@ -68,10 +80,22 @@ expected under the ``args`` key::
     ... }
     ... EOF
     {
-      "cols" : [ "date", "position" ],
-      "rows" : [ [ 308534400000, 1 ], [ 308534400000, 2 ] ],
-      "rowcount" : 2,
-      "duration" : ...
+      "cols": [
+        "date",
+        "position"
+      ],
+      "rows": [
+        [
+          308534400000,
+          1
+        ],
+        [
+          308534400000,
+          2
+        ]
+      ],
+      "rowcount": 2,
+      "duration": ...
     }
 
 .. NOTE::
@@ -88,7 +112,7 @@ expected under the ``args`` key::
 The same query using question marks as placeholders looks like this::
 
     sh$ curl -sS -H 'Content-Type: application/json' \
-    ... -X POST '127.0.0.1:4200/_sql?pretty' -d@- <<- EOF
+    ... -X POST '127.0.0.1:4200/_sql' -d@- <<- EOF
     ... {
     ...   "stmt":
     ...     "select date,position from locations
@@ -97,10 +121,22 @@ The same query using question marks as placeholders looks like this::
     ... }
     ... EOF
     {
-      "cols" : [ "date", "position" ],
-      "rows" : [ [ 308534400000, 1 ], [ 308534400000, 2 ] ],
-      "rowcount" : 2,
-      "duration" : ...
+      "cols": [
+        "date",
+        "position"
+      ],
+      "rows": [
+        [
+          308534400000,
+          1
+        ],
+        [
+          308534400000,
+          2
+        ]
+      ],
+      "rowcount": 2,
+      "duration": ...
     }
 
 .. NOTE::
@@ -116,17 +152,29 @@ It is possible to set a default schema while querying the CrateDB cluster via
 ``Default-Schema`` header with the specified schema name::
 
     sh$ curl -sS -H 'Content-Type: application/json' \
-    ... -X POST '127.0.0.1:4200/_sql?pretty' \
+    ... -X POST '127.0.0.1:4200/_sql' \
     ... -H 'Default-Schema: doc' -d@- <<- EOF
     ... {
     ...   "stmt":"select name, position from locations order by id limit 2"
     ... }
     ... EOF
     {
-      "cols" : [ "name", "position" ],
-      "rows" : [ [ "North West Ripple", 1 ], [ "Arkintoofle Minor", 3 ] ],
-      "rowcount" : 2,
-      "duration" : ...
+      "cols": [
+        "name",
+        "position"
+      ],
+      "rows": [
+        [
+          "North West Ripple",
+          1
+        ],
+        [
+          "Arkintoofle Minor",
+          3
+        ]
+      ],
+      "rowcount": 2,
+      "duration": ...
     }
 
 If the schema name is not specified in the header, the default ``doc`` schema
@@ -143,7 +191,7 @@ In order to get the list of column data types, a ``types`` query parameter must
 be passed to the request::
 
     sh$ curl -sS -H 'Content-Type: application/json' \
-    ... -X POST '127.0.0.1:4200/_sql?types&pretty' -d@- <<- EOF
+    ... -X POST '127.0.0.1:4200/_sql?types' -d@- <<- EOF
     ... {
     ...   "stmt":
     ...     "select date, position from locations
@@ -152,11 +200,26 @@ be passed to the request::
     ... }
     ... EOF
     {
-      "cols" : [ "date", "position" ],
-      "col_types" : [ 11, 9 ],
-      "rows" : [ [ 308534400000, 1 ], [ 308534400000, 2 ] ],
-      "rowcount" : 2,
-      "duration" : ...
+      "cols": [
+        "date",
+        "position"
+      ],
+      "col_types": [
+        11,
+        9
+      ],
+      "rows": [
+        [
+          308534400000,
+          1
+        ],
+        [
+          308534400000,
+          2
+        ]
+      ],
+      "rowcount": 2,
+      "duration": ...
     }
 
 Collection data types like ``Set`` or ``Array`` are displayed as a list where
@@ -236,7 +299,7 @@ The following example describes how to issue an insert bulk operation and
 insert three records at once::
 
     sh$ curl -sS -H 'Content-Type: application/json' \
-    ... -X POST '127.0.0.1:4200/_sql?pretty' -d@- <<- EOF
+    ... -X POST '127.0.0.1:4200/_sql' -d@- <<- EOF
     ... {
     ...   "stmt": "INSERT INTO locations (id, name, kind, description)
     ...           VALUES (?, ?, ?, ?)",
@@ -248,16 +311,19 @@ insert three records at once::
     ... }
     ... EOF
     {
-      "cols" : [ ],
-      "duration" : ...,
-      "results" : [ {
-        "rowcount" : 1
-      }, {
-        "rowcount" : 1
-      }, {
-        "rowcount" : 1
-      } ]
-    <BLANKLINE>
+      "cols": [],
+      "duration": ...,
+      "results": [
+        {
+          "rowcount": 1
+        },
+        {
+          "rowcount": 1
+        },
+        {
+          "rowcount": 1
+        }
+      ]
     }
 
 Error Handling
@@ -271,15 +337,15 @@ Client libraries should use the error code to translate the error into an
 appropriate exception::
 
     sh$ curl -sS -H 'Content-Type: application/json' \
-    ... -X POST '127.0.0.1:4200/_sql?pretty' -d@- <<- EOF
+    ... -X POST '127.0.0.1:4200/_sql' -d@- <<- EOF
     ... {
     ...   "stmt":"select name, position from foo.locations"
     ... }
     ... EOF
     {
-      "error" : {
-        "message" : "SQLActionException[SchemaUnknownException: Schema 'foo' unknown]",
-        "code" : 4045
+      "error": {
+        "message": "SQLActionException[SchemaUnknownException: Schema 'foo' unknown]",
+        "code": 4045
       }
     }
 
@@ -287,17 +353,17 @@ To get more insight into what exactly went wrong an additional ``error_trace``
 GET parameter can be specified to return the stack trace::
 
     sh$ curl -sS -H 'Content-Type: application/json' \
-    ... -X POST '127.0.0.1:4200/_sql?pretty&error_trace=true' -d@- <<- EOF
+    ... -X POST '127.0.0.1:4200/_sql?error_trace=true' -d@- <<- EOF
     ... {
     ...   "stmt":"select name, position from foo.locations"
     ... }
     ... EOF
     {
-      "error" : {
-        "message" : "SQLActionException[SchemaUnknownException: Schema 'foo' unknown]",
-        "code" : 4045
+      "error": {
+        "message": "SQLActionException[SchemaUnknownException: Schema 'foo' unknown]",
+        "code": 4045
       },
-      "error_trace" : "..."
+      "error_trace": "..."
     }
 
 .. NOTE::
@@ -394,7 +460,7 @@ resulting object may contain an ``error_message`` depending on the resulting
 error::
 
     sh$ curl -sS -H 'Content-Type: application/json' \
-    ... -X POST '127.0.0.1:4200/_sql?pretty' -d@- <<- EOF
+    ... -X POST '127.0.0.1:4200/_sql' -d@- <<- EOF
     ... {
     ...   "stmt": "INSERT into locations (name, id) values (?,?)",
     ...   "bulk_args": [
@@ -404,13 +470,16 @@ error::
     ... }
     ... EOF
     {
-      "cols" : [ ],
-      "duration" : ...,
-      "results" : [ {
-        "rowcount" : 1
-      }, {
-        "rowcount" : -2
-      } ]
+      "cols": [],
+      "duration": ...,
+      "results": [
+        {
+          "rowcount": 1
+        },
+        {
+          "rowcount": -2
+        }
+      ]
     }
 
 .. NOTE::

--- a/blob/src/main/java/io/crate/blob/BlobService.java
+++ b/blob/src/main/java/io/crate/blob/BlobService.java
@@ -88,7 +88,7 @@ public class BlobService extends AbstractLifecycleComponent {
     protected void doStart() throws ElasticsearchException {
         piplineRegistry.addBefore(
             new PipelineRegistry.ChannelPipelineItem(
-                "aggregator", "blob_handler", () -> new HttpBlobHandler(this, blobIndicesService))
+                "aggregator", "blob_handler", ignored -> new HttpBlobHandler(this, blobIndicesService))
         );
 
         blobHeadRequestHandler.registerHandler();

--- a/enterprise/users/src/main/java/io/crate/plugin/AuthenticationHttpAuthHandlerRegistry.java
+++ b/enterprise/users/src/main/java/io/crate/plugin/AuthenticationHttpAuthHandlerRegistry.java
@@ -37,7 +37,7 @@ public class AuthenticationHttpAuthHandlerRegistry {
         PipelineRegistry.ChannelPipelineItem pipelineItem = new PipelineRegistry.ChannelPipelineItem(
             "blob_handler",
             "auth_handler",
-            () -> new HttpAuthUpstreamHandler(settings, authentication)
+            ignored -> new HttpAuthUpstreamHandler(settings, authentication)
         );
         pipelineRegistry.addBefore(pipelineItem);
     }

--- a/http/src/main/java/io/crate/plugin/PipelineRegistry.java
+++ b/http/src/main/java/io/crate/plugin/PipelineRegistry.java
@@ -28,10 +28,11 @@ import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
 import org.elasticsearch.common.inject.Provider;
 import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.http.netty4.cors.Netty4CorsConfig;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Supplier;
+import java.util.function.Function;
 
 /**
  * The PipelineRegistry takes care of adding handlers to the existing
@@ -57,14 +58,14 @@ public class PipelineRegistry {
 
         final String base;
         final String name;
-        final Supplier<ChannelHandler> handlerFactory;
+        final Function<Netty4CorsConfig, ChannelHandler> handlerFactory;
 
         /**
          * @param base              the name of the existing handler in the pipeline before/after which the new handler should be added
          * @param name              the name of the new handler that should be added to the pipeline
          * @param handlerFactory    a supplier that provides a new instance of the handler
          */
-        public ChannelPipelineItem(String base, String name, Supplier<ChannelHandler> handlerFactory) {
+        public ChannelPipelineItem(String base, String name, Function<Netty4CorsConfig, ChannelHandler> handlerFactory) {
             this.base = base;
             this.name = name;
             this.handlerFactory = handlerFactory;
@@ -89,9 +90,9 @@ public class PipelineRegistry {
         this.sslContextProvider = sslContextProvider;
     }
 
-    public void registerItems(ChannelPipeline pipeline) {
+    public void registerItems(ChannelPipeline pipeline, Netty4CorsConfig corsConfig) {
         for (PipelineRegistry.ChannelPipelineItem item : addBeforeList) {
-            pipeline.addBefore(item.base, item.name, item.handlerFactory.get());
+            pipeline.addBefore(item.base, item.name, item.handlerFactory.apply(corsConfig));
         }
 
         if (sslContextProvider != null) {

--- a/http/src/main/java/io/crate/protocols/http/CrateNettyHttpServerTransport.java
+++ b/http/src/main/java/io/crate/protocols/http/CrateNettyHttpServerTransport.java
@@ -71,17 +71,20 @@ public class CrateNettyHttpServerTransport extends Netty4HttpServerTransport {
 
     protected class CrateHttpChannelHandler extends HttpChannelHandler {
 
+        private final CrateNettyHttpServerTransport transport;
+
         CrateHttpChannelHandler(CrateNettyHttpServerTransport transport,
                                 boolean detailedErrorsEnabled,
                                 ThreadPool threadPool) {
             super(transport, detailedErrorsEnabled, threadPool.getThreadContext());
+            this.transport = transport;
         }
 
         @Override
         protected void initChannel(Channel ch) throws Exception {
             super.initChannel(ch);
             ChannelPipeline pipeline = ch.pipeline();
-            pipelineRegistry.registerItems(pipeline);
+            pipelineRegistry.registerItems(pipeline, transport.getCorsConfig());
         }
     }
 

--- a/http/src/test/java/io/crate/plugin/PipelineRegistryTest.java
+++ b/http/src/test/java/io/crate/plugin/PipelineRegistryTest.java
@@ -32,7 +32,7 @@ import static org.junit.Assert.assertThat;
 public class PipelineRegistryTest {
 
     private static PipelineRegistry.ChannelPipelineItem channelPipelineItem(String base, String name) {
-        return new PipelineRegistry.ChannelPipelineItem(base, name, () -> new SimpleChannelInboundHandler() {
+        return new PipelineRegistry.ChannelPipelineItem(base, name, (f) -> new SimpleChannelInboundHandler() {
             @Override
             protected void channelRead0(ChannelHandlerContext ctx, Object msg) throws Exception {
 

--- a/sql/src/main/java/io/crate/action/sql/ResultReceiver.java
+++ b/sql/src/main/java/io/crate/action/sql/ResultReceiver.java
@@ -30,7 +30,7 @@ import javax.annotation.Nonnull;
 /**
  * Used via {@link RowConsumerToResultReceiver} to receive results from the execution of a plan
  */
-public interface ResultReceiver extends CompletionListenable {
+public interface ResultReceiver<T> extends CompletionListenable<T> {
 
     void setNextRow(Row row);
 

--- a/sql/src/main/java/io/crate/action/sql/SQLActionException.java
+++ b/sql/src/main/java/io/crate/action/sql/SQLActionException.java
@@ -21,7 +21,7 @@
 
 package io.crate.action.sql;
 
-import org.elasticsearch.rest.RestStatus;
+import io.netty.handler.codec.http.HttpResponseStatus;
 
 /**
  * This exception must be the only one which is thrown by our <code>TransportSQLAction</code>,
@@ -35,10 +35,10 @@ import org.elasticsearch.rest.RestStatus;
  */
 public class SQLActionException extends RuntimeException {
 
-    private final RestStatus status;
+    private final HttpResponseStatus status;
     private final int errorCode;
 
-    public SQLActionException(String message, int errorCode, RestStatus status) {
+    public SQLActionException(String message, int errorCode, HttpResponseStatus status) {
         super(message);
         this.status = status;
         this.errorCode = errorCode;
@@ -53,7 +53,7 @@ public class SQLActionException extends RuntimeException {
      * @param status             the rest status
      * @param stackTraceElements the stacktrace as array
      */
-    public SQLActionException(String message, int errorCode, RestStatus status, StackTraceElement[] stackTraceElements) {
+    public SQLActionException(String message, int errorCode, HttpResponseStatus status, StackTraceElement[] stackTraceElements) {
         this(message, errorCode, status);
         assert stackTraceElements != null : "stackTraceElements must not be null";
         setStackTrace(stackTraceElements);
@@ -62,10 +62,9 @@ public class SQLActionException extends RuntimeException {
     /**
      * Return the rest status code defined on construction
      */
-    public RestStatus status() {
+    public HttpResponseStatus status() {
         return status;
     }
-
 
     /**
      * Return the error code given defined on construction

--- a/sql/src/main/java/io/crate/action/sql/parser/SQLRequestParser.java
+++ b/sql/src/main/java/io/crate/action/sql/parser/SQLRequestParser.java
@@ -63,13 +63,14 @@ public final class SQLRequestParser {
     }
 
     public static SQLRequestParseContext parseSource(BytesReference source) throws SQLParseException {
+        if (source.length() == 0) {
+            throw new SQLParseException("Missing request body");
+        }
         XContentParser parser = null;
         try {
             SQLRequestParseContext parseContext = new SQLRequestParseContext();
-            if (source != null && source.length() != 0) {
-                parser = XContentFactory.xContent(XContentType.JSON).createParser(NamedXContentRegistry.EMPTY, source);
-                parse(parseContext, parser);
-            }
+            parser = XContentFactory.xContent(XContentType.JSON).createParser(NamedXContentRegistry.EMPTY, source);
+            parse(parseContext, parser);
             validate(parseContext);
             return parseContext;
         } catch (Exception e) {

--- a/sql/src/main/java/io/crate/concurrent/CompletionListenable.java
+++ b/sql/src/main/java/io/crate/concurrent/CompletionListenable.java
@@ -24,7 +24,7 @@ package io.crate.concurrent;
 
 import java.util.concurrent.CompletableFuture;
 
-public interface CompletionListenable {
+public interface CompletionListenable<T> {
 
-    CompletableFuture<?> completionFuture();
+    CompletableFuture<T> completionFuture();
 }

--- a/sql/src/main/java/io/crate/exceptions/SQLExceptions.java
+++ b/sql/src/main/java/io/crate/exceptions/SQLExceptions.java
@@ -27,6 +27,7 @@ import io.crate.action.sql.SQLActionException;
 import io.crate.auth.user.ExceptionAuthorizedValidator;
 import io.crate.metadata.PartitionName;
 import io.crate.sql.parser.ParsingException;
+import io.netty.handler.codec.http.HttpResponseStatus;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ResourceAlreadyExistsException;
@@ -41,7 +42,6 @@ import org.elasticsearch.index.shard.ShardNotFoundException;
 import org.elasticsearch.indices.InvalidIndexNameException;
 import org.elasticsearch.indices.InvalidIndexTemplateException;
 import org.elasticsearch.repositories.RepositoryMissingException;
-import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.snapshots.InvalidSnapshotNameException;
 import org.elasticsearch.snapshots.SnapshotCreationException;
 import org.elasticsearch.snapshots.SnapshotMissingException;
@@ -130,33 +130,33 @@ public class SQLExceptions {
 
 
         int errorCode = 5000;
-        RestStatus restStatus = RestStatus.INTERNAL_SERVER_ERROR;
+        HttpResponseStatus httpStatus = HttpResponseStatus.INTERNAL_SERVER_ERROR;
         if (e instanceof CrateException) {
             CrateException crateException = (CrateException) e;
             if (e instanceof ValidationException) {
                 errorCode = 4000 + crateException.errorCode();
-                restStatus = RestStatus.BAD_REQUEST;
+                httpStatus = HttpResponseStatus.BAD_REQUEST;
             } else if (e instanceof UnauthorizedException) {
                 errorCode = 4010 + crateException.errorCode();
-                restStatus = RestStatus.UNAUTHORIZED;
+                httpStatus = HttpResponseStatus.UNAUTHORIZED;
             } else if (e instanceof ReadOnlyException) {
                 errorCode = 4030 + crateException.errorCode();
-                restStatus = RestStatus.FORBIDDEN;
+                httpStatus = HttpResponseStatus.FORBIDDEN;
             } else if (e instanceof ResourceUnknownException) {
                 errorCode = 4040 + crateException.errorCode();
-                restStatus = RestStatus.NOT_FOUND;
+                httpStatus = HttpResponseStatus.NOT_FOUND;
             } else if (e instanceof ConflictException) {
                 errorCode = 4090 + crateException.errorCode();
-                restStatus = RestStatus.CONFLICT;
+                httpStatus = HttpResponseStatus.CONFLICT;
             } else if (e instanceof UnhandledServerException) {
                 errorCode = 5000 + crateException.errorCode();
             }
         } else if (e instanceof ParsingException) {
             errorCode = 4000;
-            restStatus = RestStatus.BAD_REQUEST;
+            httpStatus = HttpResponseStatus.BAD_REQUEST;
         } else if (e instanceof MapperParsingException) {
             errorCode = 4000;
-            restStatus = RestStatus.BAD_REQUEST;
+            httpStatus = HttpResponseStatus.BAD_REQUEST;
         }
 
         String message = e.getMessage();
@@ -173,7 +173,7 @@ public class SQLExceptions {
         } else {
             message = e.getClass().getSimpleName() + ": " + message;
         }
-        return new SQLActionException(message, errorCode, restStatus, e.getStackTrace());
+        return new SQLActionException(message, errorCode, httpStatus, e.getStackTrace());
     }
 
     private static Throwable esToCrateException(Throwable e) {

--- a/sql/src/main/java/io/crate/execution/jobs/JoinContext.java
+++ b/sql/src/main/java/io/crate/execution/jobs/JoinContext.java
@@ -39,7 +39,7 @@ class JoinContext extends AbstractExecutionSubContext implements DownstreamExecu
 
     JoinContext(Logger logger,
                 JoinPhase joinPhase,
-                CompletionListenable completionListenable,
+                CompletionListenable<?> completionListenable,
                 @Nullable PageBucketReceiver leftBucketReceiver,
                 @Nullable PageBucketReceiver rightBucketReceiver) {
         super(joinPhase.phaseId(), logger);

--- a/sql/src/main/java/io/crate/rest/action/RestResultSetReceiver.java
+++ b/sql/src/main/java/io/crate/rest/action/RestResultSetReceiver.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-class RestResultSetReceiver implements ResultReceiver {
+class RestResultSetReceiver implements ResultReceiver<XContentBuilder> {
 
     private final List<Field> outputFields;
     private final ResultToXContentBuilder builder;

--- a/sql/src/main/java/io/crate/rest/action/RestRowCountReceiver.java
+++ b/sql/src/main/java/io/crate/rest/action/RestRowCountReceiver.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 
-class RestRowCountReceiver implements ResultReceiver {
+class RestRowCountReceiver implements ResultReceiver<XContentBuilder> {
 
     private final long startTimeNs;
     private final boolean includeTypes;

--- a/sql/src/main/java/io/crate/rest/action/SqlHttpHandler.java
+++ b/sql/src/main/java/io/crate/rest/action/SqlHttpHandler.java
@@ -1,0 +1,309 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.rest.action;
+
+import io.crate.action.sql.Option;
+import io.crate.action.sql.ResultReceiver;
+import io.crate.action.sql.SQLActionException;
+import io.crate.action.sql.SQLOperations;
+import io.crate.action.sql.Session;
+import io.crate.action.sql.parser.SQLRequestParseContext;
+import io.crate.action.sql.parser.SQLRequestParser;
+import io.crate.auth.AuthSettings;
+import io.crate.auth.user.User;
+import io.crate.auth.user.UserLookup;
+import io.crate.breaker.RamAccountingContext;
+import io.crate.breaker.RowAccounting;
+import io.crate.expression.symbol.Field;
+import io.crate.expression.symbol.Symbols;
+import io.crate.rest.CrateRestMainAction;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import io.netty.handler.codec.http.QueryStringDecoder;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.elasticsearch.http.netty4.cors.Netty4CorsConfig;
+import org.elasticsearch.http.netty4.cors.Netty4CorsHandler;
+import org.elasticsearch.http.netty4.pipelining.HttpPipelinedRequest;
+import org.elasticsearch.transport.netty4.Netty4Utils;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import static io.crate.action.sql.Session.UNNAMED;
+import static io.crate.concurrent.CompletableFutures.failedFuture;
+import static io.crate.exceptions.SQLExceptions.createSQLActionException;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+
+public class SqlHttpHandler extends SimpleChannelInboundHandler<HttpPipelinedRequest> {
+
+    private static final Logger LOGGER = Loggers.getLogger(SqlHttpHandler.class);
+    private static final String REQUEST_HEADER_USER = "User";
+    private static final String REQUEST_HEADER_SCHEMA = "Default-Schema";
+    private static final int DEFAULT_SOFT_LIMIT = 10_000;
+
+    private final Settings settings;
+    private final SQLOperations sqlOperations;
+    private final CircuitBreaker circuitBreaker;
+    private final UserLookup userLookup;
+    private final Netty4CorsConfig corsConfig;
+
+    private Session session;
+
+    SqlHttpHandler(Settings settings,
+                   SQLOperations sqlOperations,
+                   CircuitBreaker circuitBreaker,
+                   UserLookup userLookup,
+                   Netty4CorsConfig corsConfig) {
+        super(false);
+        this.settings = settings;
+        this.sqlOperations = sqlOperations;
+        this.circuitBreaker = circuitBreaker;
+        this.userLookup = userLookup;
+        this.corsConfig = corsConfig;
+    }
+
+    @Override
+    protected void channelRead0(ChannelHandlerContext ctx, HttpPipelinedRequest msg) {
+        FullHttpRequest request = (FullHttpRequest) msg.last();
+        if (request.uri().startsWith("/_sql")) {
+            createNewSession(request);
+            Map<String, List<String>> parameters = new QueryStringDecoder(request.uri()).parameters();
+            ByteBuf content = request.content();
+            handleSQLRequest(content, paramContainFlag(parameters, "types"))
+                .whenComplete((result, t) -> {
+                    try {
+                        sendResponse(ctx, msg, request, parameters, result, t);
+                    } catch (Throwable ex) {
+                        LOGGER.error("Error sending response", ex);
+                        throw ex;
+                    } finally {
+                        content.release();
+                        msg.release();
+                    }
+                });
+        } else {
+            ctx.fireChannelRead(msg);
+        }
+    }
+
+    /**
+     * @return true if the parameters contains a flag entry (e.g. "/_sql?flag" or "/_sql?flag=true")
+     */
+    private static boolean paramContainFlag(Map<String, List<String>> parameters, String flag) {
+        List<String> values = parameters.get(flag);
+        return values != null && (values.equals(singletonList("")) || values.equals(singletonList("true")));
+    }
+
+    @Override
+    public void channelUnregistered(ChannelHandlerContext ctx) throws Exception {
+        if (session != null) {
+            session.close();
+            session = null;
+        }
+        super.channelUnregistered(ctx);
+    }
+
+    private void sendResponse(ChannelHandlerContext ctx,
+                              HttpPipelinedRequest msg,
+                              FullHttpRequest request,
+                              Map<String, List<String>> parameters,
+                              XContentBuilder result,
+                              @Nullable Throwable t) {
+        final HttpVersion httpVersion = request.protocolVersion();
+        final DefaultFullHttpResponse resp;
+        final ByteBuf content;
+        if (t == null) {
+            content = Netty4Utils.toByteBuf(result.bytes());
+            resp = new DefaultFullHttpResponse(httpVersion, HttpResponseStatus.OK, content);
+            resp.headers().add(HttpHeaderNames.CONTENT_TYPE, result.contentType().mediaType());
+        } else {
+            SQLActionException sqlActionException = createSQLActionException(t, session.sessionContext());
+            String mediaType;
+            boolean includeErrorTrace = paramContainFlag(parameters, "error_trace");
+            try (XContentBuilder contentBuilder = HTTPErrorFormatter.convert(sqlActionException, includeErrorTrace)) {
+                content = Netty4Utils.toByteBuf(contentBuilder.bytes());
+                mediaType = contentBuilder.contentType().mediaType();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            resp = new DefaultFullHttpResponse(httpVersion, sqlActionException.status(), content);
+            resp.headers().add(HttpHeaderNames.CONTENT_TYPE, mediaType);
+        }
+        Netty4CorsHandler.setCorsResponseHeaders(request, resp, corsConfig);
+        resp.headers().add(HttpHeaderNames.CONTENT_LENGTH, String.valueOf(content.readableBytes()));
+        boolean closeConnection = isCloseConnection(request);
+        if (httpVersion.equals(HttpVersion.HTTP_1_0) && !closeConnection) {
+            resp.headers().add(HttpHeaderNames.CONNECTION, "Keep-Alive");
+        }
+        ChannelPromise promise = ctx.newPromise();
+        if (closeConnection) {
+            promise.addListener(ChannelFutureListener.CLOSE);
+        }
+        ctx.writeAndFlush(msg.createHttpResponse(resp, promise), promise);
+    }
+
+    private boolean isCloseConnection(FullHttpRequest request) {
+        HttpHeaders headers = request.headers();
+        return HttpHeaderValues.CLOSE.contentEqualsIgnoreCase(headers.get(HttpHeaderNames.CONNECTION))
+               || (request.protocolVersion().equals(HttpVersion.HTTP_1_0)
+                   && !HttpHeaderValues.KEEP_ALIVE.contentEqualsIgnoreCase(headers.get(HttpHeaderNames.CONNECTION)));
+    }
+
+    private CompletableFuture<XContentBuilder> handleSQLRequest(ByteBuf content, boolean includeTypes) {
+        SQLRequestParseContext parseContext;
+        try {
+            parseContext = SQLRequestParser.parseSource(Netty4Utils.toBytesReference(content));
+        } catch (Throwable t) {
+            return failedFuture(t);
+        }
+        Object[] args = parseContext.args();
+        Object[][] bulkArgs = parseContext.bulkArgs();
+        if (bothProvided(args, bulkArgs)) {
+            return failedFuture(new SQLActionException(
+                "request body contains args and bulk_args. It's forbidden to provide both", 4000, HttpResponseStatus.BAD_REQUEST));
+        }
+        try {
+            if (args != null || bulkArgs == null) {
+                return executeSimpleRequest(session, parseContext.stmt(), args, includeTypes);
+            } else {
+                return executeBulkRequest(session, parseContext.stmt(), bulkArgs);
+            }
+        } catch (Throwable t) {
+            return failedFuture(t);
+        }
+    }
+
+    private void createNewSession(FullHttpRequest request) {
+        session = sqlOperations.createSession(
+            request.headers().get(REQUEST_HEADER_SCHEMA),
+            userFromAuthHeader(request.headers().get(HttpHeaderNames.AUTHORIZATION)),
+            optionsFromUserHeader(request.headers().get(REQUEST_HEADER_USER)),
+            DEFAULT_SOFT_LIMIT
+        );
+    }
+
+    private CompletableFuture<XContentBuilder> executeSimpleRequest(Session session,
+                                                                    String stmt,
+                                                                    Object[] args,
+                                                                    boolean includeTypes) throws IOException {
+        long startTimeInNs = System.nanoTime();
+        session.parse(UNNAMED, stmt, emptyList());
+        session.bind(UNNAMED, UNNAMED, args == null ? emptyList() : asList(args), null);
+        Session.DescribeResult description = session.describe('P', UNNAMED);
+        List<Field> resultFields = description.getFields();
+        ResultReceiver<XContentBuilder> resultReceiver;
+        if (resultFields == null) {
+            resultReceiver = new RestRowCountReceiver(JsonXContent.contentBuilder(), startTimeInNs, includeTypes);
+        } else {
+            resultReceiver = new RestResultSetReceiver(
+                JsonXContent.contentBuilder(),
+                resultFields,
+                startTimeInNs,
+                new RowAccounting(
+                    Symbols.typeView(resultFields),
+                    new RamAccountingContext("http-result", circuitBreaker)
+                ),
+                includeTypes
+            );
+        }
+        session.execute(UNNAMED, 0, resultReceiver);
+        return session.sync()
+            .thenCompose(ignored -> resultReceiver.completionFuture());
+    }
+
+    private CompletableFuture<XContentBuilder> executeBulkRequest(Session session,
+                                                                  String stmt,
+                                                                  Object[][] bulkArgs) {
+        final long startTimeInNs = System.nanoTime();
+        session.parse(UNNAMED, stmt, emptyList());
+        final RestBulkRowCountReceiver.Result[] results = new RestBulkRowCountReceiver.Result[bulkArgs.length];
+        for (int i = 0; i < bulkArgs.length; i++) {
+            session.bind(UNNAMED, UNNAMED, Arrays.asList(bulkArgs[i]), null);
+            ResultReceiver resultReceiver = new RestBulkRowCountReceiver(results, i);
+            session.execute(UNNAMED, 0, resultReceiver);
+        }
+        if (results.length > 0) {
+            Session.DescribeResult describeResult = session.describe('P', UNNAMED);
+            if (describeResult.getFields() != null) {
+                return failedFuture(new UnsupportedOperationException(
+                    "Bulk operations for statements that return result sets is not supported"));
+            }
+        }
+        return session.sync()
+            .thenApply(ignored -> {
+                try {
+                    return ResultToXContentBuilder.builder(JsonXContent.contentBuilder())
+                        .cols(emptyList())
+                        .duration(startTimeInNs)
+                        .bulkRows(results)
+                        .build();
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+    }
+
+    private static Set<Option> optionsFromUserHeader(String user) {
+        if (user != null && !user.isEmpty() && user.toLowerCase(Locale.ENGLISH).contains("odbc")) {
+            return EnumSet.of(Option.ALLOW_QUOTED_SUBSCRIPT);
+        }
+        return Option.NONE;
+    }
+
+    User userFromAuthHeader(@Nullable String authHeaderValue) {
+        String username = CrateRestMainAction.extractCredentialsFromHttpBasicAuthHeader(authHeaderValue).v1();
+        // Fallback to trusted user from configuration
+        if (username == null || username.isEmpty()) {
+            username = AuthSettings.AUTH_TRUST_HTTP_DEFAULT_HEADER.setting().get(settings);
+        }
+        return userLookup.findUser(username);
+    }
+
+    private static boolean bothProvided(@Nullable Object[] args, @Nullable Object[][] bulkArgs) {
+        return args != null && args.length > 0 && bulkArgs != null && bulkArgs.length > 0;
+    }
+}

--- a/sql/src/test/java/io/crate/integrationtests/RestSQLActionIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/RestSQLActionIntegrationTest.java
@@ -42,7 +42,8 @@ public class RestSQLActionIntegrationTest extends SQLHttpIntegrationTest {
         CloseableHttpResponse response = post(null);
         assertEquals(400, response.getStatusLine().getStatusCode());
         String bodyAsString = EntityUtils.toString(response.getEntity());
-        assertThat(bodyAsString, startsWith("{\"error\":{\"message\":\"SQLActionException[missing request body]\"," +
+        assertThat(bodyAsString, startsWith("{\"error\":{\"message\":\"" +
+                                            "SQLActionException[SQLParseException: Missing request body]\"," +
                                             "\"code\":4000},\"error_trace\":\"SQLActionException:"
         ));
     }
@@ -52,7 +53,7 @@ public class RestSQLActionIntegrationTest extends SQLHttpIntegrationTest {
         CloseableHttpResponse response = post("{\"foo\": \"bar\"}");
         assertEquals(400, response.getStatusLine().getStatusCode());
         String bodyAsString = EntityUtils.toString(response.getEntity());
-        assertThat(bodyAsString, startsWith("{\"error\":{\"message\":\"SQLActionException[Failed to parse source" +
+        assertThat(bodyAsString, startsWith("{\"error\":{\"message\":\"SQLActionException[SQLParseException: Failed to parse source" +
                                             " [{\\\"foo\\\": \\\"bar\\\"}]]\",\"code\":4000},\"error_trace\":\"")
         );
     }

--- a/sql/src/test/java/io/crate/rest/action/RestSQLActionTest.java
+++ b/sql/src/test/java/io/crate/rest/action/RestSQLActionTest.java
@@ -23,22 +23,13 @@
 package io.crate.rest.action;
 
 import io.crate.action.sql.SQLOperations;
-import io.crate.auth.AuthSettings;
 import io.crate.auth.user.UserManager;
 import io.crate.breaker.CrateCircuitBreakerService;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.testing.DummyUserManager;
-import io.netty.handler.codec.http.HttpHeaderNames;
 import org.elasticsearch.common.inject.Provider;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.RestController;
-import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.test.rest.FakeRestRequest;
-import org.junit.Test;
 
-import java.util.Collections;
-
-import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.mock;
 
 public class RestSQLActionTest extends CrateUnitTest {
@@ -49,53 +40,4 @@ public class RestSQLActionTest extends CrateUnitTest {
     private final RestController restController = mock(RestController.class);
     private final CrateCircuitBreakerService circuitBreakerService = mock(CrateCircuitBreakerService.class);
 
-    @Test
-    public void testDefaultUserIfHttpHeaderNotPresent() throws Exception {
-        RestSQLAction restSQLAction = new RestSQLAction(
-            Settings.EMPTY,
-            restController,
-            sqlOperations,
-            USER_MANAGER_PROVIDER,
-            circuitBreakerService
-        );
-        RestRequest request = new FakeRestRequest.Builder(xContentRegistry())
-            .withHeaders(Collections.emptyMap())
-            .build();
-        assertThat(restSQLAction.userFromRequest(request).name(), is("crate"));
-    }
-
-    @Test
-    public void testSettingUserIfHttpHeaderNotPresent() throws Exception {
-        Settings settings = Settings.builder()
-            .put(AuthSettings.AUTH_TRUST_HTTP_DEFAULT_HEADER.getKey(), "trillian")
-            .build();
-        RestSQLAction restSQLAction = new RestSQLAction(
-            settings,
-            restController,
-            sqlOperations,
-            USER_MANAGER_PROVIDER,
-            circuitBreakerService
-        );
-        RestRequest request = new FakeRestRequest.Builder(xContentRegistry())
-            .withHeaders(Collections.emptyMap())
-            .build();
-        assertThat(restSQLAction.userFromRequest(request).name(), is("trillian"));
-    }
-
-    @Test
-    public void testUserIfHttpBasicAuthIsPresent() {
-        RestSQLAction restSQLAction = new RestSQLAction(
-            Settings.EMPTY,
-            restController,
-            sqlOperations,
-            USER_MANAGER_PROVIDER,
-            circuitBreakerService
-        );
-        RestRequest request = new FakeRestRequest.Builder(xContentRegistry())
-            .withHeaders(
-                Collections.singletonMap(HttpHeaderNames.AUTHORIZATION.toString(),
-                    Collections.singletonList("Basic QWxhZGRpbjpPcGVuU2VzYW1l")))
-            .build();
-        assertThat(restSQLAction.userFromRequest(request).name(), is("Aladdin"));
-    }
 }

--- a/sql/src/test/java/io/crate/rest/action/SqlHttpHandlerTest.java
+++ b/sql/src/test/java/io/crate/rest/action/SqlHttpHandlerTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.rest.action;
+
+import io.crate.action.sql.SQLOperations;
+import io.crate.auth.AuthSettings;
+import io.crate.auth.user.User;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.http.netty4.cors.Netty4CorsConfigBuilder;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class SqlHttpHandlerTest {
+
+    @Test
+    public void testDefaultUserIfHttpHeaderNotPresent() {
+        SqlHttpHandler handler = new SqlHttpHandler(
+            Settings.EMPTY,
+            mock(SQLOperations.class),
+            new NoopCircuitBreaker("dummy"),
+            userName -> {
+                if (userName.equals("crate")) {
+                    return User.CRATE_USER;
+                }
+                return null;
+            },
+            Netty4CorsConfigBuilder.forAnyOrigin().build()
+        );
+
+        User user = handler.userFromAuthHeader(null);
+        assertThat(user, is(User.CRATE_USER));
+    }
+
+    @Test
+    public void testSettingUserIfHttpHeaderNotPresent() {
+        Settings settings = Settings.builder()
+            .put(AuthSettings.AUTH_TRUST_HTTP_DEFAULT_HEADER.getKey(), "trillian")
+            .build();
+        SqlHttpHandler handler = new SqlHttpHandler(
+            settings,
+            mock(SQLOperations.class),
+            new NoopCircuitBreaker("dummy"),
+            User::of,
+            Netty4CorsConfigBuilder.forAnyOrigin().build()
+        );
+
+        User user = handler.userFromAuthHeader(null);
+        assertThat(user.name(), is("trillian"));
+    }
+
+    @Test
+    public void testUserIfHttpBasicAuthIsPresent() {
+        SqlHttpHandler handler = new SqlHttpHandler(
+            Settings.EMPTY,
+            mock(SQLOperations.class),
+            new NoopCircuitBreaker("dummy"),
+            User::of,
+            Netty4CorsConfigBuilder.forAnyOrigin().build()
+        );
+
+        User user = handler.userFromAuthHeader("Basic QWxhZGRpbjpPcGVuU2VzYW1l");
+        assertThat(user.name(), is("Aladdin"));
+    }
+}
+

--- a/sql/src/test/java/io/crate/testing/SQLTransportExecutor.java
+++ b/sql/src/test/java/io/crate/testing/SQLTransportExecutor.java
@@ -41,6 +41,7 @@ import io.crate.shade.org.postgresql.util.PSQLException;
 import io.crate.shade.org.postgresql.util.ServerErrorMessage;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
+import io.netty.handler.codec.http.HttpResponseStatus;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.action.ActionFuture;
@@ -58,7 +59,6 @@ import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.json.JsonXContent;
-import org.elasticsearch.rest.RestStatus;
 import org.hamcrest.Matchers;
 
 import javax.annotation.Nonnull;
@@ -315,10 +315,10 @@ public class SQLTransportExecutor {
             throw new SQLActionException(
                 e.getMessage(),
                 0,
-                RestStatus.BAD_REQUEST,
+                HttpResponseStatus.BAD_REQUEST,
                 stacktrace);
         } catch (SQLException e) {
-            throw new SQLActionException(e.getMessage(), 0, RestStatus.BAD_REQUEST);
+            throw new SQLActionException(e.getMessage(), 0, HttpResponseStatus.BAD_REQUEST);
         }
     }
 


### PR DESCRIPTION
Main motiviations:

 - Being able to later on introduce a `sys.sessions` table that lists
 open sessions with their user, search_path, and so on

 - Having metrics per session to avoid threading synchronization
 overhead. For example `JobsLogs` and the `Histogram` introduced for
 `sys.query_metrics` could be per session and merged ad-hoc if the
 results are used.

There is a separate PR for the first commit: https://github.com/crate/crate/pull/7360

Actually re-using the session will be done in a follow up. This is just preparing the infrastructure