### PR TITLE
Drop support for AWS credentials using env vars and java props & enable s3.client.default.access/secret_key settings

### DIFF
--- a/app/src/main/dist/config/crate.yml
+++ b/app/src/main/dist/config/crate.yml
@@ -828,6 +828,11 @@ auth:
 # "file" urls must be prefixed with an entry configured in ``path.repo``
 #repositories.url.allowed_urls: ["http://example.org/root/*", "https://*.mydomain.com/*?*#*"]
 
+# If S3 buckets are used for snapshot repositories the following settings provide
+# default credentials to be used if no credentials are defined as parameters in the
+# SQL  ``CREATE REPOSITORY`` statement.
+#s3.client.default.access_key: Access_Key
+#s3.client.default.secret_key: Secret_Key
 
 ###################### POSTGRES WIRE PROTOCOL SUPPORT ########################
 

--- a/blackbox/docs/appendices/release-notes/3.0.0.rst
+++ b/blackbox/docs/appendices/release-notes/3.0.0.rst
@@ -72,7 +72,13 @@ Breaking Changes
   immediatelly after restart.
 
 - The discovery setting ``discovery.type`` has been removed. To enable EC2
-  discovery, the ``discovery.zen.hosts_provider`` setting must be set to ``ec2``.
+  discovery, the ``discovery.zen.hosts_provider`` setting must be set to
+  ``ec2``.
+
+- Dropped support for reading AWS credentials used for S3 and EC2 discovery
+  from environment variables ``AWS_ACCESS_KEY_ID`` and
+  ``AWS_SECRET_ACCESS_KEY`` as well as java system properties
+  ``aws.accessKeyId`` and ``aws.secretKey``.
 
 - EC2 ``cloud.aws.*`` settings have been renamed to ``discovery.ec2.*``.
 

--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -42,6 +42,11 @@ Breaking Changes
 Changes
 =======
 
+- Added settings ``s3.client.default.access_key`` and
+  ``s3.client.default.secret_key`` which can be used to set default credentials
+  for s3 repositories, if they are not passed as parameters to the
+  ``CREATE REPOSITORY`` SQL statement.
+
 - Added support for multi line SQL comments, e.g. ``/* multi line */``.
 
 - Improved performance of queries using an array access inside the ``WHERE``

--- a/blackbox/docs/config/cluster.rst
+++ b/blackbox/docs/config/cluster.rst
@@ -447,10 +447,6 @@ discovery the ``discovery.zen.hosts_provider`` settings needs to be set to
 
   The secret key to identify the API calls.
 
-Note that the AWS credentials can also be provided by environment variables
-``AWS_ACCESS_KEY_ID`` and ``AWS_SECRET_KEY`` or via system properties
-``aws.accessKeyId`` and ``aws.secretKey``.
-
 Following settings control the discovery:
 
 .. _discovery_ec2_groups:

--- a/blackbox/docs/config/cluster.rst
+++ b/blackbox/docs/config/cluster.rst
@@ -1067,3 +1067,37 @@ Metadata Gateway
   because you only want the cluster state to be recovered once all nodes are
   started. However, the value must be bigger than the half of the expected
   number of nodes in the cluster.
+
+.. _s3-credentials:
+
+Credentials for S3 Repositories
+...............................
+
+CrateDB has built-in support for configuring
+:ref:`S3 buckets as repositories for snapshots
+<ref-create-repository-types-s3>`. If no credentials are provided as parameters
+to the SQL statement the following default credentials will be used:
+
+.. _s3-credentials-access-key:
+
+**s3.client.default.access_key**
+  | *Runtime:*  ``no``
+
+  The access key ID to identify the API calls.
+
+.. _s3-credentials-secret-key:
+
+**s3.client.default.secret_key**
+  | *Runtime:*  ``no``
+
+  The secret key to identify the API calls.
+
+
+.. TIP::
+
+   Configuring the settings above in the ``crate.yml`` file, is an easy way to
+   prevent credentials from being exposed.
+
+   If a repository is created with the credentials passed as parameters to the
+   SQL statement, then those credentials will be visible as plain text to
+   anyone querying the :ref:`sys.repositories table <sys-repositories>`.

--- a/blackbox/docs/sql/statements/copy-from.rst
+++ b/blackbox/docs/sql/statements/copy-from.rst
@@ -130,13 +130,6 @@ Can be used to access buckets on the Amazon AWS S3 Service:
 
     s3://[<accesskey>:<secretkey>@]<bucketname>/<path>
 
-If ``accesskey`` and ``secretkey`` are ommited, CrateDB attempts to load the
-credentials from the environment or Java settings.
-
-Environment Variables - ``AWS_ACCESS_KEY_ID`` and ``AWS_SECRET_ACCESS_KEY``
-
-Java System Properties - ``aws.accessKeyId`` and ``aws.secretKey``
-
 If no credentials are set the s3 client will operate in anonymous mode, see
 `AWS Java Documentation`_.
 

--- a/blackbox/docs/sql/statements/copy-to.rst
+++ b/blackbox/docs/sql/statements/copy-to.rst
@@ -75,11 +75,6 @@ The resulting string should be a valid URI of one of the supporting schemes:
 If no scheme is given (e.g.: '/path/to/dir') the default uri-scheme ``file://``
 will be used.
 
-If the s3 scheme is used without specifying any credentials an attempt is made
-to read these information from the AWS_ACCESS_KEY_ID and AWS_SECRET_KEY
-environment variables. In addition to that the Java System properties
-aws.accessKeyId and aws.secretKey are also used as a fallback.
-
 .. NOTE::
 
    A ``secretkey`` provided by Amazon Web Service can contain characters such

--- a/blackbox/docs/sql/statements/create-repository.rst
+++ b/blackbox/docs/sql/statements/create-repository.rst
@@ -230,7 +230,6 @@ A repository that stores its snapshot on the Amazon S3 service.
 
 **access_key**
   | *Type:*    ``string``
-  | *Default:* Globally defined environmental variable ``AWS_ACCESS_KEY_ID``.
 
   Access key used for authentication against AWS.
 
@@ -241,7 +240,6 @@ A repository that stores its snapshot on the Amazon S3 service.
 
 **secret_key**
   | *Type:*    ``string``
-  | *Default:* Globally defined environmental variable ``AWS_SECRET_KEY``.
 
   Secret key used for authentication against AWS.
 

--- a/blackbox/docs/sql/statements/create-repository.rst
+++ b/blackbox/docs/sql/statements/create-repository.rst
@@ -230,23 +230,29 @@ A repository that stores its snapshot on the Amazon S3 service.
 
 **access_key**
   | *Type:*    ``string``
+  | *Default:* Value defined through :ref:`s3.client.default.access_key
+        <s3-credentials-access-key>` setting.
 
   Access key used for authentication against AWS.
 
   .. WARNING::
 
-     If the access key is set explicity (not via environment variable) it will
-     be visible in plain text when querying the ``sys.repositories`` table.
+     If the secret key is set explicitly (not via :ref:`configuration setting
+     <s3-credentials-access-key>`) it will be visible in plain text when
+     querying the ``sys.repositories`` table.
 
 **secret_key**
   | *Type:*    ``string``
+  | *Default:* Value defined through :ref:`s3.client.default.secret_key
+     <s3-credentials-secret-key>` setting.
 
   Secret key used for authentication against AWS.
 
   .. WARNING::
 
-     If the secret key is set explicity (not via environment variable) it will
-     be visible in plain text when querying the ``sys.repositories`` table.
+     If the secret key is set explicitly (not via :ref:`configuration setting
+     <s3-credentials-secret-key>`) it will be visible in plain text when
+     querying the ``sys.repositories`` table.
 
 **concurrent_streams**
   | *Type:*    ``integer``


### PR DESCRIPTION
Please check commit messages.