### PR TITLE
Move batch iterators from sql to dex module.

### DIFF
--- a/benchmarks/src/test/java/io/crate/data/join/RowsBatchIteratorBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/data/join/RowsBatchIteratorBenchmark.java
@@ -32,8 +32,6 @@ import io.crate.data.Row;
 import io.crate.data.Row1;
 import io.crate.data.RowN;
 import io.crate.data.SkippingBatchIterator;
-import io.crate.execution.engine.join.HashInnerJoinBatchIterator;
-import io.crate.execution.engine.join.RamAccountingBatchIterator;
 import io.crate.testing.RowGenerator;
 import io.crate.types.DataTypes;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;

--- a/dex/build.gradle
+++ b/dex/build.gradle
@@ -16,6 +16,7 @@ dependencies {
 
     testCompile "junit:junit:${versions.junit}"
     testCompile "com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedrunner}"
+    testCompile "org.elasticsearch:securemock:${versions.securemock}"
 }
 
 task jarTest (type: Jar) {

--- a/dex/src/main/java/io/crate/data/join/HashInnerJoinBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/join/HashInnerJoinBatchIterator.java
@@ -20,15 +20,13 @@
  * agreement.
  */
 
-package io.crate.execution.engine.join;
+package io.crate.data.join;
 
 import com.carrotsearch.hppc.IntObjectHashMap;
 import io.crate.data.BatchIterator;
 import io.crate.data.Paging;
 import io.crate.data.Row;
 import io.crate.data.UnsafeArrayRow;
-import io.crate.data.join.ElementCombiner;
-import io.crate.data.join.JoinBatchIterator;
 
 import java.util.ArrayList;
 import java.util.Iterator;

--- a/dex/src/main/java/io/crate/data/join/RamAccountingBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/join/RamAccountingBatchIterator.java
@@ -20,7 +20,7 @@
  * agreement.
  */
 
-package io.crate.execution.engine.join;
+package io.crate.data.join;
 
 import io.crate.breaker.RowAccounting;
 import io.crate.data.BatchIterator;
@@ -30,7 +30,7 @@ import io.crate.data.Row;
 import javax.annotation.Nonnull;
 
 /**
- * Wraps a {@link BatchIterator} and uses {@link io.crate.breaker.RamAccountingContext}
+ * Wraps a {@link BatchIterator} and uses {@link io.crate.breaker.RowAccounting}
  * to apply the circuit breaking logic by calculating memory occupied for all rows of the iterator.
  * <p>
  * This wrapper can be typically used when the BatchIterator consumer "reads" all
@@ -74,7 +74,7 @@ public class RamAccountingBatchIterator<T extends Row> extends ForwardingBatchIt
     }
 
     /**
-     * Release the accounted rows since the last #{@link RamAccountingBatchIterator#releaseAccountedRows()} call.
+     * Release the accounted rows since the last {@link #releaseAccountedRows()} call.
      */
     public void releaseAccountedRows() {
         rowAccounting.release();

--- a/dex/src/test/java/io/crate/data/join/HashInnerJoinBatchIteratorBehaviouralTest.java
+++ b/dex/src/test/java/io/crate/data/join/HashInnerJoinBatchIteratorBehaviouralTest.java
@@ -20,13 +20,15 @@
  * agreement.
  */
 
-package io.crate.execution.engine.join;
+package io.crate.data.join;
 
 import io.crate.breaker.RowAccounting;
 import io.crate.data.BatchIterator;
 import io.crate.data.Paging;
 import io.crate.data.Row;
 import io.crate.data.join.CombinedRow;
+import io.crate.data.join.HashInnerJoinBatchIterator;
+import io.crate.data.join.RamAccountingBatchIterator;
 import io.crate.testing.BatchSimulatingIterator;
 import io.crate.testing.TestingBatchIterators;
 import io.crate.testing.TestingRowConsumer;

--- a/dex/src/test/java/io/crate/data/join/HashInnerJoinBatchIteratorMemoryTest.java
+++ b/dex/src/test/java/io/crate/data/join/HashInnerJoinBatchIteratorMemoryTest.java
@@ -20,16 +20,14 @@
  * agreement.
  */
 
-package io.crate.execution.engine.join;
+package io.crate.data.join;
 
 import io.crate.breaker.RowAccounting;
 import io.crate.data.BatchIterator;
 import io.crate.data.Row;
-import io.crate.data.join.CombinedRow;
 import io.crate.testing.BatchSimulatingIterator;
 import io.crate.testing.TestingBatchIterators;
 import io.crate.testing.TestingRowConsumer;
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.junit.Test;
 
 import java.util.Objects;
@@ -39,11 +37,8 @@ import java.util.function.Predicate;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class HashInnerJoinBatchIteratorMemoryTest {
-
-    private final CircuitBreaker circuitBreaker = mock(CircuitBreaker.class);
 
     private static Predicate<Row> getCol0EqCol1JoinCondition() {
         return row -> Objects.equals(row.get(0), row.get(1));
@@ -63,9 +58,6 @@ public class HashInnerJoinBatchIteratorMemoryTest {
             new BatchSimulatingIterator<>(TestingBatchIterators.range(0, 12), 3, 3, null),
             mock(RowAccounting.class));
         BatchIterator<Row> rightIterator = new BatchSimulatingIterator<>(TestingBatchIterators.range(0, 10), 2, 4, null);
-
-        when(circuitBreaker.getLimit()).thenReturn(110L);
-        when(circuitBreaker.getUsed()).thenReturn(10L);
 
         BatchIterator<Row> it = new HashInnerJoinBatchIterator<>(
             leftIterator,

--- a/dex/src/test/java/io/crate/data/join/HashInnerJoinBatchIteratorTest.java
+++ b/dex/src/test/java/io/crate/data/join/HashInnerJoinBatchIteratorTest.java
@@ -20,7 +20,7 @@
  * agreement.
  */
 
-package io.crate.execution.engine.join;
+package io.crate.data.join;
 
 import com.carrotsearch.randomizedtesting.RandomizedRunner;
 import com.carrotsearch.randomizedtesting.annotations.Name;
@@ -29,11 +29,9 @@ import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
 import io.crate.breaker.RowAccounting;
 import io.crate.data.BatchIterator;
 import io.crate.data.Row;
-import io.crate.data.join.CombinedRow;
 import io.crate.testing.BatchIteratorTester;
 import io.crate.testing.BatchSimulatingIterator;
 import io.crate.testing.TestingBatchIterators;
-import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -46,13 +44,11 @@ import java.util.function.Supplier;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 @RunWith(RandomizedRunner.class)
 @ThreadLeakScope(ThreadLeakScope.Scope.NONE)
 public class HashInnerJoinBatchIteratorTest {
 
-    private final CircuitBreaker circuitBreaker = mock(CircuitBreaker.class);
     private final List<Object[]> expectedResult;
     private final Supplier<RamAccountingBatchIterator<Row>> leftIterator;
     private final Supplier<RamAccountingBatchIterator<Row>> rightIterator;
@@ -80,8 +76,6 @@ public class HashInnerJoinBatchIteratorTest {
         this.leftIterator = leftIterator;
         this.rightIterator = rightIterator;
         this.expectedResult = expectedResult;
-        when(circuitBreaker.getLimit()).thenReturn(110L);
-        when(circuitBreaker.getUsed()).thenReturn(10L);
     }
 
     @ParametersFactory

--- a/sql/src/main/java/io/crate/breaker/RowAccountingWithEstimators.java
+++ b/sql/src/main/java/io/crate/breaker/RowAccountingWithEstimators.java
@@ -23,7 +23,7 @@
 package io.crate.breaker;
 
 import io.crate.data.Row;
-import io.crate.execution.engine.join.HashInnerJoinBatchIterator;
+import io.crate.data.join.HashInnerJoinBatchIterator;
 import io.crate.types.DataType;
 
 import java.util.ArrayList;

--- a/sql/src/main/java/io/crate/execution/engine/join/HashJoinOperation.java
+++ b/sql/src/main/java/io/crate/execution/engine/join/HashJoinOperation.java
@@ -29,6 +29,8 @@ import io.crate.data.ListenableBatchIterator;
 import io.crate.data.Row;
 import io.crate.data.RowConsumer;
 import io.crate.data.join.CombinedRow;
+import io.crate.data.join.HashInnerJoinBatchIterator;
+import io.crate.data.join.RamAccountingBatchIterator;
 import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.expression.InputFactory;
 import io.crate.expression.symbol.Symbol;

--- a/sql/src/test/java/io/crate/execution/engine/join/RamAccountingBatchIteratorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/join/RamAccountingBatchIteratorTest.java
@@ -28,6 +28,7 @@ import io.crate.breaker.RowAccountingWithEstimators;
 import io.crate.breaker.RowAccountingWithEstimatorsTest;
 import io.crate.data.BatchIterator;
 import io.crate.data.Row;
+import io.crate.data.join.RamAccountingBatchIterator;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.testing.TestingBatchIterators;
 import io.crate.testing.TestingRowConsumer;


### PR DESCRIPTION
Since RamAccounting and RamAccounting ifaces were introduced
HashInnerJoinBatchIterator and RamAccountingBatchIterator can be moved to
dex module where all other batch iterators reside.

RamAccountingBatchIteratorTest must remain in sql module as it dependencies
to es-core and sql modules.
