### PR TITLE
Filter out archived settings on table altering.

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -86,6 +86,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue which caused tables created on version < 3.0 using not anymore
+  supported table parameters to fail on ``ALTER TABLE`` statements.
+
 - ``CORS`` pre-flight requests now no longer require authentication.
 
 - Fixed an issue which caused joins over multiple relations and implicit join

--- a/sql/src/main/java/io/crate/metadata/upgrade/IndexTemplateUpgrader.java
+++ b/sql/src/main/java/io/crate/metadata/upgrade/IndexTemplateUpgrader.java
@@ -22,9 +22,12 @@
 
 package io.crate.metadata.upgrade;
 
+import com.carrotsearch.hppc.cursors.ObjectObjectCursor;
 import io.crate.metadata.DefaultTemplateService;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.cluster.metadata.AliasMetaData;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetaData;
+import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.logging.ServerLoggers;
 import org.elasticsearch.common.settings.Settings;
 
@@ -34,6 +37,8 @@ import java.util.Map;
 import java.util.function.UnaryOperator;
 
 import static io.crate.metadata.DefaultTemplateService.TEMPLATE_NAME;
+import static org.elasticsearch.common.settings.AbstractScopedSettings.ARCHIVED_SETTINGS_PREFIX;
+import static org.elasticsearch.common.settings.IndexScopedSettings.DEFAULT_SCOPED_SETTINGS;
 
 public class IndexTemplateUpgrader implements UnaryOperator<Map<String, IndexTemplateMetaData>> {
 
@@ -45,11 +50,48 @@ public class IndexTemplateUpgrader implements UnaryOperator<Map<String, IndexTem
 
     @Override
     public Map<String, IndexTemplateMetaData> apply(Map<String, IndexTemplateMetaData> templates) {
-        HashMap<String, IndexTemplateMetaData> upgradedTemplates = new HashMap<>(templates);
+        HashMap<String, IndexTemplateMetaData> upgradedTemplates = archiveUnknownOrInvalidSettings(templates);
         try {
             upgradedTemplates.put(TEMPLATE_NAME, DefaultTemplateService.createDefaultIndexTemplateMetaData());
         } catch (IOException e) {
             logger.error("Error while trying to upgrade the default template", e);
+        }
+        return upgradedTemplates;
+    }
+
+    /**
+     * Filter out all unknown/old/invalid settings. Archiving them *only* is not working as they would be "un-archived"
+     * by {@link IndexTemplateMetaData.Builder#fromXContent} logic to prefix all settings with `index.` when applying
+     * the new cluster state.
+     */
+    private HashMap<String, IndexTemplateMetaData> archiveUnknownOrInvalidSettings(Map<String, IndexTemplateMetaData> templates) {
+        HashMap<String, IndexTemplateMetaData> upgradedTemplates = new HashMap<>(templates.size());
+        for (Map.Entry<String, IndexTemplateMetaData> entry : templates.entrySet()) {
+            IndexTemplateMetaData templateMetaData = entry.getValue();
+            Settings.Builder settingsBuilder = Settings.builder().put(templateMetaData.settings());
+            String templateName = entry.getKey();
+
+            Settings settings = DEFAULT_SCOPED_SETTINGS.archiveUnknownOrInvalidSettings(
+                settingsBuilder.build(), e -> { }, (e, ex) -> { })
+                .filter(k -> k.startsWith(ARCHIVED_SETTINGS_PREFIX) == false);
+
+            IndexTemplateMetaData.Builder builder = IndexTemplateMetaData.builder(templateName)
+                .patterns(templateMetaData.patterns())
+                .order(templateMetaData.order())
+                .settings(settings);
+            try {
+                for (ObjectObjectCursor<String, CompressedXContent> cursor : templateMetaData.getMappings()) {
+                    builder.putMapping(cursor.key, cursor.value);
+                }
+            } catch (IOException e) {
+                logger.error("Error while trying to upgrade template '" + templateName + "'", e);
+                continue;
+            }
+
+            for (ObjectObjectCursor<String, AliasMetaData> container : templateMetaData.aliases()) {
+                builder.putAlias(container.value);
+            }
+            upgradedTemplates.put(templateName, builder.build());
         }
         return upgradedTemplates;
     }

--- a/sql/src/test/java/io/crate/metadata/upgrade/IndexTemplateUpgraderTest.java
+++ b/sql/src/test/java/io/crate/metadata/upgrade/IndexTemplateUpgraderTest.java
@@ -33,7 +33,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static io.crate.metadata.DefaultTemplateService.TEMPLATE_NAME;
+import static org.elasticsearch.cluster.metadata.IndexMetaData.SETTING_NUMBER_OF_SHARDS;
+import static org.elasticsearch.common.settings.AbstractScopedSettings.ARCHIVED_SETTINGS_PREFIX;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 
 public class IndexTemplateUpgraderTest {
@@ -50,5 +53,32 @@ public class IndexTemplateUpgraderTest {
 
         Map<String, IndexTemplateMetaData> upgradedTemplates = upgrader.apply(templates);
         assertThat(upgradedTemplates.get(TEMPLATE_NAME), is(DefaultTemplateService.createDefaultIndexTemplateMetaData()));
+    }
+
+    @Test
+    public void testArchivedSettingsAreRemoved() {
+        IndexTemplateUpgrader upgrader = new IndexTemplateUpgrader(Settings.EMPTY);
+
+        Settings settings = Settings.builder()
+            .put(ARCHIVED_SETTINGS_PREFIX + "some.setting", true)   // archived, must be filtered out
+            .put(SETTING_NUMBER_OF_SHARDS, 4)
+            .build();
+
+        HashMap<String, IndexTemplateMetaData> templates = new HashMap<>();
+        IndexTemplateMetaData oldTemplate = IndexTemplateMetaData.builder("dummy")
+            .settings(settings)
+            .patterns(Collections.singletonList("*"))
+            .build();
+        templates.put("dummy", oldTemplate);
+
+        Map<String, IndexTemplateMetaData> upgradedTemplates = upgrader.apply(templates);
+        IndexTemplateMetaData upgradedTemplate = upgradedTemplates.get("dummy");
+        assertThat(upgradedTemplate.settings().keySet(), contains(SETTING_NUMBER_OF_SHARDS));
+
+        // ensure all other attributes remains the same
+        assertThat(upgradedTemplate.mappings(), is(oldTemplate.mappings()));
+        assertThat(upgradedTemplate.patterns(), is(oldTemplate.patterns()));
+        assertThat(upgradedTemplate.order(), is(oldTemplate.order()));
+        assertThat(upgradedTemplate.aliases(), is(oldTemplate.aliases()));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Filter out unsupported(old) settings at (partitioned table) templates on 
cluster upgrade and private and archived settings on table altering.
Updating a table setting including any archived or private setting
fails otherwise by settings validation.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
