### PR TITLE
Allow ANY = on object columns

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -61,8 +61,8 @@ Changes
 - Improved the handling of function expressions inside subscripts used on
   object columns. This allows expressions like ``obj['x' || 'x']`` to be used.
 
-- The ``= ANY`` operator now also supports operations on nested arrays. This
-  enables queries like ``WHERE ['foo', 'bar'] =
+- The ``= ANY`` operator now also supports operations on object arrays or
+  nested arrays. This enables queries like ``WHERE ['foo', 'bar'] =
   ANY(object_array(string_array))``.
 
 - Added support for the ``array(subquery)`` expression.

--- a/blackbox/docs/general/dql/selects.rst
+++ b/blackbox/docs/general/dql/selects.rst
@@ -686,14 +686,13 @@ Inserting objects::
 Object Arrays
 =============
 
-Arrays in CrateDB can only be queried for containment using the
-:ref:`sql_dql_any_array` operator. One exception are object arrays. As you can
-access fields of :ref:`sql_dql_objects` using subscript expressions, you can
-access fields of object arrays.
+Arrays in CrateDB can be queried for containment using the
+:ref:`sql_dql_any_array` operator. 
 
-As an object array is no object, you won't get the value for a single field,
-but an array of all the values of that field for all objects in that object
-array.
+It is possible to access fields of :ref:`sql_dql_objects` using subscript
+expressions. If the parent is an object array, you'll get an array of the
+selected field.
+
 
 Examples::
 
@@ -747,6 +746,13 @@ Examples::
     | North West Ripple |
     +-------------------+
     SELECT 2 rows in set (... sec)
+
+
+.. note::
+
+    Although it is possible to use ``? = ANY (object_array)`` it's usage is
+    discouraged as it cannot utilize the index and has to do the equivalent of
+    a table scan.
 
 .. _sql_dql_object_arrays_select:
 

--- a/sql/src/main/java/io/crate/expression/operator/any/AnyOperator.java
+++ b/sql/src/main/java/io/crate/expression/operator/any/AnyOperator.java
@@ -124,13 +124,9 @@ public final class AnyOperator extends Operator<Object> {
             DataType<?> innerType = ((CollectionType) dataTypes.get(1)).innerType();
             checkArgument(innerType.equals(dataTypes.get(0)),
                 "The inner type of the array/set passed to ANY must match its left expression");
-            checkArgument(!innerType.equals(DataTypes.OBJECT),
-                "ANY on object arrays is not supported");
 
             return new AnyOperator(
-                new FunctionInfo(new FunctionIdent(name, dataTypes), BooleanType.INSTANCE),
-                cmpIsMatch
-            );
+                new FunctionInfo(new FunctionIdent(name, dataTypes), BooleanType.INSTANCE), cmpIsMatch);
         }
     }
 }

--- a/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SelectStatementAnalyzerTest.java
@@ -890,13 +890,12 @@ public class SelectStatementAnalyzerTest extends CrateDummyClusterServiceUnitTes
         analyze("select * from users where 'George' = ANY (name)");
     }
 
-    @Test // TODO: remove this artificial limitation in general
+    @Test
     public void testArrayCompareObjectArray() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("ANY on object arrays is not supported");
-        analyze("select * from users where ? = ANY (friends)", new Object[]{
+        QueriedRelation relation = analyze("select * from users where ? = ANY (friends)", new Object[]{
             new MapBuilder<String, Object>().put("id", 1L).map()
         });
+        assertThat(relation.where().queryOrFallback(), is(isFunction("any_=")));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/expression/operator/any/AnyEqOperatorTest.java
+++ b/sql/src/test/java/io/crate/expression/operator/any/AnyEqOperatorTest.java
@@ -21,7 +21,6 @@
 
 package io.crate.expression.operator.any;
 
-import com.google.common.collect.ImmutableMap;
 import io.crate.expression.operator.input.ObjectInput;
 import io.crate.expression.scalar.AbstractScalarFunctionsTest;
 import io.crate.metadata.FunctionIdent;
@@ -51,35 +50,8 @@ public class AnyEqOperatorTest extends AbstractScalarFunctionsTest {
         assertEvaluate("1 = ANY([1])", true);
         assertEvaluate("1 = ANY([2])", false);
 
-        /*
-        below is the same as - but the ExpressionAnalyzer prohibits this currently
         assertEvaluate("{i=1, b=true} = ANY([{i=1, b=true}])", true);
         assertEvaluate("{i=1, b=true} = ANY([{i=2, b=true}])", false);
-        */
-        assertTrue(anyEq(
-            ImmutableMap.<String, Object>builder()
-                .put("int", 1)
-                .put("boolean", true)
-                .build(),
-            new Object[]{
-                ImmutableMap.<String, Object>builder()
-                    .put("int", 1)
-                    .put("boolean", true)
-                    .build()
-            }
-        ));
-        assertFalse(anyEq(
-            ImmutableMap.<String, Object>builder()
-                .put("int", 1)
-                .put("boolean", true)
-                .build(),
-            new Object[]{
-                ImmutableMap.<String, Object>builder()
-                    .put("int", 2)
-                    .put("boolean", false)
-                    .build()
-            }
-        ));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
+++ b/sql/src/test/java/io/crate/lucene/CommonQueryBuilderTest.java
@@ -532,4 +532,10 @@ public class CommonQueryBuilderTest extends LuceneQueryBuilderTest {
         expectedException.expectMessage("Cannot use any_<= when the left side is an array");
         convert("[1, 2] <= any(o_array['xs'])");
     }
+
+    @Test
+    public void testAnyOnObjectArrayResultsInXY() {
+        Query query = convert("{xs=[1, 1]} = ANY(o_array)");
+        assertThat(query, instanceOf(GenericFunctionQuery.class));
+    }
 }


### PR DESCRIPTION
We can compare objects and ANY is implemented on top of it, so we can
remove this artificial limitation.





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed