### PR TITLE
fix kill integration test assertion on MASTER

### DIFF
--- a/sql/src/test/java/io/crate/integrationtests/KillIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/KillIntegrationTest.java
@@ -29,8 +29,6 @@ import io.crate.testing.plugin.CrateTestingPlugin;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -100,8 +98,8 @@ public class KillIntegrationTest extends SQLTransportIntegrationTest {
                 assertThat(exception, instanceOf(SQLActionException.class));
                 assertThat(exception.toString(), anyOf(
                     containsString("Job killed"), // CancellationException
-                    containsString("Task for job"), // TaskMissing when job execution context not found
-                    containsString("SearchContext for job") // TaskMissing when search context not found
+                    containsString("RootTask for job"), // TaskMissing when root task not found
+                    containsString("Task for job") // TaskMissing when task not found
                 ));
             }
         } finally {


### PR DESCRIPTION
The missing context exception can only occur with either JobExecutionContext or
SubExecutionContext but not with a SearchContext

3.0 related commit https://github.com/crate/crate/pull/7416/commits/7f91bd027cd7bb52a0b5fe013d41f08973316ac5