### PR TITLE
Strict implicit conversion of numeric data types

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -308,7 +308,7 @@ installDist {
 
 ext {
     downloadDir = new File(buildDir, 'downloads')
-    adminui_version = '1.10.2'
+    adminui_version = '1.10.3'
 }
 
 def rootDir = project.parent.projectDir

--- a/blackbox/docs/admin/auth/hba.rst
+++ b/blackbox/docs/admin/auth/hba.rst
@@ -8,8 +8,8 @@ This section explains how to configure CrateDB client connection and
 authentication.
 
 By default, the boolean setting ``auth.host_based.enabled`` is ``false`` and
-therefore host based authentication is disabled. In this instance, the CrateDB
-cluster allows any unauthenticated connections.
+therefore host based authentication is disabled.
+In this instance, the CrateDB cluster allows any unauthenticated connections.
 
 To allow authenticated access to CrateDB from specific hosts, you need to set
 the ``auth.host_based.enabled`` setting in the ``crate.yml`` to ``true`` and
@@ -19,8 +19,22 @@ See: :ref:`applying-cluster-settings`.
 
 .. NOTE::
 
+   The ``crate.yml`` that is shipped with CrateDB explicitly enables host based
+   authentication and defines a set of sane rules, which take effect in case
+   HBA and Enterprise features are enabled.
+
    Host Based Authentication is an
    :ref:`enterprise feature <enterprise_features>`.
+
+.. TIP::
+
+   If you want to use Enterprise features, but do not require authentication,
+   you need to set ``auth.host_based.enabled`` to ``false``. However,
+   additionally you still need to provide the user ``crate`` when connecting to
+   CrateDB via the Postgres protocol, since the Enterprise version
+   automatically enables user management. HTTP uses
+   :ref:`auth.trust.http_default_user<auth_trust_http_default_user>` if no user
+   is provided.
 
 .. rubric:: Table of Contents
 

--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -42,6 +42,9 @@ Breaking Changes
 Changes
 =======
 
+- Disallowed implicit casts of numeric data types which could lead to a loss of
+  precision.
+
 - Added settings ``s3.client.default.access_key`` and
   ``s3.client.default.secret_key`` which can be used to set default credentials
   for s3 repositories, if they are not passed as parameters to the

--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -116,6 +116,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue where the Admin UI was not loaded when it was served from
+  another location than ``/`` resulting in a blank browser canvas.
+
 - Made table setting ``blocks.read_only_allow_delete`` configurable for
   partitioned tables.
 

--- a/core/src/main/java/io/crate/types/ArrayType.java
+++ b/core/src/main/java/io/crate/types/ArrayType.java
@@ -51,7 +51,7 @@ public class ArrayType extends CollectionType {
     }
 
     @Override
-    public Object[] value(Object value) {
+    public Object[] value(Object value, boolean lossless) {
         // We can pass in Collections and Arrays here but we always
         // have to return arrays since a lot of code makes assumptions
         // about this.
@@ -64,7 +64,7 @@ public class ArrayType extends CollectionType {
             result = new Object[values.size()];
             int idx = 0;
             for (Object o : values) {
-                result[idx] = innerType.value(o);
+                result[idx] = innerType.value(o, lossless);
                 idx++;
             }
         } else {
@@ -72,7 +72,7 @@ public class ArrayType extends CollectionType {
             result = new Object[values.length];
             int idx = 0;
             for (Object o : values) {
-                result[idx] = innerType.value(o);
+                result[idx] = innerType.value(o, lossless);
                 idx++;
             }
         }

--- a/core/src/main/java/io/crate/types/BooleanType.java
+++ b/core/src/main/java/io/crate/types/BooleanType.java
@@ -68,7 +68,7 @@ public class BooleanType extends DataType<Boolean> implements Streamer<Boolean>,
     }
 
     @Override
-    public Boolean value(Object value) {
+    public Boolean value(Object value, boolean lossless) {
         if (value == null) {
             return null;
         }

--- a/core/src/main/java/io/crate/types/ByteType.java
+++ b/core/src/main/java/io/crate/types/ByteType.java
@@ -57,7 +57,7 @@ public class ByteType extends DataType<Byte> implements Streamer<Byte>, FixedWid
     }
 
     @Override
-    public Byte value(Object value) {
+    public Byte value(Object value, boolean lossless) {
         if (value == null) {
             return null;
         }
@@ -71,7 +71,21 @@ public class ByteType extends DataType<Byte> implements Streamer<Byte>, FixedWid
         if (val < Byte.MIN_VALUE || Byte.MAX_VALUE < val) {
             throw new IllegalArgumentException("byte value out of range: " + val);
         }
-        return (byte) val;
+        Byte byteValue = ((Number) value).byteValue();
+        if (lossless) {
+            if (value instanceof Float && byteValue.floatValue() != (float) value) {
+                throw new IllegalArgumentException("Loss of precision for this float");
+            } else if (value instanceof Double && byteValue.doubleValue() != (double) value) {
+                throw new IllegalArgumentException("Loss of precision for this double");
+            } else if (value instanceof Short && byteValue.shortValue() != (short) value) {
+                throw new IllegalArgumentException("Loss of precision for this int");
+            } else if (value instanceof Integer && byteValue.intValue() != (int) value) {
+                throw new IllegalArgumentException("Loss of precision for this int");
+            } else if (value instanceof Long && byteValue.longValue() != (long) value) {
+                throw new IllegalArgumentException("Loss of precision for this long");
+            }
+        }
+        return byteValue;
     }
 
     @Override

--- a/core/src/main/java/io/crate/types/ByteType.java
+++ b/core/src/main/java/io/crate/types/ByteType.java
@@ -71,17 +71,17 @@ public class ByteType extends DataType<Byte> implements Streamer<Byte>, FixedWid
         if (val < Byte.MIN_VALUE || Byte.MAX_VALUE < val) {
             throw new IllegalArgumentException("byte value out of range: " + val);
         }
-        Byte byteValue = ((Number) value).byteValue();
+        byte byteValue = ((Number) value).byteValue();
         if (lossless) {
-            if (value instanceof Float && byteValue.floatValue() != (float) value) {
+            if (value instanceof Float && (float) byteValue != (float) value) {
                 throw new IllegalArgumentException("Loss of precision for this float");
-            } else if (value instanceof Double && byteValue.doubleValue() != (double) value) {
+            } else if (value instanceof Double && (double) byteValue != (double) value) {
                 throw new IllegalArgumentException("Loss of precision for this double");
-            } else if (value instanceof Short && byteValue.shortValue() != (short) value) {
+            } else if (value instanceof Short && (short) byteValue != (short) value) {
                 throw new IllegalArgumentException("Loss of precision for this int");
-            } else if (value instanceof Integer && byteValue.intValue() != (int) value) {
+            } else if (value instanceof Integer && (int) byteValue != (int) value) {
                 throw new IllegalArgumentException("Loss of precision for this int");
-            } else if (value instanceof Long && byteValue.longValue() != (long) value) {
+            } else if (value instanceof Long && (long) byteValue != (long) value) {
                 throw new IllegalArgumentException("Loss of precision for this long");
             }
         }

--- a/core/src/main/java/io/crate/types/DataType.java
+++ b/core/src/main/java/io/crate/types/DataType.java
@@ -78,7 +78,19 @@ public abstract class DataType<T> implements Comparable, Streamable {
 
     public abstract Streamer<T> streamer();
 
-    public abstract T value(Object value) throws IllegalArgumentException, ClassCastException;
+    /**
+     * Converts/Casts the given object into an object matching this DataType.
+     * @param value The input value to convert
+     * @param lossless Whether the conversion should throw an exception if loss of precision occurred.
+     * @return The converted Object
+     * @throws IllegalArgumentException if the value can't be converted.
+     * @throws ClassCastException if an unexpected value was provided.
+     */
+    public abstract T value(Object value, boolean lossless) throws IllegalArgumentException, ClassCastException;
+
+    public final T value(Object value) throws IllegalArgumentException, ClassCastException {
+        return value(value, true);
+    }
 
     public abstract int compareValueTo(T val1, T val2);
 

--- a/core/src/main/java/io/crate/types/DoubleType.java
+++ b/core/src/main/java/io/crate/types/DoubleType.java
@@ -57,7 +57,7 @@ public class DoubleType extends DataType<Double> implements FixedWidthType, Stre
     }
 
     @Override
-    public Double value(Object value) {
+    public Double value(Object value, boolean lossless) {
         if (value == null) {
             return null;
         }

--- a/core/src/main/java/io/crate/types/FloatType.java
+++ b/core/src/main/java/io/crate/types/FloatType.java
@@ -57,7 +57,7 @@ public class FloatType extends DataType<Float> implements Streamer<Float>, Fixed
     }
 
     @Override
-    public Float value(Object value) {
+    public Float value(Object value, boolean lossless) {
         if (value == null) {
             return null;
         }

--- a/core/src/main/java/io/crate/types/GeoPointType.java
+++ b/core/src/main/java/io/crate/types/GeoPointType.java
@@ -68,7 +68,7 @@ public class GeoPointType extends DataType<Double[]> implements Streamer<Double[
     }
 
     @Override
-    public Double[] value(Object value) {
+    public Double[] value(Object value, boolean lossless) {
         if (value == null) {
             return null;
         }

--- a/core/src/main/java/io/crate/types/GeoShapeType.java
+++ b/core/src/main/java/io/crate/types/GeoShapeType.java
@@ -63,7 +63,7 @@ public class GeoShapeType extends DataType<Map<String, Object>> implements Strea
     }
 
     @Override
-    public Map<String, Object> value(Object value) throws IllegalArgumentException, ClassCastException {
+    public Map<String, Object> value(Object value, boolean lossless) throws IllegalArgumentException, ClassCastException {
         if (value == null) {
             return null;
         }

--- a/core/src/main/java/io/crate/types/IntegerType.java
+++ b/core/src/main/java/io/crate/types/IntegerType.java
@@ -57,7 +57,7 @@ public class IntegerType extends DataType<Integer> implements Streamer<Integer>,
     }
 
     @Override
-    public Integer value(Object value) {
+    public Integer value(Object value, boolean lossless) {
         if (value == null) {
             return null;
         }
@@ -70,12 +70,19 @@ public class IntegerType extends DataType<Integer> implements Streamer<Integer>,
         if (value instanceof BytesRef) {
             return Integer.parseInt(((BytesRef) value).utf8ToString());
         }
-
         long longVal = ((Number) value).longValue();
         if (longVal < Integer.MIN_VALUE || Integer.MAX_VALUE < longVal) {
             throw new IllegalArgumentException("integer value out of range: " + longVal);
         }
-        return ((Number) value).intValue();
+        Integer intValue = ((Number) value).intValue();
+        if (lossless) {
+            if (value instanceof Double && intValue.doubleValue() != (double) value) {
+                throw new IllegalArgumentException("Loss of precision for this double");
+            } else if (value instanceof Float && intValue.floatValue() != (float) value) {
+                throw new IllegalArgumentException("Loss of precision for this float");
+            }
+        }
+        return intValue;
     }
 
     @Override

--- a/core/src/main/java/io/crate/types/IntegerType.java
+++ b/core/src/main/java/io/crate/types/IntegerType.java
@@ -74,11 +74,11 @@ public class IntegerType extends DataType<Integer> implements Streamer<Integer>,
         if (longVal < Integer.MIN_VALUE || Integer.MAX_VALUE < longVal) {
             throw new IllegalArgumentException("integer value out of range: " + longVal);
         }
-        Integer intValue = ((Number) value).intValue();
+        int intValue = ((Number) value).intValue();
         if (lossless) {
-            if (value instanceof Double && intValue.doubleValue() != (double) value) {
+            if (value instanceof Double && (double) intValue != (double) value) {
                 throw new IllegalArgumentException("Loss of precision for this double");
-            } else if (value instanceof Float && intValue.floatValue() != (float) value) {
+            } else if (value instanceof Float && (float) intValue != (float) value) {
                 throw new IllegalArgumentException("Loss of precision for this float");
             }
         }

--- a/core/src/main/java/io/crate/types/IpType.java
+++ b/core/src/main/java/io/crate/types/IpType.java
@@ -37,7 +37,7 @@ public class IpType extends StringType {
     }
 
     @Override
-    public BytesRef value(Object value) {
+    public BytesRef value(Object value, boolean lossless) {
         if (value == null) {
             return null;
         }

--- a/core/src/main/java/io/crate/types/LongType.java
+++ b/core/src/main/java/io/crate/types/LongType.java
@@ -67,11 +67,11 @@ public class LongType extends DataType<Long> implements FixedWidthType, Streamer
         if (value instanceof BytesRef) {
             return parseLong((BytesRef) value);
         }
-        Long longValue = ((Number) value).longValue();
+        long longValue = ((Number) value).longValue();
         if (lossless) {
-            if (value instanceof Double && longValue.doubleValue() != (double) value) {
+            if (value instanceof Double && (double) longValue != (double) value) {
                 throw new IllegalArgumentException("Loss of precision for this double");
-            } else if (value instanceof Float && longValue.floatValue() != (float) value) {
+            } else if (value instanceof Float && (float) longValue != (float) value) {
                 throw new IllegalArgumentException("Loss of precision for this float");
             }
         }

--- a/core/src/main/java/io/crate/types/LongType.java
+++ b/core/src/main/java/io/crate/types/LongType.java
@@ -54,7 +54,7 @@ public class LongType extends DataType<Long> implements FixedWidthType, Streamer
     }
 
     @Override
-    public Long value(Object value) {
+    public Long value(Object value, boolean lossless) {
         if (value == null) {
             return null;
         }
@@ -67,7 +67,15 @@ public class LongType extends DataType<Long> implements FixedWidthType, Streamer
         if (value instanceof BytesRef) {
             return parseLong((BytesRef) value);
         }
-        return ((Number) value).longValue();
+        Long longValue = ((Number) value).longValue();
+        if (lossless) {
+            if (value instanceof Double && longValue.doubleValue() != (double) value) {
+                throw new IllegalArgumentException("Loss of precision for this double");
+            } else if (value instanceof Float && longValue.floatValue() != (float) value) {
+                throw new IllegalArgumentException("Loss of precision for this float");
+            }
+        }
+        return longValue;
     }
 
     /**

--- a/core/src/main/java/io/crate/types/NotSupportedType.java
+++ b/core/src/main/java/io/crate/types/NotSupportedType.java
@@ -57,8 +57,8 @@ public class NotSupportedType extends DataType<Void> {
     }
 
     @Override
-    public Void value(Object value) {
-        return null;
+    public Void value(Object value, boolean lossless) {
+        throw new IllegalStateException("Can't convert to unsupported type");
     }
 
     @Override

--- a/core/src/main/java/io/crate/types/ObjectType.java
+++ b/core/src/main/java/io/crate/types/ObjectType.java
@@ -63,7 +63,7 @@ public class ObjectType extends DataType<Map<String, Object>> implements Streame
 
     @Override
     @SuppressWarnings("unchecked")
-    public Map<String, Object> value(Object value) {
+    public Map<String, Object> value(Object value, boolean lossless) {
         if (value instanceof BytesRef) {
             return mapFromBytesRef((BytesRef) value);
         }

--- a/core/src/main/java/io/crate/types/SetType.java
+++ b/core/src/main/java/io/crate/types/SetType.java
@@ -60,7 +60,7 @@ public class SetType extends CollectionType {
     }
 
     @Override
-    public Set<?> value(Object value) {
+    public Set<?> value(Object value, boolean lossless) {
         if (value instanceof Set) {
             return (Set) value;
         }

--- a/core/src/main/java/io/crate/types/ShortType.java
+++ b/core/src/main/java/io/crate/types/ShortType.java
@@ -57,7 +57,7 @@ public class ShortType extends DataType<Short> implements Streamer<Short>, Fixed
     }
 
     @Override
-    public Short value(Object value) {
+    public Short value(Object value, boolean lossless) {
         if (value == null) {
             return null;
         }
@@ -74,7 +74,19 @@ public class ShortType extends DataType<Short> implements Streamer<Short>, Fixed
         if (intVal < Short.MIN_VALUE || Short.MAX_VALUE < intVal) {
             throw new IllegalArgumentException("short value out of range: " + intVal);
         }
-        return ((Number) value).shortValue();
+        Short shortValue = ((Number) value).shortValue();
+        if (lossless) {
+            if (value instanceof Float && shortValue.floatValue() != (float) value) {
+                throw new IllegalArgumentException("Loss of precision for this float");
+            } else if (value instanceof Double && shortValue.doubleValue() != (double) value) {
+                throw new IllegalArgumentException("Loss of precision for this double");
+            } else if (value instanceof Integer && shortValue.intValue() != (int) value) {
+                throw new IllegalArgumentException("Loss of precision for this int");
+            } else if (value instanceof Long && shortValue.longValue() != (long) value) {
+                throw new IllegalArgumentException("Loss of precision for this long");
+            }
+        }
+        return shortValue;
     }
 
     @Override

--- a/core/src/main/java/io/crate/types/ShortType.java
+++ b/core/src/main/java/io/crate/types/ShortType.java
@@ -74,15 +74,15 @@ public class ShortType extends DataType<Short> implements Streamer<Short>, Fixed
         if (intVal < Short.MIN_VALUE || Short.MAX_VALUE < intVal) {
             throw new IllegalArgumentException("short value out of range: " + intVal);
         }
-        Short shortValue = ((Number) value).shortValue();
+        short shortValue = ((Number) value).shortValue();
         if (lossless) {
-            if (value instanceof Float && shortValue.floatValue() != (float) value) {
+            if (value instanceof Float && (float) shortValue != (float) value) {
                 throw new IllegalArgumentException("Loss of precision for this float");
-            } else if (value instanceof Double && shortValue.doubleValue() != (double) value) {
+            } else if (value instanceof Double && (double) shortValue != (double) value) {
                 throw new IllegalArgumentException("Loss of precision for this double");
-            } else if (value instanceof Integer && shortValue.intValue() != (int) value) {
+            } else if (value instanceof Integer && (int) shortValue != (int) value) {
                 throw new IllegalArgumentException("Loss of precision for this int");
-            } else if (value instanceof Long && shortValue.longValue() != (long) value) {
+            } else if (value instanceof Long && (long) shortValue != (long) value) {
                 throw new IllegalArgumentException("Loss of precision for this long");
             }
         }

--- a/core/src/main/java/io/crate/types/StringType.java
+++ b/core/src/main/java/io/crate/types/StringType.java
@@ -64,7 +64,7 @@ public class StringType extends DataType<BytesRef> implements Streamer<BytesRef>
     }
 
     @Override
-    public BytesRef value(Object value) {
+    public BytesRef value(Object value, boolean lossless) {
         if (value == null) {
             return null;
         }

--- a/core/src/main/java/io/crate/types/TimestampType.java
+++ b/core/src/main/java/io/crate/types/TimestampType.java
@@ -58,7 +58,7 @@ public class TimestampType extends DataType<Long> implements FixedWidthType, Str
     }
 
     @Override
-    public Long value(Object value) throws ClassCastException {
+    public Long value(Object value, boolean lossless) throws ClassCastException {
         if (value == null) {
             return null;
         }

--- a/core/src/main/java/io/crate/types/UndefinedType.java
+++ b/core/src/main/java/io/crate/types/UndefinedType.java
@@ -57,7 +57,7 @@ public class UndefinedType extends DataType<Object> implements Streamer<Object> 
     }
 
     @Override
-    public Object value(Object value) {
+    public Object value(Object value, boolean lossless) {
         return value;
     }
 

--- a/core/src/test/java/io/crate/types/TypeConversionTest.java
+++ b/core/src/test/java/io/crate/types/TypeConversionTest.java
@@ -166,6 +166,62 @@ public class TypeConversionTest extends CrateUnitTest {
         DataTypes.INTEGER.value(Long.MIN_VALUE);
     }
 
+    @Test
+    public void testDoubleToIntegerLossOfPrecision() {
+        assertThat(DataTypes.INTEGER.value(1.0), is(1));
+        expectedException.expect(IllegalArgumentException.class);
+        DataTypes.INTEGER.value(1.4);
+    }
+
+    @Test
+    public void testDoubleToShortLossOfPrecision() {
+        assertThat(DataTypes.SHORT.value(1.0), is((short) 1));
+        expectedException.expect(IllegalArgumentException.class);
+        DataTypes.SHORT.value(1.4);
+    }
+
+    @Test
+    public void testDoubleToByteLossOfPrecision() {
+        assertThat(DataTypes.BYTE.value(1.0), is((byte) 1));
+        expectedException.expect(IllegalArgumentException.class);
+        DataTypes.BYTE.value(1.4);
+    }
+
+    @Test
+    public void testFloatToIntegerLossOfPrecision() {
+        assertThat(DataTypes.INTEGER.value(1.0f), is(1));
+        expectedException.expect(IllegalArgumentException.class);
+        DataTypes.INTEGER.value(1.4f);
+    }
+
+    @Test
+    public void testFloatToShortLossOfPrecision() {
+        assertThat(DataTypes.SHORT.value(1.0f), is((short) 1));
+        expectedException.expect(IllegalArgumentException.class);
+        DataTypes.SHORT.value(1.4f);
+    }
+
+    @Test
+    public void testFloatToByteLossOfPrecision() {
+        assertThat(DataTypes.BYTE.value(1.0f), is((byte) 1));
+        expectedException.expect(IllegalArgumentException.class);
+        DataTypes.BYTE.value(1.4f);
+    }
+
+    @Test
+    public void testDoubleToLongLossOfPrecision() {
+        assertThat(DataTypes.LONG.value(1.0), is(1L));
+        expectedException.expect(IllegalArgumentException.class);
+        DataTypes.LONG.value(1.4);
+    }
+
+    @Test
+    public void testFloatToLongLossOfPrecision() {
+        assertThat(DataTypes.LONG.value(1.0f), is(1L));
+        expectedException.expect(IllegalArgumentException.class);
+        DataTypes.LONG.value(1.4f);
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void testFloatOutOfRangePositive() throws Exception {
         DataTypes.FLOAT.value(Double.MAX_VALUE);

--- a/enterprise/hll/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregation.java
+++ b/enterprise/hll/src/main/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregation.java
@@ -244,7 +244,7 @@ public class HyperLogLogDistinctAggregation extends AggregationFunction<HyperLog
         }
 
         @Override
-        public HyperLogLogDistinctAggregation.HllState value(Object value) throws IllegalArgumentException, ClassCastException {
+        public HyperLogLogDistinctAggregation.HllState value(Object value, boolean lossless) throws IllegalArgumentException, ClassCastException {
             return (HyperLogLogDistinctAggregation.HllState) value;
         }
 

--- a/sql/src/main/java/io/crate/analyze/relations/AbstractTableRelation.java
+++ b/sql/src/main/java/io/crate/analyze/relations/AbstractTableRelation.java
@@ -134,9 +134,6 @@ public abstract class AbstractTableRelation<T extends TableInfo> implements Anal
         if (outputs == null) {
             outputs = new ArrayList<>(tableInfo.columns().size());
             for (Reference reference : tableInfo.columns()) {
-                if (reference.valueType().equals(DataTypes.NOT_SUPPORTED)) {
-                    continue;
-                }
                 ColumnIdent columnIdent = reference.column();
                 outputs.add(getField(columnIdent));
             }

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/AverageAggregation.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/AverageAggregation.java
@@ -124,7 +124,7 @@ public class AverageAggregation extends AggregationFunction<AverageAggregation.A
         }
 
         @Override
-        public AverageState value(Object value) throws IllegalArgumentException, ClassCastException {
+        public AverageState value(Object value, boolean lossless) throws IllegalArgumentException, ClassCastException {
             return (AverageState) value;
         }
 

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/CountAggregation.java
@@ -226,7 +226,7 @@ public class CountAggregation extends AggregationFunction<CountAggregation.LongS
         }
 
         @Override
-        public LongState value(Object value) throws IllegalArgumentException, ClassCastException {
+        public LongState value(Object value, boolean lossless) throws IllegalArgumentException, ClassCastException {
             return (LongState) value;
         }
 

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregation.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregation.java
@@ -144,7 +144,7 @@ public class GeometricMeanAggregation extends AggregationFunction<GeometricMeanA
         }
 
         @Override
-        public GeometricMeanState value(Object value) throws IllegalArgumentException, ClassCastException {
+        public GeometricMeanState value(Object value, boolean lossless) throws IllegalArgumentException, ClassCastException {
             return (GeometricMeanState) value;
         }
 

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/StandardDeviationAggregation.java
@@ -110,7 +110,7 @@ public class StandardDeviationAggregation extends AggregationFunction<StandardDe
         }
 
         @Override
-        public StdDevState value(Object value) throws IllegalArgumentException, ClassCastException {
+        public StdDevState value(Object value, boolean lossless) throws IllegalArgumentException, ClassCastException {
             return (StdDevState) value;
         }
 

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/TDigestStateType.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/TDigestStateType.java
@@ -68,7 +68,7 @@ class TDigestStateType extends DataType<TDigestState> implements Streamer<TDiges
     }
 
     @Override
-    public TDigestState value(Object value) throws IllegalArgumentException, ClassCastException {
+    public TDigestState value(Object value, boolean lossless) throws IllegalArgumentException, ClassCastException {
         return (TDigestState) value;
     }
 

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/impl/VarianceAggregation.java
@@ -111,7 +111,7 @@ public class VarianceAggregation extends AggregationFunction<VarianceAggregation
         }
 
         @Override
-        public VarianceState value(Object value) throws IllegalArgumentException, ClassCastException {
+        public VarianceState value(Object value, boolean lossless) throws IllegalArgumentException, ClassCastException {
             return (VarianceState) value;
         }
 

--- a/sql/src/main/java/io/crate/expression/scalar/cast/CastFunction.java
+++ b/sql/src/main/java/io/crate/expression/scalar/cast/CastFunction.java
@@ -66,7 +66,7 @@ public class CastFunction extends Scalar<Object, Object> implements FunctionForm
         assert args.length == 1 : "Number of arguments must be 1";
         Object value = args[0].value();
         try {
-            return returnType.value(value);
+            return returnType.value(value, false);
         } catch (ClassCastException | IllegalArgumentException e) {
             return onEvaluateException(value);
         }
@@ -84,7 +84,7 @@ public class CastFunction extends Scalar<Object, Object> implements FunctionForm
         if (argument.symbolType().isValueSymbol()) {
             Object value = ((Input) argument).value();
             try {
-                return Literal.of(returnType, returnType.value(value));
+                return Literal.of(returnType, returnType.value(value, false));
             } catch (ClassCastException | IllegalArgumentException e) {
                 return onNormalizeException(argument);
             }

--- a/sql/src/main/java/io/crate/expression/symbol/Literal.java
+++ b/sql/src/main/java/io/crate/expression/symbol/Literal.java
@@ -113,7 +113,7 @@ public class Literal<ReturnType> extends Symbol implements Input<ReturnType>, Co
                 }
                 return true;
             } else {
-                return Arrays.equals((Object[]) value, ((ArrayType) type).value(value));
+                return Arrays.equals((Object[]) value, ((ArrayType) type).value(value, true));
             }
         }
         // types like GeoPoint are represented as arrays
@@ -290,7 +290,7 @@ public class Literal<ReturnType> extends Symbol implements Input<ReturnType>, Co
             return literal;
         }
         try {
-            return of(type, type.value(literal.value()));
+            return of(type, type.value(literal.value(), false));
         } catch (IllegalArgumentException | ClassCastException e) {
             throw new ConversionException(symbol, type);
         }

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -891,8 +891,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
 
     @Test
     public void testArrayCompareAnyNeq() throws Exception {
-        QueriedRelation relation = analyze("select * from users where ? != ANY (counters)",
-            new Object[]{4.3F});
+        QueriedRelation relation = analyze("select * from users where ? != ANY (counters)", new Object[]{4});
         assertThat(relation.querySpec().where().hasQuery(), is(true));
 
         FunctionInfo anyInfo = ((Function) relation.querySpec().where().query()).info();

--- a/sql/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/UpdateAnalyzerTest.java
@@ -235,7 +235,7 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testUpdateAssignmentConvertableType() throws Exception {
-        AnalyzedUpdateStatement update = analyze("update users set other_id=9.9");
+        AnalyzedUpdateStatement update = analyze("update users set other_id=9.0");
         Reference ref = update.assignmentByTargetCol().keySet().iterator().next();
         assertThat(ref, not(instanceOf(DynamicReference.class)));
         assertEquals(DataTypes.LONG, ref.valueType());
@@ -249,7 +249,7 @@ public class UpdateAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testUpdateMuchAssignments() throws Exception {
         AnalyzedUpdateStatement update = analyze(
-            "update users set other_id=9.9, name='Trillian', details=?, stuff=true, foo='bar'",
+            "update users set other_id=9.0, name='Trillian', details=?, stuff=true, foo='bar'",
             new Object[]{new HashMap<String, Object>()});
         assertThat(update.assignmentByTargetCol().size(), is(5));
     }

--- a/sql/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/expressions/ExpressionAnalyzerTest.java
@@ -314,7 +314,7 @@ public class ExpressionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testColumnsCannotBeCastedToLiteralType() {
         SqlExpressions expressions = new SqlExpressions(T3.SOURCES);
-        Function symbol = (Function) expressions.asSymbol("doc.t2.i = 1.1");
+        Function symbol = (Function) expressions.asSymbol("doc.t2.i = 1.0");
         assertThat(symbol.arguments().get(0), isField("i"));
         assertThat(symbol.arguments().get(0).valueType(), is(DataTypes.INTEGER));
     }

--- a/sql/src/test/java/io/crate/expression/scalar/ArrayUniqueFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/ArrayUniqueFunctionTest.java
@@ -76,14 +76,14 @@ public class ArrayUniqueFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testDifferentButConvertableInnerTypes() throws Exception {
-        assertEvaluate("array_unique([10, 20], [10.1, 20.0])", new Long[] {10L, 20L });
+        assertEvaluate("array_unique([10, 20], [10.0, 20.0])", new Long[] { 10L, 20L });
     }
 
     @Test
     public void testConvertNonNumericStringToNumber() throws Exception {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast ['foo', 'bar'] to type long_array");
-        assertEvaluate("array_unique([10, 20], ['foo', 'bar'])", null);
+        expectedException.expectMessage("Cannot cast [['foo', 'bar']] to type long_array");
+        assertEvaluate("array_unique([10, 20], [['foo', 'bar']])", null);
     }
 
     @Test

--- a/sql/src/test/java/io/crate/expression/scalar/ArrayUniqueFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/ArrayUniqueFunctionTest.java
@@ -82,8 +82,8 @@ public class ArrayUniqueFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testConvertNonNumericStringToNumber() throws Exception {
         expectedException.expect(ConversionException.class);
-        expectedException.expectMessage("Cannot cast [['foo', 'bar']] to type long_array");
-        assertEvaluate("array_unique([10, 20], [['foo', 'bar']])", null);
+        expectedException.expectMessage("Cannot cast ['foo', 'bar'] to type long_array");
+        assertEvaluate("array_unique([10, 20], ['foo', 'bar'])", null);
     }
 
     @Test

--- a/sql/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/cast/CastFunctionTest.java
@@ -46,8 +46,12 @@ public class CastFunctionTest extends AbstractScalarFunctionsTest {
     public void testCasts() throws Exception {
         assertEvaluate("cast(10.4 as string)", new BytesRef("10.4"));
         assertEvaluate("cast(null as string)", null);
+        assertEvaluate("cast(10.0 as long)", 10L);
         assertEvaluate("cast(10.4 as long)", 10L);
-        assertEvaluate("to_long_array([10.2, 12.3])", new Long[] { 10L, 12L });
+        assertEvaluate("cast(10.4 as integer)", 10);
+        assertEvaluate("cast(10.4 as short)", (short) 10);
+        assertEvaluate("cast(10.4 as byte)", (byte) 10);
+        assertEvaluate("to_long_array([10.4, 12.3])", new Long[] { 10L, 12L });
         Map<String, Object> object = new HashMap<>();
         object.put("x", 10);
         assertEvaluate("'{\"x\": 10}'::object", object);
@@ -59,6 +63,10 @@ public class CastFunctionTest extends AbstractScalarFunctionsTest {
     @Test
     public void testDoubleColonOperatorCast() {
         assertEvaluate("10.4::string", new BytesRef("10.4"));
+        assertEvaluate("10.4::long", 10L);
+        assertEvaluate("10.4::integer", 10);
+        assertEvaluate("10.4::short", (short) 10);
+        assertEvaluate("10.4::byte", (byte) 10);
         assertEvaluate("[1, 2, 0]::array(boolean)", new Boolean[]{true, true, false});
         assertEvaluate("(1+3)/2::string", new BytesRef("2"));
         assertEvaluate("'10'::long + 5", 15L);


### PR DESCRIPTION
We allowed conversions to take place with a loss of precision. This can lead to
unexpected behavior and thus should be prevented.

We still allow explicit downcasts.

Based on #7466.