### PR TITLE
Remove custom gradle logger code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -163,47 +163,6 @@ allprojects {
     }
 }
 
-final testOutputs = [:].withDefault { [] }
-
-
-project.gradle.addListener(new TestOutputListener() {
-    @Override
-    void onOutput(TestDescriptor test, TestOutputEvent outputEvent) {
-        testOutputs[test] << outputEvent.getMessage()
-    }
-})
-
-project.gradle.addListener(new TestListener() {
-
-    @Override
-    void beforeSuite(TestDescriptor suite) {
-        logger.lifecycle('Running: ' + suite)
-    }
-
-    @Override
-    void afterSuite(TestDescriptor suite, TestResult result) {
-    }
-
-    @Override
-    void beforeTest(TestDescriptor test) {
-    }
-
-    @Override
-    void afterTest(TestDescriptor test, TestResult result) {
-        if (result.getResultType() == TestResult.ResultType.FAILURE) {
-            logger.error('## FAILURE: ' + test)
-            testOutputs[test].each { e ->
-                print e
-            }
-            result.getExceptions().each { e ->
-                e.printStackTrace()
-            }
-        }
-        testOutputs.remove(test)
-    }
-})
-
-
 def jacocoProjects() {
     subprojects.findAll {
         !['es-core',


### PR DESCRIPTION
No longer needed, the gradle defaults are fine.





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed