### PR TITLE
Expose number of HTTP connections

### DIFF
--- a/blackbox/docs/admin/system-information.rst
+++ b/blackbox/docs/admin/system-information.rst
@@ -602,6 +602,32 @@ in subsequent versions. All ``LONG`` columns always return ``0``.
 |                                                        | See `tools.ietf.org <https://tools.ietf.org/html/rfc2525#page-50>`_.                       |             |
 +--------------------------------------------------------+--------------------------------------------------------------------------------------------+-------------+
 
+``connections``
+---------------
+
++---------------------------------------+-------------------+-------------------+
+| Column Name                           | Description       | Return Type       |
++=======================================+===================+===================+
+| ``http``                              | Number of         | ``OBJECT``        |
+|                                       | connections       |                   |
+|                                       | established via   |                   |
+|                                       | HTTP              |                   |
++---------------------------------------+-------------------+-------------------+
+| ``http['open']``                      | The currently     | ``LONG``          |
+|                                       | open connections  |                   |
+|                                       | established via   |                   |
+|                                       | HTTP              |                   |
++---------------------------------------+-------------------+-------------------+
+| ``http['total']``                     | The total number  | ``LONG``          |
+|                                       | of connections    |                   |
+|                                       | that have been    |                   |
+|                                       | established via   |                   |
+|                                       | HTTP over the     |                   |
+|                                       | life time of a    |                   |
+|                                       | CrateDB node      |                   |
++---------------------------------------+-------------------+-------------------+
+
+
 ``process``
 -----------
 

--- a/blackbox/docs/appendices/release-notes/upcoming.rst
+++ b/blackbox/docs/appendices/release-notes/upcoming.rst
@@ -18,6 +18,10 @@ Breaking Changes
 Changes
 =======
 
+- Added a new ``connections`` column to the ``sys.nodes`` table which contains
+  the number of currently open ``HTTP`` connections and the total number of
+  ``HTTP`` connections opened over the life-time of a node.
+
 - Added support for ``COPY FROM ... RETURN SUMMARY`` which will return a result
   set with detailed error reporting of imported rows.
 

--- a/sql/src/main/java/io/crate/expression/reference/ObjectCollectExpression.java
+++ b/sql/src/main/java/io/crate/expression/reference/ObjectCollectExpression.java
@@ -30,10 +30,18 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-public abstract class ObjectCollectExpression<R> extends NestableCollectExpression<R, Map<String, Object>> {
+public class ObjectCollectExpression<R> extends NestableCollectExpression<R, Map<String, Object>> {
 
-    protected Map<String, NestableInput> childImplementations = new HashMap<>();
+    protected final Map<String, NestableInput> childImplementations;
     protected R row;
+
+    public ObjectCollectExpression(Map<String, NestableInput> childImplementations) {
+        this.childImplementations = childImplementations;
+    }
+
+    public ObjectCollectExpression() {
+        this.childImplementations = new HashMap<>();
+    }
 
     public void setNextRow(R row) {
         this.row = row;

--- a/sql/src/main/java/io/crate/expression/reference/sys/node/NodeStatsContext.java
+++ b/sql/src/main/java/io/crate/expression/reference/sys/node/NodeStatsContext.java
@@ -33,6 +33,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.lucene.BytesRefs;
+import org.elasticsearch.http.HttpStats;
 import org.elasticsearch.monitor.fs.FsInfo;
 import org.elasticsearch.monitor.jvm.JvmStats;
 import org.elasticsearch.monitor.os.OsInfo;
@@ -62,6 +63,7 @@ public class NodeStatsContext implements Streamable {
     private ExtendedOsStats extendedOsStats;
     private FsInfo fsInfo;
     private ThreadPools threadPools;
+    private HttpStats httpStats;
 
     private BytesRef osName;
     private BytesRef osArch;
@@ -183,6 +185,10 @@ public class NodeStatsContext implements Streamable {
         return jvmVersion;
     }
 
+    public HttpStats httpStats() {
+        return httpStats;
+    }
+
     public void id(BytesRef id) {
         this.id = id;
     }
@@ -243,6 +249,10 @@ public class NodeStatsContext implements Streamable {
         this.threadPools = threadPools;
     }
 
+    public void httpStats(HttpStats httpStats) {
+        this.httpStats = httpStats;
+    }
+
     @Override
     public void readFrom(StreamInput in) throws IOException {
         id = DataTypes.STRING.readValueFrom(in);
@@ -268,6 +278,7 @@ public class NodeStatsContext implements Streamable {
         fsInfo = in.readOptionalWriteable(FsInfo::new);
         extendedOsStats = in.readBoolean() ? ExtendedOsStats.readExtendedOsStat(in) : null;
         threadPools = in.readBoolean() ? ThreadPools.readThreadPools(in) : null;
+        httpStats = in.readOptionalWriteable(HttpStats::new);
 
         osName = DataTypes.STRING.readValueFrom(in);
         osArch = DataTypes.STRING.readValueFrom(in);
@@ -308,6 +319,7 @@ public class NodeStatsContext implements Streamable {
         out.writeOptionalWriteable(fsInfo);
         out.writeOptionalStreamable(extendedOsStats);
         out.writeOptionalStreamable(threadPools);
+        out.writeOptionalWriteable(httpStats);
 
         DataTypes.STRING.writeValueTo(out, osName);
         DataTypes.STRING.writeValueTo(out, osArch);

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -209,10 +209,26 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     public void testAllColumnNodes() throws Exception {
         QueriedRelation relation = analyze("select id, * from sys.nodes");
         List<String> outputNames = outputNames(relation);
-        assertThat(outputNames.get(0), is("id"));
-        assertThat(outputNames.get(1), is("fs"));
-        assertThat(outputNames.size(), is(16));
-        assertThat(relation.querySpec().outputs().size(), is(16));
+        assertThat(outputNames, contains(
+            "id",
+            "connections",
+            "fs",
+            "heap",
+            "hostname",
+            "id",
+            "load",
+            "mem",
+            "name",
+            "network",
+            "os",
+            "os_info",
+            "port",
+            "process",
+            "rest_url",
+            "thread_pools",
+            "version"
+        ));
+        assertThat(relation.querySpec().outputs().size(), is(outputNames.size()));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/InformationSchemaTest.java
@@ -569,7 +569,7 @@ public class InformationSchemaTest extends SQLTransportIntegrationTest {
     @Test
     public void testDefaultColumns() {
         execute("select * from information_schema.columns order by table_schema, table_name");
-        assertEquals(520, response.rowCount());
+        assertEquals(524, response.rowCount());
     }
 
     @Test


### PR DESCRIPTION
This adds a new `connections` column to `sys.nodes` to expose the number
of total and open connections made via HTTP.

`connections` was choosen as top-level column instead of nesting it into
`network` because `network` is deprecated and we prefer to have a lower
number of nestings.

Other protocols (transport, postres) will be exposed separately
