### PR TITLE
Remove measure logic from CollectTask

### DIFF
--- a/sql/src/main/java/io/crate/execution/engine/collect/CollectTask.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/CollectTask.java
@@ -35,7 +35,6 @@ import io.crate.execution.jobs.AbstractTask;
 import io.crate.execution.jobs.SharedShardContexts;
 import io.crate.metadata.RowGranularity;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.common.StopWatch;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -145,19 +144,7 @@ public class CollectTask extends AbstractTask {
 
     @Override
     protected void innerStart() {
-        if (logger.isTraceEnabled()) {
-            measureCollectTime();
-        }
         collectOperation.launch(() -> consumer.accept(batchIterator, null), threadPoolName);
-    }
-
-    private void measureCollectTime() {
-        final StopWatch stopWatch = new StopWatch(collectPhase.phaseId() + ": " + collectPhase.name());
-        stopWatch.start("starting collectors");
-        consumer.completionFuture().whenComplete((result, ex) -> {
-            stopWatch.stop();
-            logger.trace("Collectors finished: {}", stopWatch.shortSummary());
-        });
     }
 
     public RamAccountingContext queryPhaseRamAccountingContext() {


### PR DESCRIPTION
We've `EXPLAIN ANALYZE` which can be used to get the duration breakdown
of specific queries instead.