### PR TITLE
Return size zero when the StoreStats have already been closed

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -32,3 +32,6 @@ Fixes
 
 - Fixed an issue that could cause ``HTTP`` requests using empty ``bulk_args``
   to fail.
+
+- Fixed NullPointerException which could be thrown when deleting a table and
+  querying `size` from the `sys.shards` table.

--- a/sql/src/test/java/io/crate/execution/engine/collect/ShardCollectorProviderTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/ShardCollectorProviderTest.java
@@ -23,8 +23,8 @@
 package io.crate.execution.engine.collect;
 
 import com.google.common.collect.Lists;
-import io.crate.integrationtests.SQLTransportIntegrationTest;
 import io.crate.execution.engine.collect.sources.ShardCollectSource;
+import io.crate.integrationtests.SQLTransportIntegrationTest;
 import org.elasticsearch.action.admin.indices.close.CloseIndexRequest;
 import org.elasticsearch.index.shard.ShardId;
 import org.junit.Test;
@@ -70,6 +70,7 @@ public class ShardCollectorProviderTest extends SQLTransportIntegrationTest {
         assertNoShardEntriesLeftInShardCollectSource();
     }
 
+    @Test
     public void testQuerySysShardsWhileDropTable() throws Exception {
         execute("create table t1 (x int)");
         execute("create table t2 (x int)");

--- a/sql/src/test/java/io/crate/expression/reference/sys/SysShardsExpressionsTest.java
+++ b/sql/src/test/java/io/crate/expression/reference/sys/SysShardsExpressionsTest.java
@@ -27,6 +27,7 @@ import io.crate.expression.reference.NestedObjectExpression;
 import io.crate.expression.reference.ReferenceResolver;
 import io.crate.expression.reference.sys.shard.ShardPathExpression;
 import io.crate.expression.reference.sys.shard.ShardRecoveryStateExpression;
+import io.crate.expression.reference.sys.shard.ShardSizeExpression;
 import io.crate.expression.udf.UserDefinedFunctionService;
 import io.crate.metadata.Functions;
 import io.crate.metadata.IndexParts;
@@ -63,6 +64,7 @@ import org.elasticsearch.index.store.StoreStats;
 import org.elasticsearch.indices.recovery.RecoveryState;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -352,5 +354,12 @@ public class SysShardsExpressionsTest extends CrateDummyClusterServiceUnitTest {
         };
 
         assertNull(shardRecoveryStateExpression.value());
+    }
+
+    @Test
+    public void testShardSizeExpressionWhenIndexShardHasBeenClosed() {
+        IndexShard mock = Mockito.mock(IndexShard.class);
+        ShardSizeExpression shardSizeExpression = new ShardSizeExpression(mock);
+        assertThat(shardSizeExpression.value(), is(0L));
     }
 }


### PR DESCRIPTION
The StoreStats are not available anymore when the shard has been deleted.
