### PR TITLE
Remove http.enabled from crate.yml

### DIFF
--- a/app/src/main/dist/config/crate.yml
+++ b/app/src/main/dist/config/crate.yml
@@ -401,10 +401,6 @@ auth:
 # Set a custom allowed content length:
 #http.max_content_length: 100mb
 
-# Disable HTTP completely:
-#http.enabled: false
-
-
 ################################### Gateway ##################################
 
 # The gateway persists cluster meta data on disk every time the meta data

--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -54,6 +54,8 @@ Changes
 
 - Upgraded to Elasticsearch 6.4.2
 
+- Deprecated the ``http.enabled`` setting.
+
 - Added a ``remove_duplicates`` token filter.
 
 - Added a ``char_group`` tokenizer.


### PR DESCRIPTION
The setting is deprecated in ES.

We haven't documented the setting elsewhere.





 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed