### PR TITLE
Add a `stats.jobs_log_persist_filter` setting to log queries to file

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -23,6 +23,8 @@ Changes
 
 - Added a new ``stats.jobs_log_filter`` setting which can be used to control
   what kind of entries are recorded into the ``sys.jobs_log`` table.
+  In addition there is a new ``stats.jobs_log_persistent_filter`` setting which
+  can be used to record entries also in the regular CrateDB log file.
 
 - Expose statement classification in ``sys.jobs_log`` table.
 

--- a/blackbox/docs/admin/system-information.rst
+++ b/blackbox/docs/admin/system-information.rst
@@ -169,6 +169,7 @@ applied cluster settings.
     | settings['stats']['enabled']                                                      | boolean      |
     | settings['stats']['jobs_log_expiration']                                          | string       |
     | settings['stats']['jobs_log_filter']                                              | string       |
+    | settings['stats']['jobs_log_persistent_filter']                                   | string       |
     | settings['stats']['jobs_log_size']                                                | integer      |
     | settings['stats']['operations_log_expiration']                                    | string       |
     | settings['stats']['operations_log_size']                                          | integer      |

--- a/blackbox/docs/config/cluster.rst
+++ b/blackbox/docs/config/cluster.rst
@@ -90,7 +90,7 @@ Collecting Stats
      settings are disabled, jobs will not be recorded.
 
 **stats.jobs_log_filter**
-  | *Default:* ``true`` (Include all jobs)
+  | *Default:* ``true`` (Include everything)
   | *Runtime:* ``yes``
 
   An expression to determine if a job should be recorded into ``sys.jobs_log``.
@@ -104,6 +104,20 @@ Collecting Stats
 
     cr> SET GLOBAL "stats.jobs_log_filter" = 'ended - started > 100';
 
+**stats.jobs_log_persistent_filter**
+  | *Default:* ``false`` (Include nothing)
+  | *Runtime:* ``yes``
+
+  An expression to determine if a job should also be recorded to the regular
+  ``CrateDB`` log. Entries that match this filter will be logged under the
+  ``StatementLog`` logger with the ``INFO`` level.
+
+  This is similar to ``stats.jobs_log_filter`` except that these entries are
+  persisted to the log file. This should be used with caution and shouldn't be
+  set to an expression that matches many queries as the logging operation will
+  block on IO and can therefore affect performance.
+
+  A common use case is to use this for slow query logging.
 
 .. _stats.operations_log_size:
 

--- a/sql/src/main/java/io/crate/expression/ExpressionsInput.java
+++ b/sql/src/main/java/io/crate/expression/ExpressionsInput.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression;
+
+import io.crate.data.Input;
+import io.crate.execution.engine.collect.CollectExpression;
+
+import java.util.List;
+import java.util.RandomAccess;
+
+/**
+ * An {@link Input} that is linked and coupled with some {@link CollectExpression}
+ */
+public final class ExpressionsInput<TRow, TResult> {
+
+    private final Input<TResult> input;
+    private final List<? extends CollectExpression<TRow, ?>> expressions;
+
+    public ExpressionsInput(Input<TResult> input, List<? extends CollectExpression<TRow, ?>> expressions) {
+        assert expressions instanceof RandomAccess : "expressions must be a RandomAccess list to avoid iterator allocations";
+        this.input = input;
+        this.expressions = expressions;
+    }
+
+    public TResult value(TRow row) {
+        for (int i = 0; i < expressions.size(); i++) {
+            expressions.get(i).setNextRow(row);
+        }
+        return input.value();
+    }
+}

--- a/sql/src/main/java/io/crate/metadata/settings/CrateSettings.java
+++ b/sql/src/main/java/io/crate/metadata/settings/CrateSettings.java
@@ -79,6 +79,7 @@ public final class CrateSettings implements ClusterStateListener {
             JobsLogService.STATS_JOBS_LOG_SIZE_SETTING,
             JobsLogService.STATS_JOBS_LOG_EXPIRATION_SETTING,
             JobsLogService.STATS_JOBS_LOG_FILTER,
+            JobsLogService.STATS_JOBS_LOG_PERSIST_FILTER,
             JobsLogService.STATS_OPERATIONS_LOG_SIZE_SETTING,
             JobsLogService.STATS_OPERATIONS_LOG_EXPIRATION_SETTING,
             TableStatsService.STATS_SERVICE_REFRESH_INTERVAL_SETTING,

--- a/sql/src/test/java/io/crate/analyze/SetAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SetAnalyzerTest.java
@@ -179,6 +179,7 @@ public class SetAnalyzerTest extends CrateDummyClusterServiceUnitTest {
                 "stats.jobs_log_size",
                 "stats.jobs_log_expiration",
                 "stats.jobs_log_filter",
+                "stats.jobs_log_persistent_filter",
                 "stats.operations_log_size",
                 "stats.operations_log_expiration",
                 "stats.service.interval")

--- a/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -569,7 +569,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(519, response.rowCount());
+        assertEquals(520, response.rowCount());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/metadata/settings/CrateSettingsTest.java
+++ b/sql/src/test/java/io/crate/metadata/settings/CrateSettingsTest.java
@@ -67,6 +67,7 @@ public class CrateSettingsTest extends CrateDummyClusterServiceUnitTest {
         assertThat(CrateSettings.settingNamesByPrefix("stats.jobs_log"), containsInAnyOrder(
             JobsLogService.STATS_JOBS_LOG_SIZE_SETTING.getKey(),
             JobsLogService.STATS_JOBS_LOG_FILTER.getKey(),
+            JobsLogService.STATS_JOBS_LOG_PERSIST_FILTER.getKey(),
             JobsLogService.STATS_JOBS_LOG_EXPIRATION_SETTING.getKey()
             ));
     }


### PR DESCRIPTION
This is an addition to `stats.jobs_log_filter` which enables user to
also persist query entries to the regular log file. This has the
advantage that the information survives a node restart but the
disadvantage that it is not queryable.

Sample entry:

    [INFO ][StatementLog             ] Statement execution: stmt="set global "stats.jobs_log_persist_filter" = 'ended - started < 100'" duration=25, error="null"

/cc @joemoe 