### PR TITLE
Optimize GROUP BY on single string column

### DIFF
--- a/sql/src/main/java/io/crate/breaker/BytesRefSizeEstimator.java
+++ b/sql/src/main/java/io/crate/breaker/BytesRefSizeEstimator.java
@@ -25,7 +25,13 @@ import org.apache.lucene.util.BytesRef;
 
 import javax.annotation.Nullable;
 
-public class BytesRefSizeEstimator extends SizeEstimator<BytesRef> {
+public final class BytesRefSizeEstimator extends SizeEstimator<BytesRef> {
+
+    public static final BytesRefSizeEstimator INSTANCE = new BytesRefSizeEstimator();
+
+    private BytesRefSizeEstimator() {
+    }
+
     @Override
     public long estimateSize(@Nullable BytesRef value) {
         if (value == null) {

--- a/sql/src/main/java/io/crate/breaker/SizeEstimatorFactory.java
+++ b/sql/src/main/java/io/crate/breaker/SizeEstimatorFactory.java
@@ -42,7 +42,7 @@ public class SizeEstimatorFactory {
                 return (SizeEstimator<T>) new ConstSizeEstimator(0);
             case StringType.ID:
             case IpType.ID:
-                return (SizeEstimator<T>) new BytesRefSizeEstimator();
+                return (SizeEstimator<T>) BytesRefSizeEstimator.INSTANCE;
             case ObjectType.ID:
                 // no type info for inner types so we just use an arbitrary constant size for now
                 return (SizeEstimator<T>) new ConstSizeEstimator(60);

--- a/sql/src/main/java/io/crate/execution/engine/collect/BlobShardCollectorProvider.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/BlobShardCollectorProvider.java
@@ -43,6 +43,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.threadpool.ThreadPool;
 
+import javax.annotation.Nullable;
 import java.io.File;
 
 public class BlobShardCollectorProvider extends ShardCollectorProvider {
@@ -63,6 +64,12 @@ public class BlobShardCollectorProvider extends ShardCollectorProvider {
             threadPool, settings, transportActionProvider, blobShard.indexShard(), bigArrays);
         inputFactory = new InputFactory(functions);
         this.blobShard = blobShard;
+    }
+
+    @Nullable
+    @Override
+    protected BatchIterator<Row> getProjectionFusedIterator(RoutedCollectPhase normalizedPhase, CollectTask collectTask) {
+        return null;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/GroupByOptimizedIterator.java
@@ -1,0 +1,359 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.engine.collect;
+
+import io.crate.breaker.BytesRefSizeEstimator;
+import io.crate.breaker.RamAccountingContext;
+import io.crate.data.BatchIterator;
+import io.crate.data.CollectingBatchIterator;
+import io.crate.data.Row;
+import io.crate.data.RowN;
+import io.crate.exceptions.GroupByOnArrayUnsupportedException;
+import io.crate.execution.dsl.phases.RoutedCollectPhase;
+import io.crate.execution.dsl.projection.GroupProjection;
+import io.crate.execution.dsl.projection.Projection;
+import io.crate.execution.engine.aggregation.AggregationContext;
+import io.crate.execution.engine.aggregation.AggregationFunction;
+import io.crate.execution.jobs.SharedShardContext;
+import io.crate.expression.InputFactory;
+import io.crate.expression.InputRow;
+import io.crate.expression.reference.doc.lucene.CollectorContext;
+import io.crate.expression.reference.doc.lucene.LuceneCollectorExpression;
+import io.crate.expression.symbol.AggregateMode;
+import io.crate.expression.symbol.InputColumn;
+import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.Symbols;
+import io.crate.lucene.FieldTypeLookup;
+import io.crate.lucene.LuceneQueryBuilder;
+import io.crate.metadata.Reference;
+import io.crate.metadata.doc.DocSysColumns;
+import io.crate.types.DataTypes;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.SortedSetDocValues;
+import org.apache.lucene.search.DocIdSetIterator;
+import org.apache.lucene.search.Scorer;
+import org.apache.lucene.search.Weight;
+import org.apache.lucene.util.Bits;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.ObjectArray;
+import org.elasticsearch.index.engine.Engine;
+import org.elasticsearch.index.fielddata.IndexOrdinalsFieldData;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.ShardId;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+import static io.crate.breaker.RamAccountingContext.roundUp;
+import static io.crate.concurrent.CompletableFutures.failedFuture;
+import static io.crate.execution.dsl.projection.Projections.shardProjections;
+import static io.crate.execution.engine.collect.LuceneShardCollectorProvider.getCollectorContext;
+
+final class GroupByOptimizedIterator {
+
+    @Nullable
+    static BatchIterator<Row> tryOptimizeSingleStringKey(IndexShard indexShard,
+                                                         LuceneQueryBuilder luceneQueryBuilder,
+                                                         FieldTypeLookup fieldTypeLookup,
+                                                         BigArrays bigArrays,
+                                                         InputFactory inputFactory,
+                                                         DocInputFactory docInputFactory,
+                                                         RoutedCollectPhase collectPhase,
+                                                         CollectTask collectTask) {
+        Collection<? extends Projection> shardProjections = shardProjections(collectPhase.projections());
+        GroupProjection groupProjection = getSingleStringKeyGroupProjection(shardProjections);
+        if (groupProjection == null) {
+            return null;
+        }
+        assert groupProjection.keys().size() == 1 : "Must have 1 key if getSingleStringKeyGroupProjection returned a projection";
+        Reference keyRef = getKeyRef(collectPhase.toCollect(), groupProjection.keys().get(0));
+        if (keyRef == null) {
+            return null; // group by on non-reference
+        }
+        MappedFieldType keyFieldType = fieldTypeLookup.get(keyRef.column().fqn());
+        if (keyFieldType == null || !keyFieldType.hasDocValues()) {
+            return null;
+        }
+        if (Symbols.containsColumn(collectPhase.toCollect(), DocSysColumns.SCORE)
+            || Symbols.containsColumn(collectPhase.where(), DocSysColumns.SCORE)) {
+            // We could optimize this, but since it's assumed to be an uncommon case we fallback to generic group-by
+            // to keep the optimized implementation a bit simpler
+            return null;
+        }
+
+        ShardId shardId = indexShard.shardId();
+        SharedShardContext sharedShardContext = collectTask.sharedShardContexts().getOrCreateContext(shardId);
+        Engine.Searcher searcher = sharedShardContext.acquireSearcher();
+        try {
+            QueryShardContext queryShardContext = sharedShardContext.indexService().newQueryShardContext(
+                shardId.getId(),
+                searcher.reader(),
+                System::currentTimeMillis,
+                null
+            );
+            collectTask.addSearcher(sharedShardContext.readerId(), searcher);
+
+            InputFactory.Context<? extends LuceneCollectorExpression<?>> docCtx = docInputFactory.getCtx();
+            docCtx.add(collectPhase.toCollect().stream().filter(s -> !s.equals(keyRef))::iterator);
+            IndexOrdinalsFieldData keyIndexFieldData = queryShardContext.getForField(keyFieldType);
+
+            InputFactory.Context<CollectExpression<Row, ?>> ctxForAggregations = inputFactory.ctxForAggregations();
+            ctxForAggregations.add(groupProjection.values());
+
+            List<AggregationContext> aggregations = ctxForAggregations.aggregations();
+            List<? extends LuceneCollectorExpression<?>> expressions = docCtx.expressions();
+
+            RamAccountingContext ramAccounting = collectTask.queryPhaseRamAccountingContext();
+
+            CollectorContext collectorContext = getCollectorContext(
+                sharedShardContext.readerId(), docCtx, queryShardContext::getForField);
+
+            for (LuceneCollectorExpression<?> expression: expressions) {
+                expression.startCollect(collectorContext);
+            }
+            InputRow inputRow = new InputRow(docCtx.topLevelInputs());
+
+            LuceneQueryBuilder.Context queryContext = luceneQueryBuilder.convert(
+                collectPhase.where(),
+                indexShard.mapperService(),
+                queryShardContext,
+                sharedShardContext.indexService().cache()
+            );
+            return CollectingBatchIterator.newInstance(
+                searcher::close,
+                t -> {},
+                () -> {
+                    try {
+                        return CompletableFuture.completedFuture(
+                            getRows(
+                                applyAggregatesGroupedByKey(
+                                    bigArrays,
+                                    searcher,
+                                    keyIndexFieldData,
+                                    ctxForAggregations,
+                                    aggregations,
+                                    expressions,
+                                    ramAccounting,
+                                    inputRow,
+                                    queryContext
+                                ),
+                                ramAccounting,
+                                aggregations,
+                                groupProjection.mode()
+                            )
+                        );
+                    } catch (Throwable t) {
+                        return failedFuture(t);
+                    }
+                }
+            );
+        } catch (Throwable t) {
+            searcher.close();
+            throw t;
+        }
+    }
+
+    private static Iterable<Row> getRows(Map<BytesRef, Object[]> groupedStates,
+                                         RamAccountingContext ramAccounting,
+                                         List<AggregationContext> aggregations,
+                                         AggregateMode mode) {
+        return () -> groupedStates.entrySet().stream()
+            .map(new Function<Map.Entry<BytesRef, Object[]>, Row>() {
+
+                final Object[] cells = new Object[1 + aggregations.size()];
+                final RowN row = new RowN(cells);
+
+                @Override
+                public Row apply(Map.Entry<BytesRef, Object[]> entry) {
+                    cells[0] = entry.getKey();
+                    Object[] states = entry.getValue();
+                    for (int i = 0, c = 1; i < states.length; i++, c++) {
+                        //noinspection unchecked
+                        cells[c] = mode.finishCollect(ramAccounting, aggregations.get(i).function(), states[i]);
+                    }
+                    return row;
+                }
+            })
+            .iterator();
+    }
+
+    private static Map<BytesRef, Object[]> applyAggregatesGroupedByKey(BigArrays bigArrays,
+                                                                       Engine.Searcher searcher,
+                                                                       IndexOrdinalsFieldData keyIndexFieldData,
+                                                                       InputFactory.Context<CollectExpression<Row, ?>> ctxForAggregations,
+                                                                       List<AggregationContext> aggregations,
+                                                                       List<? extends LuceneCollectorExpression<?>> expressions,
+                                                                       RamAccountingContext ramAccounting,
+                                                                       InputRow inputRow,
+                                                                       LuceneQueryBuilder.Context queryContext) throws IOException {
+        Map<BytesRef, Object[]> statesByKey = new HashMap<>();
+        Object[] nullStates = null;
+        Weight weight = searcher.searcher().createNormalizedWeight(queryContext.query(), false);
+        List<LeafReaderContext> leaves = searcher.searcher().getTopReaderContext().leaves();
+
+        for (LeafReaderContext leaf: leaves) {
+            Scorer scorer = weight.scorer(leaf);
+            if (scorer == null) {
+                continue;
+            }
+            for (LuceneCollectorExpression<?> expression: expressions) {
+                expression.setNextReader(leaf);
+            }
+            SortedSetDocValues values = keyIndexFieldData.load(leaf).getOrdinalsValues();
+            try (ObjectArray<Object[]> statesByOrd = bigArrays.newObjectArray(values.getValueCount())) {
+                DocIdSetIterator docs = scorer.iterator();
+                Bits liveDocs = leaf.reader().getLiveDocs();
+                for (int doc = docs.nextDoc(); doc != DocIdSetIterator.NO_MORE_DOCS; doc = docs.nextDoc()) {
+                    if (docDeleted(liveDocs, doc)) {
+                        continue;
+                    }
+                    for (LuceneCollectorExpression<?> expression : expressions) {
+                        expression.setNextDocId(doc);
+                    }
+                    for (CollectExpression<Row, ?> expression : ctxForAggregations.expressions()) {
+                        expression.setNextRow(inputRow);
+                    }
+                    if (values.advanceExact(doc)) {
+                        long ord = values.nextOrd();
+                        Object[] states = statesByOrd.get(ord);
+                        if (states == null) {
+                            statesByOrd.set(ord, initStates(bigArrays, aggregations, ramAccounting));
+                        } else {
+                            aggregateValues(aggregations, ramAccounting, states);
+                        }
+                        if (values.nextOrd() != SortedSetDocValues.NO_MORE_ORDS) {
+                            throw new GroupByOnArrayUnsupportedException(keyIndexFieldData.getFieldName());
+                        }
+                    } else {
+                        if (nullStates == null) {
+                            nullStates = initStates(bigArrays, aggregations, ramAccounting);
+                        } else {
+                            aggregateValues(aggregations, ramAccounting, nullStates);
+                        }
+                    }
+                }
+                for (long ord = 0; ord < statesByOrd.size(); ord++) {
+                    Object[] states = statesByOrd.get(ord);
+                    if (states == null) {
+                        continue;
+                    }
+                    BytesRef sharedKey = values.lookupOrd(ord);
+                    Object[] prevStates = statesByKey.get(sharedKey);
+                    if (prevStates == null) {
+                        long hashMapEntryOverhead = 36L;
+                        ramAccounting.addBytes(roundUp(
+                            BytesRefSizeEstimator.INSTANCE.estimateSize(sharedKey) + hashMapEntryOverhead));
+                        statesByKey.put(BytesRef.deepCopyOf(sharedKey), states);
+                    } else {
+                        for (int i = 0; i < aggregations.size(); i++) {
+                            AggregationContext aggregation = aggregations.get(i);
+                            //noinspection unchecked
+                            prevStates[i] = aggregation.function().reduce(
+                                ramAccounting,
+                                prevStates[i],
+                                states[i]
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        if (nullStates != null) {
+            statesByKey.put(null, nullStates);
+        }
+        return statesByKey;
+    }
+
+    private static boolean docDeleted(@Nullable Bits liveDocs, int doc) {
+        return liveDocs != null && !liveDocs.get(doc);
+    }
+
+    private static void aggregateValues(List<AggregationContext> aggregations,
+                                        RamAccountingContext ramAccounting,
+                                        Object[] states) {
+        for (int i = 0; i < aggregations.size(); i++) {
+            AggregationContext aggregation = aggregations.get(i);
+            //noinspection unchecked
+            states[i] = aggregation.function().iterate(
+                ramAccounting,
+                states[i],
+                aggregation.inputs()
+            );
+        }
+    }
+
+    private static Object[] initStates(BigArrays bigArrays,
+                                       List<AggregationContext> aggregations,
+                                       RamAccountingContext ramAccounting) {
+        Object[] states = new Object[aggregations.size()];
+        for (int i = 0; i < aggregations.size(); i++) {
+            AggregationContext aggregation = aggregations.get(i);
+            AggregationFunction function = aggregation.function();
+            //noinspection unchecked
+            states[i] = function.iterate(
+                ramAccounting,
+                function.newState(ramAccounting, Version.CURRENT, bigArrays),
+                aggregation.inputs()
+            );
+        }
+        return states;
+    }
+
+
+    @Nullable
+    private static Reference getKeyRef(List<Symbol> toCollect, Symbol key) {
+        if (key instanceof InputColumn) {
+            Symbol keyRef = toCollect.get(((InputColumn) key).index());
+            if (keyRef instanceof Reference) {
+                return ((Reference) keyRef);
+            }
+        }
+        return null;
+    }
+
+    private static GroupProjection getSingleStringKeyGroupProjection(Collection<? extends Projection> shardProjections) {
+        if (shardProjections.size() != 1) {
+            return null;
+        }
+        Projection shardProjection = shardProjections.iterator().next();
+        if (!(shardProjection instanceof GroupProjection)) {
+            return null;
+        }
+        GroupProjection groupProjection = (GroupProjection) shardProjection;
+        if (groupProjection.keys().size() != 1 || groupProjection.keys().get(0).valueType() != DataTypes.STRING) {
+            return null;
+        }
+        return groupProjection;
+    }
+}

--- a/sql/src/main/java/io/crate/execution/engine/collect/ShardCollectorProvider.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/ShardCollectorProvider.java
@@ -121,6 +121,10 @@ public abstract class ShardCollectorProvider {
             "granularity must be DOC";
 
         RoutedCollectPhase normalizedCollectNode = collectPhase.normalize(shardNormalizer, null);
+        BatchIterator<Row> fusedIterator = getProjectionFusedIterator(normalizedCollectNode, collectTask);
+        if (fusedIterator != null) {
+            return fusedIterator;
+        }
         final BatchIterator<Row> iterator;
         if (QueryClause.canMatch(normalizedCollectNode.where())) {
             iterator = getUnorderedIterator(normalizedCollectNode, requiresScroll, collectTask);
@@ -135,6 +139,15 @@ public abstract class ShardCollectorProvider {
             iterator
         );
     }
+
+    /**
+     * @return A BatchIterator which already applies the transformation described in the shardProjections of the collectPhase.
+     *         This can be used to return a specialized BatchIterator for certain projections. If this returns null
+     *         a fallback/default BatchIterator will be created and projections will be applied using the projectorFactory
+     */
+    @Nullable
+    protected abstract BatchIterator<Row> getProjectionFusedIterator(RoutedCollectPhase normalizedPhase,
+                                                                     CollectTask collectTask);
 
     protected abstract BatchIterator<Row> getUnorderedIterator(RoutedCollectPhase collectPhase,
                                                                boolean requiresScroll,

--- a/sql/src/test/java/io/crate/execution/engine/collect/GroupByOptimizedIteratorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/GroupByOptimizedIteratorTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.engine.collect;
+
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.SortedDocValuesField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.store.RAMDirectory;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.index.engine.Engine;
+import org.elasticsearch.index.mapper.KeywordFieldMapper;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class GroupByOptimizedIteratorTest {
+
+
+    @Test
+    public void testHighCardinalityRatioReturnsTrueForHighCardinality() throws Exception {
+        IndexWriter iw = new IndexWriter(new RAMDirectory(), new IndexWriterConfig(new StandardAnalyzer()));
+        String columnName = "x";
+        for (int i = 0; i < 10; i++) {
+            Document doc = new Document();
+            BytesRef value = new BytesRef(Integer.toString(i));
+            doc.add(new Field(columnName, value, KeywordFieldMapper.Defaults.FIELD_TYPE.clone()));
+            iw.addDocument(doc);
+        }
+        iw.commit();
+
+        IndexSearcher indexSearcher = new IndexSearcher(DirectoryReader.open(iw));
+
+        assertThat(
+            GroupByOptimizedIterator.hasHighCardinalityRatio(() -> new Engine.Searcher("dummy", indexSearcher), "x"),
+            is(true)
+        );
+    }
+
+    @Test
+    public void testHighCardinalityRatioReturnsTrueForLowCardinality() throws Exception {
+        IndexWriter iw = new IndexWriter(new RAMDirectory(), new IndexWriterConfig(new StandardAnalyzer()));
+        String columnName = "x";
+        for (int i = 0; i < 10; i++) {
+            Document doc = new Document();
+            BytesRef value = new BytesRef("1");
+            doc.add(new Field(columnName, value, KeywordFieldMapper.Defaults.FIELD_TYPE.clone()));
+            iw.addDocument(doc);
+        }
+        iw.commit();
+
+        IndexSearcher indexSearcher = new IndexSearcher(DirectoryReader.open(iw));
+
+        assertThat(
+            GroupByOptimizedIterator.hasHighCardinalityRatio(() -> new Engine.Searcher("dummy", indexSearcher), "x"),
+            is(false)
+        );
+    }
+}


### PR DESCRIPTION
This adds a new specialized BatchIterator implementation which can be
used if a GROUP BY on shard-level for single string column is done.

This specialized BatchIterator implementation utilizes Lucene ordinal
values to reduce the number of key value retrievals from one per row to
one per unique key value.

Cases which should see a big improvement are GROUP BY on low cardinality
columns with few aggregations.


```
V1: 3.1.0-c3a321f28a9a0abd1d963180007f88aeaaee13be
V2: 3.1.0-8e7f59712ca26de466832694da2cfb2ea3109c55

Q: select "cCode", count(*) from uservisits group by "cCode"
C: 1
  147.71% mean difference. Likely significant
             V1    →   V2
  mean:  339.379 →  51.034
  stdev:  28.136 →  38.005
  max:   589.710 → 422.792
  min:   313.943 →  34.308

Q: select min("adRevenue") from uservisits group by "cCode"
C: 1
  68.32% mean difference. Likely significant
             V1    →   V2
  mean:  364.508 → 178.885
  stdev:  14.848 →  75.244
  max:   409.392 → 789.264
  min:   334.004 → 138.263

Q: select max("adRevenue") from uservisits group by "cCode"
C: 1
  76.70% mean difference. Likely significant
             V1    →   V2
  mean:  365.177 → 162.723
  stdev:  16.056 →  45.588
  max:   447.554 → 590.674
  min:   339.256 → 135.773

Q: select avg("adRevenue") from uservisits group by "cCode"
C: 1
  79.51% mean difference. Likely significant
             V1    →   V2
  mean:  363.576 → 156.731
  stdev:  14.117 →  10.758
  max:   403.539 → 190.785
  min:   334.786 → 129.357

Q: select count(distinct "searchWord") from uservisits group by "cCode"
C: 1
  33.78% mean difference. Likely significant
             V1    →   V2
  mean:  1046.754 → 744.235
  stdev:  39.760 →  68.410
  max:   1305.067 → 1312.638
  min:   980.169 → 685.295

Q: select arbitrary("searchWord") from uservisits group by "cCode"
C: 1
  58.21% mean difference. Likely significant
             V1    →   V2
  mean:  722.474 → 396.746
  stdev:  77.180 →  12.042
  max:   1179.716 → 427.690
  min:   661.673 → 370.212
```