### PR TITLE
Amend 3.0.7 notes with notice about changes to CREATE REPOSITORY

### DIFF
--- a/blackbox/docs/appendices/release-notes/3.0.7.rst
+++ b/blackbox/docs/appendices/release-notes/3.0.7.rst
@@ -48,6 +48,17 @@ Released on 2018/09/25.
 Changelog
 =========
 
+Breaking Changes
+----------------
+
+- Previously, :ref:`version_3.0.0` advertised a breaking change for the removal
+  of the ``region`` setting when using the ``CREATE REPOSITORY`` query for S3
+  based snapshot repositories. However, due to a bug, using the ``region``
+  setting was valid syntax in versions 3.0.0 through to 3.0.6.
+
+  This bug has been fixed in 3.0.7. Due to this, ``CREATE REPOSITORY`` queries
+  that were accepted (erroneously) in 3.0.6 may no longer work in 3.0.7.
+
 Fixes
 -----
 
@@ -59,3 +70,4 @@ Fixes
 
 - Fixed processing of the ``endpoint``, ``protocol`` and ``max_retries`` S3
   repository parameters.
+


### PR DESCRIPTION
In 3.0.0, a breaking change was introduced that removed the 'region'
setting from the accepted parameters of the CREATE REPOSITORY query,
instead opting to infer the region from the endpoint parameter.

However, between 3.0.0 and 3.0.6, this 'region' setting was accepted as
valid syntax, meaning that CREATE REPOSITORY queries that should not
have been accepted, were. This was fixed in 3.0.7 with 37a4feec5afe8e6355caa08f69597b78582a6cd1

This commit adds a notice to the release notes of 3.0.7, warning that
the behaviour of the CREATE REPOSITORY query may break between 3.0.6 and
3.0.7.