### PR TITLE
use generic parser rules for priviliges statements

### DIFF
--- a/sql-parser/src/main/antlr/SqlBase.g4
+++ b/sql-parser/src/main/antlr/SqlBase.g4
@@ -78,15 +78,12 @@ statement
     | DROP USER (IF EXISTS)? name=ident                                              #dropUser
     | DROP INGEST RULE (IF EXISTS)? rule_name=ident                                  #dropIngestRule
     | DROP VIEW (IF EXISTS)? names=qnames                                            #dropView
-    | GRANT ( privilegeTypes | ALL (PRIVILEGES)? )
-      (ON clazz  ( qname (',' qname)* ))?
-      TO userNames                                                                   #grantPrivilege
-    | DENY ( privilegeTypes | ALL (PRIVILEGES)? )
-      (ON clazz  ( qname (',' qname)* ))?
-      TO userNames                                                                   #denyPrivilege
-    | REVOKE ( privilegeTypes | ALL (PRIVILEGES)? )
-      (ON clazz   ( qname (',' qname)* ))?
-      FROM userNames                                                                 #revokePrivilege
+    | GRANT (priviliges=idents | ALL PRIVILEGES?)
+        (ON clazz qnames)? TO users=idents                                           #grantPrivilege
+    | DENY (priviliges=idents | ALL PRIVILEGES?)
+        (ON clazz qnames)? TO users=idents                                           #denyPrivilege
+    | REVOKE (privileges=idents | ALL PRIVILEGES?)
+        (ON clazz qnames)? FROM users=idents                                         #revokePrivilege
     | createStmt                                                                     #create
     | DEALLOCATE (PREPARE)? (ALL | prepStmt=stringLiteralOrIdentifierOrQname)        #deallocate
     ;
@@ -177,10 +174,6 @@ aliasedColumns
 
 expr
     : booleanExpression
-    ;
-
-privilegeTypes
-    : ident (',' ident)*
     ;
 
 booleanExpression
@@ -336,6 +329,10 @@ qnames
 
 qname
     : ident ('.' ident)*
+    ;
+
+idents
+    : ident (',' ident)*
     ;
 
 ident
@@ -598,10 +595,6 @@ setExpr
 
 on
     : ON
-    ;
-
-userNames
-    : ( ident (',' ident)* )
     ;
 
 clazz

--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -304,36 +304,45 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
 
     @Override
     public Node visitGrantPrivilege(SqlBaseParser.GrantPrivilegeContext context) {
-        List<String> usernames = identsToStrings(context.userNames().ident());
-        ClassAndIdent clazzAndIdent = getClassAndIdentsForPrivileges((context.ON() == null), context.clazz(), context.qname());
+        List<String> usernames = identsToStrings(context.users.ident());
+        ClassAndIdent clazzAndIdent = getClassAndIdentsForPrivileges(
+            context.ON() == null,
+            context.clazz(),
+            context.qnames());
         if (context.ALL() != null) {
             return new GrantPrivilege(usernames, clazzAndIdent.clazz, clazzAndIdent.idents);
         } else {
-            List<String> privilegeTypes = identsToStrings(context.privilegeTypes().ident());
+            List<String> privilegeTypes = identsToStrings(context.priviliges.ident());
             return new GrantPrivilege(usernames, privilegeTypes, clazzAndIdent.clazz, clazzAndIdent.idents);
         }
     }
 
     @Override
     public Node visitDenyPrivilege(SqlBaseParser.DenyPrivilegeContext context) {
-        List<String> usernames = identsToStrings(context.userNames().ident());
-        ClassAndIdent clazzAndIdent = getClassAndIdentsForPrivileges((context.ON() == null), context.clazz(), context.qname());
+        List<String> usernames = identsToStrings(context.users.ident());
+        ClassAndIdent clazzAndIdent = getClassAndIdentsForPrivileges(
+            context.ON() == null,
+            context.clazz(),
+            context.qnames());
         if (context.ALL() != null) {
             return new DenyPrivilege(usernames, clazzAndIdent.clazz, clazzAndIdent.idents);
         } else {
-            List<String> privilegeTypes = identsToStrings(context.privilegeTypes().ident());
+            List<String> privilegeTypes = identsToStrings(context.priviliges.ident());
             return new DenyPrivilege(usernames, privilegeTypes, clazzAndIdent.clazz, clazzAndIdent.idents);
         }
     }
 
     @Override
     public Node visitRevokePrivilege(SqlBaseParser.RevokePrivilegeContext context) {
-        List<String> usernames = identsToStrings(context.userNames().ident());
-        ClassAndIdent clazzAndIdent = getClassAndIdentsForPrivileges((context.ON() == null), context.clazz(), context.qname());
+        List<String> usernames = identsToStrings(context.users.ident());
+        ClassAndIdent clazzAndIdent = getClassAndIdentsForPrivileges(
+            context.ON() == null,
+            context.clazz(),
+            context.qnames());
         if (context.ALL() != null) {
             return new RevokePrivilege(usernames, clazzAndIdent.clazz, clazzAndIdent.idents);
         } else {
-            List<String> privilegeTypes = identsToStrings(context.privilegeTypes().ident());
+            List<String> privilegeTypes = identsToStrings(context.privileges.ident());
             return new RevokePrivilege(usernames, privilegeTypes, clazzAndIdent.clazz, clazzAndIdent.idents);
         }
     }
@@ -1726,11 +1735,11 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
 
     private ClassAndIdent getClassAndIdentsForPrivileges(boolean onCluster,
                                                          SqlBaseParser.ClazzContext clazz,
-                                                         List<SqlBaseParser.QnameContext> qname) {
+                                                         SqlBaseParser.QnamesContext qnamesContext) {
         if (onCluster) {
             return new ClassAndIdent(CLUSTER, Collections.emptyList());
         } else {
-            return new ClassAndIdent(getClazz(clazz.getStart()), getIdents(qname));
+            return new ClassAndIdent(getClazz(clazz.getStart()), getIdents(qnamesContext.qname()));
         }
     }
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

There is no benefit in using special parser rules in this case,
such as we do not use any visitors for them and access them via context.

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
