### PR TITLE
Use readSlice instead of readBuffer in readStartupMessage

### DIFF
--- a/sql/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
@@ -241,7 +241,7 @@ class PostgresWireProtocol {
 
     private Properties readStartupMessage(ByteBuf buffer) {
         Properties properties = new Properties();
-        ByteBuf byteBuf = buffer.readBytes(msgLength);
+        ByteBuf byteBuf = buffer.readSlice(msgLength);
         while (true) {
             String key = readCString(byteBuf);
             if (key == null) {
@@ -253,7 +253,6 @@ class PostgresWireProtocol {
                 properties.setProperty(key, value);
             }
         }
-        byteBuf.release();
         return properties;
     }
 


### PR DESCRIPTION
We don't need to copy the bytes at that point - a view of the buffer is
sufficient.





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed