### PR TITLE
Fix table creation with generated columns inside objects

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -40,6 +40,8 @@ Breaking Changes
 Changes
 =======
 
+- Added support for using generated columns inside object columns.
+
 Fixes
 =====
 

--- a/sql/src/main/java/io/crate/metadata/GeneratedReference.java
+++ b/sql/src/main/java/io/crate/metadata/GeneratedReference.java
@@ -117,11 +117,8 @@ public class GeneratedReference extends Reference {
 
     @Override
     public String toString() {
-        return "GeneratedReference{" +
-               "formattedGeneratedExpression='" + formattedGeneratedExpression + '\'' +
-               ", generatedExpression=" + generatedExpression +
-               ", referencedReferences=" + referencedReferences +
-               '}';
+        return "Generated{" + column() + " AS " + formattedGeneratedExpression
+               + ", type=" + valueType() + '}';
     }
 
     @Override

--- a/sql/src/test/java/io/crate/execution/engine/collect/DocLevelCollectTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/DocLevelCollectTest.java
@@ -157,12 +157,12 @@ public class DocLevelCollectTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testCollectDocLevel() throws Throwable {
-        List<Symbol> toCollect = Arrays.asList(testDocLevelReference, underscoreRawReference, underscoreIdReference);
+        List<Symbol> toCollect = Arrays.asList(testDocLevelReference, underscoreIdReference);
         RoutedCollectPhase collectNode = getCollectNode(toCollect, WhereClause.MATCH_ALL);
         Bucket result = collect(collectNode);
         assertThat(result, containsInAnyOrder(
-            isRow(2, "{\"id\":1,\"doc\":2}", "1"),
-            isRow(4, "{\"id\":3,\"doc\":4}", "3")
+            isRow(2, "1"),
+            isRow(4, "3")
         ));
     }
 


### PR DESCRIPTION
Something like `create table t (obj object as (x as 1 + 1))` resulted in
a NPE because the generated columns of objects were not initialized,
causing them to have `null` as `dataType` and no formatted expression.

This also adapts the generated column injection logic to account for
nested columns. This has the side effect that `_raw` is no longer
deterministic. But the actual format of it should be considered an
implementation detail and not matter.

This is marked as change instead of a fix, because it will only go into
`3.1`. The scope of the changes is too large for a backport to `3.0`, so
`3.0` will receive a small fix that turns the `NPE` into a friendlier
error message.

Resolves https://github.com/crate/crate/issues/7642


 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed