### PR TITLE
Remove onRow abstraction from AggregateMode

### DIFF
--- a/sql/src/main/java/io/crate/execution/engine/aggregation/GroupingCollector.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/GroupingCollector.java
@@ -218,7 +218,8 @@ public class GroupingCollector<K> implements Collector<Row, Map<K, Object[]>, It
             addNewEntry(statesByKey, key);
         } else {
             for (int i = 0; i < aggregations.length; i++) {
-                states[i] = mode.onRow(ramAccountingContext, aggregations[i], states[i], inputs[i]);
+                //noinspection unchecked
+                states[i] = aggregations[i].iterate(ramAccountingContext, states[i], inputs[i]);
             }
         }
     }
@@ -228,8 +229,9 @@ public class GroupingCollector<K> implements Collector<Row, Map<K, Object[]>, It
         states = new Object[aggregations.length];
         for (int i = 0; i < aggregations.length; i++) {
             AggregationFunction aggregation = aggregations[i];
-            states[i] = mode.onRow(
-                ramAccountingContext, aggregation,
+            //noinspection unchecked
+            states[i] = aggregation.iterate(
+                ramAccountingContext,
                 aggregation.newState(ramAccountingContext, indexVersionCreated, bigArrays), inputs[i]);
         }
         addWithAccounting(statesByKey, key, states);

--- a/sql/src/main/java/io/crate/expression/symbol/AggregateMode.java
+++ b/sql/src/main/java/io/crate/expression/symbol/AggregateMode.java
@@ -24,7 +24,6 @@ package io.crate.expression.symbol;
 
 import com.google.common.collect.ImmutableList;
 import io.crate.breaker.RamAccountingContext;
-import io.crate.data.Input;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.types.DataType;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -46,21 +45,12 @@ public enum AggregateMode {
         }
     },
     ITER_FINAL,
-    PARTIAL_FINAL {
-        @Override
-        public <T> T onRow(RamAccountingContext ramAccounting, AggregationFunction<T, ?> function, T state, Input[] inputs) {
-            return function.reduce(ramAccounting, state, ((T) inputs[0].value()));
-        }
-    };
+    PARTIAL_FINAL;
 
     private static final List<AggregateMode> VALUES = ImmutableList.copyOf(values());
 
     public DataType returnType(AggregationFunction function) {
         return function.info().returnType();
-    }
-
-    public <T> T onRow(RamAccountingContext ramAccounting, AggregationFunction<T, ?> function, T state, Input... inputs) {
-        return function.iterate(ramAccounting, state, inputs);
     }
 
     public <TP, TF> TF finishCollect(RamAccountingContext ramAccounting, AggregationFunction<TP, TF> function, TP state) {


### PR DESCRIPTION
Follow up to 5f93c9f6615bc47b17916bd2a218faf7feabd01d

Since we're already using different accumulators to optimize the
`reduce` we no longer require the `onRow` abstraction.