### PR TITLE
Implement an incremental page receiver used for group by and aggregates.

### DIFF
--- a/benchmarks/src/test/java/io/crate/execution/engine/aggregation/AggregateCollectorBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/execution/engine/aggregation/AggregateCollectorBenchmark.java
@@ -79,10 +79,10 @@ public class AggregateCollectorBenchmark {
     }
 
     @Benchmark
-    public Object[] measureAggregateCollector() {
+    public Iterable<Row> measureAggregateCollector() {
         Object[] state = collector.supplier().get();
         BiConsumer<Object[], Row> accumulator = collector.accumulator();
-        Function<Object[], Object[]> finisher = collector.finisher();
+        Function<Object[], Iterable<Row>> finisher = collector.finisher();
         for (int i = 0; i < rows.size(); i++) {
             accumulator.accept(state, rows.get(i));
         }

--- a/benchmarks/src/test/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationBenchmark.java
@@ -22,6 +22,7 @@
 
 package io.crate.operation.aggregation;
 
+import io.crate.data.RowN;
 import io.crate.expression.symbol.AggregateMode;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.data.Input;
@@ -110,10 +111,10 @@ public class HyperLogLogDistinctAggregationBenchmark {
     }
 
     @Benchmark
-    public Object[] benchmarkHLLAggregation() throws Exception {
+    public Iterable<Row> benchmarkHLLAggregation() throws Exception {
         Object[] state = collector.supplier().get();
         BiConsumer<Object[], Row> accumulator = collector.accumulator();
-        Function<Object[], Object[]> finisher = collector.finisher();
+        Function<Object[], Iterable<Row>> finisher = collector.finisher();
         for (int i = 0; i < rows.size(); i++) {
             accumulator.accept(state, rows.get(i));
         }
@@ -121,10 +122,10 @@ public class HyperLogLogDistinctAggregationBenchmark {
     }
 
     @Benchmark
-    public Object[] benchmarkHLLAggregationNoDeepCopy() throws Exception {
+    public Iterable<Row> benchmarkHLLAggregationNoDeepCopy() throws Exception {
         Object[] state = collectorNoDeepCopy.supplier().get();
         BiConsumer<Object[], Row> accumulator = collectorNoDeepCopy.accumulator();
-        Function<Object[], Object[]> finisher = collectorNoDeepCopy.finisher();
+        Function<Object[], Iterable<Row>> finisher = collectorNoDeepCopy.finisher();
         for (int i = 0; i < rows.size(); i++) {
             accumulator.accept(state, rows.get(i));
         }

--- a/sql/src/main/java/io/crate/execution/IncrementalPageBucketReceiver.java
+++ b/sql/src/main/java/io/crate/execution/IncrementalPageBucketReceiver.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution;
+
+import io.crate.Streamer;
+import io.crate.data.Bucket;
+import io.crate.data.InMemoryBatchIterator;
+import io.crate.data.Row;
+import io.crate.data.RowConsumer;
+import io.crate.data.SentinelRow;
+import io.crate.execution.jobs.PageBucketReceiver;
+import io.crate.execution.jobs.PageResultListener;
+
+import javax.annotation.Nonnull;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.stream.Collector;
+
+public class IncrementalPageBucketReceiver<T> implements PageBucketReceiver {
+
+    private final Function<T, Iterable<Row>> finisher;
+    private final BiConsumer<T, Row> accumulator;
+    private final T state;
+    private final AtomicInteger remainingUpstreams;
+    private final RowConsumer consumer;
+    private final CompletableFuture<?> processingFuture = new CompletableFuture<>();
+    private final Streamer<?>[] streamers;
+
+    private volatile Throwable lastThrowable = null;
+
+    public IncrementalPageBucketReceiver(Collector<Row, T, Iterable<Row>> collector,
+                                         RowConsumer rowConsumer,
+                                         Streamer<?>[] streamers,
+                                         int upstreamsCount) {
+        this.state = collector.supplier().get();
+        this.accumulator = collector.accumulator();
+        this.finisher = collector.finisher();
+        this.consumer = rowConsumer;
+        this.streamers = streamers;
+        this.remainingUpstreams = new AtomicInteger(upstreamsCount);
+    }
+
+    @Override
+    public void setBucket(int bucketIdx, Bucket rows, boolean isLast, PageResultListener pageResultListener) {
+        synchronized (state) {
+            try {
+                for (Row row : rows) {
+                    accumulator.accept(state, row);
+                }
+            } catch (Throwable e) {
+                lastThrowable = e;
+            }
+        }
+
+        pageResultListener.needMore(!isLast);
+        if (isLast) {
+            if (remainingUpstreams.decrementAndGet() == 0) {
+                consumeRows();
+                if (lastThrowable == null) {
+                    processingFuture.complete(null);
+                } else {
+                    processingFuture.completeExceptionally(lastThrowable);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void releasePageResultListeners() {
+    }
+
+    @Override
+    public void killed(int bucketIdx, Throwable throwable) {
+        kill(throwable);
+    }
+
+    @Override
+    public Streamer<?>[] streamers() {
+        return streamers;
+    }
+
+    @Override
+    public CompletableFuture<?> completionFuture() {
+        return processingFuture;
+    }
+
+    @Override
+    public void consumeRows() {
+        consumer.accept(InMemoryBatchIterator.of(finisher.apply(state), SentinelRow.SENTINEL), lastThrowable);
+    }
+
+    @Override
+    public void kill(@Nonnull Throwable t) {
+        lastThrowable = t;
+        consumer.accept(null, t);
+        processingFuture.completeExceptionally(t);
+    }
+}

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/AggregationPipe.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/AggregationPipe.java
@@ -22,22 +22,18 @@
 
 package io.crate.execution.engine.aggregation;
 
-import io.crate.expression.symbol.AggregateMode;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.data.BatchIterator;
 import io.crate.data.CollectingBatchIterator;
 import io.crate.data.Input;
 import io.crate.data.Projector;
 import io.crate.data.Row;
-import io.crate.data.RowN;
 import io.crate.execution.engine.collect.CollectExpression;
+import io.crate.expression.symbol.AggregateMode;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.util.BigArrays;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collector;
-import java.util.stream.Collectors;
 
 public class AggregationPipe implements Projector {
 
@@ -69,13 +65,11 @@ public class AggregationPipe implements Projector {
 
     @Override
     public BatchIterator<Row> apply(BatchIterator<Row> batchIterator) {
-        Collector<Row, ?, Iterable<Row>> collectAndConvertToRows = Collectors.collectingAndThen(
-            collector,
-            cells -> {
-                Row row = new RowN(cells);
-                return Collections.singletonList(row);
-            });
-        return CollectingBatchIterator.newInstance(batchIterator, collectAndConvertToRows);
+        return CollectingBatchIterator.newInstance(batchIterator, collector);
+    }
+
+    public AggregateCollector getCollector() {
+        return collector;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/execution/engine/aggregation/GroupingProjector.java
+++ b/sql/src/main/java/io/crate/execution/engine/aggregation/GroupingProjector.java
@@ -119,6 +119,10 @@ public class GroupingProjector implements Projector {
         return CollectingBatchIterator.newInstance(batchIterator, collector);
     }
 
+    public Collector<Row, ?, Iterable<Row>> getCollector() {
+        return collector;
+    }
+
     @Override
     public boolean providesIndependentScroll() {
         return true;


### PR DESCRIPTION
When the first projection is a pipeline breaker (ie a group by or an aggregate)
we execute the grouping/aggregation in an incremental manner on each
bucket we receive (as oppose to before when we waited for all the buckets
for a page to arrive before reducing the dataset to one value).

```
Q: select "cCode", count(*) from uservisits group by "cCode"
C: 15
| Version |         Mean Â±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      269.069 Â±   73.015 |    137.635 |    260.018 |    312.446 |    458.235 |
|   V2    |       76.522 Â±   21.838 |     33.118 |     71.657 |     90.769 |    146.275 |
mean:   - 111.43%
median: - 113.58%
Likely significant

Q: select min("adRevenue") from uservisits group by "cCode"
C: 15
| Version |         Mean Â±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      340.921 Â±   91.033 |    206.123 |    326.064 |    392.856 |    662.908 |
|   V2    |      192.849 Â±   86.505 |     83.092 |    171.958 |    226.308 |    535.947 |
mean:   -  55.48%
median: -  61.89%
Likely significant

Q: select avg("adRevenue") from uservisits group by "cCode"
C: 15
| Version |         Mean Â±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      325.269 Â±   71.881 |    177.684 |    320.627 |    361.748 |    488.931 |
|   V2    |      175.961 Â±   47.054 |     74.915 |    179.826 |    211.305 |    292.299 |
mean:   -  59.58%
median: -  56.27%
Likely significant

Q: select count(distinct "searchWord") from uservisits group by "cCode"
C: 5
| Version |         Mean Â±    Stdev |        Min |     Median |         Q3 |        Max |
|   V1    |      561.376 Â±  113.013 |    397.133 |    535.428 |    580.397 |   1006.624 |
|   V2    |      511.017 Â±   79.559 |    299.237 |    500.183 |    559.474 |    739.432 |
mean:   -   9.39%
median: -   6.81%
Likely significant
```


<!--

Thank you for your contribution. Here is a quick checklist of things you should've done:

 - You've read CONTRIBUTING.rst and signed our CLA (https://crate.io/community/contribute/cla/)
 - Wrote a CHANGES.txt entry if this is a change that is relevant for users of CrateDB
 - Run tests with `./gradlew test itest` (If they fail Jenkins will block this PR anyway)

-->
