### PR TITLE
probot: Reduce daysUntilClose from 14 to 7

### DIFF
--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -1,2 +1,4 @@
 # Configuration for probot-no-response - https://github.com/probot/no-response
+---
 responseRequiredLabel: needs feedback
+daysUntilClose: 7


### PR DESCRIPTION
People usually either respond rather quickly or not at all. So let's
reduce the duration until an issue is closed without feedback a bit.