### PR TITLE
Remove TODO about reference nesting and simplify logic

### DIFF
--- a/sql/src/main/java/io/crate/analyze/relations/DocTableRelation.java
+++ b/sql/src/main/java/io/crate/analyze/relations/DocTableRelation.java
@@ -72,9 +72,7 @@ public class DocTableRelation extends AbstractTableRelation<DocTableInfo> {
                 }
             }
         }
-        reference = checkNestedArray(ci, reference);
-        // TODO: check allocated fields first?
-        return allocate(ci, reference);
+        return allocate(ci, makeArrayIfContainedInObjectArray(reference));
     }
 
     /**


### PR DESCRIPTION
The TODO was a bit miss-leading, the logic that is in place there makes
sense. Creating children of object arrays as array themselves within the
TableInfo would break insert validation and type mapping.





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed