### PR TITLE
Deprecate mqtt

### DIFF
--- a/blackbox/docs/admin/ingestion/sources/mqtt.rst
+++ b/blackbox/docs/admin/ingestion/sources/mqtt.rst
@@ -28,6 +28,10 @@ persistence.
    The MQTT ingestion source an
    :ref:`enterprise feature <enterprise_features>`.
 
+.. WARNING::
+
+   The MQTT ingestion is deprecated and will be removed in the future.
+
 .. rubric:: Table of Contents
 
 .. contents::

--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -40,6 +40,9 @@ Breaking Changes
 Changes
 =======
 
+- The ``mqtt`` endpoint has been deprecated and will be removed in a future
+  version.
+
 - Upgraded to Elasticsearch 6.2.4
 
 - Renamed the ``delimited_payload_filter`` token filter to

--- a/enterprise/mqtt/src/main/java/io/crate/mqtt/netty/Netty4MqttServerTransport.java
+++ b/enterprise/mqtt/src/main/java/io/crate/mqtt/netty/Netty4MqttServerTransport.java
@@ -47,6 +47,7 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.logging.ServerLoggers;
 import org.elasticsearch.common.network.NetworkAddress;
 import org.elasticsearch.common.network.NetworkService;
@@ -128,6 +129,12 @@ public class Netty4MqttServerTransport extends AbstractLifecycleComponent {
         port = MQTT_PORT_SETTING.setting().get(settings);
         defaultIdleTimeout = MQTT_TIMEOUT_SETTING.setting().get(settings);
         mqttMessageLogger = new MqttMessageLogger(settings);
+        if (isEnabled) {
+            DeprecationLogger deprecationLogger = new DeprecationLogger(logger);
+            deprecationLogger.deprecated(
+                "MQTT endpoint has been deprecated and will be removed in the future. " +
+                "It is recommended to use a dedicated broker and an external connector service.");
+        }
         mqttIngestService = new MqttIngestService(functions, sqlOperations, userManager, ingestionService);
         this.sslContextProvider = sslContextProvider;
     }

--- a/enterprise/mqtt/src/test/java/io/crate/mqtt/netty/MqttNettyNetworkConfigTest.java
+++ b/enterprise/mqtt/src/test/java/io/crate/mqtt/netty/MqttNettyNetworkConfigTest.java
@@ -46,6 +46,11 @@ import static org.hamcrest.Matchers.instanceOf;
 
 public class MqttNettyNetworkConfigTest extends CrateUnitTest {
 
+    @Override
+    protected boolean enableWarningsCheck() {
+        return false;
+    }
+
     @Test
     public void testPublishPortSelection() throws Exception {
         int boundPort = randomIntBetween(9000, 9100);


### PR DESCRIPTION
Some reasons:

- Hasn't seen much adoption
- It is incomplete (e.g. only supports QoS 1)
- It would require further ongoing maintenance (for MQTT v5 for example)
- Using an external broker usually has more advantages than
disadvantages


## checklist


 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed