### PR TITLE
Remove a SessionContext constructor overload

### DIFF
--- a/sql/src/main/java/io/crate/action/sql/SQLOperations.java
+++ b/sql/src/main/java/io/crate/action/sql/SQLOperations.java
@@ -28,7 +28,6 @@ import io.crate.auth.user.StatementAuthorizedValidator;
 import io.crate.auth.user.User;
 import io.crate.auth.user.UserManager;
 import io.crate.execution.engine.collect.stats.JobsLogs;
-import io.crate.metadata.sys.SysSchemaInfo;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Planner;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -41,8 +40,6 @@ import org.elasticsearch.transport.NodeDisconnectedException;
 
 import javax.annotation.Nullable;
 import java.util.Set;
-
-import static io.crate.auth.user.User.CRATE_USER;
 
 
 @Singleton
@@ -93,24 +90,11 @@ public class SQLOperations {
     }
 
     public Session newSystemSession() {
-        return createSession(new SessionContext(
-            CRATE_USER,
-            userManager.getStatementValidator(CRATE_USER, SysSchemaInfo.NAME),
-            userManager.getExceptionValidator(CRATE_USER, SysSchemaInfo.NAME),
-            SysSchemaInfo.NAME)
-        );
+        return createSession(SessionContext.systemSessionContext());
     }
 
     public Session createSession(@Nullable String defaultSchema, User user) {
-        StatementAuthorizedValidator statementValidator = userManager.getStatementValidator(user, defaultSchema);
-        ExceptionAuthorizedValidator exceptionValidator = userManager.getExceptionValidator(user, defaultSchema);
-        SessionContext sessionContext;
-        if (defaultSchema == null) {
-            sessionContext = new SessionContext(user, statementValidator, exceptionValidator);
-        } else {
-            sessionContext = new SessionContext(user, statementValidator, exceptionValidator, defaultSchema);
-        }
-        return createSession(sessionContext);
+        return createSession(defaultSchema, user, Option.NONE, 0);
     }
 
     public Session createSession(@Nullable String defaultSchema, User user, Set<Option> options, int defaultLimit) {

--- a/sql/src/main/java/io/crate/action/sql/SessionContext.java
+++ b/sql/src/main/java/io/crate/action/sql/SessionContext.java
@@ -54,15 +54,6 @@ public class SessionContext implements StatementAuthorizedValidator, ExceptionAu
         return new SessionContext(0, Option.NONE, User.CRATE_USER, s -> { }, e -> { });
     }
 
-    public SessionContext(User user,
-                          StatementAuthorizedValidator statementAuthorizedValidator,
-                          ExceptionAuthorizedValidator exceptionAuthorizedValidator,
-                          String... searchPath) {
-        this(0, Option.NONE, user,
-            statementAuthorizedValidator, exceptionAuthorizedValidator, searchPath);
-
-    }
-
     public SessionContext(int defaultLimit,
                           Set<Option> options,
                           User user,

--- a/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SQLTransportIntegrationTest.java
@@ -432,7 +432,8 @@ public abstract class SQLTransportIntegrationTest extends ESIntegTestCase {
         Planner planner = internalCluster().getInstance(Planner.class, nodeName);
 
         ParameterContext parameterContext = new ParameterContext(Row.EMPTY, Collections.<Row>emptyList());
-        SessionContext sessionContext = new SessionContext(User.CRATE_USER, x -> {}, x -> {}, sqlExecutor.getDefaultSchema());
+        SessionContext sessionContext = new SessionContext(
+            0, Option.NONE, User.CRATE_USER, x -> {}, x -> {}, sqlExecutor.getDefaultSchema());
         TransactionContext transactionContext = new TransactionContext(sessionContext);
         RoutingProvider routingProvider = new RoutingProvider(Randomness.get().nextInt(), planner.getAwarenessAttributes());
         PlannerContext plannerContext = new PlannerContext(

--- a/sql/src/test/java/io/crate/metadata/settings/session/SessionSettingRegistryTest.java
+++ b/sql/src/test/java/io/crate/metadata/settings/session/SessionSettingRegistryTest.java
@@ -23,7 +23,6 @@
 package io.crate.metadata.settings.session;
 
 import io.crate.action.sql.SessionContext;
-import io.crate.auth.user.User;
 import io.crate.data.Row;
 import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.StringLiteral;
@@ -41,14 +40,14 @@ public class SessionSettingRegistryTest {
 
     @Test
     public void testSemiJoinSessionSetting() {
-        SessionContext sessionContext = new SessionContext(User.CRATE_USER, x -> {}, x -> {});
+        SessionContext sessionContext = SessionContext.systemSessionContext();
         SessionSettingApplier applier = SessionSettingRegistry.getApplier(SessionSettingRegistry.SEMI_JOIN_KEY);
         assertBooleanNonEmptySetting(sessionContext, sessionContext::getSemiJoinsRewriteEnabled, applier, false);
     }
 
     @Test
     public void testHashJoinSessionSetting() {
-        SessionContext sessionContext = new SessionContext(User.CRATE_USER, x -> {}, x -> {});
+        SessionContext sessionContext = SessionContext.systemSessionContext();
         SessionSettingApplier applier = SessionSettingRegistry.getApplier(SessionSettingRegistry.HASH_JOIN_KEY);
         assertBooleanNonEmptySetting(sessionContext, sessionContext::isHashJoinEnabled, applier, true);
     }

--- a/sql/src/test/java/io/crate/testing/SQLExecutor.java
+++ b/sql/src/test/java/io/crate/testing/SQLExecutor.java
@@ -24,6 +24,7 @@ package io.crate.testing;
 
 import com.google.common.base.Preconditions;
 import io.crate.Constants;
+import io.crate.action.sql.Option;
 import io.crate.action.sql.SessionContext;
 import io.crate.analyze.Analysis;
 import io.crate.analyze.AnalyzedStatement;
@@ -363,7 +364,7 @@ public class SQLExecutor {
                     tableStats
                 ),
                 relationAnalyzer,
-                new SessionContext(user, s -> {}, t -> {}, searchPath),
+                new SessionContext(0, Option.NONE, user, s -> {}, t -> {}, searchPath),
                 schemas,
                 random
             );

--- a/sql/src/test/java/io/crate/testing/SqlExpressions.java
+++ b/sql/src/test/java/io/crate/testing/SqlExpressions.java
@@ -22,6 +22,7 @@
 
 package io.crate.testing;
 
+import io.crate.action.sql.Option;
 import io.crate.action.sql.SessionContext;
 import io.crate.analyze.ParamTypeHints;
 import io.crate.analyze.ParameterContext;
@@ -94,7 +95,7 @@ public class SqlExpressions {
         }
         injector = modulesBuilder.createInjector();
         functions = injector.getInstance(Functions.class);
-        transactionContext = new TransactionContext(new SessionContext(user, s -> {}, e -> {}));
+        transactionContext = new TransactionContext(new SessionContext(0, Option.NONE, user, s -> {}, e -> {}));
         expressionAnalyzer = new ExpressionAnalyzer(
             functions,
             transactionContext,


### PR DESCRIPTION
The constructor was mostly for testing convenience and the defaults for
`option` and `defaultLimit` were in two places. (Session and
SessionContext). This removes them from SessionContext





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed