### PR TITLE
Avoid deadlock in testSendUsingDistributingConsumerAndReceiveWithDistResultRXTask

### DIFF
--- a/sql/src/main/java/io/crate/execution/jobs/CumulativePageBucketReceiver.java
+++ b/sql/src/main/java/io/crate/execution/jobs/CumulativePageBucketReceiver.java
@@ -123,13 +123,16 @@ public class CumulativePageBucketReceiver implements PageBucketReceiver {
 
     @Override
     public void setBucket(int bucketIdx, Bucket rows, boolean isLast, PageResultListener pageResultListener) {
+        final boolean isLastOrHasError;
         synchronized (buckets) {
             buckets.add(bucketIdx);
-            if (!isLast && lastThrowable == null) {
+            isLastOrHasError = isLast || lastThrowable != null;
+            if (!isLastOrHasError) {
                 listenersByBucketIdx.put(bucketIdx, pageResultListener);
-            } else {
-                pageResultListener.needMore(false);
             }
+        }
+        if (isLastOrHasError) {
+            pageResultListener.needMore(false);
         }
         final boolean allBucketsOfPageReceived;
         synchronized (lock) {


### PR DESCRIPTION
Follow up to 200dda1542bf426cbbde1f1101023b17fcec9eb4

Calling `PageResultListener` early could lead to a deadlock in the test,
due to the the DistributingConsumer using a `directExecutor`.

This also moves the `PageResultListener.needMore` call outside of the
lock.



 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed