### PR TITLE
Tests: Update monitoringTest to reflect thread pool change

### DIFF
--- a/blackbox/monitoring/src/tests.py
+++ b/blackbox/monitoring/src/tests.py
@@ -215,10 +215,10 @@ class ThreadPoolsBeanTest(unittest.TestCase):
             'io.crate.monitoring:type=ThreadPools', 'Search')
         self.assertEqual(stdout, '{ \n'
                                  '  active = 0;\n'
-                                 '  completed = 2;\n'
-                                 '  largestPoolSize = 2;\n'
+                                 '  completed = 4;\n'
+                                 '  largestPoolSize = 4;\n'
                                  '  name = search;\n'
-                                 '  poolSize = 2;\n'
+                                 '  poolSize = 4;\n'
                                  '  queueSize = 0;\n'
                                  '  rejected = 0;\n'
                                  ' }\n')


### PR DESCRIPTION
Follow up of 0c58490c5b3f79f6f05ccb60afd1b46f5e77859b





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed