### PR TITLE
Fix BatchPagingIterator behaviour to first check if killed and then if closed.

### DIFF
--- a/dex/src/test/java/io/crate/testing/BatchIteratorTester.java
+++ b/dex/src/test/java/io/crate/testing/BatchIteratorTester.java
@@ -69,6 +69,7 @@ public class BatchIteratorTester {
             verifyAfterProperConsumption.accept(firstBatchIterator);
         }
         testBehaviourAfterClose(this.it.get());
+        testBehaviourAfterKill(this.it.get());
         testIteratorAccessFromDifferentThreads(this.it.get(), expectedResult);
         testIllegalNextBatchCall(this.it.get());
         testMoveNextAfterMoveNextReturnedFalse(this.it.get());
@@ -200,6 +201,14 @@ public class BatchIteratorTester {
 
         expectFailure(it::moveNext, IllegalStateException.class, "moveNext must fail after close");
         expectFailure(it::moveToStart, IllegalStateException.class, "moveToStart must fail after close");
+    }
+
+    private void testBehaviourAfterKill(BatchIterator<Row> it) {
+        it.kill(new InterruptedException("job killed"));
+        assertThat("currentElement is not affected by kill", it.currentElement(), is(it.currentElement()));
+
+        expectFailure(it::moveNext, InterruptedException.class, "moveNext must fail after kill");
+        expectFailure(it::moveToStart, InterruptedException.class, "moveToStart must fail after kill");
     }
 
     private void testProperConsumption(BatchIterator<Row> it, List<Object[]> expectedResult) throws Exception {

--- a/sql/src/main/java/io/crate/execution/engine/distribution/merge/BatchPagingIterator.java
+++ b/sql/src/main/java/io/crate/execution/engine/distribution/merge/BatchPagingIterator.java
@@ -149,15 +149,15 @@ public class BatchPagingIterator<Key> implements BatchIterator<Row> {
     }
 
     private void raiseIfClosedOrKilled() {
-        if (closed) {
-            throw new IllegalStateException("Iterator is closed");
-        }
         Throwable err;
         synchronized (this) {
             err = killed;
         }
         if (err != null) {
             Exceptions.rethrowUnchecked(err);
+        }
+        if (closed) {
+            throw new IllegalStateException("Iterator is closed");
         }
     }
 


### PR DESCRIPTION

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
