### PR TITLE
fix processing of the `operator` option of the MATCH predicate

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -113,5 +113,8 @@ Changes
 Fixes
 =====
 
+- Fixed correct processing of the ``operator`` option of the ``MATCH``
+  predicate.
+
 - Fixed syntax support for certain ``ALTER BLOB TABLE RENAME``, ``REROUTE``
   and ``OPEN/CLOSE`` queries.

--- a/sql/src/main/java/io/crate/lucene/match/MatchQueries.java
+++ b/sql/src/main/java/io/crate/lucene/match/MatchQueries.java
@@ -69,6 +69,7 @@ public final class MatchQueries {
         matchQuery.setPhraseSlop(parsedOptions.phraseSlop());
         matchQuery.setTranspositions(parsedOptions.transpositions());
         matchQuery.setZeroTermsQuery(parsedOptions.zeroTermsQuery());
+        matchQuery.setOccur(parsedOptions.operator());
 
         MatchQuery.Type matchQueryType = type.matchQueryType();
         return matchQuery.parse(matchQueryType, fieldName, queryString.utf8ToString());
@@ -99,6 +100,8 @@ public final class MatchQueries {
         multiMatchQuery.setPhraseSlop(parsedOptions.phraseSlop());
         multiMatchQuery.setTranspositions(parsedOptions.transpositions());
         multiMatchQuery.setZeroTermsQuery(parsedOptions.zeroTermsQuery());
+        multiMatchQuery.setOccur(parsedOptions.operator());
+
         return multiMatchQuery.parse(type, fieldNames, queryString, parsedOptions.minimumShouldMatch());
     }
 

--- a/sql/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/sql/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -466,4 +466,20 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
             is("subscript(Ref{doc.users.o_array, object_array}, 1) = {x=1}")
         );
     }
+
+    @Test
+    public void testMatchWithOperator() {
+        assertThat(
+            convert("match(tags, 'foo bar') using best_fields with (operator='and')").toString(),
+            is("+tags:foo +tags:bar")
+        );
+    }
+
+    @Test
+    public void testMultiMatchWithOperator() {
+        assertThat(
+            convert("match((tags, name), 'foo bar') using best_fields with (operator='and')").toString(),
+            is("(name:foo bar | (+tags:foo +tags:bar))")
+        );
+    }
 }

--- a/sql/src/test/java/io/crate/lucene/LuceneQueryBuilderTest.java
+++ b/sql/src/test/java/io/crate/lucene/LuceneQueryBuilderTest.java
@@ -105,6 +105,7 @@ public abstract class LuceneQueryBuilderTest extends CrateUnitTest {
     public void prepare() throws Exception {
         DocTableInfo users = TestingTableInfo.builder(new RelationName(Schemas.DOC_SCHEMA_NAME, "users"), null)
             .add("name", DataTypes.STRING)
+            .add("tags", DataTypes.STRING, null, ColumnPolicy.DYNAMIC, Reference.IndexType.ANALYZED, false, false)
             .add("x", DataTypes.INTEGER, null, ColumnPolicy.DYNAMIC, Reference.IndexType.NOT_ANALYZED, false, false)
             .add("d", DataTypes.DOUBLE)
             .add("d_array", new ArrayType(DataTypes.DOUBLE))
@@ -141,6 +142,7 @@ public abstract class LuceneQueryBuilderTest extends CrateUnitTest {
             .startObject("default")
                 .startObject("properties")
                     .startObject("name").field("type", "keyword").endObject()
+                    .startObject("tags").field("type", "text").endObject()
                     .startObject("x").field("type", "integer").endObject()
                     .startObject("d").field("type", "double").endObject()
                     .startObject("point").field("type", "geo_point").endObject()


### PR DESCRIPTION
The operator option was silently ignored.
Relates to https://github.com/crate/crate/issues/7575.