### PR TITLE
Tests: Close IndexService on QueryTester.close

### DIFF
--- a/sql/src/test/java/io/crate/testing/QueryTester.java
+++ b/sql/src/test/java/io/crate/testing/QueryTester.java
@@ -134,6 +134,7 @@ public final class QueryTester implements AutoCloseable {
         private final NodeEnvironment nodeEnvironment;
         private final DocTableRelation docTableRelation;
         private final QualifiedName tableName;
+        private final IndexService indexService;
 
         public Builder(Path tempDir,
                        ThreadPool threadPool,
@@ -199,7 +200,7 @@ public final class QueryTester implements AutoCloseable {
                 mapperService::fullName,
                 idxSettings
             );
-            IndexService indexService = indexModule.newIndexService(
+            indexService = indexModule.newIndexService(
                 nodeEnvironment,
                 NamedXContentRegistry.EMPTY,
                 new IndexService.ShardStoreDeleter() {
@@ -328,6 +329,7 @@ public final class QueryTester implements AutoCloseable {
                 },
                 symbol -> queryBuilder.convert(symbol, mapperService, queryShardContext.get(), indexCache).query(),
                 () -> {
+                    indexService.close("stopping", true);
                     writer.close();
                     nodeEnvironment.close();
                 }


### PR DESCRIPTION
We've seen some flaky tests due to the IndexService still being active
after the tests have completed.





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed