### PR TITLE
Change distributed result rx threadpool dispatching

### DIFF
--- a/sql/src/main/java/io/crate/execution/engine/collect/collectors/RemoteCollector.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/collectors/RemoteCollector.java
@@ -46,6 +46,7 @@ import org.elasticsearch.common.logging.Loggers;
 import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.UUID;
+import java.util.concurrent.Executor;
 
 public class RemoteCollector implements CrateCollector {
 
@@ -55,6 +56,7 @@ public class RemoteCollector implements CrateCollector {
     private final UUID jobId;
     private final String localNode;
     private final String remoteNode;
+    private final Executor executor;
     private final TransportJobAction transportJobAction;
     private final TransportKillJobsNodeAction transportKillJobsNodeAction;
     private final TasksService tasksService;
@@ -73,6 +75,7 @@ public class RemoteCollector implements CrateCollector {
                            String remoteNode,
                            TransportJobAction transportJobAction,
                            TransportKillJobsNodeAction transportKillJobsNodeAction,
+                           Executor executor,
                            TasksService tasksService,
                            RamAccountingContext ramAccountingContext,
                            RowConsumer consumer,
@@ -80,6 +83,7 @@ public class RemoteCollector implements CrateCollector {
         this.jobId = jobId;
         this.localNode = localNode;
         this.remoteNode = remoteNode;
+        this.executor = executor;
 
         /*
          * We don't wanna profile the timings of the remote execution context, because the remoteCollect is already
@@ -171,6 +175,7 @@ public class RemoteCollector implements CrateCollector {
             localNode,
             RECEIVER_PHASE_ID,
             "RemoteCollectPhase",
+            executor,
             consumer,
             pagingIterator,
             DataTypes.getStreamers(collectPhase.outputTypes()),

--- a/sql/src/main/java/io/crate/execution/engine/distribution/TransportDistributedResultAction.java
+++ b/sql/src/main/java/io/crate/execution/engine/distribution/TransportDistributedResultAction.java
@@ -26,10 +26,10 @@ import com.google.common.annotations.VisibleForTesting;
 import io.crate.concurrent.CompletableFutures;
 import io.crate.exceptions.TaskMissing;
 import io.crate.execution.jobs.DownstreamRXTask;
-import io.crate.execution.jobs.TasksService;
-import io.crate.execution.jobs.RootTask;
 import io.crate.execution.jobs.PageBucketReceiver;
 import io.crate.execution.jobs.PageResultListener;
+import io.crate.execution.jobs.RootTask;
+import io.crate.execution.jobs.TasksService;
 import io.crate.execution.jobs.kill.KillJobsRequest;
 import io.crate.execution.jobs.kill.TransportKillJobsNodeAction;
 import io.crate.execution.support.NodeAction;
@@ -43,7 +43,6 @@ import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
-import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
@@ -53,7 +52,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -62,15 +60,12 @@ public class TransportDistributedResultAction extends AbstractComponent implemen
 
     private static final String DISTRIBUTED_RESULT_ACTION = "crate/sql/node/merge/add_rows";
 
-    private static final String EXECUTOR_NAME = ThreadPool.Names.SEARCH;
-
     private final Transports transports;
     private final TasksService tasksService;
     private final ScheduledExecutorService scheduler;
     private final ClusterService clusterService;
     private final TransportKillJobsNodeAction killJobsAction;
     private final BackoffPolicy backoffPolicy;
-    private final Executor executor;
 
     @Inject
     public TransportDistributedResultAction(Transports transports,
@@ -102,7 +97,6 @@ public class TransportDistributedResultAction extends AbstractComponent implemen
         super(settings);
         this.transports = transports;
         this.tasksService = tasksService;
-        this.executor = threadPool.executor(EXECUTOR_NAME);
         scheduler = threadPool.scheduler();
         this.clusterService = clusterService;
         this.killJobsAction = killJobsAction;
@@ -152,17 +146,13 @@ public class TransportDistributedResultAction extends AbstractComponent implemen
         if (throwable == null) {
             request.streamers(pageBucketReceiver.streamers());
             SendResponsePageResultListener pageResultListener = new SendResponsePageResultListener();
-            try {
-                executor.execute(() -> pageBucketReceiver.setBucket(
-                    request.bucketIdx(),
-                    request.rows(),
-                    request.isLast(),
-                    pageResultListener));
-                return pageResultListener.future;
-            } catch (EsRejectedExecutionException e) {
-                pageBucketReceiver.failure(request.bucketIdx(), e);
-                return CompletableFuture.completedFuture(new DistributedResultResponse(false));
-            }
+            pageBucketReceiver.setBucket(
+                request.bucketIdx(),
+                request.rows(),
+                request.isLast(),
+                pageResultListener
+            );
+            return pageResultListener.future;
         } else {
             if (request.isKilled()) {
                 pageBucketReceiver.killed(request.bucketIdx(), throwable);

--- a/sql/src/main/java/io/crate/execution/jobs/JobSetup.java
+++ b/sql/src/main/java/io/crate/execution/jobs/JobSetup.java
@@ -102,6 +102,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 import java.util.function.Predicate;
 
 import static io.crate.execution.dsl.projection.Projections.nodeProjections;
@@ -121,6 +122,7 @@ public class JobSetup extends AbstractComponent {
     private final InputFactory inputFactory;
     private final ProjectorFactory projectorFactory;
     private final PKLookupOperation pkLookupOperation;
+    private final ExecutorService searchTp;
 
     @Inject
     public JobSetup(Settings settings,
@@ -148,6 +150,7 @@ public class JobSetup extends AbstractComponent {
         this.distributingConsumerFactory = distributingConsumerFactory;
         innerPreparer = new InnerPreparer();
         inputFactory = new InputFactory(functions);
+        searchTp = threadPool.executor(ThreadPool.Names.SEARCH);
         EvaluatingNormalizer normalizer = EvaluatingNormalizer.functionOnlyNormalizer(functions);
         this.projectorFactory = new ProjectionToProjectorVisitor(
             clusterService,
@@ -605,6 +608,7 @@ public class JobSetup extends AbstractComponent {
                 nodeName(),
                 phase.phaseId(),
                 phase.name(),
+                searchTp,
                 consumer,
                 PagingIterator.create(
                     phase.numUpstreams(),
@@ -821,6 +825,7 @@ public class JobSetup extends AbstractComponent {
                 nodeName(),
                 mergePhase.phaseId(),
                 mergePhase.name(),
+                searchTp,
                 rowConsumer,
                 PagingIterator.create(
                     mergePhase.numUpstreams(),

--- a/sql/src/test/java/io/crate/execution/engine/collect/collectors/RemoteCollectorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/collectors/RemoteCollectorTest.java
@@ -23,6 +23,7 @@
 package io.crate.execution.engine.collect.collectors;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.MoreExecutors;
 import io.crate.analyze.WhereClause;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.execution.dsl.phases.RoutedCollectPhase;
@@ -97,6 +98,7 @@ public class RemoteCollectorTest extends CrateDummyClusterServiceUnitTest {
             "remoteNode",
             transportJobAction,
             transportKillJobsNodeAction,
+            MoreExecutors.directExecutor(),
             tasksService,
             mock(RamAccountingContext.class),
             consumer,

--- a/sql/src/test/java/io/crate/execution/engine/distribution/DistributingConsumerTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/distribution/DistributingConsumerTest.java
@@ -27,8 +27,8 @@ import io.crate.Streamer;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.data.CollectionBucket;
 import io.crate.data.Row;
-import io.crate.execution.jobs.DistResultRXTask;
 import io.crate.execution.engine.distribution.merge.PassThroughPagingIterator;
+import io.crate.execution.jobs.DistResultRXTask;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.testing.BatchSimulatingIterator;
 import io.crate.testing.FailingBatchIterator;
@@ -147,6 +147,7 @@ public class DistributingConsumerTest extends CrateUnitTest {
                 "n1",
                 1,
                 "dummy",
+                MoreExecutors.directExecutor(),
                 collectingConsumer,
                 PassThroughPagingIterator.oneShot(),
                 streamers,

--- a/sql/src/test/java/io/crate/execution/jobs/DistResultRXTaskTest.java
+++ b/sql/src/test/java/io/crate/execution/jobs/DistResultRXTaskTest.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ForwardingIterator;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
+import com.google.common.util.concurrent.MoreExecutors;
 import io.crate.Streamer;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.data.ArrayBucket;
@@ -71,6 +72,7 @@ public class DistResultRXTaskTest extends CrateUnitTest {
             "n1",
             1,
             "dummy",
+            MoreExecutors.directExecutor(),
             batchConsumer,
             pagingIterator,
             new Streamer[1],

--- a/sql/src/test/java/io/crate/execution/jobs/RootTaskTest.java
+++ b/sql/src/test/java/io/crate/execution/jobs/RootTaskTest.java
@@ -21,6 +21,7 @@
 
 package io.crate.execution.jobs;
 
+import com.google.common.util.concurrent.MoreExecutors;
 import io.crate.Streamer;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.execution.dsl.phases.RoutedCollectPhase;
@@ -132,7 +133,9 @@ public class RootTaskTest extends CrateUnitTest {
         DistResultRXTask distResultRXTask = spy(new DistResultRXTask(
             Loggers.getLogger(DistResultRXTask.class),
             "n1",
-            2, "dummy",
+            2,
+            "dummy",
+            MoreExecutors.directExecutor(),
             batchConsumer,
             PassThroughPagingIterator.oneShot(),
             new Streamer[]{IntegerType.INSTANCE.streamer()},


### PR DESCRIPTION
Not certain that this is an improvement. See data below.

We're dispatching into the search threadpool each time a node is
receiving a result from another node. Most of the time this is a very
short operation (keeping the reference), only when a full page is formed
and the `RowConsumer` is triggered is it taking a longer time.

This changes the dispatching logic to do the short operations in the
`SAME` threadpool and only dispatch into search once the consumption is
triggered or continued.

This should help reducing `RejectedExecution` errors on clusters with a
larger number of nodes.


Single node results:
```
V1: 3.1.0-8d6f66ecdc70e4c4d8992d303b5cab43e985aaef
V2: 3.1.0-1b5f1334d107f2e18040b935d8867d343d057ef7 (patched)

Q: select "cCode", count(*) from uservisits group by "cCode"
C: 1
  3.09% mean difference. Likely NOT significant
             V1    →   V2
  mean:   38.475 →  37.302
  max:   192.607 → 194.075

Q: select min("adRevenue") from uservisits group by "cCode"
C: 1
  2.17% mean difference. Likely NOT significant
             V1    →   V2
  mean:   57.114 →  58.367
  max:   274.933 → 230.113

Q: select max("adRevenue") from uservisits group by "cCode"
C: 1
  1.56% mean difference. Likely NOT significant
             V1    →   V2
  mean:   58.474 →  57.567
  max:   115.392 → 122.548

Q: select avg("adRevenue") from uservisits group by "cCode"
C: 1
  6.28% mean difference. Likely significant
             V1    →   V2
  mean:   56.734 →  53.281
  max:    80.442 →  63.983

Q: select avg("adRevenue") from uservisits group by "cCode"
C: 25
  5.56% mean difference. Likely NOT significant
             V1    →   V2
  mean:  891.173 → 842.990
  max:   1408.697 → 1566.006

Q: select count(distinct "searchWord") from uservisits group by "cCode"
C: 1
  1.78% mean difference. Likely NOT significant
             V1    →   V2
  mean:  291.855 → 286.715
  max:   591.441 → 587.969

Q: select arbitrary("searchWord") from uservisits group by "cCode"
C: 1
  4.60% mean difference. Likely significant
             V1    →   V2
  mean:  173.432 → 165.633
  max:   204.973 → 184.209
```


5 Node results:
```
+----------------------------------------------------------------------+-------------+---------+---------------------+-------------+
| statement                                                            | concurrency | version |                mean |         max |
+----------------------------------------------------------------------+-------------+---------+---------------------+-------------+
| select "cCode", count(*) from uservisits group by "cCode"            |           1 | master  |  31.66079696        |   65.165276 |
| select "cCode", count(*) from uservisits group by "cCode"            |           1 | master  |  34.75539737        |  158.8187   |
| select "cCode", count(*) from uservisits group by "cCode"            |           1 | patched |  30.0860746         |   78.59039  |
| select "cCode", count(*) from uservisits group by "cCode"            |           1 | patched |  34.92953917        |   67.05401  |
| select arbitrary("searchWord") from uservisits group by "cCode"      |           1 | master  |  98.31356995        |  136.4892   |
| select arbitrary("searchWord") from uservisits group by "cCode"      |           1 | master  |  95.38903598        |  132.03976  |
| select arbitrary("searchWord") from uservisits group by "cCode"      |           1 | patched | 102.42175554        |  128.05264  |
| select arbitrary("searchWord") from uservisits group by "cCode"      |           1 | patched | 103.62222731        |  143.87172  |
| select avg("adRevenue") from uservisits group by "cCode"             |           1 | master  |  52.73285841        |  771.7426   |
| select avg("adRevenue") from uservisits group by "cCode"             |           1 | master  |  55.79199562        | 1440.7332   |
| select avg("adRevenue") from uservisits group by "cCode"             |           1 | patched |  48.97477904        |   86.27967  |
| select avg("adRevenue") from uservisits group by "cCode"             |           1 | patched |  48.689063420000004 |   92.58082  |
| select avg("adRevenue") from uservisits group by "cCode"             |          25 | master  | 258.02335445        |  506.73816  |
| select avg("adRevenue") from uservisits group by "cCode"             |          25 | master  | 283.3898502         |  444.26834  |
| select avg("adRevenue") from uservisits group by "cCode"             |          25 | patched | 267.40061075        |  410.40512  |
| select avg("adRevenue") from uservisits group by "cCode"             |          25 | patched | 277.81531448        |  412.4097   |
| select count(distinct "searchWord") from uservisits group by "cCode" |           1 | master  | 125.27704401        |  170.4491   |
| select count(distinct "searchWord") from uservisits group by "cCode" |           1 | master  | 129.20163795        |  675.30225  |
| select count(distinct "searchWord") from uservisits group by "cCode" |           1 | patched | 126.41994909        |  192.06499  |
| select count(distinct "searchWord") from uservisits group by "cCode" |           1 | patched | 127.70651731        |  171.29958  |
```