### PR TITLE
Implement set license 'licenseKey'

### DIFF
--- a/licensing/src/main/java/io/crate/license/LicenseMetaData.java
+++ b/licensing/src/main/java/io/crate/license/LicenseMetaData.java
@@ -38,43 +38,27 @@ public class LicenseMetaData extends AbstractNamedDiffable<MetaData.Custom> impl
 
     public static final String TYPE = "license";
 
-    private long expirationDateInMs;
-    private String issuedTo;
-    private String signature;
+    private String licenseKey;
 
-    public LicenseMetaData(long expirationDateInMs, String issuedTo, String signature) {
-        this.expirationDateInMs = expirationDateInMs;
-        this.issuedTo = issuedTo;
-        this.signature = signature;
+    public LicenseMetaData(final String licenseKey) {
+        this.licenseKey = licenseKey;
     }
 
     public LicenseMetaData(StreamInput in) throws IOException {
         readFrom(in);
     }
 
-    public long expirationDateInMs() {
-        return expirationDateInMs;
-    }
-
-    public String issuedTo() {
-        return issuedTo;
-    }
-
-    public String signature() {
-        return signature;
+    public String licenseKey() {
+        return licenseKey;
     }
 
     public void readFrom(StreamInput in) throws IOException {
-        this.expirationDateInMs = in.readLong();
-        this.issuedTo = in.readString();
-        this.signature = in.readString();
+        this.licenseKey = in.readString();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeLong(expirationDateInMs);
-        out.writeString(issuedTo);
-        out.writeString(signature);
+        out.writeString(licenseKey);
     }
 
     /*
@@ -83,9 +67,7 @@ public class LicenseMetaData extends AbstractNamedDiffable<MetaData.Custom> impl
      * <pre>
      *     {
      *       "license": {
-     *           "expirationDateInMs": 202020202,
-     *           "issuedTo": "organisation",
-     *           "signture": "XXX"
+     *           "licenseKey": "XXX"
      *       }
      *     }
      * </pre>
@@ -94,16 +76,12 @@ public class LicenseMetaData extends AbstractNamedDiffable<MetaData.Custom> impl
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         return builder
             .startObject(TYPE)
-                .field("expirationDateInMs", expirationDateInMs)
-                .field("issuedTo", issuedTo)
-                .field("signature", signature)
+                .field("licenseKey", licenseKey)
             .endObject();
     }
 
     public static LicenseMetaData fromXContent(XContentParser parser) throws IOException {
-        long expirationDateInMs = 0L;
-        String issuedTo = null;
-        String signature = null;
+        String licenseKey = null;
         // advance from metadata START_OBJECT
         XContentParser.Token token = parser.nextToken();
         if (token != XContentParser.Token.FIELD_NAME || !Objects.equals(parser.currentName(), TYPE)) {
@@ -115,12 +93,8 @@ public class LicenseMetaData extends AbstractNamedDiffable<MetaData.Custom> impl
         }
 
         while ((token = parser.nextToken()) == XContentParser.Token.FIELD_NAME) {
-            if ("expirationDateInMs".equals(parser.currentName())) {
-                expirationDateInMs = parseLongField(parser);
-            } else if ("issuedTo".equals(parser.currentName())) {
-                issuedTo = parseStringField(parser);
-            } else if ("signature".equals(parser.currentName())) {
-                signature = parseStringField(parser);
+            if ("licenseKey".equals(parser.currentName())) {
+                licenseKey = parseStringField(parser);
             } else {
                 throw new LicenseMetadataParsingException("unexpected FIELD_NAME " + parser.currentToken());
             }
@@ -135,17 +109,12 @@ public class LicenseMetaData extends AbstractNamedDiffable<MetaData.Custom> impl
             // each custom must move the parser to the end otherwise possible following customs won't be read
             throw new LicenseMetadataParsingException("expected an object token at the end");
         }
-        return new LicenseMetaData(expirationDateInMs, issuedTo, signature);
+        return new LicenseMetaData(licenseKey);
     }
 
     private static String parseStringField(XContentParser parser) throws IOException {
         parser.nextToken();
         return parser.textOrNull();
-    }
-
-    private static long parseLongField(XContentParser parser) throws IOException {
-        parser.nextToken();
-        return parser.longValue();
     }
 
     @Override
@@ -154,14 +123,12 @@ public class LicenseMetaData extends AbstractNamedDiffable<MetaData.Custom> impl
         if (o == null || getClass() != o.getClass()) return false;
 
         LicenseMetaData licenseMetaData = (LicenseMetaData) o;
-        return expirationDateInMs == licenseMetaData.expirationDateInMs &&
-               Objects.equals(issuedTo, licenseMetaData.issuedTo) &&
-               Objects.equals(signature, licenseMetaData.signature);
+        return Objects.equals(licenseKey, licenseMetaData.licenseKey);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(expirationDateInMs, issuedTo, signature);
+        return Objects.hash(licenseKey);
     }
 
     @Override

--- a/licensing/src/main/java/io/crate/license/TransportSetLicenseAction.java
+++ b/licensing/src/main/java/io/crate/license/TransportSetLicenseAction.java
@@ -69,7 +69,7 @@ public class TransportSetLicenseAction
                                    ClusterState state,
                                    ActionListener<SetLicenseResponse> listener) throws Exception {
         LicenseMetaData metaData = request.licenseMetaData();
-        clusterService.submitStateUpdateTask("register license to [" + metaData.issuedTo() + "]",
+        clusterService.submitStateUpdateTask("register license with key [" + metaData.licenseKey() + "]",
             new ClusterStateUpdateTask() {
                 @Override
                 public ClusterState execute(ClusterState currentState) throws Exception {

--- a/licensing/src/test/java/io/crate/license/LicenseMetaDataTest.java
+++ b/licensing/src/test/java/io/crate/license/LicenseMetaDataTest.java
@@ -38,12 +38,10 @@ import static org.hamcrest.Matchers.nullValue;
 
 public class LicenseMetaDataTest extends CrateUnitTest {
 
-    private static final long EXPIRATION_DATE_IN_MS = 1609376523123L;  // equivalent for EXPIRATION_DATE
-    private static final String ISSUED_TO = "me";
-    private static final String SIGNATURE = "SIGNATURE";
+    private static final String LICENSE_KEY = "ThisShouldBeAnEncryptedLicenseKey";
 
     public static LicenseMetaData createMetaData() {
-        return new LicenseMetaData(EXPIRATION_DATE_IN_MS, ISSUED_TO, SIGNATURE);
+        return new LicenseMetaData(LICENSE_KEY);
     }
 
     @Test
@@ -82,9 +80,7 @@ public class LicenseMetaDataTest extends CrateUnitTest {
         // reflects the logic used to process custom metadata in the cluster state
         builder.startObject();
         builder.startObject(LicenseMetaData.TYPE)
-            .field("expirationDateInMs", EXPIRATION_DATE_IN_MS)
-            .field("issuedTo", ISSUED_TO)
-            .field("signature", SIGNATURE)
+            .field("licenseKey", LICENSE_KEY)
             .endObject();
         builder.endObject();
 
@@ -94,27 +90,5 @@ public class LicenseMetaDataTest extends CrateUnitTest {
         assertEquals(createMetaData(), license2);
         // a metadata custom must consume the surrounded END_OBJECT token, no token must be left
         assertThat(parser.nextToken(), nullValue());
-    }
-
-    @Test
-    public void testLicenceMetaDataFromXContentInvalidArgumentThrowException() throws IOException {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("For input string: \"invalid_long_value\"");
-
-        XContentBuilder builder = XContentFactory.jsonBuilder();
-
-        // reflects the logic used to process custom metadata in the cluster state
-        builder.startObject();
-        builder.startObject(LicenseMetaData.TYPE)
-            .field("expirationDateInMs", "invalid_long_value")
-            .field("issuedTo", ISSUED_TO)
-            .field("signature", SIGNATURE)
-            .endObject();
-        builder.endObject();
-
-        XContentParser parser = JsonXContent.jsonXContent.createParser(xContentRegistry(), builder.bytes());
-
-        parser.nextToken(); // start object
-        LicenseMetaData.fromXContent(parser);
     }
 }

--- a/sql-parser/src/main/antlr/SqlBase.g4
+++ b/sql-parser/src/main/antlr/SqlBase.g4
@@ -61,7 +61,7 @@ statement
         (EQ | TO) (DEFAULT | setExpr (',' setExpr)*)                                 #set
     | SET GLOBAL (PERSISTENT | TRANSIENT)?
         setGlobalAssignment (',' setGlobalAssignment)*                               #setGlobal
-    | SET LICENSE setGlobalAssignment (',' setGlobalAssignment)*                     #setLicense
+    | SET LICENSE stringLiteral                                                      #setLicense
     | KILL (ALL | jobId=parameterOrString)                                           #kill
     | INSERT INTO table ('(' ident (',' ident)* ')')? insertSource
         (onDuplicate | onConflict)?                                                  #insert

--- a/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
+++ b/sql-parser/src/main/java/io/crate/sql/parser/AstBuilder.java
@@ -552,9 +552,11 @@ class AstBuilder extends SqlBaseBaseVisitor<Node> {
 
     @Override
     public Node visitSetLicense(SqlBaseParser.SetLicenseContext ctx) {
+        Assignment assignment = new Assignment(
+            new StringLiteral("license"), (Expression) visit(ctx.stringLiteral()));
+
         return new SetStatement(SetStatement.Scope.LICENSE,
-            SetStatement.SettingType.PERSISTENT,
-            visitCollection(ctx.setGlobalAssignment(), Assignment.class));
+            SetStatement.SettingType.PERSISTENT, Collections.singletonList(assignment));
     }
 
     @Override

--- a/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
+++ b/sql-parser/src/test/java/io/crate/sql/parser/TestStatementBuilder.java
@@ -319,8 +319,14 @@ public class TestStatementBuilder {
 
     @Test
     public void testSetLicenseStmtBuilder() throws Exception {
-        printStatement("set license expirationDate = '01/01/2020'");
-        printStatement("set license expirationDate = '01/01/2020', signature='XXX', issuedTo='anOrganisation'");
+        printStatement("set license 'LICENSE_KEY'");
+    }
+
+    @Test
+    public void testSetLicenseInputWithoutQuotesThrowsParsingException() {
+        expectedException.expect(ParsingException.class);
+        expectedException.expectMessage(containsString("no viable alternative at input"));
+        printStatement("set license LICENSE_KEY");
     }
 
     @Test
@@ -331,16 +337,29 @@ public class TestStatementBuilder {
     }
 
     @Test
+    public void testSetLicenseLikeAnExpressionThrowsParsingException() {
+        expectedException.expect(ParsingException.class);
+        expectedException.expectMessage(containsString("no viable alternative at input"));
+        printStatement("set license key='LICENSE_KEY'");
+    }
+
+    @Test
+    public void testSetLicenseMultipleInputThrowsParsingException() {
+        expectedException.expect(ParsingException.class);
+        expectedException.expectMessage(containsString("extraneous input ''LICENSE_KEY2'' expecting <EOF>"));
+        printStatement("set license 'LICENSE_KEY' 'LICENSE_KEY2'");
+    }
+
+    @Test
     public void testSetLicense() {
-        SetStatement stmt = (SetStatement) SqlParser.createStatement("set license aSetting = 'aStringValue'");
+        SetStatement stmt = (SetStatement) SqlParser.createStatement("set license 'LICENSE_KEY'");
         assertThat(stmt.scope(), is(SetStatement.Scope.LICENSE));
         assertThat(stmt.settingType(), is(SetStatement.SettingType.PERSISTENT));
         assertThat(stmt.assignments().size(), is(1));
 
         Assignment assignment = stmt.assignments().get(0);
-        assertThat(assignment.columnName().toString(), is("\"aSetting\"".toLowerCase()));
         assertThat(assignment.expressions().size(), is(1));
-        assertThat(assignment.expressions().get(0).toString(), is("'aStringValue'"));
+        assertThat(assignment.expressions().get(0).toString(), is("'LICENSE_KEY'"));
     }
 
     @Test

--- a/sql/src/main/java/io/crate/analyze/Analyzer.java
+++ b/sql/src/main/java/io/crate/analyze/Analyzer.java
@@ -137,7 +137,6 @@ public class Analyzer {
     private final CreateUserAnalyzer createUserAnalyzer;
     private final AlterUserAnalyzer alterUserAnalyzer;
     private final CreateViewAnalyzer createViewAnalyzer;
-    private final SetStatementAnalyzer setStatementAnalyzer;
     private final Schemas schemas;
 
     /**
@@ -206,7 +205,6 @@ public class Analyzer {
         this.createIngestionRuleAnalyzer = new CreateIngestionRuleAnalyzer(schemas);
         this.createUserAnalyzer = new CreateUserAnalyzer(functions);
         this.alterUserAnalyzer = new AlterUserAnalyzer(functions);
-        this.setStatementAnalyzer = new SetStatementAnalyzer(functions);
     }
 
     public Analysis boundAnalyze(Statement statement, TransactionContext transactionContext, ParameterContext parameterContext) {
@@ -367,9 +365,6 @@ public class Analyzer {
 
         @Override
         public AnalyzedStatement visitSetStatement(SetStatement node, Analysis context) {
-            if (SetStatement.Scope.LICENSE.equals(node.scope())) {
-                return setStatementAnalyzer.analyze(node, context);
-            }
             return SetStatementAnalyzer.analyze(node);
         }
 

--- a/sql/src/main/java/io/crate/analyze/SetLicenseAnalyzedStatement.java
+++ b/sql/src/main/java/io/crate/analyze/SetLicenseAnalyzedStatement.java
@@ -22,48 +22,20 @@
 
 package io.crate.analyze;
 
-import com.google.common.base.Preconditions;
-import io.crate.expression.symbol.Symbol;
-
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
+import javax.annotation.Nonnull;
 
 public class SetLicenseAnalyzedStatement implements AnalyzedStatement {
 
-    static final String EXPIRY_DATE_TOKEN = "expirationdate";
-    static final String ISSUED_TO_TOKEN = "issuedto";
-    static final String SIGN_TOKEN = "signature";
+    static final int LICENSE_TOKEN_NUM = 1;
 
-    static final int LICENSE_TOKEN_NUM = 3;
+    private final String licenseKey;
 
-    static final Set<String> LICENSE_ALLOWED_TOKENS = new HashSet<>(
-        Arrays.asList(EXPIRY_DATE_TOKEN, ISSUED_TO_TOKEN, SIGN_TOKEN));
-
-    static final String LICENSE_ALLOWED_TOKENS_AS_STRING = String.join(", ", LICENSE_ALLOWED_TOKENS);
-
-    private static final String MISSING_SETTING_ERROR_TEMPLATE = "Missing setting for SET LICENSE. Please provide the following settings: [%s]";
-
-    private final Symbol expirationDateSymbol;
-    private final Symbol issuedToSymbol;
-    private final Symbol signatureSymbol;
-
-    SetLicenseAnalyzedStatement(final Symbol expirationDateSymbol, final Symbol issuedToSymbol, final Symbol signatureSymbol) {
-        this.expirationDateSymbol = Preconditions.checkNotNull(expirationDateSymbol, MISSING_SETTING_ERROR_TEMPLATE, LICENSE_ALLOWED_TOKENS_AS_STRING);
-        this.issuedToSymbol = Preconditions.checkNotNull(issuedToSymbol, MISSING_SETTING_ERROR_TEMPLATE, LICENSE_ALLOWED_TOKENS_AS_STRING);
-        this.signatureSymbol = Preconditions.checkNotNull(signatureSymbol, MISSING_SETTING_ERROR_TEMPLATE, LICENSE_ALLOWED_TOKENS_AS_STRING);
+    SetLicenseAnalyzedStatement(@Nonnull final String licenseKey) {
+        this.licenseKey = licenseKey;
     }
 
-    public final Symbol expirationDateSymbol() {
-        return expirationDateSymbol;
-    }
-
-    public final Symbol issuedToSymbol() {
-        return issuedToSymbol;
-    }
-
-    public final Symbol signatureSymbol() {
-        return signatureSymbol;
+    public String licenseKey() {
+        return licenseKey;
     }
 
     @Override

--- a/sql/src/test/java/io/crate/analyze/SetAnalyzerTest.java
+++ b/sql/src/test/java/io/crate/analyze/SetAnalyzerTest.java
@@ -231,37 +231,8 @@ public class SetAnalyzerTest extends CrateDummyClusterServiceUnitTest {
     }
 
     @Test
-    public void testSetLicenseAcceptValidSymbolValues() throws Exception {
-        SetLicenseAnalyzedStatement analysis = analyze("SET LICENSE expirationDate='2020-12-31T01:02:03.123', issuedTo='me', signature='XXX'");
-        assertThat(analysis.expirationDateSymbol(),
-            is(io.crate.expression.symbol.Literal.of("2020-12-31T01:02:03.123")));
-        assertThat(analysis.issuedToSymbol(),
-            is(io.crate.expression.symbol.Literal.of("me")));
-        assertThat(analysis.signatureSymbol(),
-            is(io.crate.expression.symbol.Literal.of("XXX")));
-    }
-
-    @Test
-    public void testSetLicenseWrongNumberOfSettingsThrowsIllegalArgumentException() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Invalid number of settings for SET LICENSE. " +
-                                        "Please provide the following settings: [issuedto, signature, expirationdate]");
-        analyze("SET LICENSE issuedTo='me', signature='XXX'");
-    }
-
-    @Test
-    public void testSetLicenseInvalidSettingNameThrowsIllegalArgumentException() throws Exception {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Invalid setting 'expirationdat' for SET LICENSE. " +
-                                        "Please provide the following settings: [issuedto, signature, expirationdate]");
-        analyze("SET LICENSE expirationDat='2020-12-31T01:02:03.123', issuedTo='me', signature='XXX'");
-    }
-
-    @Test
-    public void testSetLicenseMissingSettingThrowsNullPointerException() throws Exception {
-        expectedException.expect(NullPointerException.class);
-        expectedException.expectMessage("Missing setting for SET LICENSE. " +
-                                        "Please provide the following settings: [issuedto, signature, expirationdate]");
-        analyze("SET LICENSE issuedTo='you', issuedTo='me', signature='XXX'");
+    public void testSetLicense() throws Exception {
+        SetLicenseAnalyzedStatement analysis = analyze("SET LICENSE 'ThisShouldBeAnEncryptedLicenseKey'");
+        assertThat(analysis.licenseKey(), is("ThisShouldBeAnEncryptedLicenseKey"));
     }
 }

--- a/sql/src/test/java/io/crate/integrationtests/SetLicenseIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SetLicenseIntegrationTest.java
@@ -29,21 +29,17 @@ import org.junit.Test;
 @ESIntegTestCase.ClusterScope()
 public class SetLicenseIntegrationTest extends SQLTransportIntegrationTest {
 
-    private static final String EXPIRATION_DATE = "2020-12-31T01:02:03.123";
-    private static final long EXPIRATION_DATE_IN_MS = 1609376523123L;  // equivalent for EXPIRATION_DATE
-    private static final String ISSUED_TO = "me";
-    private static final String SIGNATURE = "SIGNATURE";
+    private static final String ENCRYPTED_LICENSE_KEY = "ThisShouldBeTheEncryptedLicenseKey";
 
     private static LicenseMetaData createMetaData() {
-        return new LicenseMetaData(EXPIRATION_DATE_IN_MS, ISSUED_TO, SIGNATURE);
+        return new LicenseMetaData(ENCRYPTED_LICENSE_KEY);
     }
 
     @Test
     public void testLicenseIsAvailableInClusterStateAfterSetLicense () {
-        execute("set license expirationDate=?, issuedto=?, signature=?", new Object[] {EXPIRATION_DATE, ISSUED_TO, SIGNATURE});
+        execute("set license '" + ENCRYPTED_LICENSE_KEY + "'");
 
         LicenseMetaData license = clusterService().state().metaData().custom(LicenseMetaData.TYPE);
         assertEquals(createMetaData(), license);
     }
-
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Reworked the set license statement from: 
`set license expirationDate = ?, issuedTo= ?, signature = ?` to: 
`set license 'LICENCE_KEY'`

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [ ] Touched code is covered by tests
 - [ ] Documentation has been updated if necessary
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed