### PR TITLE
Avoid removal and re-adding of empty buckets for exhausted upstreams

### DIFF
--- a/sql/src/test/java/io/crate/execution/jobs/DistResultRXTaskTest.java
+++ b/sql/src/test/java/io/crate/execution/jobs/DistResultRXTaskTest.java
@@ -192,7 +192,7 @@ public class DistResultRXTaskTest extends CrateUnitTest {
         PageResultListener listener = mock(PageResultListener.class);
         bucketReceiver.setBucket(1, Bucket.EMPTY, true, listener);
 
-        verify(listener, times(2)).needMore(false);
+        verify(listener, times(1)).needMore(false);
     }
 
     @Test


### PR DESCRIPTION
Previously we removed all entries from `bucketsByIdx` whenever a page
was complete and then on the next buckets re-filled in empty buckets for
all `exhausted` upstreams.

This changes the logic to keep buckets for exhausted upstreams.

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed