### PR TITLE
Make sure blob tables also trigger table re-creation sys check

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -27,6 +27,10 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that prevented blob tables from showing up or triggering the
+  system check indicating that they'll need to be re-created in order to update
+  to CrateDB 3.0+
+
 - Fixed an issue that caused an UnsupportedFeatureException to be thrown for
   queries with a ``WHERE`` clause which contains an equality comparison that
   references a table column in both sides. E.g.::

--- a/sql/src/main/java/io/crate/expression/reference/sys/check/cluster/TablesNeedUpgradeSysCheck.java
+++ b/sql/src/main/java/io/crate/expression/reference/sys/check/cluster/TablesNeedUpgradeSysCheck.java
@@ -88,7 +88,7 @@ public class TablesNeedUpgradeSysCheck extends AbstractSysCheck {
             TablesNeedRecreationSysCheck.tablesNeedRecreation(clusterService.state().metaData());
 
         final CompletableFuture<Collection<String>> result = new CompletableFuture<>();
-        Object[] sqlParam = tablesNeedRecreation.toArray(new String[]{});
+        Object[] sqlParam = tablesNeedRecreation.toArray(new String[] {});
         try {
             session().quickExec(STMT, stmt -> PARSED_STMT, new SycCheckResultReceiver(result), new Row1(sqlParam));
         } catch (Throwable t) {

--- a/sql/src/test/java/io/crate/expression/reference/sys/check/cluster/TablesNeedRecreationSysCheckTest.java
+++ b/sql/src/test/java/io/crate/expression/reference/sys/check/cluster/TablesNeedRecreationSysCheckTest.java
@@ -35,27 +35,27 @@ public class TablesNeedRecreationSysCheckTest extends CrateUnitTest {
 
     @Test
     public void testRecreationRequired() {
-        assertThat(isRecreationRequired("noMetaData", null), is(false));
+        assertThat(isRecreationRequired(null), is(false));
 
         IndexMetaData recreationRequired = new IndexMetaData.Builder("testRecreationRequired")
             .settings(Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.V_2_4_2).build())
             .numberOfShards(5)
             .numberOfReplicas(2)
             .build();
-        assertThat(isRecreationRequired("testRecreationRequired", recreationRequired), is(true));
+        assertThat(isRecreationRequired(recreationRequired), is(true));
 
         IndexMetaData noRecreationRequired = new IndexMetaData.Builder("testNoRecreationRequired")
             .settings(Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.V_5_0_1).build())
             .numberOfShards(5)
             .numberOfReplicas(2)
             .build();
-        assertThat(isRecreationRequired("testNoRecreationRequired", noRecreationRequired), is(false));
+        assertThat(isRecreationRequired(noRecreationRequired), is(false));
 
-        IndexMetaData noRecreationRequiredBlob = new IndexMetaData.Builder(".blob_testRecreationRequired")
+        IndexMetaData recreationRequiredBlob = new IndexMetaData.Builder(".blob_testRecreationRequired")
             .settings(Settings.builder().put(IndexMetaData.SETTING_VERSION_CREATED, Version.V_2_4_2).build())
             .numberOfShards(5)
             .numberOfReplicas(2)
             .build();
-        assertThat(isRecreationRequired(".blob_testRecreationRequired", noRecreationRequiredBlob), is(false));
+        assertThat(isRecreationRequired(recreationRequiredBlob), is(true));
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/TableCompatibilitySysChecksTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/TableCompatibilitySysChecksTest.java
@@ -64,7 +64,7 @@ public class TableCompatibilitySysChecksTest extends SQLTransportIntegrationTest
         assertThat(response.rows()[0][3], is(SysCheck.Severity.MEDIUM.value()));
         assertThat(response.rows()[0][0],
             is(TablesNeedRecreationSysCheck.DESCRIPTION +
-               "[doc.test_recreation_required, doc.test_recreation_required_parted] " +
+               "[blob.test_blob_recreation_required, doc.test_recreation_required, doc.test_recreation_required_parted] " +
                LINK_PATTERN + TablesNeedRecreationSysCheck.ID));
     }
 


### PR DESCRIPTION
Although indices for blob tables contain no real documents they still
need to be re-created, otherwise CrateDB 3.0+ won't launch:

    The index [[.blob_foo/PuQxMJtsSoy2Bd_mvvpDiA]] was created with
    version [2.4.2] but the minimum compatible version is [5.0.0]. It
    should be re-indexed