### PR TITLE
Optimise NOT = ANY() by introducing a function that removes the 3-valued logic for nulls

### DIFF
--- a/blackbox/docs/appendices/release-notes/upcoming.rst
+++ b/blackbox/docs/appendices/release-notes/upcoming.rst
@@ -18,6 +18,14 @@ Breaking Changes
 Changes
 =======
 
+- Added a new scalar function ``ignore3vl`` which eliminates the 3-valued logic
+  of null handling for every logical expression beneath it. If 3-valued logic
+  is not required, the use of this function in the ``WHERE`` clause beneath a
+  ``NOT`` operator can boost the query performance significantly. E.g.::
+
+    SELECT * FROM t
+    WHERE NOT IGNORE3VL(5 = ANY(t.int_array_col))
+
 - Changed internals for DELETE and UPDATE queries which should generally result
   in a performance increase for queries which only match a subset of the rows
   and avoid ``CircuitBreakingException`` errors. But it might result in a

--- a/blackbox/docs/general/builtins/array-comparisons.rst
+++ b/blackbox/docs/general/builtins/array-comparisons.rst
@@ -94,3 +94,9 @@ The result of the ``ANY`` construct yields ``null`` if:
     - Arrays of type ``object``
 
     - Objects as ``expressions``
+
+.. TIP::
+
+    When using ``NOT <value> = ANY(<array_col>)`` the performance of the query
+    could be quite bad. To achieve better performance, consider using the
+    :ref:`ignore3vl function<ignore3vl>`.

--- a/blackbox/docs/general/dql/selects.rst
+++ b/blackbox/docs/general/dql/selects.rst
@@ -600,6 +600,12 @@ to *get all rows where race['interests'] has no value that equals 'netball'*::
     +--------------+-------------------------------+
     SELECT 1 row in set (... sec)
 
+.. NOTE::
+
+    When using the ``NOT <value> = ANY(<array_col>)`` the performance of the
+    query could be quite bad. To achieve better performance consider using the
+    :ref:`ignore3vl function<ignore3vl>`.
+
 The same behaviour (though different comparison operations involved) holds true
 for operators
 
@@ -607,7 +613,7 @@ for operators
 
  - all other comparison operators (excluding ``IS NULL`` and ``IS NOT NULL``)
 
-.. NOTE::
+.. TIP::
 
     When using the operators ``LIKE ANY`` and ``NOT LIKE ANY`` by default the
     maximum size of the array to operate on is ``8192``. To be able to use

--- a/sql/src/main/java/io/crate/expression/scalar/Ignore3vlFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/Ignore3vlFunction.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.scalar;
+
+import io.crate.data.Input;
+import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.Scalar;
+import io.crate.types.DataTypes;
+
+import java.util.Collections;
+
+/**
+ * This scalar function removes the 3-valued logic from the tree of operators below it.
+ * If used as a normal scalar (eg. SELECT ignore3vl(<some_boolean_expression)) it just
+ * evaluates NULL to false.
+ *
+ * Its main usage though is in the WHERE clause because it acts as a marker
+ * that {@link io.crate.lucene.LuceneQueryBuilder} can use in order to skip the 3-valued logic
+ * filtering on queries which results in a better performance. The 3-valued logic filtering is
+ * applied with a generic function filtering which is slow, so if this logic is not needed and
+ * the null can be translated to false, the generic function is completely removed.
+ */
+public class Ignore3vlFunction extends Scalar<Boolean, Boolean> {
+
+    public static final String NAME = "ignore3vl";
+
+    private static final FunctionInfo FUNCTION_INFO = new FunctionInfo(
+        new FunctionIdent(NAME, Collections.singletonList(DataTypes.BOOLEAN)), DataTypes.BOOLEAN);
+
+    public static void register(ScalarFunctionModule module) {
+        module.register(new Ignore3vlFunction());
+    }
+
+    @Override
+    public Boolean evaluate(Input<Boolean>... args) {
+        assert args.length == 1 : "ignore3vl expects exactly 1 argument, got: " + args.length;
+        Boolean value = args[0].value();
+        if (value == null) {
+            return Boolean.FALSE;
+        }
+        return value;
+    }
+
+    @Override
+    public FunctionInfo info() {
+        return FUNCTION_INFO;
+    }
+}

