### PR TITLE
Re-integrate NullEliminator into query-building

### DIFF
--- a/sql/src/main/java/io/crate/analyze/WhereClause.java
+++ b/sql/src/main/java/io/crate/analyze/WhereClause.java
@@ -22,13 +22,10 @@
 package io.crate.analyze;
 
 import com.google.common.base.MoreObjects;
-import io.crate.expression.eval.EvaluatingNormalizer;
-import io.crate.expression.eval.NullEliminator;
 import io.crate.expression.operator.AndOperator;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.Symbols;
-import io.crate.metadata.TransactionContext;
 import io.crate.metadata.doc.DocSysColumns;
 import org.elasticsearch.common.Nullable;
 import org.elasticsearch.common.lucene.BytesRefs;
@@ -61,19 +58,6 @@ public class WhereClause extends QueryClause {
 
     public WhereClause(@Nullable Symbol query) {
         super(query);
-    }
-
-    public WhereClause normalize(EvaluatingNormalizer normalizer, TransactionContext transactionContext) {
-        if (noMatch || query == null) {
-            return this;
-        }
-        Symbol normalizedQuery = normalizer.normalize(query, transactionContext);
-        Symbol nullReplacedQuery = NullEliminator.eliminateNullsIfPossible(
-            normalizedQuery, s -> normalizer.normalize(s, transactionContext));
-        if (nullReplacedQuery == query) {
-            return this;
-        }
-        return new WhereClause(nullReplacedQuery, partitions, clusteredBy);
     }
 
     public Set<Symbol> clusteredBy() {

--- a/sql/src/test/java/io/crate/analyze/WhereClauseTest.java
+++ b/sql/src/test/java/io/crate/analyze/WhereClauseTest.java
@@ -22,15 +22,12 @@
 
 package io.crate.analyze;
 
-import io.crate.expression.eval.EvaluatingNormalizer;
 import io.crate.expression.symbol.Literal;
 import io.crate.expression.symbol.Symbol;
-import io.crate.metadata.TransactionContext;
 import io.crate.testing.SqlExpressions;
 import io.crate.testing.T3;
 import org.junit.Test;
 
-import static io.crate.testing.TestingHelpers.getFunctions;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
@@ -62,14 +59,6 @@ public class WhereClauseTest {
         assertThat(whereLiteralFalse.hasQuery(), is(whereReplaced.hasQuery()));
         assertThat(whereLiteralFalse.noMatch(), is(whereReplaced.noMatch()));
         assertThat(whereLiteralFalse.query(), is(whereReplaced.query()));
-    }
-
-    @Test
-    public void testNormalizeEliminatesNulls() {
-        WhereClause where = new WhereClause(sqlExpressions.asSymbol("null or x = 10 or a = null"));
-        WhereClause normalizedWhere = where.normalize(
-            EvaluatingNormalizer.functionOnlyNormalizer(getFunctions()), TransactionContext.systemTransactionContext());
-        assertThat(normalizedWhere.query(), is(sqlExpressions.asSymbol("x = 10")));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/lucene/ThreeValuedLogicQueryBuilderTest.java
+++ b/sql/src/test/java/io/crate/lucene/ThreeValuedLogicQueryBuilderTest.java
@@ -22,6 +22,7 @@
 
 package io.crate.lucene;
 
+import org.apache.lucene.search.Query;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
@@ -58,5 +59,14 @@ public class ThreeValuedLogicQueryBuilderTest extends LuceneQueryBuilderTest {
             convert("NOT name = 'foo' AND NOT ignore3vl(name = 'bar')").toString(),
             is("+(+(+*:* -name:foo) +ConstantScore(DocValuesFieldExistsQuery [field=name])) +(+(+*:* -name:bar))")
         );
+    }
+
+    @Test
+    public void testNullIsReplacedWithFalseToCreateOptimizedQuery() {
+        Query q1 = convert("null or name = 'foo'");
+        Query q2 = convert("name = 'foo'");
+
+        assertThat(q1, is(q2));
+        assertThat(q1.toString(), is("name:foo"));
     }
 }


### PR DESCRIPTION
`normalize` of the `WhereClause` wasn't called, so the `NullEliminator`
wasn't used.

This integrates the `NullEliminator` into the `LuceneQueryBuilder` to
make sure we generate optimized queries.

It looks like not using the `NullEliminator` didn't result in queries as
bad as they used to (https://github.com/crate/crate/pull/6799), but
re-integrating it leads to better queries.





 - [ ] User relevant changes are recorded in ``CHANGES.txt`` (?)
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed