### PR TITLE
Do not recurse into function arguments on group by semantics validation

### DIFF
--- a/sql/src/test/java/io/crate/analyze/GroupByAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/GroupByAnalyzerTest.java
@@ -72,7 +72,7 @@ public class GroupByAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testGroupBySubscriptMissingOutput() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("column 'load['5']' must appear in the GROUP BY clause or be used in an aggregation function");
+        expectedException.expectMessage("'load['5']' must appear in the GROUP BY clause");
         analyze("select load['5'] from sys.nodes group by load['1']");
     }
 
@@ -118,7 +118,7 @@ public class GroupByAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     public void testGroupByScalarAliasedWithRealColumnNameFailsIfScalarColumnIsNotGrouped() {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage(
-            "column 'height' must appear in the GROUP BY clause or be used in an aggregation function");
+            "'(1 / height)' must appear in the GROUP BY clause");
         analyze("select 1/height as age from foo.users group by age");
     }
 
@@ -219,16 +219,14 @@ public class GroupByAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     @Test
     public void testSelectAggregationMissingGroupBy() {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage(
-            "column 'name' must appear in the GROUP BY clause or be used in an aggregation function");
+        expectedException.expectMessage("'name' must appear in the GROUP BY clause");
         analyze("select name, count(id) from users");
     }
 
     @Test
     public void testSelectGlobalDistinctAggregationMissingGroupBy() {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage(
-            "column 'name' must appear in the GROUP BY clause or be used in an aggregation function");
+        expectedException.expectMessage("'name' must appear in the GROUP BY clause");
         analyze("select distinct name, count(id) from users");
     }
 

--- a/sql/src/test/java/io/crate/analyze/relations/GroupByScalarAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/relations/GroupByScalarAnalyzerTest.java
@@ -22,7 +22,7 @@ public class GroupByScalarAnalyzerTest extends CrateDummyClusterServiceUnitTest 
     @Test
     public void testScalarFunctionArgumentsNotAllInGroupByThrowsException() throws Exception {
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("column 'other_id' must appear in the GROUP BY clause or be used in an aggregation function");
+        expectedException.expectMessage("'(id * other_id)' must appear in the GROUP BY");
         executor.analyze("select id * other_id from users group by id");
     }
 

--- a/sql/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/GroupByAggregateTest.java
@@ -664,7 +664,7 @@ public class GroupByAggregateTest extends SQLTransportIntegrationTest {
     public void testGroupByUnknownResultColumn() throws Exception {
         this.setup.groupBySetup();
         expectedException.expect(SQLActionException.class);
-        expectedException.expectMessage("column 'details_ignored['lol']' must appear in the GROUP BY clause or be used in an aggregation function");
+        expectedException.expectMessage("'details_ignored['lol']' must appear in the GROUP BY clause");
         execute("select details_ignored['lol'] from characters group by race");
     }
 


### PR DESCRIPTION
It is valid to group by a scalar function, so there is no need to
traverse into a scalars argument to generate an error message.





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed