### PR TITLE
Fix ByteBuf leak in MqttIngestService

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -89,6 +89,8 @@ Changes
 Fixes
 =====
 
+- Fixed a memory leak in the ``MQTT`` ingest service.
+
 - Fixed a memory leak that could occur with clients connecting via postgres
   protocol and invoking read queries with statements containing expressions
   that would fail (like ``1 / 0``).

--- a/enterprise/mqtt/src/main/java/io/crate/mqtt/operations/MqttIngestService.java
+++ b/enterprise/mqtt/src/main/java/io/crate/mqtt/operations/MqttIngestService.java
@@ -169,6 +169,7 @@ public class MqttIngestService implements IngestRuleListener {
         }
 
         Map<String, Object> payload = parsePayloadToMap(msg.content());
+        msg.release();
         if (payload == null) {
             return;
         }


### PR DESCRIPTION
Issue was caught by the changes being introduced in
https://github.com/crate/crate/pull/7828

There is no dedicated test because it will be caught with the generic
leak detection.





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed