### PR TITLE
Remove equals/hashCode implementations from LuceneCollectorExpression

### DIFF
--- a/sql/src/main/java/io/crate/expression/reference/doc/lucene/BooleanColumnReference.java
+++ b/sql/src/main/java/io/crate/expression/reference/doc/lucene/BooleanColumnReference.java
@@ -33,11 +33,12 @@ import java.io.IOException;
 public class BooleanColumnReference extends LuceneCollectorExpression<Boolean> {
 
     private static final BytesRef TRUE_BYTESREF = new BytesRef("1");
+    private final String columnName;
     private SortedBinaryDocValues values;
     private Boolean value;
 
     public BooleanColumnReference(String columnName) {
-        super(columnName);
+        this.columnName = columnName;
     }
 
     @Override
@@ -66,21 +67,5 @@ public class BooleanColumnReference extends LuceneCollectorExpression<Boolean> {
     public void setNextReader(LeafReaderContext context) throws IOException {
         super.setNextReader(context);
         values = FieldData.toString(DocValues.getSortedNumeric(context.reader(), columnName));
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == null)
-            return false;
-        if (obj == this)
-            return true;
-        if (!(obj instanceof BooleanColumnReference))
-            return false;
-        return columnName.equals(((BooleanColumnReference) obj).columnName);
-    }
-
-    @Override
-    public int hashCode() {
-        return columnName.hashCode();
     }
 }

--- a/sql/src/main/java/io/crate/expression/reference/doc/lucene/ByteColumnReference.java
+++ b/sql/src/main/java/io/crate/expression/reference/doc/lucene/ByteColumnReference.java
@@ -30,11 +30,12 @@ import java.io.IOException;
 
 public class ByteColumnReference extends LuceneCollectorExpression<Byte> {
 
+    private final String columnName;
     private SortedNumericDocValues values;
     private Byte value;
 
     public ByteColumnReference(String columnName) {
-        super(columnName);
+        this.columnName = columnName;
     }
 
     @Override
@@ -64,21 +65,5 @@ public class ByteColumnReference extends LuceneCollectorExpression<Byte> {
     public void setNextReader(LeafReaderContext context) throws IOException {
         super.setNextReader(context);
         values = DocValues.getSortedNumeric(context.reader(), columnName);
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == null)
-            return false;
-        if (obj == this)
-            return true;
-        if (!(obj instanceof ByteColumnReference))
-            return false;
-        return columnName.equals(((ByteColumnReference) obj).columnName);
-    }
-
-    @Override
-    public int hashCode() {
-        return columnName.hashCode();
     }
 }

--- a/sql/src/main/java/io/crate/expression/reference/doc/lucene/BytesRefColumnReference.java
+++ b/sql/src/main/java/io/crate/expression/reference/doc/lucene/BytesRefColumnReference.java
@@ -33,11 +33,13 @@ import java.io.IOException;
 
 public class BytesRefColumnReference extends FieldCacheExpression<IndexOrdinalsFieldData, BytesRef> {
 
+    private final String columnName;
     private SortedBinaryDocValues values;
     private BytesRef value;
 
     public BytesRefColumnReference(String columnName, MappedFieldType mappedFieldType) {
-        super(columnName, mappedFieldType);
+        super(mappedFieldType);
+        this.columnName = columnName;
     }
 
     @Override
@@ -66,22 +68,6 @@ public class BytesRefColumnReference extends FieldCacheExpression<IndexOrdinalsF
         //  `FieldData.maybeSlowRandomAccessOrds(DocValues.getSortedSet(reader, field));` for those.
         // But dynamic columns don't use docValues so we need to use the fieldData abstraction layer.
         values = indexFieldData.load(context).getBytesValues();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == null)
-            return false;
-        if (obj == this)
-            return true;
-        if (!(obj instanceof BytesRefColumnReference))
-            return false;
-        return columnName.equals(((BytesRefColumnReference) obj).columnName);
-    }
-
-    @Override
-    public int hashCode() {
-        return columnName.hashCode();
     }
 }
 

