### PR TITLE
Fix extraction of docKeys expressions from WHERE clause.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -37,6 +37,13 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that caused an UnsupportedFeatureException to be thrown for
+  queries with a ``WHERE`` clause which contains an equality comparison that
+  references a table column in both sides. E.g.::
+
+    SELECT * FROM t
+    WHERE t.i = abs(t.i)
+
 - Handle ``STRING_ARRAY`` as argument type for user-defined functions correctly
   to prevent an ``ArrayStoreException``.
 

--- a/sql/src/test/java/io/crate/analyze/where/EqualityExtractorTest.java
+++ b/sql/src/test/java/io/crate/analyze/where/EqualityExtractorTest.java
@@ -350,4 +350,10 @@ public class EqualityExtractorTest extends CrateUnitTest {
         List<List<Symbol>> matches = analyzeExactX(query("x not in (1, 2, 3)"));
         assertThat(matches, nullValue());
     }
+
+    @Test
+    public void testNoPKExtractionWhenColumnsOnBothSidesOfEqual() {
+        List<List<Symbol>> matches = analyzeExactX(query("x = abs(x)"));
+        assertThat(matches, nullValue());
+    }
 }


### PR DESCRIPTION
If an equality expression refers to a table column on both sides
then the extracted docKey contains a Reference instead of a parameter
or literal which cannot be handled during the plan building, as the
docKeys are supposed to contain only literals, parameters (eg: $1) or
replacable scalar subquery symbols.