### PR TITLE
Add schema of table to table aliases

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -113,6 +113,10 @@ Changes
 Fixes
 =====
 
+- Fixed an issue where, when checking the privileges of an aliased relation,
+  the default schema of "doc" would always be used, rather than the default
+  schema of the current session.
+
 - Fixed correct processing of the ``operator`` option of the ``MATCH``
   predicate.
 

--- a/enterprise/users/src/main/java/io/crate/auth/user/ExceptionPrivilegeValidator.java
+++ b/enterprise/users/src/main/java/io/crate/auth/user/ExceptionPrivilegeValidator.java
@@ -35,9 +35,11 @@ class ExceptionPrivilegeValidator implements ExceptionAuthorizedValidator {
     private static final Visitor VISITOR = new Visitor();
 
     private final User user;
+    private final String defaultSchema;
 
-    ExceptionPrivilegeValidator(User user) {
+    ExceptionPrivilegeValidator(User user, String defaultSchema) {
         this.user = user;
+        this.defaultSchema = defaultSchema;
     }
 
     @Override

--- a/enterprise/users/src/main/java/io/crate/auth/user/Privileges.java
+++ b/enterprise/users/src/main/java/io/crate/auth/user/Privileges.java
@@ -32,12 +32,13 @@ import javax.annotation.Nullable;
 class Privileges {
 
     /**
-     * Checks if the user the concrete privilege for the given class and ident, if not raise exception.
+     * Checks if the user the concrete privilege for the given class, ident and default schema, if not raise exception.
      */
     static void ensureUserHasPrivilege(Privilege.Type type,
                                        Privilege.Clazz clazz,
                                        @Nullable String ident,
-                                       User user) throws MissingPrivilegeException {
+                                       User user,
+                                       String defaultSchema) throws MissingPrivilegeException {
         assert user != null : "User must not be null when trying to validate privileges";
         assert type != null : "Privilege type must not be null";
 
@@ -46,7 +47,7 @@ class Privileges {
             return;
         }
         //noinspection PointlessBooleanExpression
-        if (user.hasPrivilege(type, clazz, ident) == false) {
+        if (user.hasPrivilege(type, clazz, ident, defaultSchema) == false) {
             boolean objectIsVisibleToUser = user.hasAnyPrivilege(clazz, ident);
             if (objectIsVisibleToUser) {
                 throw new MissingPrivilegeException(user.name(), type);

--- a/enterprise/users/src/main/java/io/crate/auth/user/StatementPrivilegeValidator.java
+++ b/enterprise/users/src/main/java/io/crate/auth/user/StatementPrivilegeValidator.java
@@ -88,15 +88,17 @@ class StatementPrivilegeValidator implements StatementAuthorizedValidator {
 
     private final UserLookup userLookup;
     private final User user;
+    private final String defaultSchema;
 
-    StatementPrivilegeValidator(UserLookup userLookup, User user) {
+    StatementPrivilegeValidator(UserLookup userLookup, User user, String defaultSchema) {
         this.userLookup = userLookup;
         this.user = user;
+        this.defaultSchema = defaultSchema;
     }
 
     @Override
     public void ensureStatementAuthorized(AnalyzedStatement statement) {
-        new StatementVisitor(userLookup).process(statement, user);
+        new StatementVisitor(userLookup, defaultSchema).process(statement, user);
     }
 
     private static void throwUnauthorized(String userName) {
@@ -107,9 +109,11 @@ class StatementPrivilegeValidator implements StatementAuthorizedValidator {
     private static final class StatementVisitor extends AnalyzedStatementVisitor<User, Void> {
 
         private final RelationVisitor relationVisitor;
+        private final String defaultSchema;
 
-        public StatementVisitor(UserLookup userLookup) {
-            this.relationVisitor = new RelationVisitor(userLookup);
+        public StatementVisitor(UserLookup userLookup, String defaultSchema) {
+            this.relationVisitor = new RelationVisitor(userLookup, defaultSchema);
+            this.defaultSchema = defaultSchema;
         }
 
         private void visitRelation(AnalyzedRelation relation, User user, Privilege.Type type) {
@@ -173,7 +177,8 @@ class StatementPrivilegeValidator implements StatementAuthorizedValidator {
                 Privilege.Type.DDL,
                 Privilege.Clazz.TABLE,
                 analysis.table().ident().toString(),
-                user);
+                user,
+                defaultSchema);
             return null;
         }
 
@@ -183,7 +188,8 @@ class StatementPrivilegeValidator implements StatementAuthorizedValidator {
                 Privilege.Type.DML,
                 Privilege.Clazz.TABLE,
                 analysis.table().ident().toString(),
-                user);
+                user,
+                defaultSchema);
             return null;
         }
 
@@ -199,7 +205,8 @@ class StatementPrivilegeValidator implements StatementAuthorizedValidator {
                 Privilege.Type.DDL,
                 Privilege.Clazz.SCHEMA,
                 analysis.tableIdent().schema(),
-                user);
+                user,
+                defaultSchema);
             return null;
         }
 
@@ -209,7 +216,8 @@ class StatementPrivilegeValidator implements StatementAuthorizedValidator {
                 Privilege.Type.DDL,
                 Privilege.Clazz.CLUSTER,
                 null,
-                user);
+                user,
+                defaultSchema);
             return null;
         }
 
@@ -225,7 +233,8 @@ class StatementPrivilegeValidator implements StatementAuthorizedValidator {
                 Privilege.Type.DML,
                 Privilege.Clazz.TABLE,
                 analysis.tableInfo().ident().toString(),
-                user);
+                user,
+                defaultSchema);
             return null;
         }
 
@@ -235,7 +244,8 @@ class StatementPrivilegeValidator implements StatementAuthorizedValidator {
                 Privilege.Type.DML,
                 Privilege.Clazz.TABLE,
                 analysis.tableInfo().ident().toString(),
-                user);
+                user,
+                defaultSchema);
             visitRelation(analysis.subQueryRelation(), user, Privilege.Type.DQL);
             return null;
         }
@@ -258,7 +268,8 @@ class StatementPrivilegeValidator implements StatementAuthorizedValidator {
                 Privilege.Type.DDL,
                 Privilege.Clazz.SCHEMA,
                 analysis.schema(),
-                user);
+                user,
+                defaultSchema);
             return null;
         }
 
@@ -268,7 +279,8 @@ class StatementPrivilegeValidator implements StatementAuthorizedValidator {
                 Privilege.Type.DDL,
                 Privilege.Clazz.SCHEMA,
                 analysis.schema(),
-                user);
+                user,
+                defaultSchema);
             return null;
         }
 
@@ -278,7 +290,8 @@ class StatementPrivilegeValidator implements StatementAuthorizedValidator {
                 Privilege.Type.DDL,
                 Privilege.Clazz.TABLE,
                 analysis.tableIdent().toString(),
-                user);
+                user,
+                defaultSchema);
             return null;
         }
 
@@ -288,7 +301,8 @@ class StatementPrivilegeValidator implements StatementAuthorizedValidator {
                 Privilege.Type.DDL,
                 Privilege.Clazz.CLUSTER,
                 null,
-                user);
+                user,
+                defaultSchema);
             return null;
         }
 
@@ -298,7 +312,8 @@ class StatementPrivilegeValidator implements StatementAuthorizedValidator {
                 Privilege.Type.DDL,
                 Privilege.Clazz.SCHEMA,
                 analysis.tableIdent().schema(),
-                user);
+                user,
+                defaultSchema);
             return null;
         }
 
@@ -308,7 +323,8 @@ class StatementPrivilegeValidator implements StatementAuthorizedValidator {
                 Privilege.Type.DDL,
                 Privilege.Clazz.TABLE,
                 analysis.tableIdent().toString(),
-                user);
+                user,
+                defaultSchema);
             return null;
         }
 
@@ -331,7 +347,8 @@ class StatementPrivilegeValidator implements StatementAuthorizedValidator {
                     Privilege.Type.DQL,
                     Privilege.Clazz.TABLE,
                     tableName,
-                    user);
+                    user,
+                    defaultSchema);
             }
             return null;
         }
@@ -342,7 +359,8 @@ class StatementPrivilegeValidator implements StatementAuthorizedValidator {
                 Privilege.Type.DDL,
                 Privilege.Clazz.TABLE,
                 analysis.sourceTableInfo().toString(),
-                user);
+                user,
+                defaultSchema);
             return null;
         }
 
@@ -352,7 +370,8 @@ class StatementPrivilegeValidator implements StatementAuthorizedValidator {
                 Privilege.Type.DDL,
                 Privilege.Clazz.TABLE,
                 analysis.table().ident().toString(),
-                user);
+                user,
+                defaultSchema);
             return null;
         }
 
@@ -371,7 +390,8 @@ class StatementPrivilegeValidator implements StatementAuthorizedValidator {
                 Privilege.Type.DDL,
                 Privilege.Clazz.TABLE,
                 analysis.table().ident().toString(),
-                user);
+                user,
+                defaultSchema);
             return null;
         }
 
