### PR TITLE
Move static inner classes from LuceneQueryBuilder to top level

### DIFF
--- a/sql/src/main/java/io/crate/lucene/AbstractAnyQuery.java
+++ b/sql/src/main/java/io/crate/lucene/AbstractAnyQuery.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.lucene;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Iterables;
+import io.crate.expression.operator.any.AnyOperators;
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.Literal;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.Reference;
+import io.crate.types.DataTypes;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.BytesRef;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+
+abstract class AbstractAnyQuery implements FunctionToQuery {
+
+    @Override
+    public Query apply(Function function, LuceneQueryBuilder.Context context) throws IOException {
+        Symbol left = function.arguments().get(0);
+        Symbol collectionSymbol = function.arguments().get(1);
+        Preconditions.checkArgument(DataTypes.isCollectionType(collectionSymbol.valueType()),
+            "invalid argument for ANY expression");
+        if (left.symbolType().isValueSymbol()) {
+            // 1 = any (array_col) - simple eq
+            if (collectionSymbol instanceof Reference) {
+                return applyArrayReference((Reference) collectionSymbol, (Literal) left, context);
+            } else {
+                // no reference found (maybe subscript) in ANY expression -> fallback to slow generic function filter
+                return null;
+            }
+        } else if (left instanceof Reference && collectionSymbol.symbolType().isValueSymbol()) {
+            return applyArrayLiteral((Reference) left, (Literal) collectionSymbol, context);
+        } else {
+            // might be the case if the left side is a function -> will fallback to (slow) generic function filter
+            return null;
+        }
+    }
+
+    /**
+     * converts Strings to BytesRef on the fly
+     */
+    static Iterable<?> toIterable(Object value) {
+        return Iterables.transform(AnyOperators.collectionValueToIterable(value), new com.google.common.base.Function<Object, Object>() {
+            @Nullable
+            @Override
+            public Object apply(@Nullable Object input) {
+                if (input instanceof String) {
+                    input = new BytesRef((String) input);
+                }
+                return input;
+            }
+        });
+    }
+
+    protected abstract Query applyArrayReference(Reference arrayReference, Literal literal, LuceneQueryBuilder.Context context) throws IOException;
+
+    protected abstract Query applyArrayLiteral(Reference reference, Literal arrayLiteral, LuceneQueryBuilder.Context context) throws IOException;
+}

--- a/sql/src/main/java/io/crate/lucene/AnyEqQuery.java
+++ b/sql/src/main/java/io/crate/lucene/AnyEqQuery.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.lucene;
+
+import io.crate.expression.symbol.Literal;
+import io.crate.metadata.Reference;
+import io.crate.types.CollectionType;
+import io.crate.types.DataTypes;
+import org.apache.lucene.search.Query;
+import org.elasticsearch.common.lucene.search.Queries;
+import org.elasticsearch.index.mapper.MappedFieldType;
+
+class AnyEqQuery extends AbstractAnyQuery {
+
+    @Override
+    protected Query applyArrayReference(Reference arrayReference, Literal literal, LuceneQueryBuilder.Context context) {
+        MappedFieldType fieldType = context.getFieldTypeOrNull(arrayReference.column().fqn());
+        if (fieldType == null) {
+            if (CollectionType.unnest(arrayReference.valueType()).equals(DataTypes.OBJECT)) {
+                return null; // fallback to generic query to enable {x=10} = any(objects)
+            }
+            return Queries.newMatchNoDocsQuery("column doesn't exist in this index");
+        }
+        return fieldType.termQuery(literal.value(), context.queryShardContext());
+    }
+
+    @Override
+    protected Query applyArrayLiteral(Reference reference, Literal arrayLiteral, LuceneQueryBuilder.Context context) {
+        String columnName = reference.column().fqn();
+        return LuceneQueryBuilder.termsQuery(context.getFieldTypeOrNull(columnName), LuceneQueryBuilder.asList(arrayLiteral), context.queryShardContext);
+    }
+}

--- a/sql/src/main/java/io/crate/lucene/AnyLikeQuery.java
+++ b/sql/src/main/java/io/crate/lucene/AnyLikeQuery.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.lucene;
+
+import io.crate.expression.symbol.Literal;
+import io.crate.metadata.Reference;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.Query;
+
+class AnyLikeQuery extends AbstractAnyQuery {
+
+    @Override
+    protected Query applyArrayReference(Reference arrayReference, Literal literal, LuceneQueryBuilder.Context context) {
+        return LikeQuery.toQuery(arrayReference, literal.value(), context);
+    }
+
+    @Override
+    protected Query applyArrayLiteral(Reference reference, Literal arrayLiteral, LuceneQueryBuilder.Context context) {
+        // col like ANY (['a', 'b']) --> or(like(col, 'a'), like(col, 'b'))
+        BooleanQuery.Builder booleanQuery = new BooleanQuery.Builder();
+        booleanQuery.setMinimumNumberShouldMatch(1);
+        for (Object value : toIterable(arrayLiteral.value())) {
+            booleanQuery.add(LikeQuery.toQuery(reference, value, context), BooleanClause.Occur.SHOULD);
+        }
+        return booleanQuery.build();
+    }
+}

--- a/sql/src/main/java/io/crate/lucene/AnyNeqQuery.java
+++ b/sql/src/main/java/io/crate/lucene/AnyNeqQuery.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.lucene;
+
+import io.crate.expression.symbol.Literal;
+import io.crate.metadata.Reference;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.Query;
+import org.elasticsearch.common.lucene.search.Queries;
+import org.elasticsearch.index.mapper.MappedFieldType;
+
+class AnyNeqQuery extends AbstractAnyQuery {
+
+    @Override
+    protected Query applyArrayReference(Reference arrayReference, Literal literal, LuceneQueryBuilder.Context context) {
+        // 1 != any ( col ) -->  gt 1 or lt 1
+        String columnName = arrayReference.column().fqn();
+        Object value = literal.value();
+
+        MappedFieldType fieldType = context.getFieldTypeOrNull(columnName);
+        if (fieldType == null) {
+            return Queries.newMatchNoDocsQuery("column does not exist in this index");
+        }
+        BooleanQuery.Builder query = new BooleanQuery.Builder();
+        query.setMinimumNumberShouldMatch(1);
+        query.add(
+            fieldType.rangeQuery(value, null, false, false, null, null, null, context.queryShardContext),
+            BooleanClause.Occur.SHOULD
+        );
+        query.add(
+            fieldType.rangeQuery(null, value, false, false, null, null, null, context.queryShardContext),
+            BooleanClause.Occur.SHOULD
+        );
+        return query.build();
+    }
+
+    @Override
+    protected Query applyArrayLiteral(Reference reference, Literal arrayLiteral, LuceneQueryBuilder.Context context) {
+        //  col != ANY ([1,2,3]) --> not(col=1 and col=2 and col=3)
+        String columnName = reference.column().fqn();
+        MappedFieldType fieldType = context.getFieldTypeOrNull(columnName);
+        if (fieldType == null) {
+            return Queries.newMatchNoDocsQuery("column does not exist in this index");
+        }
+
+        BooleanQuery.Builder andBuilder = new BooleanQuery.Builder();
+        for (Object value : toIterable(arrayLiteral.value())) {
+            andBuilder.add(fieldType.termQuery(value, context.queryShardContext()), BooleanClause.Occur.MUST);
+        }
+        return Queries.not(andBuilder.build());
+    }
+}

--- a/sql/src/main/java/io/crate/lucene/AnyNotLikeQuery.java
+++ b/sql/src/main/java/io/crate/lucene/AnyNotLikeQuery.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.lucene;
+
+import io.crate.expression.operator.LikeOperator;
+import io.crate.expression.symbol.Literal;
+import io.crate.metadata.Reference;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.RegexpQuery;
+import org.elasticsearch.common.lucene.BytesRefs;
+import org.elasticsearch.common.lucene.search.Queries;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.query.RegexpFlag;
+
+import java.util.Locale;
+
+class AnyNotLikeQuery extends AbstractAnyQuery {
+
+    static String negateWildcard(String wildCard) {
+        return String.format(Locale.ENGLISH, "~(%s)", wildCard);
+    }
+
+    @Override
+    protected Query applyArrayReference(Reference arrayReference, Literal literal, LuceneQueryBuilder.Context context) {
+        String regexString = LikeOperator.patternToRegex(BytesRefs.toString(literal.value()), LikeOperator.DEFAULT_ESCAPE, false);
+        regexString = regexString.substring(1, regexString.length() - 1);
+        String notLike = negateWildcard(regexString);
+
+        return new RegexpQuery(new Term(
+            arrayReference.column().fqn(),
+            notLike),
+            RegexpFlag.COMPLEMENT.value()
+        );
+    }
+
+    @Override
+    protected Query applyArrayLiteral(Reference reference, Literal arrayLiteral, LuceneQueryBuilder.Context context) {
+        // col not like ANY (['a', 'b']) --> not(and(like(col, 'a'), like(col, 'b')))
+        String columnName = reference.column().fqn();
+        MappedFieldType fieldType = context.getFieldTypeOrNull(columnName);
+
+        BooleanQuery.Builder andLikeQueries = new BooleanQuery.Builder();
+        for (Object value : toIterable(arrayLiteral.value())) {
+            andLikeQueries.add(
+                LikeQueryBuilder.like(reference.valueType(), fieldType, value),
+                BooleanClause.Occur.MUST);
+        }
+        return Queries.not(andLikeQueries.build());
+    }
+}

--- a/sql/src/main/java/io/crate/lucene/AnyRangeQuery.java
+++ b/sql/src/main/java/io/crate/lucene/AnyRangeQuery.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.lucene;
+
+import io.crate.expression.symbol.Literal;
+import io.crate.metadata.Reference;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.Query;
+
+class AnyRangeQuery extends AbstractAnyQuery {
+
+    private final RangeQuery rangeQuery;
+    private final RangeQuery inverseRangeQuery;
+
+    AnyRangeQuery(String comparison, String inverseComparison) {
+        rangeQuery = new RangeQuery(comparison);
+        inverseRangeQuery = new RangeQuery(inverseComparison);
+    }
+
+    @Override
+    protected Query applyArrayReference(Reference arrayReference, Literal literal, LuceneQueryBuilder.Context context) {
+        // 1 < ANY (array_col) --> array_col > 1
+        return rangeQuery.toQuery(
+            arrayReference,
+            literal.value(),
+            context::getFieldTypeOrNull,
+            context.queryShardContext);
+    }
+
+    @Override
+    protected Query applyArrayLiteral(Reference reference, Literal arrayLiteral, LuceneQueryBuilder.Context context) {
+        // col < ANY ([1,2,3]) --> or(col<1, col<2, col<3)
+        BooleanQuery.Builder booleanQuery = new BooleanQuery.Builder();
+        booleanQuery.setMinimumNumberShouldMatch(1);
+        for (Object value : toIterable(arrayLiteral.value())) {
+            booleanQuery.add(
+                inverseRangeQuery.toQuery(reference, value, context::getFieldTypeOrNull, context.queryShardContext),
+                BooleanClause.Occur.SHOULD);
+        }
+        return booleanQuery.build();
+    }
+}

--- a/sql/src/main/java/io/crate/lucene/CmpQuery.java
+++ b/sql/src/main/java/io/crate/lucene/CmpQuery.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.lucene;
+
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.Literal;
+import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.SymbolType;
+import io.crate.metadata.Reference;
+import org.elasticsearch.common.collect.Tuple;
+
+import javax.annotation.Nullable;
+
+abstract class CmpQuery implements FunctionToQuery {
+
+    @Nullable
+    protected Tuple<Reference, Literal> prepare(Function input) {
+        assert input != null : "function must not be null";
+        assert input.arguments().size() == 2 : "function's number of arguments must be 2";
+
+        Symbol left = input.arguments().get(0);
+        Symbol right = input.arguments().get(1);
+
+        if (!(left instanceof Reference) || !(right.symbolType().isValueSymbol())) {
+            return null;
+        }
+        assert right.symbolType() == SymbolType.LITERAL :
+            "right.symbolType() must be " + SymbolType.LITERAL;
+        return new Tuple<>((Reference) left, (Literal) right);
+    }
+}

--- a/sql/src/main/java/io/crate/lucene/DistanceQueries.java
+++ b/sql/src/main/java/io/crate/lucene/DistanceQueries.java
@@ -22,12 +22,12 @@
 
 package io.crate.lucene;
 
-import io.crate.expression.symbol.Function;
 import io.crate.expression.operator.EqOperator;
 import io.crate.expression.operator.GtOperator;
 import io.crate.expression.operator.GteOperator;
 import io.crate.expression.operator.LtOperator;
 import io.crate.expression.operator.LteOperator;
+import io.crate.expression.symbol.Function;
 import org.apache.lucene.document.LatLonPoint;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
@@ -35,7 +35,8 @@ import org.apache.lucene.search.Query;
 import org.elasticsearch.common.geo.GeoUtils;
 import org.elasticsearch.common.lucene.search.Queries;
 
