### PR TITLE
Fix gradle `run` and `runDebug` tasks.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -513,7 +513,7 @@ task(runDebug, dependsOn: 'classes', type: JavaExec) {
     debug = true
     enableAssertions = true
     classpath = sourceSets.main.runtimeClasspath
-    systemProperties += ['es.path.home': "${project.buildDir}/$name"]
+    systemProperties += ['es.path.home': "${rootDir}/sandbox/crate"]
 }
 
 task(run, dependsOn: 'classes', type: JavaExec) {
@@ -521,7 +521,7 @@ task(run, dependsOn: 'classes', type: JavaExec) {
     debug = false
     enableAssertions = true
     classpath = sourceSets.main.runtimeClasspath
-    systemProperties += ['es.path.home': "${project.buildDir}/$name"]
+    systemProperties += ['es.path.home': "${rootDir}/sandbox/crate"]
     systemProperties System.getProperties()
 }
 

--- a/devs/docs/basics.rst
+++ b/devs/docs/basics.rst
@@ -40,20 +40,19 @@ To compile the CrateDB sources, run::
 
     $ ./gradlew compileJava
 
-To run CrateDB as a Gradle task, you need to create configuration file for
-logging::
-
-    $ mkdir -pv config && touch config/log4j2.properties
-
-You can use a *minimal logging configuration*. For more information, see the
-`logging documentation`_.
-
 Run CrateDB like so::
+
+    $ ./gradlew run
+
+or with remote debugging enabled::
 
     $ ./gradlew runDebug
 
 *Note*: If you run CrateDB like this, CrateDB will wait for a remote debugger
 on port ``5005`` before fully starting up!
+
+Both ``run`` and ``runDebug`` comands will set the HOME to ``sandbox/crate`` and
+so uses the configuration files located there.
 
 To install the CrateDB locally, run::
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Setting the `es.path.home` to `sandbox/crate` will fix running theses
tasks as otherwise no valid configuration files are found
(a valid `log4j2.properties` is required) and CrateDB will refuse to start.
Relates https://github.com/crate/crate/issues/7543

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
