### PR TITLE
Trim long durations for sys.job_metrics

### DIFF
--- a/blackbox/docs/admin/system-information.rst
+++ b/blackbox/docs/admin/system-information.rst
@@ -1055,6 +1055,9 @@ statements.
 
   In order to reduce the memory requirements for these metrics, the times are
   statistically sampled and therefore may have slight inaccuracies.
+  In addition, durations are only tracked up to 10 minutes. Statements taking
+  longer than that are capped to 10 minutes.
+
 
 ``sys.jobs_metrics`` Table Schema
 .................................

--- a/sql/src/main/java/io/crate/execution/engine/collect/stats/JobsLogs.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/stats/JobsLogs.java
@@ -124,8 +124,7 @@ public class JobsLogs {
     private void addToHistogram(JobContextLog log) {
         StatementClassifier.Classification classification = log.classification();
         assert classification != null : "A job must have a classification";
-        histograms.getOrCreate(classification)
-            .recordValue(log.ended() - log.started());
+        histograms.recordValue(classification, log.ended() - log.started());
     }
 
     /**

--- a/sql/src/main/java/io/crate/metadata/sys/ClassifiedHistograms.java
+++ b/sql/src/main/java/io/crate/metadata/sys/ClassifiedHistograms.java
@@ -56,7 +56,11 @@ public class ClassifiedHistograms implements Iterable<ClassifiedHistograms.Class
         }
     }
 
-    public ConcurrentHistogram getOrCreate(Classification classification) {
+    public void recordValue(Classification classification, long duration) {
+        getOrCreate(classification).recordValue(Math.min(duration, HIGHEST_TRACKABLE_VALUE));
+    }
+
+    private ConcurrentHistogram getOrCreate(Classification classification) {
         ConcurrentHistogram histogram = histograms.get(classification);
         if (histogram == null) {
             histogram = new ConcurrentHistogram(HIGHEST_TRACKABLE_VALUE, NUMBER_OF_SIGNIFICANT_VALUE_DIGITS);

--- a/sql/src/test/java/io/crate/metadata/sys/ClassifiedHistogramsTest.java
+++ b/sql/src/test/java/io/crate/metadata/sys/ClassifiedHistogramsTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.sys;
+
+import io.crate.planner.Plan;
+import io.crate.planner.operators.StatementClassifier;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+public class ClassifiedHistogramsTest {
+
+    @Test
+    public void testRecordHighDurationDoesNotCauseArrayIndexOutOfBoundsException() {
+        ClassifiedHistograms histograms = new ClassifiedHistograms();
+        histograms.recordValue(
+            new StatementClassifier.Classification(Plan.StatementType.SELECT), TimeUnit.MINUTES.toMillis(30));
+    }
+}


### PR DESCRIPTION
We're only tracking durations up to 10 minutes, anything longer caused a
`ArrayIndexOutOfBoundsException`:

    ArrayIndexOutOfBoundsException: value outside of histogram covered
    range. Caused by: java.lang.IndexOutOfBoundsException: index 12669]
    occurred using: {"stmt": "COPY benchmarks.query_tests FROM
    's3://crate-stresstest-data/query-tests/*.json'"}

This changes the logic to normalize the durations to at most 10 minutes.