### PR TITLE
Make IdCollectorExpression compatible for old indices

### DIFF
--- a/sql/src/main/java/io/crate/expression/reference/doc/lucene/IdCollectorExpression.java
+++ b/sql/src/main/java/io/crate/expression/reference/doc/lucene/IdCollectorExpression.java
@@ -83,6 +83,13 @@ public final class IdCollectorExpression extends LuceneCollectorExpression<Bytes
             id = decodeId(value);
         }
 
+        @Override
+        public void stringField(FieldInfo fieldInfo, byte[] value) {
+            assert COLUMN_NAME.equals(fieldInfo.name) : "stringField must only be called for id";
+            // Indices prior to CrateDB 3.0 have id stored as string
+            id = new BytesRef(value);
+        }
+
         static BytesRef decodeId(byte[] idBytes) {
             final int magicChar = Byte.toUnsignedInt(idBytes[0]);
             if (magicChar == UTF8) {


### PR DESCRIPTION
Fixes a regression caused by 4bafcae4a5
Test for this is in https://github.com/crate/crate-qa/pull/66

(No changes because the regression is unreleased)