### PR TITLE
Fix issue with index upgrader introduced with previous fix.

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -107,5 +107,11 @@ Changes
 Fixes
 =====
 
+- Fixed an issue which was introduced with ``3.0.4`` and could result in
+  ``IllegalStateException`` being thrown during the startup of a CrateDB node,
+  which prevents its successful bootstrap and one cannot recover from this
+  state. ``3.0.4`` is a testing release and is not available in the stable
+  channels.
+
 - Fixed syntax support for certain ``ALTER BLOB TABLE RENAME``, ``REROUTE``
   and ``OPEN/CLOSE`` queries.

--- a/sql/src/main/java/io/crate/metadata/upgrade/MetaDataIndexUpgrader.java
+++ b/sql/src/main/java/io/crate/metadata/upgrade/MetaDataIndexUpgrader.java
@@ -23,6 +23,7 @@
 package io.crate.metadata.upgrade;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
 import io.crate.Constants;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
@@ -94,7 +95,9 @@ public class MetaDataIndexUpgrader implements UnaryOperator<IndexMetaData> {
         }
 
         try {
-            return new MappingMetaData(Constants.DEFAULT_MAPPING_TYPE, newMapping);
+            return new MappingMetaData(
+                Constants.DEFAULT_MAPPING_TYPE,
+                ImmutableMap.of(Constants.DEFAULT_MAPPING_TYPE, newMapping));
         } catch (IOException e) {
             logger.error("Failed to upgrade mapping for index '" + indexName + "'", e);
             return mappingMetaData;

--- a/sql/src/test/java/io/crate/metadata/upgrade/MetaDataIndexUpgraderTest.java
+++ b/sql/src/test/java/io/crate/metadata/upgrade/MetaDataIndexUpgraderTest.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.core.IsNull.nullValue;
 
 public class MetaDataIndexUpgraderTest extends CrateUnitTest {
@@ -45,6 +46,9 @@ public class MetaDataIndexUpgraderTest extends CrateUnitTest {
 
         Object dynamicTemplates = newMappingMetaData.getSourceAsMap().get("dynamic_templates");
         assertThat(dynamicTemplates, nullValue());
+
+        // Check that the new metadata still has the root "default" element
+        assertThat("{\"default\":{}}", is(newMappingMetaData.source().toString()));
     }
 
     private static CompressedXContent createDynamicStringMappingTemplate() throws IOException {


### PR DESCRIPTION
New mapping created after purging the "dynamic_templates" element
is missing the root "default" element. This results in an exception:
`java.lang.IllegalStateException: Can't derive type from mapping, no root type:...`
which prevents a CrateDB node from bootstraping.

Issue was caught with `test_upgrade_paths (bwc.test_upgrade.StorageCompatibilityTest)`
of `crate-qa` when trying to upgrade from latest `2.3` to `3.0.4` version.

Followup of: c3a321f28a9a0abd1d963180007f88aeaaee13be