### PR TITLE
fix possible job/operation log entry loss when settings changed

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -107,6 +107,10 @@ Changes
 Fixes
 =====
 
+- Fixed an issue which could result in lost entries at the ``sys.jobs_log`` and
+  ``sys.operations_log`` tables when the related settings are changed while
+  entries are written.
+
 - Fixed a dependecy issue with the bundled ``crash`` that caused the app not
   being able to connect to the server.
 

--- a/sql/src/main/java/io/crate/execution/engine/collect/stats/JobsLogService.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/stats/JobsLogService.java
@@ -235,7 +235,8 @@ public class JobsLogService extends AbstractLifecycleComponent implements Provid
         updateJobSink(size, expiration);
     }
 
-    private void updateJobSink(int size, TimeValue expiration) {
+    @VisibleForTesting
+    void updateJobSink(int size, TimeValue expiration) {
         LogSink<JobContextLog> sink = createSink(
             size, expiration, JOB_CONTEXT_LOG_ESTIMATOR, CrateCircuitBreakerService.JOBS_LOG);
         LogSink<JobContextLog> newSink = sink.equals(NoopLogSink.instance()) ? sink : new FilteredLogSink<>(
@@ -251,9 +252,8 @@ public class JobsLogService extends AbstractLifecycleComponent implements Provid
             sink
         );
         LogSink<JobContextLog> oldSink = jobsLogSink;
-        newSink.addAll(oldSink);
-        jobsLogSink = newSink;
         jobsLogs.updateJobsLog(newSink);
+        jobsLogSink = newSink;
         oldSink.close();
     }
 
@@ -310,13 +310,13 @@ public class JobsLogService extends AbstractLifecycleComponent implements Provid
         updateOperationSink(size, expiration);
     }
 
-    private void updateOperationSink(int size, TimeValue expiration) {
+    @VisibleForTesting
+    void updateOperationSink(int size, TimeValue expiration) {
         LogSink<OperationContextLog> newSink = createSink(size, expiration, OPERATION_CONTEXT_LOG_SIZE_ESTIMATOR,
             CrateCircuitBreakerService.OPERATIONS_LOG);
         LogSink<OperationContextLog> oldSink = operationsLogSink;
-        newSink.addAll(oldSink);
+        jobsLogs.updateOperationsLog(newSink);
         operationsLogSink = newSink;
-        jobsLogs.updateOperationsLog(operationsLogSink);
         oldSink.close();
     }
 

--- a/sql/src/main/java/io/crate/execution/engine/collect/stats/JobsLogService.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/stats/JobsLogService.java
@@ -127,8 +127,6 @@ public class JobsLogService extends AbstractLifecycleComponent implements Provid
     private final TransactionContext transactionContext;
 
     private JobsLogs jobsLogs;
-    LogSink<JobContextLog> jobsLogSink = NoopLogSink.instance();
-    LogSink<OperationContextLog> operationsLogSink = NoopLogSink.instance();
 
     private ExpressionsInput<JobContextLog, Boolean> memoryFilter;
     private ExpressionsInput<JobContextLog, Boolean> persistFilter;
@@ -251,10 +249,7 @@ public class JobsLogService extends AbstractLifecycleComponent implements Provid
             ),
             sink
         );
-        LogSink<JobContextLog> oldSink = jobsLogSink;
         jobsLogs.updateJobsLog(newSink);
