### PR TITLE
license: fix accessing null 'sys.cluster.license' children issue

### DIFF
--- a/sql/src/main/java/io/crate/expression/reference/sys/cluster/ClusterLicenseExpression.java
+++ b/sql/src/main/java/io/crate/expression/reference/sys/cluster/ClusterLicenseExpression.java
@@ -43,26 +43,28 @@ public class ClusterLicenseExpression extends NestedObjectExpression {
     @Override
     public NestableInput getChild(String name) {
         DecryptedLicenseData decryptedLicenseData = licenseService.currentLicense();
-        if (decryptedLicenseData != null) {
-            fillChildImplementations(decryptedLicenseData);
-        }
-
+        fillChildImplementations(decryptedLicenseData);
         return super.getChild(name);
     }
 
     private void fillChildImplementations(DecryptedLicenseData decryptedLicenseData) {
-        childImplementations.put(DecryptedLicenseData.EXPIRATION_DATE_IN_MS, () -> decryptedLicenseData.expirationDateInMs());
-        childImplementations.put(DecryptedLicenseData.ISSUED_TO, () -> decryptedLicenseData.issuedTo());
+        if (decryptedLicenseData != null) {
+            childImplementations.put(DecryptedLicenseData.EXPIRATION_DATE_IN_MS, () -> decryptedLicenseData.expirationDateInMs());
+            childImplementations.put(DecryptedLicenseData.ISSUED_TO, () -> decryptedLicenseData.issuedTo());
+        } else {
+            childImplementations.put(DecryptedLicenseData.EXPIRATION_DATE_IN_MS, () -> null);
+            childImplementations.put(DecryptedLicenseData.ISSUED_TO, () -> null);
+        }
     }
 
     @Override
     public Map<String, Object> value() {
         DecryptedLicenseData decryptedLicenseData = licenseService.currentLicense();
-        if (decryptedLicenseData != null) {
-            fillChildImplementations(decryptedLicenseData);
-            return super.value();
-        } else {
+        if (decryptedLicenseData == null) {
             return null;
         }
+
+        fillChildImplementations(decryptedLicenseData);
+        return super.value();
     }
 }

--- a/sql/src/test/java/io/crate/expression/reference/sys/cluster/ClusterLicenseExpressionTest.java
+++ b/sql/src/test/java/io/crate/expression/reference/sys/cluster/ClusterLicenseExpressionTest.java
@@ -55,6 +55,13 @@ public class ClusterLicenseExpressionTest extends CrateUnitTest {
     }
 
     @Test
+    public void testChildValueReturnsNullForMissingLicense() {
+        when(licenseService.currentLicense()).thenReturn(null);
+        assertThat(licenseExpression.getChild(EXPIRATION_DATE_IN_MS).value(), is(nullValue()));
+        assertThat(licenseExpression.getChild(ISSUED_TO).value(), is(nullValue()));
+    }
+
+    @Test
     public void testExpressionValueReturnsLicenseFields() {
         when(licenseService.currentLicense()).thenReturn(new DecryptedLicenseData(3L, "test"));
 


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB

Issue when `sys.cluster.license` is `NULL`:
```
cr> select license from sys.cluster;
+---------+
| license |
+---------+
|    NULL |
+---------+
SELECT 1 row in set (0.007 sec)

cr> select license['issuedTo'] from sys.cluster;
SQLActionException[UnsupportedFeatureException: Can't handle Symbol license['issuedTo']]

cr> SELECT if(license is not NULL, format('Licensed to: %s (expires on %tD)', license['issuedTo'], 	          
        license['expirationDateInMs']), 'unlicended') from sys.cluster;
*SQLActionException[UnsupportedFeatureException: Can't handle Symbol license['issuedTo']]*
```

With the Fix:

```
cr> select license from sys.cluster;
+---------+
| license |
+---------+
|    NULL |
+---------+
SELECT 1 row in set (0.060 sec)
cr> select license['issuedTo'] from sys.cluster;
+---------------------+
| license['issuedTo'] |
+---------------------+
|                NULL |
+---------------------+
SELECT 1 row in set (0.008 sec)
cr> SELECT if(license is not NULL, format('Licensed to: %s (expires on %tD)', license['issuedTo'], license['expirationDateInMs']), 'unlicended') as l from sys.cluster;
+------------+
| l          |
+------------+
| unlicended |
+------------+
SELECT 1 row in set (0.003 sec)
```

and when license is not  `NULL`:

```
cr> select license from sys.cluster;
+----------------------------------------------------------+
| license                                                  |
+----------------------------------------------------------+
| {"expirationDateInMs": 1544009711215, "issuedTo": "dev"} |
+----------------------------------------------------------+
SELECT 1 row in set (0.077 sec)
cr> select license['issuedTo'] from sys.cluster;
+---------------------+
| license['issuedTo'] |
+---------------------+
| dev                 |
+---------------------+
SELECT 1 row in set (0.007 sec)
cr> SELECT if(license is not NULL, format('Licensed to: %s (expires on %tD)', license['issuedTo'],          license['expirationDateInMs']), 'unlicended') as l from sys.cluster;
+----------------------------------------+
| l                                      |
+----------------------------------------+
| Licensed to: dev (expires on 12/05/18) |
+----------------------------------------+
SELECT 1 row in set (0.011 sec)
```

## Checklist

 - [ ] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
