### PR TITLE
Fix hashCode implementation of MergeCountProjection

### DIFF
--- a/sql/src/main/java/io/crate/execution/dsl/projection/MergeCountProjection.java
+++ b/sql/src/main/java/io/crate/execution/dsl/projection/MergeCountProjection.java
@@ -31,9 +31,8 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Objects;
 
-public class MergeCountProjection extends Projection {
+public final class MergeCountProjection extends Projection {
 
     public static final MergeCountProjection INSTANCE = new MergeCountProjection();
 
@@ -55,7 +54,7 @@ public class MergeCountProjection extends Projection {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(this);
+        return 0;
     }
 
     @Override

--- a/sql/src/test/java/io/crate/execution/dsl/projection/MergeCountProjectionTest.java
+++ b/sql/src/test/java/io/crate/execution/dsl/projection/MergeCountProjectionTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.execution.dsl.projection;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import static org.junit.Assert.assertThat;
+
+public class MergeCountProjectionTest {
+
+    @Test
+    public void testMergeCountProjectionHasSaneHashCode() {
+        // regression test -> used to run into a infinite recursion
+        assertThat(MergeCountProjection.INSTANCE.hashCode(), Matchers.is(0));
+    }
+}


### PR DESCRIPTION
The hashCode implementation led to a Stackoverflow due to an infinite
recursion.

Since projections so far aren't used in Maps or Sets this wasn't an
actual issue.





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed