### PR TITLE
Exclude netty from es/repository-hdfs

### DIFF
--- a/es/es-repository-hdfs/build.gradle
+++ b/es/es-repository-hdfs/build.gradle
@@ -47,12 +47,14 @@ dependencies {
         exclude module: "javax.servlet"
         exclude module: "guava"
         exclude module: "junit"
+        exclude group: "io.netty", module: "netty"
     }
     compile("org.apache.hadoop:hadoop-hdfs:${versions.hadoop2}") {
         exclude module: "guava"
         exclude module: "log4j"
         exclude module: "junit"
         exclude group: "io.netty", module: "netty"
+        exclude group: "io.netty", module: "netty-all"
     }
     requiredLibs "commons-collections:commons-collections:3.2.1"
     requiredLibs "commons-configuration:commons-configuration:1.6"


### PR DESCRIPTION
Exclude modules `netty` and `netty-all` because they are introducing
different versions of Netty than what is set in https://github.com/crate/crate/blob/master/gradle/version.properties.

<img width="437" alt="screen shot 2018-07-03 at 16 33 39" src="https://user-images.githubusercontent.com/20131679/42369737-254e5ca0-810b-11e8-9ff1-4f86d8fd0727.png">
