### PR TITLE
Validate jobs filters on SET GLOBAL statements

### DIFF
--- a/sql/src/test/java/io/crate/execution/engine/collect/stats/JobsLogsTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/stats/JobsLogsTest.java
@@ -118,6 +118,16 @@ public class JobsLogsTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
+    public void testFilterIsValidatedOnUpdate() {
+        // creating the service registers the update listener
+        new JobsLogService(Settings.EMPTY, clusterSettings, getFunctions(), scheduler, breakerService);
+
+        expectedException.expectMessage("illegal value can't update [stats.jobs_log_filter] from [true] to [statement = 'x']");
+        clusterSettings.applySettings(
+            Settings.builder().put(JobsLogService.STATS_JOBS_LOG_FILTER.getKey(), "statement = 'x'").build());
+    }
+
+    @Test
     public void testErrorIsRaisedInitiallyOnInvalidFilterExpression() {
         Settings settings = Settings.builder()
             .put(JobsLogService.STATS_JOBS_LOG_FILTER.getKey(), "invalid_column = 10")


### PR DESCRIPTION
With this change users will receive an error on invalid filters instead
of the error being logged.