### PR TITLE
Fix error thrown when deleting/updating an empty parted table. 

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -116,6 +116,10 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that caused an ``UnsupportedFeatureException`` to be thrown
+  when deleting or updating by query on an empty partitioned table, instead of
+  just returning 0 rows deleted/updated.
+
 - Store the correct name (``timestamptz``) for the timestamp type in the
   ``pg_type`` table.
 

--- a/sql/src/main/java/io/crate/execution/dsl/projection/SysUpdateProjection.java
+++ b/sql/src/main/java/io/crate/execution/dsl/projection/SysUpdateProjection.java
@@ -26,6 +26,7 @@ import io.crate.expression.symbol.InputColumn;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
 import io.crate.metadata.Reference;
+import io.crate.metadata.RowGranularity;
 import io.crate.types.DataType;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -88,5 +89,10 @@ public class SysUpdateProjection extends DMLProjection {
     @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), assignments);
+    }
+
+    @Override
+    public RowGranularity requiredGranularity() {
+        return RowGranularity.NODE;
     }
 }

--- a/sql/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectSource.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/sources/ShardCollectSource.java
@@ -285,7 +285,7 @@ public class ShardCollectSource extends AbstractComponent implements CollectSour
 
         RowConsumer firstConsumer = ProjectingRowConsumer.create(
             lastConsumer,
-            Projections.nodeProjections(normalizedPhase.projections()),
+            normalizedPhase.projections(),
             collectPhase.jobId(),
             collectTask.queryPhaseRamAccountingContext(),
             sharedProjectorFactory

--- a/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
+++ b/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
@@ -53,6 +53,7 @@ import io.crate.execution.engine.aggregation.AggregationContext;
 import io.crate.execution.engine.aggregation.AggregationPipe;
 import io.crate.execution.engine.aggregation.GroupingProjector;
 import io.crate.execution.engine.collect.CollectExpression;
+import io.crate.execution.engine.collect.NestableCollectExpression;
 import io.crate.execution.engine.export.FileWriterProjector;
 import io.crate.execution.engine.fetch.FetchProjector;
 import io.crate.execution.engine.fetch.FetchProjectorContext;
@@ -81,7 +82,7 @@ import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
-import io.crate.execution.engine.collect.NestableCollectExpression;
+import io.crate.metadata.RowGranularity;
 import io.crate.metadata.TransactionContext;
 import io.crate.types.StringType;
 import org.elasticsearch.Version;
@@ -174,6 +175,15 @@ public class ProjectionToProjectorVisitor
             bigArrays,
             null
         );
+    }
+
+    @Override
+    public RowGranularity supportedGranularity() {
+        if (this.shardId == null) {
+            return RowGranularity.NODE;
+        } else {
+            return RowGranularity.SHARD;
+        }
     }
 
     @Override

--- a/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectorFactory.java
+++ b/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectorFactory.java
@@ -25,10 +25,13 @@ package io.crate.execution.engine.pipeline;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.data.Projector;
 import io.crate.execution.dsl.projection.Projection;
+import io.crate.metadata.RowGranularity;
 
 import java.util.UUID;
 
 public interface ProjectorFactory {
 
     Projector create(Projection projection, RamAccountingContext ramAccountingContext, UUID jobId);
+
+    RowGranularity supportedGranularity();
 }

--- a/sql/src/test/java/io/crate/execution/engine/pipeline/ProjectingRowConsumerTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/pipeline/ProjectingRowConsumerTest.java
@@ -23,24 +23,24 @@
 package io.crate.execution.engine.pipeline;
 
 import com.google.common.collect.ImmutableList;
-import io.crate.expression.eval.EvaluatingNormalizer;
-import io.crate.expression.symbol.AggregateMode;
-import io.crate.expression.symbol.Function;
-import io.crate.expression.symbol.InputColumn;
-import io.crate.expression.symbol.Literal;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.data.BatchIterator;
 import io.crate.data.InMemoryBatchIterator;
 import io.crate.data.Row;
 import io.crate.data.RowConsumer;
 import io.crate.exceptions.UnhandledServerException;
+import io.crate.execution.TransportActionProvider;
 import io.crate.execution.dsl.projection.FilterProjection;
 import io.crate.execution.dsl.projection.GroupProjection;
 import io.crate.execution.dsl.projection.WriterProjection;
-import io.crate.expression.InputFactory;
-import io.crate.expression.operator.EqOperator;
 import io.crate.execution.jobs.NodeJobsCounter;
-import io.crate.execution.TransportActionProvider;
+import io.crate.expression.InputFactory;
+import io.crate.expression.eval.EvaluatingNormalizer;
+import io.crate.expression.operator.EqOperator;
+import io.crate.expression.symbol.AggregateMode;
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.InputColumn;
+import io.crate.expression.symbol.Literal;
 import io.crate.metadata.Functions;
 import io.crate.metadata.RowGranularity;
 import io.crate.test.integration.CrateUnitTest;
@@ -99,7 +99,7 @@ public class ProjectingRowConsumerTest extends CrateUnitTest {
                 r -> Literal.of(r.valueType(), r.valueType().value("1")),
                 null),
             t -> null,
-            t-> null,
+            t -> null,
             Version.CURRENT,
             BigArrays.NON_RECYCLING_INSTANCE,
             new ShardId("dummy", UUID.randomUUID().toString(), 0)
@@ -130,9 +130,8 @@ public class ProjectingRowConsumerTest extends CrateUnitTest {
         }
     }
 
-
     @Test
-    public void testConsumerRequiresScrollAndProjectorsDontSupportScrolling() throws Exception {
+    public void testConsumerRequiresScrollAndProjectorsDontSupportScrolling() {
         EqOperator op =
             (EqOperator) functions.getBuiltin(EqOperator.NAME, ImmutableList.of(DataTypes.INTEGER, DataTypes.INTEGER));
         Function function = new Function(op.info(), Arrays.asList(Literal.of(2), new InputColumn(1)));
@@ -148,9 +147,9 @@ public class ProjectingRowConsumerTest extends CrateUnitTest {
     }
 
     @Test
-    public void testConsumerRequiresScrollAndProjectorsSupportScrolling() throws Exception {
+    public void testConsumerRequiresScrollAndProjectorsSupportScrolling() {
         GroupProjection groupProjection = new GroupProjection(
-            new ArrayList<>(), new ArrayList<>(), AggregateMode.ITER_FINAL, RowGranularity.DOC);
+            new ArrayList<>(), new ArrayList<>(), AggregateMode.ITER_FINAL, RowGranularity.SHARD);
 
         RowConsumer delegateConsumerRequiresScroll = new DummyRowConsumer(true);
 
@@ -161,7 +160,7 @@ public class ProjectingRowConsumerTest extends CrateUnitTest {
     }
 
     @Test
-    public void testConsumerDoesNotRequireScrollYieldsProjectingConsumerWithoutScrollRequirements() throws Exception {
+    public void testConsumerDoesNotRequireScrollYieldsProjectingConsumerWithoutScrollRequirements() {
         GroupProjection groupProjection = new GroupProjection(
             new ArrayList<>(), new ArrayList<>(), AggregateMode.ITER_FINAL, RowGranularity.DOC);
         RowConsumer delegateConsumerRequiresScroll = new DummyRowConsumer(false);

--- a/sql/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
@@ -42,7 +42,6 @@ import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.hamcrest.Matchers;
-import org.junit.After;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -83,26 +82,23 @@ public class PartitionedTableConcurrentIntegrationTest extends SQLTransportInteg
         final AtomicReference<Throwable> lastThrowable = new AtomicReference<>();
         final CountDownLatch selects = new CountDownLatch(100);
 
-        Thread t = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                while (selects.getCount() > 0) {
-                    try {
-                        execute("select * from t");
-                    } catch (Throwable t) {
-                        // The failed job should have three started operations
-                        SQLResponse res = execute("select id from sys.jobs_log where error is not null order by started desc limit 1");
-                        if (res.rowCount() > 0) {
-                            String id = (String) res.rows()[0][0];
-                            res = execute("select count(*) from sys.operations_log where name=? or name = ? and job_id = ?", new Object[]{"collect", "fetchContext", id});
-                            if ((long) res.rows()[0][0] < 3) {
-                                // set the error if there where less than three attempts
-                                lastThrowable.set(t);
-                            }
+        Thread t = new Thread(() -> {
+            while (selects.getCount() > 0) {
+                try {
+                    execute("select * from t");
+                } catch (Throwable t1) {
+                    // The failed job should have three started operations
+                    SQLResponse res = execute("select id from sys.jobs_log where error is not null order by started desc limit 1");
+                    if (res.rowCount() > 0) {
+                        String id = (String) res.rows()[0][0];
+                        res = execute("select count(*) from sys.operations_log where name=? or name = ? and job_id = ?", new Object[]{"collect", "fetchContext", id});
+                        if ((long) res.rows()[0][0] < 3) {
+                            // set the error if there where less than three attempts
+                            lastThrowable.set(t1);
                         }
-                    } finally {
-                        selects.countDown();
                     }
+                } finally {
+                    selects.countDown();
                 }
             }
         });
@@ -126,39 +122,36 @@ public class PartitionedTableConcurrentIntegrationTest extends SQLTransportInteg
         nodeSwap.put(nodeIds.get(1), nodeIds.get(0));
 
         final CountDownLatch relocations = new CountDownLatch(20);
-        Thread relocatingThread = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                while (relocations.getCount() > 0) {
-                    ClusterStateResponse clusterStateResponse = admin().cluster().prepareState().setIndices(indexName).execute().actionGet();
-                    List<ShardRouting> shardRoutings = clusterStateResponse.getState().routingTable().allShards(indexName);
+        Thread relocatingThread = new Thread(() -> {
+            while (relocations.getCount() > 0) {
+                ClusterStateResponse clusterStateResponse = admin().cluster().prepareState().setIndices(indexName).execute().actionGet();
+                List<ShardRouting> shardRoutings = clusterStateResponse.getState().routingTable().allShards(indexName);
 
-                    ClusterRerouteRequestBuilder clusterRerouteRequestBuilder = admin().cluster().prepareReroute();
-                    int numMoves = 0;
-                    for (ShardRouting shardRouting : shardRoutings) {
-                        if (shardRouting.currentNodeId() == null) {
-                            continue;
-                        }
-                        if (shardRouting.state() != ShardRoutingState.STARTED) {
-                            continue;
-                        }
-                        String toNode = nodeSwap.get(shardRouting.currentNodeId());
-                        clusterRerouteRequestBuilder.add(new MoveAllocationCommand(
-                            shardRouting.getIndexName(),
-                            shardRouting.shardId().id(),
-                            shardRouting.currentNodeId(),
-                            toNode));
-                        numMoves++;
+                ClusterRerouteRequestBuilder clusterRerouteRequestBuilder = admin().cluster().prepareReroute();
+                int numMoves = 0;
+                for (ShardRouting shardRouting : shardRoutings) {
+                    if (shardRouting.currentNodeId() == null) {
+                        continue;
                     }
+                    if (shardRouting.state() != ShardRoutingState.STARTED) {
+                        continue;
+                    }
+                    String toNode = nodeSwap.get(shardRouting.currentNodeId());
+                    clusterRerouteRequestBuilder.add(new MoveAllocationCommand(
+                        shardRouting.getIndexName(),
+                        shardRouting.shardId().id(),
+                        shardRouting.currentNodeId(),
+                        toNode));
+                    numMoves++;
+                }
 
-                    if (numMoves > 0) {
-                        clusterRerouteRequestBuilder.execute().actionGet();
-                        client().admin().cluster().prepareHealth()
-                            .setWaitForEvents(Priority.LANGUID)
-                            .setWaitForNoRelocatingShards(false)
-                            .setTimeout(ACCEPTABLE_RELOCATION_TIME).execute().actionGet();
-                        relocations.countDown();
-                    }
+                if (numMoves > 0) {
+                    clusterRerouteRequestBuilder.execute().actionGet();
+                    client().admin().cluster().prepareHealth()
+                        .setWaitForEvents(Priority.LANGUID)
+                        .setWaitForNoRelocatingShards(false)
+                        .setTimeout(ACCEPTABLE_RELOCATION_TIME).execute().actionGet();
+                    relocations.countDown();
                 }
             }
         });
@@ -202,7 +195,7 @@ public class PartitionedTableConcurrentIntegrationTest extends SQLTransportInteg
     @Test
     public void testTableUnknownExceptionNotRaisedIfPartitionsDeletedAfterCountPlan() throws Exception {
         Bucket bucket = deletePartitionsAndExecutePlan("select count(*) from t");
-        assertThat((Long) bucket.iterator().next().get(0), is(0L));
+        assertThat(bucket.iterator().next().get(0), is(0L));
     }
 
     @Test
@@ -249,22 +242,19 @@ public class PartitionedTableConcurrentIntegrationTest extends SQLTransportInteg
         final AtomicReference<Exception> exceptionRef = new AtomicReference<>();
         final CountDownLatch insertLatch = new CountDownLatch(1);
         final String insertStmt = "insert into parted (id, name) values (?, ?)";
-        Thread insertThread = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    if (useBulk) {
-                        execute(insertStmt, bulkArgs);
-                    } else {
-                        for (Object[] args : bulkArgs) {
-                            execute(insertStmt, args);
-                        }
+        Thread insertThread = new Thread(() -> {
+            try {
+                if (useBulk) {
+                    execute(insertStmt, bulkArgs);
+                } else {
+                    for (Object[] args : bulkArgs) {
+                        execute(insertStmt, args);
                     }
-                } catch (Exception t) {
-                    exceptionRef.set(t);
-                } finally {
-                    insertLatch.countDown();
                 }
+            } catch (Exception t) {
+                exceptionRef.set(t);
+            } finally {
+                insertLatch.countDown();
             }
         });
 
@@ -274,24 +264,21 @@ public class PartitionedTableConcurrentIntegrationTest extends SQLTransportInteg
             Collections.singletonList(new BytesRef(String.valueOf(idToDelete)))
         ).asIndexName();
         final Object[] deleteArgs = new Object[]{idToDelete};
-        Thread deleteThread = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                boolean deleted = false;
-                while (!deleted) {
-                    try {
-                        MetaData metaData = client().admin().cluster().prepareState().execute().actionGet()
-                            .getState().metaData();
-                        if (metaData.indices().get(partitionName) != null) {
-                            execute("delete from parted where id = ?", deleteArgs);
-                            deleted = true;
-                        }
-                    } catch (Throwable t) {
-                        // ignore (mostly partition index does not exists yet)
+        Thread deleteThread = new Thread(() -> {
+            boolean deleted = false;
+            while (!deleted) {
+                try {
+                    MetaData metaData = client().admin().cluster().prepareState().execute().actionGet()
+                        .getState().metaData();
+                    if (metaData.indices().get(partitionName) != null) {
+                        execute("delete from parted where id = ?", deleteArgs);
+                        deleted = true;
                     }
+                } catch (Throwable t) {
+                    // ignore (mostly partition index does not exists yet)
                 }
-                deleteLatch.countDown();
             }
+            deleteLatch.countDown();
         });
 
         insertThread.start();

--- a/sql/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
@@ -24,6 +24,7 @@ package io.crate.integrationtests;
 
 import io.crate.data.Bucket;
 import io.crate.data.CollectionBucket;
+import io.crate.data.Row;
 import io.crate.metadata.PartitionName;
 import io.crate.metadata.RelationName;
 import io.crate.testing.SQLResponse;
@@ -176,6 +177,42 @@ public class PartitionedTableConcurrentIntegrationTest extends SQLTransportInteg
         PlanForNode plan = plan(stmt);
         execute("delete from t");
         return new CollectionBucket(execute(plan).getResult());
+    }
+
+    @Test
+    public void testExecuteDeleteAllPartitions_PartitionsAreDeletedMeanwhile() throws Exception {
+        Bucket bucket = deletePartitionsAndExecutePlan("delete from t");
+        assertThat(bucket.size(), is(1));
+        Row row = bucket.iterator().next();
+        assertThat(row.numColumns(), is(1));
+        assertThat(row.get(0), is(-1L));
+    }
+
+    @Test
+    public void testExecuteDeleteSomePartitions_PartitionsAreDeletedMeanwhile() throws Exception {
+        Bucket bucket = deletePartitionsAndExecutePlan("delete from t where name = 'Trillian'");
+        assertThat(bucket.size(), is(1));
+        Row row = bucket.iterator().next();
+        assertThat(row.numColumns(), is(1));
+        assertThat(row.get(0), is(0L));
+    }
+
+    @Test
+    public void testExecuteDeleteByQuery_PartitionsAreDeletedMeanwhile() throws Exception {
+        Bucket bucket = deletePartitionsAndExecutePlan("delete from t where p = 'a'");
+        assertThat(bucket.size(), is(1));
+        Row row = bucket.iterator().next();
+        assertThat(row.numColumns(), is(1));
+        assertThat(row.get(0), is(-1L));
+    }
+
+    @Test
+    public void testExecuteUpdate_PartitionsAreDeletedMeanwhile() throws Exception {
+        Bucket bucket = deletePartitionsAndExecutePlan("update t set name = 'BoyceCodd'");
+        assertThat(bucket.size(), is(1));
+        Row row = bucket.iterator().next();
+        assertThat(row.numColumns(), is(1));
+        assertThat(row.get(0), is(0L));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -913,7 +913,6 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
             new Object[]{2, "Don't panic", 1395961200000L});
         execute("insert into quotes (id, quote, timestamp) values(?, ?, ?)",
             new Object[]{3, "Don't panic", 1396303200000L});
-        ensureYellow();
         refresh();
 
         execute("delete from quotes where not timestamp=? and quote=?", new Object[]{1396303200000L, "Don't panic"});

--- a/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PartitionedTableIntegrationTest.java
@@ -748,6 +748,15 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
         assertThat(response.rowCount(), is(1L));
     }
 
+    @Test
+    public void testUpdateByQueryOnEmptyPartitionedTable() {
+        execute("create table empty_parted(id integer, timestamp timestamp) " +
+                "partitioned by(timestamp) with (number_of_replicas=0)");
+        ensureYellow();
+
+        execute("update empty_parted set id = 10 where timestamp = 1396303200000");
+        assertThat(response.rowCount(), is(0L));
+    }
 
     @Test
     public void testDeleteFromPartitionedTable() throws Exception {
@@ -919,6 +928,16 @@ public class PartitionedTableIntegrationTest extends SQLTransportIntegrationTest
         refresh();
         execute("select * from quotes");
         assertThat(response.rowCount(), is(1L));
+    }
+
+    @Test
+    public void testDeleteByQueryFromEmptyPartitionedTable() {
+        execute("create table empty_parted (id integer, timestamp timestamp) " +
+                "partitioned by(timestamp) with (number_of_replicas=0)");
+        ensureYellow();
+
+        execute("delete from empty_parted where not timestamp = 1396303200000");
+        assertThat(response.rowCount(), is(0L));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/SelectPlannerTest.java
@@ -461,7 +461,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
                 .collect(Collectors.toList()),
             contains(
                 is(".partitioned.parted.04732cpp6ksjcc9i60o30c1g")
-        ));
+            ));
     }
 
     @Test
@@ -548,17 +548,17 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void test3TableJoinQuerySplitting() throws Exception {
         QueryThenFetch qtf = e.plan("select" +
-                                  "  u1.id as u1, " +
-                                  "  u2.id as u2, " +
-                                  "  u3.id as u3 " +
-                                  "from " +
-                                  "  users u1," +
-                                  "  users u2," +
-                                  "  users u3 " +
-                                  "where " +
-                                  "  u1.name = 'Arthur'" +
-                                  "  and u2.id = u1.id" +
-                                  "  and u2.name = u1.name");
+                                    "  u1.id as u1, " +
+                                    "  u2.id as u2, " +
+                                    "  u3.id as u3 " +
+                                    "from " +
+                                    "  users u1," +
+                                    "  users u2," +
+                                    "  users u3 " +
+                                    "where " +
+                                    "  u1.name = 'Arthur'" +
+                                    "  and u2.id = u1.id" +
+                                    "  and u2.name = u1.name");
         Join outerNl = (Join) qtf.subPlan();
         Join innerNl = (Join) outerNl.left();
 
@@ -577,9 +577,9 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         // disable hash joins otherwise it will be a distributed join and the plan differs
         e.getSessionContext().setHashJoinEnabled(false);
         QueryThenFetch qtf = e.plan("select u1.text, u2.text " +
-                                  "from users u1 left join users u2 on u1.id = u2.id " +
-                                  "where u2.name = 'Arthur'" +
-                                  "and u2.id > 1 ");
+                                    "from users u1 left join users u2 on u1.id = u2.id " +
+                                    "where u2.name = 'Arthur'" +
+                                    "and u2.id > 1 ");
         Join nl = (Join) ((Merge) qtf.subPlan()).subPlan();
         assertThat(nl.joinPhase().joinType(), is(JoinType.INNER));
         Collect rightCM = (Collect) nl.right();
@@ -663,7 +663,7 @@ public class SelectPlannerTest extends CrateDummyClusterServiceUnitTest {
         assertThat(innerNL.joinPhase().outputTypes().get(0), is(DataTypes.LONG));
 
         plan = e.plan("select count(t1.other_id) from users t1, users t2, users t3 " +
-                            "where t1.id = t2.id and t2.id = t3.id");
+                      "where t1.id = t2.id and t2.id = t3.id");
         assertThat(plan.subPlan(), instanceOf(Join.class));
         outerNL = (Join)plan.subPlan();
         assertThat(outerNL.joinPhase().joinCondition(), isSQL("(INPUT(2) = INPUT(3))"));

--- a/sql/src/test/java/io/crate/planner/consumer/GroupByPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/consumer/GroupByPlannerTest.java
@@ -547,7 +547,7 @@ public class GroupByPlannerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testNonDistributedGroupByProjectionHasShardLevelGranularity() throws Exception {
         Merge distributedGroupByMerge = e.plan("select count(distinct id), name from users" +
-                                                       " group by name order by count(distinct id)");
+                                               " group by name order by count(distinct id)");
         Merge reduceMerge = (Merge) distributedGroupByMerge.subPlan();
         CollectPhase collectPhase = ((Collect) reduceMerge.subPlan()).collectPhase();
         assertThat(collectPhase.projections().size(), is(1));
@@ -619,10 +619,10 @@ public class GroupByPlannerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testNestedGroupByAggregation() throws Exception {
         Collect collect = e.plan("select count(*) from (" +
-                             "  select max(load['1']) as maxLoad, hostname " +
-                             "  from sys.nodes " +
-                             "  group by hostname having max(load['1']) > 50) as nodes " +
-                             "group by hostname");
+                                 "  select max(load['1']) as maxLoad, hostname " +
+                                 "  from sys.nodes " +
+                                 "  group by hostname having max(load['1']) > 50) as nodes " +
+                                 "group by hostname");
         assertThat("would require merge if more than 1 nodeIds", collect.nodeIds().size(), is(1));
 
         CollectPhase collectPhase = collect.collectPhase();


### PR DESCRIPTION
This is an alternative fix to https://github.com/crate/crate/pull/7465
Since this change is big in terms of plans, I'd like some feedback before proceeding and adapting all unit tests.

The idea is that when operating on a table with no shards -> emptyCollectSource we don't use the ProjectionToProjectorVisitor any more so there is no projection added to the rowConsumer.

This fixes the issue with DELETE/UPDATE on an empty partitioned table, but creates an issue with Aggregations and GroupBy aggregations: The issue is that if there is an empty table, since no projection is added, we always need a final Merge phase with a final AggregationProjection that will convert the 0 rows to: `count=0` or `min(col) = null`, etc.