### PR TITLE
Protect against negative durations in system metrics histogram

### DIFF
--- a/sql/src/main/java/io/crate/metadata/sys/ClassifiedHistograms.java
+++ b/sql/src/main/java/io/crate/metadata/sys/ClassifiedHistograms.java
@@ -57,7 +57,10 @@ public class ClassifiedHistograms implements Iterable<ClassifiedHistograms.Class
     }
 
     public void recordValue(Classification classification, long duration) {
-        getOrCreate(classification).recordValue(Math.min(duration, HIGHEST_TRACKABLE_VALUE));
+        // We use start and end time to calculate the duration (since we track them anyway)
+        // If the system time is adjusted this can lead to negative durations
+        // so we protect here against it.
+        getOrCreate(classification).recordValue(Math.min(Math.max(0, duration), HIGHEST_TRACKABLE_VALUE));
     }
 
     private ConcurrentHistogram getOrCreate(Classification classification) {

--- a/sql/src/test/java/io/crate/metadata/sys/ClassifiedHistogramsTest.java
+++ b/sql/src/test/java/io/crate/metadata/sys/ClassifiedHistogramsTest.java
@@ -24,9 +24,13 @@ package io.crate.metadata.sys;
 
 import io.crate.planner.Plan;
 import io.crate.planner.operators.StatementClassifier;
+import org.HdrHistogram.Histogram;
 import org.junit.Test;
 
 import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
 
 public class ClassifiedHistogramsTest {
 
@@ -35,5 +39,15 @@ public class ClassifiedHistogramsTest {
         ClassifiedHistograms histograms = new ClassifiedHistograms();
         histograms.recordValue(
             new StatementClassifier.Classification(Plan.StatementType.SELECT), TimeUnit.MINUTES.toMillis(30));
+    }
+
+    @Test
+    public void testRecordValueWithNegativeDurationDoesNotThrowException() {
+        ClassifiedHistograms histograms = new ClassifiedHistograms();
+        histograms.recordValue(
+            new StatementClassifier.Classification(Plan.StatementType.SELECT), -2);
+        Histogram histogram = histograms.iterator().next().histogram();
+        assertThat(histogram.getTotalCount(), is(1L));
+        assertThat(histogram.getMinValue(), is(0L));
     }
 }


### PR DESCRIPTION
System time adjustements can lead to negative durations as we utilize
the start and end time of query execution instead of having a separate
duration clock.





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed