### PR TITLE
Run sys.shards and sys.nodes queries in GET thread-pool

### DIFF
--- a/sql/src/main/java/io/crate/execution/engine/collect/CollectTask.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/CollectTask.java
@@ -175,7 +175,7 @@ public class CollectTask extends AbstractTask {
             if (collectPhase.maxRowGranularity() == RowGranularity.NODE
                        || collectPhase.maxRowGranularity() == RowGranularity.SHARD) {
                 // Node or Shard system table collector
-                return ThreadPool.Names.MANAGEMENT;
+                return ThreadPool.Names.GET;
             }
         }
 

--- a/sql/src/test/java/io/crate/execution/engine/collect/CollectTaskTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/CollectTaskTest.java
@@ -24,14 +24,11 @@ package io.crate.execution.engine.collect;
 import com.carrotsearch.randomizedtesting.RandomizedTest;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.data.BatchIterator;
-import io.crate.data.InMemoryBatchIterator;
 import io.crate.data.Row;
-import io.crate.data.SentinelRow;
 import io.crate.execution.dsl.phases.RoutedCollectPhase;
 import io.crate.execution.jobs.SharedShardContexts;
 import io.crate.metadata.Routing;
 import io.crate.metadata.RowGranularity;
-import io.crate.testing.TestingBatchIterators;
 import io.crate.testing.TestingRowConsumer;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -156,13 +153,13 @@ public class CollectTaskTest extends RandomizedTest {
         // sys.nodes (single row collector)
         when(collectPhase.maxRowGranularity()).thenReturn(RowGranularity.NODE);
         threadPoolExecutorName = CollectTask.threadPoolName(collectPhase);
-        assertThat(threadPoolExecutorName, is(ThreadPool.Names.MANAGEMENT));
+        assertThat(threadPoolExecutorName, is(ThreadPool.Names.GET));
 
         // sys.shards
         when(routing.containsShards(localNodeId)).thenReturn(true);
         when(collectPhase.maxRowGranularity()).thenReturn(RowGranularity.SHARD);
         threadPoolExecutorName = CollectTask.threadPoolName(collectPhase);
-        assertThat(threadPoolExecutorName, is(ThreadPool.Names.MANAGEMENT));
+        assertThat(threadPoolExecutorName, is(ThreadPool.Names.GET));
         when(routing.containsShards(localNodeId)).thenReturn(false);
 
         // information_schema.*


### PR DESCRIPTION
The MANAGEMENT threadpool is used for certain cluster management
activities. We shouldn't have user invoked read queries interfere with
those.

This therefore changes the threadpool used to GET which was so far not
used at all.