### PR TITLE
Backport of PR #7787

### DIFF
--- a/sql/src/main/java/io/crate/execution/ddl/tables/AlterTableOperation.java
+++ b/sql/src/main/java/io/crate/execution/ddl/tables/AlterTableOperation.java
@@ -517,13 +517,10 @@ public class AlterTableOperation {
      */
     @VisibleForTesting
     static Settings markArchivedSettings(Settings settings) {
-        if (settings.getGroups("archived").keySet().isEmpty() == false) {
-            return Settings.builder()
-                .put(settings)
-                .putNull(ARCHIVED_SETTINGS_PREFIX + "*")
-                .build();
-        }
-        return settings;
+        return Settings.builder()
+            .put(settings)
+            .putNull(ARCHIVED_SETTINGS_PREFIX + "*")
+            .build();
     }
 
     private void addColumnToTable(AddColumnAnalyzedStatement analysis, final CompletableFuture<?> result) {

--- a/sql/src/test/java/io/crate/execution/ddl/tables/AlterTableOperationTest.java
+++ b/sql/src/test/java/io/crate/execution/ddl/tables/AlterTableOperationTest.java
@@ -90,15 +90,9 @@ public class AlterTableOperationTest extends CrateUnitTest {
 
     @Test
     public void testMarkArchivedSettings() {
-        String oldSetting = ARCHIVED_SETTINGS_PREFIX + "some.old.setting";
         Settings.Builder builder = Settings.builder()
-            .put(oldSetting, true);
-        Settings preparedSettings = AlterTableOperation.markArchivedSettings(builder.build());
-        assertThat(preparedSettings.keySet(), containsInAnyOrder(ARCHIVED_SETTINGS_PREFIX + "*", oldSetting));
-
-        builder = Settings.builder()
             .put(SETTING_NUMBER_OF_SHARDS, 4);
-        preparedSettings = AlterTableOperation.markArchivedSettings(builder.build());
-        assertThat(preparedSettings.keySet(), contains(SETTING_NUMBER_OF_SHARDS));
+        Settings preparedSettings = AlterTableOperation.markArchivedSettings(builder.build());
+        assertThat(preparedSettings.keySet(), containsInAnyOrder(SETTING_NUMBER_OF_SHARDS, ARCHIVED_SETTINGS_PREFIX + "*"));
     }
 }


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
We must always mark archived settings to be removed on alter
table operations as we do not know at this stage if the table
contain any archived settings (tables only list supported settings).
Follow up of 82815b7f84f64ec7f427b32b0c2df8afd1cdb38b.

