### PR TITLE
Optimize group by single long columns

### DIFF
--- a/sql/src/main/java/io/crate/execution/engine/aggregation/GroupBySingleLongCollector.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/GroupBySingleLongCollector.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.engine.aggregation;
+
+import io.crate.breaker.RamAccountingContext;
+import io.crate.data.Input;
+import io.crate.data.Row;
+import io.crate.data.RowN;
+import io.crate.execution.engine.collect.CollectExpression;
+import io.crate.expression.symbol.AggregateMode;
+import io.netty.util.collection.LongObjectHashMap;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.util.BigArrays;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public final class GroupBySingleLongCollector implements Collector<Row, GroupBySingleLongCollector.Groups, Iterable<Row>> {
+
+    private final CollectExpression<Row, ?>[] expressions;
+    private final AggregateMode mode;
+    private final AggregationFunction[] aggregations;
+    private final Input[][] inputs;
+    private final RamAccountingContext ramAccounting;
+    private final Input<Long> keyInput;
+    private final Version indexVersionCreated;
+    private final BigArrays bigArrays;
+    private final BiConsumer<Groups, Row> accumulator;
+
+    GroupBySingleLongCollector(CollectExpression<Row, ?>[] expressions,
+                               AggregateMode mode,
+                               AggregationFunction[] aggregations,
+                               Input[][] inputs,
+                               RamAccountingContext ramAccounting,
+                               Input<Long> keyInput,
+                               Version indexVersionCreated,
+                               BigArrays bigArrays) {
+        this.expressions = expressions;
+        this.mode = mode;
+        this.aggregations = aggregations;
+        this.inputs = inputs;
+        this.ramAccounting = ramAccounting;
+        this.keyInput = keyInput;
+        this.indexVersionCreated = indexVersionCreated;
+        this.bigArrays = bigArrays;
+        this.accumulator = mode == AggregateMode.PARTIAL_FINAL ? this::reduce : this::iter;
+    }
+
+    static class Groups {
+
+        final LongObjectHashMap<Object[]> statesByKey = new LongObjectHashMap<>();
+        Object[] statesByNullValue = null;
+    }
+
+    @Override
+    public Supplier<Groups> supplier() {
+        return Groups::new;
+    }
+
+    @Override
+    public BiConsumer<Groups, Row> accumulator() {
+        return accumulator;
+    }
+
+    @Override
+    public BinaryOperator<Groups> combiner() {
+        return (state1, state2) -> {
+            throw new UnsupportedOperationException("Combine not supported");
+        };
+    }
+
+    @Override
+    public Function<Groups, Iterable<Row>> finisher() {
+        return this::groupsToRows;
+    }
+
+    @Override
+    public Set<Characteristics> characteristics() {
+        return Collections.emptySet();
+    }
+
+    private void reduce(Groups groups, Row row) {
+        for (CollectExpression<Row, ?> expression : expressions) {
+            expression.setNextRow(row);
+        }
+        Long key = keyInput.value();
+        if (key == null) {
+            if (groups.statesByNullValue == null) {
+                groups.statesByNullValue = statesFromInputRow();
+            } else {
+                mergeStatesWithInputRowInPlace(groups.statesByNullValue);
+            }
+        } else {
+            Object[] states = groups.statesByKey.get(key);
+            if (states == null) {
+                addWithAccounting(groups, key, statesFromInputRow());
+            } else {
+                mergeStatesWithInputRowInPlace(states);
+            }
+        }
+    }
+
+    private void mergeStatesWithInputRowInPlace(Object[] states) {
+        for (int i = 0; i < aggregations.length; i++) {
+            states[i] = aggregations[i].reduce(ramAccounting, states[i], inputs[i][0].value());
+        }
+    }
+
+    private Object[] statesFromInputRow() {
+        Object[] states = new Object[aggregations.length];
+        for (int i = 0; i < aggregations.length; i++) {
+            states[i] = inputs[i][0].value();
+        }
+        return states;
+    }
+
+    private void iter(Groups groups, Row row) {
+        for (CollectExpression<Row, ?> expression : expressions) {
+            expression.setNextRow(row);
+        }
+        Long key = keyInput.value();
+        if (key == null) {
+            if (groups.statesByNullValue == null) {
+                groups.statesByNullValue = createNewStates();
+            } else {
+                for (int i = 0; i < aggregations.length; i++) {
+                    //noinspection unchecked
+                    groups.statesByNullValue[i] = aggregations[i].iterate(ramAccounting, groups.statesByNullValue[i], inputs[i]);
+                }
+            }
+        } else {
+            Object[] states = groups.statesByKey.get(key);
+            if (states == null) {
+                addWithAccounting(groups, key, createNewStates());
+            } else {
+                for (int i = 0; i < aggregations.length; i++) {
+                    //noinspection unchecked
+                    states[i] = aggregations[i].iterate(ramAccounting,  states[i], inputs[i]);
+                }
+            }
+        }
+    }
+
+    private void addWithAccounting(Groups groups, long key, Object[] newStates) {
+        /* This is "best effort" accounting for the "entry overhead" (newStates are already accounted for)
+         * The LongObjectHashMap internally has a long array for keys and an object array for values
+         *
+         * They're not-resized per key added but capacity is doubled if it runs out
+         *
+         * Size has been inferred using JOL
+         *
+         * 24 [J                     .keys      [0]
+         * 24 [Ljava.lang.Object;    .values    [null]
+         *
+         * 32 [J                     .keys      [10, 0]
+         * 24 [Ljava.lang.Object;    .values    [(object), null]
+         *
+         * 48 [J                     .keys      [20, 0, 10, 0]
+         * 32 [Ljava.lang.Object;    .values    [(object), null, (object), null]
+         *
+         * 80 [J                     .keys      [0, 0, 10, 0, 20, 0, 30, 0]
+         * 48 [Ljava.lang.Object;    .values    [null, null, (object), null, (object), null, (object), null]
+         */
+        ramAccounting.addBytes(12L);
+        groups.statesByKey.put(key, newStates);
+    }
+
+    private Object[] createNewStates() {
+        Object[] states = new Object[aggregations.length];
+        for (int i = 0; i < aggregations.length; i++) {
+            AggregationFunction aggregation = aggregations[i];
+            //noinspection unchecked
+            states[i] = aggregation.iterate(
+                ramAccounting,
+                aggregation.newState(ramAccounting, indexVersionCreated, bigArrays),
+                inputs[i]
+            );
+        }
+        return states;
+    }
+
+    private Iterable<Row> groupsToRows(Groups groups) {
+        final Object[] cells = new Object[1 + aggregations.length];
+        final Row row = new RowN(cells);
+        Stream<Row> rows = StreamSupport.stream(groups.statesByKey.entries().spliterator(), false)
+            .map(entry -> {
+                cells[0] = entry.key();
+                Object[] states = entry.value();
+                for (int i = 0; i < states.length; i++) {
+                    //noinspection unchecked
+                    cells[i + 1] = mode.finishCollect(ramAccounting, aggregations[i], states[i]);
+                }
+                return row;
+            });
+
+        if (groups.statesByNullValue == null) {
+            return rows::iterator;
+        }
+
+        Object[] nullRow = new Object[1 + aggregations.length];
+        nullRow[0] = null;
+        for (int i = 0; i < groups.statesByNullValue.length; i++) {
+            //noinspection unchecked
+            nullRow[i + 1] = mode.finishCollect(ramAccounting, aggregations[i], groups.statesByNullValue[i]);
+        }
+        return Stream.concat(rows, Stream.of(new RowN(nullRow)))::iterator;
+    }
+}

