### PR TITLE
Remove the prepare method from Task

### DIFF
--- a/sql/src/main/java/io/crate/execution/engine/collect/CollectTask.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/CollectTask.java
@@ -134,12 +134,8 @@ public class CollectTask extends AbstractTask {
     }
 
     @Override
-    public void innerPrepare() throws Exception {
-        batchIterator = collectOperation.createIterator(collectPhase, consumer.requiresScroll(), this);
-    }
-
-    @Override
     protected void innerStart() {
+        batchIterator = collectOperation.createIterator(collectPhase, consumer.requiresScroll(), this);
         collectOperation.launch(() -> consumer.accept(batchIterator, null), threadPoolName);
     }
 

--- a/sql/src/main/java/io/crate/execution/engine/fetch/FetchTask.java
+++ b/sql/src/main/java/io/crate/execution/engine/fetch/FetchTask.java
@@ -91,8 +91,7 @@ public class FetchTask extends AbstractTask {
         return isKilled;
     }
 
-    @Override
-    public void innerPrepare() {
+    private void allocateSearchers() {
         HashMap<String, RelationName> index2TableIdent = new HashMap<>();
         for (Map.Entry<RelationName, Collection<String>> entry : phase.tableIndices().asMap().entrySet()) {
             for (String indexName : entry.getValue()) {
@@ -156,6 +155,7 @@ public class FetchTask extends AbstractTask {
 
     @Override
     protected void innerStart() {
+        allocateSearchers();
         if (searchers.isEmpty() || phase.fetchRefs().isEmpty()) {
             // no fetch references means there will be no fetch requests
             // this context is only here to allow the collectors to generate docids with the right bases

--- a/sql/src/main/java/io/crate/execution/jobs/AbstractTask.java
+++ b/sql/src/main/java/io/crate/execution/jobs/AbstractTask.java
@@ -51,19 +51,6 @@ public abstract class AbstractTask implements Task {
     protected void innerStart() {
     }
 
-    protected void innerPrepare() throws Exception {
-    }
-
-    @Override
-    public final void prepare() throws Exception {
-        try {
-            innerPrepare();
-        } catch (Exception e) {
-            close(e);
-            throw e;
-        }
-    }
-
     @Override
     public final void start() {
         if (!firstClose.get()) {

--- a/sql/src/main/java/io/crate/execution/jobs/Task.java
+++ b/sql/src/main/java/io/crate/execution/jobs/Task.java
@@ -27,12 +27,6 @@ import io.crate.data.Killable;
 public interface Task extends CompletionListenable<CompletionState>, Killable {
 
     /**
-     * In the prepare phase implementations of this interface can allocate any resources.
-     * Exception are required to be thrown directly and must not be set on the downstream.
-     */
-    void prepare() throws Exception;
-
-    /**
      * In the start phase implementations of this interface are required to start any executors.
      * <p>
      * In this phase failures must not be propagated to downstream phases directly.

--- a/sql/src/test/java/io/crate/execution/engine/collect/CollectTaskTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/CollectTaskTest.java
@@ -119,7 +119,6 @@ public class CollectTaskTest extends RandomizedTest {
         BatchIterator<Row> batchIterator = mock(BatchIterator.class);
         when(collectOperationMock.createIterator(eq(collectPhase), anyBoolean(), eq(jobCtx)))
             .thenReturn(batchIterator);
-        jobCtx.prepare();
         jobCtx.start();
         jobCtx.kill(new JobKilledException());
 

--- a/sql/src/test/java/io/crate/execution/engine/fetch/FetchTaskTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/fetch/FetchTaskTest.java
@@ -109,7 +109,7 @@ public class FetchTaskTest extends CrateDummyClusterServiceUnitTest {
             metaData,
             ImmutableList.of(routing));
 
-        context.prepare();
+        context.start();
 
         assertThat(context.searcher(1), Matchers.notNullValue());
         assertThat(context.searcher(2), Matchers.notNullValue());

--- a/sql/src/test/java/io/crate/execution/jobs/CountTaskTest.java
+++ b/sql/src/test/java/io/crate/execution/jobs/CountTaskTest.java
@@ -65,7 +65,6 @@ public class CountTaskTest extends CrateUnitTest {
         when(countOperation.count(anyMap(), any(Symbol.class))).thenReturn(future);
 
         CountTask countTask = new CountTask(countPhaseWithId(1), countOperation, new TestingRowConsumer(), null);
-        countTask.prepare();
         countTask.start();
         future.complete(1L);
         assertTrue(countTask.isClosed());
@@ -77,7 +76,6 @@ public class CountTaskTest extends CrateUnitTest {
         when(countOperation.count(anyMap(), any(Symbol.class))).thenReturn(future);
 
         countTask = new CountTask(countPhaseWithId(2), countOperation, new TestingRowConsumer(), null);
-        countTask.prepare();
         countTask.start();
         future.completeExceptionally(new UnhandledServerException("dummy"));
         assertTrue(countTask.isClosed());
@@ -92,7 +90,6 @@ public class CountTaskTest extends CrateUnitTest {
 
         CountTask countTask = new CountTask(countPhaseWithId(1), countOperation, new TestingRowConsumer(), null);
 
-        countTask.prepare();
         countTask.start();
         countTask.kill(new JobKilledException());
 


### PR DESCRIPTION
Can be integrated into `start`


I've extracted this from the previous PR (https://github.com/crate/crate/pull/7571) - I adopted it a bit (removed the try/catch - as it's already part of the start/innerStart AbstractTask)