### PR TITLE
Allow downcasts of Literals if convertible

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -119,6 +119,9 @@ Fixes
 - Made table setting ``blocks.read_only_allow_delete`` configurable for
   partitioned tables.
 
+- Improved performance for expressions involving literal and type conversions,
+  e.g. ``int_arr[1] = 123456``.
+
 - Fixed syntax support for certain ``ALTER BLOB TABLE RENAME``, ``REROUTE``
   and ``OPEN/CLOSE`` queries.
 

--- a/sql/src/main/java/io/crate/expression/symbol/FuncArg.java
+++ b/sql/src/main/java/io/crate/expression/symbol/FuncArg.java
@@ -46,4 +46,13 @@ public interface FuncArg {
      * @return True is casting is possible, false otherwise.
      */
     boolean canBeCasted();
+
+    /**
+     * Returns true if this Symbol holds a value that may be cast
+     * preferably before other Symbols, ie. Literal and ParameterSymbols.
+     * @return True if it is a value symbol, False otherwise
+     */
+    default boolean isValueSymbol() {
+        return false;
+    }
 }

--- a/sql/src/main/java/io/crate/expression/symbol/Function.java
+++ b/sql/src/main/java/io/crate/expression/symbol/Function.java
@@ -76,6 +76,16 @@ public class Function extends Symbol implements Cloneable {
     }
 
     @Override
+    public boolean isValueSymbol() {
+        for (Symbol argument : arguments) {
+            if (!argument.isValueSymbol()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
     public Symbol cast(DataType newDataType, boolean tryCast) {
         if (newDataType instanceof CollectionType && info.ident().name().equals(ArrayFunction.NAME)) {
             /* We treat _array(...) in a special way since it's a value constructor and no regular function

--- a/sql/src/main/java/io/crate/expression/symbol/Literal.java
+++ b/sql/src/main/java/io/crate/expression/symbol/Literal.java
@@ -159,6 +159,11 @@ public class Literal<ReturnType> extends Symbol implements Input<ReturnType>, Co
     }
 
     @Override
+    public boolean isValueSymbol() {
+        return true;
+    }
+
+    @Override
     public <C, R> R accept(SymbolVisitor<C, R> visitor, C context) {
         return visitor.visitLiteral(this, context);
     }

--- a/sql/src/main/java/io/crate/expression/symbol/ParameterSymbol.java
+++ b/sql/src/main/java/io/crate/expression/symbol/ParameterSymbol.java
@@ -75,6 +75,11 @@ public class ParameterSymbol extends Symbol {
     }
 
     @Override
+    public boolean isValueSymbol() {
+        return true;
+    }
+
+    @Override
     public <C, R> R accept(SymbolVisitor<C, R> visitor, C context) {
         return visitor.visitParameterSymbol(this, context);
     }

--- a/sql/src/main/java/io/crate/expression/symbol/SelectSymbol.java
+++ b/sql/src/main/java/io/crate/expression/symbol/SelectSymbol.java
@@ -74,6 +74,16 @@ public class SelectSymbol extends Symbol {
     }
 
     @Override
+    public boolean isValueSymbol() {
+        for (Symbol symbol : relation.outputs()) {
+            if (!symbol.isValueSymbol()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
     public <C, R> R accept(SymbolVisitor<C, R> visitor, C context) {
         return visitor.visitSelectSymbol(this, context);
     }

--- a/sql/src/test/java/io/crate/analyze/GroupByAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/GroupByAnalyzerTest.java
@@ -425,13 +425,11 @@ public class GroupByAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(relation.querySpec().having().query(), isFunction("op_="));
         Function havingFunction = (Function) relation.querySpec().having().query();
         assertThat(havingFunction.arguments().size(), is(2));
-        assertThat(havingFunction.arguments().get(0), isFunction("to_long"));
-        Function castFunction = (Function) havingFunction.arguments().get(0);
-        assertThat(castFunction.arguments().get(0), isFunction("max"));
-        Function maxFunction = (Function) castFunction.arguments().get(0);
+        assertThat(havingFunction.arguments().get(0), isFunction("max"));
+        Function maxFunction = (Function) havingFunction.arguments().get(0);
 
         assertThat(maxFunction.arguments().get(0), isReference("bytes"));
-        assertThat(havingFunction.arguments().get(1), isLiteral(4L));
+        assertThat(havingFunction.arguments().get(1), isLiteral((byte) 4));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/analyze/relations/RelationSplitterTest.java
+++ b/sql/src/test/java/io/crate/analyze/relations/RelationSplitterTest.java
@@ -109,7 +109,7 @@ public class RelationSplitterTest extends CrateUnitTest {
         QuerySpec querySpec = fromQuery("x = 1 and y = 3 and x + y = 4");
         RelationSplitter splitter = split(querySpec);
 
-        assertThat(querySpec, isSQL("SELECT true WHERE (to_long(add(doc.t1.x, doc.t2.y)) = 4)"));
+        assertThat(querySpec, isSQL("SELECT true WHERE (add(doc.t1.x, doc.t2.y) = 4)"));
         assertThat(splitter.getSpec(T3.TR_1), isSQL("SELECT doc.t1.x WHERE (doc.t1.x = 1)"));
         assertThat(splitter.getSpec(T3.TR_2), isSQL("SELECT doc.t2.y WHERE (doc.t2.y = 3)"));
     }
@@ -120,7 +120,7 @@ public class RelationSplitterTest extends CrateUnitTest {
         QuerySpec querySpec = fromQuery("x + y + z = 5").limit(Literal.of(30));
         RelationSplitter splitter = split(querySpec);
 
-        assertThat(querySpec, isSQL("SELECT true WHERE (to_long(add(add(doc.t1.x, doc.t2.y), doc.t3.z)) = 5) LIMIT 30"));
+        assertThat(querySpec, isSQL("SELECT true WHERE (add(add(doc.t1.x, doc.t2.y), doc.t3.z) = 5) LIMIT 30"));
         assertThat(splitter.getSpec(T3.TR_1), isSQL("SELECT doc.t1.x"));
         assertThat(splitter.getSpec(T3.TR_2), isSQL("SELECT doc.t2.y"));
         assertThat(splitter.getSpec(T3.TR_3), isSQL("SELECT doc.t3.z"));

--- a/sql/src/test/java/io/crate/planner/PlanPrinterTest.java
+++ b/sql/src/test/java/io/crate/planner/PlanPrinterTest.java
@@ -83,7 +83,7 @@ public class PlanPrinterTest extends CrateDummyClusterServiceUnitTest {
                    "projections=[" +
                        "{type=HashAggregation, keys=IC{1, string}, aggregations=Aggregation{max, args=[IC{0, integer}]}}, " +
                        "{type=HashAggregation, keys=IC{0, string}, aggregations=Aggregation{max, args=[IC{1, integer}]}}, " +
-                       "{type=Filter, filter=to_long(IC{1, integer}) > 10}, " +
+                       "{type=Filter, filter=IC{1, integer} > 10}, " +
                        "{type=OrderByTopN, limit=-1, offset=0, outputs=IC{0, string}, IC{1, integer}, orderBy=[IC{0, string} ASC]}], " +
                     "routing={n1={t1=[0]}}, where=true}}}}"));
     }

--- a/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -127,7 +127,7 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
     public void testHavingGlobalAggregation() throws Exception {
         LogicalPlan plan = plan("select min(a), min(x) from t1 having min(x) < 33 and max(x) > 100");
         assertThat(plan, isPlan("FetchOrEval[min(a), min(x)]\n" +
-                                "Filter[((cast(min(x) AS long) < 33) AND (cast(max(x) AS long) > 100))]\n" +
+                                "Filter[((min(x) < 33) AND (max(x) > 100))]\n" +
                                 "Aggregate[min(a), min(x), max(x)]\n" +
                                 "Collect[doc.t1 | [a, x] | All]\n"));
     }


### PR DESCRIPTION
The patch makes it possible to downcast Literals with higher precedence in expressions which also contain other castable arguments.

```
Before: int_arr[1] = 123 => to_long(subscript(int_arr, 1)) = 123
          ^^^^^      ^^^
         castable castable
After:  int_arr[1] = 123 => subscript(int_arr, 1) = to_int(123)
```

This has the advantage that the lossless conversion is only performed once for
the Literal, whereas it might have to be performed for every record in case of a
column. The LuceneQueryBuilder is only able to generate a fast Lucene index
query if no cast function is applied.