### PR TITLE
Remove some TestingTableInfo usages

### DIFF
--- a/sql/src/test/java/io/crate/action/sql/SessionTest.java
+++ b/sql/src/test/java/io/crate/action/sql/SessionTest.java
@@ -132,7 +132,7 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testExtractTypesFromDelete() throws Exception {
-        SQLExecutor e = SQLExecutor.builder(clusterService).addDocTable(TableDefinitions.USER_TABLE_INFO).build();
+        SQLExecutor e = SQLExecutor.builder(clusterService).addTable(TableDefinitions.USER_TABLE_INFO).build();
         AnalyzedStatement analyzedStatement = e.analyzer.unboundAnalyze(
             SqlParser.createStatement("delete from users where name = ?"),
             SessionContext.systemSessionContext(),
@@ -146,7 +146,7 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testExtractTypesFromUpdate() throws Exception {
-        SQLExecutor e = SQLExecutor.builder(clusterService).addDocTable(TableDefinitions.USER_TABLE_INFO).build();
+        SQLExecutor e = SQLExecutor.builder(clusterService).addTable(TableDefinitions.USER_TABLE_INFO).build();
         AnalyzedStatement analyzedStatement = e.analyzer.unboundAnalyze(
             SqlParser.createStatement("update users set name = ? || '_updated' where id = ?"),
             SessionContext.systemSessionContext(),
@@ -160,7 +160,7 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testExtractTypesFromInsertValues() throws Exception {
-        SQLExecutor e = SQLExecutor.builder(clusterService).addDocTable(TableDefinitions.USER_TABLE_INFO).build();
+        SQLExecutor e = SQLExecutor.builder(clusterService).addTable(TableDefinitions.USER_TABLE_INFO).build();
         AnalyzedStatement analyzedStatement = e.analyzer.unboundAnalyze(
             SqlParser.createStatement("INSERT INTO users (id, name) values (?, ?)"),
             SessionContext.systemSessionContext(),
@@ -175,7 +175,7 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testExtractTypesFromInsertFromQuery() throws Exception {
         SQLExecutor e = SQLExecutor.builder(clusterService).
-            addDocTable(TableDefinitions.USER_TABLE_INFO).
+            addTable(TableDefinitions.USER_TABLE_INFO).
             addDocTable(TableDefinitions.USER_TABLE_INFO_CLUSTERED_BY_ONLY).
             build();
         AnalyzedStatement analyzedStatement = e.analyzer.unboundAnalyze(
@@ -193,7 +193,7 @@ public class SessionTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testExtractTypesFromInsertWithOnDuplicateKey() throws Exception {
         SQLExecutor e = SQLExecutor.builder(clusterService).
-            addDocTable(TableDefinitions.USER_TABLE_INFO).
+            addTable(TableDefinitions.USER_TABLE_INFO).
             addDocTable(TableDefinitions.USER_TABLE_INFO_CLUSTERED_BY_ONLY).
             build();
         AnalyzedStatement analyzedStatement = e.analyzer.unboundAnalyze(

--- a/sql/src/test/java/io/crate/analyze/AlterTableAddColumnAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/AlterTableAddColumnAnalyzerTest.java
@@ -31,6 +31,7 @@ import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -46,7 +47,7 @@ public class AlterTableAddColumnAnalyzerTest extends CrateDummyClusterServiceUni
     private SQLExecutor e;
 
     @Before
-    public void prepare() {
+    public void prepare() throws IOException {
         e = SQLExecutor.builder(clusterService).enableDefaultTables().build();
     }
 

--- a/sql/src/test/java/io/crate/analyze/AlterTableOpenCloseAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/AlterTableOpenCloseAnalyzerTest.java
@@ -27,12 +27,14 @@ import io.crate.testing.SQLExecutor;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
+
 public class AlterTableOpenCloseAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     private SQLExecutor e;
 
     @Before
-    public void prepare() {
+    public void prepare() throws IOException {
         e = SQLExecutor.builder(clusterService).enableDefaultTables().build();
     }
 

--- a/sql/src/test/java/io/crate/analyze/AlterTableRenameAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/AlterTableRenameAnalyzerTest.java
@@ -28,12 +28,14 @@ import io.crate.testing.SQLExecutor;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
+
 public class AlterTableRenameAnalyzerTest extends CrateDummyClusterServiceUnitTest {
 
     private SQLExecutor e;
 
     @Before
-    public void prepare() {
+    public void prepare() throws IOException {
         e = SQLExecutor.builder(clusterService).enableDefaultTables().build();
     }
 

--- a/sql/src/test/java/io/crate/analyze/AlterTableRerouteAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/AlterTableRerouteAnalyzerTest.java
@@ -31,6 +31,7 @@ import io.crate.testing.SQLExecutor;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.Arrays;
 
 import static org.hamcrest.Matchers.is;
@@ -40,7 +41,7 @@ public class AlterTableRerouteAnalyzerTest extends CrateDummyClusterServiceUnitT
     private SQLExecutor e;
 
     @Before
-    public void prepare() {
+    public void prepare() throws IOException {
         RelationName myBlobsIdent = new RelationName(BlobSchemaInfo.NAME, "blobs");
         TestingBlobTableInfo myBlobsTableInfo = TableDefinitions.createBlobTable(myBlobsIdent);
         e = SQLExecutor.builder(clusterService).addBlobTable(myBlobsTableInfo).enableDefaultTables().build();

--- a/sql/src/test/java/io/crate/analyze/CopyAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CopyAnalyzerTest.java
@@ -41,6 +41,7 @@ import org.elasticsearch.common.lucene.BytesRefs;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.Collections;
 
 import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
@@ -59,7 +60,7 @@ public class CopyAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     private SQLExecutor e;
 
     @Before
-    public void prepare() {
+    public void prepare() throws IOException {
         e = SQLExecutor.builder(clusterService).enableDefaultTables().build();
     }
 

--- a/sql/src/test/java/io/crate/analyze/CreateAlterPartitionedTableAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateAlterPartitionedTableAnalyzerTest.java
@@ -41,6 +41,7 @@ import org.elasticsearch.test.ClusterServiceUtils;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -58,7 +59,7 @@ public class CreateAlterPartitionedTableAnalyzerTest extends CrateDummyClusterSe
     private SQLExecutor e;
 
     @Before
-    public void prepare() {
+    public void prepare() throws IOException {
         String analyzerSettings = FulltextAnalyzerResolver.encodeSettings(
             Settings.builder().put("search", "foobar").build()).utf8ToString();
         MetaData metaData = MetaData.builder()

--- a/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateAlterTableStatementAnalyzerTest.java
@@ -53,6 +53,7 @@ import org.elasticsearch.test.ClusterServiceUtils;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -72,7 +73,7 @@ public class CreateAlterTableStatementAnalyzerTest extends CrateDummyClusterServ
     private SQLExecutor e;
 
     @Before
-    public void prepare() {
+    public void prepare() throws IOException {
         String analyzerSettings = FulltextAnalyzerResolver.encodeSettings(
             Settings.builder().put("search", "foobar").build()).utf8ToString();
         MetaData metaData = MetaData.builder()

--- a/sql/src/test/java/io/crate/analyze/CreateAnalyzerAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/CreateAnalyzerAnalyzerTest.java
@@ -27,6 +27,8 @@ import org.elasticsearch.common.settings.Settings;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
+
 import static io.crate.testing.SettingMatcher.hasEntry;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -37,7 +39,7 @@ public class CreateAnalyzerAnalyzerTest extends CrateDummyClusterServiceUnitTest
     private SQLExecutor e;
 
     @Before
-    public void prepare() {
+    public void prepare() throws IOException {
         e = SQLExecutor.builder(clusterService).enableDefaultTables().build();
     }
 

--- a/sql/src/test/java/io/crate/analyze/DeleteAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/DeleteAnalyzerTest.java
@@ -33,6 +33,8 @@ import io.crate.testing.SQLExecutor;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
+
 import static io.crate.analyze.TableDefinitions.USER_TABLE_IDENT;
 import static io.crate.testing.SymbolMatchers.isFunction;
 import static io.crate.testing.SymbolMatchers.isLiteral;
@@ -46,7 +48,7 @@ public class DeleteAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     private SQLExecutor e;
 
     @Before
-    public void prepare() {
+    public void prepare() throws IOException {
         e = SQLExecutor.builder(clusterService).enableDefaultTables().build();
     }
 

--- a/sql/src/test/java/io/crate/analyze/DropTableAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/DropTableAnalyzerTest.java
@@ -35,6 +35,8 @@ import io.crate.types.DataTypes;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
+
 import static io.crate.analyze.TableDefinitions.SHARD_ROUTING;
 import static io.crate.analyze.TableDefinitions.USER_TABLE_IDENT;
 import static java.util.Locale.ENGLISH;
@@ -52,7 +54,7 @@ public class DropTableAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     private SQLExecutor e;
 
     @Before
-    public void prepare() {
+    public void prepare() throws IOException {
         e = SQLExecutor.builder(clusterService).enableDefaultTables().addDocTable(aliasInfo).build();
     }
 

--- a/sql/src/test/java/io/crate/analyze/ExplainAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/ExplainAnalyzerTest.java
@@ -30,9 +30,10 @@ import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
+
 import static io.crate.testing.SymbolMatchers.isField;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -41,7 +42,7 @@ public class ExplainAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     private SQLExecutor e;
 
     @Before
-    public void prepare() {
+    public void prepare() throws IOException {
         e = SQLExecutor.builder(clusterService).enableDefaultTables().build();
     }
 

--- a/sql/src/test/java/io/crate/analyze/InsertFromSubQueryAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/InsertFromSubQueryAnalyzerTest.java
@@ -44,6 +44,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
@@ -61,7 +62,7 @@ public class InsertFromSubQueryAnalyzerTest extends CrateDummyClusterServiceUnit
     private SQLExecutor e;
 
     @Before
-    public void prepare() {
+    public void prepare() throws IOException {
         SQLExecutor.Builder builder = SQLExecutor.builder(clusterService).enableDefaultTables();
 
         RelationName usersGeneratedIdent = new RelationName(Schemas.DOC_SCHEMA_NAME, "users_generated");
@@ -124,12 +125,8 @@ public class InsertFromSubQueryAnalyzerTest extends CrateDummyClusterServiceUnit
     @Test
     public void testFromQueryWithSubQueryColumns() throws Exception {
         InsertFromSubQueryAnalyzedStatement analysis =
-            e.analyze("insert into users (" +
-                      "  select id, other_id, name, text, no_index, details, address, " +
-                      "      awesome, counters, friends, tags, bytes, shorts, date, shape, ints, floats " +
-                      "  from users " +
-                      "  where name = 'Trillian'" +
-                      ")");
+            e.analyze("insert into users (id, name) (" +
+                      "  select id, name from users where name = 'Trillian' )");
         assertCompatibleColumns(analysis);
     }
 

--- a/sql/src/test/java/io/crate/analyze/InsertFromValuesAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/InsertFromValuesAnalyzerTest.java
@@ -49,6 +49,7 @@ import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -104,7 +105,7 @@ public class InsertFromValuesAnalyzerTest extends CrateDummyClusterServiceUnitTe
     private SQLExecutor e;
 
     @Before
-    public void prepare() {
+    public void prepare() throws IOException {
         SQLExecutor.Builder executorBuilder = SQLExecutor.builder(clusterService)
             .enableDefaultTables()
             .addDocTable(TEST_ALIAS_TABLE_INFO)
@@ -274,7 +275,7 @@ public class InsertFromValuesAnalyzerTest extends CrateDummyClusterServiceUnitTe
 
     @Test
     public void testInsertWithoutColumns() throws Exception {
-        InsertFromValuesAnalyzedStatement analysis = e.analyze("insert into users values (1, 1, 'Trillian')");
+        InsertFromValuesAnalyzedStatement analysis = e.analyze("insert into users (id, other_id, name) values (1, 1, 'Trillian')");
         assertThat(analysis.tableInfo().ident(), is(USER_TABLE_IDENT));
         assertThat(analysis.columns().size(), is(3));
 
@@ -296,7 +297,7 @@ public class InsertFromValuesAnalyzerTest extends CrateDummyClusterServiceUnitTe
 
     @Test
     public void testInsertWithoutColumnsAndOnlyOneColumn() throws Exception {
-        InsertFromValuesAnalyzedStatement analysis = e.analyze("insert into users values (1)");
+        InsertFromValuesAnalyzedStatement analysis = e.analyze("insert into users (id) values (1)");
         assertThat(analysis.tableInfo().ident(), is(USER_TABLE_IDENT));
         assertThat(analysis.columns().size(), is(1));
 

--- a/sql/src/test/java/io/crate/analyze/OptimizeTableAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/OptimizeTableAnalyzerTest.java
@@ -32,6 +32,8 @@ import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
+
 import static io.crate.analyze.OptimizeTableAnalyzer.FLUSH;
 import static io.crate.analyze.OptimizeTableAnalyzer.MAX_NUM_SEGMENTS;
 import static io.crate.analyze.OptimizeTableAnalyzer.ONLY_EXPUNGE_DELETES;
@@ -45,7 +47,7 @@ public class OptimizeTableAnalyzerTest extends CrateDummyClusterServiceUnitTest 
     private SQLExecutor e;
 
     @Before
-    public void prepare() {
+    public void prepare() throws IOException {
         RelationName myBlobsIdent = new RelationName(BlobSchemaInfo.NAME, "blobs");
         TestingBlobTableInfo myBlobsTableInfo = TableDefinitions.createBlobTable(myBlobsIdent);
         e = SQLExecutor.builder(clusterService).enableDefaultTables().addBlobTable(myBlobsTableInfo).build();

--- a/sql/src/test/java/io/crate/analyze/QuerySpecTest.java
+++ b/sql/src/test/java/io/crate/analyze/QuerySpecTest.java
@@ -28,6 +28,7 @@ import io.crate.testing.SQLExecutor;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.hamcrest.core.Is.is;
@@ -37,7 +38,7 @@ public class QuerySpecTest extends CrateDummyClusterServiceUnitTest {
     private SQLExecutor e;
 
     @Before
-    public void prepare() {
+    public void prepare() throws IOException {
         e = SQLExecutor.builder(clusterService).enableDefaultTables().build();
     }
 

--- a/sql/src/test/java/io/crate/analyze/RefreshAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/RefreshAnalyzerTest.java
@@ -33,6 +33,7 @@ import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.Arrays;
 
 import static org.hamcrest.Matchers.contains;
@@ -44,7 +45,7 @@ public class RefreshAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     private SQLExecutor e;
 
     @Before
-    public void prepare() {
+    public void prepare() throws IOException {
         TestingBlobTableInfo myBlobsTableInfo = TableDefinitions.createBlobTable(myBlobsIdent);
         e = SQLExecutor.builder(clusterService).enableDefaultTables().addBlobTable(myBlobsTableInfo).build();
     }

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -79,7 +79,6 @@ import org.junit.Test;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
-
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -112,7 +111,7 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
     private SQLExecutor sqlExecutor;
 
     @Before
-    public void prepare() {
+    public void prepare() throws IOException {
         DocTableInfo fooUserTableInfo = TestingTableInfo.builder(new RelationName("foo", "users"), SHARD_ROUTING)
             .add("id", DataTypes.LONG, null)
             .add("name", DataTypes.STRING, null)

--- a/sql/src/test/java/io/crate/analyze/SingleRowSubselectAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SingleRowSubselectAnalyzerTest.java
@@ -31,6 +31,8 @@ import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
+
 import static io.crate.testing.SymbolMatchers.isFunction;
 import static io.crate.testing.SymbolMatchers.isReference;
 import static io.crate.testing.TestingHelpers.isSQL;
@@ -41,7 +43,7 @@ public class SingleRowSubselectAnalyzerTest extends CrateDummyClusterServiceUnit
     private SQLExecutor e;
 
     @Before
-    public void prepare() {
+    public void prepare() throws IOException {
         e = SQLExecutor.builder(clusterService).enableDefaultTables().build();
     }
 

--- a/sql/src/test/java/io/crate/analyze/SnapshotRestoreAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SnapshotRestoreAnalyzerTest.java
@@ -46,6 +46,8 @@ import org.elasticsearch.test.ClusterServiceUtils;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
+
 import static io.crate.analyze.TableDefinitions.TEST_DOC_LOCATIONS_TABLE_INFO;
 import static io.crate.analyze.TableDefinitions.TEST_PARTITIONED_TABLE_INFO;
 import static io.crate.analyze.TableDefinitions.USER_TABLE_INFO;
@@ -62,7 +64,7 @@ public class SnapshotRestoreAnalyzerTest extends CrateDummyClusterServiceUnitTes
     private SQLExecutor executor;
 
     @Before
-    public void prepare() {
+    public void prepare() throws IOException {
         RepositoriesMetaData repositoriesMetaData = new RepositoriesMetaData(
             new RepositoryMetaData(
                 "my_repo",
@@ -77,7 +79,7 @@ public class SnapshotRestoreAnalyzerTest extends CrateDummyClusterServiceUnitTes
         RelationName myBlobsIdent = new RelationName(BlobSchemaInfo.NAME, "my_blobs");
         TestingBlobTableInfo myBlobsTableInfo = TableDefinitions.createBlobTable(myBlobsIdent);
         executor = SQLExecutor.builder(clusterService)
-            .addDocTable(USER_TABLE_INFO)
+            .addTable(USER_TABLE_INFO)
             .addDocTable(TEST_DOC_LOCATIONS_TABLE_INFO)
             .addDocTable(TEST_PARTITIONED_TABLE_INFO)
             .addBlobTable(myBlobsTableInfo)
@@ -189,8 +191,8 @@ public class SnapshotRestoreAnalyzerTest extends CrateDummyClusterServiceUnitTes
     @Test
     public void testCreateSnapshotNoWildcards() throws Exception {
         expectedException.expect(RelationUnknown.class);
-        expectedException.expectMessage("Relation 'user*' unknown");
-        analyze("CREATE SNAPSHOT my_repo.my_snapshot TABLE \"user*\"");
+        expectedException.expectMessage("Relation 'foobar*' unknown");
+        analyze("CREATE SNAPSHOT my_repo.my_snapshot TABLE \"foobar*\"");
     }
 
     @Test

--- a/sql/src/test/java/io/crate/analyze/SubSelectAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SubSelectAnalyzerTest.java
@@ -32,6 +32,8 @@ import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
+
 import static io.crate.testing.SymbolMatchers.isField;
 import static io.crate.testing.SymbolMatchers.isFunction;
 import static io.crate.testing.SymbolMatchers.isLiteral;
@@ -46,7 +48,7 @@ public class SubSelectAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     private SQLExecutor executor;
 
     @Before
-    public void prepare() {
+    public void prepare() throws IOException {
         executor = SQLExecutor.builder(clusterService).enableDefaultTables().build();
     }
 

--- a/sql/src/test/java/io/crate/analyze/TableDefinitions.java
+++ b/sql/src/test/java/io/crate/analyze/TableDefinitions.java
@@ -25,9 +25,7 @@ import com.carrotsearch.hppc.IntArrayList;
 import com.carrotsearch.hppc.IntIndexedContainer;
 import com.google.common.collect.ImmutableMap;
 import io.crate.core.collections.TreeMapBuilder;
-import io.crate.metadata.ColumnIdent;
 import io.crate.metadata.PartitionName;
-import io.crate.metadata.Reference;
 import io.crate.metadata.RelationName;
 import io.crate.metadata.Routing;
 import io.crate.metadata.Schemas;
@@ -40,8 +38,6 @@ import org.apache.lucene.util.BytesRef;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 public final class TableDefinitions {
@@ -69,31 +65,32 @@ public final class TableDefinitions {
 
     public static final RelationName USER_TABLE_IDENT = new RelationName(Schemas.DOC_SCHEMA_NAME, "users");
 
-    public static final DocTableInfo USER_TABLE_INFO = TestingTableInfo.builder(USER_TABLE_IDENT, SHARD_ROUTING)
-        .add("id", DataTypes.LONG, null)
-        .add("other_id", DataTypes.LONG, null)
-        .add("name", DataTypes.STRING, null)
-        .add("text", DataTypes.STRING, null, Reference.IndexType.ANALYZED)
-        .add("no_index", DataTypes.STRING, null, Reference.IndexType.NO)
-        .add("details", DataTypes.OBJECT, null)
-        .add("address", DataTypes.OBJECT, null, ColumnPolicy.STRICT)
-        .add("postcode", DataTypes.STRING, Collections.singletonList("address"))
-        .add("awesome", DataTypes.BOOLEAN, null)
-        .add("counters", new ArrayType(DataTypes.LONG), null)
-        .add("friends", new ArrayType(DataTypes.OBJECT), null, ColumnPolicy.DYNAMIC)
-        .add("friends", DataTypes.LONG, Arrays.asList("id"))
-        .add("friends", new ArrayType(DataTypes.STRING), Arrays.asList("groups"))
-        .add("tags", new ArrayType(DataTypes.STRING), null)
-        .add("bytes", DataTypes.BYTE, null)
-        .add("shorts", DataTypes.SHORT, null)
-        .add("date", DataTypes.TIMESTAMP, null)
-        .add("shape", DataTypes.GEO_SHAPE)
-        .add("ints", DataTypes.INTEGER, null)
-        .add("floats", DataTypes.FLOAT, null)
-        .addIndex(ColumnIdent.fromPath("name_text_ft"), Reference.IndexType.ANALYZED)
-        .addPrimaryKey("id")
-        .clusteredBy("id")
-        .build();
+    public static final String USER_TABLE_INFO =
+        "create table doc.users (" +
+         "  id long primary key," +
+         "  other_id long," +
+         "  name string," +
+         "  text string index using fulltext," +
+         "  no_index string index off," +
+         "  details object," +
+         "  address object (strict) as (" +
+         "      postcode string" +
+         "  )," +
+         "  awesome boolean," +
+         "  counters array(long)," +
+         "  friends array(object as (" +
+         "      id long," +
+         "      groups array(string)" +
+         "  ))," +
+         "  tags array(string)," +
+         "  bytes byte," +
+         "  shorts short," +
+         "  date timestamp," +
+         "  shape geo_shape," +
+         "  ints integer," +
+         "  floats float," +
+         "  index name_text_ft using fulltext (name, text)" +
+         ") clustered by (id)";
     public static final RelationName USER_TABLE_IDENT_MULTI_PK = new RelationName(Schemas.DOC_SCHEMA_NAME, "users_multi_pk");
     public static final DocTableInfo USER_TABLE_INFO_MULTI_PK = TestingTableInfo.builder(USER_TABLE_IDENT_MULTI_PK, SHARD_ROUTING)
         .add("id", DataTypes.LONG, null)

--- a/sql/src/test/java/io/crate/analyze/UnionAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/UnionAnalyzerTest.java
@@ -31,6 +31,8 @@ import io.crate.testing.SQLExecutor;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
+
 import static io.crate.testing.SymbolMatchers.isLiteral;
 import static io.crate.testing.TestingHelpers.isSQL;
 import static org.hamcrest.Matchers.instanceOf;
@@ -40,7 +42,7 @@ public class UnionAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     private SQLExecutor sqlExecutor;
 
     @Before
-    public void prepare() {
+    public void prepare() throws IOException {
         sqlExecutor = SQLExecutor.builder(clusterService)
             .enableDefaultTables()
             .build();

--- a/sql/src/test/java/io/crate/analyze/relations/GroupByScalarAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/relations/GroupByScalarAnalyzerTest.java
@@ -5,6 +5,8 @@ import io.crate.testing.SQLExecutor;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
+
 import static org.hamcrest.core.Is.is;
 
 
@@ -13,7 +15,7 @@ public class GroupByScalarAnalyzerTest extends CrateDummyClusterServiceUnitTest 
     private SQLExecutor executor;
 
     @Before
-    public void prepare() {
+    public void prepare() throws IOException {
         executor = SQLExecutor.builder(clusterService).enableDefaultTables().build();
     }
 

--- a/sql/src/test/java/io/crate/analyze/relations/RelationAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/relations/RelationAnalyzerTest.java
@@ -28,6 +28,8 @@ import io.crate.testing.SQLExecutor;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
+
 import static org.hamcrest.core.Is.is;
 
 public class RelationAnalyzerTest extends CrateDummyClusterServiceUnitTest {
@@ -35,7 +37,7 @@ public class RelationAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     private SQLExecutor executor;
 
     @Before
-    public void prepare() {
+    public void prepare() throws IOException {
         executor = SQLExecutor.builder(clusterService).enableDefaultTables().build();
     }
 

--- a/sql/src/test/java/io/crate/expression/udf/UdfUnitTest.java
+++ b/sql/src/test/java/io/crate/expression/udf/UdfUnitTest.java
@@ -26,7 +26,7 @@ import io.crate.data.Input;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Scalar;
-import io.crate.test.integration.CrateUnitTest;
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import org.elasticsearch.cluster.service.ClusterService;
 
 import javax.annotation.Nullable;
@@ -35,7 +35,7 @@ import javax.script.ScriptException;
 import static io.crate.testing.TestingHelpers.getFunctions;
 import static org.mockito.Mockito.mock;
 
-public abstract class UdfUnitTest extends CrateUnitTest {
+public abstract class UdfUnitTest extends CrateDummyClusterServiceUnitTest {
 
     UserDefinedFunctionService udfService = new UserDefinedFunctionService(mock(ClusterService.class), getFunctions());
 

--- a/sql/src/test/java/io/crate/expression/udf/UserDefinedFunctionsTest.java
+++ b/sql/src/test/java/io/crate/expression/udf/UserDefinedFunctionsTest.java
@@ -30,7 +30,10 @@ import io.crate.analyze.relations.DocTableRelation;
 import io.crate.metadata.FunctionIdent;
 import io.crate.metadata.FunctionImplementation;
 import io.crate.metadata.Functions;
+import io.crate.metadata.RelationName;
+import io.crate.metadata.doc.DocTableInfo;
 import io.crate.sql.tree.QualifiedName;
+import io.crate.testing.SQLExecutor;
 import io.crate.testing.SqlExpressions;
 import io.crate.types.DataType;
 import io.crate.types.DataTypes;
@@ -49,14 +52,18 @@ import static io.crate.testing.SymbolMatchers.isLiteral;
 public class UserDefinedFunctionsTest extends UdfUnitTest {
 
     private Functions functions;
-    private SqlExpressions sqlExpressions = new SqlExpressions(
-        ImmutableMap.of(new QualifiedName("users"), new DocTableRelation(TableDefinitions.USER_TABLE_INFO))
-    );
+    private SqlExpressions sqlExpressions;
 
     private Map<FunctionIdent, FunctionImplementation> functionImplementations = new HashMap<>();
 
     @Before
     public void prepare() throws Exception {
+        SQLExecutor sqlExecutor = SQLExecutor.builder(clusterService)
+            .addTable(TableDefinitions.USER_TABLE_INFO)
+            .build();
+        DocTableInfo users = sqlExecutor.schemas().getTableInfo(new RelationName("doc", "users"));
+        sqlExpressions = new SqlExpressions(
+            ImmutableMap.of(new QualifiedName("users"), new DocTableRelation(users)));
         functions = sqlExpressions.functions();
         udfService.registerLanguage(DUMMY_LANG);
     }

--- a/sql/src/test/java/io/crate/planner/DeletePlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/DeletePlannerTest.java
@@ -37,6 +37,7 @@ import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -50,7 +51,7 @@ public class DeletePlannerTest extends CrateDummyClusterServiceUnitTest {
     private SQLExecutor e;
 
     @Before
-    public void prepare() {
+    public void prepare() throws IOException {
         e = SQLExecutor.builder(clusterService)
             .enableDefaultTables()
             .addDocTable(TableDefinitions.PARTED_PKS_TI)

--- a/sql/src/test/java/io/crate/planner/DropTablePlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/DropTablePlannerTest.java
@@ -31,6 +31,8 @@ import io.crate.testing.SQLExecutor;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
+
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
@@ -39,7 +41,7 @@ public class DropTablePlannerTest extends CrateDummyClusterServiceUnitTest {
     private SQLExecutor e;
 
     @Before
-    public void prepare() {
+    public void prepare() throws IOException {
         e = SQLExecutor.builder(clusterService)
             .enableDefaultTables()
             .addBlobTable(TableDefinitions.createBlobTable(new RelationName("blob", "screenshots")))

--- a/sql/src/test/java/io/crate/planner/ExplainPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/ExplainPlannerTest.java
@@ -35,6 +35,7 @@ import io.crate.testing.SQLExecutor;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -61,7 +62,7 @@ public class ExplainPlannerTest extends CrateDummyClusterServiceUnitTest {
     private SQLExecutor e;
 
     @Before
-    public void prepare() {
+    public void prepare() throws IOException {
         e = SQLExecutor.builder(clusterService).enableDefaultTables().build();
     }
 

--- a/sql/src/test/java/io/crate/planner/GroupByScalarPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/GroupByScalarPlannerTest.java
@@ -1,19 +1,22 @@
 package io.crate.planner;
 
 
+import com.carrotsearch.randomizedtesting.RandomizedTest;
 import com.google.common.collect.Iterables;
-import io.crate.expression.symbol.Function;
-import io.crate.metadata.RowGranularity;
-import io.crate.planner.node.dql.Collect;
 import io.crate.execution.dsl.phases.MergePhase;
 import io.crate.execution.dsl.phases.RoutedCollectPhase;
 import io.crate.execution.dsl.projection.EvalProjection;
 import io.crate.execution.dsl.projection.GroupProjection;
+import io.crate.expression.symbol.Function;
+import io.crate.metadata.RowGranularity;
+import io.crate.planner.node.dql.Collect;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.types.DataTypes;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.io.IOException;
 
 import static io.crate.testing.SymbolMatchers.isFunction;
 import static io.crate.testing.SymbolMatchers.isReference;
@@ -26,8 +29,8 @@ public class GroupByScalarPlannerTest extends CrateDummyClusterServiceUnitTest {
     private SQLExecutor e;
 
     @Before
-    public void prepare() {
-        e = SQLExecutor.builder(clusterService)
+    public void prepare() throws IOException {
+        e = SQLExecutor.builder(clusterService, 2, RandomizedTest.getRandom())
             .enableDefaultTables()
             .build();
     }

--- a/sql/src/test/java/io/crate/planner/PlanPrinterTest.java
+++ b/sql/src/test/java/io/crate/planner/PlanPrinterTest.java
@@ -27,6 +27,7 @@ import io.crate.testing.SQLExecutor;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.containsString;
@@ -37,7 +38,7 @@ public class PlanPrinterTest extends CrateDummyClusterServiceUnitTest {
     private SQLExecutor e;
 
     @Before
-    public void setUpExecutor() {
+    public void setUpExecutor() throws IOException {
         e = SQLExecutor.builder(clusterService).enableDefaultTables().build();
     }
 

--- a/sql/src/test/java/io/crate/planner/SingleRowSubselectPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/SingleRowSubselectPlannerTest.java
@@ -29,6 +29,8 @@ import io.crate.testing.SQLExecutor;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
+
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.instanceOf;
 
@@ -37,7 +39,7 @@ public class SingleRowSubselectPlannerTest extends CrateDummyClusterServiceUnitT
     private SQLExecutor e;
 
     @Before
-    public void prepare() {
+    public void prepare() throws IOException {
         e = SQLExecutor.builder(clusterService).enableDefaultTables().build();
     }
 

--- a/sql/src/test/java/io/crate/planner/UnionPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/UnionPlannerTest.java
@@ -22,10 +22,11 @@
 
 package io.crate.planner;
 
+import com.carrotsearch.randomizedtesting.RandomizedTest;
 import io.crate.analyze.TableDefinitions;
-import io.crate.planner.node.dql.Collect;
 import io.crate.execution.dsl.projection.OrderedTopNProjection;
 import io.crate.execution.dsl.projection.TopNProjection;
+import io.crate.planner.node.dql.Collect;
 import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import org.junit.Before;
@@ -42,8 +43,8 @@ public class UnionPlannerTest extends CrateDummyClusterServiceUnitTest {
 
     @Before
     public void setUpExecutor() throws Exception {
-        e = SQLExecutor.builder(clusterService)
-            .addDocTable(TableDefinitions.USER_TABLE_INFO)
+        e = SQLExecutor.builder(clusterService, 2, RandomizedTest.getRandom())
+            .addTable(TableDefinitions.USER_TABLE_INFO)
             .addDocTable(TableDefinitions.TEST_DOC_LOCATIONS_TABLE_INFO)
             .build();
     }

--- a/sql/src/test/java/io/crate/planner/consumer/GlobalAggregatePlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/consumer/GlobalAggregatePlannerTest.java
@@ -51,7 +51,7 @@ public class GlobalAggregatePlannerTest extends CrateDummyClusterServiceUnitTest
     @Before
     public void setUpExecutor() throws Exception {
         e = SQLExecutor.builder(clusterService)
-            .addDocTable(TableDefinitions.USER_TABLE_INFO)
+            .addTable(TableDefinitions.USER_TABLE_INFO)
             .addDocTable(T3.T1_INFO)
             .build();
     }

--- a/sql/src/test/java/io/crate/planner/consumer/GroupByPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/consumer/GroupByPlannerTest.java
@@ -22,6 +22,7 @@
 
 package io.crate.planner.consumer;
 
+import com.carrotsearch.randomizedtesting.RandomizedTest;
 import com.google.common.collect.Iterables;
 import io.crate.analyze.TableDefinitions;
 import io.crate.execution.dsl.phases.CollectPhase;
@@ -61,6 +62,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.List;
 
 import static io.crate.analyze.TableDefinitions.shardRouting;
@@ -80,9 +82,8 @@ public class GroupByPlannerTest extends CrateDummyClusterServiceUnitTest {
     private SQLExecutor e;
 
     @Before
-    public void prepare() {
-        e  = SQLExecutor.builder(
-            clusterService)
+    public void prepare() throws IOException {
+        e  = SQLExecutor.builder(clusterService, 2, RandomizedTest.getRandom())
             .enableDefaultTables()
             .addDocTable(TableDefinitions.CLUSTERED_PARTED)
             .addDocTable(TestingTableInfo.builder(

--- a/sql/src/test/java/io/crate/planner/operators/JoinTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/JoinTest.java
@@ -49,6 +49,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.Collections;
 
 import static io.crate.testing.TestingHelpers.getFunctions;
@@ -67,9 +68,9 @@ public class JoinTest extends CrateDummyClusterServiceUnitTest {
     private TransactionContext txnCtx = TransactionContext.systemTransactionContext();
 
     @Before
-    public void setUpExecutor() {
+    public void setUpExecutor() throws IOException {
         e = SQLExecutor.builder(clusterService)
-            .addDocTable(TableDefinitions.USER_TABLE_INFO)
+            .addTable(TableDefinitions.USER_TABLE_INFO)
             .addDocTable(TableDefinitions.TEST_DOC_LOCATIONS_TABLE_INFO)
             .addDocTable(T3.T1_INFO)
             .addDocTable(T3.T2_INFO)

--- a/sql/src/test/java/io/crate/planner/operators/LimitTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/LimitTest.java
@@ -22,6 +22,7 @@
 
 package io.crate.planner.operators;
 
+import com.carrotsearch.randomizedtesting.RandomizedTest;
 import io.crate.analyze.QueriedTable;
 import io.crate.analyze.TableDefinitions;
 import io.crate.data.Row;
@@ -45,8 +46,8 @@ public class LimitTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
     public void testLimitOnLimitOperator() throws Exception {
-        SQLExecutor e = SQLExecutor.builder(clusterService)
-            .addDocTable(TableDefinitions.USER_TABLE_INFO)
+        SQLExecutor e = SQLExecutor.builder(clusterService, 2, RandomizedTest.getRandom())
+            .addTable(TableDefinitions.USER_TABLE_INFO)
             .build();
         QueriedTable queriedDocTable = e.analyze("select name from users");
 

--- a/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/LogicalPlannerTest.java
@@ -43,6 +43,7 @@ import org.hamcrest.Matcher;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.Map;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
@@ -57,7 +58,7 @@ public class LogicalPlannerTest extends CrateDummyClusterServiceUnitTest {
     private TableStats tableStats;
 
     @Before
-    public void prepare() {
+    public void prepare() throws IOException {
         sqlExecutor = SQLExecutor.builder(clusterService)
             .enableDefaultTables()
             .addView(new RelationName("doc", "v2"), "select a, x from doc.t1")

--- a/sql/src/test/java/io/crate/planner/operators/PushDownTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/PushDownTest.java
@@ -28,8 +28,9 @@ import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
 import io.crate.testing.SQLExecutor;
 import io.crate.testing.T3;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
+
+import java.io.IOException;
 
 import static io.crate.planner.operators.LogicalPlannerTest.isPlan;
 
@@ -39,12 +40,12 @@ public class PushDownTest extends CrateDummyClusterServiceUnitTest {
     private SQLExecutor sqlExecutor;
 
     @Before
-    public void setup() {
+    public void setup() throws IOException {
         tableStats = new TableStats();
         sqlExecutor = SQLExecutor.builder(clusterService)
             .addDocTable(T3.T1_INFO)
             .addDocTable(T3.T2_INFO)
-            .addDocTable(TableDefinitions.USER_TABLE_INFO)
+            .addTable(TableDefinitions.USER_TABLE_INFO)
             .build();
 
         // push down is currently NOT possible when using hash joins. To test the push downs we must disable hash joins.

--- a/sql/src/test/java/io/crate/planner/operators/StatementClassifierTest.java
+++ b/sql/src/test/java/io/crate/planner/operators/StatementClassifierTest.java
@@ -28,6 +28,7 @@ import io.crate.testing.SQLExecutor;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.Collections;
 
 import static org.hamcrest.Matchers.contains;
@@ -38,7 +39,7 @@ public class StatementClassifierTest extends CrateDummyClusterServiceUnitTest {
     private SQLExecutor e;
 
     @Before
-    public void prepare() {
+    public void prepare() throws IOException {
         e = SQLExecutor.builder(clusterService)
             .enableDefaultTables()
             .build();

--- a/sql/src/test/java/io/crate/protocols/postgres/BatchPortalTest.java
+++ b/sql/src/test/java/io/crate/protocols/postgres/BatchPortalTest.java
@@ -40,6 +40,7 @@ import io.crate.testing.SQLExecutor;
 import org.elasticsearch.common.settings.Settings;
 import org.junit.Test;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -49,7 +50,7 @@ import static org.mockito.Mockito.mock;
 public class BatchPortalTest extends CrateDummyClusterServiceUnitTest {
 
     @Test
-    public void testEachStatementReceivesCorrectParams() {
+    public void testEachStatementReceivesCorrectParams() throws IOException {
         SQLExecutor sqlExecutor = SQLExecutor.builder(clusterService).enableDefaultTables().build();
 
         AtomicReference<Row> lastParams = new AtomicReference<>();


### PR DESCRIPTION
We should get rid of the `TestingTableInfo`, using it in tests usually
leads to a inconsistent `clusterState` / `tableInfo/routing`
representation.

For example, we've had tests that asserted that an update statement on a
`users` table had a routing that contained the indices `t1` and `t2`.

We also relied on the columns being in the order of the `add` calls, but
that is not how columns are ordered if created via `CREATE TABLE`.



 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed