### PR TITLE
Fix the portal resume handling

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -102,6 +102,9 @@ Changes
 Fixes
 =====
 
+- Fixed an issue that caused zombie entries in ``sys.jobs`` if the
+  ``fetchSize`` functionality of postgres wire protocol based clients is used.
+
 - Fixed a memory leak in the ``MQTT`` ingest service.
 
 - Fixed a memory leak that could occur with clients connecting via postgres

--- a/dex/src/main/java/io/crate/data/AsyncOperationBatchIterator.java
+++ b/dex/src/main/java/io/crate/data/AsyncOperationBatchIterator.java
@@ -191,4 +191,17 @@ public class AsyncOperationBatchIterator<T> implements BatchIterator<T> {
     public void kill(@Nonnull Throwable throwable) {
         killed = throwable;
     }
+
+    @Override
+    public String toString() {
+        return "AsyncOperationBatchIterator{" +
+               "source=" + source +
+               ", batchSize=" + batchSize +
+               ", batchAccumulator=" + batchAccumulator +
+               ", idxWithinBatch=" + idxWithinBatch +
+               ", sourceExhausted=" + sourceExhausted +
+               ", closed=" + closed +
+               ", killed=" + killed +
+               '}';
+    }
 }

--- a/sql/src/main/java/io/crate/expression/reference/sys/job/JobContext.java
+++ b/sql/src/main/java/io/crate/expression/reference/sys/job/JobContext.java
@@ -64,4 +64,15 @@ public class JobContext {
     public Classification classification() {
         return classification;
     }
+
+    @Override
+    public String toString() {
+        return "JobContext{" +
+               "id=" + id +
+               ", username='" + username + '\'' +
+               ", stmt='" + stmt + '\'' +
+               ", started=" + started +
+               ", classification=" + classification +
+               '}';
+    }
 }

--- a/sql/src/main/java/io/crate/planner/node/management/ExplainPlan.java
+++ b/sql/src/main/java/io/crate/planner/node/management/ExplainPlan.java
@@ -107,7 +107,7 @@ public class ExplainPlan implements Plan {
             if (plan.dependencies().isEmpty()) {
                 UUID jobId = plannerContext.jobId();
                 BaseResultReceiver resultReceiver = new BaseResultReceiver();
-                RowConsumer noopRowConsumer = new RowConsumerToResultReceiver(resultReceiver, 0);
+                RowConsumer noopRowConsumer = new RowConsumerToResultReceiver(resultReceiver, 0, t -> {});
 
                 Timer timer = context.createTimer(Phase.Execute.name());
                 timer.start();

--- a/sql/src/main/java/io/crate/protocols/postgres/BatchPortal.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/BatchPortal.java
@@ -175,11 +175,9 @@ class BatchPortal extends AbstractPortal {
             jobsLogs.logExecutionStart(jobId, stmt, sessionContext.user(), classification);
             JobsLogsUpdateListener jobsLogsUpdateListener = new JobsLogsUpdateListener(jobId, jobsLogs);
 
-            resultReceiver.completionFuture()
-                .whenComplete(jobsLogsUpdateListener)
-                .whenComplete(completionCallback);
+            resultReceiver.completionFuture().whenComplete(completionCallback);
 
-            RowConsumer consumer = new RowConsumerToResultReceiver(resultReceiver, 0);
+            RowConsumer consumer = new RowConsumerToResultReceiver(resultReceiver, 0, jobsLogsUpdateListener);
             plan.execute(
                 portalContext.getExecutor(),
                 plannerContext,

--- a/sql/src/main/java/io/crate/protocols/postgres/JobsLogsUpdateListener.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/JobsLogsUpdateListener.java
@@ -25,10 +25,11 @@ package io.crate.protocols.postgres;
 import io.crate.exceptions.SQLExceptions;
 import io.crate.execution.engine.collect.stats.JobsLogs;
 
+import javax.annotation.Nullable;
 import java.util.UUID;
-import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
-public class JobsLogsUpdateListener implements BiConsumer<Object, Throwable> {
+public class JobsLogsUpdateListener implements Consumer<Throwable> {
 
     private final UUID jobId;
     private final JobsLogs jobsLogs;
@@ -39,11 +40,11 @@ public class JobsLogsUpdateListener implements BiConsumer<Object, Throwable> {
     }
 
     @Override
-    public void accept(Object o, Throwable t) {
-        if (t == null) {
+    public void accept(@Nullable Throwable throwable) {
+        if (throwable == null) {
             jobsLogs.logExecutionEnd(jobId, null);
         } else {
-            jobsLogs.logExecutionEnd(jobId, SQLExceptions.messageOf(t));
+            jobsLogs.logExecutionEnd(jobId, SQLExceptions.messageOf(throwable));
         }
     }
 }

--- a/sql/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/PostgresWireProtocol.java
@@ -265,11 +265,9 @@ class PostgresWireProtocol {
 
         @Override
         public void accept(Object result, Throwable t) {
-            if (t != null) {
-                if (!(t.getCause() instanceof ClientInterrupted)) {
-                    Messages.sendReadyForQuery(channel);
-                }
-            } else {
+            boolean clientInterrupted = t instanceof ClientInterrupted
+                                        || (t != null && t.getCause() instanceof ClientInterrupted);
+            if (!clientInterrupted) {
                 Messages.sendReadyForQuery(channel);
             }
         }

--- a/sql/src/main/java/io/crate/protocols/postgres/RetryOnFailureResultReceiver.java
+++ b/sql/src/main/java/io/crate/protocols/postgres/RetryOnFailureResultReceiver.java
@@ -137,4 +137,13 @@ public class RetryOnFailureResultReceiver implements ResultReceiver {
     public CompletableFuture<?> completionFuture() {
         return delegate.completionFuture();
     }
+
+    @Override
+    public String toString() {
+        return "RetryOnFailureResultReceiver{" +
+               "delegate=" + delegate +
+               ", jobId=" + jobId +
+               ", attempt=" + attempt +
+               '}';
+    }
 }

--- a/sql/src/test/java/io/crate/action/sql/RowConsumerToResultReceiverTest.java
+++ b/sql/src/test/java/io/crate/action/sql/RowConsumerToResultReceiverTest.java
@@ -47,7 +47,7 @@ public class RowConsumerToResultReceiverTest {
             .collect(Collectors.toList());
 
         BatchSimulatingIterator batchSimulatingIterator =
-            new BatchSimulatingIterator(TestingBatchIterators.range(0, 10),
+            new BatchSimulatingIterator<>(TestingBatchIterators.range(0, 10),
                 2,
                 5,
                 null);
@@ -61,7 +61,7 @@ public class RowConsumerToResultReceiverTest {
             }
         };
         RowConsumerToResultReceiver batchConsumer =
-            new RowConsumerToResultReceiver(resultReceiver, 0);
+            new RowConsumerToResultReceiver(resultReceiver, 0, t -> {});
 
         batchConsumer.accept(batchSimulatingIterator, null);
         resultReceiver.completionFuture().get(10, TimeUnit.SECONDS);
@@ -73,7 +73,7 @@ public class RowConsumerToResultReceiverTest {
     @Test
     public void testExceptionOnAllLoadedCallIsForwardedToResultReceiver() throws Exception {
         BaseResultReceiver resultReceiver = new BaseResultReceiver();
-        RowConsumerToResultReceiver consumer = new RowConsumerToResultReceiver(resultReceiver, 0);
+        RowConsumerToResultReceiver consumer = new RowConsumerToResultReceiver(resultReceiver, 0, t -> {});
 
         consumer.accept(FailingBatchIterator.failOnAllLoaded(), null);
         assertThat(resultReceiver.completionFuture().isCompletedExceptionally(), is(true));

--- a/sql/src/test/java/io/crate/integrationtests/PostgresJobsLogsITest.java
+++ b/sql/src/test/java/io/crate/integrationtests/PostgresJobsLogsITest.java
@@ -171,7 +171,7 @@ public class PostgresJobsLogsITest extends SQLTransportIntegrationTest {
                         "sys.jobs_log must have an entry WHERE stmt=" + stmtStr, resultSet.next(), is(true));
                     assertThat(resultSet.getString(1), is(stmtStr));
                     if (checkForError) {
-                        assertThat(resultSet.getString(2), is("SQLParseException: \"a\" must not be null"));
+                        assertThat(resultSet.getString(2), is("\"a\" must not be null"));
                     }
                 }
             } catch (Exception e) {


### PR DESCRIPTION
The execution+sync of a suspended portal with the postgres wire protocol
resulted in too much work being done and multiple sys.jobs entries being
generated which were then not cleaned up correctly in all cases.

This shuffles the logic around a bit and moves the hook to remove the
jobs entry into the `RowConsumerToResultReceiver` which is kept alive
across suspend. (The `ResultReceiver` components are re-created on the
execute message, making it more difficult to attach the sys.job hook
onto their future)

Fixes https://github.com/crate/crate/issues/7808

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed