### PR TITLE
Enforce setting the streamers to retrieve rows from DistributedResultRequest

### DIFF
--- a/sql/src/main/java/io/crate/execution/engine/distribution/DistributedResultRequest.java
+++ b/sql/src/main/java/io/crate/execution/engine/distribution/DistributedResultRequest.java
@@ -96,22 +96,11 @@ public class DistributedResultRequest extends TransportRequest {
         return bucketIdx;
     }
 
-    public void streamers(Streamer<?>[] streamers) {
+    public Bucket readRows(Streamer<?>[] streamers) {
         if (rows instanceof StreamBucket) {
-            assert streamers != null : "streamers must not be null";
             ((StreamBucket) rows).streamers(streamers);
         }
         this.streamers = streamers;
-    }
-
-    public boolean rowsCanBeRead() {
-        if (rows instanceof StreamBucket) {
-            return streamers != null;
-        }
-        return true;
-    }
-
-    public Bucket rows() {
         return rows;
     }
 
@@ -164,7 +153,6 @@ public class DistributedResultRequest extends TransportRequest {
             out.writeException(throwable);
             out.writeBoolean(isKilled);
         } else {
-            // TODO: we should not rely on another bucket in this class and instead write to the stream directly
             StreamBucket.writeBucket(out, streamers, rows);
         }
     }

--- a/sql/src/main/java/io/crate/execution/engine/distribution/TransportDistributedResultAction.java
+++ b/sql/src/main/java/io/crate/execution/engine/distribution/TransportDistributedResultAction.java
@@ -150,11 +150,10 @@ public class TransportDistributedResultAction extends AbstractComponent implemen
 
         Throwable throwable = request.throwable();
         if (throwable == null) {
-            request.streamers(pageBucketReceiver.streamers());
             SendResponsePageResultListener pageResultListener = new SendResponsePageResultListener();
             pageBucketReceiver.setBucket(
                 request.bucketIdx(),
-                request.rows(),
+                request.readRows(pageBucketReceiver.streamers()),
                 request.isLast(),
                 pageResultListener
             );

--- a/sql/src/test/java/io/crate/execution/engine/distribution/DistributedResultRequestTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/distribution/DistributedResultRequestTest.java
@@ -58,14 +58,12 @@ public class DistributedResultRequestTest extends CrateUnitTest {
         StreamInput in = out.bytes().streamInput();
         DistributedResultRequest r2 = new DistributedResultRequest();
         r2.readFrom(in);
-        r2.streamers(streamers);
-        assertTrue(r2.rowsCanBeRead());
 
-        assertEquals(r1.rows().size(), r2.rows().size());
+        assertEquals(r1.readRows(streamers).size(), r2.readRows(streamers).size());
         assertThat(r1.isLast(), is(r2.isLast()));
         assertThat(r1.executionPhaseInputId(), is(r2.executionPhaseInputId()));
 
-        assertThat(r2.rows(), contains(isRow("ab"), isNullRow(), isRow("cd")));
+        assertThat(r2.readRows(streamers), contains(isRow("ab"), isNullRow(), isRow("cd")));
     }
 
     @Test

--- a/sql/src/test/java/io/crate/execution/engine/distribution/DistributingConsumerTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/distribution/DistributingConsumerTest.java
@@ -186,10 +186,9 @@ public class DistributingConsumerTest extends CrateUnitTest {
             PageBucketReceiver bucketReceiver = distResultRXTask.getBucketReceiver(resultRequest.executionPhaseInputId());
             assertThat(bucketReceiver, Matchers.notNullValue());
             if (throwable == null) {
-                resultRequest.streamers(streamers);
                 bucketReceiver.setBucket(
                     resultRequest.bucketIdx(),
-                    resultRequest.rows(),
+                    resultRequest.readRows(streamers),
                     resultRequest.isLast(),
                     needMore -> listener.onResponse(new DistributedResultResponse(needMore)));
             } else {


### PR DESCRIPTION
There was an implicit contract that the streamers have to be set to
de-serialize the rows. This changes the API to make the contract
explicit.





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed