### PR TITLE
Use stored fields to lookup _id

### DIFF
--- a/blackbox/docs/appendices/release-notes/upcoming.rst
+++ b/blackbox/docs/appendices/release-notes/upcoming.rst
@@ -18,6 +18,12 @@ Breaking Changes
 Changes
 =======
 
+- Changed internals for DELETE and UPDATE queries which should generally result
+  in a performance increase for queries which only match a subset of the rows
+  and avoid ``CircuitBreakingException`` errors. But it might result in a
+  slight performance decrease if the queries match all
+  or almost all records.
+
 - Added a new ``Connections`` MBean for JMX which exposes the number of open
   connections per protocol.
 

--- a/sql/src/main/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolver.java
+++ b/sql/src/main/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolver.java
@@ -52,8 +52,6 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 
 import java.util.Locale;
 
-import static java.util.Objects.requireNonNull;
-
 public class LuceneReferenceResolver implements ReferenceResolver<LuceneCollectorExpression<?>> {
 
     private final FieldTypeLookup fieldTypeLookup;
@@ -91,14 +89,12 @@ public class LuceneReferenceResolver implements ReferenceResolver<LuceneCollecto
         } else if (UidCollectorExpression.COLUMN_NAME.equals(name)) {
             if (indexSettings.isSingleType()) {
                 // _uid and _id is the same
-                return new IdCollectorExpression(
-                    requireNonNull(fieldTypeLookup.get(IdCollectorExpression.COLUMN_NAME), "_id field must have a fieldType"));
+                return new IdCollectorExpression();
             }
             return new UidCollectorExpression();
         } else if (IdCollectorExpression.COLUMN_NAME.equals(name)) {
             if (indexSettings.isSingleType()) {
-                return new IdCollectorExpression(
-                    requireNonNull(fieldTypeLookup.get(IdCollectorExpression.COLUMN_NAME), "_id field must have a fieldType"));
+                return new IdCollectorExpression();
             }
             return new IdFromUidCollectorExpression();
         } else if (DocCollectorExpression.COLUMN_NAME.equals(name)) {


### PR DESCRIPTION
Using the fieldcache requires a lot of HEAP as it loads all values of
the field into memory.
This should improve the performance for most uses-cases, but can result
in a performance decrease for delete queries which match most records.

Benchmark results:

    Q: delete from t where id < 300
    C: 1
      119.44% mean difference
                V1   →    V2
      mean:  329.456 →  83.083

    Q: delete from t
    C: 1
      50.59% mean difference.
                V1  →     V2
      mean:   4606.528 → 7725.752