### PR TITLE
Expose the cluster state version under a new ClusterInfo bean instead of NodeInfo

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -43,7 +43,7 @@ Changes
 =======
 
 - Exposed the cluster state version in the ``sys.nodes`` table under the
-  ``cluster_state_version`` column and under the ``NodeInfo`` MXBean in JMX.
+  ``cluster_state_version`` column and under the ``ClusterInfo`` MXBean in JMX.
 
 - Added a new ``ThreadPools`` MXBean for JMX which exposes statistics of all
   used thread pools.

--- a/enterprise/jmx-monitoring/src/main/java/io/crate/beans/ClusterInfo.java
+++ b/enterprise/jmx-monitoring/src/main/java/io/crate/beans/ClusterInfo.java
@@ -18,18 +18,20 @@
 
 package io.crate.beans;
 
-import io.crate.testing.DiscoveryNodes;
-import org.junit.Test;
+import java.util.function.LongSupplier;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+public class ClusterInfo implements ClusterInfoMBean {
 
-public class NodeInfoTest {
+    public static final String NAME = "io.crate.monitoring:type=ClusterInfo";
 
-    @Test
-    public void testNodeInfo() {
-        NodeInfo nodeInfo = new NodeInfo(() -> DiscoveryNodes.newNode("testNode", "testNodeId"));
-        assertThat(nodeInfo.getNodeId(), is("testNodeId"));
-        assertThat(nodeInfo.getNodeName(), is("testNode"));
+    private final LongSupplier clusterStateVersion;
+
+    public ClusterInfo(LongSupplier clusterStateVersion) {
+        this.clusterStateVersion = clusterStateVersion;
+    }
+
+    @Override
+    public long getClusterStateVersion() {
+        return clusterStateVersion.getAsLong();
     }
 }

--- a/enterprise/jmx-monitoring/src/main/java/io/crate/beans/ClusterInfoMBean.java
+++ b/enterprise/jmx-monitoring/src/main/java/io/crate/beans/ClusterInfoMBean.java
@@ -18,18 +18,16 @@
 
 package io.crate.beans;
 
-import io.crate.testing.DiscoveryNodes;
-import org.junit.Test;
+/**
+ * The {@link ClusterInfoMBean | interface is required to define a standard MBean,
+ * such as a standard MBean is composed of an MBean interface and a class.
+ *
+ * This interface lists the methods for all exposed attributes.
+ *
+ * @see <a href="https://docs.oracle.com/javase/tutorial/jmx/mbeans/standard.html">
+ *     https://docs.oracle.com/javase/tutorial/jmx/mbeans/standard.html</a>
+ */
+public interface ClusterInfoMBean {
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-
-public class NodeInfoTest {
-
-    @Test
-    public void testNodeInfo() {
-        NodeInfo nodeInfo = new NodeInfo(() -> DiscoveryNodes.newNode("testNode", "testNodeId"));
-        assertThat(nodeInfo.getNodeId(), is("testNodeId"));
-        assertThat(nodeInfo.getNodeName(), is("testNode"));
-    }
+    long getClusterStateVersion();
 }

--- a/enterprise/jmx-monitoring/src/main/java/io/crate/beans/NodeInfo.java
+++ b/enterprise/jmx-monitoring/src/main/java/io/crate/beans/NodeInfo.java
@@ -20,19 +20,16 @@ package io.crate.beans;
 
 import org.elasticsearch.cluster.node.DiscoveryNode;
 
-import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 
 public class NodeInfo implements NodeInfoMBean {
 
     public static final String NAME = "io.crate.monitoring:type=NodeInfo";
 
-    private final LongSupplier clusterStateVersion;
     private final Supplier<DiscoveryNode> localNode;
 
-    public NodeInfo(Supplier<DiscoveryNode> localNode, LongSupplier clusterStateVersion) {
+    public NodeInfo(Supplier<DiscoveryNode> localNode) {
         this.localNode = localNode;
-        this.clusterStateVersion = clusterStateVersion;
     }
 
     @Override
@@ -43,10 +40,5 @@ public class NodeInfo implements NodeInfoMBean {
     @Override
     public String getNodeName() {
         return localNode.get().getName();
-    }
-
-    @Override
-    public Long getClusterStateVersion() {
-        return clusterStateVersion.getAsLong();
     }
 }

--- a/enterprise/jmx-monitoring/src/main/java/io/crate/beans/NodeInfoMBean.java
+++ b/enterprise/jmx-monitoring/src/main/java/io/crate/beans/NodeInfoMBean.java
@@ -32,6 +32,4 @@ public interface NodeInfoMBean {
     String getNodeId();
 
     String getNodeName();
-
-    Long getClusterStateVersion();
 }

--- a/enterprise/jmx-monitoring/src/main/java/io/crate/plugin/CrateMonitor.java
+++ b/enterprise/jmx-monitoring/src/main/java/io/crate/plugin/CrateMonitor.java
@@ -19,6 +19,7 @@
 package io.crate.plugin;
 
 import io.crate.action.sql.SQLOperations;
+import io.crate.beans.ClusterInfo;
 import io.crate.beans.Connections;
 import io.crate.beans.NodeInfo;
 import io.crate.beans.NodeStatus;
@@ -62,7 +63,8 @@ public class CrateMonitor {
         logger = Loggers.getLogger(CrateMonitor.class, settings);
         registerMBean(QueryStats.NAME, new QueryStats(jobsLogs));
         registerMBean(NodeStatus.NAME, new NodeStatus(sqlOperations::isEnabled));
-        registerMBean(NodeInfo.NAME, new NodeInfo(clusterService::localNode, () -> clusterService.state().version()));
+        registerMBean(NodeInfo.NAME, new NodeInfo(clusterService::localNode));
+        registerMBean(ClusterInfo.NAME, new ClusterInfo(() -> clusterService.state().version()));
         registerMBean(Connections.NAME, new Connections(
             () -> httpServerTransport == null ? null : httpServerTransport.stats(),
             () -> new ConnectionStats(postgresNetty.openConnections(), postgresNetty.totalConnections()),

--- a/enterprise/jmx-monitoring/src/test/java/io/crate/beans/ClusterInfoTest.java
+++ b/enterprise/jmx-monitoring/src/test/java/io/crate/beans/ClusterInfoTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.beans;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class ClusterInfoTest {
+
+    @Test
+    public void testClusterInfo() {
+        ClusterInfo clusterInfo = new ClusterInfo(() -> 2L);
+        assertThat(clusterInfo.getClusterStateVersion(), is(2L));
+    }
+
+}


### PR DESCRIPTION


<!--

Thank you for your contribution. Here is a quick checklist of things you should've done:

 - You've read CONTRIBUTING.rst and signed our CLA (https://crate.io/community/contribute/cla/)
 - Wrote a CHANGES.txt entry if this is a change that is relevant for users of CrateDB
 - Run tests with `./gradlew test itest` (If they fail Jenkins will block this PR anyway)

-->