@@ -381,7 +401,8 @@ class StatementPrivilegeValidator implements StatementAuthorizedValidator {
                 Privilege.Type.DDL,
                 Privilege.Clazz.TABLE,
                 analysis.tableInfo().ident().toString(),
-                user);
+                user,
+                defaultSchema);
             return null;
         }
 
@@ -402,7 +423,8 @@ class StatementPrivilegeValidator implements StatementAuthorizedValidator {
                 Privilege.Type.DQL,
                 Privilege.Clazz.TABLE,
                 analysis.tableInfo().ident().toString(),
-                user);
+                user,
+                defaultSchema);
             return null;
         }
 
@@ -412,7 +434,8 @@ class StatementPrivilegeValidator implements StatementAuthorizedValidator {
                 Privilege.Type.DDL,
                 Privilege.Clazz.CLUSTER,
                 null,
-                user);
+                user,
+                defaultSchema);
             return null;
         }
 
@@ -422,7 +445,8 @@ class StatementPrivilegeValidator implements StatementAuthorizedValidator {
                 Privilege.Type.DDL,
                 Privilege.Clazz.CLUSTER,
                 null,
-                user);
+                user,
+                defaultSchema);
             return null;
         }
 
@@ -432,7 +456,8 @@ class StatementPrivilegeValidator implements StatementAuthorizedValidator {
                 Privilege.Type.DDL,
                 Privilege.Clazz.CLUSTER,
                 null,
-                user);
+                user,
+                defaultSchema);
             return null;
         }
 
@@ -442,7 +467,8 @@ class StatementPrivilegeValidator implements StatementAuthorizedValidator {
                 Privilege.Type.DDL,
                 Privilege.Clazz.CLUSTER,
                 null,
-                user);
+                user,
+                defaultSchema);
             return null;
         }
 
@@ -473,8 +499,8 @@ class StatementPrivilegeValidator implements StatementAuthorizedValidator {
                 Privilege.Type.DDL,
                 Privilege.Clazz.SCHEMA,
                 createViewStmt.name().schema(),
-                user
-            );
+                user,
+                defaultSchema);
             visitRelation(createViewStmt.query(), user, Privilege.Type.DQL);
             return null;
         }
@@ -486,8 +512,8 @@ class StatementPrivilegeValidator implements StatementAuthorizedValidator {
                     Privilege.Type.DDL,
                     Privilege.Clazz.VIEW,
                     name.toString(),
-                    user
-                );
+                    user,
+                    defaultSchema);
             }
             return null;
         }
@@ -508,9 +534,11 @@ class StatementPrivilegeValidator implements StatementAuthorizedValidator {
     private static final class RelationVisitor extends AnalyzedRelationVisitor<RelationContext, Void> {
 
         private final UserLookup userLookup;
+        private final String defaultSchema;
 
-        public RelationVisitor(UserLookup userLookup) {
+        public RelationVisitor(UserLookup userLookup, String defaultSchema) {
             this.userLookup = userLookup;
+            this.defaultSchema = defaultSchema;
         }
 
         @Override
@@ -551,7 +579,8 @@ class StatementPrivilegeValidator implements StatementAuthorizedValidator {
                 context.type,
                 Privilege.Clazz.TABLE,
                 tableRelation.getQualifiedName().toString(),
-                context.user);
+                context.user,
+                defaultSchema);
             return null;
         }
 
@@ -561,7 +590,8 @@ class StatementPrivilegeValidator implements StatementAuthorizedValidator {
                 context.type,
                 Privilege.Clazz.TABLE,
                 relation.getQualifiedName().toString(),
-                context.user);
+                context.user,
+                defaultSchema);
             return null;
         }
 
@@ -582,8 +612,8 @@ class StatementPrivilegeValidator implements StatementAuthorizedValidator {
                 context.type,
                 Privilege.Clazz.VIEW,
                 analyzedView.name().toString(),
-                context.user
-            );
+                context.user,
+                defaultSchema);
             User owner = analyzedView.owner() == null ? null : userLookup.findUser(analyzedView.owner());
             if (owner == null) {
                 throw new UnauthorizedException(

--- a/enterprise/users/src/main/java/io/crate/auth/user/UserManagerService.java
+++ b/enterprise/users/src/main/java/io/crate/auth/user/UserManagerService.java
@@ -181,21 +181,21 @@ public class UserManagerService implements UserManager, ClusterStateListener {
     }
 
     @Override
-    public StatementAuthorizedValidator getStatementValidator(User user) {
+    public StatementAuthorizedValidator getStatementValidator(User user, String defaultSchema) {
         requireNonNull(user, "User must not be null");
         if (user.isSuperUser()) {
             return BYPASS_AUTHORIZATION_CHECKS;
         }
-        return new StatementPrivilegeValidator(this, user);
+        return new StatementPrivilegeValidator(this, user, defaultSchema);
     }
 
     @Override
-    public ExceptionAuthorizedValidator getExceptionValidator(User user) {
+    public ExceptionAuthorizedValidator getExceptionValidator(User user, String defaultSchema) {
         requireNonNull(user, "User must not be null");
         if (user.isSuperUser()) {
             return NOOP_EXCEPTION_VALIDATOR;
         }
-        return new ExceptionPrivilegeValidator(user);
+        return new ExceptionPrivilegeValidator(user, defaultSchema);
     }
 
     @Override

--- a/enterprise/users/src/test/java/io/crate/auth/user/ExceptionPrivilegeValidatorTest.java
+++ b/enterprise/users/src/test/java/io/crate/auth/user/ExceptionPrivilegeValidatorTest.java
@@ -26,6 +26,7 @@ import io.crate.exceptions.SchemaUnknownException;
 import io.crate.exceptions.UnhandledServerException;
 import io.crate.exceptions.UnsupportedFeatureException;
 import io.crate.metadata.RelationName;
+import io.crate.metadata.Schemas;
 import io.crate.test.integration.CrateUnitTest;
 import org.hamcrest.Matcher;
 import org.junit.Before;
@@ -55,7 +56,7 @@ public class ExceptionPrivilegeValidatorTest extends CrateUnitTest {
                 return true;
             }
         };
-        validator = new ExceptionPrivilegeValidator(user);
+        validator = new ExceptionPrivilegeValidator(user, Schemas.DOC_SCHEMA_NAME);
     }
 
     @SuppressWarnings("unchecked")

--- a/enterprise/users/src/test/java/io/crate/auth/user/PrivilegesTest.java
+++ b/enterprise/users/src/test/java/io/crate/auth/user/PrivilegesTest.java
@@ -20,6 +20,7 @@ package io.crate.auth.user;
 
 import io.crate.analyze.user.Privilege;
 import io.crate.exceptions.MissingPrivilegeException;
+import io.crate.metadata.Schemas;
 import io.crate.test.integration.CrateUnitTest;
 import org.junit.Test;
 
@@ -31,13 +32,13 @@ public class PrivilegesTest extends CrateUnitTest {
     public void testExceptionIsThrownIfUserHasNotRequiredPrivilege() throws Exception {
         expectedException.expect(MissingPrivilegeException.class);
         expectedException.expectMessage("Missing 'DQL' privilege for user 'ford'");
-        Privileges.ensureUserHasPrivilege(Privilege.Type.DQL, Privilege.Clazz.CLUSTER, null, user);
+        Privileges.ensureUserHasPrivilege(Privilege.Type.DQL, Privilege.Clazz.CLUSTER, null, user, Schemas.DOC_SCHEMA_NAME);
     }
 
     @Test
     public void testNoExceptionIsThrownIfUserHasNotRequiredPrivilegeOnInformationSchema() throws Exception {
         //ensureUserHasPrivilege will not throw an exception if the schema is `information_schema`
-        Privileges.ensureUserHasPrivilege(Privilege.Type.DQL, Privilege.Clazz.SCHEMA, "information_schema", user);
+        Privileges.ensureUserHasPrivilege(Privilege.Type.DQL, Privilege.Clazz.SCHEMA, "information_schema", user, Schemas.DOC_SCHEMA_NAME);
     }
 
     @Test

--- a/enterprise/users/src/test/java/io/crate/auth/user/StatementPrivilegeValidatorTest.java
+++ b/enterprise/users/src/test/java/io/crate/auth/user/StatementPrivilegeValidatorTest.java
@@ -28,6 +28,7 @@ import io.crate.analyze.user.Privilege;
 import io.crate.exceptions.UnauthorizedException;
 import io.crate.execution.engine.collect.sources.SysTableRegistry;
 import io.crate.metadata.RelationName;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.TransactionContext;
 import io.crate.metadata.blob.BlobSchemaInfo;
 import io.crate.metadata.cluster.DDLClusterStateService;
@@ -80,14 +81,14 @@ public class StatementPrivilegeValidatorTest extends CrateDummyClusterServiceUni
 
         user = new User("normal", ImmutableSet.of(), ImmutableSet.of(), null) {
             @Override
-            public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, String ident) {
+            public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, String ident, String defaultSchema) {
                 validationCallArguments.add(Lists.newArrayList(type, clazz, ident, user.name()));
                 return true;
             }
         };
         superUser = new User("crate", EnumSet.of(User.Role.SUPERUSER), ImmutableSet.of(), null) {
             @Override
-            public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, @Nullable String ident) {
+            public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, @Nullable String ident, String defaultSchema) {
                 validationCallArguments.add(Lists.newArrayList(type, clazz, ident, superUser.name()));
                 return true;
             }
@@ -124,8 +125,8 @@ public class StatementPrivilegeValidatorTest extends CrateDummyClusterServiceUni
     private void analyze(String stmt, User user) {
         e.analyzer.boundAnalyze(SqlParser.createStatement(stmt),
             new TransactionContext(new SessionContext(0, Option.NONE, null, user,
-                userManager.getStatementValidator(user),
-                userManager.getExceptionValidator(user))), ParameterContext.EMPTY);
+                userManager.getStatementValidator(user, Schemas.DOC_SCHEMA_NAME),
+                userManager.getExceptionValidator(user, Schemas.DOC_SCHEMA_NAME))), ParameterContext.EMPTY);
     }
 
     @SuppressWarnings("unchecked")

--- a/enterprise/users/src/test/java/io/crate/auth/user/UserManagerServiceTest.java
+++ b/enterprise/users/src/test/java/io/crate/auth/user/UserManagerServiceTest.java
@@ -19,6 +19,7 @@
 package io.crate.auth.user;
 
 import io.crate.execution.engine.collect.sources.SysTableRegistry;
+import io.crate.metadata.Schemas;
 import io.crate.metadata.UserDefinitions;
 import io.crate.metadata.UsersMetaData;
 import io.crate.metadata.UsersPrivilegesMetaData;
@@ -66,24 +67,24 @@ public class UserManagerServiceTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testUserIsRequiredToGetStatementValidator() throws Exception {
         expectedException.expectMessage("User must not be null");
-        userManagerService.getStatementValidator(null);
+        userManagerService.getStatementValidator(null, Schemas.DOC_SCHEMA_NAME);
     }
 
     @Test
     public void testGetNoopStatementValidatorForSuperUser() throws Exception {
-        StatementAuthorizedValidator validator = userManagerService.getStatementValidator(CRATE_USER);
+        StatementAuthorizedValidator validator = userManagerService.getStatementValidator(CRATE_USER, Schemas.DOC_SCHEMA_NAME);
         assertThat(validator, is(BYPASS_AUTHORIZATION_CHECKS));
     }
 
     @Test
     public void testUserIsRequiredToGetExceptionValidator() throws Exception {
         expectedException.expectMessage("User must not be null");
-        userManagerService.getExceptionValidator(null);
+        userManagerService.getExceptionValidator(null, Schemas.DOC_SCHEMA_NAME);
     }
 
     @Test
     public void testGetNoopExceptionValidatorForSuperUser() throws Exception {
-        ExceptionAuthorizedValidator validator = userManagerService.getExceptionValidator(CRATE_USER);
+        ExceptionAuthorizedValidator validator = userManagerService.getExceptionValidator(CRATE_USER, Schemas.DOC_SCHEMA_NAME);
         assertThat(validator, is(NOOP_EXCEPTION_VALIDATOR));
     }
 }

--- a/sql/src/main/java/io/crate/action/sql/SQLOperations.java
+++ b/sql/src/main/java/io/crate/action/sql/SQLOperations.java
@@ -94,19 +94,19 @@ public class SQLOperations {
         return createSession(new SessionContext(
             SysSchemaInfo.NAME,
             CRATE_USER,
-            userManager.getStatementValidator(CRATE_USER),
-            userManager.getExceptionValidator(CRATE_USER))
+            userManager.getStatementValidator(CRATE_USER, SysSchemaInfo.NAME),
+            userManager.getExceptionValidator(CRATE_USER, SysSchemaInfo.NAME))
         );
     }
 
     public Session createSession(@Nullable String defaultSchema, User user) {
         return createSession(new SessionContext(defaultSchema, user,
-            userManager.getStatementValidator(user), userManager.getExceptionValidator(user)));
+            userManager.getStatementValidator(user, defaultSchema), userManager.getExceptionValidator(user, defaultSchema)));
     }
 
     public Session createSession(@Nullable String defaultSchema, User user, Set<Option> options, int defaultLimit) {
         return createSession(new SessionContext(defaultLimit, options, defaultSchema, user,
-            userManager.getStatementValidator(user), userManager.getExceptionValidator(user)));
+            userManager.getStatementValidator(user, defaultSchema), userManager.getExceptionValidator(user, defaultSchema)));
     }
 
     /**

--- a/sql/src/main/java/io/crate/auth/user/User.java
+++ b/sql/src/main/java/io/crate/auth/user/User.java
@@ -85,14 +85,16 @@ public class User {
     }
 
     /**
-     * Checks if the user has a privilege that matches the given class, type and ident
-     * currently only the type is checked since Class is always CLUSTER and ident null.
+     * Checks if the user has a privilege that matches the given class, type, ident and
+     * default schema. Currently only the type is checked since Class is always
+     * CLUSTER and ident null.
      * @param type           privilege type
      * @param clazz          privilege class (ie. CLUSTER, TABLE, etc)
      * @param ident          ident of the object
+     * @param defaultSchema  the default schema of the current session
      */
-    public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, @Nullable String ident) {
-        return isSuperUser() || privileges.matchPrivilege(type, clazz, ident);
+    public boolean hasPrivilege(Privilege.Type type, Privilege.Clazz clazz, @Nullable String ident, String defaultSchema) {
+        return isSuperUser() || privileges.matchPrivilege(type, clazz, ident, defaultSchema);
     }
 
     /**

--- a/sql/src/main/java/io/crate/auth/user/UserManager.java
+++ b/sql/src/main/java/io/crate/auth/user/UserManager.java
@@ -76,11 +76,11 @@ public interface UserManager extends UserLookup {
      * Look up a statement authorization validator for the given user.
      * All statements will be validated by this before planning/executing.
      */
-    StatementAuthorizedValidator getStatementValidator(@Nullable User user);
+    StatementAuthorizedValidator getStatementValidator(@Nullable User user, String defaultSchema);
 
     /**
      * Look up a exception authorization validator for the given user.
      * All exceptions will be validated by this before sending them to the client.
      */
-    ExceptionAuthorizedValidator getExceptionValidator(@Nullable User user);
+    ExceptionAuthorizedValidator getExceptionValidator(@Nullable User user, String defaultSchema);
 }

--- a/sql/src/main/java/io/crate/auth/user/UserPrivileges.java
+++ b/sql/src/main/java/io/crate/auth/user/UserPrivileges.java
@@ -120,7 +120,8 @@ class UserPrivileges implements Iterable<Privilege> {
      */
     boolean matchPrivilege(@Nullable Privilege.Type type,
                            Privilege.Clazz clazz,
-                           @Nullable String ident) {
+                           @Nullable String ident,
+                           String defaultSchema) {
         Privilege foundPrivilege = privilegeByIdent.get(new PrivilegeIdent(type, clazz, ident));
         if (foundPrivilege == null) {
             switch (clazz) {
@@ -129,7 +130,7 @@ class UserPrivileges implements Iterable<Privilege> {
                     break;
                 case TABLE:
                 case VIEW:
-                    String schemaIdent = new IndexParts(ident).getSchema();
+                    String schemaIdent = new IndexParts(ident, defaultSchema).getSchema();
                     foundPrivilege = privilegeByIdent.get(new PrivilegeIdent(type, Privilege.Clazz.SCHEMA, schemaIdent));
                     if (foundPrivilege == null) {
                         foundPrivilege = privilegeByIdent.get(new PrivilegeIdent(type, Privilege.Clazz.CLUSTER, null));

--- a/sql/src/main/java/io/crate/metadata/IndexParts.java
+++ b/sql/src/main/java/io/crate/metadata/IndexParts.java
@@ -48,6 +48,10 @@ public class IndexParts {
     private final String partitionIdent;
 
     public IndexParts(String indexName) {
+        this(indexName, Schemas.DOC_SCHEMA_NAME);
+    }
+
+    public IndexParts(String indexName, String defaultSchema) {
         if (BlobIndex.isBlobIndex(indexName)) {
             schema = BlobSchemaInfo.NAME;
             table = BlobIndex.stripPrefix(indexName);
@@ -57,7 +61,7 @@ public class IndexParts {
             switch (parts.size()) {
                 case 1:
                     // "table_name"
-                    schema = Schemas.DOC_SCHEMA_NAME;
+                    schema = defaultSchema;
                     table = indexName;
                     partitionIdent = null;
                     break;
@@ -70,7 +74,7 @@ public class IndexParts {
                 case 4:
                     // ""."partitioned"."table_name". ["ident"]
                     assertEmpty(parts.get(0));
-                    schema = Schemas.DOC_SCHEMA_NAME;
+                    schema = defaultSchema;
                     assertPartitionPrefix(parts.get(1));
                     table = parts.get(2);
                     partitionIdent = parts.get(3);

--- a/sql/src/main/java/io/crate/user/StubUserManager.java
+++ b/sql/src/main/java/io/crate/user/StubUserManager.java
@@ -72,13 +72,13 @@ public class StubUserManager implements UserManager {
     }
 
     @Override
-    public StatementAuthorizedValidator getStatementValidator(@Nullable User user) {
+    public StatementAuthorizedValidator getStatementValidator(@Nullable User user, String defaultSchema) {
         return s -> {
         };
     }
 
     @Override
-    public ExceptionAuthorizedValidator getExceptionValidator(@Nullable User user) {
+    public ExceptionAuthorizedValidator getExceptionValidator(@Nullable User user, String defaultSchema) {
         return t -> {
         };
     }

--- a/sql/src/test/java/io/crate/auth/user/UserPrivilegesTest.java
+++ b/sql/src/test/java/io/crate/auth/user/UserPrivilegesTest.java
@@ -54,9 +54,9 @@ public class UserPrivilegesTest extends CrateUnitTest {
     @Test
     public void testMatchPrivilegesEmpty() throws Exception {
         UserPrivileges userPrivileges = new UserPrivileges(Collections.emptyList());
-        assertThat(userPrivileges.matchPrivilege(Privilege.Type.DDL, Privilege.Clazz.CLUSTER, null), is(false));
-        assertThat(userPrivileges.matchPrivilege(Privilege.Type.DDL, Privilege.Clazz.SCHEMA, "doc"), is(false));
-        assertThat(userPrivileges.matchPrivilege(Privilege.Type.DDL, Privilege.Clazz.TABLE, "doc.t1"), is(false));
+        assertThat(userPrivileges.matchPrivilege(Privilege.Type.DDL, Privilege.Clazz.CLUSTER, null, "doc"), is(false));
+        assertThat(userPrivileges.matchPrivilege(Privilege.Type.DDL, Privilege.Clazz.SCHEMA, "doc", "doc"), is(false));
+        assertThat(userPrivileges.matchPrivilege(Privilege.Type.DDL, Privilege.Clazz.TABLE, "doc.t1", "doc"), is(false));
         assertThat(userPrivileges.matchPrivilegeOfAnyType(Privilege.Clazz.CLUSTER, null), is(false));
         assertThat(userPrivileges.matchPrivilegeOfAnyType(Privilege.Clazz.SCHEMA, "doc"), is(false));
         assertThat(userPrivileges.matchPrivilegeOfAnyType(Privilege.Clazz.TABLE, "doc.t1"), is(false));
@@ -64,9 +64,9 @@ public class UserPrivilegesTest extends CrateUnitTest {
 
     @Test
     public void testMatchPrivilegeNoType() throws Exception {
-        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DDL, Privilege.Clazz.CLUSTER, null), is(false));
-        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DDL, Privilege.Clazz.SCHEMA, "doc"), is(false));
-        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DDL, Privilege.Clazz.TABLE, "doc.t1"), is(false));
+        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DDL, Privilege.Clazz.CLUSTER, null, "doc"), is(false));
+        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DDL, Privilege.Clazz.SCHEMA, "doc", "doc"), is(false));
+        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DDL, Privilege.Clazz.TABLE, "doc.t1", "doc"), is(false));
         assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilegeOfAnyType(Privilege.Clazz.CLUSTER, null), is(true));
         assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilegeOfAnyType(Privilege.Clazz.SCHEMA, "doc"), is(true));
         assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilegeOfAnyType(Privilege.Clazz.TABLE, "doc.t1"), is(true));
@@ -74,25 +74,25 @@ public class UserPrivilegesTest extends CrateUnitTest {
 
     @Test
     public void testMatchPrivilegeType() throws Exception {
-        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.CLUSTER, null), is(true));
+        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.CLUSTER, null, "doc"), is(true));
         assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilegeOfAnyType(Privilege.Clazz.CLUSTER, null), is(true));
     }
 
     @Test
     public void testMatchPrivilegeSchema() throws Exception {
-        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.SCHEMA, "doc"), is(true));
+        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.SCHEMA, "doc", "doc"), is(true));
         assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilegeOfAnyType(Privilege.Clazz.SCHEMA, "doc"), is(true));
-        assertThat(USER_PRIVILEGES_SCHEMA.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.SCHEMA, "doc"), is(true));
+        assertThat(USER_PRIVILEGES_SCHEMA.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.SCHEMA, "doc", "doc"), is(true));
         assertThat(USER_PRIVILEGES_SCHEMA.matchPrivilegeOfAnyType(Privilege.Clazz.SCHEMA, "doc"), is(true));
     }
 
     @Test
     public void testMatchPrivilegeTable() throws Exception {
-        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t1"), is(true));
+        assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t1", "doc"), is(true));
         assertThat(USER_PRIVILEGES_CLUSTER.matchPrivilegeOfAnyType(Privilege.Clazz.TABLE, "doc.t1"), is(true));
-        assertThat(USER_PRIVILEGES_SCHEMA.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t1"), is(true));
+        assertThat(USER_PRIVILEGES_SCHEMA.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t1", "doc"), is(true));
         assertThat(USER_PRIVILEGES_SCHEMA.matchPrivilegeOfAnyType(Privilege.Clazz.TABLE, "doc.t1"), is(true));
-        assertThat(USER_PRIVILEGES_TABLE.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t1"), is(true));
+        assertThat(USER_PRIVILEGES_TABLE.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t1", "doc"), is(true));
         assertThat(USER_PRIVILEGES_TABLE.matchPrivilegeOfAnyType(Privilege.Clazz.TABLE, "doc.t1"), is(true));
     }
 
@@ -102,9 +102,9 @@ public class UserPrivilegesTest extends CrateUnitTest {
             new Privilege(Privilege.State.DENY, Privilege.Type.DQL, Privilege.Clazz.CLUSTER, null, "crate")
         );
         UserPrivileges userPrivileges = new UserPrivileges(privileges);
-        assertThat(userPrivileges.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.CLUSTER, null), is(false));
-        assertThat(userPrivileges.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.SCHEMA, "doc"), is(false));
-        assertThat(userPrivileges.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t1"), is(false));
+        assertThat(userPrivileges.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.CLUSTER, null, "doc"), is(false));
+        assertThat(userPrivileges.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.SCHEMA, "doc", "doc"), is(false));
+        assertThat(userPrivileges.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t1", "doc"), is(false));
         assertThat(userPrivileges.matchPrivilegeOfAnyType(Privilege.Clazz.CLUSTER, null), is(false));
         assertThat(userPrivileges.matchPrivilegeOfAnyType(Privilege.Clazz.SCHEMA, "doc"), is(false));
         assertThat(userPrivileges.matchPrivilegeOfAnyType(Privilege.Clazz.TABLE, "doc.t1"), is(false));
@@ -118,8 +118,8 @@ public class UserPrivilegesTest extends CrateUnitTest {
             new Privilege(Privilege.State.GRANT, Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t1", "crate")
         );
         UserPrivileges userPrivileges = new UserPrivileges(privileges);
-        assertThat(userPrivileges.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t1"), is(true));
-        assertThat(userPrivileges.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t2"), is(false));
-        assertThat(userPrivileges.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.SCHEMA, "my_schema"), is(true));
+        assertThat(userPrivileges.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t1", "doc"), is(true));
+        assertThat(userPrivileges.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.TABLE, "doc.t2", "doc"), is(false));
+        assertThat(userPrivileges.matchPrivilege(Privilege.Type.DQL, Privilege.Clazz.SCHEMA, "my_schema", "doc"), is(true));
     }
 }

--- a/sql/src/test/java/io/crate/testing/DummyUserManager.java
+++ b/sql/src/test/java/io/crate/testing/DummyUserManager.java
@@ -62,12 +62,12 @@ public class DummyUserManager implements UserManager {
     }
 
     @Override
-    public StatementAuthorizedValidator getStatementValidator(@Nullable User user) {
+    public StatementAuthorizedValidator getStatementValidator(@Nullable User user, String defaultSchema) {
         return s -> {};
     }
 
     @Override
-    public ExceptionAuthorizedValidator getExceptionValidator(@Nullable User user) {
+    public ExceptionAuthorizedValidator getExceptionValidator(@Nullable User user, String defaultSchema) {
         return t -> {};
     }
 }


### PR DESCRIPTION
This commit aims to fix an issue where users with privilges on a schema,
for example 'abc', but not on 'doc', would not be able to use an alias
on a table within 'abc'. This is because the schema would be given the
schema of 'doc', rather than the schema of the table it was created
from, and would fail when privileges were checked.