### PR TITLE
Remove synchronization from CollectTask searchers

### DIFF
--- a/sql/src/main/java/io/crate/execution/engine/distribution/SingleBucketBuilder.java
+++ b/sql/src/main/java/io/crate/execution/engine/distribution/SingleBucketBuilder.java
@@ -34,7 +34,7 @@ import javax.annotation.Nullable;
 import java.util.concurrent.CompletableFuture;
 
 
-public class SingleBucketBuilder implements RowConsumer, CompletionListenable {
+public class SingleBucketBuilder implements RowConsumer, CompletionListenable<Bucket> {
 
     private final Streamer<?>[] streamers;
     private final CompletableFuture<Bucket> bucketFuture = new CompletableFuture<>();

--- a/sql/src/main/java/io/crate/execution/jobs/RootTask.java
+++ b/sql/src/main/java/io/crate/execution/jobs/RootTask.java
@@ -50,7 +50,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 
-public class RootTask implements CompletionListenable {
+public class RootTask implements CompletionListenable<Void> {
 
     private static final Logger LOGGER = Loggers.getLogger(RootTask.class);
 

--- a/sql/src/main/java/io/crate/execution/jobs/Task.java
+++ b/sql/src/main/java/io/crate/execution/jobs/Task.java
@@ -24,10 +24,8 @@ package io.crate.execution.jobs;
 import io.crate.concurrent.CompletionListenable;
 
 import javax.annotation.Nullable;
-import java.util.concurrent.CompletableFuture;
 
-public interface Task extends CompletionListenable {
-
+public interface Task extends CompletionListenable<CompletionState> {
 
     /**
      * In the prepare phase implementations of this interface can allocate any resources.
@@ -54,7 +52,4 @@ public interface Task extends CompletionListenable {
      * Hook to cleanup the resources of this context. This might be called at any time in the lifecycle of the context.
      */
     void cleanup();
-
-    @Override
-    CompletableFuture<CompletionState> completionFuture();
 }


### PR DESCRIPTION
`addSearcher` is called during the single threaded task setup and
`close` / `cleanup` is protected by the `AbstractTask` machinery which
avoids concurrent calls, so synchronization shouldn't be necessary.