### PR TITLE
Switch to int64 binary timestamp encoding in pgwire

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -42,6 +42,10 @@ Breaking Changes
 Changes
 =======
 
+- Changed the postgres wire protocol binary encoding format for ``timestamp``
+  columns to use the newer ``int64`` format. This will enable compatibility
+  with clients like ``pgx``.
+
 - Added support for multi line SQL comments, e.g. ``/* multi line */``.
 
 - Improved performance of queries using an array access inside the ``WHERE``

--- a/sql/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
@@ -431,6 +431,7 @@ class PostgresWireProtocol {
         Messages.sendParameterStatus(channel, "client_encoding", "UTF8");
         Messages.sendParameterStatus(channel, "datestyle", "ISO");
         Messages.sendParameterStatus(channel, "TimeZone", "UTC");
+        Messages.sendParameterStatus(channel, "integer_datetimes", "on");
         Messages.sendReadyForQuery(channel);
     }
 

--- a/sql/src/test/java/io/crate/protocols/postgres/types/BasePGTypeTest.java
+++ b/sql/src/test/java/io/crate/protocols/postgres/types/BasePGTypeTest.java
@@ -31,7 +31,7 @@ import static org.hamcrest.Matchers.is;
 
 public abstract class BasePGTypeTest<T> extends CrateUnitTest {
 
-    private PGType pgType;
+    PGType pgType;
 
     BasePGTypeTest(PGType pgType) {
         this.pgType = pgType;


### PR DESCRIPTION
Some postgres clients do not check for the server parameter for the
binary encoding but simply assume that the newer int64 binary encoding
is used.

Examples are pgx, and asyncpg.

(E.g. https://github.com/MagicStack/asyncpg/blob/3565ef8c68beb3cf5c22dce50388c9d226360a3f/asyncpg/protocol/codecs/datetime.pyx#L69)

This changes the encoding to make these clients work. The double
encoding has been removed from Postgres a while ago:
https://github.com/postgres/postgres/commit/b6aa17e0ae367afdcea07118e016111af4fa6bc3