### PR TITLE
Reflect releases of 3.0.7 and 3.1.1

### DIFF
--- a/blackbox/docs/appendices/release-notes/3.0.7.rst
+++ b/blackbox/docs/appendices/release-notes/3.0.7.rst
@@ -1,0 +1,61 @@
+.. _version_3.0.7:
+
+=============
+Version 3.0.7
+=============
+
+Released on 2018/09/25.
+
+.. NOTE::
+
+   If you are upgrading a cluster, you must be running CrateDB 2.0.4 or higher
+   before you upgrade to 3.0.7.
+
+   We recommend that you upgrade to the latest 2.3 release before moving to
+   3.0.7.
+
+   If you want to perform a `rolling upgrade`_, your current CrateDB version
+   number must be at least :ref:`version_3.0.0`. Any upgrade from a version
+   prior to this will require a `full restart upgrade`_.
+
+   When restarting, CrateDB will migrate indexes to a newer format. Depending
+   on the amount of data, this may delay node start-up time.
+
+   Please consult the :ref:`version_3.0.0_upgrade_notes` before upgrading.
+
+.. WARNING::
+
+    Tables that were created prior to upgrading to CrateDB 2.x will not
+    function with 3.0 and must be recreated before moving to 3.0.x.
+
+    You can recreate tables using ``COPY TO`` and ``COPY FROM`` while running a
+    2.x release into a new table, or by `inserting the data into a new table`_.
+
+.. WARNING::
+
+   Before upgrading, you should `back up your data`_.
+
+.. _rolling upgrade: http://crate.io/docs/crate/guide/best_practices/rolling_upgrade.html
+.. _full restart upgrade: http://crate.io/docs/crate/guide/best_practices/full_restart_upgrade.html
+.. _back up your data: https://crate.io/a/backing-up-and-restoring-crate/
+.. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
+
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
+Changelog
+=========
+
+Fixes
+-----
+
+- Calling an unknown user defined function now results in an appropriate error
+  message instead of a ``NullPointerException``.
+
+- Trying to create a table with a generated column inside an object column now
+  results in a friendly error message instead of a ``NullPointerException``.
+
+- Fixed processing of the ``endpoint``, ``protocol`` and ``max_retries`` S3
+  repository parameters.

--- a/blackbox/docs/appendices/release-notes/3.1.1.rst
+++ b/blackbox/docs/appendices/release-notes/3.1.1.rst
@@ -1,0 +1,59 @@
+.. _version_3.1.1:
+
+=============
+Version 3.1.1
+=============
+
+Released on 2018/09/25.
+
+.. NOTE::
+
+    If you are upgrading a cluster, you must be running CrateDB 2.0.4 or higher
+    before you upgrade to 3.1.1.
+
+    We recommend that you upgrade to the latest 3.0 release before moving to
+    3.1.1.
+
+    You cannot perform a `rolling upgrade`_ to this version. Any upgrade to this
+    version will require a `full restart upgrade`_.
+
+    When restarting, CrateDB will migrate indexes to a newer format. Depending
+    on the amount of data, this may delay node start-up time.
+
+.. WARNING::
+
+    Tables that were created prior to upgrading to CrateDB 2.x will not
+    function with 3.1 and must be recreated before moving to 3.1.x.
+
+    You can recreate tables using ``COPY TO`` and ``COPY FROM`` while running a
+    2.x release into a new table, or by `inserting the data into a new table`_.
+
+    Before upgrading, you should `back up your data`_.
+
+.. _rolling upgrade: http://crate.io/docs/crate/guide/best_practices/rolling_upgrade.html
+.. _full restart upgrade: http://crate.io/docs/crate/guide/best_practices/full_restart_upgrade.html
+.. _back up your data: https://crate.io/a/backing-up-and-restoring-crate/
+.. _inserting the data into a new table: https://crate.io/docs/crate/reference/en/latest/admin/system-information.html#tables-need-to-be-recreated
+
+
+.. rubric:: Table of Contents
+
+.. contents::
+   :local:
+
+Changelog
+=========
+
+Changes
+-------
+
+- Added support for using generated columns inside object columns.
+
+Fixes
+-----
+
+- Calling an unknown user defined function now results in an appropriate error
+  message instead of a ``NullPointerException``.
+
+- Fixed processing of the ``endpoint``, ``protocol`` and ``max_retries`` S3
+  repository parameters.

--- a/blackbox/docs/appendices/release-notes/index.rst
+++ b/blackbox/docs/appendices/release-notes/index.rst
@@ -31,6 +31,7 @@ Versions
 .. toctree::
     :maxdepth: 1
 
+    3.1.1
     3.1.0
 
 3.0.x
@@ -39,6 +40,7 @@ Versions
 .. toctree::
     :maxdepth: 1
 
+    3.0.7
     3.0.6
     3.0.5
     3.0.4

--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -64,13 +64,5 @@ Changes
 - Added support of using units inside byte-size or time bases statement
   parameters values. E.g. '1mb' for 1 MegaByte or '1s' for 1 Second.
 
-- Added support for using generated columns inside object columns.
-
 Fixes
 =====
-
-- Calling an unknown user defined function now results in an appropriate error
-  message instead of a ``NullPointerException``.
-
-- Fixed processing of the ``endpoint``, ``protocol`` and ``max_retries`` S3
-  repository parameters.


### PR DESCRIPTION
- [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed