### PR TITLE
Remove synchronized from Variance result

### DIFF
--- a/sql/src/main/java/io/crate/execution/engine/aggregation/statistics/Variance.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/statistics/Variance.java
@@ -45,7 +45,7 @@ public class Variance implements Streamable {
         count++;
     }
 
-    public synchronized double result() {
+    public double result() {
         if (count == 0) {
             return Double.NaN;
         }


### PR DESCRIPTION
It's not used in a multi-threaded context and results in a warning in
`lgtm` because `StandardDeviation` extends `Variance` but doesn't use
synchronized.