### PR TITLE
Avoid some allocations in the ChildDocCollectorExpression

### DIFF
--- a/sql/src/main/java/io/crate/expression/reference/doc/lucene/CollectorContext.java
+++ b/sql/src/main/java/io/crate/expression/reference/doc/lucene/CollectorContext.java
@@ -24,7 +24,6 @@ package io.crate.expression.reference.doc.lucene;
 import io.crate.execution.engine.collect.collectors.CollectorFieldsVisitor;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.mapper.MappedFieldType;
-import org.elasticsearch.search.lookup.SourceLookup;
 
 import java.util.function.Function;
 

--- a/sql/src/main/java/io/crate/expression/reference/doc/lucene/DocCollectorExpression.java
+++ b/sql/src/main/java/io/crate/expression/reference/doc/lucene/DocCollectorExpression.java
@@ -21,7 +21,6 @@
 
 package io.crate.expression.reference.doc.lucene;
 
-import com.google.common.base.Joiner;
 import io.crate.execution.engine.collect.collectors.CollectorFieldsVisitor;
 import io.crate.metadata.Reference;
 import io.crate.metadata.doc.DocSysColumns;
@@ -31,7 +30,10 @@ import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.search.lookup.SourceLookup;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.RandomAccess;
 
 public class DocCollectorExpression extends LuceneCollectorExpression<Map<String, Object>> {
 
@@ -60,22 +62,19 @@ public class DocCollectorExpression extends LuceneCollectorExpression<Map<String
         if (reference.column().path().size() == 0) {
             return new DocCollectorExpression();
         }
-
-        assert reference.column().path().size() > 0 : "column's path size must be > 0";
-        final String fqn = Joiner.on(".").join(reference.column().path());
-        return new ChildDocCollectorExpression(reference.valueType(), fqn);
+        return new ChildDocCollectorExpression(reference.valueType(), reference.column().path());
     }
 
     static final class ChildDocCollectorExpression extends LuceneCollectorExpression<Object> {
 
         private final DataType returnType;
-        private final String columnName;
-        SourceLookup sourceLookup;
+        private final List<String> path;
+        private SourceLookup sourceLookup;
         private LeafReaderContext context;
 
-        ChildDocCollectorExpression(DataType returnType, String columnName) {
+        ChildDocCollectorExpression(DataType returnType, List<String> path) {
             this.returnType = returnType;
-            this.columnName = columnName;
+            this.path = path;
         }
 
         @Override
@@ -99,7 +98,34 @@ public class DocCollectorExpression extends LuceneCollectorExpression<Map<String
             // for example:
             //      sourceExtractor might read byte as int and
             //      then eq(byte, byte) would get eq(byte, int) and fail
-            return returnType.value(sourceLookup.extractValue(columnName));
+            return returnType.value(extractValue(sourceLookup, 0, path));
+        }
+
+        @SuppressWarnings("unchecked")
+        private static Object extractValue(final Map map, int index, List<String> path) {
+            assert path instanceof RandomAccess : "path should support RandomAccess for fast index optimized loop";
+            Map m = map;
+            Object tmp = null;
+            for (int i = index; i < path.size(); i++) {
+                tmp = m.get(path.get(i));
+                if (tmp instanceof Map) {
+                    m = (Map) tmp;
+                } else if (tmp instanceof List) {
+                    List list = (List) tmp;
+                    List newList = new ArrayList(list.size());
+                    for (Object o : list) {
+                        if (o instanceof Map && i + 1 < path.size()) {
+                            newList.add(extractValue((Map) o, i + 1, path));
+                        } else {
+                            newList.add(o);
+                        }
+                    }
+                    return newList;
+                } else {
+                    break;
+                }
+            }
+            return tmp;
         }
     }
 }

--- a/sql/src/main/java/io/crate/expression/reference/doc/lucene/DocCollectorExpression.java
+++ b/sql/src/main/java/io/crate/expression/reference/doc/lucene/DocCollectorExpression.java
@@ -28,12 +28,9 @@ import io.crate.types.DataType;
 import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentType;
-import org.elasticsearch.search.lookup.SourceLookup;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.RandomAccess;
 
 public class DocCollectorExpression extends LuceneCollectorExpression<Map<String, Object>> {
 
@@ -98,34 +95,7 @@ public class DocCollectorExpression extends LuceneCollectorExpression<Map<String
             // for example:
             //      sourceExtractor might read byte as int and
             //      then eq(byte, byte) would get eq(byte, int) and fail
-            return returnType.value(extractValue(sourceLookup, 0, path));
-        }
-
-        @SuppressWarnings("unchecked")
-        private static Object extractValue(final Map map, int index, List<String> path) {
-            assert path instanceof RandomAccess : "path should support RandomAccess for fast index optimized loop";
-            Map m = map;
-            Object tmp = null;
-            for (int i = index; i < path.size(); i++) {
-                tmp = m.get(path.get(i));
-                if (tmp instanceof Map) {
-                    m = (Map) tmp;
-                } else if (tmp instanceof List) {
-                    List list = (List) tmp;
-                    List newList = new ArrayList(list.size());
-                    for (Object o : list) {
-                        if (o instanceof Map && i + 1 < path.size()) {
-                            newList.add(extractValue((Map) o, i + 1, path));
-                        } else {
-                            newList.add(o);
-                        }
-                    }
-                    return newList;
-                } else {
-                    break;
-                }
-            }
-            return tmp;
+            return returnType.value(sourceLookup.get(path));
         }
     }
 }

--- a/sql/src/main/java/io/crate/expression/reference/doc/lucene/SourceLookup.java
+++ b/sql/src/main/java/io/crate/expression/reference/doc/lucene/SourceLookup.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.reference.doc.lucene;
+
+
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.StoredFieldVisitor;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.mapper.SourceFieldMapper;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.RandomAccess;
+
+public final class SourceLookup {
+
+    private final Visitor fieldsVisitor = new Visitor();
+    private LeafReader reader;
+    private int doc;
+    private Map<String, Object> source;
+
+    SourceLookup() {
+    }
+
+    public void setSegmentAndDocument(LeafReaderContext context, int doc) {
+        if (this.doc == doc && this.reader == context.reader()) {
+            // Don't invalidate source
+            return;
+        }
+        fieldsVisitor.reset();
+        this.source = null;
+        this.reader = context.reader();
+        this.doc = doc;
+    }
+
+    public Object get(List<String> path) {
+        if (source == null) {
+            try {
+                source = loadSource();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return extractValue(source, path, 0);
+    }
+
+    private Map<String, Object> loadSource() throws IOException {
+        reader.document(doc, fieldsVisitor);
+        return XContentHelper.convertToMap(fieldsVisitor.source, false, XContentType.JSON).v2();
+    }
+
+    @SuppressWarnings("unchecked")
+    static Object extractValue(final Map map, List<String> path, int pathStartIndex) {
+        assert path instanceof RandomAccess : "path should support RandomAccess for fast index optimized loop";
+        Map m = map;
+        Object tmp = null;
+        for (int i = pathStartIndex; i < path.size(); i++) {
+            tmp = m.get(path.get(i));
+            if (tmp instanceof Map) {
+                m = (Map) tmp;
+            } else if (tmp instanceof List) {
+                List list = (List) tmp;
+                if (i + 1 == path.size()) {
+                    return list;
+                }
+                List newList = new ArrayList(list.size());
+                for (Object o : list) {
+                    if (o instanceof Map) {
+                        newList.add(extractValue((Map) o, path, i + 1));
+                    } else {
+                        newList.add(o);
+                    }
+                }
+                return newList;
+            } else {
+                break;
+            }
+        }
+        return tmp;
+    }
+
+    private static class Visitor extends StoredFieldVisitor {
+
+        private boolean done = false;
+        private BytesArray source;
+
+        @Override
+        public Status needsField(FieldInfo fieldInfo) {
+            if (fieldInfo.name.equals(SourceFieldMapper.NAME)) {
+                done = true;
+                return Status.YES;
+            }
+            return done ? Status.STOP : Status.NO;
+        }
+
+        @Override
+        public void binaryField(FieldInfo fieldInfo, byte[] value) {
+            assert SourceFieldMapper.NAME.equals(fieldInfo.name) : "Must only receive a source field";
+            source = new BytesArray(value);
+        }
+
+        public void reset() {
+            done = false;
+            source = null;
+        }
+    }
+}

--- a/sql/src/test/java/io/crate/expression/reference/doc/lucene/SourceLookupTest.java
+++ b/sql/src/test/java/io/crate/expression/reference/doc/lucene/SourceLookupTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.expression.reference.doc.lucene;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class SourceLookupTest {
+
+    @Test
+    public void testExtractValueFromNestedObject() {
+        Map<String, Map<String, Integer>> map = singletonMap("x", singletonMap("y", 10));
+        Object o = SourceLookup.extractValue(map, Arrays.asList("x", "y"), 0);
+        assertThat(o, is(10));
+    }
+
+    @Test
+    public void testExtractValueFromNestedObjectWithinList() {
+        Map<String, List<Map<String, Map<String, Integer>>>> m = singletonMap("x", Arrays.asList(
+            singletonMap("y", singletonMap("z", 10)),
+            singletonMap("y", singletonMap("z", 20))
+        ));
+        Object o = SourceLookup.extractValue(m, Arrays.asList("x", "y", "z"), 0);
+        assertThat((Collection<Integer>) o, contains(is(10), is(20)));
+    }
+
+    @Test
+    public void testExtractValueFromNestedObjectWithListAsLeaf() {
+        Map<String, List<Integer>> m = singletonMap("x", Arrays.asList(10, 20));
+        Object o = SourceLookup.extractValue(m, singletonList("x"), 0);
+        assertThat((Collection<Integer>) o, contains(is(10), is(20)));
+    }
+}


### PR DESCRIPTION
See commit messages


Some benchmark comparison results: Note that these tend to fluctuate quite a bit. So they don't tell us much.

```
Q: select * from uservisits limit 10000
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      215.206 ±    5.525 |    206.004 |    215.200 |    220.286 |    233.767 |
|   V2    |      203.807 ±    2.451 |    201.409 |    203.063 |    204.232 |    217.277 |
mean:   -   5.44%
median: -   5.80%
Likely significant

Q: select * from uservisits limit 100000
C: 1
| Version |         Mean ±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |     2220.406 ±   59.684 |   2124.056 |   2225.557 |   2268.096 |   2465.309 |
|   V2    |     2097.554 ±   18.876 |   2071.618 |   2093.148 |   2105.304 |   2290.942 |
mean:   -   5.69%
median: -   6.13%
Likely significant

```