### PR TITLE
use default keystore type for SSL context

### DIFF
--- a/app/src/main/java/io/crate/plugin/PluginLoaderPlugin.java
+++ b/app/src/main/java/io/crate/plugin/PluginLoaderPlugin.java
@@ -52,8 +52,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import static io.crate.Constants.KEYSTORE_DEFAULT_TYPE;
-
 public class PluginLoaderPlugin extends Plugin implements ActionPlugin, MapperPlugin, ClusterPlugin {
 
     private static final Logger LOGGER = Loggers.getLogger(PluginLoaderPlugin.class);
@@ -156,7 +154,7 @@ public class PluginLoaderPlugin extends Plugin implements ActionPlugin, MapperPl
             if (trustStream == null) {
                 throw new FileNotFoundException("Resource [" + trustStorePath + "] not found in classpath");
             }
-            KeyStore trustStore = KeyStore.getInstance(KEYSTORE_DEFAULT_TYPE);
+            KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
 
             // load the stream to our store
             trustStore.load(trustStream, trustPassword.toCharArray());

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,6 @@
+import java.security.Security
+import org.gradle.api.JavaVersion
+
 buildscript {
     repositories {
         mavenCentral()
@@ -62,6 +65,12 @@ allprojects {
 
         // tell ES to add required permissions for gradle
         systemProperty "tests.gradle", "true"
+
+        if (JavaVersion.current() > JavaVersion.VERSION_1_9) {
+            // Java 10 uses JKCS12 as detault store type
+            // but for tests we want to use JKS only
+            systemProperty "java.security.properties", file("$rootDir/gradle/java10.security")
+        }
 
         // pass system properties to gradle process
         // you you can filter tests by test groups,

--- a/core/src/main/java/io/crate/Constants.java
+++ b/core/src/main/java/io/crate/Constants.java
@@ -31,6 +31,4 @@ public class Constants {
     public static final String TRANSPORT_PORT_RANGE = "4300-4400";
 
     public static final int MAX_SHARD_MISSING_RETRIES = 3;
-
-    public static final String KEYSTORE_DEFAULT_TYPE = "jks";
 }

--- a/enterprise/mqtt/src/test/java/io/crate/mqtt/netty/CrateMqttSslTransportIntegrationTest.java
+++ b/enterprise/mqtt/src/test/java/io/crate/mqtt/netty/CrateMqttSslTransportIntegrationTest.java
@@ -60,13 +60,14 @@ public class CrateMqttSslTransportIntegrationTest extends SQLTransportIntegratio
 
     @BeforeClass
     public static void beforeIntegrationTest() throws IOException {
-        keyStoreFile = getFile(CrateMqttSslTransportIntegrationTest.class.getClassLoader(), "keystore.jks");
-        trustStoreFile = getFile(CrateMqttSslTransportIntegrationTest.class.getClassLoader(), "truststore.jks");
+        keyStoreFile = getAbsoluteFilePathFromClassPath("keystore.jks");
+        trustStoreFile = getAbsoluteFilePathFromClassPath("truststore.jks");
         System.setProperty("javax.net.ssl.trustStore", trustStoreFile.getAbsolutePath());
         System.setProperty("javax.net.ssl.trustStorePassword", "truststorePassword");
     }
 
-    private static File getFile(ClassLoader classLoader, String fileName) throws IOException {
+    private static File getAbsoluteFilePathFromClassPath(String fileName) throws IOException {
+        ClassLoader classLoader = CrateMqttSslTransportIntegrationTest.class.getClassLoader();
         final URL fileUrl = classLoader.getResource(fileName);
         if (fileUrl == null) {
             throw new FileNotFoundException("Resource was not found: " + fileName);

--- a/gradle/java10.security
+++ b/gradle/java10.security
@@ -1,0 +1,1 @@
+keystore.type=jks


### PR DESCRIPTION
Java 10 and newer use JKCS12 as default keystore type. We want to use the default type.

For testing, however, we want JKS to keep it simple and consistent across multiple Java versions. That's why we don't want to use the default type. The type can only be overwritten within a `java.security` file.