### PR TITLE
Add support for multiline comments

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -42,6 +42,8 @@ Breaking Changes
 Changes
 =======
 
+- Added support for multi line SQL comments, e.g. ``/* multi line */``.
+
 - Improved performance of queries using an array access inside the ``WHERE``
   clause. E.g.::
 

--- a/blackbox/docs/sql/general/lexical-structure.rst
+++ b/blackbox/docs/sql/general/lexical-structure.rst
@@ -157,13 +157,15 @@ described.
 Comments
 ========
 
-An SQL input can contain comments. Comments are not implemented on the server
-side, but the `crash`_ command line interface ignores single line comments.
-Single line comments start with a double dash (``--``) and end at the end of
-that line.
+An SQL statement can contain comments. Single line comments start with a double
+dash (``--``) and end at the end of that line. Multi line comments start with
+``/*`` and end with ``*/``.
 
 Example::
 
+  /*
+   * Retrieve information about all tables in the 'doc' schema.
+   */
   SELECT *
     FROM information_schema.tables
     WHERE table_schema = 'doc'; -- query information schema for doc tables

--- a/sql-parser/src/main/antlr/SqlBase.g4
+++ b/sql-parser/src/main/antlr/SqlBase.g4
@@ -946,7 +946,7 @@ fragment LETTER
     ;
 
 COMMENT
-    : '--' ~[\r\n]* '\r'? '\n'? -> channel(HIDDEN)
+    : ('--' ~[\r\n]* '\r'? '\n'? | '/*' .*? '*/') -> channel(HIDDEN)
     ;
 
 WS

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestSqlParser.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestSqlParser.java
@@ -47,6 +47,52 @@ public class TestSqlParser {
     public ExpectedException expectedException = ExpectedException.none();
 
     @Test
+    public void testComments() {
+        assertThat(
+            SqlParser.createStatement("-- this is a line comment\nSelect 1"),
+            instanceOf(Query.class));
+        assertThat(
+            SqlParser.createStatement("Select 1\n-- this is a line comment"),
+            instanceOf(Query.class));
+        assertThat(
+            SqlParser.createStatement("-- this is a line comment\nSelect 1\n-- this is a line comment"),
+            instanceOf(Query.class));
+        assertThat(
+            SqlParser.createStatement("-- this is a line comment\nSelect \n-- this is a line comment\n1"),
+            instanceOf(Query.class));
+        assertThat(
+            SqlParser.createStatement("/* this\n" +
+                                  "       is a multiline\n" +
+                                  "       comment\n" +
+                                  "    */\nSelect 1;"),
+            instanceOf(Query.class));
+        assertThat(
+            SqlParser.createStatement("Select 1;" +
+                                  "    /* this\n" +
+                                  "       is a multiline\n" +
+                                  "       comment\n" +
+                                  "    */"),
+            instanceOf(Query.class));
+        assertThat(
+            SqlParser.createStatement("Select" +
+                                             "    /* this\n" +
+                                             "       is a multiline\n" +
+                                             "       comment\n" +
+                                             "    */" +
+                                             "1"),
+            instanceOf(Query.class));
+        assertThat(
+            SqlParser.createStatement("Select" +
+                                      "    /* this\n" +
+                                      "       is a multiline\n" +
+                                      "       comment\n" +
+                                      "    */\n" +
+                                      "-- line comment\n" +
+                                      "1"),
+            instanceOf(Query.class));
+    }
+
+    @Test
     public void testPossibleExponentialBacktracking()
         throws Exception {
         SqlParser.createExpression("(((((((((((((((((((((((((((true)))))))))))))))))))))))))))");


### PR DESCRIPTION
This enables to use multiline comments like

```
/* this
   is a multiline
   comment
*/
-- this is a line comment
select 1
```

Co-authored-by: Emily Woods <emily@crate.io>