### PR TITLE
Introduce sys.jobs_metrics table

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -18,6 +18,8 @@ Breaking Changes
 Changes
 =======
 
+- Added a ``sys.jobs_metrics`` table which contains query latency information.
+
 - The setting ``es.api.enabled`` has been marked as deprecated and will be
   removed in a future version. Once removed it will no longer be possible to
   use the ES API.

--- a/blackbox/docs/admin/system-information.rst
+++ b/blackbox/docs/admin/system-information.rst
@@ -1042,6 +1042,40 @@ Every request that queries data or manipulates data is considered a "job" if it
 is a valid query. Requests that are not valid queries (for example, a request
 that tries to query a non-existent table) will not show up as jobs.
 
+Jobs Metrics
+------------
+
+The ``sys.jobs_metrics`` table provides an overview of the query latency in the
+cluster for each node. Jobs metrics are not persisted across node restarts.
+
+.. note::
+
+  In order to reduce the memory requirements for these metrics, the times are
+  statistically sampled and therefore may have slight inaccuracies.
+
+``sys.jobs_metrics`` Table Schema
+.................................
+
++------------------------------------+----------------------------------------------------+---------------+
+| Column Name                        | Description                                        |  Return Type  |
++====================================+====================================================+===============+
+| ``node``                           | An object containing the id and name of the node   | ``OBJECT``    |
+|                                    | on which the metrics have been sampled.            |               |
++------------------------------------+----------------------------------------------------+---------------+
+| ``total_count``                    | Total number of queries executed                   | ``LONG``      |
++------------------------------------+----------------------------------------------------+---------------+
+| ``mean``                           | The mean query latency in ms                       | ``DOUBLE``    |
++------------------------------------+----------------------------------------------------+---------------+
+| ``stdev``                          | The standard deviation of the query latencies      | ``DOUBLE``    |
++------------------------------------+----------------------------------------------------+---------------+
+| ``max``                            | The maximum query latency in ms                    | ``LONG``      |
++------------------------------------+----------------------------------------------------+---------------+
+| ``min``                            | The minimum query latency in ms                    | ``LONG``      |
++------------------------------------+----------------------------------------------------+---------------+
+| ``percentiles``                    | An object containing different percentiles         | ``OBJECT``    |
++------------------------------------+----------------------------------------------------+---------------+
+
+
 .. _sys-operations:
 
 Operations

--- a/blackbox/docs/admin/system-information.rst
+++ b/blackbox/docs/admin/system-information.rst
@@ -1046,7 +1046,10 @@ Jobs Metrics
 ------------
 
 The ``sys.jobs_metrics`` table provides an overview of the query latency in the
-cluster for each node. Jobs metrics are not persisted across node restarts.
+cluster. Jobs metrics are not persisted across node restarts.
+
+The metrics are aggregated for each node and each unique classification of the
+statements.
 
 .. note::
 
@@ -1056,25 +1059,34 @@ cluster for each node. Jobs metrics are not persisted across node restarts.
 ``sys.jobs_metrics`` Table Schema
 .................................
 
-+------------------------------------+----------------------------------------------------+---------------+
-| Column Name                        | Description                                        |  Return Type  |
-+====================================+====================================================+===============+
-| ``node``                           | An object containing the id and name of the node   | ``OBJECT``    |
-|                                    | on which the metrics have been sampled.            |               |
-+------------------------------------+----------------------------------------------------+---------------+
-| ``total_count``                    | Total number of queries executed                   | ``LONG``      |
-+------------------------------------+----------------------------------------------------+---------------+
-| ``mean``                           | The mean query latency in ms                       | ``DOUBLE``    |
-+------------------------------------+----------------------------------------------------+---------------+
-| ``stdev``                          | The standard deviation of the query latencies      | ``DOUBLE``    |
-+------------------------------------+----------------------------------------------------+---------------+
-| ``max``                            | The maximum query latency in ms                    | ``LONG``      |
-+------------------------------------+----------------------------------------------------+---------------+
-| ``min``                            | The minimum query latency in ms                    | ``LONG``      |
-+------------------------------------+----------------------------------------------------+---------------+
-| ``percentiles``                    | An object containing different percentiles         | ``OBJECT``    |
-+------------------------------------+----------------------------------------------------+---------------+
-
++------------------------------+----------------------------------------------------+------------------+
+| Column Name                  | Description                                        |  Return Type     |
++==============================+====================================================+==================+
+| ``node``                     | An object containing the id and name of the node   | ``OBJECT``       |
+|                              | on which the metrics have been sampled.            |                  |
++------------------------------+----------------------------------------------------+------------------+
+| ``classification``           | An object containing the statement classification. | ``OBJECT``       |
++------------------------------+----------------------------------------------------+------------------+
+| ``classification['type']``   | The general type of the statement. Types are:      | ``STRING``       |
+|                              | ``INSERT``, ``SELECT``, ``UPDATE``, ``DELETE``,    |                  |
+|                              | ``COPY``, ``DDL``, and ``MANAGEMENT``.             |                  |
++------------------------------+----------------------------------------------------+------------------+
+| ``classification['labels']`` | Labels are only available for certain statement    | ``STRING_ARRAY`` |
+|                              | types that can be classified more accurately than  |                  |
+|                              | just by their type.                                |                  |
++------------------------------+----------------------------------------------------+------------------+
+| ``total_count``              | Total number of queries executed                   | ``LONG``         |
++------------------------------+----------------------------------------------------+------------------+
+| ``stdev``                    | The standard deviation of the query latencies      | ``DOUBLE``       |
++------------------------------+----------------------------------------------------+------------------+
+| ``mean``                     | The mean query latency in ms                       | ``DOUBLE``       |
++------------------------------+----------------------------------------------------+------------------+
+| ``max``                      | The maximum query latency in ms                    | ``LONG``         |
++------------------------------+----------------------------------------------------+------------------+
+| ``min``                      | The minimum query latency in ms                    | ``LONG``         |
++------------------------------+----------------------------------------------------+------------------+
+| ``percentiles``              | An object containing different percentiles         | ``OBJECT``       |
++------------------------------+----------------------------------------------------+------------------+
 
 .. _sys-operations:
 

--- a/blackbox/docs/general/information-schema.rst
+++ b/blackbox/docs/general/information-schema.rst
@@ -88,6 +88,7 @@ number of replicas.
     | sys                | health                  | BASE TABLE |             NULL | NULL               |
     | sys                | jobs                    | BASE TABLE |             NULL | NULL               |
     | sys                | jobs_log                | BASE TABLE |             NULL | NULL               |
+    | sys                | jobs_metrics            | BASE TABLE |             NULL | NULL               |
     | sys                | node_checks             | BASE TABLE |             NULL | NULL               |
     | sys                | nodes                   | BASE TABLE |             NULL | NULL               |
     | sys                | operations              | BASE TABLE |             NULL | NULL               |
@@ -99,7 +100,7 @@ number of replicas.
     | sys                | summits                 | BASE TABLE |             NULL | NULL               |
     | sys                | users                   | BASE TABLE |             NULL | NULL               |
     +--------------------+-------------------------+------------+------------------+--------------------+
-    SELECT 32 rows in set (... sec)
+    SELECT 33 rows in set (... sec)
 
 The table also contains additional information such as specified routing
 (:ref:`sql_ddl_sharding`) and partitioned by (:ref:`partitioned_tables`)

--- a/enterprise/jmx-monitoring/src/test/java/io/crate/beans/QueryStatsTest.java
+++ b/enterprise/jmx-monitoring/src/test/java/io/crate/beans/QueryStatsTest.java
@@ -23,6 +23,8 @@ import io.crate.auth.user.User;
 import io.crate.execution.engine.collect.stats.JobsLogs;
 import io.crate.expression.reference.sys.job.JobContext;
 import io.crate.expression.reference.sys.job.JobContextLog;
+import io.crate.planner.Plan.StatementType;
+import io.crate.planner.operators.StatementClassifier.Classification;
 import org.junit.Test;
 
 import java.util.List;
@@ -34,42 +36,48 @@ import static org.junit.Assert.assertThat;
 
 public class QueryStatsTest {
 
+    private static final Classification SELECT_CLASSIFICATION = new Classification(StatementType.SELECT);
+    private static final Classification UPDATE_CLASSIFICATION = new Classification(StatementType.UPDATE);
+    private static final Classification DELETE_CLASSIFICATION = new Classification(StatementType.DELETE);
+    private static final Classification INSERT_CLASSIFICATION = new Classification(StatementType.INSERT);
+    private static final Classification DDL_CLASSIFICATION = new Classification(StatementType.DDL);
+
     private final List<JobContextLog> log = ImmutableList.of(
-        new JobContextLog(new JobContext(UUID.randomUUID(), "select name", 100L, User.CRATE_USER), null, 150L),
-        new JobContextLog(new JobContext(UUID.randomUUID(), "select name", 300L, User.CRATE_USER), null, 320L),
-        new JobContextLog(new JobContext(UUID.randomUUID(), "update t1 set x = 10", 400L, User.CRATE_USER), null, 420L),
-        new JobContextLog(new JobContext(UUID.randomUUID(), "insert into t1 (x) values (20)", 111L, User.CRATE_USER), null, 130L),
-        new JobContextLog(new JobContext(UUID.randomUUID(), "delete from t1", 410L, User.CRATE_USER), null, 415L),
-        new JobContextLog(new JobContext(UUID.randomUUID(), "delete from t1", 110L, User.CRATE_USER), null, 120L),
-        new JobContextLog(new JobContext(UUID.randomUUID(), "create table t1 (x int)", 105L, User.CRATE_USER), null, 106L)
+        new JobContextLog(new JobContext(UUID.randomUUID(), "select name", 100L, User.CRATE_USER, SELECT_CLASSIFICATION), null, 150L),
+        new JobContextLog(new JobContext(UUID.randomUUID(), "select name", 300L, User.CRATE_USER, SELECT_CLASSIFICATION), null, 320L),
+        new JobContextLog(new JobContext(UUID.randomUUID(), "update t1 set x = 10", 400L, User.CRATE_USER, UPDATE_CLASSIFICATION), null, 420L),
+        new JobContextLog(new JobContext(UUID.randomUUID(), "insert into t1 (x) values (20)", 111L, User.CRATE_USER, INSERT_CLASSIFICATION), null, 130L),
+        new JobContextLog(new JobContext(UUID.randomUUID(), "delete from t1", 410L, User.CRATE_USER, DELETE_CLASSIFICATION), null, 415L),
+        new JobContextLog(new JobContext(UUID.randomUUID(), "delete from t1", 110L, User.CRATE_USER, DELETE_CLASSIFICATION), null, 120L),
+        new JobContextLog(new JobContext(UUID.randomUUID(), "create table t1 (x int)", 105L, User.CRATE_USER, DDL_CLASSIFICATION), null, 106L)
     );
 
     @Test
-    public void testCreateMetricsMap() throws Exception {
-        Map<String, QueryStats.Metric> metricsByCommand = QueryStats.createMetricsMap(log, 2000, 0L);
+    public void testCreateMetricsMap() {
+        Map<StatementType, QueryStats.Metric> metricsByCommand = QueryStats.createMetricsMap(log, 2000, 0L);
         assertThat(metricsByCommand.size(), is(6));
 
-        assertThat(metricsByCommand.get(QueryStats.Commands.SELECT).avgDurationInMs(), is(35.0));
-        assertThat(metricsByCommand.get(QueryStats.Commands.SELECT).statementsPerSec(), is(1.0));
+        assertThat(metricsByCommand.get(StatementType.SELECT).avgDurationInMs(), is(35.0));
+        assertThat(metricsByCommand.get(StatementType.SELECT).statementsPerSec(), is(1.0));
 
-        assertThat(metricsByCommand.get(QueryStats.Commands.INSERT).avgDurationInMs(), is(19.0));
-        assertThat(metricsByCommand.get(QueryStats.Commands.INSERT).statementsPerSec(), is(0.5));
+        assertThat(metricsByCommand.get(StatementType.INSERT).avgDurationInMs(), is(19.0));
+        assertThat(metricsByCommand.get(StatementType.INSERT).statementsPerSec(), is(0.5));
 
-        assertThat(metricsByCommand.get(QueryStats.Commands.UPDATE).avgDurationInMs(), is(20.0));
-        assertThat(metricsByCommand.get(QueryStats.Commands.UPDATE).statementsPerSec(), is(0.5));
+        assertThat(metricsByCommand.get(StatementType.UPDATE).avgDurationInMs(), is(20.0));
+        assertThat(metricsByCommand.get(StatementType.UPDATE).statementsPerSec(), is(0.5));
 
-        assertThat(metricsByCommand.get(QueryStats.Commands.DELETE).avgDurationInMs(), is(7.0));
-        assertThat(metricsByCommand.get(QueryStats.Commands.DELETE).statementsPerSec(), is(1.0));
+        assertThat(metricsByCommand.get(StatementType.DELETE).avgDurationInMs(), is(7.0));
+        assertThat(metricsByCommand.get(StatementType.DELETE).statementsPerSec(), is(1.0));
 
-        assertThat(metricsByCommand.get(QueryStats.Commands.UNCLASSIFIED).avgDurationInMs(), is(1.0));
-        assertThat(metricsByCommand.get(QueryStats.Commands.UNCLASSIFIED).statementsPerSec(), is(0.5));
+        assertThat(metricsByCommand.get(StatementType.UNDEFINED).avgDurationInMs(), is(1.0));
+        assertThat(metricsByCommand.get(StatementType.UNDEFINED).statementsPerSec(), is(0.5));
 
-        assertThat(metricsByCommand.get(QueryStats.Commands.TOTAL).avgDurationInMs(), is(15.0));
-        assertThat(metricsByCommand.get(QueryStats.Commands.TOTAL).statementsPerSec(), is(4.0));
+        assertThat(metricsByCommand.get(StatementType.ALL).avgDurationInMs(), is(15.0));
+        assertThat(metricsByCommand.get(StatementType.ALL).statementsPerSec(), is(4.0));
     }
 
     @Test
-    public void testDefaultValue() throws Exception {
+    public void testDefaultValue() {
         QueryStats queryStats = new QueryStats(new JobsLogs(() -> true));
         assertThat(queryStats.getSelectQueryFrequency(), is(0.0));
         assertThat(queryStats.getSelectQueryAverageDuration(), is(0.0));

--- a/sql/src/main/java/io/crate/action/sql/Session.java
+++ b/sql/src/main/java/io/crate/action/sql/Session.java
@@ -44,6 +44,7 @@ import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Plan;
 import io.crate.planner.Planner;
 import io.crate.planner.PlannerContext;
+import io.crate.planner.operators.StatementClassifier;
 import io.crate.planner.operators.SubQueryResults;
 import io.crate.protocols.postgres.FormatCodes;
 import io.crate.protocols.postgres.JobsLogsUpdateListener;
@@ -183,7 +184,8 @@ public class Session implements AutoCloseable {
             jobsLogs.logPreExecutionFailure(jobId, statement, SQLExceptions.messageOf(t), sessionContext.user());
             throw t;
         }
-        jobsLogs.logExecutionStart(jobId, statement, sessionContext.user());
+        StatementClassifier.Classification classification = StatementClassifier.classify(plan);
+        jobsLogs.logExecutionStart(jobId, statement, sessionContext.user(), classification);
         resultReceiver.completionFuture().whenComplete(new JobsLogsUpdateListener(jobId, jobsLogs));
 
         if (!analyzedStatement.isWriteOperation()) {

--- a/sql/src/main/java/io/crate/execution/engine/collect/stats/JobsLogService.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/stats/JobsLogService.java
@@ -203,6 +203,7 @@ public class JobsLogService extends AbstractLifecycleComponent implements Provid
             isEnabled = false;
             updateOperationSink(0, TimeValue.timeValueSeconds(0));
             updateJobSink(0, TimeValue.timeValueSeconds(0));
+            jobsLogs.resetMetricHistograms();
         }
     }
 

--- a/sql/src/main/java/io/crate/expression/reference/sys/job/JobContext.java
+++ b/sql/src/main/java/io/crate/expression/reference/sys/job/JobContext.java
@@ -22,21 +22,26 @@
 package io.crate.expression.reference.sys.job;
 
 import io.crate.auth.user.User;
+import io.crate.planner.operators.StatementClassifier.Classification;
 
+import javax.annotation.Nullable;
 import java.util.UUID;
 
 public class JobContext {
 
-    public final UUID id;
-    public final String username;
-    public final String stmt;
-    public final long started;
+    private final UUID id;
+    private final String username;
+    private final String stmt;
+    private final long started;
+    @Nullable
+    private final Classification classification;
 
-    public JobContext(UUID id, String stmt, long started, User user) {
+    public JobContext(UUID id, String stmt, long started, User user, @Nullable Classification classification) {
         this.id = id;
         this.stmt = stmt;
         this.started = started;
         this.username = user.name();
+        this.classification = classification;
     }
 
     public UUID id() {
@@ -53,5 +58,10 @@ public class JobContext {
 
     public long started() {
         return started;
+    }
+
+    @Nullable
+    public Classification classification() {
+        return classification;
     }
 }

--- a/sql/src/main/java/io/crate/expression/reference/sys/job/JobContextLog.java
+++ b/sql/src/main/java/io/crate/expression/reference/sys/job/JobContextLog.java
@@ -22,6 +22,7 @@
 package io.crate.expression.reference.sys.job;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.crate.planner.operators.StatementClassifier;
 
 import javax.annotation.Nullable;
 import java.util.UUID;
@@ -49,7 +50,7 @@ public class JobContextLog implements ContextLog {
     }
 
     public UUID id() {
-        return jobContext.id;
+        return jobContext.id();
     }
 
     @Nullable
@@ -58,11 +59,16 @@ public class JobContextLog implements ContextLog {
     }
 
     public String statement() {
-        return jobContext.stmt;
+        return jobContext.stmt();
     }
 
     public long started() {
-        return jobContext.started;
+        return jobContext.started();
+    }
+
+    @Nullable
+    public StatementClassifier.Classification classification() {
+        return jobContext.classification();
     }
 
     @Override

--- a/sql/src/main/java/io/crate/metadata/sys/ClassifiedHistograms.java
+++ b/sql/src/main/java/io/crate/metadata/sys/ClassifiedHistograms.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.sys;
+
+import io.crate.planner.operators.StatementClassifier.Classification;
+import org.HdrHistogram.ConcurrentHistogram;
+import org.HdrHistogram.Histogram;
+
+import java.util.Iterator;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+public class ClassifiedHistograms implements Iterable<ClassifiedHistograms.ClassifiedHistogram> {
+
+    private static final long HIGHEST_TRACKABLE_VALUE = TimeUnit.MINUTES.toMillis(10);
+    private static final int NUMBER_OF_SIGNIFICANT_VALUE_DIGITS = 3;
+
+    private final ConcurrentHashMap<Classification, ConcurrentHistogram> histograms = new ConcurrentHashMap<>();
+
+    public static class ClassifiedHistogram {
+
+        private Histogram histogram;
+        private Classification classification;
+
+        ClassifiedHistogram(Histogram histogram, Classification classification) {
+            this.histogram = histogram;
+            this.classification = classification;
+        }
+
+        public Histogram histogram() {
+            return histogram;
+        }
+
+        public Classification classification() {
+            return classification;
+        }
+    }
+
+    public ConcurrentHistogram getOrCreate(Classification classification) {
+        ConcurrentHistogram histogram = histograms.get(classification);
+        if (histogram == null) {
+            histogram = new ConcurrentHistogram(HIGHEST_TRACKABLE_VALUE, NUMBER_OF_SIGNIFICANT_VALUE_DIGITS);
+            histograms.put(classification, histogram);
+        }
+        return histogram;
+    }
+
+    public void reset() {
+        histograms.clear();
+    }
+
+    @Override
+    public Iterator<ClassifiedHistogram> iterator() {
+        return histograms.entrySet()
+            .stream()
+            .map(e -> new ClassifiedHistogram(e.getValue().copy(), e.getKey()))
+            .iterator();
+    }
+}

--- a/sql/src/main/java/io/crate/metadata/sys/SysMetricsTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysMetricsTableInfo.java
@@ -34,10 +34,10 @@ import io.crate.metadata.expressions.RowCollectExpressionFactory;
 import io.crate.metadata.table.ColumnRegistrar;
 import io.crate.metadata.table.StaticTableInfo;
 import io.crate.types.DataTypes;
-import org.HdrHistogram.Histogram;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.lucene.BytesRefs;
 
 import java.util.Collections;
 import java.util.Map;
@@ -65,24 +65,9 @@ public class SysMetricsTableInfo extends StaticTableInfo {
         static final ColumnIdent NODE = new ColumnIdent("node");
         static final ColumnIdent NODE_ID = new ColumnIdent("node", "id");
         static final ColumnIdent NODE_NAME = new ColumnIdent("node", "name");
-    }
-
-    public static class ClassifiedHist {
-        Histogram histogram;
-        String type;
-
-        public ClassifiedHist(Histogram histogram, String type) {
-            this.histogram = histogram;
-            this.type = type;
-        }
-
-        public Histogram histogram() {
-            return histogram;
-        }
-
-        public String type() {
-            return type;
-        }
+        static final ColumnIdent CLASS = new ColumnIdent("classification");
+        static final ColumnIdent CLASS_TYPE = new ColumnIdent("classification", "type");
+        static final ColumnIdent CLASS_LABELS = new ColumnIdent("classification", "labels");
     }
 
     SysMetricsTableInfo() {
@@ -102,33 +87,36 @@ public class SysMetricsTableInfo extends StaticTableInfo {
                 .register(Columns.P99, DataTypes.LONG)
                 .register(Columns.NODE, DataTypes.OBJECT)
                 .register(Columns.NODE_ID, DataTypes.STRING)
-                .register(Columns.NODE_NAME, DataTypes.STRING),
+                .register(Columns.NODE_NAME, DataTypes.STRING)
+                .register(Columns.CLASS, DataTypes.OBJECT)
+                .register(Columns.CLASS_TYPE, DataTypes.STRING)
+                .register(Columns.CLASS_LABELS, DataTypes.STRING_ARRAY),
             Collections.emptyList()
         );
     }
 
-    public static Map<ColumnIdent, RowCollectExpressionFactory<ClassifiedHist>> expressions(Supplier<DiscoveryNode> localNode) {
-        return ImmutableMap.<ColumnIdent, RowCollectExpressionFactory<ClassifiedHist>>builder()
-            .put(Columns.TOTAL_COUNT, () -> forFunction(h -> h.histogram.getTotalCount()))
-            .put(Columns.MEAN, () -> forFunction(h -> h.histogram.getMean()))
-            .put(Columns.STDEV, () -> forFunction(h -> h.histogram.getStdDeviation()))
-            .put(Columns.MAX, () -> forFunction(h -> h.histogram.getMaxValue()))
-            .put(Columns.MIN, () -> forFunction(h -> h.histogram.getTotalCount() == 0 ? 0 : h.histogram.getMinNonZeroValue()))
+    public static Map<ColumnIdent, RowCollectExpressionFactory<ClassifiedHistograms.ClassifiedHistogram>> expressions(Supplier<DiscoveryNode> localNode) {
+        return ImmutableMap.<ColumnIdent, RowCollectExpressionFactory<ClassifiedHistograms.ClassifiedHistogram>>builder()
+            .put(Columns.TOTAL_COUNT, () -> forFunction(h -> h.histogram().getTotalCount()))
+            .put(Columns.MEAN, () -> forFunction(h -> h.histogram().getMean()))
+            .put(Columns.STDEV, () -> forFunction(h -> h.histogram().getStdDeviation()))
+            .put(Columns.MAX, () -> forFunction(h -> h.histogram().getMaxValue()))
+            .put(Columns.MIN, () -> forFunction(h -> h.histogram().getTotalCount() == 0 ? 0 : h.histogram().getMinNonZeroValue()))
             .put(Columns.PERCENTILES, () -> forFunction(h -> ImmutableMap.builder()
-                .put("25", h.histogram.getValueAtPercentile(25.0))
-                .put("50", h.histogram.getValueAtPercentile(50.0))
-                .put("75", h.histogram.getValueAtPercentile(75.0))
-                .put("90", h.histogram.getValueAtPercentile(90.0))
-                .put("95", h.histogram.getValueAtPercentile(95.0))
-                .put("99", h.histogram.getValueAtPercentile(99.0))
+                .put("25", h.histogram().getValueAtPercentile(25.0))
+                .put("50", h.histogram().getValueAtPercentile(50.0))
+                .put("75", h.histogram().getValueAtPercentile(75.0))
+                .put("90", h.histogram().getValueAtPercentile(90.0))
+                .put("95", h.histogram().getValueAtPercentile(95.0))
+                .put("99", h.histogram().getValueAtPercentile(99.0))
                 .build()
             ))
-            .put(Columns.P25, () -> forFunction(h -> h.histogram.getValueAtPercentile(25.0)))
-            .put(Columns.P50, () -> forFunction(h -> h.histogram.getValueAtPercentile(50.0)))
-            .put(Columns.P75, () -> forFunction(h -> h.histogram.getValueAtPercentile(75.0)))
-            .put(Columns.P90, () -> forFunction(h -> h.histogram.getValueAtPercentile(90.0)))
-            .put(Columns.P95, () -> forFunction(h -> h.histogram.getValueAtPercentile(95.0)))
-            .put(Columns.P99, () -> forFunction(h -> h.histogram.getValueAtPercentile(99.0)))
+            .put(Columns.P25, () -> forFunction(h -> h.histogram().getValueAtPercentile(25.0)))
+            .put(Columns.P50, () -> forFunction(h -> h.histogram().getValueAtPercentile(50.0)))
+            .put(Columns.P75, () -> forFunction(h -> h.histogram().getValueAtPercentile(75.0)))
+            .put(Columns.P90, () -> forFunction(h -> h.histogram().getValueAtPercentile(90.0)))
+            .put(Columns.P95, () -> forFunction(h -> h.histogram().getValueAtPercentile(95.0)))
+            .put(Columns.P99, () -> forFunction(h -> h.histogram().getValueAtPercentile(99.0)))
             .put(Columns.NODE, () -> forFunction(ignored -> ImmutableMap.builder()
                 .put("id", new BytesRef(localNode.get().getId()))
                 .put("name", new BytesRef(localNode.get().getName()))
@@ -136,6 +124,21 @@ public class SysMetricsTableInfo extends StaticTableInfo {
             ))
             .put(Columns.NODE_ID, () -> forFunction(ignored -> new BytesRef(localNode.get().getId())))
             .put(Columns.NODE_NAME, () -> forFunction(ignored -> new BytesRef(localNode.get().getName())))
+            .put(Columns.CLASS, () -> forFunction(h -> ImmutableMap.builder()
+                .put("type", new BytesRef(h.classification().type().name()))
+                .put("labels", h.classification().labels()
+                    .stream()
+                    .map(BytesRefs::toBytesRef)
+                    .toArray(BytesRef[]::new)
+                )
+                .build()
+            ))
+            .put(Columns.CLASS_TYPE, () -> forFunction(h -> new BytesRef(h.classification().type().name())))
+            .put(Columns.CLASS_LABELS, () -> forFunction(h -> h.classification().labels()
+                .stream()
+                .map(BytesRefs::toBytesRef)
+                .toArray(BytesRef[]::new)
+            ))
             .build();
     }
 

--- a/sql/src/main/java/io/crate/metadata/sys/SysMetricsTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysMetricsTableInfo.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.sys;
+
+import com.google.common.collect.ImmutableMap;
+import io.crate.action.sql.SessionContext;
+import io.crate.analyze.WhereClause;
+import io.crate.metadata.ColumnIdent;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.Routing;
+import io.crate.metadata.RoutingProvider;
+import io.crate.metadata.RowGranularity;
+import io.crate.metadata.expressions.RowCollectExpressionFactory;
+import io.crate.metadata.table.ColumnRegistrar;
+import io.crate.metadata.table.StaticTableInfo;
+import io.crate.types.DataTypes;
+import org.HdrHistogram.Histogram;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static io.crate.metadata.RowContextCollectorExpression.forFunction;
+
+public class SysMetricsTableInfo extends StaticTableInfo {
+
+    public static final RelationName NAME = new RelationName(SysSchemaInfo.NAME, "jobs_metrics");
+
+    static class Columns {
+        static final ColumnIdent TOTAL_COUNT = new ColumnIdent("total_count");
+        static final ColumnIdent MEAN = new ColumnIdent("mean");
+        static final ColumnIdent STDEV = new ColumnIdent("stdev");
+        static final ColumnIdent MAX = new ColumnIdent("max");
+        static final ColumnIdent MIN = new ColumnIdent("min");
+        static final ColumnIdent PERCENTILES = new ColumnIdent("percentiles");
+        static final ColumnIdent P25 = new ColumnIdent("percentiles", "25");
+        static final ColumnIdent P50 = new ColumnIdent("percentiles", "50");
+        static final ColumnIdent P75 = new ColumnIdent("percentiles", "75");
+        static final ColumnIdent P90 = new ColumnIdent("percentiles", "90");
+        static final ColumnIdent P95 = new ColumnIdent("percentiles", "95");
+        static final ColumnIdent P99 = new ColumnIdent("percentiles", "99");
+        static final ColumnIdent NODE = new ColumnIdent("node");
+        static final ColumnIdent NODE_ID = new ColumnIdent("node", "id");
+        static final ColumnIdent NODE_NAME = new ColumnIdent("node", "name");
+    }
+
+    public static class ClassifiedHist {
+        Histogram histogram;
+        String type;
+
+        public ClassifiedHist(Histogram histogram, String type) {
+            this.histogram = histogram;
+            this.type = type;
+        }
+
+        public Histogram histogram() {
+            return histogram;
+        }
+
+        public String type() {
+            return type;
+        }
+    }
+
+    SysMetricsTableInfo() {
+        super(NAME,
+            new ColumnRegistrar(NAME, RowGranularity.DOC)
+                .register(Columns.TOTAL_COUNT, DataTypes.LONG)
+                .register(Columns.MEAN, DataTypes.DOUBLE)
+                .register(Columns.STDEV, DataTypes.DOUBLE)
+                .register(Columns.MAX, DataTypes.LONG)
+                .register(Columns.MIN, DataTypes.LONG)
+                .register(Columns.PERCENTILES, DataTypes.OBJECT)
+                .register(Columns.P25, DataTypes.LONG)
+                .register(Columns.P50, DataTypes.LONG)
+                .register(Columns.P75, DataTypes.LONG)
+                .register(Columns.P90, DataTypes.LONG)
+                .register(Columns.P95, DataTypes.LONG)
+                .register(Columns.P99, DataTypes.LONG)
+                .register(Columns.NODE, DataTypes.OBJECT)
+                .register(Columns.NODE_ID, DataTypes.STRING)
+                .register(Columns.NODE_NAME, DataTypes.STRING),
+            Collections.emptyList()
+        );
+    }
+
+    public static Map<ColumnIdent, RowCollectExpressionFactory<ClassifiedHist>> expressions(Supplier<DiscoveryNode> localNode) {
+        return ImmutableMap.<ColumnIdent, RowCollectExpressionFactory<ClassifiedHist>>builder()
+            .put(Columns.TOTAL_COUNT, () -> forFunction(h -> h.histogram.getTotalCount()))
+            .put(Columns.MEAN, () -> forFunction(h -> h.histogram.getMean()))
+            .put(Columns.STDEV, () -> forFunction(h -> h.histogram.getStdDeviation()))
+            .put(Columns.MAX, () -> forFunction(h -> h.histogram.getMaxValue()))
+            .put(Columns.MIN, () -> forFunction(h -> h.histogram.getTotalCount() == 0 ? 0 : h.histogram.getMinNonZeroValue()))
+            .put(Columns.PERCENTILES, () -> forFunction(h -> ImmutableMap.builder()
+                .put("25", h.histogram.getValueAtPercentile(25.0))
+                .put("50", h.histogram.getValueAtPercentile(50.0))
+                .put("75", h.histogram.getValueAtPercentile(75.0))
+                .put("90", h.histogram.getValueAtPercentile(90.0))
+                .put("95", h.histogram.getValueAtPercentile(95.0))
+                .put("99", h.histogram.getValueAtPercentile(99.0))
+                .build()
+            ))
+            .put(Columns.P25, () -> forFunction(h -> h.histogram.getValueAtPercentile(25.0)))
+            .put(Columns.P50, () -> forFunction(h -> h.histogram.getValueAtPercentile(50.0)))
+            .put(Columns.P75, () -> forFunction(h -> h.histogram.getValueAtPercentile(75.0)))
+            .put(Columns.P90, () -> forFunction(h -> h.histogram.getValueAtPercentile(90.0)))
+            .put(Columns.P95, () -> forFunction(h -> h.histogram.getValueAtPercentile(95.0)))
+            .put(Columns.P99, () -> forFunction(h -> h.histogram.getValueAtPercentile(99.0)))
+            .put(Columns.NODE, () -> forFunction(ignored -> ImmutableMap.builder()
+                .put("id", new BytesRef(localNode.get().getId()))
+                .put("name", new BytesRef(localNode.get().getName()))
+                .build()
+            ))
+            .put(Columns.NODE_ID, () -> forFunction(ignored -> new BytesRef(localNode.get().getId())))
+            .put(Columns.NODE_NAME, () -> forFunction(ignored -> new BytesRef(localNode.get().getName())))
+            .build();
+    }
+
+    @Override
+    public Routing getRouting(ClusterState state, RoutingProvider routingProvider, WhereClause whereClause, RoutingProvider.ShardSelection shardSelection, SessionContext sessionContext) {
+        return Routing.forTableOnAllNodes(NAME, state.getNodes());
+    }
+
+    @Override
+    public RowGranularity rowGranularity() {
+        return RowGranularity.DOC;
+    }
+}

--- a/sql/src/main/java/io/crate/metadata/sys/SysSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysSchemaInfo.java
@@ -55,6 +55,7 @@ public class SysSchemaInfo implements SchemaInfo {
         tableInfos.put(SysSummitsTableInfo.IDENT.name(), new SysSummitsTableInfo());
         tableInfos.put(SysAllocationsTableInfo.IDENT.name(), new SysAllocationsTableInfo());
         tableInfos.put(SysHealthTableInfo.IDENT.name(), new SysHealthTableInfo());
+        tableInfos.put(SysMetricsTableInfo.NAME.name(), new SysMetricsTableInfo());
     }
 
     @Override

--- a/sql/src/main/java/io/crate/metadata/sys/SysTableDefinitions.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysTableDefinitions.java
@@ -112,6 +112,10 @@ public class SysTableDefinitions {
             SysHealthTableInfo.expressions(),
             (user, tableHealth) -> user.hasAnyPrivilege(Privilege.Clazz.TABLE, tableHealth.fqn())
         ));
+        tableDefinitions.put(SysMetricsTableInfo.NAME, new StaticTableDefinition<>(
+            () -> completedFuture(jobsLogs.metrics()),
+            SysMetricsTableInfo.expressions(clusterService::localNode)
+        ));
     }
 
     public StaticTableDefinition<?> get(RelationName relationName) {

--- a/sql/src/main/java/io/crate/planner/CreateViewPlan.java
+++ b/sql/src/main/java/io/crate/planner/CreateViewPlan.java
@@ -41,6 +41,11 @@ public final class CreateViewPlan implements Plan {
     }
 
     @Override
+    public StatementType type() {
+        return StatementType.DDL;
+    }
+
+    @Override
     public void execute(DependencyCarrier dependencies,
                         PlannerContext plannerContext,
                         RowConsumer consumer,

--- a/sql/src/main/java/io/crate/planner/DropViewPlan.java
+++ b/sql/src/main/java/io/crate/planner/DropViewPlan.java
@@ -43,6 +43,11 @@ public class DropViewPlan implements Plan {
     }
 
     @Override
+    public StatementType type() {
+        return StatementType.DDL;
+    }
+
+    @Override
     public void execute(DependencyCarrier dependencies,
                         PlannerContext plannerContext,
                         RowConsumer consumer,

--- a/sql/src/main/java/io/crate/planner/MultiPhasePlan.java
+++ b/sql/src/main/java/io/crate/planner/MultiPhasePlan.java
@@ -63,6 +63,11 @@ public class MultiPhasePlan implements Plan {
     }
 
     @Override
+    public StatementType type() {
+        return StatementType.SELECT;
+    }
+
+    @Override
     public void execute(DependencyCarrier executor,
                         PlannerContext plannerContext,
                         RowConsumer consumer,

--- a/sql/src/main/java/io/crate/planner/NoopPlan.java
+++ b/sql/src/main/java/io/crate/planner/NoopPlan.java
@@ -39,6 +39,11 @@ public final class NoopPlan implements Plan {
     }
 
     @Override
+    public StatementType type() {
+        return StatementType.UNDEFINED;
+    }
+
+    @Override
     public void execute(DependencyCarrier executor,
                         PlannerContext plannerContext,
                         RowConsumer consumer,

--- a/sql/src/main/java/io/crate/planner/Plan.java
+++ b/sql/src/main/java/io/crate/planner/Plan.java
@@ -34,6 +34,24 @@ import java.util.concurrent.CompletableFuture;
  */
 public interface Plan {
 
+    enum StatementType {
+        INSERT,
+        SELECT,
+        UPDATE,
+        DELETE,
+        COPY,
+        DDL,
+        MANAGEMENT,
+        UNDEFINED,
+        /**
+         * ALL is used in {@link io.crate.beans.QueryStats} as a key to hold the aggregation of all other query types.
+         * This type must never be used to classify a plan.
+         */
+        ALL,
+    }
+
+    StatementType type();
+
     void execute(DependencyCarrier executor,
                  PlannerContext plannerContext,
                  RowConsumer consumer,

--- a/sql/src/main/java/io/crate/planner/consumer/UpdatePlanner.java
+++ b/sql/src/main/java/io/crate/planner/consumer/UpdatePlanner.java
@@ -138,6 +138,11 @@ public final class UpdatePlanner {
         }
 
         @Override
+        public StatementType type() {
+            return StatementType.UPDATE;
+        }
+
+        @Override
         public void execute(DependencyCarrier executor,
                             PlannerContext plannerContext,
                             RowConsumer consumer,

--- a/sql/src/main/java/io/crate/planner/node/dcl/GenericDCLPlan.java
+++ b/sql/src/main/java/io/crate/planner/node/dcl/GenericDCLPlan.java
@@ -41,6 +41,11 @@ public class GenericDCLPlan implements Plan {
     }
 
     @Override
+    public StatementType type() {
+        return StatementType.MANAGEMENT;
+    }
+
+    @Override
     public void execute(DependencyCarrier executor,
                         PlannerContext plannerContext,
                         RowConsumer consumer,

--- a/sql/src/main/java/io/crate/planner/node/ddl/CreateAnalyzerPlan.java
+++ b/sql/src/main/java/io/crate/planner/node/ddl/CreateAnalyzerPlan.java
@@ -45,6 +45,11 @@ public class CreateAnalyzerPlan implements Plan {
     }
 
     @Override
+    public StatementType type() {
+        return StatementType.DDL;
+    }
+
+    @Override
     public void execute(DependencyCarrier executor,
                         PlannerContext plannerContext,
                         RowConsumer consumer,

--- a/sql/src/main/java/io/crate/planner/node/ddl/DeleteAllPartitions.java
+++ b/sql/src/main/java/io/crate/planner/node/ddl/DeleteAllPartitions.java
@@ -45,6 +45,11 @@ public final class DeleteAllPartitions implements Plan {
     }
 
     @Override
+    public StatementType type() {
+        return StatementType.DELETE;
+    }
+
+    @Override
     public void execute(DependencyCarrier executor,
                         PlannerContext plannerContext,
                         RowConsumer consumer,

--- a/sql/src/main/java/io/crate/planner/node/ddl/DeletePartitions.java
+++ b/sql/src/main/java/io/crate/planner/node/ddl/DeletePartitions.java
@@ -61,6 +61,11 @@ public class DeletePartitions implements Plan {
     }
 
     @Override
+    public StatementType type() {
+        return StatementType.DELETE;
+    }
+
+    @Override
     public void execute(DependencyCarrier executor,
                         PlannerContext plannerContext,
                         RowConsumer consumer,

--- a/sql/src/main/java/io/crate/planner/node/ddl/DropTablePlan.java
+++ b/sql/src/main/java/io/crate/planner/node/ddl/DropTablePlan.java
@@ -49,6 +49,11 @@ public class DropTablePlan implements Plan {
     }
 
     @Override
+    public StatementType type() {
+        return StatementType.DDL;
+    }
+
+    @Override
     public void execute(DependencyCarrier executor,
                         PlannerContext plannerContext,
                         RowConsumer consumer,

--- a/sql/src/main/java/io/crate/planner/node/ddl/ESClusterUpdateSettingsPlan.java
+++ b/sql/src/main/java/io/crate/planner/node/ddl/ESClusterUpdateSettingsPlan.java
@@ -63,6 +63,11 @@ public class ESClusterUpdateSettingsPlan implements Plan {
     }
 
     @Override
+    public StatementType type() {
+        return StatementType.MANAGEMENT;
+    }
+
+    @Override
     public void execute(DependencyCarrier executor,
                         PlannerContext plannerContext,
                         RowConsumer consumer,

--- a/sql/src/main/java/io/crate/planner/node/ddl/GenericDDLPlan.java
+++ b/sql/src/main/java/io/crate/planner/node/ddl/GenericDDLPlan.java
@@ -40,6 +40,11 @@ public class GenericDDLPlan implements Plan {
     }
 
     @Override
+    public StatementType type() {
+        return StatementType.DDL;
+    }
+
+    @Override
     public void execute(DependencyCarrier executor,
                         PlannerContext plannerContext,
                         RowConsumer consumer,

--- a/sql/src/main/java/io/crate/planner/node/dml/DeleteById.java
+++ b/sql/src/main/java/io/crate/planner/node/dml/DeleteById.java
@@ -53,6 +53,11 @@ public class DeleteById implements Plan {
     }
 
     @Override
+    public StatementType type() {
+        return StatementType.DELETE;
+    }
+
+    @Override
     public void execute(DependencyCarrier executor,
                         PlannerContext plannerContext,
                         RowConsumer consumer,

--- a/sql/src/main/java/io/crate/planner/node/dml/LegacyUpsertById.java
+++ b/sql/src/main/java/io/crate/planner/node/dml/LegacyUpsertById.java
@@ -46,7 +46,6 @@ import java.util.concurrent.CompletableFuture;
 @Deprecated
 public class LegacyUpsertById implements Plan {
 
-
     /**
      * A single update item.
      */
@@ -169,6 +168,11 @@ public class LegacyUpsertById implements Plan {
 
     public List<Item> items() {
         return items;
+    }
+
+    @Override
+    public StatementType type() {
+        return StatementType.INSERT;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/node/dml/UpdateById.java
+++ b/sql/src/main/java/io/crate/planner/node/dml/UpdateById.java
@@ -63,6 +63,11 @@ public final class UpdateById implements Plan {
     }
 
     @Override
+    public StatementType type() {
+        return StatementType.UPDATE;
+    }
+
+    @Override
     public void execute(DependencyCarrier executor,
                         PlannerContext plannerCtx,
                         RowConsumer consumer,

--- a/sql/src/main/java/io/crate/planner/node/management/ExplainPlan.java
+++ b/sql/src/main/java/io/crate/planner/node/management/ExplainPlan.java
@@ -83,6 +83,11 @@ public class ExplainPlan implements Plan {
     }
 
     @Override
+    public StatementType type() {
+        return StatementType.MANAGEMENT;
+    }
+
+    @Override
     public void execute(DependencyCarrier executor,
                         PlannerContext plannerContext,
                         RowConsumer consumer,

--- a/sql/src/main/java/io/crate/planner/node/management/KillPlan.java
+++ b/sql/src/main/java/io/crate/planner/node/management/KillPlan.java
@@ -71,6 +71,11 @@ public class KillPlan implements Plan {
     }
 
     @Override
+    public StatementType type() {
+        return StatementType.MANAGEMENT;
+    }
+
+    @Override
     public void execute(DependencyCarrier executor,
                         PlannerContext plannerContext,
                         RowConsumer consumer,

--- a/sql/src/main/java/io/crate/planner/node/management/ShowCreateTablePlan.java
+++ b/sql/src/main/java/io/crate/planner/node/management/ShowCreateTablePlan.java
@@ -46,6 +46,11 @@ public class ShowCreateTablePlan implements Plan {
     }
 
     @Override
+    public StatementType type() {
+        return StatementType.MANAGEMENT;
+    }
+
+    @Override
     public void execute(DependencyCarrier executor,
                         PlannerContext plannerContext,
                         RowConsumer consumer,

--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlan.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlan.java
@@ -233,4 +233,8 @@ public interface LogicalPlan extends Plan {
     }
 
     <C, R> R accept(LogicalPlanVisitor<C, R> visitor, C context);
+
+    default StatementType type() {
+        return StatementType.SELECT;
+    }
 }

--- a/sql/src/main/java/io/crate/planner/operators/StatementClassifier.java
+++ b/sql/src/main/java/io/crate/planner/operators/StatementClassifier.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.operators;
+
+import io.crate.planner.Plan;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Utility to classify SQL statements based on their {@link Plan}.
+ *
+ * A classification consists of the {@link io.crate.planner.Plan.StatementType} that is provided by the {@link Plan}
+ * implementation, such as DDL, SELECT, INSERT, UPDATE, DELETE, etc., and in case of a SELECT statement, additional
+ * labels. These labels are a set of {@link LogicalPlan}s that the statement plan consists of, for example:
+ *
+ * <pre>
+ *     SELECT * FROM users ORDER BY age DESC;
+ * </pre>
+ *
+ * Would result in a classification of:
+ *
+ * <pre>
+ *     type = SELECT
+ *     labels = [FetchOrEval, Collect, Order]
+ * </pre>
+ */
+public final class StatementClassifier {
+
+    private StatementClassifier() {
+    }
+
+    private static final Visitor CLASS_EXTRACTOR = new Visitor();
+
+    public static Classification classify(Plan plan) {
+        if (plan instanceof LogicalPlan) {
+            HashSet<String> classes = new HashSet<>();
+            CLASS_EXTRACTOR.process((LogicalPlan) plan, classes);
+            return new Classification(plan.type(), classes);
+        } else {
+            return new Classification(plan.type());
+        }
+    }
+
+    public static class Classification {
+
+        private final Set<String> labels;
+        private final Plan.StatementType type;
+
+        public Classification(Plan.StatementType type, Set<String> labels) {
+            this.type = type;
+            this.labels = labels;
+        }
+
+        public Classification(Plan.StatementType type) {
+            this.type = type;
+            this.labels = Collections.emptySet();
+        }
+
+        public Set<String> labels() {
+            return labels;
+        }
+
+        public Plan.StatementType type() {
+            return type;
+        }
+
+        @Override
+        public String toString() {
+            return "Classification{type=" + type + ", labels=" + labels + "}";
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Classification that = (Classification) o;
+            return Objects.equals(labels, that.labels) &&
+                   type == that.type;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(labels, type);
+        }
+    }
+
+    private static class Visitor extends LogicalPlanVisitor<Set<String>, Void> {
+
+        @Override
+        protected Void visitPlan(LogicalPlan logicalPlan, Set<String> context) {
+            context.add(logicalPlan.getClass().getSimpleName());
+            return null;
+        }
+
+        @Override
+        public Void visitRootRelationBoundary(RootRelationBoundary logicalPlan, Set<String> context) {
+            process(logicalPlan.source, context);
+            return null;
+        }
+
+        @Override
+        public Void visitRelationBoundary(RelationBoundary logicalPlan, Set<String> context) {
+            process(logicalPlan.source, context);
+            return null;
+        }
+
+        @Override
+        public Void visitFetchOrEval(FetchOrEval logicalPlan, Set<String> context) {
+            process(logicalPlan.source, context);
+            return visitPlan(logicalPlan, context);
+        }
+
+        @Override
+        public Void visitLimit(Limit logicalPlan, Set<String> context) {
+            process(logicalPlan.source, context);
+            return null;
+        }
+
+        @Override
+        public Void visitHashJoin(HashJoin logicalPlan, Set<String> context) {
+            process(logicalPlan.lhs, context);
+            process(logicalPlan.rhs, context);
+            return visitPlan(logicalPlan, context);
+        }
+
+        @Override
+        public Void visitNestedLoopJoin(NestedLoopJoin logicalPlan, Set<String> context) {
+            process(logicalPlan.lhs, context);
+            process(logicalPlan.rhs, context);
+            return visitPlan(logicalPlan, context);
+        }
+
+        @Override
+        public Void visitUnion(Union logicalPlan, Set<String> context) {
+            process(logicalPlan.lhs, context);
+            process(logicalPlan.rhs, context);
+            return visitPlan(logicalPlan, context);
+        }
+
+        @Override
+        public Void visitGroupHashAggregate(GroupHashAggregate logicalPlan, Set<String> context) {
+            process(logicalPlan.source, context);
+            return visitPlan(logicalPlan, context);
+        }
+
+        @Override
+        public Void visitHashAggregate(HashAggregate logicalPlan, Set<String> context) {
+            process(logicalPlan.source, context);
+            return visitPlan(logicalPlan, context);
+        }
+
+        @Override
+        public Void visitInsert(Insert logicalPlan, Set<String> context) {
+            process(logicalPlan.source, context);
+            return visitPlan(logicalPlan, context);
+        }
+
+        @Override
+        public Void visitOrder(Order logicalPlan, Set<String> context) {
+            process(logicalPlan.source, context);
+            return visitPlan(logicalPlan, context);
+        }
+
+        @Override
+        public Void visitMultiPhase(MultiPhase logicalPlan, Set<String> context) {
+            for (LogicalPlan plan : logicalPlan.dependencies().keySet()) {
+                process(plan, context);
+            }
+            return visitPlan(logicalPlan, context);
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/planner/statement/CopyStatementPlanner.java
+++ b/sql/src/main/java/io/crate/planner/statement/CopyStatementPlanner.java
@@ -105,6 +105,11 @@ public final class CopyStatementPlanner {
         }
 
         @Override
+        public StatementType type() {
+            return StatementType.COPY;
+        }
+
+        @Override
         public void execute(DependencyCarrier executor,
                             PlannerContext plannerContext,
                             RowConsumer consumer,
@@ -125,6 +130,11 @@ public final class CopyStatementPlanner {
 
         CopyFrom(CopyFromAnalyzedStatement copyFrom) {
             this.copyFrom = copyFrom;
+        }
+
+        @Override
+        public StatementType type() {
+            return StatementType.COPY;
         }
 
         @Override

--- a/sql/src/main/java/io/crate/planner/statement/DeletePlanner.java
+++ b/sql/src/main/java/io/crate/planner/statement/DeletePlanner.java
@@ -116,6 +116,11 @@ public final class DeletePlanner {
         }
 
         @Override
+        public StatementType type() {
+            return StatementType.DELETE;
+        }
+
+        @Override
         public void execute(DependencyCarrier executor,
                             PlannerContext plannerContext,
                             RowConsumer consumer,

--- a/sql/src/main/java/io/crate/planner/statement/SetSessionPlan.java
+++ b/sql/src/main/java/io/crate/planner/statement/SetSessionPlan.java
@@ -54,6 +54,11 @@ public class SetSessionPlan implements Plan {
     }
 
     @Override
+    public StatementType type() {
+        return StatementType.MANAGEMENT;
+    }
+
+    @Override
     public void execute(DependencyCarrier executor,
                         PlannerContext plannerContext,
                         RowConsumer consumer,

--- a/sql/src/main/java/io/crate/protocols/postgres/BatchPortal.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/BatchPortal.java
@@ -43,6 +43,7 @@ import io.crate.metadata.TransactionContext;
 import io.crate.planner.Plan;
 import io.crate.planner.Planner;
 import io.crate.planner.PlannerContext;
+import io.crate.planner.operators.StatementClassifier;
 import io.crate.planner.operators.SubQueryResults;
 import io.crate.sql.tree.Statement;
 import io.crate.types.DataType;
@@ -170,7 +171,8 @@ class BatchPortal extends AbstractPortal {
                 throw t;
             }
             ResultReceiver resultReceiver = resultReceivers.get(i);
-            jobsLogs.logExecutionStart(jobId, stmt, sessionContext.user());
+            StatementClassifier.Classification classification = StatementClassifier.classify(plan);
+            jobsLogs.logExecutionStart(jobId, stmt, sessionContext.user(), classification);
             JobsLogsUpdateListener jobsLogsUpdateListener = new JobsLogsUpdateListener(jobId, jobsLogs);
 
             resultReceiver.completionFuture()

--- a/sql/src/main/java/io/crate/protocols/postgres/BulkPortal.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/BulkPortal.java
@@ -40,6 +40,7 @@ import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Plan;
 import io.crate.planner.Planner;
 import io.crate.planner.PlannerContext;
+import io.crate.planner.operators.StatementClassifier;
 import io.crate.planner.operators.SubQueryResults;
 import io.crate.sql.tree.Statement;
 import io.crate.types.DataType;
@@ -166,7 +167,8 @@ class BulkPortal extends AbstractPortal {
             jobsLogs.logPreExecutionFailure(jobId, query, SQLExceptions.messageOf(t), sessionContext.user());
             throw t;
         }
-        jobsLogs.logExecutionStart(jobId, query, sessionContext.user());
+        StatementClassifier.Classification classification = StatementClassifier.classify(plan);
+        jobsLogs.logExecutionStart(jobId, query, sessionContext.user(), classification);
         synced = true;
         return executeBulk(portalContext.getExecutor(), plan, plannerContext, jobId, jobsLogs, bulkParams);
     }

--- a/sql/src/main/java/io/crate/protocols/postgres/SimplePortal.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/SimplePortal.java
@@ -43,6 +43,7 @@ import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Plan;
 import io.crate.planner.Planner;
 import io.crate.planner.PlannerContext;
+import io.crate.planner.operators.StatementClassifier;
 import io.crate.planner.operators.SubQueryResults;
 import io.crate.sql.tree.Statement;
 import io.crate.types.DataType;
@@ -211,7 +212,7 @@ public class SimplePortal extends AbstractPortal {
             );
         }
 
-        jobsLogs.logExecutionStart(jobId, query, sessionContext.user());
+        jobsLogs.logExecutionStart(jobId, query, sessionContext.user(), StatementClassifier.classify(plan));
         JobsLogsUpdateListener jobsLogsUpdateListener = new JobsLogsUpdateListener(jobId, jobsLogs);
         CompletableFuture<?> completableFuture = resultReceiver.completionFuture()
             .whenComplete(jobsLogsUpdateListener);

--- a/sql/src/test/java/io/crate/execution/engine/collect/stats/JobsLogsTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/stats/JobsLogsTest.java
@@ -23,6 +23,7 @@
 package io.crate.execution.engine.collect.stats;
 
 import com.google.common.collect.ImmutableList;
+import io.crate.auth.user.User;
 import io.crate.breaker.CrateCircuitBreakerService;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.core.collections.BlockingEvictingQueue;
@@ -30,7 +31,6 @@ import io.crate.expression.reference.sys.job.JobContext;
 import io.crate.expression.reference.sys.job.JobContextLog;
 import io.crate.expression.reference.sys.operation.OperationContext;
 import io.crate.expression.reference.sys.operation.OperationContextLog;
-import io.crate.auth.user.User;
 import io.crate.plugin.SQLPlugin;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import org.elasticsearch.common.settings.ClusterSettings;

--- a/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -569,7 +569,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(512, response.rowCount());
+        assertEquals(515, response.rowCount());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -61,7 +61,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultTables() {
         execute("select * from information_schema.tables order by table_schema, table_name");
-        assertEquals(26L, response.rowCount());
+        assertEquals(27L, response.rowCount());
 
         assertThat(TestingHelpers.printedTable(response.rows()), is(
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| information_schema| columns| information_schema| BASE TABLE| NULL\n" +
@@ -82,6 +82,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| sys| health| sys| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| sys| jobs| sys| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| sys| jobs_log| sys| BASE TABLE| NULL\n" +
+            "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| sys| jobs_metrics| sys| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| sys| node_checks| sys| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| sys| nodes| sys| BASE TABLE| NULL\n" +
             "NULL| NULL| NULL| strict| NULL| NULL| NULL| SYSTEM GENERATED| NULL| NULL| NULL| sys| operations| sys| BASE TABLE| NULL\n" +
@@ -186,13 +187,13 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testSearchInformationSchemaTablesRefresh() {
         execute("select * from information_schema.tables");
-        assertEquals(26L, response.rowCount());
+        assertEquals(27L, response.rowCount());
 
         execute("create table t4 (col1 integer, col2 string) with(number_of_replicas=0)");
         ensureYellow(getFqn("t4"));
 
         execute("select * from information_schema.tables");
-        assertEquals(27L, response.rowCount());
+        assertEquals(28L, response.rowCount());
     }
 
     @Test
@@ -568,7 +569,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(497, response.rowCount());
+        assertEquals(512, response.rowCount());
     }
 
     @Test
@@ -785,7 +786,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
         ensureYellow();
         execute("select count(*) from information_schema.tables");
         assertEquals(1, response.rowCount());
-        assertEquals(29L, response.rows()[0][0]);
+        assertEquals(30L, response.rows()[0][0]);
     }
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/MetricsITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/MetricsITest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.integrationtests;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+public class MetricsITest extends SQLTransportIntegrationTest {
+
+    @Test
+    public void testSimpleQueryOnMetrics() {
+        execute("SELECT 1");
+
+        execute("SELECT node, " +
+                "node['id'], " +
+                "node['name'], " +
+                "min, " +
+                "max, " +
+                "mean, " +
+                "percentiles, " +
+                "percentiles['25'], " +
+                "percentiles['50'], " +
+                "percentiles['75'], " +
+                "percentiles['90'], " +
+                "percentiles['95'], " +
+                "percentiles['99'], " +
+                "total_count " +
+                "FROM sys.jobs_metrics ORDER BY max DESC");
+
+        for (Object[] row : response.rows()) {
+            assertThat((long) row[3], Matchers.greaterThanOrEqualTo(0L));
+            assertThat((long) row[4], Matchers.greaterThanOrEqualTo(0L));
+            assertThat((double) row[5], Matchers.greaterThanOrEqualTo(0.0d));
+        }
+    }
+
+    @Test
+    public void testTotalCountOnMetrics() {
+        int numQueries = 10;
+        for (int i = 0; i < numQueries; i++) {
+            execute("SELECT 1");
+        }
+
+        execute("SELECT sum(total_count) FROM sys.jobs_metrics");
+        assertThat((long) response.rows()[0][0], Matchers.greaterThanOrEqualTo((long) numQueries));
+    }
+}

--- a/sql/src/test/java/io/crate/integrationtests/MetricsITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/MetricsITest.java
@@ -23,9 +23,22 @@
 package io.crate.integrationtests;
 
 import org.hamcrest.Matchers;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 public class MetricsITest extends SQLTransportIntegrationTest {
+
+    @Before
+    public void clearStats() {
+        execute("SET GLOBAL \"stats.enabled\" = FALSE");
+        execute("SET GLOBAL \"stats.enabled\" = TRUE");
+    }
+
+    @After
+    public void resetStats() {
+        execute("RESET GLOBAL \"stats.enabled\"");
+    }
 
     @Test
     public void testSimpleQueryOnMetrics() {
@@ -44,24 +57,28 @@ public class MetricsITest extends SQLTransportIntegrationTest {
                 "percentiles['90'], " +
                 "percentiles['95'], " +
                 "percentiles['99'], " +
-                "total_count " +
-                "FROM sys.jobs_metrics ORDER BY max DESC");
+                "total_count, " +
+                "classification " +
+                "FROM sys.jobs_metrics " +
+                "WHERE classification['type'] = 'SELECT' " +
+                "ORDER BY max DESC");
 
         for (Object[] row : response.rows()) {
             assertThat((long) row[3], Matchers.greaterThanOrEqualTo(0L));
             assertThat((long) row[4], Matchers.greaterThanOrEqualTo(0L));
             assertThat((double) row[5], Matchers.greaterThanOrEqualTo(0.0d));
+            assertThat(row[13], Matchers.is(1L));
         }
     }
 
     @Test
     public void testTotalCountOnMetrics() {
-        int numQueries = 10;
+        int numQueries = 100;
         for (int i = 0; i < numQueries; i++) {
             execute("SELECT 1");
         }
 
-        execute("SELECT sum(total_count) FROM sys.jobs_metrics");
-        assertThat((long) response.rows()[0][0], Matchers.greaterThanOrEqualTo((long) numQueries));
+        execute("SELECT sum(total_count) FROM sys.jobs_metrics WHERE classification['type'] = 'SELECT'");
+        assertThat(response.rows()[0][0], Matchers.is((long) numQueries));
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/TableSettingsTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TableSettingsTest.java
@@ -85,7 +85,7 @@ public class TableSettingsTest extends SQLTransportIntegrationTest {
     public void testFilterOnNull() throws Exception {
         execute("select * from information_schema.tables " +
                 "where settings IS NULL");
-        assertEquals(26L, response.rowCount());
+        assertEquals(27L, response.rowCount());
         execute("select * from information_schema.tables " +
                 "where table_name = 'settings_table' and settings['warmer']['enabled'] IS NULL");
         assertEquals(0, response.rowCount());

--- a/sql/src/test/java/io/crate/planner/operators/StatementClassifierTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/StatementClassifierTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.operators;
+
+import com.google.common.collect.ImmutableSet;
+import io.crate.planner.Plan;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import io.crate.testing.SQLExecutor;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+
+public class StatementClassifierTest extends CrateDummyClusterServiceUnitTest {
+
+    private SQLExecutor e;
+
+    @Before
+    public void prepare() {
+        e = SQLExecutor.builder(clusterService)
+            .enableDefaultTables()
+            .build();
+    }
+
+    @Test
+    public void testClassifySelectStatements() {
+        LogicalPlan plan = e.logicalPlan("SELECT 1");
+        StatementClassifier.Classification classification = StatementClassifier.classify(plan);
+        assertThat(classification.type(), is(Plan.StatementType.SELECT));
+        assertThat(classification.labels(), is(ImmutableSet.of("Collect")));
+
+        plan = e.logicalPlan("SELECT * FROM users WHERE id = 1");
+        classification = StatementClassifier.classify(plan);
+        assertThat(classification.type(), is(Plan.StatementType.SELECT));
+        assertThat(classification.labels(), is(ImmutableSet.of("Get")));
+
+        plan = e.logicalPlan("SELECT * FROM users ORDER BY id");
+        classification = StatementClassifier.classify(plan);
+        assertThat(classification.type(), is(Plan.StatementType.SELECT));
+        assertThat(classification.labels(), is(ImmutableSet.of("Order", "Collect", "FetchOrEval")));
+
+        plan = e.logicalPlan("SELECT a.id, b.id FROM users a, users b WHERE a.id = b.id");
+        classification = StatementClassifier.classify(plan);
+        assertThat(classification.type(), is(Plan.StatementType.SELECT));
+        assertThat(classification.labels(), is(ImmutableSet.of("HashJoin", "Collect")));
+
+        plan = e.logicalPlan("SELECT a.id, b.id FROM users a, users b WHERE a.id > b.id");
+        classification = StatementClassifier.classify(plan);
+        assertThat(classification.type(), is(Plan.StatementType.SELECT));
+        assertThat(classification.labels(), is(ImmutableSet.of("Collect", "NestedLoopJoin")));
+
+        plan = e.logicalPlan("SELECT id FROM users UNION ALL SELECT id FROM users");
+        classification = StatementClassifier.classify(plan);
+        assertThat(classification.type(), is(Plan.StatementType.SELECT));
+        assertThat(classification.labels(), is(ImmutableSet.of("Collect", "Union")));
+
+        plan = e.logicalPlan("SELECT count(*) FROM users");
+        classification = StatementClassifier.classify(plan);
+        assertThat(classification.type(), is(Plan.StatementType.SELECT));
+        assertThat(classification.labels(), is(ImmutableSet.of("Count")));
+
+        plan = e.logicalPlan("SELECT count(*), name FROM users GROUP BY 2");
+        classification = StatementClassifier.classify(plan);
+        assertThat(classification.type(), is(Plan.StatementType.SELECT));
+        assertThat(classification.labels(), is(ImmutableSet.of("Collect", "GroupHashAggregate", "FetchOrEval")));
+
+        plan = e.logicalPlan("SELECT * FROM users WHERE id = (SELECT 1) OR name = (SELECT 'Arthur')");
+        classification = StatementClassifier.classify(plan);
+        assertThat(classification.type(), is(Plan.StatementType.SELECT));
+        assertThat(classification.labels(), is(ImmutableSet.of("Collect", "MultiPhase")));
+    }
+}


### PR DESCRIPTION
The `sys.jobs_metrics` table can be used to identify performance regressions of different types of statements over a longer period of time.

On each node, for each query classification a statistically significant sample of query latencies is hold to calculate `min`, `mean`, `max` and various `percentiles`. These samples are transient and are not persisted across node restarts.