-import static io.crate.lucene.LuceneQueryBuilder.Visitor.genericFunctionFilter;
+import static io.crate.lucene.LuceneQueryBuilder.genericFunctionFilter;
+
 
 enum DistanceQueries {
     ;

--- a/sql/src/main/java/io/crate/lucene/DistanceQuery.java
+++ b/sql/src/main/java/io/crate/lucene/DistanceQuery.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.lucene;
+
+import io.crate.data.Input;
+import io.crate.expression.scalar.geo.DistanceFunction;
+import io.crate.expression.symbol.Function;
+import io.crate.types.DataTypes;
+import org.apache.lucene.search.Query;
+
+import static io.crate.lucene.DistanceQueries.esV5DistanceQuery;
+
+class DistanceQuery implements InnerFunctionToQuery {
+
+    /**
+     * @param parent the outer function. E.g. in the case of
+     *               <pre>where distance(p1, POINT (10 20)) > 20</pre>
+     *               this would be
+     *               <pre>gt( \<inner function\>,  20)</pre>
+     * @param inner  has to be the distance function
+     */
+    @Override
+    public Query apply(Function parent, Function inner, LuceneQueryBuilder.Context context) {
+        assert inner.info().ident().name().equals(DistanceFunction.NAME) :
+            "function must be " + DistanceFunction.NAME;
+
+        RefLiteralPair distanceRefLiteral = new RefLiteralPair(inner);
+        if (!distanceRefLiteral.isValid()) {
+            // can't use distance filter without literal, fallback to genericFunction
+            return null;
+        }
+        FunctionLiteralPair functionLiteralPair = new FunctionLiteralPair(parent);
+        if (!functionLiteralPair.isValid()) {
+            // must be something like eq(distance(..), non-literal) - fallback to genericFunction
+            return null;
+        }
+        Double distance = DataTypes.DOUBLE.value(functionLiteralPair.input().value());
+
+        String parentName = functionLiteralPair.functionName();
+        Input geoPointInput = distanceRefLiteral.input();
+        String fieldName = distanceRefLiteral.reference().column().fqn();
+        Double[] pointValue = (Double[]) geoPointInput.value();
+        return esV5DistanceQuery(parent, context, parentName, fieldName, distance, pointValue);
+    }
+}

--- a/sql/src/main/java/io/crate/lucene/EqQuery.java
+++ b/sql/src/main/java/io/crate/lucene/EqQuery.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.lucene;
+
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.Literal;
+import io.crate.metadata.Reference;
+import io.crate.types.DataTypes;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.Query;
+import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.lucene.search.Queries;
+import org.elasticsearch.index.mapper.MappedFieldType;
+
+import java.util.List;
+
+class EqQuery extends CmpQuery {
+
+    @Override
+    public Query apply(Function input, LuceneQueryBuilder.Context context) {
+        Tuple<Reference, Literal> tuple = super.prepare(input);
+        if (tuple == null) {
+            return null;
+        }
+        Reference reference = tuple.v1();
+        Literal literal = tuple.v2();
+        String columnName = reference.column().fqn();
+        MappedFieldType fieldType = context.getFieldTypeOrNull(columnName);
+        if (fieldType == null) {
+            if (reference.valueType().equals(DataTypes.OBJECT)) {
+                return null; // fallback to generic filter for  "o = {x=10, y=20}"
+            }
+            // field doesn't exist, can't match
+            return Queries.newMatchNoDocsQuery("column does not exist in this index");
+        }
+        if (DataTypes.isCollectionType(reference.valueType()) &&
+            DataTypes.isCollectionType(literal.valueType())) {
+
+            List values = LuceneQueryBuilder.asList(literal);
+            if (values.isEmpty()) {
+                return LuceneQueryBuilder.genericFunctionFilter(input, context);
+            }
+            Query termsQuery = LuceneQueryBuilder.termsQuery(fieldType, values, context.queryShardContext);
+
+            // wrap boolTermsFilter and genericFunction filter in an additional BooleanFilter to control the ordering of the filters
+            // termsFilter is applied first
+            // afterwards the more expensive genericFunctionFilter
+            BooleanQuery.Builder filterClauses = new BooleanQuery.Builder();
+            filterClauses.add(termsQuery, BooleanClause.Occur.MUST);
+            filterClauses.add(LuceneQueryBuilder.genericFunctionFilter(input, context), BooleanClause.Occur.MUST);
+            return filterClauses.build();
+        }
+        return fieldType.termQuery(literal.value(), context.queryShardContext);
+    }
+}

--- a/sql/src/main/java/io/crate/lucene/FunctionLiteralPair.java
+++ b/sql/src/main/java/io/crate/lucene/FunctionLiteralPair.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.lucene;
+
+import io.crate.data.Input;
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.Symbol;
+
+class FunctionLiteralPair {
+
+    private final String functionName;
+    private final Function function;
+    private final Input input;
+
+    FunctionLiteralPair(Function outerFunction) {
+        assert outerFunction.arguments().size() == 2 : "function requires 2 arguments";
+        Symbol left = outerFunction.arguments().get(0);
+        Symbol right = outerFunction.arguments().get(1);
+
+        functionName = outerFunction.info().ident().name();
+
+        if (left instanceof Function) {
+            function = (Function) left;
+        } else if (right instanceof Function) {
+            function = (Function) right;
+        } else {
+            function = null;
+        }
+
+        if (left.symbolType().isValueSymbol()) {
+            input = (Input) left;
+        } else if (right.symbolType().isValueSymbol()) {
+            input = (Input) right;
+        } else {
+            input = null;
+        }
+    }
+
+    boolean isValid() {
+        return input != null && function != null;
+    }
+
+    Input input() {
+        return input;
+    }
+
+    String functionName() {
+        return functionName;
+    }
+}

--- a/sql/src/main/java/io/crate/lucene/FunctionToQuery.java
+++ b/sql/src/main/java/io/crate/lucene/FunctionToQuery.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.lucene;
+
+import io.crate.expression.symbol.Function;
+import org.apache.lucene.search.Query;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+
+interface FunctionToQuery {
+
+    @Nullable
+    Query apply(Function input, LuceneQueryBuilder.Context context) throws IOException;
+}

--- a/sql/src/main/java/io/crate/lucene/InnerFunctionToQuery.java
+++ b/sql/src/main/java/io/crate/lucene/InnerFunctionToQuery.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.lucene;
+
+import io.crate.expression.symbol.Function;
+import org.apache.lucene.search.Query;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+
+/**
+ * interface for functions that can be used to generate a query from inner functions.
+ * Has only a single method {@link #apply(Function, Function, LuceneQueryBuilder.Context)}
+ * <p>
+ * e.g. in a query like
+ * <pre>
+ *     where distance(p1, 'POINT (10 20)') = 20
+ * </pre>
+ * <p>
+ * The first parameter (parent) would be the "eq" function.
+ * The second parameter (inner) would be the "distance" function.
+ * <p>
+ * The returned Query must "contain" both the parent and inner functions.
+ */
+interface InnerFunctionToQuery {
+
+    /**
+     * returns a query for the given functions or null if it can't build a query.
+     */
+    @Nullable
+    Query apply(Function parent, Function inner, LuceneQueryBuilder.Context context) throws IOException;
+}

--- a/sql/src/main/java/io/crate/lucene/IsNullQuery.java
+++ b/sql/src/main/java/io/crate/lucene/IsNullQuery.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.lucene;
+
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.Symbol;
+import io.crate.expression.symbol.SymbolType;
+import io.crate.metadata.Reference;
+import io.crate.types.CollectionType;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.ConstantScoreQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.elasticsearch.common.lucene.search.Queries;
+import org.elasticsearch.index.mapper.FieldNamesFieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.query.ExistsQueryBuilder;
+
+class IsNullQuery implements FunctionToQuery {
+
+    @Override
+    public Query apply(Function input, LuceneQueryBuilder.Context context) {
+        assert input != null : "input must not be null";
+        assert input.arguments().size() == 1 : "function's number of arguments must be 1";
+        Symbol arg = input.arguments().get(0);
+        if (arg.symbolType() != SymbolType.REFERENCE) {
+            return null;
+        }
+        Reference reference = (Reference) arg;
+        String columnName = reference.column().fqn();
+
+        // ExistsQueryBuilder.newFilter doesn't build the correct exists query for arrays
+        // because ES isn't really aware of explicit array types
+        if (reference.valueType() instanceof CollectionType) {
+            MappedFieldType fieldType = context.getFieldTypeOrNull(columnName);
+            if (fieldType != null) {
+                return Queries.not(fieldType.existsQuery(context.queryShardContext));
+            }
+            MappedFieldType fieldNames = context.getFieldTypeOrNull(FieldNamesFieldMapper.NAME);
+            if (fieldNames != null) {
+                return Queries.not(new ConstantScoreQuery(
+                    new TermQuery(new Term(FieldNamesFieldMapper.NAME, columnName))));
+            }
+        }
+        return Queries.not(ExistsQueryBuilder.newFilter(context.queryShardContext, columnName));
+    }
+}

--- a/sql/src/main/java/io/crate/lucene/LikeQuery.java
+++ b/sql/src/main/java/io/crate/lucene/LikeQuery.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.lucene;
+
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.Literal;
+import io.crate.metadata.Reference;
+import io.crate.types.CollectionType;
+import io.crate.types.DataType;
+import org.apache.lucene.search.Query;
+import org.elasticsearch.common.collect.Tuple;
+
+class LikeQuery extends CmpQuery {
+
+    @Override
+    public Query apply(Function input, LuceneQueryBuilder.Context context) {
+        Tuple<Reference, Literal> tuple = prepare(input);
+        if (tuple == null) {
+            return null;
+        }
+        return toQuery(tuple.v1(), tuple.v2().value(), context);
+    }
+
+    static Query toQuery(Reference reference, Object value, LuceneQueryBuilder.Context context) {
+        DataType dataType = CollectionType.unnest(reference.valueType());
+        return LikeQueryBuilder.like(
+            dataType,
+            context.getFieldTypeOrNull(reference.column().fqn()),
+            value
+        );
+    }
+}

--- a/sql/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
+++ b/sql/src/main/java/io/crate/lucene/LuceneQueryBuilder.java
@@ -21,16 +21,9 @@
 
 package io.crate.lucene;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.CoordinateArrays;
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.GeometryFactory;
-import io.crate.analyze.MatchOptionsAnalysis;
 import io.crate.data.Input;
 import io.crate.exceptions.UnsupportedFeatureException;
 import io.crate.exceptions.VersionInvalidException;
@@ -67,75 +60,41 @@ import io.crate.expression.symbol.SymbolType;
 import io.crate.expression.symbol.SymbolVisitor;
 import io.crate.expression.symbol.format.SymbolFormatter;
 import io.crate.expression.symbol.format.SymbolPrinter;
-import io.crate.geo.GeoJSONUtils;
-import io.crate.lucene.match.CrateRegexCapabilities;
-import io.crate.lucene.match.CrateRegexQuery;
-import io.crate.lucene.match.MatchQueries;
 import io.crate.metadata.DocReferences;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Reference;
 import io.crate.metadata.doc.DocSysColumns;
 import io.crate.metadata.table.ColumnPolicy;
-import io.crate.types.CollectionType;
-import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.apache.logging.log4j.Logger;
-import org.apache.lucene.document.LatLonPoint;
-import org.apache.lucene.geo.Polygon;
-import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
-import org.apache.lucene.search.BoostQuery;
-import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.Query;
-import org.apache.lucene.search.RegexpQuery;
-import org.apache.lucene.search.TermQuery;
-import org.apache.lucene.search.TermRangeQuery;
-import org.apache.lucene.spatial.prefix.PrefixTreeStrategy;
-import org.apache.lucene.spatial.query.SpatialArgs;
-import org.apache.lucene.spatial.query.SpatialOperation;
-import org.apache.lucene.util.BytesRef;
-import org.apache.lucene.util.automaton.RegExp;
 import org.elasticsearch.ExceptionsHelper;
-import org.elasticsearch.common.collect.Tuple;
-import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
 import org.elasticsearch.common.logging.Loggers;
-import org.elasticsearch.common.lucene.BytesRefs;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.index.cache.IndexCache;
-import org.elasticsearch.index.mapper.FieldNamesFieldMapper;
-import org.elasticsearch.index.mapper.GeoPointFieldMapper;
-import org.elasticsearch.index.mapper.GeoShapeFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.ExistsQueryBuilder;
 import org.elasticsearch.index.query.QueryShardContext;
-import org.elasticsearch.index.query.RegexpFlag;
-import org.locationtech.spatial4j.context.jts.JtsSpatialContext;
-import org.locationtech.spatial4j.exception.InvalidShapeException;
-import org.locationtech.spatial4j.shape.Shape;
-import org.locationtech.spatial4j.shape.ShapeCollection;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static io.crate.expression.scalar.regex.RegexMatcher.isPcrePattern;
-import static io.crate.lucene.DistanceQueries.esV5DistanceQuery;
 import static io.crate.metadata.DocReferences.inverseSourceLookup;
 
 
@@ -163,15 +122,14 @@ public class LuceneQueryBuilder {
         return ctx;
     }
 
-    private static Query termsQuery(@Nullable MappedFieldType fieldType, List values, QueryShardContext context) {
+    static Query termsQuery(@Nullable MappedFieldType fieldType, List values, QueryShardContext context) {
         if (fieldType == null) {
             return Queries.newMatchNoDocsQuery("column does not exist in this index");
         }
         return fieldType.termsQuery(values, context);
     }
 
-
-    private static List asList(Literal literal) {
+    static List asList(Literal literal) {
         Object val = literal.value();
         if (val instanceof Object[]) {
             return Stream.of((Object[]) val).filter(Objects::nonNull).collect(Collectors.toList());
@@ -249,258 +207,14 @@ public class LuceneQueryBuilder {
         }
     }
 
-    public static String convertSqlLikeToLuceneWildcard(String wildcardString) {
-        // lucene uses * and ? as wildcard characters
-        // but via SQL they are used as % and _
-        // here they are converted back.
-        StringBuilder regex = new StringBuilder();
-
-        boolean escaped = false;
-        for (char currentChar : wildcardString.toCharArray()) {
-            if (!escaped && currentChar == LikeOperator.DEFAULT_ESCAPE) {
-                escaped = true;
-            } else {
-                switch (currentChar) {
-                    case '%':
-                        regex.append(escaped ? '%' : '*');
-                        escaped = false;
-                        break;
-                    case '_':
-                        regex.append(escaped ? '_' : '?');
-                        escaped = false;
-                        break;
-                    default:
-                        switch (currentChar) {
-                            case '\\':
-                            case '*':
-                            case '?':
-                                regex.append('\\');
-                                break;
-                            default:
-                        }
-                        regex.append(currentChar);
-                        escaped = false;
-                }
-            }
-        }
-        return regex.toString();
-    }
-
-    static String negateWildcard(String wildCard) {
-        return String.format(Locale.ENGLISH, "~(%s)", wildCard);
-    }
 
     static class Visitor extends SymbolVisitor<Context, Query> {
-
-        interface FunctionToQuery {
-
-            @Nullable
-            Query apply(Function input, Context context) throws IOException;
-        }
-
-        abstract static class CmpQuery implements FunctionToQuery {
-
-            @Nullable
-            protected Tuple<Reference, Literal> prepare(Function input) {
-                assert input != null : "function must not be null";
-                assert input.arguments().size() == 2 : "function's number of arguments must be 2";
-
-                Symbol left = input.arguments().get(0);
-                Symbol right = input.arguments().get(1);
-
-                if (!(left instanceof Reference) || !(right.symbolType().isValueSymbol())) {
-                    return null;
-                }
-                assert right.symbolType() == SymbolType.LITERAL :
-                    "right.symbolType() must be " + SymbolType.LITERAL;
-                return new Tuple<>((Reference) left, (Literal) right);
-            }
-        }
-
-        abstract static class AbstractAnyQuery implements FunctionToQuery {
-
-            @Override
-            public Query apply(Function function, Context context) throws IOException {
-                Symbol left = function.arguments().get(0);
-                Symbol collectionSymbol = function.arguments().get(1);
-                Preconditions.checkArgument(DataTypes.isCollectionType(collectionSymbol.valueType()),
-                    "invalid argument for ANY expression");
-                if (left.symbolType().isValueSymbol()) {
-                    // 1 = any (array_col) - simple eq
-                    if (collectionSymbol instanceof Reference) {
-                        return applyArrayReference((Reference) collectionSymbol, (Literal) left, context);
-                    } else {
-                        // no reference found (maybe subscript) in ANY expression -> fallback to slow generic function filter
-                        return null;
-                    }
-                } else if (left instanceof Reference && collectionSymbol.symbolType().isValueSymbol()) {
-                    return applyArrayLiteral((Reference) left, (Literal) collectionSymbol, context);
-                } else {
-                    // might be the case if the left side is a function -> will fallback to (slow) generic function filter
-                    return null;
-                }
-            }
-
-            /**
-             * converts Strings to BytesRef on the fly
-             */
-            static Iterable<?> toIterable(Object value) {
-                return Iterables.transform(AnyOperators.collectionValueToIterable(value), new com.google.common.base.Function<Object, Object>() {
-                    @Nullable
-                    @Override
-                    public Object apply(@Nullable Object input) {
-                        if (input instanceof String) {
-                            input = new BytesRef((String) input);
-                        }
-                        return input;
-                    }
-                });
-            }
-
-            protected abstract Query applyArrayReference(Reference arrayReference, Literal literal, Context context) throws IOException;
-
-            protected abstract Query applyArrayLiteral(Reference reference, Literal arrayLiteral, Context context) throws IOException;
-        }
-
-        static class AnyEqQuery extends AbstractAnyQuery {
-
-            @Override
-            protected Query applyArrayReference(Reference arrayReference, Literal literal, Context context) {
-                MappedFieldType fieldType = context.getFieldTypeOrNull(arrayReference.column().fqn());
-                if (fieldType == null) {
-                    if (CollectionType.unnest(arrayReference.valueType()).equals(DataTypes.OBJECT)) {
-                        return null; // fallback to generic query to enable {x=10} = any(objects)
-                    }
-                    return Queries.newMatchNoDocsQuery("column doesn't exist in this index");
-                }
-                return fieldType.termQuery(literal.value(), context.queryShardContext());
-            }
-
-            @Override
-            protected Query applyArrayLiteral(Reference reference, Literal arrayLiteral, Context context) {
-                String columnName = reference.column().fqn();
-                return termsQuery(context.getFieldTypeOrNull(columnName), asList(arrayLiteral), context.queryShardContext);
-            }
-        }
-
-        static class AnyNeqQuery extends AbstractAnyQuery {
-
-            @Override
-            protected Query applyArrayReference(Reference arrayReference, Literal literal, Context context) {
-                // 1 != any ( col ) -->  gt 1 or lt 1
-                String columnName = arrayReference.column().fqn();
-                Object value = literal.value();
-
-                MappedFieldType fieldType = context.getFieldTypeOrNull(columnName);
-                if (fieldType == null) {
-                    return Queries.newMatchNoDocsQuery("column does not exist in this index");
-                }
-                BooleanQuery.Builder query = new BooleanQuery.Builder();
-                query.setMinimumNumberShouldMatch(1);
-                query.add(
-                    fieldType.rangeQuery(value, null, false, false, null, null, null, context.queryShardContext),
-                    BooleanClause.Occur.SHOULD
-                );
-                query.add(
-                    fieldType.rangeQuery(null, value, false, false, null, null, null, context.queryShardContext),
-                    BooleanClause.Occur.SHOULD
-                );
-                return query.build();
-            }
-
-            @Override
-            protected Query applyArrayLiteral(Reference reference, Literal arrayLiteral, Context context) {
-                //  col != ANY ([1,2,3]) --> not(col=1 and col=2 and col=3)
-                String columnName = reference.column().fqn();
-                MappedFieldType fieldType = context.getFieldTypeOrNull(columnName);
-                if (fieldType == null) {
-                    return Queries.newMatchNoDocsQuery("column does not exist in this index");
-                }
-
-                BooleanQuery.Builder andBuilder = new BooleanQuery.Builder();
-                for (Object value : toIterable(arrayLiteral.value())) {
-                    andBuilder.add(fieldType.termQuery(value, context.queryShardContext()), BooleanClause.Occur.MUST);
-                }
-                return Queries.not(andBuilder.build());
-            }
-        }
-
-        static class AnyNotLikeQuery extends AbstractAnyQuery {
-
-            @Override
-            protected Query applyArrayReference(Reference arrayReference, Literal literal, Context context) {
-                String regexString = LikeOperator.patternToRegex(BytesRefs.toString(literal.value()), LikeOperator.DEFAULT_ESCAPE, false);
-                regexString = regexString.substring(1, regexString.length() - 1);
-                String notLike = negateWildcard(regexString);
-
-                return new RegexpQuery(new Term(
-                    arrayReference.column().fqn(),
-                    notLike),
-                    RegexpFlag.COMPLEMENT.value()
-                );
-            }
-
-            @Override
-            protected Query applyArrayLiteral(Reference reference, Literal arrayLiteral, Context context) {
-                // col not like ANY (['a', 'b']) --> not(and(like(col, 'a'), like(col, 'b')))
-                String columnName = reference.column().fqn();
-                MappedFieldType fieldType = context.getFieldTypeOrNull(columnName);
-
-                BooleanQuery.Builder andLikeQueries = new BooleanQuery.Builder();
-                for (Object value : toIterable(arrayLiteral.value())) {
-                    andLikeQueries.add(
-                        LikeQueryBuilder.like(reference.valueType(), fieldType, value),
-                        BooleanClause.Occur.MUST);
-                }
-                return Queries.not(andLikeQueries.build());
-            }
-        }
-
-        static class AnyLikeQuery extends AbstractAnyQuery {
-
-            @Override
-            protected Query applyArrayReference(Reference arrayReference, Literal literal, Context context) {
-                return LikeQuery.toQuery(arrayReference, literal.value(), context);
-            }
-
-            @Override
-            protected Query applyArrayLiteral(Reference reference, Literal arrayLiteral, Context context) {
-                // col like ANY (['a', 'b']) --> or(like(col, 'a'), like(col, 'b'))
-                BooleanQuery.Builder booleanQuery = new BooleanQuery.Builder();
-                booleanQuery.setMinimumNumberShouldMatch(1);
-                for (Object value : toIterable(arrayLiteral.value())) {
-                    booleanQuery.add(LikeQuery.toQuery(reference, value, context), BooleanClause.Occur.SHOULD);
-                }
-                return booleanQuery.build();
-            }
-        }
-
-        static class LikeQuery extends CmpQuery {
-
-            @Override
-            public Query apply(Function input, Context context) {
-                Tuple<Reference, Literal> tuple = prepare(input);
-                if (tuple == null) {
-                    return null;
-                }
-                return toQuery(tuple.v1(), tuple.v2().value(), context);
-            }
-
-            static Query toQuery(Reference reference, Object value, Context context) {
-                DataType dataType = CollectionType.unnest(reference.valueType());
-                return LikeQueryBuilder.like(
-                    dataType,
-                    context.getFieldTypeOrNull(reference.column().fqn()),
-                    value
-                );
-            }
-        }
 
         class Ignore3vlQuery implements FunctionToQuery {
 
             @Nullable
             @Override
-            public Query apply(Function input, Context context) throws IOException {
+            public Query apply(Function input, Context context) {
                 List<Symbol> args = input.arguments();
                 assert args.size() == 1 : "ignore3vl expects exactly 1 argument, got: " + args.size();
                 return process(args.get(0), context);
@@ -620,76 +334,6 @@ public class LuceneQueryBuilder {
             }
         }
 
-        static class IsNullQuery implements FunctionToQuery {
-
-            @Override
-            public Query apply(Function input, Context context) {
-                assert input != null : "input must not be null";
-                assert input.arguments().size() == 1 : "function's number of arguments must be 1";
-                Symbol arg = input.arguments().get(0);
-                if (arg.symbolType() != SymbolType.REFERENCE) {
-                    return null;
-                }
-                Reference reference = (Reference) arg;
-                String columnName = reference.column().fqn();
-
-                // ExistsQueryBuilder.newFilter doesn't build the correct exists query for arrays
-                // because ES isn't really aware of explicit array types
-                if (reference.valueType() instanceof CollectionType) {
-                    MappedFieldType fieldType = context.getFieldTypeOrNull(columnName);
-                    if (fieldType != null) {
-                        return Queries.not(fieldType.existsQuery(context.queryShardContext));
-                    }
-                    MappedFieldType fieldNames = context.getFieldTypeOrNull(FieldNamesFieldMapper.NAME);
-                    if (fieldNames != null) {
-                        return Queries.not(new ConstantScoreQuery(
-                            new TermQuery(new Term(FieldNamesFieldMapper.NAME, columnName))));
-                    }
-                }
-                return Queries.not(ExistsQueryBuilder.newFilter(context.queryShardContext, columnName));
-            }
-        }
-
-        static class EqQuery extends CmpQuery {
-
-            @Override
-            public Query apply(Function input, Context context) {
-                Tuple<Reference, Literal> tuple = super.prepare(input);
-                if (tuple == null) {
-                    return null;
-                }
-                Reference reference = tuple.v1();
-                Literal literal = tuple.v2();
-                String columnName = reference.column().fqn();
-                MappedFieldType fieldType = context.getFieldTypeOrNull(columnName);
-                if (fieldType == null) {
-                    if (reference.valueType().equals(DataTypes.OBJECT)) {
-                        return null; // fallback to generic filter for  "o = {x=10, y=20}"
-                    }
-                    // field doesn't exist, can't match
-                    return Queries.newMatchNoDocsQuery("column does not exist in this index");
-                }
-                if (DataTypes.isCollectionType(reference.valueType()) &&
-                    DataTypes.isCollectionType(literal.valueType())) {
-
-                    List values = asList(literal);
-                    if (values.isEmpty()) {
-                        return genericFunctionFilter(input, context);
-                    }
-                    Query termsQuery = termsQuery(fieldType, values, context.queryShardContext);
-
-                    // wrap boolTermsFilter and genericFunction filter in an additional BooleanFilter to control the ordering of the filters
-                    // termsFilter is applied first
-                    // afterwards the more expensive genericFunctionFilter
-                    BooleanQuery.Builder filterClauses = new BooleanQuery.Builder();
-                    filterClauses.add(termsQuery, BooleanClause.Occur.MUST);
-                    filterClauses.add(genericFunctionFilter(input, context), BooleanClause.Occur.MUST);
-                    return filterClauses.build();
-                }
-                return fieldType.termQuery(literal.value(), context.queryShardContext);
-            }
-        }
-
         class AndQuery implements FunctionToQuery {
             @Override
             public Query apply(Function input, Context context) {
@@ -715,490 +359,6 @@ public class LuceneQueryBuilder {
             }
         }
 
-        static class AnyRangeQuery extends AbstractAnyQuery {
-
-            private final RangeQuery rangeQuery;
-            private final RangeQuery inverseRangeQuery;
-
-            AnyRangeQuery(String comparison, String inverseComparison) {
-                rangeQuery = new RangeQuery(comparison);
-                inverseRangeQuery = new RangeQuery(inverseComparison);
-            }
-
-            @Override
-            protected Query applyArrayReference(Reference arrayReference, Literal literal, Context context) {
-                // 1 < ANY (array_col) --> array_col > 1
-                return rangeQuery.toQuery(
-                    arrayReference,
-                    literal.value(),
-                    context::getFieldTypeOrNull,
-                    context.queryShardContext);
-            }
-
-            @Override
-            protected Query applyArrayLiteral(Reference reference, Literal arrayLiteral, Context context) {
-                // col < ANY ([1,2,3]) --> or(col<1, col<2, col<3)
-                BooleanQuery.Builder booleanQuery = new BooleanQuery.Builder();
-                booleanQuery.setMinimumNumberShouldMatch(1);
-                for (Object value : toIterable(arrayLiteral.value())) {
-                    booleanQuery.add(
-                        inverseRangeQuery.toQuery(reference, value, context::getFieldTypeOrNull, context.queryShardContext),
-                        BooleanClause.Occur.SHOULD);
-                }
-                return booleanQuery.build();
-            }
-        }
-
-        static class RangeQuery extends CmpQuery {
-
-            private final boolean includeLower;
-            private final boolean includeUpper;
-            private final java.util.function.Function<Object, Tuple<?, ?>> boundsFunction;
-
-            private static final java.util.function.Function<Object, Tuple<?, ?>> LOWER_BOUND = in -> new Tuple<>(in, null);
-            private static final java.util.function.Function<Object, Tuple<?, ?>> UPPER_BOUND = in -> new Tuple<>(null, in);
-
-            RangeQuery(String comparison) {
-                switch (comparison) {
-                    case "lt":
-                        boundsFunction = UPPER_BOUND;
-                        includeLower = false;
-                        includeUpper = false;
-                        break;
-                    case "gt":
-                        boundsFunction = LOWER_BOUND;
-                        includeLower = false;
-                        includeUpper = false;
-                        break;
-                    case "lte":
-                        boundsFunction = UPPER_BOUND;
-                        includeLower = false;
-                        includeUpper = true;
-                        break;
-                    case "gte":
-                        boundsFunction = LOWER_BOUND;
-                        includeLower = true;
-                        includeUpper = false;
-                        break;
-                    default:
-                        throw new IllegalArgumentException("invalid comparison");
-                }
-            }
-
-            @Override
-            public Query apply(Function input, Context context) {
-                Tuple<Reference, Literal> tuple = super.prepare(input);
-                if (tuple == null) {
-                    return null;
-                }
-                return toQuery(tuple.v1(), tuple.v2().value(), context::getFieldTypeOrNull, context.queryShardContext);
-            }
-
-            public Query toQuery(Reference reference, Object value, FieldTypeLookup fieldTypeLookup, QueryShardContext queryShardContext) {
-                String columnName = reference.column().fqn();
-                MappedFieldType fieldType = fieldTypeLookup.get(columnName);
-                if (fieldType == null) {
-                    // can't match column that doesn't exist or is an object ( "o >= {x=10}" is not supported)
-                    return Queries.newMatchNoDocsQuery("column does not exist in this index");
-                }
-                Tuple<?, ?> bounds = boundsFunction.apply(value);
-                assert bounds != null : "bounds must not be null";
-                return fieldType.rangeQuery(bounds.v1(), bounds.v2(), includeLower, includeUpper, null, null, null, queryShardContext);
-            }
-        }
-
-        static class ToMatchQuery implements FunctionToQuery {
-
-            @Override
-            public Query apply(Function input, Context context) throws IOException {
-                List<Symbol> arguments = input.arguments();
-                assert arguments.size() == 4 : "invalid number of arguments";
-                assert Symbol.isLiteral(arguments.get(0), DataTypes.OBJECT) :
-                    "fields must be literal";
-                assert Symbol.isLiteral(arguments.get(2), DataTypes.STRING) :
-                    "matchType must be literal";
-
-                Symbol queryTerm = arguments.get(1);
-                Preconditions.checkArgument(queryTerm instanceof Input, "queryTerm must be a literal");
-                Object queryTermVal = ((Input) queryTerm).value();
-                if (queryTermVal == null) {
-                    throw new IllegalArgumentException("cannot use NULL as query term in match predicate");
-                }
-                if (queryTerm.valueType().equals(DataTypes.GEO_SHAPE)) {
-                    return geoMatch(context, arguments, queryTermVal);
-                }
-                return stringMatch(context, arguments, queryTermVal);
-            }
-
-            private Query geoMatch(Context context, List<Symbol> arguments, Object queryTerm) {
-
-                Map fields = (Map) ((Literal) arguments.get(0)).value();
-                String fieldName = ((String) Iterables.getOnlyElement(fields.keySet()));
-                MappedFieldType fieldType = context.mapperService.fullName(fieldName);
-                GeoShapeFieldMapper.GeoShapeFieldType geoShapeFieldType = (GeoShapeFieldMapper.GeoShapeFieldType) fieldType;
-                String matchType = ((BytesRef) ((Input) arguments.get(2)).value()).utf8ToString();
-                @SuppressWarnings("unchecked")
-                Shape shape = GeoJSONUtils.map2Shape((Map<String, Object>) queryTerm);
-
-                ShapeRelation relation = ShapeRelation.getRelationByName(matchType);
-                assert relation != null : "invalid matchType: " + matchType;
-
-                PrefixTreeStrategy prefixTreeStrategy = geoShapeFieldType.defaultStrategy();
-                if (relation == ShapeRelation.DISJOINT) {
-                    /**
-                     * See {@link org.elasticsearch.index.query.GeoShapeQueryParser}:
-                     */
-                    // this strategy doesn't support disjoint anymore: but it did before, including creating lucene fieldcache (!)
-                    // in this case, execute disjoint as exists && !intersects
-
-                    BooleanQuery.Builder bool = new BooleanQuery.Builder();
-
-                    Query exists = new TermRangeQuery(fieldName, null, null, true, true);
-
-                    Query intersects = prefixTreeStrategy.makeQuery(getArgs(shape, ShapeRelation.INTERSECTS));
-                    bool.add(exists, BooleanClause.Occur.MUST);
-                    bool.add(intersects, BooleanClause.Occur.MUST_NOT);
-                    return new ConstantScoreQuery(bool.build());
-                }
-
-                SpatialArgs spatialArgs = getArgs(shape, relation);
-                return prefixTreeStrategy.makeQuery(spatialArgs);
-            }
-
-            private SpatialArgs getArgs(Shape shape, ShapeRelation relation) {
-                switch (relation) {
-                    case INTERSECTS:
-                        return new SpatialArgs(SpatialOperation.Intersects, shape);
-                    case DISJOINT:
-                        return new SpatialArgs(SpatialOperation.IsDisjointTo, shape);
-                    case WITHIN:
-                        return new SpatialArgs(SpatialOperation.IsWithin, shape);
-                    default:
-                        throw invalidMatchType(relation.getRelationName());
-                }
-            }
-
-            private AssertionError invalidMatchType(String matchType) {
-                throw new AssertionError(String.format(Locale.ENGLISH,
-                    "Invalid match type: %s. Analyzer should have made sure that it is valid", matchType));
-            }
-
-            private static Query stringMatch(Context context, List<Symbol> arguments, Object queryTerm) throws IOException {
-                @SuppressWarnings("unchecked")
-                Map<String, Object> fields = (Map) ((Literal) arguments.get(0)).value();
-                BytesRef queryString = (BytesRef) queryTerm;
-                BytesRef matchType = (BytesRef) ((Literal) arguments.get(2)).value();
-                //noinspection unchecked
-                Map<String, Object> options = (Map<String, Object>) ((Literal) arguments.get(3)).value();
-
-                MatchOptionsAnalysis.validate(options);
-
-                if (fields.size() == 1) {
-                    return singleMatchQuery(
-                        context.queryShardContext,
-                        fields.entrySet().iterator().next(),
-                        queryString,
-                        matchType,
-                        options
-                    );
-                } else {
-                    fields.replaceAll((s, o) -> {
-                        if (o instanceof Number) {
-                            return ((Number) o).floatValue();
-                        }
-                        return null;
-                    });
-                    //noinspection unchecked
-                    return MatchQueries.multiMatch(
-                        context.queryShardContext,
-                        matchType,
-                        (Map<String, Float>) (Map) fields,
-                        queryString.utf8ToString(),
-                        options
-                    );
-                }
-            }
-
-            private static Query singleMatchQuery(QueryShardContext queryShardContext,
-                                                  Map.Entry<String, Object> entry,
-                                                  BytesRef queryString,
-                                                  BytesRef matchType,
-                                                  Map<String, Object> options) throws IOException {
-                Query query = MatchQueries.singleMatch(
-                    queryShardContext,
-                    entry.getKey(),
-                    queryString,
-                    matchType,
-                    options
-                );
-                Object boost = entry.getValue();
-                if (boost instanceof Number) {
-                    return new BoostQuery(query, ((Number) boost).floatValue());
-                }
-                return query;
-            }
-        }
-
-        static class RegexpMatchQuery extends CmpQuery {
-
-            private Query toLuceneRegexpQuery(String fieldName, BytesRef value) {
-                return new ConstantScoreQuery(
-                    new RegexpQuery(new Term(fieldName, value), RegExp.ALL));
-            }
-
-            @Override
-            public Query apply(Function input, Context context) {
-                Tuple<Reference, Literal> prepare = prepare(input);
-                if (prepare == null) {
-                    return null;
-                }
-                String fieldName = prepare.v1().column().fqn();
-                BytesRef pattern = BytesRefs.toBytesRef(prepare.v2().value());
-                if (pattern == null) {
-                    // cannot build query using null pattern value
-                    return null;
-                }
-
-                if (isPcrePattern(pattern.utf8ToString())) {
-                    return new CrateRegexQuery(new Term(fieldName, pattern));
-                } else {
-                    return toLuceneRegexpQuery(fieldName, pattern);
-                }
-            }
-        }
-
-        static class RegexMatchQueryCaseInsensitive extends CmpQuery {
-
-            @Override
-            public Query apply(Function input, Context context) {
-                Tuple<Reference, Literal> prepare = prepare(input);
-                if (prepare == null) {
-                    return null;
-                }
-                String fieldName = prepare.v1().column().fqn();
-                Object value = prepare.v2().value();
-
-                if (value instanceof BytesRef) {
-                    return new CrateRegexQuery(
-                        new Term(fieldName, BytesRefs.toBytesRef(value)),
-                        CrateRegexCapabilities.FLAG_CASE_INSENSITIVE | CrateRegexCapabilities.FLAG_UNICODE_CASE);
-                }
-                throw new IllegalArgumentException("Can only use ~* with patterns of type string");
-            }
-        }
-
-        /**
-         * interface for functions that can be used to generate a query from inner functions.
-         * Has only a single method {@link #apply(io.crate.expression.symbol.Function, io.crate.expression.symbol.Function, io.crate.lucene.LuceneQueryBuilder.Context)}
-         * <p>
-         * e.g. in a query like
-         * <pre>
-         *     where distance(p1, 'POINT (10 20)') = 20
-         * </pre>
-         * <p>
-         * The first parameter (parent) would be the "eq" function.
-         * The second parameter (inner) would be the "distance" function.
-         * <p>
-         * The returned Query must "contain" both the parent and inner functions.
-         */
-        interface InnerFunctionToQuery {
-
-            /**
-             * returns a query for the given functions or null if it can't build a query.
-             */
-            @Nullable
-            Query apply(Function parent, Function inner, Context context) throws IOException;
-        }
-
-        /**
-         * for where within(shape1, shape2) = [ true | false ]
-         */
-        static class WithinQuery implements FunctionToQuery, InnerFunctionToQuery {
-
-            @Override
-            public Query apply(Function parent, Function inner, Context context) {
-                FunctionLiteralPair outerPair = new FunctionLiteralPair(parent);
-                if (!outerPair.isValid()) {
-                    return null;
-                }
-                Query query = getQuery(inner, context);
-                if (query == null) return null;
-                boolean negate = !(Boolean) outerPair.input().value();
-                if (negate) {
-                    return Queries.not(query);
-                } else {
-                    return query;
-                }
-            }
-
-            private Query getQuery(Function inner, Context context) {
-                RefLiteralPair innerPair = new RefLiteralPair(inner);
-                if (!innerPair.isValid()) {
-                    return null;
-                }
-                if (innerPair.reference().valueType().equals(DataTypes.GEO_SHAPE)) {
-                    // we have within('POINT(0 0)', shape_column)
-                    return genericFunctionFilter(inner, context);
-                }
-                GeoPointFieldMapper.GeoPointFieldType geoPointFieldType = getGeoPointFieldType(
-                    innerPair.reference().column().fqn(),
-                    context.mapperService);
-
-                Map<String, Object> geoJSON = (Map<String, Object>) innerPair.input().value();
-                Geometry geometry;
-                Shape shape = GeoJSONUtils.map2Shape(geoJSON);
-                if (shape instanceof ShapeCollection) {
-                    int i = 0;
-                    ShapeCollection<Shape> collection = (ShapeCollection) shape;
-                    com.vividsolutions.jts.geom.Polygon[] polygons = new com.vividsolutions.jts.geom.Polygon[collection.size()];
-                    for (Shape s : collection.getShapes()) {
-                        Geometry subGeometry = JtsSpatialContext.GEO.getShapeFactory().getGeometryFrom(s);
-                        if (subGeometry instanceof com.vividsolutions.jts.geom.Polygon) {
-                            polygons[i++] = (com.vividsolutions.jts.geom.Polygon) subGeometry;
-                        } else {
-                            throw new InvalidShapeException("Shape collection must contain only Polygon shapes.");
-                        }
-                    }
-                    GeometryFactory geometryFactory = JtsSpatialContext.GEO.getShapeFactory().getGeometryFactory();
-                    geometry = geometryFactory.createMultiPolygon(polygons);
-                } else {
-                    geometry = JtsSpatialContext.GEO.getShapeFactory().getGeometryFrom(shape);
-                }
-
-                return getPolygonQuery(geometry, geoPointFieldType);
-            }
-
-            private static Query getPolygonQuery(Geometry geometry,
-                                                 GeoPointFieldMapper.GeoPointFieldType fieldType) {
-                Coordinate[] coordinates = geometry.getCoordinates();
-                // close the polygon shape if startpoint != endpoint
-                if (!CoordinateArrays.isRing(coordinates)) {
-                    coordinates = Arrays.copyOf(coordinates, coordinates.length + 1);
-                    coordinates[coordinates.length - 1] = coordinates[0];
-                }
-
-                final double[] lats = new double[coordinates.length];
-                final double[] lons = new double[coordinates.length];
-                for (int i = 0; i < coordinates.length; i++) {
-                    lats[i] = coordinates[i].y;
-                    lons[i] = coordinates[i].x;
-                }
-
-                return LatLonPoint.newPolygonQuery(fieldType.name(), new Polygon(lats, lons));
-            }
-
-            @Override
-            public Query apply(Function input, Context context) {
-                return getQuery(input, context);
-            }
-        }
-
-        static class DistanceQuery implements InnerFunctionToQuery {
-
-            /**
-             * @param parent the outer function. E.g. in the case of
-             *               <pre>where distance(p1, POINT (10 20)) > 20</pre>
-             *               this would be
-             *               <pre>gt( \<inner function\>,  20)</pre>
-             * @param inner  has to be the distance function
-             */
-            @Override
-            public Query apply(Function parent, Function inner, Context context) {
-                assert inner.info().ident().name().equals(DistanceFunction.NAME) :
-                    "function must be " + DistanceFunction.NAME;
-
-                RefLiteralPair distanceRefLiteral = new RefLiteralPair(inner);
-                if (!distanceRefLiteral.isValid()) {
-                    // can't use distance filter without literal, fallback to genericFunction
-                    return null;
-                }
-                FunctionLiteralPair functionLiteralPair = new FunctionLiteralPair(parent);
-                if (!functionLiteralPair.isValid()) {
-                    // must be something like eq(distance(..), non-literal) - fallback to genericFunction
-                    return null;
-                }
-                Double distance = DataTypes.DOUBLE.value(functionLiteralPair.input().value());
-
-                String parentName = functionLiteralPair.functionName();
-                Input geoPointInput = distanceRefLiteral.input();
-                String fieldName = distanceRefLiteral.reference().column().fqn();
-                Double[] pointValue = (Double[]) geoPointInput.value();
-                return esV5DistanceQuery(parent, context, parentName, fieldName, distance, pointValue);
-            }
-        }
-
-        static class SubscriptQuery implements InnerFunctionToQuery {
-
-            private interface PreFilterQueryBuilder {
-                Query buildQuery(MappedFieldType fieldType, Object value, QueryShardContext context);
-            }
-
-            private static final ImmutableMap<String, PreFilterQueryBuilder> PRE_FILTER_QUERY_BUILDER_BY_OP =
-                ImmutableMap.<String, PreFilterQueryBuilder>builder()
-                    .put(EqOperator.NAME, MappedFieldType::termQuery)
-                    .put(GteOperator.NAME, (fieldType, value, context)
-                        -> fieldType.rangeQuery(value, null, true, false, null, null, null, context))
-                    .put(GtOperator.NAME, (fieldType, value, context)
-                        -> fieldType.rangeQuery(value, null, false, false, null, null, null, context))
-                    .put(LteOperator.NAME, (fieldType, value, context)
-                        -> fieldType.rangeQuery(null, value, false, true, null, null, null, context))
-                    .put(LtOperator.NAME, (fieldType, value, context)
-                        -> fieldType.rangeQuery(null, value, false, false, null, null, null, context))
-                    .build();
-
-            @Nullable
-            @Override
-            public Query apply(Function parent, Function inner, Context context) throws IOException {
-                assert inner.info().ident().name().equals(SubscriptFunction.NAME) :
-                    "function must be " + SubscriptFunction.NAME;
-
-                RefLiteralPair innerPair = new RefLiteralPair(inner);
-                if (!innerPair.isValid()) {
-                    return null;
-                }
-                Reference reference = innerPair.reference();
-
-                if (DataTypes.isCollectionType(innerPair.reference().valueType())) {
-                    PreFilterQueryBuilder preFilterQueryBuilder =
-                        PRE_FILTER_QUERY_BUILDER_BY_OP.get(parent.info().ident().name());
-                    if (preFilterQueryBuilder == null) {
-                        return null;
-                    }
-
-                    FunctionLiteralPair functionLiteralPair = new FunctionLiteralPair(parent);
-                    if (!functionLiteralPair.isValid()) {
-                        return null;
-                    }
-                    Input input = functionLiteralPair.input();
-
-                    MappedFieldType fieldType = context.getFieldTypeOrNull(reference.column().fqn());
-                    if (fieldType == null) {
-                        if (CollectionType.unnest(reference.valueType()).equals(DataTypes.OBJECT)) {
-                            return null; // fallback to generic query to enable objects[1] = {x=10}
-                        }
-                        return Queries.newMatchNoDocsQuery("column doesn't exist in this index");
-                    }
-                    BooleanQuery.Builder builder = new BooleanQuery.Builder();
-                    builder.add(
-                        preFilterQueryBuilder.buildQuery(fieldType, input.value(), context.queryShardContext),
-                        BooleanClause.Occur.MUST);
-                    builder.add(genericFunctionFilter(parent, context), BooleanClause.Occur.FILTER);
-                    return builder.build();
-                }
-                return null;
-            }
-        }
-
-        private static GeoPointFieldMapper.GeoPointFieldType getGeoPointFieldType(String fieldName, MapperService mapperService) {
-            MappedFieldType fieldType = mapperService.fullName(fieldName);
-            if (fieldType == null) {
-                throw new IllegalArgumentException(String.format(Locale.ENGLISH, "column \"%s\" doesn't exist", fieldName));
-            }
-            if (!(fieldType instanceof GeoPointFieldMapper.GeoPointFieldType)) {
-                throw new IllegalArgumentException(String.format(Locale.ENGLISH, "column \"%s\" isn't of type geo_point", fieldName));
-            }
-            return (GeoPointFieldMapper.GeoPointFieldType) fieldType;
-        }
 
         private static final EqQuery eqQuery = new EqQuery();
         private static final RangeQuery ltQuery = new RangeQuery("lt");
@@ -1290,11 +450,10 @@ public class LuceneQueryBuilder {
             return null;
         }
 
-        private boolean fieldIgnored(Function function, Context context) {
+        private static boolean fieldIgnored(Function function, Context context) {
             if (function.arguments().size() != 2) {
                 return false;
             }
-
             Symbol left = function.arguments().get(0);
             Symbol right = function.arguments().get(1);
             if (left.symbolType() == SymbolType.REFERENCE && right.symbolType().isValueSymbol()) {
@@ -1334,38 +493,6 @@ public class LuceneQueryBuilder {
             return function;
         }
 
-        static Query genericFunctionFilter(Function function, Context context) {
-            if (function.valueType() != DataTypes.BOOLEAN) {
-                raiseUnsupported(function);
-            }
-            // rewrite references to source lookup instead of using the docValues column store if:
-            // - no docValues are available for the related column, currently only on objects defined as `ignored`
-            // - docValues value differs from source, currently happening on GeoPoint types as lucene's internal format
-            //   results in precision changes (e.g. longitude 11.0 will be 10.999999966)
-            function = (Function) DocReferences.toSourceLookup(function,
-                r -> r.columnPolicy() == ColumnPolicy.IGNORED
-                     || r.valueType() == DataTypes.GEO_POINT);
-
-            final InputFactory.Context<? extends LuceneCollectorExpression<?>> ctx = context.docInputFactory.getCtx();
-            @SuppressWarnings("unchecked")
-            final Input<Boolean> condition = (Input<Boolean>) ctx.add(function);
-            @SuppressWarnings("unchecked")
-            final Collection<? extends LuceneCollectorExpression<?>> expressions = ctx.expressions();
-            final CollectorContext collectorContext = new CollectorContext(
-                context.queryShardContext::getForField,
-                new CollectorFieldsVisitor(expressions.size())
-            );
-
-            for (LuceneCollectorExpression expression : expressions) {
-                expression.startCollect(collectorContext);
-            }
-            return new GenericFunctionQuery(function, expressions, collectorContext, condition);
-        }
-
-        private static void raiseUnsupported(Function function) {
-            throw new UnsupportedOperationException(
-                SymbolFormatter.format("Cannot convert function %s into a query", function));
-        }
 
         @Override
         public Query visitReference(Reference symbol, Context context) {
@@ -1404,86 +531,36 @@ public class LuceneQueryBuilder {
         }
     }
 
-    private static class FunctionLiteralPair {
-
-        private final String functionName;
-        private final Function function;
-        private final Input input;
-
-        private FunctionLiteralPair(Function outerFunction) {
-            assert outerFunction.arguments().size() == 2 : "function requires 2 arguments";
-            Symbol left = outerFunction.arguments().get(0);
-            Symbol right = outerFunction.arguments().get(1);
-
-            functionName = outerFunction.info().ident().name();
-
-            if (left instanceof Function) {
-                function = (Function) left;
-            } else if (right instanceof Function) {
-                function = (Function) right;
-            } else {
-                function = null;
-            }
-
-            if (left.symbolType().isValueSymbol()) {
-                input = (Input) left;
-            } else if (right.symbolType().isValueSymbol()) {
-                input = (Input) right;
-            } else {
-                input = null;
-            }
+    static Query genericFunctionFilter(Function function, Context context) {
+        if (function.valueType() != DataTypes.BOOLEAN) {
+            raiseUnsupported(function);
         }
+        // rewrite references to source lookup instead of using the docValues column store if:
+        // - no docValues are available for the related column, currently only on objects defined as `ignored`
+        // - docValues value differs from source, currently happening on GeoPoint types as lucene's internal format
+        //   results in precision changes (e.g. longitude 11.0 will be 10.999999966)
+        function = (Function) DocReferences.toSourceLookup(function,
+            r -> r.columnPolicy() == ColumnPolicy.IGNORED
+                 || r.valueType() == DataTypes.GEO_POINT);
 
-        private boolean isValid() {
-            return input != null && function != null;
-        }
+        final InputFactory.Context<? extends LuceneCollectorExpression<?>> ctx = context.docInputFactory.getCtx();
+        @SuppressWarnings("unchecked")
+        final Input<Boolean> condition = (Input<Boolean>) ctx.add(function);
+        @SuppressWarnings("unchecked")
+        final Collection<? extends LuceneCollectorExpression<?>> expressions = ctx.expressions();
+        final CollectorContext collectorContext = new CollectorContext(
+            context.queryShardContext::getForField,
+            new CollectorFieldsVisitor(expressions.size())
+        );
 
-        private Input input() {
-            return input;
+        for (LuceneCollectorExpression expression : expressions) {
+            expression.startCollect(collectorContext);
         }
-
-        private String functionName() {
-            return functionName;
-        }
+        return new GenericFunctionQuery(function, expressions, collectorContext, condition);
     }
 
-    private static class RefLiteralPair {
-
-        private final Reference reference;
-        private final Input input;
-
-        private RefLiteralPair(Function function) {
-            assert function.arguments().size() == 2 : "function requires 2 arguments";
-            Symbol left = function.arguments().get(0);
-            Symbol right = function.arguments().get(1);
-
-            if (left instanceof Reference) {
-                reference = (Reference) left;
-            } else if (right instanceof Reference) {
-                reference = (Reference) right;
-            } else {
-                reference = null;
-            }
-
-            if (left.symbolType().isValueSymbol()) {
-                input = (Input) left;
-            } else if (right.symbolType().isValueSymbol()) {
-                input = (Input) right;
-            } else {
-                input = null;
-            }
-        }
-
-        private boolean isValid() {
-            return input != null && reference != null;
-        }
-
-        private Reference reference() {
-            return reference;
-        }
-
-        private Input input() {
-            return input;
-        }
+    private static void raiseUnsupported(Function function) {
+        throw new UnsupportedOperationException(
+            SymbolFormatter.format("Cannot convert function %s into a query", function));
     }
 }

--- a/sql/src/main/java/io/crate/lucene/RangeQuery.java
+++ b/sql/src/main/java/io/crate/lucene/RangeQuery.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.lucene;
+
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.Literal;
+import io.crate.metadata.Reference;
+import org.apache.lucene.search.Query;
+import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.lucene.search.Queries;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.query.QueryShardContext;
+
+class RangeQuery extends CmpQuery {
+
+    private final boolean includeLower;
+    private final boolean includeUpper;
+    private final java.util.function.Function<Object, Tuple<?, ?>> boundsFunction;
+
+    private static final java.util.function.Function<Object, Tuple<?, ?>> LOWER_BOUND = in -> new Tuple<>(in, null);
+    private static final java.util.function.Function<Object, Tuple<?, ?>> UPPER_BOUND = in -> new Tuple<>(null, in);
+
+    RangeQuery(String comparison) {
+        switch (comparison) {
+            case "lt":
+                boundsFunction = UPPER_BOUND;
+                includeLower = false;
+                includeUpper = false;
+                break;
+            case "gt":
+                boundsFunction = LOWER_BOUND;
+                includeLower = false;
+                includeUpper = false;
+                break;
+            case "lte":
+                boundsFunction = UPPER_BOUND;
+                includeLower = false;
+                includeUpper = true;
+                break;
+            case "gte":
+                boundsFunction = LOWER_BOUND;
+                includeLower = true;
+                includeUpper = false;
+                break;
+            default:
+                throw new IllegalArgumentException("invalid comparison");
+        }
+    }
+
+    @Override
+    public Query apply(Function input, LuceneQueryBuilder.Context context) {
+        Tuple<Reference, Literal> tuple = super.prepare(input);
+        if (tuple == null) {
+            return null;
+        }
+        return toQuery(tuple.v1(), tuple.v2().value(), context::getFieldTypeOrNull, context.queryShardContext);
+    }
+
+    public Query toQuery(Reference reference, Object value, FieldTypeLookup fieldTypeLookup, QueryShardContext queryShardContext) {
+        String columnName = reference.column().fqn();
+        MappedFieldType fieldType = fieldTypeLookup.get(columnName);
+        if (fieldType == null) {
+            // can't match column that doesn't exist or is an object ( "o >= {x=10}" is not supported)
+            return Queries.newMatchNoDocsQuery("column does not exist in this index");
+        }
+        Tuple<?, ?> bounds = boundsFunction.apply(value);
+        assert bounds != null : "bounds must not be null";
+        return fieldType.rangeQuery(bounds.v1(), bounds.v2(), includeLower, includeUpper, null, null, null, queryShardContext);
+    }
+}

--- a/sql/src/main/java/io/crate/lucene/RefLiteralPair.java
+++ b/sql/src/main/java/io/crate/lucene/RefLiteralPair.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.lucene;
+
+import io.crate.data.Input;
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.Reference;
+
+class RefLiteralPair {
+
+    private final Reference reference;
+    private final Input input;
+
+    RefLiteralPair(Function function) {
+        assert function.arguments().size() == 2 : "function requires 2 arguments";
+        Symbol left = function.arguments().get(0);
+        Symbol right = function.arguments().get(1);
+
+        if (left instanceof Reference) {
+            reference = (Reference) left;
+        } else if (right instanceof Reference) {
+            reference = (Reference) right;
+        } else {
+            reference = null;
+        }
+
+        if (left.symbolType().isValueSymbol()) {
+            input = (Input) left;
+        } else if (right.symbolType().isValueSymbol()) {
+            input = (Input) right;
+        } else {
+            input = null;
+        }
+    }
+
+    boolean isValid() {
+        return input != null && reference != null;
+    }
+
+    Reference reference() {
+        return reference;
+    }
+
+    Input input() {
+        return input;
+    }
+}

--- a/sql/src/main/java/io/crate/lucene/RegexMatchQueryCaseInsensitive.java
+++ b/sql/src/main/java/io/crate/lucene/RegexMatchQueryCaseInsensitive.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.lucene;
+
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.Literal;
+import io.crate.lucene.match.CrateRegexCapabilities;
+import io.crate.lucene.match.CrateRegexQuery;
+import io.crate.metadata.Reference;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.lucene.BytesRefs;
+
+class RegexMatchQueryCaseInsensitive extends CmpQuery {
+
+    @Override
+    public Query apply(Function input, LuceneQueryBuilder.Context context) {
+        Tuple<Reference, Literal> prepare = prepare(input);
+        if (prepare == null) {
+            return null;
+        }
+        String fieldName = prepare.v1().column().fqn();
+        Object value = prepare.v2().value();
+
+        if (value instanceof BytesRef) {
+            return new CrateRegexQuery(
+                new Term(fieldName, BytesRefs.toBytesRef(value)),
+                CrateRegexCapabilities.FLAG_CASE_INSENSITIVE | CrateRegexCapabilities.FLAG_UNICODE_CASE);
+        }
+        throw new IllegalArgumentException("Can only use ~* with patterns of type string");
+    }
+}

--- a/sql/src/main/java/io/crate/lucene/RegexpMatchQuery.java
+++ b/sql/src/main/java/io/crate/lucene/RegexpMatchQuery.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.lucene;
+
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.Literal;
+import io.crate.lucene.match.CrateRegexQuery;
+import io.crate.metadata.Reference;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.ConstantScoreQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.RegexpQuery;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.automaton.RegExp;
+import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.lucene.BytesRefs;
+
+import static io.crate.expression.scalar.regex.RegexMatcher.isPcrePattern;
+
+class RegexpMatchQuery extends CmpQuery {
+
+    private static Query toLuceneRegexpQuery(String fieldName, BytesRef value) {
+        return new ConstantScoreQuery(
+            new RegexpQuery(new Term(fieldName, value), RegExp.ALL));
+    }
+
+    @Override
+    public Query apply(Function input, LuceneQueryBuilder.Context context) {
+        Tuple<Reference, Literal> prepare = prepare(input);
+        if (prepare == null) {
+            return null;
+        }
+        String fieldName = prepare.v1().column().fqn();
+        BytesRef pattern = BytesRefs.toBytesRef(prepare.v2().value());
+        if (pattern == null) {
+            // cannot build query using null pattern value
+            return null;
+        }
+
+        if (isPcrePattern(pattern.utf8ToString())) {
+            return new CrateRegexQuery(new Term(fieldName, pattern));
+        } else {
+            return toLuceneRegexpQuery(fieldName, pattern);
+        }
+    }
+}

--- a/sql/src/main/java/io/crate/lucene/SubscriptQuery.java
+++ b/sql/src/main/java/io/crate/lucene/SubscriptQuery.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.lucene;
+
+import com.google.common.collect.ImmutableMap;
+import io.crate.data.Input;
+import io.crate.expression.operator.EqOperator;
+import io.crate.expression.operator.GtOperator;
+import io.crate.expression.operator.GteOperator;
+import io.crate.expression.operator.LtOperator;
+import io.crate.expression.operator.LteOperator;
+import io.crate.expression.scalar.SubscriptFunction;
+import io.crate.expression.symbol.Function;
+import io.crate.metadata.Reference;
+import io.crate.types.CollectionType;
+import io.crate.types.DataTypes;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.Query;
+import org.elasticsearch.common.lucene.search.Queries;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.query.QueryShardContext;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+
+class SubscriptQuery implements InnerFunctionToQuery {
+
+    private interface PreFilterQueryBuilder {
+        Query buildQuery(MappedFieldType fieldType, Object value, QueryShardContext context);
+    }
+
+    private static final ImmutableMap<String, PreFilterQueryBuilder> PRE_FILTER_QUERY_BUILDER_BY_OP =
+        ImmutableMap.<String, PreFilterQueryBuilder>builder()
+            .put(EqOperator.NAME, MappedFieldType::termQuery)
+            .put(GteOperator.NAME, (fieldType, value, context)
+                -> fieldType.rangeQuery(value, null, true, false, null, null, null, context))
+            .put(GtOperator.NAME, (fieldType, value, context)
+                -> fieldType.rangeQuery(value, null, false, false, null, null, null, context))
+            .put(LteOperator.NAME, (fieldType, value, context)
+                -> fieldType.rangeQuery(null, value, false, true, null, null, null, context))
+            .put(LtOperator.NAME, (fieldType, value, context)
+                -> fieldType.rangeQuery(null, value, false, false, null, null, null, context))
+            .build();
+
+    @Nullable
+    @Override
+    public Query apply(Function parent, Function inner, LuceneQueryBuilder.Context context) throws IOException {
+        assert inner.info().ident().name().equals(SubscriptFunction.NAME) :
+            "function must be " + SubscriptFunction.NAME;
+
+        RefLiteralPair innerPair = new RefLiteralPair(inner);
+        if (!innerPair.isValid()) {
+            return null;
+        }
+        Reference reference = innerPair.reference();
+
+        if (DataTypes.isCollectionType(innerPair.reference().valueType())) {
+            PreFilterQueryBuilder preFilterQueryBuilder =
+                PRE_FILTER_QUERY_BUILDER_BY_OP.get(parent.info().ident().name());
+            if (preFilterQueryBuilder == null) {
+                return null;
+            }
+
+            FunctionLiteralPair functionLiteralPair = new FunctionLiteralPair(parent);
+            if (!functionLiteralPair.isValid()) {
+                return null;
+            }
+            Input input = functionLiteralPair.input();
+
+            MappedFieldType fieldType = context.getFieldTypeOrNull(reference.column().fqn());
+            if (fieldType == null) {
+                if (CollectionType.unnest(reference.valueType()).equals(DataTypes.OBJECT)) {
+                    return null; // fallback to generic query to enable objects[1] = {x=10}
+                }
+                return Queries.newMatchNoDocsQuery("column doesn't exist in this index");
+            }
+            BooleanQuery.Builder builder = new BooleanQuery.Builder();
+            builder.add(
+                preFilterQueryBuilder.buildQuery(fieldType, input.value(), context.queryShardContext),
+                BooleanClause.Occur.MUST);
+            builder.add(LuceneQueryBuilder.genericFunctionFilter(parent, context), BooleanClause.Occur.FILTER);
+            return builder.build();
+        }
+        return null;
+    }
+}

--- a/sql/src/main/java/io/crate/lucene/ToMatchQuery.java
+++ b/sql/src/main/java/io/crate/lucene/ToMatchQuery.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.lucene;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Iterables;
+import io.crate.analyze.MatchOptionsAnalysis;
+import io.crate.data.Input;
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.Literal;
+import io.crate.expression.symbol.Symbol;
+import io.crate.geo.GeoJSONUtils;
+import io.crate.lucene.match.MatchQueries;
+import io.crate.types.DataTypes;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.BoostQuery;
+import org.apache.lucene.search.ConstantScoreQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermRangeQuery;
+import org.apache.lucene.spatial.prefix.PrefixTreeStrategy;
+import org.apache.lucene.spatial.query.SpatialArgs;
+import org.apache.lucene.spatial.query.SpatialOperation;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.geo.ShapeRelation;
+import org.elasticsearch.index.mapper.GeoShapeFieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.query.QueryShardContext;
+import org.locationtech.spatial4j.shape.Shape;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+class ToMatchQuery implements FunctionToQuery {
+
+    @Override
+    public Query apply(Function input, LuceneQueryBuilder.Context context) throws IOException {
+        List<Symbol> arguments = input.arguments();
+        assert arguments.size() == 4 : "invalid number of arguments";
+        assert Symbol.isLiteral(arguments.get(0), DataTypes.OBJECT) :
+            "fields must be literal";
+        assert Symbol.isLiteral(arguments.get(2), DataTypes.STRING) :
+            "matchType must be literal";
+
+        Symbol queryTerm = arguments.get(1);
+        Preconditions.checkArgument(queryTerm instanceof Input, "queryTerm must be a literal");
+        Object queryTermVal = ((Input) queryTerm).value();
+        if (queryTermVal == null) {
+            throw new IllegalArgumentException("cannot use NULL as query term in match predicate");
+        }
+        if (queryTerm.valueType().equals(DataTypes.GEO_SHAPE)) {
+            return geoMatch(context, arguments, queryTermVal);
+        }
+        return stringMatch(context, arguments, queryTermVal);
+    }
+
+    private Query geoMatch(LuceneQueryBuilder.Context context, List<Symbol> arguments, Object queryTerm) {
+
+        Map fields = (Map) ((Literal) arguments.get(0)).value();
+        String fieldName = ((String) Iterables.getOnlyElement(fields.keySet()));
+        MappedFieldType fieldType = context.mapperService.fullName(fieldName);
+        GeoShapeFieldMapper.GeoShapeFieldType geoShapeFieldType = (GeoShapeFieldMapper.GeoShapeFieldType) fieldType;
+        String matchType = ((BytesRef) ((Input) arguments.get(2)).value()).utf8ToString();
+        @SuppressWarnings("unchecked")
+        Shape shape = GeoJSONUtils.map2Shape((Map<String, Object>) queryTerm);
+
+        ShapeRelation relation = ShapeRelation.getRelationByName(matchType);
+        assert relation != null : "invalid matchType: " + matchType;
+
+        PrefixTreeStrategy prefixTreeStrategy = geoShapeFieldType.defaultStrategy();
+        if (relation == ShapeRelation.DISJOINT) {
+            /**
+             * See {@link org.elasticsearch.index.query.GeoShapeQueryParser}:
+             */
+            // this strategy doesn't support disjoint anymore: but it did before, including creating lucene fieldcache (!)
+            // in this case, execute disjoint as exists && !intersects
+
+            BooleanQuery.Builder bool = new BooleanQuery.Builder();
+
+            Query exists = new TermRangeQuery(fieldName, null, null, true, true);
+
+            Query intersects = prefixTreeStrategy.makeQuery(getArgs(shape, ShapeRelation.INTERSECTS));
+            bool.add(exists, BooleanClause.Occur.MUST);
+            bool.add(intersects, BooleanClause.Occur.MUST_NOT);
+            return new ConstantScoreQuery(bool.build());
+        }
+
+        SpatialArgs spatialArgs = getArgs(shape, relation);
+        return prefixTreeStrategy.makeQuery(spatialArgs);
+    }
+
+    private SpatialArgs getArgs(Shape shape, ShapeRelation relation) {
+        switch (relation) {
+            case INTERSECTS:
+                return new SpatialArgs(SpatialOperation.Intersects, shape);
+            case DISJOINT:
+                return new SpatialArgs(SpatialOperation.IsDisjointTo, shape);
+            case WITHIN:
+                return new SpatialArgs(SpatialOperation.IsWithin, shape);
+            default:
+                throw invalidMatchType(relation.getRelationName());
+        }
+    }
+
+    private AssertionError invalidMatchType(String matchType) {
+        throw new AssertionError(String.format(Locale.ENGLISH,
+            "Invalid match type: %s. Analyzer should have made sure that it is valid", matchType));
+    }
+
+    private static Query stringMatch(LuceneQueryBuilder.Context context, List<Symbol> arguments, Object queryTerm) throws IOException {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> fields = (Map) ((Literal) arguments.get(0)).value();
+        BytesRef queryString = (BytesRef) queryTerm;
+        BytesRef matchType = (BytesRef) ((Literal) arguments.get(2)).value();
+        //noinspection unchecked
+        Map<String, Object> options = (Map<String, Object>) ((Literal) arguments.get(3)).value();
+
+        MatchOptionsAnalysis.validate(options);
+
+        if (fields.size() == 1) {
+            return singleMatchQuery(
+                context.queryShardContext,
+                fields.entrySet().iterator().next(),
+                queryString,
+                matchType,
+                options
+            );
+        } else {
+            fields.replaceAll((s, o) -> {
+                if (o instanceof Number) {
+                    return ((Number) o).floatValue();
+                }
+                return null;
+            });
+            //noinspection unchecked
+            return MatchQueries.multiMatch(
+                context.queryShardContext,
+                matchType,
+                (Map<String, Float>) (Map) fields,
+                queryString.utf8ToString(),
+                options
+            );
+        }
+    }
+
+    private static Query singleMatchQuery(QueryShardContext queryShardContext,
+                                          Map.Entry<String, Object> entry,
+                                          BytesRef queryString,
+                                          BytesRef matchType,
+                                          Map<String, Object> options) throws IOException {
+        Query query = MatchQueries.singleMatch(
+            queryShardContext,
+            entry.getKey(),
+            queryString,
+            matchType,
+            options
+        );
+        Object boost = entry.getValue();
+        if (boost instanceof Number) {
+            return new BoostQuery(query, ((Number) boost).floatValue());
+        }
+        return query;
+    }
+}

--- a/sql/src/main/java/io/crate/lucene/WithinQuery.java
+++ b/sql/src/main/java/io/crate/lucene/WithinQuery.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.lucene;
+
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.CoordinateArrays;
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.GeometryFactory;
+import io.crate.expression.symbol.Function;
+import io.crate.geo.GeoJSONUtils;
+import io.crate.types.DataTypes;
+import org.apache.lucene.document.LatLonPoint;
+import org.apache.lucene.geo.Polygon;
+import org.apache.lucene.search.Query;
+import org.elasticsearch.common.lucene.search.Queries;
+import org.elasticsearch.index.mapper.GeoPointFieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.MapperService;
+import org.locationtech.spatial4j.context.jts.JtsSpatialContext;
+import org.locationtech.spatial4j.exception.InvalidShapeException;
+import org.locationtech.spatial4j.shape.Shape;
+import org.locationtech.spatial4j.shape.ShapeCollection;
+
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * for where within(shape1, shape2) = [ true | false ]
+ */
+class WithinQuery implements FunctionToQuery, InnerFunctionToQuery {
+
+    @Override
+    public Query apply(Function parent, Function inner, LuceneQueryBuilder.Context context) {
+        FunctionLiteralPair outerPair = new FunctionLiteralPair(parent);
+        if (!outerPair.isValid()) {
+            return null;
+        }
+        Query query = getQuery(inner, context);
+        if (query == null) return null;
+        boolean negate = !(Boolean) outerPair.input().value();
+        if (negate) {
+            return Queries.not(query);
+        } else {
+            return query;
+        }
+    }
+
+    private Query getQuery(Function inner, LuceneQueryBuilder.Context context) {
+        RefLiteralPair innerPair = new RefLiteralPair(inner);
+        if (!innerPair.isValid()) {
+            return null;
+        }
+        if (innerPair.reference().valueType().equals(DataTypes.GEO_SHAPE)) {
+            // we have within('POINT(0 0)', shape_column)
+            return LuceneQueryBuilder.genericFunctionFilter(inner, context);
+        }
+        GeoPointFieldMapper.GeoPointFieldType geoPointFieldType = getGeoPointFieldType(
+            innerPair.reference().column().fqn(),
+            context.mapperService);
+
+        Map<String, Object> geoJSON = (Map<String, Object>) innerPair.input().value();
+        Geometry geometry;
+        Shape shape = GeoJSONUtils.map2Shape(geoJSON);
+        if (shape instanceof ShapeCollection) {
+            int i = 0;
+            ShapeCollection<Shape> collection = (ShapeCollection) shape;
+            com.vividsolutions.jts.geom.Polygon[] polygons = new com.vividsolutions.jts.geom.Polygon[collection.size()];
+            for (Shape s : collection.getShapes()) {
+                Geometry subGeometry = JtsSpatialContext.GEO.getShapeFactory().getGeometryFrom(s);
+                if (subGeometry instanceof com.vividsolutions.jts.geom.Polygon) {
+                    polygons[i++] = (com.vividsolutions.jts.geom.Polygon) subGeometry;
+                } else {
+                    throw new InvalidShapeException("Shape collection must contain only Polygon shapes.");
+                }
+            }
+            GeometryFactory geometryFactory = JtsSpatialContext.GEO.getShapeFactory().getGeometryFactory();
+            geometry = geometryFactory.createMultiPolygon(polygons);
+        } else {
+            geometry = JtsSpatialContext.GEO.getShapeFactory().getGeometryFrom(shape);
+        }
+
+        return getPolygonQuery(geometry, geoPointFieldType);
+    }
+
+    private static Query getPolygonQuery(Geometry geometry,
+                                         GeoPointFieldMapper.GeoPointFieldType fieldType) {
+        Coordinate[] coordinates = geometry.getCoordinates();
+        // close the polygon shape if startpoint != endpoint
+        if (!CoordinateArrays.isRing(coordinates)) {
+            coordinates = Arrays.copyOf(coordinates, coordinates.length + 1);
+            coordinates[coordinates.length - 1] = coordinates[0];
+        }
+
+        final double[] lats = new double[coordinates.length];
+        final double[] lons = new double[coordinates.length];
+        for (int i = 0; i < coordinates.length; i++) {
+            lats[i] = coordinates[i].y;
+            lons[i] = coordinates[i].x;
+        }
+
+        return LatLonPoint.newPolygonQuery(fieldType.name(), new Polygon(lats, lons));
+    }
+
+    private static GeoPointFieldMapper.GeoPointFieldType getGeoPointFieldType(String fieldName, MapperService mapperService) {
+        MappedFieldType fieldType = mapperService.fullName(fieldName);
+        if (fieldType == null) {
+            throw new IllegalArgumentException(String.format(Locale.ENGLISH, "column \"%s\" doesn't exist", fieldName));
+        }
+        if (!(fieldType instanceof GeoPointFieldMapper.GeoPointFieldType)) {
+            throw new IllegalArgumentException(String.format(Locale.ENGLISH, "column \"%s\" isn't of type geo_point", fieldName));
+        }
+        return (GeoPointFieldMapper.GeoPointFieldType) fieldType;
+    }
+
+    @Override
+    public Query apply(Function input, LuceneQueryBuilder.Context context) {
+        return getQuery(input, context);
+    }
+}

--- a/sql/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/sql/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -54,6 +54,7 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.Map;
 
+import static io.crate.lucene.LikeQueryBuilder.convertSqlLikeToLuceneWildcard;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -294,17 +295,17 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
 
     @Test
     public void testSqlLikeToLuceneWildcard() throws Exception {
-        assertThat(LuceneQueryBuilder.convertSqlLikeToLuceneWildcard("%\\\\%"), is("*\\\\*"));
-        assertThat(LuceneQueryBuilder.convertSqlLikeToLuceneWildcard("%\\\\_"), is("*\\\\?"));
-        assertThat(LuceneQueryBuilder.convertSqlLikeToLuceneWildcard("%\\%"), is("*%"));
+        assertThat(convertSqlLikeToLuceneWildcard("%\\\\%"), is("*\\\\*"));
+        assertThat(convertSqlLikeToLuceneWildcard("%\\\\_"), is("*\\\\?"));
+        assertThat(convertSqlLikeToLuceneWildcard("%\\%"), is("*%"));
 
-        assertThat(LuceneQueryBuilder.convertSqlLikeToLuceneWildcard("%me"), is("*me"));
-        assertThat(LuceneQueryBuilder.convertSqlLikeToLuceneWildcard("\\%me"), is("%me"));
-        assertThat(LuceneQueryBuilder.convertSqlLikeToLuceneWildcard("*me"), is("\\*me"));
+        assertThat(convertSqlLikeToLuceneWildcard("%me"), is("*me"));
+        assertThat(convertSqlLikeToLuceneWildcard("\\%me"), is("%me"));
+        assertThat(convertSqlLikeToLuceneWildcard("*me"), is("\\*me"));
 
-        assertThat(LuceneQueryBuilder.convertSqlLikeToLuceneWildcard("_me"), is("?me"));
-        assertThat(LuceneQueryBuilder.convertSqlLikeToLuceneWildcard("\\_me"), is("_me"));
-        assertThat(LuceneQueryBuilder.convertSqlLikeToLuceneWildcard("?me"), is("\\?me"));
+        assertThat(convertSqlLikeToLuceneWildcard("_me"), is("?me"));
+        assertThat(convertSqlLikeToLuceneWildcard("\\_me"), is("_me"));
+        assertThat(convertSqlLikeToLuceneWildcard("?me"), is("\\?me"));
     }
 
 


### PR DESCRIPTION
- Reduces the level of nesting inside the LuceneQueryBuilder.

 - Makes it clearer that those query components have a single
 responsibility and could be unit tested.

Some things can be moved around further to group related functionality. E.g. we've now `DistanceQueries` and `DinstanceQuery` which is related. I'll look into that in another commit / PR. This here is focused on extracting all static classes.


## checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed