### PR TITLE
Added a TimeZone parameter response for Django psycopg2 clients

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -104,6 +104,8 @@ Changes
 
 - Added support for the ``SHOW TRANSACTION_ISOLATION`` statement.
 
+- Added TimeZone parameter response to Postgres Wire Protocol.
+
 Fixes
 =====
 

--- a/sql/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
@@ -430,6 +430,7 @@ class PostgresWireProtocol {
         Messages.sendParameterStatus(channel, "server_encoding", "UTF8");
         Messages.sendParameterStatus(channel, "client_encoding", "UTF8");
         Messages.sendParameterStatus(channel, "datestyle", "ISO");
+        Messages.sendParameterStatus(channel, "TimeZone", "UTC");
         Messages.sendReadyForQuery(channel);
     }
 


### PR DESCRIPTION
Issue: https://github.com/crate/crate/issues/7468