### PR TITLE
Optimize group by single primitive columns.

### DIFF
--- a/benchmarks/src/test/java/io/crate/execution/engine/aggregation/GroupingLongCollectorBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/execution/engine/aggregation/GroupingLongCollectorBenchmark.java
@@ -68,7 +68,7 @@ public class GroupingLongCollectorBenchmark {
     private GroupingCollector groupBySumCollector;
     private BatchIterator<Row> rowsIterator;
     private List<Row> rows;
-    private GroupBySingleLongCollector groupBySumSingleLongCollector;
+    private GroupBySingleNumberCollector groupBySumSingleLongCollector;
 
     @Setup
     public void createGroupingCollector() {
@@ -85,15 +85,16 @@ public class GroupingLongCollectorBenchmark {
         }
     }
 
-    private GroupBySingleLongCollector createOptimizedCollector(AggregationFunction sumAgg) {
+    private GroupBySingleNumberCollector createOptimizedCollector(AggregationFunction sumAgg) {
         InputCollectExpression keyInput = new InputCollectExpression(0);
-        return new GroupBySingleLongCollector(
+        return new GroupBySingleNumberCollector(
+            DataTypes.LONG,
             new CollectExpression[] { keyInput },
             AggregateMode.ITER_FINAL,
             new AggregationFunction[] { sumAgg },
             new Input[][] { new Input[] { keyInput }},
             RAM_ACCOUNTING_CONTEXT,
-            (Input<Long>)(Input) keyInput,
+            keyInput,
             Version.CURRENT,
             BigArrays.NON_RECYCLING_INSTANCE
         );

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/GroupingProjector.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/GroupingProjector.java
@@ -67,14 +67,17 @@ public class GroupingProjector implements Projector {
         }
         if (keys.size() == 1) {
             Symbol key = keys.get(0);
-            if (key.valueType().equals(DataTypes.LONG)) {
-                collector = new GroupBySingleLongCollector(
+            if (DataTypes.NUMERIC_PRIMITIVE_TYPES.contains(key.valueType()) &&
+                !key.valueType().equals(DataTypes.FLOAT) &&
+                !key.valueType().equals(DataTypes.DOUBLE)) {
+                collector = new GroupBySingleNumberCollector(
+                    key.valueType(),
                     collectExpressions,
                     mode,
                     functions,
                     inputs,
                     ramAccountingContext,
-                    (Input<Long>) keyInputs.get(0),
+                    keyInputs.get(0),
                     indexVersionCreated,
                     bigArrays
                 );

--- a/sql/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
@@ -1238,13 +1238,28 @@ public class GroupByAggregateTest extends SQLTransportIntegrationTest {
     }
 
     @Test
-    public void testGroupBySingleLongWithNullValues() {
-        execute("create table t (x long) clustered into 2 shards with (number_of_replicas = 0)");
-        execute("insert into t (x) values (1), (1), (1), (2), (2), (null), (null), (null), (null)");
+    public void testGroupBySingleNumberWithNullValues() {
+        execute("create table t (along long, aint int, ashort short) clustered into 2 shards with (number_of_replicas = 0)");
+        execute("insert into t (along,aint,ashort) values (1,1,1), (1,1,1), (1,1,1), (2,2,2), (2,2,2), (null,null,null), " +
+                "(null,null,null), (null,null,null), (null,null,null)");
         execute("refresh table t");
 
         assertThat(
-            printedTable(execute("select x, count(*) from t group by x order by 2 desc").rows()),
+            printedTable(execute("select along, count(*) from t group by along order by 2 desc").rows()),
+            is("NULL| 4\n" +
+               "1| 3\n" +
+               "2| 2\n")
+        );
+
+        assertThat(
+            printedTable(execute("select aint, count(*) from t group by aint order by 2 desc").rows()),
+            is("NULL| 4\n" +
+               "1| 3\n" +
+               "2| 2\n")
+        );
+
+        assertThat(
+            printedTable(execute("select ashort, count(*) from t group by ashort order by 2 desc").rows()),
             is("NULL| 4\n" +
                "1| 3\n" +
                "2| 2\n")


### PR DESCRIPTION
We initially did this optimisation for long columns, this is an extension
of the same optimisation for byte, short and integer.

Follow-up https://github.com/crate/crate/pull/7541

```
Benchmark                                                    Mode  Cnt    Score   Error  Units
GroupingIntCollectorBenchmark.measureGroupBySumInt           avgt  200  819.425 ± 8.276  ms/op
GroupingIntCollectorBenchmark.measureGroupBySumIntOptimized  avgt  200  676.864 ± 6.254  ms/op

GroupingByteCollectorBenchmark.measureGroupBySumByte           avgt  200  603.575 ± 2.576  ms/op
GroupingByteCollectorBenchmark.measureGroupBySumByteOptimized  avgt  200  573.886 ± 2.754  ms/op
```


<!--

Thank you for your contribution. Here is a quick checklist of things you should've done:

 - You've read CONTRIBUTING.rst and signed our CLA (https://crate.io/community/contribute/cla/)
 - Wrote a CHANGES.txt entry if this is a change that is relevant for users of CrateDB
 - Run tests with `./gradlew test itest` (If they fail Jenkins will block this PR anyway)

-->
