### PR TITLE
Remove unused functionality from TimeExpiring

### DIFF
--- a/sql/src/main/java/io/crate/execution/engine/collect/stats/JobsLogService.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/stats/JobsLogService.java
@@ -159,8 +159,14 @@ public class JobsLogService extends AbstractLifecycleComponent implements Provid
             return NoopLogSink.instance();
         } else if (expirationMillis > 0) {
             q = new ConcurrentLinkedDeque<>();
-            TimeExpiring lbTimeExpiring = new TimeExpiring(clearInterval(expiration));
-            ScheduledFuture<?> scheduledFuture = lbTimeExpiring.registerTruncateTask(q, scheduler, expiration);
+            long delay = 0L;
+            ScheduledFuture<?> scheduledFuture = TimeBasedQEviction.scheduleTruncate(
+                delay,
+                clearInterval(expiration),
+                q,
+                scheduler,
+                expiration
+            );
             onClose = () -> scheduledFuture.cancel(false);
         } else {
             q = new BlockingEvictingQueue<>(size);

--- a/sql/src/main/java/io/crate/execution/engine/collect/stats/TimeBasedQEviction.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/stats/TimeBasedQEviction.java
@@ -31,36 +31,21 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
-class TimeExpiring {
+final class TimeBasedQEviction {
 
-    /**
-     * clean interval in milliseconds
-     */
-    private static final long DEFAULT_QUEUE_CLEAN_INTERVAL = 5000L;
-
-    private static TimeExpiring INSTANCE = new TimeExpiring(DEFAULT_QUEUE_CLEAN_INTERVAL, 0L);
-    private final long interval;
-    private final long delay;
-
-    TimeExpiring(long interval, long delay) {
-        this.interval = interval;
-        this.delay = delay;
+    private TimeBasedQEviction() {
     }
 
-    public TimeExpiring(long interval) {
-        this(interval, 0L);
-    }
-
-    public static TimeExpiring instance() {
-        return INSTANCE;
-    }
-
-    public ScheduledFuture<?> registerTruncateTask(Queue<? extends ContextLog> q,
-                                                   ScheduledExecutorService scheduler,
-                                                   TimeValue expiration) {
+    static ScheduledFuture<?> scheduleTruncate(long delayInMs,
+                                               long intervalInMs,
+                                               Queue<? extends ContextLog> q,
+                                               ScheduledExecutorService scheduler,
+                                               TimeValue expiration) {
         return scheduler.scheduleWithFixedDelay(
             () -> removeExpiredLogs(q, System.currentTimeMillis(), expiration.getMillis()),
-            delay, interval, TimeUnit.MILLISECONDS);
+            delayInMs,
+            intervalInMs,
+            TimeUnit.MILLISECONDS);
     }
 
     @VisibleForTesting


### PR DESCRIPTION
- `instance()` was never used
 - Instances were only created to temporarily hold onto the delay and
 interval, which were immediately used in the next call. So this also
 changes it to a static method.
 - Renames `TimeExpiring → TimeBasedQEviction` and
 `registerTruncateTask → scheduleTruncate`