### PR TITLE
Implement 'Set License' Statement

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,6 +32,7 @@ evaluationDependsOn(':blob')
 evaluationDependsOn(':http')
 evaluationDependsOn(':udc')
 evaluationDependsOn(':dns-discovery')
+evaluationDependsOn(':licensing')
 
 dependencies {
     compile project(':sql')
@@ -66,6 +67,7 @@ dependencies {
     compileNotTransitive project(':blob')
     compileNotTransitive project(':http')
     compileNotTransitive project(':udc')
+    compileNotTransitive project(':licensing')
     compileNotTransitive project(':dns-discovery')
     compileNotTransitive project(':es:es-discovery-ec2')
     compileNotTransitive project(':es:es-repository-url')
@@ -129,7 +131,8 @@ task myJavadocs(type: Javadoc, dependsOn: processResources) {
             project(':dex').sourceSets.main.allJava +
             project(':shared').sourceSets.main.allJava +
             project(':blob').sourceSets.main.allJava +
-            project(':udc').sourceSets.main.allJava
+            project(':udc').sourceSets.main.allJava +
+            project(':licensing').sourceSets.main.allJava
 }
 
 task javadocJar(type: Jar, dependsOn: [myJavadocs]) {
@@ -157,7 +160,8 @@ task sourceJar(type: Jar) {
             project(':dex').sourceSets.main.allJava +
             project(':shared').sourceSets.main.allJava +
             project(':blob').sourceSets.main.allJava +
-            project(':udc').sourceSets.main.allJava)
+            project(':udc').sourceSets.main.allJava +
+            project(':licensing').sourceSets.main.allJava)
     manifest {
         attributes("Implementation-Title": "Crate.IO")
     }

--- a/licensing/src/main/java/io/crate/license/LicenseMetaData.java
+++ b/licensing/src/main/java/io/crate/license/LicenseMetaData.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.license;
+
+import io.crate.license.exception.LicenseMetadataParsingException;
+import org.elasticsearch.cluster.AbstractNamedDiffable;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.EnumSet;
+import java.util.Objects;
+
+public class LicenseMetaData extends AbstractNamedDiffable<MetaData.Custom> implements MetaData.Custom {
+
+    public static final String TYPE = "license";
+
+    private long expirationDateInMs;
+    private String issuedTo;
+    private String signature;
+
+    public LicenseMetaData(long expirationDateInMs, String issuedTo, String signature) {
+        this.expirationDateInMs = expirationDateInMs;
+        this.issuedTo = issuedTo;
+        this.signature = signature;
+    }
+
+    public LicenseMetaData(StreamInput in) throws IOException {
+        readFrom(in);
+    }
+
+    public long expirationDateInMs() {
+        return expirationDateInMs;
+    }
+
+    public String issuedTo() {
+        return issuedTo;
+    }
+
+    public String signature() {
+        return signature;
+    }
+
+    public void readFrom(StreamInput in) throws IOException {
+        this.expirationDateInMs = in.readLong();
+        this.issuedTo = in.readString();
+        this.signature = in.readString();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeLong(expirationDateInMs);
+        out.writeString(issuedTo);
+        out.writeString(signature);
+    }
+
+    /*
+     * LicenseMetaData XContent has the following structure:
+     *
+     * <pre>
+     *     {
+     *       "license": {
+     *           "expirationDateInMs": 202020202,
+     *           "issuedTo": "organisation",
+     *           "signture": "XXX"
+     *       }
+     *     }
+     * </pre>
+     */
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        return builder
+            .startObject(TYPE)
+                .field("expirationDateInMs", expirationDateInMs)
+                .field("issuedTo", issuedTo)
+                .field("signature", signature)
+            .endObject();
+    }
+
+    public static LicenseMetaData fromXContent(XContentParser parser) throws IOException {
+        long expirationDateInMs = 0L;
+        String issuedTo = null;
+        String signature = null;
+        // advance from metadata START_OBJECT
+        XContentParser.Token token = parser.nextToken();
+        if (token != XContentParser.Token.FIELD_NAME || !Objects.equals(parser.currentName(), TYPE)) {
+            throw new LicenseMetadataParsingException("license FIELD_NAME expected but got " + parser.currentToken());
+        }
+        // advance to license START_OBJECT
+        if (parser.nextToken() != XContentParser.Token.START_OBJECT) {
+            throw new LicenseMetadataParsingException("license START_OBJECT expected but got " + parser.currentToken());
+        }
+
+        while ((token = parser.nextToken()) == XContentParser.Token.FIELD_NAME) {
+            if ("expirationDateInMs".equals(parser.currentName())) {
+                expirationDateInMs = parseLongField(parser);
+            } else if ("issuedTo".equals(parser.currentName())) {
+                issuedTo = parseStringField(parser);
+            } else if ("signature".equals(parser.currentName())) {
+                signature = parseStringField(parser);
+            } else {
+                throw new LicenseMetadataParsingException("unexpected FIELD_NAME " + parser.currentToken());
+            }
+        }
+        // license END_OBJECT is already consumed - check for correctness
+        if (parser.currentToken() != XContentParser.Token.END_OBJECT) {
+            throw new LicenseMetadataParsingException("expected the license object token at the end");
+
+        }
+        if (parser.nextToken() != XContentParser.Token.END_OBJECT) {
+            // each custom metadata is packed inside an object.
+            // each custom must move the parser to the end otherwise possible following customs won't be read
+            throw new LicenseMetadataParsingException("expected an object token at the end");
+        }
+        return new LicenseMetaData(expirationDateInMs, issuedTo, signature);
+    }
+
+    private static String parseStringField(XContentParser parser) throws IOException {
+        parser.nextToken();
+        return parser.textOrNull();
+    }
+
+    private static long parseLongField(XContentParser parser) throws IOException {
+        parser.nextToken();
+        return parser.longValue();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        LicenseMetaData licenseMetaData = (LicenseMetaData) o;
+        return expirationDateInMs == licenseMetaData.expirationDateInMs &&
+               Objects.equals(issuedTo, licenseMetaData.issuedTo) &&
+               Objects.equals(signature, licenseMetaData.signature);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(expirationDateInMs, issuedTo, signature);
+    }
+
+    @Override
+    public EnumSet<MetaData.XContentContext> context() {
+        return EnumSet.of(MetaData.XContentContext.GATEWAY, MetaData.XContentContext.SNAPSHOT);
+    }
+
+    @Override
+    public String getWriteableName() {
+        return TYPE;
+    }
+
+}

--- a/licensing/src/main/java/io/crate/license/LicenseService.java
+++ b/licensing/src/main/java/io/crate/license/LicenseService.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.license;
+
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateUpdateTask;
+import org.elasticsearch.cluster.metadata.MetaData;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.unit.TimeValue;
+
+@Singleton
+public class LicenseService {
+
+    private static final Logger LOGGER = Loggers.getLogger(LicenseService.class);
+
+    private final ClusterService clusterService;
+
+    @Inject
+    public LicenseService(ClusterService clusterService) {
+        this.clusterService = clusterService;
+    }
+
+    boolean validateLicense(final LicenseMetaData license) {
+        // todo: implement
+        // 1. check for future expiry date
+        // 2. validate signature
+        return true;
+    }
+
+
+    void registerLicense(final LicenseMetaData licenseMetaData,
+                         final ActionListener<SetLicenseResponse> listener,
+                         final TimeValue timeout) {
+        clusterService.submitStateUpdateTask("register license to [" + licenseMetaData.issuedTo() + "]",
+            new ClusterStateUpdateTask() {
+                @Override
+                public ClusterState execute(ClusterState currentState) throws Exception {
+                    MetaData.Builder mdBuilder = MetaData.builder(currentState.metaData());
+                    mdBuilder.putCustom(LicenseMetaData.TYPE, licenseMetaData);
+                    return ClusterState.builder(currentState).metaData(mdBuilder).build();
+                }
+
+                @Override
+                public TimeValue timeout() {
+                    return timeout;
+                }
+
+                @Override
+                public void clusterStateProcessed(String source, ClusterState oldState, ClusterState newState) {
+                    listener.onResponse(new SetLicenseResponse(true));
+                }
+
+                @Override
+                public void onFailure(String source, Exception e) {
+                    listener.onFailure(e);
+                }
+            });
+    }
+}

--- a/licensing/src/main/java/io/crate/license/SetLicenseRequest.java
+++ b/licensing/src/main/java/io/crate/license/SetLicenseRequest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.license;
+
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ValidateActions;
+import org.elasticsearch.action.support.master.MasterNodeRequest;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+public class SetLicenseRequest extends MasterNodeRequest<SetLicenseRequest> {
+
+    private LicenseMetaData licenseMetaData;
+
+    public SetLicenseRequest() {
+    }
+
+    public SetLicenseRequest(LicenseMetaData licenseMetaData) {
+        this.licenseMetaData = licenseMetaData;
+    }
+
+    public LicenseMetaData licenseMetaData() {
+        return licenseMetaData;
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        if (licenseMetaData == null) {
+            return ValidateActions.addValidationError("licenseMetaData is missing", null);
+        }
+        return null;
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        licenseMetaData = new LicenseMetaData(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        licenseMetaData.writeTo(out);
+    }
+}

--- a/licensing/src/main/java/io/crate/license/SetLicenseResponse.java
+++ b/licensing/src/main/java/io/crate/license/SetLicenseResponse.java
@@ -20,14 +20,32 @@
  * agreement.
  */
 
-apply from: "$rootDir/gradle/javaModule.gradle"
+package io.crate.license;
 
-archivesBaseName = 'crate-license'
-group = 'io.crate'
-description = 'CrateDB License Management'
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 
-dependencies {
-    compile project(':es:es-core')
-    testCompile "junit:junit:${versions.junit}"
-    testCompile project(':integration-testing')
+import java.io.IOException;
+
+public class SetLicenseResponse extends AcknowledgedResponse {
+
+    public SetLicenseResponse() {
+    }
+
+    public SetLicenseResponse(boolean acknowledged) {
+        super(acknowledged);
+    }
+
+    @Override
+    public void readFrom(StreamInput in) throws IOException {
+        super.readFrom(in);
+        readAcknowledged(in);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        writeAcknowledged(out);
+    }
 }

--- a/licensing/src/main/java/io/crate/license/TransportSetLicenseAction.java
+++ b/licensing/src/main/java/io/crate/license/TransportSetLicenseAction.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.license;
+
+import io.crate.license.exception.LicenseInvalidException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.master.TransportMasterNodeAction;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlockException;
+import org.elasticsearch.cluster.block.ClusterBlockLevel;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+
+@Singleton
+public class TransportSetLicenseAction
+    extends TransportMasterNodeAction<SetLicenseRequest, SetLicenseResponse> {
+
+    private final LicenseService licenseService;
+
+    @Inject
+    public TransportSetLicenseAction(Settings settings,
+                                     TransportService transportService,
+                                     ClusterService clusterService,
+                                     ThreadPool threadPool,
+                                     LicenseService licenseService,
+                                     ActionFilters actionFilters,
+                                     IndexNameExpressionResolver indexNameExpressionResolver) {
+        super(settings, "crate/sql/set_license", transportService, clusterService, threadPool, actionFilters,
+            indexNameExpressionResolver, SetLicenseRequest::new);
+        this.licenseService = licenseService;
+    }
+
+    @Override
+    protected String executor() {
+        return ThreadPool.Names.GENERIC;
+    }
+
+    @Override
+    protected SetLicenseResponse newResponse() {
+        return new SetLicenseResponse();
+    }
+
+    @Override
+    protected void masterOperation(final SetLicenseRequest request,
+                                   ClusterState state,
+                                   ActionListener<SetLicenseResponse> listener) throws Exception {
+
+        LicenseMetaData metaData = request.licenseMetaData();
+        if (licenseService.validateLicense(metaData)) {
+            licenseService.registerLicense(metaData, listener, request.masterNodeTimeout());
+        } else {
+            listener.onFailure(new LicenseInvalidException());
+        }
+    }
+
+    @Override
+    protected ClusterBlockException checkBlock(SetLicenseRequest request, ClusterState state) {
+        return state.blocks().globalBlockedException(ClusterBlockLevel.METADATA_READ);
+    }
+}

--- a/licensing/src/main/java/io/crate/license/exception/LicenseException.java
+++ b/licensing/src/main/java/io/crate/license/exception/LicenseException.java
@@ -20,14 +20,17 @@
  * agreement.
  */
 
-apply from: "$rootDir/gradle/javaModule.gradle"
+package io.crate.license.exception;
 
-archivesBaseName = 'crate-license'
-group = 'io.crate'
-description = 'CrateDB License Management'
 
-dependencies {
-    compile project(':es:es-core')
-    testCompile "junit:junit:${versions.junit}"
-    testCompile project(':integration-testing')
+abstract class LicenseException extends RuntimeException {
+
+    public LicenseException(String message) {
+        super(message);
+    }
+
+    public LicenseException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
 }

--- a/licensing/src/main/java/io/crate/license/exception/LicenseInvalidException.java
+++ b/licensing/src/main/java/io/crate/license/exception/LicenseInvalidException.java
@@ -20,14 +20,11 @@
  * agreement.
  */
 
-apply from: "$rootDir/gradle/javaModule.gradle"
+package io.crate.license.exception;
 
-archivesBaseName = 'crate-license'
-group = 'io.crate'
-description = 'CrateDB License Management'
+public class LicenseInvalidException extends LicenseException {
 
-dependencies {
-    compile project(':es:es-core')
-    testCompile "junit:junit:${versions.junit}"
-    testCompile project(':integration-testing')
+    public LicenseInvalidException() {
+        super("Unable to validate license");
+    }
 }

--- a/licensing/src/main/java/io/crate/license/exception/LicenseMetadataParsingException.java
+++ b/licensing/src/main/java/io/crate/license/exception/LicenseMetadataParsingException.java
@@ -20,29 +20,15 @@
  * agreement.
  */
 
-package io.crate.sql.tree;
+package io.crate.license.exception;
 
-import com.google.common.base.MoreObjects;
+public class LicenseMetadataParsingException extends LicenseException {
 
-import java.util.List;
-
-public class SetLicenseStatement extends SetStatement {
-
-
-    public SetLicenseStatement(List<Assignment> assignments) {
-        // treat License settings as Global and Persistent
-        super(Scope.GLOBAL, SettingType.PERSISTENT, assignments);
+    public LicenseMetadataParsingException(String message) {
+        super("License Metadata parsing error: " + message);
     }
 
-    @Override
-    public String toString() {
-        return MoreObjects.toStringHelper(this)
-            .add("assignments", assignments())
-            .toString();
-    }
-
-    @Override
-    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
-        return visitor.visitSetLicenseStatement(this, context);
+    public LicenseMetadataParsingException(String message, Throwable cause) {
+        super("License Metadata parsing error: " + message, cause);
     }
 }

--- a/licensing/src/test/java/io/crate/license/LicenseMetaDataTest.java
+++ b/licensing/src/test/java/io/crate/license/LicenseMetaDataTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.license;
+
+import io.crate.test.integration.CrateUnitTest;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.xcontent.ToXContent;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.json.JsonXContent;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.Matchers.nullValue;
+
+public class LicenseMetaDataTest extends CrateUnitTest {
+
+    private static final long EXPIRATION_DATE_IN_MS = 1609376523123L;  // equivalent for EXPIRATION_DATE
+    private static final String ISSUED_TO = "me";
+    private static final String SIGNATURE = "SIGNATURE";
+
+    public static LicenseMetaData createMetaData() {
+        return new LicenseMetaData(EXPIRATION_DATE_IN_MS, ISSUED_TO, SIGNATURE);
+    }
+
+    @Test
+    public void testLicenseMetaDataStreaming() throws IOException {
+        BytesStreamOutput stream = new BytesStreamOutput();
+        LicenseMetaData license = createMetaData();
+        license.writeTo(stream);
+
+        StreamInput in = stream.bytes().streamInput();
+        LicenseMetaData license2 = new LicenseMetaData(in);
+        assertEquals(license, license2);
+    }
+
+    @Test
+    public void testLicenceMetaDataToXContent() throws IOException {
+        LicenseMetaData license = createMetaData();
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+
+        // reflects the logic used to process custom metadata in the cluster state
+        builder.startObject();
+        license.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
+
+        XContentParser parser = JsonXContent.jsonXContent.createParser(xContentRegistry(), builder.bytes());
+        parser.nextToken(); // start object
+        LicenseMetaData license2 = LicenseMetaData.fromXContent(parser);
+        assertEquals(license, license2);
+        // a metadata custom must consume the surrounded END_OBJECT token, no token must be left
+        assertThat(parser.nextToken(), nullValue());
+    }
+
+    @Test
+    public void testLicenceMetaDataFromXContent() throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+
+        // reflects the logic used to process custom metadata in the cluster state
+        builder.startObject();
+        builder.startObject(LicenseMetaData.TYPE)
+            .field("expirationDateInMs", EXPIRATION_DATE_IN_MS)
+            .field("issuedTo", ISSUED_TO)
+            .field("signature", SIGNATURE)
+            .endObject();
+        builder.endObject();
+
+        XContentParser parser = JsonXContent.jsonXContent.createParser(xContentRegistry(), builder.bytes());
+        parser.nextToken(); // start object
+        LicenseMetaData license2 = LicenseMetaData.fromXContent(parser);
+        assertEquals(createMetaData(), license2);
+        // a metadata custom must consume the surrounded END_OBJECT token, no token must be left
+        assertThat(parser.nextToken(), nullValue());
+    }
+
+    @Test
+    public void testLicenceMetaDataFromXContentInvalidArgumentThrowException() throws IOException {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("For input string: \"invalid_long_value\"");
+
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+
+        // reflects the logic used to process custom metadata in the cluster state
+        builder.startObject();
+        builder.startObject(LicenseMetaData.TYPE)
+            .field("expirationDateInMs", "invalid_long_value")
+            .field("issuedTo", ISSUED_TO)
+            .field("signature", SIGNATURE)
+            .endObject();
+        builder.endObject();
+
+        XContentParser parser = JsonXContent.jsonXContent.createParser(xContentRegistry(), builder.bytes());
+
+        parser.nextToken(); // start object
+        LicenseMetaData.fromXContent(parser);
+    }
+}

--- a/sql-parser/src/main/antlr/SqlBase.g4
+++ b/sql-parser/src/main/antlr/SqlBase.g4
@@ -61,6 +61,7 @@ statement
         (EQ | TO) (DEFAULT | setExpr (',' setExpr)*)                                 #set
     | SET GLOBAL (PERSISTENT | TRANSIENT)?
         setGlobalAssignment (',' setGlobalAssignment)*                               #setGlobal
+    | SET LICENSE setGlobalAssignment (',' setGlobalAssignment)*                     #setLicense
     | KILL (ALL | jobId=parameterOrString)                                           #kill
     | INSERT INTO table ('(' ident (',' ident)* ')')? insertSource
         (onDuplicate | onConflict)?                                                  #insert
@@ -611,7 +612,7 @@ nonReserved
     : ALIAS | ANALYZE | ANALYZER | BERNOULLI | BLOB | CATALOGS | CHAR_FILTERS | CLUSTERED
     | COLUMNS | COPY | CURRENT | DATE | DAY | DEALLOCATE | DISTRIBUTED | DUPLICATE | DYNAMIC | EXPLAIN
     | EXTENDS | FOLLOWING | FORMAT | FULLTEXT | FUNCTIONS | GEO_POINT | GEO_SHAPE | GLOBAL
-    | GRAPHVIZ | HOUR | IGNORED | KEY | KILL | LOGICAL | LOCAL | MATERIALIZED | MINUTE
+    | GRAPHVIZ | HOUR | IGNORED | KEY | KILL | LICENSE | LOGICAL | LOCAL | MATERIALIZED | MINUTE
     | MONTH | OFF | ONLY | OVER | OPTIMIZE | PARTITION | PARTITIONED | PARTITIONS | PLAIN
     | PRECEDING | RANGE | REFRESH | ROW | ROWS | SCHEMAS | SECOND | SESSION
     | SHARDS | SHOW | STORAGE | STRICT | SYSTEM | TABLES | TABLESAMPLE | TEXT | TIME
@@ -747,6 +748,7 @@ GEO_SHAPE: 'GEO_SHAPE';
 GLOBAL : 'GLOBAL';
 SESSION : 'SESSION';
 LOCAL : 'LOCAL';
+LICENSE : 'LICENSE';
 
 BEGIN: 'BEGIN';
 COMMIT: 'COMMIT';

--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -147,7 +147,6 @@ import io.crate.sql.tree.RevokePrivilege;
 import io.crate.sql.tree.SearchedCaseExpression;
 import io.crate.sql.tree.Select;
 import io.crate.sql.tree.SelectItem;
-import io.crate.sql.tree.SetLicenseStatement;
 import io.crate.sql.tree.SetStatement;
 import io.crate.sql.tree.ShowColumns;
 import io.crate.sql.tree.ShowCreateTable;
@@ -553,7 +552,9 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
 
     @Override
     public Node visitSetLicense(SqlBaseParser.SetLicenseContext ctx) {
-        return new SetLicenseStatement(visitCollection(ctx.setGlobalAssignment(), Assignment.class));
+        return new SetStatement(SetStatement.Scope.LICENSE,
+            SetStatement.SettingType.PERSISTENT,
+            visitCollection(ctx.setGlobalAssignment(), Assignment.class));
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -147,6 +147,7 @@ import io.crate.sql.tree.RevokePrivilege;
 import io.crate.sql.tree.SearchedCaseExpression;
 import io.crate.sql.tree.Select;
 import io.crate.sql.tree.SelectItem;
+import io.crate.sql.tree.SetLicenseStatement;
 import io.crate.sql.tree.SetStatement;
 import io.crate.sql.tree.ShowColumns;
 import io.crate.sql.tree.ShowCreateTable;
@@ -548,6 +549,11 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
                 visitCollection(context.setGlobalAssignment(), Assignment.class));
         }
         return new SetStatement(SetStatement.Scope.GLOBAL, visitCollection(context.setGlobalAssignment(), Assignment.class));
+    }
+
+    @Override
+    public Node visitSetLicense(SqlBaseParser.SetLicenseContext ctx) {
+        return new SetLicenseStatement(visitCollection(ctx.setGlobalAssignment(), Assignment.class));
     }
 
     @Override

--- a/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
@@ -477,10 +477,6 @@ public abstract class AstVisitor<R, C> {
         return visitStatement(node, context);
     }
 
-    public R visitSetLicenseStatement(SetLicenseStatement node, C context) {
-        return visitStatement(node, context);
-    }
-
     public R visitResetStatement(ResetStatement node, C context) {
         return visitStatement(node, context);
     }

--- a/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/AstVisitor.java
@@ -477,6 +477,10 @@ public abstract class AstVisitor<R, C> {
         return visitStatement(node, context);
     }
 
+    public R visitSetLicenseStatement(SetLicenseStatement node, C context) {
+        return visitStatement(node, context);
+    }
+
     public R visitResetStatement(ResetStatement node, C context) {
         return visitStatement(node, context);
     }

--- a/sql-parser/src/main/java/io/crate/sql/tree/SetLicenseStatement.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/SetLicenseStatement.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.sql.tree;
+
+import com.google.common.base.MoreObjects;
+
+import java.util.List;
+
+public class SetLicenseStatement extends SetStatement {
+
+
+    public SetLicenseStatement(List<Assignment> assignments) {
+        // treat License settings as Global and Persistent
+        super(Scope.GLOBAL, SettingType.PERSISTENT, assignments);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+            .add("assignments", assignments())
+            .toString();
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitSetLicenseStatement(this, context);
+    }
+}

--- a/sql-parser/src/main/java/io/crate/sql/tree/SetStatement.java
+++ b/sql-parser/src/main/java/io/crate/sql/tree/SetStatement.java
@@ -31,7 +31,7 @@ import java.util.List;
 public class SetStatement extends Statement {
 
     public enum Scope {
-        GLOBAL, SESSION, LOCAL, SESSION_TRANSACTION_MODE
+        GLOBAL, SESSION, LOCAL, SESSION_TRANSACTION_MODE, LICENSE
     }
 
     public enum SettingType {

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -55,7 +55,7 @@ import io.crate.sql.tree.QualifiedName;
 import io.crate.sql.tree.QualifiedNameReference;
 import io.crate.sql.tree.Query;
 import io.crate.sql.tree.RevokePrivilege;
-import io.crate.sql.tree.SetLicenseStatement;
+import io.crate.sql.tree.SetStatement;
 import io.crate.sql.tree.ShowCreateTable;
 import io.crate.sql.tree.Statement;
 import io.crate.sql.tree.StringLiteral;
@@ -332,9 +332,9 @@ public class TestStatementBuilder {
 
     @Test
     public void testSetLicense() {
-        SetLicenseStatement stmt = (SetLicenseStatement) SqlParser.createStatement("set license aSetting = 'aStringValue'");
-        assertThat(stmt.scope(), is(SetLicenseStatement.Scope.GLOBAL));
-        assertThat(stmt.settingType(), is(SetLicenseStatement.SettingType.PERSISTENT));
+        SetStatement stmt = (SetStatement) SqlParser.createStatement("set license aSetting = 'aStringValue'");
+        assertThat(stmt.scope(), is(SetStatement.Scope.LICENSE));
+        assertThat(stmt.settingType(), is(SetStatement.SettingType.PERSISTENT));
         assertThat(stmt.assignments().size(), is(1));
 
         Assignment assignment = stmt.assignments().get(0);

--- a/sql/src/main/java/io/crate/analyze/AnalyzedStatementVisitor.java
+++ b/sql/src/main/java/io/crate/analyze/AnalyzedStatementVisitor.java
@@ -131,6 +131,10 @@ public class AnalyzedStatementVisitor<C, R> {
         return visitAnalyzedStatement(analysis, context);
     }
 
+    public R visitSetLicenseStatement(SetLicenseAnalyzedStatement analysis, C context) {
+        return visitAnalyzedStatement(analysis, context);
+    }
+
     public R visitAddColumnStatement(AddColumnAnalyzedStatement analysis, C context) {
         return visitDDLStatement(analysis, context);
     }

--- a/sql/src/main/java/io/crate/analyze/Analyzer.java
+++ b/sql/src/main/java/io/crate/analyze/Analyzer.java
@@ -79,6 +79,7 @@ import io.crate.sql.tree.RefreshStatement;
 import io.crate.sql.tree.ResetStatement;
 import io.crate.sql.tree.RestoreSnapshot;
 import io.crate.sql.tree.RevokePrivilege;
+import io.crate.sql.tree.SetLicenseStatement;
 import io.crate.sql.tree.SetStatement;
 import io.crate.sql.tree.ShowColumns;
 import io.crate.sql.tree.ShowCreateTable;
@@ -365,6 +366,11 @@ public class Analyzer {
 
         @Override
         public AnalyzedStatement visitSetStatement(SetStatement node, Analysis context) {
+            return SetStatementAnalyzer.analyze(node);
+        }
+
+        @Override
+        public AnalyzedStatement visitSetLicenseStatement(SetLicenseStatement node, Analysis context) {
             return SetStatementAnalyzer.analyze(node);
         }
 

--- a/sql/src/main/java/io/crate/analyze/Analyzer.java
+++ b/sql/src/main/java/io/crate/analyze/Analyzer.java
@@ -79,7 +79,6 @@ import io.crate.sql.tree.RefreshStatement;
 import io.crate.sql.tree.ResetStatement;
 import io.crate.sql.tree.RestoreSnapshot;
 import io.crate.sql.tree.RevokePrivilege;
-import io.crate.sql.tree.SetLicenseStatement;
 import io.crate.sql.tree.SetStatement;
 import io.crate.sql.tree.ShowColumns;
 import io.crate.sql.tree.ShowCreateTable;
@@ -138,6 +137,7 @@ public class Analyzer {
     private final CreateUserAnalyzer createUserAnalyzer;
     private final AlterUserAnalyzer alterUserAnalyzer;
     private final CreateViewAnalyzer createViewAnalyzer;
+    private final SetStatementAnalyzer setStatementAnalyzer;
     private final Schemas schemas;
 
     /**
@@ -206,6 +206,7 @@ public class Analyzer {
         this.createIngestionRuleAnalyzer = new CreateIngestionRuleAnalyzer(schemas);
         this.createUserAnalyzer = new CreateUserAnalyzer(functions);
         this.alterUserAnalyzer = new AlterUserAnalyzer(functions);
+        this.setStatementAnalyzer = new SetStatementAnalyzer(functions);
     }
 
     public Analysis boundAnalyze(Statement statement, TransactionContext transactionContext, ParameterContext parameterContext) {
@@ -366,11 +367,9 @@ public class Analyzer {
 
         @Override
         public AnalyzedStatement visitSetStatement(SetStatement node, Analysis context) {
-            return SetStatementAnalyzer.analyze(node);
-        }
-
-        @Override
-        public AnalyzedStatement visitSetLicenseStatement(SetLicenseStatement node, Analysis context) {
+            if (SetStatement.Scope.LICENSE.equals(node.scope())) {
+                return setStatementAnalyzer.analyze(node, context);
+            }
             return SetStatementAnalyzer.analyze(node);
         }
 

--- a/sql/src/main/java/io/crate/analyze/SetLicenseAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/SetLicenseAnalyzedStatement.java
@@ -22,21 +22,48 @@
 
 package io.crate.analyze;
 
-import io.crate.sql.tree.Expression;
+import com.google.common.base.Preconditions;
+import io.crate.expression.symbol.Symbol;
 
-import java.util.List;
-import java.util.Map;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 public class SetLicenseAnalyzedStatement implements AnalyzedStatement {
 
-    private final Map<String, List<Expression>> settings;
+    static final String EXPIRY_DATE_TOKEN = "expirationdate";
+    static final String ISSUED_TO_TOKEN = "issuedto";
+    static final String SIGN_TOKEN = "signature";
 
-    SetLicenseAnalyzedStatement(Map<String, List<Expression>> settings) {
-        this.settings = settings;
+    static final int LICENSE_TOKEN_NUM = 3;
+
+    static final Set<String> LICENSE_ALLOWED_TOKENS = new HashSet<>(
+        Arrays.asList(EXPIRY_DATE_TOKEN, ISSUED_TO_TOKEN, SIGN_TOKEN));
+
+    static final String LICENSE_ALLOWED_TOKENS_AS_STRING = String.join(", ", LICENSE_ALLOWED_TOKENS);
+
+    private static final String MISSING_SETTING_ERROR_TEMPLATE = "Missing setting for SET LICENSE. Please provide the following settings: [%s]";
+
+    private final Symbol expirationDateSymbol;
+    private final Symbol issuedToSymbol;
+    private final Symbol signatureSymbol;
+
+    SetLicenseAnalyzedStatement(final Symbol expirationDateSymbol, final Symbol issuedToSymbol, final Symbol signatureSymbol) {
+        this.expirationDateSymbol = Preconditions.checkNotNull(expirationDateSymbol, MISSING_SETTING_ERROR_TEMPLATE, LICENSE_ALLOWED_TOKENS_AS_STRING);
+        this.issuedToSymbol = Preconditions.checkNotNull(issuedToSymbol, MISSING_SETTING_ERROR_TEMPLATE, LICENSE_ALLOWED_TOKENS_AS_STRING);
+        this.signatureSymbol = Preconditions.checkNotNull(signatureSymbol, MISSING_SETTING_ERROR_TEMPLATE, LICENSE_ALLOWED_TOKENS_AS_STRING);
     }
 
-    public Map<String, List<Expression>> settings() {
-        return settings;
+    public final Symbol expirationDateSymbol() {
+        return expirationDateSymbol;
+    }
+
+    public final Symbol issuedToSymbol() {
+        return issuedToSymbol;
+    }
+
+    public final Symbol signatureSymbol() {
+        return signatureSymbol;
     }
 
     @Override

--- a/sql/src/main/java/io/crate/analyze/SetLicenseAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/SetLicenseAnalyzedStatement.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.analyze;
+
+import io.crate.sql.tree.Expression;
+
+import java.util.List;
+import java.util.Map;
+
+public class SetLicenseAnalyzedStatement implements AnalyzedStatement {
+
+    private final Map<String, List<Expression>> settings;
+
+    SetLicenseAnalyzedStatement(Map<String, List<Expression>> settings) {
+        this.settings = settings;
+    }
+
+    public Map<String, List<Expression>> settings() {
+        return settings;
+    }
+
+    @Override
+    public <C, R> R accept(AnalyzedStatementVisitor<C, R> analyzedStatementVisitor, C context) {
+        return analyzedStatementVisitor.visitSetLicenseStatement(this, context);
+    }
+
+    @Override
+    public boolean isWriteOperation() {
+        return true;
+    }
+}

--- a/sql/src/main/java/io/crate/analyze/SetStatementAnalyzer.java
+++ b/sql/src/main/java/io/crate/analyze/SetStatementAnalyzer.java
@@ -34,6 +34,7 @@ import io.crate.sql.tree.Node;
 import io.crate.sql.tree.ObjectLiteral;
 import io.crate.sql.tree.ParameterExpression;
 import io.crate.sql.tree.ResetStatement;
+import io.crate.sql.tree.SetLicenseStatement;
 import io.crate.sql.tree.SetStatement;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.logging.Loggers;
@@ -76,6 +77,15 @@ class SetStatementAnalyzer {
             }
             return new SetAnalyzedStatement(node.scope(), settings, isPersistent);
         }
+    }
+
+    public static SetLicenseAnalyzedStatement analyze(SetLicenseStatement node) {
+        Map<String, List<Expression>> settings = new HashMap<>();
+        for (Assignment assignment : node.assignments()) {
+            String settingName = ExpressionToStringVisitor.convert(assignment.columnName(), Row.EMPTY);
+            settings.put(settingName, ImmutableList.of(assignment.expression()));
+        }
+        return new SetLicenseAnalyzedStatement(settings);
     }
 
     public static ResetAnalyzedStatement analyze(ResetStatement node) {

--- a/sql/src/main/java/io/crate/analyze/relations/FieldProvider.java
+++ b/sql/src/main/java/io/crate/analyze/relations/FieldProvider.java
@@ -31,4 +31,9 @@ import java.util.List;
 public interface FieldProvider<T extends Symbol> {
 
     T resolveField(QualifiedName qualifiedName, @Nullable List<String> path, Operation operation);
+
+
+    FieldProvider UNSUPPORTED  = (qualifiedName, path, operation) -> {
+        throw new UnsupportedOperationException("Cannot resolve field references");
+    };
 }

--- a/sql/src/main/java/io/crate/execution/TransportActionProvider.java
+++ b/sql/src/main/java/io/crate/execution/TransportActionProvider.java
@@ -29,6 +29,7 @@ import io.crate.execution.jobs.transport.TransportJobAction;
 import io.crate.execution.engine.fetch.TransportFetchNodeAction;
 import io.crate.execution.jobs.kill.TransportKillAllNodeAction;
 import io.crate.execution.jobs.kill.TransportKillJobsNodeAction;
+import io.crate.license.TransportSetLicenseAction;
 import org.elasticsearch.action.admin.cluster.settings.TransportClusterUpdateSettingsAction;
 import org.elasticsearch.action.admin.cluster.snapshots.create.TransportCreateSnapshotAction;
 import org.elasticsearch.action.admin.cluster.snapshots.delete.TransportDeleteSnapshotAction;
@@ -59,6 +60,7 @@ public class TransportActionProvider {
     private final Provider<TransportDeleteSnapshotAction> transportDeleteSnapshotActionProvider;
     private final Provider<TransportRestoreSnapshotAction> transportRestoreSnapshotActionProvider;
     private final Provider<TransportGetSnapshotsAction> transportGetSnapshotsActionProvider;
+    private final Provider<TransportSetLicenseAction> transportSetLicenseActionProvider;
 
     @Inject
     public TransportActionProvider(Provider<TransportFetchNodeAction> transportFetchNodeActionProvider,
@@ -74,7 +76,8 @@ public class TransportActionProvider {
                                    Provider<TransportDeleteSnapshotAction> transportDeleteSnapshotActionProvider,
                                    Provider<TransportCreateSnapshotAction> transportCreateSnapshotActionProvider,
                                    Provider<TransportRestoreSnapshotAction> transportRestoreSnapshotActionProvider,
-                                   Provider<TransportGetSnapshotsAction> transportGetSnapshotsActionPovider) {
+                                   Provider<TransportGetSnapshotsAction> transportGetSnapshotsActionPovider,
+                                   Provider<TransportSetLicenseAction> transportSetLicenseActionProvider) {
         this.transportDeleteIndexActionProvider = transportDeleteIndexActionProvider;
         this.transportClusterUpdateSettingsActionProvider = transportClusterUpdateSettingsActionProvider;
         this.transportShardDeleteActionProvider = transportShardDeleteActionProvider;
@@ -89,6 +92,7 @@ public class TransportActionProvider {
         this.transportCreateSnapshotActionProvider = transportCreateSnapshotActionProvider;
         this.transportRestoreSnapshotActionProvider = transportRestoreSnapshotActionProvider;
         this.transportGetSnapshotsActionProvider = transportGetSnapshotsActionPovider;
+        this.transportSetLicenseActionProvider = transportSetLicenseActionProvider;
     }
 
     public TransportCreatePartitionsAction transportBulkCreateIndicesAction() {
@@ -147,4 +151,7 @@ public class TransportActionProvider {
         return transportGetSnapshotsActionProvider.get();
     }
 
+    public TransportSetLicenseAction transportSetLicenseAction() {
+        return transportSetLicenseActionProvider.get();
+    }
 }

--- a/sql/src/main/java/io/crate/execution/TransportExecutorModule.java
+++ b/sql/src/main/java/io/crate/execution/TransportExecutorModule.java
@@ -38,6 +38,7 @@ import io.crate.execution.jobs.JobSetup;
 import io.crate.execution.jobs.kill.TransportKillAllNodeAction;
 import io.crate.execution.jobs.kill.TransportKillJobsNodeAction;
 import io.crate.execution.jobs.transport.TransportJobAction;
+import io.crate.license.TransportSetLicenseAction;
 import io.crate.lucene.LuceneQueryBuilder;
 import org.elasticsearch.common.inject.AbstractModule;
 
@@ -64,5 +65,6 @@ public class TransportExecutorModule extends AbstractModule {
         bind(TransportDropTableAction.class).asEagerSingleton();
         bind(TransportCreateViewAction.class).asEagerSingleton();
         bind(TransportDropViewAction.class).asEagerSingleton();
+        bind(TransportSetLicenseAction.class).asEagerSingleton();
     }
 }

--- a/sql/src/main/java/io/crate/planner/Planner.java
+++ b/sql/src/main/java/io/crate/planner/Planner.java
@@ -46,6 +46,7 @@ import io.crate.analyze.InsertFromValuesAnalyzedStatement;
 import io.crate.analyze.KillAnalyzedStatement;
 import io.crate.analyze.ResetAnalyzedStatement;
 import io.crate.analyze.SetAnalyzedStatement;
+import io.crate.analyze.SetLicenseAnalyzedStatement;
 import io.crate.analyze.ShowCreateTableAnalyzedStatement;
 import io.crate.analyze.relations.QueriedRelation;
 import io.crate.exceptions.UnhandledServerException;
@@ -66,6 +67,7 @@ import io.crate.planner.node.management.ShowCreateTablePlan;
 import io.crate.planner.operators.LogicalPlanner;
 import io.crate.planner.statement.CopyStatementPlanner;
 import io.crate.planner.statement.DeletePlanner;
+import io.crate.planner.statement.SetLicensePlan;
 import io.crate.planner.statement.SetSessionPlan;
 import io.crate.profile.ProfilingContext;
 import io.crate.profile.Timer;
@@ -260,8 +262,11 @@ public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
     @Override
     public Plan visitSetStatement(SetAnalyzedStatement setStatement, PlannerContext context) {
         switch (setStatement.scope()) {
+            case LICENSE:
+                LOGGER.warn("SET LICENSE STATEMENT WILL BE IGNORED: {}", setStatement.settings());
+                return NoopPlan.INSTANCE;
             case LOCAL:
-                LOGGER.warn("SET LOCAL STATEMENT  WILL BE IGNORED: {}", setStatement.settings());
+                LOGGER.warn("SET LOCAL STATEMENT WILL BE IGNORED: {}", setStatement.settings());
                 return NoopPlan.INSTANCE;
             case SESSION_TRANSACTION_MODE:
                 LOGGER.warn("'SET SESSION CHARACTERISTICS AS TRANSACTION' STATEMENT WILL BE IGNORED");
@@ -279,6 +284,11 @@ public class Planner extends AnalyzedStatementVisitor<PlannerContext, Plan> {
                     );
                 }
         }
+    }
+
+    @Override
+    public Plan visitSetLicenseStatement(SetLicenseAnalyzedStatement setLicenseAnalyzedStatement, PlannerContext context) {
+        return new SetLicensePlan(setLicenseAnalyzedStatement);
     }
 
     @Override

--- a/sql/src/main/java/io/crate/planner/statement/SetLicensePlan.java
+++ b/sql/src/main/java/io/crate/planner/statement/SetLicensePlan.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.planner.statement;
+
+import io.crate.analyze.SetLicenseAnalyzedStatement;
+import io.crate.analyze.SymbolEvaluator;
+import io.crate.data.Row;
+import io.crate.data.Row1;
+import io.crate.data.RowConsumer;
+import io.crate.execution.support.OneRowActionListener;
+import io.crate.expression.symbol.Symbol;
+import io.crate.license.LicenseMetaData;
+import io.crate.license.SetLicenseRequest;
+import io.crate.planner.DependencyCarrier;
+import io.crate.planner.Plan;
+import io.crate.planner.PlannerContext;
+import io.crate.planner.operators.SubQueryResults;
+import io.crate.types.DataTypes;
+import org.apache.lucene.util.BytesRef;
+
+import java.util.Locale;
+import java.util.function.Function;
+
+public class SetLicensePlan implements Plan {
+
+    private final SetLicenseAnalyzedStatement stmt;
+
+    public SetLicensePlan(final SetLicenseAnalyzedStatement stmt) {
+        this.stmt = stmt;
+    }
+
+    static <T, R> R cast(Function<T, R> function, T argument, Symbol subject) {
+        try {
+            return function.apply(argument);
+        } catch (ClassCastException e) {
+            throw new IllegalArgumentException(String.format(Locale.ENGLISH,
+                "SET LICENSE - Invalid type for setting '%s'", subject.toString()), e);
+        }
+    }
+
+    @Override
+    public StatementType type() {
+        return StatementType.MANAGEMENT;
+    }
+
+    @Override
+    public void execute(DependencyCarrier executor,
+                        PlannerContext plannerContext,
+                        RowConsumer consumer,
+                        Row params,
+                        SubQueryResults subQueryResults) {
+
+        Long expirationDateMs = cast(DataTypes.TIMESTAMP::value,
+            SymbolEvaluator.evaluate(plannerContext.functions(), stmt.expirationDateSymbol(), params, subQueryResults),
+            stmt.expirationDateSymbol());
+
+        BytesRef issueTo = cast(DataTypes.STRING::value,
+            SymbolEvaluator.evaluate(plannerContext.functions(), stmt.issuedToSymbol(), params, subQueryResults),
+            stmt.issuedToSymbol());
+
+        BytesRef signature = cast(DataTypes.STRING::value,
+            SymbolEvaluator.evaluate(plannerContext.functions(), stmt.signatureSymbol(), params, subQueryResults),
+            stmt.signatureSymbol());
+
+        LicenseMetaData metaData = new LicenseMetaData(expirationDateMs,
+            issueTo.utf8ToString(), signature.utf8ToString());
+        SetLicenseRequest request = new SetLicenseRequest(metaData);
+        executor.transportActionProvider().transportSetLicenseAction().execute(request, new
+            OneRowActionListener<>(consumer, response -> new Row1(1L)));
+    }
+}

--- a/sql/src/main/java/io/crate/plugin/SQLPlugin.java
+++ b/sql/src/main/java/io/crate/plugin/SQLPlugin.java
@@ -46,6 +46,7 @@ import io.crate.expression.tablefunctions.TableFunctionModule;
 import io.crate.expression.udf.UserDefinedFunctionsMetaData;
 import io.crate.ingestion.IngestionModules;
 import io.crate.ingestion.IngestionService;
+import io.crate.license.LicenseMetaData;
 import io.crate.lucene.ArrayMapperService;
 import io.crate.metadata.MetaDataModule;
 import io.crate.metadata.Schemas;
@@ -255,6 +256,11 @@ public class SQLPlugin extends Plugin implements ActionPlugin, MapperPlugin, Clu
             ViewsMetaData::new
         ));
         entries.add(new NamedWriteableRegistry.Entry(
+            MetaData.Custom.class,
+            LicenseMetaData.TYPE,
+            LicenseMetaData::new
+        ));
+        entries.add(new NamedWriteableRegistry.Entry(
             NamedDiff.class,
             UserDefinedFunctionsMetaData.TYPE,
             in -> UserDefinedFunctionsMetaData.readDiffFrom(MetaData.Custom.class, UserDefinedFunctionsMetaData.TYPE, in)
@@ -268,6 +274,11 @@ public class SQLPlugin extends Plugin implements ActionPlugin, MapperPlugin, Clu
             NamedDiff.class,
             ViewsMetaData.TYPE,
             in -> ViewsMetaData.readDiffFrom(MetaData.Custom.class, ViewsMetaData.TYPE, in)
+        ));
+        entries.add(new NamedWriteableRegistry.Entry(
+            NamedDiff.class,
+            LicenseMetaData.TYPE,
+            in -> LicenseMetaData.readDiffFrom(MetaData.Custom.class, LicenseMetaData.TYPE, in)
         ));
         if (userExtension != null) {
             entries.addAll(userExtension.getNamedWriteables());
@@ -293,6 +304,12 @@ public class SQLPlugin extends Plugin implements ActionPlugin, MapperPlugin, Clu
             new ParseField(ViewsMetaData.TYPE),
             ViewsMetaData::fromXContent
         ));
+        entries.add(new NamedXContentRegistry.Entry(
+            MetaData.Custom.class,
+            new ParseField(LicenseMetaData.TYPE),
+            LicenseMetaData::fromXContent
+        ));
+
         if (userExtension != null) {
             entries.addAll(userExtension.getNamedXContent());
         }

--- a/sql/src/test/java/io/crate/analyze/SetAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SetAnalyzerTest.java
@@ -29,6 +29,7 @@ import io.crate.sql.tree.Expression;
 import io.crate.sql.tree.Literal;
 import io.crate.sql.tree.ObjectLiteral;
 import io.crate.sql.tree.SetStatement;
+import io.crate.sql.tree.StringLiteral;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import org.hamcrest.Matchers;
@@ -228,5 +229,19 @@ public class SetAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     public void testResetLoggingSetting() {
         ResetAnalyzedStatement analysis = analyze("RESET GLOBAL \"logger.action\"");
         assertThat(analysis.settingsToRemove(), Matchers.<Set<String>>is(ImmutableSet.of("logger.action")));
+    }
+
+    @Test
+    public void testSetLicense() throws Exception {
+        SetLicenseAnalyzedStatement analysis = analyze("SET LICENSE expiryDate='01/01/2099', signature='XXX'");
+        assertThat(analysis.settings().size(), is(2));
+        assertThat(
+            analysis.settings().get("expiryDate".toLowerCase()).get(0),
+            Matchers.<Expression>is(StringLiteral.fromObject("01/01/2099"))
+        );
+        assertThat(
+            analysis.settings().get("signature".toLowerCase()).get(0),
+            Matchers.<Expression>is(StringLiteral.fromObject("XXX"))
+        );
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/SetLicenseIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SetLicenseIntegrationTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.integrationtests;
+
+import io.crate.license.LicenseMetaData;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.junit.Test;
+
+@ESIntegTestCase.ClusterScope()
+public class SetLicenseIntegrationTest extends SQLTransportIntegrationTest {
+
+    private static final String EXPIRATION_DATE = "2020-12-31T01:02:03.123";
+    private static final long EXPIRATION_DATE_IN_MS = 1609376523123L;  // equivalent for EXPIRATION_DATE
+    private static final String ISSUED_TO = "me";
+    private static final String SIGNATURE = "SIGNATURE";
+
+    private static LicenseMetaData createMetaData() {
+        return new LicenseMetaData(EXPIRATION_DATE_IN_MS, ISSUED_TO, SIGNATURE);
+    }
+
+    @Test
+    public void testLicenseIsAvailableInClusterStateAfterSetLicense () {
+        execute("set license expirationDate=?, issuedto=?, signature=?", new Object[] {EXPIRATION_DATE, ISSUED_TO, SIGNATURE});
+
+        LicenseMetaData license = clusterService().state().metaData().custom(LicenseMetaData.TYPE);
+        assertEquals(createMetaData(), license);
+    }
+
+}


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Implementation of the ``Set License`` statement. 
Scope in this PR is storing the license information as custom metadata at Cluster State.

Documentation was updated in previous PR and it will be revised in a later PR

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
