### PR TITLE
Remove unused functionality from TreeMapBuilder

### DIFF
--- a/core/src/main/java/io/crate/core/collections/TreeMapBuilder.java
+++ b/core/src/main/java/io/crate/core/collections/TreeMapBuilder.java
@@ -22,51 +22,24 @@
 package io.crate.core.collections;
 
 import java.util.Map;
+import java.util.TreeMap;
 
-import static com.google.common.collect.Maps.newTreeMap;
 
-public class TreeMapBuilder<K extends Comparable, V> {
+public final class TreeMapBuilder<K extends Comparable, V> {
 
     public static <K extends Comparable, V> TreeMapBuilder<K, V> newMapBuilder() {
         return new TreeMapBuilder<>();
     }
 
-    private Map<K, V> map = newTreeMap();
+    private final Map<K, V> map;
 
     public TreeMapBuilder() {
-        this.map = newTreeMap();
-    }
-
-    public TreeMapBuilder<K, V> putAll(Map<K, V> map) {
-        this.map.putAll(map);
-        return this;
+        this.map = new TreeMap<>();
     }
 
     public TreeMapBuilder<K, V> put(K key, V value) {
         this.map.put(key, value);
         return this;
-    }
-
-    public TreeMapBuilder<K, V> remove(K key) {
-        this.map.remove(key);
-        return this;
-    }
-
-    public TreeMapBuilder<K, V> clear() {
-        this.map.clear();
-        return this;
-    }
-
-    public V get(K key) {
-        return map.get(key);
-    }
-
-    public boolean containsKey(K key) {
-        return map.containsKey(key);
-    }
-
-    public boolean isEmpty() {
-        return map.isEmpty();
     }
 
     public Map<K, V> map() {

--- a/core/src/test/java/io/crate/core/collections/TreeMapBuilderTest.java
+++ b/core/src/test/java/io/crate/core/collections/TreeMapBuilderTest.java
@@ -36,22 +36,11 @@ public class TreeMapBuilderTest extends CrateUnitTest {
         TreeMapBuilder<Integer, Integer> builder = TreeMapBuilder.newMapBuilder();
 
         assertThat(builder.put(1, 1), instanceOf(TreeMapBuilder.class));
-        assertTrue(builder.containsKey(1));
-        assertThat(builder.get(1), is(1));
-        assertFalse(builder.isEmpty());
-
-        assertThat(builder.remove(1), instanceOf(TreeMapBuilder.class));
-        assertTrue(builder.isEmpty());
+        assertTrue(builder.map().containsKey(1));
+        assertThat(builder.map().get(1), is(1));
+        assertFalse(builder.map().isEmpty());
 
         builder.put(1, 1);
         assertThat(builder.map(), instanceOf(TreeMap.class));
-
-        TreeMapBuilder<Integer, Integer> builder2 = TreeMapBuilder.<Integer, Integer>newMapBuilder();
-        assertThat(builder2.putAll(builder.map()), instanceOf(TreeMapBuilder.class));
-        assertThat(builder2.get(1), is(1));
-        assertFalse(builder2.isEmpty());
-
-        assertThat(builder2.clear(), instanceOf(TreeMapBuilder.class));
-        assertTrue(builder2.isEmpty());
     }
 }


### PR DESCRIPTION
- and avoids the duplicate map initialization