### PR TITLE
Tests: Reduce number of threads spawned if -PtestForks is used

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,7 @@ allprojects {
         // allow to set the number of test forks from the CLI
         if (project.hasProperty('testForks')) {
             maxParallelForks = project.testForks as int
+            systemProperty "processors", Math.max(maxParallelForks / 2.0d, 1) as int
         }
         if (project.hasProperty('disableAssertions')) {
             enableAssertions = false


### PR DESCRIPTION
Should help reducing context-switching and system overload, making the
tests overall a bit faster.