--- a/sql/src/main/java/io/crate/expression/reference/doc/lucene/DocCollectorExpression.java
+++ b/sql/src/main/java/io/crate/expression/reference/doc/lucene/DocCollectorExpression.java
@@ -40,7 +40,7 @@ public class DocCollectorExpression extends LuceneCollectorExpression<Map<String
     private CollectorFieldsVisitor visitor;
 
     public DocCollectorExpression() {
-        super(COLUMN_NAME);
+        super();
     }
 
     @Override
@@ -69,12 +69,13 @@ public class DocCollectorExpression extends LuceneCollectorExpression<Map<String
     static final class ChildDocCollectorExpression extends LuceneCollectorExpression<Object> {
 
         private final DataType returnType;
+        private final String columnName;
         SourceLookup sourceLookup;
         private LeafReaderContext context;
 
         ChildDocCollectorExpression(DataType returnType, String columnName) {
-            super(columnName);
             this.returnType = returnType;
+            this.columnName = columnName;
         }
 
         @Override

--- a/sql/src/main/java/io/crate/expression/reference/doc/lucene/DoubleColumnReference.java
+++ b/sql/src/main/java/io/crate/expression/reference/doc/lucene/DoubleColumnReference.java
@@ -31,11 +31,13 @@ import java.io.IOException;
 
 public class DoubleColumnReference extends FieldCacheExpression<IndexNumericFieldData, Double> {
 
+    private final String columnName;
     private SortedNumericDoubleValues values;
     private Double value;
 
     public DoubleColumnReference(String columnName, MappedFieldType mappedFieldType) {
-        super(columnName, mappedFieldType);
+        super(mappedFieldType);
+        this.columnName = columnName;
     }
 
     @Override
@@ -64,22 +66,6 @@ public class DoubleColumnReference extends FieldCacheExpression<IndexNumericFiel
     public void setNextReader(LeafReaderContext context) throws IOException {
         super.setNextReader(context);
         values = indexFieldData.load(context).getDoubleValues();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == null)
-            return false;
-        if (obj == this)
-            return true;
-        if (!(obj instanceof DoubleColumnReference))
-            return false;
-        return columnName.equals(((DoubleColumnReference) obj).columnName);
-    }
-
-    @Override
-    public int hashCode() {
-        return columnName.hashCode();
     }
 }
 

--- a/sql/src/main/java/io/crate/expression/reference/doc/lucene/FetchIdCollectorExpression.java
+++ b/sql/src/main/java/io/crate/expression/reference/doc/lucene/FetchIdCollectorExpression.java
@@ -35,10 +35,6 @@ public class FetchIdCollectorExpression extends LuceneCollectorExpression<Long> 
     private int jobSearchContextId;
     private int docBase;
 
-    public FetchIdCollectorExpression() {
-        super(COLUMN_NAME);
-    }
-
     @Override
     public void startCollect(CollectorContext context) {
         super.startCollect(context);

--- a/sql/src/main/java/io/crate/expression/reference/doc/lucene/FieldCacheExpression.java
+++ b/sql/src/main/java/io/crate/expression/reference/doc/lucene/FieldCacheExpression.java
@@ -31,8 +31,7 @@ public abstract class FieldCacheExpression<IFD extends IndexFieldData, ReturnTyp
     private final MappedFieldType fieldType;
     protected IFD indexFieldData;
 
-    FieldCacheExpression(String columnName, MappedFieldType fieldType) {
-        super(columnName);
+    FieldCacheExpression(MappedFieldType fieldType) {
         this.fieldType = fieldType;
     }
 

--- a/sql/src/main/java/io/crate/expression/reference/doc/lucene/FloatColumnReference.java
+++ b/sql/src/main/java/io/crate/expression/reference/doc/lucene/FloatColumnReference.java
@@ -31,11 +31,13 @@ import java.io.IOException;
 
 public class FloatColumnReference extends FieldCacheExpression<IndexNumericFieldData, Float> {
 
+    private final String columnName;
     private SortedNumericDoubleValues values;
     private Float value;
 
     public FloatColumnReference(String columnName, MappedFieldType fieldType) {
-        super(columnName, fieldType);
+        super(fieldType);
+        this.columnName = columnName;
     }
 
     @Override
@@ -64,21 +66,5 @@ public class FloatColumnReference extends FieldCacheExpression<IndexNumericField
     public void setNextReader(LeafReaderContext context) throws IOException {
         super.setNextReader(context);
         values = indexFieldData.load(context).getDoubleValues();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == null)
-            return false;
-        if (obj == this)
-            return true;
-        if (!(obj instanceof FloatColumnReference))
-            return false;
-        return columnName.equals(((FloatColumnReference) obj).columnName);
-    }
-
-    @Override
-    public int hashCode() {
-        return columnName.hashCode();
     }
 }

--- a/sql/src/main/java/io/crate/expression/reference/doc/lucene/GeoPointColumnReference.java
+++ b/sql/src/main/java/io/crate/expression/reference/doc/lucene/GeoPointColumnReference.java
@@ -32,11 +32,13 @@ import java.io.IOException;
 
 public class GeoPointColumnReference extends FieldCacheExpression<IndexGeoPointFieldData, Double[]> {
 
+    private final String columnName;
     private MultiGeoPointValues values;
     private Double[] value;
 
     public GeoPointColumnReference(String columnName, MappedFieldType mappedFieldType) {
-        super(columnName, mappedFieldType);
+        super(mappedFieldType);
+        this.columnName = columnName;
     }
 
     @Override
@@ -67,16 +69,4 @@ public class GeoPointColumnReference extends FieldCacheExpression<IndexGeoPointF
         super.setNextReader(context);
         values = indexFieldData.load(context).getGeoPointValues();
     }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == null)
-            return false;
-        if (obj == this)
-            return true;
-        if (!(obj instanceof GeoPointColumnReference))
-            return false;
-        return columnName.equals(((GeoPointColumnReference) obj).columnName);
-    }
-
 }

--- a/sql/src/main/java/io/crate/expression/reference/doc/lucene/IdCollectorExpression.java
+++ b/sql/src/main/java/io/crate/expression/reference/doc/lucene/IdCollectorExpression.java
@@ -38,7 +38,6 @@ public final class IdCollectorExpression extends LuceneCollectorExpression<Bytes
     private LeafReader reader;
 
     public IdCollectorExpression() {
-        super(COLUMN_NAME);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/expression/reference/doc/lucene/IdFromUidCollectorExpression.java
+++ b/sql/src/main/java/io/crate/expression/reference/doc/lucene/IdFromUidCollectorExpression.java
@@ -22,8 +22,8 @@
 
 package io.crate.expression.reference.doc.lucene;
 
-import io.crate.metadata.doc.DocSysColumns;
 import io.crate.execution.engine.collect.collectors.CollectorFieldsVisitor;
+import io.crate.metadata.doc.DocSysColumns;
 import org.apache.lucene.util.BytesRef;
 
 public class IdFromUidCollectorExpression extends LuceneCollectorExpression<BytesRef> {
@@ -33,7 +33,7 @@ public class IdFromUidCollectorExpression extends LuceneCollectorExpression<Byte
     private CollectorFieldsVisitor visitor;
 
     public IdFromUidCollectorExpression() {
-        super(COLUMN_NAME);
+        super();
     }
 
     @Override

--- a/sql/src/main/java/io/crate/expression/reference/doc/lucene/IntegerColumnReference.java
+++ b/sql/src/main/java/io/crate/expression/reference/doc/lucene/IntegerColumnReference.java
@@ -30,11 +30,12 @@ import java.io.IOException;
 
 public class IntegerColumnReference extends LuceneCollectorExpression<Integer> {
 
+    private final String columnName;
     private SortedNumericDocValues values;
     private Integer value;
 
     public IntegerColumnReference(String columnName) {
-        super(columnName);
+        this.columnName = columnName;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/expression/reference/doc/lucene/IpColumnReference.java
+++ b/sql/src/main/java/io/crate/expression/reference/doc/lucene/IpColumnReference.java
@@ -34,11 +34,12 @@ import java.io.IOException;
 
 public class IpColumnReference extends LuceneCollectorExpression<BytesRef> {
 
+    private final String columnName;
     private BytesRef value;
     private SortedSetDocValues values;
 
     public IpColumnReference(String columnName) {
-        super(columnName);
+        this.columnName = columnName;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/expression/reference/doc/lucene/LongColumnReference.java
+++ b/sql/src/main/java/io/crate/expression/reference/doc/lucene/LongColumnReference.java
@@ -30,11 +30,12 @@ import java.io.IOException;
 
 public class LongColumnReference extends LuceneCollectorExpression<Long> {
 
+    private final String columnName;
     private SortedNumericDocValues values;
     private Long value;
 
     public LongColumnReference(String columnName) {
-        super(columnName);
+        this.columnName = columnName;
     }
 
     @Override
@@ -63,22 +64,6 @@ public class LongColumnReference extends LuceneCollectorExpression<Long> {
     public void setNextReader(LeafReaderContext context) throws IOException {
         super.setNextReader(context);
         values = DocValues.getSortedNumeric(context.reader(), columnName);
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == null)
-            return false;
-        if (obj == this)
-            return true;
-        if (!(obj instanceof LongColumnReference))
-            return false;
-        return columnName.equals(((LongColumnReference) obj).columnName);
-    }
-
-    @Override
-    public int hashCode() {
-        return columnName.hashCode();
     }
 }
 

--- a/sql/src/main/java/io/crate/expression/reference/doc/lucene/LuceneCollectorExpression.java
+++ b/sql/src/main/java/io/crate/expression/reference/doc/lucene/LuceneCollectorExpression.java
@@ -32,10 +32,7 @@ import java.io.IOException;
  */
 public abstract class LuceneCollectorExpression<ReturnType> implements Input<ReturnType> {
 
-    final String columnName;
-
-    public LuceneCollectorExpression(String columnName) {
-        this.columnName = columnName;
+    public LuceneCollectorExpression() {
     }
 
     public void startCollect(CollectorContext context) {
@@ -50,20 +47,5 @@ public abstract class LuceneCollectorExpression<ReturnType> implements Input<Ret
 
     public void setScorer(Scorer scorer) {
 
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        LuceneCollectorExpression<?> that = (LuceneCollectorExpression<?>) o;
-
-        return columnName.equals(that.columnName);
-    }
-
-    @Override
-    public int hashCode() {
-        return columnName.hashCode();
     }
 }

--- a/sql/src/main/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolver.java
+++ b/sql/src/main/java/io/crate/expression/reference/doc/lucene/LuceneReferenceResolver.java
@@ -111,7 +111,7 @@ public class LuceneReferenceResolver implements ReferenceResolver<LuceneCollecto
         if (fieldType == null) {
             return NO_FIELD_TYPES.contains(unnest(ref.valueType()))
                 ? DocCollectorExpression.create(toSourceLookup(ref))
-                : new NullValueCollectorExpression(fqn);
+                : new NullValueCollectorExpression();
         }
         if (!fieldType.hasDocValues()) {
             return DocCollectorExpression.create(toSourceLookup(ref));
@@ -147,10 +147,6 @@ public class LuceneReferenceResolver implements ReferenceResolver<LuceneCollecto
     }
 
     private static class NullValueCollectorExpression extends LuceneCollectorExpression<Void> {
-
-        NullValueCollectorExpression(String columnName) {
-            super(columnName);
-        }
 
         @Override
         public Void value() {

--- a/sql/src/main/java/io/crate/expression/reference/doc/lucene/OrderByCollectorExpression.java
+++ b/sql/src/main/java/io/crate/expression/reference/doc/lucene/OrderByCollectorExpression.java
@@ -22,8 +22,8 @@
 
 package io.crate.expression.reference.doc.lucene;
 
-import io.crate.execution.engine.sort.SortSymbolVisitor;
 import io.crate.analyze.OrderBy;
+import io.crate.execution.engine.sort.SortSymbolVisitor;
 import io.crate.metadata.Reference;
 import org.apache.lucene.search.FieldDoc;
 
@@ -42,7 +42,6 @@ public class OrderByCollectorExpression extends LuceneCollectorExpression<Object
     private Object value;
 
     public OrderByCollectorExpression(Reference ref, OrderBy orderBy, Function<Object, Object> valueConversion) {
-        super(ref.column().fqn());
         this.valueConversion = valueConversion;
         assert orderBy.orderBySymbols().contains(ref) : "symbol must be part of orderBy symbols";
         orderIndex = orderBy.orderBySymbols().indexOf(ref);

--- a/sql/src/main/java/io/crate/expression/reference/doc/lucene/RawCollectorExpression.java
+++ b/sql/src/main/java/io/crate/expression/reference/doc/lucene/RawCollectorExpression.java
@@ -21,8 +21,8 @@
 
 package io.crate.expression.reference.doc.lucene;
 
-import io.crate.metadata.doc.DocSysColumns;
 import io.crate.execution.engine.collect.collectors.CollectorFieldsVisitor;
+import io.crate.metadata.doc.DocSysColumns;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.compress.CompressorFactory;
 
@@ -33,10 +33,6 @@ public class RawCollectorExpression extends LuceneCollectorExpression<BytesRef> 
     public static final String COLUMN_NAME = DocSysColumns.RAW.name();
 
     private CollectorFieldsVisitor visitor;
-
-    public RawCollectorExpression() {
-        super(COLUMN_NAME);
-    }
 
     @Override
     public void startCollect(CollectorContext context) {

--- a/sql/src/main/java/io/crate/expression/reference/doc/lucene/ScoreCollectorExpression.java
+++ b/sql/src/main/java/io/crate/expression/reference/doc/lucene/ScoreCollectorExpression.java
@@ -33,9 +33,6 @@ public class ScoreCollectorExpression extends LuceneCollectorExpression<Float> {
     private Scorer scorer;
     private float score;
 
-    public ScoreCollectorExpression() {
-        super(COLUMN_NAME);
-    }
 
     @Override
     public void setScorer(Scorer scorer) {

--- a/sql/src/main/java/io/crate/expression/reference/doc/lucene/ShortColumnReference.java
+++ b/sql/src/main/java/io/crate/expression/reference/doc/lucene/ShortColumnReference.java
@@ -30,11 +30,12 @@ import java.io.IOException;
 
 public class ShortColumnReference extends LuceneCollectorExpression<Short> {
 
+    private final String columnName;
     private SortedNumericDocValues values;
     private Short value;
 
     public ShortColumnReference(String columnName) {
-        super(columnName);
+        this.columnName = columnName;
     }
 
     @Override
@@ -63,21 +64,5 @@ public class ShortColumnReference extends LuceneCollectorExpression<Short> {
     public void setNextReader(LeafReaderContext context) throws IOException {
         super.setNextReader(context);
         values = DocValues.getSortedNumeric(context.reader(), columnName);
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == null)
-            return false;
-        if (obj == this)
-            return true;
-        if (!(obj instanceof ShortColumnReference))
-            return false;
-        return columnName.equals(((ShortColumnReference) obj).columnName);
-    }
-
-    @Override
-    public int hashCode() {
-        return columnName.hashCode();
     }
 }

--- a/sql/src/main/java/io/crate/expression/reference/doc/lucene/UidCollectorExpression.java
+++ b/sql/src/main/java/io/crate/expression/reference/doc/lucene/UidCollectorExpression.java
@@ -22,8 +22,8 @@
 
 package io.crate.expression.reference.doc.lucene;
 
-import io.crate.metadata.doc.DocSysColumns;
 import io.crate.execution.engine.collect.collectors.CollectorFieldsVisitor;
+import io.crate.metadata.doc.DocSysColumns;
 import org.apache.lucene.util.BytesRef;
 
 public class UidCollectorExpression extends LuceneCollectorExpression<BytesRef> {
@@ -33,7 +33,7 @@ public class UidCollectorExpression extends LuceneCollectorExpression<BytesRef> 
     private CollectorFieldsVisitor visitor;
 
     public UidCollectorExpression() {
-        super(COLUMN_NAME);
+        super();
     }
 
     @Override

--- a/sql/src/main/java/io/crate/expression/reference/doc/lucene/VersionCollectorExpression.java
+++ b/sql/src/main/java/io/crate/expression/reference/doc/lucene/VersionCollectorExpression.java
@@ -33,14 +33,10 @@ public class VersionCollectorExpression extends LuceneCollectorExpression<Long> 
     private NumericDocValues versions = null;
     private long value;
 
-    public VersionCollectorExpression() {
-        super(DocSysColumns.VERSION.name());
-    }
-
     @Override
     public void setNextReader(LeafReaderContext reader) {
         try {
-            versions = reader.reader().getNumericDocValues(columnName);
+            versions = reader.reader().getNumericDocValues(DocSysColumns.VERSION.name());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
Shouldn't be required and was inconsistent (E.g.
`GeoPointColumnReference` having `equals` but not `hashCode`)