### PR TITLE
psql: send transaction state to clients

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -42,6 +42,10 @@ Breaking Changes
 Changes
 =======
 
+- Send transaction state to to Postgres clients. This will improve
+  compatibility with certain clients that check the state when sending
+  ``BEGIN`` and ``COMMIT`` when doing bulk operations.
+
 - Added support for multi line SQL comments, e.g. ``/* multi line */``.
 
 - Improved performance of queries using an array access inside the ``WHERE``

--- a/sql/src/main/java/io/crate/action/sql/Session.java
+++ b/sql/src/main/java/io/crate/action/sql/Session.java
@@ -66,6 +66,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
@@ -488,6 +489,32 @@ public class Session implements AutoCloseable {
         portals.clear();
         preparedStatements.clear();
         pendingExecutions.clear();
+    }
+
+    public TransactionContext.TransactionState transactionState() {
+        return sessionContext.transactionState();
+    }
+
+    public void updateTransactionStatusIfNeeded(String query) {
+        int delim = query.indexOf(" ");
+        if (delim < 0) {
+            return;
+        }
+        String stmtType = query.substring(0, delim).toUpperCase(Locale.ENGLISH);
+        switch (stmtType) {
+            case "BEGIN":
+                sessionContext.transactionState(TransactionContext.TransactionState.OPEN);
+                break;
+            case "COMMIT":
+                sessionContext.transactionState(TransactionContext.TransactionState.IDLE);
+                break;
+            default:
+                break;
+        }
+    }
+
+    public void resetTransactionState() {
+        sessionContext.transactionState(TransactionContext.TransactionState.IDLE);
     }
 
     static class ParameterTypeExtractor extends DefaultTraversalSymbolVisitor<Void, Void> implements Consumer<Symbol> {

--- a/sql/src/main/java/io/crate/action/sql/SessionContext.java
+++ b/sql/src/main/java/io/crate/action/sql/SessionContext.java
@@ -28,6 +28,7 @@ import io.crate.auth.user.StatementAuthorizedValidator;
 import io.crate.auth.user.User;
 import io.crate.exceptions.MissingPrivilegeException;
 import io.crate.metadata.Schemas;
+import io.crate.metadata.TransactionContext.TransactionState;
 
 import javax.annotation.Nullable;
 import java.util.Set;
@@ -45,6 +46,8 @@ public class SessionContext implements StatementAuthorizedValidator, ExceptionAu
     private String defaultSchema;
     private boolean semiJoinsRewriteEnabled = false;
     private boolean hashJoinEnabled = true;
+
+    private TransactionState transactionState = TransactionState.IDLE;
 
     /**
      * Creates a new SessionContext suitable to use as system SessionContext
@@ -135,5 +138,13 @@ public class SessionContext implements StatementAuthorizedValidator, ExceptionAu
         resetSchema();
         semiJoinsRewriteEnabled = false;
         hashJoinEnabled = true;
+    }
+
+    TransactionState transactionState() {
+        return transactionState;
+    }
+
+    void transactionState(TransactionState transactionState) {
+        this.transactionState = transactionState;
     }
 }

--- a/sql/src/main/java/io/crate/metadata/TransactionContext.java
+++ b/sql/src/main/java/io/crate/metadata/TransactionContext.java
@@ -38,6 +38,26 @@ public class TransactionContext {
     private final SessionContext sessionContext;
     private Long currentTimeMillis = null;
 
+    /**
+     * Naming taken from org.postgres.core.TransactionState
+     * https://github.com/pgjdbc/pgjdbc/blob/master/pgjdbc/src/main/java/org/postgresql/core/TransactionState.java
+     */
+    public enum TransactionState {
+        IDLE('I'),
+        OPEN('T'),
+        FAILED('E');
+
+        private final byte message;
+
+        TransactionState(char message) {
+            this.message = (byte) message;
+        }
+
+        public byte message() {
+            return message;
+        }
+    }
+
     public static TransactionContext systemTransactionContext() {
         return new TransactionContext(SessionContext.systemSessionContext());
     }

--- a/sql/src/main/java/io/crate/protocols/postgres/Messages.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/Messages.java
@@ -129,11 +129,11 @@ public class Messages {
      * block; or 'E' if in a failed transaction block (queries will be
      * rejected until block is ended).
      */
-    static void sendReadyForQuery(Channel channel) {
+    static void sendReadyForQuery(Channel channel, byte transactionStatus) {
         ByteBuf buffer = channel.alloc().buffer(6);
         buffer.writeByte('Z');
         buffer.writeInt(5);
-        buffer.writeByte('I');
+        buffer.writeByte(transactionStatus);
         ChannelFuture channelFuture = channel.writeAndFlush(buffer);
         if (LOGGER.isTraceEnabled()) {
             channelFuture.addListener((ChannelFutureListener) future -> LOGGER.trace("sentReadyForQuery"));

--- a/sql/src/test/java/io/crate/integrationtests/PostgresCompatIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PostgresCompatIntegrationTest.java
@@ -28,6 +28,8 @@ import org.junit.Test;
 
 import java.sql.PreparedStatement;
 
+import static org.hamcrest.Matchers.is;
+
 @UseJdbc(value = 1)
 public class PostgresCompatIntegrationTest extends SQLTransportIntegrationTest {
 
@@ -83,6 +85,13 @@ public class PostgresCompatIntegrationTest extends SQLTransportIntegrationTest {
     public void testCommitStatement() {
         execute("COMMIT");
         assertNoErrorResponse(response);
+    }
+
+    @Test
+    @UseJdbc(0) // Simulate explicit call by a user through HTTP protocol
+    public void testProperTerminationOfDeallocateThroughHttpProtocol() {
+        execute("DEALLOCATE ALL");
+        assertThat(response.rowCount(), is(0L));
     }
 
     /**

--- a/sql/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
+++ b/sql/src/test/java/io/crate/protocols/postgres/PostgresWireProtocolTest.java
@@ -108,13 +108,18 @@ public class PostgresWireProtocolTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
-    public void testHandleEmptySimpleQuery() throws Exception {
+    public void testHandleEmptySimpleQuery() {
         PostgresWireProtocol ctx =
             new PostgresWireProtocol(
-                mock(SQLOperations.class),
+                sqlOperations,
                 new AlwaysOKNullAuthentication(),
                 null);
-        EmbeddedChannel channel = new EmbeddedChannel(ctx.decoder, ctx.handler);
+        channel = new EmbeddedChannel(ctx.decoder, ctx.handler);
+
+        // send startup message to initialize session
+        // but ignore all following response messages
+        sendStartupMessage(channel);
+        channel.releaseOutbound();
 
         ByteBuf buffer = Unpooled.buffer();
         try {


### PR DESCRIPTION
Certain clients (such as [lib/pq](https://github.com/lib/pq/blob/master/conn.go#L551-L554)) require the changed transaction state to be pushed to the client via the `readyForQuery` message, when the client issues a `BEGIN` or `COMMIT`.