--- a/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
+++ b/sql/src/main/java/io/crate/execution/engine/pipeline/ProjectionToProjectorVisitor.java
@@ -76,7 +76,6 @@ import io.crate.expression.reference.StaticTableDefinition;
 import io.crate.expression.reference.sys.SysRowUpdater;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
-import io.crate.expression.symbol.Symbols;
 import io.crate.expression.symbol.ValueSymbolVisitor;
 import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.Functions;
@@ -248,7 +247,7 @@ public class ProjectionToProjectorVisitor
 
         List<Input<?>> keyInputs = ctx.topLevelInputs();
         return new GroupingProjector(
-            Symbols.typeView(projection.keys()),
+            projection.keys(),
             keyInputs,
             Iterables.toArray(ctx.expressions(), CollectExpression.class),
             projection.mode(),

--- a/sql/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
@@ -1236,4 +1236,18 @@ public class GroupByAggregateTest extends SQLTransportIntegrationTest {
         execute("select sum(i), max(s) from t1");
         assertThat(printedTable(response.rows()), is("4| foobar\n"));
     }
+
+    @Test
+    public void testGroupBySingleLongWithNullValues() {
+        execute("create table t (x long) clustered into 2 shards with (number_of_replicas = 0)");
+        execute("insert into t (x) values (1), (1), (1), (2), (2), (null), (null), (null), (null)");
+        execute("refresh table t");
+
+        assertThat(
+            printedTable(execute("select x, count(*) from t group by x order by 2 desc").rows()),
+            is("NULL| 4\n" +
+               "1| 3\n" +
+               "2| 2\n")
+        );
+    }
 }


### PR DESCRIPTION
```
Benchmark                                                      Mode  Cnt    Score   Error  Units
GroupingLongCollectorBenchmark.measureGroupBySumLong           avgt  200  566.502 ± 3.660  ms/op
GroupingLongCollectorBenchmark.measureGroupBySumLongOptimized  avgt  200  485.423 ± 4.758  ms/op
```

### run 1
```
# Results (server side duration in ms)
V1: 3.1.0-71940e50768d75d80e80e7eb02055758e6467c7b
V2: 3.1.0-dc8f4e4b8351013377b3faef0c0e2b5ed8ec9455

Q: select count(*) from (select distinct x from t090) t
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |     6975.742 ± 2034.624 |   1394.776 |   6639.046 |   9042.808 |  10284.664 |
|   V2    |     2333.336 ±  485.493 |   1017.462 |   2301.601 |   2592.907 |   3660.166 |
mean:   -  99.74%
median: -  97.03%
Likely significant

Q: select count(*) from (select distinct x from t075) t
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |     4738.452 ± 1022.934 |    257.029 |   4960.692 |   5365.796 |   7234.047 |
|   V2    |     2049.369 ±  516.112 |    598.386 |   1942.409 |   2109.260 |   3481.397 |
mean:   -  79.23%
median: -  87.45%
Likely significant

Q: select count(*) from (select distinct x from t050) t
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |     2080.230 ±  802.035 |    635.679 |   2248.007 |   2620.298 |   4047.369 |
|   V2    |      927.741 ±  377.066 |    325.007 |    773.215 |   1225.511 |   1700.408 |
mean:   -  76.63%
median: -  97.63%
Likely significant

Q: select count(*) from (select distinct x from t025) t
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      870.551 ±  510.566 |    197.231 |    554.926 |   1428.937 |   2187.077 |
|   V2    |      446.674 ±   94.210 |    222.356 |    427.676 |    485.754 |    758.684 |
mean:   -  64.36%
median: -  25.90%
Likely significant
```

### run 2

```
# Results (server side duration in ms)
V1: 3.1.0-71940e50768d75d80e80e7eb02055758e6467c7b
V2: 3.1.0-dc8f4e4b8351013377b3faef0c0e2b5ed8ec9455

Q: select count(*) from (select distinct x from t090) t
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |     6016.842 ± 1900.426 |   2936.146 |   6124.341 |   7251.793 |  10108.084 |
|   V2    |     2576.903 ±  735.732 |   1365.651 |   2267.273 |   3229.371 |   4042.445 |
mean:   -  80.06%
median: -  91.93%
Likely significant

Q: select count(*) from (select distinct x from t075) t
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |     3442.928 ± 1355.553 |    771.407 |   2859.311 |   4663.134 |   8020.849 |
|   V2    |     6533.723 ±  943.046 |   4405.697 |   6617.557 |   7352.488 |   8345.293 |
mean:   +  61.96%
median: +  79.31%
Likely significant

Q: select count(*) from (select distinct x from t050) t
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |     2020.365 ±  781.345 |    649.959 |   2191.720 |   2576.414 |   3883.637 |
|   V2    |     1109.604 ±  392.267 |    387.773 |    949.335 |   1436.464 |   2074.401 |
mean:   -  58.20%
median: -  79.11%
Likely significant

Q: select count(*) from (select distinct x from t025) t
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      895.728 ±  383.140 |    230.919 |    656.888 |   1261.118 |   1972.430 |
|   V2    |      494.235 ±  313.644 |    168.962 |    338.626 |    480.707 |   1369.232 |
mean:   -  57.77%
median: -  63.94%
Likely significant
```

### run 3

```
# Results (server side duration in ms)
V1: 3.1.0-71940e50768d75d80e80e7eb02055758e6467c7b
V2: 3.1.0-dc8f4e4b8351013377b3faef0c0e2b5ed8ec9455

Q: select count(*) from (select distinct x from t090) t
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |     6777.261 ± 1926.659 |   1773.658 |   6315.287 |   8729.821 |  10188.853 |
|   V2    |     4960.349 ±  690.449 |   3162.189 |   4977.529 |   5463.291 |   6835.190 |
mean:   -  30.96%
median: -  23.69%
Likely significant

Q: select count(*) from (select distinct x from t075) t
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |     2275.069 ±  467.498 |    744.612 |   2350.660 |   2478.280 |   4516.736 |
|   V2    |     2529.203 ±  691.175 |    555.277 |   2185.492 |   3228.855 |   4093.665 |
mean:   +  10.58%
median: -   7.28%
Likely significant

Q: select count(*) from (select distinct x from t050) t
C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |     2027.843 ±  723.704 |    227.636 |   2225.601 |   2555.283 |   2882.648 |
|   V2    |      925.682 ±  400.659 |    341.714 |    779.014 |   1214.951 |   2034.414 |
mean:   -  74.63%
median: -  96.29%
Likely significant

Q: select count(*) from (select distinct x from t025) t

C: 10
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      822.196 ±  398.043 |    200.758 |    603.540 |   1297.467 |   1687.896 |
|   V2    |      451.089 ±  259.404 |    242.448 |    326.681 |    439.118 |   1341.171 |
mean:   -  58.29%
median: -  59.53%
Likely significant
```