### PR TITLE
ci: Don't run tests in parallel on azure pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,13 +11,13 @@ jobs:
         inputs:
           workingDirectory: ''
           gradleWrapperFile: 'gradlew'
-          gradleOptions: '-Xmx3072m'
+          gradleOptions: '-Xmx2048m'
           javaHomeOption: 'JDKVersion'
           jdkVersionOption: '1.10'
           jdkArchitectureOption: 'x64'
           publishJUnitResults: true
           testResultsFiles: '**/TEST-*.xml'
-          tasks: ':sql:test -PtestForks=2'
+          tasks: ':sql:test'
 
   - job: Windows
     pool:
@@ -30,10 +30,10 @@ jobs:
         inputs:
           workingDirectory: ''
           gradleWrapperFile: 'gradlew'
-          gradleOptions: '-Xmx3072m'
+          gradleOptions: '-Xmx2048m'
           javaHomeOption: 'JDKVersion'
           jdkVersionOption: '1.10'
           jdkArchitectureOption: 'x64'
           publishJUnitResults: true
           testResultsFiles: '**/TEST-*.xml'
-          tasks: ':sql:test -PtestForks=2'
+          tasks: ':sql:test'


### PR DESCRIPTION
Seems to be too much for the machines. We've had test failures within
`assertBusy` blocks.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
