### PR TITLE
Automatically regenerate outdated parser classes via Gradle

### DIFF
--- a/sql-parser/build.gradle
+++ b/sql-parser/build.gradle
@@ -30,7 +30,7 @@ task antlrOutputDir {
 }
 
 task generateGrammarSource(dependsOn: antlrOutputDir, type: JavaExec) {
-    inputs.dir file(antlr.source)
+    inputs.files(fileTree(antlr.source))
     outputs.dir file(antlr.output)
 
     def grammars = fileTree(antlr.source).include('**/*.g4')


### PR DESCRIPTION
This patch auto-detects changes in the parser grammar source files and
regenerates the parser classes. Without this patch, the sql-parser module had to
be rebuilt manually whenever the parser grammar files changed.