### PR TITLE
Fix parsing of pg array literal single char elements

### DIFF
--- a/sql/src/main/java/io/crate/protocols/postgres/types/PGArray.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/types/PGArray.java
@@ -206,7 +206,7 @@ class PGArray extends PGType {
                             // n-dimensions array -> call recursively
                             List<Object> nestedObjects = new ArrayList<>();
                             i = decodeUTF8Text(bytes, i + 1, endIdx, nestedObjects);
-                            valIdx = i;
+                            valIdx = i + 1;
                             objects.add(nestedObjects.toArray());
                         } else {
                             // 1-dimension array -> call recursively
@@ -247,12 +247,16 @@ class PGArray extends PGType {
 
     // Decode individual inner object
     private void addObject(byte[] bytes, int startIdx, int endIdx, List<Object> objects) {
-        if (endIdx > startIdx) {
+        if (endIdx >= startIdx) {
             byte firstValueByte = bytes[startIdx];
             if (firstValueByte == 'N') {
                 objects.add(null);
             } else {
                 if (firstValueByte == '"') {
+                    // skip any quote character
+                    if (startIdx == endIdx) {
+                        return;
+                    }
                     startIdx++;
                     endIdx--;
                 }

--- a/sql/src/test/java/io/crate/protocols/postgres/types/PGArrayTest.java
+++ b/sql/src/test/java/io/crate/protocols/postgres/types/PGArrayTest.java
@@ -145,12 +145,16 @@ public class PGArrayTest extends BasePGTypeTest<PGArray> {
         assertThat(o, is(new Object[] {10, 20}));
 
         // ensure unquoted integer values are decoded correctly (a bug prevented that once)
-        o = pgArray.decodeUTF8Text("{10,20}".getBytes(StandardCharsets.UTF_8));
-        assertThat(o, is(new Object[] {10, 20}));
+        o = pgArray.decodeUTF8Text("{10,2}".getBytes(StandardCharsets.UTF_8));
+        assertThat(o, is(new Object[] {10, 2}));
 
         // ensure array with single value is decoded correctly (a bug prevented that once)
         o = pgArray.decodeUTF8Text("{10}".getBytes(StandardCharsets.UTF_8));
         assertThat(o, is(new Object[] {10}));
+
+        // ensure that elements consisting of only a single character within an array can be decoded (a bug prevented that once)
+        o = pgArray.decodeUTF8Text("{1}".getBytes(StandardCharsets.UTF_8));
+        assertThat(o, is(new Object[]{1}));
 
         // 2-dimension array
         o = pgArray.decodeUTF8Text("{{\"1\",NULL,\"2\"},{NULL,\"3\",\"4\"}}".getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
If an array literal element value contains only 1 char, it was not 
decoded correctly and ignored.
Follow up of 6058407e8f24dc13db2ce23fd5794c950a958b24.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
