### PR TITLE
Remove methods from PageBucketReceiver

### DIFF
--- a/sql/src/main/java/io/crate/execution/IncrementalPageBucketReceiver.java
+++ b/sql/src/main/java/io/crate/execution/IncrementalPageBucketReceiver.java
@@ -92,11 +92,6 @@ public class IncrementalPageBucketReceiver<T> implements PageBucketReceiver {
     }
 
     @Override
-    public void killed(int bucketIdx, Throwable throwable) {
-        kill(throwable);
-    }
-
-    @Override
     public Streamer<?>[] streamers() {
         return streamers;
     }

--- a/sql/src/main/java/io/crate/execution/IncrementalPageBucketReceiver.java
+++ b/sql/src/main/java/io/crate/execution/IncrementalPageBucketReceiver.java
@@ -88,10 +88,6 @@ public class IncrementalPageBucketReceiver<T> implements PageBucketReceiver {
     }
 
     @Override
-    public void releasePageResultListeners() {
-    }
-
-    @Override
     public Streamer<?>[] streamers() {
         return streamers;
     }

--- a/sql/src/main/java/io/crate/execution/engine/BucketForwarder.java
+++ b/sql/src/main/java/io/crate/execution/engine/BucketForwarder.java
@@ -84,7 +84,7 @@ final class BucketForwarder {
     protected void failed(@Nonnull Throwable t) {
         initializationTracker.jobInitializationFailed(t);
         for (PageBucketReceiver pageBucketReceiver : pageBucketReceivers) {
-            pageBucketReceiver.killed(bucketIdx, t);
+            pageBucketReceiver.kill(t);
         }
     }
 

--- a/sql/src/main/java/io/crate/execution/engine/distribution/TransportDistributedResultAction.java
+++ b/sql/src/main/java/io/crate/execution/engine/distribution/TransportDistributedResultAction.java
@@ -25,8 +25,8 @@ package io.crate.execution.engine.distribution;
 import com.google.common.annotations.VisibleForTesting;
 import io.crate.concurrent.CompletableFutures;
 import io.crate.exceptions.TaskMissing;
-import io.crate.execution.jobs.PageBucketReceiver;
 import io.crate.execution.jobs.DownstreamRXTask;
+import io.crate.execution.jobs.PageBucketReceiver;
 import io.crate.execution.jobs.PageResultListener;
 import io.crate.execution.jobs.RootTask;
 import io.crate.execution.jobs.TasksService;
@@ -154,7 +154,7 @@ public class TransportDistributedResultAction extends AbstractComponent implemen
             );
             return pageResultListener.future;
         } else {
-            pageBucketReceiver.killed(request.bucketIdx(), throwable);
+            pageBucketReceiver.kill(throwable);
             return CompletableFuture.completedFuture(new DistributedResultResponse(false));
         }
     }

--- a/sql/src/main/java/io/crate/execution/jobs/DistResultRXTask.java
+++ b/sql/src/main/java/io/crate/execution/jobs/DistResultRXTask.java
@@ -54,14 +54,9 @@ public class DistResultRXTask extends AbstractTask implements DownstreamRXTask {
             if (ex instanceof IllegalStateException) {
                 kill(ex);
             } else {
-                releaseListenersAndCloseContext(ex);
+                close(ex);
             }
         });
-    }
-
-    private void releaseListenersAndCloseContext(@Nullable Throwable throwable) {
-        pageBucketReceiver.releasePageResultListeners();
-        close(throwable);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/execution/jobs/PageBucketReceiver.java
+++ b/sql/src/main/java/io/crate/execution/jobs/PageBucketReceiver.java
@@ -80,8 +80,6 @@ public interface PageBucketReceiver extends CompletionListenable, Killable {
      */
     void releasePageResultListeners();
 
-    void killed(int bucketIdx, Throwable throwable);
-
     Streamer<?>[] streamers();
 
     /**

--- a/sql/src/main/java/io/crate/execution/jobs/PageBucketReceiver.java
+++ b/sql/src/main/java/io/crate/execution/jobs/PageBucketReceiver.java
@@ -72,21 +72,11 @@ public interface PageBucketReceiver extends CompletionListenable, Killable {
      */
     void setBucket(int bucketIdx, Bucket rows, boolean isLast, PageResultListener pageResultListener);
 
-    /**
-     * Each buckedId has an associated {@link PageResultListener} and for each listener this will signal no more data
-     * is needed using {@link PageResultListener#needMore}.
-     * Implementations should make sure the upstream is notified when all data is consumed or if an error that causes
-     * the interruption of data processing is encountered.
-     */
-    void releasePageResultListeners();
-
     Streamer<?>[] streamers();
 
     /**
      * Returns a future that will complete successfully when the all data is processed (operation is complete). It will
-     * complete exceptionally when the processing of data failed and the operation needs to be stopped. This is
-     * typically the place where the {@link PageResultListener}s should be released (using
-     * {@link #releasePageResultListeners}) and dependant clients notified.
+     * complete exceptionally when the processing of data failed and the operation needs to be stopped.
      */
     CompletableFuture<?> completionFuture();
 

--- a/sql/src/test/java/io/crate/execution/engine/distribution/DistributingConsumerTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/distribution/DistributingConsumerTest.java
@@ -182,7 +182,7 @@ public class DistributingConsumerTest extends CrateUnitTest {
                     resultRequest.isLast(),
                     needMore -> listener.onResponse(new DistributedResultResponse(needMore)));
             } else {
-                bucketReceiver.killed(resultRequest.bucketIdx(), throwable);
+                bucketReceiver.kill(throwable);
             }
             return null;
         }).when(distributedResultAction).pushResult(anyString(), any(), any());

--- a/sql/src/test/java/io/crate/execution/jobs/DistResultRXTaskTest.java
+++ b/sql/src/test/java/io/crate/execution/jobs/DistResultRXTaskTest.java
@@ -176,7 +176,7 @@ public class DistResultRXTaskTest extends CrateUnitTest {
         PageBucketReceiver bucketReceiver = ctx.getBucketReceiver((byte) 0);
         assertThat(bucketReceiver, notNullValue());
         bucketReceiver.setBucket(0, Bucket.EMPTY, false, listener);
-        bucketReceiver.killed(1, new Exception("dummy"));
+        bucketReceiver.kill(new Exception("dummy"));
 
         verify(listener, times(1)).needMore(false);
     }
@@ -188,11 +188,11 @@ public class DistResultRXTaskTest extends CrateUnitTest {
         PageBucketReceiver bucketReceiver = ctx.getBucketReceiver((byte) 0);
         assertThat(bucketReceiver, notNullValue());
 
-        bucketReceiver.killed(0, new Exception("dummy"));
+        bucketReceiver.kill(new Exception("dummy"));
         PageResultListener listener = mock(PageResultListener.class);
         bucketReceiver.setBucket(1, Bucket.EMPTY, true, listener);
 
-        verify(listener, times(1)).needMore(false);
+        verify(listener, times(2)).needMore(false);
     }
 
     @Test


### PR DESCRIPTION
Having `kill` is sufficient. Both methods had the same semantics.

`releasePageResultListeners` can be removed as well.
The `PageBucketReceiver` knows internally when it is done because it
triggers the `completionFuture` itself. Releasing the listeners can be
done internally as well.

The single usage looked like this:

    *pageBucketReceiver*
      .completionFuture()
      .whenComplete(.. ->
        *pageBucketReceiver*.releasePageResultListeners()



 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed