### PR TITLE
Only filter settings of partitioned table templates on upgrade

### DIFF
--- a/sql/src/main/java/io/crate/metadata/upgrade/IndexTemplateUpgrader.java
+++ b/sql/src/main/java/io/crate/metadata/upgrade/IndexTemplateUpgrader.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.function.UnaryOperator;
 
 import static io.crate.metadata.DefaultTemplateService.TEMPLATE_NAME;
+import static io.crate.metadata.IndexParts.PARTITIONED_TABLE_PART;
 import static org.elasticsearch.common.settings.AbstractScopedSettings.ARCHIVED_SETTINGS_PREFIX;
 import static org.elasticsearch.common.settings.IndexScopedSettings.DEFAULT_SCOPED_SETTINGS;
 
@@ -70,6 +71,12 @@ public class IndexTemplateUpgrader implements UnaryOperator<Map<String, IndexTem
             IndexTemplateMetaData templateMetaData = entry.getValue();
             Settings.Builder settingsBuilder = Settings.builder().put(templateMetaData.settings());
             String templateName = entry.getKey();
+
+            // only process partition table templates
+            if (templateName.startsWith(PARTITIONED_TABLE_PART) == false) {
+                upgradedTemplates.put(templateName, templateMetaData);
+                continue;
+            }
 
             Settings settings = DEFAULT_SCOPED_SETTINGS.archiveUnknownOrInvalidSettings(
                 settingsBuilder.build(), e -> { }, (e, ex) -> { })


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
Other templates (like e.g. random testing templates) can contain unknown
settings which is wanted, don’t touch these.
Follow up of 82815b7f84f64ec7f427b32b0c2df8afd1cdb38b.


## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
