### PR TITLE
Encapsulate function lookup logic within Functions

### DIFF
--- a/app/src/test/java/io/crate/plugin/PluginLoaderTest.java
+++ b/app/src/test/java/io/crate/plugin/PluginLoaderTest.java
@@ -92,16 +92,14 @@ public class PluginLoaderTest extends ESIntegTestCase {
         assertThat(pluginLoader.plugins.get(0).getClass().getCanonicalName(), is("io.crate.plugin.ExamplePlugin"));
 
         Functions functions = internalCluster().getInstance(Functions.class);
-        assertThat(functions.getBuiltin("is_even", Collections.singletonList(DataTypes.LONG)).info(),
-                   is(new FunctionInfo(
-                       new FunctionIdent("is_even", Collections.singletonList(DataTypes.LONG)),
-                       DataTypes.BOOLEAN)));
+        FunctionIdent isEven = new FunctionIdent("is_even", Collections.singletonList(DataTypes.LONG));
+        assertThat(functions.getQualified(isEven).info(),
+                   is(new FunctionInfo( isEven, DataTypes.BOOLEAN)));
 
         // Also check that the built-in functions are not lost
-        assertThat(functions.getBuiltin("abs", Collections.singletonList(DataTypes.LONG)).info(),
-                   is(new FunctionInfo(
-                       new FunctionIdent("abs", Collections.singletonList(DataTypes.LONG)),
-                       DataTypes.LONG)));
+        FunctionIdent abs = new FunctionIdent("abs", Collections.singletonList(DataTypes.LONG));
+        assertThat(functions.getQualified(abs).info(),
+                   is(new FunctionInfo(abs, DataTypes.LONG)));
     }
 
     @Test

--- a/benchmarks/src/test/java/io/crate/execution/engine/aggregation/AggregateCollectorBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/execution/engine/aggregation/AggregateCollectorBenchmark.java
@@ -22,13 +22,14 @@
 
 package io.crate.execution.engine.aggregation;
 
-import io.crate.expression.symbol.AggregateMode;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.data.Row1;
 import io.crate.execution.engine.aggregation.impl.SumAggregation;
 import io.crate.execution.engine.collect.InputCollectExpression;
+import io.crate.expression.symbol.AggregateMode;
+import io.crate.metadata.FunctionIdent;
 import io.crate.types.DataTypes;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
@@ -65,8 +66,8 @@ public class AggregateCollectorBenchmark {
     @Setup
     public void setup() {
         InputCollectExpression inExpr0 = new InputCollectExpression(0);
-        SumAggregation sumAggregation = ((SumAggregation) getFunctions().getBuiltin(
-            SumAggregation.NAME, Collections.singletonList(DataTypes.INTEGER)));
+        SumAggregation sumAggregation = ((SumAggregation) getFunctions().getQualified(
+            new FunctionIdent(SumAggregation.NAME, Collections.singletonList(DataTypes.INTEGER))));
         collector = new AggregateCollector(
             Collections.singletonList(inExpr0),
             RAM_ACCOUNTING_CONTEXT,

--- a/benchmarks/src/test/java/io/crate/execution/engine/aggregation/GroupingBytesRefCollectorBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/execution/engine/aggregation/GroupingBytesRefCollectorBenchmark.java
@@ -22,7 +22,6 @@
 
 package io.crate.execution.engine.aggregation;
 
-import io.crate.expression.symbol.AggregateMode;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.data.BatchIterator;
 import io.crate.data.BatchIterators;
@@ -32,9 +31,11 @@ import io.crate.data.Row;
 import io.crate.data.Row1;
 import io.crate.execution.engine.aggregation.impl.AggregationImplModule;
 import io.crate.execution.engine.aggregation.impl.MinimumAggregation;
-import io.crate.metadata.Functions;
 import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.execution.engine.collect.InputCollectExpression;
+import io.crate.expression.symbol.AggregateMode;
+import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.Functions;
 import io.crate.types.DataTypes;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.Version;
@@ -94,8 +95,8 @@ public class GroupingBytesRefCollectorBenchmark {
         List<Input<?>> keyInputs = Collections.singletonList(keyInput);
         CollectExpression[] collectExpressions = new CollectExpression[]{keyInput};
 
-        AggregationFunction minAgg =
-            (AggregationFunction) functions.getBuiltin(MinimumAggregation.NAME, Collections.singletonList(DataTypes.STRING));
+        AggregationFunction minAgg = (AggregationFunction) functions.getQualified(
+                new FunctionIdent(MinimumAggregation.NAME, Collections.singletonList(DataTypes.STRING)));
 
         return GroupingCollector.singleKey(
             collectExpressions,

--- a/benchmarks/src/test/java/io/crate/execution/engine/aggregation/GroupingLongCollectorBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/execution/engine/aggregation/GroupingLongCollectorBenchmark.java
@@ -34,6 +34,7 @@ import io.crate.execution.engine.aggregation.impl.SumAggregation;
 import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.execution.engine.collect.InputCollectExpression;
 import io.crate.expression.symbol.AggregateMode;
+import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.Functions;
 import io.crate.types.DataTypes;
 import org.elasticsearch.Version;
@@ -74,8 +75,8 @@ public class GroupingLongCollectorBenchmark {
     public void createGroupingCollector() {
         Functions functions = new ModulesBuilder().add(new AggregationImplModule())
             .createInjector().getInstance(Functions.class);
-        AggregationFunction sumAgg =
-            (AggregationFunction) functions.getBuiltin(SumAggregation.NAME, Arrays.asList(DataTypes.INTEGER));
+        AggregationFunction sumAgg = (AggregationFunction) functions.getQualified(
+            new FunctionIdent(SumAggregation.NAME, Arrays.asList(DataTypes.INTEGER)));
         groupBySumCollector = createGroupBySumCollector(sumAgg);
         groupBySumSingleLongCollector = createOptimizedCollector(sumAgg);
 

--- a/benchmarks/src/test/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationBenchmark.java
+++ b/benchmarks/src/test/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationBenchmark.java
@@ -22,17 +22,17 @@
 
 package io.crate.operation.aggregation;
 
-import io.crate.data.RowN;
-import io.crate.expression.symbol.AggregateMode;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.data.Row1;
+import io.crate.execution.engine.aggregation.AggregateCollector;
 import io.crate.execution.engine.aggregation.AggregationFunction;
+import io.crate.execution.engine.collect.InputCollectExpression;
+import io.crate.expression.symbol.AggregateMode;
+import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.Functions;
 import io.crate.module.HyperLogLogModule;
-import io.crate.execution.engine.collect.InputCollectExpression;
-import io.crate.execution.engine.aggregation.AggregateCollector;
 import io.crate.types.DataTypes;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.Version;
@@ -78,8 +78,8 @@ public class HyperLogLogDistinctAggregationBenchmark {
         Functions functions = new ModulesBuilder()
             .add(new HyperLogLogModule())
             .createInjector().getInstance(Functions.class);
-        HyperLogLogDistinctAggregation hllAggregation = ((HyperLogLogDistinctAggregation) functions.getBuiltin(
-            HyperLogLogDistinctAggregation.NAME, Collections.singletonList(DataTypes.STRING)));
+        HyperLogLogDistinctAggregation hllAggregation = ((HyperLogLogDistinctAggregation) functions.getQualified(
+            new FunctionIdent(HyperLogLogDistinctAggregation.NAME, Collections.singletonList(DataTypes.STRING))));
         collector = new AggregateCollector(
             Collections.singletonList(inExpr0),
             RAM_ACCOUNTING_CONTEXT,

--- a/enterprise/hll/src/test/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationTest.java
+++ b/enterprise/hll/src/test/java/io/crate/operation/aggregation/HyperLogLogDistinctAggregationTest.java
@@ -20,6 +20,8 @@ package io.crate.operation.aggregation;
 
 import com.google.common.collect.ImmutableList;
 import io.crate.Streamer;
+import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.Functions;
 import io.crate.module.HyperLogLogModule;
 import io.crate.types.DataType;
@@ -49,8 +51,7 @@ public class HyperLogLogDistinctAggregationTest extends AggregationTest {
     }
 
     private Object[][] executeAggregation(DataType dataType, Object[][] data) throws Exception {
-        return executeAggregation(HyperLogLogDistinctAggregation.NAME, dataType, data,
-            Collections.singletonList(dataType));
+        return executeAggregation(HyperLogLogDistinctAggregation.NAME, dataType, data, Collections.singletonList(dataType));
     }
 
     private Object[][] executeAggregationWithPrecision(DataType dataType, Object[][] data) throws Exception {
@@ -73,10 +74,12 @@ public class HyperLogLogDistinctAggregationTest extends AggregationTest {
     @Test
     public void testReturnTypeIsAlwaysLong() {
         // Return type is fixed to Long
-        assertEquals(DataTypes.LONG,
-            functions.getBuiltin(HyperLogLogDistinctAggregation.NAME, ImmutableList.of(DataTypes.INTEGER)).info().returnType());
-        assertEquals(DataTypes.LONG,
-            functions.getBuiltin(HyperLogLogDistinctAggregation.NAME, ImmutableList.of(DataTypes.INTEGER, DataTypes.INTEGER)).info().returnType());
+        FunctionImplementation func = functions.getQualified(
+            new FunctionIdent(HyperLogLogDistinctAggregation.NAME, ImmutableList.of(DataTypes.INTEGER)));
+        assertEquals(DataTypes.LONG, func.info().returnType());
+        func = functions.getQualified(
+            new FunctionIdent(HyperLogLogDistinctAggregation.NAME, ImmutableList.of(DataTypes.INTEGER, DataTypes.INTEGER)));
+        assertEquals(DataTypes.LONG, func.info().returnType());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/analyze/EvaluatingNormalizerTest.java
+++ b/sql/src/test/java/io/crate/analyze/EvaluatingNormalizerTest.java
@@ -2,25 +2,26 @@ package io.crate.analyze;
 
 import com.google.common.collect.ImmutableList;
 import io.crate.action.sql.SessionContext;
-import io.crate.expression.eval.EvaluatingNormalizer;
-import io.crate.expression.symbol.Function;
-import io.crate.expression.symbol.Literal;
-import io.crate.expression.symbol.Symbol;
-import io.crate.metadata.ClusterReferenceResolver;
-import io.crate.metadata.FunctionInfo;
-import io.crate.metadata.Functions;
-import io.crate.metadata.Reference;
-import io.crate.metadata.ReferenceIdent;
 import io.crate.expression.NestableInput;
-import io.crate.metadata.RelationName;
-import io.crate.metadata.RowGranularity;
-import io.crate.metadata.Schemas;
-import io.crate.metadata.TransactionContext;
+import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.operator.AndOperator;
 import io.crate.expression.operator.EqOperator;
 import io.crate.expression.operator.OrOperator;
 import io.crate.expression.predicate.NotPredicate;
 import io.crate.expression.reference.LiteralNestableInput;
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.Literal;
+import io.crate.expression.symbol.Symbol;
+import io.crate.metadata.ClusterReferenceResolver;
+import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.Functions;
+import io.crate.metadata.Reference;
+import io.crate.metadata.ReferenceIdent;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.RowGranularity;
+import io.crate.metadata.Schemas;
+import io.crate.metadata.TransactionContext;
 import io.crate.test.integration.CrateUnitTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -118,13 +119,13 @@ public class EvaluatingNormalizerTest extends CrateUnitTest {
     }
 
     private FunctionInfo functionInfo(String name, DataType dataType, boolean isPredicate) {
-        ImmutableList dataTypes = null;
+        ImmutableList<DataType> dataTypes;
         if (isPredicate) {
             dataTypes = ImmutableList.of(dataType);
         } else {
             dataTypes = ImmutableList.of(dataType, dataType);
         }
-        return functions.getBuiltin(name, dataTypes).info();
+        return functions.getQualified(new FunctionIdent(name, dataTypes)).info();
     }
 
     private FunctionInfo functionInfo(String name, DataType dataType) {

--- a/sql/src/test/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregationTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/aggregation/impl/ArbitraryAggregationTest.java
@@ -22,6 +22,9 @@
 package io.crate.execution.engine.aggregation.impl;
 
 import com.google.common.collect.ImmutableList;
+import io.crate.expression.symbol.Value;
+import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.SearchPath;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -38,8 +41,9 @@ public class ArbitraryAggregationTest extends AggregationTest {
 
     @Test
     public void testReturnType() throws Exception {
-        assertEquals(DataTypes.INTEGER,
-            functions.getBuiltin("arbitrary", ImmutableList.of(DataTypes.INTEGER)).info().returnType());
+        FunctionImplementation arbitrary = functions.get(
+            null, "arbitrary", ImmutableList.of(new Value(DataTypes.INTEGER)), SearchPath.pathWithPGCatalogAndDoc());
+        assertEquals(DataTypes.INTEGER, arbitrary.info().returnType());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/execution/engine/aggregation/impl/AverageAggregationTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/aggregation/impl/AverageAggregationTest.java
@@ -22,6 +22,9 @@
 package io.crate.execution.engine.aggregation.impl;
 
 import com.google.common.collect.ImmutableList;
+import io.crate.expression.symbol.Value;
+import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.SearchPath;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -36,8 +39,13 @@ public class AverageAggregationTest extends AggregationTest {
     @Test
     public void testReturnType() throws Exception {
         // Return type is fixed to Double
-        assertEquals(DataTypes.DOUBLE, functions.getBuiltin("avg", ImmutableList.of(DataTypes.INTEGER)).info().returnType());
-        assertEquals(DataTypes.DOUBLE, functions.getBuiltin("mean", ImmutableList.of(DataTypes.INTEGER)).info().returnType());
+        assertEquals(DataTypes.DOUBLE, getFunction("avg").info().returnType());
+        assertEquals(DataTypes.DOUBLE, getFunction("mean").info().returnType());
+    }
+
+    private FunctionImplementation getFunction(String name) {
+        return functions.get(
+            null, name, ImmutableList.of(new Value(DataTypes.INTEGER)), SearchPath.pathWithPGCatalogAndDoc());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregationTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/aggregation/impl/CollectSetAggregationTest.java
@@ -23,6 +23,9 @@ package io.crate.execution.engine.aggregation.impl;
 
 import com.google.common.collect.ImmutableList;
 import io.crate.execution.engine.aggregation.AggregationFunction;
+import io.crate.expression.symbol.Value;
+import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.SearchPath;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -45,8 +48,9 @@ public class CollectSetAggregationTest extends AggregationTest {
 
     @Test
     public void testReturnType() throws Exception {
-        assertEquals(new SetType(DataTypes.INTEGER),
-            functions.getBuiltin("collect_set", ImmutableList.of(DataTypes.INTEGER)).info().returnType());
+        FunctionImplementation collectSet = functions.get(
+            null, "collect_set", ImmutableList.of(new Value(DataTypes.INTEGER)), SearchPath.pathWithPGCatalogAndDoc());
+        assertEquals(new SetType(DataTypes.INTEGER), collectSet.info().returnType());
     }
 
     @Test
@@ -60,8 +64,8 @@ public class CollectSetAggregationTest extends AggregationTest {
 
     @Test
     public void testLongSerialization() throws Exception {
-        AggregationFunction impl
-            = (AggregationFunction) functions.getBuiltin("collect_set", ImmutableList.of(DataTypes.LONG));
+        AggregationFunction impl = (AggregationFunction) functions.get(
+                null, "collect_set", ImmutableList.of(new Value(DataTypes.LONG)), SearchPath.pathWithPGCatalogAndDoc());
 
         Object state = impl.newState(ramAccountingContext, Version.CURRENT, BigArrays.NON_RECYCLING_INSTANCE);
 

--- a/sql/src/test/java/io/crate/execution/engine/aggregation/impl/CountAggregationTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/aggregation/impl/CountAggregationTest.java
@@ -23,6 +23,9 @@ package io.crate.execution.engine.aggregation.impl;
 
 import com.google.common.collect.ImmutableList;
 import io.crate.Streamer;
+import io.crate.expression.symbol.Value;
+import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.SearchPath;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -42,8 +45,12 @@ public class CountAggregationTest extends AggregationTest {
     @Test
     public void testReturnType() throws Exception {
         // Return type is fixed to Long
-        assertEquals(DataTypes.LONG,
-            functions.getBuiltin("count", ImmutableList.of(DataTypes.INTEGER)).info().returnType());
+        assertEquals(DataTypes.LONG, getCount().info().returnType());
+    }
+
+    private FunctionImplementation getCount() {
+        return functions.get(
+            null, "count", ImmutableList.of(new Value(DataTypes.INTEGER)), SearchPath.pathWithPGCatalogAndDoc());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregationtest.java
+++ b/sql/src/test/java/io/crate/execution/engine/aggregation/impl/GeometricMeanAggregationtest.java
@@ -23,6 +23,9 @@ package io.crate.execution.engine.aggregation.impl;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import io.crate.expression.symbol.Value;
+import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.SearchPath;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -41,8 +44,13 @@ public class GeometricMeanAggregationtest extends AggregationTest {
         for (DataType<?> type : Iterables.concat(DataTypes.NUMERIC_PRIMITIVE_TYPES, Arrays.asList(DataTypes.TIMESTAMP))) {
             // Return type is fixed to Double
             assertEquals(DataTypes.DOUBLE,
-                functions.getBuiltin("geometric_mean", ImmutableList.of(type)).info().returnType());
+                getGeometricMean(type).info().returnType());
         }
+    }
+
+    private FunctionImplementation getGeometricMean(DataType<?> type) {
+        return functions.get(
+            null, "geometric_mean", ImmutableList.of(new Value(type)), SearchPath.pathWithPGCatalogAndDoc());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/execution/engine/aggregation/impl/MaximumAggregationTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/aggregation/impl/MaximumAggregationTest.java
@@ -22,6 +22,8 @@
 package io.crate.execution.engine.aggregation.impl;
 
 import com.google.common.collect.ImmutableList;
+import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.FunctionImplementation;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -36,7 +38,8 @@ public class MaximumAggregationTest extends AggregationTest {
 
     @Test
     public void testReturnType() throws Exception {
-        assertEquals(DataTypes.INTEGER, functions.getBuiltin("max", ImmutableList.of(DataTypes.INTEGER)).info().returnType());
+        FunctionImplementation max = functions.getQualified(new FunctionIdent("max", ImmutableList.of(DataTypes.INTEGER)));
+        assertEquals(DataTypes.INTEGER, max.info().returnType());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/execution/engine/aggregation/impl/MinimumAggregationTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/aggregation/impl/MinimumAggregationTest.java
@@ -22,6 +22,8 @@
 package io.crate.execution.engine.aggregation.impl;
 
 import com.google.common.collect.ImmutableList;
+import io.crate.metadata.FunctionIdent;
+import io.crate.metadata.FunctionImplementation;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -36,8 +38,8 @@ public class MinimumAggregationTest extends AggregationTest {
 
     @Test
     public void testReturnType() throws Exception {
-        assertEquals(DataTypes.INTEGER,
-            functions.getBuiltin("min", ImmutableList.of(DataTypes.INTEGER)).info().returnType());
+        FunctionImplementation min = functions.getQualified(new FunctionIdent("min", ImmutableList.of(DataTypes.INTEGER)));
+        assertEquals(DataTypes.INTEGER, min.info().returnType());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/execution/engine/aggregation/impl/PercentileAggregationTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/aggregation/impl/PercentileAggregationTest.java
@@ -25,8 +25,7 @@ import com.google.common.collect.ImmutableList;
 import io.crate.breaker.RamAccountingContext;
 import io.crate.execution.engine.aggregation.AggregationFunction;
 import io.crate.expression.symbol.Literal;
-import io.crate.metadata.FunctionImplementation;
-import io.crate.metadata.FunctionInfo;
+import io.crate.metadata.FunctionIdent;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.ArrayType;
 import io.crate.types.DataType;
@@ -42,7 +41,6 @@ import java.util.Arrays;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.mockito.Mockito.mock;
 
 public class PercentileAggregationTest extends AggregationTest {
 
@@ -63,10 +61,10 @@ public class PercentileAggregationTest extends AggregationTest {
 
     @Before
     public void initFunctions() throws Exception {
-        singleArgPercentile = (PercentileAggregation) functions.getBuiltin(
-            NAME, Arrays.asList(DataTypes.DOUBLE, DataTypes.DOUBLE));
-        arraysPercentile = (PercentileAggregation) functions.getBuiltin(
-            NAME, Arrays.asList(DataTypes.DOUBLE, new ArrayType(DataTypes.DOUBLE)));
+        singleArgPercentile = (PercentileAggregation) functions.getQualified(
+            new FunctionIdent(NAME, Arrays.asList(DataTypes.DOUBLE, DataTypes.DOUBLE)));
+        arraysPercentile = (PercentileAggregation) functions.getQualified(
+            new FunctionIdent(NAME, Arrays.asList(DataTypes.DOUBLE, new ArrayType(DataTypes.DOUBLE))));
     }
 
     @Test
@@ -198,8 +196,8 @@ public class PercentileAggregationTest extends AggregationTest {
     @Test
     public void testSingleItemFractionsArgumentResultsInArrayResult() {
         ArrayType doubleArray = new ArrayType(DataTypes.DOUBLE);
-        AggregationFunction impl = (AggregationFunction<?, ?>) functions.getBuiltin(
-            NAME, Arrays.asList(DataTypes.LONG, doubleArray));
+        AggregationFunction impl = (AggregationFunction<?, ?>) functions.getQualified(
+            new FunctionIdent(NAME, Arrays.asList(DataTypes.LONG, doubleArray)));
 
         RamAccountingContext memoryCtx = new RamAccountingContext("dummy", new NoopCircuitBreaker("dummy"));
         Object state = impl.newState(memoryCtx, Version.CURRENT, BigArrays.NON_RECYCLING_INSTANCE);

--- a/sql/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevAggregationTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/aggregation/impl/StdDevAggregationTest.java
@@ -23,6 +23,9 @@ package io.crate.execution.engine.aggregation.impl;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import io.crate.expression.symbol.Value;
+import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.SearchPath;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -40,7 +43,9 @@ public class StdDevAggregationTest extends AggregationTest {
     public void testReturnType() throws Exception {
         for (DataType<?> type : Iterables.concat(DataTypes.NUMERIC_PRIMITIVE_TYPES, Arrays.asList(DataTypes.TIMESTAMP))) {
             // Return type is fixed to Double
-            assertEquals(DataTypes.DOUBLE, functions.getBuiltin("stddev", ImmutableList.of(type)).info().returnType());
+            FunctionImplementation stddev = functions.get(
+                null, "stddev", ImmutableList.of(new Value(type)), SearchPath.pathWithPGCatalogAndDoc());
+            assertEquals(DataTypes.DOUBLE, stddev.info().returnType());
         }
     }
 

--- a/sql/src/test/java/io/crate/execution/engine/aggregation/impl/SumAggregationTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/aggregation/impl/SumAggregationTest.java
@@ -22,6 +22,9 @@
 package io.crate.execution.engine.aggregation.impl;
 
 import com.google.common.collect.ImmutableList;
+import io.crate.expression.symbol.Value;
+import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.SearchPath;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -36,16 +39,20 @@ public class SumAggregationTest extends AggregationTest {
     @Test
     public void testReturnType() throws Exception {
         DataType type = DataTypes.DOUBLE;
-        assertEquals(type, functions.getBuiltin("sum", ImmutableList.of(type)).info().returnType());
+        assertEquals(type, getSum(type).info().returnType());
 
         type = DataTypes.FLOAT;
-        assertEquals(type, functions.getBuiltin("sum", ImmutableList.of(type)).info().returnType());
+        assertEquals(type, getSum(type).info().returnType());
 
         type = DataTypes.LONG;
-        assertEquals(type, functions.getBuiltin("sum", ImmutableList.of(type)).info().returnType());
-        assertEquals(type, functions.getBuiltin("sum", ImmutableList.of(DataTypes.INTEGER)).info().returnType());
-        assertEquals(type, functions.getBuiltin("sum", ImmutableList.of(DataTypes.SHORT)).info().returnType());
-        assertEquals(type, functions.getBuiltin("sum", ImmutableList.of(DataTypes.BYTE)).info().returnType());
+        assertEquals(type, getSum(type).info().returnType());
+        assertEquals(type, getSum(DataTypes.INTEGER).info().returnType());
+        assertEquals(type, getSum(DataTypes.SHORT).info().returnType());
+        assertEquals(type, getSum(DataTypes.BYTE).info().returnType());
+    }
+
+    private FunctionImplementation getSum(DataType type) {
+        return functions.get(null, "sum", ImmutableList.of(new Value(type)), SearchPath.pathWithPGCatalogAndDoc());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/execution/engine/aggregation/impl/VarianceAggregationTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/aggregation/impl/VarianceAggregationTest.java
@@ -23,6 +23,9 @@ package io.crate.execution.engine.aggregation.impl;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
+import io.crate.expression.symbol.Value;
+import io.crate.metadata.FunctionImplementation;
+import io.crate.metadata.SearchPath;
 import io.crate.operation.aggregation.AggregationTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -41,8 +44,12 @@ public class VarianceAggregationTest extends AggregationTest {
         for (DataType<?> type : Iterables.concat(DataTypes.NUMERIC_PRIMITIVE_TYPES, Arrays.asList(DataTypes.TIMESTAMP))) {
             // Return type is fixed to Double
             assertEquals(DataTypes.DOUBLE,
-                functions.getBuiltin("variance", ImmutableList.of(type)).info().returnType());
+                getVariance(type).info().returnType());
         }
+    }
+
+    private FunctionImplementation getVariance(DataType<?> type) {
+        return functions.get(null, "variance", ImmutableList.of(new Value(type)), SearchPath.pathWithPGCatalogAndDoc());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/execution/engine/collect/DocLevelCollectTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/DocLevelCollectTest.java
@@ -48,6 +48,7 @@ import io.crate.metadata.Routing;
 import io.crate.metadata.RoutingProvider;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.Schemas;
+import io.crate.metadata.SearchPath;
 import io.crate.planner.distribution.DistributionInfo;
 import io.crate.testing.UseRandomizedSchema;
 import io.crate.types.DataTypes;
@@ -168,12 +169,13 @@ public class DocLevelCollectTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testCollectDocLevelWhereClause() throws Throwable {
+        List<Symbol> arguments = Arrays.asList(testDocLevelReference, Literal.of(2));
         EqOperator op =
-            (EqOperator) functions.getBuiltin(EqOperator.NAME, ImmutableList.of(DataTypes.INTEGER, DataTypes.INTEGER));
-        List<Symbol> toCollect = Collections.<Symbol>singletonList(testDocLevelReference);
+            (EqOperator) functions.get(null, EqOperator.NAME, arguments, SearchPath.pathWithPGCatalogAndDoc());
+        List<Symbol> toCollect = Collections.singletonList(testDocLevelReference);
         WhereClause whereClause = new WhereClause(new Function(
             op.info(),
-            Arrays.asList(testDocLevelReference, Literal.of(2)))
+            arguments)
         );
         RoutedCollectPhase collectNode = getCollectNode(toCollect, whereClause);
 

--- a/sql/src/test/java/io/crate/execution/engine/collect/HandlerSideLevelCollectTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/collect/HandlerSideLevelCollectTest.java
@@ -46,6 +46,7 @@ import io.crate.metadata.Routing;
 import io.crate.metadata.RoutingProvider;
 import io.crate.metadata.RowGranularity;
 import io.crate.metadata.Schemas;
+import io.crate.metadata.SearchPath;
 import io.crate.metadata.information.InformationSchemaInfo;
 import io.crate.metadata.sys.SysClusterTableInfo;
 import io.crate.metadata.table.TableInfo;
@@ -139,10 +140,10 @@ public class HandlerSideLevelCollectTest extends SQLTransportIntegrationTest {
         }
         Symbol tableNameRef = toCollect.get(12);
 
+        List<Symbol> arguments = Arrays.asList(tableNameRef, Literal.of("shards"));
         FunctionImplementation eqImpl
-            = functions.getBuiltin(EqOperator.NAME, ImmutableList.of(DataTypes.STRING, DataTypes.STRING));
-        Function whereClause = new Function(eqImpl.info(),
-            Arrays.asList(tableNameRef, Literal.of("shards")));
+            = functions.get(null, EqOperator.NAME, arguments, SearchPath.pathWithPGCatalogAndDoc());
+        Function whereClause = new Function(eqImpl.info(), arguments);
 
         RoutedCollectPhase collectNode = collectNode(routing, toCollect, RowGranularity.DOC, new WhereClause(whereClause));
         Bucket result = collect(collectNode);

--- a/sql/src/test/java/io/crate/expression/InputFactoryTest.java
+++ b/sql/src/test/java/io/crate/expression/InputFactoryTest.java
@@ -23,17 +23,17 @@
 package io.crate.expression;
 
 import com.google.common.collect.ImmutableMap;
-import io.crate.expression.symbol.Aggregation;
-import io.crate.expression.symbol.Function;
-import io.crate.expression.symbol.InputColumn;
-import io.crate.expression.symbol.Literal;
-import io.crate.expression.symbol.Symbol;
 import io.crate.data.Input;
 import io.crate.data.Row;
 import io.crate.data.RowN;
 import io.crate.execution.engine.aggregation.AggregationContext;
 import io.crate.execution.engine.collect.CollectExpression;
 import io.crate.expression.scalar.arithmetic.ArithmeticFunctions;
+import io.crate.expression.symbol.Aggregation;
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.InputColumn;
+import io.crate.expression.symbol.Literal;
+import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.FunctionInfo;
@@ -175,7 +175,7 @@ public class InputFactoryTest extends CrateUnitTest {
         assertThat(impl.info(), is(function.info()));
 
         FunctionIdent ident = function.info().ident();
-        FunctionImplementation uncompiled = expressions.functions().getBuiltin(ident.name(), ident.argumentTypes());
+        FunctionImplementation uncompiled = expressions.functions().getQualified(ident);
         assertThat(uncompiled, not(sameInstance(impl)));
     }
 

--- a/sql/src/test/java/io/crate/expression/scalar/arithmetic/AddFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/arithmetic/AddFunctionTest.java
@@ -22,6 +22,8 @@
 package io.crate.expression.scalar.arithmetic;
 
 import io.crate.expression.scalar.AbstractScalarFunctionsTest;
+import io.crate.expression.symbol.Value;
+import io.crate.metadata.SearchPath;
 import io.crate.types.DataTypes;
 import org.junit.Test;
 
@@ -31,6 +33,11 @@ public class AddFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testTimestampTypeValidation() throws Exception {
-        functions.getBuiltin(ArithmeticFunctions.Names.ADD, Arrays.asList(DataTypes.TIMESTAMP, DataTypes.TIMESTAMP));
+        functions.get(
+            null,
+            ArithmeticFunctions.Names.ADD,
+            Arrays.asList(new Value(DataTypes.TIMESTAMP), new Value(DataTypes.TIMESTAMP)),
+            SearchPath.pathWithPGCatalogAndDoc()
+        );
     }
 }

--- a/sql/src/test/java/io/crate/expression/scalar/arithmetic/LogFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/arithmetic/LogFunctionTest.java
@@ -22,20 +22,23 @@
 package io.crate.expression.scalar.arithmetic;
 
 import io.crate.action.sql.SessionContext;
+import io.crate.data.Input;
+import io.crate.exceptions.ConversionException;
+import io.crate.expression.scalar.AbstractScalarFunctionsTest;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
-import io.crate.data.Input;
-import io.crate.exceptions.ConversionException;
+import io.crate.expression.symbol.Value;
 import io.crate.metadata.Reference;
+import io.crate.metadata.SearchPath;
 import io.crate.metadata.TransactionContext;
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import static io.crate.testing.SymbolMatchers.isLiteral;
 import static io.crate.testing.TestingHelpers.createReference;
@@ -47,11 +50,13 @@ public class LogFunctionTest extends AbstractScalarFunctionsTest {
     private TransactionContext transactionContext = new TransactionContext(SessionContext.systemSessionContext());
 
     private LogFunction getFunction(String name, DataType value) {
-        return (LogFunction) functions.getBuiltin(name, Arrays.asList(value));
+        return (LogFunction) functions.get(
+            null, name, Collections.singletonList(new Value(value)), SearchPath.pathWithPGCatalogAndDoc());
     }
 
     private LogFunction getFunction(String name, DataType value, DataType base) {
-        return (LogFunction) functions.getBuiltin(name, Arrays.asList(value, base));
+        return (LogFunction) functions.get(
+            null, name, Arrays.asList(new Value(value), new Value(base)), SearchPath.pathWithPGCatalogAndDoc());
     }
 
     private Symbol normalizeLog(Number value, DataType valueType) {

--- a/sql/src/test/java/io/crate/expression/scalar/arithmetic/RandomFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/arithmetic/RandomFunctionTest.java
@@ -22,11 +22,12 @@
 package io.crate.expression.scalar.arithmetic;
 
 import io.crate.action.sql.SessionContext;
+import io.crate.data.Input;
+import io.crate.expression.scalar.AbstractScalarFunctionsTest;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
-import io.crate.data.Input;
+import io.crate.metadata.SearchPath;
 import io.crate.metadata.TransactionContext;
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -45,8 +46,8 @@ public class RandomFunctionTest extends AbstractScalarFunctionsTest {
 
     @Before
     public void prepareRandom() {
-        random = (RandomFunction) functions.getBuiltin(RandomFunction.NAME, Collections.emptyList());
-
+        random = (RandomFunction) functions.get(
+            null, RandomFunction.NAME, Collections.emptyList(), SearchPath.pathWithPGCatalogAndDoc());
     }
 
     @Test

--- a/sql/src/test/java/io/crate/expression/scalar/geo/WithinFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/geo/WithinFunctionTest.java
@@ -22,11 +22,12 @@
 package io.crate.expression.scalar.geo;
 
 import com.google.common.collect.ImmutableMap;
+import io.crate.exceptions.ConversionException;
+import io.crate.expression.scalar.AbstractScalarFunctionsTest;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolType;
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
 import io.crate.types.DataTypes;
 import org.junit.Test;
 
@@ -34,7 +35,6 @@ import static io.crate.testing.SymbolMatchers.isFunction;
 import static io.crate.testing.SymbolMatchers.isLiteral;
 import static io.crate.testing.TestingHelpers.createReference;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 
@@ -122,12 +122,14 @@ public class WithinFunctionTest extends AbstractScalarFunctionsTest {
 
     @Test
     public void testFirstArgumentWithInvalidType() throws Exception {
-        assertThat(getFunction(FNAME, DataTypes.LONG, DataTypes.GEO_POINT), is(nullValue()));
+        expectedException.expect(ConversionException.class);
+        getFunction(FNAME, DataTypes.LONG, DataTypes.GEO_POINT);
     }
 
     @Test
     public void testSecondArgumentWithInvalidType() throws Exception {
-        assertThat(getFunction(FNAME, DataTypes.GEO_POINT, DataTypes.LONG), is(nullValue()));
+        expectedException.expect(ConversionException.class);
+        getFunction(FNAME, DataTypes.GEO_POINT, DataTypes.LONG);
     }
 
     @Test

--- a/sql/src/test/java/io/crate/expression/scalar/systeminformation/CurrentSchemaFunctionTest.java
+++ b/sql/src/test/java/io/crate/expression/scalar/systeminformation/CurrentSchemaFunctionTest.java
@@ -22,11 +22,11 @@
 
 package io.crate.expression.scalar.systeminformation;
 
+import io.crate.expression.scalar.AbstractScalarFunctionsTest;
 import io.crate.expression.symbol.Function;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.Functions;
 import io.crate.metadata.Scalar;
-import io.crate.expression.scalar.AbstractScalarFunctionsTest;
 import io.crate.testing.SqlExpressions;
 import org.junit.Test;
 
@@ -56,7 +56,7 @@ public class CurrentSchemaFunctionTest extends AbstractScalarFunctionsTest {
         expectedException.expectMessage("Cannot evaluate CURRENT_SCHEMA function.");
         Function function = (Function) sqlExpressions.asSymbol("current_schema()");
         FunctionIdent ident = function.info().ident();
-        Scalar impl = (Scalar) functions.getBuiltin(ident.name(), ident.argumentTypes());
+        Scalar impl = (Scalar) functions.getQualified(ident);
         impl.evaluate();
     }
 }

--- a/sql/src/test/java/io/crate/expression/tablefunctions/AbstractTableFunctionsTest.java
+++ b/sql/src/test/java/io/crate/expression/tablefunctions/AbstractTableFunctionsTest.java
@@ -24,10 +24,10 @@ package io.crate.expression.tablefunctions;
 
 import com.google.common.collect.ImmutableMap;
 import io.crate.analyze.relations.DocTableRelation;
-import io.crate.expression.symbol.Function;
-import io.crate.expression.symbol.Symbol;
 import io.crate.data.Bucket;
 import io.crate.data.Input;
+import io.crate.expression.symbol.Function;
+import io.crate.expression.symbol.Symbol;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.Functions;
 import io.crate.metadata.tablefunctions.TableFunctionImplementation;
@@ -58,8 +58,7 @@ public abstract class AbstractTableFunctionsTest extends CrateUnitTest {
         functionSymbol = sqlExpressions.normalize(functionSymbol);
         Function function = (Function) functionSymbol;
         FunctionIdent ident = function.info().ident();
-        TableFunctionImplementation tableFunction = (TableFunctionImplementation)
-            functions.getBuiltin(ident.name(), ident.argumentTypes());
+        TableFunctionImplementation tableFunction = (TableFunctionImplementation) functions.getQualified(ident);
         return tableFunction.execute(function.arguments().stream().map(a -> (Input) a).collect(Collectors.toList()));
     }
 

--- a/sql/src/test/java/io/crate/metadata/doc/DocSchemaInfoTest.java
+++ b/sql/src/test/java/io/crate/metadata/doc/DocSchemaInfoTest.java
@@ -111,9 +111,10 @@ public class DocSchemaInfoTest extends CrateDummyClusterServiceUnitTest {
 
         udfService.updateImplementations("my_schema", metaData.functionsMetaData().stream());
 
-        assertThat(functions.resolveUserDefinedByArgs("my_schema", "valid", ImmutableList.of(), pathWithPGCatalogAndDoc()), Matchers.notNullValue());
+        assertThat(functions.get("my_schema", "valid", ImmutableList.of(), pathWithPGCatalogAndDoc()), Matchers.notNullValue());
 
-        assertThat(functions.resolveUserDefinedByArgs("my_schema", "invalid", ImmutableList.of(), pathWithPGCatalogAndDoc()), Matchers.nullValue());
+        expectedException.expectMessage("unknown function: my_schema.invalid()");
+        functions.get("my_schema", "invalid", ImmutableList.of(), pathWithPGCatalogAndDoc());
     }
 
     @Test


### PR DESCRIPTION
Moves `getImpl` from `ExpressionAnalyzer` into `Functions` - making all
other methods private.

Although it made testing a bit more convenient in a couple of places, it
shouldn't be possible to by-pass the regular function lookup logic.





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed