### PR TITLE
Re-implement thread utilization down-scale logic

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -42,6 +42,11 @@ None
 Changes
 =======
 
+- Implemented a thread-utilization down-scaling logic which dynamically adapts
+  the number of threads used for ``SELECT`` queries involving aggregations to
+  avoid running into ``RejectedExcecution`` errors if there are many shards per
+  node involved in the queries.
+
 - Added the full PostgreSQL syntax of the ``BEGIN`` statement and the
   ``COMMIT`` statement.
   This improves the support for clients that are based on the Postgres wire

--- a/sql/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectSource.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectSource.java
@@ -99,6 +99,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.function.IntSupplier;
 import java.util.function.Supplier;
 
 import static io.crate.data.SentinelRow.SENTINEL;
@@ -165,6 +167,7 @@ public class ShardCollectSource extends AbstractComponent implements CollectSour
     private final Map<ShardId, Supplier<ShardCollectorProvider>> shards = new ConcurrentHashMap<>();
     private final ShardCollectorProviderFactory shardCollectorProviderFactory;
     private final StaticTableReferenceResolver<UnassignedShard> unassignedShardReferenceResolver;
+    private final IntSupplier availableThreads;
 
     @Inject
     public ShardCollectSource(Settings settings,
@@ -188,7 +191,9 @@ public class ShardCollectSource extends AbstractComponent implements CollectSour
         this.clusterService = clusterService;
         this.remoteCollectorFactory = remoteCollectorFactory;
         this.systemCollectSource = systemCollectSource;
-        this.executor = new DirectFallbackExecutor(threadPool.executor(ThreadPool.Names.SEARCH));
+        ThreadPoolExecutor executor = (ThreadPoolExecutor) threadPool.executor(ThreadPool.Names.SEARCH);
+        this.availableThreads = () -> Math.max(executor.getMaximumPoolSize() - executor.getActiveCount(), 1);
+        this.executor = new DirectFallbackExecutor(executor);
         this.shardCollectorProviderFactory = new ShardCollectorProviderFactory(
             clusterService,
             settings,
@@ -348,7 +353,7 @@ public class ShardCollectSource extends AbstractComponent implements CollectSour
                     return new CompositeCollector(
                         builders,
                         firstConsumer,
-                        iterators -> new AsyncCompositeBatchIterator<>(executor, iterators)
+                        iterators -> new AsyncCompositeBatchIterator<>(executor, availableThreads, iterators)
                     );
                 } else {
                     return new CompositeCollector(builders, firstConsumer, CompositeBatchIterator::new);


### PR DESCRIPTION
With the BatchIterator refactoring we also removed the usage of
`ThreadPools.runWithAvailableThreads` for queries involving concurrent
shard-projections. Due to this clusters with a high number of shards per
node could run earlier into `RejectedExcecution` errors.

This integrates the downscaling logic back into the
`AsyncCompositeBatchIterator`.

Benchmarks look good or are within fluctuation (v2 is with the patch):

    Q: select "cCode", count(*) from uservisits group by "cCode"
    C: 1
                V1    →   V2
      mean:  230.229 → 260.607

    Q: select min("adRevenue") from uservisits group by "cCode"
    C: 1
                V1    →   V2
      mean:  278.154 → 257.083

    Q: select max("adRevenue") from uservisits group by "cCode"
    C: 1
                V1    →   V2
      mean:  283.175 → 260.103

    Q: select avg("adRevenue") from uservisits group by "cCode"
    C: 1
                V1    →   V2
      mean:  283.279 → 256.177

    Q: select avg("adRevenue") from uservisits group by "cCode"
    C: 25
                V1    →   V2
      mean:  5317.554 → 5083.838

    Q: select count(distinct "searchWord") from uservisits group by "cCode"
    C: 1
                V1    →   V2
      mean:  1125.548 → 1089.546

    Q: select arbitrary("searchWord") from uservisits group by "cCode"
    C: 1
                V1    →   V2
      mean:  518.977 → 525.721
