### PR TITLE
Fix a ByteBuf leak when sending rows to pg clients that contain failing expressions

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -89,6 +89,10 @@ Changes
 Fixes
 =====
 
+- Fixed a memory leak that could occur with clients connecting via postgres
+  protocol and invoking read queries with statements containing expressions
+  that would fail (like ``1 / 0``).
+
 - Fixed an issue in the postgres wire protocol that could result in nodes
   crashing with ``OutOfMemoryError`` if clients queried very large tables
   without specifying the fetch size.

--- a/sql/src/main/java/io/crate/protocols/postgres/Messages.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/Messages.java
@@ -22,9 +22,9 @@
 
 package io.crate.protocols.postgres;
 
-import io.crate.expression.symbol.Field;
 import io.crate.data.Row;
 import io.crate.exceptions.SQLExceptions;
+import io.crate.expression.symbol.Field;
 import io.crate.protocols.postgres.types.PGType;
 import io.crate.protocols.postgres.types.PGTypes;
 import io.crate.types.DataType;
@@ -298,8 +298,15 @@ public class Messages {
 
         for (int i = 0; i < row.numColumns(); i++) {
             DataType dataType = columnTypes.get(i);
-            PGType pgType = PGTypes.get(dataType);
-            Object value = row.get(i);
+            PGType pgType;
+            Object value;
+            try {
+                pgType = PGTypes.get(dataType);
+                value = row.get(i);
+            } catch (Exception e) {
+                buffer.release();
+                throw e;
+            }
             if (value == null) {
                 buffer.writeInt(-1);
                 length += 4;


### PR DESCRIPTION
- [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed