### PR TITLE
Fix implicit->explicit join condition conversion.

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -81,6 +81,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue which caused joins over multiple relations and implicit join
+  conditions inside the ``WHERE`` clause to fail.
+
 - The ``Access-Control-Allow-Origin`` header is now correctly served by
   resources in the ``/_blobs`` endpoint if the relevant settings are enabled.
 

--- a/sql/src/test/java/io/crate/execution/engine/join/JoinOperationsTest.java
+++ b/sql/src/test/java/io/crate/execution/engine/join/JoinOperationsTest.java
@@ -162,4 +162,22 @@ public class JoinOperationsTest extends CrateUnitTest {
         assertThat(joinPair.joinType(), is(JoinType.SEMI));
         assertThat(remainingQueries.size(), is(1));
     }
+
+    @Test
+    public void testImplicitToExplicit_OrderOfPairsRemains() {
+        List<JoinPair> joinPairs = new ArrayList<>();
+        joinPairs.add(JoinPair.of(T3.T1, T3.T2, JoinType.INNER, asSymbol("t1.a = t2.b")));
+        joinPairs.add(JoinPair.of(T3.T2, T3.T3, JoinType.INNER, asSymbol("t2.y = t3.z")));
+        Map<Set<QualifiedName>, Symbol> remainingQueries = new HashMap<>();
+        remainingQueries.put(Sets.newHashSet(T3.T2, T3.T3), asSymbol("t2.b = t3.c"));
+        List<JoinPair> newJoinPairs =
+            JoinOperations.convertImplicitJoinConditionsToJoinPairs(joinPairs, remainingQueries);
+
+        for (int i = 0; i < joinPairs.size(); i++) {
+            JoinPair oldPairAtPos = joinPairs.get(i);
+            JoinPair newPairAtPos = newJoinPairs.get(i);
+            assertThat(oldPairAtPos.left(), is(newPairAtPos.left()));
+            assertThat(oldPairAtPos.right(), is(newPairAtPos.right()));
+        }
+    }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
The conversion helper did not retain the given join pair list order which
resulted in a wrong order of join operations and so may caused a join to
fail as the join condition symbols could not be resolved.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
