### PR TITLE
Throw a sensible error if table function is used in WHERE

### DIFF
--- a/sql/src/main/java/io/crate/analyze/where/WhereClauseValidator.java
+++ b/sql/src/main/java/io/crate/analyze/where/WhereClauseValidator.java
@@ -33,6 +33,7 @@ import io.crate.expression.symbol.Field;
 import io.crate.expression.symbol.Function;
 import io.crate.expression.symbol.Symbol;
 import io.crate.expression.symbol.SymbolVisitor;
+import io.crate.metadata.FunctionInfo;
 import io.crate.metadata.Reference;
 import io.crate.metadata.doc.DocSysColumns;
 import io.crate.sql.tree.ComparisonExpression;
@@ -89,6 +90,9 @@ public final class WhereClauseValidator {
         @Override
         public Symbol visitFunction(Function function, Context context) {
             context.functions.push(function);
+            if (function.info().type().equals(FunctionInfo.Type.TABLE)) {
+                throw new UnsupportedOperationException("Table functions are not allowed in WHERE");
+            }
             continueTraversal(function, context);
             context.functions.pop();
             return function;

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -2011,4 +2011,10 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         expectedException.expectMessage("Table functions are not allowed in HAVING");
         analyze("select count(*) from t1 having unnest([1]) > 1");
     }
+
+    @Test
+    public void testUsingTableFunctionInWhereClauseIsNotAllowed() {
+        expectedException.expectMessage("Table functions are not allowed in WHERE");
+        analyze("select * from sys.nodes where unnest([1]) = 1");
+    }
 }


### PR DESCRIPTION
- [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed