### PR TITLE
Fix privilege check in case table aliases are present

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -85,3 +85,6 @@ Changes
 
 Fixes
 =====
+
+- Fixed an issue that caused missing privilege errors if table aliases were
+  used.

--- a/enterprise/users/src/main/java/io/crate/auth/user/StatementPrivilegeValidator.java
+++ b/enterprise/users/src/main/java/io/crate/auth/user/StatementPrivilegeValidator.java
@@ -578,7 +578,7 @@ class StatementPrivilegeValidator implements StatementAuthorizedValidator {
             Privileges.ensureUserHasPrivilege(
                 context.type,
                 Privilege.Clazz.TABLE,
-                tableRelation.getQualifiedName().toString(),
+                tableRelation.tableInfo().ident().fqn(),
                 context.user,
                 defaultSchema);
             return null;
@@ -589,7 +589,7 @@ class StatementPrivilegeValidator implements StatementAuthorizedValidator {
             Privileges.ensureUserHasPrivilege(
                 context.type,
                 Privilege.Clazz.TABLE,
-                relation.getQualifiedName().toString(),
+                relation.tableInfo().ident().fqn(),
                 context.user,
                 defaultSchema);
             return null;

--- a/enterprise/users/src/test/java/io/crate/auth/user/StatementPrivilegeValidatorTest.java
+++ b/enterprise/users/src/test/java/io/crate/auth/user/StatementPrivilegeValidatorTest.java
@@ -471,5 +471,11 @@ public class StatementPrivilegeValidatorTest extends CrateDummyClusterServiceUni
         analyze("select 1");
         assertThat(validationCallArguments.size(), is(0));
     }
+
+    @Test
+    public void testPermissionCheckIsDoneOnSchemaAndTableNotOnTableAlias() {
+        analyze("select * from doc.users as t");
+        assertAskedForTable(Privilege.Type.DQL, "doc.users");
+    }
 }
 

--- a/enterprise/users/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
+++ b/enterprise/users/src/test/java/io/crate/integrationtests/PrivilegesIntegrationTest.java
@@ -357,14 +357,14 @@ public class PrivilegesIntegrationTest extends BaseUsersIntegrationTest {
 
     @Test
     public void testPermissionsValidOnTableAlias() {
-        executeAsSuperuser("create table s.t1 (x int)");
+        executeAsSuperuser("create table test.test (x int)");
 
-        executeAsSuperuser("grant dql on schema s to " + TEST_USERNAME);
+        executeAsSuperuser("grant dql on schema test to " + TEST_USERNAME);
         executeAsSuperuser("deny dql on schema doc to " + TEST_USERNAME);
         assertThat(response.rowCount(), is(1L));
         ensureYellow();
 
-        execute("select t.x from t1 as t", null, testUserSession("s"));
+        execute("select t.x from test.test as t", null, testUserSession("s"));
         assertThat(response.rowCount(), is(0L));
     }
 


### PR DESCRIPTION
We've to do the privilege check on the underlying table, not on the
alias.





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed