### PR TITLE
Use default SHIPPABLE env var instead of custom one.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -22,7 +22,7 @@ build:
     - CIUSER_BUILD_DIR=/home/ciuser/build
     - mv $SHIPPABLE_BUILD_DIR $CIUSER_BUILD_DIR
     - chown -R ciuser:ciuser /home/ciuser
-    - su -c "cd $CIUSER_BUILD_DIR && IS_SHIPPABLE_CI_BUILD=true ./gradlew --no-daemon :sql:test" ciuser
+    - su -c "cd $CIUSER_BUILD_DIR && ./gradlew --no-daemon :sql:test" ciuser
   cache: true
   cache_dir_list:
     - /home/ciuser/.m2

--- a/sql/src/test/java/io/crate/integrationtests/NodeStatsTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/NodeStatsTest.java
@@ -201,7 +201,7 @@ public class NodeStatsTest extends SQLTransportIntegrationTest {
 
     @Test
     public void testSysNodesCgroup() throws Exception {
-        if (Constants.LINUX && !"true".equals(System.getenv("IS_SHIPPABLE_CI_BUILD"))) { // cgroups are only available on Linux
+        if (Constants.LINUX && !"true".equals(System.getenv("SHIPPABLE"))) { // cgroups are only available on Linux
             SQLResponse response = execute("select" +
                                            " os['cgroup']['cpuacct']['control_group']," +
                                            " os['cgroup']['cpuacct']['usage_nanos']," +


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Shippable provides already some standard ENV vars, lets use them.
See http://docs.shippable.com/ci/env-vars/#stdEnv

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
