### PR TITLE
Fix decoding of postgres array literal constants

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -79,3 +79,7 @@ Changes
 
 Fixes
 =====
+
+- Fixed decoding of postgres specific array literal constant: unquoted elements
+  and single element arrays were not decoded correctly and resulted in an empty
+  array.

--- a/blackbox/docs/interfaces/postgres.rst
+++ b/blackbox/docs/interfaces/postgres.rst
@@ -305,9 +305,6 @@ Arrays
 Declaration of Arrays
 .....................
 
-The definition of an array by writing its values as a literal constant with the
-syntax of  ``'{ val1 delim val2 delim ... }'`` is not supported.
-
 While multidimensional arrays in PostgreSQL must have matching extends for each
 dimension, CrateDB allows different length nested arrays as this example
 shows::

--- a/sql/src/test/java/io/crate/protocols/postgres/types/PGArrayTest.java
+++ b/sql/src/test/java/io/crate/protocols/postgres/types/PGArrayTest.java
@@ -144,6 +144,14 @@ public class PGArrayTest extends BasePGTypeTest<PGArray> {
         Object o = pgArray.decodeUTF8Text("{\"10\",\"20\"}".getBytes(StandardCharsets.UTF_8));
         assertThat(o, is(new Object[] {10, 20}));
 
+        // ensure unquoted integer values are decoded correctly (a bug prevented that once)
+        o = pgArray.decodeUTF8Text("{10,20}".getBytes(StandardCharsets.UTF_8));
+        assertThat(o, is(new Object[] {10, 20}));
+
+        // ensure array with single value is decoded correctly (a bug prevented that once)
+        o = pgArray.decodeUTF8Text("{10}".getBytes(StandardCharsets.UTF_8));
+        assertThat(o, is(new Object[] {10}));
+
         // 2-dimension array
         o = pgArray.decodeUTF8Text("{{\"1\",NULL,\"2\"},{NULL,\"3\",\"4\"}}".getBytes(StandardCharsets.UTF_8));
         assertThat(o, is(new Object[][] {{1, null, 2}, {null, 3, 4}}));


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Unquoted elements and single element arrays were not decoded correctly
and resulted in empty arrays.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
