### PR TITLE
Fix the TimestampType equality definition (to not be identical to the LongType)

### DIFF
--- a/blackbox/docs/appendices/release-notes/upcoming.rst
+++ b/blackbox/docs/appendices/release-notes/upcoming.rst
@@ -49,5 +49,8 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that would cause a ``CAST`` from ``TIMESTAMP`` to ``LONG`` to
+  be ignored.
+
 - Handle ``STRING_ARRAY`` as argument type for user-defined functions correctly
   to prevent an ``ArrayStoreException``.

--- a/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -873,11 +873,11 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
             "create table foo (ts timestamp, day timestamp GENERATED ALWAYS as ts + 1)");
         Map<String, Object> metaMapping = ((Map) analysis.mapping().get("_meta"));
         Map<String, String> generatedColumnsMapping = (Map<String, String>) metaMapping.get("generated_columns");
-        assertThat(generatedColumnsMapping.get("day"), is("(ts + 1)"));
+        assertThat(generatedColumnsMapping.get("day"), is("cast((cast(ts AS long) + 1) AS timestamp)"));
 
         Map<String, Object> mappingProperties = analysis.mappingProperties();
         Map<String, Object> dayMapping = (Map<String, Object>) mappingProperties.get("day");
-        assertThat((String) dayMapping.get("type"), is("long"));
+        assertThat((String) dayMapping.get("type"), is("date"));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -349,6 +349,13 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
+    public void testTimestampIsCastedToLong() {
+        SqlExpressions expressions = new SqlExpressions(T3.SOURCES);
+        Symbol symbol = expressions.asSymbol("doc.t5.ts :: long");
+        assertThat(symbol.valueType(), is(DataTypes.LONG));
+    }
+
+    @Test
     public void testBetweenIsEagerlyEvaluatedIfPossible() throws Exception {
         Symbol x = expressions.asSymbol("5 between 1 and 10");
         assertThat(x, isLiteral(true));

--- a/sql/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/ShowIntegrationTest.java
@@ -220,9 +220,9 @@ public class ShowIntegrationTest extends SQLTransportIntegrationTest {
                 ")");
         execute("show create table test_generated_column");
         assertRow("CREATE TABLE IF NOT EXISTS \"doc\".\"test_generated_column\" (\n" +
-                  "   \"col1\" LONG GENERATED ALWAYS AS \"ts\" + 1,\n" +
-                  "   \"col2\" STRING GENERATED ALWAYS AS CAST((\"ts\" + 1) AS string),\n" +
-                  "   \"col3\" STRING GENERATED ALWAYS AS CAST((\"ts\" + 1) AS string),\n" +
+                  "   \"col1\" LONG GENERATED ALWAYS AS CAST(\"ts\" AS long) + 1,\n" +
+                  "   \"col2\" STRING GENERATED ALWAYS AS CAST((CAST(\"ts\" AS long) + 1) AS string),\n" +
+                  "   \"col3\" STRING GENERATED ALWAYS AS CAST((CAST(\"ts\" AS long) + 1) AS string),\n" +
                   "   \"day1\" TIMESTAMP GENERATED ALWAYS AS date_trunc('day', \"ts\"),\n" +
                   "   \"day2\" TIMESTAMP GENERATED ALWAYS AS date_trunc('day', \"ts\") INDEX OFF,\n" +
                   "   \"day3\" TIMESTAMP GENERATED ALWAYS AS date_trunc('day', \"ts\"),\n" +

--- a/sql/src/test/java/io/crate/testing/T3.java
+++ b/sql/src/test/java/io/crate/testing/T3.java
@@ -100,6 +100,7 @@ public class T3 {
         new TestingTableInfo.Builder(new RelationName(Schemas.DOC_SCHEMA_NAME, "t5"), t5Routing)
             .add("i", DataTypes.INTEGER)
             .add("w", DataTypes.LONG)
+            .add("ts", DataTypes.TIMESTAMP)
             .build();
     public static final DocTableRelation TR_5 = new DocTableRelation(T5_INFO);
 


### PR DESCRIPTION
The Timestamp type is treated as an extension of the Long type because of the
common storage format, but the type semantics are very different.
This makes the TimestampType "idenfity itself" as different than the LongType.

<!--

Thank you for your contribution. Here is a quick checklist of things you should've done:

 - You've read CONTRIBUTING.rst and signed our CLA (https://crate.io/community/contribute/cla/)
 - Wrote a CHANGES.txt entry if this is a change that is relevant for users of CrateDB
 - Run tests with `./gradlew test itest` (If they fail Jenkins will block this PR anyway)

-->
