### PR TITLE
ci: Reduce HEAP used on azure pipelines for gradle

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ jobs:
         inputs:
           workingDirectory: ''
           gradleWrapperFile: 'gradlew'
-          gradleOptions: '-Xmx2048m'
+          gradleOptions: '-Xmx512m'
           javaHomeOption: 'JDKVersion'
           jdkVersionOption: '1.10'
           jdkArchitectureOption: 'x64'
@@ -30,7 +30,7 @@ jobs:
         inputs:
           workingDirectory: ''
           gradleWrapperFile: 'gradlew'
-          gradleOptions: '-Xmx2048m'
+          gradleOptions: '-Xmx512m'
           javaHomeOption: 'JDKVersion'
           jdkVersionOption: '1.8'
           jdkArchitectureOption: 'x64'
@@ -49,7 +49,7 @@ jobs:
         inputs:
           workingDirectory: ''
           gradleWrapperFile: 'gradlew'
-          gradleOptions: '-Xmx2048m'
+          gradleOptions: '-Xmx512m'
           javaHomeOption: 'JDKVersion'
           jdkVersionOption: '1.10'
           jdkArchitectureOption: 'x64'


### PR DESCRIPTION
We fork off javac with different heap settings, so gradle itself
shouldn't consume that much.





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed