### PR TITLE
Tests: Avoid mocking TransportKillAllNodeAction for Java11 compat

### DIFF
--- a/sql/src/test/java/io/crate/execution/engine/collect/collectors/RemoteCollectorTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/collectors/RemoteCollectorTest.java
@@ -43,6 +43,7 @@ import io.crate.testing.TestingRowConsumer;
 import io.crate.types.DataTypes;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.transport.TransportService;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -51,8 +52,10 @@ import org.mockito.MockitoAnnotations;
 
 import java.util.Collections;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static io.crate.testing.TestingHelpers.createReference;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -68,6 +71,7 @@ public class RemoteCollectorTest extends CrateDummyClusterServiceUnitTest {
 
     @Captor
     public ArgumentCaptor<ActionListener<JobResponse>> listenerCaptor;
+    private AtomicInteger numBroadcastCalls;
 
     @Before
     public void prepare() {
@@ -86,13 +90,23 @@ public class RemoteCollectorTest extends CrateDummyClusterServiceUnitTest {
             null
         );
         transportJobAction = mock(TransportJobAction.class);
-        transportKillJobsNodeAction = mock(TransportKillJobsNodeAction.class);
-        consumer = new TestingRowConsumer();
-
         TasksService tasksService = new TasksService(
             Settings.EMPTY,
             clusterService,
             new JobsLogs(() -> true));
+        numBroadcastCalls = new AtomicInteger(0);
+        transportKillJobsNodeAction = new TransportKillJobsNodeAction(
+            Settings.EMPTY,
+            tasksService,
+            clusterService,
+            mock(TransportService.class)
+        ) {
+            @Override
+            public void broadcast(KillJobsRequest request, ActionListener<Long> listener) {
+                numBroadcastCalls.incrementAndGet();
+            }
+        };
+        consumer = new TestingRowConsumer();
         remoteCollector = new RemoteCollector(
             jobId,
             "localNode",
@@ -140,6 +154,6 @@ public class RemoteCollectorTest extends CrateDummyClusterServiceUnitTest {
         ActionListener<JobResponse> listener = listenerCaptor.getValue();
         listener.onResponse(new JobResponse());
 
-        verify(transportKillJobsNodeAction, times(1)).broadcast(any(KillJobsRequest.class), any(ActionListener.class));
+        assertThat(numBroadcastCalls.get(), is(1));
     }
 }

--- a/sql/src/test/java/io/crate/execution/engine/distribution/TransportDistributedResultActionTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/distribution/TransportDistributedResultActionTest.java
@@ -27,9 +27,11 @@ import io.crate.data.Bucket;
 import io.crate.exceptions.TaskMissing;
 import io.crate.execution.engine.collect.stats.JobsLogs;
 import io.crate.execution.jobs.TasksService;
+import io.crate.execution.jobs.kill.KillJobsRequest;
 import io.crate.execution.jobs.kill.TransportKillJobsNodeAction;
 import io.crate.execution.support.Transports;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.bulk.BackoffPolicy;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
@@ -37,15 +39,15 @@ import org.elasticsearch.transport.TransportService;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
+import java.util.Collection;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.mockito.Matchers.any;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 public class TransportDistributedResultActionTest extends CrateDummyClusterServiceUnitTest {
 
@@ -53,7 +55,18 @@ public class TransportDistributedResultActionTest extends CrateDummyClusterServi
     public void testKillIsInvokedIfContextIsNotFound() throws InterruptedException, TimeoutException {
         TasksService tasksService = new TasksService(
             Settings.EMPTY, clusterService, new JobsLogs(() -> false));
-        TransportKillJobsNodeAction killJobsAction = mock(TransportKillJobsNodeAction.class);
+        AtomicInteger numBroadcasts = new AtomicInteger(0);
+        TransportKillJobsNodeAction killJobsAction = new TransportKillJobsNodeAction(
+            Settings.EMPTY,
+            tasksService,
+            clusterService,
+            mock(TransportService.class)
+        ) {
+            @Override
+            public void broadcast(KillJobsRequest request, ActionListener<Long> listener, Collection<String> excludedNodeIds) {
+                numBroadcasts.incrementAndGet();
+            }
+        };
         TransportDistributedResultAction transportDistributedResultAction = new TransportDistributedResultAction(
             mock(Transports.class),
             tasksService,
@@ -74,6 +87,6 @@ public class TransportDistributedResultActionTest extends CrateDummyClusterServi
             assertThat(e.getCause(), Matchers.instanceOf(TaskMissing.class));
         }
 
-        verify(killJobsAction, times(1)).broadcast(any(), any(), any());
+        assertThat(numBroadcasts.get(), is(1));
     }
 }

--- a/sql/src/test/java/io/crate/execution/jobs/transport/NodeDisconnectJobMonitorServiceTest.java
+++ b/sql/src/test/java/io/crate/execution/jobs/transport/NodeDisconnectJobMonitorServiceTest.java
@@ -38,15 +38,14 @@ import org.elasticsearch.transport.TransportService;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static io.crate.testing.DiscoveryNodes.newNode;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 public class NodeDisconnectJobMonitorServiceTest extends CrateDummyClusterServiceUnitTest {
 
@@ -93,7 +92,18 @@ public class NodeDisconnectJobMonitorServiceTest extends CrateDummyClusterServic
         builder.addTask(new DummyTask());
         tasksService.createTask(builder);
 
-        TransportKillJobsNodeAction killAction = mock(TransportKillJobsNodeAction.class);
+        AtomicInteger broadcasts = new AtomicInteger(0);
+        TransportKillJobsNodeAction killAction = new TransportKillJobsNodeAction(
+            Settings.EMPTY,
+            tasksService,
+            clusterService,
+            mock(TransportService.class)
+        ) {
+            @Override
+            public void broadcast(KillJobsRequest request, ActionListener<Long> listener, Collection<String> excludedNodeIds) {
+                broadcasts.incrementAndGet();
+            }
+        };
         NodeDisconnectJobMonitorService monitorService = new NodeDisconnectJobMonitorService(
             Settings.EMPTY,
             tasksService,
@@ -102,9 +112,6 @@ public class NodeDisconnectJobMonitorServiceTest extends CrateDummyClusterServic
 
         monitorService.onNodeDisconnected(dataNode);
 
-        verify(killAction, times(1)).broadcast(
-            any(KillJobsRequest.class),
-            any(ActionListener.class),
-            eq(Arrays.asList(dataNode.getId())));
+        assertThat(broadcasts.get(), is(1));
     }
 }

--- a/sql/src/test/java/io/crate/planner/node/management/KillPlanTest.java
+++ b/sql/src/test/java/io/crate/planner/node/management/KillPlanTest.java
@@ -22,29 +22,53 @@
 
 package io.crate.planner.node.management;
 
+import io.crate.execution.engine.collect.stats.JobsLogs;
+import io.crate.execution.jobs.TasksService;
 import io.crate.execution.jobs.kill.KillAllRequest;
+import io.crate.execution.jobs.kill.KillResponse;
 import io.crate.execution.jobs.kill.TransportKillAllNodeAction;
 import io.crate.execution.jobs.kill.TransportKillJobsNodeAction;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.TestingRowConsumer;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.transport.TransportService;
 import org.junit.Test;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
 
-public class KillPlanTest {
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+
+public class KillPlanTest extends CrateDummyClusterServiceUnitTest {
 
     @SuppressWarnings("unchecked")
     @Test
     public void testKillTaskCallsBroadcastOnTransportKillAllNodeAction() throws Exception {
-        TransportKillAllNodeAction killAllNodeAction = mock(TransportKillAllNodeAction.class);
-        KillPlan killPlan = new KillPlan();
+        AtomicInteger broadcastCalls = new AtomicInteger(0);
+        AtomicInteger nodeOperationCalls = new AtomicInteger(0);
+        TransportKillAllNodeAction killAllNodeAction = new TransportKillAllNodeAction(
+            Settings.EMPTY,
+            new TasksService(Settings.EMPTY, clusterService, new JobsLogs(() -> false)),
+            clusterService,
+            mock(TransportService.class)
+        ) {
+            @Override
+            public void broadcast(KillAllRequest request, ActionListener<Long> listener) {
+                broadcastCalls.incrementAndGet();
+            }
 
+            @Override
+            public CompletableFuture<KillResponse> nodeOperation(KillAllRequest request) {
+                nodeOperationCalls.incrementAndGet();
+                return super.nodeOperation(request);
+            }
+        };
+        KillPlan killPlan = new KillPlan();
         killPlan.execute(killAllNodeAction, mock(TransportKillJobsNodeAction.class), new TestingRowConsumer());;
-        verify(killAllNodeAction, times(1)).broadcast(any(KillAllRequest.class), any(ActionListener.class));
-        verify(killAllNodeAction, times(0)).nodeOperation(any(KillAllRequest.class));
+        assertThat(broadcastCalls.get(), is(1));
+        assertThat(nodeOperationCalls.get(), is(0));
     }
 
 }


### PR DESCRIPTION
Due to the use of an old mockito version which doesn't fully work with
Java 11 some tests failed with a NullPointerException.

Since updating the ``securemock`` to be based on a newer mockito version
is not trivial this changes the tests to not use mocks.