### PR TITLE
Fix array_length query generation for >=

### DIFF
--- a/sql/src/main/java/io/crate/lucene/ArrayLengthQuery.java
+++ b/sql/src/main/java/io/crate/lucene/ArrayLengthQuery.java
@@ -162,8 +162,11 @@ public final class ArrayLengthQuery implements InnerFunctionToQuery {
             case GteOperator.NAME:
                 if (cmpVal == 0) {
                     return existsQuery(context, arrayRef);
+                } else if (cmpVal == 1) {
+                    return numTermsPerDocQuery(arrayRef, valueCountIsMatch);
+                } else {
+                    return genericFunctionFilter(parent, context);
                 }
-                return numTermsPerDocQuery(arrayRef, valueCountIsMatch);
 
             case LtOperator.NAME:
                 if (cmpVal == 0 || cmpVal == 1) {


### PR DESCRIPTION
testArrayLengthWithAllSupportedTypes failed with seed
749F087E446B5B70:ED052D6D893AC621

(Resulted in the generation of 2 empty strings)





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed