### PR TITLE
Docs: Remove outdated partitioned table limitation

### DIFF
--- a/blackbox/docs/general/ddl/partitioned-tables.rst
+++ b/blackbox/docs/general/ddl/partitioned-tables.rst
@@ -470,7 +470,6 @@ partitioned table.
 Limitations
 ===========
 
-* ``PARTITIONED BY`` columns cannot be used in ``ORDER BY``
 * ``PARTITIONED BY`` columns cannot be updated
 * ``WHERE`` clauses cannot contain queries like ``partitioned_by_column='x' OR
   normal_column=x``


### PR DESCRIPTION
- ORDER BY on partitioned by columns work since 6f85ba5271748f693c9715f2f634f27591c34e5e