--- a/sql/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
+++ b/sql/src/main/java/io/crate/expression/scalar/ScalarFunctionModule.java
@@ -121,6 +121,8 @@ public class ScalarFunctionModule extends AbstractModule {
         LengthFunction.register(this);
         HashFunctions.register(this);
 
+        Ignore3vlFunction.register(this);
+
         MapFunction.register(this);
         ArrayFunction.register(this);
         ArrayCatFunction.register(this);

--- a/sql/src/test/java/io/crate/expression/scalar/arithmetic/Ignore3vlFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/arithmetic/Ignore3vlFunctionTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.scalar.arithmetic;
+
+import io.crate.exceptions.ConversionException;
+import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import org.junit.Test;
+
+import static io.crate.testing.SymbolMatchers.isFunction;
+import static io.crate.testing.SymbolMatchers.isLiteral;
+
+public class Ignore3vlFunctionTest extends AbstractScalarFunctionsTest {
+
+    @Test
+    public void testIgnore3vlFunction() {
+        assertEvaluate("ignore3vl(false)", false);
+        assertEvaluate("ignore3vl(true)", true);
+        assertEvaluate("ignore3vl(null)", false);
+    }
+
+    @Test
+    public void testWrongType() {
+        expectedException.expect(ConversionException.class);
+        expectedException.expectMessage("Cannot cast 'foo' to type boolean");
+        assertEvaluate("ignore3vl('foo')", null);
+    }
+
+    @Test
+    public void testNormalizeReference() {
+        assertNormalize("ignore3vl(is_awesome)", isFunction("ignore3vl"));
+    }
+
+    @Test
+    public void testNormalizeNull() {
+        assertNormalize("ignore3vl(null)", isLiteral(false));
+    }
+}

--- a/sql/src/test/java/io/crate/lucene/ThreeValuedLogicQueryBuilderTest.java
+++ b/sql/src/test/java/io/crate/lucene/ThreeValuedLogicQueryBuilderTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.lucene;
+
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+
+public class ThreeValuedLogicQueryBuilderTest extends LuceneQueryBuilderTest {
+
+    @Test
+    public void testNotAnyEqWith3vl() {
+        assertThat(
+            convert("NOT 10 = ANY(y_array)").toString(),
+            is("+(+*:* -y_array:[10 TO 10]) +(+*:* -op_isnull(any_=(10, Ref{doc.users.y_array, long_array})))")
+        );
+        assertThat(
+            convert("NOT d = ANY([1,2,3])").toString(),
+            is("+(+*:* -d:{1.0 2.0 3.0}) +(+*:* -op_isnull(any_=(Ref{doc.users.d, double}, [1.0, 2.0, 3.0])))")
+        );
+    }
+
+    @Test
+    public void testNotAnyEqWithout3vl() {
+        assertThat(
+            convert("NOT ignore3vl(20 = ANY(y_array))").toString(),
+            is("+(+*:* -y_array:[20 TO 20])")
+        );
+        assertThat(
+            convert("NOT ignore3vl(d = ANY([1,2,3]))").toString(),
+            is("+(+*:* -d:{1.0 2.0 3.0})")
+        );
+    }
+
+    @Test
+    public void testComplexOperatorTreeWith3vlAndIgnore3vl() {
+        assertThat(
+            convert("NOT name = 'foo' AND NOT ignore3vl(name = 'bar')").toString(),
+            is("+(+(+*:* -name:foo) +ConstantScore(DocValuesFieldExistsQuery [field=name])) +(+(+*:* -name:bar))")
+        );
+    }
+}


### PR DESCRIPTION
Benchmark Setup:
- create table t(a array(integer));
- 400k records
- 100k records have an array [1..100] matched in the 1st query
- 300k records have an array of [1..101]
- 2nd query matches no records


Benchmark Results:
```
+----------------------------------------------------------+-----------------------+
| statement                                                | runtime_stats['mean'] |
+----------------------------------------------------------+-----------------------+
| select count(*) from t where not 101 = any(a)            |          36.776370926 |
| select count(*) from t where not ignore3vl(101 = any(a)) |           0.798499682 |
| select count(*) from t where not 20 = any(a)             |           1.095777218 |
| select count(*) from t where not ignore3vl(20 = any(a))  |           0.565805947 |
+----------------------------------------------------------+-----------------------+
```

Another scenario:
- 1M records
- 250k records have an array [1..100] matched in the 1st query
- 750k records have an array of [1..101]
- 2nd query matches no records


Benchmark Results:
```
+----------------------------------------------------------+-----------------------+
| statement                                                | runtime_stats['mean'] |
+----------------------------------------------------------+-----------------------+
| select count(*) from t where not 101 = any(a)            |         377.185134926 |
| select count(*) from t where not ignore3vl(101 = any(a)) |           2.106383348 |
| select count(*) from t where not 20 = any(a)             |           6.490458073 |
| select count(*) from t where not ignore3vl(20 = any(a))  |           1.722016933 |
+----------------------------------------------------------+-----------------------+
```
