### PR TITLE
Tests: remove testClusterNameInPathCheckDoesNotFailWithDefaultConfig

### DIFF
--- a/sql/src/test/java/io/crate/integrationtests/SysNodeResiliencyIntegrationTest.java
+++ b/sql/src/test/java/io/crate/integrationtests/SysNodeResiliencyIntegrationTest.java
@@ -76,16 +76,4 @@ public class SysNodeResiliencyIntegrationTest extends SQLTransportIntegrationTes
             waitNoPendingTasksOnAll();
         }
     }
-
-    /**
-     * Test cluster name check, when path.data does not contain cluster
-     * name as a folder.
-     * <p>
-     * TODO-ES6: Remove this when ES >= 6.0
-     */
-    @Test
-    public void testClusterNameInPathCheckDoesNotFailWithDefaultConfig() throws Exception {
-        execute("select description, passed from sys.node_checks where not passed and id=1000");
-        assertThat(response.rowCount(), is(0L));
-    }
 }


### PR DESCRIPTION
The node check has been removed a while ago





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed