### PR TITLE
Remove change detection from jobs filter update

### DIFF
--- a/sql/src/main/java/io/crate/execution/engine/collect/stats/JobsLogService.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/stats/JobsLogService.java
@@ -187,10 +187,8 @@ public class JobsLogService extends AbstractLifecycleComponent implements Provid
                 logger.error("Could not update {}, error: {}", STATS_JOBS_LOG_FILTER.getKey(), t);
                 return;
             }
-            if (!JobsLogService.this.memoryFilter.equals(newFilter)) {
-                JobsLogService.this.memoryFilter = newFilter;
-                updateJobSink(jobsLogSize, jobsLogExpiration);
-            }
+            JobsLogService.this.memoryFilter = newFilter;
+            updateJobSink(jobsLogSize, jobsLogExpiration);
         });
         clusterSettings.addSettingsUpdateConsumer(STATS_JOBS_LOG_PERSIST_FILTER.setting(), filter -> {
             ExpressionsInput<JobContextLog, Boolean> newFilter;
@@ -200,10 +198,8 @@ public class JobsLogService extends AbstractLifecycleComponent implements Provid
                 logger.error("Could not update {}, error: {}", STATS_JOBS_LOG_PERSIST_FILTER.getKey(), t);
                 return;
             }
-            if (!JobsLogService.this.persistFilter.equals(newFilter)) {
-                JobsLogService.this.persistFilter = newFilter;
-                updateJobSink(jobsLogSize, jobsLogExpiration);
-            }
+            JobsLogService.this.persistFilter = newFilter;
+            updateJobSink(jobsLogSize, jobsLogExpiration);
         });
         clusterSettings.addSettingsUpdateConsumer(STATS_ENABLED_SETTING.setting(), this::setStatsEnabled);
         clusterSettings.addSettingsUpdateConsumer(


### PR DESCRIPTION
The settings-update-consumer is only triggered if the setting actually
changed, so there is no need to compare the new filter with the old
filter.