### PR TITLE
Switch to psycopg2-binary

### DIFF
--- a/blackbox/requirements.txt
+++ b/blackbox/requirements.txt
@@ -4,7 +4,7 @@
 crash
 crate
 crate-docs-theme
-psycopg2==2.7.5
+psycopg2-binary==2.7.5
 tqdm==4.24.0
 sphinx-csv-filter>=0.2.0
 pycodestyle==2.4.0


### PR DESCRIPTION
Fixes a warning:

    crate/blackbox/.venv/lib/python3.7/site-packages/psycopg2/__init__.py:144:
    UserWarning: The psycopg2 wheel package will be renamed from release
    2.8; in order to keep installing from binary please use "pip install
    psycopg2-binary" instead. For details see:
    <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed