### PR TITLE
Tests: Initialize Schemas correctly in SQLExecutor

### DIFF
--- a/sql/src/main/java/io/crate/metadata/DefaultTemplateService.java
+++ b/sql/src/main/java/io/crate/metadata/DefaultTemplateService.java
@@ -38,6 +38,7 @@ import org.elasticsearch.common.xcontent.XContentFactory;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.Objects;
 
 /**
  * Service that ensures a "crate_defaults" template exists.
@@ -61,7 +62,7 @@ public class DefaultTemplateService extends AbstractComponent {
 
     void createIfNotExists(ClusterState state) {
         DiscoveryNodes nodes = state.nodes();
-        if (nodes.getMasterNodeId().equals(nodes.getLocalNodeId()) == false) {
+        if (Objects.equals(nodes.getMasterNodeId(), nodes.getLocalNodeId()) == false) {
             return;
         }
         if (state.getMetaData().getTemplates().containsKey(TEMPLATE_NAME) == false) {

--- a/sql/src/test/java/io/crate/testing/SQLExecutor.java
+++ b/sql/src/test/java/io/crate/testing/SQLExecutor.java
@@ -91,6 +91,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.repositories.delete.TransportDeleteRepositoryAction;
 import org.elasticsearch.action.admin.cluster.repositories.put.TransportPutRepositoryAction;
 import org.elasticsearch.analysis.common.CommonAnalysisPlugin;
+import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.EmptyClusterInfoService;
 import org.elasticsearch.cluster.metadata.AliasMetaData;
@@ -338,6 +339,7 @@ public class SQLExecutor {
                 clusterService,
                 new DocSchemaInfoFactory(testingDocTableInfoFactory, testingViewInfoFactory, functions, udfService)
             );
+            schemas.clusterChanged(new ClusterChangedEvent("init", clusterService.state(), ClusterState.EMPTY_STATE));
             RelationAnalyzer relationAnalyzer = new RelationAnalyzer(functions, schemas);
             return new SQLExecutor(
                 functions,


### PR DESCRIPTION
We need to trigger an initial `ClusterChangedEvent` in order to load
custom schemas.





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed