### PR TITLE
fix error handling at the postgres protocol

### DIFF
--- a/blackbox/docs/appendices/release-notes/upcoming.rst
+++ b/blackbox/docs/appendices/release-notes/upcoming.rst
@@ -66,6 +66,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that could prevent postgres clients from receiving an error and
+  therefore getting stuck.
+
 - Fixed an issue that would cause a ``CAST`` from ``TIMESTAMP`` to ``LONG`` to
   be ignored.
 

--- a/sql/src/main/java/io/crate/action/sql/BaseResultReceiver.java
+++ b/sql/src/main/java/io/crate/action/sql/BaseResultReceiver.java
@@ -23,6 +23,7 @@
 package io.crate.action.sql;
 
 import io.crate.data.Row;
+import io.crate.protocols.postgres.ClientInterrupted;
 
 import javax.annotation.Nonnull;
 import javax.annotation.OverridingMethodsMustInvokeSuper;
@@ -44,8 +45,7 @@ public class BaseResultReceiver implements ResultReceiver {
     @OverridingMethodsMustInvokeSuper
     public void allFinished(boolean interrupted) {
         if (interrupted) {
-            completionFuture.completeExceptionally(
-                new InterruptedException("Interrupted before finished receiving results"));
+            completionFuture.completeExceptionally(new ClientInterrupted());
         } else {
             completionFuture.complete(null);
         }

--- a/sql/src/main/java/io/crate/protocols/postgres/ClientInterrupted.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/ClientInterrupted.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.protocols.postgres;
+
+/**
+ * Marker exception used to indicate that a client interrupted the current query.
+ */
+public class ClientInterrupted extends RuntimeException {
+}

--- a/sql/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
@@ -267,8 +267,7 @@ class PostgresWireProtocol {
         @Override
         public void accept(Object result, Throwable t) {
             if (t != null) {
-                if (!(t.getCause() instanceof InterruptedException)) {
-                    Messages.sendErrorResponse(channel, t);
+                if (!(t.getCause() instanceof ClientInterrupted)) {
                     Messages.sendReadyForQuery(channel);
                 }
             } else {
@@ -687,6 +686,7 @@ class PostgresWireProtocol {
             return session.sync();
         } catch (Throwable t) {
             session.clearState();
+            Messages.sendErrorResponse(channel, t);
             result.completeExceptionally(t);
             return result;
         }

--- a/sql/src/main/java/io/crate/protocols/postgres/ResultSetReceiver.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/ResultSetReceiver.java
@@ -80,7 +80,7 @@ class ResultSetReceiver extends BaseResultReceiver {
 
     @Override
     public void fail(@Nonnull Throwable throwable) {
-        Messages.sendErrorResponse(channel, SQLExceptions.createSQLActionException(throwable, exceptionAuthorizedValidator))
-            .addListener(f -> super.fail(throwable));
+        final Throwable t =  SQLExceptions.createSQLActionException(throwable, exceptionAuthorizedValidator);
+        Messages.sendErrorResponse(channel, t).addListener(f -> super.fail(t));
     }
 }

--- a/sql/src/main/java/io/crate/protocols/postgres/RowCountReceiver.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/RowCountReceiver.java
@@ -62,7 +62,7 @@ class RowCountReceiver extends BaseResultReceiver {
 
     @Override
     public void fail(@Nonnull Throwable throwable) {
-        Messages.sendErrorResponse(channel, SQLExceptions.createSQLActionException(throwable, exceptionAuthorizedValidator))
-            .addListener(f -> super.fail(throwable));
+        final Throwable t =  SQLExceptions.createSQLActionException(throwable, exceptionAuthorizedValidator);
+        Messages.sendErrorResponse(channel, t).addListener(f -> super.fail(t));
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/PostgresJobsLogsITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PostgresJobsLogsITest.java
@@ -171,7 +171,7 @@ public class PostgresJobsLogsITest extends SQLTransportIntegrationTest {
                         "sys.jobs_log must have an entry WHERE stmt=" + stmtStr, resultSet.next(), is(true));
                     assertThat(resultSet.getString(1), is(stmtStr));
                     if (checkForError) {
-                        assertThat(resultSet.getString(2), is("\"a\" must not be null"));
+                        assertThat(resultSet.getString(2), is("SQLParseException: \"a\" must not be null"));
                     }
                 }
             } catch (Exception e) {


### PR DESCRIPTION
On all server side errors one “errorResponse” and one “readForQuery”
message must be sent to the client. Only if the client cancelled the
operation by itself e.g. due to a new statement while the old has unfinished
results, no “readForQuery” should be sent.
The existing code was doing this by checking for a “InterruptedException”
which could also be thrown by server side failures (e.g. kill), this
“marker” exception is now replaced by a concrete “ClientInterrupted” exception.
Also currently 2 error responses were sent sometimes instead of just 1.