-        jobsLogSink = newSink;
-        oldSink.close();
     }
 
     /**
@@ -314,10 +309,7 @@ public class JobsLogService extends AbstractLifecycleComponent implements Provid
     void updateOperationSink(int size, TimeValue expiration) {
         LogSink<OperationContextLog> newSink = createSink(size, expiration, OPERATION_CONTEXT_LOG_SIZE_ESTIMATOR,
             CrateCircuitBreakerService.OPERATIONS_LOG);
-        LogSink<OperationContextLog> oldSink = operationsLogSink;
         jobsLogs.updateOperationsLog(newSink);
-        operationsLogSink = newSink;
-        oldSink.close();
     }
 
     private void setStatsEnabled(boolean enableStats) {
@@ -351,8 +343,7 @@ public class JobsLogService extends AbstractLifecycleComponent implements Provid
 
     @Override
     protected void doClose() {
-        jobsLogSink.close();
-        operationsLogSink.close();
+        jobsLogs.close();
     }
 
     private JobsLogs statsTables() {

--- a/sql/src/test/java/io/crate/execution/engine/collect/stats/JobsLogsTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/stats/JobsLogsTest.java
@@ -55,8 +55,13 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static io.crate.testing.TestingHelpers.getFunctions;
 import static org.hamcrest.Matchers.is;
@@ -267,6 +272,89 @@ public class JobsLogsTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
+    public void testRunningJobsAreNotLostOnSettingsChange() throws Exception {
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+
+        Settings settings = Settings.builder()
+            .put(JobsLogService.STATS_ENABLED_SETTING.getKey(), true).build();
+        JobsLogService jobsLogService = new JobsLogService(settings, clusterSettings, getFunctions(), scheduler, breakerService);
+        JobsLogs jobsLogs = jobsLogService.get();
+
+        StatementClassifier.Classification classification =
+            new StatementClassifier.Classification(Plan.StatementType.SELECT, Collections.singleton("Collect"));
+
+        CountDownLatch latch = new CountDownLatch(2);
+        AtomicBoolean doInsertJobs = new AtomicBoolean(true);
+        AtomicInteger numJobs = new AtomicInteger();
+        int maxQueueSize = JobsLogService.STATS_JOBS_LOG_SIZE_SETTING.getDefault();
+
+        try {
+            executor.submit(() -> {
+                while (doInsertJobs.get() && numJobs.get() < maxQueueSize) {
+                    UUID uuid = UUID.randomUUID();
+                    int i = numJobs.getAndIncrement();
+                    jobsLogs.logExecutionStart(uuid, "select 1", User.CRATE_USER, classification);
+                    if (i % 2 == 0) {
+                        jobsLogs.logExecutionEnd(uuid, null);
+                    } else {
+                        jobsLogs.logPreExecutionFailure(uuid, "select 1", "failure", User.CRATE_USER);
+                    }
+                }
+                latch.countDown();
+            });
+            executor.submit(() -> {
+                jobsLogService.updateJobSink(maxQueueSize + 10, JobsLogService.STATS_JOBS_LOG_EXPIRATION_SETTING.getDefault());
+                doInsertJobs.set(false);
+                latch.countDown();
+            });
+
+            latch.await(10, TimeUnit.SECONDS);
+            assertThat(ImmutableList.copyOf(jobsLogs.jobsLog().iterator()).size(), is(numJobs.get()));
+        } finally {
+            executor.shutdown();
+            executor.awaitTermination(2, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
+    public void testRunningOperationsAreNotLostOnSettingsChange() throws Exception {
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+
+        Settings settings = Settings.builder()
+            .put(JobsLogService.STATS_ENABLED_SETTING.getKey(), true).build();
+        JobsLogService jobsLogService = new JobsLogService(settings, clusterSettings, getFunctions(), scheduler, breakerService);
+        JobsLogs jobsLogs = jobsLogService.get();
+
+        CountDownLatch latch = new CountDownLatch(2);
+        AtomicBoolean doInsertJobs = new AtomicBoolean(true);
+        AtomicInteger numJobs = new AtomicInteger();
+        int maxQueueSize = JobsLogService.STATS_OPERATIONS_LOG_SIZE_SETTING.getDefault();
+
+        try {
+            executor.submit(() -> {
+                while (doInsertJobs.get() && numJobs.get() < maxQueueSize) {
+                    UUID uuid = UUID.randomUUID();
+                    jobsLogs.operationStarted(1, uuid, "dummy");
+                    jobsLogs.operationFinished(1, uuid, null, 1);
+                    numJobs.incrementAndGet();
+                }
+                latch.countDown();
+            });
+            executor.submit(() -> {
+                jobsLogService.updateOperationSink(maxQueueSize + 10, JobsLogService.STATS_OPERATIONS_LOG_EXPIRATION_SETTING.getDefault());
+                doInsertJobs.set(false);
+                latch.countDown();
+            });
+
+            latch.await(10, TimeUnit.SECONDS);
+            assertThat(ImmutableList.copyOf(jobsLogs.operationsLog().iterator()).size(), is(numJobs.get()));
+        } finally {
+            executor.shutdown();
+            executor.awaitTermination(2, TimeUnit.SECONDS);
+        }
+    }
+
+    @Test
     public void testExecutionStart() {
         JobsLogs jobsLogs = new JobsLogs(() -> true);
         User user = User.of("arthur");
@@ -314,13 +402,13 @@ public class JobsLogsTest extends CrateDummyClusterServiceUnitTest {
         jobsLogs.operationStarted(ctxB.id, ctxB.jobId, ctxB.name);
 
         jobsLogs.operationFinished(ctxB.id, ctxB.jobId, null, -1);
-        List<OperationContextLog> entries = ImmutableList.copyOf(jobsLogs.operationsLog.get().iterator());
+        List<OperationContextLog> entries = ImmutableList.copyOf(jobsLogs.operationsLog().iterator());
 
         assertTrue(entries.contains(new OperationContextLog(ctxB, null)));
         assertFalse(entries.contains(new OperationContextLog(ctxA, null)));
 
         jobsLogs.operationFinished(ctxA.id, ctxA.jobId, null, -1);
-        entries = ImmutableList.copyOf(jobsLogs.operationsLog.get());
+        entries = ImmutableList.copyOf(jobsLogs.operationsLog());
         assertTrue(entries.contains(new OperationContextLog(ctxA, null)));
     }
 


### PR DESCRIPTION
When a new log sink for the `jobs` or `operations` is created due to a
settings change, concurrent created entries could have been lost.