### PR TITLE
Remove close and kill handling from LimitingBatchIterator

### DIFF
--- a/dex/src/main/java/io/crate/data/LimitingBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/LimitingBatchIterator.java
@@ -26,9 +26,10 @@ import io.crate.concurrent.CompletableFutures;
 
 import java.util.concurrent.CompletionStage;
 
-public class LimitingBatchIterator<T> extends CloseAssertingBatchIterator<T> {
+public final class LimitingBatchIterator<T> extends ForwardingBatchIterator<T> {
 
     private final int endPos;
+    private final BatchIterator<T> delegate;
     private int pos = -1;
 
     public static <T> BatchIterator<T> newInstance(BatchIterator<T> delegate, int limit) {
@@ -36,8 +37,13 @@ public class LimitingBatchIterator<T> extends CloseAssertingBatchIterator<T> {
     }
 
     private LimitingBatchIterator(BatchIterator<T> delegate, int limit) {
-        super(delegate);
+        this.delegate = delegate;
         this.endPos = limit - 1;
+    }
+
+    @Override
+    protected BatchIterator<T> delegate() {
+        return delegate;
     }
 
     @Override


### PR DESCRIPTION
The `LimitingBatchIterator` forwards most calls to its delegate which
should have proper kill/close checks. Therefore we can avoid the
additional kill/close state checks in the `LimitingBatchIterator`. (They
were part of the `CloseAssertingBatchIterator`.