### PR TITLE
Replace user with security.principal in hdfs repo

### DIFF
--- a/blackbox/docs/appendices/release-notes/unreleased.rst
+++ b/blackbox/docs/appendices/release-notes/unreleased.rst
@@ -106,6 +106,11 @@ Changes
 Fixes
 =====
 
+- Changed the ``user`` hdfs repository parameter to ``security.principal`` as that is
+  the parameter used by the underlying repository-hdfs plugin.
+
+- Removed the ``conf_location`` hdfs repository parameter as it is not used anymore.
+
 - Fixed an issue that caused zombie entries in ``sys.jobs`` if the
   ``fetchSize`` functionality of postgres wire protocol based clients is used.
 

--- a/blackbox/docs/sql/statements/create-repository.rst
+++ b/blackbox/docs/sql/statements/create-repository.rst
@@ -144,10 +144,10 @@ A repository that stores its snapshot inside an HDFS file-system.
 
   HDFS uri of the form ``hdfs:// <host>:<port>/``.
 
-**user**
+**security.principal**
   | *Type:*    ``string``
 
-  The HDFS user as string.
+  A qualified kerberos principal used to authenticate against HDFS.
 
 **path**
   | *Type:*    ``string``
@@ -159,11 +159,6 @@ A repository that stores its snapshot inside an HDFS file-system.
   | *Default:* ``true``
 
   Whether to load the default Hadoop Configuration.
-
-**conf_location**
-  | *Type:*    ``string``
-
-  Comma separated string of files to Hadoop XML configuration files to load.
 
 **conf.<key>**
   | *Type:*    various

--- a/sql/src/main/java/io/crate/analyze/repositories/RepositorySettingsModule.java
+++ b/sql/src/main/java/io/crate/analyze/repositories/RepositorySettingsModule.java
@@ -64,10 +64,9 @@ public class RepositorySettingsModule extends AbstractModule {
         Collections.emptyMap(),
         ImmutableMap.<String, Setting>builder()
             .put("uri", Setting.simpleString("uri", Setting.Property.NodeScope))
-            .put("user", Setting.simpleString("user", Setting.Property.NodeScope))
+            .put("security.principal", Setting.simpleString("security.principal", Setting.Property.NodeScope))
             .put("path", Setting.simpleString("path", Setting.Property.NodeScope))
             .put("load_defaults", Setting.boolSetting("load_defaults", true, Setting.Property.NodeScope))
-            .put("conf_location", Setting.simpleString("conf_location", Setting.Property.NodeScope))
             .put("concurrent_streams", Setting.intSetting("concurrent_streams", 5, Setting.Property.NodeScope))
             .put("compress", Setting.boolSetting("compress", true, Setting.Property.NodeScope))
             // We cannot use a ByteSize setting as it doesn't support NULL and it must be NULL as default to indicate to

--- a/sql/src/test/java/io/crate/analyze/RepositoryParamValidatorTest.java
+++ b/sql/src/test/java/io/crate/analyze/RepositoryParamValidatorTest.java
@@ -80,6 +80,18 @@ public class RepositoryParamValidatorTest extends CrateUnitTest {
     }
 
     @Test
+    public void testHdfsSecurityPrincipal() throws Exception {
+        GenericProperties genericProperties = new GenericProperties();
+        genericProperties.add(new GenericProperty("uri", new StringLiteral("hdfs://ha-name:8020")));
+        genericProperties.add(new GenericProperty("security.principal", new StringLiteral("myuserid@REALM.DOMAIN")));
+        genericProperties.add(new GenericProperty("path", new StringLiteral("/user/name/data")));
+        genericProperties.add(new GenericProperty("conf.foobar", new StringLiteral("bar")));
+        Settings settings = validator.convertAndValidate("hdfs", genericProperties, ParameterContext.EMPTY);
+        assertThat(settings.get("security.principal"), is("myuserid@REALM.DOMAIN"));
+        assertThat(settings.get("uri"), is("hdfs://ha-name:8020"));
+    }
+
+    @Test
     public void testS3ConfigParams() throws Exception {
         GenericProperties genericProperties = new GenericProperties();
         genericProperties.add(new GenericProperty("access_key", new StringLiteral("foobar")));


### PR DESCRIPTION
## Summary of the changes / Why this improves CrateDB
The hdfs repository plugin uses a different settings value than the one exposed in the repository parameters. These changes update that param, test it's working, and document expectations for end users: how to configure the plugin properly given the plugin architecture, where to put relevant config files, etc.

## Checklist

 - [x] User relevant changes are recorded in ``CHANGES.txt``
 - [x] Touched code is covered by tests
 - [x] Documentation has been updated if necessary
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
