### PR TITLE
Remove hard-coded data type names from parser grammar

### DIFF
--- a/sql-parser/src/main/antlr/SqlBase.g4
+++ b/sql-parser/src/main/antlr/SqlBase.g4
@@ -495,19 +495,9 @@ rerouteOption
     ;
 
 dataType
-    : STRING_TYPE
-    | BOOLEAN
-    | BYTE
-    | SHORT
-    | INT
-    | INTEGER
-    | LONG
-    | FLOAT
-    | DOUBLE
-    | TIMESTAMP
-    | IP
-    | GEO_POINT
-    | GEO_SHAPE
+    : IDENTIFIER
+    | quotedIdentifier
+    | nonReserved
     | objectTypeDefinition
     | arrayTypeDefinition
     | setTypeDefinition
@@ -632,6 +622,7 @@ nonReserved
     | REROUTE | MOVE | SHARD | ALLOCATE | REPLICA | CANCEL | CLUSTER | RETRY | FAILED
     | DO | NOTHING | CONFLICT | TRANSACTION_ISOLATION | RETURN | SUMMARY
     | WORK | SERIALIZABLE | REPEATABLE | COMMITTED | UNCOMMITTED | READ | WRITE | DEFERRABLE
+    | STRING_TYPE | IP | DOUBLE | FLOAT | TIMESTAMP | LONG | INT | INTEGER | SHORT | BYTE | BOOLEAN
     ;
 
 SELECT: 'SELECT';


### PR DESCRIPTION
To support type aliases we'll need to allow any identifier as type name.





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed