### PR TITLE
Move logging for task actions into RootTask

### DIFF
--- a/sql/src/main/java/io/crate/execution/engine/collect/CollectTask.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/CollectTask.java
@@ -34,8 +34,6 @@ import io.crate.execution.dsl.phases.RoutedCollectPhase;
 import io.crate.execution.jobs.AbstractTask;
 import io.crate.execution.jobs.SharedShardContexts;
 import io.crate.metadata.RowGranularity;
-import org.apache.logging.log4j.Logger;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.threadpool.ThreadPool;
 
@@ -44,8 +42,6 @@ import javax.annotation.Nullable;
 import java.util.Locale;
 
 public class CollectTask extends AbstractTask {
-
-    private static final Logger LOGGER = Loggers.getLogger(CollectTask.class);
 
     private final CollectPhase collectPhase;
     private final MapSideDataCollectOperation collectOperation;
@@ -64,7 +60,7 @@ public class CollectTask extends AbstractTask {
                        RamAccountingContext queryPhaseRamAccountingContext,
                        RowConsumer consumer,
                        SharedShardContexts sharedShardContexts) {
-        super(collectPhase.phaseId(), LOGGER);
+        super(collectPhase.phaseId());
         this.collectPhase = collectPhase;
         this.collectOperation = collectOperation;
         this.queryPhaseRamAccountingContext = queryPhaseRamAccountingContext;

--- a/sql/src/main/java/io/crate/execution/engine/collect/collectors/RemoteCollector.java
+++ b/sql/src/main/java/io/crate/execution/engine/collect/collectors/RemoteCollector.java
@@ -29,9 +29,9 @@ import io.crate.data.RowConsumer;
 import io.crate.execution.dsl.phases.NodeOperation;
 import io.crate.execution.dsl.phases.RoutedCollectPhase;
 import io.crate.execution.engine.distribution.merge.PassThroughPagingIterator;
-import io.crate.execution.jobs.PageBucketReceiver;
-import io.crate.execution.jobs.DistResultRXTask;
 import io.crate.execution.jobs.CumulativePageBucketReceiver;
+import io.crate.execution.jobs.DistResultRXTask;
+import io.crate.execution.jobs.PageBucketReceiver;
 import io.crate.execution.jobs.RootTask;
 import io.crate.execution.jobs.TasksService;
 import io.crate.execution.jobs.kill.KillJobsRequest;
@@ -181,7 +181,6 @@ public class RemoteCollector {
             1);
 
         builder.addTask(new DistResultRXTask(
-            LOGGER,
             RECEIVER_PHASE_ID,
             "RemoteCollectPhase",
             pageBucketReceiver,

--- a/sql/src/main/java/io/crate/execution/engine/fetch/FetchTask.java
+++ b/sql/src/main/java/io/crate/execution/engine/fetch/FetchTask.java
@@ -33,10 +33,8 @@ import io.crate.metadata.IndexParts;
 import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Routing;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.metadata.IndexMetaData;
 import org.elasticsearch.cluster.metadata.MetaData;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.IndexService;
@@ -57,7 +55,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 public class FetchTask extends AbstractTask {
 
-    private static final Logger LOGGER = Loggers.getLogger(FetchTask.class);
     private final IntObjectHashMap<Engine.Searcher> searchers = new IntObjectHashMap<>();
     private final IntObjectHashMap<SharedShardContext> shardContexts = new IntObjectHashMap<>();
     private final FetchPhase phase;
@@ -74,7 +71,7 @@ public class FetchTask extends AbstractTask {
                      SharedShardContexts sharedShardContexts,
                      MetaData metaData,
                      Iterable<? extends Routing> routingIterable) {
-        super(phase.phaseId(), LOGGER);
+        super(phase.phaseId());
         this.phase = phase;
         this.localNodeId = localNodeId;
         this.sharedShardContexts = sharedShardContexts;

--- a/sql/src/main/java/io/crate/execution/jobs/CountTask.java
+++ b/sql/src/main/java/io/crate/execution/jobs/CountTask.java
@@ -29,8 +29,6 @@ import io.crate.data.Row1;
 import io.crate.data.RowConsumer;
 import io.crate.execution.dsl.phases.CountPhase;
 import io.crate.execution.engine.collect.count.CountOperation;
-import org.apache.logging.log4j.Logger;
-import org.elasticsearch.common.logging.Loggers;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -42,8 +40,6 @@ import static io.crate.data.SentinelRow.SENTINEL;
 
 public class CountTask extends AbstractTask {
 
-    private static final Logger LOGGER = Loggers.getLogger(CountTask.class);
-
     private final CountPhase countPhase;
     private final CountOperation countOperation;
     private final RowConsumer consumer;
@@ -54,7 +50,7 @@ public class CountTask extends AbstractTask {
               CountOperation countOperation,
               RowConsumer consumer,
               Map<String, IntIndexedContainer> indexShardMap) {
-        super(countPhase.phaseId(), LOGGER);
+        super(countPhase.phaseId());
         this.countPhase = countPhase;
         this.countOperation = countOperation;
         this.consumer = consumer;

--- a/sql/src/main/java/io/crate/execution/jobs/DistResultRXTask.java
+++ b/sql/src/main/java/io/crate/execution/jobs/DistResultRXTask.java
@@ -22,7 +22,6 @@
 package io.crate.execution.jobs;
 
 import io.crate.breaker.RamAccountingContext;
-import org.apache.logging.log4j.Logger;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -38,13 +37,12 @@ public class DistResultRXTask extends AbstractTask implements DownstreamRXTask {
     private final int numBuckets;
     private final PageBucketReceiver pageBucketReceiver;
 
-    public DistResultRXTask(Logger logger,
-                            int id,
+    public DistResultRXTask(int id,
                             String name,
                             PageBucketReceiver pageBucketReceiver,
                             RamAccountingContext ramAccountingContext,
                             int numBuckets) {
-        super(id, logger);
+        super(id);
         this.name = name;
         this.ramAccountingContext = ramAccountingContext;
         this.numBuckets = numBuckets;

--- a/sql/src/main/java/io/crate/execution/jobs/JobSetup.java
+++ b/sql/src/main/java/io/crate/execution/jobs/JobSetup.java
@@ -120,7 +120,6 @@ public class JobSetup extends AbstractComponent {
 
     private final MapSideDataCollectOperation collectOperation;
     private final Logger distResultRXTaskLogger;
-    private final Logger joinTaskLogger;
     private final ClusterService clusterService;
     private final CountOperation countOperation;
     private final CrateCircuitBreakerService circuitBreakerService;
@@ -147,7 +146,6 @@ public class JobSetup extends AbstractComponent {
                     ShardCollectSource shardCollectSource,
                     BigArrays bigArrays) {
         super(settings);
-        joinTaskLogger = Loggers.getLogger(JoinTask.class, settings);
         distResultRXTaskLogger = Loggers.getLogger(DistResultRXTask.class, settings);
         this.collectOperation = collectOperation;
         this.clusterService = clusterService;
@@ -668,7 +666,6 @@ public class JobSetup extends AbstractComponent {
             }
 
             context.registerSubContext(new DistResultRXTask(
-                distResultRXTaskLogger,
                 phase.phaseId(),
                 phase.name(),
                 pageBucketReceiver,
@@ -787,7 +784,6 @@ public class JobSetup extends AbstractComponent {
                 context.registerSubContext(right);
             }
             context.registerSubContext(new JoinTask(
-                joinTaskLogger,
                 phase,
                 joinOperation,
                 left != null ? left.getBucketReceiver((byte) 0) : null,
@@ -843,7 +839,6 @@ public class JobSetup extends AbstractComponent {
                 context.registerSubContext(right);
             }
             context.registerSubContext(new JoinTask(
-                joinTaskLogger,
                 phase,
                 joinOperation,
                 left != null ? left.getBucketReceiver((byte) 0) : null,
@@ -892,7 +887,6 @@ public class JobSetup extends AbstractComponent {
                 mergePhase.numUpstreams());
 
             return new DistResultRXTask(
-                distResultRXTaskLogger,
                 mergePhase.phaseId(),
                 mergePhase.name(),
                 pageBucketReceiver,

--- a/sql/src/main/java/io/crate/execution/jobs/JoinTask.java
+++ b/sql/src/main/java/io/crate/execution/jobs/JoinTask.java
@@ -23,7 +23,6 @@ package io.crate.execution.jobs;
 
 import io.crate.concurrent.CompletionListenable;
 import io.crate.execution.dsl.phases.JoinPhase;
-import org.apache.logging.log4j.Logger;
 
 import javax.annotation.Nullable;
 
@@ -37,12 +36,11 @@ class JoinTask extends AbstractTask implements DownstreamRXTask {
     @Nullable
     private final PageBucketReceiver rightPageBucketReceiver;
 
-    JoinTask(Logger logger,
-             JoinPhase joinPhase,
+    JoinTask(JoinPhase joinPhase,
              CompletionListenable<?> completionListenable,
              @Nullable PageBucketReceiver leftPageBucketReceiver,
              @Nullable PageBucketReceiver rightPageBucketReceiver) {
-        super(joinPhase.phaseId(), logger);
+        super(joinPhase.phaseId());
 
         this.joinPhase = joinPhase;
         this.leftPageBucketReceiver = leftPageBucketReceiver;

--- a/sql/src/main/java/io/crate/execution/jobs/PKLookupTask.java
+++ b/sql/src/main/java/io/crate/execution/jobs/PKLookupTask.java
@@ -36,8 +36,6 @@ import io.crate.expression.reference.GetResultRefResolver;
 import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.ColumnIdent;
 import io.crate.planner.operators.PKAndVersion;
-import org.apache.logging.log4j.Logger;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.index.get.GetResult;
 import org.elasticsearch.index.shard.ShardId;
 
@@ -48,7 +46,6 @@ import java.util.UUID;
 
 public final class PKLookupTask extends AbstractTask {
 
-    private static final Logger LOGGER = Loggers.getLogger(PKLookupTask.class);
     private final UUID jobId;
     private final RamAccountingContext ramAccountingContext;
     private final PKLookupOperation pkLookupOperation;
@@ -71,7 +68,7 @@ public final class PKLookupTask extends AbstractTask {
                  Map<ShardId, List<PKAndVersion>> idsByShard,
                  Collection<? extends Projection> shardProjections,
                  RowConsumer consumer) {
-        super(phaseId, LOGGER);
+        super(phaseId);
         this.jobId = jobId;
         this.name = name;
         this.ramAccountingContext = ramAccountingContext;

--- a/sql/src/main/java/io/crate/execution/jobs/TasksService.java
+++ b/sql/src/main/java/io/crate/execution/jobs/TasksService.java
@@ -111,11 +111,11 @@ public class TasksService extends AbstractLifecycleComponent {
 
     @VisibleForTesting
     public RootTask.Builder newBuilder(UUID jobId) {
-        return new RootTask.Builder(jobId, clusterService.localNode().getId(), Collections.emptySet(), jobsLogs);
+        return new RootTask.Builder(logger, jobId, clusterService.localNode().getId(), Collections.emptySet(), jobsLogs);
     }
 
     public RootTask.Builder newBuilder(UUID jobId, String coordinatorNodeId, Collection<String> participatingNodes) {
-        return new RootTask.Builder(jobId, coordinatorNodeId, participatingNodes, jobsLogs);
+        return new RootTask.Builder(logger, jobId, coordinatorNodeId, participatingNodes, jobsLogs);
     }
 
     public int numActive() {

--- a/sql/src/test/java/io/crate/execution/engine/distribution/DistributingConsumerTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/distribution/DistributingConsumerTest.java
@@ -156,7 +156,6 @@ public class DistributingConsumerTest extends CrateUnitTest {
             1);
 
         return new DistResultRXTask(
-            logger,
             1,
             "dummy",
             pageBucketReceiver,

--- a/sql/src/test/java/io/crate/execution/jobs/AbstractTaskTest.java
+++ b/sql/src/test/java/io/crate/execution/jobs/AbstractTaskTest.java
@@ -90,7 +90,7 @@ public class AbstractTaskTest extends CrateUnitTest {
         final AtomicInteger numKill = new AtomicInteger();
 
         TestingTask(int id) {
-            super(id, LOGGER);
+            super(id);
         }
 
         public TestingTask() {

--- a/sql/src/test/java/io/crate/execution/jobs/DistResultRXTaskTest.java
+++ b/sql/src/test/java/io/crate/execution/jobs/DistResultRXTaskTest.java
@@ -80,7 +80,6 @@ public class DistResultRXTaskTest extends CrateUnitTest {
             numBuckets);
 
         return new DistResultRXTask(
-            Loggers.getLogger(DistResultRXTask.class),
             1,
             "dummy",
             pageBucketReceiver,

--- a/sql/src/test/java/io/crate/execution/jobs/DummyTask.java
+++ b/sql/src/test/java/io/crate/execution/jobs/DummyTask.java
@@ -22,19 +22,14 @@
 
 package io.crate.execution.jobs;
 
-import org.apache.logging.log4j.Logger;
-import org.elasticsearch.common.logging.Loggers;
-
 public class DummyTask extends AbstractTask {
-
-    private static final Logger LOGGER = Loggers.getLogger(DummyTask.class);
 
     public DummyTask() {
         this(1);
     }
 
     public DummyTask(int id) {
-        super(id, LOGGER);
+        super(id);
     }
 
     @Override

--- a/sql/src/test/java/io/crate/execution/jobs/RootTaskTest.java
+++ b/sql/src/test/java/io/crate/execution/jobs/RootTaskTest.java
@@ -35,6 +35,7 @@ import io.crate.profile.ProfilingContext;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.testing.TestingRowConsumer;
 import io.crate.types.IntegerType;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.logging.Loggers;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -59,12 +60,14 @@ import static org.mockito.Mockito.when;
 
 public class RootTaskTest extends CrateUnitTest {
 
+    private Logger logger = Loggers.getLogger(RootTaskTest.class);
+
     private String coordinatorNode = "dummyNode";
 
     @Test
     public void testAddTheSameContextTwiceThrowsAnError() throws Exception {
         RootTask.Builder builder =
-            new RootTask.Builder(UUID.randomUUID(), coordinatorNode, Collections.emptySet(), mock(JobsLogs.class));
+            new RootTask.Builder(logger, UUID.randomUUID(), coordinatorNode, Collections.emptySet(), mock(JobsLogs.class));
         builder.addTask(new AbstractTaskTest.TestingTask());
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Task for 0 already added");
@@ -75,7 +78,7 @@ public class RootTaskTest extends CrateUnitTest {
     @Test
     public void testKillPropagatesToSubContexts() throws Exception {
         RootTask.Builder builder =
-            new RootTask.Builder(UUID.randomUUID(), coordinatorNode, Collections.emptySet(), mock(JobsLogs.class));
+            new RootTask.Builder(logger, UUID.randomUUID(), coordinatorNode, Collections.emptySet(), mock(JobsLogs.class));
 
 
         AbstractTaskTest.TestingTask ctx1 = new AbstractTaskTest.TestingTask(1);
@@ -96,9 +99,9 @@ public class RootTaskTest extends CrateUnitTest {
     public void testErrorMessageIsIncludedInStatsTableOnFailure() throws Exception {
         JobsLogs jobsLogs = mock(JobsLogs.class);
         RootTask.Builder builder =
-            new RootTask.Builder(UUID.randomUUID(), coordinatorNode, Collections.emptySet(), jobsLogs);
+            new RootTask.Builder(logger, UUID.randomUUID(), coordinatorNode, Collections.emptySet(), jobsLogs);
 
-        Task task = new AbstractTask(0, logger) {
+        Task task = new AbstractTask(0) {
             @Override
             public String name() {
                 return "dummy";
@@ -121,7 +124,7 @@ public class RootTaskTest extends CrateUnitTest {
         when(collectPhase.maxRowGranularity()).thenReturn(RowGranularity.DOC);
 
         RootTask.Builder builder =
-            new RootTask.Builder(UUID.randomUUID(), coordinatorNode, Collections.emptySet(), mock(JobsLogs.class));
+            new RootTask.Builder(logger, UUID.randomUUID(), coordinatorNode, Collections.emptySet(), mock(JobsLogs.class));
 
         CollectTask collectChildTask = new CollectTask(
             collectPhase,
@@ -141,7 +144,6 @@ public class RootTaskTest extends CrateUnitTest {
             PassThroughPagingIterator.oneShot(),
             1);
         DistResultRXTask distResultRXTask = spy(new DistResultRXTask(
-            Loggers.getLogger(DistResultRXTask.class),
             2,
             "dummy",
             pageBucketReceiver,
@@ -167,7 +169,7 @@ public class RootTaskTest extends CrateUnitTest {
     @Test
     public void testEnablingProfilingGathersExecutionTimes() throws Throwable {
         RootTask.Builder builder =
-            new RootTask.Builder(UUID.randomUUID(), coordinatorNode, Collections.emptySet(), mock(JobsLogs.class));
+            new RootTask.Builder(logger, UUID.randomUUID(), coordinatorNode, Collections.emptySet(), mock(JobsLogs.class));
         ProfilingContext profilingContext = new ProfilingContext(Collections::emptyList);
         builder.profilingContext(profilingContext);
 


### PR DESCRIPTION
Instead of having each task take care of start/kill/stop logging we can
do it centralized in the RootTask.

So far it was done in the `AbstractTask`, which arguably is also a
single place, but possible `Task` implementations not extending
`AbstractTask` would lack the logging logic or have to re-implement it.




 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed