### PR TITLE
Add Block Nested Loop algorithm for single node cross/inner joins

### DIFF
--- a/benchmarks/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorBenchmark.java
@@ -26,6 +26,7 @@ import com.google.common.util.concurrent.MoreExecutors;
 import io.crate.analyze.OrderBy;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.breaker.RowAccounting;
+import io.crate.breaker.RowAccountingWithEstimators;
 import io.crate.data.BatchIterator;
 import io.crate.data.Row;
 import io.crate.execution.engine.sort.OrderingByPosition;
@@ -73,7 +74,7 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Benchmark)
 public class OrderedLuceneBatchIteratorBenchmark {
 
-    private static final RowAccounting ROW_ACCOUNTING = new RowAccounting(Collections.singleton(LongType.INSTANCE),
+    private static final RowAccounting ROW_ACCOUNTING = new RowAccountingWithEstimators(Collections.singleton(LongType.INSTANCE),
         new RamAccountingContext("dummy", new NoopCircuitBreaker(CircuitBreaker.FIELDDATA))
     );
 

--- a/dex/src/main/java/io/crate/breaker/RamAccounting.java
+++ b/dex/src/main/java/io/crate/breaker/RamAccounting.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.breaker;
+
+/**
+ * Accounts for RAM usage by counting allocated bytes.
+ * Throws a CircuitBreakingException to avoid OutOfMemoryErrors,
+ * in case it thinks that too many bytes have been allocated.
+ */
+public interface RamAccounting {
+
+    /**
+     * Accounts for the supplied number of bytes
+     * @throws CircuitBreakingException if too many bytes have been added.
+     */
+    void addBytes(long bytes);
+
+    /**
+     * Stops accounting for previously accounted rows.
+     */
+    void release();
+
+    /**
+     * Closes this RamAccounting and prevents further use.
+     */
+    void close();
+
+}

--- a/dex/src/main/java/io/crate/breaker/RowAccounting.java
+++ b/dex/src/main/java/io/crate/breaker/RowAccounting.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.breaker;
+
+import io.crate.data.Row;
+
+/**
+ * Accounts for memory of Rows to avoid OutOfMemoryErrors.
+ * Calculated memory usage can be released.
+ */
+public interface RowAccounting {
+
+    /**
+     * Accounts memory usage of the supplied row.
+     * May throw an exception if it thinks that the rows accounted for
+     * occupy too much memory.
+     * @throws CircuitBreakingException if too much memory would be consumed
+     *         after materializing this row.
+     */
+    void accountForAndMaybeBreak(Row row);
+
+    /**
+     * Stops accounting for previously accounted rows.
+     */
+    void release();
+
+    /**
+     * Closes this accounting and prevents further use.
+     */
+    void close();
+}

--- a/dex/src/main/java/io/crate/data/InMemoryBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/InMemoryBatchIterator.java
@@ -51,6 +51,7 @@ public class InMemoryBatchIterator<T> implements BatchIterator<T> {
     }
 
     /**
+     * @param items An iterable over the items. It has to be repeatable if {@code moveToStart()} is used.
      * @param sentinel the value for {@link #currentElement()} if un-positioned
      */
     public static <T> BatchIterator<T> of(Iterable<? extends T> items, @Nullable T sentinel) {

--- a/dex/src/main/java/io/crate/data/join/CrossJoinBlockNLBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/join/CrossJoinBlockNLBatchIterator.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.data.join;
+
+
+import io.crate.breaker.RowAccounting;
+import io.crate.data.BatchIterator;
+import io.crate.data.Row;
+import io.crate.data.UnsafeArrayRow;
+
+import java.util.ArrayList;
+import java.util.function.IntSupplier;
+
+/**
+ * This BatchIterator is used for both CrossJoins and InnerJoins as for the InnerJoins
+ * the joinCondition is tested later on as a filter Projection.
+ *
+ * The Block Nested Loop algorithm is used to implement this cross join. For the regular
+ * Nested Loop, see {@link CrossJoinNLBatchIterator}.
+ *
+ * <pre>
+ *     // Block Nested Loop
+ *     fill buffer with next items from the left
+ *     for (row in buffer) {
+ *         for (rightRow in right) {
+ *             match?
+ *         }
+ *     }
+ *     repeat
+ * </pre>
+ */
+public class CrossJoinBlockNLBatchIterator extends JoinBatchIterator<Row, Row, Row> {
+
+    private final IntSupplier blockSizeCalculator;
+    private final ArrayList<Object[]> blockBuffer;
+    private final UnsafeArrayRow rowWrapper;
+    private final RowAccounting rowAccounting;
+
+    private int blockBufferMaxSize;
+    private int bufferPos;
+    private boolean rightInitialized;
+
+    CrossJoinBlockNLBatchIterator(BatchIterator<Row> left,
+                                  BatchIterator<Row> right,
+                                  ElementCombiner<Row, Row, Row> combiner,
+                                  IntSupplier blockSizeCalculator,
+                                  RowAccounting rowAccounting) {
+        super(left, right, combiner);
+        this.blockSizeCalculator = blockSizeCalculator;
+        this.blockBuffer = new ArrayList<>(0);
+        this.rowWrapper = new UnsafeArrayRow();
+        this.rowAccounting = rowAccounting;
+        resizeBlockBuffer();
+    }
+
+    private void resizeBlockBuffer() {
+        rowAccounting.release();
+        blockBufferMaxSize = blockSizeCalculator.getAsInt();
+        blockBuffer.clear();
+        blockBuffer.ensureCapacity(blockBufferMaxSize);
+        bufferPos = -1;
+    }
+
+    @Override
+    public void moveToStart() {
+        left.moveToStart();
+        right.moveToStart();
+        activeIt = right;
+        rightInitialized = false;
+        resizeBlockBuffer();
+    }
+
+    @Override
+    public boolean moveNext() {
+        do {
+            if (bufferPos == -1) {
+                // block buffer needs to be filled
+                activeIt = right;
+                // try advancing the right side first to check if we have items on the right
+                if (!rightInitialized) {
+                    if (right.moveNext()) {
+                        rightInitialized = true;
+                    } else {
+                        return false;
+                    }
+                }
+                activeIt = left;
+                while (blockBuffer.size() < blockBufferMaxSize) {
+                    if (left.moveNext()) {
+                        Row row = left.currentElement();
+                        rowAccounting.accountForAndMaybeBreak(row);
+                        blockBuffer.add(row.materialize());
+                    } else {
+                        if (left.allLoaded()) {
+                            break;
+                        } else {
+                            return false;
+                        }
+                    }
+                }
+                bufferPos = 0;
+            }
+            if (blockBuffer.isEmpty()) {
+                // last buffer is empty we're done
+                return false;
+            }
+
+            activeIt = right;
+            // we have iterated through the entire left block,
+            // go to the next item on right.
+            if (bufferPos == blockBuffer.size()) {
+                if (right.moveNext()) {
+                    // emit items in block again with the new right item
+                    bufferPos = 0;
+                } else {
+                    if (right.allLoaded()) {
+                        // right side is done, need to trigger loading of next block on the left side
+                        right.moveToStart();
+                        rightInitialized = false;
+                        resizeBlockBuffer();
+                    } else {
+                        return false;
+                    }
+                }
+            }
+        // we need to re-fill the buffer if we have iterated once through the right side
+        } while (bufferPos == -1);
+
+        combiner.setRight(right.currentElement());
+        rowWrapper.cells(blockBuffer.get(bufferPos));
+        combiner.setLeft(rowWrapper);
+        bufferPos++;
+        return true;
+    }
+
+    @Override
+    public void close() {
+        super.close();
+        blockBuffer.clear();
+    }
+}

--- a/dex/src/main/java/io/crate/data/join/JoinBatchIterators.java
+++ b/dex/src/main/java/io/crate/data/join/JoinBatchIterators.java
@@ -22,14 +22,18 @@
 
 package io.crate.data.join;
 
+import io.crate.breaker.RowAccounting;
 import io.crate.data.BatchIterator;
+import io.crate.data.Row;
 
+import java.util.function.IntSupplier;
 import java.util.function.Predicate;
 
 /**
  * BatchIterator implementations for Joins
  * <ul>
- * <li>{@link #crossJoin(BatchIterator, BatchIterator, ElementCombiner)}</li>
+ * <li>{@link #crossJoinNL(BatchIterator, BatchIterator, ElementCombiner)}</li>
+ * <li>{@link #crossJoinBlockNL(BatchIterator, BatchIterator, ElementCombiner, BlockSizeCalculator, RowAccounting)}</li>
  * <li>{@link #leftJoin(BatchIterator, BatchIterator, ElementCombiner, Predicate)}</li>
  * <li>{@link #rightJoin(BatchIterator, BatchIterator, ElementCombiner, Predicate)}</li>
  * <li>{@link #fullOuterJoin(BatchIterator, BatchIterator, ElementCombiner, Predicate)}</li>
@@ -55,10 +59,21 @@ public final class JoinBatchIterators {
     /**
      * Create a NestedLoop BatchIterator that creates a cross-join of {@code left} and {@code right}.
      */
-    public static <L, R, C> BatchIterator<C> crossJoin(BatchIterator<L> left,
-                                                       BatchIterator<R> right,
-                                                       ElementCombiner<L, R, C> combiner) {
+    public static <L, R, C> BatchIterator<C> crossJoinNL(BatchIterator<L> left,
+                                                         BatchIterator<R> right,
+                                                         ElementCombiner<L, R, C> combiner) {
         return new CrossJoinNLBatchIterator<>(left, right, combiner);
+    }
+
+    /**
+     * Create a BlockNestedLoop BatchIterator that creates a cross-join of {@code left} and {@code right}.
+     */
+    public static BatchIterator<Row> crossJoinBlockNL(BatchIterator<Row> left,
+                                                      BatchIterator<Row> right,
+                                                      ElementCombiner<Row, Row, Row> combiner,
+                                                      IntSupplier blockSizeCalculator,
+                                                      RowAccounting rowAccounting) {
+        return new CrossJoinBlockNLBatchIterator(left, right, combiner, blockSizeCalculator, rowAccounting);
     }
 
     /**

--- a/dex/src/test/java/io/crate/data/join/CrossJoinBlockNLBatchIteratorTest.java
+++ b/dex/src/test/java/io/crate/data/join/CrossJoinBlockNLBatchIteratorTest.java
@@ -1,0 +1,254 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.data.join;
+
+import com.carrotsearch.randomizedtesting.RandomizedRunner;
+import com.carrotsearch.randomizedtesting.annotations.Name;
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import io.crate.breaker.RowAccounting;
+import io.crate.data.BatchIterator;
+import io.crate.data.InMemoryBatchIterator;
+import io.crate.data.Row;
+import io.crate.testing.BatchIteratorTester;
+import io.crate.testing.BatchSimulatingIterator;
+import io.crate.testing.TestingBatchIterators;
+import io.crate.testing.TestingRowConsumer;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.IntSupplier;
+import java.util.function.Supplier;
+
+import static io.crate.data.SentinelRow.SENTINEL;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasItemInArray;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+@RunWith(RandomizedRunner.class)
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+public class CrossJoinBlockNLBatchIteratorTest {
+
+    private final int id;
+    private final Supplier<BatchIterator<Row>> left;
+    private final Supplier<BatchIterator<Row>> right;
+    private final IntSupplier blockSizeCalculator;
+    private final TestingRowAccounting testingRowAccounting;
+    private final List<Object[]> expectedResults;
+    private int expectedRowsLeft;
+    private int expectedRowsRight;
+
+    public CrossJoinBlockNLBatchIteratorTest(@Name("id") int id,
+                                             Supplier<BatchIterator<Row>> left,
+                                             Supplier<BatchIterator<Row>> right,
+                                             IntSupplier blockSizeCalculator) throws Exception {
+
+        this.id = id;
+        this.left = left;
+        this.right = right;
+        this.blockSizeCalculator = blockSizeCalculator;
+        this.testingRowAccounting = new TestingRowAccounting();
+        this.expectedResults = createExpectedResult(left.get(), right.get());
+    }
+
+    private List<Object[]> createExpectedResult(BatchIterator<Row> left, BatchIterator<Row> right) throws Exception {
+        TestingRowConsumer leftConsumer = new TestingRowConsumer();
+        leftConsumer.accept(left, null);
+        TestingRowConsumer rightConsumer = new TestingRowConsumer();
+        rightConsumer.accept(right, null);
+
+        List<Object[]> expectedResults = new ArrayList<>();
+
+        List<Object[]> leftResults = leftConsumer.getResult();
+        List<Object[]> rightResults = rightConsumer.getResult();
+        expectedRowsLeft = leftResults.size();
+        expectedRowsRight = rightResults.size();
+
+        for (Object[] leftRow : leftResults) {
+            for (Object[] rightRow : rightResults) {
+                Object[] combinedRow = Arrays.copyOf(leftRow, leftRow.length + rightRow.length);
+                System.arraycopy(rightRow, 0, combinedRow, leftRow.length, rightRow.length);
+                expectedResults.add(combinedRow);
+            }
+        }
+        return expectedResults;
+    }
+
+    @ParametersFactory
+    public static Iterable<Object[]> parameters() {
+        return Arrays.asList(
+            $(0, () -> TestingBatchIterators.range(0, 3), () -> TestingBatchIterators.range(0, 3), () -> 1),
+            $(1, () -> TestingBatchIterators.range(0, 1), () -> TestingBatchIterators.range(0, 5), () -> 2),
+            $(2, () -> TestingBatchIterators.range(0, 3), () -> TestingBatchIterators.range(0, 3), () -> 3),
+            $(3, () -> TestingBatchIterators.range(0, 3), () -> TestingBatchIterators.range(0, 3), () -> 10),
+            $(4, () -> TestingBatchIterators.range(0, 1), () -> TestingBatchIterators.range(0, 5), () -> 100),
+            $(5, () -> TestingBatchIterators.range(0, 3), () -> TestingBatchIterators.range(0, 3), () -> 10000),
+            $(6, () -> TestingBatchIterators.range(0, 100), () -> TestingBatchIterators.range(0, 30), () -> 1),
+            $(7, () -> TestingBatchIterators.range(0, 10), () -> TestingBatchIterators.range(0, 250), () -> 2),
+            $(8, () -> TestingBatchIterators.range(0, 30), () -> TestingBatchIterators.range(0, 100), () -> 3),
+            $(9, () -> TestingBatchIterators.range(0, 250), () -> TestingBatchIterators.range(0, 30), () -> 10),
+            $(10, () -> TestingBatchIterators.range(0, 100), () -> TestingBatchIterators.range(0, 50), () -> 100),
+            $(11, () -> TestingBatchIterators.range(0, 30), () -> TestingBatchIterators.range(0, 200), () -> 10000)
+        );
+    }
+
+    private static Object[] $(int id,
+                              Supplier<BatchIterator<Row>> left,
+                              Supplier<BatchIterator<Row>> right,
+                              IntSupplier blockSize) {
+        return new Object[]{
+            id, left, right, blockSize
+        };
+    }
+
+    @Test
+    public void testNestedLoopBatchIterator() throws Exception {
+        BatchIteratorTester tester = new BatchIteratorTester(
+            () -> JoinBatchIterators.crossJoinBlockNL(
+                left.get(),
+                right.get(),
+                new CombinedRow(1, 1),
+                blockSizeCalculator,
+                testingRowAccounting
+            )
+        );
+        tester.verifyResultAndEdgeCaseBehaviour(expectedResults,
+            it -> {
+                assertThat(testingRowAccounting.numRows, is(expectedRowsLeft));
+                assertThat(testingRowAccounting.numReleaseCalled, greaterThan(expectedRowsLeft / blockSizeCalculator.getAsInt()));
+            });
+    }
+
+    @Test
+    public void testNestedLoopWithBatchedSource() throws Exception {
+        int batchSize = 50;
+        BatchIteratorTester tester = new BatchIteratorTester(
+            () -> JoinBatchIterators.crossJoinBlockNL(
+                new BatchSimulatingIterator<>(left.get(), batchSize, expectedRowsLeft / batchSize + 1, null),
+                new BatchSimulatingIterator<>(right.get(), batchSize, expectedRowsRight / batchSize + 1, null),
+                new CombinedRow(1, 1),
+                blockSizeCalculator,
+                testingRowAccounting
+            )
+        );
+        tester.verifyResultAndEdgeCaseBehaviour(expectedResults,
+            it -> {
+                assertThat(testingRowAccounting.numRows, is(expectedRowsLeft));
+                assertThat(testingRowAccounting.numReleaseCalled, greaterThan(expectedRowsLeft / blockSizeCalculator.getAsInt()));
+            });
+    }
+
+    @Test
+    public void testNestedLoopLeftAndRightEmpty() throws Exception {
+        BatchIterator<Row> iterator = JoinBatchIterators.crossJoinBlockNL(
+            InMemoryBatchIterator.empty(SENTINEL),
+            InMemoryBatchIterator.empty(SENTINEL),
+            new CombinedRow(0, 0),
+            blockSizeCalculator,
+            testingRowAccounting
+        );
+        TestingRowConsumer consumer = new TestingRowConsumer();
+        consumer.accept(iterator, null);
+        assertThat(consumer.getResult(), Matchers.empty());
+    }
+
+    @Test
+    public void testNestedLoopLeftEmpty() throws Exception {
+        BatchIterator<Row> iterator = JoinBatchIterators.crossJoinBlockNL(
+            InMemoryBatchIterator.empty(SENTINEL),
+            right.get(),
+            new CombinedRow(0, 1),
+            blockSizeCalculator,
+            testingRowAccounting
+        );
+        TestingRowConsumer consumer = new TestingRowConsumer();
+        consumer.accept(iterator, null);
+        assertThat(consumer.getResult(), Matchers.empty());
+    }
+
+    @Test
+    public void testNestedLoopRightEmpty() throws Exception {
+        BatchIterator<Row> iterator = JoinBatchIterators.crossJoinBlockNL(
+            left.get(),
+            InMemoryBatchIterator.empty(SENTINEL),
+            new CombinedRow(1, 0),
+            blockSizeCalculator,
+            testingRowAccounting
+        );
+        TestingRowConsumer consumer = new TestingRowConsumer();
+        consumer.accept(iterator, null);
+        assertThat(consumer.getResult(), Matchers.empty());
+    }
+
+    @Test
+    public void testMoveToStartWhileRightSideIsActive() {
+        BatchIterator<Row> batchIterator = JoinBatchIterators.crossJoinBlockNL(
+            left.get(),
+            right.get(),
+            new CombinedRow(1, 1),
+            blockSizeCalculator,
+            testingRowAccounting
+        );
+
+        assertThat(batchIterator.moveNext(), is(true));
+        assertThat(expectedResults.toArray(), hasItemInArray(batchIterator.currentElement().materialize()));
+
+        batchIterator.moveToStart();
+
+        assertThat(batchIterator.moveNext(), is(true));
+        assertThat(expectedResults.toArray(), hasItemInArray(batchIterator.currentElement().materialize()));
+    }
+
+    private static class TestingRowAccounting implements RowAccounting {
+
+        int numRows;
+        int numReleaseCalled;
+        boolean closed;
+
+        @Override
+        public void accountForAndMaybeBreak(Row row) {
+            if (closed) {
+                throw new RuntimeException("Already closed!");
+            }
+            numRows++;
+        }
+
+        @Override
+        public void release() {
+            if (closed) {
+                throw new RuntimeException("Already closed!");
+            }
+            numReleaseCalled++;
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+        }
+    }
+}

--- a/dex/src/test/java/io/crate/data/join/NestedLoopBatchIteratorsTest.java
+++ b/dex/src/test/java/io/crate/data/join/NestedLoopBatchIteratorsTest.java
@@ -100,7 +100,7 @@ public class NestedLoopBatchIteratorsTest {
     @Test
     public void testNestedLoopBatchIterator() throws Exception {
         BatchIteratorTester tester = new BatchIteratorTester(
-            () -> JoinBatchIterators.crossJoin(
+            () -> JoinBatchIterators.crossJoinNL(
                 TestingBatchIterators.range(0, 3),
                 TestingBatchIterators.range(0, 3),
                 new CombinedRow(1, 1)
@@ -112,7 +112,7 @@ public class NestedLoopBatchIteratorsTest {
     @Test
     public void testNestedLoopWithBatchedSource() throws Exception {
         BatchIteratorTester tester = new BatchIteratorTester(
-            () -> JoinBatchIterators.crossJoin(
+            () -> JoinBatchIterators.crossJoinNL(
                 new BatchSimulatingIterator<>(TestingBatchIterators.range(0, 3), 2, 2, null),
                 new BatchSimulatingIterator<>(TestingBatchIterators.range(0, 3), 2, 2, null),
                 new CombinedRow(1, 1)
@@ -123,7 +123,7 @@ public class NestedLoopBatchIteratorsTest {
 
     @Test
     public void testNestedLoopLeftAndRightEmpty() throws Exception {
-        BatchIterator<Row> iterator = JoinBatchIterators.crossJoin(
+        BatchIterator<Row> iterator = JoinBatchIterators.crossJoinNL(
             InMemoryBatchIterator.empty(SENTINEL),
             InMemoryBatchIterator.empty(SENTINEL),
             new CombinedRow(0, 0)
@@ -135,7 +135,7 @@ public class NestedLoopBatchIteratorsTest {
 
     @Test
     public void testNestedLoopLeftEmpty() throws Exception {
-        BatchIterator<Row> iterator = JoinBatchIterators.crossJoin(
+        BatchIterator<Row> iterator = JoinBatchIterators.crossJoinNL(
             InMemoryBatchIterator.empty(SENTINEL),
             TestingBatchIterators.range(0, 5),
             new CombinedRow(0, 1)
@@ -147,7 +147,7 @@ public class NestedLoopBatchIteratorsTest {
 
     @Test
     public void testNestedLoopRightEmpty() throws Exception {
-        BatchIterator<Row> iterator = JoinBatchIterators.crossJoin(
+        BatchIterator<Row> iterator = JoinBatchIterators.crossJoinNL(
             TestingBatchIterators.range(0, 5),
             InMemoryBatchIterator.empty(SENTINEL),
             new CombinedRow(1, 0)
@@ -232,7 +232,7 @@ public class NestedLoopBatchIteratorsTest {
 
     @Test
     public void testMoveToStartWhileRightSideIsActive() {
-        BatchIterator<Row> batchIterator = JoinBatchIterators.crossJoin(
+        BatchIterator<Row> batchIterator = JoinBatchIterators.crossJoinNL(
             TestingBatchIterators.range(0, 3),
             TestingBatchIterators.range(10, 20),
             new CombinedRow(1, 1)

--- a/sql/src/main/java/io/crate/breaker/RamAccountingContext.java
+++ b/sql/src/main/java/io/crate/breaker/RamAccountingContext.java
@@ -32,7 +32,7 @@ import java.util.Locale;
 import java.util.concurrent.atomic.AtomicLong;
 
 @ThreadSafe
-public class RamAccountingContext {
+public class RamAccountingContext implements RamAccounting {
 
     // this must not be final so tests could adjust it
     // Flush every 2mb
@@ -65,6 +65,7 @@ public class RamAccountingContext {
      * @param bytes bytes to be added
      * @throws CircuitBreakingException in case the breaker tripped
      */
+    @Override
     public void addBytes(long bytes) throws CircuitBreakingException {
         addBytes(bytes, true);
     }
@@ -149,6 +150,7 @@ public class RamAccountingContext {
      * A remaining flush buffer will not be flushed to avoid breaking on close.
      * (all ram operations expected to be finished at this point)
      */
+    @Override
     public void close() {
         if (closed) {
             return;
@@ -171,6 +173,7 @@ public class RamAccountingContext {
      * to be reused in a multi-phase operation where a subsequent phase needs to make decisions based on the available
      * memory after the previous phase completed (and needs to be unloaded/released from the breaker)
      */
+    @Override
     public void release() {
         if (totalBytes.get() != 0) {
             if (logger.isTraceEnabled() && totalBytes() > FLUSH_BUFFER_SIZE) {

--- a/sql/src/main/java/io/crate/breaker/RowAccountingWithEstimators.java
+++ b/sql/src/main/java/io/crate/breaker/RowAccountingWithEstimators.java
@@ -29,16 +29,16 @@ import io.crate.types.DataType;
 import java.util.ArrayList;
 import java.util.Collection;
 
-public class RowAccounting {
+public class RowAccountingWithEstimators implements RowAccounting {
 
     private final RamAccountingContext ramAccountingContext;
     private final ArrayList<SizeEstimator<Object>> estimators;
     private int extraSizePerRow = 0;
 
     /**
-     * See {@link RowAccounting#RowAccounting(Collection, RamAccountingContext, int)}
+     * See {@link RowAccountingWithEstimators#RowAccountingWithEstimators(Collection, RamAccountingContext, int)}
      */
-    public RowAccounting(Collection<? extends DataType> columnTypes, RamAccountingContext ramAccountingContext) {
+    public RowAccountingWithEstimators(Collection<? extends DataType> columnTypes, RamAccountingContext ramAccountingContext) {
         this.estimators = new ArrayList<>(columnTypes.size());
         for (DataType columnType : columnTypes) {
             estimators.add(SizeEstimatorFactory.create(columnType));
@@ -52,9 +52,9 @@ public class RowAccounting {
      * @param extraSizePerRow       Extra size that need to be calculated per row. E.g. {@link HashInnerJoinBatchIterator}
      *                              might instantiate an ArrayList per row used for the internal hash->row buffer
      */
-    public RowAccounting(Collection<? extends DataType> columnTypes,
-                         RamAccountingContext ramAccountingContext,
-                         int extraSizePerRow) {
+    public RowAccountingWithEstimators(Collection<? extends DataType> columnTypes,
+                                       RamAccountingContext ramAccountingContext,
+                                       int extraSizePerRow) {
         this(columnTypes, ramAccountingContext);
         this.extraSizePerRow = extraSizePerRow;
     }
@@ -64,6 +64,7 @@ public class RowAccounting {
      *
      * This should only be used if the values are stored/buffered in another in-memory data structure.
      */
+    @Override
     public void accountForAndMaybeBreak(Row row) {
         assert row.numColumns() == estimators.size() : "Size of row must match the number of estimators";
 
@@ -76,11 +77,14 @@ public class RowAccounting {
         ramAccountingContext.addBytes(size);
     }
 
+    @Override
+    public void release() {
+        ramAccountingContext.release();
+    }
+
+    @Override
     public void close() {
         ramAccountingContext.close();
     }
 
-    public void release() {
-        ramAccountingContext.release();
-    }
 }

--- a/sql/src/main/java/io/crate/execution/engine/collect/PKLookupOperation.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/PKLookupOperation.java
@@ -29,6 +29,7 @@ import io.crate.data.CompositeBatchIterator;
 import io.crate.data.InMemoryBatchIterator;
 import io.crate.data.Row;
 import io.crate.data.RowConsumer;
+import io.crate.data.RowN;
 import io.crate.execution.dsl.projection.Projection;
 import io.crate.execution.engine.collect.collectors.MultiConsumer;
 import io.crate.execution.engine.collect.sources.ShardCollectSource;

--- a/sql/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectSource.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectSource.java
@@ -25,7 +25,7 @@ import com.google.common.base.Suppliers;
 import com.google.common.collect.Iterables;
 import io.crate.analyze.OrderBy;
 import io.crate.blob.v2.BlobIndicesService;
-import io.crate.breaker.RowAccounting;
+import io.crate.breaker.RowAccountingWithEstimators;
 import io.crate.data.AsyncCompositeBatchIterator;
 import io.crate.data.BatchIterator;
 import io.crate.data.Buckets;
@@ -411,7 +411,7 @@ public class ShardCollectSource extends AbstractComponent implements CollectSour
                     orderBy.reverseFlags(),
                     orderBy.nullsFirst()
                 ),
-                new RowAccounting(columnTypes, collectTask.queryPhaseRamAccountingContext()),
+                new RowAccountingWithEstimators(columnTypes, collectTask.queryPhaseRamAccountingContext()),
                 executor,
                 consumer.requiresScroll()
             ),

--- a/sql/src/main/java/io/crate/execution/engine/join/HashInnerJoinBatchIterator.java
+++ b/sql/src/main/java/io/crate/execution/engine/join/HashInnerJoinBatchIterator.java
@@ -35,8 +35,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
+import java.util.function.IntSupplier;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 
 /**
  * <pre>
@@ -86,7 +86,7 @@ public class HashInnerJoinBatchIterator<L extends Row, R extends Row, C> extends
     private final UnsafeArrayRow leftRow = new UnsafeArrayRow();
     private final Function<L, Integer> hashBuilderForLeft;
     private final Function<R, Integer> hashBuilderForRight;
-    private final Supplier<Integer> blockSizeSupplier;
+    private final IntSupplier blockSizeSupplier;
     private final IntObjectHashMap<List<Object[]>> buffer;
 
     private int blockSize;
@@ -102,7 +102,7 @@ public class HashInnerJoinBatchIterator<L extends Row, R extends Row, C> extends
                                       Predicate<C> joinCondition,
                                       Function<L, Integer> hashBuilderForLeft,
                                       Function<R, Integer> hashBuilderForRight,
-                                      Supplier<Integer> blockSizeSupplier) {
+                                      IntSupplier blockSizeSupplier) {
         super(left, right, combiner);
         this.joinCondition = joinCondition;
         this.hashBuilderForLeft = hashBuilderForLeft;
@@ -163,7 +163,7 @@ public class HashInnerJoinBatchIterator<L extends Row, R extends Row, C> extends
     }
 
     private void recreateBuffer() {
-        blockSize = blockSizeSupplier.get();
+        blockSize = blockSizeSupplier.getAsInt();
         buffer.release();
         buffer.ensureCapacity(blockSize);
         numberOfRowsInBuffer = 0;

--- a/sql/src/main/java/io/crate/execution/engine/join/HashJoinOperation.java
+++ b/sql/src/main/java/io/crate/execution/engine/join/HashJoinOperation.java
@@ -72,7 +72,7 @@ public class HashJoinOperation implements CompletionListenable {
                             getHashBuilderFromSymbols(inputFactory, joinLeftInputs),
                             getHashBuilderFromSymbols(inputFactory, joinRightInputs),
                             rowAccounting,
-                            new BlockSizeCalculator(circuitBreaker, estimatedRowSizeForLeft, numberOfRowsForLeft)
+                            new RamBlockSizeCalculator(circuitBreaker, estimatedRowSizeForLeft, numberOfRowsForLeft)
                         ), completionFuture);
                         nlResultConsumer.accept(joinIterator, null);
                     } catch (Exception e) {
@@ -120,7 +120,7 @@ public class HashJoinOperation implements CompletionListenable {
                                                              Function<Row, Integer> hashBuilderForLeft,
                                                              Function<Row, Integer> hashBuilderForRight,
                                                              RowAccounting rowAccounting,
-                                                             BlockSizeCalculator blockSizeCalculator) {
+                                                             RamBlockSizeCalculator blockSizeCalculator) {
         CombinedRow combiner = new CombinedRow(leftNumCols, rightNumCols);
         return new HashInnerJoinBatchIterator<>(
             new RamAccountingBatchIterator<>(left, rowAccounting),

--- a/sql/src/main/java/io/crate/execution/jobs/PKLookupTask.java
+++ b/sql/src/main/java/io/crate/execution/jobs/PKLookupTask.java
@@ -93,7 +93,7 @@ public final class PKLookupTask extends AbstractTask {
     @Override
     protected void innerStart() {
         if (shardProjections.isEmpty()) {
-            BatchIterator<GetResult> batchIterator = pkLookupOperation.lookup(ignoreMissing, idsByShard);
+            BatchIterator<GetResult> batchIterator = pkLookupOperation.lookup(ignoreMissing, idsByShard, consumer.requiresScroll());
             consumer.accept(BatchIterators.map(batchIterator, this::resultToRow), null);
         } else {
             pkLookupOperation.runWithShardProjections(

--- a/sql/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
+++ b/sql/src/main/java/io/crate/planner/operators/JoinPlanBuilder.java
@@ -97,7 +97,7 @@ public class JoinPlanBuilder implements LogicalPlan.Builder {
             JoinOperations.buildRelationsToJoinPairsMap(
                 JoinOperations.convertImplicitJoinConditionsToJoinPairs(mss.joinPairs(), queryParts));
 
-        final boolean hasOuterJoins = joinPairs.values().stream().anyMatch(p -> p.joinType().isOuter());
+        final boolean orderByCanBePushedDown = joinPairs.values().stream().noneMatch(p -> p.joinType().isOuter());
 
         Collection<QualifiedName> orderedRelationNames;
         if (mss.sources().size() > 2) {
@@ -159,7 +159,7 @@ public class JoinPlanBuilder implements LogicalPlan.Builder {
             lhs,
             rhs,
             query,
-            hasOuterJoins,
+            orderByCanBePushedDown,
             txnCtx.sessionContext(),
             tableStats);
 
@@ -175,7 +175,7 @@ public class JoinPlanBuilder implements LogicalPlan.Builder {
                 joinPairs,
                 queryParts,
                 subqueryPlanner,
-                hasOuterJoins,
+                orderByCanBePushedDown,
                 lhs,
                 functions,
                 txnCtx);
@@ -194,7 +194,7 @@ public class JoinPlanBuilder implements LogicalPlan.Builder {
                                               QueriedRelation lhs,
                                               QueriedRelation rhs,
                                               Symbol query,
-                                              boolean hasOuterJoins,
+                                              boolean orderByCanBePushedDown,
                                               SessionContext sessionContext,
                                               TableStats tableStats) {
         if (isHashJoinPossible(joinType, joinCondition, sessionContext)) {
@@ -211,7 +211,7 @@ public class JoinPlanBuilder implements LogicalPlan.Builder {
                 joinType,
                 joinCondition,
                 !query.symbolType().isValueSymbol(),
-                hasOuterJoins,
+                orderByCanBePushedDown,
                 lhs);
         }
     }
@@ -239,7 +239,7 @@ public class JoinPlanBuilder implements LogicalPlan.Builder {
                                             Map<Set<QualifiedName>, JoinPair> joinPairs,
                                             Map<Set<QualifiedName>, Symbol> queryParts,
                                             SubqueryPlanner subqueryPlanner,
-                                            boolean hasOuterJoins,
+                                            boolean orderByCanBePushedDown,
                                             QueriedRelation leftRelation,
                                             Functions functions,
                                             TransactionContext txnCtx) {
@@ -284,7 +284,7 @@ public class JoinPlanBuilder implements LogicalPlan.Builder {
                 leftRelation,
                 nextRel,
                 query,
-                hasOuterJoins,
+                orderByCanBePushedDown,
                 txnCtx.sessionContext(),
                 tableStats),
             query

--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlan.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlan.java
@@ -215,6 +215,10 @@ public interface LogicalPlan extends Plan {
      */
     Map<LogicalPlan, SelectSymbol> dependencies();
 
+    /**
+     * Returns the total number of rows this logical operation is expected to return.
+     * @return The number of expected rows if available, -1 otherwise.
+     */
     long numExpectedRows();
 
     /**

--- a/sql/src/main/java/io/crate/rest/action/SqlHttpHandler.java
+++ b/sql/src/main/java/io/crate/rest/action/SqlHttpHandler.java
@@ -34,7 +34,7 @@ import io.crate.auth.AuthSettings;
 import io.crate.auth.user.User;
 import io.crate.auth.user.UserLookup;
 import io.crate.breaker.RamAccountingContext;
-import io.crate.breaker.RowAccounting;
+import io.crate.breaker.RowAccountingWithEstimators;
 import io.crate.expression.symbol.Field;
 import io.crate.expression.symbol.Symbols;
 import io.crate.rest.CrateRestMainAction;
@@ -259,7 +259,7 @@ public class SqlHttpHandler extends SimpleChannelInboundHandler<HttpPipelinedReq
                 JsonXContent.contentBuilder(),
                 resultFields,
                 startTimeInNs,
-                new RowAccounting(
+                new RowAccountingWithEstimators(
                     Symbols.typeView(resultFields),
                     new RamAccountingContext("http-result", circuitBreaker)
                 ),

--- a/sql/src/test/java/io/crate/breaker/RowAccountingWithEstimatorsTest.java
+++ b/sql/src/test/java/io/crate/breaker/RowAccountingWithEstimatorsTest.java
@@ -36,7 +36,7 @@ import org.junit.Test;
 
 import java.util.Collections;
 
-public class RowAccountingTest extends CrateUnitTest {
+public class RowAccountingWithEstimatorsTest extends CrateUnitTest {
 
     private long originalBufferSize;
 
@@ -53,11 +53,11 @@ public class RowAccountingTest extends CrateUnitTest {
 
     @Test
     public void testCircuitBreakingWorks() throws Exception {
-        RowAccounting rowAccounting = new RowAccounting(Collections.singletonList(DataTypes.INTEGER),
+        RowAccounting rowAccounting = new RowAccountingWithEstimators(Collections.singletonList(DataTypes.INTEGER),
             new RamAccountingContext(
                 "test",
                 new MemoryCircuitBreaker(
-                    new ByteSizeValue(10, ByteSizeUnit.BYTES), 1.01, Loggers.getLogger(RowAccountingTest.class))
+                    new ByteSizeValue(10, ByteSizeUnit.BYTES), 1.01, Loggers.getLogger(RowAccountingWithEstimatorsTest.class))
             ));
 
         expectedException.expect(CircuitBreakingException.class);
@@ -66,11 +66,11 @@ public class RowAccountingTest extends CrateUnitTest {
 
     @Test
     public void testCircuitBreakingWorksWithExtraSizePerRow() throws Exception {
-        RowAccounting rowAccounting = new RowAccounting(Collections.singletonList(DataTypes.INTEGER),
+        RowAccounting rowAccounting = new RowAccountingWithEstimators(Collections.singletonList(DataTypes.INTEGER),
             new RamAccountingContext(
                 "test",
                 new MemoryCircuitBreaker(
-                    new ByteSizeValue(10, ByteSizeUnit.BYTES), 1.01, Loggers.getLogger(RowAccountingTest.class))
+                    new ByteSizeValue(10, ByteSizeUnit.BYTES), 1.01, Loggers.getLogger(RowAccountingWithEstimatorsTest.class))
             ),
             2);
 

--- a/sql/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorFactoryTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/collectors/OrderedLuceneBatchIteratorFactoryTest.java
@@ -27,6 +27,7 @@ import com.google.common.util.concurrent.MoreExecutors;
 import io.crate.analyze.OrderBy;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.breaker.RowAccounting;
+import io.crate.breaker.RowAccountingWithEstimators;
 import io.crate.data.BatchIterator;
 import io.crate.data.Row;
 import io.crate.exceptions.CircuitBreakingException;
@@ -73,7 +74,7 @@ import static org.mockito.Mockito.mock;
 
 public class OrderedLuceneBatchIteratorFactoryTest extends CrateUnitTest {
 
-    private static final RowAccounting ROW_ACCOUNTING = new RowAccounting(Collections.singleton(LongType.INSTANCE),
+    private static final RowAccounting ROW_ACCOUNTING = new RowAccountingWithEstimators(Collections.singleton(LongType.INSTANCE),
         new RamAccountingContext("dummy", new NoopCircuitBreaker(CircuitBreaker.FIELDDATA))
     );
 
@@ -154,7 +155,7 @@ public class OrderedLuceneBatchIteratorFactoryTest extends CrateUnitTest {
 
     @Test
     public void testOrderedLuceneBatchIteratorWithMultipleCollectorsTripsCircuitBreaker() throws Exception {
-        RowAccounting rowAccounting = mock(RowAccounting.class);
+        RowAccounting rowAccounting = mock(RowAccountingWithEstimators.class);
         CircuitBreakingException circuitBreakingException = new CircuitBreakingException("tripped circuit breaker");
         doThrow(circuitBreakingException)
             .when(rowAccounting).accountForAndMaybeBreak(any(Row.class));

--- a/sql/src/test/java/io/crate/execution/engine/distribution/merge/RamAccountingPageIteratorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/distribution/merge/RamAccountingPageIteratorTest.java
@@ -25,8 +25,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
 import io.crate.analyze.OrderBy;
 import io.crate.breaker.RamAccountingContext;
-import io.crate.breaker.RowAccounting;
-import io.crate.breaker.RowAccountingTest;
+import io.crate.breaker.RowAccountingWithEstimators;
+import io.crate.breaker.RowAccountingWithEstimatorsTest;
 import io.crate.data.Row;
 import io.crate.data.RowN;
 import io.crate.expression.symbol.Literal;
@@ -126,7 +126,7 @@ public class RamAccountingPageIteratorTest extends CrateUnitTest {
             2,
             true,
             null,
-            () -> new RowAccounting(ImmutableList.of(DataTypes.STRING, DataTypes.STRING, DataTypes.STRING),
+            () -> new RowAccountingWithEstimators(ImmutableList.of(DataTypes.STRING, DataTypes.STRING, DataTypes.STRING),
                                     new RamAccountingContext("test", NOOP_CIRCUIT_BREAKER)));
         assertThat(pagingIterator, instanceOf(RamAccountingPageIterator.class));
         assertThat(((RamAccountingPageIterator) pagingIterator).delegatePagingIterator,
@@ -148,13 +148,13 @@ public class RamAccountingPageIteratorTest extends CrateUnitTest {
             2,
             true,
             null,
-            () -> new RowAccounting(ImmutableList.of(DataTypes.STRING, DataTypes.STRING, DataTypes.STRING),
+            () -> new RowAccountingWithEstimators(ImmutableList.of(DataTypes.STRING, DataTypes.STRING, DataTypes.STRING),
                                     new RamAccountingContext(
                                         "test",
                                         new MemoryCircuitBreaker(
                                             new ByteSizeValue(197, ByteSizeUnit.BYTES),
                                             1,
-                                            Loggers.getLogger(RowAccountingTest.class)))));
+                                            Loggers.getLogger(RowAccountingWithEstimatorsTest.class)))));
 
         expectedException.expect(CircuitBreakingException.class);
         expectedException.expectMessage(

--- a/sql/src/test/java/io/crate/execution/engine/join/NestedLoopOperationTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/join/NestedLoopOperationTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.engine.join;
+
+import io.crate.breaker.RamAccountingContext;
+import io.crate.data.BatchIterator;
+import io.crate.data.Row;
+import io.crate.data.join.CrossJoinBlockNLBatchIterator;
+import io.crate.data.join.CrossJoinNLBatchIterator;
+import io.crate.planner.node.dql.join.JoinType;
+import org.elasticsearch.common.breaker.NoopCircuitBreaker;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+
+public class NestedLoopOperationTest {
+
+    @Test
+    public void testCrossJoinWithBlockNestedLoopIfSingleNodeExecution() {
+        BatchIterator<Row> singleNodeLeftSideSmaller = createBatchIterator(true);
+        assertThat(singleNodeLeftSideSmaller, instanceOf(CrossJoinBlockNLBatchIterator.class));
+    }
+
+    @Test
+    public void testCrossJoinWithNestedLoopIfMultipleNodes() {
+        BatchIterator<Row> singleNodeLeftSideSmaller = createBatchIterator(false);
+        assertThat(singleNodeLeftSideSmaller, instanceOf(CrossJoinNLBatchIterator.class));
+    }
+
+
+    private static BatchIterator<Row> createBatchIterator(boolean blockNlPossible) {
+        NoopCircuitBreaker noopCircuitBreaker = new NoopCircuitBreaker("test");
+        return NestedLoopOperation.createNestedLoopIterator(
+            null,
+            2,
+            null,
+            3,
+            JoinType.CROSS,
+            row -> false,
+            noopCircuitBreaker,
+            new RamAccountingContext("test", noopCircuitBreaker),
+            Collections.emptyList(),
+            64L,
+            9L,
+            blockNlPossible);
+    }
+
+}

--- a/sql/src/test/java/io/crate/execution/engine/join/RamAccountingBatchIteratorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/join/RamAccountingBatchIteratorTest.java
@@ -24,8 +24,8 @@ package io.crate.execution.engine.join;
 
 import com.google.common.collect.ImmutableList;
 import io.crate.breaker.RamAccountingContext;
-import io.crate.breaker.RowAccounting;
-import io.crate.breaker.RowAccountingTest;
+import io.crate.breaker.RowAccountingWithEstimators;
+import io.crate.breaker.RowAccountingWithEstimatorsTest;
 import io.crate.data.BatchIterator;
 import io.crate.data.Row;
 import io.crate.test.integration.CrateUnitTest;
@@ -67,7 +67,7 @@ public class RamAccountingBatchIteratorTest extends CrateUnitTest {
     public void testNoCircuitBreaking() throws Exception {
         BatchIterator<Row> batchIterator = new RamAccountingBatchIterator<>(
             TestingBatchIterators.ofValues(Arrays.asList(new BytesRef("a"), new BytesRef("b"), new BytesRef("c"))),
-            new RowAccounting(
+            new RowAccountingWithEstimators(
                 ImmutableList.of(DataTypes.STRING),
                 new RamAccountingContext("test", NOOP_CIRCUIT_BREAKER)));
 
@@ -84,14 +84,14 @@ public class RamAccountingBatchIteratorTest extends CrateUnitTest {
         BatchIterator<Row> batchIterator = new RamAccountingBatchIterator<>(
             TestingBatchIterators.ofValues(Arrays.asList(new BytesRef("aaa"), new BytesRef("bbb"), new BytesRef("ccc"),
                                                          new BytesRef("ddd"), new BytesRef("eee"), new BytesRef("fff"))),
-            new RowAccounting(
+            new RowAccountingWithEstimators(
                 ImmutableList.of(DataTypes.STRING),
                 new RamAccountingContext(
                     "test",
                     new MemoryCircuitBreaker(
                         new ByteSizeValue(34, ByteSizeUnit.BYTES),
                         1,
-                        Loggers.getLogger(RowAccountingTest.class)))));
+                        Loggers.getLogger(RowAccountingWithEstimatorsTest.class)))));
 
         expectedException.expect(CircuitBreakingException.class);
         expectedException.expectMessage(

--- a/sql/src/test/java/io/crate/execution/engine/join/RamBlockSizeCalculatorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/join/RamBlockSizeCalculatorTest.java
@@ -25,13 +25,13 @@ package io.crate.execution.engine.join;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.junit.Test;
 
-import static io.crate.execution.engine.join.BlockSizeCalculator.DEFAULT_BLOCK_SIZE;
+import static io.crate.execution.engine.join.RamBlockSizeCalculator.DEFAULT_BLOCK_SIZE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class BlockSizeCalculatorTest {
+public class RamBlockSizeCalculatorTest {
 
     private final CircuitBreaker circuitBreaker = mock(CircuitBreaker.class);
 
@@ -39,48 +39,48 @@ public class BlockSizeCalculatorTest {
     public void testCalculationOfBlockSize() {
         when(circuitBreaker.getLimit()).thenReturn(110L);
         when(circuitBreaker.getUsed()).thenReturn(10L);
-        BlockSizeCalculator blockCalculator100leftRows = new BlockSizeCalculator(circuitBreaker, 5, 100);
-        assertThat(blockCalculator100leftRows.calculateBlockSize(), is(20));
-        BlockSizeCalculator blockCalculator10LeftRows = new BlockSizeCalculator(circuitBreaker, 5, 10);
-        assertThat(blockCalculator10LeftRows.calculateBlockSize(), is(10));
+        RamBlockSizeCalculator blockCalculator100leftRows = new RamBlockSizeCalculator(circuitBreaker, 5, 100);
+        assertThat(blockCalculator100leftRows.getAsInt(), is(20));
+        RamBlockSizeCalculator blockCalculator10LeftRows = new RamBlockSizeCalculator(circuitBreaker, 5, 10);
+        assertThat(blockCalculator10LeftRows.getAsInt(), is(10));
     }
 
     @Test
     public void testCalculationOfBlockSizeWithMissingStats() {
         when(circuitBreaker.getLimit()).thenReturn(-1L);
-        BlockSizeCalculator blockSizeCalculator = new BlockSizeCalculator(circuitBreaker, 10, 10);
-        assertThat(blockSizeCalculator.calculateBlockSize(), is(DEFAULT_BLOCK_SIZE));
+        RamBlockSizeCalculator blockSizeCalculator = new RamBlockSizeCalculator(circuitBreaker, 10, 10);
+        assertThat(blockSizeCalculator.getAsInt(), is(DEFAULT_BLOCK_SIZE));
 
         when(circuitBreaker.getLimit()).thenReturn(110L);
         when(circuitBreaker.getUsed()).thenReturn(10L);
-        BlockSizeCalculator blockCalculatorNoNumberOrRowsStats = new BlockSizeCalculator(circuitBreaker, 10, -1);
-        assertThat(blockCalculatorNoNumberOrRowsStats.calculateBlockSize(), is(DEFAULT_BLOCK_SIZE));
+        RamBlockSizeCalculator blockCalculatorNoNumberOrRowsStats = new RamBlockSizeCalculator(circuitBreaker, 10, -1);
+        assertThat(blockCalculatorNoNumberOrRowsStats.getAsInt(), is(DEFAULT_BLOCK_SIZE));
 
-        BlockSizeCalculator blockCalculatorNoRowSizeStats = new BlockSizeCalculator(circuitBreaker, -1, 10);
-        assertThat(blockCalculatorNoRowSizeStats.calculateBlockSize(), is(DEFAULT_BLOCK_SIZE));
+        RamBlockSizeCalculator blockCalculatorNoRowSizeStats = new RamBlockSizeCalculator(circuitBreaker, -1, 10);
+        assertThat(blockCalculatorNoRowSizeStats.getAsInt(), is(DEFAULT_BLOCK_SIZE));
     }
 
     @Test
     public void testCalculationOfBlockSizeWithNoMemLeft() {
         when(circuitBreaker.getLimit()).thenReturn(110L);
         when(circuitBreaker.getUsed()).thenReturn(110L);
-        BlockSizeCalculator blockSizeCalculator = new BlockSizeCalculator(circuitBreaker, 10, 10);
-        assertThat(blockSizeCalculator.calculateBlockSize(), is(10));
+        RamBlockSizeCalculator blockSizeCalculator = new RamBlockSizeCalculator(circuitBreaker, 10, 10);
+        assertThat(blockSizeCalculator.getAsInt(), is(10));
     }
 
     @Test
     public void testCalculationOfBlockSizeWithIntegerOverflow() {
         when(circuitBreaker.getLimit()).thenReturn(Integer.MAX_VALUE + 1L);
         when(circuitBreaker.getUsed()).thenReturn(0L);
-        BlockSizeCalculator blockSizeCalculator = new BlockSizeCalculator(circuitBreaker, 1, 1);
-        assertThat(blockSizeCalculator.calculateBlockSize(), is(1));
+        RamBlockSizeCalculator blockSizeCalculator = new RamBlockSizeCalculator(circuitBreaker, 1, 1);
+        assertThat(blockSizeCalculator.getAsInt(), is(1));
     }
 
     @Test
     public void testBlockSizeIsNotGreaterThanPageSize() {
         when(circuitBreaker.getLimit()).thenReturn(DEFAULT_BLOCK_SIZE * 2L);
         when(circuitBreaker.getUsed()).thenReturn(0L);
-        BlockSizeCalculator blockSizeCalculator = new BlockSizeCalculator(circuitBreaker, 1, DEFAULT_BLOCK_SIZE * 2L);
-        assertThat(blockSizeCalculator.calculateBlockSize(), is(DEFAULT_BLOCK_SIZE));
+        RamBlockSizeCalculator blockSizeCalculator = new RamBlockSizeCalculator(circuitBreaker, 1, DEFAULT_BLOCK_SIZE * 2L);
+        assertThat(blockSizeCalculator.getAsInt(), is(DEFAULT_BLOCK_SIZE));
     }
 }

--- a/sql/src/test/java/io/crate/planner/node/dql/JoinPhaseTest.java
+++ b/sql/src/test/java/io/crate/planner/node/dql/JoinPhaseTest.java
@@ -34,6 +34,7 @@ import io.crate.expression.symbol.Symbol;
 import io.crate.planner.distribution.DistributionInfo;
 import io.crate.planner.node.dql.join.JoinType;
 import io.crate.test.integration.CrateUnitTest;
+import io.crate.types.ArrayType;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
@@ -98,7 +99,11 @@ public class JoinPhaseTest extends CrateUnitTest {
             3,
             Sets.newHashSet("node1", "node2"),
             JoinType.FULL,
-            joinCondition);
+            joinCondition,
+            ImmutableList.of(DataTypes.LONG, DataTypes.STRING, new ArrayType(DataTypes.INTEGER)),
+            32L,
+            100_000,
+            true);
 
         BytesStreamOutput output = new BytesStreamOutput();
         node.writeTo(output);
@@ -116,6 +121,9 @@ public class JoinPhaseTest extends CrateUnitTest {
         assertThat(node.outputTypes(), is(node2.outputTypes()));
         assertThat(node.joinType(), is(node2.joinType()));
         assertThat(node.joinCondition(), is(node2.joinCondition()));
+        assertThat(node.estimatedRowsSizeLeft, is(32L));
+        assertThat(node.estimatedNumberOfRowsLeft, is(100_000L));
+        assertThat(node.blockNestedLoop, is(true));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/planner/operators/JoinTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/JoinTest.java
@@ -33,10 +33,12 @@ import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.TransactionContext;
+import io.crate.planner.ExecutionPlan;
 import io.crate.planner.PlannerContext;
 import io.crate.planner.SubqueryPlanner;
 import io.crate.planner.TableStats;
 import io.crate.planner.node.dql.Collect;
+import io.crate.planner.node.dql.QueryThenFetch;
 import io.crate.planner.node.dql.join.Join;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
@@ -72,6 +74,7 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
             .addDocTable(T3.T1_INFO)
             .addDocTable(T3.T2_INFO)
             .addDocTable(T3.T3_INFO)
+            .addDocTable(T3.T4_INFO)
             .build();
         plannerCtx = e.getPlannerContext(clusterService.state());
     }
@@ -222,5 +225,98 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
         assertThat(join.joinPhase(), instanceOf(NestedLoopPhase.class));
         assertThat(join.left(), instanceOf(Join.class));
         assertThat(((Join)join.left()).joinPhase(), instanceOf(HashJoinPhase.class));
+    }
+
+    @Test
+    public void testBlockNestedLoopWhenTableSizeUnknownAndOneExecutionNode() {
+        MultiSourceSelect mss = e.analyze("select * from t1, t4");
+
+        LogicalPlan operator = createLogicalPlan(mss, new TableStats());
+        assertThat(operator, instanceOf(NestedLoopJoin.class));
+
+        Join join = buildJoin(operator);
+        assertThat(join.joinPhase(), instanceOf(NestedLoopPhase.class));
+        NestedLoopPhase joinPhase = (NestedLoopPhase) join.joinPhase();
+        assertThat(joinPhase.blockNestedLoop, is(true));
+    }
+
+    @Test
+    public void testBlockNestedLoopWhenLeftSideIsSmallerAndOneExecutionNode() {
+        TableStats tableStats = new TableStats();
+        ObjectObjectHashMap<RelationName, TableStats.Stats> stats = new ObjectObjectHashMap<>();
+        stats.put(T3.T1_INFO.ident(), new TableStats.Stats(23, 64));
+        stats.put(T3.T4_INFO.ident(), new TableStats.Stats(42, 64));
+        tableStats.updateTableStats(stats);
+        e = SQLExecutor.builder(clusterService)
+            .addDocTable(T3.T1_INFO)
+            .addDocTable(T3.T4_INFO)
+            .setTableStats(tableStats)
+            .build();
+
+        MultiSourceSelect mss = e.analyze("select * from t1, t4");
+
+        LogicalPlan operator = createLogicalPlan(mss, tableStats);
+        assertThat(operator, instanceOf(NestedLoopJoin.class));
+
+        Join join = buildJoin(operator);
+        assertThat(join.joinPhase(), instanceOf(NestedLoopPhase.class));
+        NestedLoopPhase joinPhase = (NestedLoopPhase) join.joinPhase();
+        assertThat(joinPhase.blockNestedLoop, is(true));
+
+        assertThat(join.left(), instanceOf(Collect.class));
+        // no table switch should have been made
+        assertThat(((Reference) ((Collect) join.left()).collectPhase().toCollect().get(0)).ident().tableIdent(),
+            is(T3.T1_INFO.ident()));
+    }
+
+    @Test
+    public void testBlockNestedLoopWhenRightSideIsSmallerAndOneExecutionNode() {
+        TableStats tableStats = new TableStats();
+        ObjectObjectHashMap<RelationName, TableStats.Stats> stats = new ObjectObjectHashMap<>();
+        stats.put(T3.T1_INFO.ident(), new TableStats.Stats(23, 64));
+        stats.put(T3.T4_INFO.ident(), new TableStats.Stats(42, 64));
+        tableStats.updateTableStats(stats);
+        e = SQLExecutor.builder(clusterService)
+            .addDocTable(T3.T1_INFO)
+            .addDocTable(T3.T4_INFO)
+            .setTableStats(tableStats)
+            .build();
+        MultiSourceSelect mss = e.analyze("select * from t4, t1");
+
+        LogicalPlan operator = createLogicalPlan(mss, tableStats);
+        assertThat(operator, instanceOf(NestedLoopJoin.class));
+
+        Join join = buildJoin(operator);
+        assertThat(join.joinPhase(), instanceOf(NestedLoopPhase.class));
+        NestedLoopPhase joinPhase = (NestedLoopPhase) join.joinPhase();
+        assertThat(joinPhase.blockNestedLoop, is(true));
+
+        assertThat(join.left(), instanceOf(Collect.class));
+        // right side will be flipped to the left
+        assertThat(((Reference) ((Collect) join.left()).collectPhase().toCollect().get(0)).ident().tableIdent(),
+            is(T3.T1_INFO.ident()));
+    }
+
+    @Test
+    public void testNoBlockNestedLoopWithOrderBy() {
+        TableStats tableStats = new TableStats();
+        ObjectObjectHashMap<RelationName, TableStats.Stats> stats = new ObjectObjectHashMap<>();
+        stats.put(T3.T1_INFO.ident(), new TableStats.Stats(23, 64));
+        stats.put(T3.T4_INFO.ident(), new TableStats.Stats(42, 64));
+        tableStats.updateTableStats(stats);
+        e = SQLExecutor.builder(clusterService)
+            .addDocTable(T3.T1_INFO)
+            .addDocTable(T3.T4_INFO)
+            .setTableStats(tableStats)
+            .build();
+        MultiSourceSelect mss = e.analyze("select * from t1, t4 order by t1.x");
+
+        LogicalPlanner logicalPlanner = new LogicalPlanner(functions, tableStats);
+        LogicalPlan operator = logicalPlanner.plan(mss, plannerCtx);
+        ExecutionPlan build = operator.build(plannerCtx, projectionBuilder, -1, 0, null,
+            null, Row.EMPTY, SubQueryResults.EMPTY);
+
+        assertThat((((NestedLoopPhase) ((Join) ((QueryThenFetch) build).subPlan()).joinPhase())).blockNestedLoop,
+            is(false));
     }
 }

--- a/sql/src/test/java/io/crate/planner/operators/PushDownTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/PushDownTest.java
@@ -28,6 +28,7 @@ import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.testing.T3;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static io.crate.planner.operators.LogicalPlannerTest.isPlan;

--- a/sql/src/test/java/io/crate/rest/action/RestActionReceiversTest.java
+++ b/sql/src/test/java/io/crate/rest/action/RestActionReceiversTest.java
@@ -24,7 +24,7 @@ package io.crate.rest.action;
 
 import com.google.common.collect.ImmutableList;
 import io.crate.breaker.RamAccountingContext;
-import io.crate.breaker.RowAccounting;
+import io.crate.breaker.RowAccountingWithEstimators;
 import io.crate.data.Row;
 import io.crate.data.Row1;
 import io.crate.data.RowN;
@@ -92,7 +92,7 @@ public class RestActionReceiversTest extends CrateUnitTest {
             JsonXContent.contentBuilder(),
             fields,
             0L,
-            new RowAccounting(Symbols.typeView(fields), new RamAccountingContext("dummy", new NoopCircuitBreaker("dummy"))),
+            new RowAccountingWithEstimators(Symbols.typeView(fields), new RamAccountingContext("dummy", new NoopCircuitBreaker("dummy"))),
             true
         );
         for (Row row : rows) {


### PR DESCRIPTION
The block nested loop algorithm is an extension to the nested loop
algorithm. Instead of processing the items of the right relation once for every
item of the left relation, it builds blocks with items of the left relation and
processes the blocks for each item on the right.

This should save IO operations. Benchmarks have shown that the performance
increases significantly in a single node execution context. When multiple nodes
are involved, the performance may be worse because there is already a paging
functionality built in.

Due to the nature of the block nested loop algorithm, not being able to
preserve the order of the two relations, we can only use it when no order by has
been pushed down.

The following interfaces were created in the to keep the
CrossJoinNLBatchIterator in the :dex module.

- BlockSizecalculator
- RamAccounting
- RowAccounting