### PR TITLE
return 0 in sys.jobs_metrics if min value is udefined

### DIFF
--- a/sql/src/main/java/io/crate/execution/engine/collect/stats/JobsLogs.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/stats/JobsLogs.java
@@ -123,7 +123,7 @@ public class JobsLogs {
 
     private void addToHistogram(JobContextLog log) {
         StatementClassifier.Classification classification = log.classification();
-        assert classification != null : "A job must have a classificiation";
+        assert classification != null : "A job must have a classification";
         histograms.getOrCreate(classification)
             .recordValue(log.ended() - log.started());
     }

--- a/sql/src/main/java/io/crate/metadata/sys/SysMetricsTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysMetricsTableInfo.java
@@ -101,7 +101,7 @@ public class SysMetricsTableInfo extends StaticTableInfo {
             .put(Columns.MEAN, () -> forFunction(h -> h.histogram().getMean()))
             .put(Columns.STDEV, () -> forFunction(h -> h.histogram().getStdDeviation()))
             .put(Columns.MAX, () -> forFunction(h -> h.histogram().getMaxValue()))
-            .put(Columns.MIN, () -> forFunction(h -> h.histogram().getTotalCount() == 0 ? 0 : h.histogram().getMinNonZeroValue()))
+            .put(Columns.MIN, () -> forFunction(h -> h.histogram().getMinValue() == Long.MAX_VALUE ? 0L : h.histogram().getMinValue()))
             .put(Columns.PERCENTILES, () -> forFunction(h -> ImmutableMap.builder()
                 .put("25", h.histogram().getValueAtPercentile(25.0))
                 .put("50", h.histogram().getValueAtPercentile(50.0))


### PR DESCRIPTION
in case the histogram of a classification does not contain any non-null values
we want to return `0`, not `Long.MAX_VALUE`