### PR TITLE
Prepare release 3.1.1

### DIFF
--- a/blackbox/docs/appendices/release-notes/3.1.1.rst
+++ b/blackbox/docs/appendices/release-notes/3.1.1.rst
@@ -1,0 +1,59 @@
+.. _version_3.1.1:
+
+=============
+Version 3.1.1
+=============
+
+Released on 2018/09/25.
+
+.. NOTE::
+
+    If you are upgrading a cluster, you must be running CrateDB 2.0.4 or higher
+    before you upgrade to 3.1.1.
+
+    We recommend that you upgrade to the latest 3.0 release before moving to
+    3.1.1.
+
+    You cannot perform a `rolling upgrade`_ to this version. Any upgrade to this
+    version will require a `full restart upgrade`_.
+
+    When restarting, CrateDB will migrate indexes to a newer format. Depending
+    on the amount of data, this may delay node start-up time.
+
+.. WARNING::
+
+    Tables that were created prior to upgrading to CrateDB 2.x will not
+    function with 3.1 and must be recreated before moving to 3.1.x.
+
+    You can recreate tables using ``COPY TO`` and ``COPY FROM`` while running a
+    2.x release into a new table, or by `inserting the data into a new table`_.
+
+    Before upgrading, you should `back up your data`_.
+
+.. _rolling upgrade: http://crate.io/docs/crate/guide/best_practices/rolling_upgrade.html
+.. _full restart upgrade: http://crate.io/docs/crate/guide/best_practices/full_restart_upgrade.html
+.. _back up your data: https://crate.io/a/backing-up-and-restoring-crate/
+.. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
+
+
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
+Changelog
+=========
+
+Changes
+-------
+
+- Added support for using generated columns inside object columns.
+
+Fixes
+-----
+
+- Calling an unknown user defined function now results in an appropriate error
+  message instead of a ``NullPointerException``.
+
+- Fixed processing of the ``endpoint``, ``protocol`` and ``max_retries`` S3
+  repository parameters.

--- a/blackbox/docs/appendices/release-notes/index.rst
+++ b/blackbox/docs/appendices/release-notes/index.rst
@@ -31,6 +31,7 @@ Versions
 .. toctree::
     :maxdepth: 1
 
+    3.1.1
     3.1.0
 
 3.0.x

--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -40,13 +40,6 @@ Breaking Changes
 Changes
 =======
 
-- Added support for using generated columns inside object columns.
 
 Fixes
 =====
-
-- Calling an unknown user defined function now results in an appropriate error
-  message instead of a ``NullPointerException``.
-
-- Fixed processing of the ``endpoint``, ``protocol`` and ``max_retries`` S3
-  repository parameters.

--- a/core/src/main/java/io/crate/Version.java
+++ b/core/src/main/java/io/crate/Version.java
@@ -41,7 +41,7 @@ public class Version {
 
 
     public static final boolean SNAPSHOT = false;
-    public static final Version CURRENT = new Version(3010099, SNAPSHOT, org.elasticsearch.Version.CURRENT);
+    public static final Version CURRENT = new Version(3010199, SNAPSHOT, org.elasticsearch.Version.CURRENT);
 
     static {
         // safe-guard that we don't release a version with DEBUG_MODE set to true


### PR DESCRIPTION
- [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed