### PR TITLE
add template upgrade service to upgrade the `crate_defaults` template

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -104,6 +104,10 @@ Changes
 Fixes
 =====
 
+- Fixed an issue which prevents adding new string typed columns into dynamic
+  objects if a cluster was initially created with a version between
+  ``1.1.0 and 2.0.0``.
+
 - Fixed an issue that caused runtime changes to the
   ``indices.breaker.query.limit`` and ``indices.breaker.query.overhead``
   settings by using the ``SET GLOBAL [TRANSIENT]`` command, to get ignored.

--- a/sql/src/main/java/io/crate/metadata/DefaultTemplateService.java
+++ b/sql/src/main/java/io/crate/metadata/DefaultTemplateService.java
@@ -48,18 +48,18 @@ import java.util.Collections;
  */
 public class DefaultTemplateService extends AbstractComponent {
 
-    static final String TEMPLATE_NAME = "crate_defaults";
+    public static final String TEMPLATE_NAME = "crate_defaults";
 
     private static final String DEFAULT_MAPPING_SOURCE = createDefaultMappingSource();
     private final ClusterService clusterService;
 
 
-    public DefaultTemplateService(Settings settings, ClusterService clusterService) {
+    DefaultTemplateService(Settings settings, ClusterService clusterService) {
         super(settings);
         this.clusterService = clusterService;
     }
 
-    public void createIfNotExists(ClusterState state) {
+    void createIfNotExists(ClusterState state) {
         DiscoveryNodes nodes = state.nodes();
         if (nodes.getMasterNodeId().equals(nodes.getLocalNodeId()) == false) {
             return;
@@ -95,14 +95,17 @@ public class DefaultTemplateService extends AbstractComponent {
     private static ImmutableOpenMap<String, IndexTemplateMetaData> createCopyWithDefaultTemplateAdded(
         ImmutableOpenMap<String, IndexTemplateMetaData> currentTemplates) throws IOException {
 
-        IndexTemplateMetaData defaultTemplate = IndexTemplateMetaData.builder(TEMPLATE_NAME)
+        ImmutableOpenMap.Builder<String, IndexTemplateMetaData> builder = ImmutableOpenMap.builder(currentTemplates);
+        builder.put(TEMPLATE_NAME, createDefaultIndexTemplateMetaData());
+        return builder.build();
+    }
+
+    public static IndexTemplateMetaData createDefaultIndexTemplateMetaData() throws IOException {
+        return IndexTemplateMetaData.builder(TEMPLATE_NAME)
             .order(0)
             .putMapping(Constants.DEFAULT_MAPPING_TYPE, DEFAULT_MAPPING_SOURCE)
             .patterns(Collections.singletonList("*"))
             .build();
-        ImmutableOpenMap.Builder<String, IndexTemplateMetaData> builder = ImmutableOpenMap.builder(currentTemplates);
-        builder.put(TEMPLATE_NAME, defaultTemplate);
-        return builder.build();
     }
 
     private static String createDefaultMappingSource() {

--- a/sql/src/main/java/io/crate/metadata/upgrade/IndexTemplateUpgrader.java
+++ b/sql/src/main/java/io/crate/metadata/upgrade/IndexTemplateUpgrader.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.upgrade;
+
+import io.crate.metadata.DefaultTemplateService;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Settings;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.UnaryOperator;
+
+import static io.crate.metadata.DefaultTemplateService.TEMPLATE_NAME;
+
+public class IndexTemplateUpgrader implements UnaryOperator<Map<String, IndexTemplateMetaData>> {
+
+    private final Logger logger;
+
+    public IndexTemplateUpgrader(Settings settings) {
+        this.logger = Loggers.getLogger(IndexTemplateUpgrader.class, settings);
+    }
+
+    @Override
+    public Map<String, IndexTemplateMetaData> apply(Map<String, IndexTemplateMetaData> templates) {
+        HashMap<String, IndexTemplateMetaData> upgradedTemplates = new HashMap<>(templates);
+        try {
+            upgradedTemplates.put(TEMPLATE_NAME, DefaultTemplateService.createDefaultIndexTemplateMetaData());
+        } catch (IOException e) {
+            logger.error("Error while trying to upgrade the default template", e);
+        }
+        return upgradedTemplates;
+    }
+}

--- a/sql/src/main/java/io/crate/metadata/upgrade/MetaDataIndexUpgrader.java
+++ b/sql/src/main/java/io/crate/metadata/upgrade/MetaDataIndexUpgrader.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.upgrade;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.crate.Constants;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.MappingMetaData;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.mapper.MapperParsingException;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.UnaryOperator;
+
+public class MetaDataIndexUpgrader implements UnaryOperator<IndexMetaData> {
+
+    private final Logger logger;
+
+    public MetaDataIndexUpgrader(Settings settings) {
+        this.logger = Loggers.getLogger(MetaDataIndexUpgrader.class, settings);
+    }
+
+    @Override
+    public IndexMetaData apply(IndexMetaData indexMetaData) {
+        return purgeDynamicStringTemplate(indexMetaData);
+    }
+
+    /**
+     * Purges any dynamic template from the index metadata because they might be out-dated and the general default
+     * template will apply any defaults for all indices.
+     */
+    private IndexMetaData purgeDynamicStringTemplate(IndexMetaData indexMetaData) {
+        return IndexMetaData.builder(indexMetaData)
+            .putMapping(purgeDynamicStringTemplate(
+                indexMetaData.mapping(Constants.DEFAULT_MAPPING_TYPE),
+                indexMetaData.getIndex().getName()))
+            .build();
+    }
+
+    @VisibleForTesting
+    MappingMetaData purgeDynamicStringTemplate(MappingMetaData mappingMetaData, String indexName) {
+        Map<String, Object> oldMapping = mappingMetaData.getSourceAsMap();
+        HashMap<String, Object> newMapping = new HashMap<>(oldMapping.size());
+        for (Map.Entry<String, Object> entry : oldMapping.entrySet()) {
+            String fieldName = entry.getKey();
+            Object fieldNode = entry.getValue();
+            if (fieldName.equals("dynamic_templates")) {
+                List<?> tmplNodes = (List<?>) fieldNode;
+                List<Object> templates = new ArrayList<>();
+                for (Object tmplNode : tmplNodes) {
+                    //noinspection unchecked
+                    Map<String, Object> tmpl = (Map<String, Object>) tmplNode;
+                    if (tmpl.size() != 1) {
+                        throw new MapperParsingException("A dynamic template must be defined with a name");
+                    }
+                    Map.Entry<String, Object> tmpEntry = tmpl.entrySet().iterator().next();
+                    String templateName = tmpEntry.getKey();
+                    if (templateName.equals("strings") == false) {
+                        templates.add(tmplNode);
+                    }
+                }
+                if (templates.size() > 0) {
+                    newMapping.put(fieldName, templates);
+                }
+            } else {
+                newMapping.put(fieldName, fieldNode);
+            }
+        }
+
+        try {
+            return new MappingMetaData(Constants.DEFAULT_MAPPING_TYPE, newMapping);
+        } catch (IOException e) {
+            logger.error("Failed to upgrade mapping for index '" + indexName + "'", e);
+            return mappingMetaData;
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/plugin/SQLPlugin.java
+++ b/sql/src/main/java/io/crate/plugin/SQLPlugin.java
@@ -33,8 +33,8 @@ import io.crate.execution.TransportExecutorModule;
 import io.crate.execution.engine.aggregation.impl.AggregationImplModule;
 import io.crate.execution.engine.collect.CollectOperationModule;
 import io.crate.execution.engine.collect.files.FileCollectModule;
-import io.crate.execution.jobs.TasksService;
 import io.crate.execution.jobs.JobModule;
+import io.crate.execution.jobs.TasksService;
 import io.crate.execution.jobs.transport.NodeDisconnectJobMonitorService;
 import io.crate.expression.operator.OperatorModule;
 import io.crate.expression.predicate.PredicateModule;
@@ -56,6 +56,8 @@ import io.crate.metadata.rule.ingest.IngestRulesMetaData;
 import io.crate.metadata.settings.AnalyzerSettings;
 import io.crate.metadata.settings.CrateSettings;
 import io.crate.metadata.sys.MetaDataSysModule;
+import io.crate.metadata.upgrade.IndexTemplateUpgrader;
+import io.crate.metadata.upgrade.MetaDataIndexUpgrader;
 import io.crate.metadata.view.ViewsMetaData;
 import io.crate.monitor.MonitorModule;
 import io.crate.protocols.postgres.PostgresNetty;
@@ -65,6 +67,8 @@ import io.crate.user.UserExtension;
 import io.crate.user.UserFallbackModule;
 import org.elasticsearch.action.bulk.BulkModule;
 import org.elasticsearch.cluster.NamedDiff;
+import org.elasticsearch.cluster.metadata.IndexMetaData;
+import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.cluster.routing.allocation.decider.AllocationDecider;
 import org.elasticsearch.common.ParseField;
@@ -89,6 +93,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.UnaryOperator;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static io.crate.settings.SharedSettings.ENTERPRISE_LICENSE_SETTING;
@@ -292,5 +297,15 @@ public class SQLPlugin extends Plugin implements ActionPlugin, MapperPlugin, Clu
             entries.addAll(userExtension.getNamedXContent());
         }
         return entries;
+    }
+
+    @Override
+    public UnaryOperator<IndexMetaData> getIndexMetaDataUpgrader() {
+        return new MetaDataIndexUpgrader(settings);
+    }
+
+    @Override
+    public UnaryOperator<Map<String, IndexTemplateMetaData>> getIndexTemplateMetaDataUpgrader() {
+        return new IndexTemplateUpgrader(settings);
     }
 }

--- a/sql/src/test/java/io/crate/metadata/upgrade/IndexTemplateUpgraderTest.java
+++ b/sql/src/test/java/io/crate/metadata/upgrade/IndexTemplateUpgraderTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.upgrade;
+
+import io.crate.metadata.DefaultTemplateService;
+import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
+import org.elasticsearch.common.settings.Settings;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.crate.metadata.DefaultTemplateService.TEMPLATE_NAME;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class IndexTemplateUpgraderTest {
+
+    @Test
+    public void testDefaultTemplateIsUpgraded() throws IOException {
+        IndexTemplateUpgrader upgrader = new IndexTemplateUpgrader(Settings.EMPTY);
+
+        HashMap<String, IndexTemplateMetaData> templates = new HashMap<>();
+        IndexTemplateMetaData oldTemplate = IndexTemplateMetaData.builder(TEMPLATE_NAME)
+            .patterns(Collections.singletonList("*"))
+            .build();
+        templates.put(TEMPLATE_NAME, oldTemplate);
+
+        Map<String, IndexTemplateMetaData> upgradedTemplates = upgrader.apply(templates);
+        assertThat(upgradedTemplates.get(TEMPLATE_NAME), is(DefaultTemplateService.createDefaultIndexTemplateMetaData()));
+    }
+}

--- a/sql/src/test/java/io/crate/metadata/upgrade/MetaDataIndexUpgraderTest.java
+++ b/sql/src/test/java/io/crate/metadata/upgrade/MetaDataIndexUpgraderTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.metadata.upgrade;
+
+import io.crate.Constants;
+import io.crate.test.integration.CrateUnitTest;
+import org.elasticsearch.cluster.metadata.MappingMetaData;
+import org.elasticsearch.common.compress.CompressedXContent;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.core.IsNull.nullValue;
+
+public class MetaDataIndexUpgraderTest extends CrateUnitTest {
+
+    @Test
+    public void testDynamicStringTemplateIsPurged() throws IOException {
+        MetaDataIndexUpgrader metaDataIndexUpgrader = new MetaDataIndexUpgrader(Settings.EMPTY);
+        MappingMetaData mappingMetaData = new MappingMetaData(createDynamicStringMappingTemplate());
+        MappingMetaData newMappingMetaData = metaDataIndexUpgrader.purgeDynamicStringTemplate(mappingMetaData, "dummy");
+
+        Object dynamicTemplates = newMappingMetaData.getSourceAsMap().get("dynamic_templates");
+        assertThat(dynamicTemplates, nullValue());
+    }
+
+    private static CompressedXContent createDynamicStringMappingTemplate() throws IOException {
+        // @formatter:off
+        XContentBuilder builder = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject(Constants.DEFAULT_MAPPING_TYPE)
+                .startArray("dynamic_templates")
+                    .startObject()
+                        .startObject("strings")
+                            .field("match_mapping_type", "string")
+                            .startObject("mapping")
+                                .field("type", "keyword")
+                                .field("doc_values", true)
+                                .field("store", false)
+                            .endObject()
+                        .endObject()
+                    .endObject()
+                .endArray()
+            .endObject()
+            .endObject();
+        // @formatter:on
+
+        return new CompressedXContent(builder.bytes().utf8ToString());
+    }
+}


### PR DESCRIPTION
The `crate_defaults` template once created was never updated and so
could contain invalid values when created within an old CrateDB version.
CrateDB v1.1.0 to v2.2.0 creates templates which are not compatible
with versions >= 3.0.
Also this old dynamic templates could then already end up in newer indices
so they must be purged from existing indices or snaphots.

Relates https://github.com/crate/crate/issues/7524