### PR TITLE
Make sure CORS preflight requests are handled before auth checks

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -81,6 +81,8 @@ Changes
 Fixes
 =====
 
+- ``CORS`` pre-flight requests now no longer require authentication.
+
 - Fixed an issue which caused joins over multiple relations and implicit join
   conditions inside the ``WHERE`` clause to fail.
 


### PR DESCRIPTION
See https://fetch.spec.whatwg.org/#http-access-control-allow-credentials

> For a CORS-preflight request, request’s credentials mode is always
> "omit", but for any subsequent CORS requests it might not be. Support
> therefore needs to be indicated as part of the HTTP response to the
> CORS-preflight request as well.





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed