### PR TITLE
WIP: Reduce chance of JobKilled errors on high load nodes

### DIFF
--- a/sql/src/main/java/io/crate/execution/engine/distribution/TransportDistributedResultAction.java
+++ b/sql/src/main/java/io/crate/execution/engine/distribution/TransportDistributedResultAction.java
@@ -179,6 +179,9 @@ public class TransportDistributedResultAction extends AbstractComponent implemen
             scheduler.schedule(operationRunnable::run, delay.getMillis(), TimeUnit.MILLISECONDS);
             return operationRunnable;
         } else {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Terminating job={} received result but job context was missing", request.jobId());
+            }
             List<String> excludedNodeIds = Collections.singletonList(clusterService.localNode().getId());
             /* The upstream (DistributingConsumer) forwards failures to other downstreams and eventually considers its job done.
              * But it cannot inform the handler-merge about a failure because the JobResponse is sent eagerly.

--- a/sql/src/main/java/io/crate/execution/jobs/transport/TransportJobAction.java
+++ b/sql/src/main/java/io/crate/execution/jobs/transport/TransportJobAction.java
@@ -24,11 +24,11 @@ package io.crate.execution.jobs.transport;
 
 import io.crate.concurrent.CompletableFutures;
 import io.crate.data.Bucket;
-import io.crate.execution.jobs.JobSetup;
 import io.crate.execution.jobs.InstrumentedIndexSearcher;
+import io.crate.execution.jobs.JobSetup;
 import io.crate.execution.jobs.RootTask;
-import io.crate.execution.jobs.TasksService;
 import io.crate.execution.jobs.SharedShardContexts;
+import io.crate.execution.jobs.TasksService;
 import io.crate.execution.support.NodeAction;
 import io.crate.execution.support.NodeActionRequestHandler;
 import io.crate.execution.support.Transports;
@@ -72,6 +72,8 @@ public class TransportJobAction implements NodeAction<JobRequest, JobResponse> {
             ACTION_NAME,
             JobRequest::new,
             EXECUTOR,
+            true,
+            true,
             new NodeActionRequestHandler<>(this));
     }
 


### PR DESCRIPTION
This changes the `TransportJobAction` request handling to force
execution even if the `Search` threadpool is already full.

Queries will still fail a bit later if the pool is full when the
operation is dispatched again within `task.start()`. But this will make
sure that merge tasks are being setup so that results sent from other
nodes can be received.