### PR TITLE
Avoid starting iterator consumption multiple times by using a CollectingBatchIterator.

### DIFF
--- a/dex/src/main/java/io/crate/data/CollectingBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/CollectingBatchIterator.java
@@ -136,6 +136,10 @@ public final class CollectingBatchIterator<T> implements BatchIterator<T> {
                 .whenComplete((r, t) -> {
                     if (t == null) {
                         it = r.iterator();
+                    } else if (t instanceof RuntimeException) {
+                        throw (RuntimeException) t;
+                    } else {
+                        throw new RuntimeException(t);
                     }
                 });
             return resultFuture;


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
