### PR TITLE
use existing collect expression for same reference

### DIFF
--- a/sql/src/test/java/io/crate/expression/InputFactoryTest.java
+++ b/sql/src/test/java/io/crate/expression/InputFactoryTest.java
@@ -178,4 +178,14 @@ public class InputFactoryTest extends CrateUnitTest {
         FunctionImplementation uncompiled = expressions.functions().getBuiltin(ident.name(), ident.argumentTypes());
         assertThat(uncompiled, not(sameInstance(impl)));
     }
+
+    @Test
+    public void testSameReferenceResultsInSameExpressionInstance() {
+        Symbol symbol = expressions.normalize(expressions.asSymbol("a"));
+        InputFactory.Context<Input<?>> ctx = factory.ctxForRefs(i -> Literal.of("foo"));
+        Input<?> input1 = ctx.add(symbol);
+        Input<?> input2 = ctx.add(symbol);
+
+        assertThat(input1, sameInstance(input2));
+    }
 }


### PR DESCRIPTION
If a reference occurs multiple times, an existing collect expression is
used instead of creating a new one.
This reduces the memory footprint (allocations) and also slightly
improves performance.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
