### PR TITLE
Add a jobs_log filter setting to control entries being recorded

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -18,6 +18,9 @@ Breaking Changes
 Changes
 =======
 
+- Added a new ``stats.jobs_log_filter`` setting which can be used to control
+  what kind of entries are recorded into the ``sys.jobs_log`` table.
+
 - Expose statement classification in ``sys.jobs_log`` table.
 
 - Added a ``sys.jobs_metrics`` table which contains query latency information.

--- a/blackbox/docs/admin/runtime-config.rst
+++ b/blackbox/docs/admin/runtime-config.rst
@@ -56,12 +56,15 @@ settings::
 
 ::
 
-    cr> select settings['stats'] from sys.cluster;
-    +--...--------------------------------------------------------------------------------------------------------------------------------------...--+
-    | settings['stats']                                                                                                                              |
-    +--...--------------------------------------------------------------------------------------------------------------------------------------...--+
-    | {... "enabled": true, "jobs_log_expiration": "0s", "jobs_log_size": 2048, "operations_log_expiration": "0s", "operations_log_size": 8192, ...} |
-    +--...--------------------------------------------------------------------------------------------------------------------------------------...--+
+    cr> SELECT 
+    ...   settings['stats']['jobs_log_size'] AS jobs_size,
+    ...   settings['stats']['operations_log_size'] AS op_size 
+    ... FROM sys.cluster;
+    +-----------+---------+
+    | jobs_size | op_size |
+    +-----------+---------+
+    |      2048 |    8192 |
+    +-----------+---------+
     SELECT 1 row in set (... sec)
 
 Using the ``RESET`` statement, a setting will be reset to either on node
@@ -72,12 +75,15 @@ startup defined configuration file value or to its default value::
 
 ::
 
-    cr> select settings['stats'] from sys.cluster;
-    +--...---------------------------------------------------------------------------------------------------------------------------------------...--+
-    | settings['stats']                                                                                                                               |
-    +--...---------------------------------------------------------------------------------------------------------------------------------------...--+
-    | {... "enabled": true, "jobs_log_expiration": "0s", "jobs_log_size": 2048, "operations_log_expiration": "0s", "operations_log_size": 10000, ...} |
-    +--...---------------------------------------------------------------------------------------------------------------------------------------...--+
+    cr> SELECT 
+    ...   settings['stats']['jobs_log_size'] AS jobs_size,
+    ...   settings['stats']['operations_log_size'] AS op_size 
+    ... FROM sys.cluster;
+    +-----------+---------+
+    | jobs_size | op_size |
+    +-----------+---------+
+    |      2048 |   10000 |
+    +-----------+---------+
     SELECT 1 row in set (... sec)
 
 ``RESET`` can also be done on objects::
@@ -87,10 +93,13 @@ startup defined configuration file value or to its default value::
 
 ::
 
-    cr> select settings['stats'] from sys.cluster;
-    +--...----------------------------------------------------------------------------------------------------------------------------------------...--+
-    | settings['stats']                                                                                                                                |
-    +--...----------------------------------------------------------------------------------------------------------------------------------------...--+
-    | {... "enabled": true, "jobs_log_expiration": "0s", "jobs_log_size": 10000, "operations_log_expiration": "0s", "operations_log_size": 10000, ...} |
-    +--...----------------------------------------------------------------------------------------------------------------------------------------...--+
+    cr> SELECT 
+    ...   settings['stats']['jobs_log_size'] AS jobs_size,
+    ...   settings['stats']['operations_log_size'] AS op_size 
+    ... FROM sys.cluster;
+    +-----------+---------+
+    | jobs_size | op_size |
+    +-----------+---------+
+    |     10000 |   10000 |
+    +-----------+---------+
     SELECT 1 row in set (... sec)

--- a/blackbox/docs/admin/system-information.rst
+++ b/blackbox/docs/admin/system-information.rst
@@ -168,6 +168,7 @@ applied cluster settings.
     | settings['stats']['breaker']['log']['operations']['overhead']                     | double       |
     | settings['stats']['enabled']                                                      | boolean      |
     | settings['stats']['jobs_log_expiration']                                          | string       |
+    | settings['stats']['jobs_log_filter']                                              | string       |
     | settings['stats']['jobs_log_size']                                                | integer      |
     | settings['stats']['operations_log_expiration']                                    | string       |
     | settings['stats']['operations_log_size']                                          | integer      |

--- a/blackbox/docs/config/cluster.rst
+++ b/blackbox/docs/config/cluster.rst
@@ -89,6 +89,22 @@ Collecting Stats
      :ref:`stats.operations_log_expiration <stats.operations_log_expiration>`
      settings are disabled, jobs will not be recorded.
 
+**stats.jobs_log_filter**
+  | *Default:* ``true`` (Include all jobs)
+  | *Runtime:* ``yes``
+
+  An expression to determine if a job should be recorded into ``sys.jobs_log``.
+  The expression must evaluate to a boolean. If it evaluates to ``true`` the
+  statement will show up ``sys.jobs_log`` until it's evicted due to one of the
+  other rules. (expiration or size limit reached).
+
+  The expression may reference all columns contained in ``sys.jobs_log``. A
+  common use case is to include only jobs that took a certain amount of time to
+  execute::
+
+    cr> SET GLOBAL "stats.jobs_log_filter" = 'ended - started > 100';
+
+
 .. _stats.operations_log_size:
 
 **stats.operations_log_size**

--- a/sql/src/main/java/io/crate/execution/engine/collect/stats/FilteredLogSink.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/stats/FilteredLogSink.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.engine.collect.stats;
+
+import io.crate.data.Input;
+import io.crate.execution.engine.collect.NestableCollectExpression;
+import io.crate.expression.InputCondition;
+
+import javax.annotation.Nonnull;
+import java.util.Iterator;
+import java.util.List;
+
+public final class FilteredLogSink<T> implements LogSink<T> {
+
+    private final Input<Boolean> filter;
+    private final List<NestableCollectExpression<T, ?>> filterExpressions;
+    final LogSink<T> delegate;
+
+    FilteredLogSink(Input<Boolean> filter,
+                    List<NestableCollectExpression<T, ?>> filterExpressions,
+                    LogSink<T> delegate) {
+        this.filter = filter;
+        this.filterExpressions = filterExpressions;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void add(T item) {
+        for (int i = 0; i < filterExpressions.size(); i++) {
+            filterExpressions.get(i).setNextRow(item);
+        }
+        if (InputCondition.matches(filter)) {
+            delegate.add(item);
+        }
+    }
+
+    @Override
+    public void addAll(Iterable<T> iterable) {
+        iterable.forEach(this::add);
+    }
+
+    @Override
+    public void close() {
+        delegate.close();
+    }
+
+    @Override
+    @Nonnull
+    public Iterator<T> iterator() {
+        return delegate.iterator();
+    }
+}

--- a/sql/src/main/java/io/crate/execution/engine/collect/stats/JobsLogService.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/stats/JobsLogService.java
@@ -23,16 +23,34 @@
 package io.crate.execution.engine.collect.stats;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.crate.analyze.ParamTypeHints;
+import io.crate.analyze.expressions.ExpressionAnalysisContext;
+import io.crate.analyze.expressions.ExpressionAnalyzer;
+import io.crate.analyze.relations.NameFieldProvider;
+import io.crate.analyze.relations.TableRelation;
 import io.crate.breaker.CrateCircuitBreakerService;
 import io.crate.breaker.JobContextLogSizeEstimator;
 import io.crate.breaker.OperationContextLogSizeEstimator;
 import io.crate.breaker.SizeEstimator;
 import io.crate.core.collections.BlockingEvictingQueue;
+import io.crate.data.Input;
+import io.crate.execution.engine.collect.NestableCollectExpression;
+import io.crate.expression.InputFactory;
+import io.crate.expression.eval.EvaluatingNormalizer;
+import io.crate.expression.reference.StaticTableReferenceResolver;
 import io.crate.expression.reference.sys.job.ContextLog;
 import io.crate.expression.reference.sys.job.JobContextLog;
 import io.crate.expression.reference.sys.operation.OperationContextLog;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.Functions;
+import io.crate.metadata.RowGranularity;
+import io.crate.metadata.TransactionContext;
+import io.crate.metadata.sys.SysJobsLogTableInfo;
+import io.crate.metadata.table.Operation;
 import io.crate.settings.CrateSetting;
+import io.crate.sql.parser.SqlParser;
 import io.crate.types.DataTypes;
+import org.elasticsearch.common.collect.Tuple;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Provider;
@@ -43,10 +61,14 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.threadpool.ThreadPool;
 
+import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
+import java.util.function.Function;
+
+import static org.elasticsearch.common.collect.Tuple.tuple;
 
 /**
  * The JobsLogService is available on each node and holds the meta data of the cluster, such as active jobs and operations.
@@ -65,6 +87,15 @@ public class JobsLogService extends AbstractLifecycleComponent implements Provid
     public static final CrateSetting<TimeValue> STATS_JOBS_LOG_EXPIRATION_SETTING = CrateSetting.of(Setting.timeSetting(
         "stats.jobs_log_expiration", TimeValue.timeValueSeconds(0L), Setting.Property.NodeScope, Setting.Property.Dynamic),
         DataTypes.STRING);
+    public static final CrateSetting<String> STATS_JOBS_LOG_FILTER = CrateSetting.of(
+        new Setting<>(
+            "stats.jobs_log_filter",
+            "true",
+            Function.identity(),
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic),
+        DataTypes.STRING
+    );
     public static final CrateSetting<Integer> STATS_OPERATIONS_LOG_SIZE_SETTING = CrateSetting.of(Setting.intSetting(
         "stats.operations_log_size", 10_000, 0, Setting.Property.NodeScope, Setting.Property.Dynamic), DataTypes.INTEGER);
     public static final CrateSetting<TimeValue> STATS_OPERATIONS_LOG_EXPIRATION_SETTING = CrateSetting.of(Setting.timeSetting(
@@ -76,10 +107,16 @@ public class JobsLogService extends AbstractLifecycleComponent implements Provid
 
     private final ScheduledExecutorService scheduler;
     private final CrateCircuitBreakerService breakerService;
+    private final InputFactory inputFactory;
+    private final StaticTableReferenceResolver<JobContextLog> refResolver;
+    private final ExpressionAnalyzer expressionAnalyzer;
+    private final EvaluatingNormalizer normalizer;
+    private final TransactionContext transactionContext;
 
     private JobsLogs jobsLogs;
     LogSink<JobContextLog> jobsLogSink = NoopLogSink.instance();
     LogSink<OperationContextLog> operationsLogSink = NoopLogSink.instance();
+    private Tuple<? extends Input<Boolean>, List<NestableCollectExpression<JobContextLog, ?>>> filter;
 
     private volatile boolean isEnabled;
     volatile int jobsLogSize;
@@ -89,33 +126,82 @@ public class JobsLogService extends AbstractLifecycleComponent implements Provid
 
     @Inject
     public JobsLogService(Settings settings,
-                              ClusterSettings clusterSettings,
-                              ThreadPool threadPool,
-                              CrateCircuitBreakerService breakerService) {
-        this(settings, clusterSettings, threadPool.scheduler(), breakerService);
+                          ClusterSettings clusterSettings,
+                          Functions functions,
+                          ThreadPool threadPool,
+                          CrateCircuitBreakerService breakerService) {
+        this(settings, clusterSettings, functions, threadPool.scheduler(), breakerService);
     }
 
     @VisibleForTesting
     JobsLogService(Settings settings,
-                       ClusterSettings clusterSettings,
-                       ScheduledExecutorService scheduledExecutorService,
-                       CrateCircuitBreakerService breakerService) {
+                   ClusterSettings clusterSettings,
+                   Functions functions,
+                   ScheduledExecutorService scheduledExecutorService,
+                   CrateCircuitBreakerService breakerService) {
         super(settings);
         scheduler = scheduledExecutorService;
         this.breakerService = breakerService;
+        this.inputFactory = new InputFactory(functions);
+        this.refResolver = new StaticTableReferenceResolver<>(SysJobsLogTableInfo.expressions());
+        TableRelation sysJobsLogRelation = new TableRelation(SysJobsLogTableInfo.INSTANCE);
+        transactionContext = TransactionContext.systemTransactionContext();
+        this.expressionAnalyzer = new ExpressionAnalyzer(
+            functions,
+            transactionContext,
+            ParamTypeHints.EMPTY,
+            new NameFieldProvider(sysJobsLogRelation),
+            null,
+            Operation.READ
+        );
+        normalizer = new EvaluatingNormalizer(functions, RowGranularity.DOC, refResolver, sysJobsLogRelation);
 
         isEnabled = STATS_ENABLED_SETTING.setting().get(settings);
         jobsLogs = new JobsLogs(this::isEnabled);
+        filter = createFilter(STATS_JOBS_LOG_FILTER.setting().get(settings));
         setJobsLogSink(
-            STATS_JOBS_LOG_SIZE_SETTING.setting().get(settings), STATS_JOBS_LOG_EXPIRATION_SETTING.setting().get(settings));
+            STATS_JOBS_LOG_SIZE_SETTING.setting().get(settings),
+            STATS_JOBS_LOG_EXPIRATION_SETTING.setting().get(settings)
+        );
         setOperationsLogSink(
             STATS_OPERATIONS_LOG_SIZE_SETTING.setting().get(settings), STATS_OPERATIONS_LOG_EXPIRATION_SETTING.setting().get(settings));
 
+        clusterSettings.addSettingsUpdateConsumer(STATS_JOBS_LOG_FILTER.setting(), filter -> {
+            try {
+                this.filter = createFilter(filter);
+            } catch (Throwable t) {
+                logger.error("Could not update {}, error: {}", STATS_JOBS_LOG_FILTER.getKey(), t);
+                return;
+            }
+            updateJobSink(jobsLogSize, jobsLogExpiration);
+        });
         clusterSettings.addSettingsUpdateConsumer(STATS_ENABLED_SETTING.setting(), this::setStatsEnabled);
         clusterSettings.addSettingsUpdateConsumer(
-            STATS_JOBS_LOG_SIZE_SETTING.setting(), STATS_JOBS_LOG_EXPIRATION_SETTING.setting(), this::setJobsLogSink);
+            STATS_JOBS_LOG_SIZE_SETTING.setting(),
+            STATS_JOBS_LOG_EXPIRATION_SETTING.setting(),
+            this::setJobsLogSink);
         clusterSettings.addSettingsUpdateConsumer(
             STATS_OPERATIONS_LOG_SIZE_SETTING.setting(), STATS_OPERATIONS_LOG_EXPIRATION_SETTING.setting(), this::setOperationsLogSink);
+    }
+
+    private Tuple<Input<Boolean>, List<NestableCollectExpression<JobContextLog, ?>>> createFilter(String filterExpression) {
+        Symbol filter;
+        try {
+            filter = normalizer.normalize(
+                expressionAnalyzer.convert(SqlParser.createExpression(filterExpression), new ExpressionAnalysisContext()),
+                transactionContext
+            );
+        } catch (Throwable t) {
+            throw new IllegalArgumentException("Invalid filter expression: " + filterExpression + ": " + t.getMessage(), t);
+        }
+        if (!filter.valueType().equals(DataTypes.BOOLEAN)) {
+            throw new IllegalArgumentException(
+                "Filter expression for sys.jobs_log must result in a boolean, not: " + filter.valueType());
+        }
+        InputFactory.Context<NestableCollectExpression<JobContextLog, ?>> ctx = inputFactory.ctxForRefs(refResolver);
+        @SuppressWarnings("unchecked")
+        Input<Boolean> filterInput = (Input<Boolean>) ctx.add(filter);
+        return tuple(filterInput, ctx.expressions());
     }
 
     private void setJobsLogSink(int size, TimeValue expiration) {
@@ -128,12 +214,17 @@ public class JobsLogService extends AbstractLifecycleComponent implements Provid
     }
 
     private void updateJobSink(int size, TimeValue expiration) {
-        LogSink<JobContextLog> newSink = createSink(
+        LogSink<JobContextLog> sink = createSink(
             size, expiration, JOB_CONTEXT_LOG_ESTIMATOR, CrateCircuitBreakerService.JOBS_LOG);
+        LogSink<JobContextLog> newSink = sink.equals(NoopLogSink.instance()) ? sink : new FilteredLogSink<>(
+            filter.v1(),
+            filter.v2(),
+            sink
+        );
         LogSink<JobContextLog> oldSink = jobsLogSink;
         newSink.addAll(oldSink);
         jobsLogSink = newSink;
-        jobsLogs.updateJobsLog(jobsLogSink);
+        jobsLogs.updateJobsLog(newSink);
         oldSink.close();
     }
 

--- a/sql/src/main/java/io/crate/metadata/settings/CrateSettings.java
+++ b/sql/src/main/java/io/crate/metadata/settings/CrateSettings.java
@@ -78,6 +78,7 @@ public final class CrateSettings implements ClusterStateListener {
             JobsLogService.STATS_ENABLED_SETTING,
             JobsLogService.STATS_JOBS_LOG_SIZE_SETTING,
             JobsLogService.STATS_JOBS_LOG_EXPIRATION_SETTING,
+            JobsLogService.STATS_JOBS_LOG_FILTER,
             JobsLogService.STATS_OPERATIONS_LOG_SIZE_SETTING,
             JobsLogService.STATS_OPERATIONS_LOG_EXPIRATION_SETTING,
             TableStatsService.STATS_SERVICE_REFRESH_INTERVAL_SETTING,

--- a/sql/src/main/java/io/crate/metadata/sys/SysJobsLogTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysJobsLogTableInfo.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.crate.action.sql.SessionContext;
 import io.crate.analyze.WhereClause;
+import io.crate.expression.reference.sys.job.JobContextLog;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Routing;
@@ -33,7 +34,7 @@ import io.crate.metadata.RowGranularity;
 import io.crate.metadata.expressions.RowCollectExpressionFactory;
 import io.crate.metadata.table.ColumnRegistrar;
 import io.crate.metadata.table.StaticTableInfo;
-import io.crate.expression.reference.sys.job.JobContextLog;
+import io.crate.metadata.table.TableInfo;
 import io.crate.types.DataTypes;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.cluster.ClusterState;
@@ -47,8 +48,10 @@ import static io.crate.metadata.NestableContextCollectorExpression.withNullableP
 
 public class SysJobsLogTableInfo extends StaticTableInfo {
 
-    public static final RelationName IDENT = new RelationName(SysSchemaInfo.NAME, "jobs_log");
     private static final List<ColumnIdent> PRIMARY_KEYS = ImmutableList.of(Columns.ID);
+
+    public static final RelationName IDENT = new RelationName(SysSchemaInfo.NAME, "jobs_log");
+    public static final TableInfo INSTANCE = new SysJobsLogTableInfo();
 
     public static class Columns {
         public static final ColumnIdent ID = new ColumnIdent("id");
@@ -88,7 +91,7 @@ public class SysJobsLogTableInfo extends StaticTableInfo {
             .build();
     }
 
-    SysJobsLogTableInfo() {
+    private SysJobsLogTableInfo() {
         super(IDENT, new ColumnRegistrar(IDENT, RowGranularity.DOC)
             .register(Columns.ID, DataTypes.STRING)
             .register(Columns.USERNAME, DataTypes.STRING)

--- a/sql/src/main/java/io/crate/metadata/sys/SysSchemaInfo.java
+++ b/sql/src/main/java/io/crate/metadata/sys/SysSchemaInfo.java
@@ -45,7 +45,7 @@ public class SysSchemaInfo implements SchemaInfo {
         tableInfos.put(SysNodesTableInfo.IDENT.name(), new SysNodesTableInfo());
         tableInfos.put(SysShardsTableInfo.IDENT.name(), new SysShardsTableInfo());
         tableInfos.put(SysJobsTableInfo.IDENT.name(), new SysJobsTableInfo());
-        tableInfos.put(SysJobsLogTableInfo.IDENT.name(), new SysJobsLogTableInfo());
+        tableInfos.put(SysJobsLogTableInfo.IDENT.name(), SysJobsLogTableInfo.INSTANCE);
         tableInfos.put(SysOperationsTableInfo.IDENT.name(), new SysOperationsTableInfo());
         tableInfos.put(SysOperationsLogTableInfo.IDENT.name(), new SysOperationsLogTableInfo());
         tableInfos.put(SysChecksTableInfo.IDENT.name(), new SysChecksTableInfo());

--- a/sql/src/test/java/io/crate/analyze/SetAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SetAnalyzerTest.java
@@ -178,6 +178,7 @@ public class SetAnalyzerTest extends CrateDummyClusterServiceUnitTest {
                 "stats.enabled",
                 "stats.jobs_log_size",
                 "stats.jobs_log_expiration",
+                "stats.jobs_log_filter",
                 "stats.operations_log_size",
                 "stats.operations_log_expiration",
                 "stats.service.interval")

--- a/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -569,7 +569,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(518, response.rowCount());
+        assertEquals(519, response.rowCount());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/metadata/settings/CrateSettingsTest.java
+++ b/sql/src/test/java/io/crate/metadata/settings/CrateSettingsTest.java
@@ -22,8 +22,8 @@
 
 package io.crate.metadata.settings;
 
-import io.crate.expression.NestableInput;
 import io.crate.execution.engine.collect.stats.JobsLogService;
+import io.crate.expression.NestableInput;
 import io.crate.expression.reference.NestedObjectExpression;
 import io.crate.settings.CrateSetting;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
@@ -66,6 +66,7 @@ public class CrateSettingsTest extends CrateDummyClusterServiceUnitTest {
     public void testSettingsByNamePrefix() {
         assertThat(CrateSettings.settingNamesByPrefix("stats.jobs_log"), containsInAnyOrder(
             JobsLogService.STATS_JOBS_LOG_SIZE_SETTING.getKey(),
+            JobsLogService.STATS_JOBS_LOG_FILTER.getKey(),
             JobsLogService.STATS_JOBS_LOG_EXPIRATION_SETTING.getKey()
             ));
     }


### PR DESCRIPTION
Depending on the retention policy (size or expiration), `sys.jobs_log`
might be flooded or grow too large in size on a high traffic cluster.

This introduces a new `stats.jobs_log_filter` setting which can contain
an expression evaluated against a `sys.jobs_log` record to determine if
it should be included in `sys.jobs_log`.

This can for example be used to only include entries with a certain
duration (`ended - started > 30`)