### PR TITLE
Handle _fetchId correctly in the ProjectSet operator

### DIFF
--- a/sql/src/main/java/io/crate/execution/dsl/projection/builder/SplitPoints.java
+++ b/sql/src/main/java/io/crate/execution/dsl/projection/builder/SplitPoints.java
@@ -47,18 +47,15 @@ import java.util.List;
 public class SplitPoints {
 
     private final List<Symbol> toCollect;
-    private final List<Symbol> standalone;
     private final List<Function> aggregatesOrTableFunctions;
 
     @Nullable
     private final FunctionInfo.Type functionsType;
 
     SplitPoints(List<Symbol> toCollect,
-                List<Symbol> standalone,
                 List<Function> aggregatesOrTableFunctions,
                 @Nullable FunctionInfo.Type functionsType) {
         this.toCollect = toCollect;
-        this.standalone = standalone;
         this.aggregatesOrTableFunctions = aggregatesOrTableFunctions;
         this.functionsType = functionsType;
     }
@@ -81,9 +78,5 @@ public class SplitPoints {
         } else {
             return Collections.emptyList();
         }
-    }
-
-    public List<Symbol> standalone() {
-        return standalone;
     }
 }

--- a/sql/src/main/java/io/crate/execution/dsl/projection/builder/SplitPointsBuilder.java
+++ b/sql/src/main/java/io/crate/execution/dsl/projection/builder/SplitPointsBuilder.java
@@ -89,7 +89,6 @@ public final class SplitPointsBuilder extends DefaultTraversalSymbolVisitor<Spli
         }
         return new SplitPoints(
             new ArrayList<>(context.toCollect),
-            context.standalone,
             context.aggregatesOrTableFunctions,
             context.functionsType
         );

--- a/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
+++ b/sql/src/main/java/io/crate/planner/operators/LogicalPlanner.java
@@ -210,8 +210,7 @@ public class LogicalPlanner {
                                 splitPoints.aggregates()),
                             relation.having()
                         ),
-                        splitPoints.tableFunctions(),
-                        splitPoints.standalone()
+                        splitPoints.tableFunctions()
                     ),
                     relation.orderBy()
                 ),

--- a/sql/src/test/groovy/io/crate/integrationtests/TableFunctionITest.groovy
+++ b/sql/src/test/groovy/io/crate/integrationtests/TableFunctionITest.groovy
@@ -107,4 +107,15 @@ class TableFunctionITest extends SQLTransportIntegrationTest {
         execute("select max(x) from (select unnest([1, 2, 3, 4]) as x) as t");
         assert response.rows()[0][0] == 4L;
     }
+
+    @Test
+    public void testSelectUnnestAndStandaloneColumnFromUserTable() {
+        execute("create table t1 (x int, arr array(string))");
+        execute("insert into t1 (x, arr) values (1, ['foo', 'bar'])");
+        execute("refresh table t1");
+        execute("select x, unnest(arr) from t1");
+        assert printedTable(response.rows()) == "" +
+                "1| foo\n" +
+                "1| bar\n";
+    }
 }


### PR DESCRIPTION
In a query like `select unnest(arr), x` the Collect operator is allowed
to re-write `x` to `_fetchId`. The `ProjectSet` operator didn't handle
that case correctly.





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed