### PR TITLE
Make getByPath implementations consistent

### DIFF
--- a/sql/src/main/java/io/crate/analyze/InsertFromValuesAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/InsertFromValuesAnalyzer.java
@@ -389,7 +389,7 @@ class InsertFromValuesAnalyzer extends AbstractInsertAnalyzer {
                             continue;
                         }
                         int pkIdx = primaryKey.indexOf(pkIdent);
-                        Object nestedValue = StringObjectMaps.fromMapByPath((Map) value, pkIdent.path());
+                        Object nestedValue = StringObjectMaps.getByPath((Map) value, pkIdent.path());
                         addPrimaryKeyValue(pkIdx, nestedValue, primaryKeyValues);
                     }
                 } else {
@@ -477,7 +477,7 @@ class InsertFromValuesAnalyzer extends AbstractInsertAnalyzer {
         if (columnValue != null && !columnIdent.equals(clusteredByIdent)) {
             // oh my gosh! A nested clustered by value!!!
             assert columnValue instanceof Map : "columnValue must be instance of Map";
-            columnValue = StringObjectMaps.fromMapByPath((Map) columnValue, clusteredByIdent.path());
+            columnValue = StringObjectMaps.getByPath((Map) columnValue, clusteredByIdent.path());
         }
         if (columnValue == null) {
             throw new IllegalArgumentException("Clustered by value must not be NULL");

--- a/sql/src/main/java/io/crate/expression/ValueExtractors.java
+++ b/sql/src/main/java/io/crate/expression/ValueExtractors.java
@@ -30,7 +30,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
-import static io.crate.core.collections.StringObjectMaps.fromMapByPath;
+import static io.crate.core.collections.StringObjectMaps.getByPath;
+
 
 public final class ValueExtractors {
 
@@ -74,7 +75,7 @@ public final class ValueExtractors {
         public Object apply(Map<String, Object> map) {
             Object m = map.get(column.name());
             if (m instanceof Map) {
-                return stringAsBytesRef(fromMapByPath((Map) m, column.path()));
+                return stringAsBytesRef(getByPath((Map) m, column.path()));
             }
             return null;
         }
@@ -93,7 +94,7 @@ public final class ValueExtractors {
         public Object apply(Row row) {
             Object o = row.get(idx);
             if (o instanceof Map) {
-                return stringAsBytesRef(fromMapByPath((Map) o, subscript));
+                return stringAsBytesRef(getByPath((Map) o, subscript));
             }
             return null;
         }

--- a/sql/src/main/java/io/crate/expression/reference/MapLookupByPathExpression.java
+++ b/sql/src/main/java/io/crate/expression/reference/MapLookupByPathExpression.java
@@ -48,7 +48,7 @@ public final class MapLookupByPathExpression<T, R> extends NestableCollectExpres
 
     @Override
     public void setNextRow(T row) {
-        value = castResultValue.apply(StringObjectMaps.fromMapByPath(getMap.apply(row), path));
+        value = castResultValue.apply(StringObjectMaps.getByPath(getMap.apply(row), path));
     }
 
     @Override


### PR DESCRIPTION
Previously one implementation aborted early if a key wasn't present in
the dictionary, returning the last value instead of null.

    getByPath({o: 1}, ["o", "x"]) --> returned 1 instead of null


As far as I can tell this wasn't an issue in practice. But this also de-duplicates the code a bit.




 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed