### PR TITLE
Implement parsing for array(subquery) expressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ build/
 
 # intellij files
 .idea/
+.shelf/
 *.iml
 *.ipr
 *.iws

--- a/sql-parser/src/main/antlr/SqlBase.g4
+++ b/sql-parser/src/main/antlr/SqlBase.g4
@@ -244,6 +244,7 @@ primaryExpression
     | CASE valueExpression whenClause+ (ELSE elseExpr=expr)? END                     #simpleCase
     | CASE whenClause+ (ELSE elseExpr=expr)? END                                     #searchedCase
     | IF '('condition=expr ',' trueValue=expr (',' falseValue=expr)? ')'             #ifCase
+    | ARRAY subqueryExpression                                                       #arraySubquery
     ;
 
 parenthesizedPrimaryExpressionOrSubquery

--- a/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
+++ b/sql-parser/src/main/java/io/crate/sql/ExpressionFormatter.java
@@ -30,6 +30,7 @@ import io.crate.sql.tree.ArithmeticExpression;
 import io.crate.sql.tree.ArrayComparisonExpression;
 import io.crate.sql.tree.ArrayLikePredicate;
 import io.crate.sql.tree.ArrayLiteral;
+import io.crate.sql.tree.ArraySubQueryExpression;
 import io.crate.sql.tree.AstVisitor;
 import io.crate.sql.tree.BetweenPredicate;
 import io.crate.sql.tree.BooleanLiteral;
@@ -144,6 +145,14 @@ public final class ExpressionFormatter {
 
             builder.append(left + " " + type + " ANY(" + array + ")");
             return builder.toString();
+        }
+
+        @Override
+        public String visitArraySubQueryExpression(ArraySubQueryExpression node, Void context) {
+            StringBuilder builder = new StringBuilder();
+            String subqueryExpression = node.subqueryExpression().toString();
+
+            return builder.append("ARRAY(").append(subqueryExpression).append(")").toString();
         }
 
         @Override

--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -44,6 +44,7 @@ import io.crate.sql.tree.ArithmeticExpression;
 import io.crate.sql.tree.ArrayComparisonExpression;
 import io.crate.sql.tree.ArrayLikePredicate;
 import io.crate.sql.tree.ArrayLiteral;
+import io.crate.sql.tree.ArraySubQueryExpression;
 import io.crate.sql.tree.Assignment;
 import io.crate.sql.tree.BeginStatement;
 import io.crate.sql.tree.BetweenPredicate;
@@ -974,6 +975,11 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
     @Override
     public Node visitSelectSingle(SqlBaseParser.SelectSingleContext context) {
         return new SingleColumn((Expression) visit(context.expr()), getIdentText(context.ident()));
+    }
+
+    @Override
+    public Node visitArraySubquery(SqlBaseParser.ArraySubqueryContext ctx) {
+        return new ArraySubQueryExpression((SubqueryExpression) visit(ctx.subqueryExpression()));
     }
 
     /*

--- a/sql-parser/src/main/java/io/crate/sql/tree/ArraySubQueryExpression.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/ArraySubQueryExpression.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.sql.tree;
+
+import java.util.Objects;
+
+public class ArraySubQueryExpression extends Expression {
+
+    private final SubqueryExpression subqueryExpression;
+
+    public ArraySubQueryExpression(SubqueryExpression subqueryExpression) {
+        this.subqueryExpression = subqueryExpression;
+    }
+
+    public SubqueryExpression subqueryExpression() {
+        return subqueryExpression;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(subqueryExpression);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+        ArraySubQueryExpression that = (ArraySubQueryExpression) obj;
+        return Objects.equals(subqueryExpression, that.subqueryExpression);
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitArraySubQueryExpression(this, context);
+    }
+}

--- a/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
@@ -457,6 +457,10 @@ public abstract class AstVisitor<R, C> {
         return visitExpression(node, context);
     }
 
+    public R visitArraySubQueryExpression(ArraySubQueryExpression node, C context) {
+        return visitExpression(node, context);
+    }
+
     public R visitArrayLiteral(ArrayLiteral node, C context) {
         return visitLiteral(node, context);
     }

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -750,6 +750,28 @@ public class TestStatementBuilder {
     }
 
     @Test
+    public void testArrayConstructorSubSelectBuilder() throws Exception {
+        printStatement("select array(select foo from f1) from f2");
+        printStatement("select array(select * from f1) as array1 from f2");
+        printStatement("select count(*) from f1 where f1.array1 = array(select foo from f2)");
+    }
+
+
+    @Test
+    public void testArrayConstructorSubSelectBuilderNoParenthesisThrowsParsingException() throws Exception {
+        expectedException.expect(ParsingException.class);
+        expectedException.expectMessage(containsString("no viable alternative at input 'select array from'"));
+        printStatement("select array from f2");
+    }
+
+   @Test
+    public void testArrayConstructorSubSelectBuilderNoSubQueryThrowsParsingException() throws Exception {
+        expectedException.expect(ParsingException.class);
+        expectedException.expectMessage(containsString("no viable alternative at input 'select array()'"));
+        printStatement("select array() as array1 from f2");
+    }
+
+    @Test
     public void testTableFunctions() throws Exception {
         printStatement("select * from unnest([1, 2], ['Arthur', 'Marvin'])");
         printStatement("select * from unnest(?, ?)");


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Update parser grammar and add a new AST node: `ArraySubQueryExpression` for allowing parsing of the array(subquery) feature.

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
