### PR TITLE
The master node generates a license at startup if one is missing.

### DIFF
--- a/licensing/src/main/java/io/crate/license/DecodedLicense.java
+++ b/licensing/src/main/java/io/crate/license/DecodedLicense.java
@@ -20,17 +20,29 @@
  * agreement.
  */
 
-package io.crate.license.exception;
+package io.crate.license;
 
+public class DecodedLicense {
 
-abstract class LicenseException extends RuntimeException {
+    private final int type;
+    private final int version;
+    private final byte[] encryptedContent;
 
-    LicenseException(String message) {
-        super(message);
+    DecodedLicense(int type, int version, byte[] encryptedContent) {
+        this.type = type;
+        this.version = version;
+        this.encryptedContent = encryptedContent;
     }
 
-    LicenseException(String message, Throwable cause) {
-        super(message, cause);
+    public int type() {
+        return type;
     }
 
+    public int version() {
+        return version;
+    }
+
+    byte[] encryptedContent() {
+        return encryptedContent;
+    }
 }

--- a/licensing/src/main/java/io/crate/license/DecryptedLicenseData.java
+++ b/licensing/src/main/java/io/crate/license/DecryptedLicenseData.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.license;
+
+import org.elasticsearch.common.xcontent.NamedXContentRegistry;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentParser;
+import org.elasticsearch.common.xcontent.XContentType;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+
+public class DecryptedLicenseData {
+
+    private static final String EXPIRATION_DATE_IN_MS = "expirationDateInMs";
+    private static final String ISSUED_TO = "issuedTo";
+
+    private final long expirationDateInMs;
+    private final String issuedTo;
+
+    DecryptedLicenseData(long expirationDateInMs, String issuedTo) {
+        this.expirationDateInMs = expirationDateInMs;
+        this.issuedTo = issuedTo;
+    }
+
+    long expirationDateInMs() {
+        return expirationDateInMs;
+    }
+
+    String issuedTo() {
+        return issuedTo;
+    }
+
+    /*
+     * Creates the json representation of the license information with the following structure:
+     *
+     * <pre>
+     *      {
+     *          "expirationDateInMs": "XXX",
+     *          "issuedTo": "YYY"
+     *      }
+     * </pre>
+     */
+    byte[] formatLicenseData() {
+        try {
+            XContentBuilder contentBuilder = XContentFactory.contentBuilder(XContentType.JSON);
+            contentBuilder.startObject()
+                .field(EXPIRATION_DATE_IN_MS, expirationDateInMs)
+                .field(ISSUED_TO, issuedTo)
+                .endObject();
+            return contentBuilder.string().getBytes(StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    static DecryptedLicenseData fromFormattedLicenseData(byte[] licenseData) throws IOException {
+        try (XContentParser parser = XContentFactory.xContent(XContentType.JSON)
+            .createParser(NamedXContentRegistry.EMPTY, licenseData)) {
+            XContentParser.Token token;
+            long expirationDate = 0;
+            String issuedTo = null;
+            while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+                if (token == XContentParser.Token.FIELD_NAME) {
+                    String currentFieldName = parser.currentName();
+                    parser.nextToken();
+                    if (currentFieldName.equals(EXPIRATION_DATE_IN_MS)) {
+                        expirationDate = parser.longValue();
+                    } else if (currentFieldName.equals(ISSUED_TO)) {
+                        issuedTo = parser.text();
+                    }
+                }
+            }
+            return new DecryptedLicenseData(expirationDate, issuedTo);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DecryptedLicenseData that = (DecryptedLicenseData) o;
+        return expirationDateInMs == that.expirationDateInMs &&
+               Objects.equals(issuedTo, that.issuedTo);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(expirationDateInMs, issuedTo);
+    }
+}

--- a/licensing/src/main/java/io/crate/license/LicenseService.java
+++ b/licensing/src/main/java/io/crate/license/LicenseService.java
@@ -24,33 +24,147 @@ package io.crate.license;
 
 import io.crate.license.exception.InvalidLicenseException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateListener;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.inject.Singleton;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.gateway.Gateway;
+import org.elasticsearch.gateway.GatewayService;
 
-@Singleton
-public class LicenseService {
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.crate.license.LicenseKey.SELF_GENERATED;
+import static io.crate.license.LicenseKey.decodeLicense;
+import static io.crate.license.SelfGeneratedLicense.decryptLicenseContent;
+
+public class LicenseService extends AbstractLifecycleComponent implements ClusterStateListener, Gateway.GatewayStateRecoveredListener {
 
     private final TransportSetLicenseAction transportSetLicenseAction;
+    private final ClusterService clusterService;
+
+    private AtomicReference<LicenseKey> currentLicense = new AtomicReference<>();
 
     @Inject
-    public LicenseService(TransportSetLicenseAction transportSetLicenseAction) {
+    public LicenseService(Settings settings,
+                          TransportSetLicenseAction transportSetLicenseAction,
+                          ClusterService clusterService) {
+        super(settings);
         this.transportSetLicenseAction = transportSetLicenseAction;
+        this.clusterService = clusterService;
     }
 
-    boolean validateLicense(final License license) {
-        // todo: implement
-        // 1. check for future expiry date
-        // 2. validate signature
-        return true;
-    }
-
-
-    public void registerLicense(final License license,
+    public void registerLicense(final LicenseKey licenseKey,
                                 final ActionListener<SetLicenseResponse> listener) {
-        if (validateLicense(license)) {
-            transportSetLicenseAction.execute(new SetLicenseRequest(license), listener);
+        if (verifyLicense(licenseKey)) {
+            transportSetLicenseAction.execute(new SetLicenseRequest(licenseKey), listener);
         } else {
-            listener.onFailure(new InvalidLicenseException());
+            listener.onFailure(new InvalidLicenseException("Unable to register the provided license key"));
         }
+    }
+
+    /**
+     * Encrypts the provided license data and creates a #{@link LicenseKey}
+     */
+    LicenseKey createLicenseKey(int licenseType, int version, DecryptedLicenseData decryptedLicenseData) {
+        byte[] encryptedContent;
+        if (licenseType == SELF_GENERATED) {
+            encryptedContent = SelfGeneratedLicense.encryptLicenseContent(decryptedLicenseData.formatLicenseData());
+        } else {
+            throw new UnsupportedOperationException("Only self generated licenses are supported.");
+        }
+        return LicenseKey.createLicenseKey(licenseType, version, encryptedContent);
+    }
+
+
+    boolean verifyLicense(LicenseKey licenseKey) {
+        try {
+            DecodedLicense decodedLicense = decodeLicense(licenseKey);
+            if (decodedLicense.type() == LicenseKey.SELF_GENERATED) {
+                DecryptedLicenseData licenseInfo = decryptLicenseContent(decodedLicense.encryptedContent());
+                return System.currentTimeMillis() < licenseInfo.expirationDateInMs();
+            }
+            return false;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    @Override
+    protected void doStart() {
+        clusterService.addListener(this);
+    }
+
+    private LicenseKey getLicenseMetadata(ClusterState clusterState) {
+        return clusterState.getMetaData().custom(LicenseKey.WRITEABLE_TYPE);
+    }
+
+    private void registerSelfGeneratedLicense(ClusterState clusterState) {
+        DiscoveryNodes nodes = clusterState.getNodes();
+        if (nodes != null) {
+            if (nodes.isLocalNodeElectedMaster()) {
+                LicenseKey licenseKey = createLicenseKey(
+                    LicenseKey.SELF_GENERATED,
+                    LicenseKey.VERSION,
+                    new DecryptedLicenseData(Long.MAX_VALUE, clusterState.getClusterName().value())
+                );
+                currentLicense.set(licenseKey);
+                registerLicense(licenseKey,
+                    new ActionListener<SetLicenseResponse>() {
+
+                        @Override
+                        public void onResponse(SetLicenseResponse setLicenseResponse) {
+                        }
+
+                        @Override
+                        public void onFailure(Exception e) {
+                            logger.error("Unable to register license", e);
+                        }
+                    });
+            }
+        }
+    }
+
+    @Override
+    protected void doStop() {
+    }
+
+    @Override
+    protected void doClose() {
+        clusterService.removeListener(this);
+        currentLicense.set(null);
+    }
+
+    @Override
+    public void clusterChanged(ClusterChangedEvent event) {
+        ClusterState currentState = event.state();
+
+        if (currentState.blocks().hasGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK)) {
+            return;
+        }
+
+        LicenseKey newLicenseKey = getLicenseMetadata(currentState);
+
+        LicenseKey currentLicense = this.currentLicense.get();
+        if (currentLicense == null && newLicenseKey == null) {
+            registerSelfGeneratedLicense(currentState);
+            return;
+        }
+
+        if (newLicenseKey != null && !newLicenseKey.equals(currentLicense)) {
+            this.currentLicense.set(newLicenseKey);
+        }
+    }
+
+    @Override
+    public void onSuccess(ClusterState build) {
+    }
+
+    @Override
+    public void onFailure(String s) {
     }
 }

--- a/licensing/src/main/java/io/crate/license/SelfGeneratedLicense.java
+++ b/licensing/src/main/java/io/crate/license/SelfGeneratedLicense.java
@@ -20,17 +20,23 @@
  * agreement.
  */
 
-package io.crate.license.exception;
+package io.crate.license;
 
+import java.io.IOException;
 
-abstract class LicenseException extends RuntimeException {
+import static io.crate.license.DecryptedLicenseData.fromFormattedLicenseData;
 
-    LicenseException(String message) {
-        super(message);
+final class SelfGeneratedLicense {
+
+    private SelfGeneratedLicense() {
     }
 
-    LicenseException(String message, Throwable cause) {
-        super(message, cause);
+    static byte[] encryptLicenseContent(byte[] content) {
+        return Cryptos.encrypt(content);
     }
 
+    static DecryptedLicenseData decryptLicenseContent(byte[] encryptedContent) throws IOException {
+        byte[] decryptedContent = Cryptos.decrypt(encryptedContent);
+        return fromFormattedLicenseData(decryptedContent);
+    }
 }

--- a/licensing/src/main/java/io/crate/license/SetLicenseRequest.java
+++ b/licensing/src/main/java/io/crate/license/SetLicenseRequest.java
@@ -32,22 +32,22 @@ import java.io.IOException;
 
 public class SetLicenseRequest extends MasterNodeRequest<SetLicenseRequest> {
 
-    private License license;
+    private LicenseKey licenseKey;
 
     public SetLicenseRequest() {
     }
 
-    public SetLicenseRequest(License license) {
-        this.license = license;
+    public SetLicenseRequest(LicenseKey licenseKey) {
+        this.licenseKey = licenseKey;
     }
 
-    public License licenseMetaData() {
-        return license;
+    public LicenseKey licenseMetaData() {
+        return licenseKey;
     }
 
     @Override
     public ActionRequestValidationException validate() {
-        if (license == null) {
+        if (licenseKey == null) {
             return ValidateActions.addValidationError("licenseMetaData is missing", null);
         }
         return null;
@@ -56,12 +56,12 @@ public class SetLicenseRequest extends MasterNodeRequest<SetLicenseRequest> {
     @Override
     public void readFrom(StreamInput in) throws IOException {
         super.readFrom(in);
-        license = new License(in);
+        licenseKey = new LicenseKey(in);
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        license.writeTo(out);
+        licenseKey.writeTo(out);
     }
 }

--- a/licensing/src/main/java/io/crate/license/TransportSetLicenseAction.java
+++ b/licensing/src/main/java/io/crate/license/TransportSetLicenseAction.java
@@ -68,13 +68,13 @@ public class TransportSetLicenseAction
     protected void masterOperation(final SetLicenseRequest request,
                                    ClusterState state,
                                    ActionListener<SetLicenseResponse> listener) throws Exception {
-        License metaData = request.licenseMetaData();
+        LicenseKey metaData = request.licenseMetaData();
         clusterService.submitStateUpdateTask("register license with key [" + metaData.licenseKey() + "]",
             new ClusterStateUpdateTask() {
                 @Override
                 public ClusterState execute(ClusterState currentState) throws Exception {
                     MetaData.Builder mdBuilder = MetaData.builder(currentState.metaData());
-                    mdBuilder.putCustom(License.TYPE, metaData);
+                    mdBuilder.putCustom(LicenseKey.WRITEABLE_TYPE, metaData);
                     return ClusterState.builder(currentState).metaData(mdBuilder).build();
                 }
 

--- a/licensing/src/main/java/io/crate/license/exception/InvalidLicenseException.java
+++ b/licensing/src/main/java/io/crate/license/exception/InvalidLicenseException.java
@@ -24,7 +24,7 @@ package io.crate.license.exception;
 
 public class InvalidLicenseException extends LicenseException {
 
-    public InvalidLicenseException() {
-        super("Unable to validate license");
+    public InvalidLicenseException(String message) {
+        super(message);
     }
 }

--- a/licensing/src/main/java/io/crate/license/exception/LicenseMetadataParsingException.java
+++ b/licensing/src/main/java/io/crate/license/exception/LicenseMetadataParsingException.java
@@ -27,8 +27,4 @@ public class LicenseMetadataParsingException extends LicenseException {
     public LicenseMetadataParsingException(String message) {
         super("License Metadata parsing error: " + message);
     }
-
-    public LicenseMetadataParsingException(String message, Throwable cause) {
-        super("License Metadata parsing error: " + message, cause);
-    }
 }

--- a/licensing/src/main/java/io/crate/plugin/LicensePlugin.java
+++ b/licensing/src/main/java/io/crate/plugin/LicensePlugin.java
@@ -22,8 +22,9 @@
 
 package io.crate.plugin;
 
-import io.crate.license.License;
+import io.crate.license.LicenseKey;
 import io.crate.license.LicenseModule;
+import io.crate.license.LicenseService;
 import org.elasticsearch.cluster.NamedDiff;
 import org.elasticsearch.cluster.metadata.MetaData;
 import org.elasticsearch.common.ParseField;
@@ -57,12 +58,12 @@ public class LicensePlugin extends Plugin implements ActionPlugin {
 
     @Override
     public List<Setting<?>> getSettings() {
-        return Collections.EMPTY_LIST;
+        return Collections.emptyList();
     }
 
     @Override
     public Collection<Class<? extends LifecycleComponent>> getGuiceServiceClasses() {
-        return Collections.EMPTY_LIST;
+        return Collections.singletonList(LicenseService.class);
     }
 
     @Override
@@ -70,13 +71,13 @@ public class LicensePlugin extends Plugin implements ActionPlugin {
         List<NamedWriteableRegistry.Entry> entries = new ArrayList<>();
         entries.add(new NamedWriteableRegistry.Entry(
             MetaData.Custom.class,
-            License.TYPE,
-            License::new
+            LicenseKey.WRITEABLE_TYPE,
+            LicenseKey::new
         ));
         entries.add(new NamedWriteableRegistry.Entry(
             NamedDiff.class,
-            License.TYPE,
-            in -> License.readDiffFrom(MetaData.Custom.class, License.TYPE, in)
+            LicenseKey.WRITEABLE_TYPE,
+            in -> LicenseKey.readDiffFrom(MetaData.Custom.class, LicenseKey.WRITEABLE_TYPE, in)
         ));
         return entries;
     }
@@ -85,8 +86,8 @@ public class LicensePlugin extends Plugin implements ActionPlugin {
     public List<NamedXContentRegistry.Entry> getNamedXContent() {
         return Collections.singletonList(new NamedXContentRegistry.Entry(
             MetaData.Custom.class,
-            new ParseField(License.TYPE),
-            License::fromXContent
+            new ParseField(LicenseKey.WRITEABLE_TYPE),
+            LicenseKey::fromXContent
         ));
     }
 }

--- a/licensing/src/test/java/io/crate/license/LicenseKeyTest.java
+++ b/licensing/src/test/java/io/crate/license/LicenseKeyTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.license;
+
+import io.crate.license.exception.InvalidLicenseException;
+import io.crate.test.integration.CrateUnitTest;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.stream.IntStream;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class LicenseKeyTest extends CrateUnitTest {
+
+    @Test
+    public void createLicenseKey() {
+        LicenseKey licenseKey =
+            LicenseKey.createLicenseKey(
+                LicenseKey.SELF_GENERATED,
+                LicenseKey.VERSION,
+                "testLicense".getBytes(StandardCharsets.UTF_8));
+        assertThat(licenseKey, is(notNullValue()));
+    }
+
+    @Test
+    public void decodeLicense() {
+        DecodedLicense decodedLicense =
+            LicenseKey.decodeLicense(new LicenseKey("AAAAAAAAAAEAAABACYK5Ua3JBI98IJ99P/AsXCsV7UpHiBzSjkg+pFNDkpYAZUttlnqldjF5BAtRfzuJHA+2091XDmHACmF+M1J0NQ=="));
+
+        assertThat(decodedLicense, is(notNullValue()));
+        assertThat(decodedLicense.type(), is(LicenseKey.SELF_GENERATED));
+        assertThat(decodedLicense.version(), is(1));
+    }
+
+    @Test
+    public void decodeTooLongLicenseRaisesException() {
+        byte[] largeContent = new byte[257];
+        IntStream.range(0, 257).forEach(i -> largeContent[i] = 15);
+
+        expectedException.expect(InvalidLicenseException.class);
+        expectedException.expectMessage("The provided license key exceeds the maximum length of 256");
+        LicenseKey.decodeLicense(new LicenseKey(new String(Base64.getEncoder().encode(largeContent))));
+    }
+}

--- a/licensing/src/test/java/io/crate/license/LicenseServiceTest.java
+++ b/licensing/src/test/java/io/crate/license/LicenseServiceTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.license;
+
+import io.crate.test.integration.CrateDummyClusterServiceUnitTest;
+import org.elasticsearch.common.settings.Settings;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.mock;
+
+public class LicenseServiceTest extends CrateDummyClusterServiceUnitTest {
+
+    private LicenseService licenseService;
+
+    @Before
+    public void setupLicenseService() {
+        licenseService = new LicenseService(Settings.EMPTY, mock(TransportSetLicenseAction.class), clusterService);
+    }
+
+    @Test
+    public void testVerifyValidLicense() {
+        LicenseKey licenseKey = licenseService.createLicenseKey(LicenseKey.SELF_GENERATED, LicenseKey.VERSION,
+            new DecryptedLicenseData(Long.MAX_VALUE, "test"));
+        assertThat(licenseService.verifyLicense(licenseKey), is(true));
+    }
+
+    @Test
+    public void testVerifyExpiredLicense() {
+        LicenseKey expiredLicense = licenseService.createLicenseKey(LicenseKey.SELF_GENERATED, LicenseKey.VERSION,
+            new DecryptedLicenseData(System.currentTimeMillis() - 5 * 60 * 60 * 1000, "test"));
+
+        assertThat(licenseService.verifyLicense(expiredLicense), is(false));
+    }
+
+    @Test
+    public void testOnlySelfGeneratedLicenseIsSupported() {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("Only self generated licenses are supported");
+
+        licenseService.createLicenseKey(-2, LicenseKey.VERSION, new DecryptedLicenseData(Long.MAX_VALUE, "test"));
+    }
+}

--- a/licensing/src/test/java/io/crate/license/LicenseTest.java
+++ b/licensing/src/test/java/io/crate/license/LicenseTest.java
@@ -40,35 +40,35 @@ public class LicenseTest extends CrateUnitTest {
 
     private static final String LICENSE_KEY = "ThisShouldBeAnEncryptedLicenseKey";
 
-    public static License createMetaData() {
-        return new License(LICENSE_KEY);
+    public static LicenseKey createMetaData() {
+        return new LicenseKey(LICENSE_KEY);
     }
 
     @Test
     public void testLicenseMetaDataStreaming() throws IOException {
         BytesStreamOutput stream = new BytesStreamOutput();
-        License license = createMetaData();
-        license.writeTo(stream);
+        LicenseKey licenseKey = createMetaData();
+        licenseKey.writeTo(stream);
 
         StreamInput in = stream.bytes().streamInput();
-        License license2 = new License(in);
-        assertEquals(license, license2);
+        LicenseKey licenseKey2 = new LicenseKey(in);
+        assertEquals(licenseKey, licenseKey2);
     }
 
     @Test
     public void testLicenceMetaDataToXContent() throws IOException {
-        License license = createMetaData();
+        LicenseKey licenseKey = createMetaData();
         XContentBuilder builder = XContentFactory.jsonBuilder();
 
         // reflects the logic used to process custom metadata in the cluster state
         builder.startObject();
-        license.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        licenseKey.toXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.endObject();
 
         XContentParser parser = JsonXContent.jsonXContent.createParser(xContentRegistry(), builder.bytes());
         parser.nextToken(); // start object
-        License license2 = License.fromXContent(parser);
-        assertEquals(license, license2);
+        LicenseKey licenseKey2 = LicenseKey.fromXContent(parser);
+        assertEquals(licenseKey, licenseKey2);
         // a metadata custom must consume the surrounded END_OBJECT token, no token must be left
         assertThat(parser.nextToken(), nullValue());
     }
@@ -79,15 +79,15 @@ public class LicenseTest extends CrateUnitTest {
 
         // reflects the logic used to process custom metadata in the cluster state
         builder.startObject();
-        builder.startObject(License.TYPE)
-            .field("licenseKey", LICENSE_KEY)
+        builder.startObject(LicenseKey.WRITEABLE_TYPE)
+            .field("license_key", LICENSE_KEY)
             .endObject();
         builder.endObject();
 
         XContentParser parser = JsonXContent.jsonXContent.createParser(xContentRegistry(), builder.bytes());
         parser.nextToken(); // start object
-        License license2 = License.fromXContent(parser);
-        assertEquals(createMetaData(), license2);
+        LicenseKey licenseKey2 = LicenseKey.fromXContent(parser);
+        assertEquals(createMetaData(), licenseKey2);
         // a metadata custom must consume the surrounded END_OBJECT token, no token must be left
         assertThat(parser.nextToken(), nullValue());
     }

--- a/licensing/src/test/java/io/crate/license/SelfGeneratedLicenseTest.java
+++ b/licensing/src/test/java/io/crate/license/SelfGeneratedLicenseTest.java
@@ -22,30 +22,31 @@
 
 package io.crate.license;
 
-import org.elasticsearch.action.support.master.AcknowledgedResponse;
-import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
+import org.junit.Test;
 
 import java.io.IOException;
 
-public class SetLicenseResponse extends AcknowledgedResponse {
+import static io.crate.license.SelfGeneratedLicense.decryptLicenseContent;
+import static io.crate.license.SelfGeneratedLicense.encryptLicenseContent;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
 
-    SetLicenseResponse() {
+public class SelfGeneratedLicenseTest {
+
+    @Test
+    public void testGenerateSelfGeneratedKey() {
+        byte[] encryptedContent = encryptLicenseContent(new DecryptedLicenseData(Long.MAX_VALUE, "test").formatLicenseData());
+        assertThat(encryptedContent, is(notNullValue()));
     }
 
-    SetLicenseResponse(boolean acknowledged) {
-        super(acknowledged);
-    }
+    @Test
+    public void testDecryptSelfGeneratedLicense() throws IOException {
+        byte[] encryptedContent = encryptLicenseContent(new DecryptedLicenseData(Long.MAX_VALUE, "test").formatLicenseData());
 
-    @Override
-    public void readFrom(StreamInput in) throws IOException {
-        super.readFrom(in);
-        readAcknowledged(in);
-    }
+        DecryptedLicenseData licenseInfo = decryptLicenseContent(encryptedContent);
 
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
-        writeAcknowledged(out);
+        assertThat(licenseInfo.expirationDateInMs(), is(Long.MAX_VALUE));
+        assertThat(licenseInfo.issuedTo(), is("test"));
     }
 }

--- a/sql/src/main/java/io/crate/planner/statement/SetLicensePlan.java
+++ b/sql/src/main/java/io/crate/planner/statement/SetLicensePlan.java
@@ -27,7 +27,7 @@ import io.crate.data.Row;
 import io.crate.data.Row1;
 import io.crate.data.RowConsumer;
 import io.crate.execution.support.OneRowActionListener;
-import io.crate.license.License;
+import io.crate.license.LicenseKey;
 import io.crate.planner.DependencyCarrier;
 import io.crate.planner.Plan;
 import io.crate.planner.PlannerContext;
@@ -52,7 +52,7 @@ public class SetLicensePlan implements Plan {
                         RowConsumer consumer,
                         Row params,
                         SubQueryResults subQueryResults) {
-        License metaData = new License(stmt.licenseKey());
+        LicenseKey metaData = new LicenseKey(stmt.licenseKey());
         executor.licenseService().registerLicense(metaData, new OneRowActionListener<>(consumer, response -> new Row1(1L)));
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PartitionedTableConcurrentIntegrationTest.java
@@ -59,7 +59,9 @@ import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
 import static com.carrotsearch.randomizedtesting.RandomizedTest.randomAsciiLettersOfLength;
 import static org.hamcrest.core.Is.is;
 
-@ESIntegTestCase.ClusterScope(numDataNodes = 2)
+// disabling the transport clients because the _other_ types of nodes are likely to load a CrateDB license in the
+// metadata custom and these transport clients will not be able to deserialize it (as they're not part of the cluster)
+@ESIntegTestCase.ClusterScope(numDataNodes = 2, transportClientRatio = 0)
 public class PartitionedTableConcurrentIntegrationTest extends SQLTransportIntegrationTest {
 
     private final TimeValue ACCEPTABLE_RELOCATION_TIME = new TimeValue(10, TimeUnit.SECONDS);

--- a/sql/src/test/java/io/crate/integrationtests/RemoteCollectorIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/RemoteCollectorIntegrationTest.java
@@ -34,7 +34,9 @@ import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
 
-@ESIntegTestCase.ClusterScope(numDataNodes = 2)
+// disabling the transport clients because the _other_ types of nodes are likely to load a CrateDB license in the
+// metadata custom and these transport clients will not be able to deserialize it (as they're not part of the cluster)
+@ESIntegTestCase.ClusterScope(numDataNodes = 2, transportClientRatio = 0)
 public class RemoteCollectorIntegrationTest extends SQLTransportIntegrationTest {
 
     @Test

--- a/sql/src/test/java/io/crate/integrationtests/SetLicenseIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SetLicenseIntegrationTest.java
@@ -22,24 +22,20 @@
 
 package io.crate.integrationtests;
 
-import io.crate.license.License;
-import org.elasticsearch.test.ESIntegTestCase;
+import io.crate.license.LicenseKey;
 import org.junit.Test;
 
-@ESIntegTestCase.ClusterScope()
+import static org.hamcrest.core.Is.is;
+
 public class SetLicenseIntegrationTest extends SQLTransportIntegrationTest {
 
-    private static final String ENCRYPTED_LICENSE_KEY = "ThisShouldBeTheEncryptedLicenseKey";
-
-    private static License createMetaData() {
-        return new License(ENCRYPTED_LICENSE_KEY);
-    }
+    private static final String LICENSE_KEY = "AAAAAAAAAAEAAABACYK5Ua3JBI98IJ99P/AsXCsV7UpHiBzSjkg+pFNDkpYAZUttlnqldjF5BAtRfzuJHA+2091XDmHACmF+M1J0NQ==";
 
     @Test
-    public void testLicenseIsAvailableInClusterStateAfterSetLicense () {
-        execute("set license '" + ENCRYPTED_LICENSE_KEY + "'");
+    public void testLicenseIsAvailableInClusterStateAfterSetLicense() {
+        execute("set license '" + LICENSE_KEY + "'");
 
-        License license = clusterService().state().metaData().custom(License.TYPE);
-        assertEquals(createMetaData(), license);
+        LicenseKey licenseKey = clusterService().state().metaData().custom(LicenseKey.WRITEABLE_TYPE);
+        assertThat(licenseKey, is(new LicenseKey(LICENSE_KEY)));
     }
 }


### PR DESCRIPTION
When crate starts up the nodes will check if a license is present. If one
is found the node will validate it and continue bootstrapping in case it is
valid or stop otherwise. If no license is present, the master node will
generate one and save it in the cluster state.

## Summary of the changes / Why this improves CrateDB


## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
