### PR TITLE
Fixed syntax support for ALTER BLOB TABLE RENAME/REROUTE/OPEN/CLOSE queries

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -107,6 +107,9 @@ Changes
 Fixes
 =====
 
+- Fixed syntax support for certain ``ALTER BLOB TABLE RENAME``, ``REROUTE``
+  and ``OPEN/CLOSE`` queries.
+
 - Fixed an issue which could result in lost entries at the ``sys.jobs_log`` and
   ``sys.operations_log`` tables when the related settings are changed while
   entries are written.

--- a/sql-parser/src/main/antlr/SqlBase.g4
+++ b/sql-parser/src/main/antlr/SqlBase.g4
@@ -50,9 +50,9 @@ statement
         (SET '(' genericProperties ')' | RESET ('(' ident (',' ident)* ')')?)        #alterTableProperties
     | ALTER BLOB TABLE alterTableDefinition
         (SET '(' genericProperties ')' | RESET ('(' ident (',' ident)* ')')?)        #alterBlobTableProperties
-    | ALTER TABLE alterTableDefinition (OPEN | CLOSE)                                #alterTableOpenClose
-    | ALTER TABLE alterTableDefinition RENAME TO qname                               #alterTableRename
-    | ALTER TABLE alterTableDefinition REROUTE rerouteOption                         #alterTableReroute
+    | ALTER (BLOB)? TABLE alterTableDefinition (OPEN | CLOSE)                        #alterTableOpenClose
+    | ALTER (BLOB)? TABLE alterTableDefinition RENAME TO qname                       #alterTableRename
+    | ALTER (BLOB)? TABLE alterTableDefinition REROUTE rerouteOption                 #alterTableReroute
     | ALTER CLUSTER REROUTE RETRY FAILED                                             #alterClusterRerouteRetryFailed
     | ALTER USER name=ident SET '(' genericProperties ')'                            #alterUser
     | RESET GLOBAL primaryExpression (',' primaryExpression)*                        #resetGlobal

--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -821,6 +821,7 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     public Node visitAlterTableOpenClose(SqlBaseParser.AlterTableOpenCloseContext context) {
         return new AlterTableOpenClose(
             (Table) visit(context.alterTableDefinition()),
+            context.BLOB() != null,
             context.OPEN() != null
         );
     }
@@ -829,6 +830,7 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     public Node visitAlterTableRename(SqlBaseParser.AlterTableRenameContext context) {
         return new AlterTableRename(
             (Table) visit(context.alterTableDefinition()),
+            context.BLOB() != null,
             getQualifiedName(context.qname())
         );
     }
@@ -837,6 +839,7 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     public Node visitAlterTableReroute(SqlBaseParser.AlterTableRerouteContext context) {
         return new AlterTableReroute(
             (Table) visit(context.alterTableDefinition()),
+            context.BLOB() != null,
             (RerouteOption) visit(context.rerouteOption()));
     }
 

--- a/sql-parser/src/main/java/io/crate/sql/tree/AlterTableOpenClose.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AlterTableOpenClose.java
@@ -27,10 +27,12 @@ import com.google.common.base.MoreObjects;
 public class AlterTableOpenClose extends Statement {
 
     private final Table table;
+    private final boolean blob;
     private final boolean openTable;
 
-    public AlterTableOpenClose(Table table, boolean openTable) {
+    public AlterTableOpenClose(Table table, boolean blob, boolean openTable) {
         this.table = table;
+        this.blob = blob;
         this.openTable = openTable;
     }
 
@@ -44,6 +46,10 @@ public class AlterTableOpenClose extends Statement {
         return table;
     }
 
+    public boolean blob() {
+        return blob;
+    }
+
     public boolean openTable() {
         return openTable;
     }
@@ -52,6 +58,7 @@ public class AlterTableOpenClose extends Statement {
     public String toString() {
         return MoreObjects.toStringHelper(this)
             .add("table", table)
+            .add("blob", blob)
             .add("open table", openTable).toString();
     }
 
@@ -62,6 +69,7 @@ public class AlterTableOpenClose extends Statement {
 
         AlterTableOpenClose that = (AlterTableOpenClose) o;
 
+        if (!blob == that.blob) return false;
         if (!openTable == that.openTable) return false;
         if (!table.equals(that.table)) return false;
 
@@ -71,6 +79,7 @@ public class AlterTableOpenClose extends Statement {
     @Override
     public int hashCode() {
         int result = table.hashCode();
+        result = 31 * result + (blob ? 1 : 0);
         result = 31 * result + Boolean.hashCode(openTable);
         return result;
     }

--- a/sql-parser/src/main/java/io/crate/sql/tree/AlterTableRename.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AlterTableRename.java
@@ -27,10 +27,12 @@ import com.google.common.base.MoreObjects;
 public class AlterTableRename extends Statement {
 
     private final Table table;
+    private final boolean blob;
     private final QualifiedName newName;
 
-    public AlterTableRename(Table table, QualifiedName newName) {
+    public AlterTableRename(Table table, boolean blob, QualifiedName newName) {
         this.table = table;
+        this.blob = blob;
         this.newName = newName;
     }
 
@@ -44,6 +46,10 @@ public class AlterTableRename extends Statement {
         return table;
     }
 
+    public boolean blob() {
+        return blob;
+    }
+
     public QualifiedName newName() {
         return newName;
     }
@@ -52,6 +58,7 @@ public class AlterTableRename extends Statement {
     public String toString() {
         return MoreObjects.toStringHelper(this)
             .add("table", table)
+            .add("blob", blob)
             .add("new name", newName).toString();
     }
 
@@ -62,6 +69,7 @@ public class AlterTableRename extends Statement {
 
         AlterTableRename that = (AlterTableRename) o;
 
+        if (!blob == blob) return false;
         if (!newName.equals(that.newName)) return false;
         if (!table.equals(that.table)) return false;
 
@@ -71,6 +79,7 @@ public class AlterTableRename extends Statement {
     @Override
     public int hashCode() {
         int result = table.hashCode();
+        result = 31 * result + (blob ? 1 : 0);
         result = 31 * result + newName.hashCode();
         return result;
     }

--- a/sql-parser/src/main/java/io/crate/sql/tree/AlterTableReroute.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AlterTableReroute.java
@@ -28,9 +28,11 @@ public class AlterTableReroute extends Statement {
 
     private final Table table;
     private final RerouteOption rerouteOption;
+    private final boolean blob;
 
-    public AlterTableReroute(Table table, RerouteOption rerouteOption) {
+    public AlterTableReroute(Table table, boolean blob, RerouteOption rerouteOption) {
         this.table = table;
+        this.blob = blob;
         this.rerouteOption = rerouteOption;
     }
 
@@ -44,6 +46,10 @@ public class AlterTableReroute extends Statement {
         return table;
     }
 
+    public boolean blob() {
+        return blob;
+    }
+
     public RerouteOption rerouteOption() {
         return rerouteOption;
     }
@@ -52,6 +58,7 @@ public class AlterTableReroute extends Statement {
     public String toString() {
         return MoreObjects.toStringHelper(this)
             .add("table", table)
+            .add("blob", blob)
             .add("reroute option", rerouteOption).toString();
     }
 
@@ -62,6 +69,7 @@ public class AlterTableReroute extends Statement {
 
         AlterTableReroute that = (AlterTableReroute) o;
 
+        if (!blob == that.blob) return false;
         if (!rerouteOption.equals(that.rerouteOption)) return false;
         if (!table.equals(that.table)) return false;
 
@@ -71,6 +79,7 @@ public class AlterTableReroute extends Statement {
     @Override
     public int hashCode() {
         int result = table.hashCode();
+        result = 31 * result + (blob ? 1 : 0);
         result = 31 * result + rerouteOption.hashCode();
         return result;
     }

--- a/sql/src/main/java/io/crate/analyze/AlterTableAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/AlterTableAnalyzer.java
@@ -38,6 +38,8 @@ import org.elasticsearch.common.settings.Settings;
 import javax.annotation.Nullable;
 import java.util.List;
 
+import static io.crate.analyze.BlobTableAnalyzer.tableToIdent;
+
 public class AlterTableAnalyzer {
 
     private final Schemas schemas;
@@ -69,8 +71,14 @@ public class AlterTableAnalyzer {
             throw new IllegalArgumentException("Target table name must not include a schema");
         }
 
-        RelationName relationName = RelationName.of(node.table(), sessionContext.defaultSchema());
-        DocTableInfo tableInfo = schemas.getTableInfo(relationName);
+        RelationName relationName;
+        if (node.blob()) {
+            relationName = tableToIdent(node.table());
+        } else {
+            relationName = RelationName.of(node.table(), sessionContext.defaultSchema());
+        }
+
+        DocTableInfo tableInfo = schemas.getTableInfo(relationName, Operation.ALTER_TABLE_RENAME);
         RelationName newRelationName = new RelationName(relationName.schema(), newIdentParts.get(0));
         newRelationName.ensureValidForRelationCreation();
         return new AlterTableRenameAnalyzedStatement(tableInfo, newRelationName);

--- a/sql/src/main/java/io/crate/analyze/AlterTableOpenCloseAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/AlterTableOpenCloseAnalyzer.java
@@ -25,12 +25,14 @@ package io.crate.analyze;
 
 import io.crate.action.sql.SessionContext;
 import io.crate.metadata.PartitionName;
-import io.crate.metadata.Schemas;
 import io.crate.metadata.RelationName;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.doc.DocTableInfo;
 import io.crate.metadata.table.Operation;
 import io.crate.sql.tree.AlterTableOpenClose;
 import io.crate.sql.tree.Table;
+
+import static io.crate.analyze.BlobTableAnalyzer.tableToIdent;
 
 class AlterTableOpenCloseAnalyzer {
 
@@ -42,8 +44,14 @@ class AlterTableOpenCloseAnalyzer {
 
     public AlterTableOpenCloseAnalyzedStatement analyze(AlterTableOpenClose node, SessionContext sessionContext) {
         Table table = node.table();
-        DocTableInfo tableInfo = schemas.getTableInfo(RelationName.of(table, sessionContext.defaultSchema()),
-            Operation.ALTER_OPEN_CLOSE);
+        RelationName relationName;
+        if (node.blob()) {
+            relationName = tableToIdent(table);
+        } else {
+            relationName = RelationName.of(table, sessionContext.defaultSchema());
+        }
+
+        DocTableInfo tableInfo = schemas.getTableInfo(relationName, Operation.ALTER_OPEN_CLOSE);
         PartitionName partitionName = null;
         if (tableInfo.isPartitioned()) {
             partitionName = AlterTableAnalyzer.createPartitionName(table.partitionProperties(), tableInfo, null);

--- a/sql/src/test/java/io/crate/analyze/AlterTableRerouteAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/AlterTableRerouteAnalyzerTest.java
@@ -77,6 +77,14 @@ public class AlterTableRerouteAnalyzerTest extends CrateDummyClusterServiceUnitT
         assertThat(analyzed.tableInfo().concreteIndices().length, is(1));
         assertThat(analyzed.tableInfo().concreteIndices()[0], is(".blob_blobs"));
         assertThat(analyzed.isWriteOperation(), is(true));
+        analyzed = e.analyze("ALTER BLOB TABLE blob.blobs REROUTE MOVE SHARD 0 FROM 'nodeOne' TO 'nodeTwo'");
+        assertThat(analyzed.tableInfo().concreteIndices().length, is(1));
+        assertThat(analyzed.tableInfo().concreteIndices()[0], is(".blob_blobs"));
+        assertThat(analyzed.isWriteOperation(), is(true));
+        analyzed = e.analyze("ALTER BLOB TABLE blobs REROUTE MOVE SHARD 0 FROM 'nodeOne' TO 'nodeTwo'");
+        assertThat(analyzed.tableInfo().concreteIndices().length, is(1));
+        assertThat(analyzed.tableInfo().concreteIndices()[0], is(".blob_blobs"));
+        assertThat(analyzed.isWriteOperation(), is(true));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/analyze/BlobTableAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/BlobTableAnalyzerTest.java
@@ -23,6 +23,7 @@ package io.crate.analyze;
 
 import io.crate.blob.v2.BlobIndicesService;
 import io.crate.exceptions.InvalidRelationName;
+import io.crate.exceptions.OperationOnInaccessibleRelationException;
 import io.crate.exceptions.RelationAlreadyExists;
 import io.crate.exceptions.RelationUnknown;
 import io.crate.metadata.RelationName;
@@ -203,5 +204,33 @@ public class BlobTableAnalyzerTest extends CrateDummyClusterServiceUnitTest {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("invalid number 'foo'");
         e.analyze("create blob table screenshots clustered into ? shards", new Object[]{"foo"});
+    }
+
+    @Test
+    public void testAlterBlobTableRename() {
+        expectedException.expect(OperationOnInaccessibleRelationException.class);
+        expectedException.expectMessage("The relation \"blob.blobs\" doesn't support or allow ALTER RENAME operations.");
+        e.analyze("alter blob table blobs rename to blobbier");
+    }
+
+    @Test
+    public void testAlterBlobTableRenameWithExplicitSchema() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("The Schema \"schema\" isn't valid in a [CREATE | ALTER] BLOB TABLE clause");
+        e.analyze("alter blob table schema.blobs rename to blobbier");
+    }
+
+    @Test
+    public void testAlterBlobTableOpenClose() throws Exception {
+        expectedException.expect(OperationOnInaccessibleRelationException.class);
+        expectedException.expectMessage("The relation \"blob.blobs\" doesn't support or allow ALTER OPEN/CLOSE operations.");
+        e.analyze("alter blob table blobs close");
+    }
+
+    @Test
+    public void testAlterBlobTableOpenCloseWithExplicitSchema() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("The Schema \"schema\" isn't valid in a [CREATE | ALTER] BLOB TABLE clause");
+        e.analyze("alter blob table schema.blob close");
     }
 }


### PR DESCRIPTION
This means that we now syntactically support queries like ALTER BLOB
TABLE OPEN, as described in our documentation. The operations themselves
are still unsupported on blob tables, but this now has the
expected/documented behaviour and will also return a useful error
message to the user, rather than an SQL syntax error.