### PR TITLE
Re-work comparison operators to use composition

### DIFF
--- a/sql/src/main/java/io/crate/expression/operator/CmpOperator.java
+++ b/sql/src/main/java/io/crate/expression/operator/CmpOperator.java
@@ -36,26 +36,16 @@ import io.crate.types.DataTypes;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Function;
+import java.util.function.IntPredicate;
 
-public abstract class CmpOperator extends Operator<Object> {
+public final class CmpOperator extends Operator<Object> {
 
-    /**
-     * called inside {@link #normalizeSymbol(io.crate.expression.symbol.Function)}
-     * in order to interpret the result of compareTo
-     * <p>
-     * subclass has to implement this to evaluate the -1, 0, 1 to boolean
-     * e.g. for Lt  -1 is true, 0 and 1 is false.
-     *
-     * @param comparisonResult the result of someLiteral.compareTo(otherLiteral)
-     * @return true/false
-     */
-    protected abstract boolean compare(int comparisonResult);
+    private final FunctionInfo info;
+    private final IntPredicate isMatch;
 
-    protected FunctionInfo info;
-
-    protected CmpOperator(FunctionInfo info) {
+    public CmpOperator(FunctionInfo info, IntPredicate cmpResultIsMatch) {
         this.info = info;
+        this.isMatch = cmpResultIsMatch;
     }
 
     @Override
@@ -78,9 +68,9 @@ public abstract class CmpOperator extends Operator<Object> {
         assert (left.getClass().equals(right.getClass())) : "left and right must have the same type for comparison";
 
         if (left instanceof Comparable) {
-            return compare(((Comparable) left).compareTo(right));
+            return isMatch.test(((Comparable) left).compareTo(right));
         } else if (left instanceof Map) {
-            return compare(Objects.compare((Map) left, (Map) right, MapComparator.getInstance()));
+            return isMatch.test(Objects.compare((Map) left, (Map) right, MapComparator.getInstance()));
         } else {
             return null;
         }
@@ -91,31 +81,27 @@ public abstract class CmpOperator extends Operator<Object> {
         private static final Param primitiveTypes = Param.of(DataTypes.PRIMITIVE_TYPES);
 
         private final String name;
-        private final Function<FunctionInfo, FunctionImplementation> functionFactory;
+        private final IntPredicate isMatch;
 
-        CmpResolver(String name, Function<FunctionInfo, FunctionImplementation> functionFactory) {
-            this(name, FuncParams.builder(primitiveTypes, primitiveTypes).build(), functionFactory);
+        CmpResolver(String name, IntPredicate isMatch) {
+            this(name, FuncParams.builder(primitiveTypes, primitiveTypes).build(), isMatch);
         }
 
-        CmpResolver(String name,
-                    FuncParams funcParams,
-                    Function<FunctionInfo, FunctionImplementation> functionFactory) {
+        CmpResolver(String name, FuncParams funcParams, IntPredicate isMatch) {
             super(funcParams);
             this.name = name;
-            this.functionFactory = functionFactory;
+            this.isMatch = isMatch;
         }
 
         @Override
         public FunctionImplementation getForTypes(List<DataType> dataTypes) throws IllegalArgumentException {
             FunctionInfo info = createInfo(name, dataTypes);
-            return functionFactory.apply(info);
+            return new CmpOperator(info, isMatch);
         }
 
 
         protected static FunctionInfo createInfo(String name, List<DataType> dataTypes) {
             return new FunctionInfo(new FunctionIdent(name, dataTypes), DataTypes.BOOLEAN);
         }
-
     }
-
 }

--- a/sql/src/main/java/io/crate/expression/operator/GtOperator.java
+++ b/sql/src/main/java/io/crate/expression/operator/GtOperator.java
@@ -22,22 +22,15 @@
 
 package io.crate.expression.operator;
 
-import io.crate.metadata.FunctionInfo;
-
-public class GtOperator extends CmpOperator {
+public final class GtOperator {
 
     public static final String NAME = "op_>";
 
     public static void register(OperatorModule module) {
-        module.registerDynamicOperatorFunction(NAME, new CmpResolver(NAME, GtOperator::new));
+        module.registerDynamicOperatorFunction(NAME, new CmpOperator.CmpResolver(NAME, GtOperator::cmpMatches));
     }
 
-    private GtOperator(FunctionInfo info) {
-        super(info);
-    }
-
-    @Override
-    protected boolean compare(int comparisonResult) {
-        return comparisonResult > 0;
+    private static boolean cmpMatches(int cmpResult) {
+        return cmpResult > 0;
     }
 }

--- a/sql/src/main/java/io/crate/expression/operator/GteOperator.java
+++ b/sql/src/main/java/io/crate/expression/operator/GteOperator.java
@@ -22,23 +22,16 @@
 
 package io.crate.expression.operator;
 
-import io.crate.metadata.FunctionInfo;
-
-public class GteOperator extends CmpOperator {
+public final class GteOperator {
 
     public static final String NAME = "op_>=";
 
     public static void register(OperatorModule module) {
-        module.registerDynamicOperatorFunction(NAME, new CmpResolver(NAME, GteOperator::new));
+        module.registerDynamicOperatorFunction(NAME, new CmpOperator.CmpResolver(NAME, GteOperator::cmpMatches));
 
     }
 
-    private GteOperator(FunctionInfo info) {
-        super(info);
-    }
-
-    @Override
-    protected boolean compare(int comparisonResult) {
-        return comparisonResult >= 0;
+    private static boolean cmpMatches(int cmpResult) {
+        return cmpResult >= 0;
     }
 }

--- a/sql/src/main/java/io/crate/expression/operator/LtOperator.java
+++ b/sql/src/main/java/io/crate/expression/operator/LtOperator.java
@@ -22,22 +22,15 @@
 
 package io.crate.expression.operator;
 
-import io.crate.metadata.FunctionInfo;
-
-public class LtOperator extends CmpOperator {
+public final class LtOperator {
 
     public static final String NAME = "op_<";
 
     public static void register(OperatorModule module) {
-        module.registerDynamicOperatorFunction(NAME, new CmpResolver(NAME, LtOperator::new));
+        module.registerDynamicOperatorFunction(NAME, new CmpOperator.CmpResolver(NAME, LtOperator::cmpMatches));
     }
 
-    LtOperator(FunctionInfo info) {
-        super(info);
-    }
-
-    @Override
-    protected boolean compare(int comparisonResult) {
-        return comparisonResult < 0;
+    private static boolean cmpMatches(int cmpResult) {
+        return cmpResult < 0;
     }
 }

--- a/sql/src/main/java/io/crate/expression/operator/LteOperator.java
+++ b/sql/src/main/java/io/crate/expression/operator/LteOperator.java
@@ -22,23 +22,15 @@
 
 package io.crate.expression.operator;
 
-import io.crate.metadata.FunctionInfo;
-
-public class LteOperator extends CmpOperator {
+public final class LteOperator {
 
     public static final String NAME = "op_<=";
 
     public static void register(OperatorModule module) {
-        module.registerDynamicOperatorFunction(NAME, new CmpResolver(NAME, LteOperator::new));
-
+        module.registerDynamicOperatorFunction(NAME, new CmpOperator.CmpResolver(NAME, LteOperator::cmpMatches));
     }
 
-    private LteOperator(FunctionInfo info) {
-        super(info);
-    }
-
-    @Override
-    protected boolean compare(int comparisonResult) {
-        return comparisonResult <= 0;
+    private static boolean cmpMatches(int cmpResult) {
+        return cmpResult <= 0;
     }
 }


### PR DESCRIPTION
This changes the operator implementations to use a `IntPredicate` that
indicates if the comparisons result should be considered a match or not
instead of having an abstract `compare` method that is overriden by
several sub-classes.

The motivation for this change is to be able to re-use the
`IntPredicate` implementations later on in a query optimization for
`array_length` / `array_upper`.





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed