### PR TITLE
Handle blob indices correctly in RelationName / IndexParts

### DIFF
--- a/sql/src/main/java/io/crate/metadata/RelationName.java
+++ b/sql/src/main/java/io/crate/metadata/RelationName.java
@@ -24,8 +24,10 @@ package io.crate.metadata;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
+import io.crate.blob.v2.BlobIndex;
 import io.crate.exceptions.InvalidRelationName;
 import io.crate.exceptions.InvalidSchemaNameException;
+import io.crate.metadata.blob.BlobSchemaInfo;
 import io.crate.sql.Identifiers;
 import io.crate.sql.tree.QualifiedName;
 import io.crate.sql.tree.Table;
@@ -97,6 +99,8 @@ public final class RelationName implements Writeable {
     public String indexName() {
         if (schema.equalsIgnoreCase(Schemas.DOC_SCHEMA_NAME)) {
             return name;
+        } else if (schema.equalsIgnoreCase(BlobSchemaInfo.NAME)) {
+            return BlobIndex.fullIndexName(name);
         }
         return fqn();
     }

--- a/sql/src/main/java/io/crate/metadata/blob/BlobTableInfo.java
+++ b/sql/src/main/java/io/crate/metadata/blob/BlobTableInfo.java
@@ -85,6 +85,7 @@ public class BlobTableInfo implements TableInfo, ShardedTable, StoredTable {
                          @Nullable Version versionCreated,
                          @Nullable Version versionUpgraded,
                          boolean closed) {
+        assert ident.indexName().equals(index) : "RelationName indexName must match index";
         this.ident = ident;
         this.index = index;
         this.numberOfShards = numberOfShards;

--- a/sql/src/test/java/io/crate/analyze/AlterTableRerouteAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/AlterTableRerouteAnalyzerTest.java
@@ -75,7 +75,7 @@ public class AlterTableRerouteAnalyzerTest extends CrateDummyClusterServiceUnitT
     public void testRerouteOnBlobTable() throws Exception {
         RerouteMoveShardAnalyzedStatement analyzed = e.analyze("ALTER TABLE blob.blobs REROUTE MOVE SHARD 0 FROM 'nodeOne' TO 'nodeTwo'");
         assertThat(analyzed.tableInfo().concreteIndices().length, is(1));
-        assertThat(analyzed.tableInfo().concreteIndices()[0], is("blob.blobs"));
+        assertThat(analyzed.tableInfo().concreteIndices()[0], is(".blob_blobs"));
         assertThat(analyzed.isWriteOperation(), is(true));
     }
 

--- a/sql/src/test/java/io/crate/analyze/OptimizeTableAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/OptimizeTableAnalyzerTest.java
@@ -66,7 +66,7 @@ public class OptimizeTableAnalyzerTest extends CrateDummyClusterServiceUnitTest 
     public void testOptimizeBlobTable() throws Exception {
         OptimizeTableAnalyzedStatement analysis = e.analyze("OPTIMIZE TABLE blob.blobs");
         assertThat(analysis.indexNames().size(), is(1));
-        assertThat(analysis.indexNames(), hasItem("blob.blobs"));
+        assertThat(analysis.indexNames(), hasItem(".blob_blobs"));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/execution/ddl/RerouteActionsTest.java
+++ b/sql/src/test/java/io/crate/execution/ddl/RerouteActionsTest.java
@@ -66,7 +66,7 @@ public class RerouteActionsTest extends CrateUnitTest {
             SqlParser.createExpression("node2")
         );
         String index = RerouteActions.getRerouteIndex(statement, Row.EMPTY);
-        assertThat(index, is("blob.screenshots"));
+        assertThat(index, is(".blob_screenshots"));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/metadata/RelationNameTest.java
+++ b/sql/src/test/java/io/crate/metadata/RelationNameTest.java
@@ -23,6 +23,7 @@
 package io.crate.metadata;
 
 import com.google.common.collect.ImmutableList;
+import io.crate.blob.v2.BlobIndex;
 import io.crate.test.integration.CrateUnitTest;
 import org.apache.lucene.util.BytesRef;
 import org.junit.Test;
@@ -49,6 +50,14 @@ public class RelationNameTest extends CrateUnitTest {
 
         pn = new PartitionName(new RelationName("doc", "t"), ImmutableList.of(new BytesRef("v1")));
         assertThat(RelationName.fromIndexName(pn.asIndexName()), is(new RelationName(Schemas.DOC_SCHEMA_NAME, "t")));
+    }
+
+    @Test
+    public void testFromIndexNameCreatesCorrectBlobRelationName() {
+        RelationName relationName = new RelationName("blob", "foobar");
+        String indexName = relationName.indexName();
+        assertThat(BlobIndex.isBlobIndex(indexName), is(true));
+        assertThat(RelationName.fromIndexName(indexName), is(relationName));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/metadata/blob/BlobTableInfoTest.java
+++ b/sql/src/test/java/io/crate/metadata/blob/BlobTableInfoTest.java
@@ -31,13 +31,13 @@ import io.crate.types.DataTypes;
 import org.apache.lucene.util.BytesRef;
 import org.junit.Test;
 
-import java.util.Arrays;
+import java.util.Collections;
 
 public class BlobTableInfoTest extends CrateUnitTest {
 
     private BlobTableInfo info = new BlobTableInfo(
         new RelationName("blob", "dummy"),
-        "dummy",
+        ".blob_dummy",
         5,
         new BytesRef("0"),
         ImmutableMap.of(),
@@ -55,7 +55,7 @@ public class BlobTableInfoTest extends CrateUnitTest {
 
     @Test
     public void testPrimaryKey() throws Exception {
-        assertEquals(Arrays.asList(new ColumnIdent[]{new ColumnIdent("digest")}), info.primaryKey());
+        assertEquals(Collections.singletonList(new ColumnIdent("digest")), info.primaryKey());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/metadata/sys/TableHealthServiceTest.java
+++ b/sql/src/test/java/io/crate/metadata/sys/TableHealthServiceTest.java
@@ -111,7 +111,7 @@ public class TableHealthServiceTest extends CrateDummyClusterServiceUnitTest {
         Schemas schemas = mock(Schemas.class);
         when(schemas.getTableInfo(relationName)).thenReturn(new BlobTableInfo(
             relationName,
-            ".blob.my_blob_table",
+            ".blob_my_blob_table",
             2,
             new BytesRef(1),
             null,


### PR DESCRIPTION
Affected only tests where we created `RelationName` instances directly.
In production code we used `indexMetaData.getIndex().getName()` to
retrieve the index name.